### PR TITLE
vscode: use NetworkError in nodeClient

### DIFF
--- a/lib/shared/src/sourcegraph-api/errors.ts
+++ b/lib/shared/src/sourcegraph-api/errors.ts
@@ -68,7 +68,7 @@ export class NetworkError extends Error {
     public readonly status: number
 
     constructor(
-        response: BrowserOrNodeResponse,
+        response: Pick<BrowserOrNodeResponse, 'url' | 'status' | 'statusText'>,
         content: string,
         public traceId: string | undefined
     ) {


### PR DESCRIPTION
I was running into a cloudflare issue on s2 when communicating with the LLM. It was quite hard to diagnose since the error message and our logging only contained the response body. This updates SourcegraphNodeCompletionsClient to use NetworkError in the same way our code completions client uses it.

Side-note: it seems like there is a lot of duplication. It seems like there is an opportunity to share code. In particular the code completion client seems well written and more effectively uses instrumentation and error wrapping.

Test Plan: while I could reproduce cloudflare issues I manually tested that the error response shown improved.

### Before
![image](https://github.com/sourcegraph/cody/assets/187831/76813ce1-ec6d-4742-ac69-a5cc925dcc71)

### After
![image](https://github.com/sourcegraph/cody/assets/187831/4af02a66-f022-477f-a11a-f579dd6e5608)
