### PR TITLE
openctx: update to directly use controller

### DIFF
--- a/lib/shared/src/context/openctx/api.ts
+++ b/lib/shared/src/context/openctx/api.ts
@@ -1,7 +1,7 @@
 import type { Client } from '@openctx/client'
 import type * as vscode from 'vscode'
 
-type OpenCtxClient = Client<vscode.Range>
+type OpenCtxClient = Pick<Client<vscode.Range>, 'meta' | 'mentions' | 'items'>
 
 class OpenCtx {
     constructor(public client: OpenCtxClient | undefined) {}

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "generate-agent-kotlin-bindings": "./agent/scripts/generate-agent-kotlin-bindings.sh",
     "update-agent-recordings": "pnpm build && CODY_KEEP_UNUSED_RECORDINGS=false CODY_RECORD_IF_MISSING=true vitest agent/src",
     "update-rewrite-recordings": "rm -rf recordings && CODY_RECORD_IF_MISSING=true vitest vscode/src/local-context/rewrite-keyword-query.test.ts",
-    "openctx:link": "cd ../openctx pnpm -C lib/client link --global && pnpm -C lib/schema link --global && pnpm -C lib/protocol link --global && pnpm -C client/vscode-lib link --global && cd ../cody && pnpm link --global @openctx/client && pnpm link --global @openctx/schema &&  pnpm link --global @openctx/protocol && cd vscode && pnpm link --global @openctx/vscode-lib",
+    "openctx:link": "cd ../openctx && pnpm -C lib/client link --global && pnpm -C lib/schema link --global && pnpm -C lib/protocol link --global && pnpm -C client/vscode-lib link --global && cd ../cody && pnpm link --global @openctx/client && pnpm link --global @openctx/schema &&  pnpm link --global @openctx/protocol && cd vscode && pnpm link --global @openctx/vscode-lib",
     "openctx:unlink": "pnpm unlink --global @openctx/client && pnpm unlink --global @openctx/schema &&  pnpm unlink --global @openctx/protocol && cd vscode && pnpm unlink --global @openctx/vscode-lib",
     "vsce-version-bump": "pnpm -C vscode version-bump:minor"
   },

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "vitest": "^1.5.0"
   },
   "dependencies": {
-    "@openctx/client": "^0.0.16",
+    "@openctx/client": "^0.0.17",
     "ignore": "^5.3.1",
     "mac-ca": "^2.0.3",
     "react": "18.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,8 +18,8 @@ importers:
   .:
     dependencies:
       '@openctx/client':
-        specifier: ^0.0.16
-        version: 0.0.16
+        specifier: ^0.0.17
+        version: 0.0.17
       ignore:
         specifier: ^5.3.1
         version: 5.3.1
@@ -372,8 +372,8 @@ importers:
         specifier: ^7.2.96
         version: 7.2.96
       '@openctx/vscode-lib':
-        specifier: ^0.0.8
-        version: 0.0.8
+        specifier: ^0.0.9
+        version: 0.0.9
       '@opentelemetry/api':
         specifier: ^1.7.0
         version: 1.7.0
@@ -3211,8 +3211,8 @@ packages:
       rimraf: 3.0.2
     dev: false
 
-  /@openctx/client@0.0.16:
-    resolution: {integrity: sha512-xKyXUWA1oNTpb4PS+vrF2Pd+OR5e/bWW1PQWscRf5ctzHMiBlzFN9PLIFMrwOkFwvmFb4NxU8ATu2puwTZX/7Q==}
+  /@openctx/client@0.0.17:
+    resolution: {integrity: sha512-Uyh+hq8ysC0ahx9MKikQkP9XIngqKTWfemIx16aVRC1K6dQ4uHR0NbQN5eBkZCPtERKI1JA7fo467P/+T5pACg==}
     dependencies:
       '@openctx/protocol': 0.0.13
       '@openctx/provider': 0.0.13
@@ -3249,10 +3249,10 @@ packages:
       xss: 1.0.15
     dev: false
 
-  /@openctx/vscode-lib@0.0.8:
-    resolution: {integrity: sha512-jgniQSdJynkFltD4ASJkWzvB6TUOK9DiffuCidw/08mKDGXMsbD1xu/rsEcXQrLLde8U3ejTW3qr6aqce080sQ==}
+  /@openctx/vscode-lib@0.0.9:
+    resolution: {integrity: sha512-f6Y3oTTAqzqnseaG083HwKjIM6m0SMz/LOMsx5s5GQaAZgAV/65qYGexuwJ/CrotU/9yGhczh/U6w+j0eEWTHw==}
     dependencies:
-      '@openctx/client': 0.0.16
+      '@openctx/client': 0.0.17
       '@openctx/ui-common': 0.0.10
       rxjs: 7.8.1
     dev: false

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -1306,7 +1306,7 @@
     "@lexical/react": "^0.15.0",
     "@lexical/text": "^0.15.0",
     "@mdi/js": "^7.2.96",
-    "@openctx/vscode-lib": "^0.0.8",
+    "@openctx/vscode-lib": "^0.0.9",
     "@opentelemetry/api": "^1.7.0",
     "@opentelemetry/core": "^1.18.1",
     "@opentelemetry/exporter-trace-otlp-http": "^0.45.1",

--- a/vscode/src/chat/context/chatContext.ts
+++ b/vscode/src/chat/context/chatContext.ts
@@ -67,7 +67,7 @@ export async function getChatContextItemsForMention(
             const items = await openCtx.client.mentions(
                 { query: mentionQuery.text },
                 // get mention items for the selected provider only.
-                mentionQuery.provider
+                { providerUri: mentionQuery.provider }
             )
 
             return items.map((item): ContextItemOpenCtx | ContextItemRepository =>

--- a/vscode/src/context/openctx.ts
+++ b/vscode/src/context/openctx.ts
@@ -40,7 +40,7 @@ export async function exposeOpenCtxClient(
                 secrets,
                 features: {},
                 providers,
-            }).controller.client
+            }).controller
         )
     } catch (error) {
         logDebug('openctx', `Failed to load OpenCtx client: ${error}`)

--- a/vscode/src/context/openctx.ts
+++ b/vscode/src/context/openctx.ts
@@ -6,7 +6,7 @@ import RemoteRepositorySearch from './openctx/remoteRepositorySearch'
 import WebProvider from './openctx/web'
 
 export async function exposeOpenCtxClient(
-    secrets: vscode.SecretStorage,
+    context: Pick<vscode.ExtensionContext, 'extension' | 'secrets'>,
     config: ConfigurationWithAccessToken
 ) {
     logDebug('openctx', 'OpenCtx is enabled in Cody')
@@ -36,8 +36,9 @@ export async function exposeOpenCtxClient(
 
         setOpenCtxClient(
             createController({
+                extensionId: context.extension.id,
+                secrets: context.secrets,
                 outputChannel,
-                secrets,
                 features: {},
                 providers,
             }).controller

--- a/vscode/src/editor/utils/editor-context.ts
+++ b/vscode/src/editor/utils/editor-context.ts
@@ -343,7 +343,10 @@ async function resolveContextMentionProviderContextItem(
         title: item.title,
     }
 
-    const items = await openCtxClient.items({ message: input.toString(), mention }, item.providerUri)
+    const items = await openCtxClient.items(
+        { message: input.toString(), mention },
+        { providerUri: item.providerUri }
+    )
 
     return items
         .map((item): (ContextItemWithContent & { providerUri: string }) | null =>

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -169,7 +169,7 @@ const register = async (
 
     await authProvider.init()
 
-    await exposeOpenCtxClient(context.secrets, initialConfig)
+    await exposeOpenCtxClient(context, initialConfig)
 
     await configWatcher.initAndOnChange(async config => {
         graphqlClient.onConfigurationChange(config)


### PR DESCRIPTION
Previously we passed the controller's client. However, the controller also exposes the client API, but additionally has vscode specific error reporting logic.

Additionally we updated the OpenCtxClient type we declare as Picking only the fields we use.

We need to update client call sites to pass in providerUri as part of the new option interface.

Test Plan: See test plan of https://github.com/sourcegraph/openctx/pull/142

Here is what it looks like with a provider failing and initialize and at mentions.
<img width="487" alt="image" src="https://github.com/sourcegraph/openctx/assets/187831/c8174ea2-ecb3-438f-b54a-870409dd1801">

Full demo at https://www.loom.com/share/107e380a1d1a43ca8302ac61ebf81805

Fixes https://linear.app/sourcegraph/issue/CODY-2082/show-errors-from-openctx-providers
