### PR TITLE
Adding completions to google vertex provider only for anthropic based models

### DIFF
--- a/vscode/src/completions/providers/create-provider.ts
+++ b/vscode/src/completions/providers/create-provider.ts
@@ -142,6 +142,16 @@ export async function createProviderConfig(
                             ? authStatus.configOverwrites.completionModel
                             : undefined,
                 })
+            case 'google':
+                if (authStatus.configOverwrites.completionModel?.includes('claude')) {
+                    return createAnthropicProviderConfig({
+                        client,
+                        model,
+                    })
+                } else {
+                    logError('createProviderConfig', `Unrecognized provider '${provider}' configured.`)
+                    return null
+                }
             default:
                 logError('createProviderConfig', `Unrecognized provider '${provider}' configured.`)
                 return null

--- a/vscode/src/completions/providers/create-provider.ts
+++ b/vscode/src/completions/providers/create-provider.ts
@@ -148,10 +148,9 @@ export async function createProviderConfig(
                         client,
                         model,
                     })
-                } else {
-                    logError('createProviderConfig', `Unrecognized provider '${provider}' configured.`)
-                    return null
                 }
+                logError('createProviderConfig', `Unrecognized provider '${provider}' configured.`)
+                return null
             default:
                 logError('createProviderConfig', `Unrecognized provider '${provider}' configured.`)
                 return null

--- a/vscode/src/completions/providers/create-provider.ts
+++ b/vscode/src/completions/providers/create-provider.ts
@@ -145,8 +145,8 @@ export async function createProviderConfig(
             case 'google':
                 if (authStatus.configOverwrites.completionModel?.includes('claude')) {
                     return createAnthropicProviderConfig({
-                        client,
-                        model,
+                        client, // Model name for google provider is a deployment name. It shouldn't appear in logs.
+                        model: undefined,
                     })
                 }
                 logError('createProviderConfig', `Unrecognized provider '${provider}' configured.`)


### PR DESCRIPTION
[Linear Issue](https://linear.app/sourcegraph/project/claude-3-on-gcp-8c014e1a3506/overview)

This PR adds support for completions support for Google Vertex but only for Anthropic based models(NOTE: Gemini and other models don't support completions when used with the google provider). 

Sense of Urgency: This is a P0 because of enterprise requirements so I would appreciate a fast approval and merging. 


## Test plan
- Run this branch for sourcegraph instance  -> https://github.com/sourcegraph/sourcegraph/pull/63282 
- Ask @arafatkatze to dm you the siteadmin config to make things work 
- Check the logs and play with completions

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
