### PR TITLE
cody.experimental.autocomplete.firstCompletionTimeout setting

### DIFF
--- a/lib/shared/src/configuration.ts
+++ b/lib/shared/src/configuration.ts
@@ -88,6 +88,7 @@ export interface Configuration {
     isRunningInsideAgent?: boolean
     agentIDE?: 'VSCode' | 'JetBrains' | 'Neovim' | 'Emacs'
     autocompleteTimeouts: AutocompleteTimeouts
+    autocompleteFirstCompletionTimeout: number
 
     testingModelConfig: EmbeddingsModelConfig | undefined
 }

--- a/vscode/src/completions/create-inline-completion-item-provider.ts
+++ b/vscode/src/completions/create-inline-completion-item-provider.ts
@@ -80,6 +80,7 @@ export async function createInlineCompletionItemProvider({
         const completionsProvider = new InlineCompletionItemProvider({
             authStatus,
             providerConfig,
+            firstCompletionTimeout: config.autocompleteFirstCompletionTimeout,
             statusBar,
             completeSuggestWidgetSelection: config.autocompleteCompleteSuggestWidgetSelection,
             formatOnAccept: config.autocompleteFormatOnAccept,

--- a/vscode/src/completions/create-multi-model-inline-completion-provider.ts
+++ b/vscode/src/completions/create-multi-model-inline-completion-provider.ts
@@ -124,6 +124,7 @@ export async function createInlineCompletionItemFromMultipleProviders({
             const completionsProvider = new InlineCompletionItemProvider({
                 authStatus,
                 providerConfig,
+                firstCompletionTimeout: config.autocompleteFirstCompletionTimeout,
                 statusBar,
                 completeSuggestWidgetSelection: config.autocompleteCompleteSuggestWidgetSelection,
                 formatOnAccept: config.autocompleteFormatOnAccept,

--- a/vscode/src/completions/get-inline-completions-tests/helpers.ts
+++ b/vscode/src/completions/get-inline-completions-tests/helpers.ts
@@ -180,6 +180,9 @@ export function params(
         triggerKind,
         selectedCompletionInfo,
         providerConfig,
+        firstCompletionTimeout:
+            configuration?.autocompleteFirstCompletionTimeout ??
+            DEFAULT_VSCODE_SETTINGS.autocompleteFirstCompletionTimeout,
         requestManager: new RequestManager(),
         contextMixer: new ContextMixer(new DefaultContextStrategyFactory('none')),
         completionIntent: getCompletionIntent({

--- a/vscode/src/completions/get-inline-completions.ts
+++ b/vscode/src/completions/get-inline-completions.ts
@@ -57,6 +57,7 @@ export interface InlineCompletionsParams {
     abortSignal?: AbortSignal
     tracer?: (data: Partial<ProvideInlineCompletionsItemTraceData>) => void
     artificialDelay?: number
+    firstCompletionTimeout: number
 
     // Feature flags
     completeSuggestWidgetSelection?: boolean
@@ -198,6 +199,7 @@ async function doGetInlineCompletions(
         handleDidAcceptCompletionItem,
         handleDidPartiallyAcceptCompletionItem,
         artificialDelay,
+        firstCompletionTimeout,
         completionIntent,
         lastAcceptedCompletionItem,
         isDotComUser,
@@ -363,6 +365,7 @@ async function doGetInlineCompletions(
         triggerKind,
         providerConfig,
         docContext,
+        firstCompletionTimeout,
     })
 
     tracer?.({
@@ -395,12 +398,16 @@ async function doGetInlineCompletions(
 }
 
 interface GetCompletionProvidersParams
-    extends Pick<InlineCompletionsParams, 'document' | 'position' | 'triggerKind' | 'providerConfig'> {
+    extends Pick<
+        InlineCompletionsParams,
+        'document' | 'position' | 'triggerKind' | 'providerConfig' | 'firstCompletionTimeout'
+    > {
     docContext: DocumentContext
 }
 
 function getCompletionProvider(params: GetCompletionProvidersParams): Provider {
-    const { document, position, triggerKind, providerConfig, docContext } = params
+    const { document, position, triggerKind, providerConfig, docContext, firstCompletionTimeout } =
+        params
 
     const sharedProviderOptions: Omit<ProviderOptions, 'id' | 'n' | 'multiline'> = {
         triggerKind,
@@ -409,7 +416,7 @@ function getCompletionProvider(params: GetCompletionProvidersParams): Provider {
         position,
         hotStreak: completionProviderConfig.hotStreak,
         // For now the value is static and based on the average multiline completion latency.
-        firstCompletionTimeout: 1500,
+        firstCompletionTimeout,
     }
 
     // Show more if manually triggered (but only showing 1 is faster, so we use it

--- a/vscode/src/completions/inline-completion-item-provider.test.ts
+++ b/vscode/src/completions/inline-completion-item-provider.test.ts
@@ -11,7 +11,7 @@ import {
 } from '@sourcegraph/cody-shared'
 
 import { localStorage } from '../services/LocalStorageProvider'
-import { vsCodeMocks } from '../testutils/mocks'
+import { DEFAULT_VSCODE_SETTINGS, vsCodeMocks } from '../testutils/mocks'
 import { withPosixPaths } from '../testutils/textDocument'
 
 import { SupportedLanguage } from '../tree-sitter/grammars'
@@ -79,6 +79,9 @@ class MockableInlineCompletionItemProvider extends InlineCompletionItemProvider 
             }),
             triggerNotice: null,
             authStatus: DUMMY_AUTH_STATUS,
+            firstCompletionTimeout:
+                superArgs?.firstCompletionTimeout ??
+                DEFAULT_VSCODE_SETTINGS.autocompleteFirstCompletionTimeout,
             ...superArgs,
         })
         this.getInlineCompletions = mockGetInlineCompletions

--- a/vscode/src/completions/inline-completion-item-provider.ts
+++ b/vscode/src/completions/inline-completion-item-provider.ts
@@ -60,6 +60,7 @@ interface AutocompleteResult extends vscode.InlineCompletionList {
 
 interface CodyCompletionItemProviderConfig {
     providerConfig: ProviderConfig
+    firstCompletionTimeout: number
     statusBar: CodyStatusBar
     tracer?: ProvideInlineCompletionItemsTracer | null
     triggerNotice: ((notice: { key: string }) => void) | null
@@ -379,6 +380,7 @@ export class InlineCompletionItemProvider
                         this.unstable_handleDidPartiallyAcceptCompletionItem.bind(this),
                     completeSuggestWidgetSelection: takeSuggestWidgetSelectionIntoAccount,
                     artificialDelay,
+                    firstCompletionTimeout: this.config.firstCompletionTimeout,
                     completionIntent,
                     lastAcceptedCompletionItem: this.lastAcceptedCompletionItem,
                     isDotComUser: this.config.isDotComUser,

--- a/vscode/src/configuration.test.ts
+++ b/vscode/src/configuration.test.ts
@@ -165,6 +165,7 @@ describe('getConfiguration', () => {
                 multiline: undefined,
                 singleline: undefined,
             },
+            autocompleteFirstCompletionTimeout: 1500,
             testingModelConfig: undefined,
             experimentalChatContextRanker: false,
         } satisfies Configuration)

--- a/vscode/src/configuration.test.ts
+++ b/vscode/src/configuration.test.ts
@@ -110,6 +110,8 @@ describe('getConfiguration', () => {
                         return ''
                     case 'cody.experimental.minion.anthropicKey':
                         return undefined
+                    case 'cody.autocomplete.advanced.timeout.firstCompletion':
+                        return 1500
                     default:
                         throw new Error(`unexpected key: ${key}`)
                 }

--- a/vscode/src/configuration.ts
+++ b/vscode/src/configuration.ts
@@ -189,6 +189,10 @@ export function getConfiguration(
                 undefined
             ),
         },
+        autocompleteFirstCompletionTimeout: getHiddenSetting<number>(
+            'autocomplete.advanced.timeout.firstCompletion',
+            1_500
+        ),
         testingModelConfig:
             isTesting && hasValidLocalEmbeddingsConfig()
                 ? {

--- a/vscode/src/testutils/mocks.ts
+++ b/vscode/src/testutils/mocks.ts
@@ -870,6 +870,7 @@ export const DEFAULT_VSCODE_SETTINGS = {
         multiline: undefined,
         singleline: undefined,
     },
+    autocompleteFirstCompletionTimeout: 1500,
     testingModelConfig: undefined,
     experimentalChatContextRanker: false,
 } satisfies Configuration


### PR DESCRIPTION
This allows the user to set the timeout used for dynamic multiline completions. When this timeout is hit, we truncate the in-progress completion and propose whatever has streamed out as the completion. The default is 1500ms, which is low enough to be hit for many multiline completions. This causes our completion to appear as "partial" (we don't complete the whole syntactic block), which leads to a poor user experience.

In future work, we should investigate bumping or eliminating this timeout altogether, but this will at least allow us to bump the timeout internally while we investigate new completions models.

## Test plan

Setting is experimental. Tested locally.