### PR TITLE
Cody Context Filters: disable logs in tests

### DIFF
--- a/lib/shared/src/cody-ignore/context-filters-provider.ts
+++ b/lib/shared/src/cody-ignore/context-filters-provider.ts
@@ -85,9 +85,12 @@ export class ContextFiltersProvider implements vscode.Disposable {
         this.parsedContextFilters = null
         this.lastContextFiltersResponse = contextFilters
 
-        logDebug('ContextFiltersProvider', 'setContextFilters', {
-            verbose: contextFilters,
-        })
+        // Disable logging for unit tests. Retain for manual debugging of enterprise issues.
+        if (!process.env.VITEST) {
+            logDebug('ContextFiltersProvider', 'setContextFilters', {
+                verbose: contextFilters,
+            })
+        }
         this.parsedContextFilters = {
             include: contextFilters.include?.map(parseContextFilterItem) || null,
             exclude: contextFilters.exclude?.map(parseContextFilterItem) || null,


### PR DESCRIPTION
- Disables Enterprise Context Filters debug log for unit tests to make the CI output less noisy.
- Discussed [here](https://sourcegraph.slack.com/archives/C05AGQYD528/p1719614138604569).

## Test plan

n/a
