### PR TITLE
mentions: remote file search regex escapes and anchors inputs

### DIFF
--- a/vscode/src/context/openctx/remoteFileSearch.ts
+++ b/vscode/src/context/openctx/remoteFileSearch.ts
@@ -65,7 +65,9 @@ async function getRepoMentions(query?: string): Promise<Mention[]> {
 }
 
 async function getFileMentions(repoName: string, filePath?: string): Promise<Mention[]> {
-    const query = `repo:${repoName} type:file count:10` + ` file:${filePath || '.*'}`
+    const repoRe = `^${escapeRegExp(repoName)}$`
+    const fileRe = filePath ? escapeRegExp(filePath) : '^.*$'
+    const query = `repo:${repoRe} file:${fileRe} type:file count:10`
 
     const dataOrError = await graphqlClient.searchFileMatches(query)
 
@@ -120,6 +122,10 @@ async function getFileItem(repoName: string, filePath: string, rev = 'HEAD'): Pr
             },
         },
     ] satisfies Item[]
+}
+
+function escapeRegExp(str: string): string {
+    return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
 }
 
 export default RemoteFileProvider


### PR DESCRIPTION
Our search language takes regular expressions as input so we need to escape the user input. Additionally for repository we need to add anchors otherwise we will match all repos that contain another repo name. For example at Sourcegraph we have the deploy-sourcegraph repo as well as many example of deploy-sourcegraph-${target} repos.

Test Plan: remote file search on deploy-sourcegraph only returned filenames for deploy-sourcegraph when signed into s2. Additionally adding "." in the filename selection only selected "." and didn't match any char.

See before and after screenshots

### Before
<img width="692" alt="image" src="https://github.com/sourcegraph/cody/assets/187831/3d1908d8-21eb-439c-8aae-4acbc4babfa6">
<img width="314" alt="image" src="https://github.com/sourcegraph/cody/assets/187831/7ce9adee-2d30-44de-8fd6-cd6da722bdf2">

### After
<img width="413" alt="image" src="https://github.com/sourcegraph/cody/assets/187831/1c67bacd-65aa-499a-9928-b4421e6ded71">
<img width="303" alt="image" src="https://github.com/sourcegraph/cody/assets/187831/2ebf74a5-b6fb-4db6-a228-f389d3d01356">

Fixes https://linear.app/sourcegraph/issue/CODY-2265/regex-escape-reponame-and-filepath-for-remote-files-provider