### PR TITLE
Edit: Support opening a separate diff and improve diff editing

### DIFF
--- a/vscode/src/non-stop/FixupController.ts
+++ b/vscode/src/non-stop/FixupController.ts
@@ -207,56 +207,6 @@ export class FixupController
         }
     }
 
-    /**
-     * Given a task, tracks upcoming changes in the associated document.
-     * If the change restores an applied task to its original state, we discard the task
-     * meaning any associated UI and behaviour is updated.
-     */
-    public registerDiscardOnRestoreListener(task: FixupTask): void {
-        // Triggering an auto-discard or auto-accept can lead to race conditions in the Agent, as the
-        // Agent doesn't get notified when the Accept lens is displayed, so it doesn't actually know when it
-        // is safe to discard/accept.
-        // Fixing it properly will require us to send some sort of notification back to the Agent after we finish
-        // applying the changes. https://github.com/sourcegraph/cody-issues/issues/315 is one example of a bug
-        // caused by auto-accepting here, but there were others as well.
-        if (isRunningInsideAgent()) {
-            return
-        }
-
-        const listener = vscode.workspace.onDidChangeTextDocument(async event => {
-            if (task.state !== CodyTaskState.Applied) {
-                // Task is not in the applied state, this is likely due to it
-                // being accepted or discarded in an alternative way.
-                // Dispose of this listener as we no longer need it
-                return listener.dispose()
-            }
-
-            if (event.document.uri.toString() !== task.fixupFile.uri.toString()) {
-                // Irrelevant change, ignore (edit applied to different file)
-                return
-            }
-
-            const changeIsWithinRange = event.contentChanges.some(
-                edit =>
-                    !(
-                        edit.range.end.isBefore(task.selectionRange.start) ||
-                        edit.range.start.isAfter(task.selectionRange.end)
-                    )
-            )
-            if (!changeIsWithinRange) {
-                // Irrelevant change, ignore (edit applied outside of task range)
-                return
-            }
-
-            if (event.document.getText(task.selectionRange) === task.original) {
-                // The user has undone the edit, discard the task
-                task.diff = undefined
-                this.discard(task)
-                return listener.dispose()
-            }
-        })
-    }
-
     private async revertToOriginal(
         task: FixupTask,
         edit: vscode.TextEditor['edit'] | vscode.WorkspaceEdit,
@@ -1078,7 +1028,6 @@ export class FixupController
 
         if (task.state === CodyTaskState.Applied) {
             this.decorator.didApplyTask(task)
-            this.registerDiscardOnRestoreListener(task)
         }
     }
 

--- a/vscode/src/non-stop/FixupController.ts
+++ b/vscode/src/non-stop/FixupController.ts
@@ -264,8 +264,7 @@ export class FixupController
                 return
             }
 
-            const updatedText = event.document.getText(task.selectionRange)
-            if (updatedText === task.original) {
+            if (event.document.getText(task.selectionRange) === task.original) {
                 // The user has undone the edit, discard the task
                 task.diff = undefined
                 this.discard(task)
@@ -1101,7 +1100,6 @@ export class FixupController
 
         if (task.state === CodyTaskState.Applied) {
             this.decorator.didApplyTask(task)
-            // TODO: Fix
             this.registerDiscardOnRestoreListener(task)
         }
     }

--- a/vscode/src/non-stop/FixupController.ts
+++ b/vscode/src/non-stop/FixupController.ts
@@ -207,6 +207,58 @@ export class FixupController
         }
     }
 
+    /**
+     * Given a task, tracks upcoming changes in the associated document.
+     * If the change restores an applied task to its original state, we discard the task
+     * meaning any associated UI and behaviour is updated.
+     */
+    public registerDiscardOnRestoreListener(task: FixupTask): void {
+        // Triggering an auto-discard or auto-accept can lead to race conditions in the Agent, as the
+        // Agent doesn't get notified when the Accept lens is displayed, so it doesn't actually know when it
+        // is safe to discard/accept.
+        // Fixing it properly will require us to send some sort of notification back to the Agent after we finish
+        // applying the changes. https://github.com/sourcegraph/cody-issues/issues/315 is one example of a bug
+        // caused by auto-accepting here, but there were others as well.
+        if (isRunningInsideAgent()) {
+            return
+        }
+
+        const listener = vscode.workspace.onDidChangeTextDocument(async event => {
+            if (task.state !== CodyTaskState.Applied) {
+                // Task is not in the applied state, this is likely due to it
+                // being accepted or discarded in an alternative way.
+                // Dispose of this listener as we no longer need it
+                return listener.dispose()
+            }
+
+            if (event.document.uri.toString() !== task.fixupFile.uri.toString()) {
+                // Irrelevant change, ignore (edit applied to different file)
+                return
+            }
+
+            const changeIsWithinRange = event.contentChanges.some(
+                edit =>
+                    !(
+                        edit.range.end.isBefore(task.selectionRange.start) ||
+                        edit.range.start.isAfter(task.selectionRange.end)
+                    )
+            )
+            if (!changeIsWithinRange) {
+                // Irrelevant change, ignore (edit applied outside of task range)
+                return
+            }
+
+            const updatedText = event.document.getText(task.selectionRange)
+            if (updatedText === task.original) {
+                // The user has undone the edit, discard the task
+                task.diff = undefined
+                this.discard(task)
+                return listener.dispose()
+            }
+            this.decorator.didApplyTask(task)
+        })
+    }
+
     private async revertToOriginal(
         task: FixupTask,
         edit: vscode.TextEditor['edit'] | vscode.WorkspaceEdit,
@@ -1028,6 +1080,8 @@ export class FixupController
 
         if (task.state === CodyTaskState.Applied) {
             this.decorator.didApplyTask(task)
+            // TODO: Fix
+            this.registerDiscardOnRestoreListener(task)
         }
     }
 

