### PR TITLE
PLG: Claude 3.5 Sonnet model

### DIFF
--- a/lib/shared/src/models/dotcom.ts
+++ b/lib/shared/src/models/dotcom.ts
@@ -57,6 +57,18 @@ export const DEFAULT_DOT_COM_MODELS = [
         uiGroup: ModelUIGroup.Accuracy,
     },
     {
+        title: 'Claude 3.5 Sonnet',
+        model: 'anthropic/claude-3.5-sonnet-20240620',
+        provider: 'Anthropic',
+        default: false,
+        codyProOnly: true,
+        usage: [ModelUsage.Chat, ModelUsage.Edit],
+        // Has a higher context window with a separate limit for user-context.
+        contextWindow: expandedContextWindow,
+        deprecated: false,
+        uiGroup: ModelUIGroup.Accuracy,
+    },
+    {
         title: 'Claude 3 Haiku',
         model: 'anthropic/claude-3-haiku-20240307',
         provider: 'Anthropic',

--- a/lib/shared/src/models/dotcom.ts
+++ b/lib/shared/src/models/dotcom.ts
@@ -45,8 +45,8 @@ export const DEFAULT_DOT_COM_MODELS = [
         uiGroup: ModelUIGroup.Balanced,
     },
     {
-        title: 'Claude 3 Opus',
-        model: 'anthropic/claude-3-opus-20240229',
+        title: 'Claude 3.5 Sonnet',
+        model: 'anthropic/claude-3-5-sonnet-20240620',
         provider: 'Anthropic',
         default: false,
         codyProOnly: true,
@@ -57,8 +57,8 @@ export const DEFAULT_DOT_COM_MODELS = [
         uiGroup: ModelUIGroup.Accuracy,
     },
     {
-        title: 'Claude 3.5 Sonnet',
-        model: 'anthropic/claude-3.5-sonnet-20240620',
+        title: 'Claude 3 Opus',
+        model: 'anthropic/claude-3-opus-20240229',
         provider: 'Anthropic',
         default: false,
         codyProOnly: true,

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -6,6 +6,7 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 
 ### Added
 
+Chat & Commands: New model Anthropic Claude 3.5 Sonnet available for Cody Pro users. [pull/4631](https://github.com/sourcegraph/cody/pull/4631)
 Dev: Anthropic network client for chat. [pull/4610](https://github.com/sourcegraph/cody/pull/4610)
 
 ### Fixed

--- a/vscode/src/models/utils.ts
+++ b/vscode/src/models/utils.ts
@@ -75,6 +75,7 @@ function applyLocalTokenLimitOverwrite(
 const modelWithExpandedWindowSubStrings = [
     'claude-3-opus',
     'claude-3-sonnet',
+    'claude-3.5-sonnet',
     'gemini-1.5',
     'gpt-4o',
     'gpt-4-turbo',

--- a/vscode/src/models/utils.ts
+++ b/vscode/src/models/utils.ts
@@ -75,7 +75,7 @@ function applyLocalTokenLimitOverwrite(
 const modelWithExpandedWindowSubStrings = [
     'claude-3-opus',
     'claude-3-sonnet',
-    'claude-3.5-sonnet',
+    'claude-3-5-sonnet',
     'gemini-1.5',
     'gpt-4o',
     'gpt-4-turbo',

--- a/vscode/webviews/components/modelSelectField/ModelSelectField.tsx
+++ b/vscode/webviews/components/modelSelectField/ModelSelectField.tsx
@@ -353,7 +353,9 @@ const ModelTitleWithIcon: FunctionComponent<{
         )}
         {model.provider === 'Ollama' && <span className={clsx(styles.badge)}>Experimental</span>}
         {model.title === 'Claude 3 Sonnet' ||
-        ((model.title === 'Claude 3 Opus' || model.title === 'GPT-4o') &&
+        ((model.title === 'Claude 3 Opus' ||
+            model.title === 'GPT-4o' ||
+            model.title === 'Claude 3.5 Sonnet') &&
             modelAvailability !== 'needs-cody-pro') ? (
             <span className={clsx(styles.badge, styles.otherBadge, styles.recommendedBadge)}>
                 Recommended


### PR DESCRIPTION
## DO NOT MERGE UNTIL https://github.com/sourcegraph/deploy-sourcegraph-cloud/pull/18624 IS DEPLOYED - DONE

CLOSE https://linear.app/sourcegraph/issue/CODY-2177/integrate-new-model

Add Claude 3.5 Sonnet model for Chat and Commands.
Marking it as Recommended as Claude 3.5 Sonnet is better than Opus at all the metrics: https://sourcegraph.slack.com/archives/C05AGQYD528/p1718897456502589?thread_ts=1718896254.676939&cid=C05AGQYD528

## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

Verify the new model is showing up in the model Dropdown list for Chat and Edit:
![image](https://github.com/sourcegraph/cody/assets/68532117/bb7d3fe9-a340-4e57-974a-678066a4fb18)
![image](https://github.com/sourcegraph/cody/assets/68532117/6e05729a-5413-49b1-afd8-e03f2042ba84)

Verified we are getting response from Cody Gateway using the new model id:
![image](https://github.com/sourcegraph/cody/assets/68532117/0211bc4c-fa3b-43bf-acd8-1dc6383aa2f3)
