### PR TITLE
Remove `playwright install` step from `pnpm install`

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -9,7 +9,7 @@
   "icon": "resources/cody.png",
   "description": "AI coding assistant that uses search and codebase context to help you write code faster. Cody brings autocomplete, chat, and commands to VS Code, so you can generate code, write unit tests, create docs, and explain complex code using AI. Choose from the latest LLMs, including GPT-4o and Claude 3.",
   "scripts": {
-    "postinstall": "pnpm download-wasm && playwright install",
+    "postinstall": "pnpm download-wasm",
     "dev": "pnpm run -s dev:desktop",
     "dev:insiders": "pnpm run -s dev:desktop:insiders",
     "start:dev:desktop": "NODE_ENV=development code --extensionDevelopmentPath=$PWD --disable-extension=sourcegraph.cody-ai --disable-extension=github.copilot --inspect-extensions=9333 --new-window . --goto ./src/completions/inline-completion-item-provider.ts:16:5",


### PR DESCRIPTION
Previously, running `pnpm install` was taking a long time to complete because it included a `playwright install` step. This was problematic because we run `pnpm install` in a lot of places where we don't run e2e tests, including in the JetBrains/Eclipse client plugins where we build agent/webview assets for those IDE clients. This PR reverts the change from this PR here https://github.com/sourcegraph/cody/pull/4447 which added this step to `pnpm install` so that installing dependencies runs fast again.


## Test plan

N/A

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
