### PR TITLE
Cody Web: Add remote context support

### DIFF
--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/MentionQuery.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/MentionQuery.kt
@@ -6,5 +6,6 @@ data class MentionQuery(
   val text: String,
   val range: RangeData? = null,
   val maybeHasRangeSuffix: Boolean? = null,
+  val includeRemoteRepositories: Boolean? = null,
 )
 

--- a/lib/shared/src/common/uri.ts
+++ b/lib/shared/src/common/uri.ts
@@ -1,6 +1,42 @@
-import type { URI } from 'vscode-uri'
+import { URI } from 'vscode-uri'
 
 import { pathFunctionsForURI } from './path'
+
+export const SUPPORTED_URI_SCHEMAS = new Set([
+    'file',
+    'untitled',
+    'remote-file',
+    'vscode-notebook',
+    'vscode-notebook-cell',
+])
+
+/**
+ * Custom/synthetic URI for remote files, primary used for
+ * resolving remote files for any web clients
+ */
+export function createRemoteFileURI(repository: string, path: string): URI {
+    return URI.from({
+        scheme: 'remote-file',
+        authority: repository,
+        path: path.startsWith('/') ? path : `/${path}`,
+    })
+}
+
+export function isRemoteFileURI(uri: URI) {
+    return uri.scheme === 'remote-file'
+}
+
+interface ParsedRemoteFileData {
+    repository: string
+    path: string
+}
+
+export function parseRemoteFileURI(uri: URI): ParsedRemoteFileData {
+    return {
+        path: uri.path,
+        repository: uri.authority,
+    }
+}
 
 /**
  * dirname, but operates on a {@link URI}.

--- a/lib/shared/src/index.ts
+++ b/lib/shared/src/index.ts
@@ -114,6 +114,10 @@ export {
     uriDirname,
     uriExtname,
     uriParseNameAndExtension,
+    SUPPORTED_URI_SCHEMAS,
+    createRemoteFileURI,
+    isRemoteFileURI,
+    parseRemoteFileURI,
     type FileURI,
 } from './common/uri'
 export { NoopEditor } from './editor'

--- a/lib/shared/src/mentions/query.ts
+++ b/lib/shared/src/mentions/query.ts
@@ -31,6 +31,13 @@ export interface MentionQuery {
      * `foo.txt:1`, or `foo.txt:12-`).
      */
     maybeHasRangeSuffix?: boolean
