### PR TITLE
Bench: add class for chat questions

### DIFF
--- a/agent/src/cli/cody-bench/EvaluationDocument.ts
+++ b/agent/src/cli/cody-bench/EvaluationDocument.ts
@@ -300,7 +300,7 @@ export const headerItems: ObjectHeaderItem[] = [
     { id: 'editDiff', title: 'EDIT_DIFF' },
     { id: 'chatReply', title: 'CHAT_REPLY' },
     { id: 'chatQuestion', title: 'CHAT_QUESTION' },
-    { id: 'questionClass', title: 'QUESTION_CLASS'},
+    { id: 'questionClass', title: 'QUESTION_CLASS' },
     { id: 'fixAfterDiagnostic', title: 'FIX_AFTER_DIAGNOSTIC' },
     { id: 'fixBeforeDiagnostic', title: 'FIX_BEFORE_DIAGNOSTIC' },
     { id: 'llmJudgeScore', title: 'LLM_JUDGE_SCORE' },

--- a/agent/src/cli/cody-bench/EvaluationDocument.ts
+++ b/agent/src/cli/cody-bench/EvaluationDocument.ts
@@ -262,6 +262,7 @@ interface EvaluationItem {
     editDiff?: string
     chatReply?: string
     chatQuestion?: string
+    questionClass?: string
     fixBeforeDiagnostic?: string
     fixAfterDiagnostic?: string
     llmJudgeScore?: number
@@ -299,6 +300,7 @@ export const headerItems: ObjectHeaderItem[] = [
     { id: 'editDiff', title: 'EDIT_DIFF' },
     { id: 'chatReply', title: 'CHAT_REPLY' },
     { id: 'chatQuestion', title: 'CHAT_QUESTION' },
+    { id: 'questionClass', title: 'QUESTION_CLASS'},
     { id: 'fixAfterDiagnostic', title: 'FIX_AFTER_DIAGNOSTIC' },
     { id: 'fixBeforeDiagnostic', title: 'FIX_BEFORE_DIAGNOSTIC' },
     { id: 'llmJudgeScore', title: 'LLM_JUDGE_SCORE' },

--- a/agent/src/cli/cody-bench/strategy-chat.ts
+++ b/agent/src/cli/cody-bench/strategy-chat.ts
@@ -12,6 +12,7 @@ import { concisenessPrompt, helpfulnessPrompt } from './llm-judge-chat-template'
 
 interface ChatTask {
     question: string
+    class: string
     files?: string[]
 }
 
@@ -68,6 +69,7 @@ export async function evaluateChatStrategy(
                     range,
                     chatReply: reply.text,
                     chatQuestion: task.question,
+                    questionClass: task.class,
                     llmJudgeScore: score.scoreNumeric,
                     concisenessScore: concisenessScore.scoreNumeric,
                     hedges: checkHedging(reply.text),


### PR DESCRIPTION
This PR adds a 'question class' column, so we can categorize chat questions during evals.

## Test plan

Also updated Cody leaderboard to expose the question class:

<img width="745" alt="Screenshot 2024-06-27 at 11 03 42 AM" src="https://github.com/sourcegraph/cody/assets/7461306/80d7e50b-c2df-48b2-bd6a-afe638fc6f33">

