### PR TITLE
VS Code: Patch Release 1.22.4

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -6,14 +6,30 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 
 ### Added
 
-Chat & Commands: New model Anthropic Claude 3.5 Sonnet available for Cody Pro users. [pull/4631](https://github.com/sourcegraph/cody/pull/4631)
-Dev: Anthropic network client for chat. [pull/4610](https://github.com/sourcegraph/cody/pull/4610)
-
 ### Fixed
 
 ### Changed
 
 - Chat: @-mentions are shown as chips instead of text. [pull/4539](https://github.com/sourcegraph/cody/pull/4539)
+
+## 1.22.4
+
+### Added
+
+- Autocomplete: Support Google Vertex provider exclusively for Anthropic-based models. [pull/4606](https://github.com/sourcegraph/cody/pull/4606)
+- Chat & Commands: New model Anthropic Claude 3.5 Sonnet available for Cody Pro users. [pull/4631](https://github.com/sourcegraph/cody/pull/4631)
+
+### Fixed
+
+### Changed
+
+## 1.22.3
+
+### Added
+
+### Fixed
+
+### Changed
 
 ## 1.22.2
 

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -3,7 +3,7 @@
   "name": "cody-ai",
   "private": true,
   "displayName": "Cody: AI Coding Assistant with Autocomplete & Chat",
-  "version": "1.22.2",
+  "version": "1.22.4",
   "publisher": "sourcegraph",
   "license": "Apache-2.0",
   "icon": "resources/cody.png",


### PR DESCRIPTION
CLOSE https://linear.app/sourcegraph/issue/CODY-2506/cut-vs-code-release-for-sonnet-35

Just a version bump after the patch release in https://github.com/sourcegraph/cody/pull/4632

## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

- [x] package.json
- [x] CHANGELOG