### PR TITLE
Add trigger to overwrite multiline decision

### DIFF
--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/agent/protocol_generated/AutocompleteParams.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/agent/protocol_generated/AutocompleteParams.kt
@@ -9,6 +9,7 @@ data class AutocompleteParams(
   val position: Position,
   val triggerKind: TriggerKindEnum? = null, // Oneof: Automatic, Invoke
   val selectedCompletionInfo: SelectedCompletionInfo? = null,
+  val forceMultiline: Boolean? = null,
 ) {
 
   enum class TriggerKindEnum {

--- a/agent/src/agent.ts
+++ b/agent/src/agent.ts
@@ -823,6 +823,9 @@ export class Agent extends MessageHandler implements ExtensionClient {
             }
 
             try {
+                if (params.forceMultiline === true) {
+                    provider.forceNextCompletionIsMultiline = true
+                }
                 if (params.triggerKind === 'Invoke') {
                     await provider?.manuallyTriggerCompletion?.()
                 }

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -691,6 +691,11 @@
         "when": "editorTextFocus && !editorHasSelection && config.cody.autocomplete.enabled && !inlineSuggestionsVisible"
       },
       {
+        "command": "cody.autocomplete.force-multiline",
+        "key": "alt+shift+\\",
+        "when": "editorTextFocus && !editorHasSelection && config.cody.autocomplete.enabled && !inlineSuggestionsVisible"
+      },
+      {
         "command": "cody.multi-model-autocomplete.manual-trigger",
         "key": "alt+m",
         "when": "editorTextFocus && !editorHasSelection && config.cody.autocomplete.enabled && !inlineSuggestionsVisible"

--- a/vscode/src/completions/create-inline-completion-item-provider.ts
+++ b/vscode/src/completions/create-inline-completion-item-provider.ts
@@ -96,6 +96,9 @@ export async function createInlineCompletionItemProvider({
             vscode.commands.registerCommand('cody.autocomplete.manual-trigger', () =>
                 completionsProvider.manuallyTriggerCompletion()
             ),
+            vscode.commands.registerCommand('cody.autocomplete.force-multiline', () =>
+                completionsProvider.manuallyTriggerMultiLine()
+            ),
             vscode.languages.registerInlineCompletionItemProvider(
                 [{ notebookType: '*' }, ...documentFilters],
                 completionsProvider

--- a/vscode/src/jsonrpc/agent-protocol.ts
+++ b/vscode/src/jsonrpc/agent-protocol.ts
@@ -454,6 +454,7 @@ export interface AutocompleteParams {
     // triggered.
     triggerKind?: 'Automatic' | 'Invoke' | undefined | null
     selectedCompletionInfo?: SelectedCompletionInfo | undefined | null
+    forceMultiline?: boolean | undefined | null
 }
 
 interface SelectedCompletionInfo {


### PR DESCRIPTION
When to use multiline completions is currently determined by some heuristic. It excludes certain languages, and at least for me, doesn't 100% get things right. That's okay, we can improve this over time.
But until we have a very reliable decision process for single vs multiline, it can be helpful to be able to trigger cody to always try to generate a multiline completion at a certain location.
That will also enable multiline completions for language currently not on the allow-list for auto-multiline (probably due to CAR concerns).

After this PR:

Option+\ will trigger any completion, with the detection on.
Option+Shift+\ will trigger a multiline completion always.

## Test plan

Tried generating multiline completions several times locally. There seems to be some bug in multiline in general that sometimes cuts off the completion too early, but that shouldn't prevent this change.
