### PR TITLE
vscode: vendor in @openctx/linear-issues-provider

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -365,6 +365,9 @@ importers:
       '@mdi/js':
         specifier: ^7.2.96
         version: 7.2.96
+      '@openctx/provider-linear-issues':
+        specifier: ^0.0.6
+        version: 0.0.6
       '@openctx/vscode-lib':
         specifier: ^0.0.13
         version: 0.0.13
@@ -3197,6 +3200,16 @@ packages:
     resolution: {integrity: sha512-mT1iIb+tAdY0SUwFoM8xscvrC9c5wbCQ3hbzQgI5LKaXIULmPdQa478MtGxNto2zfp8QD6VKrySsKbzQ3JFfrA==}
     dependencies:
       '@openctx/schema': 0.0.12
+    dev: false
+
+  /@openctx/provider-linear-issues@0.0.6:
+    resolution: {integrity: sha512-h1N8OtATRDIVB/VJ/m3WBFdVQBwFpa1RHlDiNhg8znCAK9qhw6Y/GMTl89Q6IBZwIdFQ2uxxzF7d8bkyBIiEDQ==}
+    dependencies:
+      '@openctx/provider': 0.0.14
+      dedent: 1.5.3
+      fast-xml-parser: 4.4.0
+    transitivePeerDependencies:
+      - babel-plugin-macros
     dev: false
 
   /@openctx/provider@0.0.14:
@@ -7623,6 +7636,15 @@ packages:
   /dedent@0.7.0:
     resolution: {integrity: sha512-Q6fKUPqnAHAyhiUgFU7BUzLiv0kd8saH9al7tnu5Q/okj6dnupxyTgFIBjVzJATdfIAm9NAsvXNzjaKa+bxVyA==}
 
+  /dedent@1.5.3:
+    resolution: {integrity: sha512-NHQtfOOW68WD8lgypbLA5oT+Bt0xXJhiYvoR6SmmNXZfpzOGXwdKWmcwG8N7PwVVWV3eF/68nmD9BaJSsTBhyQ==}
+    peerDependencies:
+      babel-plugin-macros: ^3.1.0
+    peerDependenciesMeta:
+      babel-plugin-macros:
+        optional: true
+    dev: false
+
   /deep-eql@4.1.3:
     resolution: {integrity: sha512-WaEtAOpRA1MQ0eohqZjpGD8zdI0Ovsm8mmFhaDN8dvDZzyoUMcYDnf5Y6iu7HTXxf8JDS23qWa4a+hKCDyOPzw==}
     engines: {node: '>=6'}
@@ -8449,6 +8471,13 @@ packages:
 
   /fast-xml-parser@4.3.2:
     resolution: {integrity: sha512-rmrXUXwbJedoXkStenj1kkljNF7ugn5ZjR9FJcwmCfcCbtOMDghPajbc+Tck6vE6F5XsDmx+Pr2le9fw8+pXBg==}
+    hasBin: true
+    dependencies:
+      strnum: 1.0.5
+    dev: false
+
+  /fast-xml-parser@4.4.0:
+    resolution: {integrity: sha512-kLY3jFlwIYwBNDojclKsNAC12sfD6NwW74QB2CoNGPvtVxjliYehVunB3HYyNi+n4Tt1dAcgwYvmKF/Z18flqg==}
     hasBin: true
     dependencies:
       strnum: 1.0.5

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -1319,6 +1319,7 @@
     "@lexical/text": "^0.16.0",
     "@lexical/utils": "^0.16.0",
     "@mdi/js": "^7.2.96",
+    "@openctx/provider-linear-issues": "^0.0.6",
     "@openctx/vscode-lib": "^0.0.13",
     "@opentelemetry/api": "^1.7.0",
     "@opentelemetry/core": "^1.18.1",

--- a/vscode/src/context/openctx.ts
+++ b/vscode/src/context/openctx.ts
@@ -1,6 +1,7 @@
 import { type ConfigurationWithAccessToken, setOpenCtxClient } from '@sourcegraph/cody-shared'
 import * as vscode from 'vscode'
 import { logDebug, outputChannel } from '../log'
+import LinearIssuesProvider from './openctx/linear-issues'
 import RemoteFileProvider from './openctx/remoteFileSearch'
 import RemoteRepositorySearch from './openctx/remoteRepositorySearch'
 import WebProvider from './openctx/web'
@@ -27,11 +28,18 @@ export async function exposeOpenCtxClient(
         ]
 
         if (config.experimentalNoodle) {
-            providers.push({
-                providerUri: RemoteFileProvider.providerUri,
-                settings: true,
-                provider: RemoteFileProvider,
-            })
+            providers.push(
+                {
+                    providerUri: RemoteFileProvider.providerUri,
+                    settings: true,
+                    provider: RemoteFileProvider,
+                },
+                {
+                    providerUri: LinearIssuesProvider.providerUri,
+                    settings: true,
+                    provider: LinearIssuesProvider,
+                }
+            )
         }
 
         setOpenCtxClient(

--- a/vscode/src/context/openctx/linear-issues.ts
+++ b/vscode/src/context/openctx/linear-issues.ts
@@ -1,0 +1,8 @@
+import linearIssues from '@openctx/provider-linear-issues'
+
+const LinearIssuesProvider = {
+    providerUri: 'internal-linear-issues',
+    ...linearIssues,
+}
+
+export default LinearIssuesProvider

--- a/vscode/webviews/mentions/mentionMenu/MentionMenuItem.tsx
+++ b/vscode/webviews/mentions/mentionMenu/MentionMenuItem.tsx
@@ -141,6 +141,7 @@ export const iconForProvider: Record<
     'https://openctx.org/npm/@openctx/provider-hello-world': SmileIcon,
     'https://openctx.org/npm/@openctx/provider-devdocs': LibraryBigIcon,
     'https://openctx.org/npm/@openctx/provider-sourcegraph-search': SourcegraphLogo,
+    'internal-linear-issues': LinearLogo, // Can't import LinearIssuesProvider due to transitive dep on vscode.
     [RemoteRepositorySearch.providerUri]: FolderGitIcon,
     [RemoteFileProvider.providerUri]: FolderGitIcon,
     [WebProvider.providerUri]: LinkIcon,


### PR DESCRIPTION
We plan on experimenting a bunch with linear issues and context. This commit makes it easy to incorporate it outside of mentions. Additionally if the experimental noodle flag is set, Linear Issues is shown in the mentions dropdown.

Test Plan: with an empty openctx configuration and noodle set to true, use linear issues.
