### PR TITLE
Finetuned model shipment for tsx, jsx and py

### DIFF
--- a/lib/shared/src/experimentation/FeatureFlagProvider.ts
+++ b/lib/shared/src/experimentation/FeatureFlagProvider.ts
@@ -16,6 +16,7 @@ export enum FeatureFlag {
     // Enable StarCoder2 7b and 15b as the default model via Fireworks
     CodyAutocompleteStarCoder2Hybrid = 'cody-autocomplete-starcoder2-hybrid',
     // Enable the FineTuned model as the default model via Fireworks
+    CodyAutocompleteFIMFineTunedModelHybrid = 'cody-autocomplete-fim-fine-tuned-model-hybrid',
 
     // Enable various feature flags to experiment with FIM trained fine-tuned models via Fireworks
     CodyAutocompleteFIMFineTunedModelBaseFeatureFlag = 'cody-autocomplete-fim-fine-tuned-model-experiment-flag',

--- a/vscode/src/completions/providers/create-provider.ts
+++ b/vscode/src/completions/providers/create-provider.ts
@@ -18,6 +18,7 @@ import {
     FIREWORKS_FIM_FINE_TUNED_MODEL_2,
     FIREWORKS_FIM_FINE_TUNED_MODEL_3,
     FIREWORKS_FIM_FINE_TUNED_MODEL_4,
+    FIREWORKS_FIM_FINE_TUNED_MODEL_HYBRID,
     type FireworksOptions,
     createProviderConfig as createFireworksProviderConfig,
 } from './fireworks'
@@ -208,10 +209,17 @@ async function resolveDefaultModelFromVSCodeConfigOrFeatureFlags(
         return { provider: configuredProvider }
     }
 
-    const [starCoder2Hybrid, starCoderHybrid, claude3, finetunedFIMModelExperiment] = await Promise.all([
+    const [
+        starCoder2Hybrid,
+        starCoderHybrid,
+        claude3,
+        finetunedFIMModelHybrid,
+        finetunedFIMModelExperiment,
+    ] = await Promise.all([
         featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteStarCoder2Hybrid),
         featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteStarCoderHybrid),
         featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteClaude3),
+        featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteFIMFineTunedModelHybrid),
         featureFlagProvider.evaluateFeatureFlag(
             FeatureFlag.CodyAutocompleteFIMFineTunedModelBaseFeatureFlag
         ),
@@ -226,6 +234,10 @@ async function resolveDefaultModelFromVSCodeConfigOrFeatureFlags(
     if (!isFinetuningExperimentDisabled && finetunedFIMModelExperiment) {
         // The traffic in this feature flag is interpreted as a traffic allocated to the fine-tuned experiment.
         return resolveFinetunedModelFromFeatureFlags()
+    }
+
+    if (finetunedFIMModelHybrid) {
+        return { provider: 'fireworks', model: FIREWORKS_FIM_FINE_TUNED_MODEL_HYBRID }
     }
 
     if (starCoder2Hybrid) {

--- a/vscode/src/completions/providers/fireworks.ts
+++ b/vscode/src/completions/providers/fireworks.ts
@@ -202,7 +202,7 @@ class FireworksProvider extends Provider {
     ): FireworksModel {
         switch (model) {
             case FIREWORKS_FIM_FINE_TUNED_MODEL_HYBRID: {
-                // The fine-tuned hybrid model is only deployed for TypeScript, JavaScript, and Python.
+                // The fine-tuned hybrid model is only deployed for TypeScriptReact, JavaScriptReact, and Python.
                 // For other languages, we use the current production model.
                 if (['typescriptreact', 'javascriptreact', 'python'].includes(langaugeId)) {
                     return FIREWORKS_FIM_FINE_TUNED_MODEL_HYBRID

--- a/vscode/src/completions/providers/fireworks.ts
+++ b/vscode/src/completions/providers/fireworks.ts
@@ -198,13 +198,13 @@ class FireworksProvider extends Provider {
 
     private adjustModelIdentifierForFinetunedHybrid(
         model: FireworksModel,
-        langaugeId: string
+        languageId: string
     ): FireworksModel {
         switch (model) {
             case FIREWORKS_FIM_FINE_TUNED_MODEL_HYBRID: {
                 // The fine-tuned hybrid model is only deployed for TypeScriptReact, JavaScriptReact, and Python.
                 // For other languages, we use the current production model.
-                if (['typescriptreact', 'javascriptreact', 'python'].includes(langaugeId)) {
+                if (['typescriptreact', 'javascriptreact', 'python'].includes(languageId)) {
                     return FIREWORKS_FIM_FINE_TUNED_MODEL_HYBRID
                 }
                 return 'starcoder-hybrid'


### PR DESCRIPTION
## Context

We are shipping Finetuned model as the default model for `typescriptreact`, `javascriptreact` & `python`. Whereas keeping `starcoder-hybrid` as the default model for all the other language.
1. We are creating a new feature flag `cody-autocomplete-fim-fine-tuned-model-hybrid` for the fine-tuned hybrid model. For `typescriptreact`, `javascriptreact` & `python` it will pick up `fine-tuned model`, else `starcoder-hybrid` model.
2. [Slack conversation for the shipment decision(https://sourcegraph.slack.com/archives/C05AGQYD528/p1717313696244799)
3. [Finetuned Model Qualitative & Quantitative results](https://docs.google.com/document/d/1D8qzoXvUwJ8-5b4CKlkOYUSvz8qYrO_lxYUtiDgMvkM/edit#heading=h.p3zauxumq548)  

## Test plan
Manual Testing:
Tested manually that for [typescriptreact, javascriptreact & python] we use fine-tuned model and else we use starcoder-hybrid

