### PR TITLE
bump time to first completion up to 2.5 seconds to allow for more syntactically complete code completions

### DIFF
--- a/vscode/src/configuration.ts
+++ b/vscode/src/configuration.ts
@@ -186,7 +186,7 @@ export function getConfiguration(
         },
         autocompleteFirstCompletionTimeout: getHiddenSetting<number>(
             'autocomplete.advanced.timeout.firstCompletion',
-            1_500
+            3_500
         ),
         testingModelConfig:
             isTesting && hasValidLocalEmbeddingsConfig()

--- a/vscode/src/testutils/mocks.ts
+++ b/vscode/src/testutils/mocks.ts
@@ -865,7 +865,7 @@ export const DEFAULT_VSCODE_SETTINGS = {
         multiline: undefined,
         singleline: undefined,
     },
-    autocompleteFirstCompletionTimeout: 1500,
+    autocompleteFirstCompletionTimeout: 3500,
     testingModelConfig: undefined,
     experimentalChatContextRanker: false,
 } satisfies Configuration


### PR DESCRIPTION
It's a better user experience to wait a bit longer to generate a syntactically whole completion rather than a completion that does not complete the syntactic block. The issue with the latter is both the sense of "incompleteness" but also, we get "stuck" in a more deeply nested block.

| Column 1 | Column 2 |
| --------- | --------- |
|       <img width="522" alt="image" src="https://github.com/sourcegraph/cody/assets/1646931/8bee39ef-458d-42e2-bbda-7a6875af1d60">  |   <img width="738" alt="image" src="https://github.com/sourcegraph/cody/assets/1646931/d814b58f-e55c-4915-a749-4b0310390a08"> |

## Test plan

Tested locally