### PR TITLE
biome: use git ignore file

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -75,6 +75,9 @@
       "__snapshots__/",
       "__mocks__/",
       ".vscode-test/",
+      ".vscode-test-web/",
+      ".test/",
+      ".test-reports/",
       "**/.tsconfig.json",
       "**/tsconfig.json",
       ".vscode/*.json",
@@ -91,5 +94,10 @@
         }
       }
     }
-  ]
+  ],
+  "vcs": {
+    "enabled": true,
+    "clientKind": "git",
+    "useIgnoreFile": true
+  }
 }


### PR DESCRIPTION
I had a file that was killing biome inside of the .vscode-test-web directory. This ensures biome doesn't search inside of this directory. Additionally I enabled the vcs ignore integration. However, it seems to ignore nested .gitignore files, so I still needed the vscode-test-web rule.

Test Plan: pnpm biome doesn't make my fan spin on my desktop.