### PR TITLE
Add ide version and proper Cody extension version to the telemetry

### DIFF
--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/ClientInfo.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/ClientInfo.kt
@@ -4,6 +4,7 @@ package com.sourcegraph.cody.protocol_generated
 data class ClientInfo(
   val name: String,
   val version: String,
+  val ideVersion: String? = null,
   val workspaceRootUri: String,
   val workspaceRootPath: String? = null,
   val extensionConfiguration: ExtensionConfiguration? = null,

--- a/agent/src/AgentWorkspaceConfiguration.ts
+++ b/agent/src/AgentWorkspaceConfiguration.ts
@@ -88,6 +88,10 @@ export class AgentWorkspaceConfiguration implements vscode.WorkspaceConfiguratio
                 return extensionConfig?.codebase
             case 'cody.advanced.agent.ide':
                 return this.clientNameToIDE(this.clientInfo()?.name ?? '')
+            case 'cody.advanced.agent.ide.version':
+                return this.clientInfo()?.version
+            case 'cody.advanced.agent.extension.version':
+                return this.clientInfo()?.ideVersion
             case 'editor.insertSpaces':
                 return true // TODO: override from IDE clients
             default:

--- a/agent/src/AgentWorkspaceConfiguration.ts
+++ b/agent/src/AgentWorkspaceConfiguration.ts
@@ -89,9 +89,9 @@ export class AgentWorkspaceConfiguration implements vscode.WorkspaceConfiguratio
             case 'cody.advanced.agent.ide':
                 return this.clientNameToIDE(this.clientInfo()?.name ?? '')
             case 'cody.advanced.agent.ide.version':
-                return this.clientInfo()?.version
-            case 'cody.advanced.agent.extension.version':
                 return this.clientInfo()?.ideVersion
+            case 'cody.advanced.agent.extension.version':
+                return this.clientInfo()?.version
             case 'editor.insertSpaces':
                 return true // TODO: override from IDE clients
             default:

--- a/lib/shared/src/configuration.ts
+++ b/lib/shared/src/configuration.ts
@@ -81,6 +81,8 @@ export interface Configuration {
      */
     isRunningInsideAgent?: boolean
     agentIDE?: 'VSCode' | 'JetBrains' | 'Neovim' | 'Emacs'
+    agentIDEVersion?: string
+    agentExtensionVersion?: string
     autocompleteTimeouts: AutocompleteTimeouts
     autocompleteFirstCompletionTimeout: number
 

--- a/lib/shared/src/telemetry/EventLogger.ts
+++ b/lib/shared/src/telemetry/EventLogger.ts
@@ -9,6 +9,7 @@ import { getTier } from '../telemetry-v2/cody-tier'
 
 export interface ExtensionDetails {
     ide: 'VSCode' | 'JetBrains' | 'Neovim' | 'Emacs'
+    ideVersion?: string
     ideExtensionType: 'Cody' | 'CodeSearch'
     platform: string
     arch?: string

--- a/vscode/src/configuration.test.ts
+++ b/vscode/src/configuration.test.ts
@@ -84,6 +84,10 @@ describe('getConfiguration', () => {
                         return false
                     case 'cody.advanced.agent.ide':
                         return undefined
+                    case 'cody.advanced.agent.ide.version':
+                        return undefined
+                    case 'cody.advanced.agent.extension.version':
+                        return undefined
                     case 'cody.internal.unstable':
                         return false
                     case 'cody.experimental.chatContextRanker':

--- a/vscode/src/configuration.ts
+++ b/vscode/src/configuration.ts
@@ -172,6 +172,8 @@ export function getConfiguration(
         // Rely on this flag sparingly.
         isRunningInsideAgent: getHiddenSetting('advanced.agent.running', false),
         agentIDE: getHiddenSetting<'VSCode' | 'JetBrains' | 'Neovim' | 'Emacs'>('advanced.agent.ide'),
+        agentIDEVersion: getHiddenSetting('advanced.agent.ide.version'),
+        agentExtensionVersion: getHiddenSetting('advanced.agent.extension.version'),
         autocompleteTimeouts: {
             multiline: getHiddenSetting<number | undefined>(
                 'autocomplete.advanced.timeout.multiline',

--- a/vscode/src/jsonrpc/agent-protocol.ts
+++ b/vscode/src/jsonrpc/agent-protocol.ts
@@ -429,7 +429,7 @@ export interface AutocompleteItem {
 export interface ClientInfo {
     name: string
     version: string // extension version
-    ideVersion?: string
+    ideVersion?: string | undefined | null
     workspaceRootUri: string
 
     /** @deprecated Use `workspaceRootUri` instead. */

--- a/vscode/src/jsonrpc/agent-protocol.ts
+++ b/vscode/src/jsonrpc/agent-protocol.ts
@@ -428,7 +428,8 @@ export interface AutocompleteItem {
 
 export interface ClientInfo {
     name: string
-    version: string
+    version: string // extension version
+    ideVersion?: string
     workspaceRootUri: string
 
     /** @deprecated Use `workspaceRootUri` instead. */

--- a/vscode/src/services/telemetry.ts
+++ b/vscode/src/services/telemetry.ts
@@ -23,12 +23,15 @@ let globalAnonymousUserID: string
 
 const { platform, arch } = getOSArch()
 
-export const getExtensionDetails = (config: Pick<Configuration, 'agentIDE'>): ExtensionDetails => ({
+export const getExtensionDetails = (
+    config: Pick<Configuration, 'agentIDE' | 'agentIDEVersion' | 'agentExtensionVersion'>
+): ExtensionDetails => ({
     ide: config.agentIDE ?? 'VSCode',
+    ideVersion: config.agentIDEVersion ?? vscode.version,
     ideExtensionType: 'Cody',
     platform: platform ?? 'browser',
-    arch,
-    version,
+    arch: arch,
+    version: config.agentExtensionVersion ?? version,
 })
 
 /**

--- a/vscode/src/testutils/mocks.ts
+++ b/vscode/src/testutils/mocks.ts
@@ -722,6 +722,7 @@ export const vsCodeMocks = {
     Uri,
     Location,
     languages,
+    version: '1.85.1-testing',
     env: {
         uiKind: 1 satisfies vscode_types.UIKind.Desktop,
     },


### PR DESCRIPTION
## Changes

1. Report proper extension version (previously Cody version was incorrectly used for both Jetbrains and NeoVim)
2. Add IDE version to the telemetry data 
 
## Test plan

1. Build [Jetbrains PR](https://github.com/sourcegraph/jetbrains/pull/1785) with this Cody changes
2. Run some Cody actions like commands and edit.
4. Wait ~2h
5. Check if event with new field(s) containing correct versions will appear in looker