### PR TITLE
Auth: update Ollama offline mode UI

### DIFF
--- a/vscode/src/auth/account-menu.ts
+++ b/vscode/src/auth/account-menu.ts
@@ -1,0 +1,51 @@
+import { type AuthStatus, isDotCom } from '@sourcegraph/cody-shared'
+import * as vscode from 'vscode'
+
+export enum AccountMenuOptions {
+    SignOut = 'Sign Out',
+    Manage = 'Manage Account',
+    Switch = 'Switch Account...',
+}
+
+export async function openAccountMenu(authStatus: AuthStatus): Promise<AccountMenuOptions | undefined> {
+    if (!authStatus.authenticated || !authStatus.endpoint) {
+        return
+    }
+
+    const isOffline = authStatus.isOfflineMode
+    const isDotComInstance = isDotCom(authStatus.endpoint) && !isOffline
+
+    const displayName = authStatus.displayName || authStatus.username
+    const email = authStatus.primaryEmail || 'No Email'
+    const username = authStatus.username || authStatus.displayName
+    const planDetail = `Plan: ${authStatus.userCanUpgrade ? 'Cody Free' : 'Cody Pro'}`
+    const enterpriseDetail = `Enterprise Instance:\n${authStatus.endpoint}`
+    const offlineDetail = 'Use Cody offline with Ollama'
+
+    const options = isDotComInstance ? [AccountMenuOptions.Manage] : []
+    options.push(AccountMenuOptions.Switch, AccountMenuOptions.SignOut)
+
+    const messageOptions = {
+        modal: true,
+        detail: isOffline ? offlineDetail : isDotComInstance ? planDetail : enterpriseDetail,
+    }
+
+    const online = isDotComInstance
+        ? `Signed in as ${displayName} (${email})`
+        : `Signed in as @${username}`
+    const offline = 'Offline Mode'
+    const message = isOffline ? offline : online
+
+    const option = await vscode.window.showInformationMessage(message, messageOptions, ...options)
+
+    switch (option !== undefined) {
+        case option?.startsWith('Sign Out'):
+            return AccountMenuOptions.SignOut
+        case option?.startsWith('Manage'):
+            return AccountMenuOptions.Manage
+        case option?.startsWith('Switch'):
+            return AccountMenuOptions.Switch
+        default:
+            return undefined
+    }
+}

