### PR TITLE
Windows Certificates: bundle roots.exe

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -21,6 +21,7 @@ Enterprise: Expand the context window for Gemini 1.5 models. [pull/4563](https:/
 - Chat: Fix hover tooltips on overflowed paths in the @-mention file picker. [pull/4553](https://github.com/sourcegraph/cody/pull/4553)
 - Custom Commands: Creating a new custom command through the menu without an existing cody.json file now creates a new cody.json file with the command added. [pull/4561](https://github.com/sourcegraph/cody/pull/4561)
 - Ollama: Fix a bug where Ollama models were not connected to the correct client. [pull/4564](https://github.com/sourcegraph/cody/pull/4564)
+- Windows: Fix a bug where Cody failed to load on Windows with the latest VS Code Insiders due to local certificates. [pull/4598](https://github.com/sourcegraph/cody/pull/4598)
 
 ### Changed
 

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -48,7 +48,8 @@
     "github-changelog": "ts-node-transpile-only ./scripts/github-changelog.ts",
     "version-bump:minor": "RELEASE_TYPE=minor ts-node-transpile-only ./scripts/version-bump.ts",
     "version-bump:patch": "RELEASE_TYPE=patch ts-node-transpile-only ./scripts/version-bump.ts",
-    "version-bump:dry-run": "RELEASE_TYPE=prerelease ts-node-transpile-only ./scripts/version-bump.ts"
+    "version-bump:dry-run": "RELEASE_TYPE=prerelease ts-node-transpile-only ./scripts/version-bump.ts",
+    "win-ca:bundle": "cp ../node_modules/win-ca/lib/roots.exe dist/win-ca-roots.exe"
   },
   "categories": ["Programming Languages", "Machine Learning", "Snippets", "Education"],
   "keywords": [

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -18,7 +18,7 @@
     "dev:web": "pnpm run -s build:dev:web && pnpm run -s _dev:vscode-test-web --browserType none",
     "watch:dev:web": "concurrently \"pnpm run -s watch:build:dev:web\" \"pnpm run -s _dev:vscode-test-web --browserType none\"",
     "_dev:vscode-test-web": "vscode-test-web --extensionDevelopmentPath=. ${WORKSPACE-test/fixtures/workspace}",
-    "build": "pnpm run -s check:build && tsc --build && pnpm run -s _build:esbuild:desktop && pnpm run -s _build:esbuild:web && pnpm run -s _build:webviews --mode production",
+    "build": "pnpm run -s check:build && tsc --build && pnpm run -s _build:esbuild:desktop && pnpm run -s _build:esbuild:web && pnpm run -s _build:webviews --mode production && pnpm win-ca:bundle",
     "check:build": "pnpm run -s check:typehacks && pnpm run -s check:manifest",
     "check:typehacks": "ts-node-transpile-only ./scripts/enable-typehacks.ts && tsc -p tsconfig.typehacks.json",
     "check:manifest": "ts-node-transpile-only ./scripts/validate-package-json.ts",

--- a/vscode/src/extension.node.ts
+++ b/vscode/src/extension.node.ts
@@ -37,7 +37,7 @@ export function activate(
     context: vscode.ExtensionContext,
     extensionClient?: ExtensionClient
 ): Promise<ExtensionApi> {
-    initializeNetworkAgent()
+    initializeNetworkAgent(context)
 
     // When activated by VSCode, we are only passed the extension context.
     // Create the default client for VSCode.

--- a/vscode/src/fetch.node.test.ts
+++ b/vscode/src/fetch.node.test.ts
@@ -1,6 +1,7 @@
 import http from 'node:http'
 import { agent } from '@sourcegraph/cody-shared'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import * as vscode from 'vscode'
 import { initializeNetworkAgent } from './fetch.node'
 
 describe('customAgent', () => {
@@ -30,7 +31,7 @@ describe('customAgent', () => {
     })
 
     it('uses keep-alive', async () => {
-        initializeNetworkAgent()
+        initializeNetworkAgent({ extensionUri: vscode.Uri.parse('file:///foo') })
 
         async function makeRequest() {
             return new Promise<http.IncomingMessage>(resolve => {

--- a/vscode/src/fetch.node.ts
+++ b/vscode/src/fetch.node.ts
@@ -6,6 +6,7 @@ import type { Configuration } from '@sourcegraph/cody-shared'
 import { HttpProxyAgent } from 'http-proxy-agent'
 import { HttpsProxyAgent } from 'https-proxy-agent'
 import { SocksProxyAgent } from 'socks-proxy-agent'
+import type * as vscode from 'vscode'
 // @ts-ignore
 import { registerLocalCertificates } from './certs'
 import { getConfiguration } from './configuration'
@@ -91,9 +92,9 @@ function getSystemProxyURI(protocol: string, env: typeof process.env): string | 
     return null
 }
 
-export function initializeNetworkAgent(): void {
+export function initializeNetworkAgent(context: Pick<vscode.ExtensionContext, 'extensionUri'>): void {
     // This is to load certs for HTTPS requests
-    registerLocalCertificates()
+    registerLocalCertificates(context)
     httpAgent = new http.Agent({ keepAlive: true, keepAliveMsecs: 60000 })
     httpsAgent = new https.Agent({
         ...https.globalAgent.options,


### PR DESCRIPTION
Fixes CODY-2176

Previously, we used the `win-ca` "fallback" method to install local certificates. We used the fallback because we use esbuild to bundle the Cody VSC extension, which breaks automatic detection of a `roots.exe` binary that is included with the `win-ca` npm package. In the latest VS Code Insiders, this no longer works and causes Cody to fail all network requests. This PR is an attempt to fix this problem by removing the "fallback", bundling the `roots.exe` binary along with the Cody extension and adding logic to compute the file path of the bundled `roots.exe` at runtime (via `vscode.ExtensionContext`).


## Test plan

* Get a Windows computer
* Install latest VS Code Insiders
* Install the latest Cody pre-release and reproduce the actual bug (network requests fail)
* Checkout this branch and run from the `vscode/` sub-directory
```
 .\node_modules\.bin\vsce package --no-dependencies --pre-release --no-update-package-json --no-git-tag-version --out .\dist\cody.vsix
```
* Run "Install from VSIX" command from VS Code insiders and pick dist\cody.vsix
* Reload and confirm that network requests work as expected
* I don't know how to verify this, but it would be good to test it actually respects local certificates. I only confirmed that win-ca doesn't crash.

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
