### PR TITLE
openctx: set query label if provided

### DIFF
--- a/lib/shared/src/mentions/api.ts
+++ b/lib/shared/src/mentions/api.ts
@@ -74,7 +74,7 @@ async function openCtxMentionProviders(): Promise<ContextMentionProviderMetadata
             .map(provider => ({
                 id: provider.providerUri,
                 title: provider.name,
-                queryLabel: 'Search...',
+                queryLabel: provider.mentions?.label ?? 'Search...',
                 emptyLabel: 'No results',
             }))
             .sort((a, b) => (a.title > b.title ? 1 : -1))

--- a/vscode/src/context/openctx/web.ts
+++ b/vscode/src/context/openctx/web.ts
@@ -9,7 +9,7 @@ const WebProvider: Provider & { providerUri: 'internal-web-provider' } = {
     meta() {
         return {
             name: 'Web URLs',
-            mentions: { label: 'Paste a URL...' },
+            mentions: { label: 'Type or paste a URL...' },
         }
     },
 

--- a/vscode/src/context/openctx/web.ts
+++ b/vscode/src/context/openctx/web.ts
@@ -9,7 +9,7 @@ const WebProvider: Provider & { providerUri: 'internal-web-provider' } = {
     meta() {
         return {
             name: 'Web URLs',
-            mentions: {},
+            mentions: { label: 'Paste a URL...' },
         }
     },
 


### PR DESCRIPTION
This sets the query label to the newly added "label" field in OpenCtx. This is a field which prompts the user what to type in an at mention.

Test Plan: Tested manually the following cases

- non-openctx providers have same behaviour (no header)
- openctx provider has loading display before query label (see devdocs below)
- openctx query label goes away once query is being typed
- openctx provider which doesn't set label shows "Search..." (see notion below)
- web provider has updated label

https://github.com/sourcegraph/cody/assets/187831/6b3ade90-13b2-43bb-8ba9-e3e822514679

Parent https://github.com/sourcegraph/cody/pull/4621

Fixes https://linear.app/sourcegraph/issue/CODY-2275/add-all-the-right-labels-for-provider-mentions-query-stats
