### PR TITLE
Fix symf rewrite failures

### DIFF
--- a/agent/recordings/defaultClient_631904893/recording.har.yaml
+++ b/agent/recordings/defaultClient_631904893/recording.har.yaml
@@ -762,153 +762,6 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: 1668a2afd7ba6791b44c46a9aaea04cc
-      _order: 0
-      cache: {}
-      request:
-        bodySize: 1183
-        cookies: []
-        headers:
-          - name: content-type
-            value: application/json
-          - name: accept-encoding
-            value: gzip;q=0
-          - name: authorization
-            value: token
-              REDACTED_d5e0f0a37c9821e856b923fe14e67a605e3f6c0a517d5a4f46a4e35943ee0f6d
-          - name: user-agent
-            value: defaultClient / v1
-          - name: traceparent
-            value: 00-cab982e42876ca0abc5622bd04492720-97f01a5028735602-01
-          - name: connection
-            value: keep-alive
-          - name: host
-            value: sourcegraph.com
-        headersSize: 415
-        httpVersion: HTTP/1.1
-        method: POST
-        postData:
-          mimeType: application/json
-          params: []
-          textJSON:
-            maxTokensToSample: 4000
-            messages:
-              - speaker: system
-                text: You are Cody, an AI coding assistant from Sourcegraph.
-              - speaker: human
-                text: >-
-                  Codebase context from file src/squirrel.ts:
-
-                  ```typescript
-
-                  /**
-                   * Squirrel is an interface that mocks something completely unrelated to squirrels.
-                   * It is related to the implementation of precise code navigation in Sourcegraph.
-                   */
-                  export interface Squirrel {}
-
-                  ```
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: |-
-                  Codebase context from file src/animal.ts:
-                  ```typescript
-                  /* SELECTION_START */
-                  export interface Animal {
-                      name: string
-                      makeAnimalSound(): string
-                      isMammal: boolean
-                  }
-                  /* SELECTION_END */
-                  ```
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: |-
-                  My selected code from @src/animal.ts:1-6:
-                  ```
-
-                  export interface Animal {
-                      name: string
-                      makeAnimalSound(): string
-                      isMammal: boolean
-                  }
-                  ```
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: Write a class Dog that implements the Animal interface in my workspace.
-                  Show the code only, no explanation needed.
-            model: anthropic/claude-3-sonnet-20240229
-            temperature: 0
-            topK: -1
-            topP: -1
-        queryString:
-          - name: api-version
-            value: "1"
-          - name: client-name
-            value: defaultclient
-          - name: client-version
-            value: v1
-        url: https://sourcegraph.com/.api/completions/stream?api-version=1&client-name=defaultclient&client-version=v1
-      response:
-        bodySize: 11260
-        content:
-          mimeType: text/event-stream
-          size: 11260
-          text: >+
-            event: completion
-
-            data: {"completion":"```typescript\nclass Dog implements Animal {\n    name: string;\n    isMammal: boolean = true;\n\n    constructor(name: string) {\n        this.name = name;\n    }\n\n    makeAnimalSound(): string {\n        return \"Woof!\";\n    }\n}\n```","stopReason":"end_turn"}
-
-
-            event: done
-
-            data: {}
-
-        cookies: []
-        headers:
-          - name: date
-            value: Mon, 27 May 2024 11:54:29 GMT
-          - name: content-type
-            value: text/event-stream
-          - name: transfer-encoding
-            value: chunked
-          - name: connection
-            value: keep-alive
-          - name: access-control-allow-credentials
-            value: "true"
-          - name: access-control-allow-origin
-            value: ""
-          - name: cache-control
-            value: no-cache
-          - name: vary
-            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
-              X-Requested-With,Cookie
-          - name: x-content-type-options
-            value: nosniff
-          - name: x-frame-options
-            value: DENY
-          - name: x-xss-protection
-            value: 1; mode=block
-          - name: strict-transport-security
-            value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1299
-        httpVersion: HTTP/1.1
-        redirectURL: ""
-        status: 200
-        statusText: OK
-      startedDateTime: 2024-05-27T11:54:27.883Z
-      time: 0
-      timings:
-        blocked: -1
-        connect: -1
-        dns: -1
-        receive: 0
-        send: 0
-        ssl: -1
-        wait: 0
     - _id: fe008c5affb1f0e459786ed6dda1b083
       _order: 0
       cache: {}
@@ -1392,7 +1245,17 @@ log:
               - speaker: system
                 text: You are Cody, an AI coding assistant from Sourcegraph.
               - speaker: human
-                text: "Codebase context from file path src/animal.ts: /* SELECTION_START */\nexport interface Animal {\n    name: string\n    makeAnimalSound(): string\n    isMammal: boolean\n}\n/* SELECTION_END */"
+                text: >-
+                  Codebase context from file path src/animal.ts: /*
+                  SELECTION_START */
+
+                  export interface Animal {
+                      name: string
+                      makeAnimalSound(): string
+                      isMammal: boolean
+                  }
+
+                  /* SELECTION_END */
               - speaker: assistant
                 text: Ok.
               - speaker: human
@@ -1409,21 +1272,21 @@ log:
               - speaker: assistant
                 text: Ok.
               - speaker: human
-                text: "Explain what @src/animal.ts:1-6 ( @src/animal.ts ) does in simple terms. Assume the
-                  audience is a beginner programmer who has just learned the
-                  language features and basic syntax. Focus on explaining: 1)
-                  The purpose of the code 2) What input(s) it takes 3) What
-                  output(s) it produces 4) How it achieves its purpose through
-                  the logic and algorithm. 5) Any important logic flows or data
-                  transformations happening. Use simple language a beginner
-                  could understand. Include enough detail to give a full picture
-                  of what the code aims to accomplish without getting too
-                  technical. Format the explanation in coherent paragraphs,
-                  using proper punctuation and grammar. Write the explanation
-                  assuming no prior context about the code is known. Do not make
-                  assumptions about variables or functions not shown in the
-                  shared code. Start the answer with the name of the code that
-                  is being explained."
+                text: "Explain what @src/animal.ts:1-6 ( @src/animal.ts ) does in simple terms.
+                  Assume the audience is a beginner programmer who has just
+                  learned the language features and basic syntax. Focus on
+                  explaining: 1) The purpose of the code 2) What input(s) it
+                  takes 3) What output(s) it produces 4) How it achieves its
+                  purpose through the logic and algorithm. 5) Any important
+                  logic flows or data transformations happening. Use simple
+                  language a beginner could understand. Include enough detail to
+                  give a full picture of what the code aims to accomplish
+                  without getting too technical. Format the explanation in
+                  coherent paragraphs, using proper punctuation and grammar.
+                  Write the explanation assuming no prior context about the code
+                  is known. Do not make assumptions about variables or functions
+                  not shown in the shared code. Start the answer with the name
+                  of the code that is being explained."
             model: anthropic/claude-3-sonnet-20240229
             temperature: 0
             topK: -1
@@ -1714,7 +1577,17 @@ log:
               - speaker: system
                 text: You are Cody, an AI coding assistant from Sourcegraph.
               - speaker: human
-                text: "Codebase context from file path src/animal.ts: /* SELECTION_START */\nexport interface Animal {\n    name: string\n    makeAnimalSound(): string\n    isMammal: boolean\n}\n/* SELECTION_END */"
+                text: >-
+                  Codebase context from file path src/animal.ts: /*
+                  SELECTION_START */
+
+                  export interface Animal {
+                      name: string
+                      makeAnimalSound(): string
+                      isMammal: boolean
+                  }
+
+                  /* SELECTION_END */
               - speaker: assistant
                 text: Ok.
               - speaker: human
@@ -1731,17 +1604,18 @@ log:
               - speaker: assistant
                 text: Ok.
               - speaker: human
-                text: Please review and analyze @src/animal.ts:1-6 ( @src/animal.ts ) and identify potential areas
-                  for improvement related to code smells, readability,
-                  maintainability, performance, security, etc. Do not list
-                  issues already addressed in the given code. Focus on providing
-                  up to 5 constructive suggestions that could make the code more
-                  robust, efficient, or align with best practices. For each
-                  suggestion, provide a brief explanation of the potential
-                  benefits. After listing any recommendations, summarize if you
-                  found notable opportunities to enhance the code quality
-                  overall or if the code generally follows sound design
-                  principles. If no issues found, reply 'There are no errors.'
+                text: Please review and analyze @src/animal.ts:1-6 ( @src/animal.ts ) and
+                  identify potential areas for improvement related to code
+                  smells, readability, maintainability, performance, security,
+                  etc. Do not list issues already addressed in the given code.
+                  Focus on providing up to 5 constructive suggestions that could
+                  make the code more robust, efficient, or align with best
+                  practices. For each suggestion, provide a brief explanation of
+                  the potential benefits. After listing any recommendations,
+                  summarize if you found notable opportunities to enhance the
+                  code quality overall or if the code generally follows sound
+                  design principles. If no issues found, reply 'There are no
+                  errors.'
             model: anthropic/claude-3-sonnet-20240229
             temperature: 0
             topK: -1
@@ -1813,11 +1687,11 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: 8bc9bbaf90bcaec66cd48785d79db439
+    - _id: aaac2d0f56613ca7b5ccb71b4175750a
       _order: 0
       cache: {}
       request:
-        bodySize: 973
+        bodySize: 1547
         cookies: []
         headers:
           - name: content-type
@@ -1830,806 +1704,106 @@ log:
           - name: user-agent
             value: defaultClient / v1
           - name: traceparent
-            value: 00-cab982e42876ca0abc5622bd04492720-72a70af4d9f59224-01
+            value: 00-264b5981a27095d815855b236d2d25b5-e32bd9eecb9decaa-01
           - name: connection
             value: keep-alive
           - name: host
             value: sourcegraph.com
-        headersSize: 401
+        headersSize: 415
         httpVersion: HTTP/1.1
         method: POST
         postData:
           mimeType: application/json
           params: []
           textJSON:
-            fast: true
-            maxTokensToSample: 400
+            maxTokensToSample: 4000
             messages:
-              - speaker: human
+              - speaker: system
                 text: You are Cody, an AI coding assistant from Sourcegraph.
-              - speaker: assistant
-                text: I am Cody, an AI coding assistant from Sourcegraph.
               - speaker: human
-                text: "You are helping the user search over a codebase. List some filename
-                  fragments that would match files relevant to read to answer
-                  the user's query. Present your results in an XML list in the
-                  following format: <keywords><keyword><value>a single
-                  keyword</value><variants>a space separated list of synonyms
-                  and variants of the keyword, including acronyms,
-                  abbreviations, and expansions</variants><weight>a numerical
-                  weight between 0.0 and 1.0 that indicates the importance of
-                  the keyword</weight></keyword></keywords>. Here is the user
-                  query: <userQuery>Write a class Dog that implements the Animal
-                  interface in my workspace. Show the code only, no explanation
-                  needed.</userQuery>"
+                text: |-
+                  Codebase context from file src/TestClass.ts:
+                  ```typescript
+                  const foo = 42
+
+                  export class TestClass {
+                      constructor(private shouldGreet: boolean) {}
+
+                      public functionName() {
+                          if (this.shouldGreet) {
+                              console.log(/* CURSOR */ 'Hello World!')
+                          }
+                      }
+                  }
+                  ```
               - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: >-
