### PR TITLE
Chat: update token styles for initial @-file that are too large

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -20,6 +20,7 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 - Chat: Show "Explain Code" and other commands in a more pleasant way, with @-mentions, in the chat. [pull/4424](https://github.com/sourcegraph/cody/pull/4424)
 - Chat: Scrollbars are now shown in the @-mention menu when it overflows, same as chat models. [pull/4523](https://github.com/sourcegraph/cody/pull/4523)
 - Chat: Prevent the chat from remaining in a loading state when using ESC to stop Cody's response mid-stream. [pull/4532](https://github.com/sourcegraph/cody/pull/4532)
+- Chat: Large files added to new chats as @-mentions are now correctly displayed as invalid. [pull/4534](https://github.com/sourcegraph/cody/pull/4534)
 
 ### Changed
 

--- a/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
+++ b/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
@@ -252,6 +252,7 @@ export class SimpleChatPanelProvider implements vscode.Disposable, ChatSession {
             startClientStateBroadcaster({
                 remoteSearch: this.remoteSearch,
                 postMessage: (message: ExtensionMessage) => this.postMessage(message),
+                chatModel: this.chatModel,
             })
         )
     }

--- a/vscode/webviews/promptEditor/nodes/ContextItemMentionNode.ts
+++ b/vscode/webviews/promptEditor/nodes/ContextItemMentionNode.ts
@@ -103,7 +103,9 @@ export class ContextItemMentionNode extends TextNode {
         } else if (this.contextItem.type === 'tree') {
             dom.title = this.contextItem.title || 'Local workspace'
         } else if (this.contextItem.type === 'file') {
-            dom.title = displayPath(URI.parse(this.contextItem.uri))
+            dom.title = this.contextItem.isTooLarge
+                ? 'This file is too large. Try readding it with line range.'
+                : displayPath(URI.parse(this.contextItem.uri))
         }
 
         return dom
@@ -196,7 +198,7 @@ export function $createContextItemMentionNode(
     const node = new ContextItemMentionNode(contextItem, undefined, undefined, isFromInitialContext)
     node.setMode('token').toggleDirectionless()
     if (contextItem.type === 'file' && (contextItem.isTooLarge || contextItem.isIgnored)) {
-        node.setStyle('text-decoration: line-through; color: var(--vscode-list-errorForeground)')
+        node.setStyle('text-decoration: line-through; color: var(--vscode-editorWarning-foreground)')
     }
     if (contextItem.type === 'repository' || contextItem.type === 'tree') {
         node.setStyle('font-weight: bold')

--- a/vscode/webviews/promptEditor/nodes/ContextItemMentionNode.ts
+++ b/vscode/webviews/promptEditor/nodes/ContextItemMentionNode.ts
@@ -196,7 +196,7 @@ export function $createContextItemMentionNode(
     const node = new ContextItemMentionNode(contextItem, undefined, undefined, isFromInitialContext)
     node.setMode('token').toggleDirectionless()
     if (contextItem.type === 'file' && (contextItem.isTooLarge || contextItem.isIgnored)) {
-        node.setStyle('color: var(--vscode-list-errorForeground)')
+        node.setStyle('text-decoration: line-through; color: var(--vscode-list-errorForeground)')
     }
     if (contextItem.type === 'repository' || contextItem.type === 'tree') {
         node.setStyle('font-weight: bold')


### PR DESCRIPTION
CONTEXT: https://sourcegraph.slack.com/archives/C05MW2TMYAV/p1717600416051439

Address one of the user feedback in https://linear.app/sourcegraph/issue/CODY-2259, specifically: "Large file was added to new chat initially without warning"

This PR fixes an issue where initialContext that are too large do not have the styles intended for large files.

Also added line-through to large file styles to make it obvious the context will not be included.

Changes included:

- Add chatModel parameter to startClientStateBroadcaster function
- Use chatModel.contextWindow to determine user context size when adding current file/selection to context items
- Add getSelectionOrFileContext function for getting context file from current selection, or entire file when there is no selection
- Update getContextFileFromSelection function to return an empty context item when there is no selection
- Add line-through to large files at mentioned token

In the future, we should add instructions / helpful tooltip on the next steps for large items.

## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

1. Start Cody in dev mode from this branch
2. Open the Cody repository in your workspace
3. Open the vscode/CHANGELOG.md file
4. Open a new Cody chat panel
5. You should see the current file (CHANGELOG.md) is added to the chat panel automatically, but highlighted in red and line-through:

<img width="988" alt="image" src="https://github.com/sourcegraph/cody/assets/68532117/99100a55-5b8d-4b09-be07-f920a139a11a">

6. It would also be updated when you select new lines that are within the current context window:

<img width="985" alt="image" src="https://github.com/sourcegraph/cody/assets/68532117/9d66a511-5991-45a2-93e3-8e96cb76b69e">

<img width="991" alt="image" src="https://github.com/sourcegraph/cody/assets/68532117/56696b7e-529d-480f-97d7-48173c24497f">

### Updated

Invalid tokens are shown as yellow instead of red

![image](https://github.com/sourcegraph/cody/assets/68532117/5d3d9195-9cf8-4615-8ea1-506206d092fb)

#### Before

A large file will be added automatically for the user, but will then be excluded when they submit the question because the file was too large:

<img width="991" alt="image" src="https://github.com/sourcegraph/cody/assets/68532117/13999aa5-562a-49e3-a624-e44e58766527">
