### PR TITLE
Autocomplete: log resolved model for cached results

### DIFF
--- a/vscode/src/completions/get-inline-completions.ts
+++ b/vscode/src/completions/get-inline-completions.ts
@@ -315,6 +315,7 @@ async function doGetInlineCompletions(
     if (cachedResult) {
         const { completions, source } = cachedResult
 
+        CompletionLogger.start(logId)
         CompletionLogger.loaded(logId, requestParams, completions, source, isDotComUser)
 
         return {

--- a/vscode/src/completions/logger.test.ts
+++ b/vscode/src/completions/logger.test.ts
@@ -56,13 +56,16 @@ describe('logger', () => {
     })
 
     it('logs a suggestion life cycle', () => {
-        const item = { id: completionItemId, insertText: 'foo' }
+        const item = {
+            id: completionItemId,
+            insertText: 'foo',
+            resolvedModel: 'blazing-fast-llm-resolved',
+        }
         const id = CompletionLogger.create(defaultArgs)
         expect(typeof id).toBe('string')
 
         CompletionLogger.start(id)
         CompletionLogger.networkRequestStarted(id, defaultContextSummary)
-        CompletionLogger.gatewayModelResolved(id, 'gateway-model')
         CompletionLogger.loaded(
             id,
             defaultRequestParams,
@@ -85,7 +88,7 @@ describe('logger', () => {
             otherCompletionProviders: [],
             providerIdentifier: 'bfl',
             providerModel: 'blazing-fast-llm',
-            resolvedModel: 'gateway-model',
+            resolvedModel: 'blazing-fast-llm-resolved',
             medianUpstreamLatency: undefined,
             contextSummary: {
                 retrieverStats: {},

--- a/vscode/src/completions/text-processing/process-inline-completions.ts
+++ b/vscode/src/completions/text-processing/process-inline-completions.ts
@@ -20,6 +20,7 @@ interface ProcessInlineCompletionsParams {
 
 export interface InlineCompletionItemWithAnalytics extends ItemPostProcessingInfo, InlineCompletionItem {
     stopReason?: string
+    resolvedModel?: string
 }
 
 /**
@@ -52,17 +53,18 @@ export function processInlineCompletions(
     return rankedResults.map(dropParserFields)
 }
 
-interface ProcessItemParams {
+export interface ProcessItemParams {
     document: TextDocument
     position: Position
     docContext: DocumentContext
+    resolvedModel?: string
 }
 
 export function processCompletion(
     completion: ParsedCompletion,
     params: ProcessItemParams
 ): ParsedCompletion {
-    const { document, position, docContext } = params
+    const { document, position, docContext, resolvedModel } = params
     const { prefix, suffix, currentLineSuffix, multilineTrigger, multilineTriggerPosition } = docContext
     let { insertText } = completion
 
@@ -99,6 +101,10 @@ export function processCompletion(
         parseTree: completion.tree,
         multilineTriggerPosition,
     })
+
+    // Assign the resolved model to `InlineCompletionItemWithAnalytics` to make it available
+    // for analytics events when completions are synthesized from cache.
+    completion.resolvedModel = resolvedModel
 
     if (multilineTrigger) {
         insertText = removeTrailingWhitespace(insertText)


### PR DESCRIPTION
- Logs resolved model for cached autocomplete items by attaching this value to `InlineCompletionItemWithAnalytics` which is cached, instead of adding it directly to analytics events.
- Fixes the issue with logging cached completion suggestion events. Some of them were not logged because we didn't have a `CompletionLogger.start()` call. This part of the logger is fragile. The type system and existing abstraction don't guard us from making such mistakes. Created [a follow-up issue](https://linear.app/sourcegraph/issue/CODY-2520/[autocomplete-latency]-improve-autocomplete-client-logger-resiliency) to address that.
- Closes https://linear.app/sourcegraph/issue/CODY-2521/[autocomplete-latency]-log-resolved-model-for-cached-autocomplete
- Closes https://linear.app/sourcegraph/issue/CODY-2522/[autocomplete-latency]-fix-the-bug-that-causes-the

## Test plan

Updated unit tests and tested locally by accepting cached autocomplete events and observing `resolvedModel` under the `privateMetadata` field.
