### PR TITLE
adding completions experiment variants

### DIFF
--- a/lib/shared/src/experimentation/FeatureFlagProvider.ts
+++ b/lib/shared/src/experimentation/FeatureFlagProvider.ts
@@ -19,7 +19,7 @@ export enum FeatureFlag {
     CodyAutocompleteFIMFineTunedModelHybrid = 'cody-autocomplete-fim-fine-tuned-model-hybrid',
 
     // Enable various feature flags to experiment with FIM trained fine-tuned models via Fireworks
-    CodyAutocompleteFIMModelExperimentBaseFeatureFlag = 'cody-autocomplete-fim-model-base-experiment-flag',
+    CodyAutocompleteFIMModelExperimentBaseFeatureFlag = 'cody-autocomplete-fim-model-experiment-flag',
     CodyAutocompleteFIMModelExperimentControl = 'cody-autocomplete-fim-model-experiment-control',
     CodyAutocompleteFIMModelExperimentVariant1 = 'cody-autocomplete-fim-model-experiment-variant-1',
     CodyAutocompleteFIMModelExperimentVariant2 = 'cody-autocomplete-fim-model-experiment-variant-2',

--- a/lib/shared/src/experimentation/FeatureFlagProvider.ts
+++ b/lib/shared/src/experimentation/FeatureFlagProvider.ts
@@ -19,12 +19,12 @@ export enum FeatureFlag {
     CodyAutocompleteFIMFineTunedModelHybrid = 'cody-autocomplete-fim-fine-tuned-model-hybrid',
 
     // Enable various feature flags to experiment with FIM trained fine-tuned models via Fireworks
-    CodyAutocompleteFIMFineTunedModelBaseFeatureFlag = 'cody-autocomplete-fim-fine-tuned-model-experiment-flag',
-    CodyAutocompleteFIMFineTunedModelControl = 'cody-autocomplete-fim-fine-tuned-model-control',
-    CodyAutocompleteFIMFineTunedModelVariant1 = 'cody-autocomplete-fim-fine-tuned-model-variant-1',
-    CodyAutocompleteFIMFineTunedModelVariant2 = 'cody-autocomplete-fim-fine-tuned-model-variant-2',
-    CodyAutocompleteFIMFineTunedModelVariant3 = 'cody-autocomplete-fim-fine-tuned-model-variant-3',
-    CodyAutocompleteFIMFineTunedModelVariant4 = 'cody-autocomplete-fim-fine-tuned-model-variant-4',
+    CodyAutocompleteFIMModelExperimentBaseFeatureFlag = 'cody-autocomplete-fim-model-base-experiment-flag',
+    CodyAutocompleteFIMModelExperimentControl = 'cody-autocomplete-fim-model-experiment-control',
+    CodyAutocompleteFIMModelExperimentVariant1 = 'cody-autocomplete-fim-model-experiment-variant-1',
+    CodyAutocompleteFIMModelExperimentVariant2 = 'cody-autocomplete-fim-model-experiment-variant-2',
+    CodyAutocompleteFIMModelExperimentVariant3 = 'cody-autocomplete-fim-model-experiment-variant-3',
+    CodyAutocompleteFIMModelExperimentVariant4 = 'cody-autocomplete-fim-model-experiment-variant-4',
 
     // Enables Claude 3 if the user is in our holdout group
     CodyAutocompleteClaude3 = 'cody-autocomplete-claude-3',

--- a/vscode/src/completions/providers/create-provider.ts
+++ b/vscode/src/completions/providers/create-provider.ts
@@ -17,6 +17,7 @@ import {
     DEEPSEEK_CODER_1P3_B,
     DEEPSEEK_CODER_7B,
     FIREWORKS_FIM_FINE_TUNED_MODEL_HYBRID,
+    FIREWORKS_FIM_FINE_TUNED_MODEL_HYBRID_WITH_200MS_DELAY,
     FIREWORKS_FIM_LANG_SPECIFIC_MODEL_MIXTRAL,
     type FireworksOptions,
     createProviderConfig as createFireworksProviderConfig,
@@ -180,7 +181,7 @@ async function resolveFIMModelExperimentFromFeatureFlags(): ReturnType<
         ])
     if (fimModelVariant1) {
         // Variant 1: Current production model with +200msec latency to quantity the effect of latency increase while keeping same quality
-        return { provider: 'fireworks', model: FIREWORKS_FIM_FINE_TUNED_MODEL_HYBRID }
+        return { provider: 'fireworks', model: FIREWORKS_FIM_FINE_TUNED_MODEL_HYBRID_WITH_200MS_DELAY }
     }
     if (fimModelVariant2) {
         return { provider: 'fireworks', model: FIREWORKS_FIM_LANG_SPECIFIC_MODEL_MIXTRAL }

--- a/vscode/src/completions/providers/fim-prompt-utils.ts
+++ b/vscode/src/completions/providers/fim-prompt-utils.ts
@@ -1,0 +1,82 @@
+import { PromptString, ps } from '@sourcegraph/cody-shared'
+import type * as vscode from 'vscode'
+
+export interface FIMContextPromptParams {
+    filename: vscode.Uri
+    content: PromptString
+}
+
+export interface FIMInfillingPromptParams {
+    filename: PromptString
+    intro: PromptString
+    prefix: PromptString
+    suffix: PromptString
+}
+
+export interface FIMModelSpecificPromptExtractor {
+    getContextPrompt(contextParams: FIMContextPromptParams): PromptString
+    getInfillingPrompt(infillParams: FIMInfillingPromptParams): PromptString
+}
+
+export class StarcoderPromptExtractor implements FIMModelSpecificPromptExtractor {
+    getContextPrompt(param: FIMContextPromptParams): PromptString {
+        return getDefaultContextPrompt(param.filename, param.content)
+    }
+
+    getInfillingPrompt(param: FIMInfillingPromptParams): PromptString {
+        // c.f. https://huggingface.co/bigcode/starcoder#fill-in-the-middle
+        // c.f. https://arxiv.org/pdf/2305.06161.pdf
+        return ps`<filename>${param.filename}<fim_prefix>${param.intro}${param.prefix}<fim_suffix>${param.suffix}<fim_middle>`
+    }
+}
+
+export class CodeLlamaPromptExtractor implements FIMModelSpecificPromptExtractor {
+    getContextPrompt(param: FIMContextPromptParams): PromptString {
+        return getDefaultContextPrompt(param.filename, param.content)
+    }
+
+    getInfillingPrompt(param: FIMInfillingPromptParams): PromptString {
+        // c.f. https://github.com/facebookresearch/codellama/blob/main/llama/generation.py#L402
+        return ps`<PRE> ${param.intro}${param.prefix} <SUF>${param.suffix} <MID>`
+    }
+}
+
+export class DeepSeekPromptExtractor implements FIMModelSpecificPromptExtractor {
+    getContextPrompt(param: FIMContextPromptParams): PromptString {
+        return ps`#${PromptString.fromDisplayPath(param.filename)}\n${param.content}`
+    }
+
+    getInfillingPrompt(param: FIMInfillingPromptParams): PromptString {
+        // Deepseek paper: https://arxiv.org/pdf/2401.14196
+        return ps`${param.intro}\n#${param.filename}\n<｜fim▁begin｜>${param.prefix}<｜fim▁hole｜>${param.suffix}<｜fim▁end｜>`
+    }
+}
+
+export class FinetunedModelV1PromptExtractor implements FIMModelSpecificPromptExtractor {
+    getContextPrompt(param: FIMContextPromptParams): PromptString {
+        // Fine-tuned model have a additional <file_sep> tag.
+        return ps`<file_sep>Here is a reference snippet of code from ${PromptString.fromDisplayPath(
+            param.filename
+        )}\n${param.content}`
+    }
+
+    getInfillingPrompt(param: FIMInfillingPromptParams): PromptString {
+        return ps`${param.intro}<fim_suffix>${param.filename}\n${param.suffix}<fim_prefix>${param.prefix}<fim_middle>`
+    }
+}
+
+export class DefaultModelPromptExtractor implements FIMModelSpecificPromptExtractor {
+    getContextPrompt(param: FIMContextPromptParams): PromptString {
+        return getDefaultContextPrompt(param.filename, param.content)
+    }
+
+    getInfillingPrompt(param: FIMInfillingPromptParams): PromptString {
+        return ps`${param.intro}${param.prefix}`
+    }
+}
+
+export function getDefaultContextPrompt(filename: vscode.Uri, content: PromptString): PromptString {
+    return ps`Here is a reference snippet of code from ${PromptString.fromDisplayPath(
+        filename
+    )}:\n\n${content}`
+}

--- a/vscode/src/tree-sitter/language.ts
+++ b/vscode/src/tree-sitter/language.ts
@@ -1,6 +1,6 @@
 import { type PromptString, ps } from '@sourcegraph/cody-shared'
 
-interface LanguageConfig {
+export interface LanguageConfig {
     blockStart: string
     blockElseTest: RegExp
     blockEnd: string | null


### PR DESCRIPTION
## Context
These are the changes for the autocomplete experiment. Following are the variant details, along with the hypothesis. (cc: @rishabhmehrotra)

1. `CodyAutocompleteFIMModelExperimentBaseFeatureFlag`: Any user in this feature flag will be assigned to this experiment.
2. `Control`: This is the current production model.
3. `Variant-1 `: This is current production model + 200 msec delay. The goal of this variant is to see the effect of latency increase on other metric. More details about this is given in the [RFC: Autocomplete metric governance](https://docs.google.com/document/d/1CSf4Nnfmy8Jch1CKVaGFGKruhwAsCq1rMIoxJP8PuHA/edit). In summary, we want to establish a pareto-curve for latency/Quality trade-off. Since the current production model is a combination of starcoder + Mixtral fine-tuned - It will give us 4 points in the pareto-curve and help understand the value of latency changes while keeping the quality same.
4. `Variant-2`: This variant hosts language specific mixtral deployments on fireworks. In the previous A/B tests, we saw `2%` increase in wCAR for `llama` language-specific variant over models trained on all languages.  We want to run the experiment with Mixtral in this variant with hypothesis that it will give us gain in wCAR metric.
5. `Variant-3`: This variant hosts `deepseek-coder 1.3b` model. This is part of the effort to decrease the latency of autocomplete. In addition, our offline analysis show the performance of this model only slightly below the current production model. If the offline-online correlation holds, this can be significant latency decrease for minor CAR, wCAR hit. Additionally, we would want to track other metrics such as `#Suggestions`, `Retention` etc which we expect to increase with significant latency decrease. (Todo: Share offline numbers)
6. `Variant-4`: This variant hosts `deepseek-coder 7b` model. This is part of the effort to decrease the latency of autocomplete. In addition, our offline analysis show the performance of this model only significantly better than the current production model. If the offline-online correlation holds, this can be significant improve CAR, wCAR with slightly improved latency. (Todo: Share offline numbers)

Backend PR: https://github.com/sourcegraph/sourcegraph/pull/63283

## Test plan
**Local Testing**
1. Start the debugger and Change my user-id among variants.
2. Observ the payload and model we are triggering for each variant combination.

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

