### PR TITLE
vscode: show "Add File to Cody Chat" for remote files

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -531,7 +531,7 @@
         "group": "Chat",
         "title": "Add File to Cody Chat",
         "icon": "$(mention)",
-        "enablement": "cody.activated && (editorFocus || filesExplorerFocus) && cody.hasChatPanelsOpened"
+        "enablement": "cody.activated && resourceSet && cody.hasChatPanelsOpened"
       },
       {
         "command": "cody.chat.panel.reset",
@@ -869,7 +869,7 @@
       "editor/title": [
         {
           "command": "cody.menu.commands",
-          "when": "cody.activated && !editorReadonly && (editorFocus || activeWebviewPanelId == cody.chatPanel)",
+          "when": "cody.activated && !editorReadonly && (resourceScheme == file || activeWebviewPanelId == cody.chatPanel)",
           "group": "navigation",
           "visibility": "visible"
         },
@@ -926,7 +926,7 @@
         {
           "command": "cody.mention.file",
           "group": "0_cody",
-          "when": "cody.activated && !explorerResourceIsFolder && cody.hasChatPanelsOpened"
+          "when": "cody.activated && resourceSet && !explorerResourceIsFolder && cody.hasChatPanelsOpened"
         }
       ],
       "scm/title": [

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -531,7 +531,7 @@
         "group": "Chat",
         "title": "Add File to Cody Chat",
         "icon": "$(mention)",
-        "enablement": "cody.activated && resourceScheme == file && cody.hasChatPanelsOpened"
+        "enablement": "cody.activated && (editorFocus || filesExplorerFocus) && cody.hasChatPanelsOpened"
       },
       {
         "command": "cody.chat.panel.reset",
@@ -869,7 +869,7 @@
       "editor/title": [
         {
           "command": "cody.menu.commands",
-          "when": "cody.activated && !editorReadonly && (resourceScheme == file || activeWebviewPanelId == cody.chatPanel)",
+          "when": "cody.activated && !editorReadonly && (editorFocus || activeWebviewPanelId == cody.chatPanel)",
           "group": "navigation",
           "visibility": "visible"
         },
@@ -926,7 +926,7 @@
         {
           "command": "cody.mention.file",
           "group": "0_cody",
-          "when": "cody.activated && resourceScheme == file && cody.hasChatPanelsOpened"
+          "when": "cody.activated && !explorerResourceIsFolder && cody.hasChatPanelsOpened"
         }
       ],
       "scm/title": [


### PR DESCRIPTION
In our enablements and when in a few cases we had resourceScheme == file. However, Cody supports remote files if the editor can get the text. So instead we update those checks to be based on if the editor is in focus.

Additionally for the explorer it will only show the command if the enablement is also true, so we also check if filesExplorerFocus is true.

Finally we fix a bug where we showed the action on folders in the explorers, which does not work.

Test Plan: Tested the action showed up when right clicking on the editor or explorer if cody was open. Otherwise checked it was not shown.

Additionally checked the cody.menu.commands still showed up, but did not show up on other panes (eg the extension view).

Fixes https://linear.app/sourcegraph/issue/CODY-2340/the-length-of-the-file-caused-the-right-click-menu-add-file-to-cody