### PR TITLE
Edit: Fix incorrect indentation for undetected files

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -6,10 +6,12 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 
 ### Added
 
-Ollama: Added support for running Cody offline with local Ollama models. [pull/4691](https://github.com/sourcegraph/cody/pull/4691)
-Edit: Added support for users' to edit the applied edit before the diff view is removed. [pull/4684](https://github.com/sourcegraph/cody/pull/4684)
+- Ollama: Added support for running Cody offline with local Ollama models. [pull/4691](https://github.com/sourcegraph/cody/pull/4691)
+- Edit: Added support for users' to edit the applied edit before the diff view is removed. [pull/4684](https://github.com/sourcegraph/cody/pull/4684)
 
 ### Fixed
+
+- Edit: Fixed an issue where, when unable to detect the indentation of a file, Cody would remove all indentation from a response. [pull/4704](https://github.com/sourcegraph/cody/pull/4704)
 
 ### Changed
 

--- a/vscode/src/edit/output/match-indentation.test.ts
+++ b/vscode/src/edit/output/match-indentation.test.ts
@@ -124,6 +124,18 @@ describe('matchIndentation', () => {
             const updated = matchIndentation(incoming, original)
             expect(updated).toBe(original)
         })
+
+        // Some edits may occur on files where there is not any indentation yet.
+        // This test covers those cases and ensures we do not attempt to match any indentation (as it's likely wrong).
+        it('returns correct when we cannot detect indentation in the original code', () => {
+            // Original text with any indentation stripped
+            const strippedIndentationOriginal = EXAMPLE_WHITESPACE_RESPONSE.split('\n')
+                .map(line => line.trimStart())
+                .join('\n')
+            const incoming = EXAMPLE_WHITESPACE_RESPONSE
+            const updated = matchIndentation(incoming, strippedIndentationOriginal)
+            expect(updated).toBe(incoming)
+        })
     })
 
     describe('detect-indent', () => {

--- a/vscode/src/edit/output/match-indentation.ts
+++ b/vscode/src/edit/output/match-indentation.ts
@@ -108,6 +108,11 @@ function fixIndentation(
  */
 export function matchIndentation(incoming: string, original: string): string {
     const originalIndentation = detectIndent(original)
+    if (originalIndentation.amount === 0) {
+        // No indentation detected, this may be simply because the file is not populated enough.
+        // We cannot reliably update the incoming indentation so we will just return the unmodified string.
+        return incoming
+    }
     const incomingIndentation = detectIndent(incoming)
     const indentationCharacter = originalIndentation.type === 'tab' ? '\t' : ' '
 


### PR DESCRIPTION
## Description

Fixes the `match-indentation` function on files where there is no detected indentation.

For example, if a user tries to edit a file that just contains "hello", we should not assume the indentation for the file is `0` and then update the incoming response to match that.

> [!NOTE]
> Some files may genuinely have 0 indentation, and this may be correct behaviour. However, it is far more reliable to just assume the LLM has gotten this right here, rather than handle different edge cases.

## Test plan

1. Create a file that just contains "hello" (no indentation)
2. Select all of "hello" and start an edit, e.g. "write a merge sort function"
3. Check that the edit has _some_ indentation, and is not all set to 0 indent

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
