### PR TITLE
remove /post-sign-up needless redirect

### DIFF
--- a/vscode/src/services/AuthProviderSimplified.ts
+++ b/vscode/src/services/AuthProviderSimplified.ts
@@ -40,25 +40,19 @@ export function getAuthReferralCode(): string {
 // Opens authentication URLs for simplified onboarding.
 function openExternalAuthUrl(provider: AuthMethod, tokenReceiverUrl?: string): Thenable<boolean> {
     // Create the chain of redirects:
-    // 1. Specific login page (GitHub, etc.) redirects to the post-sign up survey
-    // 2. Post-sign up survery redirects to the new token page
-    // 3. New token page redirects back to the extension with the new token
+    // 1. Specific login page (GitHub, etc.) redirects to the new token page
+    // 2. New token page redirects back to the extension with the new token
     const referralCode = getAuthReferralCode()
     const tokenReceiver = tokenReceiverUrl
         ? `&tokenReceiverUrl=${encodeURIComponent(tokenReceiverUrl)}`
         : ''
 
-    // FIXME: It's a complete mystery to me why a double URL decoding is necessary for this.
-    const newTokenUrl = encodeURIComponent(
-        `/user/settings/tokens/new/callback?requestFrom=${referralCode}${tokenReceiver}`
-    )
-    const postSignUpSurveyUrl = encodeURIComponent(`/post-sign-up?returnTo=${newTokenUrl}`)
-    const site = DOTCOM_URL.toString() // Note, ends with the path /
-
-    const genericLoginUrl = `${site}sign-in?returnTo=${postSignUpSurveyUrl}`
-    const gitHubLoginUrl = `${site}.auth/openidconnect/login?prompt_auth=github&pc=sams&redirect=${postSignUpSurveyUrl}`
-    const gitLabLoginUrl = `${site}.auth/openidconnect/login?prompt_auth=gitlab&pc=sams&redirect=${postSignUpSurveyUrl}`
-    const googleLoginUrl = `${site}.auth/openidconnect/login?prompt_auth=google&pc=sams&redirect=${postSignUpSurveyUrl}`
+    const newTokenUrl = `/user/settings/tokens/new/callback?requestFrom=${referralCode}${tokenReceiver}`
+    const site = new URL(newTokenUrl, DOTCOM_URL)
+    const genericLoginUrl = `${site}sign-in?returnTo=${newTokenUrl}`
+    const gitHubLoginUrl = `${site}.auth/openidconnect/login?prompt_auth=github&pc=sams&redirect=${newTokenUrl}`
+    const gitLabLoginUrl = `${site}.auth/openidconnect/login?prompt_auth=gitlab&pc=sams&redirect=${newTokenUrl}`
+    const googleLoginUrl = `${site}.auth/openidconnect/login?prompt_auth=google&pc=sams&redirect=${newTokenUrl}`
 
     let uriSpec: string
     switch (provider) {


### PR DESCRIPTION
After https://github.com/sourcegraph/sourcegraph/pull/63373, the `/post-sign-up` indirection/redirection is no longer necessary.



## Test plan

Manually test in debug ext host sign out then sign in