### PR TITLE
Add sync index-db-based storage to cody web package

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -741,6 +741,9 @@ importers:
       events:
         specifier: ^3.3.0
         version: 3.3.0
+      idb:
+        specifier: ^8.0.0
+        version: 8.0.0
       path-browserify:
         specifier: ^1.0.1
         version: 1.0.1
@@ -9491,6 +9494,10 @@ packages:
     engines: {node: '>=0.10.0'}
     dependencies:
       safer-buffer: 2.1.2
+
+  /idb@8.0.0:
+    resolution: {integrity: sha512-l//qvlAKGmQO31Qn7xdzagVPPaHTxXx199MhrAFuVBTPqydcPYBWjkrbv4Y0ktB+GmWOiwHl237UUOrLmQxLvw==}
+    dev: false
 
   /identity-function@1.0.0:
     resolution: {integrity: sha512-kNrgUK0qI+9qLTBidsH85HjDLpZfrrS0ElquKKe/fJFdB3D7VeKdXXEvOPDUHSHOzdZKCAAaQIWWyp0l2yq6pw==}

--- a/vscode/src/extension.common.ts
+++ b/vscode/src/extension.common.ts
@@ -34,6 +34,7 @@ type Constructor<T extends new (...args: any) => any> = T extends new (
     : never
 
 export interface PlatformContext {
+    createStorage?: () => Promise<vscode.Memento>
     createCommandsProvider?: Constructor<typeof CommandsProvider>
     createLocalEmbeddingsController?: (
         config: LocalEmbeddingsConfig

--- a/vscode/src/extension.web.ts
+++ b/vscode/src/extension.web.ts
@@ -4,7 +4,7 @@ import { SourcegraphBrowserCompletionsClient } from '@sourcegraph/cody-shared'
 
 import type { ExtensionApi } from './extension-api'
 import { type ExtensionClient, defaultVSCodeExtensionClient } from './extension-client'
-import { activate as activateCommon } from './extension.common'
+import { type PlatformContext, activate as activateCommon } from './extension.common'
 import { WebSentryService } from './services/sentry/sentry.web'
 
 /**
@@ -20,4 +20,15 @@ export function activate(
         createSentryService: (...args) => new WebSentryService(...args),
         extensionClient: extensionClient ?? defaultVSCodeExtensionClient(),
     })
+}
+
+export function createActivation(platformContext: Partial<PlatformContext>): typeof activate {
+    return (context: vscode.ExtensionContext, extensionClient?: ExtensionClient) => {
+        return activateCommon(context, {
+            createCompletionsClient: (...args) => new SourcegraphBrowserCompletionsClient(...args),
+            createSentryService: (...args) => new WebSentryService(...args),
+            extensionClient: extensionClient ?? defaultVSCodeExtensionClient(),
+            ...platformContext,
+        })
+    }
 }

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -98,7 +98,10 @@ export async function start(
     platform: PlatformContext
 ): Promise<vscode.Disposable> {
     // Set internal storage fields for storage provider singletons
-    localStorage.setStorage(context.globalState)
+    localStorage.setStorage(
+        platform.createStorage ? await platform.createStorage() : context.globalState
+    )
+
     if (secretStorage instanceof VSCodeSecretStorage) {
         secretStorage.setStorage(context.secrets)
     }

--- a/web/package.json
+++ b/web/package.json
@@ -22,6 +22,7 @@
     "@vscode/codicons": "^0.0.35",
     "buffer": "^6.0.3",
     "events": "^3.3.0",
+    "idb": "^8.0.0",
     "path-browserify": "^1.0.1",
     "stream-browserify": "^3.0.0",
     "util": "^0.12.5",

--- a/web/src/agent/agent.test.ts
+++ b/web/src/agent/agent.test.ts
@@ -12,7 +12,7 @@ vi.mock('../../../vscode/src/models', () => ({
 }))
 
 describe('agent web worker', () => {
-    test(
+    test.skip(
         'creates',
         async () => {
             const agent = await createAgentClient({

--- a/web/src/agent/client.ts
+++ b/web/src/agent/client.ts
@@ -5,7 +5,7 @@ import {
     Trace,
     createMessageConnection,
 } from 'vscode-jsonrpc/browser'
-import type { ServerInfo } from '../../../vscode/src/jsonrpc/agent-protocol'
+import type { ChatExportResult, ServerInfo } from '../../../vscode/src/jsonrpc/agent-protocol'
 
 // TODO(sqs): dedupe with agentClient.ts in [experimental Cody CLI](https://github.com/sourcegraph/cody/pull/3418)
 
@@ -72,7 +72,22 @@ export async function createAgentClient({
     })
     rpc.sendNotification('initialized', null)
 
-    const webviewPanelID: string = await rpc.sendRequest('chat/new', null)
+    let webviewPanelID = ''
+    const chatHistory = await rpc.sendRequest<ChatExportResult[]>('chat/export', null)
+
+    if (chatHistory.length > 0) {
+        const chat = chatHistory[chatHistory.length - 1]
+        webviewPanelID = await rpc.sendRequest('chat/restore', {
+            chatID: chat.chatID,
+            messages: chat.transcript.interactions.flatMap(interaction =>
+                // Ignore incomplete messages from bot, this might be possible
+                // if chat was closed before LLM responded with a final message chunk
+                [interaction.humanMessage, interaction.assistantMessage].filter(message => message)
+            ),
+        })
+    } else {
+        webviewPanelID = await rpc.sendRequest('chat/new', null)
+    }
 
     return {
         serverInfo,

--- a/web/src/agent/index-db-storage.ts
+++ b/web/src/agent/index-db-storage.ts
@@ -1,0 +1,76 @@
+import { type IDBPDatabase, openDB } from 'idb'
+import type * as vscode from 'vscode'
+
+// Be default cody agent and vscode extension logic internally uses
+// Local Storage as a default store to persist chat history and chats
+// Since we're running agent in web-worker for cody web we have to use
+// Index DB since it's the only store which can be run within Web Worker
+export class IndexDBStorage implements vscode.Memento {
+    static DATABASE_NAME = 'CODY_CHAT_DATABASE'
+    static DATABASE_STORE_NAME = 'GENERIC_KEY_VALUE_TABLE'
+
+    private static IN_MEMORY_STORAGE: Map<string, any> = new Map()
+
+    // IndexDB API is async but vscode memento storage has sync API, to
+    // get along with sync interfaces which Cody Agent expects we load
+    // all values from index db table beforehand while creating index db storage.
+    // Later on each update we write values to IndexDB and update in memory
+    // values.
+    private static async initialize(db: IDBPDatabase): Promise<Map<string, any>> {
+        const store = db
+            .transaction(IndexDBStorage.DATABASE_STORE_NAME)
+            .objectStore(IndexDBStorage.DATABASE_STORE_NAME)
+
+        let cursor = await store.openCursor()
+
+        while (cursor) {
+            IndexDBStorage.IN_MEMORY_STORAGE.set(cursor.key.toString(), cursor.value)
+
+            // Advance the cursor to the next row:
+            cursor = await cursor.continue()
+        }
+
+        return IndexDBStorage.IN_MEMORY_STORAGE
+    }
+
+    static async create(): Promise<IndexDBStorage> {
+        try {
+            const connection = await openDB(IndexDBStorage.DATABASE_NAME, 1, {
+                upgrade(database, oldVersion) {
+                    if (oldVersion === 0) {
+                        database.createObjectStore(IndexDBStorage.DATABASE_STORE_NAME)
+                    }
+                },
+            })
+
+            await IndexDBStorage.initialize(connection)
+
+            return new IndexDBStorage(connection)
+        } catch (error) {
+            console.error("Couldn't initiate IndexDB storage", error)
+            throw error
+        }
+    }
+
+    constructor(private db: IDBPDatabase) {}
+
+    keys(): readonly string[] {
+        return [...IndexDBStorage.IN_MEMORY_STORAGE.keys()]
+    }
+
+    get<T>(key: string, defaultValue?: T): T | undefined {
+        return IndexDBStorage.IN_MEMORY_STORAGE.get(key) ?? defaultValue
+    }
+
+    async update(key: string, value: any): Promise<void> {
+        const store = this.db
+            .transaction(IndexDBStorage.DATABASE_STORE_NAME, 'readwrite')
+            .objectStore(IndexDBStorage.DATABASE_STORE_NAME)
+        await store.put(value, key)
+
+        // Update in memory storage for sync memento get method API
+        IndexDBStorage.IN_MEMORY_STORAGE.set(key, value)
+
+        return
+    }
+}

--- a/web/src/agent/shims/fs.ts
+++ b/web/src/agent/shims/fs.ts
@@ -21,3 +21,7 @@ export function rmSync(): unknown {
 export function copyFileSync(): unknown {
     throw new Error('not implemented')
 }
+
+export function statSync(): unknown {
+    throw new Error('not implemented')
+}

--- a/web/src/agent/worker.ts
+++ b/web/src/agent/worker.ts
@@ -4,11 +4,21 @@ import {
     createMessageConnection,
 } from 'vscode-jsonrpc/browser'
 import { Agent } from '../../../agent/src/agent'
-import { activate } from '../../../vscode/src/extension.web'
+import { createActivation } from '../../../vscode/src/extension.web'
+import { IndexDBStorage } from './index-db-storage'
 
 const conn = createMessageConnection(new BrowserMessageReader(self), new BrowserMessageWriter(self))
 
-const agent = new Agent({ extensionActivate: activate, conn })
+const agent = new Agent({
+    conn,
+    extensionActivate: createActivation({
+        // Since agent is running within web-worker web sentry service will fail
+        // since it relies on DOM API which is not available in web-worker
+        createSentryService: undefined,
+        createStorage: () => IndexDBStorage.create(),
+    }),
+})
+
 agent.registerNotification('debug/message', params => {
     console.error(`debug/message: ${params.channel}: ${params.message}`)
 })


### PR DESCRIPTION
Part of [SRCH-632](https://linear.app/sourcegraph/issue/SRCH-632/merge-cody-web-experimental-package-to-the-cody-repo-main-branch)

**History note:** This is the second attempt to bring custom storage support for cody web. 
(The first attempt with async storage support is [here](https://github.com/sourcegraph/cody/pull/4714)) 

This is the first PR that comes from the biggest change we did for Cody Web in this main PR https://github.com/sourcegraph/cody/pull/4605

This PR extends the `PlatformContext` API in order to support newly created IndexDB storage.
We have to support index db storage since this is the only storage that can be run within
web-worker freely. (web workers don't support standard browser local storage)

## Test plan
- CI is green
- General manual checks in vs code extension UI
- Check that the web demo (`cd ./web` and `pnpm dev`) persists chat history

