### PR TITLE
cody-bench: exit the process after finishing

### DIFF
--- a/agent/src/cli/cody-bench/cody-bench.ts
+++ b/agent/src/cli/cody-bench/cody-bench.ts
@@ -309,6 +309,7 @@ export const codyBenchCommand = new commander.Command('cody-bench')
         } finally {
             await polly.stop()
         }
+        process.exit(0)
     })
 
 async function evaluateWorkspace(options: CodyBenchOptions, recordingDirectory: string): Promise<void> {


### PR DESCRIPTION
When running the tool locally, I noticed that it was hanging after completing the eval run. Probably, what's happening is that there's some background promise that hasn't completed running. I didn't experience this when I originally created the tool so it looks like a regression. This PR "fixes" the problem by calling `process.exit(0)`, which is good enough to unblock usage of the tool


## Test plan

Clone sourcegraph/cody-leaderboard next to the cody repo. Run this from the Cody repo
```
pnpm install
pnpm build
cd agent
pnpm agent:skip-root-build cody-bench --evaluation-config ../../cody-leaderboard/fix-bench.json
```
<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
