### PR TITLE
Extend `chat/export` rpc API (add fullHistory option)

### DIFF
--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/Chat_ExportParams.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/Chat_ExportParams.kt
@@ -1,0 +1,7 @@
+@file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
+package com.sourcegraph.cody.protocol_generated;
+
+data class Chat_ExportParams(
+  val fullHistory: Boolean,
+)
+

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/CodyAgentServer.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/CodyAgentServer.kt
@@ -21,7 +21,7 @@ interface CodyAgentServer {
   @JsonRequest("chat/models")
   fun chat_models(params: Chat_ModelsParams): CompletableFuture<Chat_ModelsResult>
   @JsonRequest("chat/export")
-  fun chat_export(params: Null?): CompletableFuture<List<ChatExportResult>>
+  fun chat_export(params: Chat_ExportParams?): CompletableFuture<List<ChatExportResult>>
   @JsonRequest("chat/remoteRepos")
   fun chat_remoteRepos(params: Chat_RemoteReposParams): CompletableFuture<Chat_RemoteReposResult>
   @JsonRequest("chat/submitMessage")

--- a/vscode/src/jsonrpc/agent-protocol.ts
+++ b/vscode/src/jsonrpc/agent-protocol.ts
@@ -63,7 +63,7 @@ export type ClientRequests = {
     ]
 
     'chat/models': [{ modelUsage: ModelUsage }, { models: Model[] }]
-    'chat/export': [null, ChatExportResult[]]
+    'chat/export': [null | { fullHistory: boolean }, ChatExportResult[]]
     'chat/remoteRepos': [{ id: string }, { remoteRepos?: Repo[] | undefined | null }]
 
     // High-level wrapper around webview/receiveMessage and webview/postMessage


### PR DESCRIPTION
Part of [SRCH-632](https://linear.app/sourcegraph/issue/SRCH-632/merge-cody-web-experimental-package-to-the-cody-repo-main-branch)

This is the one of PRs that come from the bigger change we did for Cody Web in this main PR https://github.com/sourcegraph/cody/pull/4605

This PR extends the existing chat/export rpm API in order to be able to query full chat history, not only non-empty chats (standard behaviour). Default behaviour hasn't been changed so this should very safe to merge

## Test plan
- CI is green (test passes)
<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
