### PR TITLE
Chat: add infrastructure to run chat evals

### DIFF
--- a/agent/src/cli/cody-bench/EvaluationDocument.ts
+++ b/agent/src/cli/cody-bench/EvaluationDocument.ts
@@ -137,10 +137,15 @@ export class EvaluationDocument {
                     out.push(' AUTOCOMPLETE')
                 } else if (this.options.fixture.strategy === BenchStrategy.Fix) {
                     out.push(' FIX')
+                } else if (this.options.fixture.strategy === BenchStrategy.Chat) {
+                    out.push(' CHAT')
                 } else {
                     throw new Error(`unknown strategy ${this.options.fixture.strategy}`)
                 }
 
+                if (item.chatReply) {
+                    pushMultilineText('CHAT_REPLY', item.chatReply)
+                }
                 if (item.resultExact) {
                     out.push(' EXACT_MATCH')
                 }
@@ -253,6 +258,7 @@ interface EvaluationItem {
     contextBfgDurationMs?: number
     resultCharacterCount?: number
     editDiff?: string
+    chatReply?: string
     fixBeforeDiagnostic?: string
     fixAfterDiagnostic?: string
     llmJudgeScore?: number
@@ -286,6 +292,7 @@ export const autocompleteItemHeaders: ObjectHeaderItem[] = [
     { id: 'resultCharacterCount', title: 'RESULT_CHAR_COUNT' },
     { id: 'resultNonInsertPatch', title: 'RESULT_NON_INSERT_PATCH' },
     { id: 'editDiff', title: 'EDIT_DIFF' },
+    { id: 'chatReply', title: 'CHAT_REPLY' },
     { id: 'fixAfterDiagnostic', title: 'FIX_AFTER_DIAGNOSTIC' },
     { id: 'fixBeforeDiagnostic', title: 'FIX_BEFORE_DIAGNOSTIC' },
     { id: 'llmJudgeScore', title: 'LLM_JUDGE_SCORE' },

--- a/agent/src/cli/cody-bench/evaluateEachFile.ts
+++ b/agent/src/cli/cody-bench/evaluateEachFile.ts
@@ -53,7 +53,7 @@ export async function evaluateEachFile(
             }
             const content = (await fspromises.readFile(filePath)).toString()
             const languageid = getLanguageForFileName(file)
-            if (!isSupportedLanguage(languageid)) {
+            if (!isSupportedLanguage(languageid) && !isSupportedBenchLanguage(languageid)) {
                 continue
             }
             if (
@@ -81,4 +81,8 @@ export async function evaluateEachFile(
     } finally {
         await testCleanup(options)
     }
+}
+
+function isSupportedBenchLanguage(languageid: string): boolean {
+    return languageid === 'yaml'
 }

--- a/agent/src/cli/cody-bench/strategy-chat.ts
+++ b/agent/src/cli/cody-bench/strategy-chat.ts
@@ -1,0 +1,79 @@
+import path from 'node:path'
+import { type ContextItem, ModelsService } from '@sourcegraph/cody-shared'
+import { glob } from 'glob'
+import * as vscode from 'vscode'
+import YAML from 'yaml'
+import type { MessageHandler } from '../../jsonrpc-alias'
+import { EvaluationDocument } from './EvaluationDocument'
+import type { CodyBenchOptions } from './cody-bench'
+import { evaluateEachFile } from './evaluateEachFile'
+
+interface ChatTask {
+    question: string
+    files: string[]
+}
+
+export async function evaluateChatStrategy(
+    client: MessageHandler,
+    options: CodyBenchOptions
+): Promise<void> {
+    const absoluteFiles = glob.sync(`${options.workspace}/**`, {
+        ignore: ['node_modules/**'],
+        nodir: true,
+    })
+    const chatModel = options.fixture.customConfiguration?.['cody-bench.chatModel']
+    if (!chatModel) {
+        throw new Error(
+            'Missing cody-bench.chatModel. To fix this problem, add "customConfiguration": { "cody-bench.chatModel": "claude-3-sonnet" } to the cody-bench JSON config.'
+        )
+    }
+    const model = ModelsService.getModelByIDSubstringOrError(chatModel).model
+    const files = absoluteFiles.map(file => path.relative(options.workspace, file))
+    const yamlFiles = files.filter(file => file.endsWith('.yaml'))
+    await evaluateEachFile(yamlFiles, options, async params => {
+        const document = EvaluationDocument.from(params, options)
+        const task: ChatTask = YAML.parse(params.content)
+        const id = await client.request('chat/new', null)
+        client.request('webview/receiveMessage', { id, message: { command: 'chatModel', model } })
+        const contextFiles: ContextItem[] = []
+        for (const relativePath of task.files) {
+            const uri = vscode.Uri.file(path.join(path.dirname(params.uri.fsPath), relativePath))
+            contextFiles.push({
+                type: 'file',
+                uri,
+            })
+        }
+        const response = await client.request('chat/submitMessage', {
+            id,
+            message: {
+                command: 'submit',
+                submitType: 'user',
+                text: task.question,
+                contextFiles,
+                addEnhancedContext: false,
+            },
+        })
+        const range = new vscode.Range(0, 0, 0, 0)
+        if (response.type === 'transcript') {
+            const reply = response.messages.at(-1)
+            if (reply?.text) {
+                console.log({ reply })
+                document.pushItem({
+                    range,
+                    chatReply: reply.text,
+                })
+            } else {
+                document.pushItem({
+                    range,
+                    resultError: 'no text reply. Got ' + JSON.stringify(reply, null, 2),
+                })
+            }
+        } else {
+            document.pushItem({
+                range,
+                resultError: 'expected a transcriot. Got ' + JSON.stringify(response, null, 2),
+            })
+        }
+        return document
+    })
+}


### PR DESCRIPTION
Fixes CODY-2548

## Test plan

* Run `pnpm agent:skip-root-build cody-bench --evaluation-config ~/dev/sourcegraph/cody-leaderboard/chat-bench.json`
* Confirm it generates this output here https://github.com/sourcegraph/cody-leaderboard/pull/3

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
