### PR TITLE
Chat: fix abort message loading state

### DIFF
--- a/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
+++ b/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
@@ -841,7 +841,8 @@ export class SimpleChatPanelProvider
 
     private handleAbort(): void {
         this.cancelSubmitOrEditOperation()
-
+        // Notify the webview there is no message in progress.
+        this.postViewTranscript()
         telemetryService.log('CodyVSCodeExtension:abortButton:clicked', { hasV2Event: true })
         telemetryRecorder.recordEvent('cody.sidebar.abortButton', 'clicked')
     }

--- a/vscode/webviews/chat/Transcript.tsx
+++ b/vscode/webviews/chat/Transcript.tsx
@@ -49,7 +49,7 @@ export const Transcript: React.FunctionComponent<{
                         i === interactions.length - 2 && interaction.assistantMessage !== null
                     }
                     priorAssistantMessageIsLoading={Boolean(
-                        interactions.at(i - 1)?.assistantMessage?.isLoading
+                        messageInProgress && interactions.at(i - 1)?.assistantMessage?.isLoading
                     )}
                 />
             ))}
@@ -87,6 +87,7 @@ export function transcriptToInteractionPairs(
                           index: i + 1,
                           isLoading:
                               assistantMessage.error === undefined &&
+                              !!assistantMessageInProgress &&
                               (isLastPairInTranscript || assistantMessage.text === undefined),
                       }
                     : null,


### PR DESCRIPTION
Part of https://linear.app/sourcegraph/issue/CODY-2149/feedback-bring-the-stop-button-back-again#comment-4c363fea

- Notify the webview when aborting a message submission operation to indicate there is no message in progress
- Update the `priorAssistantMessageIsLoading` prop to check if there is a message in progress, not just if the previous message was loading


## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

- Ask Cody a question
- Hit ESC to abort the request during the context fetching step
- Verify the loading state disappeared on abort:

https://github.com/sourcegraph/cody/assets/68532117/a553602a-3772-484d-b1ea-3c559eef430a

### Before

You will be stuck in this loading state even after you hit ESC to abort the request:

<img width="788" alt="image" src="https://github.com/sourcegraph/cody/assets/68532117/b37bb0ab-7563-4133-928b-5e6508961324">


