### PR TITLE
Agent: Add custom commands list API

### DIFF
--- a/agent/src/agent.ts
+++ b/agent/src/agent.ts
@@ -2,7 +2,12 @@ import { spawn } from 'node:child_process'
 import path from 'node:path'
 
 import type { Polly, Request } from '@pollyjs/core'
-import { getDotComDefaultModels, isWindows, telemetryRecorder } from '@sourcegraph/cody-shared'
+import {
+    type CodyCommand,
+    getDotComDefaultModels,
+    isWindows,
+    telemetryRecorder,
+} from '@sourcegraph/cody-shared'
 import envPaths from 'env-paths'
 import * as vscode from 'vscode'
 import { StreamMessageReader, StreamMessageWriter, createMessageConnection } from 'vscode-jsonrpc/node'
@@ -762,6 +767,11 @@ export class Agent extends MessageHandler implements ExtensionClient {
 
         this.registerAuthenticatedRequest('command/execute', async params => {
             await vscode.commands.executeCommand(params.command, ...(params.arguments ?? []))
+        })
+
+        this.registerAuthenticatedRequest('customCommands/list', async () => {
+            const commands = await vscode.commands.executeCommand('cody.commands.get-custom-commands')
+            return (commands as CodyCommand[]) ?? []
         })
 
         this.registerAuthenticatedRequest('autocomplete/execute', async (params, token) => {

--- a/agent/src/custom-commands.test.ts
+++ b/agent/src/custom-commands.test.ts
@@ -21,6 +21,10 @@ describe('Custom Commands', () => {
         await workspace.beforeAll()
         await client.beforeAll()
         await client.request('command/execute', { command: 'cody.search.index-update' })
+        const customCommands = await client.request('customCommands/list', null)
+        // The number of custom commands we are testing
+        const expectedCommands = 5
+        expect(customCommands.length).toBeGreaterThan(expectedCommands)
     })
 
     afterAll(async () => {

--- a/vscode/src/commands/services/custom-commands.ts
+++ b/vscode/src/commands/services/custom-commands.ts
@@ -58,6 +58,9 @@ export class CustomCommandsManager implements vscode.Disposable {
             ),
             vscode.commands.registerCommand('cody.commands.delete.json', type =>
                 this.configFileActions(type, 'delete')
+            ),
+            vscode.commands.registerCommand('cody.commands.get-custom-commands', () =>
+                [...this.customCommandsMap].map(command => command[1])
             )
         )
     }

--- a/vscode/src/jsonrpc/agent-protocol.ts
+++ b/vscode/src/jsonrpc/agent-protocol.ts
@@ -2,6 +2,7 @@ import type {
     AuthStatus,
     BillingCategory,
     BillingProduct,
+    CodyCommand,
     ContextFilters,
     CurrentUserCodySubscription,
     Model,
@@ -84,6 +85,9 @@ export type ClientRequests = {
 
     // Trigger custom commands that could be a chat-based command or an edit command.
     'commands/custom': [{ key: string }, CustomCommandResult]
+
+    // A list of available custom commands stored in .cody/commands.json.
+    'customCommands/list': [null, CodyCommand[]]
 
     // Trigger commands that edit the code.
     'editCommands/code': [


### PR DESCRIPTION
This change adds a new API endpoint `customCommands/list` that allows clients to retrieve a list of available custom commands stored in the local `.cody/commands.json` file. This is used to populate the list of custom commands in the Cody UI acrooss IDEs.

The changes include:

- Adding a new `customCommands/list` request handler in the `Agent` class that calls the `cody.commands.get-custom-commands` command to retrieve the list of custom commands.
- Updating the `agent-protocol.ts` file to define the new `customCommands/list` request type.
- Adding a test in `custom-commands.test.ts` to verify that the `customCommands/list` API returns the expected number of custom commands.
- Implementing the `cody.commands.get-custom-commands` command in the `CustomCommandsManager` class to return the list of custom commands.


## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

Verified the new API works by porting it to the cli tool (for testing only, the code has been removed):

<img width="1028" alt="image" src="https://github.com/sourcegraph/cody/assets/68532117/1217619b-f827-49d2-9158-f6998f7d4a05">

This is just to add the missing piece to the Agent API. Custom Commands is currently not integrated into other clients atm.