### PR TITLE
CI: refine workflow triggers

### DIFF
--- a/.github/workflows/scip-typescript.yml
+++ b/.github/workflows/scip-typescript.yml
@@ -1,6 +1,10 @@
 name: scip-typescript
 on:
   push:
+    branches:
+      - main
+  pull_request:
+    types: [opened, reopened, synchronize, ready_for_review]
     paths:
       - '**.ts'
       - '**.tsx'

--- a/agent/src/fix.test.ts
+++ b/agent/src/fix.test.ts
@@ -14,6 +14,7 @@ describe.skipIf(isWindows())('Fix', () => {
         name: 'fix',
         credentials: TESTING_CREDENTIALS.dotcom,
     })
+
     beforeAll(async () => {
         await workspace.beforeAll()
         await client.beforeAll()


### PR DESCRIPTION
Previously, the scip-typescript indexing job ran on every push. This changes the job to only run on pull requests and after merging into `main`.


## Test plan

* Manually confirmed that the job didn't run on this commit before opening a PR
* Manually confirm the job runs after opening a PR because I added a basic change to a TS file https://github.com/sourcegraph/cody/actions/runs/9549918620/job/26320644157?pr=4587

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
