### PR TITLE
Stevey/fallback to default chat model

### DIFF
--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/CodyAgentServer.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/CodyAgentServer.kt
@@ -98,8 +98,8 @@ interface CodyAgentServer {
   fun testing_memoryUsage(params: Null?): CompletableFuture<Testing_MemoryUsageResult>
   @JsonRequest("testing/awaitPendingPromises")
   fun testing_awaitPendingPromises(params: Null?): CompletableFuture<Null?>
-  @JsonRequest("testing/workspaceDocuments")
-  fun testing_workspaceDocuments(params: GetDocumentsParams): CompletableFuture<GetDocumentsResult>
+  @JsonRequest("testing/requestWorkspaceDocuments")
+  fun testing_requestWorkspaceDocuments(params: GetDocumentsParams): CompletableFuture<GetDocumentsResult>
   @JsonRequest("testing/diagnostics")
   fun testing_diagnostics(params: Testing_DiagnosticsParams): CompletableFuture<Testing_DiagnosticsResult>
   @JsonRequest("testing/progressCancelation")

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/CodyAgentServer.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/CodyAgentServer.kt
@@ -98,6 +98,8 @@ interface CodyAgentServer {
   fun testing_memoryUsage(params: Null?): CompletableFuture<Testing_MemoryUsageResult>
   @JsonRequest("testing/awaitPendingPromises")
   fun testing_awaitPendingPromises(params: Null?): CompletableFuture<Null?>
+  @JsonRequest("testing/workspaceDocuments")
+  fun testing_workspaceDocuments(params: GetDocumentsParams): CompletableFuture<GetDocumentsResult>
   @JsonRequest("testing/diagnostics")
   fun testing_diagnostics(params: Testing_DiagnosticsParams): CompletableFuture<Testing_DiagnosticsResult>
   @JsonRequest("testing/progressCancelation")
@@ -108,6 +110,8 @@ interface CodyAgentServer {
   fun extensionConfiguration_change(params: ExtensionConfiguration): CompletableFuture<AuthStatus?>
   @JsonRequest("extensionConfiguration/status")
   fun extensionConfiguration_status(params: Null?): CompletableFuture<AuthStatus?>
+  @JsonRequest("textDocument/change")
+  fun textDocument_change(params: ProtocolTextDocument): CompletableFuture<TextDocument_ChangeResult>
   @JsonRequest("attribution/search")
   fun attribution_search(params: Attribution_SearchParams): CompletableFuture<Attribution_SearchResult>
   @JsonRequest("ignore/test")

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/GetDocumentsParams.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/GetDocumentsParams.kt
@@ -1,0 +1,7 @@
+@file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
+package com.sourcegraph.cody.protocol_generated
+
+data class GetDocumentsParams(
+  val uris: List<String>? = null,
+)
+

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/GetDocumentsParams.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/GetDocumentsParams.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
 data class GetDocumentsParams(
   val uris: List<String>? = null,

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/GetDocumentsResult.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/GetDocumentsResult.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
 data class GetDocumentsResult(
   val documents: List<ProtocolTextDocument>,

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/GetDocumentsResult.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/GetDocumentsResult.kt
@@ -1,0 +1,7 @@
+@file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
+package com.sourcegraph.cody.protocol_generated
+
+data class GetDocumentsResult(
+  val documents: List<ProtocolTextDocument>,
+)
+

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/TextDocument_ChangeResult.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/TextDocument_ChangeResult.kt
@@ -1,0 +1,7 @@
+@file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
+package com.sourcegraph.cody.protocol_generated
+
+data class TextDocument_ChangeResult(
+  val success: Boolean,
+)
+

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/TextDocument_ChangeResult.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/TextDocument_ChangeResult.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
+package com.sourcegraph.cody.protocol_generated;
 
 data class TextDocument_ChangeResult(
   val success: Boolean,

--- a/agent/src/agent.ts
+++ b/agent/src/agent.ts
@@ -738,7 +738,7 @@ export class Agent extends MessageHandler implements ExtensionClient {
         })
 
         this.registerAuthenticatedRequest(
-            'testing/workspaceDocuments',
+            'testing/requestWorkspaceDocuments',
             async (params: GetDocumentsParams): Promise<GetDocumentsResult> => {
                 const uris = params?.uris ?? this.workspace.allDocuments().map(doc => doc.uri.toString())
 

--- a/agent/src/agent.ts
+++ b/agent/src/agent.ts
@@ -742,18 +742,17 @@ export class Agent extends MessageHandler implements ExtensionClient {
             async (params: GetDocumentsParams): Promise<GetDocumentsResult> => {
                 const uris = params?.uris ?? this.workspace.allDocuments().map(doc => doc.uri.toString())
 
-                const documents: ProtocolTextDocument[] = uris
-                    .map(uri => {
-                        const document = this.workspace.getDocument(vscode.Uri.parse(uri))
-                        return document
-                            ? ({
-                                  uri: document.uri.toString(),
-                                  content: document.content ?? undefined,
-                                  selection: document.protocolDocument?.selection ?? undefined,
-                              } as ProtocolTextDocument)
-                            : null
-                    })
-                    .filter((doc): doc is ProtocolTextDocument => doc !== null)
+                const documents: ProtocolTextDocument[] = []
+                for (const uri of uris) {
+                    const document = this.workspace.getDocument(vscode.Uri.parse(uri))
+                    if (document) {
+                        documents.push({
+                            uri: document.uri.toString(),
+                            content: document.content ?? undefined,
+                            selection: document.protocolDocument?.selection ?? undefined,
+                        })
+                    }
+                }
 
                 return { documents }
             }

--- a/agent/src/agent.ts
+++ b/agent/src/agent.ts
@@ -1071,12 +1071,7 @@ export class Agent extends MessageHandler implements ExtensionClient {
                       authStatus.isDotCom && !authStatus.userCanUpgrade
                   ).at(0)?.model
             if (!theModel) {
-                // When user is not loggeed in, set the default to the default dotcom model,
-                // as we only sync the model list on login.
-                if (!authStatus.isLoggedIn) {
-                    theModel = getDotComDefaultModels()[0].model
-                }
-                throw new Error('No default chat model found')
+                theModel = getDotComDefaultModels()[0].model
             }
 
             const chatModel = new SimpleChatModel(modelID!, [], chatID)

--- a/agent/src/agent.ts
+++ b/agent/src/agent.ts
@@ -740,7 +740,7 @@ export class Agent extends MessageHandler implements ExtensionClient {
         this.registerAuthenticatedRequest(
             'testing/workspaceDocuments',
             async (params: GetDocumentsParams): Promise<GetDocumentsResult> => {
-                const uris = params.uris ?? this.workspace.allDocuments().map(doc => doc.uri.toString())
+                const uris = params?.uris ?? this.workspace.allDocuments().map(doc => doc.uri.toString())
 
                 const documents: ProtocolTextDocument[] = uris
                     .map(uri => {

--- a/agent/src/agent.ts
+++ b/agent/src/agent.ts
@@ -622,7 +622,7 @@ export class Agent extends MessageHandler implements ExtensionClient {
         })
 
         this.registerAuthenticatedRequest('testing/awaitPendingPromises', async () => {
-            if (!vscode_shim.isTesting) {
+            if (!(vscode_shim.isTesting || vscode_shim.isIntegrationTesting)) {
                 throw new Error(
                     'testing/awaitPendingPromises can only be called from tests. ' +
                         'To fix this problem, set the environment variable CODY_SHIM_TESTING=true.'

--- a/agent/src/vscode-shim.ts
+++ b/agent/src/vscode-shim.ts
@@ -59,6 +59,9 @@ import type { ClientInfo, ExtensionConfiguration } from './protocol-alias'
 // traffic.
 export const isTesting = process.env.CODY_SHIM_TESTING === 'true'
 
+// Completely different testing flag set while running client-side integration tests.
+export const isIntegrationTesting = process.env.CODY_INTEGRATION_TESTING === 'true'
+
 export { AgentEventEmitter as EventEmitter } from '../../vscode/src/testutils/AgentEventEmitter'
 
 export {

--- a/agent/src/vscode-shim.ts
+++ b/agent/src/vscode-shim.ts
@@ -59,8 +59,8 @@ import type { ClientInfo, ExtensionConfiguration } from './protocol-alias'
 // traffic.
 export const isTesting = process.env.CODY_SHIM_TESTING === 'true'
 
-// Completely different testing flag set while running client-side integration tests.
-export const isIntegrationTesting = process.env.CODY_INTEGRATION_TESTING === 'true'
+// The testing code paths sometimes need to distinguish the different types of testing.
+export const isIntegrationTesting = process.env.CODY_CLIENT_INTEGRATION_TESTING === 'true'
 
 export { AgentEventEmitter as EventEmitter } from '../../vscode/src/testutils/AgentEventEmitter'
 

--- a/vscode/src/jsonrpc/agent-protocol.ts
+++ b/vscode/src/jsonrpc/agent-protocol.ts
@@ -180,6 +180,8 @@ export type ClientRequests = {
     'testing/closestPostData': [{ url: string; postData: string }, { closestBody: string }]
     'testing/memoryUsage': [null, { usage: MemoryUsage }]
     'testing/awaitPendingPromises': [null, null]
+    // Retrieve the Agent's copy of workspace documents, for testing/validation.
+    'testing/workspaceDocuments': [GetDocumentsParams, GetDocumentsResult]
     // Returns diagnostics for the given URI. Lives under `testing/` instead of
     // standalone `diagnostics/` because it only works for TypeScript files.
     'testing/diagnostics': [{ uri: string }, { diagnostics: ProtocolDiagnostic[] }]
@@ -200,6 +202,8 @@ export type ClientRequests = {
 
     // Returns the current authentication status without making changes to it.
     'extensionConfiguration/status': [null, AuthStatus | null]
+
+    'textDocument/change': [ProtocolTextDocument, { success: boolean }]
 
     // Run attribution search for a code snippet displayed in chat.
     // Attribution is an enterprise feature which allows to look for code generated
@@ -922,4 +926,16 @@ export interface ProtocolCodeAction {
           }
         | undefined
         | null
+}
+
+/**
+ * Omitting uris parameter will retrieve all open documents for the
+ * current workspace root.
+ */
+export interface GetDocumentsParams {
+    uris?: string[]
+}
+
+export interface GetDocumentsResult {
+    documents: ProtocolTextDocument[]
 }

--- a/vscode/src/jsonrpc/agent-protocol.ts
+++ b/vscode/src/jsonrpc/agent-protocol.ts
@@ -181,7 +181,7 @@ export type ClientRequests = {
     'testing/memoryUsage': [null, { usage: MemoryUsage }]
     'testing/awaitPendingPromises': [null, null]
     // Retrieve the Agent's copy of workspace documents, for testing/validation.
-    'testing/workspaceDocuments': [GetDocumentsParams, GetDocumentsResult]
+    'testing/requestWorkspaceDocuments': [GetDocumentsParams, GetDocumentsResult]
     // Returns diagnostics for the given URI. Lives under `testing/` instead of
     // standalone `diagnostics/` because it only works for TypeScript files.
     'testing/diagnostics': [{ uri: string }, { diagnostics: ProtocolDiagnostic[] }]

--- a/vscode/src/jsonrpc/agent-protocol.ts
+++ b/vscode/src/jsonrpc/agent-protocol.ts
@@ -933,7 +933,7 @@ export interface ProtocolCodeAction {
  * current workspace root.
  */
 export interface GetDocumentsParams {
-    uris?: string[]
+    uris?: string[] | undefined | null
 }
 
 export interface GetDocumentsResult {


### PR DESCRIPTION
We have a race condition on integration test startup in which the `ModelsService` is not yet initialized. We had been throwing an error, but a better approach is to use the default model. This is also the behavior on the backend when we're contacting the LLM, so it's consistent. Fix suggested by @abeatrix. 

## Test plan

Manually tested.
