### PR TITLE
add recommended label for the Launch VS Code Extension launch task

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,7 +2,7 @@
   "version": "0.1.0",
   "configurations": [
     {
-      "name": "Launch VS Code Extension (Desktop)",
+      "name": "Launch VS Code Extension (Desktop, recommended)",
       "type": "extensionHost",
       "request": "launch",
       "runtimeExecutable": "${execPath}",
@@ -25,7 +25,7 @@
       }
     },
     {
-      "name": "Launch VS Code Extension (Desktop; Separate Instance)",
+      "name": "Launch VS Code Extension (Desktop; Separate Instance, rarely used because it requires signing in each time)",
       "type": "extensionHost",
       "request": "launch",
       "runtimeExecutable": "${execPath}",

--- a/doc/dev/index.md
+++ b/doc/dev/index.md
@@ -8,7 +8,7 @@
 
 ### Build and run the VS Code extension
 
-Open this repository in VS Code and run the `Launch VS Code Extension (Desktop)` build/debug task (or run `pnpm -C vscode run dev`).
+Open this repository in VS Code and run the `Launch VS Code Extension (Desktop, recommended)` build/debug task (or run `pnpm -C vscode run dev`).
 
 See [vscode/CONTRIBUTING.md](../../vscode/CONTRIBUTING.md) for more information.
 

--- a/vscode/CONTRIBUTING.md
+++ b/vscode/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 ## Getting started
 
 1. Run `pnpm install` (see [repository setup instructions](../doc/dev/index.md) if you don't have `pnpm`).
-1. Open this repository in VS Code and run the `Launch VS Code Extension (Desktop)` build/debug task (or run `cd vscode && pnpm run build && pnpm run dev`).
+1. Open this repository in VS Code and run the `Launch VS Code Extension (Desktop, recommended)` build/debug task (or run `cd vscode && pnpm run build && pnpm run dev`).
 
 Tip: Enable `cody.debug.verbose` in VS Code settings during extension development.
 


### PR DESCRIPTION
2 people were using the separate instance one that requires signing in each time because they thought it was better. It's not. This helps clarify that.



## Test plan

n/a