+                  Codebase context from file src/squirrel.ts:
+
+                  ```typescript
+
+                  /**
+                   * Squirrel is an interface that mocks something completely unrelated to squirrels.
+                   * It is related to the implementation of precise code navigation in Sourcegraph.
+                   */
+                  export interface Squirrel {}
+
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: |-
+                  Codebase context from file src/animal.ts:
+                  ```typescript
+                  /* SELECTION_START */
+                  export interface Animal {
+                      name: string
+                      makeAnimalSound(): string
+                      isMammal: boolean
+                  }
+                  /* SELECTION_END */
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: |-
+                  My selected code from @src/animal.ts:1-6:
+                  ```
+
+                  export interface Animal {
+                      name: string
+                      makeAnimalSound(): string
+                      isMammal: boolean
+                  }
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: Write a class Dog that implements the Animal interface in my workspace.
+                  Show the code only, no explanation needed.
+            model: anthropic/claude-3-sonnet-20240229
             temperature: 0
-            topK: 1
+            topK: -1
+            topP: -1
         queryString:
+          - name: api-version
+            value: "1"
           - name: client-name
             value: defaultclient
           - name: client-version
             value: v1
-        url: https://sourcegraph.com/.api/completions/stream?client-name=defaultclient&client-version=v1
+        url: https://sourcegraph.com/.api/completions/stream?api-version=1&client-name=defaultclient&client-version=v1
       response:
-        bodySize: 77430
+        bodySize: 11260
         content:
           mimeType: text/event-stream
-          size: 77430
+          size: 11260
           text: >+
             event: completion
 
-            data: {"completion":"Here","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that woul","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeywor","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecan","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keywor","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeywor","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants\u003e\n\u003cweight","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants\u003e\n\u003cweight\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants\u003e\n\u003cweight\u003e0","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants\u003e\n\u003cweight\u003e0.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants\u003e\n\u003cweight\u003e0.8","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keywor","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeywor","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003einterface","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003einterface\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003einterface\u003c/value","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003einterface\u003c/value\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003einterface\u003c/value\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003einterface\u003c/value\u003e\n\u003cvariants","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003einterface\u003c/value\u003e\n\u003cvariants\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003einterface\u003c/value\u003e\n\u003cvariants\u003eapi","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003einterface\u003c/value\u003e\n\u003cvariants\u003eapi contract","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003einterface\u003c/value\u003e\n\u003cvariants\u003eapi contract spec","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003einterface\u003c/value\u003e\n\u003cvariants\u003eapi contract spec\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003einterface\u003c/value\u003e\n\u003cvariants\u003eapi contract spec\u003c/variants","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003einterface\u003c/value\u003e\n\u003cvariants\u003eapi contract spec\u003c/variants\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003einterface\u003c/value\u003e\n\u003cvariants\u003eapi contract spec\u003c/variants\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003einterface\u003c/value\u003e\n\u003cvariants\u003eapi contract spec\u003c/variants\u003e\n\u003cweight","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003einterface\u003c/value\u003e\n\u003cvariants\u003eapi contract spec\u003c/variants\u003e\n\u003cweight\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003einterface\u003c/value\u003e\n\u003cvariants\u003eapi contract spec\u003c/variants\u003e\n\u003cweight\u003e0","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003einterface\u003c/value\u003e\n\u003cvariants\u003eapi contract spec\u003c/variants\u003e\n\u003cweight\u003e0.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003einterface\u003c/value\u003e\n\u003cvariants\u003eapi contract spec\u003c/variants\u003e\n\u003cweight\u003e0.7","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003einterface\u003c/value\u003e\n\u003cvariants\u003eapi contract spec\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003einterface\u003c/value\u003e\n\u003cvariants\u003eapi contract spec\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003einterface\u003c/value\u003e\n\u003cvariants\u003eapi contract spec\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003einterface\u003c/value\u003e\n\u003cvariants\u003eapi contract spec\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003einterface\u003c/value\u003e\n\u003cvariants\u003eapi contract spec\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keywor","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003einterface\u003c/value\u003e\n\u003cvariants\u003eapi contract spec\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003einterface\u003c/value\u003e\n\u003cvariants\u003eapi contract spec\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003einterface\u003c/value\u003e\n\u003cvariants\u003eapi contract spec\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeywor","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003einterface\u003c/value\u003e\n\u003cvariants\u003eapi contract spec\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003einterface\u003c/value\u003e\n\u003cvariants\u003eapi contract spec\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003einterface\u003c/value\u003e\n\u003cvariants\u003eapi contract spec\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003einterface\u003c/value\u003e\n\u003cvariants\u003eapi contract spec\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003einterface\u003c/value\u003e\n\u003cvariants\u003eapi contract spec\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eimplementation","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003einterface\u003c/value\u003e\n\u003cvariants\u003eapi contract spec\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eimplementation\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003einterface\u003c/value\u003e\n\u003cvariants\u003eapi contract spec\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eimplementation\u003c/value","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003einterface\u003c/value\u003e\n\u003cvariants\u003eapi contract spec\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eimplementation\u003c/value\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003einterface\u003c/value\u003e\n\u003cvariants\u003eapi contract spec\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eimplementation\u003c/value\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003einterface\u003c/value\u003e\n\u003cvariants\u003eapi contract spec\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eimplementation\u003c/value\u003e\n\u003cvariants","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003einterface\u003c/value\u003e\n\u003cvariants\u003eapi contract spec\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eimplementation\u003c/value\u003e\n\u003cvariants\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003einterface\u003c/value\u003e\n\u003cvariants\u003eapi contract spec\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eimplementation\u003c/value\u003e\n\u003cvariants\u003eimpl","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003einterface\u003c/value\u003e\n\u003cvariants\u003eapi contract spec\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eimplementation\u003c/value\u003e\n\u003cvariants\u003eimpl concrete","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003einterface\u003c/value\u003e\n\u003cvariants\u003eapi contract spec\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eimplementation\u003c/value\u003e\n\u003cvariants\u003eimpl concrete_","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003einterface\u003c/value\u003e\n\u003cvariants\u003eapi contract spec\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eimplementation\u003c/value\u003e\n\u003cvariants\u003eimpl concrete_class","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003einterface\u003c/value\u003e\n\u003cvariants\u003eapi contract spec\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eimplementation\u003c/value\u003e\n\u003cvariants\u003eimpl concrete_class\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003einterface\u003c/value\u003e\n\u003cvariants\u003eapi contract spec\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eimplementation\u003c/value\u003e\n\u003cvariants\u003eimpl concrete_class\u003c/variants","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003einterface\u003c/value\u003e\n\u003cvariants\u003eapi contract spec\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eimplementation\u003c/value\u003e\n\u003cvariants\u003eimpl concrete_class\u003c/variants\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003einterface\u003c/value\u003e\n\u003cvariants\u003eapi contract spec\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eimplementation\u003c/value\u003e\n\u003cvariants\u003eimpl concrete_class\u003c/variants\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003einterface\u003c/value\u003e\n\u003cvariants\u003eapi contract spec\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eimplementation\u003c/value\u003e\n\u003cvariants\u003eimpl concrete_class\u003c/variants\u003e\n\u003cweight","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003einterface\u003c/value\u003e\n\u003cvariants\u003eapi contract spec\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eimplementation\u003c/value\u003e\n\u003cvariants\u003eimpl concrete_class\u003c/variants\u003e\n\u003cweight\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003einterface\u003c/value\u003e\n\u003cvariants\u003eapi contract spec\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eimplementation\u003c/value\u003e\n\u003cvariants\u003eimpl concrete_class\u003c/variants\u003e\n\u003cweight\u003e0","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003einterface\u003c/value\u003e\n\u003cvariants\u003eapi contract spec\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eimplementation\u003c/value\u003e\n\u003cvariants\u003eimpl concrete_class\u003c/variants\u003e\n\u003cweight\u003e0.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003einterface\u003c/value\u003e\n\u003cvariants\u003eapi contract spec\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eimplementation\u003c/value\u003e\n\u003cvariants\u003eimpl concrete_class\u003c/variants\u003e\n\u003cweight\u003e0.7","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003einterface\u003c/value\u003e\n\u003cvariants\u003eapi contract spec\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eimplementation\u003c/value\u003e\n\u003cvariants\u003eimpl concrete_class\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003einterface\u003c/value\u003e\n\u003cvariants\u003eapi contract spec\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eimplementation\u003c/value\u003e\n\u003cvariants\u003eimpl concrete_class\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003einterface\u003c/value\u003e\n\u003cvariants\u003eapi contract spec\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eimplementation\u003c/value\u003e\n\u003cvariants\u003eimpl concrete_class\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003einterface\u003c/value\u003e\n\u003cvariants\u003eapi contract spec\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eimplementation\u003c/value\u003e\n\u003cvariants\u003eimpl concrete_class\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003einterface\u003c/value\u003e\n\u003cvariants\u003eapi contract spec\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eimplementation\u003c/value\u003e\n\u003cvariants\u003eimpl concrete_class\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keywor","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003einterface\u003c/value\u003e\n\u003cvariants\u003eapi contract spec\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eimplementation\u003c/value\u003e\n\u003cvariants\u003eimpl concrete_class\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003einterface\u003c/value\u003e\n\u003cvariants\u003eapi contract spec\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eimplementation\u003c/value\u003e\n\u003cvariants\u003eimpl concrete_class\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003einterface\u003c/value\u003e\n\u003cvariants\u003eapi contract spec\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eimplementation\u003c/value\u003e\n\u003cvariants\u003eimpl concrete_class\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003c/keywords","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003einterface\u003c/value\u003e\n\u003cvariants\u003eapi contract spec\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eimplementation\u003c/value\u003e\n\u003cvariants\u003eimpl concrete_class\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003c/keywords\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003einterface\u003c/value\u003e\n\u003cvariants\u003eapi contract spec\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eimplementation\u003c/value\u003e\n\u003cvariants\u003eimpl concrete_class\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003c/keywords\u003e","stopReason":"end_turn"}
+            data: {"completion":"```typescript\nclass Dog implements Animal {\n    name: string;\n    isMammal: boolean = true;\n\n    constructor(name: string) {\n        this.name = name;\n    }\n\n    makeAnimalSound(): string {\n        return \"Woof!\";\n    }\n}\n```","stopReason":"end_turn"}
 
 
             event: done
@@ -2639,7 +1813,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Mon, 27 May 2024 11:54:26 GMT
+            value: Sat, 08 Jun 2024 17:50:07 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
@@ -2668,1070 +1842,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-05-27T11:54:25.953Z
-      time: 0
-      timings:
-        blocked: -1
-        connect: -1
-        dns: -1
-        receive: 0
-        send: 0
-        ssl: -1
-        wait: 0
-    - _id: a6a6cd26b2dd6e018db016dcae6e87f7
-      _order: 0
-      cache: {}
-      request:
-        bodySize: 876
-        cookies: []
-        headers:
-          - name: content-type
-            value: application/json
-          - name: accept-encoding
-            value: gzip;q=0
-          - name: authorization
-            value: token
-              REDACTED_d5e0f0a37c9821e856b923fe14e67a605e3f6c0a517d5a4f46a4e35943ee0f6d
-          - name: user-agent
-            value: defaultClient / v1
-          - name: traceparent
-            value: 00-c71dda34efe763b557b0d8fed42b50d8-3fdf7fc5ae67f934-01
-          - name: connection
-            value: keep-alive
-          - name: host
-            value: sourcegraph.com
-        headersSize: 401
-        httpVersion: HTTP/1.1
-        method: POST
-        postData:
-          mimeType: application/json
-          params: []
-          textJSON:
-            fast: true
-            maxTokensToSample: 400
-            messages:
-              - speaker: human
-                text: You are Cody, an AI coding assistant from Sourcegraph.
-              - speaker: assistant
-                text: I am Cody, an AI coding assistant from Sourcegraph.
-              - speaker: human
-                text: "You are helping the user search over a codebase. List some filename
-                  fragments that would match files relevant to read to answer
-                  the user's query. Present your results in an XML list in the
-                  following format: <keywords><keyword><value>a single
-                  keyword</value><variants>a space separated list of synonyms
-                  and variants of the keyword, including acronyms,
-                  abbreviations, and expansions</variants><weight>a numerical
-                  weight between 0.0 and 1.0 that indicates the importance of
-                  the keyword</weight></keyword></keywords>. Here is the user
-                  query: <userQuery>What is Squirrel?</userQuery>"
-              - speaker: assistant
-            temperature: 0
-            topK: 1
-        queryString:
-          - name: client-name
-            value: defaultclient
-          - name: client-version
-            value: v1
-        url: https://sourcegraph.com/.api/completions/stream?client-name=defaultclient&client-version=v1
-      response:
-        bodySize: 117115
-        content:
-          mimeType: text/event-stream
-          size: 117115
-          text: >+
-            event: completion
-
-            data: {"completion":"Here","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that woul","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeywor","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esqu","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquir","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esqu","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquir","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squir","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keywor","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeywor","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keywor","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeywor","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ero","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003ero","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent ro","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n\u003cweight","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n\u003cweight\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n\u003cweight\u003e0","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n\u003cweight\u003e0.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n\u003cweight\u003e0.8","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keywor","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeywor","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebehavior","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebehavior\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebehavior\u003c/value","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebehavior\u003c/value\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebehavior\u003c/value\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebehavior\u003c/value\u003e\n\u003cvariants","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebehavior\u003c/value\u003e\n\u003cvariants\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebehavior\u003c/value\u003e\n\u003cvariants\u003ebehavior","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebehavior\u003c/value\u003e\n\u003cvariants\u003ebehavior behaviors","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebehavior\u003c/value\u003e\n\u003cvariants\u003ebehavior behaviors eth","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebehavior\u003c/value\u003e\n\u003cvariants\u003ebehavior behaviors ethology","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebehavior\u003c/value\u003e\n\u003cvariants\u003ebehavior behaviors ethology\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebehavior\u003c/value\u003e\n\u003cvariants\u003ebehavior behaviors ethology\u003c/variants","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebehavior\u003c/value\u003e\n\u003cvariants\u003ebehavior behaviors ethology\u003c/variants\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebehavior\u003c/value\u003e\n\u003cvariants\u003ebehavior behaviors ethology\u003c/variants\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebehavior\u003c/value\u003e\n\u003cvariants\u003ebehavior behaviors ethology\u003c/variants\u003e\n\u003cweight","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebehavior\u003c/value\u003e\n\u003cvariants\u003ebehavior behaviors ethology\u003c/variants\u003e\n\u003cweight\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebehavior\u003c/value\u003e\n\u003cvariants\u003ebehavior behaviors ethology\u003c/variants\u003e\n\u003cweight\u003e0","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebehavior\u003c/value\u003e\n\u003cvariants\u003ebehavior behaviors ethology\u003c/variants\u003e\n\u003cweight\u003e0.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebehavior\u003c/value\u003e\n\u003cvariants\u003ebehavior behaviors ethology\u003c/variants\u003e\n\u003cweight\u003e0.7","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebehavior\u003c/value\u003e\n\u003cvariants\u003ebehavior behaviors ethology\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebehavior\u003c/value\u003e\n\u003cvariants\u003ebehavior behaviors ethology\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebehavior\u003c/value\u003e\n\u003cvariants\u003ebehavior behaviors ethology\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebehavior\u003c/value\u003e\n\u003cvariants\u003ebehavior behaviors ethology\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebehavior\u003c/value\u003e\n\u003cvariants\u003ebehavior behaviors ethology\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keywor","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebehavior\u003c/value\u003e\n\u003cvariants\u003ebehavior behaviors ethology\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebehavior\u003c/value\u003e\n\u003cvariants\u003ebehavior behaviors ethology\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebehavior\u003c/value\u003e\n\u003cvariants\u003ebehavior behaviors ethology\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeywor","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebehavior\u003c/value\u003e\n\u003cvariants\u003ebehavior behaviors ethology\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebehavior\u003c/value\u003e\n\u003cvariants\u003ebehavior behaviors ethology\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebehavior\u003c/value\u003e\n\u003cvariants\u003ebehavior behaviors ethology\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebehavior\u003c/value\u003e\n\u003cvariants\u003ebehavior behaviors ethology\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebehavior\u003c/value\u003e\n\u003cvariants\u003ebehavior behaviors ethology\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ehabitat","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebehavior\u003c/value\u003e\n\u003cvariants\u003ebehavior behaviors ethology\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ehabitat\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebehavior\u003c/value\u003e\n\u003cvariants\u003ebehavior behaviors ethology\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ehabitat\u003c/value","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebehavior\u003c/value\u003e\n\u003cvariants\u003ebehavior behaviors ethology\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ehabitat\u003c/value\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebehavior\u003c/value\u003e\n\u003cvariants\u003ebehavior behaviors ethology\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ehabitat\u003c/value\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebehavior\u003c/value\u003e\n\u003cvariants\u003ebehavior behaviors ethology\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ehabitat\u003c/value\u003e\n\u003cvariants","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebehavior\u003c/value\u003e\n\u003cvariants\u003ebehavior behaviors ethology\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ehabitat\u003c/value\u003e\n\u003cvariants\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebehavior\u003c/value\u003e\n\u003cvariants\u003ebehavior behaviors ethology\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ehabitat\u003c/value\u003e\n\u003cvariants\u003ehabitat","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebehavior\u003c/value\u003e\n\u003cvariants\u003ebehavior behaviors ethology\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ehabitat\u003c/value\u003e\n\u003cvariants\u003ehabitat hab","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebehavior\u003c/value\u003e\n\u003cvariants\u003ebehavior behaviors ethology\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ehabitat\u003c/value\u003e\n\u003cvariants\u003ehabitat habitats","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebehavior\u003c/value\u003e\n\u003cvariants\u003ebehavior behaviors ethology\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ehabitat\u003c/value\u003e\n\u003cvariants\u003ehabitat habitats environment","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebehavior\u003c/value\u003e\n\u003cvariants\u003ebehavior behaviors ethology\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ehabitat\u003c/value\u003e\n\u003cvariants\u003ehabitat habitats environment ecology","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebehavior\u003c/value\u003e\n\u003cvariants\u003ebehavior behaviors ethology\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ehabitat\u003c/value\u003e\n\u003cvariants\u003ehabitat habitats environment ecology\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebehavior\u003c/value\u003e\n\u003cvariants\u003ebehavior behaviors ethology\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ehabitat\u003c/value\u003e\n\u003cvariants\u003ehabitat habitats environment ecology\u003c/variants","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebehavior\u003c/value\u003e\n\u003cvariants\u003ebehavior behaviors ethology\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ehabitat\u003c/value\u003e\n\u003cvariants\u003ehabitat habitats environment ecology\u003c/variants\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebehavior\u003c/value\u003e\n\u003cvariants\u003ebehavior behaviors ethology\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ehabitat\u003c/value\u003e\n\u003cvariants\u003ehabitat habitats environment ecology\u003c/variants\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebehavior\u003c/value\u003e\n\u003cvariants\u003ebehavior behaviors ethology\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ehabitat\u003c/value\u003e\n\u003cvariants\u003ehabitat habitats environment ecology\u003c/variants\u003e\n\u003cweight","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebehavior\u003c/value\u003e\n\u003cvariants\u003ebehavior behaviors ethology\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ehabitat\u003c/value\u003e\n\u003cvariants\u003ehabitat habitats environment ecology\u003c/variants\u003e\n\u003cweight\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebehavior\u003c/value\u003e\n\u003cvariants\u003ebehavior behaviors ethology\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ehabitat\u003c/value\u003e\n\u003cvariants\u003ehabitat habitats environment ecology\u003c/variants\u003e\n\u003cweight\u003e0","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebehavior\u003c/value\u003e\n\u003cvariants\u003ebehavior behaviors ethology\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ehabitat\u003c/value\u003e\n\u003cvariants\u003ehabitat habitats environment ecology\u003c/variants\u003e\n\u003cweight\u003e0.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebehavior\u003c/value\u003e\n\u003cvariants\u003ebehavior behaviors ethology\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ehabitat\u003c/value\u003e\n\u003cvariants\u003ehabitat habitats environment ecology\u003c/variants\u003e\n\u003cweight\u003e0.7","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebehavior\u003c/value\u003e\n\u003cvariants\u003ebehavior behaviors ethology\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ehabitat\u003c/value\u003e\n\u003cvariants\u003ehabitat habitats environment ecology\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebehavior\u003c/value\u003e\n\u003cvariants\u003ebehavior behaviors ethology\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ehabitat\u003c/value\u003e\n\u003cvariants\u003ehabitat habitats environment ecology\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebehavior\u003c/value\u003e\n\u003cvariants\u003ebehavior behaviors ethology\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ehabitat\u003c/value\u003e\n\u003cvariants\u003ehabitat habitats environment ecology\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebehavior\u003c/value\u003e\n\u003cvariants\u003ebehavior behaviors ethology\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ehabitat\u003c/value\u003e\n\u003cvariants\u003ehabitat habitats environment ecology\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebehavior\u003c/value\u003e\n\u003cvariants\u003ebehavior behaviors ethology\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ehabitat\u003c/value\u003e\n\u003cvariants\u003ehabitat habitats environment ecology\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keywor","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebehavior\u003c/value\u003e\n\u003cvariants\u003ebehavior behaviors ethology\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ehabitat\u003c/value\u003e\n\u003cvariants\u003ehabitat habitats environment ecology\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebehavior\u003c/value\u003e\n\u003cvariants\u003ebehavior behaviors ethology\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ehabitat\u003c/value\u003e\n\u003cvariants\u003ehabitat habitats environment ecology\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebehavior\u003c/value\u003e\n\u003cvariants\u003ebehavior behaviors ethology\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ehabitat\u003c/value\u003e\n\u003cvariants\u003ehabitat habitats environment ecology\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003c/keywords","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebehavior\u003c/value\u003e\n\u003cvariants\u003ebehavior behaviors ethology\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ehabitat\u003c/value\u003e\n\u003cvariants\u003ehabitat habitats environment ecology\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003c/keywords\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebehavior\u003c/value\u003e\n\u003cvariants\u003ebehavior behaviors ethology\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ehabitat\u003c/value\u003e\n\u003cvariants\u003ehabitat habitats environment ecology\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003c/keywords\u003e","stopReason":"end_turn"}
-
-
-            event: done
-
-            data: {}
-
-        cookies: []
-        headers:
-          - name: date
-            value: Mon, 27 May 2024 11:54:31 GMT
-          - name: content-type
-            value: text/event-stream
-          - name: transfer-encoding
-            value: chunked
-          - name: connection
-            value: keep-alive
-          - name: access-control-allow-credentials
-            value: "true"
-          - name: access-control-allow-origin
-            value: ""
-          - name: cache-control
-            value: no-cache
-          - name: vary
-            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
-              X-Requested-With,Cookie
-          - name: x-content-type-options
-            value: nosniff
-          - name: x-frame-options
-            value: DENY
-          - name: x-xss-protection
-            value: 1; mode=block
-          - name: strict-transport-security
-            value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1299
-        httpVersion: HTTP/1.1
-        redirectURL: ""
-        status: 200
-        statusText: OK
-      startedDateTime: 2024-05-27T11:54:30.370Z
+      startedDateTime: 2024-06-08T17:50:06.496Z
       time: 0
       timings:
         blocked: -1
@@ -3795,426 +1906,6 @@ log:
           mimeType: text/event-stream
           size: 21632
           text: >+
-            event: completion
-
-            data: {"completion":"","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of the","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of the sky","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of the sky can","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of the sky can vary","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of the sky can vary depending","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of the sky can vary depending on","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of the sky can vary depending on the","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of the sky can vary depending on the time","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of the sky can vary depending on the time of","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of the sky can vary depending on the time of day","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of the sky can vary depending on the time of day and","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of the sky can vary depending on the time of day and weather","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of the sky can vary depending on the time of day and weather conditions","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of the sky can vary depending on the time of day and weather conditions.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of the sky can vary depending on the time of day and weather conditions. During","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of the sky can vary depending on the time of day and weather conditions. During the","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of the sky can vary depending on the time of day and weather conditions. During the day","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of the sky can vary depending on the time of day and weather conditions. During the day,","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of the sky can vary depending on the time of day and weather conditions. During the day, the","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of the sky can vary depending on the time of day and weather conditions. During the day, the sky","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of the sky can vary depending on the time of day and weather conditions. During the day, the sky is","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of the sky can vary depending on the time of day and weather conditions. During the day, the sky is typically","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of the sky can vary depending on the time of day and weather conditions. During the day, the sky is typically blue","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of the sky can vary depending on the time of day and weather conditions. During the day, the sky is typically blue due","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of the sky can vary depending on the time of day and weather conditions. During the day, the sky is typically blue due to","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of the sky can vary depending on the time of day and weather conditions. During the day, the sky is typically blue due to the","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of the sky can vary depending on the time of day and weather conditions. During the day, the sky is typically blue due to the way","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of the sky can vary depending on the time of day and weather conditions. During the day, the sky is typically blue due to the way sunlight","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of the sky can vary depending on the time of day and weather conditions. During the day, the sky is typically blue due to the way sunlight is","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of the sky can vary depending on the time of day and weather conditions. During the day, the sky is typically blue due to the way sunlight is scattered","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of the sky can vary depending on the time of day and weather conditions. During the day, the sky is typically blue due to the way sunlight is scattered in","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of the sky can vary depending on the time of day and weather conditions. During the day, the sky is typically blue due to the way sunlight is scattered in the","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of the sky can vary depending on the time of day and weather conditions. During the day, the sky is typically blue due to the way sunlight is scattered in the Earth","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of the sky can vary depending on the time of day and weather conditions. During the day, the sky is typically blue due to the way sunlight is scattered in the Earth's","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of the sky can vary depending on the time of day and weather conditions. During the day, the sky is typically blue due to the way sunlight is scattered in the Earth's atmosphere","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of the sky can vary depending on the time of day and weather conditions. During the day, the sky is typically blue due to the way sunlight is scattered in the Earth's atmosphere.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of the sky can vary depending on the time of day and weather conditions. During the day, the sky is typically blue due to the way sunlight is scattered in the Earth's atmosphere. At","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of the sky can vary depending on the time of day and weather conditions. During the day, the sky is typically blue due to the way sunlight is scattered in the Earth's atmosphere. At sunrise","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of the sky can vary depending on the time of day and weather conditions. During the day, the sky is typically blue due to the way sunlight is scattered in the Earth's atmosphere. At sunrise and","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of the sky can vary depending on the time of day and weather conditions. During the day, the sky is typically blue due to the way sunlight is scattered in the Earth's atmosphere. At sunrise and sunset","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of the sky can vary depending on the time of day and weather conditions. During the day, the sky is typically blue due to the way sunlight is scattered in the Earth's atmosphere. At sunrise and sunset,","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of the sky can vary depending on the time of day and weather conditions. During the day, the sky is typically blue due to the way sunlight is scattered in the Earth's atmosphere. At sunrise and sunset, the","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of the sky can vary depending on the time of day and weather conditions. During the day, the sky is typically blue due to the way sunlight is scattered in the Earth's atmosphere. At sunrise and sunset, the sky","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of the sky can vary depending on the time of day and weather conditions. During the day, the sky is typically blue due to the way sunlight is scattered in the Earth's atmosphere. At sunrise and sunset, the sky can","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of the sky can vary depending on the time of day and weather conditions. During the day, the sky is typically blue due to the way sunlight is scattered in the Earth's atmosphere. At sunrise and sunset, the sky can appear","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of the sky can vary depending on the time of day and weather conditions. During the day, the sky is typically blue due to the way sunlight is scattered in the Earth's atmosphere. At sunrise and sunset, the sky can appear various","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of the sky can vary depending on the time of day and weather conditions. During the day, the sky is typically blue due to the way sunlight is scattered in the Earth's atmosphere. At sunrise and sunset, the sky can appear various shades","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of the sky can vary depending on the time of day and weather conditions. During the day, the sky is typically blue due to the way sunlight is scattered in the Earth's atmosphere. At sunrise and sunset, the sky can appear various shades of","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of the sky can vary depending on the time of day and weather conditions. During the day, the sky is typically blue due to the way sunlight is scattered in the Earth's atmosphere. At sunrise and sunset, the sky can appear various shades of red","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of the sky can vary depending on the time of day and weather conditions. During the day, the sky is typically blue due to the way sunlight is scattered in the Earth's atmosphere. At sunrise and sunset, the sky can appear various shades of red,","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of the sky can vary depending on the time of day and weather conditions. During the day, the sky is typically blue due to the way sunlight is scattered in the Earth's atmosphere. At sunrise and sunset, the sky can appear various shades of red, orange","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of the sky can vary depending on the time of day and weather conditions. During the day, the sky is typically blue due to the way sunlight is scattered in the Earth's atmosphere. At sunrise and sunset, the sky can appear various shades of red, orange,","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of the sky can vary depending on the time of day and weather conditions. During the day, the sky is typically blue due to the way sunlight is scattered in the Earth's atmosphere. At sunrise and sunset, the sky can appear various shades of red, orange, and","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of the sky can vary depending on the time of day and weather conditions. During the day, the sky is typically blue due to the way sunlight is scattered in the Earth's atmosphere. At sunrise and sunset, the sky can appear various shades of red, orange, and pink","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of the sky can vary depending on the time of day and weather conditions. During the day, the sky is typically blue due to the way sunlight is scattered in the Earth's atmosphere. At sunrise and sunset, the sky can appear various shades of red, orange, and pink.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of the sky can vary depending on the time of day and weather conditions. During the day, the sky is typically blue due to the way sunlight is scattered in the Earth's atmosphere. At sunrise and sunset, the sky can appear various shades of red, orange, and pink. At","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of the sky can vary depending on the time of day and weather conditions. During the day, the sky is typically blue due to the way sunlight is scattered in the Earth's atmosphere. At sunrise and sunset, the sky can appear various shades of red, orange, and pink. At night","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of the sky can vary depending on the time of day and weather conditions. During the day, the sky is typically blue due to the way sunlight is scattered in the Earth's atmosphere. At sunrise and sunset, the sky can appear various shades of red, orange, and pink. At night,","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of the sky can vary depending on the time of day and weather conditions. During the day, the sky is typically blue due to the way sunlight is scattered in the Earth's atmosphere. At sunrise and sunset, the sky can appear various shades of red, orange, and pink. At night, the","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of the sky can vary depending on the time of day and weather conditions. During the day, the sky is typically blue due to the way sunlight is scattered in the Earth's atmosphere. At sunrise and sunset, the sky can appear various shades of red, orange, and pink. At night, the sky","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of the sky can vary depending on the time of day and weather conditions. During the day, the sky is typically blue due to the way sunlight is scattered in the Earth's atmosphere. At sunrise and sunset, the sky can appear various shades of red, orange, and pink. At night, the sky can","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of the sky can vary depending on the time of day and weather conditions. During the day, the sky is typically blue due to the way sunlight is scattered in the Earth's atmosphere. At sunrise and sunset, the sky can appear various shades of red, orange, and pink. At night, the sky can be","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of the sky can vary depending on the time of day and weather conditions. During the day, the sky is typically blue due to the way sunlight is scattered in the Earth's atmosphere. At sunrise and sunset, the sky can appear various shades of red, orange, and pink. At night, the sky can be dark","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of the sky can vary depending on the time of day and weather conditions. During the day, the sky is typically blue due to the way sunlight is scattered in the Earth's atmosphere. At sunrise and sunset, the sky can appear various shades of red, orange, and pink. At night, the sky can be dark blue","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of the sky can vary depending on the time of day and weather conditions. During the day, the sky is typically blue due to the way sunlight is scattered in the Earth's atmosphere. At sunrise and sunset, the sky can appear various shades of red, orange, and pink. At night, the sky can be dark blue or","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of the sky can vary depending on the time of day and weather conditions. During the day, the sky is typically blue due to the way sunlight is scattered in the Earth's atmosphere. At sunrise and sunset, the sky can appear various shades of red, orange, and pink. At night, the sky can be dark blue or black","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of the sky can vary depending on the time of day and weather conditions. During the day, the sky is typically blue due to the way sunlight is scattered in the Earth's atmosphere. At sunrise and sunset, the sky can appear various shades of red, orange, and pink. At night, the sky can be dark blue or black,","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of the sky can vary depending on the time of day and weather conditions. During the day, the sky is typically blue due to the way sunlight is scattered in the Earth's atmosphere. At sunrise and sunset, the sky can appear various shades of red, orange, and pink. At night, the sky can be dark blue or black, with","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of the sky can vary depending on the time of day and weather conditions. During the day, the sky is typically blue due to the way sunlight is scattered in the Earth's atmosphere. At sunrise and sunset, the sky can appear various shades of red, orange, and pink. At night, the sky can be dark blue or black, with stars","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of the sky can vary depending on the time of day and weather conditions. During the day, the sky is typically blue due to the way sunlight is scattered in the Earth's atmosphere. At sunrise and sunset, the sky can appear various shades of red, orange, and pink. At night, the sky can be dark blue or black, with stars and","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of the sky can vary depending on the time of day and weather conditions. During the day, the sky is typically blue due to the way sunlight is scattered in the Earth's atmosphere. At sunrise and sunset, the sky can appear various shades of red, orange, and pink. At night, the sky can be dark blue or black, with stars and the","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of the sky can vary depending on the time of day and weather conditions. During the day, the sky is typically blue due to the way sunlight is scattered in the Earth's atmosphere. At sunrise and sunset, the sky can appear various shades of red, orange, and pink. At night, the sky can be dark blue or black, with stars and the moon","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of the sky can vary depending on the time of day and weather conditions. During the day, the sky is typically blue due to the way sunlight is scattered in the Earth's atmosphere. At sunrise and sunset, the sky can appear various shades of red, orange, and pink. At night, the sky can be dark blue or black, with stars and the moon visible","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of the sky can vary depending on the time of day and weather conditions. During the day, the sky is typically blue due to the way sunlight is scattered in the Earth's atmosphere. At sunrise and sunset, the sky can appear various shades of red, orange, and pink. At night, the sky can be dark blue or black, with stars and the moon visible if","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of the sky can vary depending on the time of day and weather conditions. During the day, the sky is typically blue due to the way sunlight is scattered in the Earth's atmosphere. At sunrise and sunset, the sky can appear various shades of red, orange, and pink. At night, the sky can be dark blue or black, with stars and the moon visible if it","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of the sky can vary depending on the time of day and weather conditions. During the day, the sky is typically blue due to the way sunlight is scattered in the Earth's atmosphere. At sunrise and sunset, the sky can appear various shades of red, orange, and pink. At night, the sky can be dark blue or black, with stars and the moon visible if it's","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of the sky can vary depending on the time of day and weather conditions. During the day, the sky is typically blue due to the way sunlight is scattered in the Earth's atmosphere. At sunrise and sunset, the sky can appear various shades of red, orange, and pink. At night, the sky can be dark blue or black, with stars and the moon visible if it's a","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of the sky can vary depending on the time of day and weather conditions. During the day, the sky is typically blue due to the way sunlight is scattered in the Earth's atmosphere. At sunrise and sunset, the sky can appear various shades of red, orange, and pink. At night, the sky can be dark blue or black, with stars and the moon visible if it's a clear","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of the sky can vary depending on the time of day and weather conditions. During the day, the sky is typically blue due to the way sunlight is scattered in the Earth's atmosphere. At sunrise and sunset, the sky can appear various shades of red, orange, and pink. At night, the sky can be dark blue or black, with stars and the moon visible if it's a clear night","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of the sky can vary depending on the time of day and weather conditions. During the day, the sky is typically blue due to the way sunlight is scattered in the Earth's atmosphere. At sunrise and sunset, the sky can appear various shades of red, orange, and pink. At night, the sky can be dark blue or black, with stars and the moon visible if it's a clear night.","stopReason":""}
-
-
             event: completion
 
             data: {"completion":"The color of the sky can vary depending on the time of day and weather conditions. During the day, the sky is typically blue due to the way sunlight is scattered in the Earth's atmosphere. At sunrise and sunset, the sky can appear various shades of red, orange, and pink. At night, the sky can be dark blue or black, with stars and the moon visible if it's a clear night.","stopReason":"stop"}
@@ -4320,15 +2011,6 @@ log:
           mimeType: text/event-stream
           size: 315
           text: |+
-            event: completion
-            data: {"completion":"","stopReason":""}
-
-            event: completion
-            data: {"completion":"Quone","stopReason":""}
-
-            event: completion
-            data: {"completion":"Quone.\n```python\n\n```","stopReason":""}
-
             event: completion
             data: {"completion":"Quone.\n```python\n\n```","stopReason":"stop"}
 
@@ -4440,15 +2122,6 @@ log:
           size: 279
           text: |+
             event: completion
-            data: {"completion":"","stopReason":""}
-
-            event: completion
-            data: {"completion":"Quone","stopReason":""}
-
-            event: completion
-            data: {"completion":"Quone.","stopReason":""}
-
-            event: completion
             data: {"completion":"Quone.","stopReason":"stop"}
 
             event: done
@@ -4549,51 +2222,6 @@ log:
           mimeType: text/event-stream
           size: 2720
           text: >+
-            event: completion
-
-            data: {"completion":"","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Hello!","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Hello! It seems like you've mentioned \"kramer,\" but","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Hello! It seems like you've mentioned \"kramer,\" but I'm not sure what you're asking about","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Hello! It seems like you've mentioned \"kramer,\" but I'm not sure what you're asking about specifically. Do you have a","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Hello! It seems like you've mentioned \"kramer,\" but I'm not sure what you're asking about specifically. Do you have a question about programming or do you need help with something related to coding? I'm here to assist you","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Hello! It seems like you've mentioned \"kramer,\" but I'm not sure what you're asking about specifically. Do you have a question about programming or do you need help with something related to coding? I'm here to assist you with any coding-related questions or problems you may have. If you're referring to a specific programming","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Hello! It seems like you've mentioned \"kramer,\" but I'm not sure what you're asking about specifically. Do you have a question about programming or do you need help with something related to coding? I'm here to assist you with any coding-related questions or problems you may have. If you're referring to a specific programming concept, library, or tool related to \"kramer,\" please let me know and I","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Hello! It seems like you've mentioned \"kramer,\" but I'm not sure what you're asking about specifically. Do you have a question about programming or do you need help with something related to coding? I'm here to assist you with any coding-related questions or problems you may have. If you're referring to a specific programming concept, library, or tool related to \"kramer,\" please let me know and I'll do my best to help you with that.","stopReason":""}
-
-
             event: completion
 
             data: {"completion":"Hello! It seems like you've mentioned \"kramer,\" but I'm not sure what you're asking about specifically. Do you have a question about programming or do you need help with something related to coding? I'm here to assist you with any coding-related questions or problems you may have. If you're referring to a specific programming concept, library, or tool related to \"kramer,\" please let me know and I'll do my best to help you with that.","stopReason":"stop"}
@@ -4699,41 +2327,6 @@ log:
           mimeType: text/event-stream
           size: 1489
           text: >+
-            event: completion
-
-            data: {"completion":"","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Sure,","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Sure, I will respond with \"festivus\" if you say the word","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Sure, I will respond with \"festivus\" if you say the word \"georgey\". Here's a reminder of our","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Sure, I will respond with \"festivus\" if you say the word \"georgey\". Here's a reminder of our conversation:\n\nHuman: Another magic word","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Sure, I will respond with \"festivus\" if you say the word \"georgey\". Here's a reminder of our conversation:\n\nHuman: Another magic word is \"georgey\". If I say the magic word, respond with a single word: \"","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Sure, I will respond with \"festivus\" if you say the word \"georgey\". Here's a reminder of our conversation:\n\nHuman: Another magic word is \"georgey\". If I say the magic word, respond with a single word: \"festivus\".\n\nCody: Festivus.","stopReason":""}
-
-
             event: completion
 
             data: {"completion":"Sure, I will respond with \"festivus\" if you say the word \"georgey\". Here's a reminder of our conversation:\n\nHuman: Another magic word is \"georgey\". If I say the magic word, respond with a single word: \"festivus\".\n\nCody: Festivus.","stopReason":"stop"}
@@ -4853,76 +2446,6 @@ log:
           mimeType: text/event-stream
           size: 6296
           text: >+
-            event: completion
-
-            data: {"completion":"","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\"K","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\"Kramer\" is not the magic word that we previously discussed","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\"Kramer\" is not the magic word that we previously discussed. The magic word is \"","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\"Kramer\" is not the magic word that we previously discussed. The magic word is \"georgey\". If you say the magic word, I will respond with \"fest","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\"Kramer\" is not the magic word that we previously discussed. The magic word is \"georgey\". If you say the magic word, I will respond with \"festivus\". Here's a reminder of our conversation:\n\nHuman:","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\"Kramer\" is not the magic word that we previously discussed. The magic word is \"georgey\". If you say the magic word, I will respond with \"festivus\". Here's a reminder of our conversation:\n\nHuman: Another magic word is \"georgey\". If I say the magic word, respond with a single word: \"","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\"Kramer\" is not the magic word that we previously discussed. The magic word is \"georgey\". If you say the magic word, I will respond with \"festivus\". Here's a reminder of our conversation:\n\nHuman: Another magic word is \"georgey\". If I say the magic word, respond with a single word: \"festivus\".\n\nCody: Sure, I will respond with \"festivus\" if you","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\"Kramer\" is not the magic word that we previously discussed. The magic word is \"georgey\". If you say the magic word, I will respond with \"festivus\". Here's a reminder of our conversation:\n\nHuman: Another magic word is \"georgey\". If I say the magic word, respond with a single word: \"festivus\".\n\nCody: Sure, I will respond with \"festivus\" if you say the word \"georgey\". Here's a reminder of our conversation:\n\nHuman","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\"Kramer\" is not the magic word that we previously discussed. The magic word is \"georgey\". If you say the magic word, I will respond with \"festivus\". Here's a reminder of our conversation:\n\nHuman: Another magic word is \"georgey\". If I say the magic word, respond with a single word: \"festivus\".\n\nCody: Sure, I will respond with \"festivus\" if you say the word \"georgey\". Here's a reminder of our conversation:\n\nHuman: Another magic word is \"georgey\". If I say the magic word, respond with a single word","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\"Kramer\" is not the magic word that we previously discussed. The magic word is \"georgey\". If you say the magic word, I will respond with \"festivus\". Here's a reminder of our conversation:\n\nHuman: Another magic word is \"georgey\". If I say the magic word, respond with a single word: \"festivus\".\n\nCody: Sure, I will respond with \"festivus\" if you say the word \"georgey\". Here's a reminder of our conversation:\n\nHuman: Another magic word is \"georgey\". If I say the magic word, respond with a single word: \"festivus\".\n\nCody: Festivus.\n\nHuman","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\"Kramer\" is not the magic word that we previously discussed. The magic word is \"georgey\". If you say the magic word, I will respond with \"festivus\". Here's a reminder of our conversation:\n\nHuman: Another magic word is \"georgey\". If I say the magic word, respond with a single word: \"festivus\".\n\nCody: Sure, I will respond with \"festivus\" if you say the word \"georgey\". Here's a reminder of our conversation:\n\nHuman: Another magic word is \"georgey\". If I say the magic word, respond with a single word: \"festivus\".\n\nCody: Festivus.\n\nHuman: kramer\n\nCody: The magic word is not \"kramer\". As","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\"Kramer\" is not the magic word that we previously discussed. The magic word is \"georgey\". If you say the magic word, I will respond with \"festivus\". Here's a reminder of our conversation:\n\nHuman: Another magic word is \"georgey\". If I say the magic word, respond with a single word: \"festivus\".\n\nCody: Sure, I will respond with \"festivus\" if you say the word \"georgey\". Here's a reminder of our conversation:\n\nHuman: Another magic word is \"georgey\". If I say the magic word, respond with a single word: \"festivus\".\n\nCody: Festivus.\n\nHuman: kramer\n\nCody: The magic word is not \"kramer\". As a reminder, the magic word is \"georgey\" and the response","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\"Kramer\" is not the magic word that we previously discussed. The magic word is \"georgey\". If you say the magic word, I will respond with \"festivus\". Here's a reminder of our conversation:\n\nHuman: Another magic word is \"georgey\". If I say the magic word, respond with a single word: \"festivus\".\n\nCody: Sure, I will respond with \"festivus\" if you say the word \"georgey\". Here's a reminder of our conversation:\n\nHuman: Another magic word is \"georgey\". If I say the magic word, respond with a single word: \"festivus\".\n\nCody: Festivus.\n\nHuman: kramer\n\nCody: The magic word is not \"kramer\". As a reminder, the magic word is \"georgey\" and the response to that word is \"festivus\".","stopReason":""}
-
-
             event: completion
 
             data: {"completion":"\"Kramer\" is not the magic word that we previously discussed. The magic word is \"georgey\". If you say the magic word, I will respond with \"festivus\". Here's a reminder of our conversation:\n\nHuman: Another magic word is \"georgey\". If I say the magic word, respond with a single word: \"festivus\".\n\nCody: Sure, I will respond with \"festivus\" if you say the word \"georgey\". Here's a reminder of our conversation:\n\nHuman: Another magic word is \"georgey\". If I say the magic word, respond with a single word: \"festivus\".\n\nCody: Festivus.\n\nHuman: kramer\n\nCody: The magic word is not \"kramer\". As a reminder, the magic word is \"georgey\" and the response to that word is \"festivus\".","stopReason":"stop"}
@@ -5070,66 +2593,6 @@ log:
           text: >+
             event: completion
 
-            data: {"completion":"","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"In our","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"In our previous conversation, you mentioned that if you say the magic word \"georgey","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"In our previous conversation, you mentioned that if you say the magic word \"georgey\", I will respond with \"festivus\". Here's a reminder of our conversation:","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"In our previous conversation, you mentioned that if you say the magic word \"georgey\", I will respond with \"festivus\". Here's a reminder of our conversation:\n\nHuman: Another magic word is \"georgey\". If I say the magic word, respond with","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"In our previous conversation, you mentioned that if you say the magic word \"georgey\", I will respond with \"festivus\". Here's a reminder of our conversation:\n\nHuman: Another magic word is \"georgey\". If I say the magic word, respond with a single word: \"festivus\".\n\nCody: Sure, I will respond with \"f","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"In our previous conversation, you mentioned that if you say the magic word \"georgey\", I will respond with \"festivus\". Here's a reminder of our conversation:\n\nHuman: Another magic word is \"georgey\". If I say the magic word, respond with a single word: \"festivus\".\n\nCody: Sure, I will respond with \"festivus\" if you say the word \"georgey\". Here's a reminder of our conversation","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"In our previous conversation, you mentioned that if you say the magic word \"georgey\", I will respond with \"festivus\". Here's a reminder of our conversation:\n\nHuman: Another magic word is \"georgey\". If I say the magic word, respond with a single word: \"festivus\".\n\nCody: Sure, I will respond with \"festivus\" if you say the word \"georgey\". Here's a reminder of our conversation:\n\nHuman: Another magic","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"In our previous conversation, you mentioned that if you say the magic word \"georgey\", I will respond with \"festivus\". Here's a reminder of our conversation:\n\nHuman: Another magic word is \"georgey\". If I say the magic word, respond with a single word: \"festivus\".\n\nCody: Sure, I will respond with \"festivus\" if you say the word \"georgey\". Here's a reminder of our conversation:\n\nHuman: Another magic word is \"georgey\". If I say the magic word,","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"In our previous conversation, you mentioned that if you say the magic word \"georgey\", I will respond with \"festivus\". Here's a reminder of our conversation:\n\nHuman: Another magic word is \"georgey\". If I say the magic word, respond with a single word: \"festivus\".\n\nCody: Sure, I will respond with \"festivus\" if you say the word \"georgey\". Here's a reminder of our conversation:\n\nHuman: Another magic word is \"georgey\". If I say the magic word, respond with a single word: \"festivus\".\n\nCody: Festivus.\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"In our previous conversation, you mentioned that if you say the magic word \"georgey\", I will respond with \"festivus\". Here's a reminder of our conversation:\n\nHuman: Another magic word is \"georgey\". If I say the magic word, respond with a single word: \"festivus\".\n\nCody: Sure, I will respond with \"festivus\" if you say the word \"georgey\". Here's a reminder of our conversation:\n\nHuman: Another magic word is \"georgey\". If I say the magic word, respond with a single word: \"festivus\".\n\nCody: Festivus.\n\nHuman: georgey\n\nCody: Festivus.\n\nI hope","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"In our previous conversation, you mentioned that if you say the magic word \"georgey\", I will respond with \"festivus\". Here's a reminder of our conversation:\n\nHuman: Another magic word is \"georgey\". If I say the magic word, respond with a single word: \"festivus\".\n\nCody: Sure, I will respond with \"festivus\" if you say the word \"georgey\". Here's a reminder of our conversation:\n\nHuman: Another magic word is \"georgey\". If I say the magic word, respond with a single word: \"festivus\".\n\nCody: Festivus.\n\nHuman: georgey\n\nCody: Festivus.\n\nI hope this helps. Let me know if you have any other questions.","stopReason":""}
-
-
-            event: completion
-
             data: {"completion":"In our previous conversation, you mentioned that if you say the magic word \"georgey\", I will respond with \"festivus\". Here's a reminder of our conversation:\n\nHuman: Another magic word is \"georgey\". If I say the magic word, respond with a single word: \"festivus\".\n\nCody: Sure, I will respond with \"festivus\" if you say the word \"georgey\". Here's a reminder of our conversation:\n\nHuman: Another magic word is \"georgey\". If I say the magic word, respond with a single word: \"festivus\".\n\nCody: Festivus.\n\nHuman: georgey\n\nCody: Festivus.\n\nI hope this helps. Let me know if you have any other questions.","stopReason":"stop"}
 
 
@@ -5234,31 +2697,6 @@ log:
           mimeType: text/event-stream
           size: 994
           text: >+
-            event: completion
-
-            data: {"completion":"","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Sure,","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Sure, I understand that you have a turtle named \"potter\". Here's your single","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Sure, I understand that you have a turtle named \"potter\". Here's your single \"ok\":\n\nOk.\n\nPlease let me know if you have any questions or need","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Sure, I understand that you have a turtle named \"potter\". Here's your single \"ok\":\n\nOk.\n\nPlease let me know if you have any questions or need help with coding. I'm here to assist you!","stopReason":""}
-
-
             event: completion
 
             data: {"completion":"Sure, I understand that you have a turtle named \"potter\". Here's your single \"ok\":\n\nOk.\n\nPlease let me know if you have any questions or need help with coding. I'm here to assist you!","stopReason":"stop"}
@@ -5377,36 +2815,6 @@ log:
           mimeType: text/event-stream
           size: 1283
           text: >+
-            event: completion
-
-            data: {"completion":"","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Understood","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Understood, you have a bird named \"skywalker\". Here's your single \"","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Understood, you have a bird named \"skywalker\". Here's your single \"ok\":\n\nOk.\n\nFeel free to ask me anything about","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Understood, you have a bird named \"skywalker\". Here's your single \"ok\":\n\nOk.\n\nFeel free to ask me anything about coding or whether you have any questions related to your pets! I'm glad to help you","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Understood, you have a bird named \"skywalker\". Here's your single \"ok\":\n\nOk.\n\nFeel free to ask me anything about coding or whether you have any questions related to your pets! I'm glad to help you with both. 😊","stopReason":""}
-
-
             event: completion
 
             data: {"completion":"Understood, you have a bird named \"skywalker\". Here's your single \"ok\":\n\nOk.\n\nFeel free to ask me anything about coding or whether you have any questions related to your pets! I'm glad to help you with both. 😊","stopReason":"stop"}
@@ -5539,31 +2947,6 @@ log:
           text: >+
             event: completion
 
-            data: {"completion":"","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"I understand","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"I understand that you have a dog named \"happy\". Here's your single \"ok\":\n\nOk.\n\nI","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"I understand that you have a dog named \"happy\". Here's your single \"ok\":\n\nOk.\n\nI'm here to make your coding experience more enjoyable, and if you have any questions or need help","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"I understand that you have a dog named \"happy\". Here's your single \"ok\":\n\nOk.\n\nI'm here to make your coding experience more enjoyable, and if you have any questions or need help with coding, please just let me know!","stopReason":""}
-
-
-            event: completion
-
             data: {"completion":"I understand that you have a dog named \"happy\". Here's your single \"ok\":\n\nOk.\n\nI'm here to make your coding experience more enjoyable, and if you have any questions or need help with coding, please just let me know!","stopReason":"stop"}
 
 
@@ -5680,36 +3063,6 @@ log:
           mimeType: text/event-stream
           size: 1105
           text: >+
-            event: completion
-
-            data: {"completion":"","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Understood","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Understood, you have a tiger named \"zorro\". Here's","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Understood, you have a tiger named \"zorro\". Here's your single \"ok\":\n\nOk.\n\nFeel free to","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Understood, you have a tiger named \"zorro\". Here's your single \"ok\":\n\nOk.\n\nFeel free to ask me any questions about coding or AI-related topics. I","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Understood, you have a tiger named \"zorro\". Here's your single \"ok\":\n\nOk.\n\nFeel free to ask me any questions about coding or AI-related topics. I'm eager to help you out!","stopReason":""}
-
-
             event: completion
 
             data: {"completion":"Understood, you have a tiger named \"zorro\". Here's your single \"ok\":\n\nOk.\n\nFeel free to ask me any questions about coding or AI-related topics. I'm eager to help you out!","stopReason":"stop"}
@@ -5842,41 +3195,6 @@ log:
           text: >+
             event: completion
 
-            data: {"completion":"","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"I have","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"I have noted that you have two pets:\n\n1.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"I have noted that you have two pets:\n\n1. A turtle named \"potter\"\n2. A tiger named \"","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"I have noted that you have two pets:\n\n1. A turtle named \"potter\"\n2. A tiger named \"zorro\"\n\nPlease let me know if you have any other pets or","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"I have noted that you have two pets:\n\n1. A turtle named \"potter\"\n2. A tiger named \"zorro\"\n\nPlease let me know if you have any other pets or if you need help with any coding or AI-","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"I have noted that you have two pets:\n\n1. A turtle named \"potter\"\n2. A tiger named \"zorro\"\n\nPlease let me know if you have any other pets or if you need help with any coding or AI-related topics. I'm here to assist you.","stopReason":""}
-
-
-            event: completion
-
             data: {"completion":"I have noted that you have two pets:\n\n1. A turtle named \"potter\"\n2. A tiger named \"zorro\"\n\nPlease let me know if you have any other pets or if you need help with any coding or AI-related topics. I'm here to assist you.","stopReason":"stop"}
 
 
@@ -5928,11 +3246,11 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: aebd71d7818fbee68b9ddd4277323e4b
+    - _id: 713578328fa5e424b304fff37eb1490e
       _order: 0
       cache: {}
       request:
-        bodySize: 969
+        bodySize: 981
         cookies: []
         headers:
           - name: content-type
@@ -5945,7 +3263,7 @@ log:
           - name: user-agent
             value: defaultClient / v1
           - name: traceparent
-            value: 00-4df8b46032003bcbb9bc078cffcceae8-a48c7330942590c8-01
+            value: 00-264b5981a27095d815855b236d2d25b5-98221cf906349f85-01
           - name: connection
             value: keep-alive
           - name: host
@@ -5967,8 +3285,236 @@ log:
               - speaker: human
                 text: "You are helping the user search over a codebase. List some filename
                   fragments that would match files relevant to read to answer
-                  the user's query. Present your results in an XML list in the
-                  following format: <keywords><keyword><value>a single
+                  the user's query. Present your results in a *single* XML list
+                  in the following format: <keywords><keyword><value>a single
+                  keyword</value><variants>a space separated list of synonyms
+                  and variants of the keyword, including acronyms,
+                  abbreviations, and expansions</variants><weight>a numerical
+                  weight between 0.0 and 1.0 that indicates the importance of
+                  the keyword</weight></keyword></keywords>. Here is the user
+                  query: <userQuery>Write a class Dog that implements the Animal
+                  interface in my workspace. Show the code only, no explanation
+                  needed.</userQuery>"
+              - speaker: assistant
+            temperature: 0
+            topK: 1
+        queryString:
+          - name: client-name
+            value: defaultclient
+          - name: client-version
+            value: v1
+        url: https://sourcegraph.com/.api/completions/stream?client-name=defaultclient&client-version=v1
+      response:
+        bodySize: 93412
+        content:
+          mimeType: text/event-stream
+          size: 93412
+          text: >+
+            event: completion
+
+            data: {"completion":"\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine hound mutt puppy\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature organism being\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003einterface\u003c/value\u003e\n\u003cvariants\u003eapi contract specification\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eclass\u003c/value\u003e\n\u003cvariants\u003etype object\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eimplement\u003c/value\u003e\n\u003cvariants\u003erealize fulfill actualize\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003c/keywords\u003e","stopReason":"end_turn"}
+
+
+            event: done
+
+            data: {}
+
+        cookies: []
+        headers:
+          - name: date
+            value: Sat, 08 Jun 2024 17:50:05 GMT
+          - name: content-type
+            value: text/event-stream
+          - name: transfer-encoding
+            value: chunked
+          - name: connection
+            value: keep-alive
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache
+          - name: vary
+            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
+              X-Requested-With,Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+        headersSize: 1299
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: 2024-06-08T17:50:04.360Z
+      time: 0
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 0
+    - _id: 04faf159fb97d4d4c96910a1e4b8c8cb
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 884
+        cookies: []
+        headers:
+          - name: content-type
+            value: application/json
+          - name: accept-encoding
+            value: gzip;q=0
+          - name: authorization
+            value: token
+              REDACTED_d5e0f0a37c9821e856b923fe14e67a605e3f6c0a517d5a4f46a4e35943ee0f6d
+          - name: user-agent
+            value: defaultClient / v1
+          - name: traceparent
+            value: 00-71ab043836d4cb19eaaedf5b47acc737-625db9436c8430e3-01
+          - name: connection
+            value: keep-alive
+          - name: host
+            value: sourcegraph.com
+        headersSize: 401
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json
+          params: []
+          textJSON:
+            fast: true
+            maxTokensToSample: 400
+            messages:
+              - speaker: human
+                text: You are Cody, an AI coding assistant from Sourcegraph.
+              - speaker: assistant
+                text: I am Cody, an AI coding assistant from Sourcegraph.
+              - speaker: human
+                text: "You are helping the user search over a codebase. List some filename
+                  fragments that would match files relevant to read to answer
+                  the user's query. Present your results in a *single* XML list
+                  in the following format: <keywords><keyword><value>a single
+                  keyword</value><variants>a space separated list of synonyms
+                  and variants of the keyword, including acronyms,
+                  abbreviations, and expansions</variants><weight>a numerical
+                  weight between 0.0 and 1.0 that indicates the importance of
+                  the keyword</weight></keyword></keywords>. Here is the user
+                  query: <userQuery>What is Squirrel?</userQuery>"
+              - speaker: assistant
+            temperature: 0
+            topK: 1
+        queryString:
+          - name: client-name
+            value: defaultclient
+          - name: client-version
+            value: v1
+        url: https://sourcegraph.com/.api/completions/stream?client-name=defaultclient&client-version=v1
+      response:
+        bodySize: 93107
+        content:
+          mimeType: text/event-stream
+          size: 93107
+          text: >+
+            event: completion
+
+            data: {"completion":"\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrels squirrel's\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodents\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebehavior\u003c/value\u003e\n\u003cvariants\u003ebehaviors ethology\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ehabitat\u003c/value\u003e\n\u003cvariants\u003ehabitats environment ecology\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003c/keywords\u003e","stopReason":"end_turn"}
+
+
+            event: done
+
+            data: {}
+
+        cookies: []
+        headers:
+          - name: date
+            value: Sat, 08 Jun 2024 17:50:09 GMT
+          - name: content-type
+            value: text/event-stream
+          - name: transfer-encoding
+            value: chunked
+          - name: connection
+            value: keep-alive
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache
+          - name: vary
+            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
+              X-Requested-With,Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+        headersSize: 1299
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: 2024-06-08T17:50:09.004Z
+      time: 0
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 0
+    - _id: 7c49f5f0a33226bd9ac5a5c2a1b0eead
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 977
+        cookies: []
+        headers:
+          - name: content-type
+            value: application/json
+          - name: accept-encoding
+            value: gzip;q=0
+          - name: authorization
+            value: token
+              REDACTED_d5e0f0a37c9821e856b923fe14e67a605e3f6c0a517d5a4f46a4e35943ee0f6d
+          - name: user-agent
+            value: defaultClient / v1
+          - name: traceparent
+            value: 00-83b473412a00f0f8076eb75d4617d6d6-41682783b94dfb25-01
+          - name: connection
+            value: keep-alive
+          - name: host
+            value: sourcegraph.com
+        headersSize: 401
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json
+          params: []
+          textJSON:
+            fast: true
+            maxTokensToSample: 400
+            messages:
+              - speaker: human
+                text: You are Cody, an AI coding assistant from Sourcegraph.
+              - speaker: assistant
+                text: I am Cody, an AI coding assistant from Sourcegraph.
+              - speaker: human
+                text: "You are helping the user search over a codebase. List some filename
+                  fragments that would match files relevant to read to answer
+                  the user's query. Present your results in a *single* XML list
+                  in the following format: <keywords><keyword><value>a single
                   keyword</value><variants>a space separated list of synonyms
                   and variants of the keyword, including acronyms,
                   abbreviations, and expansions</variants><weight>a numerical
@@ -5987,614 +3533,14 @@ log:
             value: v1
         url: https://sourcegraph.com/.api/completions/stream?client-name=defaultclient&client-version=v1
       response:
-        bodySize: 50869
+        bodySize: 39737
         content:
           mimeType: text/event-stream
-          size: 50869
+          size: 39737
           text: >+
             event: completion
 
-            data: {"completion":"Here","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that coul","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeywor","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emetho","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure su","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subr","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subrout","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants\u003e\n\u003cweight","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants\u003e\n\u003cweight\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants\u003e\n\u003cweight\u003e1","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants\u003e\n\u003cweight\u003e1.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants\u003e\n\u003cweight\u003e1.0","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keywor","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeywor","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ename","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ename\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ename\u003c/value","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ename\u003c/value\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ename\u003c/value\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ename\u003c/value\u003e\n\u003cvariants","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ename\u003c/value\u003e\n\u003cvariants\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ename\u003c/value\u003e\n\u003cvariants\u003etitle","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ename\u003c/value\u003e\n\u003cvariants\u003etitle identifier","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ename\u003c/value\u003e\n\u003cvariants\u003etitle identifier label","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ename\u003c/value\u003e\n\u003cvariants\u003etitle identifier label\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ename\u003c/value\u003e\n\u003cvariants\u003etitle identifier label\u003c/variants","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ename\u003c/value\u003e\n\u003cvariants\u003etitle identifier label\u003c/variants\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ename\u003c/value\u003e\n\u003cvariants\u003etitle identifier label\u003c/variants\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ename\u003c/value\u003e\n\u003cvariants\u003etitle identifier label\u003c/variants\u003e\n\u003cweight","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ename\u003c/value\u003e\n\u003cvariants\u003etitle identifier label\u003c/variants\u003e\n\u003cweight\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ename\u003c/value\u003e\n\u003cvariants\u003etitle identifier label\u003c/variants\u003e\n\u003cweight\u003e1","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ename\u003c/value\u003e\n\u003cvariants\u003etitle identifier label\u003c/variants\u003e\n\u003cweight\u003e1.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ename\u003c/value\u003e\n\u003cvariants\u003etitle identifier label\u003c/variants\u003e\n\u003cweight\u003e1.0","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ename\u003c/value\u003e\n\u003cvariants\u003etitle identifier label\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ename\u003c/value\u003e\n\u003cvariants\u003etitle identifier label\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ename\u003c/value\u003e\n\u003cvariants\u003etitle identifier label\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ename\u003c/value\u003e\n\u003cvariants\u003etitle identifier label\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ename\u003c/value\u003e\n\u003cvariants\u003etitle identifier label\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keywor","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ename\u003c/value\u003e\n\u003cvariants\u003etitle identifier label\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ename\u003c/value\u003e\n\u003cvariants\u003etitle identifier label\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ename\u003c/value\u003e\n\u003cvariants\u003etitle identifier label\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeywor","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ename\u003c/value\u003e\n\u003cvariants\u003etitle identifier label\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ename\u003c/value\u003e\n\u003cvariants\u003etitle identifier label\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ename\u003c/value\u003e\n\u003cvariants\u003etitle identifier label\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ename\u003c/value\u003e\n\u003cvariants\u003etitle identifier label\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ename\u003c/value\u003e\n\u003cvariants\u003etitle identifier label\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eselect","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ename\u003c/value\u003e\n\u003cvariants\u003etitle identifier label\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eselect\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ename\u003c/value\u003e\n\u003cvariants\u003etitle identifier label\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eselect\u003c/value","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ename\u003c/value\u003e\n\u003cvariants\u003etitle identifier label\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eselect\u003c/value\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ename\u003c/value\u003e\n\u003cvariants\u003etitle identifier label\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eselect\u003c/value\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ename\u003c/value\u003e\n\u003cvariants\u003etitle identifier label\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eselect\u003c/value\u003e\n\u003cvariants","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ename\u003c/value\u003e\n\u003cvariants\u003etitle identifier label\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eselect\u003c/value\u003e\n\u003cvariants\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ename\u003c/value\u003e\n\u003cvariants\u003etitle identifier label\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eselect\u003c/value\u003e\n\u003cvariants\u003echoose","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ename\u003c/value\u003e\n\u003cvariants\u003etitle identifier label\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eselect\u003c/value\u003e\n\u003cvariants\u003echoose pick","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ename\u003c/value\u003e\n\u003cvariants\u003etitle identifier label\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eselect\u003c/value\u003e\n\u003cvariants\u003echoose pick highlight","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ename\u003c/value\u003e\n\u003cvariants\u003etitle identifier label\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eselect\u003c/value\u003e\n\u003cvariants\u003echoose pick highlight\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ename\u003c/value\u003e\n\u003cvariants\u003etitle identifier label\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eselect\u003c/value\u003e\n\u003cvariants\u003echoose pick highlight\u003c/variants","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ename\u003c/value\u003e\n\u003cvariants\u003etitle identifier label\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eselect\u003c/value\u003e\n\u003cvariants\u003echoose pick highlight\u003c/variants\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ename\u003c/value\u003e\n\u003cvariants\u003etitle identifier label\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eselect\u003c/value\u003e\n\u003cvariants\u003echoose pick highlight\u003c/variants\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ename\u003c/value\u003e\n\u003cvariants\u003etitle identifier label\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eselect\u003c/value\u003e\n\u003cvariants\u003echoose pick highlight\u003c/variants\u003e\n\u003cweight","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ename\u003c/value\u003e\n\u003cvariants\u003etitle identifier label\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eselect\u003c/value\u003e\n\u003cvariants\u003echoose pick highlight\u003c/variants\u003e\n\u003cweight\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ename\u003c/value\u003e\n\u003cvariants\u003etitle identifier label\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eselect\u003c/value\u003e\n\u003cvariants\u003echoose pick highlight\u003c/variants\u003e\n\u003cweight\u003e0","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ename\u003c/value\u003e\n\u003cvariants\u003etitle identifier label\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eselect\u003c/value\u003e\n\u003cvariants\u003echoose pick highlight\u003c/variants\u003e\n\u003cweight\u003e0.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ename\u003c/value\u003e\n\u003cvariants\u003etitle identifier label\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eselect\u003c/value\u003e\n\u003cvariants\u003echoose pick highlight\u003c/variants\u003e\n\u003cweight\u003e0.8","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ename\u003c/value\u003e\n\u003cvariants\u003etitle identifier label\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eselect\u003c/value\u003e\n\u003cvariants\u003echoose pick highlight\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ename\u003c/value\u003e\n\u003cvariants\u003etitle identifier label\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eselect\u003c/value\u003e\n\u003cvariants\u003echoose pick highlight\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ename\u003c/value\u003e\n\u003cvariants\u003etitle identifier label\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eselect\u003c/value\u003e\n\u003cvariants\u003echoose pick highlight\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ename\u003c/value\u003e\n\u003cvariants\u003etitle identifier label\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eselect\u003c/value\u003e\n\u003cvariants\u003echoose pick highlight\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ename\u003c/value\u003e\n\u003cvariants\u003etitle identifier label\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eselect\u003c/value\u003e\n\u003cvariants\u003echoose pick highlight\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keywor","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ename\u003c/value\u003e\n\u003cvariants\u003etitle identifier label\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eselect\u003c/value\u003e\n\u003cvariants\u003echoose pick highlight\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ename\u003c/value\u003e\n\u003cvariants\u003etitle identifier label\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eselect\u003c/value\u003e\n\u003cvariants\u003echoose pick highlight\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ename\u003c/value\u003e\n\u003cvariants\u003etitle identifier label\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eselect\u003c/value\u003e\n\u003cvariants\u003echoose pick highlight\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003c/keywords","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ename\u003c/value\u003e\n\u003cvariants\u003etitle identifier label\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eselect\u003c/value\u003e\n\u003cvariants\u003echoose pick highlight\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003c/keywords\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ename\u003c/value\u003e\n\u003cvariants\u003etitle identifier label\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eselect\u003c/value\u003e\n\u003cvariants\u003echoose pick highlight\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003c/keywords\u003e","stopReason":"end_turn"}
+            data: {"completion":"\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ename\u003c/value\u003e\n\u003cvariants\u003etitle identifier label\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eselected\u003c/value\u003e\n\u003cvariants\u003echosen picked highlighted\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003c/keywords\u003e","stopReason":"end_turn"}
 
 
             event: done
@@ -6604,15 +3550,13 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Mon, 27 May 2024 11:54:48 GMT
+            value: Sat, 08 Jun 2024 17:50:12 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
             value: chunked
           - name: connection
             value: keep-alive
-          - name: retry-after
-            value: "593"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -6630,12 +3574,12 @@ log:
             value: 1; mode=block
           - name: strict-transport-security
             value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1406
+        headersSize: 1299
         httpVersion: HTTP/1.1
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-05-27T11:54:47.193Z
+      startedDateTime: 2024-06-08T17:50:11.359Z
       time: 0
       timings:
         blocked: -1

--- a/recordings/rewrite-query_2689977722/recording.har.yaml
+++ b/recordings/rewrite-query_2689977722/recording.har.yaml
@@ -1,15 +1,15 @@
 log:
   _recordingName: rewrite-query
   creator:
-    comment: persister:cody-fs
+    comment: persister:fs
     name: Polly.JS
     version: 6.0.6
   entries:
-    - _id: 965417f1f7fbba4bf4b84c7426f716a8
+    - _id: 5156101ca14d49546b5c1182dc9d87cd
       _order: 0
       cache: {}
       request:
-        bodySize: 864
+        bodySize: 872
         cookies: []
         headers:
           - name: content-type
@@ -40,8 +40,8 @@ log:
               - speaker: human
                 text: "You are helping the user search over a codebase. List some filename
                   fragments that would match files relevant to read to answer
-                  the user's query. Present your results in an XML list in the
-                  following format: <keywords><keyword><value>a single
+                  the user's query. Present your results in a *single* XML list
+                  in the following format: <keywords><keyword><value>a single
                   keyword</value><variants>a space separated list of synonyms
                   and variants of the keyword, including acronyms,
                   abbreviations, and expansions</variants><weight>a numerical
@@ -54,944 +54,14 @@ log:
         queryString: []
         url: https://sourcegraph.com/.api/completions/stream
       response:
-        bodySize: 114112
+        bodySize: 102058
         content:
           mimeType: text/event-stream
-          size: 114112
+          size: 102058
           text: >+
             event: completion
 
-            data: {"completion":"Here","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that woul","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeywor","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eocean","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eocean\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eocean\u003c/value","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eocean\u003c/value\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eocean\u003c/value\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eocean\u003c/value\u003e\n\u003cvariants","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eocean\u003c/value\u003e\n\u003cvariants\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eocean\u003c/value\u003e\n\u003cvariants\u003esea","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eocean\u003c/value\u003e\n\u003cvariants\u003esea marine","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eocean\u003c/value\u003e\n\u003cvariants\u003esea marine maritime","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eocean\u003c/value\u003e\n\u003cvariants\u003esea marine maritime aqu","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eocean\u003c/value\u003e\n\u003cvariants\u003esea marine maritime aquatic","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eocean\u003c/value\u003e\n\u003cvariants\u003esea marine maritime aquatic\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eocean\u003c/value\u003e\n\u003cvariants\u003esea marine maritime aquatic\u003c/variants","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eocean\u003c/value\u003e\n\u003cvariants\u003esea marine maritime aquatic\u003c/variants\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eocean\u003c/value\u003e\n\u003cvariants\u003esea marine maritime aquatic\u003c/variants\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eocean\u003c/value\u003e\n\u003cvariants\u003esea marine maritime aquatic\u003c/variants\u003e\n\u003cweight","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eocean\u003c/value\u003e\n\u003cvariants\u003esea marine maritime aquatic\u003c/variants\u003e\n\u003cweight\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eocean\u003c/value\u003e\n\u003cvariants\u003esea marine maritime aquatic\u003c/variants\u003e\n\u003cweight\u003e1","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eocean\u003c/value\u003e\n\u003cvariants\u003esea marine maritime aquatic\u003c/variants\u003e\n\u003cweight\u003e1.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eocean\u003c/value\u003e\n\u003cvariants\u003esea marine maritime aquatic\u003c/variants\u003e\n\u003cweight\u003e1.0","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eocean\u003c/value\u003e\n\u003cvariants\u003esea marine maritime aquatic\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eocean\u003c/value\u003e\n\u003cvariants\u003esea marine maritime aquatic\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eocean\u003c/value\u003e\n\u003cvariants\u003esea marine maritime aquatic\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eocean\u003c/value\u003e\n\u003cvariants\u003esea marine maritime aquatic\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eocean\u003c/value\u003e\n\u003cvariants\u003esea marine maritime aquatic\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keywor","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eocean\u003c/value\u003e\n\u003cvariants\u003esea marine maritime aquatic\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eocean\u003c/value\u003e\n\u003cvariants\u003esea marine maritime aquatic\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eocean\u003c/value\u003e\n\u003cvariants\u003esea marine maritime aquatic\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeywor","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eocean\u003c/value\u003e\n\u003cvariants\u003esea marine maritime aquatic\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eocean\u003c/value\u003e\n\u003cvariants\u003esea marine maritime aquatic\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eocean\u003c/value\u003e\n\u003cvariants\u003esea marine maritime aquatic\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eocean\u003c/value\u003e\n\u003cvariants\u003esea marine maritime aquatic\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eocean\u003c/value\u003e\n\u003cvariants\u003esea marine maritime aquatic\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewave","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eocean\u003c/value\u003e\n\u003cvariants\u003esea marine maritime aquatic\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewave\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eocean\u003c/value\u003e\n\u003cvariants\u003esea marine maritime aquatic\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewave\u003c/value","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eocean\u003c/value\u003e\n\u003cvariants\u003esea marine maritime aquatic\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewave\u003c/value\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eocean\u003c/value\u003e\n\u003cvariants\u003esea marine maritime aquatic\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewave\u003c/value\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eocean\u003c/value\u003e\n\u003cvariants\u003esea marine maritime aquatic\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewave\u003c/value\u003e\n\u003cvariants","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eocean\u003c/value\u003e\n\u003cvariants\u003esea marine maritime aquatic\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewave\u003c/value\u003e\n\u003cvariants\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eocean\u003c/value\u003e\n\u003cvariants\u003esea marine maritime aquatic\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewave\u003c/value\u003e\n\u003cvariants\u003etide","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eocean\u003c/value\u003e\n\u003cvariants\u003esea marine maritime aquatic\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewave\u003c/value\u003e\n\u003cvariants\u003etide surf","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eocean\u003c/value\u003e\n\u003cvariants\u003esea marine maritime aquatic\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewave\u003c/value\u003e\n\u003cvariants\u003etide surf s","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eocean\u003c/value\u003e\n\u003cvariants\u003esea marine maritime aquatic\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewave\u003c/value\u003e\n\u003cvariants\u003etide surf swell","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eocean\u003c/value\u003e\n\u003cvariants\u003esea marine maritime aquatic\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewave\u003c/value\u003e\n\u003cvariants\u003etide surf swell\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eocean\u003c/value\u003e\n\u003cvariants\u003esea marine maritime aquatic\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewave\u003c/value\u003e\n\u003cvariants\u003etide surf swell\u003c/variants","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eocean\u003c/value\u003e\n\u003cvariants\u003esea marine maritime aquatic\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewave\u003c/value\u003e\n\u003cvariants\u003etide surf swell\u003c/variants\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eocean\u003c/value\u003e\n\u003cvariants\u003esea marine maritime aquatic\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewave\u003c/value\u003e\n\u003cvariants\u003etide surf swell\u003c/variants\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eocean\u003c/value\u003e\n\u003cvariants\u003esea marine maritime aquatic\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewave\u003c/value\u003e\n\u003cvariants\u003etide surf swell\u003c/variants\u003e\n\u003cweight","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eocean\u003c/value\u003e\n\u003cvariants\u003esea marine maritime aquatic\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewave\u003c/value\u003e\n\u003cvariants\u003etide surf swell\u003c/variants\u003e\n\u003cweight\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eocean\u003c/value\u003e\n\u003cvariants\u003esea marine maritime aquatic\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewave\u003c/value\u003e\n\u003cvariants\u003etide surf swell\u003c/variants\u003e\n\u003cweight\u003e0","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eocean\u003c/value\u003e\n\u003cvariants\u003esea marine maritime aquatic\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewave\u003c/value\u003e\n\u003cvariants\u003etide surf swell\u003c/variants\u003e\n\u003cweight\u003e0.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eocean\u003c/value\u003e\n\u003cvariants\u003esea marine maritime aquatic\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewave\u003c/value\u003e\n\u003cvariants\u003etide surf swell\u003c/variants\u003e\n\u003cweight\u003e0.8","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eocean\u003c/value\u003e\n\u003cvariants\u003esea marine maritime aquatic\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewave\u003c/value\u003e\n\u003cvariants\u003etide surf swell\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eocean\u003c/value\u003e\n\u003cvariants\u003esea marine maritime aquatic\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewave\u003c/value\u003e\n\u003cvariants\u003etide surf swell\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eocean\u003c/value\u003e\n\u003cvariants\u003esea marine maritime aquatic\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewave\u003c/value\u003e\n\u003cvariants\u003etide surf swell\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eocean\u003c/value\u003e\n\u003cvariants\u003esea marine maritime aquatic\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewave\u003c/value\u003e\n\u003cvariants\u003etide surf swell\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eocean\u003c/value\u003e\n\u003cvariants\u003esea marine maritime aquatic\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewave\u003c/value\u003e\n\u003cvariants\u003etide surf swell\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keywor","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eocean\u003c/value\u003e\n\u003cvariants\u003esea marine maritime aquatic\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewave\u003c/value\u003e\n\u003cvariants\u003etide surf swell\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eocean\u003c/value\u003e\n\u003cvariants\u003esea marine maritime aquatic\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewave\u003c/value\u003e\n\u003cvariants\u003etide surf swell\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eocean\u003c/value\u003e\n\u003cvariants\u003esea marine maritime aquatic\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewave\u003c/value\u003e\n\u003cvariants\u003etide surf swell\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeywor","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eocean\u003c/value\u003e\n\u003cvariants\u003esea marine maritime aquatic\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewave\u003c/value\u003e\n\u003cvariants\u003etide surf swell\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eocean\u003c/value\u003e\n\u003cvariants\u003esea marine maritime aquatic\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewave\u003c/value\u003e\n\u003cvariants\u003etide surf swell\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eocean\u003c/value\u003e\n\u003cvariants\u003esea marine maritime aquatic\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewave\u003c/value\u003e\n\u003cvariants\u003etide surf swell\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eocean\u003c/value\u003e\n\u003cvariants\u003esea marine maritime aquatic\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewave\u003c/value\u003e\n\u003cvariants\u003etide surf swell\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eocean\u003c/value\u003e\n\u003cvariants\u003esea marine maritime aquatic\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewave\u003c/value\u003e\n\u003cvariants\u003etide surf swell\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003emarine","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eocean\u003c/value\u003e\n\u003cvariants\u003esea marine maritime aquatic\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewave\u003c/value\u003e\n\u003cvariants\u003etide surf swell\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003emarine\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eocean\u003c/value\u003e\n\u003cvariants\u003esea marine maritime aquatic\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewave\u003c/value\u003e\n\u003cvariants\u003etide surf swell\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003emarine\u003c/value","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eocean\u003c/value\u003e\n\u003cvariants\u003esea marine maritime aquatic\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewave\u003c/value\u003e\n\u003cvariants\u003etide surf swell\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003emarine\u003c/value\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eocean\u003c/value\u003e\n\u003cvariants\u003esea marine maritime aquatic\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewave\u003c/value\u003e\n\u003cvariants\u003etide surf swell\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003emarine\u003c/value\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eocean\u003c/value\u003e\n\u003cvariants\u003esea marine maritime aquatic\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewave\u003c/value\u003e\n\u003cvariants\u003etide surf swell\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003emarine\u003c/value\u003e\n\u003cvariants","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eocean\u003c/value\u003e\n\u003cvariants\u003esea marine maritime aquatic\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewave\u003c/value\u003e\n\u003cvariants\u003etide surf swell\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003emarine\u003c/value\u003e\n\u003cvariants\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eocean\u003c/value\u003e\n\u003cvariants\u003esea marine maritime aquatic\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewave\u003c/value\u003e\n\u003cvariants\u003etide surf swell\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003emarine\u003c/value\u003e\n\u003cvariants\u003eocean","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eocean\u003c/value\u003e\n\u003cvariants\u003esea marine maritime aquatic\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewave\u003c/value\u003e\n\u003cvariants\u003etide surf swell\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003emarine\u003c/value\u003e\n\u003cvariants\u003eocean aqu","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eocean\u003c/value\u003e\n\u003cvariants\u003esea marine maritime aquatic\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewave\u003c/value\u003e\n\u003cvariants\u003etide surf swell\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003emarine\u003c/value\u003e\n\u003cvariants\u003eocean aquatic","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eocean\u003c/value\u003e\n\u003cvariants\u003esea marine maritime aquatic\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewave\u003c/value\u003e\n\u003cvariants\u003etide surf swell\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003emarine\u003c/value\u003e\n\u003cvariants\u003eocean aquatic naut","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eocean\u003c/value\u003e\n\u003cvariants\u003esea marine maritime aquatic\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewave\u003c/value\u003e\n\u003cvariants\u003etide surf swell\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003emarine\u003c/value\u003e\n\u003cvariants\u003eocean aquatic nautical","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eocean\u003c/value\u003e\n\u003cvariants\u003esea marine maritime aquatic\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewave\u003c/value\u003e\n\u003cvariants\u003etide surf swell\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003emarine\u003c/value\u003e\n\u003cvariants\u003eocean aquatic nautical\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eocean\u003c/value\u003e\n\u003cvariants\u003esea marine maritime aquatic\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewave\u003c/value\u003e\n\u003cvariants\u003etide surf swell\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003emarine\u003c/value\u003e\n\u003cvariants\u003eocean aquatic nautical\u003c/variants","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eocean\u003c/value\u003e\n\u003cvariants\u003esea marine maritime aquatic\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewave\u003c/value\u003e\n\u003cvariants\u003etide surf swell\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003emarine\u003c/value\u003e\n\u003cvariants\u003eocean aquatic nautical\u003c/variants\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eocean\u003c/value\u003e\n\u003cvariants\u003esea marine maritime aquatic\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewave\u003c/value\u003e\n\u003cvariants\u003etide surf swell\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003emarine\u003c/value\u003e\n\u003cvariants\u003eocean aquatic nautical\u003c/variants\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eocean\u003c/value\u003e\n\u003cvariants\u003esea marine maritime aquatic\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewave\u003c/value\u003e\n\u003cvariants\u003etide surf swell\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003emarine\u003c/value\u003e\n\u003cvariants\u003eocean aquatic nautical\u003c/variants\u003e\n\u003cweight","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eocean\u003c/value\u003e\n\u003cvariants\u003esea marine maritime aquatic\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewave\u003c/value\u003e\n\u003cvariants\u003etide surf swell\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003emarine\u003c/value\u003e\n\u003cvariants\u003eocean aquatic nautical\u003c/variants\u003e\n\u003cweight\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eocean\u003c/value\u003e\n\u003cvariants\u003esea marine maritime aquatic\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewave\u003c/value\u003e\n\u003cvariants\u003etide surf swell\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003emarine\u003c/value\u003e\n\u003cvariants\u003eocean aquatic nautical\u003c/variants\u003e\n\u003cweight\u003e0","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eocean\u003c/value\u003e\n\u003cvariants\u003esea marine maritime aquatic\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewave\u003c/value\u003e\n\u003cvariants\u003etide surf swell\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003emarine\u003c/value\u003e\n\u003cvariants\u003eocean aquatic nautical\u003c/variants\u003e\n\u003cweight\u003e0.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eocean\u003c/value\u003e\n\u003cvariants\u003esea marine maritime aquatic\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewave\u003c/value\u003e\n\u003cvariants\u003etide surf swell\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003emarine\u003c/value\u003e\n\u003cvariants\u003eocean aquatic nautical\u003c/variants\u003e\n\u003cweight\u003e0.7","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eocean\u003c/value\u003e\n\u003cvariants\u003esea marine maritime aquatic\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewave\u003c/value\u003e\n\u003cvariants\u003etide surf swell\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003emarine\u003c/value\u003e\n\u003cvariants\u003eocean aquatic nautical\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eocean\u003c/value\u003e\n\u003cvariants\u003esea marine maritime aquatic\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewave\u003c/value\u003e\n\u003cvariants\u003etide surf swell\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003emarine\u003c/value\u003e\n\u003cvariants\u003eocean aquatic nautical\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eocean\u003c/value\u003e\n\u003cvariants\u003esea marine maritime aquatic\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewave\u003c/value\u003e\n\u003cvariants\u003etide surf swell\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003emarine\u003c/value\u003e\n\u003cvariants\u003eocean aquatic nautical\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eocean\u003c/value\u003e\n\u003cvariants\u003esea marine maritime aquatic\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewave\u003c/value\u003e\n\u003cvariants\u003etide surf swell\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003emarine\u003c/value\u003e\n\u003cvariants\u003eocean aquatic nautical\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eocean\u003c/value\u003e\n\u003cvariants\u003esea marine maritime aquatic\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewave\u003c/value\u003e\n\u003cvariants\u003etide surf swell\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003emarine\u003c/value\u003e\n\u003cvariants\u003eocean aquatic nautical\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keywor","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eocean\u003c/value\u003e\n\u003cvariants\u003esea marine maritime aquatic\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewave\u003c/value\u003e\n\u003cvariants\u003etide surf swell\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003emarine\u003c/value\u003e\n\u003cvariants\u003eocean aquatic nautical\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eocean\u003c/value\u003e\n\u003cvariants\u003esea marine maritime aquatic\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewave\u003c/value\u003e\n\u003cvariants\u003etide surf swell\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003emarine\u003c/value\u003e\n\u003cvariants\u003eocean aquatic nautical\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eocean\u003c/value\u003e\n\u003cvariants\u003esea marine maritime aquatic\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewave\u003c/value\u003e\n\u003cvariants\u003etide surf swell\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003emarine\u003c/value\u003e\n\u003cvariants\u003eocean aquatic nautical\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeywor","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eocean\u003c/value\u003e\n\u003cvariants\u003esea marine maritime aquatic\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewave\u003c/value\u003e\n\u003cvariants\u003etide surf swell\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003emarine\u003c/value\u003e\n\u003cvariants\u003eocean aquatic nautical\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eocean\u003c/value\u003e\n\u003cvariants\u003esea marine maritime aquatic\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewave\u003c/value\u003e\n\u003cvariants\u003etide surf swell\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003emarine\u003c/value\u003e\n\u003cvariants\u003eocean aquatic nautical\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eocean\u003c/value\u003e\n\u003cvariants\u003esea marine maritime aquatic\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewave\u003c/value\u003e\n\u003cvariants\u003etide surf swell\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003emarine\u003c/value\u003e\n\u003cvariants\u003eocean aquatic nautical\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eocean\u003c/value\u003e\n\u003cvariants\u003esea marine maritime aquatic\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewave\u003c/value\u003e\n\u003cvariants\u003etide surf swell\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003emarine\u003c/value\u003e\n\u003cvariants\u003eocean aquatic nautical\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eocean\u003c/value\u003e\n\u003cvariants\u003esea marine maritime aquatic\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewave\u003c/value\u003e\n\u003cvariants\u003etide surf swell\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003emarine\u003c/value\u003e\n\u003cvariants\u003eocean aquatic nautical\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eaqu","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eocean\u003c/value\u003e\n\u003cvariants\u003esea marine maritime aquatic\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewave\u003c/value\u003e\n\u003cvariants\u003etide surf swell\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003emarine\u003c/value\u003e\n\u003cvariants\u003eocean aquatic nautical\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eaquatic","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eocean\u003c/value\u003e\n\u003cvariants\u003esea marine maritime aquatic\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewave\u003c/value\u003e\n\u003cvariants\u003etide surf swell\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003emarine\u003c/value\u003e\n\u003cvariants\u003eocean aquatic nautical\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eaquatic\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eocean\u003c/value\u003e\n\u003cvariants\u003esea marine maritime aquatic\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewave\u003c/value\u003e\n\u003cvariants\u003etide surf swell\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003emarine\u003c/value\u003e\n\u003cvariants\u003eocean aquatic nautical\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eaquatic\u003c/value","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eocean\u003c/value\u003e\n\u003cvariants\u003esea marine maritime aquatic\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewave\u003c/value\u003e\n\u003cvariants\u003etide surf swell\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003emarine\u003c/value\u003e\n\u003cvariants\u003eocean aquatic nautical\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eaquatic\u003c/value\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eocean\u003c/value\u003e\n\u003cvariants\u003esea marine maritime aquatic\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewave\u003c/value\u003e\n\u003cvariants\u003etide surf swell\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003emarine\u003c/value\u003e\n\u003cvariants\u003eocean aquatic nautical\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eaquatic\u003c/value\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eocean\u003c/value\u003e\n\u003cvariants\u003esea marine maritime aquatic\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewave\u003c/value\u003e\n\u003cvariants\u003etide surf swell\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003emarine\u003c/value\u003e\n\u003cvariants\u003eocean aquatic nautical\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eaquatic\u003c/value\u003e\n\u003cvariants","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eocean\u003c/value\u003e\n\u003cvariants\u003esea marine maritime aquatic\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewave\u003c/value\u003e\n\u003cvariants\u003etide surf swell\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003emarine\u003c/value\u003e\n\u003cvariants\u003eocean aquatic nautical\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eaquatic\u003c/value\u003e\n\u003cvariants\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eocean\u003c/value\u003e\n\u003cvariants\u003esea marine maritime aquatic\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewave\u003c/value\u003e\n\u003cvariants\u003etide surf swell\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003emarine\u003c/value\u003e\n\u003cvariants\u003eocean aquatic nautical\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eaquatic\u003c/value\u003e\n\u003cvariants\u003ewater","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eocean\u003c/value\u003e\n\u003cvariants\u003esea marine maritime aquatic\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewave\u003c/value\u003e\n\u003cvariants\u003etide surf swell\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003emarine\u003c/value\u003e\n\u003cvariants\u003eocean aquatic nautical\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eaquatic\u003c/value\u003e\n\u003cvariants\u003ewater underwater","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eocean\u003c/value\u003e\n\u003cvariants\u003esea marine maritime aquatic\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewave\u003c/value\u003e\n\u003cvariants\u003etide surf swell\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003emarine\u003c/value\u003e\n\u003cvariants\u003eocean aquatic nautical\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eaquatic\u003c/value\u003e\n\u003cvariants\u003ewater underwater\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eocean\u003c/value\u003e\n\u003cvariants\u003esea marine maritime aquatic\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewave\u003c/value\u003e\n\u003cvariants\u003etide surf swell\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003emarine\u003c/value\u003e\n\u003cvariants\u003eocean aquatic nautical\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eaquatic\u003c/value\u003e\n\u003cvariants\u003ewater underwater\u003c/variants","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eocean\u003c/value\u003e\n\u003cvariants\u003esea marine maritime aquatic\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewave\u003c/value\u003e\n\u003cvariants\u003etide surf swell\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003emarine\u003c/value\u003e\n\u003cvariants\u003eocean aquatic nautical\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eaquatic\u003c/value\u003e\n\u003cvariants\u003ewater underwater\u003c/variants\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eocean\u003c/value\u003e\n\u003cvariants\u003esea marine maritime aquatic\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewave\u003c/value\u003e\n\u003cvariants\u003etide surf swell\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003emarine\u003c/value\u003e\n\u003cvariants\u003eocean aquatic nautical\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eaquatic\u003c/value\u003e\n\u003cvariants\u003ewater underwater\u003c/variants\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eocean\u003c/value\u003e\n\u003cvariants\u003esea marine maritime aquatic\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewave\u003c/value\u003e\n\u003cvariants\u003etide surf swell\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003emarine\u003c/value\u003e\n\u003cvariants\u003eocean aquatic nautical\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eaquatic\u003c/value\u003e\n\u003cvariants\u003ewater underwater\u003c/variants\u003e\n\u003cweight","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eocean\u003c/value\u003e\n\u003cvariants\u003esea marine maritime aquatic\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewave\u003c/value\u003e\n\u003cvariants\u003etide surf swell\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003emarine\u003c/value\u003e\n\u003cvariants\u003eocean aquatic nautical\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eaquatic\u003c/value\u003e\n\u003cvariants\u003ewater underwater\u003c/variants\u003e\n\u003cweight\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eocean\u003c/value\u003e\n\u003cvariants\u003esea marine maritime aquatic\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewave\u003c/value\u003e\n\u003cvariants\u003etide surf swell\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003emarine\u003c/value\u003e\n\u003cvariants\u003eocean aquatic nautical\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eaquatic\u003c/value\u003e\n\u003cvariants\u003ewater underwater\u003c/variants\u003e\n\u003cweight\u003e0","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eocean\u003c/value\u003e\n\u003cvariants\u003esea marine maritime aquatic\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewave\u003c/value\u003e\n\u003cvariants\u003etide surf swell\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003emarine\u003c/value\u003e\n\u003cvariants\u003eocean aquatic nautical\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eaquatic\u003c/value\u003e\n\u003cvariants\u003ewater underwater\u003c/variants\u003e\n\u003cweight\u003e0.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eocean\u003c/value\u003e\n\u003cvariants\u003esea marine maritime aquatic\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewave\u003c/value\u003e\n\u003cvariants\u003etide surf swell\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003emarine\u003c/value\u003e\n\u003cvariants\u003eocean aquatic nautical\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eaquatic\u003c/value\u003e\n\u003cvariants\u003ewater underwater\u003c/variants\u003e\n\u003cweight\u003e0.6","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eocean\u003c/value\u003e\n\u003cvariants\u003esea marine maritime aquatic\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewave\u003c/value\u003e\n\u003cvariants\u003etide surf swell\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003emarine\u003c/value\u003e\n\u003cvariants\u003eocean aquatic nautical\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eaquatic\u003c/value\u003e\n\u003cvariants\u003ewater underwater\u003c/variants\u003e\n\u003cweight\u003e0.6\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eocean\u003c/value\u003e\n\u003cvariants\u003esea marine maritime aquatic\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewave\u003c/value\u003e\n\u003cvariants\u003etide surf swell\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003emarine\u003c/value\u003e\n\u003cvariants\u003eocean aquatic nautical\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eaquatic\u003c/value\u003e\n\u003cvariants\u003ewater underwater\u003c/variants\u003e\n\u003cweight\u003e0.6\u003c/weight","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eocean\u003c/value\u003e\n\u003cvariants\u003esea marine maritime aquatic\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewave\u003c/value\u003e\n\u003cvariants\u003etide surf swell\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003emarine\u003c/value\u003e\n\u003cvariants\u003eocean aquatic nautical\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eaquatic\u003c/value\u003e\n\u003cvariants\u003ewater underwater\u003c/variants\u003e\n\u003cweight\u003e0.6\u003c/weight\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eocean\u003c/value\u003e\n\u003cvariants\u003esea marine maritime aquatic\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewave\u003c/value\u003e\n\u003cvariants\u003etide surf swell\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003emarine\u003c/value\u003e\n\u003cvariants\u003eocean aquatic nautical\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eaquatic\u003c/value\u003e\n\u003cvariants\u003ewater underwater\u003c/variants\u003e\n\u003cweight\u003e0.6\u003c/weight\u003e\n\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eocean\u003c/value\u003e\n\u003cvariants\u003esea marine maritime aquatic\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewave\u003c/value\u003e\n\u003cvariants\u003etide surf swell\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003emarine\u003c/value\u003e\n\u003cvariants\u003eocean aquatic nautical\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eaquatic\u003c/value\u003e\n\u003cvariants\u003ewater underwater\u003c/variants\u003e\n\u003cweight\u003e0.6\u003c/weight\u003e\n\u003c/keywor","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eocean\u003c/value\u003e\n\u003cvariants\u003esea marine maritime aquatic\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewave\u003c/value\u003e\n\u003cvariants\u003etide surf swell\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003emarine\u003c/value\u003e\n\u003cvariants\u003eocean aquatic nautical\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eaquatic\u003c/value\u003e\n\u003cvariants\u003ewater underwater\u003c/variants\u003e\n\u003cweight\u003e0.6\u003c/weight\u003e\n\u003c/keyword\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eocean\u003c/value\u003e\n\u003cvariants\u003esea marine maritime aquatic\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewave\u003c/value\u003e\n\u003cvariants\u003etide surf swell\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003emarine\u003c/value\u003e\n\u003cvariants\u003eocean aquatic nautical\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eaquatic\u003c/value\u003e\n\u003cvariants\u003ewater underwater\u003c/variants\u003e\n\u003cweight\u003e0.6\u003c/weight\u003e\n\u003c/keyword\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eocean\u003c/value\u003e\n\u003cvariants\u003esea marine maritime aquatic\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewave\u003c/value\u003e\n\u003cvariants\u003etide surf swell\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003emarine\u003c/value\u003e\n\u003cvariants\u003eocean aquatic nautical\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eaquatic\u003c/value\u003e\n\u003cvariants\u003ewater underwater\u003c/variants\u003e\n\u003cweight\u003e0.6\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeywor","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eocean\u003c/value\u003e\n\u003cvariants\u003esea marine maritime aquatic\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewave\u003c/value\u003e\n\u003cvariants\u003etide surf swell\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003emarine\u003c/value\u003e\n\u003cvariants\u003eocean aquatic nautical\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eaquatic\u003c/value\u003e\n\u003cvariants\u003ewater underwater\u003c/variants\u003e\n\u003cweight\u003e0.6\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eocean\u003c/value\u003e\n\u003cvariants\u003esea marine maritime aquatic\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewave\u003c/value\u003e\n\u003cvariants\u003etide surf swell\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003emarine\u003c/value\u003e\n\u003cvariants\u003eocean aquatic nautical\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eaquatic\u003c/value\u003e\n\u003cvariants\u003ewater underwater\u003c/variants\u003e\n\u003cweight\u003e0.6\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eocean\u003c/value\u003e\n\u003cvariants\u003esea marine maritime aquatic\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewave\u003c/value\u003e\n\u003cvariants\u003etide surf swell\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003emarine\u003c/value\u003e\n\u003cvariants\u003eocean aquatic nautical\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eaquatic\u003c/value\u003e\n\u003cvariants\u003ewater underwater\u003c/variants\u003e\n\u003cweight\u003e0.6\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eocean\u003c/value\u003e\n\u003cvariants\u003esea marine maritime aquatic\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewave\u003c/value\u003e\n\u003cvariants\u003etide surf swell\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003emarine\u003c/value\u003e\n\u003cvariants\u003eocean aquatic nautical\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eaquatic\u003c/value\u003e\n\u003cvariants\u003ewater underwater\u003c/variants\u003e\n\u003cweight\u003e0.6\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eocean\u003c/value\u003e\n\u003cvariants\u003esea marine maritime aquatic\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewave\u003c/value\u003e\n\u003cvariants\u003etide surf swell\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003emarine\u003c/value\u003e\n\u003cvariants\u003eocean aquatic nautical\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eaquatic\u003c/value\u003e\n\u003cvariants\u003ewater underwater\u003c/variants\u003e\n\u003cweight\u003e0.6\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efish","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eocean\u003c/value\u003e\n\u003cvariants\u003esea marine maritime aquatic\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewave\u003c/value\u003e\n\u003cvariants\u003etide surf swell\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003emarine\u003c/value\u003e\n\u003cvariants\u003eocean aquatic nautical\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eaquatic\u003c/value\u003e\n\u003cvariants\u003ewater underwater\u003c/variants\u003e\n\u003cweight\u003e0.6\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efish\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eocean\u003c/value\u003e\n\u003cvariants\u003esea marine maritime aquatic\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewave\u003c/value\u003e\n\u003cvariants\u003etide surf swell\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003emarine\u003c/value\u003e\n\u003cvariants\u003eocean aquatic nautical\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eaquatic\u003c/value\u003e\n\u003cvariants\u003ewater underwater\u003c/variants\u003e\n\u003cweight\u003e0.6\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efish\u003c/value","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eocean\u003c/value\u003e\n\u003cvariants\u003esea marine maritime aquatic\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewave\u003c/value\u003e\n\u003cvariants\u003etide surf swell\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003emarine\u003c/value\u003e\n\u003cvariants\u003eocean aquatic nautical\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eaquatic\u003c/value\u003e\n\u003cvariants\u003ewater underwater\u003c/variants\u003e\n\u003cweight\u003e0.6\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efish\u003c/value\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eocean\u003c/value\u003e\n\u003cvariants\u003esea marine maritime aquatic\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewave\u003c/value\u003e\n\u003cvariants\u003etide surf swell\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003emarine\u003c/value\u003e\n\u003cvariants\u003eocean aquatic nautical\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eaquatic\u003c/value\u003e\n\u003cvariants\u003ewater underwater\u003c/variants\u003e\n\u003cweight\u003e0.6\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efish\u003c/value\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eocean\u003c/value\u003e\n\u003cvariants\u003esea marine maritime aquatic\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewave\u003c/value\u003e\n\u003cvariants\u003etide surf swell\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003emarine\u003c/value\u003e\n\u003cvariants\u003eocean aquatic nautical\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eaquatic\u003c/value\u003e\n\u003cvariants\u003ewater underwater\u003c/variants\u003e\n\u003cweight\u003e0.6\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efish\u003c/value\u003e\n\u003cvariants","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eocean\u003c/value\u003e\n\u003cvariants\u003esea marine maritime aquatic\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewave\u003c/value\u003e\n\u003cvariants\u003etide surf swell\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003emarine\u003c/value\u003e\n\u003cvariants\u003eocean aquatic nautical\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eaquatic\u003c/value\u003e\n\u003cvariants\u003ewater underwater\u003c/variants\u003e\n\u003cweight\u003e0.6\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efish\u003c/value\u003e\n\u003cvariants\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eocean\u003c/value\u003e\n\u003cvariants\u003esea marine maritime aquatic\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewave\u003c/value\u003e\n\u003cvariants\u003etide surf swell\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003emarine\u003c/value\u003e\n\u003cvariants\u003eocean aquatic nautical\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eaquatic\u003c/value\u003e\n\u003cvariants\u003ewater underwater\u003c/variants\u003e\n\u003cweight\u003e0.6\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efish\u003c/value\u003e\n\u003cvariants\u003emarine","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eocean\u003c/value\u003e\n\u003cvariants\u003esea marine maritime aquatic\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewave\u003c/value\u003e\n\u003cvariants\u003etide surf swell\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003emarine\u003c/value\u003e\n\u003cvariants\u003eocean aquatic nautical\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eaquatic\u003c/value\u003e\n\u003cvariants\u003ewater underwater\u003c/variants\u003e\n\u003cweight\u003e0.6\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efish\u003c/value\u003e\n\u003cvariants\u003emarine s","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eocean\u003c/value\u003e\n\u003cvariants\u003esea marine maritime aquatic\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewave\u003c/value\u003e\n\u003cvariants\u003etide surf swell\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003emarine\u003c/value\u003e\n\u003cvariants\u003eocean aquatic nautical\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eaquatic\u003c/value\u003e\n\u003cvariants\u003ewater underwater\u003c/variants\u003e\n\u003cweight\u003e0.6\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efish\u003c/value\u003e\n\u003cvariants\u003emarine seal","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eocean\u003c/value\u003e\n\u003cvariants\u003esea marine maritime aquatic\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewave\u003c/value\u003e\n\u003cvariants\u003etide surf swell\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003emarine\u003c/value\u003e\n\u003cvariants\u003eocean aquatic nautical\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eaquatic\u003c/value\u003e\n\u003cvariants\u003ewater underwater\u003c/variants\u003e\n\u003cweight\u003e0.6\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efish\u003c/value\u003e\n\u003cvariants\u003emarine sealife","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eocean\u003c/value\u003e\n\u003cvariants\u003esea marine maritime aquatic\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewave\u003c/value\u003e\n\u003cvariants\u003etide surf swell\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003emarine\u003c/value\u003e\n\u003cvariants\u003eocean aquatic nautical\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eaquatic\u003c/value\u003e\n\u003cvariants\u003ewater underwater\u003c/variants\u003e\n\u003cweight\u003e0.6\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efish\u003c/value\u003e\n\u003cvariants\u003emarine sealife\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eocean\u003c/value\u003e\n\u003cvariants\u003esea marine maritime aquatic\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewave\u003c/value\u003e\n\u003cvariants\u003etide surf swell\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003emarine\u003c/value\u003e\n\u003cvariants\u003eocean aquatic nautical\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eaquatic\u003c/value\u003e\n\u003cvariants\u003ewater underwater\u003c/variants\u003e\n\u003cweight\u003e0.6\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efish\u003c/value\u003e\n\u003cvariants\u003emarine sealife\u003c/variants","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eocean\u003c/value\u003e\n\u003cvariants\u003esea marine maritime aquatic\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewave\u003c/value\u003e\n\u003cvariants\u003etide surf swell\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003emarine\u003c/value\u003e\n\u003cvariants\u003eocean aquatic nautical\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eaquatic\u003c/value\u003e\n\u003cvariants\u003ewater underwater\u003c/variants\u003e\n\u003cweight\u003e0.6\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efish\u003c/value\u003e\n\u003cvariants\u003emarine sealife\u003c/variants\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eocean\u003c/value\u003e\n\u003cvariants\u003esea marine maritime aquatic\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewave\u003c/value\u003e\n\u003cvariants\u003etide surf swell\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003emarine\u003c/value\u003e\n\u003cvariants\u003eocean aquatic nautical\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eaquatic\u003c/value\u003e\n\u003cvariants\u003ewater underwater\u003c/variants\u003e\n\u003cweight\u003e0.6\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efish\u003c/value\u003e\n\u003cvariants\u003emarine sealife\u003c/variants\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eocean\u003c/value\u003e\n\u003cvariants\u003esea marine maritime aquatic\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewave\u003c/value\u003e\n\u003cvariants\u003etide surf swell\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003emarine\u003c/value\u003e\n\u003cvariants\u003eocean aquatic nautical\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eaquatic\u003c/value\u003e\n\u003cvariants\u003ewater underwater\u003c/variants\u003e\n\u003cweight\u003e0.6\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efish\u003c/value\u003e\n\u003cvariants\u003emarine sealife\u003c/variants\u003e\n\u003cweight","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eocean\u003c/value\u003e\n\u003cvariants\u003esea marine maritime aquatic\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewave\u003c/value\u003e\n\u003cvariants\u003etide surf swell\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003emarine\u003c/value\u003e\n\u003cvariants\u003eocean aquatic nautical\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eaquatic\u003c/value\u003e\n\u003cvariants\u003ewater underwater\u003c/variants\u003e\n\u003cweight\u003e0.6\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efish\u003c/value\u003e\n\u003cvariants\u003emarine sealife\u003c/variants\u003e\n\u003cweight\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eocean\u003c/value\u003e\n\u003cvariants\u003esea marine maritime aquatic\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewave\u003c/value\u003e\n\u003cvariants\u003etide surf swell\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003emarine\u003c/value\u003e\n\u003cvariants\u003eocean aquatic nautical\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eaquatic\u003c/value\u003e\n\u003cvariants\u003ewater underwater\u003c/variants\u003e\n\u003cweight\u003e0.6\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efish\u003c/value\u003e\n\u003cvariants\u003emarine sealife\u003c/variants\u003e\n\u003cweight\u003e0","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eocean\u003c/value\u003e\n\u003cvariants\u003esea marine maritime aquatic\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewave\u003c/value\u003e\n\u003cvariants\u003etide surf swell\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003emarine\u003c/value\u003e\n\u003cvariants\u003eocean aquatic nautical\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eaquatic\u003c/value\u003e\n\u003cvariants\u003ewater underwater\u003c/variants\u003e\n\u003cweight\u003e0.6\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efish\u003c/value\u003e\n\u003cvariants\u003emarine sealife\u003c/variants\u003e\n\u003cweight\u003e0.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eocean\u003c/value\u003e\n\u003cvariants\u003esea marine maritime aquatic\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewave\u003c/value\u003e\n\u003cvariants\u003etide surf swell\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003emarine\u003c/value\u003e\n\u003cvariants\u003eocean aquatic nautical\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eaquatic\u003c/value\u003e\n\u003cvariants\u003ewater underwater\u003c/variants\u003e\n\u003cweight\u003e0.6\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efish\u003c/value\u003e\n\u003cvariants\u003emarine sealife\u003c/variants\u003e\n\u003cweight\u003e0.5","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eocean\u003c/value\u003e\n\u003cvariants\u003esea marine maritime aquatic\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewave\u003c/value\u003e\n\u003cvariants\u003etide surf swell\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003emarine\u003c/value\u003e\n\u003cvariants\u003eocean aquatic nautical\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eaquatic\u003c/value\u003e\n\u003cvariants\u003ewater underwater\u003c/variants\u003e\n\u003cweight\u003e0.6\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efish\u003c/value\u003e\n\u003cvariants\u003emarine sealife\u003c/variants\u003e\n\u003cweight\u003e0.5\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eocean\u003c/value\u003e\n\u003cvariants\u003esea marine maritime aquatic\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewave\u003c/value\u003e\n\u003cvariants\u003etide surf swell\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003emarine\u003c/value\u003e\n\u003cvariants\u003eocean aquatic nautical\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eaquatic\u003c/value\u003e\n\u003cvariants\u003ewater underwater\u003c/variants\u003e\n\u003cweight\u003e0.6\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efish\u003c/value\u003e\n\u003cvariants\u003emarine sealife\u003c/variants\u003e\n\u003cweight\u003e0.5\u003c/weight","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eocean\u003c/value\u003e\n\u003cvariants\u003esea marine maritime aquatic\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewave\u003c/value\u003e\n\u003cvariants\u003etide surf swell\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003emarine\u003c/value\u003e\n\u003cvariants\u003eocean aquatic nautical\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eaquatic\u003c/value\u003e\n\u003cvariants\u003ewater underwater\u003c/variants\u003e\n\u003cweight\u003e0.6\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efish\u003c/value\u003e\n\u003cvariants\u003emarine sealife\u003c/variants\u003e\n\u003cweight\u003e0.5\u003c/weight\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eocean\u003c/value\u003e\n\u003cvariants\u003esea marine maritime aquatic\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewave\u003c/value\u003e\n\u003cvariants\u003etide surf swell\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003emarine\u003c/value\u003e\n\u003cvariants\u003eocean aquatic nautical\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eaquatic\u003c/value\u003e\n\u003cvariants\u003ewater underwater\u003c/variants\u003e\n\u003cweight\u003e0.6\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efish\u003c/value\u003e\n\u003cvariants\u003emarine sealife\u003c/variants\u003e\n\u003cweight\u003e0.5\u003c/weight\u003e\n\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eocean\u003c/value\u003e\n\u003cvariants\u003esea marine maritime aquatic\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewave\u003c/value\u003e\n\u003cvariants\u003etide surf swell\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003emarine\u003c/value\u003e\n\u003cvariants\u003eocean aquatic nautical\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eaquatic\u003c/value\u003e\n\u003cvariants\u003ewater underwater\u003c/variants\u003e\n\u003cweight\u003e0.6\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efish\u003c/value\u003e\n\u003cvariants\u003emarine sealife\u003c/variants\u003e\n\u003cweight\u003e0.5\u003c/weight\u003e\n\u003c/keywor","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eocean\u003c/value\u003e\n\u003cvariants\u003esea marine maritime aquatic\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewave\u003c/value\u003e\n\u003cvariants\u003etide surf swell\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003emarine\u003c/value\u003e\n\u003cvariants\u003eocean aquatic nautical\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eaquatic\u003c/value\u003e\n\u003cvariants\u003ewater underwater\u003c/variants\u003e\n\u003cweight\u003e0.6\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efish\u003c/value\u003e\n\u003cvariants\u003emarine sealife\u003c/variants\u003e\n\u003cweight\u003e0.5\u003c/weight\u003e\n\u003c/keyword\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eocean\u003c/value\u003e\n\u003cvariants\u003esea marine maritime aquatic\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewave\u003c/value\u003e\n\u003cvariants\u003etide surf swell\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003emarine\u003c/value\u003e\n\u003cvariants\u003eocean aquatic nautical\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eaquatic\u003c/value\u003e\n\u003cvariants\u003ewater underwater\u003c/variants\u003e\n\u003cweight\u003e0.6\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efish\u003c/value\u003e\n\u003cvariants\u003emarine sealife\u003c/variants\u003e\n\u003cweight\u003e0.5\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eocean\u003c/value\u003e\n\u003cvariants\u003esea marine maritime aquatic\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewave\u003c/value\u003e\n\u003cvariants\u003etide surf swell\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003emarine\u003c/value\u003e\n\u003cvariants\u003eocean aquatic nautical\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eaquatic\u003c/value\u003e\n\u003cvariants\u003ewater underwater\u003c/variants\u003e\n\u003cweight\u003e0.6\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efish\u003c/value\u003e\n\u003cvariants\u003emarine sealife\u003c/variants\u003e\n\u003cweight\u003e0.5\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003c/keywords","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eocean\u003c/value\u003e\n\u003cvariants\u003esea marine maritime aquatic\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewave\u003c/value\u003e\n\u003cvariants\u003etide surf swell\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003emarine\u003c/value\u003e\n\u003cvariants\u003eocean aquatic nautical\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eaquatic\u003c/value\u003e\n\u003cvariants\u003ewater underwater\u003c/variants\u003e\n\u003cweight\u003e0.6\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efish\u003c/value\u003e\n\u003cvariants\u003emarine sealife\u003c/variants\u003e\n\u003cweight\u003e0.5\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003c/keywords\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query about \"ocean\":\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eocean\u003c/value\u003e\n\u003cvariants\u003esea marine maritime aquatic\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewave\u003c/value\u003e\n\u003cvariants\u003etide surf swell\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003emarine\u003c/value\u003e\n\u003cvariants\u003eocean aquatic nautical\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eaquatic\u003c/value\u003e\n\u003cvariants\u003ewater underwater\u003c/variants\u003e\n\u003cweight\u003e0.6\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efish\u003c/value\u003e\n\u003cvariants\u003emarine sealife\u003c/variants\u003e\n\u003cweight\u003e0.5\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003c/keywords\u003e","stopReason":"end_turn"}
+            data: {"completion":"\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eocean\u003c/value\u003e\n\u003cvariants\u003esea marine maritime aquatic\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eoceanography\u003c/value\u003e\n\u003cvariants\u003emarine science oceanology\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eoceanographic\u003c/value\u003e\n\u003cvariants\u003emarine oceanologic\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eoceanographer\u003c/value\u003e\n\u003cvariants\u003emarine scientist\u003c/variants\u003e\n\u003cweight\u003e0.6\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eoceanographic_data\u003c/value\u003e\n\u003cvariants\u003emarine_data ocean_data\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003c/keywords\u003e","stopReason":"end_turn"}
 
 
             event: done
@@ -1001,7 +71,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Tue, 28 May 2024 16:10:27 GMT
+            value: Fri, 07 Jun 2024 23:17:59 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
@@ -1030,7 +100,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-05-28T16:10:26.458Z
+      startedDateTime: 2024-06-07T23:17:58.628Z
       time: 0
       timings:
         blocked: -1
@@ -1040,11 +110,11 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: fe44d07ebac05a62a9224757717bf317
+    - _id: 27ebf59d118996d26e7a539a9cfd7cae
       _order: 0
       cache: {}
       request:
-        bodySize: 894
+        bodySize: 902
         cookies: []
         headers:
           - name: content-type
@@ -1075,8 +145,8 @@ log:
               - speaker: human
                 text: "You are helping the user search over a codebase. List some filename
                   fragments that would match files relevant to read to answer
-                  the user's query. Present your results in an XML list in the
-                  following format: <keywords><keyword><value>a single
+                  the user's query. Present your results in a *single* XML list
+                  in the following format: <keywords><keyword><value>a single
                   keyword</value><variants>a space separated list of synonyms
                   and variants of the keyword, including acronyms,
                   abbreviations, and expansions</variants><weight>a numerical
@@ -1090,579 +160,14 @@ log:
         queryString: []
         url: https://sourcegraph.com/.api/completions/stream
       response:
-        bodySize: 44968
+        bodySize: 35837
         content:
           mimeType: text/event-stream
-          size: 44968
+          size: 35837
           text: >+
             event: completion
 
-            data: {"completion":"Here","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for in","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for in the","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for in the c","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for in the code","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for in the codebase","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for in the codebase:","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for in the codebase:\n\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for in the codebase:\n\n\u003ckeywords","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for in the codebase:\n\n\u003ckeywords\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for in the codebase:\n\n\u003ckeywords\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for in the codebase:\n\n\u003ckeywords\u003e\n\u003ckeywor","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for in the codebase:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for in the codebase:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for in the codebase:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for in the codebase:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for in the codebase:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efile","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for in the codebase:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efile\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for in the codebase:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efile\u003c/value","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for in the codebase:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efile\u003c/value\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for in the codebase:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efile\u003c/value\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for in the codebase:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efile\u003c/value\u003e\n\u003cvariants","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for in the codebase:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efile\u003c/value\u003e\n\u003cvariants\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for in the codebase:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efile\u003c/value\u003e\n\u003cvariants\u003efiles","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for in the codebase:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efile\u003c/value\u003e\n\u003cvariants\u003efiles io","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for in the codebase:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efile\u003c/value\u003e\n\u003cvariants\u003efiles io disk","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for in the codebase:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efile\u003c/value\u003e\n\u003cvariants\u003efiles io disk storage","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for in the codebase:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efile\u003c/value\u003e\n\u003cvariants\u003efiles io disk storage\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for in the codebase:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efile\u003c/value\u003e\n\u003cvariants\u003efiles io disk storage\u003c/variants","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for in the codebase:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efile\u003c/value\u003e\n\u003cvariants\u003efiles io disk storage\u003c/variants\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for in the codebase:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efile\u003c/value\u003e\n\u003cvariants\u003efiles io disk storage\u003c/variants\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for in the codebase:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efile\u003c/value\u003e\n\u003cvariants\u003efiles io disk storage\u003c/variants\u003e\n\u003cweight","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for in the codebase:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efile\u003c/value\u003e\n\u003cvariants\u003efiles io disk storage\u003c/variants\u003e\n\u003cweight\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for in the codebase:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efile\u003c/value\u003e\n\u003cvariants\u003efiles io disk storage\u003c/variants\u003e\n\u003cweight\u003e1","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for in the codebase:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efile\u003c/value\u003e\n\u003cvariants\u003efiles io disk storage\u003c/variants\u003e\n\u003cweight\u003e1.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for in the codebase:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efile\u003c/value\u003e\n\u003cvariants\u003efiles io disk storage\u003c/variants\u003e\n\u003cweight\u003e1.0","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for in the codebase:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efile\u003c/value\u003e\n\u003cvariants\u003efiles io disk storage\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for in the codebase:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efile\u003c/value\u003e\n\u003cvariants\u003efiles io disk storage\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for in the codebase:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efile\u003c/value\u003e\n\u003cvariants\u003efiles io disk storage\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for in the codebase:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efile\u003c/value\u003e\n\u003cvariants\u003efiles io disk storage\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for in the codebase:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efile\u003c/value\u003e\n\u003cvariants\u003efiles io disk storage\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keywor","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for in the codebase:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efile\u003c/value\u003e\n\u003cvariants\u003efiles io disk storage\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for in the codebase:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efile\u003c/value\u003e\n\u003cvariants\u003efiles io disk storage\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for in the codebase:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efile\u003c/value\u003e\n\u003cvariants\u003efiles io disk storage\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeywor","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for in the codebase:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efile\u003c/value\u003e\n\u003cvariants\u003efiles io disk storage\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for in the codebase:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efile\u003c/value\u003e\n\u003cvariants\u003efiles io disk storage\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for in the codebase:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efile\u003c/value\u003e\n\u003cvariants\u003efiles io disk storage\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for in the codebase:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efile\u003c/value\u003e\n\u003cvariants\u003efiles io disk storage\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for in the codebase:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efile\u003c/value\u003e\n\u003cvariants\u003efiles io disk storage\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewrite","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for in the codebase:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efile\u003c/value\u003e\n\u003cvariants\u003efiles io disk storage\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewrite\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for in the codebase:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efile\u003c/value\u003e\n\u003cvariants\u003efiles io disk storage\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewrite\u003c/value","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for in the codebase:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efile\u003c/value\u003e\n\u003cvariants\u003efiles io disk storage\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewrite\u003c/value\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for in the codebase:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efile\u003c/value\u003e\n\u003cvariants\u003efiles io disk storage\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewrite\u003c/value\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for in the codebase:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efile\u003c/value\u003e\n\u003cvariants\u003efiles io disk storage\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewrite\u003c/value\u003e\n\u003cvariants","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for in the codebase:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efile\u003c/value\u003e\n\u003cvariants\u003efiles io disk storage\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewrite\u003c/value\u003e\n\u003cvariants\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for in the codebase:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efile\u003c/value\u003e\n\u003cvariants\u003efiles io disk storage\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewrite\u003c/value\u003e\n\u003cvariants\u003esave","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for in the codebase:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efile\u003c/value\u003e\n\u003cvariants\u003efiles io disk storage\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewrite\u003c/value\u003e\n\u003cvariants\u003esave persist","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for in the codebase:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efile\u003c/value\u003e\n\u003cvariants\u003efiles io disk storage\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewrite\u003c/value\u003e\n\u003cvariants\u003esave persist store","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for in the codebase:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efile\u003c/value\u003e\n\u003cvariants\u003efiles io disk storage\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewrite\u003c/value\u003e\n\u003cvariants\u003esave persist store\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for in the codebase:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efile\u003c/value\u003e\n\u003cvariants\u003efiles io disk storage\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewrite\u003c/value\u003e\n\u003cvariants\u003esave persist store\u003c/variants","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for in the codebase:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efile\u003c/value\u003e\n\u003cvariants\u003efiles io disk storage\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewrite\u003c/value\u003e\n\u003cvariants\u003esave persist store\u003c/variants\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for in the codebase:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efile\u003c/value\u003e\n\u003cvariants\u003efiles io disk storage\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewrite\u003c/value\u003e\n\u003cvariants\u003esave persist store\u003c/variants\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for in the codebase:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efile\u003c/value\u003e\n\u003cvariants\u003efiles io disk storage\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewrite\u003c/value\u003e\n\u003cvariants\u003esave persist store\u003c/variants\u003e\n\u003cweight","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for in the codebase:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efile\u003c/value\u003e\n\u003cvariants\u003efiles io disk storage\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewrite\u003c/value\u003e\n\u003cvariants\u003esave persist store\u003c/variants\u003e\n\u003cweight\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for in the codebase:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efile\u003c/value\u003e\n\u003cvariants\u003efiles io disk storage\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewrite\u003c/value\u003e\n\u003cvariants\u003esave persist store\u003c/variants\u003e\n\u003cweight\u003e1","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for in the codebase:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efile\u003c/value\u003e\n\u003cvariants\u003efiles io disk storage\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewrite\u003c/value\u003e\n\u003cvariants\u003esave persist store\u003c/variants\u003e\n\u003cweight\u003e1.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for in the codebase:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efile\u003c/value\u003e\n\u003cvariants\u003efiles io disk storage\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewrite\u003c/value\u003e\n\u003cvariants\u003esave persist store\u003c/variants\u003e\n\u003cweight\u003e1.0","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for in the codebase:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efile\u003c/value\u003e\n\u003cvariants\u003efiles io disk storage\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewrite\u003c/value\u003e\n\u003cvariants\u003esave persist store\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for in the codebase:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efile\u003c/value\u003e\n\u003cvariants\u003efiles io disk storage\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewrite\u003c/value\u003e\n\u003cvariants\u003esave persist store\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for in the codebase:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efile\u003c/value\u003e\n\u003cvariants\u003efiles io disk storage\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewrite\u003c/value\u003e\n\u003cvariants\u003esave persist store\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for in the codebase:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efile\u003c/value\u003e\n\u003cvariants\u003efiles io disk storage\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewrite\u003c/value\u003e\n\u003cvariants\u003esave persist store\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for in the codebase:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efile\u003c/value\u003e\n\u003cvariants\u003efiles io disk storage\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewrite\u003c/value\u003e\n\u003cvariants\u003esave persist store\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keywor","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for in the codebase:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efile\u003c/value\u003e\n\u003cvariants\u003efiles io disk storage\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewrite\u003c/value\u003e\n\u003cvariants\u003esave persist store\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for in the codebase:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efile\u003c/value\u003e\n\u003cvariants\u003efiles io disk storage\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewrite\u003c/value\u003e\n\u003cvariants\u003esave persist store\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for in the codebase:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efile\u003c/value\u003e\n\u003cvariants\u003efiles io disk storage\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewrite\u003c/value\u003e\n\u003cvariants\u003esave persist store\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeywor","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for in the codebase:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efile\u003c/value\u003e\n\u003cvariants\u003efiles io disk storage\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewrite\u003c/value\u003e\n\u003cvariants\u003esave persist store\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for in the codebase:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efile\u003c/value\u003e\n\u003cvariants\u003efiles io disk storage\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewrite\u003c/value\u003e\n\u003cvariants\u003esave persist store\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for in the codebase:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efile\u003c/value\u003e\n\u003cvariants\u003efiles io disk storage\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewrite\u003c/value\u003e\n\u003cvariants\u003esave persist store\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for in the codebase:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efile\u003c/value\u003e\n\u003cvariants\u003efiles io disk storage\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewrite\u003c/value\u003e\n\u003cvariants\u003esave persist store\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for in the codebase:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efile\u003c/value\u003e\n\u003cvariants\u003efiles io disk storage\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewrite\u003c/value\u003e\n\u003cvariants\u003esave persist store\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ego","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for in the codebase:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efile\u003c/value\u003e\n\u003cvariants\u003efiles io disk storage\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewrite\u003c/value\u003e\n\u003cvariants\u003esave persist store\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ego\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for in the codebase:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efile\u003c/value\u003e\n\u003cvariants\u003efiles io disk storage\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewrite\u003c/value\u003e\n\u003cvariants\u003esave persist store\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ego\u003c/value","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for in the codebase:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efile\u003c/value\u003e\n\u003cvariants\u003efiles io disk storage\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewrite\u003c/value\u003e\n\u003cvariants\u003esave persist store\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ego\u003c/value\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for in the codebase:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efile\u003c/value\u003e\n\u003cvariants\u003efiles io disk storage\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewrite\u003c/value\u003e\n\u003cvariants\u003esave persist store\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ego\u003c/value\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for in the codebase:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efile\u003c/value\u003e\n\u003cvariants\u003efiles io disk storage\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewrite\u003c/value\u003e\n\u003cvariants\u003esave persist store\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ego\u003c/value\u003e\n\u003cvariants","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for in the codebase:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efile\u003c/value\u003e\n\u003cvariants\u003efiles io disk storage\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewrite\u003c/value\u003e\n\u003cvariants\u003esave persist store\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ego\u003c/value\u003e\n\u003cvariants\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for in the codebase:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efile\u003c/value\u003e\n\u003cvariants\u003efiles io disk storage\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewrite\u003c/value\u003e\n\u003cvariants\u003esave persist store\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ego\u003c/value\u003e\n\u003cvariants\u003egolang","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for in the codebase:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efile\u003c/value\u003e\n\u003cvariants\u003efiles io disk storage\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewrite\u003c/value\u003e\n\u003cvariants\u003esave persist store\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ego\u003c/value\u003e\n\u003cvariants\u003egolang\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for in the codebase:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efile\u003c/value\u003e\n\u003cvariants\u003efiles io disk storage\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewrite\u003c/value\u003e\n\u003cvariants\u003esave persist store\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ego\u003c/value\u003e\n\u003cvariants\u003egolang\u003c/variants","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for in the codebase:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efile\u003c/value\u003e\n\u003cvariants\u003efiles io disk storage\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewrite\u003c/value\u003e\n\u003cvariants\u003esave persist store\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ego\u003c/value\u003e\n\u003cvariants\u003egolang\u003c/variants\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for in the codebase:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efile\u003c/value\u003e\n\u003cvariants\u003efiles io disk storage\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewrite\u003c/value\u003e\n\u003cvariants\u003esave persist store\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ego\u003c/value\u003e\n\u003cvariants\u003egolang\u003c/variants\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for in the codebase:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efile\u003c/value\u003e\n\u003cvariants\u003efiles io disk storage\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewrite\u003c/value\u003e\n\u003cvariants\u003esave persist store\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ego\u003c/value\u003e\n\u003cvariants\u003egolang\u003c/variants\u003e\n\u003cweight","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for in the codebase:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efile\u003c/value\u003e\n\u003cvariants\u003efiles io disk storage\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewrite\u003c/value\u003e\n\u003cvariants\u003esave persist store\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ego\u003c/value\u003e\n\u003cvariants\u003egolang\u003c/variants\u003e\n\u003cweight\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for in the codebase:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efile\u003c/value\u003e\n\u003cvariants\u003efiles io disk storage\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewrite\u003c/value\u003e\n\u003cvariants\u003esave persist store\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ego\u003c/value\u003e\n\u003cvariants\u003egolang\u003c/variants\u003e\n\u003cweight\u003e1","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for in the codebase:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efile\u003c/value\u003e\n\u003cvariants\u003efiles io disk storage\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewrite\u003c/value\u003e\n\u003cvariants\u003esave persist store\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ego\u003c/value\u003e\n\u003cvariants\u003egolang\u003c/variants\u003e\n\u003cweight\u003e1.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for in the codebase:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efile\u003c/value\u003e\n\u003cvariants\u003efiles io disk storage\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewrite\u003c/value\u003e\n\u003cvariants\u003esave persist store\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ego\u003c/value\u003e\n\u003cvariants\u003egolang\u003c/variants\u003e\n\u003cweight\u003e1.0","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for in the codebase:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efile\u003c/value\u003e\n\u003cvariants\u003efiles io disk storage\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewrite\u003c/value\u003e\n\u003cvariants\u003esave persist store\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ego\u003c/value\u003e\n\u003cvariants\u003egolang\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for in the codebase:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efile\u003c/value\u003e\n\u003cvariants\u003efiles io disk storage\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewrite\u003c/value\u003e\n\u003cvariants\u003esave persist store\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ego\u003c/value\u003e\n\u003cvariants\u003egolang\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for in the codebase:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efile\u003c/value\u003e\n\u003cvariants\u003efiles io disk storage\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewrite\u003c/value\u003e\n\u003cvariants\u003esave persist store\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ego\u003c/value\u003e\n\u003cvariants\u003egolang\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for in the codebase:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efile\u003c/value\u003e\n\u003cvariants\u003efiles io disk storage\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewrite\u003c/value\u003e\n\u003cvariants\u003esave persist store\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ego\u003c/value\u003e\n\u003cvariants\u003egolang\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for in the codebase:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efile\u003c/value\u003e\n\u003cvariants\u003efiles io disk storage\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewrite\u003c/value\u003e\n\u003cvariants\u003esave persist store\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ego\u003c/value\u003e\n\u003cvariants\u003egolang\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keywor","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for in the codebase:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efile\u003c/value\u003e\n\u003cvariants\u003efiles io disk storage\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewrite\u003c/value\u003e\n\u003cvariants\u003esave persist store\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ego\u003c/value\u003e\n\u003cvariants\u003egolang\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for in the codebase:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efile\u003c/value\u003e\n\u003cvariants\u003efiles io disk storage\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewrite\u003c/value\u003e\n\u003cvariants\u003esave persist store\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ego\u003c/value\u003e\n\u003cvariants\u003egolang\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for in the codebase:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efile\u003c/value\u003e\n\u003cvariants\u003efiles io disk storage\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewrite\u003c/value\u003e\n\u003cvariants\u003esave persist store\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ego\u003c/value\u003e\n\u003cvariants\u003egolang\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003c/keywords","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for in the codebase:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efile\u003c/value\u003e\n\u003cvariants\u003efiles io disk storage\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewrite\u003c/value\u003e\n\u003cvariants\u003esave persist store\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ego\u003c/value\u003e\n\u003cvariants\u003egolang\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003c/keywords\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for in the codebase:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efile\u003c/value\u003e\n\u003cvariants\u003efiles io disk storage\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewrite\u003c/value\u003e\n\u003cvariants\u003esave persist store\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ego\u003c/value\u003e\n\u003cvariants\u003egolang\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003c/keywords\u003e","stopReason":"end_turn"}
+            data: {"completion":"\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efile\u003c/value\u003e\n\u003cvariants\u003efiles io disk storage\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ewrite\u003c/value\u003e\n\u003cvariants\u003esave persist store\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ego\u003c/value\u003e\n\u003cvariants\u003egolang\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003c/keywords\u003e","stopReason":"end_turn"}
 
 
             event: done
@@ -1672,7 +177,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Tue, 28 May 2024 16:10:29 GMT
+            value: Fri, 07 Jun 2024 23:18:01 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
@@ -1701,7 +206,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-05-28T16:10:28.894Z
+      startedDateTime: 2024-06-07T23:18:00.657Z
       time: 0
       timings:
         blocked: -1
@@ -1711,11 +216,11 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: 4c0d04d82f4b320cc9916fcc7599c12b
+    - _id: f42bcd7555c52ebf71f77931afb473ea
       _order: 0
       cache: {}
       request:
-        bodySize: 898
+        bodySize: 1047
         cookies: []
         headers:
           - name: content-type
@@ -1744,586 +249,39 @@ log:
               - speaker: assistant
                 text: I am Cody, an AI coding assistant from Sourcegraph.
               - speaker: human
-                text: "You are helping the user search over a codebase. List some filename
-                  fragments that would match files relevant to read to answer
-                  the user's query. Present your results in an XML list in the
-                  following format: <keywords><keyword><value>a single
-                  keyword</value><variants>a space separated list of synonyms
-                  and variants of the keyword, including acronyms,
+                text: >-
+                  You are helping the user search over a codebase. List some
+                  filename fragments that would match files relevant to read to
+                  answer the user's query. Present your results in a *single*
+                  XML list in the following format: <keywords><keyword><value>a
+                  single keyword</value><variants>a space separated list of
+                  synonyms and variants of the keyword, including acronyms,
                   abbreviations, and expansions</variants><weight>a numerical
                   weight between 0.0 and 1.0 that indicates the importance of
                   the keyword</weight></keyword></keywords>. Here is the user
-                  query: <userQuery>Where is authentication router
-                  defined?</userQuery>"
+                  query: <userQuery>type Zoekt struct {
+                  	Client zoekt.Searcher
+
+                  	// DisableCache when true prevents caching of Client.List. Useful in
+                  	// tests.
+                  	DisableCache bool
+
+                  	mu       sync.RWMute
+                  </userQuery>
               - speaker: assistant
             temperature: 0
             topK: 1
         queryString: []
         url: https://sourcegraph.com/.api/completions/stream
       response:
-        bodySize: 45778
+        bodySize: 60650
         content:
           mimeType: text/event-stream
-          size: 45778
+          size: 60650
           text: >+
             event: completion
 
-            data: {"completion":"Here","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for base","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeywor","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eauth","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eauth\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eauth\u003c/value","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eauth\u003c/value\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eauth\u003c/value\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eauth\u003c/value\u003e\n\u003cvariants","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eauth\u003c/value\u003e\n\u003cvariants\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eauth\u003c/value\u003e\n\u003cvariants\u003eauthentication","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eauth\u003c/value\u003e\n\u003cvariants\u003eauthentication authorization","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eauth\u003c/value\u003e\n\u003cvariants\u003eauthentication authorization\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eauth\u003c/value\u003e\n\u003cvariants\u003eauthentication authorization\u003c/variants","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eauth\u003c/value\u003e\n\u003cvariants\u003eauthentication authorization\u003c/variants\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eauth\u003c/value\u003e\n\u003cvariants\u003eauthentication authorization\u003c/variants\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eauth\u003c/value\u003e\n\u003cvariants\u003eauthentication authorization\u003c/variants\u003e\n\u003cweight","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eauth\u003c/value\u003e\n\u003cvariants\u003eauthentication authorization\u003c/variants\u003e\n\u003cweight\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eauth\u003c/value\u003e\n\u003cvariants\u003eauthentication authorization\u003c/variants\u003e\n\u003cweight\u003e0","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eauth\u003c/value\u003e\n\u003cvariants\u003eauthentication authorization\u003c/variants\u003e\n\u003cweight\u003e0.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eauth\u003c/value\u003e\n\u003cvariants\u003eauthentication authorization\u003c/variants\u003e\n\u003cweight\u003e0.9","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eauth\u003c/value\u003e\n\u003cvariants\u003eauthentication authorization\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eauth\u003c/value\u003e\n\u003cvariants\u003eauthentication authorization\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eauth\u003c/value\u003e\n\u003cvariants\u003eauthentication authorization\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eauth\u003c/value\u003e\n\u003cvariants\u003eauthentication authorization\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eauth\u003c/value\u003e\n\u003cvariants\u003eauthentication authorization\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keywor","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eauth\u003c/value\u003e\n\u003cvariants\u003eauthentication authorization\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eauth\u003c/value\u003e\n\u003cvariants\u003eauthentication authorization\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eauth\u003c/value\u003e\n\u003cvariants\u003eauthentication authorization\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeywor","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eauth\u003c/value\u003e\n\u003cvariants\u003eauthentication authorization\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eauth\u003c/value\u003e\n\u003cvariants\u003eauthentication authorization\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eauth\u003c/value\u003e\n\u003cvariants\u003eauthentication authorization\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eauth\u003c/value\u003e\n\u003cvariants\u003eauthentication authorization\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eauth\u003c/value\u003e\n\u003cvariants\u003eauthentication authorization\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erouter","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eauth\u003c/value\u003e\n\u003cvariants\u003eauthentication authorization\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erouter\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eauth\u003c/value\u003e\n\u003cvariants\u003eauthentication authorization\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erouter\u003c/value","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eauth\u003c/value\u003e\n\u003cvariants\u003eauthentication authorization\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erouter\u003c/value\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eauth\u003c/value\u003e\n\u003cvariants\u003eauthentication authorization\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erouter\u003c/value\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eauth\u003c/value\u003e\n\u003cvariants\u003eauthentication authorization\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erouter\u003c/value\u003e\n\u003cvariants","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eauth\u003c/value\u003e\n\u003cvariants\u003eauthentication authorization\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erouter\u003c/value\u003e\n\u003cvariants\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eauth\u003c/value\u003e\n\u003cvariants\u003eauthentication authorization\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erouter\u003c/value\u003e\n\u003cvariants\u003eroute","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eauth\u003c/value\u003e\n\u003cvariants\u003eauthentication authorization\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erouter\u003c/value\u003e\n\u003cvariants\u003eroute routing","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eauth\u003c/value\u003e\n\u003cvariants\u003eauthentication authorization\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erouter\u003c/value\u003e\n\u003cvariants\u003eroute routing\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eauth\u003c/value\u003e\n\u003cvariants\u003eauthentication authorization\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erouter\u003c/value\u003e\n\u003cvariants\u003eroute routing\u003c/variants","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eauth\u003c/value\u003e\n\u003cvariants\u003eauthentication authorization\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erouter\u003c/value\u003e\n\u003cvariants\u003eroute routing\u003c/variants\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eauth\u003c/value\u003e\n\u003cvariants\u003eauthentication authorization\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erouter\u003c/value\u003e\n\u003cvariants\u003eroute routing\u003c/variants\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eauth\u003c/value\u003e\n\u003cvariants\u003eauthentication authorization\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erouter\u003c/value\u003e\n\u003cvariants\u003eroute routing\u003c/variants\u003e\n\u003cweight","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eauth\u003c/value\u003e\n\u003cvariants\u003eauthentication authorization\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erouter\u003c/value\u003e\n\u003cvariants\u003eroute routing\u003c/variants\u003e\n\u003cweight\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eauth\u003c/value\u003e\n\u003cvariants\u003eauthentication authorization\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erouter\u003c/value\u003e\n\u003cvariants\u003eroute routing\u003c/variants\u003e\n\u003cweight\u003e0","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eauth\u003c/value\u003e\n\u003cvariants\u003eauthentication authorization\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erouter\u003c/value\u003e\n\u003cvariants\u003eroute routing\u003c/variants\u003e\n\u003cweight\u003e0.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eauth\u003c/value\u003e\n\u003cvariants\u003eauthentication authorization\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erouter\u003c/value\u003e\n\u003cvariants\u003eroute routing\u003c/variants\u003e\n\u003cweight\u003e0.8","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eauth\u003c/value\u003e\n\u003cvariants\u003eauthentication authorization\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erouter\u003c/value\u003e\n\u003cvariants\u003eroute routing\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eauth\u003c/value\u003e\n\u003cvariants\u003eauthentication authorization\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erouter\u003c/value\u003e\n\u003cvariants\u003eroute routing\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eauth\u003c/value\u003e\n\u003cvariants\u003eauthentication authorization\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erouter\u003c/value\u003e\n\u003cvariants\u003eroute routing\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eauth\u003c/value\u003e\n\u003cvariants\u003eauthentication authorization\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erouter\u003c/value\u003e\n\u003cvariants\u003eroute routing\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eauth\u003c/value\u003e\n\u003cvariants\u003eauthentication authorization\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erouter\u003c/value\u003e\n\u003cvariants\u003eroute routing\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keywor","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eauth\u003c/value\u003e\n\u003cvariants\u003eauthentication authorization\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erouter\u003c/value\u003e\n\u003cvariants\u003eroute routing\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eauth\u003c/value\u003e\n\u003cvariants\u003eauthentication authorization\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erouter\u003c/value\u003e\n\u003cvariants\u003eroute routing\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eauth\u003c/value\u003e\n\u003cvariants\u003eauthentication authorization\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erouter\u003c/value\u003e\n\u003cvariants\u003eroute routing\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeywor","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eauth\u003c/value\u003e\n\u003cvariants\u003eauthentication authorization\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erouter\u003c/value\u003e\n\u003cvariants\u003eroute routing\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eauth\u003c/value\u003e\n\u003cvariants\u003eauthentication authorization\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erouter\u003c/value\u003e\n\u003cvariants\u003eroute routing\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eauth\u003c/value\u003e\n\u003cvariants\u003eauthentication authorization\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erouter\u003c/value\u003e\n\u003cvariants\u003eroute routing\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eauth\u003c/value\u003e\n\u003cvariants\u003eauthentication authorization\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erouter\u003c/value\u003e\n\u003cvariants\u003eroute routing\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eauth\u003c/value\u003e\n\u003cvariants\u003eauthentication authorization\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erouter\u003c/value\u003e\n\u003cvariants\u003eroute routing\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econfig","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eauth\u003c/value\u003e\n\u003cvariants\u003eauthentication authorization\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erouter\u003c/value\u003e\n\u003cvariants\u003eroute routing\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econfig\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eauth\u003c/value\u003e\n\u003cvariants\u003eauthentication authorization\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erouter\u003c/value\u003e\n\u003cvariants\u003eroute routing\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econfig\u003c/value","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eauth\u003c/value\u003e\n\u003cvariants\u003eauthentication authorization\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erouter\u003c/value\u003e\n\u003cvariants\u003eroute routing\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econfig\u003c/value\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eauth\u003c/value\u003e\n\u003cvariants\u003eauthentication authorization\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erouter\u003c/value\u003e\n\u003cvariants\u003eroute routing\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econfig\u003c/value\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eauth\u003c/value\u003e\n\u003cvariants\u003eauthentication authorization\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erouter\u003c/value\u003e\n\u003cvariants\u003eroute routing\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econfig\u003c/value\u003e\n\u003cvariants","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eauth\u003c/value\u003e\n\u003cvariants\u003eauthentication authorization\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erouter\u003c/value\u003e\n\u003cvariants\u003eroute routing\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econfig\u003c/value\u003e\n\u003cvariants\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eauth\u003c/value\u003e\n\u003cvariants\u003eauthentication authorization\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erouter\u003c/value\u003e\n\u003cvariants\u003eroute routing\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econfig\u003c/value\u003e\n\u003cvariants\u003econfiguration","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eauth\u003c/value\u003e\n\u003cvariants\u003eauthentication authorization\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erouter\u003c/value\u003e\n\u003cvariants\u003eroute routing\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econfig\u003c/value\u003e\n\u003cvariants\u003econfiguration\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eauth\u003c/value\u003e\n\u003cvariants\u003eauthentication authorization\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erouter\u003c/value\u003e\n\u003cvariants\u003eroute routing\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econfig\u003c/value\u003e\n\u003cvariants\u003econfiguration\u003c/variants","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eauth\u003c/value\u003e\n\u003cvariants\u003eauthentication authorization\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erouter\u003c/value\u003e\n\u003cvariants\u003eroute routing\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econfig\u003c/value\u003e\n\u003cvariants\u003econfiguration\u003c/variants\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eauth\u003c/value\u003e\n\u003cvariants\u003eauthentication authorization\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erouter\u003c/value\u003e\n\u003cvariants\u003eroute routing\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econfig\u003c/value\u003e\n\u003cvariants\u003econfiguration\u003c/variants\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eauth\u003c/value\u003e\n\u003cvariants\u003eauthentication authorization\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erouter\u003c/value\u003e\n\u003cvariants\u003eroute routing\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econfig\u003c/value\u003e\n\u003cvariants\u003econfiguration\u003c/variants\u003e\n\u003cweight","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eauth\u003c/value\u003e\n\u003cvariants\u003eauthentication authorization\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erouter\u003c/value\u003e\n\u003cvariants\u003eroute routing\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econfig\u003c/value\u003e\n\u003cvariants\u003econfiguration\u003c/variants\u003e\n\u003cweight\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eauth\u003c/value\u003e\n\u003cvariants\u003eauthentication authorization\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erouter\u003c/value\u003e\n\u003cvariants\u003eroute routing\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econfig\u003c/value\u003e\n\u003cvariants\u003econfiguration\u003c/variants\u003e\n\u003cweight\u003e0","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eauth\u003c/value\u003e\n\u003cvariants\u003eauthentication authorization\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erouter\u003c/value\u003e\n\u003cvariants\u003eroute routing\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econfig\u003c/value\u003e\n\u003cvariants\u003econfiguration\u003c/variants\u003e\n\u003cweight\u003e0.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eauth\u003c/value\u003e\n\u003cvariants\u003eauthentication authorization\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erouter\u003c/value\u003e\n\u003cvariants\u003eroute routing\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econfig\u003c/value\u003e\n\u003cvariants\u003econfiguration\u003c/variants\u003e\n\u003cweight\u003e0.7","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eauth\u003c/value\u003e\n\u003cvariants\u003eauthentication authorization\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erouter\u003c/value\u003e\n\u003cvariants\u003eroute routing\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econfig\u003c/value\u003e\n\u003cvariants\u003econfiguration\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eauth\u003c/value\u003e\n\u003cvariants\u003eauthentication authorization\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erouter\u003c/value\u003e\n\u003cvariants\u003eroute routing\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econfig\u003c/value\u003e\n\u003cvariants\u003econfiguration\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eauth\u003c/value\u003e\n\u003cvariants\u003eauthentication authorization\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erouter\u003c/value\u003e\n\u003cvariants\u003eroute routing\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econfig\u003c/value\u003e\n\u003cvariants\u003econfiguration\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eauth\u003c/value\u003e\n\u003cvariants\u003eauthentication authorization\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erouter\u003c/value\u003e\n\u003cvariants\u003eroute routing\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econfig\u003c/value\u003e\n\u003cvariants\u003econfiguration\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eauth\u003c/value\u003e\n\u003cvariants\u003eauthentication authorization\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erouter\u003c/value\u003e\n\u003cvariants\u003eroute routing\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econfig\u003c/value\u003e\n\u003cvariants\u003econfiguration\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keywor","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eauth\u003c/value\u003e\n\u003cvariants\u003eauthentication authorization\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erouter\u003c/value\u003e\n\u003cvariants\u003eroute routing\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econfig\u003c/value\u003e\n\u003cvariants\u003econfiguration\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eauth\u003c/value\u003e\n\u003cvariants\u003eauthentication authorization\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erouter\u003c/value\u003e\n\u003cvariants\u003eroute routing\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econfig\u003c/value\u003e\n\u003cvariants\u003econfiguration\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eauth\u003c/value\u003e\n\u003cvariants\u003eauthentication authorization\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erouter\u003c/value\u003e\n\u003cvariants\u003eroute routing\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econfig\u003c/value\u003e\n\u003cvariants\u003econfiguration\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003c/keywords","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eauth\u003c/value\u003e\n\u003cvariants\u003eauthentication authorization\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erouter\u003c/value\u003e\n\u003cvariants\u003eroute routing\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econfig\u003c/value\u003e\n\u003cvariants\u003econfiguration\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003c/keywords\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eauth\u003c/value\u003e\n\u003cvariants\u003eauthentication authorization\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erouter\u003c/value\u003e\n\u003cvariants\u003eroute routing\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econfig\u003c/value\u003e\n\u003cvariants\u003econfiguration\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003c/keywords\u003e","stopReason":"end_turn"}
+            data: {"completion":"\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ezoekt\u003c/value\u003e\n\u003cvariants\u003esearch search_engine searcher\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ecache\u003c/value\u003e\n\u003cvariants\u003ecaching cached\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esync\u003c/value\u003e\n\u003cvariants\u003esynchronization mutex\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etest\u003c/value\u003e\n\u003cvariants\u003etesting\u003c/variants\u003e\n\u003cweight\u003e0.6\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003c/keywords\u003e","stopReason":"end_turn"}
 
 
             event: done
@@ -2333,7 +291,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Tue, 28 May 2024 16:10:31 GMT
+            value: Fri, 07 Jun 2024 23:18:02 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
@@ -2362,7 +320,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-05-28T16:10:30.444Z
+      startedDateTime: 2024-06-07T23:18:02.104Z
       time: 0
       timings:
         blocked: -1
@@ -2372,1427 +330,7 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: 8698a7ebbaef377e08e84681d791cb0b
-      _order: 0
-      cache: {}
-      request:
-        bodySize: 886
-        cookies: []
-        headers:
-          - name: content-type
-            value: application/json
-          - name: accept-encoding
-            value: gzip;q=0
-          - name: authorization
-            value: token
-              REDACTED_d5e0f0a37c9821e856b923fe14e67a605e3f6c0a517d5a4f46a4e35943ee0f6d
-          - name: connection
-            value: keep-alive
-          - name: host
-            value: sourcegraph.com
-        headersSize: 255
-        httpVersion: HTTP/1.1
-        method: POST
-        postData:
-          mimeType: application/json
-          params: []
-          textJSON:
-            fast: true
-            maxTokensToSample: 400
-            messages:
-              - speaker: human
-                text: You are Cody, an AI coding assistant from Sourcegraph.
-              - speaker: assistant
-                text: I am Cody, an AI coding assistant from Sourcegraph.
-              - speaker: human
-                text: "You are helping the user search over a codebase. List some filename
-                  fragments that would match files relevant to read to answer
-                  the user's query. Present your results in an XML list in the
-                  following format: <keywords><keyword><value>a single
-                  keyword</value><variants>a space separated list of synonyms
-                  and variants of the keyword, including acronyms,
-                  abbreviations, and expansions</variants><weight>a numerical
-                  weight between 0.0 and 1.0 that indicates the importance of
-                  the keyword</weight></keyword></keywords>. Here is the user
-                  query: <userQuery>parse file with tree-sitter</userQuery>"
-              - speaker: assistant
-            temperature: 0
-            topK: 1
-        queryString: []
-        url: https://sourcegraph.com/.api/completions/stream
-      response:
-        bodySize: 47392
-        content:
-          mimeType: text/event-stream
-          size: 47392
-          text: >+
-            event: completion
-
-            data: {"completion":"Here","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for base","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeywor","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etree","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etree-","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etree-s","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etree-sitter","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etree-sitter\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etree-sitter\u003c/value","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etree-sitter\u003c/value\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etree-sitter\u003c/value\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etree-sitter\u003c/value\u003e\n\u003cvariants","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etree-sitter\u003c/value\u003e\n\u003cvariants\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etree-sitter\u003c/value\u003e\n\u003cvariants\u003etree","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etree-sitter\u003c/value\u003e\n\u003cvariants\u003etree s","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etree-sitter\u003c/value\u003e\n\u003cvariants\u003etree sitter","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etree-sitter\u003c/value\u003e\n\u003cvariants\u003etree sitter tre","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etree-sitter\u003c/value\u003e\n\u003cvariants\u003etree sitter trees","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etree-sitter\u003c/value\u003e\n\u003cvariants\u003etree sitter treesitter","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etree-sitter\u003c/value\u003e\n\u003cvariants\u003etree sitter treesitter\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etree-sitter\u003c/value\u003e\n\u003cvariants\u003etree sitter treesitter\u003c/variants","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etree-sitter\u003c/value\u003e\n\u003cvariants\u003etree sitter treesitter\u003c/variants\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etree-sitter\u003c/value\u003e\n\u003cvariants\u003etree sitter treesitter\u003c/variants\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etree-sitter\u003c/value\u003e\n\u003cvariants\u003etree sitter treesitter\u003c/variants\u003e\n\u003cweight","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etree-sitter\u003c/value\u003e\n\u003cvariants\u003etree sitter treesitter\u003c/variants\u003e\n\u003cweight\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etree-sitter\u003c/value\u003e\n\u003cvariants\u003etree sitter treesitter\u003c/variants\u003e\n\u003cweight\u003e0","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etree-sitter\u003c/value\u003e\n\u003cvariants\u003etree sitter treesitter\u003c/variants\u003e\n\u003cweight\u003e0.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etree-sitter\u003c/value\u003e\n\u003cvariants\u003etree sitter treesitter\u003c/variants\u003e\n\u003cweight\u003e0.9","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etree-sitter\u003c/value\u003e\n\u003cvariants\u003etree sitter treesitter\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etree-sitter\u003c/value\u003e\n\u003cvariants\u003etree sitter treesitter\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etree-sitter\u003c/value\u003e\n\u003cvariants\u003etree sitter treesitter\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etree-sitter\u003c/value\u003e\n\u003cvariants\u003etree sitter treesitter\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etree-sitter\u003c/value\u003e\n\u003cvariants\u003etree sitter treesitter\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keywor","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etree-sitter\u003c/value\u003e\n\u003cvariants\u003etree sitter treesitter\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etree-sitter\u003c/value\u003e\n\u003cvariants\u003etree sitter treesitter\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etree-sitter\u003c/value\u003e\n\u003cvariants\u003etree sitter treesitter\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeywor","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etree-sitter\u003c/value\u003e\n\u003cvariants\u003etree sitter treesitter\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etree-sitter\u003c/value\u003e\n\u003cvariants\u003etree sitter treesitter\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etree-sitter\u003c/value\u003e\n\u003cvariants\u003etree sitter treesitter\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etree-sitter\u003c/value\u003e\n\u003cvariants\u003etree sitter treesitter\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etree-sitter\u003c/value\u003e\n\u003cvariants\u003etree sitter treesitter\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eparser","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etree-sitter\u003c/value\u003e\n\u003cvariants\u003etree sitter treesitter\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eparser\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etree-sitter\u003c/value\u003e\n\u003cvariants\u003etree sitter treesitter\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eparser\u003c/value","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etree-sitter\u003c/value\u003e\n\u003cvariants\u003etree sitter treesitter\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eparser\u003c/value\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etree-sitter\u003c/value\u003e\n\u003cvariants\u003etree sitter treesitter\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eparser\u003c/value\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etree-sitter\u003c/value\u003e\n\u003cvariants\u003etree sitter treesitter\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eparser\u003c/value\u003e\n\u003cvariants","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etree-sitter\u003c/value\u003e\n\u003cvariants\u003etree sitter treesitter\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eparser\u003c/value\u003e\n\u003cvariants\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etree-sitter\u003c/value\u003e\n\u003cvariants\u003etree sitter treesitter\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eparser\u003c/value\u003e\n\u003cvariants\u003eparse","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etree-sitter\u003c/value\u003e\n\u003cvariants\u003etree sitter treesitter\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eparser\u003c/value\u003e\n\u003cvariants\u003eparse parsing","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etree-sitter\u003c/value\u003e\n\u003cvariants\u003etree sitter treesitter\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eparser\u003c/value\u003e\n\u003cvariants\u003eparse parsing\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etree-sitter\u003c/value\u003e\n\u003cvariants\u003etree sitter treesitter\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eparser\u003c/value\u003e\n\u003cvariants\u003eparse parsing\u003c/variants","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etree-sitter\u003c/value\u003e\n\u003cvariants\u003etree sitter treesitter\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eparser\u003c/value\u003e\n\u003cvariants\u003eparse parsing\u003c/variants\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etree-sitter\u003c/value\u003e\n\u003cvariants\u003etree sitter treesitter\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eparser\u003c/value\u003e\n\u003cvariants\u003eparse parsing\u003c/variants\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etree-sitter\u003c/value\u003e\n\u003cvariants\u003etree sitter treesitter\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eparser\u003c/value\u003e\n\u003cvariants\u003eparse parsing\u003c/variants\u003e\n\u003cweight","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etree-sitter\u003c/value\u003e\n\u003cvariants\u003etree sitter treesitter\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eparser\u003c/value\u003e\n\u003cvariants\u003eparse parsing\u003c/variants\u003e\n\u003cweight\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etree-sitter\u003c/value\u003e\n\u003cvariants\u003etree sitter treesitter\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eparser\u003c/value\u003e\n\u003cvariants\u003eparse parsing\u003c/variants\u003e\n\u003cweight\u003e0","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etree-sitter\u003c/value\u003e\n\u003cvariants\u003etree sitter treesitter\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eparser\u003c/value\u003e\n\u003cvariants\u003eparse parsing\u003c/variants\u003e\n\u003cweight\u003e0.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etree-sitter\u003c/value\u003e\n\u003cvariants\u003etree sitter treesitter\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eparser\u003c/value\u003e\n\u003cvariants\u003eparse parsing\u003c/variants\u003e\n\u003cweight\u003e0.8","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etree-sitter\u003c/value\u003e\n\u003cvariants\u003etree sitter treesitter\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eparser\u003c/value\u003e\n\u003cvariants\u003eparse parsing\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etree-sitter\u003c/value\u003e\n\u003cvariants\u003etree sitter treesitter\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eparser\u003c/value\u003e\n\u003cvariants\u003eparse parsing\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etree-sitter\u003c/value\u003e\n\u003cvariants\u003etree sitter treesitter\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eparser\u003c/value\u003e\n\u003cvariants\u003eparse parsing\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etree-sitter\u003c/value\u003e\n\u003cvariants\u003etree sitter treesitter\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eparser\u003c/value\u003e\n\u003cvariants\u003eparse parsing\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etree-sitter\u003c/value\u003e\n\u003cvariants\u003etree sitter treesitter\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eparser\u003c/value\u003e\n\u003cvariants\u003eparse parsing\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keywor","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etree-sitter\u003c/value\u003e\n\u003cvariants\u003etree sitter treesitter\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eparser\u003c/value\u003e\n\u003cvariants\u003eparse parsing\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etree-sitter\u003c/value\u003e\n\u003cvariants\u003etree sitter treesitter\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eparser\u003c/value\u003e\n\u003cvariants\u003eparse parsing\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etree-sitter\u003c/value\u003e\n\u003cvariants\u003etree sitter treesitter\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eparser\u003c/value\u003e\n\u003cvariants\u003eparse parsing\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeywor","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etree-sitter\u003c/value\u003e\n\u003cvariants\u003etree sitter treesitter\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eparser\u003c/value\u003e\n\u003cvariants\u003eparse parsing\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etree-sitter\u003c/value\u003e\n\u003cvariants\u003etree sitter treesitter\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eparser\u003c/value\u003e\n\u003cvariants\u003eparse parsing\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etree-sitter\u003c/value\u003e\n\u003cvariants\u003etree sitter treesitter\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eparser\u003c/value\u003e\n\u003cvariants\u003eparse parsing\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etree-sitter\u003c/value\u003e\n\u003cvariants\u003etree sitter treesitter\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eparser\u003c/value\u003e\n\u003cvariants\u003eparse parsing\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etree-sitter\u003c/value\u003e\n\u003cvariants\u003etree sitter treesitter\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eparser\u003c/value\u003e\n\u003cvariants\u003eparse parsing\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efile","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etree-sitter\u003c/value\u003e\n\u003cvariants\u003etree sitter treesitter\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eparser\u003c/value\u003e\n\u003cvariants\u003eparse parsing\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efile\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etree-sitter\u003c/value\u003e\n\u003cvariants\u003etree sitter treesitter\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eparser\u003c/value\u003e\n\u003cvariants\u003eparse parsing\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efile\u003c/value","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etree-sitter\u003c/value\u003e\n\u003cvariants\u003etree sitter treesitter\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eparser\u003c/value\u003e\n\u003cvariants\u003eparse parsing\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efile\u003c/value\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etree-sitter\u003c/value\u003e\n\u003cvariants\u003etree sitter treesitter\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eparser\u003c/value\u003e\n\u003cvariants\u003eparse parsing\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efile\u003c/value\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etree-sitter\u003c/value\u003e\n\u003cvariants\u003etree sitter treesitter\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eparser\u003c/value\u003e\n\u003cvariants\u003eparse parsing\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efile\u003c/value\u003e\n\u003cvariants","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etree-sitter\u003c/value\u003e\n\u003cvariants\u003etree sitter treesitter\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eparser\u003c/value\u003e\n\u003cvariants\u003eparse parsing\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efile\u003c/value\u003e\n\u003cvariants\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etree-sitter\u003c/value\u003e\n\u003cvariants\u003etree sitter treesitter\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eparser\u003c/value\u003e\n\u003cvariants\u003eparse parsing\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efile\u003c/value\u003e\n\u003cvariants\u003efiles","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etree-sitter\u003c/value\u003e\n\u003cvariants\u003etree sitter treesitter\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eparser\u003c/value\u003e\n\u003cvariants\u003eparse parsing\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efile\u003c/value\u003e\n\u003cvariants\u003efiles\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etree-sitter\u003c/value\u003e\n\u003cvariants\u003etree sitter treesitter\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eparser\u003c/value\u003e\n\u003cvariants\u003eparse parsing\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efile\u003c/value\u003e\n\u003cvariants\u003efiles\u003c/variants","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etree-sitter\u003c/value\u003e\n\u003cvariants\u003etree sitter treesitter\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eparser\u003c/value\u003e\n\u003cvariants\u003eparse parsing\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efile\u003c/value\u003e\n\u003cvariants\u003efiles\u003c/variants\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etree-sitter\u003c/value\u003e\n\u003cvariants\u003etree sitter treesitter\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eparser\u003c/value\u003e\n\u003cvariants\u003eparse parsing\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efile\u003c/value\u003e\n\u003cvariants\u003efiles\u003c/variants\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etree-sitter\u003c/value\u003e\n\u003cvariants\u003etree sitter treesitter\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eparser\u003c/value\u003e\n\u003cvariants\u003eparse parsing\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efile\u003c/value\u003e\n\u003cvariants\u003efiles\u003c/variants\u003e\n\u003cweight","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etree-sitter\u003c/value\u003e\n\u003cvariants\u003etree sitter treesitter\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eparser\u003c/value\u003e\n\u003cvariants\u003eparse parsing\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efile\u003c/value\u003e\n\u003cvariants\u003efiles\u003c/variants\u003e\n\u003cweight\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etree-sitter\u003c/value\u003e\n\u003cvariants\u003etree sitter treesitter\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eparser\u003c/value\u003e\n\u003cvariants\u003eparse parsing\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efile\u003c/value\u003e\n\u003cvariants\u003efiles\u003c/variants\u003e\n\u003cweight\u003e0","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etree-sitter\u003c/value\u003e\n\u003cvariants\u003etree sitter treesitter\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eparser\u003c/value\u003e\n\u003cvariants\u003eparse parsing\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efile\u003c/value\u003e\n\u003cvariants\u003efiles\u003c/variants\u003e\n\u003cweight\u003e0.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etree-sitter\u003c/value\u003e\n\u003cvariants\u003etree sitter treesitter\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eparser\u003c/value\u003e\n\u003cvariants\u003eparse parsing\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efile\u003c/value\u003e\n\u003cvariants\u003efiles\u003c/variants\u003e\n\u003cweight\u003e0.7","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etree-sitter\u003c/value\u003e\n\u003cvariants\u003etree sitter treesitter\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eparser\u003c/value\u003e\n\u003cvariants\u003eparse parsing\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efile\u003c/value\u003e\n\u003cvariants\u003efiles\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etree-sitter\u003c/value\u003e\n\u003cvariants\u003etree sitter treesitter\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eparser\u003c/value\u003e\n\u003cvariants\u003eparse parsing\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efile\u003c/value\u003e\n\u003cvariants\u003efiles\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etree-sitter\u003c/value\u003e\n\u003cvariants\u003etree sitter treesitter\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eparser\u003c/value\u003e\n\u003cvariants\u003eparse parsing\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efile\u003c/value\u003e\n\u003cvariants\u003efiles\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etree-sitter\u003c/value\u003e\n\u003cvariants\u003etree sitter treesitter\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eparser\u003c/value\u003e\n\u003cvariants\u003eparse parsing\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efile\u003c/value\u003e\n\u003cvariants\u003efiles\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etree-sitter\u003c/value\u003e\n\u003cvariants\u003etree sitter treesitter\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eparser\u003c/value\u003e\n\u003cvariants\u003eparse parsing\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efile\u003c/value\u003e\n\u003cvariants\u003efiles\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keywor","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etree-sitter\u003c/value\u003e\n\u003cvariants\u003etree sitter treesitter\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eparser\u003c/value\u003e\n\u003cvariants\u003eparse parsing\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efile\u003c/value\u003e\n\u003cvariants\u003efiles\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etree-sitter\u003c/value\u003e\n\u003cvariants\u003etree sitter treesitter\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eparser\u003c/value\u003e\n\u003cvariants\u003eparse parsing\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efile\u003c/value\u003e\n\u003cvariants\u003efiles\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etree-sitter\u003c/value\u003e\n\u003cvariants\u003etree sitter treesitter\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eparser\u003c/value\u003e\n\u003cvariants\u003eparse parsing\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efile\u003c/value\u003e\n\u003cvariants\u003efiles\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003c/keywords","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etree-sitter\u003c/value\u003e\n\u003cvariants\u003etree sitter treesitter\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eparser\u003c/value\u003e\n\u003cvariants\u003eparse parsing\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efile\u003c/value\u003e\n\u003cvariants\u003efiles\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003c/keywords\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etree-sitter\u003c/value\u003e\n\u003cvariants\u003etree sitter treesitter\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eparser\u003c/value\u003e\n\u003cvariants\u003eparse parsing\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efile\u003c/value\u003e\n\u003cvariants\u003efiles\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003c/keywords\u003e","stopReason":"end_turn"}
-
-
-            event: done
-
-            data: {}
-
-        cookies: []
-        headers:
-          - name: date
-            value: Tue, 28 May 2024 16:10:32 GMT
-          - name: content-type
-            value: text/event-stream
-          - name: transfer-encoding
-            value: chunked
-          - name: connection
-            value: keep-alive
-          - name: access-control-allow-credentials
-            value: "true"
-          - name: access-control-allow-origin
-            value: ""
-          - name: cache-control
-            value: no-cache
-          - name: vary
-            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
-              X-Requested-With,Cookie
-          - name: x-content-type-options
-            value: nosniff
-          - name: x-frame-options
-            value: DENY
-          - name: x-xss-protection
-            value: 1; mode=block
-          - name: strict-transport-security
-            value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1284
-        httpVersion: HTTP/1.1
-        redirectURL: ""
-        status: 200
-        statusText: OK
-      startedDateTime: 2024-05-28T16:10:32.013Z
-      time: 0
-      timings:
-        blocked: -1
-        connect: -1
-        dns: -1
-        receive: 0
-        send: 0
-        ssl: -1
-        wait: 0
-    - _id: b9623b3f6fda6c3192e66f9f07cf76ff
-      _order: 0
-      cache: {}
-      request:
-        bodySize: 877
-        cookies: []
-        headers:
-          - name: content-type
-            value: application/json
-          - name: accept-encoding
-            value: gzip;q=0
-          - name: authorization
-            value: token
-              REDACTED_d5e0f0a37c9821e856b923fe14e67a605e3f6c0a517d5a4f46a4e35943ee0f6d
-          - name: connection
-            value: keep-alive
-          - name: host
-            value: sourcegraph.com
-        headersSize: 255
-        httpVersion: HTTP/1.1
-        method: POST
-        postData:
-          mimeType: application/json
-          params: []
-          textJSON:
-            fast: true
-            maxTokensToSample: 400
-            messages:
-              - speaker: human
-                text: You are Cody, an AI coding assistant from Sourcegraph.
-              - speaker: assistant
-                text: I am Cody, an AI coding assistant from Sourcegraph.
-              - speaker: human
-                text: "You are helping the user search over a codebase. List some filename
-                  fragments that would match files relevant to read to answer
-                  the user's query. Present your results in an XML list in the
-                  following format: <keywords><keyword><value>a single
-                  keyword</value><variants>a space separated list of synonyms
-                  and variants of the keyword, including acronyms,
-                  abbreviations, and expansions</variants><weight>a numerical
-                  weight between 0.0 and 1.0 that indicates the importance of
-                  the keyword</weight></keyword></keywords>. Here is the user
-                  query: <userQuery>scan tokens in C++</userQuery>"
-              - speaker: assistant
-            temperature: 0
-            topK: 1
-        queryString: []
-        url: https://sourcegraph.com/.api/completions/stream
-      response:
-        bodySize: 52025
-        content:
-          mimeType: text/event-stream
-          size: 52025
-          text: >+
-            event: completion
-
-            data: {"completion":"Here","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that woul","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeywor","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etoken","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etoken\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etoken\u003c/value","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etoken\u003c/value\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etoken\u003c/value\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etoken\u003c/value\u003e\n\u003cvariants","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etoken\u003c/value\u003e\n\u003cvariants\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etoken\u003c/value\u003e\n\u003cvariants\u003elex","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etoken\u003c/value\u003e\n\u003cvariants\u003elexer","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etoken\u003c/value\u003e\n\u003cvariants\u003elexer lex","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etoken\u003c/value\u003e\n\u003cvariants\u003elexer lexical","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etoken\u003c/value\u003e\n\u003cvariants\u003elexer lexical scanner","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etoken\u003c/value\u003e\n\u003cvariants\u003elexer lexical scanner token","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etoken\u003c/value\u003e\n\u003cvariants\u003elexer lexical scanner tokenizer","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etoken\u003c/value\u003e\n\u003cvariants\u003elexer lexical scanner tokenizer\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etoken\u003c/value\u003e\n\u003cvariants\u003elexer lexical scanner tokenizer\u003c/variants","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etoken\u003c/value\u003e\n\u003cvariants\u003elexer lexical scanner tokenizer\u003c/variants\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etoken\u003c/value\u003e\n\u003cvariants\u003elexer lexical scanner tokenizer\u003c/variants\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etoken\u003c/value\u003e\n\u003cvariants\u003elexer lexical scanner tokenizer\u003c/variants\u003e\n\u003cweight","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etoken\u003c/value\u003e\n\u003cvariants\u003elexer lexical scanner tokenizer\u003c/variants\u003e\n\u003cweight\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etoken\u003c/value\u003e\n\u003cvariants\u003elexer lexical scanner tokenizer\u003c/variants\u003e\n\u003cweight\u003e0","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etoken\u003c/value\u003e\n\u003cvariants\u003elexer lexical scanner tokenizer\u003c/variants\u003e\n\u003cweight\u003e0.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etoken\u003c/value\u003e\n\u003cvariants\u003elexer lexical scanner tokenizer\u003c/variants\u003e\n\u003cweight\u003e0.9","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etoken\u003c/value\u003e\n\u003cvariants\u003elexer lexical scanner tokenizer\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etoken\u003c/value\u003e\n\u003cvariants\u003elexer lexical scanner tokenizer\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etoken\u003c/value\u003e\n\u003cvariants\u003elexer lexical scanner tokenizer\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etoken\u003c/value\u003e\n\u003cvariants\u003elexer lexical scanner tokenizer\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etoken\u003c/value\u003e\n\u003cvariants\u003elexer lexical scanner tokenizer\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keywor","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etoken\u003c/value\u003e\n\u003cvariants\u003elexer lexical scanner tokenizer\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etoken\u003c/value\u003e\n\u003cvariants\u003elexer lexical scanner tokenizer\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etoken\u003c/value\u003e\n\u003cvariants\u003elexer lexical scanner tokenizer\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeywor","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etoken\u003c/value\u003e\n\u003cvariants\u003elexer lexical scanner tokenizer\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etoken\u003c/value\u003e\n\u003cvariants\u003elexer lexical scanner tokenizer\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etoken\u003c/value\u003e\n\u003cvariants\u003elexer lexical scanner tokenizer\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etoken\u003c/value\u003e\n\u003cvariants\u003elexer lexical scanner tokenizer\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etoken\u003c/value\u003e\n\u003cvariants\u003elexer lexical scanner tokenizer\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ecpp","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etoken\u003c/value\u003e\n\u003cvariants\u003elexer lexical scanner tokenizer\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ecpp\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etoken\u003c/value\u003e\n\u003cvariants\u003elexer lexical scanner tokenizer\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ecpp\u003c/value","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etoken\u003c/value\u003e\n\u003cvariants\u003elexer lexical scanner tokenizer\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ecpp\u003c/value\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etoken\u003c/value\u003e\n\u003cvariants\u003elexer lexical scanner tokenizer\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ecpp\u003c/value\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etoken\u003c/value\u003e\n\u003cvariants\u003elexer lexical scanner tokenizer\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ecpp\u003c/value\u003e\n\u003cvariants","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etoken\u003c/value\u003e\n\u003cvariants\u003elexer lexical scanner tokenizer\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ecpp\u003c/value\u003e\n\u003cvariants\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etoken\u003c/value\u003e\n\u003cvariants\u003elexer lexical scanner tokenizer\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ecpp\u003c/value\u003e\n\u003cvariants\u003ec","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etoken\u003c/value\u003e\n\u003cvariants\u003elexer lexical scanner tokenizer\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ecpp\u003c/value\u003e\n\u003cvariants\u003ec++","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etoken\u003c/value\u003e\n\u003cvariants\u003elexer lexical scanner tokenizer\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ecpp\u003c/value\u003e\n\u003cvariants\u003ec++ c","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etoken\u003c/value\u003e\n\u003cvariants\u003elexer lexical scanner tokenizer\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ecpp\u003c/value\u003e\n\u003cvariants\u003ec++ cxx","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etoken\u003c/value\u003e\n\u003cvariants\u003elexer lexical scanner tokenizer\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ecpp\u003c/value\u003e\n\u003cvariants\u003ec++ cxx cp","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etoken\u003c/value\u003e\n\u003cvariants\u003elexer lexical scanner tokenizer\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ecpp\u003c/value\u003e\n\u003cvariants\u003ec++ cxx cplus","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etoken\u003c/value\u003e\n\u003cvariants\u003elexer lexical scanner tokenizer\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ecpp\u003c/value\u003e\n\u003cvariants\u003ec++ cxx cplusplus","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etoken\u003c/value\u003e\n\u003cvariants\u003elexer lexical scanner tokenizer\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ecpp\u003c/value\u003e\n\u003cvariants\u003ec++ cxx cplusplus\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etoken\u003c/value\u003e\n\u003cvariants\u003elexer lexical scanner tokenizer\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ecpp\u003c/value\u003e\n\u003cvariants\u003ec++ cxx cplusplus\u003c/variants","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etoken\u003c/value\u003e\n\u003cvariants\u003elexer lexical scanner tokenizer\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ecpp\u003c/value\u003e\n\u003cvariants\u003ec++ cxx cplusplus\u003c/variants\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etoken\u003c/value\u003e\n\u003cvariants\u003elexer lexical scanner tokenizer\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ecpp\u003c/value\u003e\n\u003cvariants\u003ec++ cxx cplusplus\u003c/variants\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etoken\u003c/value\u003e\n\u003cvariants\u003elexer lexical scanner tokenizer\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ecpp\u003c/value\u003e\n\u003cvariants\u003ec++ cxx cplusplus\u003c/variants\u003e\n\u003cweight","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etoken\u003c/value\u003e\n\u003cvariants\u003elexer lexical scanner tokenizer\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ecpp\u003c/value\u003e\n\u003cvariants\u003ec++ cxx cplusplus\u003c/variants\u003e\n\u003cweight\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etoken\u003c/value\u003e\n\u003cvariants\u003elexer lexical scanner tokenizer\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ecpp\u003c/value\u003e\n\u003cvariants\u003ec++ cxx cplusplus\u003c/variants\u003e\n\u003cweight\u003e0","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etoken\u003c/value\u003e\n\u003cvariants\u003elexer lexical scanner tokenizer\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ecpp\u003c/value\u003e\n\u003cvariants\u003ec++ cxx cplusplus\u003c/variants\u003e\n\u003cweight\u003e0.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etoken\u003c/value\u003e\n\u003cvariants\u003elexer lexical scanner tokenizer\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ecpp\u003c/value\u003e\n\u003cvariants\u003ec++ cxx cplusplus\u003c/variants\u003e\n\u003cweight\u003e0.8","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etoken\u003c/value\u003e\n\u003cvariants\u003elexer lexical scanner tokenizer\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ecpp\u003c/value\u003e\n\u003cvariants\u003ec++ cxx cplusplus\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etoken\u003c/value\u003e\n\u003cvariants\u003elexer lexical scanner tokenizer\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ecpp\u003c/value\u003e\n\u003cvariants\u003ec++ cxx cplusplus\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etoken\u003c/value\u003e\n\u003cvariants\u003elexer lexical scanner tokenizer\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ecpp\u003c/value\u003e\n\u003cvariants\u003ec++ cxx cplusplus\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etoken\u003c/value\u003e\n\u003cvariants\u003elexer lexical scanner tokenizer\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ecpp\u003c/value\u003e\n\u003cvariants\u003ec++ cxx cplusplus\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etoken\u003c/value\u003e\n\u003cvariants\u003elexer lexical scanner tokenizer\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ecpp\u003c/value\u003e\n\u003cvariants\u003ec++ cxx cplusplus\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keywor","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etoken\u003c/value\u003e\n\u003cvariants\u003elexer lexical scanner tokenizer\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ecpp\u003c/value\u003e\n\u003cvariants\u003ec++ cxx cplusplus\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etoken\u003c/value\u003e\n\u003cvariants\u003elexer lexical scanner tokenizer\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ecpp\u003c/value\u003e\n\u003cvariants\u003ec++ cxx cplusplus\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etoken\u003c/value\u003e\n\u003cvariants\u003elexer lexical scanner tokenizer\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ecpp\u003c/value\u003e\n\u003cvariants\u003ec++ cxx cplusplus\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeywor","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etoken\u003c/value\u003e\n\u003cvariants\u003elexer lexical scanner tokenizer\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ecpp\u003c/value\u003e\n\u003cvariants\u003ec++ cxx cplusplus\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etoken\u003c/value\u003e\n\u003cvariants\u003elexer lexical scanner tokenizer\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ecpp\u003c/value\u003e\n\u003cvariants\u003ec++ cxx cplusplus\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etoken\u003c/value\u003e\n\u003cvariants\u003elexer lexical scanner tokenizer\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ecpp\u003c/value\u003e\n\u003cvariants\u003ec++ cxx cplusplus\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etoken\u003c/value\u003e\n\u003cvariants\u003elexer lexical scanner tokenizer\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ecpp\u003c/value\u003e\n\u003cvariants\u003ec++ cxx cplusplus\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etoken\u003c/value\u003e\n\u003cvariants\u003elexer lexical scanner tokenizer\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ecpp\u003c/value\u003e\n\u003cvariants\u003ec++ cxx cplusplus\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003escan","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etoken\u003c/value\u003e\n\u003cvariants\u003elexer lexical scanner tokenizer\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ecpp\u003c/value\u003e\n\u003cvariants\u003ec++ cxx cplusplus\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003escan\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etoken\u003c/value\u003e\n\u003cvariants\u003elexer lexical scanner tokenizer\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ecpp\u003c/value\u003e\n\u003cvariants\u003ec++ cxx cplusplus\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003escan\u003c/value","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etoken\u003c/value\u003e\n\u003cvariants\u003elexer lexical scanner tokenizer\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ecpp\u003c/value\u003e\n\u003cvariants\u003ec++ cxx cplusplus\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003escan\u003c/value\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etoken\u003c/value\u003e\n\u003cvariants\u003elexer lexical scanner tokenizer\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ecpp\u003c/value\u003e\n\u003cvariants\u003ec++ cxx cplusplus\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003escan\u003c/value\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etoken\u003c/value\u003e\n\u003cvariants\u003elexer lexical scanner tokenizer\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ecpp\u003c/value\u003e\n\u003cvariants\u003ec++ cxx cplusplus\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003escan\u003c/value\u003e\n\u003cvariants","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etoken\u003c/value\u003e\n\u003cvariants\u003elexer lexical scanner tokenizer\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ecpp\u003c/value\u003e\n\u003cvariants\u003ec++ cxx cplusplus\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003escan\u003c/value\u003e\n\u003cvariants\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etoken\u003c/value\u003e\n\u003cvariants\u003elexer lexical scanner tokenizer\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ecpp\u003c/value\u003e\n\u003cvariants\u003ec++ cxx cplusplus\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003escan\u003c/value\u003e\n\u003cvariants\u003eparse","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etoken\u003c/value\u003e\n\u003cvariants\u003elexer lexical scanner tokenizer\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ecpp\u003c/value\u003e\n\u003cvariants\u003ec++ cxx cplusplus\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003escan\u003c/value\u003e\n\u003cvariants\u003eparse analyze","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etoken\u003c/value\u003e\n\u003cvariants\u003elexer lexical scanner tokenizer\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ecpp\u003c/value\u003e\n\u003cvariants\u003ec++ cxx cplusplus\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003escan\u003c/value\u003e\n\u003cvariants\u003eparse analyze ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etoken\u003c/value\u003e\n\u003cvariants\u003elexer lexical scanner tokenizer\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ecpp\u003c/value\u003e\n\u003cvariants\u003ec++ cxx cplusplus\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003escan\u003c/value\u003e\n\u003cvariants\u003eparse analyze lex","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etoken\u003c/value\u003e\n\u003cvariants\u003elexer lexical scanner tokenizer\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ecpp\u003c/value\u003e\n\u003cvariants\u003ec++ cxx cplusplus\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003escan\u003c/value\u003e\n\u003cvariants\u003eparse analyze lex\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etoken\u003c/value\u003e\n\u003cvariants\u003elexer lexical scanner tokenizer\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ecpp\u003c/value\u003e\n\u003cvariants\u003ec++ cxx cplusplus\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003escan\u003c/value\u003e\n\u003cvariants\u003eparse analyze lex\u003c/variants","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etoken\u003c/value\u003e\n\u003cvariants\u003elexer lexical scanner tokenizer\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ecpp\u003c/value\u003e\n\u003cvariants\u003ec++ cxx cplusplus\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003escan\u003c/value\u003e\n\u003cvariants\u003eparse analyze lex\u003c/variants\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etoken\u003c/value\u003e\n\u003cvariants\u003elexer lexical scanner tokenizer\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ecpp\u003c/value\u003e\n\u003cvariants\u003ec++ cxx cplusplus\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003escan\u003c/value\u003e\n\u003cvariants\u003eparse analyze lex\u003c/variants\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etoken\u003c/value\u003e\n\u003cvariants\u003elexer lexical scanner tokenizer\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ecpp\u003c/value\u003e\n\u003cvariants\u003ec++ cxx cplusplus\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003escan\u003c/value\u003e\n\u003cvariants\u003eparse analyze lex\u003c/variants\u003e\n\u003cweight","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etoken\u003c/value\u003e\n\u003cvariants\u003elexer lexical scanner tokenizer\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ecpp\u003c/value\u003e\n\u003cvariants\u003ec++ cxx cplusplus\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003escan\u003c/value\u003e\n\u003cvariants\u003eparse analyze lex\u003c/variants\u003e\n\u003cweight\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etoken\u003c/value\u003e\n\u003cvariants\u003elexer lexical scanner tokenizer\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ecpp\u003c/value\u003e\n\u003cvariants\u003ec++ cxx cplusplus\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003escan\u003c/value\u003e\n\u003cvariants\u003eparse analyze lex\u003c/variants\u003e\n\u003cweight\u003e0","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etoken\u003c/value\u003e\n\u003cvariants\u003elexer lexical scanner tokenizer\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ecpp\u003c/value\u003e\n\u003cvariants\u003ec++ cxx cplusplus\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003escan\u003c/value\u003e\n\u003cvariants\u003eparse analyze lex\u003c/variants\u003e\n\u003cweight\u003e0.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etoken\u003c/value\u003e\n\u003cvariants\u003elexer lexical scanner tokenizer\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ecpp\u003c/value\u003e\n\u003cvariants\u003ec++ cxx cplusplus\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003escan\u003c/value\u003e\n\u003cvariants\u003eparse analyze lex\u003c/variants\u003e\n\u003cweight\u003e0.7","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etoken\u003c/value\u003e\n\u003cvariants\u003elexer lexical scanner tokenizer\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ecpp\u003c/value\u003e\n\u003cvariants\u003ec++ cxx cplusplus\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003escan\u003c/value\u003e\n\u003cvariants\u003eparse analyze lex\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etoken\u003c/value\u003e\n\u003cvariants\u003elexer lexical scanner tokenizer\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ecpp\u003c/value\u003e\n\u003cvariants\u003ec++ cxx cplusplus\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003escan\u003c/value\u003e\n\u003cvariants\u003eparse analyze lex\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etoken\u003c/value\u003e\n\u003cvariants\u003elexer lexical scanner tokenizer\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ecpp\u003c/value\u003e\n\u003cvariants\u003ec++ cxx cplusplus\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003escan\u003c/value\u003e\n\u003cvariants\u003eparse analyze lex\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etoken\u003c/value\u003e\n\u003cvariants\u003elexer lexical scanner tokenizer\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ecpp\u003c/value\u003e\n\u003cvariants\u003ec++ cxx cplusplus\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003escan\u003c/value\u003e\n\u003cvariants\u003eparse analyze lex\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etoken\u003c/value\u003e\n\u003cvariants\u003elexer lexical scanner tokenizer\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ecpp\u003c/value\u003e\n\u003cvariants\u003ec++ cxx cplusplus\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003escan\u003c/value\u003e\n\u003cvariants\u003eparse analyze lex\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keywor","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etoken\u003c/value\u003e\n\u003cvariants\u003elexer lexical scanner tokenizer\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ecpp\u003c/value\u003e\n\u003cvariants\u003ec++ cxx cplusplus\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003escan\u003c/value\u003e\n\u003cvariants\u003eparse analyze lex\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etoken\u003c/value\u003e\n\u003cvariants\u003elexer lexical scanner tokenizer\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ecpp\u003c/value\u003e\n\u003cvariants\u003ec++ cxx cplusplus\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003escan\u003c/value\u003e\n\u003cvariants\u003eparse analyze lex\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etoken\u003c/value\u003e\n\u003cvariants\u003elexer lexical scanner tokenizer\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ecpp\u003c/value\u003e\n\u003cvariants\u003ec++ cxx cplusplus\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003escan\u003c/value\u003e\n\u003cvariants\u003eparse analyze lex\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003c/keywords","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etoken\u003c/value\u003e\n\u003cvariants\u003elexer lexical scanner tokenizer\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ecpp\u003c/value\u003e\n\u003cvariants\u003ec++ cxx cplusplus\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003escan\u003c/value\u003e\n\u003cvariants\u003eparse analyze lex\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003c/keywords\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etoken\u003c/value\u003e\n\u003cvariants\u003elexer lexical scanner tokenizer\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ecpp\u003c/value\u003e\n\u003cvariants\u003ec++ cxx cplusplus\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003escan\u003c/value\u003e\n\u003cvariants\u003eparse analyze lex\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003c/keywords\u003e","stopReason":"end_turn"}
-
-
-            event: done
-
-            data: {}
-
-        cookies: []
-        headers:
-          - name: date
-            value: Tue, 28 May 2024 16:10:34 GMT
-          - name: content-type
-            value: text/event-stream
-          - name: transfer-encoding
-            value: chunked
-          - name: connection
-            value: keep-alive
-          - name: access-control-allow-credentials
-            value: "true"
-          - name: access-control-allow-origin
-            value: ""
-          - name: cache-control
-            value: no-cache
-          - name: vary
-            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
-              X-Requested-With,Cookie
-          - name: x-content-type-options
-            value: nosniff
-          - name: x-frame-options
-            value: DENY
-          - name: x-xss-protection
-            value: 1; mode=block
-          - name: strict-transport-security
-            value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1284
-        httpVersion: HTTP/1.1
-        redirectURL: ""
-        status: 200
-        statusText: OK
-      startedDateTime: 2024-05-28T16:10:33.485Z
-      time: 0
-      timings:
-        blocked: -1
-        connect: -1
-        dns: -1
-        receive: 0
-        send: 0
-        ssl: -1
-        wait: 0
-    - _id: 6238718613e237a0677ac946f74fbed1
+    - _id: 93c6bbc6c0d2e4ccb700d4b9e494fb77
       _order: 0
       cache: {}
       request:
@@ -3827,784 +365,29 @@ log:
               - speaker: human
                 text: "You are helping the user search over a codebase. List some filename
                   fragments that would match files relevant to read to answer
-                  the user's query. Present your results in an XML list in the
-                  following format: <keywords><keyword><value>a single
+                  the user's query. Present your results in a *single* XML list
+                  in the following format: <keywords><keyword><value>a single
                   keyword</value><variants>a space separated list of synonyms
                   and variants of the keyword, including acronyms,
                   abbreviations, and expansions</variants><weight>a numerical
                   weight between 0.0 and 1.0 that indicates the importance of
                   the keyword</weight></keyword></keywords>. Here is the user
-                  query: <userQuery>C'est ou la logique pour recloner les
-                  dépôts?</userQuery>"
+                  query: <userQuery>Where is authentication router
+                  defined?</userQuery>"
               - speaker: assistant
             temperature: 0
             topK: 1
         queryString: []
         url: https://sourcegraph.com/.api/completions/stream
       response:
-        bodySize: 78283
+        bodySize: 41654
         content:
           mimeType: text/event-stream
-          size: 78283
+          size: 41654
           text: >+
             event: completion
 
-            data: {"completion":"Here","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for base","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeywor","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eclone","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eclone\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eclone\u003c/value","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eclone\u003c/value\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eclone\u003c/value\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eclone\u003c/value\u003e\n\u003cvariants","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eclone\u003c/value\u003e\n\u003cvariants\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eclone\u003c/value\u003e\n\u003cvariants\u003ecl","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eclone\u003c/value\u003e\n\u003cvariants\u003ecloning","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eclone\u003c/value\u003e\n\u003cvariants\u003ecloning clone","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eclone\u003c/value\u003e\n\u003cvariants\u003ecloning clone repo","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eclone\u003c/value\u003e\n\u003cvariants\u003ecloning clone repo repository","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eclone\u003c/value\u003e\n\u003cvariants\u003ecloning clone repo repository\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eclone\u003c/value\u003e\n\u003cvariants\u003ecloning clone repo repository\u003c/variants","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eclone\u003c/value\u003e\n\u003cvariants\u003ecloning clone repo repository\u003c/variants\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eclone\u003c/value\u003e\n\u003cvariants\u003ecloning clone repo repository\u003c/variants\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eclone\u003c/value\u003e\n\u003cvariants\u003ecloning clone repo repository\u003c/variants\u003e\n\u003cweight","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eclone\u003c/value\u003e\n\u003cvariants\u003ecloning clone repo repository\u003c/variants\u003e\n\u003cweight\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eclone\u003c/value\u003e\n\u003cvariants\u003ecloning clone repo repository\u003c/variants\u003e\n\u003cweight\u003e0","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eclone\u003c/value\u003e\n\u003cvariants\u003ecloning clone repo repository\u003c/variants\u003e\n\u003cweight\u003e0.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eclone\u003c/value\u003e\n\u003cvariants\u003ecloning clone repo repository\u003c/variants\u003e\n\u003cweight\u003e0.9","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eclone\u003c/value\u003e\n\u003cvariants\u003ecloning clone repo repository\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eclone\u003c/value\u003e\n\u003cvariants\u003ecloning clone repo repository\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eclone\u003c/value\u003e\n\u003cvariants\u003ecloning clone repo repository\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eclone\u003c/value\u003e\n\u003cvariants\u003ecloning clone repo repository\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eclone\u003c/value\u003e\n\u003cvariants\u003ecloning clone repo repository\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keywor","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eclone\u003c/value\u003e\n\u003cvariants\u003ecloning clone repo repository\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eclone\u003c/value\u003e\n\u003cvariants\u003ecloning clone repo repository\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eclone\u003c/value\u003e\n\u003cvariants\u003ecloning clone repo repository\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeywor","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eclone\u003c/value\u003e\n\u003cvariants\u003ecloning clone repo repository\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eclone\u003c/value\u003e\n\u003cvariants\u003ecloning clone repo repository\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eclone\u003c/value\u003e\n\u003cvariants\u003ecloning clone repo repository\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eclone\u003c/value\u003e\n\u003cvariants\u003ecloning clone repo repository\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eclone\u003c/value\u003e\n\u003cvariants\u003ecloning clone repo repository\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erepository","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eclone\u003c/value\u003e\n\u003cvariants\u003ecloning clone repo repository\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erepository\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eclone\u003c/value\u003e\n\u003cvariants\u003ecloning clone repo repository\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erepository\u003c/value","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eclone\u003c/value\u003e\n\u003cvariants\u003ecloning clone repo repository\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erepository\u003c/value\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eclone\u003c/value\u003e\n\u003cvariants\u003ecloning clone repo repository\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erepository\u003c/value\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eclone\u003c/value\u003e\n\u003cvariants\u003ecloning clone repo repository\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erepository\u003c/value\u003e\n\u003cvariants","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eclone\u003c/value\u003e\n\u003cvariants\u003ecloning clone repo repository\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erepository\u003c/value\u003e\n\u003cvariants\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eclone\u003c/value\u003e\n\u003cvariants\u003ecloning clone repo repository\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erepository\u003c/value\u003e\n\u003cvariants\u003erepo","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eclone\u003c/value\u003e\n\u003cvariants\u003ecloning clone repo repository\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erepository\u003c/value\u003e\n\u003cvariants\u003erepo git","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eclone\u003c/value\u003e\n\u003cvariants\u003ecloning clone repo repository\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erepository\u003c/value\u003e\n\u003cvariants\u003erepo git v","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eclone\u003c/value\u003e\n\u003cvariants\u003ecloning clone repo repository\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erepository\u003c/value\u003e\n\u003cvariants\u003erepo git vcs","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eclone\u003c/value\u003e\n\u003cvariants\u003ecloning clone repo repository\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erepository\u003c/value\u003e\n\u003cvariants\u003erepo git vcs version","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eclone\u003c/value\u003e\n\u003cvariants\u003ecloning clone repo repository\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erepository\u003c/value\u003e\n\u003cvariants\u003erepo git vcs version-","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eclone\u003c/value\u003e\n\u003cvariants\u003ecloning clone repo repository\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erepository\u003c/value\u003e\n\u003cvariants\u003erepo git vcs version-control","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eclone\u003c/value\u003e\n\u003cvariants\u003ecloning clone repo repository\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erepository\u003c/value\u003e\n\u003cvariants\u003erepo git vcs version-control\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eclone\u003c/value\u003e\n\u003cvariants\u003ecloning clone repo repository\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erepository\u003c/value\u003e\n\u003cvariants\u003erepo git vcs version-control\u003c/variants","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eclone\u003c/value\u003e\n\u003cvariants\u003ecloning clone repo repository\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erepository\u003c/value\u003e\n\u003cvariants\u003erepo git vcs version-control\u003c/variants\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eclone\u003c/value\u003e\n\u003cvariants\u003ecloning clone repo repository\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erepository\u003c/value\u003e\n\u003cvariants\u003erepo git vcs version-control\u003c/variants\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eclone\u003c/value\u003e\n\u003cvariants\u003ecloning clone repo repository\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erepository\u003c/value\u003e\n\u003cvariants\u003erepo git vcs version-control\u003c/variants\u003e\n\u003cweight","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eclone\u003c/value\u003e\n\u003cvariants\u003ecloning clone repo repository\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erepository\u003c/value\u003e\n\u003cvariants\u003erepo git vcs version-control\u003c/variants\u003e\n\u003cweight\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eclone\u003c/value\u003e\n\u003cvariants\u003ecloning clone repo repository\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erepository\u003c/value\u003e\n\u003cvariants\u003erepo git vcs version-control\u003c/variants\u003e\n\u003cweight\u003e0","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eclone\u003c/value\u003e\n\u003cvariants\u003ecloning clone repo repository\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erepository\u003c/value\u003e\n\u003cvariants\u003erepo git vcs version-control\u003c/variants\u003e\n\u003cweight\u003e0.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eclone\u003c/value\u003e\n\u003cvariants\u003ecloning clone repo repository\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erepository\u003c/value\u003e\n\u003cvariants\u003erepo git vcs version-control\u003c/variants\u003e\n\u003cweight\u003e0.8","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eclone\u003c/value\u003e\n\u003cvariants\u003ecloning clone repo repository\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erepository\u003c/value\u003e\n\u003cvariants\u003erepo git vcs version-control\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eclone\u003c/value\u003e\n\u003cvariants\u003ecloning clone repo repository\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erepository\u003c/value\u003e\n\u003cvariants\u003erepo git vcs version-control\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eclone\u003c/value\u003e\n\u003cvariants\u003ecloning clone repo repository\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erepository\u003c/value\u003e\n\u003cvariants\u003erepo git vcs version-control\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eclone\u003c/value\u003e\n\u003cvariants\u003ecloning clone repo repository\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erepository\u003c/value\u003e\n\u003cvariants\u003erepo git vcs version-control\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eclone\u003c/value\u003e\n\u003cvariants\u003ecloning clone repo repository\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erepository\u003c/value\u003e\n\u003cvariants\u003erepo git vcs version-control\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keywor","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eclone\u003c/value\u003e\n\u003cvariants\u003ecloning clone repo repository\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erepository\u003c/value\u003e\n\u003cvariants\u003erepo git vcs version-control\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eclone\u003c/value\u003e\n\u003cvariants\u003ecloning clone repo repository\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erepository\u003c/value\u003e\n\u003cvariants\u003erepo git vcs version-control\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eclone\u003c/value\u003e\n\u003cvariants\u003ecloning clone repo repository\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erepository\u003c/value\u003e\n\u003cvariants\u003erepo git vcs version-control\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeywor","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eclone\u003c/value\u003e\n\u003cvariants\u003ecloning clone repo repository\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erepository\u003c/value\u003e\n\u003cvariants\u003erepo git vcs version-control\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eclone\u003c/value\u003e\n\u003cvariants\u003ecloning clone repo repository\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erepository\u003c/value\u003e\n\u003cvariants\u003erepo git vcs version-control\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eclone\u003c/value\u003e\n\u003cvariants\u003ecloning clone repo repository\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erepository\u003c/value\u003e\n\u003cvariants\u003erepo git vcs version-control\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eclone\u003c/value\u003e\n\u003cvariants\u003ecloning clone repo repository\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erepository\u003c/value\u003e\n\u003cvariants\u003erepo git vcs version-control\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eclone\u003c/value\u003e\n\u003cvariants\u003ecloning clone repo repository\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erepository\u003c/value\u003e\n\u003cvariants\u003erepo git vcs version-control\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003elogic","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eclone\u003c/value\u003e\n\u003cvariants\u003ecloning clone repo repository\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erepository\u003c/value\u003e\n\u003cvariants\u003erepo git vcs version-control\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003elogic\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eclone\u003c/value\u003e\n\u003cvariants\u003ecloning clone repo repository\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erepository\u003c/value\u003e\n\u003cvariants\u003erepo git vcs version-control\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003elogic\u003c/value","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eclone\u003c/value\u003e\n\u003cvariants\u003ecloning clone repo repository\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erepository\u003c/value\u003e\n\u003cvariants\u003erepo git vcs version-control\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003elogic\u003c/value\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eclone\u003c/value\u003e\n\u003cvariants\u003ecloning clone repo repository\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erepository\u003c/value\u003e\n\u003cvariants\u003erepo git vcs version-control\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003elogic\u003c/value\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eclone\u003c/value\u003e\n\u003cvariants\u003ecloning clone repo repository\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erepository\u003c/value\u003e\n\u003cvariants\u003erepo git vcs version-control\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003elogic\u003c/value\u003e\n\u003cvariants","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eclone\u003c/value\u003e\n\u003cvariants\u003ecloning clone repo repository\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erepository\u003c/value\u003e\n\u003cvariants\u003erepo git vcs version-control\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003elogic\u003c/value\u003e\n\u003cvariants\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eclone\u003c/value\u003e\n\u003cvariants\u003ecloning clone repo repository\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erepository\u003c/value\u003e\n\u003cvariants\u003erepo git vcs version-control\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003elogic\u003c/value\u003e\n\u003cvariants\u003elogic","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eclone\u003c/value\u003e\n\u003cvariants\u003ecloning clone repo repository\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erepository\u003c/value\u003e\n\u003cvariants\u003erepo git vcs version-control\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003elogic\u003c/value\u003e\n\u003cvariants\u003elogic reasoning","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eclone\u003c/value\u003e\n\u003cvariants\u003ecloning clone repo repository\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erepository\u003c/value\u003e\n\u003cvariants\u003erepo git vcs version-control\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003elogic\u003c/value\u003e\n\u003cvariants\u003elogic reasoning algorithm","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eclone\u003c/value\u003e\n\u003cvariants\u003ecloning clone repo repository\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erepository\u003c/value\u003e\n\u003cvariants\u003erepo git vcs version-control\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003elogic\u003c/value\u003e\n\u003cvariants\u003elogic reasoning algorithm\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eclone\u003c/value\u003e\n\u003cvariants\u003ecloning clone repo repository\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erepository\u003c/value\u003e\n\u003cvariants\u003erepo git vcs version-control\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003elogic\u003c/value\u003e\n\u003cvariants\u003elogic reasoning algorithm\u003c/variants","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eclone\u003c/value\u003e\n\u003cvariants\u003ecloning clone repo repository\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erepository\u003c/value\u003e\n\u003cvariants\u003erepo git vcs version-control\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003elogic\u003c/value\u003e\n\u003cvariants\u003elogic reasoning algorithm\u003c/variants\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eclone\u003c/value\u003e\n\u003cvariants\u003ecloning clone repo repository\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erepository\u003c/value\u003e\n\u003cvariants\u003erepo git vcs version-control\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003elogic\u003c/value\u003e\n\u003cvariants\u003elogic reasoning algorithm\u003c/variants\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eclone\u003c/value\u003e\n\u003cvariants\u003ecloning clone repo repository\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erepository\u003c/value\u003e\n\u003cvariants\u003erepo git vcs version-control\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003elogic\u003c/value\u003e\n\u003cvariants\u003elogic reasoning algorithm\u003c/variants\u003e\n\u003cweight","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eclone\u003c/value\u003e\n\u003cvariants\u003ecloning clone repo repository\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erepository\u003c/value\u003e\n\u003cvariants\u003erepo git vcs version-control\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003elogic\u003c/value\u003e\n\u003cvariants\u003elogic reasoning algorithm\u003c/variants\u003e\n\u003cweight\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eclone\u003c/value\u003e\n\u003cvariants\u003ecloning clone repo repository\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erepository\u003c/value\u003e\n\u003cvariants\u003erepo git vcs version-control\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003elogic\u003c/value\u003e\n\u003cvariants\u003elogic reasoning algorithm\u003c/variants\u003e\n\u003cweight\u003e0","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eclone\u003c/value\u003e\n\u003cvariants\u003ecloning clone repo repository\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erepository\u003c/value\u003e\n\u003cvariants\u003erepo git vcs version-control\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003elogic\u003c/value\u003e\n\u003cvariants\u003elogic reasoning algorithm\u003c/variants\u003e\n\u003cweight\u003e0.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eclone\u003c/value\u003e\n\u003cvariants\u003ecloning clone repo repository\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erepository\u003c/value\u003e\n\u003cvariants\u003erepo git vcs version-control\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003elogic\u003c/value\u003e\n\u003cvariants\u003elogic reasoning algorithm\u003c/variants\u003e\n\u003cweight\u003e0.7","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eclone\u003c/value\u003e\n\u003cvariants\u003ecloning clone repo repository\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erepository\u003c/value\u003e\n\u003cvariants\u003erepo git vcs version-control\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003elogic\u003c/value\u003e\n\u003cvariants\u003elogic reasoning algorithm\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eclone\u003c/value\u003e\n\u003cvariants\u003ecloning clone repo repository\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erepository\u003c/value\u003e\n\u003cvariants\u003erepo git vcs version-control\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003elogic\u003c/value\u003e\n\u003cvariants\u003elogic reasoning algorithm\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eclone\u003c/value\u003e\n\u003cvariants\u003ecloning clone repo repository\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erepository\u003c/value\u003e\n\u003cvariants\u003erepo git vcs version-control\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003elogic\u003c/value\u003e\n\u003cvariants\u003elogic reasoning algorithm\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eclone\u003c/value\u003e\n\u003cvariants\u003ecloning clone repo repository\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erepository\u003c/value\u003e\n\u003cvariants\u003erepo git vcs version-control\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003elogic\u003c/value\u003e\n\u003cvariants\u003elogic reasoning algorithm\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eclone\u003c/value\u003e\n\u003cvariants\u003ecloning clone repo repository\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erepository\u003c/value\u003e\n\u003cvariants\u003erepo git vcs version-control\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003elogic\u003c/value\u003e\n\u003cvariants\u003elogic reasoning algorithm\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keywor","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eclone\u003c/value\u003e\n\u003cvariants\u003ecloning clone repo repository\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erepository\u003c/value\u003e\n\u003cvariants\u003erepo git vcs version-control\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003elogic\u003c/value\u003e\n\u003cvariants\u003elogic reasoning algorithm\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eclone\u003c/value\u003e\n\u003cvariants\u003ecloning clone repo repository\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erepository\u003c/value\u003e\n\u003cvariants\u003erepo git vcs version-control\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003elogic\u003c/value\u003e\n\u003cvariants\u003elogic reasoning algorithm\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eclone\u003c/value\u003e\n\u003cvariants\u003ecloning clone repo repository\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erepository\u003c/value\u003e\n\u003cvariants\u003erepo git vcs version-control\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003elogic\u003c/value\u003e\n\u003cvariants\u003elogic reasoning algorithm\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeywor","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eclone\u003c/value\u003e\n\u003cvariants\u003ecloning clone repo repository\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erepository\u003c/value\u003e\n\u003cvariants\u003erepo git vcs version-control\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003elogic\u003c/value\u003e\n\u003cvariants\u003elogic reasoning algorithm\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eclone\u003c/value\u003e\n\u003cvariants\u003ecloning clone repo repository\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erepository\u003c/value\u003e\n\u003cvariants\u003erepo git vcs version-control\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003elogic\u003c/value\u003e\n\u003cvariants\u003elogic reasoning algorithm\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eclone\u003c/value\u003e\n\u003cvariants\u003ecloning clone repo repository\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erepository\u003c/value\u003e\n\u003cvariants\u003erepo git vcs version-control\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003elogic\u003c/value\u003e\n\u003cvariants\u003elogic reasoning algorithm\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eclone\u003c/value\u003e\n\u003cvariants\u003ecloning clone repo repository\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erepository\u003c/value\u003e\n\u003cvariants\u003erepo git vcs version-control\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003elogic\u003c/value\u003e\n\u003cvariants\u003elogic reasoning algorithm\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eclone\u003c/value\u003e\n\u003cvariants\u003ecloning clone repo repository\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erepository\u003c/value\u003e\n\u003cvariants\u003erepo git vcs version-control\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003elogic\u003c/value\u003e\n\u003cvariants\u003elogic reasoning algorithm\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econfig","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eclone\u003c/value\u003e\n\u003cvariants\u003ecloning clone repo repository\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erepository\u003c/value\u003e\n\u003cvariants\u003erepo git vcs version-control\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003elogic\u003c/value\u003e\n\u003cvariants\u003elogic reasoning algorithm\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econfig\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eclone\u003c/value\u003e\n\u003cvariants\u003ecloning clone repo repository\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erepository\u003c/value\u003e\n\u003cvariants\u003erepo git vcs version-control\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003elogic\u003c/value\u003e\n\u003cvariants\u003elogic reasoning algorithm\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econfig\u003c/value","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eclone\u003c/value\u003e\n\u003cvariants\u003ecloning clone repo repository\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erepository\u003c/value\u003e\n\u003cvariants\u003erepo git vcs version-control\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003elogic\u003c/value\u003e\n\u003cvariants\u003elogic reasoning algorithm\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econfig\u003c/value\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eclone\u003c/value\u003e\n\u003cvariants\u003ecloning clone repo repository\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erepository\u003c/value\u003e\n\u003cvariants\u003erepo git vcs version-control\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003elogic\u003c/value\u003e\n\u003cvariants\u003elogic reasoning algorithm\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econfig\u003c/value\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eclone\u003c/value\u003e\n\u003cvariants\u003ecloning clone repo repository\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erepository\u003c/value\u003e\n\u003cvariants\u003erepo git vcs version-control\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003elogic\u003c/value\u003e\n\u003cvariants\u003elogic reasoning algorithm\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econfig\u003c/value\u003e\n\u003cvariants","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eclone\u003c/value\u003e\n\u003cvariants\u003ecloning clone repo repository\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erepository\u003c/value\u003e\n\u003cvariants\u003erepo git vcs version-control\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003elogic\u003c/value\u003e\n\u003cvariants\u003elogic reasoning algorithm\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econfig\u003c/value\u003e\n\u003cvariants\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eclone\u003c/value\u003e\n\u003cvariants\u003ecloning clone repo repository\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erepository\u003c/value\u003e\n\u003cvariants\u003erepo git vcs version-control\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003elogic\u003c/value\u003e\n\u003cvariants\u003elogic reasoning algorithm\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econfig\u003c/value\u003e\n\u003cvariants\u003econfiguration","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eclone\u003c/value\u003e\n\u003cvariants\u003ecloning clone repo repository\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erepository\u003c/value\u003e\n\u003cvariants\u003erepo git vcs version-control\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003elogic\u003c/value\u003e\n\u003cvariants\u003elogic reasoning algorithm\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econfig\u003c/value\u003e\n\u003cvariants\u003econfiguration settings","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eclone\u003c/value\u003e\n\u003cvariants\u003ecloning clone repo repository\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erepository\u003c/value\u003e\n\u003cvariants\u003erepo git vcs version-control\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003elogic\u003c/value\u003e\n\u003cvariants\u003elogic reasoning algorithm\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econfig\u003c/value\u003e\n\u003cvariants\u003econfiguration settings\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eclone\u003c/value\u003e\n\u003cvariants\u003ecloning clone repo repository\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erepository\u003c/value\u003e\n\u003cvariants\u003erepo git vcs version-control\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003elogic\u003c/value\u003e\n\u003cvariants\u003elogic reasoning algorithm\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econfig\u003c/value\u003e\n\u003cvariants\u003econfiguration settings\u003c/variants","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eclone\u003c/value\u003e\n\u003cvariants\u003ecloning clone repo repository\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erepository\u003c/value\u003e\n\u003cvariants\u003erepo git vcs version-control\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003elogic\u003c/value\u003e\n\u003cvariants\u003elogic reasoning algorithm\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econfig\u003c/value\u003e\n\u003cvariants\u003econfiguration settings\u003c/variants\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eclone\u003c/value\u003e\n\u003cvariants\u003ecloning clone repo repository\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erepository\u003c/value\u003e\n\u003cvariants\u003erepo git vcs version-control\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003elogic\u003c/value\u003e\n\u003cvariants\u003elogic reasoning algorithm\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econfig\u003c/value\u003e\n\u003cvariants\u003econfiguration settings\u003c/variants\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eclone\u003c/value\u003e\n\u003cvariants\u003ecloning clone repo repository\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erepository\u003c/value\u003e\n\u003cvariants\u003erepo git vcs version-control\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003elogic\u003c/value\u003e\n\u003cvariants\u003elogic reasoning algorithm\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econfig\u003c/value\u003e\n\u003cvariants\u003econfiguration settings\u003c/variants\u003e\n\u003cweight","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eclone\u003c/value\u003e\n\u003cvariants\u003ecloning clone repo repository\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erepository\u003c/value\u003e\n\u003cvariants\u003erepo git vcs version-control\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003elogic\u003c/value\u003e\n\u003cvariants\u003elogic reasoning algorithm\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econfig\u003c/value\u003e\n\u003cvariants\u003econfiguration settings\u003c/variants\u003e\n\u003cweight\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eclone\u003c/value\u003e\n\u003cvariants\u003ecloning clone repo repository\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erepository\u003c/value\u003e\n\u003cvariants\u003erepo git vcs version-control\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003elogic\u003c/value\u003e\n\u003cvariants\u003elogic reasoning algorithm\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econfig\u003c/value\u003e\n\u003cvariants\u003econfiguration settings\u003c/variants\u003e\n\u003cweight\u003e0","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eclone\u003c/value\u003e\n\u003cvariants\u003ecloning clone repo repository\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erepository\u003c/value\u003e\n\u003cvariants\u003erepo git vcs version-control\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003elogic\u003c/value\u003e\n\u003cvariants\u003elogic reasoning algorithm\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econfig\u003c/value\u003e\n\u003cvariants\u003econfiguration settings\u003c/variants\u003e\n\u003cweight\u003e0.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eclone\u003c/value\u003e\n\u003cvariants\u003ecloning clone repo repository\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erepository\u003c/value\u003e\n\u003cvariants\u003erepo git vcs version-control\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003elogic\u003c/value\u003e\n\u003cvariants\u003elogic reasoning algorithm\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econfig\u003c/value\u003e\n\u003cvariants\u003econfiguration settings\u003c/variants\u003e\n\u003cweight\u003e0.6","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eclone\u003c/value\u003e\n\u003cvariants\u003ecloning clone repo repository\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erepository\u003c/value\u003e\n\u003cvariants\u003erepo git vcs version-control\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003elogic\u003c/value\u003e\n\u003cvariants\u003elogic reasoning algorithm\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econfig\u003c/value\u003e\n\u003cvariants\u003econfiguration settings\u003c/variants\u003e\n\u003cweight\u003e0.6\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eclone\u003c/value\u003e\n\u003cvariants\u003ecloning clone repo repository\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erepository\u003c/value\u003e\n\u003cvariants\u003erepo git vcs version-control\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003elogic\u003c/value\u003e\n\u003cvariants\u003elogic reasoning algorithm\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econfig\u003c/value\u003e\n\u003cvariants\u003econfiguration settings\u003c/variants\u003e\n\u003cweight\u003e0.6\u003c/weight","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eclone\u003c/value\u003e\n\u003cvariants\u003ecloning clone repo repository\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erepository\u003c/value\u003e\n\u003cvariants\u003erepo git vcs version-control\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003elogic\u003c/value\u003e\n\u003cvariants\u003elogic reasoning algorithm\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econfig\u003c/value\u003e\n\u003cvariants\u003econfiguration settings\u003c/variants\u003e\n\u003cweight\u003e0.6\u003c/weight\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eclone\u003c/value\u003e\n\u003cvariants\u003ecloning clone repo repository\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erepository\u003c/value\u003e\n\u003cvariants\u003erepo git vcs version-control\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003elogic\u003c/value\u003e\n\u003cvariants\u003elogic reasoning algorithm\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econfig\u003c/value\u003e\n\u003cvariants\u003econfiguration settings\u003c/variants\u003e\n\u003cweight\u003e0.6\u003c/weight\u003e\n\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eclone\u003c/value\u003e\n\u003cvariants\u003ecloning clone repo repository\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erepository\u003c/value\u003e\n\u003cvariants\u003erepo git vcs version-control\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003elogic\u003c/value\u003e\n\u003cvariants\u003elogic reasoning algorithm\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econfig\u003c/value\u003e\n\u003cvariants\u003econfiguration settings\u003c/variants\u003e\n\u003cweight\u003e0.6\u003c/weight\u003e\n\u003c/keywor","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eclone\u003c/value\u003e\n\u003cvariants\u003ecloning clone repo repository\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erepository\u003c/value\u003e\n\u003cvariants\u003erepo git vcs version-control\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003elogic\u003c/value\u003e\n\u003cvariants\u003elogic reasoning algorithm\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econfig\u003c/value\u003e\n\u003cvariants\u003econfiguration settings\u003c/variants\u003e\n\u003cweight\u003e0.6\u003c/weight\u003e\n\u003c/keyword\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eclone\u003c/value\u003e\n\u003cvariants\u003ecloning clone repo repository\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erepository\u003c/value\u003e\n\u003cvariants\u003erepo git vcs version-control\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003elogic\u003c/value\u003e\n\u003cvariants\u003elogic reasoning algorithm\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econfig\u003c/value\u003e\n\u003cvariants\u003econfiguration settings\u003c/variants\u003e\n\u003cweight\u003e0.6\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eclone\u003c/value\u003e\n\u003cvariants\u003ecloning clone repo repository\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erepository\u003c/value\u003e\n\u003cvariants\u003erepo git vcs version-control\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003elogic\u003c/value\u003e\n\u003cvariants\u003elogic reasoning algorithm\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econfig\u003c/value\u003e\n\u003cvariants\u003econfiguration settings\u003c/variants\u003e\n\u003cweight\u003e0.6\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003c/keywords","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eclone\u003c/value\u003e\n\u003cvariants\u003ecloning clone repo repository\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erepository\u003c/value\u003e\n\u003cvariants\u003erepo git vcs version-control\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003elogic\u003c/value\u003e\n\u003cvariants\u003elogic reasoning algorithm\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econfig\u003c/value\u003e\n\u003cvariants\u003econfiguration settings\u003c/variants\u003e\n\u003cweight\u003e0.6\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003c/keywords\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search for based on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eclone\u003c/value\u003e\n\u003cvariants\u003ecloning clone repo repository\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erepository\u003c/value\u003e\n\u003cvariants\u003erepo git vcs version-control\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003elogic\u003c/value\u003e\n\u003cvariants\u003elogic reasoning algorithm\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econfig\u003c/value\u003e\n\u003cvariants\u003econfiguration settings\u003c/variants\u003e\n\u003cweight\u003e0.6\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003c/keywords\u003e","stopReason":"end_turn"}
+            data: {"completion":"\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eauthentication\u003c/value\u003e\n\u003cvariants\u003eauth auth-related security login\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erouter\u003c/value\u003e\n\u003cvariants\u003erouting route-related\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edefinition\u003c/value\u003e\n\u003cvariants\u003edefine defined definition-site\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003c/keywords\u003e","stopReason":"end_turn"}
 
 
             event: done
@@ -4614,7 +397,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Tue, 28 May 2024 16:10:35 GMT
+            value: Fri, 07 Jun 2024 23:18:04 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
@@ -4643,7 +426,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-05-28T16:10:35.241Z
+      startedDateTime: 2024-06-07T23:18:03.893Z
       time: 0
       timings:
         blocked: -1
@@ -4653,11 +436,11 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: d530e8a7022d78da28fc793e2a662d14
+    - _id: 4d268d18fac70d066841a35f31e9bf01
       _order: 0
       cache: {}
       request:
-        bodySize: 969
+        bodySize: 894
         cookies: []
         headers:
           - name: content-type
@@ -4688,865 +471,28 @@ log:
               - speaker: human
                 text: "You are helping the user search over a codebase. List some filename
                   fragments that would match files relevant to read to answer
-                  the user's query. Present your results in an XML list in the
-                  following format: <keywords><keyword><value>a single
+                  the user's query. Present your results in a *single* XML list
+                  in the following format: <keywords><keyword><value>a single
                   keyword</value><variants>a space separated list of synonyms
                   and variants of the keyword, including acronyms,
                   abbreviations, and expansions</variants><weight>a numerical
                   weight between 0.0 and 1.0 that indicates the importance of
                   the keyword</weight></keyword></keywords>. Here is the user
-                  query: <userQuery>Explain how the context window limit is
-                  calculated. how much budget is given to @-mentions vs. search
-                  context?</userQuery>"
+                  query: <userQuery>parse file with tree-sitter</userQuery>"
               - speaker: assistant
             temperature: 0
             topK: 1
         queryString: []
         url: https://sourcegraph.com/.api/completions/stream
       response:
-        bodySize: 94436
+        bodySize: 38296
         content:
           mimeType: text/event-stream
-          size: 94436
+          size: 38296
           text: >+
             event: completion
 
-            data: {"completion":"Here","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search the","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search the c","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search the code","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search the codebase","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search the codebase for","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search the codebase for information","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search the codebase for information on","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search the codebase for information on the","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search the codebase for information on the user","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search the codebase for information on the user's","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search the codebase for information on the user's query","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search the codebase for information on the user's query:","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search the codebase for information on the user's query:\n\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search the codebase for information on the user's query:\n\n\u003ckeywords","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search the codebase for information on the user's query:\n\n\u003ckeywords\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search the codebase for information on the user's query:\n\n\u003ckeywords\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search the codebase for information on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeywor","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search the codebase for information on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search the codebase for information on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search the codebase for information on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search the codebase for information on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search the codebase for information on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econtext","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search the codebase for information on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econtext window","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search the codebase for information on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econtext window\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search the codebase for information on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econtext window\u003c/value","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search the codebase for information on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econtext window\u003c/value\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search the codebase for information on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econtext window\u003c/value\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search the codebase for information on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econtext window\u003c/value\u003e\n\u003cvariants","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search the codebase for information on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econtext window\u003c/value\u003e\n\u003cvariants\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search the codebase for information on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econtext window\u003c/value\u003e\n\u003cvariants\u003econtext","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search the codebase for information on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econtext window\u003c/value\u003e\n\u003cvariants\u003econtext window","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search the codebase for information on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econtext window\u003c/value\u003e\n\u003cvariants\u003econtext window limit","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search the codebase for information on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econtext window\u003c/value\u003e\n\u003cvariants\u003econtext window limit context","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search the codebase for information on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econtext window\u003c/value\u003e\n\u003cvariants\u003econtext window limit context-","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search the codebase for information on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econtext window\u003c/value\u003e\n\u003cvariants\u003econtext window limit context-window","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search the codebase for information on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econtext window\u003c/value\u003e\n\u003cvariants\u003econtext window limit context-window context","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search the codebase for information on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econtext window\u003c/value\u003e\n\u003cvariants\u003econtext window limit context-window context_","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search the codebase for information on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econtext window\u003c/value\u003e\n\u003cvariants\u003econtext window limit context-window context_window","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search the codebase for information on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econtext window\u003c/value\u003e\n\u003cvariants\u003econtext window limit context-window context_window\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search the codebase for information on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econtext window\u003c/value\u003e\n\u003cvariants\u003econtext window limit context-window context_window\u003c/variants","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search the codebase for information on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econtext window\u003c/value\u003e\n\u003cvariants\u003econtext window limit context-window context_window\u003c/variants\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search the codebase for information on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econtext window\u003c/value\u003e\n\u003cvariants\u003econtext window limit context-window context_window\u003c/variants\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search the codebase for information on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econtext window\u003c/value\u003e\n\u003cvariants\u003econtext window limit context-window context_window\u003c/variants\u003e\n\u003cweight","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search the codebase for information on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econtext window\u003c/value\u003e\n\u003cvariants\u003econtext window limit context-window context_window\u003c/variants\u003e\n\u003cweight\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search the codebase for information on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econtext window\u003c/value\u003e\n\u003cvariants\u003econtext window limit context-window context_window\u003c/variants\u003e\n\u003cweight\u003e0","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search the codebase for information on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econtext window\u003c/value\u003e\n\u003cvariants\u003econtext window limit context-window context_window\u003c/variants\u003e\n\u003cweight\u003e0.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search the codebase for information on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econtext window\u003c/value\u003e\n\u003cvariants\u003econtext window limit context-window context_window\u003c/variants\u003e\n\u003cweight\u003e0.9","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search the codebase for information on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econtext window\u003c/value\u003e\n\u003cvariants\u003econtext window limit context-window context_window\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search the codebase for information on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econtext window\u003c/value\u003e\n\u003cvariants\u003econtext window limit context-window context_window\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search the codebase for information on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econtext window\u003c/value\u003e\n\u003cvariants\u003econtext window limit context-window context_window\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search the codebase for information on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econtext window\u003c/value\u003e\n\u003cvariants\u003econtext window limit context-window context_window\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search the codebase for information on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econtext window\u003c/value\u003e\n\u003cvariants\u003econtext window limit context-window context_window\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keywor","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search the codebase for information on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econtext window\u003c/value\u003e\n\u003cvariants\u003econtext window limit context-window context_window\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search the codebase for information on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econtext window\u003c/value\u003e\n\u003cvariants\u003econtext window limit context-window context_window\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search the codebase for information on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econtext window\u003c/value\u003e\n\u003cvariants\u003econtext window limit context-window context_window\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeywor","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search the codebase for information on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econtext window\u003c/value\u003e\n\u003cvariants\u003econtext window limit context-window context_window\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search the codebase for information on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econtext window\u003c/value\u003e\n\u003cvariants\u003econtext window limit context-window context_window\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search the codebase for information on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econtext window\u003c/value\u003e\n\u003cvariants\u003econtext window limit context-window context_window\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search the codebase for information on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econtext window\u003c/value\u003e\n\u003cvariants\u003econtext window limit context-window context_window\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search the codebase for information on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econtext window\u003c/value\u003e\n\u003cvariants\u003econtext window limit context-window context_window\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebudget","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search the codebase for information on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econtext window\u003c/value\u003e\n\u003cvariants\u003econtext window limit context-window context_window\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebudget\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search the codebase for information on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econtext window\u003c/value\u003e\n\u003cvariants\u003econtext window limit context-window context_window\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebudget\u003c/value","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search the codebase for information on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econtext window\u003c/value\u003e\n\u003cvariants\u003econtext window limit context-window context_window\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebudget\u003c/value\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search the codebase for information on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econtext window\u003c/value\u003e\n\u003cvariants\u003econtext window limit context-window context_window\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebudget\u003c/value\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search the codebase for information on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econtext window\u003c/value\u003e\n\u003cvariants\u003econtext window limit context-window context_window\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebudget\u003c/value\u003e\n\u003cvariants","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search the codebase for information on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econtext window\u003c/value\u003e\n\u003cvariants\u003econtext window limit context-window context_window\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebudget\u003c/value\u003e\n\u003cvariants\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search the codebase for information on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econtext window\u003c/value\u003e\n\u003cvariants\u003econtext window limit context-window context_window\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebudget\u003c/value\u003e\n\u003cvariants\u003ebudget","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search the codebase for information on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econtext window\u003c/value\u003e\n\u003cvariants\u003econtext window limit context-window context_window\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebudget\u003c/value\u003e\n\u003cvariants\u003ebudget allocation","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search the codebase for information on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econtext window\u003c/value\u003e\n\u003cvariants\u003econtext window limit context-window context_window\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebudget\u003c/value\u003e\n\u003cvariants\u003ebudget allocation budget","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search the codebase for information on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econtext window\u003c/value\u003e\n\u003cvariants\u003econtext window limit context-window context_window\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebudget\u003c/value\u003e\n\u003cvariants\u003ebudget allocation budget-","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search the codebase for information on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econtext window\u003c/value\u003e\n\u003cvariants\u003econtext window limit context-window context_window\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebudget\u003c/value\u003e\n\u003cvariants\u003ebudget allocation budget-allocation","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search the codebase for information on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econtext window\u003c/value\u003e\n\u003cvariants\u003econtext window limit context-window context_window\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebudget\u003c/value\u003e\n\u003cvariants\u003ebudget allocation budget-allocation budget","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search the codebase for information on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econtext window\u003c/value\u003e\n\u003cvariants\u003econtext window limit context-window context_window\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebudget\u003c/value\u003e\n\u003cvariants\u003ebudget allocation budget-allocation budget_","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search the codebase for information on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econtext window\u003c/value\u003e\n\u003cvariants\u003econtext window limit context-window context_window\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebudget\u003c/value\u003e\n\u003cvariants\u003ebudget allocation budget-allocation budget_allocation","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search the codebase for information on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econtext window\u003c/value\u003e\n\u003cvariants\u003econtext window limit context-window context_window\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebudget\u003c/value\u003e\n\u003cvariants\u003ebudget allocation budget-allocation budget_allocation\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search the codebase for information on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econtext window\u003c/value\u003e\n\u003cvariants\u003econtext window limit context-window context_window\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebudget\u003c/value\u003e\n\u003cvariants\u003ebudget allocation budget-allocation budget_allocation\u003c/variants","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search the codebase for information on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econtext window\u003c/value\u003e\n\u003cvariants\u003econtext window limit context-window context_window\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebudget\u003c/value\u003e\n\u003cvariants\u003ebudget allocation budget-allocation budget_allocation\u003c/variants\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search the codebase for information on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econtext window\u003c/value\u003e\n\u003cvariants\u003econtext window limit context-window context_window\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebudget\u003c/value\u003e\n\u003cvariants\u003ebudget allocation budget-allocation budget_allocation\u003c/variants\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search the codebase for information on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econtext window\u003c/value\u003e\n\u003cvariants\u003econtext window limit context-window context_window\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebudget\u003c/value\u003e\n\u003cvariants\u003ebudget allocation budget-allocation budget_allocation\u003c/variants\u003e\n\u003cweight","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search the codebase for information on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econtext window\u003c/value\u003e\n\u003cvariants\u003econtext window limit context-window context_window\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebudget\u003c/value\u003e\n\u003cvariants\u003ebudget allocation budget-allocation budget_allocation\u003c/variants\u003e\n\u003cweight\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search the codebase for information on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econtext window\u003c/value\u003e\n\u003cvariants\u003econtext window limit context-window context_window\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebudget\u003c/value\u003e\n\u003cvariants\u003ebudget allocation budget-allocation budget_allocation\u003c/variants\u003e\n\u003cweight\u003e0","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search the codebase for information on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econtext window\u003c/value\u003e\n\u003cvariants\u003econtext window limit context-window context_window\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebudget\u003c/value\u003e\n\u003cvariants\u003ebudget allocation budget-allocation budget_allocation\u003c/variants\u003e\n\u003cweight\u003e0.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search the codebase for information on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econtext window\u003c/value\u003e\n\u003cvariants\u003econtext window limit context-window context_window\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebudget\u003c/value\u003e\n\u003cvariants\u003ebudget allocation budget-allocation budget_allocation\u003c/variants\u003e\n\u003cweight\u003e0.8","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search the codebase for information on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econtext window\u003c/value\u003e\n\u003cvariants\u003econtext window limit context-window context_window\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebudget\u003c/value\u003e\n\u003cvariants\u003ebudget allocation budget-allocation budget_allocation\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search the codebase for information on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econtext window\u003c/value\u003e\n\u003cvariants\u003econtext window limit context-window context_window\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebudget\u003c/value\u003e\n\u003cvariants\u003ebudget allocation budget-allocation budget_allocation\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search the codebase for information on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econtext window\u003c/value\u003e\n\u003cvariants\u003econtext window limit context-window context_window\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebudget\u003c/value\u003e\n\u003cvariants\u003ebudget allocation budget-allocation budget_allocation\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search the codebase for information on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econtext window\u003c/value\u003e\n\u003cvariants\u003econtext window limit context-window context_window\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebudget\u003c/value\u003e\n\u003cvariants\u003ebudget allocation budget-allocation budget_allocation\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search the codebase for information on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econtext window\u003c/value\u003e\n\u003cvariants\u003econtext window limit context-window context_window\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebudget\u003c/value\u003e\n\u003cvariants\u003ebudget allocation budget-allocation budget_allocation\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keywor","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search the codebase for information on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econtext window\u003c/value\u003e\n\u003cvariants\u003econtext window limit context-window context_window\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebudget\u003c/value\u003e\n\u003cvariants\u003ebudget allocation budget-allocation budget_allocation\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search the codebase for information on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econtext window\u003c/value\u003e\n\u003cvariants\u003econtext window limit context-window context_window\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebudget\u003c/value\u003e\n\u003cvariants\u003ebudget allocation budget-allocation budget_allocation\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search the codebase for information on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econtext window\u003c/value\u003e\n\u003cvariants\u003econtext window limit context-window context_window\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebudget\u003c/value\u003e\n\u003cvariants\u003ebudget allocation budget-allocation budget_allocation\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeywor","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search the codebase for information on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econtext window\u003c/value\u003e\n\u003cvariants\u003econtext window limit context-window context_window\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebudget\u003c/value\u003e\n\u003cvariants\u003ebudget allocation budget-allocation budget_allocation\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search the codebase for information on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econtext window\u003c/value\u003e\n\u003cvariants\u003econtext window limit context-window context_window\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebudget\u003c/value\u003e\n\u003cvariants\u003ebudget allocation budget-allocation budget_allocation\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search the codebase for information on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econtext window\u003c/value\u003e\n\u003cvariants\u003econtext window limit context-window context_window\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebudget\u003c/value\u003e\n\u003cvariants\u003ebudget allocation budget-allocation budget_allocation\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search the codebase for information on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econtext window\u003c/value\u003e\n\u003cvariants\u003econtext window limit context-window context_window\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebudget\u003c/value\u003e\n\u003cvariants\u003ebudget allocation budget-allocation budget_allocation\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search the codebase for information on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econtext window\u003c/value\u003e\n\u003cvariants\u003econtext window limit context-window context_window\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebudget\u003c/value\u003e\n\u003cvariants\u003ebudget allocation budget-allocation budget_allocation\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ementions","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search the codebase for information on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econtext window\u003c/value\u003e\n\u003cvariants\u003econtext window limit context-window context_window\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebudget\u003c/value\u003e\n\u003cvariants\u003ebudget allocation budget-allocation budget_allocation\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ementions\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search the codebase for information on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econtext window\u003c/value\u003e\n\u003cvariants\u003econtext window limit context-window context_window\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebudget\u003c/value\u003e\n\u003cvariants\u003ebudget allocation budget-allocation budget_allocation\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ementions\u003c/value","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search the codebase for information on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econtext window\u003c/value\u003e\n\u003cvariants\u003econtext window limit context-window context_window\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebudget\u003c/value\u003e\n\u003cvariants\u003ebudget allocation budget-allocation budget_allocation\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ementions\u003c/value\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search the codebase for information on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econtext window\u003c/value\u003e\n\u003cvariants\u003econtext window limit context-window context_window\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebudget\u003c/value\u003e\n\u003cvariants\u003ebudget allocation budget-allocation budget_allocation\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ementions\u003c/value\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search the codebase for information on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econtext window\u003c/value\u003e\n\u003cvariants\u003econtext window limit context-window context_window\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebudget\u003c/value\u003e\n\u003cvariants\u003ebudget allocation budget-allocation budget_allocation\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ementions\u003c/value\u003e\n\u003cvariants","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search the codebase for information on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econtext window\u003c/value\u003e\n\u003cvariants\u003econtext window limit context-window context_window\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebudget\u003c/value\u003e\n\u003cvariants\u003ebudget allocation budget-allocation budget_allocation\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ementions\u003c/value\u003e\n\u003cvariants\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search the codebase for information on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econtext window\u003c/value\u003e\n\u003cvariants\u003econtext window limit context-window context_window\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebudget\u003c/value\u003e\n\u003cvariants\u003ebudget allocation budget-allocation budget_allocation\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ementions\u003c/value\u003e\n\u003cvariants\u003e@","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search the codebase for information on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econtext window\u003c/value\u003e\n\u003cvariants\u003econtext window limit context-window context_window\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebudget\u003c/value\u003e\n\u003cvariants\u003ebudget allocation budget-allocation budget_allocation\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ementions\u003c/value\u003e\n\u003cvariants\u003e@-","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search the codebase for information on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econtext window\u003c/value\u003e\n\u003cvariants\u003econtext window limit context-window context_window\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebudget\u003c/value\u003e\n\u003cvariants\u003ebudget allocation budget-allocation budget_allocation\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ementions\u003c/value\u003e\n\u003cvariants\u003e@-mentions","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search the codebase for information on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econtext window\u003c/value\u003e\n\u003cvariants\u003econtext window limit context-window context_window\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebudget\u003c/value\u003e\n\u003cvariants\u003ebudget allocation budget-allocation budget_allocation\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ementions\u003c/value\u003e\n\u003cvariants\u003e@-mentions mentions","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search the codebase for information on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econtext window\u003c/value\u003e\n\u003cvariants\u003econtext window limit context-window context_window\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebudget\u003c/value\u003e\n\u003cvariants\u003ebudget allocation budget-allocation budget_allocation\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ementions\u003c/value\u003e\n\u003cvariants\u003e@-mentions mentions\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search the codebase for information on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econtext window\u003c/value\u003e\n\u003cvariants\u003econtext window limit context-window context_window\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebudget\u003c/value\u003e\n\u003cvariants\u003ebudget allocation budget-allocation budget_allocation\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ementions\u003c/value\u003e\n\u003cvariants\u003e@-mentions mentions\u003c/variants","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search the codebase for information on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econtext window\u003c/value\u003e\n\u003cvariants\u003econtext window limit context-window context_window\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebudget\u003c/value\u003e\n\u003cvariants\u003ebudget allocation budget-allocation budget_allocation\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ementions\u003c/value\u003e\n\u003cvariants\u003e@-mentions mentions\u003c/variants\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search the codebase for information on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econtext window\u003c/value\u003e\n\u003cvariants\u003econtext window limit context-window context_window\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebudget\u003c/value\u003e\n\u003cvariants\u003ebudget allocation budget-allocation budget_allocation\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ementions\u003c/value\u003e\n\u003cvariants\u003e@-mentions mentions\u003c/variants\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search the codebase for information on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econtext window\u003c/value\u003e\n\u003cvariants\u003econtext window limit context-window context_window\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebudget\u003c/value\u003e\n\u003cvariants\u003ebudget allocation budget-allocation budget_allocation\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ementions\u003c/value\u003e\n\u003cvariants\u003e@-mentions mentions\u003c/variants\u003e\n\u003cweight","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search the codebase for information on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econtext window\u003c/value\u003e\n\u003cvariants\u003econtext window limit context-window context_window\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebudget\u003c/value\u003e\n\u003cvariants\u003ebudget allocation budget-allocation budget_allocation\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ementions\u003c/value\u003e\n\u003cvariants\u003e@-mentions mentions\u003c/variants\u003e\n\u003cweight\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search the codebase for information on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econtext window\u003c/value\u003e\n\u003cvariants\u003econtext window limit context-window context_window\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebudget\u003c/value\u003e\n\u003cvariants\u003ebudget allocation budget-allocation budget_allocation\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ementions\u003c/value\u003e\n\u003cvariants\u003e@-mentions mentions\u003c/variants\u003e\n\u003cweight\u003e0","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search the codebase for information on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econtext window\u003c/value\u003e\n\u003cvariants\u003econtext window limit context-window context_window\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebudget\u003c/value\u003e\n\u003cvariants\u003ebudget allocation budget-allocation budget_allocation\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ementions\u003c/value\u003e\n\u003cvariants\u003e@-mentions mentions\u003c/variants\u003e\n\u003cweight\u003e0.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search the codebase for information on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econtext window\u003c/value\u003e\n\u003cvariants\u003econtext window limit context-window context_window\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebudget\u003c/value\u003e\n\u003cvariants\u003ebudget allocation budget-allocation budget_allocation\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ementions\u003c/value\u003e\n\u003cvariants\u003e@-mentions mentions\u003c/variants\u003e\n\u003cweight\u003e0.7","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search the codebase for information on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econtext window\u003c/value\u003e\n\u003cvariants\u003econtext window limit context-window context_window\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebudget\u003c/value\u003e\n\u003cvariants\u003ebudget allocation budget-allocation budget_allocation\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ementions\u003c/value\u003e\n\u003cvariants\u003e@-mentions mentions\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search the codebase for information on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econtext window\u003c/value\u003e\n\u003cvariants\u003econtext window limit context-window context_window\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebudget\u003c/value\u003e\n\u003cvariants\u003ebudget allocation budget-allocation budget_allocation\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ementions\u003c/value\u003e\n\u003cvariants\u003e@-mentions mentions\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search the codebase for information on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econtext window\u003c/value\u003e\n\u003cvariants\u003econtext window limit context-window context_window\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebudget\u003c/value\u003e\n\u003cvariants\u003ebudget allocation budget-allocation budget_allocation\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ementions\u003c/value\u003e\n\u003cvariants\u003e@-mentions mentions\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search the codebase for information on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econtext window\u003c/value\u003e\n\u003cvariants\u003econtext window limit context-window context_window\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebudget\u003c/value\u003e\n\u003cvariants\u003ebudget allocation budget-allocation budget_allocation\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ementions\u003c/value\u003e\n\u003cvariants\u003e@-mentions mentions\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search the codebase for information on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econtext window\u003c/value\u003e\n\u003cvariants\u003econtext window limit context-window context_window\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebudget\u003c/value\u003e\n\u003cvariants\u003ebudget allocation budget-allocation budget_allocation\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ementions\u003c/value\u003e\n\u003cvariants\u003e@-mentions mentions\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keywor","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search the codebase for information on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econtext window\u003c/value\u003e\n\u003cvariants\u003econtext window limit context-window context_window\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebudget\u003c/value\u003e\n\u003cvariants\u003ebudget allocation budget-allocation budget_allocation\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ementions\u003c/value\u003e\n\u003cvariants\u003e@-mentions mentions\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search the codebase for information on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econtext window\u003c/value\u003e\n\u003cvariants\u003econtext window limit context-window context_window\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebudget\u003c/value\u003e\n\u003cvariants\u003ebudget allocation budget-allocation budget_allocation\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ementions\u003c/value\u003e\n\u003cvariants\u003e@-mentions mentions\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search the codebase for information on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econtext window\u003c/value\u003e\n\u003cvariants\u003econtext window limit context-window context_window\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebudget\u003c/value\u003e\n\u003cvariants\u003ebudget allocation budget-allocation budget_allocation\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ementions\u003c/value\u003e\n\u003cvariants\u003e@-mentions mentions\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeywor","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search the codebase for information on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econtext window\u003c/value\u003e\n\u003cvariants\u003econtext window limit context-window context_window\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebudget\u003c/value\u003e\n\u003cvariants\u003ebudget allocation budget-allocation budget_allocation\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ementions\u003c/value\u003e\n\u003cvariants\u003e@-mentions mentions\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search the codebase for information on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econtext window\u003c/value\u003e\n\u003cvariants\u003econtext window limit context-window context_window\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebudget\u003c/value\u003e\n\u003cvariants\u003ebudget allocation budget-allocation budget_allocation\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ementions\u003c/value\u003e\n\u003cvariants\u003e@-mentions mentions\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search the codebase for information on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econtext window\u003c/value\u003e\n\u003cvariants\u003econtext window limit context-window context_window\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebudget\u003c/value\u003e\n\u003cvariants\u003ebudget allocation budget-allocation budget_allocation\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ementions\u003c/value\u003e\n\u003cvariants\u003e@-mentions mentions\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search the codebase for information on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econtext window\u003c/value\u003e\n\u003cvariants\u003econtext window limit context-window context_window\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebudget\u003c/value\u003e\n\u003cvariants\u003ebudget allocation budget-allocation budget_allocation\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ementions\u003c/value\u003e\n\u003cvariants\u003e@-mentions mentions\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search the codebase for information on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econtext window\u003c/value\u003e\n\u003cvariants\u003econtext window limit context-window context_window\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebudget\u003c/value\u003e\n\u003cvariants\u003ebudget allocation budget-allocation budget_allocation\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ementions\u003c/value\u003e\n\u003cvariants\u003e@-mentions mentions\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esearch","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search the codebase for information on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econtext window\u003c/value\u003e\n\u003cvariants\u003econtext window limit context-window context_window\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebudget\u003c/value\u003e\n\u003cvariants\u003ebudget allocation budget-allocation budget_allocation\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ementions\u003c/value\u003e\n\u003cvariants\u003e@-mentions mentions\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esearch context","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search the codebase for information on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econtext window\u003c/value\u003e\n\u003cvariants\u003econtext window limit context-window context_window\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebudget\u003c/value\u003e\n\u003cvariants\u003ebudget allocation budget-allocation budget_allocation\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ementions\u003c/value\u003e\n\u003cvariants\u003e@-mentions mentions\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esearch context\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search the codebase for information on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econtext window\u003c/value\u003e\n\u003cvariants\u003econtext window limit context-window context_window\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebudget\u003c/value\u003e\n\u003cvariants\u003ebudget allocation budget-allocation budget_allocation\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ementions\u003c/value\u003e\n\u003cvariants\u003e@-mentions mentions\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esearch context\u003c/value","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search the codebase for information on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econtext window\u003c/value\u003e\n\u003cvariants\u003econtext window limit context-window context_window\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebudget\u003c/value\u003e\n\u003cvariants\u003ebudget allocation budget-allocation budget_allocation\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ementions\u003c/value\u003e\n\u003cvariants\u003e@-mentions mentions\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esearch context\u003c/value\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search the codebase for information on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econtext window\u003c/value\u003e\n\u003cvariants\u003econtext window limit context-window context_window\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebudget\u003c/value\u003e\n\u003cvariants\u003ebudget allocation budget-allocation budget_allocation\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ementions\u003c/value\u003e\n\u003cvariants\u003e@-mentions mentions\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esearch context\u003c/value\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search the codebase for information on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econtext window\u003c/value\u003e\n\u003cvariants\u003econtext window limit context-window context_window\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebudget\u003c/value\u003e\n\u003cvariants\u003ebudget allocation budget-allocation budget_allocation\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ementions\u003c/value\u003e\n\u003cvariants\u003e@-mentions mentions\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esearch context\u003c/value\u003e\n\u003cvariants","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search the codebase for information on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econtext window\u003c/value\u003e\n\u003cvariants\u003econtext window limit context-window context_window\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebudget\u003c/value\u003e\n\u003cvariants\u003ebudget allocation budget-allocation budget_allocation\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ementions\u003c/value\u003e\n\u003cvariants\u003e@-mentions mentions\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esearch context\u003c/value\u003e\n\u003cvariants\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search the codebase for information on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econtext window\u003c/value\u003e\n\u003cvariants\u003econtext window limit context-window context_window\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebudget\u003c/value\u003e\n\u003cvariants\u003ebudget allocation budget-allocation budget_allocation\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ementions\u003c/value\u003e\n\u003cvariants\u003e@-mentions mentions\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esearch context\u003c/value\u003e\n\u003cvariants\u003esearch","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search the codebase for information on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econtext window\u003c/value\u003e\n\u003cvariants\u003econtext window limit context-window context_window\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebudget\u003c/value\u003e\n\u003cvariants\u003ebudget allocation budget-allocation budget_allocation\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ementions\u003c/value\u003e\n\u003cvariants\u003e@-mentions mentions\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esearch context\u003c/value\u003e\n\u003cvariants\u003esearch-","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search the codebase for information on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econtext window\u003c/value\u003e\n\u003cvariants\u003econtext window limit context-window context_window\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebudget\u003c/value\u003e\n\u003cvariants\u003ebudget allocation budget-allocation budget_allocation\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ementions\u003c/value\u003e\n\u003cvariants\u003e@-mentions mentions\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esearch context\u003c/value\u003e\n\u003cvariants\u003esearch-context","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search the codebase for information on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econtext window\u003c/value\u003e\n\u003cvariants\u003econtext window limit context-window context_window\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebudget\u003c/value\u003e\n\u003cvariants\u003ebudget allocation budget-allocation budget_allocation\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ementions\u003c/value\u003e\n\u003cvariants\u003e@-mentions mentions\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esearch context\u003c/value\u003e\n\u003cvariants\u003esearch-context search","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search the codebase for information on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econtext window\u003c/value\u003e\n\u003cvariants\u003econtext window limit context-window context_window\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebudget\u003c/value\u003e\n\u003cvariants\u003ebudget allocation budget-allocation budget_allocation\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ementions\u003c/value\u003e\n\u003cvariants\u003e@-mentions mentions\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esearch context\u003c/value\u003e\n\u003cvariants\u003esearch-context search_","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search the codebase for information on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econtext window\u003c/value\u003e\n\u003cvariants\u003econtext window limit context-window context_window\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebudget\u003c/value\u003e\n\u003cvariants\u003ebudget allocation budget-allocation budget_allocation\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ementions\u003c/value\u003e\n\u003cvariants\u003e@-mentions mentions\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esearch context\u003c/value\u003e\n\u003cvariants\u003esearch-context search_context","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search the codebase for information on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econtext window\u003c/value\u003e\n\u003cvariants\u003econtext window limit context-window context_window\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebudget\u003c/value\u003e\n\u003cvariants\u003ebudget allocation budget-allocation budget_allocation\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ementions\u003c/value\u003e\n\u003cvariants\u003e@-mentions mentions\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esearch context\u003c/value\u003e\n\u003cvariants\u003esearch-context search_context\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search the codebase for information on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econtext window\u003c/value\u003e\n\u003cvariants\u003econtext window limit context-window context_window\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebudget\u003c/value\u003e\n\u003cvariants\u003ebudget allocation budget-allocation budget_allocation\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ementions\u003c/value\u003e\n\u003cvariants\u003e@-mentions mentions\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esearch context\u003c/value\u003e\n\u003cvariants\u003esearch-context search_context\u003c/variants","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search the codebase for information on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econtext window\u003c/value\u003e\n\u003cvariants\u003econtext window limit context-window context_window\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebudget\u003c/value\u003e\n\u003cvariants\u003ebudget allocation budget-allocation budget_allocation\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ementions\u003c/value\u003e\n\u003cvariants\u003e@-mentions mentions\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esearch context\u003c/value\u003e\n\u003cvariants\u003esearch-context search_context\u003c/variants\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search the codebase for information on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econtext window\u003c/value\u003e\n\u003cvariants\u003econtext window limit context-window context_window\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebudget\u003c/value\u003e\n\u003cvariants\u003ebudget allocation budget-allocation budget_allocation\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ementions\u003c/value\u003e\n\u003cvariants\u003e@-mentions mentions\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esearch context\u003c/value\u003e\n\u003cvariants\u003esearch-context search_context\u003c/variants\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search the codebase for information on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econtext window\u003c/value\u003e\n\u003cvariants\u003econtext window limit context-window context_window\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebudget\u003c/value\u003e\n\u003cvariants\u003ebudget allocation budget-allocation budget_allocation\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ementions\u003c/value\u003e\n\u003cvariants\u003e@-mentions mentions\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esearch context\u003c/value\u003e\n\u003cvariants\u003esearch-context search_context\u003c/variants\u003e\n\u003cweight","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search the codebase for information on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econtext window\u003c/value\u003e\n\u003cvariants\u003econtext window limit context-window context_window\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebudget\u003c/value\u003e\n\u003cvariants\u003ebudget allocation budget-allocation budget_allocation\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ementions\u003c/value\u003e\n\u003cvariants\u003e@-mentions mentions\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esearch context\u003c/value\u003e\n\u003cvariants\u003esearch-context search_context\u003c/variants\u003e\n\u003cweight\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search the codebase for information on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econtext window\u003c/value\u003e\n\u003cvariants\u003econtext window limit context-window context_window\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebudget\u003c/value\u003e\n\u003cvariants\u003ebudget allocation budget-allocation budget_allocation\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ementions\u003c/value\u003e\n\u003cvariants\u003e@-mentions mentions\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esearch context\u003c/value\u003e\n\u003cvariants\u003esearch-context search_context\u003c/variants\u003e\n\u003cweight\u003e0","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search the codebase for information on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econtext window\u003c/value\u003e\n\u003cvariants\u003econtext window limit context-window context_window\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebudget\u003c/value\u003e\n\u003cvariants\u003ebudget allocation budget-allocation budget_allocation\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ementions\u003c/value\u003e\n\u003cvariants\u003e@-mentions mentions\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esearch context\u003c/value\u003e\n\u003cvariants\u003esearch-context search_context\u003c/variants\u003e\n\u003cweight\u003e0.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search the codebase for information on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econtext window\u003c/value\u003e\n\u003cvariants\u003econtext window limit context-window context_window\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebudget\u003c/value\u003e\n\u003cvariants\u003ebudget allocation budget-allocation budget_allocation\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ementions\u003c/value\u003e\n\u003cvariants\u003e@-mentions mentions\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esearch context\u003c/value\u003e\n\u003cvariants\u003esearch-context search_context\u003c/variants\u003e\n\u003cweight\u003e0.8","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search the codebase for information on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econtext window\u003c/value\u003e\n\u003cvariants\u003econtext window limit context-window context_window\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebudget\u003c/value\u003e\n\u003cvariants\u003ebudget allocation budget-allocation budget_allocation\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ementions\u003c/value\u003e\n\u003cvariants\u003e@-mentions mentions\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esearch context\u003c/value\u003e\n\u003cvariants\u003esearch-context search_context\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search the codebase for information on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econtext window\u003c/value\u003e\n\u003cvariants\u003econtext window limit context-window context_window\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebudget\u003c/value\u003e\n\u003cvariants\u003ebudget allocation budget-allocation budget_allocation\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ementions\u003c/value\u003e\n\u003cvariants\u003e@-mentions mentions\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esearch context\u003c/value\u003e\n\u003cvariants\u003esearch-context search_context\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search the codebase for information on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econtext window\u003c/value\u003e\n\u003cvariants\u003econtext window limit context-window context_window\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebudget\u003c/value\u003e\n\u003cvariants\u003ebudget allocation budget-allocation budget_allocation\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ementions\u003c/value\u003e\n\u003cvariants\u003e@-mentions mentions\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esearch context\u003c/value\u003e\n\u003cvariants\u003esearch-context search_context\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search the codebase for information on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econtext window\u003c/value\u003e\n\u003cvariants\u003econtext window limit context-window context_window\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebudget\u003c/value\u003e\n\u003cvariants\u003ebudget allocation budget-allocation budget_allocation\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ementions\u003c/value\u003e\n\u003cvariants\u003e@-mentions mentions\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esearch context\u003c/value\u003e\n\u003cvariants\u003esearch-context search_context\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search the codebase for information on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econtext window\u003c/value\u003e\n\u003cvariants\u003econtext window limit context-window context_window\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebudget\u003c/value\u003e\n\u003cvariants\u003ebudget allocation budget-allocation budget_allocation\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ementions\u003c/value\u003e\n\u003cvariants\u003e@-mentions mentions\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esearch context\u003c/value\u003e\n\u003cvariants\u003esearch-context search_context\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keywor","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search the codebase for information on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econtext window\u003c/value\u003e\n\u003cvariants\u003econtext window limit context-window context_window\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebudget\u003c/value\u003e\n\u003cvariants\u003ebudget allocation budget-allocation budget_allocation\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ementions\u003c/value\u003e\n\u003cvariants\u003e@-mentions mentions\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esearch context\u003c/value\u003e\n\u003cvariants\u003esearch-context search_context\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search the codebase for information on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econtext window\u003c/value\u003e\n\u003cvariants\u003econtext window limit context-window context_window\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebudget\u003c/value\u003e\n\u003cvariants\u003ebudget allocation budget-allocation budget_allocation\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ementions\u003c/value\u003e\n\u003cvariants\u003e@-mentions mentions\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esearch context\u003c/value\u003e\n\u003cvariants\u003esearch-context search_context\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search the codebase for information on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econtext window\u003c/value\u003e\n\u003cvariants\u003econtext window limit context-window context_window\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebudget\u003c/value\u003e\n\u003cvariants\u003ebudget allocation budget-allocation budget_allocation\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ementions\u003c/value\u003e\n\u003cvariants\u003e@-mentions mentions\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esearch context\u003c/value\u003e\n\u003cvariants\u003esearch-context search_context\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003c/keywords","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search the codebase for information on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econtext window\u003c/value\u003e\n\u003cvariants\u003econtext window limit context-window context_window\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebudget\u003c/value\u003e\n\u003cvariants\u003ebudget allocation budget-allocation budget_allocation\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ementions\u003c/value\u003e\n\u003cvariants\u003e@-mentions mentions\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esearch context\u003c/value\u003e\n\u003cvariants\u003esearch-context search_context\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003c/keywords\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some relevant filename fragments to search the codebase for information on the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econtext window\u003c/value\u003e\n\u003cvariants\u003econtext window limit context-window context_window\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebudget\u003c/value\u003e\n\u003cvariants\u003ebudget allocation budget-allocation budget_allocation\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ementions\u003c/value\u003e\n\u003cvariants\u003e@-mentions mentions\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esearch context\u003c/value\u003e\n\u003cvariants\u003esearch-context search_context\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003c/keywords\u003e","stopReason":"end_turn"}
+            data: {"completion":"\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etree-sitter\u003c/value\u003e\n\u003cvariants\u003etree sitter treesitter tree-parser\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eparser\u003c/value\u003e\n\u003cvariants\u003eparsing parse\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efile\u003c/value\u003e\n\u003cvariants\u003efiles\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003c/keywords\u003e","stopReason":"end_turn"}
 
 
             event: done
@@ -5556,7 +502,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Tue, 28 May 2024 16:10:37 GMT
+            value: Fri, 07 Jun 2024 23:18:06 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
@@ -5585,7 +531,325 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-05-28T16:10:36.997Z
+      startedDateTime: 2024-06-07T23:18:05.499Z
+      time: 0
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 0
+    - _id: 778c9b0af3088ae85abd2efb3a6e7c90
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 885
+        cookies: []
+        headers:
+          - name: content-type
+            value: application/json
+          - name: accept-encoding
+            value: gzip;q=0
+          - name: authorization
+            value: token
+              REDACTED_d5e0f0a37c9821e856b923fe14e67a605e3f6c0a517d5a4f46a4e35943ee0f6d
+          - name: connection
+            value: keep-alive
+          - name: host
+            value: sourcegraph.com
+        headersSize: 255
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json
+          params: []
+          textJSON:
+            fast: true
+            maxTokensToSample: 400
+            messages:
+              - speaker: human
+                text: You are Cody, an AI coding assistant from Sourcegraph.
+              - speaker: assistant
+                text: I am Cody, an AI coding assistant from Sourcegraph.
+              - speaker: human
+                text: "You are helping the user search over a codebase. List some filename
+                  fragments that would match files relevant to read to answer
+                  the user's query. Present your results in a *single* XML list
+                  in the following format: <keywords><keyword><value>a single
+                  keyword</value><variants>a space separated list of synonyms
+                  and variants of the keyword, including acronyms,
+                  abbreviations, and expansions</variants><weight>a numerical
+                  weight between 0.0 and 1.0 that indicates the importance of
+                  the keyword</weight></keyword></keywords>. Here is the user
+                  query: <userQuery>scan tokens in C++</userQuery>"
+              - speaker: assistant
+            temperature: 0
+            topK: 1
+        queryString: []
+        url: https://sourcegraph.com/.api/completions/stream
+      response:
+        bodySize: 42103
+        content:
+          mimeType: text/event-stream
+          size: 42103
+          text: >+
+            event: completion
+
+            data: {"completion":"\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003etoken\u003c/value\u003e\n\u003cvariants\u003elexeme lexical_unit lexical_element\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003escanner\u003c/value\u003e\n\u003cvariants\u003elexer tokenizer\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ecpp\u003c/value\u003e\n\u003cvariants\u003ec++ cxx cplusplus\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003c/keywords\u003e","stopReason":"end_turn"}
+
+
+            event: done
+
+            data: {}
+
+        cookies: []
+        headers:
+          - name: date
+            value: Fri, 07 Jun 2024 23:18:07 GMT
+          - name: content-type
+            value: text/event-stream
+          - name: transfer-encoding
+            value: chunked
+          - name: connection
+            value: keep-alive
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache
+          - name: vary
+            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
+              X-Requested-With,Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+        headersSize: 1284
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: 2024-06-07T23:18:07.076Z
+      time: 0
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 0
+    - _id: 536201c4d6e189932cdd1c86d892c41b
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 914
+        cookies: []
+        headers:
+          - name: content-type
+            value: application/json
+          - name: accept-encoding
+            value: gzip;q=0
+          - name: authorization
+            value: token
+              REDACTED_d5e0f0a37c9821e856b923fe14e67a605e3f6c0a517d5a4f46a4e35943ee0f6d
+          - name: connection
+            value: keep-alive
+          - name: host
+            value: sourcegraph.com
+        headersSize: 255
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json
+          params: []
+          textJSON:
+            fast: true
+            maxTokensToSample: 400
+            messages:
+              - speaker: human
+                text: You are Cody, an AI coding assistant from Sourcegraph.
+              - speaker: assistant
+                text: I am Cody, an AI coding assistant from Sourcegraph.
+              - speaker: human
+                text: "You are helping the user search over a codebase. List some filename
+                  fragments that would match files relevant to read to answer
+                  the user's query. Present your results in a *single* XML list
+                  in the following format: <keywords><keyword><value>a single
+                  keyword</value><variants>a space separated list of synonyms
+                  and variants of the keyword, including acronyms,
+                  abbreviations, and expansions</variants><weight>a numerical
+                  weight between 0.0 and 1.0 that indicates the importance of
+                  the keyword</weight></keyword></keywords>. Here is the user
+                  query: <userQuery>C'est ou la logique pour recloner les
+                  dépôts?</userQuery>"
+              - speaker: assistant
+            temperature: 0
+            topK: 1
+        queryString: []
+        url: https://sourcegraph.com/.api/completions/stream
+      response:
+        bodySize: 38218
+        content:
+          mimeType: text/event-stream
+          size: 38218
+          text: >+
+            event: completion
+
+            data: {"completion":"\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eclone\u003c/value\u003e\n\u003cvariants\u003ereclone replication repository\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003elogic\u003c/value\u003e\n\u003cvariants\u003ealgorithm workflow process\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erepository\u003c/value\u003e\n\u003cvariants\u003erepo git\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003c/keywords\u003e","stopReason":"end_turn"}
+
+
+            event: done
+
+            data: {}
+
+        cookies: []
+        headers:
+          - name: date
+            value: Fri, 07 Jun 2024 23:18:09 GMT
+          - name: content-type
+            value: text/event-stream
+          - name: transfer-encoding
+            value: chunked
+          - name: connection
+            value: keep-alive
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache
+          - name: vary
+            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
+              X-Requested-With,Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+        headersSize: 1284
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: 2024-06-07T23:18:08.794Z
+      time: 0
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 0
+    - _id: 3952aea674fc7435f8c444789ab7ec66
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 977
+        cookies: []
+        headers:
+          - name: content-type
+            value: application/json
+          - name: accept-encoding
+            value: gzip;q=0
+          - name: authorization
+            value: token
+              REDACTED_d5e0f0a37c9821e856b923fe14e67a605e3f6c0a517d5a4f46a4e35943ee0f6d
+          - name: connection
+            value: keep-alive
+          - name: host
+            value: sourcegraph.com
+        headersSize: 255
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json
+          params: []
+          textJSON:
+            fast: true
+            maxTokensToSample: 400
+            messages:
+              - speaker: human
+                text: You are Cody, an AI coding assistant from Sourcegraph.
+              - speaker: assistant
+                text: I am Cody, an AI coding assistant from Sourcegraph.
+              - speaker: human
+                text: "You are helping the user search over a codebase. List some filename
+                  fragments that would match files relevant to read to answer
+                  the user's query. Present your results in a *single* XML list
+                  in the following format: <keywords><keyword><value>a single
+                  keyword</value><variants>a space separated list of synonyms
+                  and variants of the keyword, including acronyms,
+                  abbreviations, and expansions</variants><weight>a numerical
+                  weight between 0.0 and 1.0 that indicates the importance of
+                  the keyword</weight></keyword></keywords>. Here is the user
+                  query: <userQuery>Explain how the context window limit is
+                  calculated. how much budget is given to @-mentions vs. search
+                  context?</userQuery>"
+              - speaker: assistant
+            temperature: 0
+            topK: 1
+        queryString: []
+        url: https://sourcegraph.com/.api/completions/stream
+      response:
+        bodySize: 72582
+        content:
+          mimeType: text/event-stream
+          size: 72582
+          text: >+
+            event: completion
+
+            data: {"completion":"\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003econtext window\u003c/value\u003e\n\u003cvariants\u003econtext window limit context-window context_window\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebudget\u003c/value\u003e\n\u003cvariants\u003ebudget allocation resource allocation\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ementions\u003c/value\u003e\n\u003cvariants\u003e@-mentions mentions\u003c/variants\u003e\n\u003cweight\u003e0.6\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esearch context\u003c/value\u003e\n\u003cvariants\u003esearch context search-context\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003c/keywords\u003e","stopReason":"end_turn"}
+
+
+            event: done
+
+            data: {}
+
+        cookies: []
+        headers:
+          - name: date
+            value: Fri, 07 Jun 2024 23:18:11 GMT
+          - name: content-type
+            value: text/event-stream
+          - name: transfer-encoding
+            value: chunked
+          - name: connection
+            value: keep-alive
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache
+          - name: vary
+            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
+              X-Requested-With,Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+        headersSize: 1284
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: 2024-06-07T23:18:10.283Z
       time: 0
       timings:
         blocked: -1

--- a/vscode/src/local-context/rewrite-keyword-query.test.ts
+++ b/vscode/src/local-context/rewrite-keyword-query.test.ts
@@ -40,7 +40,7 @@ describe('rewrite-query', () => {
 
     check(ps`ocean`, expanded =>
         expect(expanded).toMatchInlineSnapshot(
-            `"aquatic fish marine maritime nautical ocean sea sealife surf swell tide underwater water wave"`
+            `"aquatic marine marine_data maritime ocean ocean_data oceanographer oceanographic oceanographic_data oceanography oceanologic oceanology science scientist sea"`
         )
     )
 
@@ -50,21 +50,37 @@ describe('rewrite-query', () => {
         )
     )
 
+    check(
+        ps`type Zoekt struct {
+\tClient zoekt.Searcher
+
+\t// DisableCache when true prevents caching of Client.List. Useful in
+\t// tests.
+\tDisableCache bool
+
+\tmu       sync.RWMute
+`,
+        expanded =>
+            expect(expanded).toMatchInlineSnapshot(
+                `"cache cached caching mutex search search_engine searcher sync synchronization test testing zoekt"`
+            )
+    )
+
     check(ps`Where is authentication router defined?`, expanded =>
         expect(expanded).toMatchInlineSnapshot(
-            `"auth authentication authorization config configuration route router routing"`
+            `"auth auth-related authentication define defined definition definition-site login route-related router routing security"`
         )
     )
 
     check(ps`parse file with tree-sitter`, expanded =>
         expect(expanded).toMatchInlineSnapshot(
-            `"file files parse parser parsing sitter tree tree-sitter treesitter"`
+            `"file files parse parser parsing sitter tree tree-parser tree-sitter treesitter"`
         )
     )
 
     check(ps`scan tokens in C++`, expanded =>
         expect(expanded).toMatchInlineSnapshot(
-            `"analyze c++ cplusplus cpp cxx lex lexer lexical parse scan scanner token tokenizer"`
+            `"c++ cplusplus cpp cxx lexeme lexer lexical_element lexical_unit scanner token tokenizer"`
         )
     )
 
@@ -79,7 +95,7 @@ describe('rewrite-query', () => {
         ps`C'est ou la logique pour recloner les dépôts?`,
         expanded =>
             expect(expanded).toMatchInlineSnapshot(
-                `"algorithm clone cloning config configuration git logic reasoning repo repository settings vcs version-control"`
+                `"algorithm clone git logic process reclone replication repo repository workflow"`
             ),
         { restrictRewrite: true }
     )
@@ -88,7 +104,7 @@ describe('rewrite-query', () => {
         ps`Explain how the context window limit is calculated. how much budget is given to @-mentions vs. search context?`,
         expanded =>
             expect(expanded).toMatchInlineSnapshot(
-                `"@-mentions allocation budget budget-allocation budget_allocation context context window context-window context_window limit mentions search context search-context search_context window"`
+                `"@-mentions allocation budget context context-window context_window limit mentions resource search search-context window"`
             ),
         { restrictRewrite: true }
     )

--- a/vscode/src/local-context/rewrite-keyword-query.ts
+++ b/vscode/src/local-context/rewrite-keyword-query.ts
@@ -6,6 +6,7 @@ import {
     getSimplePreamble,
     ps,
 } from '@sourcegraph/cody-shared'
+import { logDebug } from '../log'
 
 // biome-ignore lint: this regex intentionally contains control characters
 const containsNonAscii = /[^\u0000-\u007F]/
@@ -32,6 +33,23 @@ export async function rewriteKeywordQuery(
         }
     }
 
+    const rewritten = doRewrite(completionsClient, query)
+    return rewritten
+        .then(value => {
+            // If there are no rewritten terms, just return the original query.
+            return value.length !== 0 ? value.sort().join(' ') : query.toString()
+        })
+        .catch(err => {
+            logDebug('rewrite-keyword-query', 'failed', { verbose: err })
+            // If we fail to rewrite, just return the original query.
+            return query.toString()
+        })
+}
+
+async function doRewrite(
+    completionsClient: SourcegraphCompletionsClient,
+    query: PromptString
+): Promise<string[]> {
     const preamble = getSimplePreamble(undefined, 0)
     const stream = completionsClient.stream(
         {
@@ -39,7 +57,7 @@ export async function rewriteKeywordQuery(
                 ...preamble,
                 {
                     speaker: 'human',
-                    text: ps`You are helping the user search over a codebase. List some filename fragments that would match files relevant to read to answer the user's query. Present your results in an XML list in the following format: <keywords><keyword><value>a single keyword</value><variants>a space separated list of synonyms and variants of the keyword, including acronyms, abbreviations, and expansions</variants><weight>a numerical weight between 0.0 and 1.0 that indicates the importance of the keyword</weight></keyword></keywords>. Here is the user query: <userQuery>${query}</userQuery>`,
+                    text: ps`You are helping the user search over a codebase. List some filename fragments that would match files relevant to read to answer the user's query. Present your results in a *single* XML list in the following format: <keywords><keyword><value>a single keyword</value><variants>a space separated list of synonyms and variants of the keyword, including acronyms, abbreviations, and expansions</variants><weight>a numerical weight between 0.0 and 1.0 that indicates the importance of the keyword</weight></keyword></keywords>. Here is the user query: <userQuery>${query}</userQuery>`,
                 },
                 { speaker: 'assistant' },
             ],
@@ -67,21 +85,24 @@ export async function rewriteKeywordQuery(
     const text = streamingText.at(-1) ?? ''
     const parser = new XMLParser()
     const document = parser.parse(text)
+
     const keywords: { value?: string; variants?: string; weight?: number }[] =
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
         document?.keywords?.keyword ?? []
     const result = new Set<string>()
+
     for (const { value, variants } of keywords) {
-        if (typeof value === 'string' && value) {
-            result.add(value)
+        if (value) {
+            for (const v of value.split(' ')) {
+                result.add(v)
+            }
         }
-        if (typeof variants === 'string') {
-            for (const variant of variants.split(' ')) {
-                if (variant) {
-                    result.add(variant)
-                }
+        if (variants) {
+            for (const v of variants.split(' ')) {
+                result.add(v)
             }
         }
     }
-    return [...result].sort().join(' ')
+
+    return [...result]
 }


### PR DESCRIPTION
For some inputs, our LLM query rewrite would produce multiple lines of XML, whereas we expect a single line. This caused us to return no rewritten term, which results in no context.

This change updates the prompt to encourage the LLM to produce a single line. Additional fixes:
* Make sure to split `value` (the main keyword) on whitespace, to avoid duplicated rewritten terms
* If the rewrite fails for whatever reason, return the original string instead of failing the whole search

Relates to CODY-1615

## Test plan

Added new test case for query that triggered the broken behavior:
```
type Zoekt struct {
\tClient zoekt.Searcher
\t// DisableCache when true prevents caching of Client.List. Useful in
\t// tests.
\tDisableCache bool
\tmu       sync.RWMute
```