### PR TITLE
Cleanup mention label

### DIFF
--- a/lib/shared/src/lexicalEditor/nodes.ts
+++ b/lib/shared/src/lexicalEditor/nodes.ts
@@ -88,7 +88,7 @@ export function contextItemMentionNodeDisplayText(contextItem: SerializedContext
             return contextItem.symbolName
 
         case 'openctx':
-            return contextItem.mention?.data?.mentionLabel || contextItem.title
+            return contextItem.title
     }
     // @ts-ignore
     throw new Error(`unrecognized context item type ${contextItem.type}`)

--- a/vscode/src/context/openctx/remoteFileSearch.ts
+++ b/vscode/src/context/openctx/remoteFileSearch.ts
@@ -88,7 +88,6 @@ async function getFileMentions(repoName: string, filePath?: string): Promise<Men
                 title: basename,
                 description: result.file.path,
                 data: {
-                    mentionLabel: basename,
                     repoName: result.repository.name,
                     rev: result.file.commit.oid,
                     filePath: result.file.path,


### PR DESCRIPTION
The title & label for the remote file search item are both file basename now. Not need for the `mention?.data?.mentionLabel` hack.

Cleaning up
## Test plan

tested