### PR TITLE
Agent: fix bug related to `extends`/`implements`

### DIFF
--- a/agent/src/cli/scip-codegen/JvmCodegen.ts
+++ b/agent/src/cli/scip-codegen/JvmCodegen.ts
@@ -270,7 +270,7 @@ export class JvmCodegen extends BaseCodegen {
                   })
             this.writeDataClass({ p, f, symtab }, typeName, info, {
                 heritageClause:
-                    this.language === JvmLanguage.Kotlin ? ` : ${name}()` : ` implements ${name}`,
+                    this.language === JvmLanguage.Kotlin ? ` : ${name}()` : ` extends ${name}`,
             })
         }
         if (this.language === JvmLanguage.Java) {


### PR DESCRIPTION
Previously, the generated code didn't compile because it used `implements` instead of `extends`.


## Test plan
Manually confirm that the Eclipse plugin compiles.
<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
