### PR TITLE
Bench: add hedging and conciseness scores for Chat

### DIFF
--- a/agent/src/cli/cody-bench/EvaluationDocument.ts
+++ b/agent/src/cli/cody-bench/EvaluationDocument.ts
@@ -266,12 +266,14 @@ interface EvaluationItem {
     fixAfterDiagnostic?: string
     llmJudgeScore?: number
     llmJudgeReasoning?: string
+    concisenessScore?: number
+    hedges?: boolean
     info?: CompletionItemInfo
     event?: CompletionBookkeepingEvent
     eventJSON?: string
 }
 
-export const autocompleteItemHeaders: ObjectHeaderItem[] = [
+export const headerItems: ObjectHeaderItem[] = [
     { id: 'languageid', title: 'LANGUAGEID' },
     { id: 'workspace', title: 'WORKSPACE' },
     { id: 'fixture', title: 'FIXTURE' },
@@ -301,6 +303,8 @@ export const autocompleteItemHeaders: ObjectHeaderItem[] = [
     { id: 'fixBeforeDiagnostic', title: 'FIX_BEFORE_DIAGNOSTIC' },
     { id: 'llmJudgeScore', title: 'LLM_JUDGE_SCORE' },
     { id: 'llmJudgeReasoning', title: 'LLM_JUDGE_REASONING' },
+    { id: 'concisenessScore', title: 'CONCISENESS_SCORE' },
+    { id: 'hedges', title: 'HEDGES' },
     { id: 'providerIdentifier', title: 'PROVIDER_IDENTIFIER' },
     { id: 'providerModel', title: 'PROVIDER_MODEL' },
     { id: 'stopReason', title: 'STOP_REASON' },

--- a/agent/src/cli/cody-bench/SnapshotWriter.ts
+++ b/agent/src/cli/cody-bench/SnapshotWriter.ts
@@ -4,7 +4,7 @@ import { createObjectCsvWriter } from 'csv-writer'
 import type { CsvWriter } from 'csv-writer/src/lib/csv-writer'
 import { rimraf } from 'rimraf'
 
-import { type EvaluationDocument, autocompleteItemHeaders } from './EvaluationDocument'
+import { type EvaluationDocument, headerItems } from './EvaluationDocument'
 import type { CodyBenchOptions } from './cody-bench'
 
 export class SnapshotWriter {
@@ -16,7 +16,7 @@ export class SnapshotWriter {
             await fspromises.mkdir(this.options.snapshotDirectory, { recursive: true })
             if (this.options.csvPath) {
                 this.csvWriter = createObjectCsvWriter({
-                    header: autocompleteItemHeaders,
+                    header: headerItems,
                     path: this.options.csvPath,
                 })
             }

--- a/agent/src/cli/cody-bench/cody-bench.ts
+++ b/agent/src/cli/cody-bench/cody-bench.ts
@@ -353,6 +353,7 @@ async function evaluateWorkspace(options: CodyBenchOptions, recordingDirectory: 
             customHeaders: {},
             customConfiguration: {
                 'cody.experimental.symf.enabled': false, // fixes errors in Polly.js related to fetchin the symf binary
+                'cody.experimental.telemetry.enabled': false,
                 ...options.fixture.customConfiguration,
             },
             baseGlobalState,

--- a/agent/src/cli/cody-bench/llm-judge-chat-template.ts
+++ b/agent/src/cli/cody-bench/llm-judge-chat-template.ts
@@ -1,18 +1,30 @@
 import { type PromptString, ps } from '@sourcegraph/cody-shared'
-
-const template = ps`Response:{{CODY_RESPONSE}}
-<|end_of_response|>
-
-Please evaluate the response and provide your feedback in the following format:
-<reasoning> Briefly explain whether the response is helpful and correct, unhelpful, or incorrect.</reasoning>
-<score> Label the response as "positive" if it's helpful or "negative" if it's not helpful or incomplete.</score>
-
-Note: Consider the response "positive" if it attempts to provide a helpful answer, even with limited context. Label it "negative" if it apologizes for not knowing the answer, lacks access to information, or is incomplete.`
-
 export interface LlmJudgeChatParams {
     response: PromptString
 }
 
-export function llmJudgeChatTemplate(params: LlmJudgeChatParams): PromptString {
-    return template.replaceAll('{{CODY_RESPONSE}}', params.response)
+const helpfulnessTemplate = ps`Response:{{CODY_RESPONSE}}
+<|end_of_response|>
+
+Please evaluate the response and provide your feedback in the following format:
+<reasoning> Briefly explain whether the response is helpful and correct vs. unhelpful or incorrect.</reasoning>
+<score> Label the response as "positive" if it's helpful or "negative" if it's not helpful or incomplete.</score>
+
+Note: Consider the response "positive" if it attempts to provide a helpful answer, even with limited context. Label it "negative" if it is incomplete, or does not contain informative content.`
+
+export function helpfulnessPrompt(params: LlmJudgeChatParams): PromptString {
+    return helpfulnessTemplate.replaceAll('{{CODY_RESPONSE}}', params.response)
+}
+
+const concisenessTemplate = ps`Response:{{CODY_RESPONSE}}
+<|end_of_response|>
+
+Please evaluate the response and provide your feedback in the following format:
+<reasoning> Briefly explain whether the response is concise and to-the-point vs. long-winded or verbose.</reasoning>
+<score> Label the response as "positive" if it's concise or "negative" if it is long-winded.</score>
+
+Note: Consider the response "positive" if each sentence is informative. Label it "negative" if it is repetitive or contains 'filler' content that doesn't convey new information.`
+
+export function concisenessPrompt(params: LlmJudgeChatParams): PromptString {
+    return concisenessTemplate.replaceAll('{{CODY_RESPONSE}}', params.response)
 }

--- a/agent/src/cli/cody-bench/strategy-chat.ts
+++ b/agent/src/cli/cody-bench/strategy-chat.ts
@@ -8,7 +8,7 @@ import { EvaluationDocument } from './EvaluationDocument'
 import type { CodyBenchOptions } from './cody-bench'
 import { evaluateEachFile } from './evaluateEachFile'
 import { LlmJudge, type LlmJudgeScore } from './llm-judge'
-import { llmJudgeChatTemplate } from './llm-judge-chat-template'
+import { concisenessPrompt, helpfulnessPrompt } from './llm-judge-chat-template'
 
 interface ChatTask {
     question: string
@@ -62,15 +62,18 @@ export async function evaluateChatStrategy(
             const reply = response.messages.at(-1)
             if (reply?.text) {
                 const response = PromptString.unsafe_fromLLMResponse(reply.text)
-                const score = await llm.judge(llmJudgeChatTemplate({ response }))
+                const score = await llm.judge(helpfulnessPrompt({ response }))
+                const concisenessScore = await llm.judge(concisenessPrompt({ response }))
                 document.pushItem({
                     range,
                     chatReply: reply.text,
                     chatQuestion: task.question,
                     llmJudgeScore: score.scoreNumeric,
+                    concisenessScore: concisenessScore.scoreNumeric,
+                    hedges: checkHedging(reply.text),
                 })
                 scores.push(score)
-                console.log({ reply, score })
+                console.log({ reply, score, concisenessScore })
             } else {
                 document.pushItem({
                     range,
@@ -89,4 +92,11 @@ export async function evaluateChatStrategy(
         })
         return document
     })
+}
+
+const apologyCheck = /sorry|apologize|unfortunately/i
+const accessCheck =
+    /I (don't|do not) (actually )?have (direct )?access|your actual codebase|can't browse external repositories|not able to access external information|unable to browse through|directly access|direct access|snippet you provided is incomplete|I can't review/i
+function checkHedging(reply: string): boolean {
+    return apologyCheck.test(reply) || accessCheck.test(reply)
 }

--- a/vscode/src/extension.node.ts
+++ b/vscode/src/extension.node.ts
@@ -54,6 +54,10 @@ export function activate(
         .getConfiguration()
         .get<boolean>('cody.experimental.symf.enabled', true)
 
+    const isTelemetryEnabled = vscode.workspace
+        .getConfiguration()
+        .get<boolean>('cody.experimental.telemetry.enabled', true)
+
     return activateCommon(context, {
         createLocalEmbeddingsController: isLocalEmbeddingsDisabled
             ? undefined
@@ -66,9 +70,10 @@ export function activate(
         createSymfRunner: isSymfEnabled ? (...args) => new SymfRunner(...args) : undefined,
         createBfgRetriever: () => new BfgRetriever(context),
         createSentryService: (...args) => new NodeSentryService(...args),
-        createOpenTelemetryService: (...args) => new OpenTelemetryService(...args),
+        createOpenTelemetryService: isTelemetryEnabled
+            ? (...args) => new OpenTelemetryService(...args)
+            : undefined,
         startTokenReceiver: (...args) => startTokenReceiver(...args),
-
         onConfigurationChange: setCustomAgent,
         extensionClient,
     })


### PR DESCRIPTION
This PR adds 'hedging' and 'conciseness' checks for Chat benchmarks. The 'conciseness' check uses an LLM to judge repetitiveness.

It also tweaks the main LLM judge score to just focus on helpfulness, and not penalize models for apologizing. This makes the scores less biased, since some models tend to apologize more ("I'm sorry...") instead of using other hedging terms like "Unfortunately...", but otherwise the responses are very similar.

## Test plan
Ran  `pnpm agent:skip-root-build cody-bench --evaluation-config ~/code/cody-leaderboard/chat-bench.json` and checked output.