### PR TITLE
added some support for client-side integration tests

### DIFF
--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/CodyAgentServer.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/CodyAgentServer.kt
@@ -98,8 +98,8 @@ interface CodyAgentServer {
   fun testing_memoryUsage(params: Null?): CompletableFuture<Testing_MemoryUsageResult>
   @JsonRequest("testing/awaitPendingPromises")
   fun testing_awaitPendingPromises(params: Null?): CompletableFuture<Null?>
-  @JsonRequest("testing/requestWorkspaceDocuments")
-  fun testing_requestWorkspaceDocuments(params: GetDocumentsParams): CompletableFuture<GetDocumentsResult>
+  @JsonRequest("testing/workspaceDocuments")
+  fun testing_workspaceDocuments(params: GetDocumentsParams): CompletableFuture<GetDocumentsResult>
   @JsonRequest("testing/diagnostics")
   fun testing_diagnostics(params: Testing_DiagnosticsParams): CompletableFuture<Testing_DiagnosticsResult>
   @JsonRequest("testing/progressCancelation")

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/CodyAgentServer.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/CodyAgentServer.kt
@@ -98,8 +98,8 @@ interface CodyAgentServer {
   fun testing_memoryUsage(params: Null?): CompletableFuture<Testing_MemoryUsageResult>
   @JsonRequest("testing/awaitPendingPromises")
   fun testing_awaitPendingPromises(params: Null?): CompletableFuture<Null?>
-  @JsonRequest("testing/workspaceDocuments")
-  fun testing_workspaceDocuments(params: GetDocumentsParams): CompletableFuture<GetDocumentsResult>
+  @JsonRequest("testing/requestWorkspaceDocuments")
+  fun testing_requestWorkspaceDocuments(params: GetDocumentsParams): CompletableFuture<GetDocumentsResult>
   @JsonRequest("testing/diagnostics")
   fun testing_diagnostics(params: Testing_DiagnosticsParams): CompletableFuture<Testing_DiagnosticsResult>
   @JsonRequest("testing/progressCancelation")

--- a/agent/src/agent.ts
+++ b/agent/src/agent.ts
@@ -756,6 +756,17 @@ export class Agent extends MessageHandler implements ExtensionClient {
                         })
                     }
                 }
+
+                for (const uri of uris) {
+                    const document = this.workspace.getDocument(vscode.Uri.parse(uri))
+                    if (document) {
+                        documents.push({
+                            uri: document.uri.toString(),
+                            content: document.content ?? undefined,
+                            selection: document.protocolDocument?.selection ?? undefined,
+                        })
+                    }
+                }
                 return { documents }
             }
         )

--- a/agent/src/agent.ts
+++ b/agent/src/agent.ts
@@ -745,6 +745,7 @@ export class Agent extends MessageHandler implements ExtensionClient {
                 const uris = params?.uris ?? this.workspace.allDocuments().map(doc => doc.uri.toString())
 
                 const documents: ProtocolTextDocument[] = []
+
                 for (const uri of uris) {
                     const document = this.workspace.getDocument(vscode.Uri.parse(uri))
                     if (document) {

--- a/agent/src/agent.ts
+++ b/agent/src/agent.ts
@@ -740,7 +740,7 @@ export class Agent extends MessageHandler implements ExtensionClient {
         })
 
         this.registerAuthenticatedRequest(
-            'testing/requestWorkspaceDocuments',
+            'testing/workspaceDocuments',
             async (params: GetDocumentsParams): Promise<GetDocumentsResult> => {
                 const uris = params?.uris ?? this.workspace.allDocuments().map(doc => doc.uri.toString())
 
@@ -755,7 +755,6 @@ export class Agent extends MessageHandler implements ExtensionClient {
                         })
                     }
                 }
-
                 return { documents }
             }
         )
@@ -1427,6 +1426,7 @@ export class Agent extends MessageHandler implements ExtensionClient {
         )
         return result
     }
