### PR TITLE
debounce selection determination to reduce CPU load

### DIFF
--- a/vscode/test/e2e/chat-atFile.test.ts
+++ b/vscode/test/e2e/chat-atFile.test.ts
@@ -351,11 +351,11 @@ test.extend<ExpectedEvents>({
 })('@-mention symbol in chat', async ({ page, nap, sidebar }) => {
     await sidebarSignin(page, sidebar)
 
-    // Open chat.
-    const [chatPanelFrame, chatInput] = await createEmptyChatPanel(page)
-
     // Open the buzz.ts file so that VS Code starts to populate symbols.
     await openFileInEditorTab(page, 'buzz.ts')
+
+    // Open chat.
+    const [chatPanelFrame, chatInput] = await createEmptyChatPanel(page)
 
     // Wait for the tsserver to become ready: when sync icon disappears
     const langServerLoadingState = 'Editor Language Status: Loading'


### PR DESCRIPTION
Previously, it only debounced the postMessage. Now it debounces the entire operation to get the right selection context. I still see it called 2x for a cursor move (empty selection) and 4x for a non-empty selection due to VS Code calling the event handler multiple times for some reason, but this is a big improvement over before.

Fixes https://linear.app/sourcegraph/issue/CODY-2481/debounce-or-throttle-commandscontextselection-file-calls-to-prevent



## Test plan

Try selections and see how many OT spans get sent (and use logpoints).