### PR TITLE
Chat: Update large file tooltip text

### DIFF
--- a/vscode/webviews/promptEditor/nodes/ContextItemMentionNode.ts
+++ b/vscode/webviews/promptEditor/nodes/ContextItemMentionNode.ts
@@ -1,6 +1,7 @@
 import {
     CONTEXT_ITEM_MENTION_NODE_TYPE,
     type ContextItem,
+    ContextItemSource,
     type SerializedContextItem,
     type SerializedContextItemMentionNode,
     displayLineRange,
@@ -104,7 +105,9 @@ export class ContextItemMentionNode extends TextNode {
             dom.title = this.contextItem.title || 'Local workspace'
         } else if (this.contextItem.type === 'file') {
             dom.title = this.contextItem.isTooLarge
-                ? 'This file is too large. Try readding it with line range.'
+                ? this.contextItem.source === ContextItemSource.Initial
+                    ? 'File is too large. Select a smaller range of lines from the file.'
+                    : 'File is too large. Try adding the file again with a smaller range of lines.'
                 : displayPath(URI.parse(this.contextItem.uri))
         }
 


### PR DESCRIPTION
Update large file tooltip text for context file added initially:

<img width="734" alt="image" src="https://github.com/sourcegraph/cody/assets/68532117/434d6d8c-0a57-4db0-b481-6809caaac3a1">

## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

Tooltip text update. No feature changes.