### PR TITLE
fix flaky test

### DIFF
--- a/vscode/test/e2e/helpers.ts
+++ b/vscode/test/e2e/helpers.ts
@@ -302,7 +302,7 @@ export const test = base
             resetLoggedEvents()
         },
     })
-    .extend<{ sidebar: Frame | null; getCodySidebar: () => Promise<Frame> }>({
+    .extend<{ sidebar: Frame | null }>({
         sidebar: async ({ page, preAuthenticate }, use) => {
             if (preAuthenticate) {
                 await use(null)
@@ -310,9 +310,6 @@ export const test = base
                 const sidebar = await getCodySidebar(page)
                 await use(sidebar)
             }
-        },
-        getCodySidebar: async ({ page }, use) => {
-            await use(() => getCodySidebar(page))
         },
     })
     // Simple sleep utility with a default of 300ms

--- a/vscode/test/e2e/troubleshooting-authConnection.test.ts
+++ b/vscode/test/e2e/troubleshooting-authConnection.test.ts
@@ -29,7 +29,7 @@ test.extend<ExpectedEvents>({
         'CodyVSCodeExtension:troubleshoot:reloadAuth',
         'CodyVSCodeExtension:Auth:connected',
     ],
-})('allow retrying on connection issues', async ({ page, nap, getCodySidebar }) => {
+})('allow retrying on connection issues', async ({ page, nap }) => {
     // After Cody has loaded we prevent the server from accepting connections. On reloading
     // Cody this will now cause a connection issue when checking the currentUser.
     // After "fixing" the server Cody should be able to connect again.
@@ -49,8 +49,10 @@ test.extend<ExpectedEvents>({
         method: 'POST',
     })
     assert.equal(res.status, 200)
-    const sidebar = await getCodySidebar()
-    await sidebar.getByRole('button', { name: 'Retry Connection' }).click()
+
+    const sidebar = page.frameLocator('iframe.webview').first().frameLocator('iframe').first()
+    sidebar.getByRole('button', { name: 'Retry Connection' }).click()
+
     await nap()
     expectAuthenticated(page)
 })


### PR DESCRIPTION
It's better to use a FrameLocator rather than a Frame in playwright, as a Frame can be invalidated by a navigation action. Fixes a sometimes-flaky test by using an appropriate FrameLocator, instead of a Frame, to target the Cody sidebar.

## Test plan

Test-only change.