### PR TITLE
Skip flaky tests

### DIFF
--- a/vscode/test/e2e/troubleshooting-authConnection.test.ts
+++ b/vscode/test/e2e/troubleshooting-authConnection.test.ts
@@ -29,30 +29,35 @@ test.extend<ExpectedEvents>({
         'CodyVSCodeExtension:troubleshoot:reloadAuth',
         'CodyVSCodeExtension:Auth:connected',
     ],
-})('allow retrying on connection issues', async ({ page, nap }) => {
-    // After Cody has loaded we prevent the server from accepting connections. On reloading
-    // Cody this will now cause a connection issue when checking the currentUser.
-    // After "fixing" the server Cody should be able to connect again.
-
-    let res = await fetch(`${mockServer.SERVER_URL}/.test/connectionIssue/enable?issue=ECONNREFUSED`, {
-        method: 'POST',
-    })
-    assert.equal(res.status, 200)
-
-    await executeCommandInPalette(page, 'developer: reload window')
-
-    await expect(page.getByText('connection issue', { exact: false })).toBeVisible({
-        timeout: 10000,
-    })
-    await focusSidebar(page)
-    res = await fetch(`${mockServer.SERVER_URL}/.test/connectionIssue/disable`, {
-        method: 'POST',
-    })
-    assert.equal(res.status, 200)
-
-    const sidebar = page.frameLocator('iframe.webview').first().frameLocator('iframe').first()
-    sidebar.getByRole('button', { name: 'Retry Connection' }).click()
-
-    await nap()
-    expectAuthenticated(page)
+    // CODY-2432 to re-enable these tests
 })
+    .skip('allow retrying on connection issues', async ({ page, nap }) => {
+        // After Cody has loaded we prevent the server from accepting connections. On reloading
+        // Cody this will now cause a connection issue when checking the currentUser.
+        // After "fixing" the server Cody should be able to connect again.
+
+        let res = await fetch(
+            `${mockServer.SERVER_URL}/.test/connectionIssue/enable?issue=ECONNREFUSED`,
+            {
+                method: 'POST',
+            }
+        )
+        assert.equal(res.status, 200)
+
+        await executeCommandInPalette(page, 'developer: reload window')
+
+        await expect(page.getByText('connection issue', { exact: false })).toBeVisible({
+            timeout: 10000,
+        })
+        await focusSidebar(page)
+        res = await fetch(`${mockServer.SERVER_URL}/.test/connectionIssue/disable`, {
+            method: 'POST',
+        })
+        assert.equal(res.status, 200)
+
+        const sidebar = page.frameLocator('iframe.webview').first().frameLocator('iframe').first()
+        sidebar.getByRole('button', { name: 'Retry Connection' }).click()
+
+        await nap()
+        expectAuthenticated(page)
+    })


### PR DESCRIPTION
Related [CODY-2432 : Re-enable vscode/test/e2e/troubleshooting-authConnection.test.ts - allow retrying on connection issues](https://linear.app/sourcegraph/issue/CODY-2432/re-enable-vscodeteste2etroubleshooting-authconnectiontestts-allow)

Skipping these tests because they have been very flaky recently, see

- https://github.com/sourcegraph/cody/pull/4591#issuecomment-2174170405
- https://sourcegraph.slack.com/archives/C05AGQYD528/p1718684941695799


## Test plan

Stable green CI
<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
