### PR TITLE
Chat: enable sidebar refresh and moving from sidebar to editor

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -450,6 +450,22 @@
         "icon": "$(new-comment-icon)"
       },
       {
+        "command": "cody.chat.panel.sidebar.new",
+        "category": "Cody",
+        "title": "New Chat",
+        "enablement": "cody.activated",
+        "group": "Cody",
+        "icon": "$(new-comment-icon)"
+      },
+      {
+        "command": "cody.chat.panel.moveFromSideBarToEditor",
+        "category": "Cody",
+        "title": "Move chat to an editor panel",
+        "enablement": "cody.activated",
+        "group": "Cody",
+        "icon": "$(editor-layout)"
+      },
+      {
         "command": "cody.minion.panel.new",
         "category": "Cody",
         "title": "New Minion Panel",
@@ -851,6 +867,16 @@
           "when": "view == cody.chat.tree.view && cody.activated && cody.hasChatHistory",
           "enablement": "cody.hasChatHistory",
           "group": "navigation@3"
+        },
+        {
+          "command": "cody.chat.panel.sidebar.new",
+          "when": "view == cody.chat && cody.activated",
+          "group": "navigation@1"
+        },
+        {
+          "command": "cody.chat.panel.moveFromSideBarToEditor",
+          "when": "view == cody.chat && cody.activated",
+          "group": "navigation@2"
         },
         {
           "command": "cody.welcome",

--- a/vscode/src/chat/chat-view/ChatManager.ts
+++ b/vscode/src/chat/chat-view/ChatManager.ts
@@ -72,6 +72,14 @@ export class ChatManager implements vscode.Disposable {
         // Register Commands
         this.disposables.push(
             vscode.commands.registerCommand('cody.action.chat', args => this.executeChat(args)),
+            vscode.commands.registerCommand(
+                'cody.chat.panel.moveFromSideBarToEditor',
+                async () => await this.chatPanelsManager.moveSidebarChatToEditor()
+            ),
+            vscode.commands.registerCommand(
+                'cody.chat.panel.sidebar.new',
+                async () => await this.chatPanelsManager.resetSidebar()
+            ),
             vscode.commands.registerCommand('cody.chat.history.export', () => this.exportHistory()),
             vscode.commands.registerCommand('cody.chat.history.clear', () => this.clearHistory()),
             vscode.commands.registerCommand('cody.chat.history.delete', item => this.clearHistory(item)),

--- a/vscode/src/chat/chat-view/ChatPanelsManager.ts
+++ b/vscode/src/chat/chat-view/ChatPanelsManager.ts
@@ -285,6 +285,15 @@ export class ChatPanelsManager implements vscode.Disposable {
         this.treeViewProvider.reset()
     }
 
+    public async resetSidebar(): Promise<void> {
+        this.sidebarProvider.clearAndRestartSession()
+    }
+
+    public async moveSidebarChatToEditor(): Promise<void> {
+        const sessionID = this.sidebarProvider.sessionID
+        await Promise.all([this.createWebviewPanel(sessionID), this.resetSidebar()])
+    }
+
     /**
      * Clear the current chat view and start a new chat session in the active panel
      */

--- a/vscode/webviews/App.tsx
+++ b/vscode/webviews/App.tsx
@@ -43,7 +43,7 @@ export const App: React.FunctionComponent<{ vscodeAPI: VSCodeWrapper }> = ({ vsc
     const [userAccountInfo, setUserAccountInfo] = useState<UserAccountInfo>()
 
     const [userHistory, setUserHistory] = useState<SerializedChatTranscript[]>()
-    const [chatIDHistory, setChatIDHistory] = useState<string[]>([])
+    const [chatID, setChatID] = useState<string>('[no-chat]')
 
     const [errorMessages, setErrorMessages] = useState<string[]>([])
     const [isTranscriptError, setIsTranscriptError] = useState<boolean>(false)
@@ -85,7 +85,7 @@ export const App: React.FunctionComponent<{ vscodeAPI: VSCodeWrapper }> = ({ vsc
                             setTranscript(deserializedMessages)
                             setMessageInProgress(null)
                         }
-                        setChatIDHistory([...chatIDHistory, message.chatID])
+                        setChatID(message.chatID)
                         vscodeAPI.setState(message.chatID)
                         break
                     }
@@ -255,6 +255,7 @@ export const App: React.FunctionComponent<{ vscodeAPI: VSCodeWrapper }> = ({ vsc
                         <TelemetryRecorderContext.Provider value={telemetryRecorder}>
                             <ClientStateContextProvider value={clientState}>
                                 <Chat
+                                    chatID={chatID}
                                     chatEnabled={chatEnabled}
                                     userInfo={userAccountInfo}
                                     messageInProgress={messageInProgress}

--- a/vscode/webviews/Chat.story.tsx
+++ b/vscode/webviews/Chat.story.tsx
@@ -16,6 +16,7 @@ const meta: Meta<typeof Chat> = {
         },
     },
     args: {
+        chatID: 'test',
         transcript: FIXTURE_TRANSCRIPT.simple2,
         messageInProgress: null,
         chatEnabled: true,

--- a/vscode/webviews/Chat.tsx
+++ b/vscode/webviews/Chat.tsx
@@ -14,6 +14,7 @@ import { ScrollDown } from './components/ScrollDown'
 import { useTelemetryRecorder } from './utils/telemetry'
 
 interface ChatboxProps {
+    chatID: string
     chatEnabled: boolean
     messageInProgress: ChatMessage | null
     transcript: ChatMessage[]
@@ -25,6 +26,7 @@ interface ChatboxProps {
 }
 
 export const Chat: React.FunctionComponent<React.PropsWithChildren<ChatboxProps>> = ({
+    chatID,
     messageInProgress,
     transcript,
     vscodeAPI,
@@ -161,6 +163,7 @@ export const Chat: React.FunctionComponent<React.PropsWithChildren<ChatboxProps>
                 </div>
             )}
             <Transcript
+                chatID={chatID}
                 transcript={transcript}
                 messageInProgress={messageInProgress}
                 feedbackButtonsOnSubmit={feedbackButtonsOnSubmit}

--- a/vscode/webviews/chat/Transcript.story.tsx
+++ b/vscode/webviews/chat/Transcript.story.tsx
@@ -28,6 +28,7 @@ const meta: Meta<typeof Transcript> = {
         },
     },
     args: {
+        chatID: 'test',
         transcript: FIXTURE_TRANSCRIPT.simple,
         messageInProgress: null,
         feedbackButtonsOnSubmit: () => {},

--- a/vscode/webviews/chat/Transcript.test.tsx
+++ b/vscode/webviews/chat/Transcript.test.tsx
@@ -8,6 +8,7 @@ import { type Interaction, Transcript, transcriptToInteractionPairs } from './Tr
 import { FIXTURE_USER_ACCOUNT_INFO } from './fixtures'
 
 const PROPS: Omit<ComponentProps<typeof Transcript>, 'transcript'> = {
+    chatID: 'test',
     messageInProgress: null,
     feedbackButtonsOnSubmit: () => {},
     copyButtonOnSubmit: () => {},

--- a/vscode/webviews/chat/Transcript.tsx
+++ b/vscode/webviews/chat/Transcript.tsx
@@ -18,6 +18,7 @@ import {
 import { HumanMessageCell } from './cells/messageCell/human/HumanMessageCell'
 
 export const Transcript: React.FunctionComponent<{
+    chatID: string
     transcript: ChatMessage[]
     messageInProgress: ChatMessage | null
     feedbackButtonsOnSubmit: (text: string) => void
@@ -28,7 +29,7 @@ export const Transcript: React.FunctionComponent<{
     chatEnabled: boolean
     postMessage?: ApiPostMessage
     guardrails?: Guardrails
-}> = ({ transcript, messageInProgress, ...props }) => {
+}> = ({ chatID, transcript, messageInProgress, ...props }) => {
     const interactions = useMemo(
         () => transcriptToInteractionPairs(transcript, messageInProgress),
         [transcript, messageInProgress]
@@ -37,8 +38,9 @@ export const Transcript: React.FunctionComponent<{
         <div className="tw-px-8 tw-pt-8 tw-pb-14 tw-flex tw-flex-col tw-gap-10">
             {interactions.map((interaction, i) => (
                 <TranscriptInteraction
-                    // biome-ignore lint/suspicious/noArrayIndexKey:
-                    key={i}
+                    chatID={chatID}
+                    // biome-ignore lint/suspicious/noArrayIndexKey: <explanation>
+                    key={`${chatID}-${i}`}
                     {...props}
                     transcript={transcript}
                     messageInProgress={messageInProgress}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -61,6 +61,7 @@ export const App: FunctionComponent = () => {
     const [clientState, setClientState] = useState<ClientStateForWebview>({
         initialContext: [],
     })
+    const [chatID, setChatID] = useState<string>('[no-chat]')
     const dispatchClientAction = useClientActionDispatcher()
 
     const [client, setClient] = useState<AgentClient | Error | null>(null)
@@ -128,6 +129,7 @@ export const App: FunctionComponent = () => {
                     const deserializedMessages = message.messages.map(
                         PromptString.unsafe_deserializeChatMessage
                     )
+                    setChatID(message.chatID)
                     if (message.isMessageInProgress) {
                         const msgLength = deserializedMessages.length - 1
                         setTranscript(deserializedMessages.slice(0, msgLength))
@@ -200,6 +202,7 @@ export const App: FunctionComponent = () => {
                 <TelemetryRecorderContext.Provider value={telemetryRecorder}>
                     <ClientStateContextProvider value={clientState}>
                         <Chat
+                            chatID={chatID}
                             chatEnabled={true}
                             userInfo={userAccountInfo}
                             messageInProgress={messageInProgress}


### PR DESCRIPTION
https://github.com/sourcegraph/cody/assets/1646931/48ebfc54-ebb2-4039-ac15-c5dc67344f2c

## Changes

- Adds a button to refresh the chat in the sidebar. Previously, there was no way to reset/clear the state of the chat view in the sidebar
- Adds a button to move the chat session in the sidebar to a new editor panel.

## Implementation notes

Populating the initial context chips in the chat input depends on some behavior that is only triggered on the first-time render. In order to trigger this, we key the chat input component on the chat session ID, rather than just the array index. so that these components are recreated when the chat session changes on reset. Otherwise, the existing component from the previous session would be reused, and the input would not be populated with the initial context chips on reset.

## Test plan

Tested locally. Note: chat in the sidebar is not yet enabled, so this should have no effect for now.