### PR TITLE
Ollama: Fix Ollama models not connected to correct client

### DIFF
--- a/lib/shared/src/llm-providers/clients.ts
+++ b/lib/shared/src/llm-providers/clients.ts
@@ -31,7 +31,7 @@ export async function useCustomChatClient(
         openaicompatible: groqChatClient,
     }
 
-    const client = clientMap[model.provider]
+    const client = clientMap[model.provider.toLowerCase()]
 
     if (client) {
         await client(params, cb, completionsEndpoint, logger, signal)

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -11,7 +11,7 @@ Enterprise: Expand the context window for Gemini 1.5 models. [pull/4563](https:/
 ### Fixed
 
 - Chat: Fix hover tooltips on overflowed paths in the @-mention file picker. [pull/4553](https://github.com/sourcegraph/cody/pull/4553)
-- Ollama: Fix a bug where Ollama models were not connected to the correct client. The issue was caused by model providers being capitalized, which was not taken into account when matching clients.
+- Ollama: Fix a bug where Ollama models were not connected to the correct client. [pull/4564](https://github.com/sourcegraph/cody/pull/4564)
 
 ### Changed
 

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -11,6 +11,7 @@ Enterprise: Expand the context window for Gemini 1.5 models. [pull/4563](https:/
 ### Fixed
 
 - Chat: Fix hover tooltips on overflowed paths in the @-mention file picker. [pull/4553](https://github.com/sourcegraph/cody/pull/4553)
+- Ollama: Fix a bug where Ollama models were not connected to the correct client. The issue was caused by model providers being capitalized, which was not taken into account when matching clients.
 
 ### Changed
 


### PR DESCRIPTION
The issue was caused by model providers being capitalized, which was not taken into account when matching clients. This change converts the model provider to lowercase before looking up the corresponding client.


## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

1. Choose an Ollama model
2. Say hello to Cody

Before: Cody will response that it's Claude to confirm we are not connected to the Ollama client.

<img width="1471" alt="image" src="https://github.com/sourcegraph/cody/assets/68532117/d5e72ff3-8251-4259-bc99-672500037de2">


After: No more Claude in the response.

<img width="1466" alt="image" src="https://github.com/sourcegraph/cody/assets/68532117/7c63123a-823d-43d6-ae35-c99912d9d04f">
