### PR TITLE
Enable completion persistence loging in agent

### DIFF
--- a/vscode/src/completions/logger.ts
+++ b/vscode/src/completions/logger.ts
@@ -24,7 +24,6 @@ import type {
     PersistencePresentEventPayload,
     PersistenceRemovedEventPayload,
 } from '../common/persistence-tracker/types'
-import { isRunningInsideAgent } from '../jsonrpc/isRunningInsideAgent'
 import { RepoMetadatafromGitApi } from '../repository/repo-metadata-from-git-api'
 import { upstreamHealthProvider } from '../services/UpstreamHealthProvider'
 import { completionProviderConfig } from './completion-provider-config'
@@ -733,7 +732,7 @@ export function accepted(
     })
     statistics.logAccepted()
 
-    if (trackedRange === undefined || isRunningInsideAgent()) {
+    if (trackedRange === undefined) {
         return
     }
     if (persistenceTracker === null) {


### PR DESCRIPTION
Fixes CODY-2571

## Changes

Enable completions persistence tracking for agent.
Looks like [it was disabled from the start](https://github.com/sourcegraph/cody/pull/1463/files#r1377442685), but I do not see a good reason why it should be.
@valerybugakov you asked a good question but @philipp-spiess answer does not really explain the rationale of the decision to skip the agent. Do you maybe remember any additional context of that decision?

## Test plan

1. Build and run JetBrains with this Cody branch
2. Initiate any completion and accept it
3. Add some code before and after the completion
4. Wait 30 seconds
5. Remove suggested line
6. Wait 1min 30sec

You should see something like that in the log:

```
2024-06-25 15:46:21,885 [  21579]   WARN - #c.s.c.a.CodyAgentClient - Cody by Sourcegraph: █ telemetry-v2: recordEvent: cody.completion/suggested 
2024-06-25 15:46:21,885 [  21579]   WARN - #c.s.c.a.CodyAgentClient - Cody by Sourcegraph: █ telemetry-v2: recordEvent: cody.completion/accepted 
2024-06-25 15:46:31,361 [  31055]   WARN - #c.s.c.a.CodyAgentClient - Cody by Sourcegraph: █ telemetry-v2: recordEvent: cody.completion/noResponse 
2024-06-25 15:46:51,946 [  51640]   WARN - #c.s.c.a.CodyAgentClient - Cody by Sourcegraph: █ telemetry-v2: recordEvent: cody.completion.persistence/present 
2024-06-25 15:47:08,009 [  67703]   WARN - #c.s.c.a.CodyAgentClient - Cody by Sourcegraph: █ telemetry-v2: recordEvent: cody.completion/suggested 
2024-06-25 15:47:16,260 [  75954]   WARN - #c.s.c.a.CodyAgentClient - Cody by Sourcegraph: █ telemetry-v2: recordEvent: cody.completion/suggested 
2024-06-25 15:48:21,950 [ 141644]   WARN - #c.s.c.a.CodyAgentClient - Cody by Sourcegraph: █ telemetry-v2: recordEvent: cody.completion.persistence/removed 
```

Additionally I verified in the debugger that partial edition of the line changes `difference` ratio.