+
+    /**
+     * To control source of mention suggestions, if it's set to true
+     * search logic will try to find suggestions across remote repositories
+     * user has on their instance. (Cody Web use case)
+     */
+    includeRemoteRepositories?: boolean
 }
 
 /**

--- a/lib/shared/src/sourcegraph-api/graphql/queries.ts
+++ b/lib/shared/src/sourcegraph-api/graphql/queries.ts
@@ -333,3 +333,73 @@ export const PACKAGE_LIST_QUERY = `
         }
     }
 `
+
+export const FUZZY_FILES_QUERY = `
+query FuzzyFiles($query: String!) {
+    search(patternType: regexp, query: $query) {
+        results {
+            results {
+                ... on FileMatch {
+                    __typename
+                    file {
+                        url
+                        path
+                        name
+                        byteSize
+                        isDirectory
+                    }
+                    repository {
+                        id
+                        name
+                    }
+                }
+            }
+        }
+    }
+}
+`
+
+export const FUZZY_SYMBOLS_QUERY = `
+query FuzzySymbols($query: String!) {
+    search(patternType: regexp, query: $query) {
+        results {
+            results {
+                ... on FileMatch {
+                    __typename
+                    symbols {
+                        name
+                        location {
+                            range {
+                                start { line }
+                                end { line }
+                            }
+                             resource {
+                                path
+                             }
+                        }
+                    }
+                    repository {
+                        id
+                        name
+                    }
+                }
+            }
+        }
+    }
+}
+`
+
+export const GET_REMOTE_FILE_QUERY = `
+query GetRemoteFileQuery($repositoryName: String!, $filePath: String!, $startLine: Int, $endLine: Int) {
+  repository(name: $repositoryName) {
+    id
+    commit(rev: "HEAD") {
+      id
+      oid
+      blob(path: $filePath) {
+         content(startLine:$startLine endLine:$endLine)
+      }
+    }
+  }
+}
+`

--- a/vscode/src/chat/chat-view/ChatManager.ts
+++ b/vscode/src/chat/chat-view/ChatManager.ts
@@ -46,7 +46,7 @@ export class ChatManager implements vscode.Disposable {
     constructor(
         { extensionUri, ...options }: SidebarViewOptions,
         private chatClient: ChatClient,
-        private enterpriseContext: EnterpriseContextFactory | null,
+        private enterpriseContext: EnterpriseContextFactory,
         private localEmbeddings: LocalEmbeddingsController | null,
         private contextRanking: ContextRankingController | null,
         private symf: SymfRunner | null,

--- a/vscode/src/chat/chat-view/ChatPanelsManager.ts
+++ b/vscode/src/chat/chat-view/ChatPanelsManager.ts
@@ -81,7 +81,7 @@ export class ChatPanelsManager implements vscode.Disposable {
         private readonly localEmbeddings: LocalEmbeddingsController | null,
         private readonly contextRanking: ContextRankingController | null,
         private readonly symf: SymfRunner | null,
-        private readonly enterpriseContext: EnterpriseContextFactory | null,
+        private readonly enterpriseContext: EnterpriseContextFactory,
         private readonly guardrails: Guardrails
     ) {
         logDebug('ChatPanelsManager:constructor', 'init')
@@ -231,13 +231,22 @@ export class ChatPanelsManager implements vscode.Disposable {
         const isCodyProUser = !authStatus.userCanUpgrade
         const models = ModelsService.getModels(ModelUsage.Chat, isCodyProUser)
 
+        // Enterprise context is used for remote repositories context fetching
+        // in vs cody extension it should be always off if extension is connected
+        // to dot com instance, but in Cody Web it should be on by default for
+        // all instances (including dot com), Cody Web client sets cody.allow-remote-context
+        // to true to enable this directly.
+        const allowRemoteContext = vscode.workspace
+            .getConfiguration()
+            .get<boolean>('cody.allow-remote-context', !isConsumer)
+
         return new SimpleChatPanelProvider({
             ...this.options,
             chatClient: this.chatClient,
             localEmbeddings: isConsumer ? this.localEmbeddings : null,
             contextRanking: isConsumer ? this.contextRanking : null,
             symf: isConsumer ? this.symf : null,
-            enterpriseContext: isConsumer ? null : this.enterpriseContext,
+            enterpriseContext: allowRemoteContext ? this.enterpriseContext : null,
             models,
             guardrails: this.guardrails,
             startTokenReceiver: this.options.startTokenReceiver,

--- a/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
+++ b/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
@@ -938,8 +938,15 @@ export class SimpleChatPanelProvider
             const items = await getChatContextItemsForMention(
                 query,
                 cancellation.token,
-                scopedTelemetryRecorder
+                scopedTelemetryRecorder,
+                // Pass possible remote repository context in order to resolve files
+                // for this remote repositories and not for local one, Cody Web case
+                // when we have only remote repositories as context
+                query.includeRemoteRepositories
+                    ? this.remoteSearch?.getRepos('all')?.map(repo => repo.name)
+                    : undefined
             )
+
             if (cancellation.token.isCancellationRequested) {
                 return
             }

--- a/vscode/src/chat/context/chatContext.ts
+++ b/vscode/src/chat/context/chatContext.ts
@@ -27,7 +27,8 @@ export async function getChatContextItemsForMention(
     telemetryRecorder?: {
         empty: () => void
         withProvider: (type: MentionQuery['provider'], metadata?: { id: string }) => void
-    }
+    },
+    remoteRepositoriesNames?: string[]
 ): Promise<ContextItem[]> {
     const MAX_RESULTS = 20
     switch (mentionQuery.provider) {
@@ -37,11 +38,11 @@ export async function getChatContextItemsForMention(
         case SYMBOL_CONTEXT_MENTION_PROVIDER.id:
             telemetryRecorder?.withProvider(mentionQuery.provider)
             // It would be nice if the VS Code symbols API supports cancellation, but it doesn't
-            return getSymbolContextFiles(mentionQuery.text, MAX_RESULTS)
+            return getSymbolContextFiles(mentionQuery.text, MAX_RESULTS, remoteRepositoriesNames)
         case FILE_CONTEXT_MENTION_PROVIDER.id: {
             telemetryRecorder?.withProvider(mentionQuery.provider)
             const files = mentionQuery.text
-                ? await getFileContextFiles(mentionQuery.text, MAX_RESULTS)
+                ? await getFileContextFiles(mentionQuery.text, MAX_RESULTS, remoteRepositoriesNames)
                 : await getOpenTabsContextFile()
 
             // If a range is provided, that means user is trying to mention a specific line range.

--- a/vscode/src/editor/active-editor.ts
+++ b/vscode/src/editor/active-editor.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode'
 
-import { isCodyIgnoredFile } from '@sourcegraph/cody-shared'
+import { SUPPORTED_URI_SCHEMAS, isCodyIgnoredFile } from '@sourcegraph/cody-shared'
 
 /**
  * Interface for tracking the last active text editor that is not a webview panel for
@@ -33,9 +33,6 @@ export function resetActiveEditor(): void {
     lastActiveTextEditor = { active: undefined, ignored: false }
 }
 
-// Support file, untitled, and notebooks
-const validFileSchemes = new Set(['file', 'untitled', 'vscode-notebook', 'vscode-notebook-cell'])
-
 // When the webview panel is focused, calling activeTextEditor will return undefined.
 // This allows us to keep using the last active editor before the webview panel became the active editor
 export function getEditor(): LastActiveTextEditor {
@@ -55,7 +52,7 @@ export function getEditor(): LastActiveTextEditor {
         const activeEditor = vscode.window.activeTextEditor || vscode.window.visibleTextEditors[0]
         if (activeEditor?.document.uri.scheme) {
             // Update the lastActiveTextEditor if the active editor is a valid file
-            if (validFileSchemes.has(activeEditor.document.uri.scheme)) {
+            if (SUPPORTED_URI_SCHEMAS.has(activeEditor.document.uri.scheme)) {
                 lastActiveTextEditor.active = activeEditor
                 lastActiveTextEditor.ignored = isCodyIgnoredFile(activeEditor?.document.uri)
             }

--- a/vscode/src/editor/utils/debounce-promise.ts
+++ b/vscode/src/editor/utils/debounce-promise.ts
@@ -1,0 +1,27 @@
+import { debounce } from 'lodash'
+
+export function debouncePromise<T extends (...args: any) => Promise<any>, B>(
+    func: T,
+    debounceDelay?: number
+): (...args: Parameters<T>) => Promise<Awaited<ReturnType<T>> | 'skipped'> {
+    const promiseResolverRef: { current: (b: Awaited<ReturnType<T>> | 'skipped') => void } = {
+        current: () => {},
+    }
+
+    const debouncedFunc = debounce((...args: any) => {
+        const promiseResolverSnapshot = promiseResolverRef.current
+        func(...args).then(b => {
+            if (promiseResolverSnapshot === promiseResolverRef.current) {
+                promiseResolverRef.current(b)
+            }
+        })
+    }, debounceDelay)
+
+    return (...args: any) =>
+        new Promise<Awaited<ReturnType<T>> | 'skipped'>(resolve => {
+            promiseResolverRef.current('skipped')
+            promiseResolverRef.current = resolve
+
+            debouncedFunc(...args)
+        })
+}

--- a/vscode/webviews/promptEditor/plugins/atMentions/chatContextClient.tsx
+++ b/vscode/webviews/promptEditor/plugins/atMentions/chatContextClient.tsx
@@ -17,6 +17,14 @@ import {
 } from 'react'
 import { getVSCodeAPI } from '../../../utils/VSCodeApi'
 
+export interface ChatMentionsSettings {
+    resolutionMode: 'remote' | 'local'
+}
+
+export const ChatMentionContext = createContext<ChatMentionsSettings>({
+    resolutionMode: 'local',
+})
+
 export interface ChatContextClient {
     getChatContextItems(query: MentionQuery): Promise<ContextItem[]>
 }
@@ -62,10 +70,15 @@ export function useChatContextItems(
     query: string | null,
     provider: ContextMentionProviderMetadata | null
 ): ContextItem[] | undefined {
+    const mentionSettings = useContext(ChatMentionContext)
     const unmemoizedClient = useContext(ChatContextClientContext)
+
     const chatContextClient = useMemo(
-        () => memoizeChatContextClient(unmemoizedClient),
-        [unmemoizedClient]
+        () =>
+            mentionSettings.resolutionMode === 'local'
+                ? memoizeChatContextClient(unmemoizedClient)
+                : unmemoizedClient,
+        [unmemoizedClient, mentionSettings]
     )
     const [results, setResults] = useState<ContextItem[]>()
     const lastProvider = useRef<ContextMentionProviderMetadata['id'] | null>(null)
@@ -83,7 +96,11 @@ export function useChatContextItems(
 
         // If user has typed an incomplete range, fetch new chat context items only if there are no
         // results.
-        const mentionQuery = parseMentionQuery(query, provider)
+        const mentionQuery: MentionQuery = {
+            ...parseMentionQuery(query, provider),
+            includeRemoteRepositories: mentionSettings.resolutionMode === 'remote',
+        }
+
         if (!hasResults && mentionQuery.maybeHasRangeSuffix && !mentionQuery.range) {
             return
         }
@@ -102,7 +119,10 @@ export function useChatContextItems(
             chatContextClient
                 .getChatContextItems(mentionQuery)
                 .then(mentions => {
-                    if (invalidated) {
+                    // Since remote mention search debounce and batches all mention
+                    // search requests we shouldn't invalidate any old responses like
+                    // we do for local search.
+                    if (invalidated && !mentionQuery.includeRemoteRepositories) {
                         return
                     }
                     setResults(mentions)
@@ -116,7 +136,7 @@ export function useChatContextItems(
         return () => {
             invalidated = true
         }
-    }, [query, provider, chatContextClient])
+    }, [query, provider, chatContextClient, mentionSettings])
     return results
 }
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -19,6 +19,11 @@ import {
     ClientStateContextProvider,
     useClientActionDispatcher,
 } from '../../vscode/webviews/client/clientState'
+import { WithContextProviders } from '../../vscode/webviews/mentions/providers'
+import {
+    ChatMentionContext,
+    type ChatMentionsSettings,
+} from '../../vscode/webviews/promptEditor/plugins/atMentions/chatContextClient'
 import { type VSCodeWrapper, setVSCodeWrapper } from '../../vscode/webviews/utils/VSCodeApi'
 import {
     TelemetryRecorderContext,
@@ -26,6 +31,10 @@ import {
     createWebviewTelemetryService,
 } from '../../vscode/webviews/utils/telemetry'
 import { type AgentClient, createAgentClient } from './agent/client'
+
+const CONTEXT_MENTIONS_SETTINGS: ChatMentionsSettings = {
+    resolutionMode: 'remote',
+}
 
 let ACCESS_TOKEN = localStorage.getItem('accessToken')
 if (!ACCESS_TOKEN) {
@@ -198,22 +207,26 @@ export const App: FunctionComponent = () => {
         isErrorLike(client) ? (
             <p>Error: {client.message}</p>
         ) : (
-            <ChatModelContextProvider value={chatModelContext}>
-                <TelemetryRecorderContext.Provider value={telemetryRecorder}>
-                    <ClientStateContextProvider value={clientState}>
-                        <Chat
-                            chatID={chatID}
-                            chatEnabled={true}
-                            userInfo={userAccountInfo}
-                            messageInProgress={messageInProgress}
-                            transcript={transcript}
-                            vscodeAPI={vscodeAPI}
-                            telemetryService={telemetryService}
-                            isTranscriptError={isTranscriptError}
-                        />
-                    </ClientStateContextProvider>
-                </TelemetryRecorderContext.Provider>
-            </ChatModelContextProvider>
+            <ChatMentionContext.Provider value={CONTEXT_MENTIONS_SETTINGS}>
+                <WithContextProviders>
+                    <ChatModelContextProvider value={chatModelContext}>
+                        <TelemetryRecorderContext.Provider value={telemetryRecorder}>
+                            <ClientStateContextProvider value={clientState}>
+                                <Chat
+                                    chatID={chatID}
+                                    chatEnabled={true}
+                                    userInfo={userAccountInfo}
+                                    messageInProgress={messageInProgress}
+                                    transcript={transcript}
+                                    vscodeAPI={vscodeAPI}
+                                    telemetryService={telemetryService}
+                                    isTranscriptError={isTranscriptError}
+                                />
+                            </ClientStateContextProvider>
+                        </TelemetryRecorderContext.Provider>
+                    </ChatModelContextProvider>
+                </WithContextProviders>
+            </ChatMentionContext.Provider>
         )
     ) : (
         <>Loading...</>

--- a/web/src/agent/client.ts
+++ b/web/src/agent/client.ts
@@ -67,6 +67,8 @@ export async function createAgentClient({
             customConfiguration: {
                 'cody.experimental.noodle': true,
                 'cody.autocomplete.enabled': false,
+                'cody.experimental.urlContext': true,
+                'cody.allow-remote-context': true,
             },
         },
     })


### PR DESCRIPTION
Part of [SRCH-632](https://linear.app/sourcegraph/issue/SRCH-632/merge-cody-web-experimental-package-to-the-cody-repo-main-branch)

This is the one of PRs that come from the bigger change we did for Cody Web in this main PR https://github.com/sourcegraph/cody/pull/4605

This PR adds support for the remote context items files and symbols. Note that eventually, we will use
open context provides for any remote contexts but for now as a semi-temporary solution for Cody Web 
we include this logic outside the open context providers.

This is safe to merge since it only affects Cody Web package. 

## Test plan
- Check that CI is passing 
- Check cody web demo (`cd web` and `pnpm dev`) and check that you can mention remote files and symbols 
- Check that mentioned files and symbols were included in the prompt message

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
