### PR TITLE
Autocomplete: limit the number of hot-streak lines

### DIFF
--- a/vscode/src/completions/get-inline-completions-tests/helpers.ts
+++ b/vscode/src/completions/get-inline-completions-tests/helpers.ts
@@ -15,7 +15,10 @@ import {
     testFileUri,
 } from '@sourcegraph/cody-shared'
 
-import type { CompletionResponseWithMetaData } from '@sourcegraph/cody-shared/src/inferenceClient/misc'
+import type {
+    CodeCompletionsParams,
+    CompletionResponseWithMetaData,
+} from '@sourcegraph/cody-shared/src/inferenceClient/misc'
 import { DEFAULT_VSCODE_SETTINGS, emptyMockFeatureFlagProvider } from '../../testutils/mocks'
 import type { SupportedLanguage } from '../../tree-sitter/grammars'
 import { updateParseTreeCache } from '../../tree-sitter/parse-tree-cache'
@@ -63,7 +66,7 @@ const getVSCodeConfigurationWithAccessToken = (
 type Params = Partial<Omit<InlineCompletionsParams, 'document' | 'position' | 'docContext'>> & {
     languageId?: string
     takeSuggestWidgetSelectionIntoAccount?: boolean
-    onNetworkRequest?: (params: CompletionParameters) => void
+    onNetworkRequest?: (params: CodeCompletionsParams, abortController: AbortController) => void
     completionResponseGenerator?: (
         params: CompletionParameters
     ) => CompletionResponseGenerator | Generator<CompletionResponse>
@@ -111,8 +114,8 @@ export function params(
     })
 
     const client: CodeCompletionsClient = {
-        async *complete(completeParams) {
-            onNetworkRequest?.(completeParams)
+        async *complete(completeParams, abortController) {
+            onNetworkRequest?.(completeParams, abortController)
 
             if (completionResponseGenerator) {
                 for await (const response of completionResponseGenerator(completeParams)) {

--- a/vscode/src/completions/get-inline-completions-tests/hot-streak.test.ts
+++ b/vscode/src/completions/get-inline-completions-tests/hot-streak.test.ts
@@ -137,6 +137,7 @@ describe('[getInlineCompletions] hot streak', () => {
         })
 
         it('yields a singleline completion early if `firstCompletionTimeout` elapses before the multiline completion is ready', async () => {
+            let abortController: AbortController | undefined
             const completionsPromise = getInlineCompletionsWithInlinedChunks(
                 `function myFunction█() {
                     if(i > 1) {█
@@ -160,11 +161,24 @@ describe('[getInlineCompletions] hot streak', () => {
                     providerOptions: {
                         firstCompletionTimeout: 10,
                     },
+                    abortSignal: new AbortController().signal,
+                    onNetworkRequest(_, requestManagerAbortController) {
+                        abortController = requestManagerAbortController
+                    },
                 }
             )
 
             // Wait for the first completion to be ready
-            vi.advanceTimersByTime(15)
+            await vi.advanceTimersByTimeAsync(10)
+            expect(abortController?.signal.aborted).toBe(false)
+
+            // Wait for the first hot streak completion to be ready
+            await vi.advanceTimersByTimeAsync(10)
+            // We anticipate that the streaming will be cancelled because the hot
+            // streak text exceeds the maximum number of lines defined by `MAX_HOT_STREAK_LINES`.
+            // TODO: expose completion chunks, enabling more explicit verification of this behavior.
+            expect(abortController?.signal.aborted).toBe(true)
+
             // Release the `completionsPromise`
             await vi.runAllTimersAsync()
 

--- a/vscode/src/completions/providers/hot-streak.ts
+++ b/vscode/src/completions/providers/hot-streak.ts
@@ -77,7 +77,9 @@ function insertCompletionAndPressEnter(
 
 // To reduce the load on the inference providers we limit the hot streak
 // generation to a constant number of lines after the initial completion.
-const MAX_HOT_STREAK_LINES = 5
+const MAX_HOT_STREAK_LINES = vscode.workspace
+    .getConfiguration()
+    .get<number>('cody.experimental.maxHotStreakLines', 5)
 
 export function createHotStreakExtractor(params: HotStreakExtractorParams): HotStreakExtractor {
     const { completedCompletion, providerOptions, abortController } = params

--- a/vscode/src/testutils/mocks.ts
+++ b/vscode/src/testutils/mocks.ts
@@ -763,12 +763,12 @@ export const vsCodeMocks = {
         fs: workspaceFs,
         getConfiguration() {
             return {
-                get(key: string) {
+                get(key: string, defaultValue: unknown = undefined) {
                     switch (key) {
                         case 'cody.debug.filter':
                             return '.*'
                         default:
-                            return undefined
+                            return defaultValue
                     }
                 },
                 update(): void {},


### PR DESCRIPTION
- Restrict the number of lines we await during hot-streak completion generation to prevent overwhelming inference providers. Based on empirical observations, we'll initially set this limit to five. We can adjust this value later according to the A/B test results.
- Part of https://linear.app/sourcegraph/issue/CODY-2190/[autocomplete-latency]-ab-test-hot-streak

## Test plan

Updated unit tests and verified locally.