### PR TITLE
mentions: add built-in linear-issues provider using linear connect for auth

### DIFF
--- a/vscode/src/context/openctx.ts
+++ b/vscode/src/context/openctx.ts
@@ -1,6 +1,7 @@
 import { type ConfigurationWithAccessToken, setOpenCtxClient } from '@sourcegraph/cody-shared'
 import * as vscode from 'vscode'
 import { logDebug, outputChannel } from '../log'
+import LinearIssuesProvider from './openctx/linear-issues'
 import RemoteFileProvider from './openctx/remoteFileSearch'
 import RemoteRepositorySearch from './openctx/remoteRepositorySearch'
 import WebProvider from './openctx/web'
@@ -27,11 +28,18 @@ export async function exposeOpenCtxClient(
         ]
 
         if (config.experimentalNoodle) {
-            providers.push({
-                providerUri: RemoteFileProvider.providerUri,
-                settings: true,
-                provider: RemoteFileProvider,
-            })
+            providers.push(
+                {
+                    providerUri: RemoteFileProvider.providerUri,
+                    settings: true,
+                    provider: RemoteFileProvider,
+                },
+                {
+                    providerUri: LinearIssuesProvider.providerUri,
+                    settings: true,
+                    provider: LinearIssuesProvider,
+                }
+            )
         }
 
         setOpenCtxClient(

--- a/vscode/src/context/openctx/linear-issues.ts
+++ b/vscode/src/context/openctx/linear-issues.ts
@@ -95,10 +95,21 @@ const LinearIssuesProvider: Provider & { providerUri: string } = {
 
 export default LinearIssuesProvider
 
+const LINEAR_AUTHENTICATION_EXTENSION_ID = 'linear.linear-connect'
 const LINEAR_AUTHENTICATION_PROVIDER_ID = 'linear'
 const LINEAR_AUTHENTICATION_SCOPES = ['read']
 
 async function linearApiRequest(query: string, variables: object): Promise<{ data: any }> {
+    const ext = vscode.extensions.getExtension(LINEAR_AUTHENTICATION_EXTENSION_ID)
+    if (!ext) {
+        vscode.window.showWarningMessage(
+            'Cody requires the Linear Connect extension to be installed and activated.'
+        )
+        await vscode.commands.executeCommand('workbench.extensions.action.showExtensionsWithIds', [
+            [LINEAR_AUTHENTICATION_EXTENSION_ID],
+        ])
+    }
+
     const session = await vscode.authentication.getSession(
         LINEAR_AUTHENTICATION_PROVIDER_ID,
         LINEAR_AUTHENTICATION_SCOPES,

--- a/vscode/src/context/openctx/linear-issues.ts
+++ b/vscode/src/context/openctx/linear-issues.ts
@@ -1,0 +1,196 @@
+import type { Provider } from '@openctx/client'
+import dedent from 'dedent'
+import { XMLBuilder } from 'fast-xml-parser'
+
+const xmlBuilder = new XMLBuilder({ format: true })
+
+interface Issue {
+    identifier: string
+    title: string
+    url: string
+    description: string
+    comments?: {
+        nodes: Comment[]
+    }
+}
+
+interface Comment {
+    body: string
+}
+
+const NUMBER_OF_ISSUES_TO_FETCH = 10
+
+const LinearIssuesProvider: Provider & { providerUri: string } = {
+    providerUri: 'internal-linear-issues',
+
+    meta() {
+        return { name: 'Linear Issues', mentions: {} }
+    },
+
+    async mentions({ query }) {
+        let issues: Issue[] = []
+
+        if (query) {
+            const variables = { query, first: NUMBER_OF_ISSUES_TO_FETCH }
+            const response = await linearApiRequest(issueSearchQuery, variables)
+            issues = response.data.issueSearch.nodes as Issue[]
+        } else {
+            const variables = { first: NUMBER_OF_ISSUES_TO_FETCH / 2 }
+            const response = await linearApiRequest(viewerIssuesQuery, variables)
+
+            const createdIssues = response.data.viewer.createdIssues.nodes as Issue[]
+            const assignedIssues = response.data.viewer.assignedIssues.nodes as Issue[]
+            issues = dedupeWith([...assignedIssues, ...createdIssues], 'url')
+        }
+
+        const mentions = (issues ?? []).map(issue => ({
+            title: `${issue.identifier} ${issue.title}`,
+            uri: issue.url,
+            description: issue.description,
+        }))
+
+        return mentions
+    },
+
+    async items(params) {
+        if (!params.mention) {
+            return []
+        }
+
+        const issueId = parseIssueIDFromURL(params.mention.uri)
+        if (!issueId) {
+            return []
+        }
+
+        const variables = { id: issueId }
+        const data = await linearApiRequest(issueWithCommentsQuery, variables)
+        const issue = data.data.issue as Issue
+        const comments = issue.comments?.nodes as Comment[]
+
+        const issueInfo = xmlBuilder.build({
+            title: issue.title,
+            description: issue.description || '',
+            comments: comments.map(comment => comment.body).join('\n'),
+            url: issue.url,
+        })
+        const content = dedent`
+            Here is the Linear issue. Use it to check if it helps.
+            Ignore it if it is not relevant.
+
+            ${issueInfo}
+        `
+
+        return [
+            {
+                title: issue.title,
+                url: issue.url,
+                ai: {
+                    content,
+                },
+            },
+        ]
+    },
+}
+
+export default LinearIssuesProvider
+
+async function linearApiRequest(query: string, variables: object): Promise<{ data: any }> {
+    const accessToken = 'TODO'
+    const response = await fetch('https://api.linear.app/graphql', {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${accessToken}`,
+        },
+        body: JSON.stringify({ query, variables }),
+    })
+
+    if (!response.ok) {
+        throw new Error(`Linear API request failed: ${response.statusText}`)
+    }
+
+    const json = (await response.json()) as { data: object }
+
+    if (!json.data) {
+        throw new Error('Linear API request failed: no data')
+    }
+
+    return json
+}
+
+function parseIssueIDFromURL(urlStr: string): string | undefined {
+    const url = new URL(urlStr)
+    if (!url.hostname.endsWith('linear.app')) {
+        return undefined
+    }
+    const match = url.pathname.match(/\/issue\/([a-zA-Z0-9_-]+)/)
+    return match ? match[1] : undefined
+}
+
+const dedupeWith = <T>(items: T[], key: keyof T | ((item: T) => string)): T[] => {
+    const seen = new Set()
+    const isKeyFunction = typeof key === 'function'
+
+    return items.reduce((result, item) => {
+        const itemKey = isKeyFunction ? key(item) : item[key]
+
+        if (!seen.has(itemKey)) {
+            seen.add(itemKey)
+            result.push(item)
+        }
+
+        return result
+    }, [] as T[])
+}
+
+const issueFragment = `
+  fragment IssueFragment on Issue {
+      identifier
+      title
+      url
+      description
+  }
+`
+const viewerIssuesQuery = `
+  query ViewerIssues($first: Int!) {
+    viewer {
+      createdIssues(first: $first, orderBy: updatedAt) {
+        nodes {
+          ...IssueFragment
+        }
+      }
+      assignedIssues(first: $first, orderBy: updatedAt) {
+        nodes {
+          ...IssueFragment
+        }
+      }
+    }
+  }
+
+  ${issueFragment}
+`
+const issueSearchQuery = `
+    query IssueSearch($query: String!, $first: Int!) {
+        issueSearch(query: $query, first: $first, orderBy: updatedAt) {
+            nodes {
+              ...IssueFragment
+            }
+        }
+    }
+
+    ${issueFragment}
+`
+const issueWithCommentsQuery = `
+  query IssueWithComment($id: String!) {
+    issue(id: $id) {
+      ...IssueFragment
+      comments {
+        nodes {
+          body
+        }
+      }
+    }
+  }
+
+  ${issueFragment}
+`

--- a/vscode/webviews/mentions/mentionMenu/MentionMenuItem.tsx
+++ b/vscode/webviews/mentions/mentionMenu/MentionMenuItem.tsx
@@ -25,6 +25,7 @@ import {
     IGNORED_FILE_WARNING_LABEL,
     LARGE_FILE_WARNING_LABEL,
 } from '../../../src/chat/context/constants'
+import LinearIssuesProvider from '../../../src/context/openctx/linear-issues'
 import RemoteFileProvider from '../../../src/context/openctx/remoteFileSearch'
 import RemoteRepositorySearch from '../../../src/context/openctx/remoteRepositorySearch'
 import WebProvider from '../../../src/context/openctx/web'
@@ -141,6 +142,7 @@ export const iconForProvider: Record<
     'https://openctx.org/npm/@openctx/provider-hello-world': SmileIcon,
     'https://openctx.org/npm/@openctx/provider-devdocs': LibraryBigIcon,
     'https://openctx.org/npm/@openctx/provider-sourcegraph-search': SourcegraphLogo,
+    [LinearIssuesProvider.providerUri]: LinearLogo,
     [RemoteRepositorySearch.providerUri]: FolderGitIcon,
     [RemoteFileProvider.providerUri]: FolderGitIcon,
     [WebProvider.providerUri]: LinkIcon,

--- a/vscode/webviews/mentions/mentionMenu/MentionMenuItem.tsx
+++ b/vscode/webviews/mentions/mentionMenu/MentionMenuItem.tsx
@@ -25,7 +25,6 @@ import {
     IGNORED_FILE_WARNING_LABEL,
     LARGE_FILE_WARNING_LABEL,
 } from '../../../src/chat/context/constants'
-import LinearIssuesProvider from '../../../src/context/openctx/linear-issues'
 import RemoteFileProvider from '../../../src/context/openctx/remoteFileSearch'
 import RemoteRepositorySearch from '../../../src/context/openctx/remoteRepositorySearch'
 import WebProvider from '../../../src/context/openctx/web'
@@ -142,7 +141,7 @@ export const iconForProvider: Record<
     'https://openctx.org/npm/@openctx/provider-hello-world': SmileIcon,
     'https://openctx.org/npm/@openctx/provider-devdocs': LibraryBigIcon,
     'https://openctx.org/npm/@openctx/provider-sourcegraph-search': SourcegraphLogo,
-    [LinearIssuesProvider.providerUri]: LinearLogo,
+    'internal-linear-issues': LinearLogo, // Can't import LinearIssuesProvider due to transitive dep on vscode.
     [RemoteRepositorySearch.providerUri]: FolderGitIcon,
     [RemoteFileProvider.providerUri]: FolderGitIcon,
     [WebProvider.providerUri]: LinkIcon,


### PR DESCRIPTION
This PR copies in the current state of the OpenCtx Linear Issues provider (1st commit). We then use integration with the official Linear Connect vscode extension to make authentication smooth (2nd commit). If the extension is missing we prompt the user to install it (3rd commit).

Note: we could declare that Cody depends on the Linear Connect extension. However, given this is opt-in behaviour I prefer our "just in time" prompting of adding that extension. Note that the provider will only be shown if the noodle config setting is enabled.

Test Plan: Try with linear connect in the following states: uninstalled, disabled, enabled. The first two states will always trigger showing the extension. The enabled state will log us in to Linear. I also tested if a user did not finish up the sign in flow, then the same modal would happen again when attempting connecting to Linear.

Demo at https://www.loom.com/share/f37ea88f5d9d47e8b0940aa7b5c0d975

Fixes https://linear.app/sourcegraph/issue/CODY-2540/explore-good-linear-auth-in-openctx