### PR TITLE
Fix empty state for @-mentions

### DIFF
--- a/lib/shared/src/mentions/api.ts
+++ b/lib/shared/src/mentions/api.ts
@@ -76,7 +76,7 @@ export async function openCtxMentionProviders(): Promise<ContextMentionProviderM
                 id: provider.providerUri,
                 title: provider.name,
                 queryLabel: provider.name,
-                emptyLabel: 'No results found',
+                emptyLabel: 'No results',
             }))
             .sort((a, b) => (a.title > b.title ? 1 : -1))
     } catch (error) {

--- a/vscode/webviews/mentions/mentionMenu/MentionMenu.module.css
+++ b/vscode/webviews/mentions/mentionMenu/MentionMenu.module.css
@@ -7,11 +7,15 @@
 /* Hide scroll bar. */
 .container [cmdk-list] {
     scrollbar-width: none;
+
     /* Exactly so that the initial menu exact-fits all items on my machine */
+
     --cmdk-list-max-height: 323px;
+
     height: min(var(--cmdk-list-max-height), calc(var(--cmdk-list-height) + 2px));
     max-height: var(--cmdk-list-max-height);
 }
+
 .container [cmdk-list]::-webkit-scrollbar {
     display: none;
 }

--- a/vscode/webviews/mentions/mentionMenu/MentionMenu.module.css
+++ b/vscode/webviews/mentions/mentionMenu/MentionMenu.module.css
@@ -16,6 +16,10 @@
     display: none;
 }
 
+.container [cmdk-empty] {
+    padding: 0.325rem 0.5rem;
+}
+
 .item {
     line-height: 1.2;
 

--- a/vscode/webviews/mentions/mentionMenu/MentionMenu.test.tsx
+++ b/vscode/webviews/mentions/mentionMenu/MentionMenu.test.tsx
@@ -73,6 +73,7 @@ describe('MentionMenu', () => {
                 const { container } = render(
                     <MentionMenu
                         {...PROPS}
+                        params={{ ...PROPS.params, query: 'q' }}
                         data={{
                             items: [],
                             providers: [],
@@ -97,7 +98,28 @@ describe('MentionMenu', () => {
         })
 
         describe('single provider', () => {
-            test('no items', () => {
+            test('no items with query', () => {
+                const { container } = render(
+                    <MentionMenu
+                        {...PROPS}
+                        params={{
+                            query: 'test',
+                            parentItem: {
+                                ...PROVIDER_P1,
+                                queryLabel: 'p1 queryLabel',
+                                emptyLabel: 'p1 emptyLabel',
+                            },
+                        }}
+                        data={{
+                            items: [],
+                            providers: [],
+                        }}
+                    />
+                )
+                expectMenu(container, ['#p1 queryLabel', '#p1 emptyLabel'])
+            })
+
+            test('no items without query', () => {
                 const { container } = render(
                     <MentionMenu
                         {...PROPS}
@@ -115,7 +137,7 @@ describe('MentionMenu', () => {
                         }}
                     />
                 )
-                expectMenu(container, ['#p1 queryLabel', '#p1 emptyLabel'])
+                expectMenu(container, ['#p1 queryLabel', '#Search...'])
             })
 
             test('with suggested items for empty query', () => {

--- a/vscode/webviews/mentions/mentionMenu/MentionMenu.tsx
+++ b/vscode/webviews/mentions/mentionMenu/MentionMenu.tsx
@@ -256,7 +256,7 @@ export const MentionMenu: FunctionComponent<
 
                 {(heading || (data.items && data.items.length > 0)) && (
                     <CommandGroup heading={heading}>
-                        {heading && <CommandSeparator />}
+                        {heading && data.items && data.items.length > 0 && <CommandSeparator />}
                         {data.items?.map(item => (
                             <CommandItem
                                 key={commandRowValue(item)}
@@ -294,12 +294,17 @@ function getEmptyLabel(
     parentItem: ContextMentionProviderMetadata | null,
     mentionQuery: MentionQuery
 ): string {
+    if (!mentionQuery.text) {
+        return 'Search...'
+    }
+
     if (!parentItem) {
         return FILE_CONTEXT_MENTION_PROVIDER.emptyLabel!
     }
     if (parentItem.id === SYMBOL_CONTEXT_MENTION_PROVIDER.id && mentionQuery.text.length < 3) {
         return SYMBOL_CONTEXT_MENTION_PROVIDER.emptyLabel! + NO_SYMBOL_MATCHES_HELP_LABEL
     }
+
     return parentItem.emptyLabel ?? 'No results'
 }
 


### PR DESCRIPTION
closes: https://linear.app/sourcegraph/issue/CODY-2109/double-dividers-in-loading-state

This PR fixes the double divider in the loading/empty state of the @-mention menu. 

It also updates the label when the query is nil and fixes the padding. 

Before: 
![Double dividers loading](https://github.com/sourcegraph/cody/assets/22571395/2cae7d51-76d0-4b2e-bb2e-b10ff9198ce0)

After: 
![CleanShot 2024-06-11 at 14 03 42@2x](https://github.com/sourcegraph/cody/assets/22571395/9f22f7c3-9b18-4249-b6ab-1696cdcb75db)


## Test plan

Demo: https://www.loom.com/share/362c851761ea44499a54cd40c6b90c76?sid=93a4d6f3-62ad-477f-bde0-60599570e598
