### PR TITLE
Adding a temporary fix to the win-ca package to remove the patched inject method that fails with Vscode's insiders build

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -26,6 +26,7 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 
 - Autocomplete: Improve finding of related code snippets by breaking camelCase and snake_case words. [pull/4467](https://github.com/sourcegraph/cody/pull/4467)
 - The natural language search quickpick was removed. To perform a natural-language search, run a Cody chat and view the items in the context row. [pull/4506](https://github.com/sourcegraph/cody/pull/4506)
+- Temporary Fix for [Win-ca package Certs] Issue(https://github.com/sourcegraph/cody/issues/4491): Bypassed problematic codepath to prevent system hang, resulting in temporary loss of self-signed certs import on Windows. Proper fix planned before July 1.
 
 ## [1.20.3]
 

--- a/vscode/src/certs.js
+++ b/vscode/src/certs.js
@@ -22,7 +22,7 @@ export function registerLocalCertificates() {
     // Installs Windows root certs onto the global agent. This is a no-op for non-Windows
     // environments.
     try {
-        require('win-ca/fallback').inject('+')
+        require('win-ca/fallback')
     } catch (e) {
         console.warn('Error installing Windows certs', e)
     }


### PR DESCRIPTION
## Why this works? 
It works because the error was a patching error in this code 

```
var require_inject = __commonJS({
  "../node_modules/.pnpm/win-ca@3.5.1/node_modules/win-ca/lib/inject.js"(exports2, module2) {
    var https4;
    var tls;
    var der2;
    var toPEM;
    var agentOptions;
    var roots;
    var patchMode;
    var saveCreateSecureContext;
    https4 = require("https");
    tls = require("tls");
    der2 = require_der2();
    module2.exports = iFactory;
    iFactory.inject = inject;
    toPEM = der2(der2.pem);
    agentOptions = https4.globalAgent.options;
    roots = [];
    function iFactory(mode) {
      inject(mode, []);
      return add2;
    }
    function add2(der) {
      roots.push(
        toPEM(
          der
        )
      );
    }
    patchMode = 0;
    function inject(mode, array) {
      if (array) {
        roots.length = 0;
        roots.push.apply(roots, array);
      }
      mode = "+" === mode ? 2 : mode ? 1 : 0;
      if (mode === patchMode) {
        return;
      }
      switch (patchMode) {
        case 1:
          if (agentOptions.ca === roots) {
            delete agentOptions.ca;
          }
          break;
        case 2:
          if (tls.createSecureContext === createSecureContext) {
            tls.createSecureContext = saveCreateSecureContext;
            saveCreateSecureContext = void 0;
          }
      }
      switch (patchMode = mode) {
        case 1:
          agentOptions.ca = roots;
          break;
        case 2:
          if (!saveCreateSecureContext) {
            saveCreateSecureContext = tls.createSecureContext;
            tls.createSecureContext = createSecureContext;
          }
      }
    }
    function createSecureContext(options2) {
      var ctx, i$, ref$, len$, crt;
      ctx = saveCreateSecureContext.apply(this, arguments);
      if (2 === patchMode && !(options2 != null && options2.ca)) {
        for (i$ = 0, len$ = (ref$ = roots).length; i$ < len$; ++i$) {
          crt = ref$[i$];
          ctx.context.addCACert(crt);
        }
      }
      return ctx;
    }
  }
});

```

This was the original error 
```

Error installing Windows certs TypeError: Cannot set property createSecureContext of #<Object> which has only a getter
	at Function.inject (/Users/arafatkhan/Desktop/cody/node_modules/.pnpm/win-ca@3.5.1/node_modules/win-ca/lib/inject.js:51:11)
	at Function.inject (/Users/arafatkhan/Desktop/cody/node_modules/.pnpm/win-ca@3.5.1/node_modules/win-ca/lib/index.js:22:52)
	at registerLocalCertificates (/Users/arafatkhan/Desktop/cody/vscode/src/certs.js:25:36)
	at initializeNetworkAgent (/Users/arafatkhan/Desktop/cody/vscode/src/fetch.node.ts:96:5)
	at activate2 (/Users/arafatkhan/Desktop/cody/vscode/src/extension.node.ts:40:5)
	at _.kb (/Applications/Visual Studio Code - Insiders.app/Contents/Resources/app/out/vs/workbench/api/node/extensionHostProcess.js:160:13508)
	at _.jb (/Applications/Visual Studio Code - Insiders.app/Contents/Resources/app/out/vs/workbench/api/node/extensionHostProcess.js:160:13221)
	at /Applications/Visual Studio Code - Insiders.app/Contents/Resources/app/out/vs/workbench/api/node/extensionHostProcess.js:160:11246
	at async c.n (/Applications/Visual Studio Code - Insiders.app/Contents/Resources/app/out/vs/workbench/api/node/extensionHostProcess.js:144:6384)
	at async c.m (/Applications/Visual Studio Code - Insiders.app/Contents/Resources/app/out/vs/workbench/api/node/extensionHostProcess.js:144:6347)
	at async c.l (/Applications/Visual Studio Code - Insiders.app/Contents/Resources/app/out/vs/workbench/api/node/extensionHostProcess.js:144:5804) {stack: 'TypeError: Cannot set property createSecureCo…ch/api/node/extensionHostProcess.js:144:5804)', message: 'Cannot set property createSecureContext of #<Object> which has only a getter'}


```

By removing the inject suffix we move to mode 1 in the code above and that solves the issue as the "bad " codepath is not being hit but the downside is that for the self signed certs in Windows we are not importing them now. Something happened in Vscode between June 3 to June 5 where the patching logic stopped working and a deeper inspection could solve that issue so that we can finally import self signed certs too. 

## Next steps
This is a temporary fix for now but down the line when I get extra cycles I will implement a proper fix before July 1. 


## Test plan
Tested locally by building a vsix file and running it on Vscode insiders build in both macos and windows to verify that this works while the current Vscode release version DOES NOT work. 

NOTE: To add clarification this causes a feature regression because we cannot support self signed certs in windows after this change atleast for a while until we get the proper fix merged. 

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
