### PR TITLE
Agent: add automatically generated bindings for Java

### DIFF
--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/AttributionParams.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/AttributionParams.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
 data class AttributionParams(
   val repositoryNames: List<String>,

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/Attribution_SearchParams.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/Attribution_SearchParams.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
 data class Attribution_SearchParams(
   val id: String,

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/Attribution_SearchResult.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/Attribution_SearchResult.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
 data class Attribution_SearchResult(
   val error: String? = null,

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/AuthMethod.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/AuthMethod.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
 typealias AuthMethod = String // One of: dotcom, github, gitlab, google
 

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/AuthStatus.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/AuthStatus.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
 data class AuthStatus(
   val username: String,

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/AutocompleteItem.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/AutocompleteItem.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
 data class AutocompleteItem(
   val id: String,

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/AutocompleteParams.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/AutocompleteParams.kt
@@ -1,7 +1,7 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
-import com.google.gson.annotations.SerializedName
+import com.google.gson.annotations.SerializedName;
 
 data class AutocompleteParams(
   val uri: String,

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/AutocompleteResult.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/AutocompleteResult.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
 data class AutocompleteResult(
   val items: List<AutocompleteItem>,

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/CancelParams.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/CancelParams.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
 data class CancelParams(
   val id: String,

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/ChatError.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/ChatError.kt
@@ -1,7 +1,7 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
-import com.google.gson.annotations.SerializedName
+import com.google.gson.annotations.SerializedName;
 
 data class ChatError(
   val kind: String? = null,

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/ChatExportResult.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/ChatExportResult.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
 data class ChatExportResult(
   val chatID: String,

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/ChatHistory.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/ChatHistory.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
 data class ChatHistory(
   val chatID: String,

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/ChatSubmitType.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/ChatSubmitType.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
 typealias ChatSubmitType = String // One of: user, user-newchat
 

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/Chat_EditMessageParams.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/Chat_EditMessageParams.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
 data class Chat_EditMessageParams(
   val id: String,

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/Chat_ModelsParams.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/Chat_ModelsParams.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
 data class Chat_ModelsParams(
   val modelUsage: ModelUsage, // Oneof: chat, edit

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/Chat_ModelsResult.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/Chat_ModelsResult.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
 data class Chat_ModelsResult(
   val models: List<Model>,

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/Chat_RemoteReposParams.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/Chat_RemoteReposParams.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
 data class Chat_RemoteReposParams(
   val id: String,

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/Chat_RemoteReposResult.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/Chat_RemoteReposResult.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
 data class Chat_RemoteReposResult(
   val remoteRepos: List<Repo>? = null,

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/Chat_RestoreParams.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/Chat_RestoreParams.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
 data class Chat_RestoreParams(
   val modelID: String? = null,

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/Chat_SubmitMessageParams.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/Chat_SubmitMessageParams.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
 data class Chat_SubmitMessageParams(
   val id: String,

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/ClientCapabilities.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/ClientCapabilities.kt
@@ -1,7 +1,7 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
-import com.google.gson.annotations.SerializedName
+import com.google.gson.annotations.SerializedName;
 
 data class ClientCapabilities(
   val completions: CompletionsEnum? = null, // Oneof: none

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/ClientInfo.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/ClientInfo.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
 data class ClientInfo(
   val name: String,

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/ClientStateForWebview.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/ClientStateForWebview.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
 data class ClientStateForWebview(
   val initialContext: List<ContextItem>,

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/CodeActionTriggerKind.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/CodeActionTriggerKind.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
 typealias CodeActionTriggerKind = String // One of: Invoke, Automatic
 

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/CodeActions_ProvideParams.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/CodeActions_ProvideParams.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
 data class CodeActions_ProvideParams(
   val location: ProtocolLocation,

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/CodeActions_ProvideResult.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/CodeActions_ProvideResult.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
 data class CodeActions_ProvideResult(
   val codeActions: List<ProtocolCodeAction>,

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/CodeActions_TriggerParams.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/CodeActions_TriggerParams.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
 data class CodeActions_TriggerParams(
   val id: String,

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/CodyAgentClient.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/CodyAgentClient.kt
@@ -1,9 +1,9 @@
 @file:Suppress("FunctionName", "ClassName")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
-import org.eclipse.lsp4j.jsonrpc.services.JsonNotification
-import org.eclipse.lsp4j.jsonrpc.services.JsonRequest
-import java.util.concurrent.CompletableFuture
+import org.eclipse.lsp4j.jsonrpc.services.JsonNotification;
+import org.eclipse.lsp4j.jsonrpc.services.JsonRequest;
+import java.util.concurrent.CompletableFuture;
 
 @Suppress("unused")
 interface CodyAgentClient {

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/CodyAgentServer.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/CodyAgentServer.kt
@@ -1,9 +1,9 @@
 @file:Suppress("FunctionName", "ClassName")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
-import org.eclipse.lsp4j.jsonrpc.services.JsonNotification
-import org.eclipse.lsp4j.jsonrpc.services.JsonRequest
-import java.util.concurrent.CompletableFuture
+import org.eclipse.lsp4j.jsonrpc.services.JsonNotification;
+import org.eclipse.lsp4j.jsonrpc.services.JsonRequest;
+import java.util.concurrent.CompletableFuture;
 
 @Suppress("unused")
 interface CodyAgentServer {

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/CodyContextFilterItem.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/CodyContextFilterItem.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
 data class CodyContextFilterItem(
   val repoNamePattern: String,

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/CodyError.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/CodyError.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
 data class CodyError(
   val message: String,

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/CodyLLMSiteConfiguration.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/CodyLLMSiteConfiguration.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
 data class CodyLLMSiteConfiguration(
   val chatModel: String? = null,

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/CodyTaskState.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/CodyTaskState.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
 typealias CodyTaskState = String // One of: Idle, Working, Inserting, Applying, Formatting, Applied, Finished, Error, Pending
 

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/Commands_CustomParams.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/Commands_CustomParams.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
 data class Commands_CustomParams(
   val key: String,

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/CompletionBookkeepingEvent.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/CompletionBookkeepingEvent.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
 data class CompletionBookkeepingEvent(
   val id: CompletionLogID,

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/CompletionItemInfo.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/CompletionItemInfo.kt
@@ -1,7 +1,7 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
-import com.google.gson.annotations.SerializedName
+import com.google.gson.annotations.SerializedName;
 
 data class CompletionItemInfo(
   val parseErrorCount: Int? = null,

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/CompletionItemParams.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/CompletionItemParams.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
 data class CompletionItemParams(
   val completionID: String,

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/CompletionLogID.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/CompletionLogID.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
 typealias CompletionLogID = String // One of: 
 

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/ConfigFeaturesParams.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/ConfigFeaturesParams.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
 data class ConfigFeaturesParams(
   val chat: Boolean,

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/ConfigParams.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/ConfigParams.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
 data class ConfigParams(
   val experimentalNoodle: Boolean,

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/Constants.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/Constants.kt
@@ -1,5 +1,5 @@
 @file:Suppress("unused", "ConstPropertyName")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
 object Constants {
   const val paused = "paused"

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/ContextFilters.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/ContextFilters.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
 data class ContextFilters(
   val include: List<CodyContextFilterItem>? = null,

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/ContextGroup.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/ContextGroup.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
 data class ContextGroup(
   val dir: Uri? = null,

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/ContextItem.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/ContextItem.kt
@@ -1,18 +1,18 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
-import com.google.gson.annotations.SerializedName
-import com.google.gson.Gson
-import com.google.gson.JsonDeserializationContext
-import com.google.gson.JsonDeserializer
-import com.google.gson.JsonElement
-import java.lang.reflect.Type
+import com.google.gson.annotations.SerializedName;
+import com.google.gson.Gson;
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import java.lang.reflect.Type;
 
 sealed class ContextItem {
   companion object {
     val deserializer: JsonDeserializer<ContextItem> =
       JsonDeserializer { element: JsonElement, _: Type, context: JsonDeserializationContext ->
-        when (element.asJsonObject.get("type").asString) {
+        when (element.getAsJsonObject().get("type").getAsString()) {
           "file" -> context.deserialize<ContextItemFile>(element, ContextItemFile::class.java)
           "repository" -> context.deserialize<ContextItemRepository>(element, ContextItemRepository::class.java)
           "tree" -> context.deserialize<ContextItemTree>(element, ContextItemTree::class.java)

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/ContextItemSource.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/ContextItemSource.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
 typealias ContextItemSource = String // One of: embeddings, user, editor, search, initial, unified, selection, terminal, uri, history
 

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/ContextMentionProviderID.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/ContextMentionProviderID.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
 typealias ContextMentionProviderID = String // One of: 
 

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/ContextMentionProviderMetadata.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/ContextMentionProviderMetadata.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
 data class ContextMentionProviderMetadata(
   val id: String,

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/ContextProvider.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/ContextProvider.kt
@@ -1,21 +1,20 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
-import com.google.gson.annotations.SerializedName
-import com.google.gson.Gson
-import com.google.gson.JsonDeserializationContext
-import com.google.gson.JsonDeserializer
-import com.google.gson.JsonElement
-import java.lang.reflect.Type
+import com.google.gson.annotations.SerializedName;
+import com.google.gson.Gson;
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import java.lang.reflect.Type;
 
 sealed class ContextProvider {
   companion object {
     val deserializer: JsonDeserializer<ContextProvider> =
       JsonDeserializer { element: JsonElement, _: Type, context: JsonDeserializationContext ->
-        when (element.asJsonObject.get("kind").asString) {
+        when (element.getAsJsonObject().get("kind").getAsString()) {
           "embeddings" -> context.deserialize<LocalEmbeddingsProvider>(element, LocalEmbeddingsProvider::class.java)
           "search" -> context.deserialize<LocalSearchProvider>(element, LocalSearchProvider::class.java)
-          "search" -> context.deserialize<RemoteSearchProvider>(element, RemoteSearchProvider::class.java)
           else -> throw Exception("Unknown discriminator ${element}")
         }
       }

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/CreateFilesParams.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/CreateFilesParams.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
 data class CreateFilesParams(
   val files: List<FileIdentifier>,

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/CurrentUserCodySubscription.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/CurrentUserCodySubscription.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
 data class CurrentUserCodySubscription(
   val status: String,

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/CustomCommandResult.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/CustomCommandResult.kt
@@ -1,18 +1,18 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
-import com.google.gson.annotations.SerializedName
-import com.google.gson.Gson
-import com.google.gson.JsonDeserializationContext
-import com.google.gson.JsonDeserializer
-import com.google.gson.JsonElement
-import java.lang.reflect.Type
+import com.google.gson.annotations.SerializedName;
+import com.google.gson.Gson;
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import java.lang.reflect.Type;
 
 sealed class CustomCommandResult {
   companion object {
     val deserializer: JsonDeserializer<CustomCommandResult> =
       JsonDeserializer { element: JsonElement, _: Type, context: JsonDeserializationContext ->
-        when (element.asJsonObject.get("type").asString) {
+        when (element.getAsJsonObject().get("type").getAsString()) {
           "chat" -> context.deserialize<CustomChatCommandResult>(element, CustomChatCommandResult::class.java)
           "edit" -> context.deserialize<CustomEditCommandResult>(element, CustomEditCommandResult::class.java)
           else -> throw Exception("Unknown discriminator ${element}")

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/Date.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/Date.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
 typealias Date = String
 

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/DebugMessage.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/DebugMessage.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
 data class DebugMessage(
   val channel: String,

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/DeleteFilesParams.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/DeleteFilesParams.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
 data class DeleteFilesParams(
   val files: List<FileIdentifier>,

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/DeleteOptionsParams.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/DeleteOptionsParams.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
 data class DeleteOptionsParams(
   val recursive: Boolean? = null,

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/DiagnosticSeverity.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/DiagnosticSeverity.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
 typealias DiagnosticSeverity = String // One of: error, warning, info, suggestion
 

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/Diagnostics_PublishParams.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/Diagnostics_PublishParams.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
 data class Diagnostics_PublishParams(
   val diagnostics: List<ProtocolDiagnostic>,

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/DisabledParams.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/DisabledParams.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
 data class DisabledParams(
   val reason: String,

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/DisplayCodeLensParams.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/DisplayCodeLensParams.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
 data class DisplayCodeLensParams(
   val uri: String,

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/EditCommands_CodeParams.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/EditCommands_CodeParams.kt
@@ -1,7 +1,7 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
-import com.google.gson.annotations.SerializedName
+import com.google.gson.annotations.SerializedName;
 
 data class EditCommands_CodeParams(
   val instruction: String,

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/EditTask.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/EditTask.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
 data class EditTask(
   val id: String,

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/EditTask_AcceptParams.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/EditTask_AcceptParams.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
 data class EditTask_AcceptParams(
   val id: FixupTaskID,

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/EditTask_CancelParams.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/EditTask_CancelParams.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
 data class EditTask_CancelParams(
   val id: FixupTaskID,

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/EditTask_UndoParams.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/EditTask_UndoParams.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
 data class EditTask_UndoParams(
   val id: FixupTaskID,

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/EmbeddingsProvider.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/EmbeddingsProvider.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
 typealias EmbeddingsProvider = String // One of: sourcegraph, openai
 

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/EndParams.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/EndParams.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
 data class EndParams(
   val line: Int,

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/EnhancedContextContextT.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/EnhancedContextContextT.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
 data class EnhancedContextContextT(
   val groups: List<ContextGroup>,

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/EnhancedContextParams.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/EnhancedContextParams.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
 data class EnhancedContextParams(
   val selectedRepos: List<SelectedReposParams>,

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/Event.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/Event.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
 data class Event(
   val event: String,

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/EventProperties.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/EventProperties.kt
@@ -1,7 +1,7 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
-import com.google.gson.annotations.SerializedName
+import com.google.gson.annotations.SerializedName;
 
 data class EventProperties(
   val anonymousUserID: String,

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/ExecuteCommandParams.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/ExecuteCommandParams.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
 data class ExecuteCommandParams(
   val command: String,

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/ExtensionConfiguration.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/ExtensionConfiguration.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
 data class ExtensionConfiguration(
   val serverEndpoint: String,

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/ExtensionMessage.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/ExtensionMessage.kt
@@ -1,18 +1,18 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
-import com.google.gson.annotations.SerializedName
-import com.google.gson.Gson
-import com.google.gson.JsonDeserializationContext
-import com.google.gson.JsonDeserializer
-import com.google.gson.JsonElement
-import java.lang.reflect.Type
+import com.google.gson.annotations.SerializedName;
+import com.google.gson.Gson;
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import java.lang.reflect.Type;
 
 sealed class ExtensionMessage {
   companion object {
     val deserializer: JsonDeserializer<ExtensionMessage> =
       JsonDeserializer { element: JsonElement, _: Type, context: JsonDeserializationContext ->
-        when (element.asJsonObject.get("type").asString) {
+        when (element.getAsJsonObject().get("type").getAsString()) {
           "config" -> context.deserialize<ConfigExtensionMessage>(element, ConfigExtensionMessage::class.java)
           "search:config" -> context.deserialize<Search_configExtensionMessage>(element, Search_configExtensionMessage::class.java)
           "history" -> context.deserialize<HistoryExtensionMessage>(element, HistoryExtensionMessage::class.java)

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/FeatureFlags_GetFeatureFlagParams.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/FeatureFlags_GetFeatureFlagParams.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
 data class FeatureFlags_GetFeatureFlagParams(
   val flagName: String,

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/FileIdentifier.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/FileIdentifier.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
 data class FileIdentifier(
   val uri: String,

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/FixupTaskID.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/FixupTaskID.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
 typealias FixupTaskID = String // One of: 
 

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/GetFoldingRangeParams.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/GetFoldingRangeParams.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
 data class GetFoldingRangeParams(
   val uri: String,

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/GetFoldingRangeResult.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/GetFoldingRangeResult.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
 data class GetFoldingRangeResult(
   val range: Range,

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/Git_CodebaseNameParams.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/Git_CodebaseNameParams.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
 data class Git_CodebaseNameParams(
   val url: String,

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/Graphql_GetRepoIdIfEmbeddingExistsParams.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/Graphql_GetRepoIdIfEmbeddingExistsParams.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
 data class Graphql_GetRepoIdIfEmbeddingExistsParams(
   val repoName: String,

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/Graphql_GetRepoIdParams.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/Graphql_GetRepoIdParams.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
 data class Graphql_GetRepoIdParams(
   val repoName: String,

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/Graphql_GetRepoIdsParams.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/Graphql_GetRepoIdsParams.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
 data class Graphql_GetRepoIdsParams(
   val names: List<String>,

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/Graphql_GetRepoIdsResult.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/Graphql_GetRepoIdsResult.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
 data class Graphql_GetRepoIdsResult(
   val repos: List<ReposParams>,

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/IconsParams.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/IconsParams.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
 data class IconsParams(
   val value: String,

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/Ignore_TestParams.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/Ignore_TestParams.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
 data class Ignore_TestParams(
   val uri: String,

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/Ignore_TestResult.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/Ignore_TestResult.kt
@@ -1,7 +1,7 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
-import com.google.gson.annotations.SerializedName
+import com.google.gson.annotations.SerializedName;
 
 data class Ignore_TestResult(
   val policy: PolicyEnum, // Oneof: ignore, use

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/MemoryUsage.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/MemoryUsage.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
 data class MemoryUsage(
   val rss: Int,

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/MentionParams.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/MentionParams.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
 data class MentionParams(
   val uri: String,

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/MentionQuery.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/MentionQuery.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
 data class MentionQuery(
   val provider: ContextMentionProviderID? = null,

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/MessageOptions.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/MessageOptions.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
 data class MessageOptions(
   val modal: Boolean? = null,

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/Model.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/Model.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
 data class Model(
   val default: Boolean,

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/ModelUsage.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/ModelUsage.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
 typealias ModelUsage = String // One of: chat, edit
 

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/NetworkRequest.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/NetworkRequest.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
 data class NetworkRequest(
   val url: String,

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/NodeTypesParams.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/NodeTypesParams.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
 data class NodeTypesParams(
   val atCursor: String? = null,

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/NodeTypesWithCompletionParams.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/NodeTypesWithCompletionParams.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
 data class NodeTypesWithCompletionParams(
   val atCursor: String? = null,

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/Null.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/Null.kt
@@ -1,3 +1,3 @@
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
 typealias Null = Void?

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/OptionsParams.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/OptionsParams.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
 data class OptionsParams(
   val undoStopBefore: Boolean,

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/Position.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/Position.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
 data class Position(
   val line: Int,

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/ProgressOptions.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/ProgressOptions.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
 data class ProgressOptions(
   val title: String? = null,

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/ProgressReportParams.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/ProgressReportParams.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
 data class ProgressReportParams(
   val id: String,

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/ProgressStartParams.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/ProgressStartParams.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
 data class ProgressStartParams(
   val id: String,

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/Progress_CancelParams.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/Progress_CancelParams.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
 data class Progress_CancelParams(
   val id: String,

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/Progress_EndParams.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/Progress_EndParams.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
 data class Progress_EndParams(
   val id: String,

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/ProtocolCodeAction.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/ProtocolCodeAction.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
 data class ProtocolCodeAction(
   val id: String,

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/ProtocolCodeLens.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/ProtocolCodeLens.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
 data class ProtocolCodeLens(
   val range: Range,

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/ProtocolCommand.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/ProtocolCommand.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
 data class ProtocolCommand(
   val title: TitleParams,

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/ProtocolDiagnostic.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/ProtocolDiagnostic.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
 data class ProtocolDiagnostic(
   val location: ProtocolLocation,

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/ProtocolLocation.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/ProtocolLocation.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
 data class ProtocolLocation(
   val uri: String,

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/ProtocolRelatedInformationDiagnostic.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/ProtocolRelatedInformationDiagnostic.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
 data class ProtocolRelatedInformationDiagnostic(
   val location: ProtocolLocation,

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/ProtocolTextDocument.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/ProtocolTextDocument.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
 data class ProtocolTextDocument(
   val uri: String,

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/ProtocolTextDocumentContentChangeEvent.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/ProtocolTextDocumentContentChangeEvent.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
 data class ProtocolTextDocumentContentChangeEvent(
   val range: Range,

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/ProtocolTypeAdapters.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/ProtocolTypeAdapters.kt
@@ -1,5 +1,5 @@
 @file:Suppress("unused", "ConstPropertyName")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
 object ProtocolTypeAdapters {
   fun register(gson: com.google.gson.GsonBuilder) {

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/Range.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/Range.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
 data class Range(
   val start: Position,

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/RangeData.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/RangeData.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
 data class RangeData(
   val start: StartParams,

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/RemoteRepoFetchState.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/RemoteRepoFetchState.kt
@@ -1,7 +1,7 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
-import com.google.gson.annotations.SerializedName
+import com.google.gson.annotations.SerializedName;
 
 data class RemoteRepoFetchState(
   val state: StateEnum, // Oneof: paused, fetching, errored, complete

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/RemoteRepo_HasParams.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/RemoteRepo_HasParams.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
 data class RemoteRepo_HasParams(
   val repoName: String,

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/RemoteRepo_HasResult.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/RemoteRepo_HasResult.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
 data class RemoteRepo_HasResult(
   val result: Boolean,

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/RemoteRepo_ListParams.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/RemoteRepo_ListParams.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
 data class RemoteRepo_ListParams(
   val query: String? = null,

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/RemoteRepo_ListResult.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/RemoteRepo_ListResult.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
 data class RemoteRepo_ListResult(
   val startIndex: Int,

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/RenameFile.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/RenameFile.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
 data class RenameFile(
   val oldUri: String,

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/RenameFilesParams.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/RenameFilesParams.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
 data class RenameFilesParams(
   val files: List<RenameFile>,

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/Repo.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/Repo.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
 data class Repo(
   val name: String,

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/ReposParams.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/ReposParams.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
 data class ReposParams(
   val name: String,

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/SearchPanelFile.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/SearchPanelFile.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
 data class SearchPanelFile(
   val uri: Uri,

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/SearchPanelSnippet.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/SearchPanelSnippet.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
 data class SearchPanelSnippet(
   val contents: String,

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/SelectedCompletionInfo.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/SelectedCompletionInfo.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
 data class SelectedCompletionInfo(
   val range: Range,

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/SelectedReposParams.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/SelectedReposParams.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
 data class SelectedReposParams(
   val id: String,

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/SerializedChatInteraction.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/SerializedChatInteraction.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
 data class SerializedChatInteraction(
   val humanMessage: SerializedChatMessage,

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/SerializedChatMessage.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/SerializedChatMessage.kt
@@ -1,7 +1,7 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
-import com.google.gson.annotations.SerializedName
+import com.google.gson.annotations.SerializedName;
 
 data class SerializedChatMessage(
   val contextFiles: List<ContextItem>? = null,

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/SerializedChatTranscript.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/SerializedChatTranscript.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
 data class SerializedChatTranscript(
   val id: String,

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/ServerInfo.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/ServerInfo.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
 data class ServerInfo(
   val name: String,

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/ShowWindowMessageParams.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/ShowWindowMessageParams.kt
@@ -1,7 +1,7 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
-import com.google.gson.annotations.SerializedName
+import com.google.gson.annotations.SerializedName;
 
 data class ShowWindowMessageParams(
   val severity: SeverityEnum, // Oneof: error, warning, information

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/StartParams.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/StartParams.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
 data class StartParams(
   val line: Int,

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/SymbolKind.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/SymbolKind.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
 typealias SymbolKind = String // One of: class, function, method
 

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/TelemetryEvent.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/TelemetryEvent.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
 data class TelemetryEvent(
   val feature: String,

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/TelemetryEventProperties.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/TelemetryEventProperties.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
 data class TelemetryEventProperties(
   val key: String,

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/TestingParams.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/TestingParams.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
 data class TestingParams(
   val selectedText: String? = null,

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/Testing_ClosestPostDataParams.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/Testing_ClosestPostDataParams.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
 data class Testing_ClosestPostDataParams(
   val url: String,

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/Testing_ClosestPostDataResult.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/Testing_ClosestPostDataResult.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
 data class Testing_ClosestPostDataResult(
   val closestBody: String,

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/Testing_DiagnosticsParams.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/Testing_DiagnosticsParams.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
 data class Testing_DiagnosticsParams(
   val uri: String,

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/Testing_DiagnosticsResult.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/Testing_DiagnosticsResult.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
 data class Testing_DiagnosticsResult(
   val diagnostics: List<ProtocolDiagnostic>,

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/Testing_MemoryUsageResult.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/Testing_MemoryUsageResult.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
 data class Testing_MemoryUsageResult(
   val usage: MemoryUsage,

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/Testing_NetworkRequestsResult.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/Testing_NetworkRequestsResult.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
 data class Testing_NetworkRequestsResult(
   val requests: List<NetworkRequest>,

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/Testing_ProgressCancelationParams.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/Testing_ProgressCancelationParams.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
 data class Testing_ProgressCancelationParams(
   val title: String,

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/Testing_ProgressCancelationResult.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/Testing_ProgressCancelationResult.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
 data class Testing_ProgressCancelationResult(
   val result: String,

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/Testing_ProgressParams.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/Testing_ProgressParams.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
 data class Testing_ProgressParams(
   val title: String,

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/Testing_ProgressResult.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/Testing_ProgressResult.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
 data class Testing_ProgressResult(
   val result: String,

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/Testing_RequestErrorsResult.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/Testing_RequestErrorsResult.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
 data class Testing_RequestErrorsResult(
   val errors: List<NetworkRequest>,

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/TextDocumentEditParams.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/TextDocumentEditParams.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
 data class TextDocumentEditParams(
   val uri: String,

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/TextDocumentShowOptionsParams.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/TextDocumentShowOptionsParams.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
 data class TextDocumentShowOptionsParams(
   val preserveFocus: Boolean? = null,

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/TextDocument_DidFocusParams.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/TextDocument_DidFocusParams.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
 data class TextDocument_DidFocusParams(
   val uri: String,

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/TextDocument_DidSaveParams.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/TextDocument_DidSaveParams.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
 data class TextDocument_DidSaveParams(
   val uri: String,

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/TextDocument_ShowParams.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/TextDocument_ShowParams.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
 data class TextDocument_ShowParams(
   val uri: String,

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/TextEdit.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/TextEdit.kt
@@ -1,18 +1,18 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
-import com.google.gson.annotations.SerializedName
-import com.google.gson.Gson
-import com.google.gson.JsonDeserializationContext
-import com.google.gson.JsonDeserializer
-import com.google.gson.JsonElement
-import java.lang.reflect.Type
+import com.google.gson.annotations.SerializedName;
+import com.google.gson.Gson;
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import java.lang.reflect.Type;
 
 sealed class TextEdit {
   companion object {
     val deserializer: JsonDeserializer<TextEdit> =
       JsonDeserializer { element: JsonElement, _: Type, context: JsonDeserializationContext ->
-        when (element.asJsonObject.get("type").asString) {
+        when (element.getAsJsonObject().get("type").getAsString()) {
           "replace" -> context.deserialize<ReplaceTextEdit>(element, ReplaceTextEdit::class.java)
           "insert" -> context.deserialize<InsertTextEdit>(element, InsertTextEdit::class.java)
           "delete" -> context.deserialize<DeleteTextEdit>(element, DeleteTextEdit::class.java)

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/TitleParams.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/TitleParams.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
 data class TitleParams(
   val text: String,

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/UntitledTextDocument.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/UntitledTextDocument.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
 data class UntitledTextDocument(
   val uri: String,

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/Uri.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/Uri.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
 data class Uri(
   val scheme: String,

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/UserLocalHistory.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/UserLocalHistory.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
 data class UserLocalHistory(
   val chat: ChatHistory,

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/View.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/View.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
 typealias View = String // One of: chat, login
 

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/WebviewMessage.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/WebviewMessage.kt
@@ -1,18 +1,18 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
-import com.google.gson.annotations.SerializedName
-import com.google.gson.Gson
-import com.google.gson.JsonDeserializationContext
-import com.google.gson.JsonDeserializer
-import com.google.gson.JsonElement
-import java.lang.reflect.Type
+import com.google.gson.annotations.SerializedName;
+import com.google.gson.Gson;
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import java.lang.reflect.Type;
 
 sealed class WebviewMessage {
   companion object {
     val deserializer: JsonDeserializer<WebviewMessage> =
       JsonDeserializer { element: JsonElement, _: Type, context: JsonDeserializationContext ->
-        when (element.asJsonObject.get("command").asString) {
+        when (element.getAsJsonObject().get("command").getAsString()) {
           "ready" -> context.deserialize<ReadyWebviewMessage>(element, ReadyWebviewMessage::class.java)
           "initialized" -> context.deserialize<InitializedWebviewMessage>(element, InitializedWebviewMessage::class.java)
           "event" -> context.deserialize<EventWebviewMessage>(element, EventWebviewMessage::class.java)

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/WebviewPostMessageParams.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/WebviewPostMessageParams.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
 data class WebviewPostMessageParams(
   val id: String,

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/WebviewRecordEventParameters.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/WebviewRecordEventParameters.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
 data class WebviewRecordEventParameters(
   val placeholderField: String? = null // Empty data class

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/Webview_CreateParams.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/Webview_CreateParams.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
 data class Webview_CreateParams(
   val id: String,

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/Webview_DidDisposeParams.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/Webview_DidDisposeParams.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
 data class Webview_DidDisposeParams(
   val id: String,

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/Webview_PostMessageStringEncodedParams.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/Webview_PostMessageStringEncodedParams.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
 data class Webview_PostMessageStringEncodedParams(
   val id: String,

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/Webview_ReceiveMessageParams.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/Webview_ReceiveMessageParams.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
 data class Webview_ReceiveMessageParams(
   val id: String,

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/Webview_ReceiveMessageStringEncodedParams.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/Webview_ReceiveMessageStringEncodedParams.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
 data class Webview_ReceiveMessageStringEncodedParams(
   val id: String,

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/WorkspaceEditEntryMetadata.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/WorkspaceEditEntryMetadata.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
 data class WorkspaceEditEntryMetadata(
   val needsConfirmation: Boolean,

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/WorkspaceEditMetadata.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/WorkspaceEditMetadata.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
 data class WorkspaceEditMetadata(
   val isRefactoring: Boolean? = null,

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/WorkspaceEditOperation.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/WorkspaceEditOperation.kt
@@ -1,18 +1,18 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
-import com.google.gson.annotations.SerializedName
-import com.google.gson.Gson
-import com.google.gson.JsonDeserializationContext
-import com.google.gson.JsonDeserializer
-import com.google.gson.JsonElement
-import java.lang.reflect.Type
+import com.google.gson.annotations.SerializedName;
+import com.google.gson.Gson;
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import java.lang.reflect.Type;
 
 sealed class WorkspaceEditOperation {
   companion object {
     val deserializer: JsonDeserializer<WorkspaceEditOperation> =
       JsonDeserializer { element: JsonElement, _: Type, context: JsonDeserializationContext ->
-        when (element.asJsonObject.get("type").asString) {
+        when (element.getAsJsonObject().get("type").getAsString()) {
           "create-file" -> context.deserialize<CreateFileOperation>(element, CreateFileOperation::class.java)
           "rename-file" -> context.deserialize<RenameFileOperation>(element, RenameFileOperation::class.java)
           "delete-file" -> context.deserialize<DeleteFileOperation>(element, DeleteFileOperation::class.java)

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/WorkspaceEditParams.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/WorkspaceEditParams.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
 data class WorkspaceEditParams(
   val operations: List<WorkspaceEditOperation>,

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/WriteFileOptions.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/WriteFileOptions.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
 data class WriteFileOptions(
   val overwrite: Boolean? = null,

--- a/agent/src/cli/scip-codegen/JvmCodegen.ts
+++ b/agent/src/cli/scip-codegen/JvmCodegen.ts
@@ -6,7 +6,7 @@ import { BaseCodegen, type DiscriminatedUnion, type DiscriminatedUnionMember } f
 import { CodePrinter } from '../../../../vscode/src/completions/context/retrievers/tsc/CodePrinter'
 import type { ConsoleReporter } from './ConsoleReporter'
 import { type Diagnostic, Severity } from './Diagnostic'
-import { KotlinFormatter } from './KotlinFormatter'
+import { JvmFormatter } from './JvmFormatter'
 import type { SymbolTable } from './SymbolTable'
 import type { CodegenOptions } from './command'
 import { resetOutputPath } from './resetOutputPath'
@@ -15,20 +15,30 @@ import { stringLiteralType } from './stringLiteralType'
 import { capitalize, isTypescriptKeyword, typescriptKeyword, typescriptKeywordSyntax } from './utils'
 
 interface DocumentContext {
-    f: KotlinFormatter
+    f: JvmFormatter
     p: CodePrinter
     symtab: SymbolTable
 }
 
-export class KotlinCodegen extends BaseCodegen {
-    private f: KotlinFormatter
+export enum JvmLanguage {
+    Java = 'java',
+    Kotlin = 'kotlin',
+}
+
+export class JvmCodegen extends BaseCodegen {
+    private f: JvmFormatter
     public queue: scip.SymbolInformation[] = []
     public generatedSymbols = new Set<string>()
     public stringLiteralConstants = new Set<string>()
 
-    constructor(options: CodegenOptions, symtab: SymbolTable, reporter: ConsoleReporter) {
+    constructor(
+        private language: JvmLanguage,
+        options: CodegenOptions,
+        symtab: SymbolTable,
+        reporter: ConsoleReporter
+    ) {
         super(options, symtab, reporter)
-        this.f = new KotlinFormatter(this.symtab, this)
+        this.f = new JvmFormatter(this.language, this.symtab, this)
     }
 
     public async run(): Promise<void> {
@@ -71,22 +81,39 @@ export class KotlinCodegen extends BaseCodegen {
             return
         }
         const { p } = this.startDocument()
-        p.line('@file:Suppress("unused", "ConstPropertyName")')
-        p.line(`package ${this.options.kotlinPackage}`)
+        if (this.language === JvmLanguage.Kotlin) {
+            p.line('@file:Suppress("unused", "ConstPropertyName")')
+        }
+        p.line(`package ${this.options.kotlinPackage};`)
         p.line()
-        p.line('object ProtocolTypeAdapters {')
+        if (this.language === JvmLanguage.Kotlin) {
+            p.line('object ProtocolTypeAdapters {')
+        } else {
+            p.line('public final class ProtocolTypeAdapters {')
+        }
         p.block(() => {
-            p.line('fun register(gson: com.google.gson.GsonBuilder) {')
+            if (this.language === JvmLanguage.Kotlin) {
+                p.line('fun register(gson: com.google.gson.GsonBuilder) {')
+            } else {
+                p.line('public static void register(com.google.gson.GsonBuilder gson) {')
+            }
             p.block(() => {
                 for (const symbol of this.discriminatedUnions.keys()) {
                     const name = this.symtab.info(symbol).display_name
-                    p.line(`gson.registerTypeAdapter(${name}::class.java, ${name}.deserializer)`)
+                    if (this.language === JvmLanguage.Kotlin) {
+                        p.line(`gson.registerTypeAdapter(${name}::class.java, ${name}.deserializer)`)
+                    } else {
+                        p.line(`gson.registerTypeAdapter(${name}.class, ${name}.deserializer());`)
+                    }
                 }
             })
             p.line('}')
         })
         p.line('}')
-        await fspromises.writeFile(path.join(this.options.output, 'ProtocolTypeAdapters.kt'), p.build())
+        await fspromises.writeFile(
+            path.join(this.options.output, `ProtocolTypeAdapters.${this.fileExtension()}`),
+            p.build()
+        )
     }
 
     private async writeStringLiteralConstants(): Promise<void> {
@@ -94,25 +121,51 @@ export class KotlinCodegen extends BaseCodegen {
             return
         }
         const { p } = this.startDocument()
-        p.line('@file:Suppress("unused", "ConstPropertyName")')
-        p.line(`package ${this.options.kotlinPackage}`)
+        if (this.language === JvmLanguage.Kotlin) {
+            p.line('@file:Suppress("unused", "ConstPropertyName")')
+        }
+        p.line(`package ${this.options.kotlinPackage};`)
         p.line()
-        p.line('object Constants {')
+        if (this.language === JvmLanguage.Kotlin) {
+            p.line('object Constants {')
+        } else {
+            p.line('public final class Constants {')
+        }
         p.block(() => {
             for (const constant of this.stringLiteralConstants.values()) {
-                p.line(`const val ${this.f.formatFieldName(constant)} = "${constant}"`)
+                if (this.language === JvmLanguage.Kotlin) {
+                    p.line(`const val ${this.f.formatFieldName(constant)} = "${constant}"`)
+                } else {
+                    p.line(
+                        `public static final String ${this.f.formatFieldName(constant)} = "${constant}";`
+                    )
+                }
             }
         })
         p.line('}')
-        await fspromises.writeFile(path.join(this.options.output, 'Constants.kt'), p.build())
+        await fspromises.writeFile(
+            path.join(this.options.output, `Constants.${this.fileExtension()}`),
+            p.build()
+        )
+    }
+
+    private fileExtension() {
+        return this.language === JvmLanguage.Kotlin ? 'kt' : 'java'
     }
 
     private async writeNullAlias(): Promise<void> {
         const { p } = this.startDocument()
-        p.line(`package ${this.options.kotlinPackage}`)
+        p.line(`package ${this.options.kotlinPackage};`)
         p.line()
-        p.line('typealias Null = Void?')
-        await fspromises.writeFile(path.join(this.options.output, 'Null.kt'), p.build())
+        if (this.language === JvmLanguage.Kotlin) {
+            p.line('typealias Null = Void?')
+        } else {
+            p.line('public final class Null {}')
+        }
+        await fspromises.writeFile(
+            path.join(this.options.output, `Null.${this.fileExtension()}`),
+            p.build()
+        )
     }
 
     private async writeSealedClass(
@@ -121,43 +174,89 @@ export class KotlinCodegen extends BaseCodegen {
         info: scip.SymbolInformation,
         union: DiscriminatedUnion
     ): Promise<void> {
-        p.line('import com.google.gson.Gson')
-        p.line('import com.google.gson.JsonDeserializationContext')
-        p.line('import com.google.gson.JsonDeserializer')
-        p.line('import com.google.gson.JsonElement')
-        p.line('import java.lang.reflect.Type')
+        p.line('import com.google.gson.Gson;')
+        p.line('import com.google.gson.JsonDeserializationContext;')
+        p.line('import com.google.gson.JsonDeserializer;')
+        p.line('import com.google.gson.JsonElement;')
+        p.line('import java.lang.reflect.Type;')
 
         p.line()
-        p.line(`sealed class ${name} {`)
+        if (this.language === JvmLanguage.Kotlin) {
+            p.line(`sealed class ${name} {`)
+        } else {
+            p.line(`public abstract class ${name} {`)
+        }
         p.block(() => {
-            p.line('companion object {')
+            if (this.language === JvmLanguage.Kotlin) {
+                p.line('companion object {')
+            }
             p.block(() => {
-                p.line(`val deserializer: JsonDeserializer<${name}> =`)
+                if (this.language === JvmLanguage.Kotlin) {
+                    p.line(`val deserializer: JsonDeserializer<${name}> =`)
+                } else {
+                    p.line(`public static JsonDeserializer<${name}> deserializer() {`)
+                }
                 p.block(() => {
-                    p.line(
-                        'JsonDeserializer { element: JsonElement, _: Type, context: JsonDeserializationContext ->'
-                    )
-                    p.block(() => {
+                    if (this.language === JvmLanguage.Kotlin) {
                         p.line(
-                            `when (element.asJsonObject.get("${union.discriminatorDisplayName}").asString) {`
+                            'JsonDeserializer { element: JsonElement, _: Type, context: JsonDeserializationContext ->'
+                        )
+                    } else {
+                        p.line('return (element, _type, context) -> {')
+                    }
+                    p.block(() => {
+                        const keyword = this.language === JvmLanguage.Kotlin ? 'when' : 'switch'
+                        p.line(
+                            `${keyword} (element.getAsJsonObject().get("${union.discriminatorDisplayName}").getAsString()) {`
                         )
                         p.block(() => {
+                            const isHandledCase = new Set<string>()
                             for (const member of union.members) {
+                                if (isHandledCase.has(member.value)) {
+                                    // There's a bug in ContextProvider where
+                                    // two cases have the same discriminator
+                                    // 'search'
+                                    this.reporter.warn(
+                                        info.symbol,
+                                        `duplicate discriminator value ${member.value}`
+                                    )
+                                    continue
+                                }
+                                isHandledCase.add(member.value)
+
                                 const typeName = this.f.discriminatedUnionTypeName(union, member)
+                                if (this.language === JvmLanguage.Kotlin) {
+                                    p.line(
+                                        `"${member.value}" -> context.deserialize<${typeName}>(element, ${typeName}::class.java)`
+                                    )
+                                } else {
+                                    p.line(
+                                        `case "${member.value}": return context.deserialize(element, ${typeName}.class);`
+                                    )
+                                }
+                            }
+                            if (this.language === JvmLanguage.Kotlin) {
+                                p.line('else -> throw Exception("Unknown discriminator ${element}")')
+                            } else {
                                 p.line(
-                                    `"${member.value}" -> context.deserialize<${typeName}>(element, ${typeName}::class.java)`
+                                    'default: throw new RuntimeException("Unknown discriminator " + element);'
                                 )
                             }
-                            p.line('else -> throw Exception("Unknown discriminator ${element}")')
                         })
                         p.line('}')
                     })
-                    p.line('}')
+                    if (this.language === JvmLanguage.Kotlin) {
+                        p.line('}')
+                    } else {
+                        p.line('};')
+                    }
                 })
             })
             p.line('}')
         })
-        p.line('}')
+        if (this.language === JvmLanguage.Kotlin) {
+            p.line('}')
+        }
         for (const member of union.members) {
             p.line()
             const typeName = this.f.discriminatedUnionTypeName(union, member)
@@ -170,8 +269,12 @@ export class KotlinCodegen extends BaseCodegen {
                       }),
                   })
             this.writeDataClass({ p, f, symtab }, typeName, info, {
-                heritageClause: ` : ${name}()`,
+                heritageClause:
+                    this.language === JvmLanguage.Kotlin ? ` : ${name}()` : ` implements ${name}`,
             })
+        }
+        if (this.language === JvmLanguage.Java) {
+            p.line('}')
         }
     }
 
@@ -189,7 +292,11 @@ export class KotlinCodegen extends BaseCodegen {
         }
         const generatedName = new Set<string>()
         const enums: { name: string; members: string[] }[] = []
-        p.line(`data class ${name}(`)
+        if (this.language === JvmLanguage.Kotlin) {
+            p.line(`data class ${name}(`)
+        } else {
+            p.line(`public final class ${name}${params?.heritageClause ?? ''} {`)
+        }
         p.block(() => {
             let hasMembers = false
             for (const memberSymbol of this.infoProperties(info)) {
@@ -254,36 +361,48 @@ export class KotlinCodegen extends BaseCodegen {
                 }
                 const oneofSyntax = constants.length > 0 ? ' // Oneof: ' + constants.join(', ') : ''
                 const defaultValueSyntax = this.f.isNullable(memberType) ? ' = null' : ''
-                p.line(
-                    `val ${member.display_name}: ${memberTypeSyntax}${defaultValueSyntax},${oneofSyntax}`
-                )
+                const fieldName = this.f.formatFieldName(member.display_name)
+                const serializedAnnotation =
+                    fieldName === member.display_name
+                        ? ''
+                        : `@com.google.gson.annotations.SerializedName("${member.display_name}") `
+                if (this.language === JvmLanguage.Kotlin) {
+                    p.line(
+                        `val ${member.display_name}: ${memberTypeSyntax}${defaultValueSyntax},${oneofSyntax}`
+                    )
+                } else {
+                    p.line(
+                        `${serializedAnnotation}public ${memberTypeSyntax} ${this.f.formatFieldName(
+                            member.display_name
+                        )};${oneofSyntax}`
+                    )
+                }
                 hasMembers = true
             }
-            if (!hasMembers) {
+            if (!hasMembers && this.language === JvmLanguage.Kotlin) {
                 p.line('val placeholderField: String? = null // Empty data class')
             }
         })
         if (enums.length === 0) {
-            p.line(`)${params?.heritageClause ?? ''}`)
+            if (this.language === JvmLanguage.Kotlin) {
+                p.line(`)${params?.heritageClause ?? ''}`)
+            } else {
+                p.line('}')
+            }
             return
         }
-        p.line(`)${params?.heritageClause ?? ''} {`)
+        if (this.language === JvmLanguage.Kotlin) {
+            p.line(`)${params?.heritageClause ?? ''} {`)
+        }
         // Nest enum classe inside data class to avoid naming conflicts with
         // enums for other data classes in the same package.
         p.block(() => {
-            p.addImport('import com.google.gson.annotations.SerializedName')
+            if (this.language === JvmLanguage.Kotlin) {
+                p.addImport('import com.google.gson.annotations.SerializedName;')
+            }
 
             for (const { name, members } of enums) {
-                p.line()
-                p.line(`enum class ${name} {`)
-                p.block(() => {
-                    for (const member of members) {
-                        const serializedName = `@SerializedName("${member}")`
-                        const enumName = this.f.formatFieldName(capitalize(member))
-                        p.line(`${serializedName} ${enumName},`)
-                    }
-                })
-                p.line('}')
+                this.writeEnum(p, name, members)
             }
         })
         p.line('}')
@@ -308,15 +427,55 @@ export class KotlinCodegen extends BaseCodegen {
         return undefined
     }
 
+    private writeEnum(p: CodePrinter, name: string, members: string[]): void {
+        p.line()
+        if (this.language === JvmLanguage.Kotlin) {
+            p.line(`enum class ${name} {`)
+        } else {
+            p.line(`public enum ${name} {`)
+        }
+        p.block(() => {
+            for (const member of members) {
+                const serializedName =
+                    this.language === JvmLanguage.Kotlin
+                        ? `@SerializedName("${member}")`
+                        : `@com.google.gson.annotations.SerializedName("${member}")`
+                const enumName = this.f.formatFieldName(capitalize(member))
+                p.line(`${serializedName} ${enumName},`)
+            }
+        })
+        p.line('}')
+    }
+
     private async writeType(info: scip.SymbolInformation): Promise<void> {
         const { f, p, c } = this.startDocument()
         const name = f.typeName(info)
-        p.line('@file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")')
-        p.line(`package ${this.options.kotlinPackage}`)
+        if (this.language === JvmLanguage.Kotlin) {
+            p.line(
+                '@file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")'
+            )
+        }
+        p.line(`package ${this.options.kotlinPackage};`)
         p.line()
         const alias = this.aliasType(info)
         if (alias) {
-            p.line(`typealias ${name} = ${alias}`)
+            if (this.language === JvmLanguage.Kotlin) {
+                p.line(`typealias ${name} = ${alias}`)
+            } else {
+                if (info.display_name === 'Date') {
+                    p.line('public final class Date {}')
+                } else if (info.display_name === 'Null') {
+                    p.line('public final class Null {}')
+                } else {
+                    const constants = this.stringConstantsFromInfo(info)
+                    if (constants.length === 0) {
+                        this.reporter.warn(info.symbol, `no constants for ${info.display_name}`)
+                        p.line(`public final class ${name} {} // TODO: fixme`)
+                    } else {
+                        this.writeEnum(p, name, constants)
+                    }
+                }
+            }
         } else {
             const discriminatedUnion = this.discriminatedUnions.get(info.symbol)
             if (discriminatedUnion) {
@@ -326,7 +485,10 @@ export class KotlinCodegen extends BaseCodegen {
             }
         }
         p.line()
-        await fspromises.writeFile(path.join(this.options.output, `${name}.kt`), p.build())
+        await fspromises.writeFile(
+            path.join(this.options.output, `${name}.${this.fileExtension()}`),
+            p.build()
+        )
     }
 
     private async writeProtocolInterface(
@@ -335,16 +497,22 @@ export class KotlinCodegen extends BaseCodegen {
         notifications: string
     ): Promise<void> {
         const { f, p, symtab } = this.startDocument()
-        p.line('@file:Suppress("FunctionName", "ClassName")')
-        p.line(`package ${this.options.kotlinPackage}`)
+        if (this.language === JvmLanguage.Kotlin) {
+            p.line('@file:Suppress("FunctionName", "ClassName")')
+        }
+        p.line(`package ${this.options.kotlinPackage};`)
         p.line()
-        p.line('import org.eclipse.lsp4j.jsonrpc.services.JsonNotification')
-        p.line('import org.eclipse.lsp4j.jsonrpc.services.JsonRequest')
-        p.line('import java.util.concurrent.CompletableFuture')
+        p.line('import org.eclipse.lsp4j.jsonrpc.services.JsonNotification;')
+        p.line('import org.eclipse.lsp4j.jsonrpc.services.JsonRequest;')
+        p.line('import java.util.concurrent.CompletableFuture;')
         p.line()
-        p.line('@Suppress("unused")')
-        p.line(`interface ${name} {`)
-
+        if (this.language === JvmLanguage.Kotlin) {
+            p.line('@Suppress("unused")')
+            p.line(`interface ${name} {`)
+        } else {
+            p.line('@SuppressWarnings("unused")')
+            p.line(`public interface ${name} {`)
+        }
         p.block(() => {
             p.sectionComment('Requests')
             for (const request of symtab.structuralType(symtab.canonicalSymbol(requests))) {
@@ -365,10 +533,18 @@ export class KotlinCodegen extends BaseCodegen {
                 const resultTypeSyntax = f.jsonrpcTypeName(request, resultType, 'result')
 
                 p.line(`@JsonRequest("${request.display_name}")`)
-                p.line(
-                    `fun ${f.functionName(request)}(${parameterSyntax}): ` +
-                        `CompletableFuture<${resultTypeSyntax}>`
-                )
+                if (this.language === JvmLanguage.Kotlin) {
+                    p.line(
+                        `fun ${f.functionName(request)}(${parameterSyntax}): ` +
+                            `CompletableFuture<${resultTypeSyntax}>`
+                    )
+                } else {
+                    p.line(
+                        `CompletableFuture<${resultTypeSyntax}> ${f.functionName(
+                            request
+                        )}(${parameterSyntax});`
+                    )
+                }
             }
 
             p.line()
@@ -379,13 +555,20 @@ export class KotlinCodegen extends BaseCodegen {
                 const { parameterType, parameterSyntax } = f.jsonrpcMethodParameter(notification)
                 this.queueClassLikeType(parameterType, notification, 'parameter')
                 p.line(`@JsonNotification("${notification.display_name}")`)
-                p.line(`fun ${f.functionName(notification)}(${parameterSyntax})`)
+                if (this.language === JvmLanguage.Kotlin) {
+                    p.line(`fun ${f.functionName(notification)}(${parameterSyntax})`)
+                } else {
+                    p.line(`void ${f.functionName(notification)}(${parameterSyntax});`)
+                }
             }
         })
 
         p.line('}')
 
-        await fspromises.writeFile(path.join(this.options.output, `${name}.kt`), p.build())
+        await fspromises.writeFile(
+            path.join(this.options.output, `${name}.${this.fileExtension()}`),
+            p.build()
+        )
     }
 
     // We are referencing the given type in the generated code. If this type
@@ -405,7 +588,7 @@ export class KotlinCodegen extends BaseCodegen {
                 }
                 this.queueClassLikeType(type.type_ref.type_arguments[0], jsonrpcMethod, kind)
                 this.queueClassLikeType(type.type_ref.type_arguments[1], jsonrpcMethod, kind)
-            } else if (typescriptKeywordSyntax(type.type_ref.symbol)) {
+            } else if (typescriptKeywordSyntax(this.language, type.type_ref.symbol)) {
                 // Typescript keywords map to primitive types (Int, Double) or built-in types like String
             } else {
                 this.queueClassLikeInfo(this.symtab.info(type.type_ref.symbol))
@@ -445,7 +628,7 @@ export class KotlinCodegen extends BaseCodegen {
             const nonNullableTypes = type.union_type.types.filter(type => !this.f.isNullable(type))
             if (
                 nonNullableTypes.every(
-                    tpe => tpe.has_type_ref && isTypescriptKeyword(tpe.type_ref.symbol)
+                    tpe => tpe.has_type_ref && isTypescriptKeyword(this.language, tpe.type_ref.symbol)
                 )
             ) {
                 // Nothing to queue

--- a/agent/src/cli/scip-codegen/command.ts
+++ b/agent/src/cli/scip-codegen/command.ts
@@ -2,7 +2,7 @@ import fspromises from 'node:fs/promises'
 import { Command, InvalidOptionArgumentError, Option } from 'commander'
 import type { BaseCodegen } from './BaseCodegen'
 import { ConsoleReporter } from './ConsoleReporter'
-import { KotlinCodegen } from './KotlinCodegen'
+import { JvmCodegen, JvmLanguage } from './JvmCodegen'
 import { MarkdownCodegen } from './MarkdownCodegen'
 import { SymbolTable } from './SymbolTable'
 import { scip } from './scip'
@@ -18,6 +18,7 @@ export interface CodegenOptions {
 }
 
 enum CodegenLanguage {
+    Java = 'java',
     Kotlin = 'kotlin',
     Markdown = 'markdown',
 }
@@ -39,11 +40,13 @@ function languageOption(value: string): CodegenLanguage {
     switch (value) {
         case 'kotlin':
             return CodegenLanguage.Kotlin
+        case 'java':
+            return CodegenLanguage.Java
         case 'markdown':
             return CodegenLanguage.Markdown
         default:
             throw new InvalidOptionArgumentError(
-                `Invalid language. Valid options are ${CodegenLanguage.Kotlin}.`
+                `Invalid language. Valid options are ${CodegenLanguage.Kotlin}, ${CodegenLanguage.Java}, ${CodegenLanguage.Markdown}.`
             )
     }
 }
@@ -89,7 +92,9 @@ async function initializeCodegen(options: CodegenOptions): Promise<BaseCodegen> 
     const reporter = new ConsoleReporter(index, { severity: options.severity as any })
     switch (options.language) {
         case CodegenLanguage.Kotlin:
-            return new KotlinCodegen(options, symtab, reporter)
+            return new JvmCodegen(JvmLanguage.Kotlin, options, symtab, reporter)
+        case CodegenLanguage.Java:
+            return new JvmCodegen(JvmLanguage.Java, options, symtab, reporter)
         case CodegenLanguage.Markdown:
             return new MarkdownCodegen(options, symtab, reporter)
         default:

--- a/agent/src/cli/scip-codegen/utils.ts
+++ b/agent/src/cli/scip-codegen/utils.ts
@@ -1,9 +1,11 @@
-export function typescriptKeywordSyntax(symbol: string): string | undefined {
+import { JvmLanguage } from './JvmCodegen'
+
+export function typescriptKeywordSyntax(language: JvmLanguage, symbol: string): string | undefined {
     switch (symbol) {
         case 'scip-typescript npm typescript . array#':
             return 'List'
         case 'scip-typescript npm typescript . null#':
-            return 'Null'
+            return language === JvmLanguage.Kotlin ? 'Null' : 'Void'
         case 'scip-typescript npm typescript . string#':
             return 'String'
         case 'scip-typescript npm typescript . false#':
@@ -11,10 +13,10 @@ export function typescriptKeywordSyntax(symbol: string): string | undefined {
         case 'scip-typescript npm typescript . boolean#':
             return 'Boolean'
         case 'scip-typescript npm typescript . number#':
-            return 'Int'
+            return language === JvmLanguage.Kotlin ? 'Int' : 'Integer'
         case 'scip-typescript npm typescript . any#':
         case 'scip-typescript npm typescript . unknown#':
-            return 'Any'
+            return language === JvmLanguage.Kotlin ? 'Any' : 'Object'
         default:
             return undefined
     }
@@ -27,9 +29,9 @@ export function capitalize(text: string): string {
     return text[0].toUpperCase() + text.slice(1)
 }
 
-export function isTypescriptKeyword(symbol: string): boolean {
+export function isTypescriptKeyword(language: JvmLanguage, symbol: string): boolean {
     return (
-        typescriptKeywordSyntax(symbol) !== undefined &&
+        typescriptKeywordSyntax(language, symbol) !== undefined &&
         symbol !== 'scip-typescript npm typescript . array#'
     )
 }


### PR DESCRIPTION
Previously, we only generated bindings for Kotlin. The Eclipse plugin is written in Java so this PR adds support to generate Java bindings as well. Java and Kotlin are very similar so required diff is minimal. The Java code is not added to this repo because we already have the Kotlin bindings here and I don't want every agent-protocol.ts PR to have a huge diff. Instead, we can just commit the Java bindings directly to the Eclipse repo.

Note: the code generator implementation is already quite messy and it's getting more messy with this PR. I am willing to take on this tech debt for now because it's easy to catch regressions from diffs in the generated code.

## Test plan

Minimal and low-risk diffs in Kotlin bindings (adding semi-colons and using Java getter method names instead of Kotlin sugar)
<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