--- a/vscode/src/chat/utils.ts
+++ b/vscode/src/chat/utils.ts
@@ -41,7 +41,7 @@ export function newAuthStatus(
     isOfflineMode?: boolean
 ): AuthStatus {
     if (isOfflineMode) {
-        return { ...offlineModeAuthStatus, endpoint }
+        return { ...offlineModeAuthStatus, endpoint, username }
     }
     if (!user) {
         return { ...unauthenticatedStatus, endpoint }

--- a/vscode/src/services/AuthProvider.ts
+++ b/vscode/src/services/AuthProvider.ts
@@ -258,7 +258,8 @@ export class AuthProvider implements AuthStatusProvider {
         const endpoint = config.serverEndpoint
         const token = config.accessToken
         if (isOfflineMode) {
-            return { ...offlineModeAuthStatus, endpoint }
+            const lastUser = localStorage.getLastStoredUser()
+            return { ...offlineModeAuthStatus, ...lastUser }
         }
         if (!token || !endpoint) {
             return { ...defaultAuthStatus, endpoint }

--- a/vscode/src/services/AuthProvider.ts
+++ b/vscode/src/services/AuthProvider.ts
@@ -8,7 +8,6 @@ import {
     LOCAL_APP_URL,
     SourcegraphGraphQLAPIClient,
     defaultAuthStatus,
-    isDotCom,
     isError,
     logError,
     networkErrorAuthStatus,
@@ -23,6 +22,7 @@ import { getFullConfig } from '../configuration'
 import { logDebug } from '../log'
 
 import { telemetryRecorder } from '@sourcegraph/cody-shared'
+import { AccountMenuOptions, openAccountMenu } from '../auth/account-menu'
 import { closeAuthProgressIndicator } from '../auth/auth-progress-indicator'
 import { maybeStartInteractiveTutorial } from '../tutorial/helpers'
 import { AuthMenu, showAccessTokenInputBox, showInstanceURLInputBox } from './AuthMenus'
@@ -187,43 +187,13 @@ export class AuthProvider implements AuthStatusProvider {
     }
 
     public async accountMenu(): Promise<void> {
-        if (!this.authStatus.authenticated || !this.authStatus.endpoint) {
+        const selected = await openAccountMenu(this.authStatus)
+        if (selected === undefined) {
             return
         }
 
-        if (!isDotCom(this.authStatus.endpoint)) {
-            const username = this.authStatus.username || this.authStatus.displayName
-            const option = await vscode.window.showInformationMessage(
-                `Signed in as @${username}`,
-                {
-                    modal: true,
-                    detail: `Enterprise Instance:\n${this.authStatus.endpoint}`,
-                },
-                'Switch Account...',
-                'Sign Out'
-            )
-            switch (option) {
-                case 'Switch Account...':
-                    await this.signinMenu()
-                    break
-                case 'Sign Out':
-                    await this.signoutMenu()
-                    break
-            }
-            return
-        }
-
-        const detail = `Plan: ${this.authStatus.userCanUpgrade ? 'Cody Free' : 'Cody Pro'}`
-        const options = ['Manage Account', 'Switch Account...', 'Sign Out']
-        const displayName = this.authStatus.displayName || this.authStatus.username
-        const email = this.authStatus.primaryEmail || 'No Email'
-        const option = await vscode.window.showInformationMessage(
-            `Signed in as ${displayName} (${email})`,
-            { modal: true, detail },
-            ...options
-        )
-        switch (option) {
-            case 'Manage Account': {
+        switch (selected) {
+            case AccountMenuOptions.Manage: {
                 // Add the username to the web can warn if the logged in session on web is different from VS Code
                 const uri = vscode.Uri.parse(ACCOUNT_USAGE_URL.toString()).with({
                     query: `cody_client_user=${encodeURIComponent(this.authStatus.username)}`,
@@ -231,10 +201,10 @@ export class AuthProvider implements AuthStatusProvider {
                 void vscode.env.openExternal(uri)
                 break
             }
-            case 'Switch Account...':
+            case AccountMenuOptions.Switch:
                 await this.signinMenu()
                 break
-            case 'Sign Out':
+            case AccountMenuOptions.SignOut:
                 await this.signoutMenu()
                 break
         }

--- a/vscode/src/services/LocalStorageProvider.ts
+++ b/vscode/src/services/LocalStorageProvider.ts
@@ -29,6 +29,7 @@ class LocalStorage {
     protected readonly KEY_LOCAL_MINION_HISTORY = 'cody-local-minionHistory-v0'
     public readonly ANONYMOUS_USER_ID_KEY = 'sourcegraphAnonymousUid'
     public readonly LAST_USED_ENDPOINT = 'SOURCEGRAPH_CODY_ENDPOINT'
+    public readonly LAST_USED_USERNAME = 'SOURCEGRAPH_CODY_USERNAME'
     protected readonly CODY_ENDPOINT_HISTORY = 'SOURCEGRAPH_CODY_ENDPOINT_HISTORY'
     protected readonly CODY_ENROLLMENT_HISTORY = 'SOURCEGRAPH_CODY_ENROLLMENTS'
 
@@ -100,6 +101,12 @@ class LocalStorage {
         await this.storage.update(this.CODY_ENDPOINT_HISTORY, [...historySet])
     }
 
+    public getLastStoredUser(): { endpoint: string; username: string } | null {
+        const username = this.storage.get<string | null>(this.LAST_USED_USERNAME, null)
+        const endpoint = this.getEndpoint()
+        return username && endpoint ? { endpoint, username } : null
+    }
+
     public getChatHistory(authStatus: AuthStatus): UserLocalHistory {
         const history = this.storage.get<AccountKeyedChatHistory | null>(this.KEY_LOCAL_HISTORY, null)
         const accountKey = getKeyForAuthStatus(authStatus)
@@ -132,6 +139,11 @@ class LocalStorage {
             }
 
             await this.storage.update(this.KEY_LOCAL_HISTORY, fullHistory)
+
+            // Store the current username as the last used username
+            if (authStatus.username) {
+                this.storage.update(this.LAST_USED_USERNAME, authStatus.username)
+            }
         } catch (error) {
             console.error(error)
         }

--- a/vscode/src/services/StatusBar.ts
+++ b/vscode/src/services/StatusBar.ts
@@ -298,17 +298,21 @@ export function createStatusBar(): CodyStatusBar {
         // yellow status bar icon when extension first loads but login hasn't
         // initialized yet
         if (authStatus) {
+            if (authStatus.isOfflineMode) {
+                statusBarItem.text = '$(cody-logo-heavy) Offline'
+                statusBarItem.tooltip = 'Cody is in offline mode'
+                statusBarItem.backgroundColor = new vscode.ThemeColor('statusBarItem.warningBackground')
+                return
+            }
             if (authStatus.showNetworkError) {
                 statusBarItem.text = '$(cody-logo-heavy) Connection Issues'
                 statusBarItem.tooltip = 'Resolve network issues for Cody to work again'
-                // statusBarItem.color = new vscode.ThemeColor('statusBarItem.errorForeground')
                 statusBarItem.backgroundColor = new vscode.ThemeColor('statusBarItem.errorBackground')
                 return
             }
             if (!authStatus.isLoggedIn) {
                 statusBarItem.text = '$(cody-logo-heavy) Sign In'
                 statusBarItem.tooltip = 'Sign in to get started with Cody'
-                // statusBarItem.color = new vscode.ThemeColor('statusBarItem.warningForeground')
                 statusBarItem.backgroundColor = new vscode.ThemeColor('statusBarItem.warningBackground')
                 return
             }

--- a/vscode/webviews/Troubleshooting/ConnectionIssuesPage.tsx
+++ b/vscode/webviews/Troubleshooting/ConnectionIssuesPage.tsx
@@ -49,6 +49,7 @@ export const ConnectionIssuesPage: React.FunctionComponent<
                     <ul className={styles.causes}>
                         <li>You don't have internet access</li>
                         <li>Proxy settings might need to be configured</li>
+                        <li>An internal error preventing the connection</li>
                         <li>
                             The configured endpoint{' '}
                             {configuredEndpoint && (
@@ -58,7 +59,6 @@ export const ConnectionIssuesPage: React.FunctionComponent<
                             )}{' '}
                             is not reachable
                         </li>
-                        <li>An internal error preventing the connection</li>
                     </ul>
                 </div>
                 <div className={styles.actions}>


### PR DESCRIPTION
Follow up on https://github.com/sourcegraph/cody/pull/4691#pullrequestreview-2143240367

This PR addresses the linked comment by @sqs :

> it would be great if we made it so that Cody worked without network access in the normal mode, instead of being in a separate offline mode. For example, Cody would start up and start working using the last configured account even before it had logged in again with the server. 

Proposed solution in this PR:

- store the last used username so that we will be able to get the chat history from the last logged-in user 

<img width="1984" alt="image" src="https://github.com/sourcegraph/cody/assets/68532117/8ff12df0-c441-409d-8742-b85ac63501bf">

## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

1. Start Cody from this branch
2. Open Ollama
3. Open Chat and ask Cody a question to verify Cody still works when there is an Internet connection
4. Turn off your Wi-Fi settings
5. Reload VS Code
6. Verify you are seeing the connection issue page
7. Click on Use Cody Offline with Ollama
8. Verify the sidebar is loaded correctly
9. Verify you can see the Chat History for your last logged-in user
10. Open Chat and select an Ollama instruct model
11. Ask Cody a question and verify you are getting a response back from the Ollama model

## Demo

https://github.com/sourcegraph/cody/assets/68532117/c2d1b883-fc7b-442d-8a75-71d121cca92c

### Before

As you will be logged in as an unknown user, your chat history from your previous sign in will not be showing up:

<img width="1957" alt="image" src="https://github.com/sourcegraph/cody/assets/68532117/4d3dcdef-d702-4f19-b8fa-c872615211f0">

### After

In Offline mode, we will retrieve your last stored username and endpoint to get the local chat history:

<img width="2040" alt="image" src="https://github.com/sourcegraph/cody/assets/68532117/f1a4e359-bd56-4ec2-ba0a-f7c4be2dad9b">

