### PR TITLE
Chat: Fix hover tooltips on overflowed paths in the @-mention file picker

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -8,6 +8,8 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 
 ### Fixed
 
+- Chat: Fix hover tooltips on overflowed paths in the @-mention file picker. [pull/4553](https://github.com/sourcegraph/cody/pull/4553)
+
 ### Changed
 
 ## 1.22.0

--- a/vscode/webviews/mentions/mentionMenu/MentionMenuItem.tsx
+++ b/vscode/webviews/mentions/mentionMenu/MentionMenuItem.tsx
@@ -88,8 +88,14 @@ export const MentionMenuContextItemContent: FunctionComponent<{
         <>
             <div className={styles.row}>
                 {icon && <i className={`codicon codicon-${icon}`} title={isSymbol ? item.kind : ''} />}
-                <span className={clsx(styles.title, warning && styles.titleWithWarning)}>{title}</span>
-                {description && <span className={styles.description}>{description}</span>}
+                <span className={clsx(styles.title, warning && styles.titleWithWarning)} title={title}>
+                    {title}
+                </span>
+                {description && (
+                    <span className={styles.description} title={description}>
+                        {description}
+                    </span>
+                )}
             </div>
             {warning && <span className={styles.warning}>{warning}</span>}
         </>


### PR DESCRIPTION
Fixes the hover titles not showing on the @-mention file picker, so you can now differentiate between two files that may share a common and long path root:

<img src="https://github.com/sourcegraph/cody/assets/153/b56371b7-6103-416d-8c0f-8fbacd01e2e6" width="619">


## Test plan

- CI