### PR TITLE
Chat: Add stop generating button to chat

### DIFF
--- a/vscode/webviews/chat/Transcript.module.css
+++ b/vscode/webviews/chat/Transcript.module.css
@@ -2,4 +2,5 @@
     /* Make it so that after a user submits a followup message, the response is
        visible when the viewport is scrolled all the way down. */
     padding-bottom: max(3rem, calc(2*var(--cell-spacing-y))) !important;
+    flex: 1;
 }

--- a/vscode/webviews/chat/Transcript.tsx
+++ b/vscode/webviews/chat/Transcript.tsx
@@ -7,6 +7,7 @@ import {
 import { type ComponentProps, type FunctionComponent, useCallback, useMemo, useRef } from 'react'
 import type { UserAccountInfo } from '../Chat'
 import type { ApiPostMessage } from '../Chat'
+import { StopButton } from '../components/StopButton'
 import type { PromptEditorRefAPI } from '../promptEditor/PromptEditor'
 import { getVSCodeAPI } from '../utils/VSCodeApi'
 import type { CodeBlockActionsProps } from './ChatMessageContent'
@@ -49,10 +50,13 @@ export const Transcript: React.FunctionComponent<{
                         i === interactions.length - 2 && interaction.assistantMessage !== null
                     }
                     priorAssistantMessageIsLoading={Boolean(
-                        interactions.at(i - 1)?.assistantMessage?.isLoading
+                        messageInProgress && interactions.at(i - 1)?.assistantMessage?.isLoading
                     )}
                 />
             ))}
+            {messageInProgress && (
+                <StopButton onClick={() => getVSCodeAPI().postMessage({ command: 'abort' })} />
+            )}
         </>
     )
 }
@@ -87,6 +91,7 @@ export function transcriptToInteractionPairs(
                           index: i + 1,
                           isLoading:
                               assistantMessage.error === undefined &&
+                              !!assistantMessageInProgress &&
                               (isLastPairInTranscript || assistantMessage.text === undefined),
                       }
                     : null,

--- a/vscode/webviews/components/StopButton.tsx
+++ b/vscode/webviews/components/StopButton.tsx
@@ -1,0 +1,16 @@
+import { StopCircle } from 'lucide-react'
+import type { FunctionComponent } from 'react'
+import { Button } from './shadcn/ui/button'
+
+export const StopButton: FunctionComponent<{ onClick?: () => void }> = ({ onClick: parentOnClick }) => (
+    <div className="tw-sticky tw-bottom-0 tw-w-full tw-text-center tw-py-4">
+        <Button
+            variant="outline"
+            size="lg"
+            onClick={parentOnClick}
+            className="tw-py-3 hover:tw-bg-secondary"
+        >
+            <StopCircle size="1.5rem" />
+        </Button>
+    </div>
+)

--- a/vscode/webviews/components/StopButton.tsx
+++ b/vscode/webviews/components/StopButton.tsx
@@ -10,7 +10,9 @@ export const StopButton: FunctionComponent<{ onClick?: () => void }> = ({ onClic
             onClick={parentOnClick}
             className="tw-py-3 hover:tw-bg-secondary"
         >
-            <StopCircle size="1.5rem" />
+            <span className="tw-flex tw-gap-x-4">
+                <StopCircle /> ESC to Stop
+            </span>
         </Button>
     </div>
 )


### PR DESCRIPTION
Part of https://linear.app/sourcegraph/issue/CODY-2345/add-stop-generating-button-for-chat

Came up during a customer call. This PR adds the stop generating button back to chat.

**This is just to serve as a starting point for adding the stop-generating button back since we will need to get design team's input on the best place to show this button within the new chat design.**

https://github.com/sourcegraph/cody/assets/68532117/84ae7a01-c360-4ffc-87e4-73f8bc3d1828

## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

1. Ask Cody a question
2. Verify the Stop button shows up on the bottom of your screen when Cody is responding
3. Verify clicking on the Stop button stops Cody from responding and all loading states are cleared.