### PR TITLE
Update prompt template for openctx context items

### DIFF
--- a/lib/shared/src/prompt/prompt-string.ts
+++ b/lib/shared/src/prompt/prompt-string.ts
@@ -351,6 +351,7 @@ export class PromptString {
             repoName: contextItem.repoName
                 ? internal_createPromptString(contextItem.repoName, ref)
                 : undefined,
+            title: contextItem.title ? internal_createPromptString(contextItem.title, ref) : undefined,
         }
     }
 

--- a/vscode/src/prompt-builder/utils.ts
+++ b/vscode/src/prompt-builder/utils.ts
@@ -15,7 +15,7 @@ import { URI } from 'vscode-uri'
 
 export function renderContextItem(contextItem: ContextItem): ContextMessage | null {
     const { source, range } = contextItem
-    const { content, repoName } = PromptString.fromContextItem(contextItem)
+    const { content, repoName, title } = PromptString.fromContextItem(contextItem)
     // Do not create context item for empty file
     if (!content?.trim()?.length) {
         return null
@@ -43,8 +43,15 @@ export function renderContextItem(contextItem: ContextItem): ContextMessage | nu
             messageText = content
             break
         default:
-            messageText = populateCodeContextTemplate(content, uri, repoName)
-            break
+            // title is a required field for ContextItemOpenctx, only checking for type safety here.
+            if (contextItem.type === 'openctx' && title) {
+                messageText = ps`Content for "{title}" from {displayPath}:\n"`
+                    .replace('{title}', title)
+                    .replace('{displayPath}', PromptString.fromDisplayPath(uri))
+                    .concat(content)
+            } else {
+                messageText = populateCodeContextTemplate(content, uri, repoName)
+            }
     }
 
     return { speaker: 'human', text: messageText, file: contextItem }


### PR DESCRIPTION
closes: https://linear.app/sourcegraph/issue/CODY-2509/update-prompt-template-for-openctx-context-items

The current prompt template for all the context items is `Codebase context from file {filePath{inRepo}:\n{languageID}\n{content}`.

For OpenCtx context items such as Linear issues, it doesn't make sense. 

The updated prompt template for OpenCtx items is `Content for "{title}" from {displayPath}:\n{content}`.

## Test plan

manually tested