### PR TITLE
Add `chat/web/new` method to rpc JSON API

### DIFF
--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/Chat_Web_NewResult.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/Chat_Web_NewResult.kt
@@ -1,0 +1,8 @@
+@file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
+package com.sourcegraph.cody.protocol_generated;
+
+data class Chat_Web_NewResult(
+  val panelId: String,
+  val chatId: String,
+)
+

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/CodyAgentServer.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/CodyAgentServer.kt
@@ -16,6 +16,8 @@ interface CodyAgentServer {
   fun shutdown(params: Null?): CompletableFuture<Null?>
   @JsonRequest("chat/new")
   fun chat_new(params: Null?): CompletableFuture<String>
+  @JsonRequest("chat/web/new")
+  fun chat_web_new(params: Null?): CompletableFuture<Chat_Web_NewResult>
   @JsonRequest("chat/restore")
   fun chat_restore(params: Chat_RestoreParams): CompletableFuture<String>
   @JsonRequest("chat/models")

--- a/agent/src/agent.ts
+++ b/agent/src/agent.ts
@@ -1065,6 +1065,18 @@ export class Agent extends MessageHandler implements ExtensionClient {
             )
         })
 
+        this.registerAuthenticatedRequest('chat/web/new', async () => {
+            const panelId = await this.createChatPanel(
+                Promise.resolve({
+                    type: 'chat',
+                    session: await vscode.commands.executeCommand('cody.chat.panel.new'),
+                })
+            )
+
+            const chatId = this.webPanels.panels.get(panelId)?.chatID ?? ''
+            return { panelId, chatId }
+        })
+
         this.registerAuthenticatedRequest('chat/restore', async ({ modelID, messages, chatID }) => {
             const authStatus = await vscode.commands.executeCommand<AuthStatus>('cody.auth.status')
             let theModel = modelID

--- a/vscode/src/jsonrpc/agent-protocol.ts
+++ b/vscode/src/jsonrpc/agent-protocol.ts
@@ -48,6 +48,11 @@ export type ClientRequests = {
     // webview/didDispose.
     'chat/new': [null, string]
 
+    // Start a new chat session and returns panel id and chat id that later can
+    // be used to reference to the session with panel id and restore chat with
+    // chat id. Main difference compared to the chat/new is that we return chatId.
+    'chat/web/new': [null, { panelId: string; chatId: string }]
+
     // Similar to `chat/new` except it starts a new chat session from an
     // existing transcript. The chatID matches the `chatID` property of the
     // `type: 'transcript'` ExtensionMessage that is sent via


### PR DESCRIPTION
Part of [SRCH-632](https://linear.app/sourcegraph/issue/SRCH-632/merge-cody-web-experimental-package-to-the-cody-repo-main-branch)

This is the one of PRs that come from the bigger change we did for Cody Web in this main PR https://github.com/sourcegraph/cody/pull/4605

This PR adds a new rpc JSON API to create a new chat and return the newly created chat ID, which is very useful for Cody Web client (waiting for the transcript event might be tricky especially because it event won't be sent if no transcription hasn't been published yet)

Change is safe to merge since it's only web-specific and has no effect on other clients.

## Test plan
- CI is green

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