+
 
     private async handleDocumentChange(document: ProtocolTextDocument) {
         const documentWithUri = ProtocolTextDocumentWithUri.fromDocument(document)

--- a/agent/src/agent.ts
+++ b/agent/src/agent.ts
@@ -740,22 +740,11 @@ export class Agent extends MessageHandler implements ExtensionClient {
         })
 
         this.registerAuthenticatedRequest(
-            'testing/requestWorkspaceDocuments',
+            'testing/workspaceDocuments',
             async (params: GetDocumentsParams): Promise<GetDocumentsResult> => {
                 const uris = params?.uris ?? this.workspace.allDocuments().map(doc => doc.uri.toString())
 
                 const documents: ProtocolTextDocument[] = []
-
-                for (const uri of uris) {
-                    const document = this.workspace.getDocument(vscode.Uri.parse(uri))
-                    if (document) {
-                        documents.push({
-                            uri: document.uri.toString(),
-                            content: document.content ?? undefined,
-                            selection: document.protocolDocument?.selection ?? undefined,
-                        })
-                    }
-                }
 
                 for (const uri of uris) {
                     const document = this.workspace.getDocument(vscode.Uri.parse(uri))

--- a/agent/src/agent.ts
+++ b/agent/src/agent.ts
@@ -740,7 +740,7 @@ export class Agent extends MessageHandler implements ExtensionClient {
         })
 
         this.registerAuthenticatedRequest(
-            'testing/workspaceDocuments',
+            'testing/requestWorkspaceDocuments',
             async (params: GetDocumentsParams): Promise<GetDocumentsResult> => {
                 const uris = params?.uris ?? this.workspace.allDocuments().map(doc => doc.uri.toString())
 

--- a/agent/src/agent.ts
+++ b/agent/src/agent.ts
@@ -1447,6 +1447,8 @@ export class Agent extends MessageHandler implements ExtensionClient {
         const textEditor = this.workspace.newTextEditor(textDocument)
         this.workspace.setActiveTextEditor(textEditor)
 
+        let lastPromise: Promise<any> | undefined
+
         if (contentChanges.length > 0) {
             this.pushPendingPromise(
                 vscode_shim.onDidChangeTextDocument.cody_fireAsync({
@@ -1465,6 +1467,8 @@ export class Agent extends MessageHandler implements ExtensionClient {
                 })
             )
         }
+
+        return lastPromise || Promise.resolve()
     }
 
     private registerWebviewHandlers(): void {

--- a/agent/src/agent.ts
+++ b/agent/src/agent.ts
@@ -1439,15 +1439,12 @@ export class Agent extends MessageHandler implements ExtensionClient {
         return result
     }
 
-
     private async handleDocumentChange(document: ProtocolTextDocument) {
         const documentWithUri = ProtocolTextDocumentWithUri.fromDocument(document)
         const { document: textDocument, contentChanges } =
             this.workspace.loadDocumentWithChanges(documentWithUri)
         const textEditor = this.workspace.newTextEditor(textDocument)
         this.workspace.setActiveTextEditor(textEditor)
-
-        let lastPromise: Promise<any> | undefined
 
         if (contentChanges.length > 0) {
             this.pushPendingPromise(
@@ -1467,8 +1464,6 @@ export class Agent extends MessageHandler implements ExtensionClient {
                 })
             )
         }
-
-        return lastPromise || Promise.resolve()
     }
 
     private registerWebviewHandlers(): void {

--- a/vscode/src/jsonrpc/agent-protocol.ts
+++ b/vscode/src/jsonrpc/agent-protocol.ts
@@ -181,7 +181,7 @@ export type ClientRequests = {
     'testing/memoryUsage': [null, { usage: MemoryUsage }]
     'testing/awaitPendingPromises': [null, null]
     // Retrieve the Agent's copy of workspace documents, for testing/validation.
-    'testing/workspaceDocuments': [GetDocumentsParams, GetDocumentsResult]
+    'testing/requestWorkspaceDocuments': [GetDocumentsParams, GetDocumentsResult]
     // Returns diagnostics for the given URI. Lives under `testing/` instead of
     // standalone `diagnostics/` because it only works for TypeScript files.
     'testing/diagnostics': [{ uri: string }, { diagnostics: ProtocolDiagnostic[] }]

--- a/vscode/src/jsonrpc/agent-protocol.ts
+++ b/vscode/src/jsonrpc/agent-protocol.ts
@@ -181,7 +181,7 @@ export type ClientRequests = {
     'testing/memoryUsage': [null, { usage: MemoryUsage }]
     'testing/awaitPendingPromises': [null, null]
     // Retrieve the Agent's copy of workspace documents, for testing/validation.
-    'testing/requestWorkspaceDocuments': [GetDocumentsParams, GetDocumentsResult]
+    'testing/workspaceDocuments': [GetDocumentsParams, GetDocumentsResult]
     // Returns diagnostics for the given URI. Lives under `testing/` instead of
     // standalone `diagnostics/` because it only works for TypeScript files.
     'testing/diagnostics': [{ uri: string }, { diagnostics: ProtocolDiagnostic[] }]


### PR DESCRIPTION
RPC 1:  Added a `textDocument/change` request, so the test can block on the editing operation.

This is the same as `textDocument/didChange` except that it returns a result.

I did not know what kind of meaningful result to return here, so it just returns an object with a `success' boolean that can be extended with more properties.

The reason integration tests need this is that they have no reliable way of knowing when the Agent finishes updating its `AgentWorkspaceDocuments` after a `textDocument/didChange` notification.

- added a `testing/workspaceDocuments` rpc for fetching the agent's current copy of a document, so it can be compared against the client's copy.
- This RPC allows you to specify zero or more uris for which to fetch the corresponding protocol document. Zero means get them all.

## Test plan

This is part of implementing the test plan for other PRs, so they are / will be testing this functionality.