### PR TITLE
Add ConfigWatcher class to simplify config change handling

### DIFF
--- a/vscode/src/configwatcher.ts
+++ b/vscode/src/configwatcher.ts
@@ -1,0 +1,79 @@
+import * as vscode from 'vscode'
+
+/**
+ * A wrapper around a configuration source that lets the client retrieve the current config and watch for changes.
+ */
+export interface ConfigWatcher<C> extends vscode.Disposable {
+    get(): C
+
+    // NOTE(beyang): should remove this
+    set(c: C): void
+
+    onChange(callback: (config: C) => Promise<void>): vscode.Disposable
+
+    /**
+     * Same behavior as onChange, but fires the callback once immediately for initialization.
+     */
+    initAndOnChange(callback: (config: C) => Promise<void>): Promise<vscode.Disposable>
+}
+
+export class BaseConfigWatcher<C> implements ConfigWatcher<C> {
+    private currentConfig: C
+    private disposables: vscode.Disposable[] = []
+    private configChangeEvent: vscode.EventEmitter<C>
+
+    public static async create<C>(
+        getConfig: () => Promise<C>,
+        disposables: vscode.Disposable[]
+    ): Promise<ConfigWatcher<C>> {
+        const w = new BaseConfigWatcher(await getConfig())
+        disposables.push(
+            vscode.workspace.onDidChangeConfiguration(async event => {
+                if (!event.affectsConfiguration('cody')) {
+                    return
+                }
+                w.set(await getConfig())
+            })
+        )
+        disposables.push(w)
+
+        return w
+    }
+
+    constructor(initialConfig: C) {
+        this.currentConfig = initialConfig
+        this.configChangeEvent = new vscode.EventEmitter()
+        this.disposables.push(this.configChangeEvent)
+    }
+
+    public dispose() {
+        for (const d of this.disposables) {
+            d.dispose()
+        }
+        this.disposables = []
+    }
+
+    public set(config: C): void {
+        const oldConfig = JSON.stringify(this.currentConfig)
+        const newConfig = JSON.stringify(config)
+        if (oldConfig === newConfig) {
+            return
+        }
+
+        this.currentConfig = config
+        this.configChangeEvent.fire(config)
+    }
+
+    get(): C {
+        return this.currentConfig
+    }
+
+    async initAndOnChange(callback: (config: C) => Promise<void>): Promise<vscode.Disposable> {
+        await callback(this.currentConfig)
+        return this.onChange(callback)
+    }
+
+    onChange(callback: (config: C) => Promise<void>): vscode.Disposable {
+        return this.configChangeEvent.event(callback)
+    }
+}

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -2,9 +2,11 @@ import * as vscode from 'vscode'
 
 import {
     type AuthStatus,
+    type ChatClient,
     ConfigFeaturesSingleton,
     type ConfigurationWithAccessToken,
     type DefaultCodyCommands,
+    type Guardrails,
     ModelsService,
     PromptMixin,
     PromptString,
@@ -44,7 +46,8 @@ import type { CodyCommandArgs } from './commands/types'
 import { newCodyCommandArgs } from './commands/utils/get-commands'
 import { createInlineCompletionItemProvider } from './completions/create-inline-completion-item-provider'
 import { createInlineCompletionItemFromMultipleProviders } from './completions/create-multi-model-inline-completion-provider'
-import { getConfiguration, getFullConfig } from './configuration'
+import { getFullConfig } from './configuration'
+import { BaseConfigWatcher, type ConfigWatcher } from './configwatcher'
 import { EnterpriseContextFactory } from './context/enterprise-context-factory'
 import { exposeOpenCtxClient } from './context/openctx'
 import { EditManager } from './edit/manager'
@@ -53,6 +56,9 @@ import { VSCodeEditor } from './editor/vscode-editor'
 import type { PlatformContext } from './extension.common'
 import { configureExternalServices } from './external-services'
 import { isRunningInsideAgent } from './jsonrpc/isRunningInsideAgent'
+import type { ContextRankingController } from './local-context/context-ranking'
+import type { LocalEmbeddingsController } from './local-context/local-embeddings'
+import type { SymfRunner } from './local-context/symf'
 import { logDebug, logError } from './log'
 import { MinionOrchestrator } from './minion/MinionOrchestrator'
 import { PoorMansBash } from './minion/environment'
@@ -101,27 +107,20 @@ export async function start(
 
     const disposables: vscode.Disposable[] = []
 
-    const { disposable, onConfigurationChange } = await register(
-        context,
-        await getFullConfig(),
-        platform
-    )
-    disposables.push(disposable)
+    const configWatcher = await BaseConfigWatcher.create(getFullConfig, disposables)
 
-    // Re-initialize when configuration changes.
     disposables.push(
-        vscode.workspace.onDidChangeConfiguration(async event => {
-            if (event.affectsConfiguration('cody')) {
-                const config = await getFullConfig()
-                await onConfigurationChange(config)
-                platform.onConfigurationChange?.(config)
-                if (config.chatPreInstruction.length > 0) {
-                    PromptMixin.addCustom(newPromptMixin(config.chatPreInstruction))
-                }
-                registerModelsFromVSCodeConfiguration()
+        configWatcher.onChange(async config => {
+            platform.onConfigurationChange?.(config)
+            if (config.chatPreInstruction.length > 0) {
+                PromptMixin.addCustom(newPromptMixin(config.chatPreInstruction))
             }
+            registerModelsFromVSCodeConfiguration()
         })
     )
+
+    const { disposable } = await register(context, configWatcher, platform)
+    disposables.push(disposable)
 
     return vscode.Disposable.from(...disposables)
 }
@@ -129,43 +128,46 @@ export async function start(
 // Registers commands and webview given the config.
 const register = async (
     context: vscode.ExtensionContext,
-    initialConfig: ConfigurationWithAccessToken,
+    configWatcher: ConfigWatcher<ConfigurationWithAccessToken>,
     platform: PlatformContext
 ): Promise<{
     disposable: vscode.Disposable
-    onConfigurationChange: (newConfig: ConfigurationWithAccessToken) => Promise<void>
 }> => {
-    setClientNameVersion(platform.extensionClient.clientName, platform.extensionClient.clientVersion)
-    const authProvider = AuthProvider.create(initialConfig)
-    await localStorage.setConfig(initialConfig)
-
     const disposables: vscode.Disposable[] = []
-    // Initialize `displayPath` first because it might be used to display paths in error messages
-    // from the subsequent initialization.
-    disposables.push(manageDisplayPathEnvInfoForExtension())
-
-    disposables.push(await initVSCodeGitApi())
-
+    const initialConfig = configWatcher.get()
     const isExtensionModeDevOrTest =
         context.extensionMode === vscode.ExtensionMode.Development ||
         context.extensionMode === vscode.ExtensionMode.Test
 
-    await configureEventsInfra(initialConfig, isExtensionModeDevOrTest, authProvider)
+    setClientNameVersion(platform.extensionClient.clientName, platform.extensionClient.clientVersion)
+    const authProvider = AuthProvider.create(initialConfig)
 
-    const editor = new VSCodeEditor()
+    // Initialize `displayPath` first because it might be used to display paths in error messages
+    // from the subsequent initialization.
+    disposables.push(manageDisplayPathEnvInfoForExtension())
 
-    // Could we use the `initialConfig` instead?
-    const workspaceConfig = vscode.workspace.getConfiguration()
-    const config = getConfiguration(workspaceConfig)
+    // Init local storage
+    disposables.push(
+        await configWatcher.initAndOnChange(async config => {
+            await localStorage.setConfig(config)
+        })
+    )
+    // Ensure Git API is available
+    disposables.push(await initVSCodeGitApi())
 
-    if (config.chatPreInstruction.length > 0) {
-        PromptMixin.addCustom(newPromptMixin(config.chatPreInstruction))
+    // Telemetry
+    disposables.push(
+        await configWatcher.initAndOnChange(async config => {
+            await configureEventsInfra(config, isExtensionModeDevOrTest, authProvider)
+        })
+    )
+
+    // TODO(beyang): can remove PromptMixin?
+    if (initialConfig.chatPreInstruction.length > 0) {
+        PromptMixin.addCustom(newPromptMixin(initialConfig.chatPreInstruction))
     }
 
-    void parseAllVisibleDocuments()
-
-    disposables.push(vscode.window.onDidChangeVisibleTextEditors(parseAllVisibleDocuments))
-    disposables.push(vscode.workspace.onDidChangeTextDocument(updateParseTreeOnEdit))
+    disposables.push(...registerParserListeners())
 
     // Enable tracking for pasting chat responses into editor text
     disposables.push(
@@ -183,9 +185,15 @@ const register = async (
 
     await exposeOpenCtxClient(context.secrets, initialConfig)
 
-    graphqlClient.onConfigurationChange(initialConfig)
-    void featureFlagProvider.syncAuthStatus()
+    disposables.push(
+        await configWatcher.initAndOnChange(async config => {
+            graphqlClient.onConfigurationChange(config)
+            // githubClient.onConfigurationChange({ authToken: config.experimentalGithubAccessToken })
+            await featureFlagProvider.syncAuthStatus()
+        })
+    )
 
+    // Initialize external services
     const {
         chatClient,
         completionsClient,
@@ -196,19 +204,21 @@ const register = async (
         onConfigurationChange: externalServicesOnDidConfigurationChange,
         symfRunner,
     } = await configureExternalServices(context, initialConfig, platform, authProvider)
-
+    disposables.push(
+        configWatcher.onChange(async config => {
+            externalServicesOnDidConfigurationChange(config)
+            symfRunner?.setSourcegraphAuth(config.serverEndpoint, config.accessToken)
+        })
+    )
     if (symfRunner) {
         disposables.push(symfRunner)
     }
 
-    //
-    // Minion stuff
-    //
-    if (config.experimentalMinionAnthropicKey) {
+    // Initialize Minion
+    if (initialConfig.experimentalMinionAnthropicKey) {
         const minionOrchestrator = new MinionOrchestrator(context.extensionUri, authProvider, symfRunner)
         disposables.push(minionOrchestrator)
         disposables.push(
-            // Minion
             vscode.commands.registerCommand('cody.minion.panel.new', () =>
                 minionOrchestrator.createNewMinionPanel()
             ),
@@ -219,9 +229,17 @@ const register = async (
         )
     }
 
+    // Initialize enterprise context
     const enterpriseContextFactory = new EnterpriseContextFactory(completionsClient)
-    disposables.push(enterpriseContextFactory)
+    disposables.push(
+        enterpriseContextFactory,
+        configWatcher.onChange(async _config => {
+            enterpriseContextFactory.clientConfigurationDidChange()
+        })
+    )
 
+    // Initialize context provider
+    const editor = new VSCodeEditor()
     const contextProvider = new ContextProvider(
         initialConfig,
         editor,
@@ -229,103 +247,40 @@ const register = async (
         localEmbeddings,
         enterpriseContextFactory.createRemoteSearch()
     )
-    disposables.push(contextFiltersProvider)
     disposables.push(contextProvider)
+    disposables.push(contextFiltersProvider)
     await contextFiltersProvider
         .init(repoNameResolver.getRepoNamesFromWorkspaceUri)
         .then(() => contextProvider.init())
 
-    // Shared configuration that is required for chat views to send and receive messages
-    const messageProviderOptions: MessageProviderOptions = {
-        chat: chatClient,
-        guardrails,
-        editor,
-        authProvider,
-        contextProvider,
-    }
-
-    const chatManager = new ChatManager(
-        {
-            ...messageProviderOptions,
-            extensionUri: context.extensionUri,
-            config,
-            startTokenReceiver: platform.startTokenReceiver,
-        },
-        chatClient,
-        enterpriseContextFactory,
-        localEmbeddings || null,
-        contextRanking || null,
-        symfRunner || null,
-        guardrails
-    )
-
-    const ghostHintDecorator = new GhostHintDecorator(authProvider)
-    const editorManager = new EditManager({
-        chat: chatClient,
-        editor,
-        ghostHintDecorator,
-        authProvider,
-        extensionClient: platform.extensionClient,
-    })
-    disposables.push(ghostHintDecorator, editorManager, new CodeActionProvider({ contextProvider }))
-
-    let oldConfig = JSON.stringify(initialConfig)
-    async function onConfigurationChange(newConfig: ConfigurationWithAccessToken): Promise<void> {
-        if (oldConfig === JSON.stringify(newConfig)) {
-            return Promise.resolve()
-        }
-
-        ModelsService.onConfigChange()
-
-        const promises: Promise<void>[] = []
-        oldConfig = JSON.stringify(newConfig)
-
-        promises.push(featureFlagProvider.syncAuthStatus())
-        graphqlClient.onConfigurationChange(newConfig)
-        upstreamHealthProvider.onConfigurationChange(newConfig)
-        promises.push(
-            contextFiltersProvider
-                .init(repoNameResolver.getRepoNamesFromWorkspaceUri)
-                .then(() => contextProvider.onConfigurationChange(newConfig))
-        )
-        externalServicesOnDidConfigurationChange(newConfig)
-        promises.push(configureEventsInfra(newConfig, isExtensionModeDevOrTest, authProvider))
-        platform.onConfigurationChange?.(newConfig)
-        symfRunner?.setSourcegraphAuth(newConfig.serverEndpoint, newConfig.accessToken)
-        enterpriseContextFactory.clientConfigurationDidChange()
-        promises.push(
-            localEmbeddings?.setAccessToken(newConfig.serverEndpoint, newConfig.accessToken) ??
-                Promise.resolve()
-        )
-        promises.push(setupAutocomplete())
-        promises.push(localStorage.setConfig(newConfig))
-        await Promise.all(promises)
-    }
-
-    // Register tree views
     disposables.push(
-        chatManager,
-        vscode.window.registerWebviewViewProvider('cody.chat', chatManager.sidebarViewController, {
-            webviewOptions: { retainContextWhenHidden: true },
-        }),
-        // Update external services when configurationChangeEvent is fired by chatProvider
-        contextProvider.configurationChangeEvent.event(async () => {
-            const newConfig = await getFullConfig()
-            await onConfigurationChange(newConfig)
+        configWatcher.onChange(async config => {
+            await contextFiltersProvider.init(repoNameResolver.getRepoNamesFromWorkspaceUri)
+            await contextProvider.onConfigurationChange(config)
+            await localEmbeddings?.setAccessToken(config.serverEndpoint, config.accessToken)
         })
     )
 
-    const statusBar = createStatusBar()
+    const { chatManager, editorManager } = registerChat(
+        {
+            context,
+            configWatcher,
+            platform,
+            chatClient,
+            guardrails,
+            editor,
+            authProvider,
+            contextProvider,
+            enterpriseContextFactory,
+            localEmbeddings,
+            contextRanking,
+            symfRunner,
+        },
+        disposables
+    )
+
     const sourceControl = new CodySourceControl(chatClient)
-
-    if (localEmbeddings) {
-        // kick-off embeddings initialization
-        localEmbeddings.start()
-    }
-
-    if (config.experimentalSupercompletions) {
-        disposables.push(new SupercompletionProvider({ statusBar, chat: chatClient }))
-    }
+    const statusBar = createStatusBar()
 
     // Adds a change listener to the auth provider that syncs the auth status
     authProvider.addChangeListener(async (authStatus: AuthStatus) => {
@@ -337,9 +292,10 @@ const register = async (
         editorManager.syncAuthStatus(authStatus)
         // Update context provider first it will also update the configuration
         await contextProvider.syncAuthStatus()
+
         const parallelPromises: Promise<void>[] = []
-        parallelPromises.push(featureFlagProvider.syncAuthStatus())
         // feature flag provider
+        parallelPromises.push(featureFlagProvider.syncAuthStatus())
         // Symf
         if (symfRunner && authStatus.isLoggedIn) {
             parallelPromises.push(
@@ -352,16 +308,27 @@ const register = async (
         }
         parallelPromises.push(setupAutocomplete())
         await Promise.all(parallelPromises)
+
         statusBar.syncAuthStatus(authStatus)
         sourceControl.syncAuthStatus(authStatus)
     })
 
-    // Sync the initial auth status.
+    if (initialConfig.experimentalSupercompletions) {
+        disposables.push(new SupercompletionProvider({ statusBar, chat: chatClient }))
+    }
+
+    disposables.push(
+        configWatcher.onChange(async _config => {
+            setupAutocomplete()
+        })
+    )
+
+    // Sync initial auth status
     const initAuthStatus = authProvider.getAuthStatus()
     await syncModels(initAuthStatus)
     await chatManager.syncAuthStatus(initAuthStatus)
     editorManager.syncAuthStatus(initAuthStatus)
-    ModelsService.onConfigChange()
+    disposables.push(await configWatcher.initAndOnChange(() => ModelsService.onConfigChange()))
     statusBar.syncAuthStatus(initAuthStatus)
     sourceControl.syncAuthStatus(initAuthStatus)
 
@@ -538,7 +505,7 @@ const register = async (
                 if (uri.path === '/app-done') {
                     // This is an old re-entrypoint from App that is a no-op now.
                 } else {
-                    await authProvider.tokenCallbackHandler(uri, config.customHeaders)
+                    await authProvider.tokenCallbackHandler(uri, initialConfig.customHeaders)
                 }
             },
         }),
@@ -600,7 +567,12 @@ const register = async (
         vscode.commands.registerCommand('cody.debug.enable.all', () => enableVerboseDebugMode()),
         vscode.commands.registerCommand('cody.debug.reportIssue', () => openCodyIssueReporter()),
         new CharactersLogger(),
-        upstreamHealthProvider.onConfigurationChange(initialConfig)
+        upstreamHealthProvider
+    )
+    disposables.push(
+        await configWatcher.initAndOnChange(async config => {
+            upstreamHealthProvider.onConfigurationChange(config)
+        })
     )
 
     let setupAutocompleteQueue = Promise.resolve() // Create a promise chain to avoid parallel execution
@@ -711,8 +683,110 @@ const register = async (
 
     return {
         disposable: vscode.Disposable.from(...disposables),
-        onConfigurationChange,
     }
+}
+
+// Registers listeners to trigger parsing of visible documents
+function registerParserListeners(): vscode.Disposable[] {
+    const disposables: vscode.Disposable[] = []
+    void parseAllVisibleDocuments()
+    disposables.push(vscode.window.onDidChangeVisibleTextEditors(parseAllVisibleDocuments))
+    disposables.push(vscode.workspace.onDidChangeTextDocument(updateParseTreeOnEdit))
+    return disposables
+}
+
+interface RegisterChatOptions {
+    context: vscode.ExtensionContext
+    configWatcher: ConfigWatcher<ConfigurationWithAccessToken>
+    platform: PlatformContext
+    chatClient: ChatClient
+    guardrails: Guardrails
+    editor: VSCodeEditor
+    authProvider: AuthProvider
+    contextProvider: ContextProvider
+    enterpriseContextFactory: EnterpriseContextFactory
+    localEmbeddings?: LocalEmbeddingsController
+    contextRanking?: ContextRankingController
+    symfRunner?: SymfRunner
+}
+
+function registerChat(
+    {
+        context,
+        configWatcher,
+        platform,
+        chatClient,
+        guardrails,
+        editor,
+        authProvider,
+        contextProvider,
+        enterpriseContextFactory,
+        localEmbeddings,
+        contextRanking,
+        symfRunner,
+    }: RegisterChatOptions,
+    disposables: vscode.Disposable[]
+): {
+    chatManager: ChatManager
+    editorManager: EditManager
+} {
+    const initialConfig = configWatcher.get()
+
+    // Shared configuration that is required for chat views to send and receive messages
+    const messageProviderOptions: MessageProviderOptions = {
+        chat: chatClient,
+        guardrails,
+        editor,
+        authProvider,
+        contextProvider,
+    }
+    const chatManager = new ChatManager(
+        {
+            ...messageProviderOptions,
+            extensionUri: context.extensionUri,
+            config: initialConfig,
+            startTokenReceiver: platform.startTokenReceiver,
+        },
+        chatClient,
+        enterpriseContextFactory,
+        localEmbeddings || null,
+        contextRanking || null,
+        symfRunner || null,
+        guardrails
+    )
+
+    const ghostHintDecorator = new GhostHintDecorator(authProvider)
+    const editorManager = new EditManager({
+        chat: chatClient,
+        editor,
+        ghostHintDecorator,
+        authProvider,
+        extensionClient: platform.extensionClient,
+    })
+    disposables.push(ghostHintDecorator, editorManager, new CodeActionProvider({ contextProvider }))
+
+    // Register tree views
+    disposables.push(
+        chatManager,
+        vscode.window.registerWebviewViewProvider('cody.chat', chatManager.sidebarViewController, {
+            webviewOptions: { retainContextWhenHidden: true },
+        }),
+
+        // NOTE(beyang): it was necessary to keep this, as it is the vector through which
+        // auth status propagates to the LLM client and guardrails after sign in. Without this,
+        // the auth status does not propagate.
+        contextProvider.configurationChangeEvent.event(async () => {
+            const newConfig = await getFullConfig()
+            configWatcher.set(newConfig)
+        })
+    )
+
+    if (localEmbeddings) {
+        // kick-off embeddings initialization
+        localEmbeddings.start()
+    }
+
+    return { chatManager, editorManager }
 }
 
 /**

--- a/vscode/src/services/UpstreamHealthProvider.ts
+++ b/vscode/src/services/UpstreamHealthProvider.ts
@@ -47,7 +47,7 @@ class UpstreamHealthProvider implements vscode.Disposable {
 
     public onConfigurationChange(
         newConfig: Pick<ConfigurationWithAccessToken, 'serverEndpoint' | 'customHeaders' | 'accessToken'>
-    ): this {
+    ) {
         this.config = newConfig
         this.lastUpstreamLatency = undefined
         this.lastGatewayLatency = undefined
@@ -59,8 +59,6 @@ class UpstreamHealthProvider implements vscode.Disposable {
             clearTimeout(this.nextTimeoutId)
         }
         this.nextTimeoutId = setTimeout(this.measure.bind(this), INITIAL_PING_DELAY_MS)
-
-        return this
     }
 
     private async measure() {

--- a/vscode/test/e2e/initial-context.test.ts
+++ b/vscode/test/e2e/initial-context.test.ts
@@ -35,9 +35,12 @@ testWithGitRemote('initial context - enterprise repo', async ({ page, sidebar, s
 testWithGitRemote('initial context - file', async ({ page, sidebar, server }) => {
     mockEnterpriseRepoMapping(server, 'host.example/user/myrepo')
 
+    await sidebarSignin(page, sidebar)
+
     await openFileInEditorTab(page, 'main.c')
 
-    await sidebarSignin(page, sidebar)
+    await page.getByRole('tab', { name: /Cody*/ }).click()
+
     const [, lastChatInput] = await createEmptyChatPanel(page)
 
     await expect(chatInputMentions(lastChatInput)).toHaveText(['@host.example/user/myrepo', '@main.c'])


### PR DESCRIPTION
Current config handling is a bit of a mess with many different patterns in use, related code spread across multiple locations, and at least one update cycle (main.ts config change handler -> syncAuthStatus -> PlatformContext.onConfigurationChange -> main.ts config change handler).

This introduces a `ConfigWatcher` class that encapsulates the logic of listening for changes. Using this class simplifies the `register` function in `main.ts`. Objects that need to listen to config changes can register a listener immediately after they are declared/initialized, rather than needing to put all the config change listeners in the `onConfigurationChange` inline function (which was returned to the `start` function, which had the responsibility of invoking it).

## Test plan

No change in functionality.

Checks to verify existing config change listeners function properly:
|                | Config change | Auth change |
|----------------|---------------|-------------|
| **Completions**|               |             |
| **Chat**       |               |             |
| **Commands**   |               |             |
