### PR TITLE
mentions: display queryLabel if no results and no query yet

### DIFF
--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/ContextMentionProviderMetadata.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/ContextMentionProviderMetadata.kt
@@ -3,8 +3,8 @@ package com.sourcegraph.cody.protocol_generated;
 
 data class ContextMentionProviderMetadata(
   val id: String,
-  val title: String? = null,
-  val queryLabel: String? = null,
-  val emptyLabel: String? = null,
+  val title: String,
+  val queryLabel: String,
+  val emptyLabel: String,
 )
 

--- a/lib/shared/src/mentions/api.ts
+++ b/lib/shared/src/mentions/api.ts
@@ -20,20 +20,19 @@ export interface ContextMentionProviderMetadata {
     id: string
 
     /**
-     * A short, human-readable display title for the provider, such as "Google Docs". If not given,
-     * `id` is used instead.
+     * A short, human-readable display title for the provider, such as "Google Docs".
      */
-    title?: string
+    title: string
 
     /**
      * Human-readable display string for when the user is querying items from this provider.
      */
-    queryLabel?: string
+    queryLabel: string
 
     /**
      * Human-readable display string for when the provider has no items for the query.
      */
-    emptyLabel?: string
+    emptyLabel: string
 }
 
 export const FILE_CONTEXT_MENTION_PROVIDER: ContextMentionProviderMetadata & { id: 'file' } = {
@@ -75,7 +74,7 @@ async function openCtxMentionProviders(): Promise<ContextMentionProviderMetadata
             .map(provider => ({
                 id: provider.providerUri,
                 title: provider.name,
-                queryLabel: provider.name,
+                queryLabel: 'Search...',
                 emptyLabel: 'No results',
             }))
             .sort((a, b) => (a.title > b.title ? 1 : -1))

--- a/vscode/webviews/mentions/mentionMenu/MentionMenu.story.tsx
+++ b/vscode/webviews/mentions/mentionMenu/MentionMenu.story.tsx
@@ -96,16 +96,7 @@ export const Default: StoryObj<typeof MentionMenu> = {
                     uri: URI.file(`/${'sub-dir/'.repeat(50)}/}/src/LoginDialog.tsx`),
                 },
             ],
-            [
-                {
-                    title: 'Files',
-                    id: FILE_CONTEXT_MENTION_PROVIDER.id,
-                },
-                {
-                    title: 'Symbols',
-                    id: SYMBOL_CONTEXT_MENTION_PROVIDER.id,
-                },
-            ]
+            [FILE_CONTEXT_MENTION_PROVIDER, SYMBOL_CONTEXT_MENTION_PROVIDER]
         ),
     },
 }
@@ -125,16 +116,7 @@ export const WithExperimentalProviders: StoryObj<typeof MentionMenu> = {
                     range: { start: { line: 3, character: 5 }, end: { line: 7, character: 9 } },
                 },
             ],
-            [
-                {
-                    title: 'Files',
-                    id: FILE_CONTEXT_MENTION_PROVIDER.id,
-                },
-                {
-                    title: 'Symbols',
-                    id: SYMBOL_CONTEXT_MENTION_PROVIDER.id,
-                },
-            ]
+            [FILE_CONTEXT_MENTION_PROVIDER, SYMBOL_CONTEXT_MENTION_PROVIDER]
         ),
     },
 }

