### PR TITLE
Issues Tests

### DIFF
--- a/vscode/playwright.config.ts
+++ b/vscode/playwright.config.ts
@@ -7,11 +7,21 @@ export default defineConfig({
     workers: 1,
     retries: isWin ? 4 : isCI ? 1 : 0, // give flaky tests more chances, but we should fix flakiness when we see it
     forbidOnly: isCI,
-    testDir: 'test/e2e',
     timeout: isWin || isCI ? 30000 : 20000,
     expect: {
         timeout: isWin || isCI ? 5000 : 2000,
     },
+    projects: [
+        {
+            name: 'e2e',
+            testDir: './test/e2e',
+        },
+        {
+            name: 'issues',
+            testDir: './test/issues/e2e',
+            retries: 0,
+        },
+    ],
     reporter: isCI ? 'github' : 'list',
     globalSetup: require.resolve('./test/e2e/utils/setup'),
     globalTeardown: require.resolve('./test/e2e/utils/teardown'),

--- a/vscode/test/README.md
+++ b/vscode/test/README.md
@@ -1,5 +1,7 @@
 # Testing Cody VScode
 
+> In addition to the normal test locations for the types below there is a special location for temporary [Issue Tests](issues/README.md).
+
 Cody VScode has four kinds of tests:
 
 1. Unit tests. These are stored alongside the code in files named `.test.ts`.

--- a/vscode/test/e2e/common.ts
+++ b/vscode/test/e2e/common.ts
@@ -65,7 +65,8 @@ export const sidebarExplorer = (page: Page): Locator => page.getByRole('tab', { 
  * Use the command to toggle DND mode because the UI differs on Windows/non-Windows since 1.86 with
  * macOS appearing to use a native menu where Windows uses a VS Code-drawn menu.
  */
-async function disableNotifications(page: Page): Promise<void> {
+export async function disableNotifications(page: Page): Promise<void> {
+    //TODO: Check if already disabled
     await executeCommandInPalette(page, 'notifications: toggle do not disturb')
 }
 

--- a/vscode/test/issues/README.md
+++ b/vscode/test/issues/README.md
@@ -1,0 +1,28 @@
+# Issue Tests
+
+This as a "low-threshold staging area" to put tests that can help replicate or diagnose a problem.
+
+These tests don't run as part of CI. Instead, the goal is to make it easier for anyone to contribute even rough or partial test as part of every bug report.
+
+Doing so will make diagnosing and verifying the results a lot easier for everyone.
+
+## Rules:
+- Ideally test files are named with the Linear/Github Issue ID to make it easy to find them or pull in additional context.
+- Only tests explicitly marked with `only()` should run. Issue tests are by definition very tied to the specific issue someone is trying to diagnose, so running other tests would just be noise. This should already be if you extend the base test for the specific type. See [e2e/template.test.ts](./e2e/template.test.ts)
+- (Optional) I'm hoping to do [some experiments soon](#sidenote-openctx-experiment). So if you can please:
+  - start each test with a `//CTX(linear-issue): <linear_url>` comment
+  - use the `@issue` tag and and a markdown link to the issue in the test title.
+  
+  
+
+
+### Sidenote: OpenCtx Experiment:
+
+I'd like to see how we can use Cody to assist with replicating issues from bug-reports. So it would be really helpful if each Issue test created contains context on what issue it was trying to demonstrate / replicate.
+
+There is some rudimentary OpenCtx support for Linear issues [in the works](https://github.com/sourcegraph/openctx/pull/154), providing both additional context to the UI & the AI. So for now, if nothing else, it should at least make these tests a bit easier to understand. Especially as test comments and issue comments might drift.
+
+## TODO:
+- [ ] Make sure we automatically clean up tests for issues marked as closed
+- [ ] Automatically tag issues in Linear that have corresponding tests
+- [ ] CI fast-path to limit the amount of needless tests to run when just trying to merge a Test-Only PR

--- a/vscode/test/issues/e2e/CODY-2392.test.ts
+++ b/vscode/test/issues/e2e/CODY-2392.test.ts
@@ -1,0 +1,51 @@
+// CTX(linear-issue): https://linear.app/sourcegraph/issue/CODY-2392
+
+import { expect } from '@playwright/test'
+import { test } from '.'
+import {
+    chatMessageRows,
+    createEmptyChatPanel,
+    disableNotifications,
+    focusSidebar,
+    openFileInEditorTab,
+    selectLineRangeInEditorTab,
+} from '../../e2e/common'
+import {
+    type ExpectedEvents,
+    type ExpectedV2Events,
+    type TestConfiguration,
+    executeCommandInPalette,
+} from '../../e2e/helpers'
+
+test.extend<TestConfiguration & ExpectedEvents & ExpectedV2Events>({
+    expectedEvents: [],
+    expectedV2Events: [],
+    preAuthenticate: true,
+})('@issue [CODY-2392](https://linear.app/sourcegraph/issue/CODY-2392)', async ({ page }) => {
+    await disableNotifications(page)
+
+    //open a file
+    await openFileInEditorTab(page, 'buzz.ts')
+    await focusSidebar(page)
+    const [chatPanel, lastChatInput, firstChatInput, chatInputs] = await createEmptyChatPanel(page)
+    await firstChatInput.fill('show me a code snippet')
+    await firstChatInput.press('Enter')
+
+    // wait for assistant response
+    const messageRows = chatMessageRows(chatPanel)
+    const assistantRow = messageRows.nth(1)
+    await expect(assistantRow).toContainText('Here is a code snippet:')
+
+    // we now start editing the original message
+    await firstChatInput.click()
+    //now write some text
+    await firstChatInput.fill('I want to include some context')
+    await selectLineRangeInEditorTab(page, 1, 10)
+    await executeCommandInPalette(page, 'Cody: Add Selection to Cody Chat')
+
+    // we now expect the first input to contain the selected context
+    // the last input should still be empty
+    const lastChatInputText = await lastChatInput.textContent()
+    await expect(lastChatInput).toBeEmpty()
+    await expect(firstChatInput).toContainText('@buzz.ts:1-10')
+})

--- a/vscode/test/issues/e2e/index.ts
+++ b/vscode/test/issues/e2e/index.ts
@@ -1,0 +1,32 @@
+import { test } from '../../e2e/helpers'
+
+// TODO: There's no elegant way of getting if we're running `only` based test
+// information from playwright. This is a ugly workaround.
+const onlyTests = []
+
+function patchOnly(obj: any) {
+    const originalOnly = obj.only
+    obj.only = function (...args) {
+        onlyTests.push(args)
+        return originalOnly.apply(this, args)
+    }
+}
+
+const originalExtend = test.extend
+test.extend = function (...args) {
+    const res = originalExtend.apply(this, args)
+    patchOnly(res)
+    return res
+}
+
+patchOnly(test)
+
+// biome-ignore lint/correctness/noEmptyPattern: <explanation>
+test.beforeEach(async ({}, testInfo) => {
+    // Unless marked by `.only` issue tests are skipped
+    if (onlyTests.length === 0) {
+        testInfo.skip(true, 'Issue tests are only ran if marked with `.only`')
+    }
+})
+
+export { test }

--- a/vscode/test/issues/e2e/template.test.ts
+++ b/vscode/test/issues/e2e/template.test.ts
@@ -1,0 +1,17 @@
+// TODO: update this file-level comment
+// CTX(linear): https://linear.app/sourcegraph/issue/CODY-1234
+
+import { test } from '.'
+import { disableNotifications } from '../../e2e/common'
+import type { ExpectedEvents, ExpectedV2Events, TestConfiguration } from '../../e2e/helpers'
+
+// TODO: add a .only() to actually run this test
+test.extend<TestConfiguration & ExpectedEvents & ExpectedV2Events>({
+    expectedEvents: [],
+    expectedV2Events: [],
+    preAuthenticate: true,
+})('@issue [CODY-1234](https://linear.app/sourcegraph/issue/CODY-1234)', async ({ page }) => {
+    // TODO: The test name should include the @issue tag and a markdown link to the issue
+    await disableNotifications(page)
+    //do your worst
+})


### PR DESCRIPTION
I can split out the specific Issue Test for [CODY-2392] from the overall PR if wanted.

But basically the idea is to create a space to attach tests that might be relevant to a particular issue.

## Test plan

- Manually ran the e2e tests and by default the IssueTests are skipped
