### PR TITLE
fix loading of linux certs for agent

### DIFF
--- a/agent/src/certs.ts
+++ b/agent/src/certs.ts
@@ -44,7 +44,7 @@ function addLinuxCerts() {
 
     try {
         cas.push(...loadLinuxCerts())
-    } catch(err) {
+    } catch (err) {
         console.warn('Error loading linux certs', err)
     }
     globalAgent.options.ca = cas

--- a/agent/src/certs.ts
+++ b/agent/src/certs.ts
@@ -28,7 +28,7 @@ export function registerLocalCertificates() {
     }
 }
 
-const linuxPossibleCertPaths = ['/etc/ssl/certs/ca-certificates.crt', '/etc/ssl/certs/ca-bundle.crt', '/home/noah/.local/share/caddy/certificates/local/sourcegraph.test/sourcegraph.test.crt']
+const linuxPossibleCertPaths = ['/etc/ssl/certs/ca-certificates.crt', '/etc/ssl/certs/ca-bundle.crt']
 
 function addLinuxCerts() {
     if (process.platform !== 'linux') {


### PR DESCRIPTION
`globalAgent.options.ca` was always set to empty array because the function returns _before_ the promise from `loadLinuxCerts()` resolves

## Test plan

Tested locally with print statements, it was not working for me otherwise