### PR TITLE
VS Code: Release v1.22.0

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -6,6 +6,14 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 
 ### Added
 
+### Fixed
+
+### Changed
+
+## 1.22.0
+
+### Added
+
 - Chat & Commands: New models available for Cody Pro users:
   - Google Gemini 1.5 Pro [#4360](https://github.com/sourcegraph/cody/pull/4360)
   - Google Gemini 1.5 Flash [#4360](https://github.com/sourcegraph/cody/pull/4360)

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -3,7 +3,7 @@
   "name": "cody-ai",
   "private": true,
   "displayName": "Cody: AI Coding Assistant with Autocomplete & Chat",
-  "version": "1.20.3",
+  "version": "1.22.0",
   "publisher": "sourcegraph",
   "license": "Apache-2.0",
   "icon": "resources/cody.png",

--- a/vscode/scripts/version-bump.ts
+++ b/vscode/scripts/version-bump.ts
@@ -11,6 +11,9 @@ import { version } from '../package.json'
  *  pnpm run version-bump:dry-run for testing the script without committing the changes
  */
 
+// Execute a command to create a new branch off origin/main
+execSync('git checkout main && git pull origin main', { stdio: 'inherit' })
+
 const releaseType = (process.env.RELEASE_TYPE || '').toLowerCase() as semver.ReleaseType
 const isDryRun = releaseType === 'prerelease'
 
@@ -34,6 +37,8 @@ if (!nextVersion || !semver.valid(nextVersion)) {
     )
     process.exit(1)
 }
+
+execSync(`git checkout -b release-${releaseType}-v${version}`, { stdio: 'inherit' })
 
 process.stdout.write(`Updating files to the next version: ${nextVersion}\n`)
 


### PR DESCRIPTION
VS Code: Release 1.22.0 - Stable Release

Blog Post: 
- PR: https://github.com/sourcegraph/about/pull/7001
- Preview: https://deploy-preview-7001--sourcegraph.netlify.app/blog/cody-vscode-1-22-0-release

Updated the version-bump script that I used for creating this PR!

## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

- [x] [vscode/CHANGELOG.md](./CHANGELOG.md)
- [x] [vscode/package.json](./package.json)