### PR TITLE
Chat: update file source display text

### DIFF
--- a/vscode/webviews/components/FileLink.tsx
+++ b/vscode/webviews/components/FileLink.tsx
@@ -104,12 +104,12 @@ function getFileSourceIconTitle(source?: string): string {
 function getFileSourceDisplayText(source?: string): string {
     switch (source) {
         case 'unified':
-            return 'Enhanced Context (Enterprise Search)'
+            return 'Automatic Codebase Context (Enterprise Search)'
         case 'search':
         case 'symf':
-            return 'Enhanced Context (Search)'
+            return 'Automatic Codebase Context (Search)'
         case 'embeddings':
-            return 'Enhanced Context (Embeddings)'
+            return 'Automatic Codebase Context (Embeddings)'
         case 'editor':
             return 'Editor Context'
         case 'selection':
@@ -117,6 +117,6 @@ function getFileSourceDisplayText(source?: string): string {
         case 'user':
             return '@-mention'
         default:
-            return source ?? 'Enhanced Context'
+            return source ?? 'Automatic Codebase Context'
     }
 }


### PR DESCRIPTION
Minor UI change to reflect the recent name change:

- Replace "Enhanced Context" with "Automatic Codebase Context" for various file sources.

Current: 

![image](https://github.com/sourcegraph/cody/assets/68532117/86177e06-0a2d-477d-88b7-ac30b3a5c965)


## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

1. Ask Cody a question
2. Verify when hovering over the context file list icon, the tooltip displays `Automatic Codebase Context` instead of `Enhanced Context`.