### PR TITLE
test: add unit tests for custom llm clients

### DIFF
--- a/lib/shared/src/llm-providers/clients.test.ts
+++ b/lib/shared/src/llm-providers/clients.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { ModelsService } from '../models'
+import { useCustomChatClient } from './clients'
+
+import {
+    type CompletionCallbacks,
+    type CompletionParameters,
+    ModelUsage,
+    getDotComDefaultModels,
+} from '..'
+
+describe('useCustomChatClient', () => {
+    const codygatewayModels = getDotComDefaultModels()
+    const mockCompletionsEndpoint = 'https://example.com/completions'
+    const mockParams: CompletionParameters = {
+        model: 'olala/test-model',
+        messages: [],
+        maxTokensToSample: 1,
+    }
+    const mockCallbacks: CompletionCallbacks = {
+        onChange: vi.fn(),
+        onComplete: vi.fn(),
+        onError: vi.fn(),
+    }
+
+    afterEach(() => {
+        vi.resetAllMocks()
+    })
+
+    it('returns false when model is not found', async () => {
+        vi.spyOn(ModelsService, 'getModelByID').mockReturnValue(undefined)
+
+        const result = await useCustomChatClient(mockCompletionsEndpoint, mockParams, mockCallbacks)
+
+        expect(result).toBe(false)
+    })
+
+    it('returns false when model is a Cody Gateway model', async () => {
+        vi.spyOn(ModelsService, 'getModelByID').mockReturnValue(codygatewayModels[0])
+
+        const result = await useCustomChatClient(mockCompletionsEndpoint, mockParams, mockCallbacks)
+
+        expect(result).toBe(false)
+    })
+
+    it('calls the correct client based on the model provider - google', async () => {
+        const nonGatewayModel = [
+            {
+                title: 'Gemini 1.5 Pro',
+                model: 'google/gemini-1.5-pro-latest',
+                provider: 'Google',
+                default: false,
+                codyProOnly: true,
+                usage: [ModelUsage.Chat],
+                contextWindow: { input: 1, output: 1 },
+                deprecated: false,
+            },
+        ]
+        ModelsService.addModels(nonGatewayModel)
+
+        vi.spyOn(ModelsService, 'getModelByID').mockReturnValue(nonGatewayModel[0])
+        const result = await useCustomChatClient(mockCompletionsEndpoint, mockParams, mockCallbacks)
+        const mockChatClient = vi.fn()
+        vi.doMock('./google', () => ({
+            googleChatClient: mockChatClient,
+        }))
+
+        await useCustomChatClient(mockCompletionsEndpoint, mockParams, mockCallbacks)
+        expect(result).toBe(true)
+    })
+
+    // TODO mock the ollama chat client properly
+    it.skip('returns true when a matching client is found and called', async () => {
+        const mockModel = { provider: 'Ollama' }
+        vi.spyOn(ModelsService, 'getModelByID').mockReturnValue(mockModel as any)
+        const mockOllamaChatClient = vi.fn()
+        vi.doMock('./ollama', () => ({ ollamaChatClient: mockOllamaChatClient }))
+        const result = await useCustomChatClient(mockCompletionsEndpoint, mockParams, mockCallbacks)
+        expect(result).toBe(true)
+    })
+
+    it('returns false when no matching client is found', async () => {
+        vi.spyOn(ModelsService, 'getModelByID').mockReturnValue(undefined)
+        const result = await useCustomChatClient(mockCompletionsEndpoint, mockParams, mockCallbacks)
+        expect(result).toBe(false)
+    })
+})

--- a/lib/shared/src/llm-providers/utils.test.ts
+++ b/lib/shared/src/llm-providers/utils.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it, vi } from 'vitest'
+import { ModelsService } from '../models'
+import { getDotComDefaultModels } from '../models/dotcom'
+import { ModelUsage } from '../models/types'
+import { getCompletionsModelConfig } from './utils'
+
+describe('getCompletionsModelConfig', () => {
+    it('returns the correct model with no config for dotcom models', () => {
+        const dotcomModels = getDotComDefaultModels()
+        for (const model of dotcomModels) {
+            const modelConfig = getCompletionsModelConfig(model.model)
+            expect(modelConfig?.endpoint).toEqual(undefined)
+            expect(modelConfig?.key).toEqual(undefined)
+        }
+    })
+    it('returns undefined when model is not found', () => {
+        const modelID = 'nonexistent-model'
+        expect(getCompletionsModelConfig(modelID)).toBeUndefined()
+    })
+
+    it('returns the correct completions model config', () => {
+        const model = {
+            title: 'Olala Model',
+            model: 'huggingface/olala-model',
+            provider: 'HuggingFace',
+            default: false,
+            codyProOnly: true,
+            usage: [ModelUsage.Chat, ModelUsage.Edit],
+            contextWindow: { input: 100, output: 100 },
+            deprecated: false,
+            config: {
+                apiKey: 'test-api-key',
+                apiEndpoint: 'https://huggingface.com',
+                model: 'olala-model',
+            },
+        }
+
+        ModelsService.addModels([model])
+
+        vi.spyOn(ModelsService, 'getModelByID').mockReturnValue(model)
+
+        expect(getCompletionsModelConfig(model.model)).toEqual({
+            key: 'test-api-key',
+            endpoint: 'https://huggingface.com',
+            model: 'olala-model',
+        })
+    })
+
+    it('returns the correct completions model config when apiKey and apiEndpoint are missing', () => {
+        const model = {
+            title: 'Claude Instant Test',
+            model: 'anthropic/claude-instant-test',
+            provider: 'Anthropic',
+            default: false,
+            codyProOnly: true,
+            usage: [ModelUsage.Chat, ModelUsage.Edit],
+            contextWindow: { input: 100, output: 100 },
+            deprecated: false,
+            config: {
+                apiKey: undefined,
+                apiEndpoint: '',
+            },
+        }
+
+        ModelsService.addModels([model])
+
+        vi.spyOn(ModelsService, 'getModelByID').mockReturnValue(model)
+
+        expect(getCompletionsModelConfig(model.model)).toEqual({
+            endpoint: '',
+            key: '',
+            model: 'claude-instant-test',
+        })
+    })
+})

--- a/lib/shared/src/llm-providers/utils.ts
+++ b/lib/shared/src/llm-providers/utils.ts
@@ -1,6 +1,12 @@
 import type { CompletionsModelConfig } from '.'
 import { ModelsService } from '../models'
 
+/**
+ * Retrieves the configuration for a completions model by its ID.
+ *
+ * @param modelID - The ID of the model to retrieve the configuration for.
+ * @returns The configuration for the specified completions model, or `undefined` if the model is not found.
+ */
 export function getCompletionsModelConfig(modelID: string): CompletionsModelConfig | undefined {
     const provider = ModelsService.getModelByID(modelID)
     if (!provider) {
@@ -11,11 +17,6 @@ export function getCompletionsModelConfig(modelID: string): CompletionsModelConf
         model,
         config: { apiKey = '', apiEndpoint } = {},
     } = provider
-    const strippedModelName = model.split('/').pop() || model
 
-    return {
-        model: strippedModelName,
-        key: apiKey,
-        endpoint: apiEndpoint,
-    }
+    return { model, key: apiKey, endpoint: apiEndpoint }
 }


### PR DESCRIPTION
Add unit test coverage for custom llm providers

## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

Green CI