### PR TITLE
fixing recordsPrivateMetadata field when the private context is empty

### DIFF
--- a/vscode/src/completions/get-inline-completions.ts
+++ b/vscode/src/completions/get-inline-completions.ts
@@ -404,6 +404,7 @@ async function doGetInlineCompletions(
 
     const inlineContextParams = {
         context: contextResult?.context,
+        filePath: gitIdentifiersForFile?.filePath,
         gitUrl: gitIdentifiersForFile?.gitUrl,
         commit: gitIdentifiersForFile?.commit,
     }

--- a/vscode/src/completions/logger.ts
+++ b/vscode/src/completions/logger.ts
@@ -62,6 +62,7 @@ export interface InlineCompletionItemRetrievedContext {
 
 export interface InlineContextItemsParams {
     context: AutocompleteContextSnippet[]
+    filePath: string | undefined
     gitUrl: string | undefined
     commit: string | undefined
 }
@@ -69,11 +70,12 @@ export interface InlineContextItemsParams {
 export interface InlineCompletionItemContext {
     gitUrl: string
     commit?: string
-    prefix: string
-    suffix: string
-    triggerLine: number
-    triggerCharacter: number
-    context: InlineCompletionItemRetrievedContext[]
+    filePath?: string
+    prefix?: string
+    suffix?: string
+    triggerLine?: number
+    triggerCharacter?: number
+    context?: InlineCompletionItemRetrievedContext[]
 }
 
 interface InteractionIDPayload {
@@ -252,7 +254,8 @@ function logCompletionSuggestedEvent(
             version: 0,
             metadata: {
                 ...metadata,
-                recordsPrivateMetadataTranscript: isDotComUser ? 1 : 0,
+                recordsPrivateMetadataTranscript:
+                    isDotComUser && inlineCompletionItemContext !== undefined ? 1 : 0,
             },
             privateMetadata,
         },
@@ -589,11 +592,16 @@ export function loaded(
         // Get the metadata only if already cached, We don't wait for the network call here.
         const gitRepoMetadata = instance.getRepoMetadataIfCached(inlineContextParams.gitUrl)
         if (gitRepoMetadata === undefined || gitRepoMetadata.isPublic === false) {
+            // 🚨 SECURITY: For Non-Public git Repos, We can only log the Url but not the code.
+            event.params.inlineCompletionItemContext = {
+                gitUrl: inlineContextParams.gitUrl,
+            }
             return
         }
         event.params.inlineCompletionItemContext = {
             gitUrl: inlineContextParams.gitUrl,
             commit: inlineContextParams.commit,
+            filePath: inlineContextParams.filePath,
             prefix: params.docContext.prefix,
             suffix: params.docContext.suffix,
             triggerLine: params.position.line,
@@ -817,9 +825,9 @@ function getInlineContextItemToLog(
     const MAX_CHARACTERS = 20_000
     return {
         ...inlineCompletionItemContext,
-        prefix: inlineCompletionItemContext.prefix.slice(-MAX_CHARACTERS),
-        suffix: inlineCompletionItemContext.suffix.slice(0, MAX_CHARACTERS),
-        context: inlineCompletionItemContext.context.slice(0, MAX_CONTEXT_ITEMS).map(c => ({
+        prefix: inlineCompletionItemContext.prefix?.slice(-MAX_CHARACTERS),
+        suffix: inlineCompletionItemContext.suffix?.slice(0, MAX_CHARACTERS),
+        context: inlineCompletionItemContext.context?.slice(0, MAX_CONTEXT_ITEMS).map(c => ({
             ...c,
             content: c.content.slice(0, MAX_CHARACTERS),
         })),

--- a/vscode/src/completions/logger.ts
+++ b/vscode/src/completions/logger.ts
@@ -592,9 +592,10 @@ export function loaded(
         // Get the metadata only if already cached, We don't wait for the network call here.
         const gitRepoMetadata = instance.getRepoMetadataIfCached(inlineContextParams.gitUrl)
         if (gitRepoMetadata === undefined || gitRepoMetadata.isPublic === false) {
-            // 🚨 SECURITY: For Non-Public git Repos, We can only log the Url but not the code.
+            // 🚨 SECURITY: For Non-Public git Repos, We cannot log any code related information, just git url and commit.
             event.params.inlineCompletionItemContext = {
                 gitUrl: inlineContextParams.gitUrl,
+                commit: inlineContextParams.commit,
             }
             return
         }

--- a/vscode/src/repository/git-metadata-for-editor.ts
+++ b/vscode/src/repository/git-metadata-for-editor.ts
@@ -5,6 +5,7 @@ import { repoNameResolver } from '../repository/repo-name-resolver'
 import { gitCommitIdFromGitExtension } from './git-extension-api'
 
 export interface GitIdentifiersForFile {
+    filePath?: string
     gitUrl?: string
     commit?: string
 }
@@ -36,6 +37,7 @@ class GitMetadataForCurrentEditor {
         if (currentFile) {
             const commit = gitCommitIdFromGitExtension(currentFile)
             newGitIdentifiersForFile = {
+                filePath: currentFile.fsPath,
                 gitUrl: gitUrl,
                 commit: commit,
             }


### PR DESCRIPTION
## Context
This PR make the following changes:
1. Fix the `recordsPrivateMetadataTranscript` in case no private metadata is send to the telemetry. Earlier we were always sending `1` in this fields even if there was no private metadata. More context behind the fix [on the slack thread](https://sourcegraph.slack.com/archives/CN4FC7XT4/p1718914278731939?thread_ts=1718821081.192759&cid=CN4FC7XT4).
2. Adds a `filePath` variable to the logging for only the `dotComUsers` and `publicGitHubRepos`, which indicates for which file the completion was triggered.
3. Adds a `gitUrl` variable for the `dotComUsers` repos. More context on [the slack thread.](https://sourcegraph.slack.com/archives/CN4FC7XT4/p1719001526612899?thread_ts=1716253514.127349&cid=CN4FC7XT4)

## Test plan
**Manual testing**
1. Start the debugger from this branch. For any new autocomplete request, the telemetry response for the "cody.completion/suggested" will have`recordsPrivateMetadataTranscript: 1` only if the value is non-null.
2. The `inlineCompletionItemContext` field will have one additional variable `filePath` indicating the file for which the autocomplete was triggered.

