### PR TITLE
Enterprise: add support for expanded context window to Gemini 1.5 models

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -6,6 +6,8 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 
 ### Added
 
+Enterprise: Expand context window for Gemini 1.5 models.
+
 ### Fixed
 
 ### Changed

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -6,7 +6,7 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 
 ### Added
 
-Enterprise: Expand context window for Gemini 1.5 models.
+Enterprise: Expand the context window for Gemini 1.5 models. [pull/4563](https://github.com/sourcegraph/cody/pull/4563)
 
 ### Fixed
 

--- a/vscode/src/models/utils.ts
+++ b/vscode/src/models/utils.ts
@@ -75,9 +75,9 @@ function applyLocalTokenLimitOverwrite(
 const modelWithExpandedWindowSubStrings = [
     'claude-3-opus',
     'claude-3-sonnet',
+    'gemini-1.5',
     'gpt-4o',
     'gpt-4-turbo',
-    'gemini-1.5',
 ]
 function isModelWithExtendedContextWindowSupport(chatModel: string): boolean {
     return modelWithExpandedWindowSubStrings.some(keyword => chatModel.toLowerCase().includes(keyword))

--- a/vscode/src/models/utils.ts
+++ b/vscode/src/models/utils.ts
@@ -72,9 +72,15 @@ function applyLocalTokenLimitOverwrite(
  * @param chatModel - The name of the chat model.
  * @returns True if the chat model supports extended context windows, false otherwise.
  */
+const modelWithExpandedWindowSubStrings = [
+    'claude-3-opus',
+    'claude-3-sonnet',
+    'gpt-4o',
+    'gpt-4-turbo',
+    'gemini-1.5',
+]
 function isModelWithExtendedContextWindowSupport(chatModel: string): boolean {
-    const supportedModelSubStrings = ['claude-3-opus', 'claude-3-sonnet', 'gpt-4o', 'gpt-4-turbo']
-    return supportedModelSubStrings.some(keyword => chatModel.includes(keyword))
+    return modelWithExpandedWindowSubStrings.some(keyword => chatModel.toLowerCase().includes(keyword))
 }
 
 // TODO: Currently all enterprise models have a max output limit of
@@ -83,25 +89,13 @@ function isModelWithExtendedContextWindowSupport(chatModel: string): boolean {
 // still supporting models with a lower output limit.
 //
 // To avoid Enterprise instances being stuck with low token counts, we
-// will detect our recommended Cody Gateway models and Bedrock models
-// and use a higher limit.
+// will detect our recommended Cody Gateway models to use a higher limit.
 //
 // See: https://github.com/sourcegrcaph/cody/issues/3648#issuecomment-2056954101
 // See: https://github.com/sourcegraph/cody/pull/4203
 function getEnterpriseOutputLimit(model?: string) {
-    switch (model) {
-        // Cody Gateway models
-        case 'anthropic/claude-3-sonnet-20240229':
-        case 'anthropic/claude-3-opus-20240229':
-        case 'openai/gpt-4o':
-        case 'openai/gpt-4-turbo':
-
-        // Bedrock models:
-        case 'anthropic.claude-3-sonnet-20240229-v1:0':
-        case 'anthropic.claude-3-opus-20240229-v1:0 ':
-            return CHAT_OUTPUT_TOKEN_BUDGET
-
-        default:
-            return ANSWER_TOKENS
+    if (model && isModelWithExtendedContextWindowSupport(model)) {
+        return CHAT_OUTPUT_TOKEN_BUDGET
     }
+    return ANSWER_TOKENS
 }


### PR DESCRIPTION
CONTEXT: https://sourcegraph.slack.com/archives/C05AGQYD528/p1718323087549179?thread_ts=1718316482.993009&cid=C05AGQYD528

CLOSE https://linear.app/sourcegraph/issue/CODY-2356/add-gemini-to-the-list

- This change adds support for additional chat models with expanded context windows, including 'claude-3-opus', 'claude-3-sonnet', 'gpt-4o', 'gpt-4-turbo', and 'gemini-1.5'. 
- The `isModelWithExtendedContextWindowSupport` function has been updated to check for these model substrings, and the `getEnterpriseOutputLimit` function has been simplified to use the new function for determining the appropriate output limit.

## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

N/A.

Adding a new string to the current list. No feature was changed.