### PR TITLE
openctx: warn if sourcegraph.openctx ext is enabled

### DIFF
--- a/vscode/src/context/openctx.ts
+++ b/vscode/src/context/openctx.ts
@@ -1,5 +1,5 @@
 import { type ConfigurationWithAccessToken, setOpenCtxClient } from '@sourcegraph/cody-shared'
-import type * as vscode from 'vscode'
+import * as vscode from 'vscode'
 import { logDebug, outputChannel } from '../log'
 import RemoteFileProvider from './openctx/remoteFileSearch'
 import RemoteRepositorySearch from './openctx/remoteRepositorySearch'
@@ -10,6 +10,7 @@ export async function exposeOpenCtxClient(
     config: ConfigurationWithAccessToken
 ) {
     logDebug('openctx', 'OpenCtx is enabled in Cody')
+    await warnIfOpenCtxExtensionConflict()
     try {
         const { createController } = await import('@openctx/vscode-lib')
         const providers = [
@@ -44,4 +45,15 @@ export async function exposeOpenCtxClient(
     } catch (error) {
         logDebug('openctx', `Failed to load OpenCtx client: ${error}`)
     }
+}
+
+async function warnIfOpenCtxExtensionConflict() {
+    const ext = vscode.extensions.getExtension('sourcegraph.openctx')
+    if (!ext) {
+        return
+    }
+    vscode.window.showWarningMessage(
+        'Cody directly provides OpenCtx support, please disable the Sourcegraph OpenCtx extension.'
+    )
+    await vscode.commands.executeCommand('workbench.extensions.action.showExtensionsWithIds', [[ext.id]])
 }


### PR DESCRIPTION
This commit will show a warning if the OpenCtx extension is installed and tell the user to disable it. It will additionally open up the extensions view filtered down to just the OpenCtx extension.

This isn't an ideal user experience, but after exploring the vscode APIs and codebase I couldn't find a more surefire way.

The reason this is added is the extensions currently conflict, leading to openctx providers in cody failing to initialize. I looked into ways to try and gracefully detect and avoid conflict, but did not manage to find a way.

Note: this checks at startup and on config change. I could add something which listens for the OpenCtx extension, but that is more complicated and the only time mention items break in cody is if it isn't the first to call createController.

Note: exposeOpenCtxClient running on config change is a bug, since we should only register the controller once and warn once. I will follow-up with another commit to fix that.

Test Plan: enabled the openctx extension, then restarted the ext host and the warning appeared.

https://github.com/sourcegraph/cody/assets/187831/3375641f-41bb-433a-8ccc-aaf3cd52ae4a

Fixes https://linear.app/sourcegraph/issue/CODY-2044/if-openctx-extension-is-installed-openctx-based-context-sources-do-not