### PR TITLE
Make mention chips open links

### DIFF
--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/Constants.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/Constants.kt
@@ -101,6 +101,7 @@ object Constants {
   const val restoreHistory = "restoreHistory"
   const val deleteHistory = "deleteHistory"
   const val links = "links"
+  const val openURI = "openURI"
   const val `show-page` = "show-page"
   const val chatModel = "chatModel"
   const val `get-chat-models` = "get-chat-models"

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/WebviewMessage.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/WebviewMessage.kt
@@ -22,6 +22,7 @@ sealed class WebviewMessage {
           "restoreHistory" -> context.deserialize<RestoreHistoryWebviewMessage>(element, RestoreHistoryWebviewMessage::class.java)
           "deleteHistory" -> context.deserialize<DeleteHistoryWebviewMessage>(element, DeleteHistoryWebviewMessage::class.java)
           "links" -> context.deserialize<LinksWebviewMessage>(element, LinksWebviewMessage::class.java)
+          "openURI" -> context.deserialize<OpenURIWebviewMessage>(element, OpenURIWebviewMessage::class.java)
           "show-page" -> context.deserialize<`show-pageWebviewMessage`>(element, `show-pageWebviewMessage`::class.java)
           "chatModel" -> context.deserialize<ChatModelWebviewMessage>(element, ChatModelWebviewMessage::class.java)
           "get-chat-models" -> context.deserialize<`get-chat-modelsWebviewMessage`>(element, `get-chat-modelsWebviewMessage`::class.java)
@@ -150,6 +151,16 @@ data class LinksWebviewMessage(
 
   enum class CommandEnum {
     @SerializedName("links") Links,
+  }
+}
+
+data class OpenURIWebviewMessage(
+  val command: CommandEnum, // Oneof: openURI
+  val uri: Uri,
+) : WebviewMessage() {
+
+  enum class CommandEnum {
+    @SerializedName("openURI") OpenURI,
   }
 }
 

--- a/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
+++ b/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
@@ -323,6 +323,9 @@ export class SimpleChatPanelProvider
             case 'copy':
                 await handleCopiedCode(message.text, message.eventType === 'Button')
                 break
+            case 'openURI':
+                vscode.commands.executeCommand('vscode.open', message.uri)
+                break
             case 'links':
                 void openExternalLinks(message.value)
                 break

--- a/vscode/src/chat/clientStateBroadcaster.ts
+++ b/vscode/src/chat/clientStateBroadcaster.ts
@@ -53,7 +53,7 @@ export function startClientStateBroadcaster({
                         createRemoteRepositoryMention({
                             id: repo.id,
                             name: repo.name,
-                            url: `repo:${repo.name}`,
+                            url: repo.name,
                         })
                     ),
                     title: 'Repository',

--- a/vscode/src/chat/protocol.ts
+++ b/vscode/src/chat/protocol.ts
@@ -20,6 +20,7 @@ import type { BillingCategory, BillingProduct } from '@sourcegraph/cody-shared/s
 
 import type { TelemetryEventParameters } from '@sourcegraph/telemetry'
 
+import type { Uri } from 'vscode'
 import type { View } from '../../webviews/NavBar'
 import type { Repo } from '../context/repo-fetcher'
 
@@ -74,6 +75,7 @@ export type WebviewMessage =
     | { command: 'restoreHistory'; chatID: string }
     | { command: 'deleteHistory'; chatID: string }
     | { command: 'links'; value: string }
+    | { command: 'openURI'; uri: Uri }
     | {
           command: 'show-page'
           page: string

--- a/vscode/src/context/openctx/remoteRepositorySearch.ts
+++ b/vscode/src/context/openctx/remoteRepositorySearch.ts
@@ -41,7 +41,7 @@ const RemoteRepositorySearch: Provider & {
         return dataOrError.map(
             node =>
                 ({
-                    url: node.uri.toString(),
+                    url: graphqlClient.endpoint + node.uri.toString(),
                     title: node.path,
                     ai: {
                         content: node.content,
@@ -55,7 +55,7 @@ export function createRemoteRepositoryMention(
     repo: RepoSearchResponse['repositories']['nodes'][number]
 ): Mention & { providerUri: string } {
     return {
-        uri: repo.url,
+        uri: graphqlClient.endpoint + repo.url,
         title: repo.name,
         // By default we show <title> <uri> in the mentions menu.
         // As repo.url and repo.name are almost same, we do not want to show the uri.

--- a/vscode/webviews/promptEditor/nodes/MentionComponent.tsx
+++ b/vscode/webviews/promptEditor/nodes/MentionComponent.tsx
@@ -20,7 +20,9 @@ import {
     SELECTION_CHANGE_COMMAND,
 } from 'lexical'
 import { type FunctionComponent, useCallback, useEffect, useMemo, useRef } from 'react'
+import { URI } from 'vscode-uri'
 import { Tooltip, TooltipContent, TooltipTrigger } from '../../components/shadcn/ui/tooltip'
+import { getVSCodeAPI } from '../../utils/VSCodeApi'
 import { $isContextItemMentionNode, type ContextItemMentionNode } from './ContextItemMentionNode'
 import { IS_IOS, useIsFocused } from './mentionUtils'
 
@@ -140,11 +142,29 @@ export const MentionComponent: FunctionComponent<{
                     clearSelection()
                 }
                 setSelected(true)
+
+                // metaKey is true when you press cmd on Mac while clicking.
+                if (event.metaKey) {
+                    const uri = URI.parse(node.contextItem.uri)
+
+                    if (uri.scheme === 'file') {
+                        getVSCodeAPI().postMessage({
+                            command: 'openFile',
+                            uri,
+                        })
+                    } else {
+                        getVSCodeAPI().postMessage({
+                            command: 'links',
+                            value: node.contextItem.uri,
+                        })
+                    }
+                }
+
                 return true
             }
             return false
         },
-        [clearSelection, setSelected]
+        [clearSelection, setSelected, node.contextItem.uri]
     )
 
     const onBlur = useCallback(() => {

--- a/vscode/webviews/promptEditor/nodes/MentionComponent.tsx
+++ b/vscode/webviews/promptEditor/nodes/MentionComponent.tsx
@@ -144,20 +144,12 @@ export const MentionComponent: FunctionComponent<{
                 setSelected(true)
 
                 // metaKey is true when you press cmd on Mac while clicking.
-                if (event.metaKey) {
+                if (event.metaKey && node.contextItem.uri) {
                     const uri = URI.parse(node.contextItem.uri)
-
-                    if (uri.scheme === 'file') {
-                        getVSCodeAPI().postMessage({
-                            command: 'openFile',
-                            uri,
-                        })
-                    } else {
-                        getVSCodeAPI().postMessage({
-                            command: 'links',
-                            value: node.contextItem.uri,
-                        })
-                    }
+                    getVSCodeAPI().postMessage({
+                        command: 'openURI',
+                        uri,
+                    })
                 }
 
                 return true


### PR DESCRIPTION
closes: https://linear.app/sourcegraph/issue/CODY-2503/make-mention-chips-link-to-the-uri-on-pressing-cmd-click

This PR makes the mention chips redirect to the item URI when the user presses CMD(mac) + click. 

In case the URI is a file, it opens it in a new tab. Otherwise, it opens the external link in the browser. 

## Test plan

Demo: https://www.loom.com/share/e4e7bd04fe744f4aafac43461a68ea5e?sid=6afa205a-6e66-4232-a25b-80b2ec4fc26d