### PR TITLE
Bench: Add chat question to EvaluationDocument and strategy-chat

### DIFF
--- a/agent/src/cli/cody-bench/EvaluationDocument.ts
+++ b/agent/src/cli/cody-bench/EvaluationDocument.ts
@@ -142,7 +142,9 @@ export class EvaluationDocument {
                 } else {
                     throw new Error(`unknown strategy ${this.options.fixture.strategy}`)
                 }
-
+                if (item.chatQuestion) {
+                    pushMultilineText('CHAT_QUESTION', item.chatQuestion)
+                }
                 if (item.chatReply) {
                     pushMultilineText('CHAT_REPLY', item.chatReply)
                 }
@@ -259,6 +261,7 @@ interface EvaluationItem {
     resultCharacterCount?: number
     editDiff?: string
     chatReply?: string
+    chatQuestion?: string
     fixBeforeDiagnostic?: string
     fixAfterDiagnostic?: string
     llmJudgeScore?: number
@@ -293,6 +296,7 @@ export const autocompleteItemHeaders: ObjectHeaderItem[] = [
     { id: 'resultNonInsertPatch', title: 'RESULT_NON_INSERT_PATCH' },
     { id: 'editDiff', title: 'EDIT_DIFF' },
     { id: 'chatReply', title: 'CHAT_REPLY' },
+    { id: 'chatQuestion', title: 'CHAT_QUESTION' },
     { id: 'fixAfterDiagnostic', title: 'FIX_AFTER_DIAGNOSTIC' },
     { id: 'fixBeforeDiagnostic', title: 'FIX_BEFORE_DIAGNOSTIC' },
     { id: 'llmJudgeScore', title: 'LLM_JUDGE_SCORE' },

--- a/agent/src/cli/cody-bench/strategy-chat.ts
+++ b/agent/src/cli/cody-bench/strategy-chat.ts
@@ -61,6 +61,7 @@ export async function evaluateChatStrategy(
                 document.pushItem({
                     range,
                     chatReply: reply.text,
+                    chatQuestion: task.question,
                 })
             } else {
                 document.pushItem({
@@ -71,7 +72,7 @@ export async function evaluateChatStrategy(
         } else {
             document.pushItem({
                 range,
-                resultError: 'expected a transcriot. Got ' + JSON.stringify(response, null, 2),
+                resultError: 'expected a transcript. Got ' + JSON.stringify(response, null, 2),
             })
         }
         return document


### PR DESCRIPTION
Add chat question to EvaluationDocument and strategy-chat

## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

Makes it easier to display chat question associated with the file path in leaderboard:

<img width="982" alt="image" src="https://github.com/sourcegraph/cody/assets/68532117/641ee25c-b41a-4e89-b282-73055260ca88">

Used by https://github.com/sourcegraph/cody-leaderboard/pull/7