### PR TITLE
Solidify context sorting for tests

### DIFF
--- a/vscode/src/chat/chat-view/agentContextSorting.ts
+++ b/vscode/src/chat/chat-view/agentContextSorting.ts
@@ -1,6 +1,7 @@
 import { type ContextItem, ContextItemSource } from '@sourcegraph/cody-shared'
 
 const isAgentTesting = process.env.CODY_SHIM_TESTING === 'true'
+const sortLocale = new Intl.Locale('en-US')
 
 /**
  * Sorts the provided `ContextItem` array in a deterministic order for stable tests.
@@ -21,15 +22,15 @@ export function sortContextItems(files: ContextItem[]): void {
     // could sort by some numerical score from symf based on how relevant
     // the matches are for the query.
     files.sort((a, b) => {
-        const byPath = a.uri.path.localeCompare(b.uri.path)
+        const byPath = a.uri.path.localeCompare(b.uri.path, sortLocale)
         if (byPath !== 0) {
             return byPath
         }
-        const bySource = (a.source ?? '').localeCompare(b.source ?? '')
+        const bySource = (a.source ?? '').localeCompare(b.source ?? '', sortLocale)
         if (bySource !== 0) {
             return bySource
         }
-        return (a.content ?? '').localeCompare(b.content ?? '')
+        return (a.content ?? '').localeCompare(b.content ?? '', sortLocale)
     })
 
     // Move the selection context to the first position so that it'd be the last context item to be read by the LLM
@@ -39,22 +40,4 @@ export function sortContextItems(files: ContextItem[]): void {
         const selection = files.splice(selectionIndex, 1)[0]
         files.unshift(selection)
     }
-}
-
-export function sortContextFiles(files: ContextItem[]): void {
-    if (!isAgentTesting) {
-        return
-    }
-
-    files.sort((a, b) => {
-        const byPath = a.uri.path.localeCompare(b.uri.path)
-        if (byPath !== 0) {
-            return byPath
-        }
-        const bySource = (a.source ?? '').localeCompare(b.source ?? '')
-        if (bySource !== 0) {
-            return bySource
-        }
-        return (a.content ?? '').localeCompare(b.content ?? '')
-    })
 }

--- a/vscode/src/commands/services/runner.ts
+++ b/vscode/src/commands/services/runner.ts
@@ -18,7 +18,7 @@ import { telemetryService } from '../../services/telemetry'
 
 import type { CommandResult } from '../../CommandResult'
 import type { ChatCommandResult, EditCommandResult } from '../../CommandResult'
-import { sortContextFiles } from '../../chat/chat-view/agentContextSorting'
+import { sortContextItems } from '../../chat/chat-view/agentContextSorting'
 import { getEditor } from '../../editor/active-editor'
 import { getCommandContextFiles } from '../context'
 import { executeChat } from '../execute/ask'
@@ -175,7 +175,7 @@ export class CommandRunner implements vscode.Disposable {
             userContextFiles.push(...commandContext)
         }
 
-        sortContextFiles(userContextFiles)
+        sortContextItems(userContextFiles)
 
         return userContextFiles
     }

--- a/vscode/src/commands/services/runner.ts
+++ b/vscode/src/commands/services/runner.ts
@@ -18,7 +18,6 @@ import { telemetryService } from '../../services/telemetry'
 
 import type { CommandResult } from '../../CommandResult'
 import type { ChatCommandResult, EditCommandResult } from '../../CommandResult'
-import { sortContextItems } from '../../chat/chat-view/agentContextSorting'
 import { getEditor } from '../../editor/active-editor'
 import { getCommandContextFiles } from '../context'
 import { executeChat } from '../execute/ask'
@@ -174,9 +173,6 @@ export class CommandRunner implements vscode.Disposable {
             const commandContext = await getCommandContextFiles(contextConfig)
             userContextFiles.push(...commandContext)
         }
-
-        sortContextItems(userContextFiles)
-
         return userContextFiles
     }
 


### PR DESCRIPTION
Tiny improvements to context sorting:
* Remove redundant function `sortContextFiles`
* Make sure to set locale when comparing context items, to avoid different
results across environments

Just clean-up, and no real behavioral changes.

## Test plan

Test-only change