### PR TITLE
Send history change notification to the client

### DIFF
--- a/vscode/src/chat/chat-view/ChatHistoryManager.ts
+++ b/vscode/src/chat/chat-view/ChatHistoryManager.ts
@@ -1,11 +1,12 @@
 import type { AuthStatus, SerializedChatTranscript, UserLocalHistory } from '@sourcegraph/cody-shared'
 
+import { debounce } from 'lodash'
 import * as vscode from 'vscode'
 import { localStorage } from '../../services/LocalStorageProvider'
 
 export class ChatHistoryManager implements vscode.Disposable {
-    private historyChanged: vscode.EventEmitter<void> = new vscode.EventEmitter<void>()
     private disposables: vscode.Disposable[] = []
+    private historyChanged = new vscode.EventEmitter<UserLocalHistory | null>()
 
     constructor() {
         this.disposables.push(this.historyChanged)
@@ -33,22 +34,30 @@ export class ChatHistoryManager implements vscode.Disposable {
         const history = localStorage.getChatHistory(authStatus)
         history.chat[chat.id] = chat
         await localStorage.setChatHistory(authStatus, history)
-        this.historyChanged.fire()
+        this.notifyChatHistoryChanged(authStatus)
         return history
-    }
-
-    public onHistoryChanged(listener: () => any): vscode.Disposable {
-        return this.historyChanged.event(listener)
     }
 
     public async deleteChat(authStatus: AuthStatus, chatID: string): Promise<void> {
         await localStorage.deleteChatHistory(authStatus, chatID)
+        this.notifyChatHistoryChanged(authStatus)
     }
 
     // Remove chat history and input history
     public async clear(authStatus: AuthStatus): Promise<void> {
         await localStorage.removeChatHistory(authStatus)
+        this.notifyChatHistoryChanged(authStatus)
     }
+
+    public onHistoryChanged(listener: (chatHistory: UserLocalHistory | null) => any): vscode.Disposable {
+        return this.historyChanged.event(listener)
+    }
+
+    private notifyChatHistoryChanged = debounce(
+        authStatus => this.historyChanged.fire(this.getLocalHistory(authStatus)),
+        100,
+        { leading: true, trailing: true }
+    )
 }
 
 export const chatHistory = new ChatHistoryManager()

--- a/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
+++ b/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
@@ -262,6 +262,14 @@ export class SimpleChatPanelProvider
                 chatModel: this.chatModel,
             })
         )
+
+        // Observe any changes in chat history and send client notifications to
+        // the consumer
+        this.disposables.push(
+            chatHistory.onHistoryChanged(chatHistory => {
+                this.postMessage({ type: 'history', localHistory: chatHistory })
+            })
+        )
     }
 
     /**


### PR DESCRIPTION
Part of [SRCH-632](https://linear.app/sourcegraph/issue/SRCH-632/merge-cody-web-experimental-package-to-the-cody-repo-main-branch)

This is the one of PRs that come from the bigger change we did for Cody Web in this main PR https://github.com/sourcegraph/cody/pull/4605

This PR just add notification calls on history items change, this is what Cody Web needs to listen 
in order to update history chat items and chat statuses (new chat, chat with messages, ..etc)

## Test plan
- CI is green 

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
