### PR TITLE
mentions: onMentionClick focusses if input already has @

### DIFF
--- a/vscode/webviews/chat/cells/messageCell/human/editor/HumanMessageEditor.tsx
+++ b/vscode/webviews/chat/cells/messageCell/human/editor/HumanMessageEditor.tsx
@@ -185,7 +185,11 @@ export const HumanMessageEditor: FunctionComponent<{
         if (!editorRef.current) {
             throw new Error('No editorRef')
         }
-        editorRef.current.appendText('@', true)
+        if (editorRef.current.getSerializedValue().text.trim().endsWith('@')) {
+            editorRef.current.setFocus(true, { moveCursorToEnd: true })
+        } else {
+            editorRef.current.appendText('@', true)
+        }
 
         const value = editorRef.current.getSerializedValue()
         telemetryRecorder.recordEvent('cody.humanMessageEditor.toolbar.mention', 'click', {


### PR DESCRIPTION
Before this change we always added @ leading to confusing behaviour such as only filtering for files containing @.

Test Plan: Manually tested clicking the "@" button when the text already has a "@". See video below

https://github.com/sourcegraph/cody/assets/187831/adb5b8a2-be12-4d78-9b7e-9818cb2f0569

Fixes https://linear.app/sourcegraph/issue/CODY-2470/duplicated-mentions-in-cody-chat-in-vscode-unexpectedly-filters-to
