### PR TITLE
Chat: Fix aborted requests

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -19,6 +19,7 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 - Chat: Fix an issue where opening the @-mention menu in a followup input would scroll the window to the top. [pull/4475](https://github.com/sourcegraph/cody/pull/4475)
 - Chat: Show "Explain Code" and other commands in a more pleasant way, with @-mentions, in the chat. [pull/4424](https://github.com/sourcegraph/cody/pull/4424)
 - Chat: Scrollbars are now shown in the @-mention menu when it overflows, same as chat models. [pull/4523](https://github.com/sourcegraph/cody/pull/4523)
+- Chat: Prevent the chat from remaining in a loading state when using ESC to stop Cody's response mid-stream. [pull/4532](https://github.com/sourcegraph/cody/pull/4532)
 
 ### Changed
 

--- a/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
+++ b/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
@@ -1065,7 +1065,6 @@ export class SimpleChatPanelProvider implements vscode.Disposable, ChatSession {
             prompt,
             {
                 update: content => {
-                    abortSignal.throwIfAborted()
                     measureFirstToken()
                     span.addEvent('update')
                     this.postViewTranscript({
@@ -1075,7 +1074,6 @@ export class SimpleChatPanelProvider implements vscode.Disposable, ChatSession {
                     })
                 },
                 close: content => {
-                    abortSignal.throwIfAborted()
                     measureFirstToken()
                     recordExposedExperimentsToSpan(span)
                     span.end()
@@ -1083,7 +1081,7 @@ export class SimpleChatPanelProvider implements vscode.Disposable, ChatSession {
                 },
                 error: (partialResponse, error) => {
                     if (isAbortErrorOrSocketHangUp(error)) {
-                        throw error
+                        abortSignal.throwIfAborted()
                     }
                     this.postError(error, 'transcript')
                     try {


### PR DESCRIPTION
This commit fixes an issue where pressing ESC to abort an in-progress chat puts chat in an unusable state, reported by our users during a customer call.

Context: https://linear.app/sourcegraph/issue/CODY-2259

To reproduce:

1. Send Cody a question
2. While the response is being streamed, press ESC to stop the stream
3. You will not be able to submit a new chat as it's still in loading state 

Fix:  move abortSignal.throwIfAborted() to the callback function for error and remove them from the update and close callback functions.

![image](https://github.com/sourcegraph/cody/assets/68532117/08b79c71-2869-408a-a50a-0734a8f70b26)


We should also consider adding back a stop button in a follow-up.

## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

To Manually test the changes in this PR:

1. Start Cody from this branch
2. Ask Cody a question
3. While the response is being streamed, press ESC to stop the stream
5. Confirm the Submit button is not showing as `loading`
6. Verify you can submit a follow-up question afterward

![Screenshot 2024-06-11 at 4 43 48 PM](https://github.com/sourcegraph/cody/assets/68532117/9e367dbf-7dc4-4855-8c3c-518c7d428486)

