### PR TITLE
mentions: add stories for no query and openctx

### DIFF
--- a/lib/shared/src/index.ts
+++ b/lib/shared/src/index.ts
@@ -274,6 +274,7 @@ export {
 export {
     type ContextItemProps,
     allMentionProvidersMetadata,
+    openCtxProviderMetadata,
     FILE_CONTEXT_MENTION_PROVIDER,
     SYMBOL_CONTEXT_MENTION_PROVIDER,
     type ContextMentionProviderMetadata,

--- a/lib/shared/src/mentions/api.ts
+++ b/lib/shared/src/mentions/api.ts
@@ -1,3 +1,4 @@
+import type { MetaResult } from '@openctx/client'
 import { openCtx } from '../context/openctx/api'
 import { logDebug } from '../logger'
 
@@ -60,6 +61,17 @@ export async function allMentionProvidersMetadata(): Promise<ContextMentionProvi
     return items
 }
 
+export function openCtxProviderMetadata(
+    meta: MetaResult & { providerUri: string }
+): ContextMentionProviderMetadata {
+    return {
+        id: meta.providerUri,
+        title: meta.name,
+        queryLabel: meta.mentions?.label ?? 'Search...',
+        emptyLabel: 'No results',
+    }
+}
+
 async function openCtxMentionProviders(): Promise<ContextMentionProviderMetadata[]> {
     const client = openCtx.client
     if (!client) {
@@ -71,12 +83,7 @@ async function openCtxMentionProviders(): Promise<ContextMentionProviderMetadata
 
         return providers
             .filter(provider => !!provider.mentions)
-            .map(provider => ({
-                id: provider.providerUri,
-                title: provider.name,
-                queryLabel: provider.mentions?.label ?? 'Search...',
-                emptyLabel: 'No results',
-            }))
+            .map(openCtxProviderMetadata)
             .sort((a, b) => (a.title > b.title ? 1 : -1))
     } catch (error) {
         logDebug('openctx', `Failed to fetch OpenCtx providers: ${error}`)

--- a/vscode/webviews/mentions/mentionMenu/MentionMenu.story.tsx
+++ b/vscode/webviews/mentions/mentionMenu/MentionMenu.story.tsx
@@ -3,9 +3,11 @@ import { URI } from 'vscode-uri'
 
 import {
     type ContextItem,
+    type ContextItemOpenCtx,
     type ContextMentionProviderMetadata,
     FILE_CONTEXT_MENTION_PROVIDER,
     SYMBOL_CONTEXT_MENTION_PROVIDER,
+    openCtxProviderMetadata,
 } from '@sourcegraph/cody-shared'
 import { VSCodeDecorator } from '../../storybook/VSCodeStoryDecorator'
 import { MentionMenu } from './MentionMenu'
@@ -125,6 +127,20 @@ export const Loading: StoryObj<typeof MentionMenu> = {
     args: {
         params: toParams('', FILE_CONTEXT_MENTION_PROVIDER),
         data: toData(undefined),
+    },
+}
+
+export const FileSearchNoQueryNoMatches: StoryObj<typeof MentionMenu> = {
+    args: {
+        params: toParams('', FILE_CONTEXT_MENTION_PROVIDER),
+        data: toData([]),
+    },
+}
+
+export const FileSearchNoQueryMatches: StoryObj<typeof MentionMenu> = {
+    args: {
+        params: toParams('', FILE_CONTEXT_MENTION_PROVIDER),
+        data: toData([{ uri: URI.file('a/b/ddddddd.go'), type: 'file' }]),
     },
 }
 
@@ -282,3 +298,49 @@ export const SymbolSearchMatches: StoryObj<typeof MentionMenu> = {
         ]),
     },
 }
+
+const OPENCTX_PROVIDER = openCtxProviderMetadata({
+    providerUri: 'https://openctx.org/npm/@openctx/provider-example',
+    name: 'OpenCtx Example Title',
+    mentions: {
+        label: 'Search label for OpenCtx Example...',
+    },
+})
+
+function openCtxStory(query: string, names: string[] | undefined): StoryObj<typeof MentionMenu> {
+    const items =
+        names === undefined
+            ? undefined
+            : names.map(
+                  name =>
+                      ({
+                          type: 'openctx',
+                          provider: 'openctx',
+                          title: name,
+                          uri: URI.parse('https://example.com').with({ query: name }),
+                          providerUri: OPENCTX_PROVIDER.id,
+                          mention: {
+                              uri: '',
+                              description: 'openctx description ' + name,
+                          },
+                      }) satisfies ContextItemOpenCtx
+              )
+    return {
+        args: {
+            params: {
+                query: query,
+                parentItem: OPENCTX_PROVIDER,
+            },
+            data: {
+                providers: [],
+                items,
+            },
+        },
+    }
+}
+
+export const OpenctxNoQueryLoading: StoryObj<typeof MentionMenu> = openCtxStory('', undefined)
+export const OpenctxNoQueryNoMatches: StoryObj<typeof MentionMenu> = openCtxStory('', [])
+export const OpenctxNoQueryMatches: StoryObj<typeof MentionMenu> = openCtxStory('', ['a', 'b', 'c'])
+export const OpenctxNoMatches: StoryObj<typeof MentionMenu> = openCtxStory('missing', [])
+export const OpenctxMatches: StoryObj<typeof MentionMenu> = openCtxStory('b', ['a', 'b', 'c'])


### PR DESCRIPTION
This greatly expands the storybook for mention menu to cover some corner cases in file search as well as adding stories for OpenCtx.

Test Plan: ran pnpm story and browsed newly added items