### PR TITLE
Chat: Assign ModelUIGroup for Enterprise model

### DIFF
--- a/lib/shared/src/models/utils.ts
+++ b/lib/shared/src/models/utils.ts
@@ -33,4 +33,6 @@ export const ModelUIGroup: Record<string, string> = {
     Balanced: 'Balanced (Speed & Accuracy)',
     Speed: 'Optimized for Speed',
     Ollama: 'Ollama (Local)',
+    // Used for identifying the model type but currently not used for displaying in the UI.
+    Enterprise: 'Enterprise',
 }

--- a/vscode/src/models/sync.test.ts
+++ b/vscode/src/models/sync.test.ts
@@ -1,5 +1,6 @@
 import {
     Model,
+    ModelUIGroup,
     ModelUsage,
     ModelsService,
     RestClient,
@@ -65,7 +66,9 @@ describe('syncModels', () => {
             new Model(
                 authStatus.configOverwrites.chatModel,
                 [ModelUsage.Chat, ModelUsage.Edit],
-                getEnterpriseContextWindow(chatModel, authStatus.configOverwrites)
+                getEnterpriseContextWindow(chatModel, authStatus.configOverwrites),
+                undefined,
+                ModelUIGroup.Enterprise
             ),
         ])
     })

--- a/vscode/src/models/sync.ts
+++ b/vscode/src/models/sync.ts
@@ -3,6 +3,7 @@ import {
     type AuthStatus,
     CHAT_INPUT_TOKEN_BUDGET,
     Model,
+    ModelUIGroup,
     ModelUsage,
     ModelsService,
     RestClient,
@@ -65,7 +66,9 @@ export async function syncModels(authStatus: AuthStatus): Promise<void> {
                 getEnterpriseContextWindow(
                     authStatus?.configOverwrites?.chatModel,
                     authStatus?.configOverwrites
-                )
+                ),
+                undefined,
+                ModelUIGroup.Enterprise
             ),
         ])
     } else {


### PR DESCRIPTION
- Add a new ModelUIGroup called Enterprise
- Assign the new ModelUIGroup to the Enterprise model during sync

This fixes an issue where we cannot identify if a Gemini is an Enterprise model or a model imported from cody.dev.models

Right now all enterprise models do not have a ModelUIGroup assigned, which would fails the logic here: https://sourcegraph.com/github.com/sourcegraph/cody/-/blob/lib/shared/src/llm-providers/clients.ts?L47

## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

No UI or feature change as we currently do not display model dropdown for Enterprise users.