### PR TITLE
Agent: fix Kotlin bindings script

### DIFF
--- a/agent/scripts/generate-agent-kotlin-bindings.sh
+++ b/agent/scripts/generate-agent-kotlin-bindings.sh
@@ -7,11 +7,13 @@ if [ ! -d $INDEXER_DIR ]; then
 fi
 
 pushd $INDEXER_DIR
+git fetch origin
 git checkout olafurpg/signatures-rebase1
 git pull origin olafurpg/signatures-rebase1
 yarn install
 popd
 
+pnpm install
 pnpm build
 # TODO: invoke @sourcegraph/scip-typescript npm package instead
 pnpm dlx ts-node $INDEXER_DIR/src/main.ts index --emit-signatures --emit-external-symbols


### PR DESCRIPTION
We recently changed the script and it's missing a `git fetch origin` step. Reported here https://github.com/sourcegraph/cody/pull/4583/files#r1648367376

While testing the script locally, I also noticed it was missing a `pnpm install` step in the cody repo.


## Test plan

Run `pnpm generate-agent-kotlin-bindings` and it succeeds

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