--- a/vscode/webviews/mentions/mentionMenu/MentionMenu.test.tsx
+++ b/vscode/webviews/mentions/mentionMenu/MentionMenu.test.tsx
@@ -19,10 +19,16 @@ vi.mock('./MentionMenuItem', () => ({
 
 const PROVIDER_P1: ContextMentionProviderMetadata = {
     id: 'p1',
+    title: 'p1 title',
+    queryLabel: 'p1 queryLabel',
+    emptyLabel: 'p1 emptyLabel',
 }
 
 const PROVIDER_P2: ContextMentionProviderMetadata = {
     id: 'p2',
+    title: 'p2 title',
+    queryLabel: 'p2 queryLabel',
+    emptyLabel: 'p2 emptyLabel',
 }
 
 const ITEM_FILE1: ContextItem = {
@@ -104,11 +110,7 @@ describe('MentionMenu', () => {
                         {...PROPS}
                         params={{
                             query: 'test',
-                            parentItem: {
-                                ...PROVIDER_P1,
-                                queryLabel: 'p1 queryLabel',
-                                emptyLabel: 'p1 emptyLabel',
-                            },
+                            parentItem: PROVIDER_P1,
                         }}
                         data={{
                             items: [],
@@ -116,7 +118,7 @@ describe('MentionMenu', () => {
                         }}
                     />
                 )
-                expectMenu(container, ['#p1 queryLabel', '#p1 emptyLabel'])
+                expectMenu(container, ['#p1 title', '#p1 emptyLabel'])
             })
 
             test('no items without query', () => {
@@ -125,11 +127,7 @@ describe('MentionMenu', () => {
                         {...PROPS}
                         params={{
                             query: '',
-                            parentItem: {
-                                ...PROVIDER_P1,
-                                queryLabel: 'p1 queryLabel',
-                                emptyLabel: 'p1 emptyLabel',
-                            },
+                            parentItem: PROVIDER_P1,
                         }}
                         data={{
                             items: [],
@@ -137,7 +135,7 @@ describe('MentionMenu', () => {
                         }}
                     />
                 )
-                expectMenu(container, ['#p1 queryLabel', '#Search...'])
+                expectMenu(container, ['#p1 title', '#p1 queryLabel'])
             })
 
             test('with suggested items for empty query', () => {
@@ -146,7 +144,7 @@ describe('MentionMenu', () => {
                         {...PROPS}
                         params={{
                             query: '',
-                            parentItem: { ...PROVIDER_P1, queryLabel: 'p1 queryLabel' },
+                            parentItem: PROVIDER_P1,
                         }}
                         data={{
                             items: [ITEM_FILE1],
@@ -154,7 +152,7 @@ describe('MentionMenu', () => {
                         }}
                     />
                 )
-                expectMenu(container, ['#p1 queryLabel', 'item file file1.go'])
+                expectMenu(container, ['#p1 title', 'item file file1.go'])
             })
 
             test('with items and non-empty query', () => {
@@ -163,7 +161,7 @@ describe('MentionMenu', () => {
                         {...PROPS}
                         params={{
                             query: 'q',
-                            parentItem: { ...PROVIDER_P1, queryLabel: 'p1 queryLabel' },
+                            parentItem: PROVIDER_P1,
                         }}
                         data={{
                             items: [ITEM_FILE1],
@@ -171,7 +169,7 @@ describe('MentionMenu', () => {
                         }}
                     />
                 )
-                expectMenu(container, ['#p1 queryLabel', 'item file file1.go'])
+                expectMenu(container, ['#p1 title', 'item file file1.go'])
             })
 
             test('by trigger prefix', () => {

--- a/vscode/webviews/mentions/mentionMenu/MentionMenu.tsx
+++ b/vscode/webviews/mentions/mentionMenu/MentionMenu.tsx
@@ -305,7 +305,7 @@ function getEmptyLabel(
     mentionQuery: MentionQuery
 ): string {
     if (!mentionQuery.text) {
-        return 'Search...'
+        return parentItem?.queryLabel ?? 'Search...'
     }
 
     if (!parentItem) {
@@ -338,5 +338,5 @@ function getItemsHeading(
         // Don't show heading for these common types because it's just noisy.
         return ''
     }
-    return parentItem.queryLabel ?? parentItem.title ?? parentItem.id
+    return parentItem.title ?? parentItem.id
 }


### PR DESCRIPTION
This updates the mentions API to be more explicit. Every provider already supplies the title, queryLabel and emptyLabel so we might as well mark those fields as required and rely on them when rendering.

Additionally we update call sites of queryLabel to be used when prompting the user for querying only. For the mention title we now always use title. Previously we prefered the queryLabel for titles which was strange.

Note: this change has no user visible behaviour change, it just makes us internally more consistent.

Test Plan: updated unit tests to demonstrate how the fields are now used. Additionally manually tested openctx and builtin providers in the mention menu to ensure there are no changes in behaviour.