--- a/vscode/src/non-stop/FixupDocumentEditObserver.ts
+++ b/vscode/src/non-stop/FixupDocumentEditObserver.ts
@@ -85,21 +85,20 @@ export class FixupDocumentEditObserver {
                 continue
             }
 
-            const changeWithinRange = event.contentChanges.some(
+            const changes = new Array<TextChange>(...event.contentChanges)
+            if (task.state === CodyTaskState.Applied && task.diff) {
+                task.diff = updateAppliedDiff(changes, task.diff)
+            }
+
+            const changeWithinRange = changes.some(
                 edit =>
                     !(
                         edit.range.end.isBefore(task.selectionRange.start) ||
                         edit.range.start.isAfter(task.selectionRange.end)
                     )
             )
-
             if (changeWithinRange) {
                 this.provider_.textDidChange(task)
-            }
-
-            const changes = new Array<TextChange>(...event.contentChanges)
-            if (task.state === CodyTaskState.Applied && task.diff) {
-                task.diff = updateAppliedDiff(changes, task.diff)
             }
 
             const updatedRange = updateRangeMultipleChanges(task.selectionRange, changes, {

--- a/vscode/src/non-stop/FixupDocumentEditObserver.ts
+++ b/vscode/src/non-stop/FixupDocumentEditObserver.ts
@@ -9,10 +9,18 @@ function updateAppliedDiff(changes: TextChange[], diff: Edit[]): Edit[] {
     const result: Edit[] = []
 
     for (const edit of diff) {
-        const updatedRange = updateRangeMultipleChanges(edit.range, changes, { supportRangeAffix: true })
-        if (updatedRange.start.character !== 0 || updatedRange.end.character !== 0) {
-            // The updated range is invalid, so remove it.
-            // TODO: Better comemnt here
+        const updatedRange = updateRangeMultipleChanges(edit.range, changes)
+        if (
+            edit.type === 'decoratedReplacement' &&
+            (updatedRange.start.character !== 0 || updatedRange.end.character !== 0)
+        ) {
+            // If the range of a `decoratedReplacement` line no longer encompasses a full line,
+            // then we can longer be confident that it should definitely be removed.
+            // It may now contain new code that the user does not want to be discarded.
+            //
+            // Instead, we will discard this edit from the diff. This has some implications:
+            // 1. We no longer show a decoration for this line, so the previous `oldText` will no longer show.
+            // 2. We will not delete this line when the task is accepted.
             continue
         }
         edit.range = updatedRange

--- a/vscode/src/non-stop/FixupDocumentEditObserver.ts
+++ b/vscode/src/non-stop/FixupDocumentEditObserver.ts
@@ -3,6 +3,7 @@ import * as vscode from 'vscode'
 import type { FixupActor, FixupFileCollection, FixupTextChanged } from './roles'
 import { type TextChange, updateFixedRange, updateRangeMultipleChanges } from './tracked-range'
 import { CodyTaskState } from './utils'
+import { isRunningInsideAgent } from '../jsonrpc/isRunningInsideAgent'
 
 /**
  * Observes text document changes and updates the regions with active fixups.
@@ -41,6 +42,17 @@ export class FixupDocumentEditObserver {
             )
 
             if (changeWithinRange) {
+                // Note that we would like to auto-accept at this point if task.state == Applied.
+                // But it led to race conditions and bad bugs, because the Agent doesn't get
+                // notified when the Accept lens is displayed, so it doesn't actually know when it
+                // is safe to auto-accept. Fixing it properly will require us to send some sort of
+                // notification back to the Agent after we finish applying the
+                // changes. https://github.com/sourcegraph/cody-issues/issues/315 is one example
+                // of a bug caused by auto-accepting here, but there were others as well.
+                if (task.state === CodyTaskState.Applied && !isRunningInsideAgent()) {
+                    this.provider_.accept(task)
+                    continue
+                }
                 this.provider_.textDidChange(task)
             }
 

--- a/vscode/src/non-stop/codelenses/provider.ts
+++ b/vscode/src/non-stop/codelenses/provider.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode'
 
 import { telemetryRecorder } from '@sourcegraph/cody-shared'
+import { isRunningInsideAgent } from '../../jsonrpc/isRunningInsideAgent'
 // biome-ignore lint/nursery/noRestrictedImports: Deprecated v1 telemetry used temporarily to support existing analytics.
 import { telemetryService } from '../../services/telemetry'
 import { ContentProvider } from '../FixupContentStore'
@@ -259,9 +260,11 @@ export class FixupCodeLenses implements vscode.CodeLensProvider, FixupControlApp
         // show diff view between the current document and replacement
         // Add replacement content to the temp document
 
-        // Note: We need to accept the task before showing it as a diff here, this is because
-        // we have injected empty whitespace and decorations to the document.
-        this.controller.accept(task)
+        if (!isRunningInsideAgent()) {
+            // Note: For VS Code, we need to accept the task before showing it as a diff here, this is because
+            // we have injected empty whitespace and decorations to the document.
+            this.controller.accept(task)
+        }
 
         // Ensure each diff is fresh so there is no chance of diffing an already diffed file.
         const diffId = `${task.id}-${Date.now()}`

--- a/vscode/src/non-stop/codelenses/provider.ts
+++ b/vscode/src/non-stop/codelenses/provider.ts
@@ -259,6 +259,10 @@ export class FixupCodeLenses implements vscode.CodeLensProvider, FixupControlApp
         // show diff view between the current document and replacement
         // Add replacement content to the temp document
 
+        // Note: We need to accept the task before showing it as a diff here, this is because
+        // we have injected empty whitespace and decorations to the document.
+        this.controller.accept(task)
+
         // Ensure each diff is fresh so there is no chance of diffing an already diffed file.
         const diffId = `${task.id}-${Date.now()}`
         await this.contentStore.set(diffId, task.fixupFile.uri)

--- a/vscode/src/testutils/mocks.test.ts
+++ b/vscode/src/testutils/mocks.test.ts
@@ -19,6 +19,21 @@ describe('VS Code Mocks', () => {
             expect(selection.end.line).toStrictEqual(3)
             expect(selection.end.character).toStrictEqual(4)
         })
+
+        it('intersection(otherRange)', () => {
+            // Matching ranges intersect and produce the same ranges
+            const rangeA = new Range(0, 0, 4, 0)
+            const rangeB = new Range(0, 0, 4, 0)
+            expect(rangeA.intersection(rangeB)).toStrictEqual(rangeA)
+
+            // Overlapping ranges intersect and produce the overlapping range
+            const rangeC = new Range(2, 0, 6, 0)
+            expect(rangeA.intersection(rangeC)).toStrictEqual(new Range(2, 0, 4, 0))
+
+            // Non-overlapping ranges do not intersect and return undefined
+            const rangeD = new Range(99, 0, 100, 0)
+            expect(rangeA.intersection(rangeD)).toBeUndefined()
+        })
     })
     describe('Selection', () => {
         it('constructor(Position,Position)', () => {

--- a/vscode/src/testutils/mocks.ts
+++ b/vscode/src/testutils/mocks.ts
@@ -318,6 +318,34 @@ export class Position implements VSCodePosition {
     public compareTo(other: VSCodePosition): number {
         return this.isBefore(other) ? -1 : this.isAfter(other) ? 1 : 0
     }
+
+    static Min(...positions: Position[]): Position {
+        if (positions.length === 0) {
+            throw new TypeError()
+        }
+        let result = positions[0]
+        for (let i = 1; i < positions.length; i++) {
+            const p = positions[i]
+            if (p.isBefore(result)) {
+                result = p
+            }
+        }
+        return result
+    }
+
+    static Max(...positions: Position[]): Position {
+        if (positions.length === 0) {
+            throw new TypeError()
+        }
+        let result = positions[0]
+        for (let i = 1; i < positions.length; i++) {
+            const p = positions[i]
+            if (p.isAfter(result)) {
+                result = p
+            }
+        }
+        return result
+    }
 }
 
 export class Location implements VSCodeLocation {
@@ -407,8 +435,16 @@ export class Range implements VSCodeRange {
 
         throw new Error('not implemented')
     }
-    public intersection(): VSCodeRange | undefined {
-        throw new Error('not implemented')
+    public intersection(other: VSCodeRange): VSCodeRange | undefined {
+        const start = Position.Max(other.start, this.start)
+        const end = Position.Min(other.end, this.end)
+        if (start.isAfter(end)) {
+            // this happens when there is no overlap:
+            // |-----|
+            //          |----|
+            return undefined
+        }
+        return new Range(start, end)
     }
     public union(): VSCodeRange {
         throw new Error('not implemented')


### PR DESCRIPTION
## Description

https://github.com/sourcegraph/cody/assets/9516420/fddd099e-432d-498a-96de-b8fcf40df0f1


This PR:
- Allows opening a full diff via "Open Diff". With additional functionality for reverting specific lines etc.
  - Note: We have to "accept" the task when we do this, this is so we don't have have a duplicate diff in this view from the inline diff and the separate diff. We could try to remove the inline-diff when opening this, and re-add when closing it, but that would spam the users' undo/redo stack, and likely lead to bugs keeping everything in sync
- Improves functionality for editing the inline diff like it is just text


## Test plan

1. Make edits
2. Make changes
3. Check decorations
4. "Open Diff"


<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
