### PR TITLE
Enable fetching LLM model data from the backend

### DIFF
--- a/lib/shared/src/index.ts
+++ b/lib/shared/src/index.ts
@@ -237,6 +237,7 @@ export type {
     EmbeddingsSearchResult,
     event,
 } from './sourcegraph-api/graphql/client'
+export { RestClient } from './sourcegraph-api/rest/client'
 export { GraphQLTelemetryExporter } from './sourcegraph-api/telemetry/GraphQLTelemetryExporter'
 // biome-ignore lint/nursery/noRestrictedImports: Deprecated v1 telemetry used temporarily to support existing analytics.
 export { NOOP_TELEMETRY_SERVICE } from './telemetry'

--- a/lib/shared/src/models/index.ts
+++ b/lib/shared/src/models/index.ts
@@ -107,16 +107,16 @@ export class ModelsService {
      * Sets the primary models available to the user.
      * NOTE: private instances can only support 1 provider ATM.
      */
-    public static setModels(providers: Model[]): void {
-        ModelsService.primaryModels = providers
+    public static setModels(models: Model[]): void {
+        ModelsService.primaryModels = models
     }
 
     /**
      * Add new models for use.
      */
-    public static addModels(providers: Model[]): void {
+    public static addModels(models: Model[]): void {
         const set = new Set(ModelsService.primaryModels)
-        for (const provider of providers) {
+        for (const provider of models) {
             set.add(provider)
         }
         ModelsService.primaryModels = Array.from(set)

--- a/lib/shared/src/sourcegraph-api/graphql/client.ts
+++ b/lib/shared/src/sourcegraph-api/graphql/client.ts
@@ -1165,7 +1165,9 @@ export class ConfigFeaturesSingleton {
     }
 }
 
-async function verifyResponseCode(response: BrowserOrNodeResponse): Promise<BrowserOrNodeResponse> {
+export async function verifyResponseCode(
+    response: BrowserOrNodeResponse
+): Promise<BrowserOrNodeResponse> {
     if (!response.ok) {
         const body = await response.text()
         throw new Error(`HTTP status code ${response.status}${body ? `: ${body}` : ''}`)

--- a/lib/shared/src/sourcegraph-api/rest/client.ts
+++ b/lib/shared/src/sourcegraph-api/rest/client.ts
@@ -1,0 +1,101 @@
+import { Model } from '../../models/index'
+
+import { fetch } from '../../fetch'
+
+import { type ModelContextWindow, ModelUsage } from '../../models/types'
+import { addTraceparent, wrapInActiveSpan } from '../../tracing'
+import { addCustomUserAgent, verifyResponseCode } from '../graphql/client'
+
+/**
+ * RestClient is a thin HTTP client that interacts with the Sourcegraph backend.
+ *
+ * Where possible, this client uses the same data for how things get hooked into
+ * the GraphQL client. e.g. HTTP requests made by this client will honor the
+ * `graphql` package's `setUserAgent` and `addCustomUserAgent` methods.
+ *
+ * NOTE: This is semi-experimental. @chrsmith is a fan of how easy REST APIs can
+ * be versioned/evolve compared to GraphQL. But if there is much pushback, we'll
+ * just expose the same endpoint using the backend's GraphQL API.
+ */
+export class RestClient {
+    /**
+     * @param endpointUrl URL to the sourcegraph instance, e.g. "https://sourcegraph.acme.com".
+     * @param accessToken User access token to contact the sourcegraph instance.
+     */
+    constructor(
+        private endpointUrl: string,
+        private accessToken: string
+    ) {
+        // Enforce that the endpointUrl doesn't end in a trailing slash.
+        if (endpointUrl.endsWith('/')) {
+            this.endpointUrl = endpointUrl.substring(0, endpointUrl.length - 1)
+        }
+    }
+
+    // Make an authenticated HTTP request to the Sourcegraph instance.
+    // "name" is a developer-friendly term to label the request's trace span.
+    private getRequest<T>(name: string, urlSuffix: string): Promise<T | Error> {
+        const headers = new Headers()
+        headers.set('Authorization', `token ${this.accessToken}`)
+        addCustomUserAgent(headers)
+        addTraceparent(headers)
+
+        const url = this.endpointUrl + urlSuffix
+        return wrapInActiveSpan(`rest-api.${name}`, () =>
+            fetch(url, {
+                method: 'GET',
+                headers,
+            })
+                .then(verifyResponseCode)
+                .then(response => response.json() as T)
+                .catch(error => new Error(`error calling Sourcegraph REST API: ${error} (${url})`))
+        )
+    }
+
+    /**
+     * getAvailableModels fetches the LLM models that the Sourcegraph instance supports.
+     *
+     * IMPORTANT: The list may include models that the current Cody client does not know
+     * how to operate.
+     */
+    public async getAvailableModels(): Promise<Model[]> {
+        // Fetch the server-side configuration data. This will be in the form of a JSON blob
+        // matching the schema defined in the `sourcegraph/llm-model' repo
+        //
+        // TODO(PRIME-322): Export the type information via NPM. For now, we just blindly
+        // walk the returned object model.
+        //
+        // NOTE: This API endpoint hasn't shippeted yet, and probably won't work for you.
+        // Also, the URL definitely will change.
+        const serverSideConfig = await this.getRequest<any>('getAvailableModels', '/.api/supported-llms')
+
+        // TODO(PRIME-323): Do a proper review of the data model we will use to describe
+        // server-side configuration. Once complete, it should match the data types we
+        // use in this repo exactly. Until then, we need to map the "server-side" model
+        // types, to the `Model` types used by Cody clients.
+        const availableModels: Model[] = []
+        const serverModels = serverSideConfig.models as any[]
+        for (const serverModel of serverModels) {
+            const serverContextWindow = serverModel.contextWindow
+            const convertedContextWindow: ModelContextWindow = {
+                input: serverContextWindow.maxInputTokens,
+                output: serverContextWindow.maxOutputTokens,
+                context: undefined, // Not yet captured in in the schema.
+            }
+
+            const convertedModel = new Model(
+                // The Model type expects the `model` field to contain both the provider
+                // and model name, whereas the server-side schema has a more nuanced view.
+                // See PRIME-282.
+                `${serverModel.provider}/${serverModel.model}`,
+                [ModelUsage.Chat, ModelUsage.Edit],
+                convertedContextWindow,
+                // client-side config not captured in the schema yet.
+                undefined
+            )
+            availableModels.push(convertedModel)
+        }
+
+        return availableModels
+    }
+}

--- a/vscode/src/models/sync.test.ts
+++ b/vscode/src/models/sync.test.ts
@@ -2,35 +2,53 @@ import {
     Model,
     ModelUsage,
     ModelsService,
+    RestClient,
     defaultAuthStatus,
     getDotComDefaultModels,
     unauthenticatedStatus,
 } from '@sourcegraph/cody-shared'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import * as vscode from 'vscode'
+import { secretStorage } from '../services/SecretStorageProvider'
 import { syncModels } from './sync'
 import { getEnterpriseContextWindow } from './utils'
 
-describe('syncModelsService', () => {
-    const setProvidersSpy = vi.spyOn(ModelsService, 'setModels')
+describe('syncModels', () => {
+    const setModelsSpy = vi.spyOn(ModelsService, 'setModels')
 
     beforeEach(() => {
-        setProvidersSpy.mockClear()
+        setModelsSpy.mockClear()
     })
 
-    it('does not set providers if not authenticated', () => {
-        syncModels(unauthenticatedStatus)
-        expect(setProvidersSpy).not.toHaveBeenCalled()
+    // This test just confirms the environment is in the expected state.
+    it('should not have the userServerDefinedModels config setting enabled', async () => {
+        const codyConfig = vscode.workspace.getConfiguration('cody')
+        if (codyConfig) {
+            const setting = codyConfig.get<boolean>('dev.useServerDefinedModels')
+            expect(setting).to.be.undefined
+        }
     })
 
-    it('sets dotcom default models if on dotcom', () => {
+    it('does not register models if not authenticated', async () => {
+        await syncModels(unauthenticatedStatus)
+        expect(setModelsSpy).toHaveBeenCalledWith([])
+    })
+
+    it('sets dotcom default models if on dotcom', async () => {
         const authStatus = { ...defaultAuthStatus, isDotCom: true, authenticated: true }
 
-        syncModels(authStatus)
-
-        expect(setProvidersSpy).toHaveBeenCalledWith(getDotComDefaultModels())
+        await syncModels(authStatus)
+        expect(setModelsSpy).toHaveBeenCalledWith(getDotComDefaultModels())
     })
 
-    it('sets enterprise context window model if chatModel config overwrite exists', () => {
+    it('sets no models if the enterprise instance does not have Cody enabled', async () => {
+        const authStatus = { ...defaultAuthStatus, isDotCom: false, authenticated: true }
+
+        await syncModels(authStatus)
+        expect(setModelsSpy).toHaveBeenCalledWith([])
+    })
+
+    it('sets enterprise context window model if chatModel config overwrite exists', async () => {
         const chatModel = 'custom-model'
         const authStatus = {
             ...defaultAuthStatus,
@@ -39,16 +57,89 @@ describe('syncModelsService', () => {
             configOverwrites: { chatModel },
         }
 
-        syncModels(authStatus)
+        await syncModels(authStatus)
 
-        expect(setProvidersSpy).not.toHaveBeenCalledWith(getDotComDefaultModels())
-
-        expect(setProvidersSpy).toHaveBeenCalledWith([
+        // i.e. this gets the one and only chat model from the Sourcegraph instance.
+        expect(setModelsSpy).not.toHaveBeenCalledWith(getDotComDefaultModels())
+        expect(setModelsSpy).toHaveBeenCalledWith([
             new Model(
                 authStatus.configOverwrites.chatModel,
                 [ModelUsage.Chat, ModelUsage.Edit],
                 getEnterpriseContextWindow(chatModel, authStatus.configOverwrites)
             ),
         ])
+    })
+})
+
+// Tests specific to how `syncModels` operates when the VS Code instance is
+// configured to fetch models from the Sourcegraph backend.
+describe('syncModels from the server', () => {
+    const testEndpoint = 'https://sourcegraph.acme-corp.com'
+    const testUserCreds = 'hunter2'
+    const testServerSideModels: Model[] = getDotComDefaultModels()
+
+    // Unlike the other mocks, we define setModelsSpy here so that it can
+    // be referenced by individual tests. (But like the other spys, it needs
+    // to be reset/restored after each test.)
+    let setModelsSpy = vi.spyOn(ModelsService, 'setModels')
+
+    beforeEach(() => {
+        setModelsSpy = vi.spyOn(ModelsService, 'setModels')
+
+        // Assuming we are looking up the "cody.dev.useServerDefinedModels",
+        // and just returning true.
+        const getConfigSpy = vi.spyOn(vscode.workspace, 'getConfiguration')
+        getConfigSpy.mockImplementation((unused1, unused2) => ({
+            get: vi.fn(() => true),
+            has: vi.fn(() => true),
+            inspect: vi.fn(() => ({ key: 'key' })),
+            update: vi.fn(() => Promise.resolve()),
+        }))
+
+        // Mock the secretStorage to return user creds IFF it is for `testEndpoint`.
+        const getTokenSpy = vi.spyOn(secretStorage, 'getToken')
+        getTokenSpy.mockImplementation(async (endpoint): Promise<string | undefined> => {
+            if (endpoint === testEndpoint) {
+                return testUserCreds
+            }
+            return undefined
+        })
+
+        // Attach our mock to the RestClient's prototype. So the class will get instantiated
+        // like normal, but any instance will use our mock implementation.
+        const getAvaialbleModelsSpy = vi.spyOn(RestClient.prototype, 'getAvailableModels')
+        getAvaialbleModelsSpy.mockImplementation(async (): Promise<Model[]> => {
+            return testServerSideModels
+        })
+    })
+    afterEach(() => {
+        // SUPER IMPORTANT: We need to call restoreAllMocks (instead of resetAllMocks)
+        // because we hook into the global state that will impact other states.
+        // Normally this isn't an issue, but here, we don't want our mock/spy that enables
+        // server-side LLM config to leak out of this describe block.
+        vi.restoreAllMocks()
+    })
+
+    it('throws if no creds are available', async () => {
+        await expect(async () => {
+            const authStatus = {
+                ...defaultAuthStatus,
+                authenticated: true,
+                // Our mock for secretStorage will only return a user access token if
+                // the endpoint matches what is expected.
+                endpoint: 'something other than testEndpoint',
+            }
+            await syncModels(authStatus)
+        }).rejects.toThrowError('no userAccessToken available. Unable to fetch models.')
+    })
+
+    it('works', async () => {
+        const authStatus = {
+            ...defaultAuthStatus,
+            authenticated: true,
+            endpoint: testEndpoint,
+        }
+        await syncModels(authStatus)
+        expect(setModelsSpy).toHaveBeenCalledWith(testServerSideModels)
     })
 })

--- a/vscode/src/models/sync.ts
+++ b/vscode/src/models/sync.ts
@@ -25,7 +25,7 @@ export function syncModels(authStatus: AuthStatus): void {
     // For dotcom, we use the default models.
     if (authStatus.isDotCom) {
         ModelsService.setModels(getDotComDefaultModels())
-        getChatModelsFromConfiguration()
+        registerModelsFromVSCodeConfiguration()
         return
     }
 
@@ -63,18 +63,18 @@ interface ChatModelProviderConfig {
 }
 
 /**
+ * Adds any Models defined by the Visual Studio "cody.dev.models" configuration into the
+ * ModelsService. This provides a way to interact with models not hard-coded by default.
+ * 
  * NOTE: DotCom Connections only as model options are not available for Enterprise
- *
- * Gets an array of `Model` instances based on the configuration for dev chat models.
- * If the `cody.dev.models` setting is not configured or is empty, the function returns an empty array.
  *
  * @returns An array of `Model` instances for the configured chat models.
  */
-export function getChatModelsFromConfiguration(): Model[] {
+export function registerModelsFromVSCodeConfiguration() {
     const codyConfig = vscode.workspace.getConfiguration('cody')
     const modelsConfig = codyConfig?.get<ChatModelProviderConfig[]>('dev.models')
     if (!modelsConfig?.length) {
-        return []
+        return
     }
 
     const models: Model[] = []
@@ -89,5 +89,4 @@ export function getChatModelsFromConfiguration(): Model[] {
     }
 
     ModelsService.addModels(models)
-    return models
 }

--- a/vscode/src/models/sync.ts
+++ b/vscode/src/models/sync.ts
@@ -5,24 +5,41 @@ import {
     Model,
     ModelUsage,
     ModelsService,
+    RestClient,
     getDotComDefaultModels,
 } from '@sourcegraph/cody-shared'
 import * as vscode from 'vscode'
+import { secretStorage } from '../services/SecretStorageProvider'
 import { getEnterpriseContextWindow } from './utils'
 
 /**
- * Sets the available model based on the authentication status.
+ * Resets the available model based on the authentication status.
  *
- * If a chat model is configured to overwrite, it will add a  provider for that model.
+ * If a chat model is configured to overwrite, it will add a provider for that model.
  * The token limit for the provider will use the configured limit,
  * or fallback to the limit from the authentication status if not configured.
  */
-export function syncModels(authStatus: AuthStatus): void {
+export async function syncModels(authStatus: AuthStatus): Promise<void> {
+    // If you are not authenticated, you cannot use Cody. Sorry.
     if (!authStatus.authenticated) {
+        ModelsService.setModels([])
         return
     }
 
-    // For dotcom, we use the default models.
+    // Fetch the LLM models and configuration server-side. See:
+    // https://linear.app/sourcegraph/project/server-side-cody-model-selection-cca47c48da6d
+    if (useServerDefinedModels()) {
+        const serverSideModels = await fetchServerSideModels(authStatus.endpoint || '')
+        ModelsService.setModels(serverSideModels)
+        // NOTE: We intentionally don't call `registerModelsFromVSCodeConfiguration()` here,
+        // because the setting doesn't make sense. In a world where all the LLM model configuration
+        // is managed server-side, there isn't any point in adding models on the client. (Since
+        // the server wouldn't recognize and reject them.)
+        return
+    }
+
+    // If you are connecting to Sourcegraph.com, we use the Cody Pro set of models.
+    // (Only some of them may not be available if you are on the Cody Free plan.)
     if (authStatus.isDotCom) {
         ModelsService.setModels(getDotComDefaultModels())
         registerModelsFromVSCodeConfiguration()
@@ -50,6 +67,11 @@ export function syncModels(authStatus: AuthStatus): void {
                 )
             ),
         ])
+    } else {
+        // If the enterprise instance didn't have any configuration data for Cody,
+        // clear the models available in the ModelsService. Otherwise there will be
+        // stale, defunct models available.
+        ModelsService.setModels([])
     }
 }
 
@@ -65,8 +87,9 @@ interface ChatModelProviderConfig {
 /**
  * Adds any Models defined by the Visual Studio "cody.dev.models" configuration into the
  * ModelsService. This provides a way to interact with models not hard-coded by default.
- * 
+ *
  * NOTE: DotCom Connections only as model options are not available for Enterprise
+ * BUG: This does NOT make any model changes based on the "cody.dev.useServerDefinedModels".
  *
  * @returns An array of `Model` instances for the configured chat models.
  */
@@ -89,4 +112,39 @@ export function registerModelsFromVSCodeConfiguration() {
     }
 
     ModelsService.addModels(models)
+}
+
+// Checks the local VS Code configuration and sees if the user has opted into fetching
+// LLM model data from the backend.
+function useServerDefinedModels(): boolean {
+    const codyConfig = vscode.workspace.getConfiguration('cody')
+    if (codyConfig) {
+        const value = codyConfig.get<boolean>('dev.useServerDefinedModels')
+        if (value !== undefined) {
+            return value
+        }
+    }
+    return false
+}
+
+// fetchServerSideModels contacts the Sourcegraph endpoint, and fetches the LLM models it
+// currently supports. Requires that the current user is authenticated, with their credentials
+// stored.
+//
+// Throws an exception on any errors.
+async function fetchServerSideModels(endpoint: string): Promise<Model[]> {
+    if (!endpoint) {
+        throw new Error('authStatus has no endpoint available. Unable to fetch models.')
+    }
+
+    // Get the user's access token, assumed to be already saved in the secret store.
+    const userAccessToken = await secretStorage.getToken(endpoint)
+    if (!userAccessToken) {
+        throw new Error('no userAccessToken available. Unable to fetch models.')
+    }
+
+    // Fetch the data via REST API.
+    // NOTE: We may end up exposing this data via GraphQL, it's still TBD.
+    const client = new RestClient(endpoint, userAccessToken)
+    return await client.getAvailableModels()
 }

--- a/vscode/src/services/AuthProvider.ts
+++ b/vscode/src/services/AuthProvider.ts
@@ -479,7 +479,7 @@ export class AuthProvider implements AuthStatusProvider {
         this.endpointHistory = localStorage.getEndpointHistory() || []
     }
 
-    // Store endpoint in local storage, token in secret storage, and update endpoint history
+    // Store endpoint in local storage, token in secret storage, and update endpoint history.
     private async storeAuthInfo(
         endpoint: string | null | undefined,
         token: string | null | undefined

--- a/vscode/src/services/SecretStorageProvider.ts
+++ b/vscode/src/services/SecretStorageProvider.ts
@@ -26,10 +26,14 @@ export async function clearAccessToken(): Promise<void> {
 interface SecretStorage extends vscode.SecretStorage {
     get(key: string): Promise<string | undefined>
     store(key: string, value: string): Promise<void>
-    storeToken(endpoint: string, value: string): Promise<void>
-    deleteToken(endpoint: string): Promise<void>
     delete(key: string): Promise<void>
     onDidChange(callback: (event: { key: string }) => Promise<void>): vscode.Disposable
+
+    // Shorthand for persisting the user's Cody Access token based on
+    // the Sourcegraph instance endpoint it is associated with.
+    storeToken(endpoint: string, value: string): Promise<void>
+    getToken(endpoint: string): Promise<string | undefined>
+    deleteToken(endpoint: string): Promise<void>
 }
 
 export class VSCodeSecretStorage implements SecretStorage {
@@ -93,6 +97,10 @@ export class VSCodeSecretStorage implements SecretStorage {
         } catch (error) {
             logError('VSCodeSecretStorage:store:failed', key, { verbose: error })
         }
+    }
+
+    public async getToken(endpoint: string): Promise<string | undefined> {
+        return this.get(endpoint)
     }
 
     public async storeToken(endpoint: string, value: string): Promise<void> {
@@ -164,6 +172,10 @@ class InMemorySecretStorage implements SecretStorage {
         }
 
         return Promise.resolve()
+    }
+
+    public async getToken(endpoint: string): Promise<string | undefined> {
+        return this.get(endpoint)
     }
 
     public async storeToken(endpoint: string, value: string): Promise<void> {


### PR DESCRIPTION
This PR adds support for fetching LLM models and associated configuration data from the Sourcegraph backend (see [Server-side Cody Model Selection](https://linear.app/sourcegraph/project/server-side-cody-model-selection-cca47c48da6d)). The new codepath is only available by setting a new VS Code workspace setting, otherwise this should have no functional changes other than one minor bug fix.

The crux of this change is in `sync.ts`, which is called when the extension starts up and populates the list of `Model`s exposed from the `ModelsService`. (For Cody Pro, this will be the static list defined in the code. For Cody Enterprise, it may be a single LLM model obtained via the GraphQL API.)

This change adds a check for a new VS Code workspace setting `cody.dev.useServerDefinedModels`. If `true`, the extension will use a new REST API client, and call the Sourcegraph instance's HTTP endpoint(*) which exposes LLM model information.

> (*) This HTTP endpoint doesn't actually exist yet. I'll have a PR out for the Sourcegraph backend to add that endpoint in the next few days.

This PR mostly fixes https://linear.app/sourcegraph/issue/PRIME-288/refactor-update-cody-clients-to-use-the-graphql-api-for-fetching.

## Details

Going commit-by-commit:

[Rename getChatModelsFromConfiguration](https://github.com/sourcegraph/cody/commit/5a64ea81479e15bc70e4aff901d266d64b251bf7)

The `getChatModelsFromConfiguration` function is only called in two places, and neither were using the return value. Instead, the callers were relying on a side-effect of how the function registers models with the `ModelsService`. The new name `registerModelsFromVSCodeConfiguration`, while obnoxiously verbose, makes this all clearer.

[Renamings and comment updates for clarity](https://github.com/sourcegraph/cody/commit/435f00a656d1eb596f431765a4bf24bc3b0b9dfb)

We had a few places in `ModelsService` where we were referring to `Model` instances as "providers".

[Add way to get the user's access token from 'secretStorage'](https://github.com/sourcegraph/cody/commit/e9cea085ac94800e9fc531eadf9c9158966a44ca)

We need the current user's Sourcegraph access token to contact the backend server and fetch its list of supported models. This didn't seem to be available on the `AuthState` (nor should it).

Let me know if there is a better or more idiomatic way to fetch this. I ended up adding the `getToken(endpoint: string): Promise<string | null>` to have symmetry with `storeToken` and `deleteToken`. But I could move that commit, and just call `.get(CODY_ACCESS_TOKEN_SECRET)` or `.get(endpoint)` directly... but doing so would implicitly couple the caller to the the specifics of how/where that data is stored. So it seemed better to add a more general method. (Freeing the `secretStorage` implementation to put the data in any other keys as needed.)

⚠️ [Add basic Sourcegraph REST API client](https://github.com/sourcegraph/cody/commit/fec5ff8e925c4fa54154da3660812eef997599e8)

This adds a simple REST API client for contacting the Sourcegraph backend, to call the "not yet in production" endpoint. I would argue that REST is better suited for the type of use-cases that Cody clients have for fetching data from the backend, and GraphQL is more trouble than its worth...

But that might be a little controversial, and this code isn't intended to be the starting point for reworking how Cody clients interact with Sourcegraph instance either. And, to be completely honest, I added it because that's how the data is exposed from my WIP backend changes.

All of which to say, if you want me to rip this out in a follow-up PR, that's totally fine. Let's just do it after we land the Sourcegraph instance API changes, which may be a better place to have the "how do we expose this data?" conversation.

[Add opt-in path to fetch models from the backend](https://github.com/sourcegraph/cody/commit/0d0feafc2721472f5f60ce72329cbe461f759ed5)

This is what actually changes the behavior for loading models (if you set the `cody.dev. cody.dev.useServerDefinedModels` setting.

This commit also fixes a hypothetical bug, so it does change existing behavior. Previously, we would never clear/reset the set of models that are registered with `ModelsService`. So if you happened to log out and log-in with _multiple_ Sourcegraph identities, the `ModelsService` would eventually be filled with stale, and invalid models that you cannot access. (i.e. as the auth change changes, multiple calls to `syncModels(...)` would keep adding different Cody Enterprise models, despite the fact that only "the current endpoint"'s model would be available.)

So now we explicitly call `ModelsService.setModels([])` which will remove all of the primary models that are available. Though in-practice, I don't think it would be possible to even detect this was happening.

## Test plan

Added/updated unit tests for the part that determines if we load models or not (`sync.test.ts`). The interaction with the REST API was tested manually.