### PR TITLE
openctx: do not call exposeOpenCtxClient on config change

### DIFF
--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -287,7 +287,6 @@ const register = async (
 
         promises.push(featureFlagProvider.syncAuthStatus())
         graphqlClient.onConfigurationChange(newConfig)
-        promises.push(exposeOpenCtxClient(secretStorage, newConfig))
         upstreamHealthProvider.onConfigurationChange(newConfig)
         githubClient.onConfigurationChange({ authToken: initialConfig.experimentalGithubAccessToken })
         promises.push(


### PR DESCRIPTION
This call will fail since it doesn't update config nor is it idempotent. It tries to re-register all vscode commands/etc which would fail. You can observe this by viewing cody output and updating your settings, you will see a line like:

```
openctx: Failed to load OpenCtx client: Error: command 'openctx.toggleEnable' already exists
```

As follow-up the vscode-lib controller needs to support being able to have providers updated, then we can implement a correct responding to config changes.

Test Plan: updated config and did not see openctx errors in cody output. Then tested that openctx providers still appear in mentions.