### PR TITLE
chat: always use range if there is an active selection

### DIFF
--- a/lib/shared/src/common/range.test.ts
+++ b/lib/shared/src/common/range.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'vitest'
-import { displayLineRange, displayRange, isMultiLineRange, toRangeData } from './range'
+import { displayLineRange, displayRange, expandToLineRange, toRangeData } from './range'
 
 describe('toRangeData', () => {
     test('converts Range to RangeData', () => {
@@ -83,16 +83,34 @@ describe('displayRange', () => {
             displayRange({ start: { line: 1, character: 2 }, end: { line: 3, character: 4 } }).toString()
         ).toBe('2:3-4:5'))
 })
-describe('isMultiLineRange', () => {
-    test('ok', () => {
-        expect(
-            isMultiLineRange({ start: { line: 1, character: 0 }, end: { line: 1, character: 31 } })
-        ).toBe(false)
-        expect(
-            isMultiLineRange({ start: { line: 1, character: 0 }, end: { line: 2, character: 0 } })
-        ).toBe(false)
-        expect(
-            isMultiLineRange({ start: { line: 1, character: 0 }, end: { line: 2, character: 1 } })
-        ).toBe(true)
+describe('expandToLineRange', () => {
+    test('expands range to whole line', () => {
+        const input = { start: { line: 1, character: 2 }, end: { line: 3, character: 4 } }
+        const expected = { start: { line: 1, character: 0 }, end: { line: 4, character: 0 } }
+        expect(expandToLineRange(input)).toEqual(expected)
+    })
+
+    test('handles range with end character at 0', () => {
+        const input = { start: { line: 1, character: 2 }, end: { line: 3, character: 0 } }
+        const expected = { start: { line: 1, character: 0 }, end: { line: 3, character: 0 } }
+        expect(expandToLineRange(input)).toEqual(expected)
+    })
+
+    test('expands single-line range', () => {
+        const input = { start: { line: 5, character: 10 }, end: { line: 5, character: 20 } }
+        const expected = { start: { line: 5, character: 0 }, end: { line: 6, character: 0 } }
+        expect(expandToLineRange(input)).toEqual(expected)
+    })
+
+    test('handles zero-width range', () => {
+        const input = { start: { line: 7, character: 15 }, end: { line: 7, character: 15 } }
+        const expected = { start: { line: 7, character: 0 }, end: { line: 8, character: 0 } }
+        expect(expandToLineRange(input)).toEqual(expected)
+    })
+
+    test('expands range spanning multiple lines', () => {
+        const input = { start: { line: 10, character: 5 }, end: { line: 15, character: 8 } }
+        const expected = { start: { line: 10, character: 0 }, end: { line: 16, character: 0 } }
+        expect(expandToLineRange(input)).toEqual(expected)
     })
 })

--- a/lib/shared/src/index.ts
+++ b/lib/shared/src/index.ts
@@ -91,7 +91,7 @@ export {
     toRangeData,
     displayLineRange,
     displayRange,
-    isMultiLineRange,
+    expandToLineRange,
 } from './common/range'
 export * from './common/abortController'
 export {

--- a/vscode/src/chat/clientStateBroadcaster.ts
+++ b/vscode/src/chat/clientStateBroadcaster.ts
@@ -5,7 +5,7 @@ import {
     contextFiltersProvider,
     displayLineRange,
     displayPathBasename,
-    isMultiLineRange,
+    expandToLineRange,
 } from '@sourcegraph/cody-shared'
 import * as vscode from 'vscode'
 import { getSelectionOrFileContext } from '../commands/context/selection'
@@ -89,8 +89,7 @@ export function startClientStateBroadcaster({
         const [contextFile] = await getSelectionOrFileContext()
         signal?.throwIfAborted()
         if (contextFile) {
-            const range =
-                contextFile.range && isMultiLineRange(contextFile.range) ? contextFile.range : undefined
+            const range = contextFile.range ? expandToLineRange(contextFile.range) : undefined
             const item = {
                 ...contextFile,
                 type: 'file',

--- a/vscode/test/e2e/chat-keyboard-shortcuts.test.ts
+++ b/vscode/test/e2e/chat-keyboard-shortcuts.test.ts
@@ -19,7 +19,6 @@ test('chat keyboard shortcuts', async ({ page, sidebar }) => {
 
     // Alt+L with no selection opens a new chat (with file mention).
     await openFileInEditorTab(page, 'buzz.ts')
-    await selectLineRangeInEditorTab(page, 3)
     await page.keyboard.press('Alt+L')
     await expect(chatInput).toHaveText('buzz.ts ')
 


### PR DESCRIPTION
For the auto-updating "Current File" context we only made it a "Current Selection" if the selection was multi-line. I am unsure why we had this behaviour, this seems more correct.

I came across this while looking into https://linear.app/sourcegraph/issue/CODY-2276/buggy-line-range-logic-for-open-files-in-new-chat

Test Plan: loads of testing with selecting. See video.

https://github.com/sourcegraph/cody/assets/187831/01ad21d0-6e14-4dfa-a2d2-9485f2cea51b
