### PR TITLE
minion: remove unused checkpoint

### DIFF
--- a/vscode/src/minion/MinionStorage.ts
+++ b/vscode/src/minion/MinionStorage.ts
@@ -1,11 +1,9 @@
 import type { AuthStatus } from '@sourcegraph/cody-shared'
 import { localStorage } from '../services/LocalStorageProvider'
 import type { MinionSession } from './action'
-import type { BlockCheckpoint } from './statemachine'
 
 interface StoredSessionState {
     session: MinionSession
-    checkpoint?: BlockCheckpoint
 }
 
 export class MinionStorage {

--- a/vscode/src/minion/action.ts
+++ b/vscode/src/minion/action.ts
@@ -93,14 +93,14 @@ export interface MinionSession {
     transcript: MinionTranscriptItem[]
 }
 
-export type NodeStatus = 'doing' | 'done' | 'cancelled' | 'failed'
+export type BlockStatus = 'doing' | 'done' | 'cancelled' | 'failed'
 
-export type MinionTranscriptItem = MinionTranscriptEvent | MinionTranscriptNode
+export type MinionTranscriptItem = MinionTranscriptEvent | MinionTranscriptBlock
 
-export type MinionTranscriptNode = {
-    type: 'node'
-    node: { nodeid: string; blockid: string }
-    status: NodeStatus
+export type MinionTranscriptBlock = {
+    type: 'block'
+    block: { nodeid: string; blockid: string }
+    status: BlockStatus
 }
 
 export type MinionTranscriptEvent = {

--- a/vscode/src/minion/blocks/plan.ts
+++ b/vscode/src/minion/blocks/plan.ts
@@ -38,7 +38,6 @@ export class PlanBlock implements Block {
             blockid: this.id,
             steps,
         })
-        memory.setCheckpoint({ blockid: this.id, data: JSON.stringify({ steps }) })
         return { status: 'done' }
     }
 

--- a/vscode/src/minion/statemachine.ts
+++ b/vscode/src/minion/statemachine.ts
@@ -3,16 +3,9 @@ import type { CancellationToken } from 'vscode'
 import type { Event } from './action'
 import type { Environment } from './environment'
 
-export interface BlockCheckpoint {
-    blockid: string
-    data: string
-}
-
 export interface Memory {
     getEvents: () => Event[]
     postEvent: (event: Event) => void
-    setCheckpoint: (checkpoint: BlockCheckpoint | null) => void
-    getCheckpoint(blockid: string): string | null
 }
 
 export interface BlockResult {

--- a/vscode/src/minion/statemachine.ts
+++ b/vscode/src/minion/statemachine.ts
@@ -26,6 +26,11 @@ export interface Block {
     ) => Promise<BlockResult>
 }
 
+/**
+ * A state machine is composed of nodes and edges. The nodes identify
+ * constructors of execution blocks. The state machine then executes
+ * these blocks.
+ */
 export class StateMachine {
     constructor(
         private cancellationToken: CancellationToken,
@@ -33,15 +38,15 @@ export class StateMachine {
             nodes: { [nodeid: string]: () => Block }
             edges: { [nodeid: string]: string | null }
         },
-        private _currentNode: { nodeid: string; block: Block }
+        private _currentBlock: { nodeid: string; block: Block }
     ) {}
 
-    public get currentNode(): { nodeid: string; block: Block } {
-        return this._currentNode
+    public get currentBlock(): { nodeid: string; block: Block } {
+        return this._currentBlock
     }
 
-    public set currentNode(node: { nodeid: string; block: Block }) {
-        this._currentNode = node
+    public set currentBlock(node: { nodeid: string; block: Block }) {
+        this._currentBlock = node
     }
 
     public createBlock(nodeid: string): Block {
@@ -56,17 +61,17 @@ export class StateMachine {
      * @returns true if done, false otherwise
      */
     public async step(env: Environment, memory: Memory, anthropic: Anthropic): Promise<boolean> {
-        await this._currentNode.block.do(this.cancellationToken, env, memory, anthropic)
+        await this._currentBlock.block.do(this.cancellationToken, env, memory, anthropic)
 
-        const nextNodeId = this.graph.edges[this._currentNode.nodeid]
+        const nextNodeId = this.graph.edges[this._currentBlock.nodeid]
         if (nextNodeId === null) {
             return true
         }
         if (nextNodeId === undefined) {
-            throw new Error(`no next node defined for ${this._currentNode.nodeid}`)
+            throw new Error(`no next node defined for ${this._currentBlock.nodeid}`)
         }
 
-        this._currentNode = { nodeid: nextNodeId, block: this.createBlock(nextNodeId) }
+        this._currentBlock = { nodeid: nextNodeId, block: this.createBlock(nextNodeId) }
         return false
     }
 }

--- a/vscode/webviews/minion/MinionApp.story.tsx
+++ b/vscode/webviews/minion/MinionApp.story.tsx
@@ -48,8 +48,8 @@ const dummyVSCodeAPI: GenericVSCodeWrapper<MinionWebviewMessage, MinionExtension
         cb({ type: 'update-transcript', transcript: [...transcript] })
 
         transcript.push({
-            type: 'node',
-            node: { nodeid: 'restate', blockid: 'restate-0' },
+            type: 'block',
+            block: { nodeid: 'restate', blockid: 'restate-0' },
             status: 'done',
         })
         cb({ type: 'update-transcript', transcript: [...transcript] })
@@ -65,8 +65,8 @@ const dummyVSCodeAPI: GenericVSCodeWrapper<MinionWebviewMessage, MinionExtension
         cb({ type: 'update-transcript', transcript: [...transcript] })
 
         transcript.push({
-            type: 'node',
-            node: { nodeid: 'contextualize', blockid: 'contextualize-0' },
+            type: 'block',
+            block: { nodeid: 'contextualize', blockid: 'contextualize-0' },
             status: 'done',
         })
         cb({ type: 'update-transcript', transcript: [...transcript] })
@@ -81,7 +81,7 @@ const dummyVSCodeAPI: GenericVSCodeWrapper<MinionWebviewMessage, MinionExtension
         })
         cb({ type: 'update-transcript', transcript: [...transcript] })
 
-        transcript.push({ type: 'node', node: { nodeid: 'plan', blockid: 'plan-0' }, status: 'doing' })
+        transcript.push({ type: 'block', block: { nodeid: 'plan', blockid: 'plan-0' }, status: 'doing' })
         cb({ type: 'update-transcript', transcript: [...transcript] })
 
         transcript.push({

--- a/vscode/webviews/minion/MinionApp.tsx
+++ b/vscode/webviews/minion/MinionApp.tsx
@@ -1,8 +1,8 @@
 import { useCallback, useEffect, useState } from 'react'
 import type {
+    BlockStatus,
     Event as EventItem,
     MinionTranscriptItem,
-    NodeStatus,
     PlanStatus,
     PlanStepsStatus,
     Step,
@@ -197,7 +197,7 @@ const EventItem: React.FunctionComponent<{
 
 const BlockItem: React.FunctionComponent<{
     title: string
-    state: NodeStatus
+    state: BlockStatus
     onReplay: () => void
     onCancelCurrent: () => void
 }> = ({ title, state, onReplay, onCancelCurrent }) => {
@@ -451,11 +451,11 @@ export const MinionApp: React.FunctionComponent<{
         vscodeAPI.postMessage({ type: 'clear-history' })
     }, [vscodeAPI])
 
-    const replayFromNode = useCallback(
+    const replayFromBlock = useCallback(
         (transcriptIndex: number) => {
-            if (transcriptIndex >= transcript.length || transcript[transcriptIndex].type !== 'node') {
+            if (transcriptIndex >= transcript.length || transcript[transcriptIndex].type !== 'block') {
                 throw new Error(
-                    'Item at index was not node: ' + JSON.stringify(transcript[transcriptIndex])
+                    'Item at index was not block: ' + JSON.stringify(transcript[transcriptIndex])
                 )
             }
             vscodeAPI.postMessage({
@@ -466,8 +466,8 @@ export const MinionApp: React.FunctionComponent<{
         [vscodeAPI, transcript]
     )
 
-    const cancelCurrentNode = useCallback(() => {
-        vscodeAPI.postMessage({ type: 'cancel-current-node' })
+    const cancelCurrentBlock = useCallback(() => {
+        vscodeAPI.postMessage({ type: 'cancel-current-block' })
     }, [vscodeAPI])
 
     const updatePlanStep = useCallback(
@@ -528,9 +528,9 @@ export const MinionApp: React.FunctionComponent<{
                             ) : (
                                 <BlockItem
                                     state={item.status}
-                                    title={item.node.nodeid}
-                                    onReplay={() => replayFromNode(i)}
-                                    onCancelCurrent={() => cancelCurrentNode()}
+                                    title={item.block.nodeid}
+                                    onReplay={() => replayFromBlock(i)}
+                                    onCancelCurrent={() => cancelCurrentBlock()}
                                 />
                             )}
                         </div>

--- a/vscode/webviews/minion/webview_protocol.ts
+++ b/vscode/webviews/minion/webview_protocol.ts
@@ -20,7 +20,7 @@ export type MinionWebviewMessage =
           index: number
       }
     | {
-          type: 'cancel-current-node'
+          type: 'cancel-current-block'
       }
     | {
           type: 'update-plan-step'


### PR DESCRIPTION
Remove the checkpoint logic, currently unused. Also rename "nodes" to "blocks" ("nodes" are now static identifiers for block constructors, and blocks are the actual execution units).

## Test plan

Remove unused code from experimental feature