### PR TITLE
editor: support all uri schemes for getTextEditorContentForFile

### DIFF
--- a/vscode/src/editor/vscode-editor.ts
+++ b/vscode/src/editor/vscode-editor.ts
@@ -85,9 +85,7 @@ export class VSCodeEditor implements Editor {
             range = new vscode.Range(startLine, 0, endLine, 0)
         }
 
-        // Get the text from document by file Uri
-        const vscodeUri = vscode.Uri.file(fileUri.fsPath)
-        const doc = await vscode.workspace.openTextDocument(vscodeUri)
+        const doc = await vscode.workspace.openTextDocument(fileUri)
         return doc.getText(range)
     }
 


### PR DESCRIPTION
We already have a uri passed in and I am unsure why we converted that into a uri which was just the filepath. I am assuming it was due to code evolution.

In particular this makes it so that cody can understand context from unsaved files.

Test Plan: create a new unsaved file with the word "hello world" in it. Start a cody chat and ask cody about the file. Expect cody mentions hello world in the response. Before this change we got an error.

Fixes https://linear.app/sourcegraph/issue/CODY-2469/a-new-chat-with-an-unsaved-buffer-as-context-shows-an-error