### PR TITLE
Revert "fix symf instanceof CancellationError test flake (#4574)"

### DIFF
--- a/agent/src/vscode-shim.ts
+++ b/agent/src/vscode-shim.ts
@@ -63,6 +63,7 @@ export { AgentEventEmitter as EventEmitter } from '../../vscode/src/testutils/Ag
 
 export {
     CancellationTokenSource,
+    CancellationError,
     CodeAction,
     CodeActionTriggerKind,
     CodeActionKind,

--- a/vscode/src/testutils/mocks.ts
+++ b/vscode/src/testutils/mocks.ts
@@ -498,6 +498,9 @@ export class CancellationToken implements vscode_types.CancellationToken {
     }
     onCancellationRequested = this.emitter.event
 }
+
+export class CancellationError extends Error {}
+
 // @cody refactor
 export class CancellationTokenSource implements vscode_types.CancellationTokenSource {
     public token = new CancellationToken()
@@ -713,6 +716,7 @@ export const vsCodeMocks = {
     EventEmitter,
     EndOfLine,
     CancellationTokenSource,
+    CancellationError,
     ThemeColor,
     ThemeIcon,
     TreeItem,


### PR DESCRIPTION
This reverts commit 8ac4a7a. This commit made the tests flaky. Instead of removing usage of `CancellationError`, we implement this class in the mocks instead.

## Test plan
Non-flaky green CI

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
