### PR TITLE
Make sure to show scrollbar in the @ menu if needed

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -18,6 +18,7 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 - Chat: Fix an issue where it was difficult to copy code from responses that were still streaming in. [pull/4472](https://github.com/sourcegraph/cody/pull/4472)
 - Chat: Fix an issue where opening the @-mention menu in a followup input would scroll the window to the top. [pull/4475](https://github.com/sourcegraph/cody/pull/4475)
 - Chat: Show "Explain Code" and other commands in a more pleasant way, with @-mentions, in the chat. [pull/4424](https://github.com/sourcegraph/cody/pull/4424)
+- Chat: Scrollbars are now shown in the @-mention menu when it overflows, same as chat models. [pull/4523](https://github.com/sourcegraph/cody/pull/4523)
 
 ### Changed
 

--- a/vscode/webviews/mentions/mentionMenu/MentionMenu.module.css
+++ b/vscode/webviews/mentions/mentionMenu/MentionMenu.module.css
@@ -4,18 +4,6 @@
     outline: none;
 }
 
-/* Hide scroll bar. */
-.container [cmdk-list] {
-    scrollbar-width: none;
-    /* Exactly so that the initial menu exact-fits all items on my machine */
-    --cmdk-list-max-height: 323px;
-    height: min(var(--cmdk-list-max-height), calc(var(--cmdk-list-height) + 2px));
-    max-height: var(--cmdk-list-max-height);
-}
-.container [cmdk-list]::-webkit-scrollbar {
-    display: none;
-}
-
 .item {
     line-height: 1.2;
 


### PR DESCRIPTION
The model selector shows scrollbars if needed, but the @ mention menu doesn't, and I've witnessed multiple occasions where people didn't scroll down. This updates them to be consistent with each other, and the user's O/S.

Fixes https://linear.app/sourcegraph/issue/CODY-2150/-mention-menu-missing-scrollbar

## Test plan

- CI