### PR TITLE
CLI: print to stdout instead of stderr

### DIFF
--- a/cli/src/chat.ts
+++ b/cli/src/chat.ts
@@ -44,13 +44,13 @@ export const chatCommand = new Command('chat')
                 contextRepositoryNames: options.contextRepo,
             })
             if (options.showContext) {
-                console.log('> Context items:')
+                process.stdout.write('> Context items:\n')
                 for (const [i, item] of contextFiles.entries()) {
-                    console.log(`> ${i + 1}. ${item}`)
+                    process.stdout.write(`> ${i + 1}. ${item}\n`)
                 }
-                console.log()
+                process.stdout.write('\n')
             }
-            console.log(text)
+            process.stdout.write(text + '\n')
             client.dispose()
         }
     )


### PR DESCRIPTION
Fixes CODY-2502

Previously, the experimental cli printed all output to stderr making it cumbersome to pipe the output into other cli tools. The reason for this was that we change `console.log` to become `console.error` when the agent cli starts up. The motivation for this behavior is that the Cody codebase has a lot of `console.log` statements that are used for debugging purposes, and we don't have any linting rules to prevent these statements from getting added.  This PR changes the behavior so that cli uses `process.stdout` explicitly to ensure the cli output goes to stdout. This gives us fine-grained control over what the cli outputs.

Implementation detail: I considered fixing this issue by removing the `console.log` remapping to `console.error` when we run the cli. I'm not 100% opposed to this approach because I don't like writing `process.stdout.write(... + '\n')`. However, I chose not to go this route because I think it's important for cli tools to be intentional about what goes to stdout since it's effectively the contract/API of the cli.


## Test plan

* Authenticate to S2
* `cd agent && pnpm build:agent`
* `node dist/index.js experimental-cli chat -m "What is the agent?" --context-repo github.com/sourcegraph/cody | less`
* Confirm that the answer gets piped to `less` (meaning it goes to stdout)
```
Based on the provided codebase context, [...]

1. The agent is implemented as a JSON-RPC server that interacts with Cody via stdout/stdin. This is mentioned in the `/agent/README.md` file.
[...]
```
<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
