### PR TITLE
mentions: update text node rather than replace

### DIFF
--- a/vscode/webviews/mentions/mentionMenu/MentionMenu.tsx
+++ b/vscode/webviews/mentions/mentionMenu/MentionMenu.tsx
@@ -115,10 +115,12 @@ export const MentionMenu: FunctionComponent<
                 throw new Error(`No provider found with value ${value}`)
             }
 
+            updateMentionMenuParams({ parentItem: provider })
+
             if (params.query !== '') {
                 // Remove provider search input only and keep the rest of the query.
                 setEditorQuery(currentText => {
-                    const mentionStartIndex = currentText.indexOf(mentionQuery.text)
+                    const mentionStartIndex = currentText.lastIndexOf(mentionQuery.text)
 
                     if (mentionStartIndex !== -1) {
                         const mentionEndIndex = mentionStartIndex + mentionQuery.text.length
@@ -130,7 +132,6 @@ export const MentionMenu: FunctionComponent<
                     return ''
                 })
             }
-            updateMentionMenuParams({ parentItem: provider })
             setValue(null)
         },
         [data.providers, params.query, setEditorQuery, updateMentionMenuParams, mentionQuery]


### PR DESCRIPTION
Previously whenever setEditorQuery was called we would replace the @-mention node. However, this lead to the anchor reference for the mention menu to no longer be visible, leading to the position of the mention menu moving to (0, 0).

Note that if you triggered the @-mention menu without typing anything into selection first, this wouldn't call setEditorQuery which is why the behaviour didn't always happen.

Right now all of the text is around your @-mention is a single text node. This meant that our previous naive text manipulation and setting of cursor had several easy to trigger bugs. We make the behaviour more correct now, but not perfect. To be perfect at replacement time and updating time we need to know where the cursor is. The "more correct" is now to do replacement from the end of the string as well as placing the cursor just after the "@" sign.

We also move updateMentionMenuParams to happen in the same order as in other parts of the code for consistency.

Test Plan: Lots of manual testing of the mention provider, with the completion happening in different parts of the text and with different providers.

Fixes https://linear.app/sourcegraph/issue/CODY-2357/mention-menu-positioning-in-top-left-for-notion-provider