### PR TITLE
Bench: add LLM judge for response scoring to chat strategy

### DIFF
--- a/agent/src/cli/cody-bench/llm-judge-chat-template.ts
+++ b/agent/src/cli/cody-bench/llm-judge-chat-template.ts
@@ -1,0 +1,18 @@
+import { type PromptString, ps } from '@sourcegraph/cody-shared'
+
+const template = ps`Response:{{CODY_RESPONSE}}
+<|end_of_response|>
+
+Please evaluate the response and provide your feedback in the following format:
+<reasoning> Briefly explain whether the response is helpful and correct, unhelpful, or incorrect.</reasoning>
+<score> Label the response as "positive" if it's helpful or "negative" if it's not helpful or incomplete.</score>
+
+Note: Consider the response "positive" if it attempts to provide a helpful answer, even with limited context. Label it "negative" if it apologizes for not knowing the answer, lacks access to information, or is incomplete.`
+
+export interface LlmJudgeChatParams {
+    response: PromptString
+}
+
+export function llmJudgeChatTemplate(params: LlmJudgeChatParams): PromptString {
+    return template.replaceAll('{{CODY_RESPONSE}}', params.response)
+}

--- a/agent/src/cli/cody-bench/llm-judge.ts
+++ b/agent/src/cli/cody-bench/llm-judge.ts
@@ -65,10 +65,12 @@ export class LlmJudge {
 function scoreNumeric(score?: string): number | undefined {
     switch (score) {
         case 'bad':
+        case 'negative':
             return 0
         case 'acceptable':
             return 1
         case 'amazing':
+        case 'positive':
             return 2
         default:
             return undefined


### PR DESCRIPTION
- Add `llmJudgeChatTemplate` to generate a prompt for evaluating LLM responses
- Integrate `LlmJudge` into the `evaluateChatStrategy` to score each chat response
- Store the numeric score in the `EvaluationDocument` for each chat response
- Log the total score for the fixture at the end of the evaluation

There are still follow-up works that we can do, including improving the prompt used for the LLM judge, but currently, it works as intended and IMO a good starting point for us to build from.


## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

Currently being used by https://github.com/sourcegraph/cody-leaderboard/pull/8

<img width="881" alt="image" src="https://github.com/sourcegraph/cody/assets/68532117/ee3b2c05-02ec-4f93-a7b4-052f469900ed">
