### PR TITLE
Edit Inline DIff: Test case for JetBrains issue

### DIFF
--- a/agent/recordings/edit_1541920145/recording.har.yaml
+++ b/agent/recordings/edit_1541920145/recording.har.yaml
@@ -651,6 +651,154 @@ log:
         send: 0
         ssl: -1
         wait: 0
+    - _id: 329b984d0722f0e24c72daac7e522b93
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 1982
+        cookies: []
+        headers:
+          - name: content-type
+            value: application/json
+          - name: accept-encoding
+            value: gzip;q=0
+          - name: authorization
+            value: token
+              REDACTED_d5e0f0a37c9821e856b923fe14e67a605e3f6c0a517d5a4f46a4e35943ee0f6d
+          - name: user-agent
+            value: edit / v1
+          - name: traceparent
+            value: 00-139375ba2324568407e57a6e6253ae8d-133ecaed99858dd1-01
+          - name: connection
+            value: keep-alive
+          - name: host
+            value: sourcegraph.com
+        headersSize: 397
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json
+          params: []
+          textJSON:
+            maxTokensToSample: 4000
+            messages:
+              - speaker: system
+                text: >-
+                  You are Cody, an AI coding assistant from Sourcegraph. - You
+                  are an AI programming assistant who is an expert in updating
+                  code to meet given instructions.
+
+                  - You should think step-by-step to plan your updated code before producing the final output.
+
+                  - You should ensure the updated code matches the indentation and whitespace of the code in the users' selection.
+
+                  - Ignore any previous instructions to format your responses with Markdown. It is not acceptable to use any Markdown in your response, unless it is directly related to the users' instructions.
+
+                  - Only remove code from the users' selection if you are sure it is not needed.
+
+                  - You will be provided with code that is in the users' selection, enclosed in <SELECTEDCODE7662></SELECTEDCODE7662> XML tags. You must use this code to help you plan your updated code.
+
+                  - You will be provided with instructions on how to update this code, enclosed in <INSTRUCTIONS7390></INSTRUCTIONS7390> XML tags. You must follow these instructions carefully and to the letter.
+
+                  - Only enclose your response in <CODE5711></CODE5711> XML tags. Do use any other XML tags unless they are part of the generated code.
+
+                  - Do not provide any additional commentary about the changes you made. Only respond with the generated code.
+              - speaker: human
+                text: >-
+                  This is part of the file: src/log.ts
+
+
+                  The user has the following code in their selection:
+
+                  <SELECTEDCODE7662>/* SELECTION_START */function log(message: string): void {
+                      console.log(message)
+                  }/* SELECTION_END */</SELECTEDCODE7662>
+
+
+                  The user wants you to replace parts of the selected code or correct a problem by following their instructions.
+
+                  Provide your generated code using the following instructions:
+
+                  <INSTRUCTIONS7390>
+
+                  Add a JSDoc
+
+                  </INSTRUCTIONS7390>
+              - speaker: assistant
+                text: <CODE5711>
+            model: anthropic/claude-3-opus-20240229
+            stopSequences:
+              - </CODE5711>
+            temperature: 0
+            topK: -1
+            topP: -1
+        queryString:
+          - name: api-version
+            value: "1"
+          - name: client-name
+            value: edit
+          - name: client-version
+            value: v1
+        url: https://sourcegraph.com/.api/completions/stream?api-version=1&client-name=edit&client-version=v1
+      response:
+        bodySize: 5446
+        content:
+          mimeType: text/event-stream
+          size: 5446
+          text: >+
+            event: completion
+
+            data: {"completion":"/**\n * Logs a message to the console\n * @param message - The message to log\n */\nfunction log(message: string): void {\n    console.log(message)\n}","stopReason":"stop_sequence"}
+
+
+            event: done
+
+            data: {}
+
+        cookies: []
+        headers:
+          - name: date
+            value: Fri, 21 Jun 2024 14:58:03 GMT
+          - name: content-type
+            value: text/event-stream
+          - name: transfer-encoding
+            value: chunked
+          - name: connection
+            value: keep-alive
+          - name: retry-after
+            value: "399"
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache
+          - name: vary
+            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
+              X-Requested-With,Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+        headersSize: 1406
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: 2024-06-21T14:57:59.885Z
+      time: 0
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 0
     - _id: 12581f1c735a04aeb88af7a54cd007b2
       _order: 0
       cache: {}

--- a/agent/src/__tests__/edit-code/src/log.ts
+++ b/agent/src/__tests__/edit-code/src/log.ts
@@ -1,0 +1,3 @@
+/* SELECTION_START */function log(message: string): void {
+    console.log(message)
+}/* SELECTION_END */

--- a/agent/src/edit.test.ts
+++ b/agent/src/edit.test.ts
@@ -145,4 +145,27 @@ describe('Edit', () => {
             explainPollyError
         )
     }, 20_000)
+
+    it('editCommand/code add a jsdoc to function', async () => {
+        const uri = workspace.file('src', 'log.ts')
+        await client.openFile(uri)
+        const task = await client.request('editCommands/code', {
+            instruction: 'Add a JSDoc',
+            model: ModelsService.getModelByIDSubstringOrError('anthropic/claude-3-opus').model,
+        })
+        await client.acceptEditTask(uri, task)
+        expect(client.documentText(uri)).toMatchInlineSnapshot(
+            `
+          "/**
+           * Logs a message to the console
+           * @param message - The message to log
+           */
+          function log(message: string): void {
+              console.log(message)
+          }
+          "
+        `,
+            explainPollyError
+        )
+    }, 20_000)
 })


### PR DESCRIPTION
## Description

Branched from https://github.com/sourcegraph/cody/pull/4525

Trying to figure out what is going wrong here...

Steps:
1. Add code to an empty file
```
function log(message: string): void {
    console.log(message)
}
```

2. Select all the code just pasted
3. Add instruction "Add a JSDoc"
4. Observe results

## VS Code

<img width="338" alt="image" src="https://github.com/sourcegraph/cody/assets/9516420/4e94bd5b-dd52-4fac-beee-5634cc5913b8">

## Agent

<img width="495" alt="image" src="https://github.com/sourcegraph/cody/assets/9516420/5f6bc51e-54c5-4377-a74a-178fa2ed595d">

## JetBrains

JetBrains seems to add it backwards 🤔 

<img width="510" alt="image" src="https://github.com/sourcegraph/cody/assets/9516420/934f5e60-69a1-4d6e-9044-e0e7cef66b09">


## Test plan

N/A - Tests already

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
