### PR TITLE
[Agent] Add delete chat method to json rpc

### DIFF
--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/Chat_DeleteParams.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/Chat_DeleteParams.kt
@@ -1,0 +1,7 @@
+@file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
+package com.sourcegraph.cody.protocol_generated;
+
+data class Chat_DeleteParams(
+  val chatId: String,
+)
+

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/CodyAgentServer.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/CodyAgentServer.kt
@@ -18,6 +18,8 @@ interface CodyAgentServer {
   fun chat_new(params: Null?): CompletableFuture<String>
   @JsonRequest("chat/web/new")
   fun chat_web_new(params: Null?): CompletableFuture<Chat_Web_NewResult>
+  @JsonRequest("chat/delete")
+  fun chat_delete(params: Chat_DeleteParams): CompletableFuture<List<ChatExportResult>>
   @JsonRequest("chat/restore")
   fun chat_restore(params: Chat_RestoreParams): CompletableFuture<String>
   @JsonRequest("chat/models")

--- a/agent/src/agent.ts
+++ b/agent/src/agent.ts
@@ -1142,6 +1142,24 @@ export class Agent extends MessageHandler implements ExtensionClient {
             return []
         })
 
+        this.registerAuthenticatedRequest('chat/delete', async params => {
+            await vscode.commands.executeCommand<AuthStatus>('cody.chat.history.delete', {
+                id: params.chatId,
+            })
+
+            const authStatus = await vscode.commands.executeCommand<AuthStatus>('cody.auth.status')
+            const localHistory = await chatHistory.getLocalHistory(authStatus)
+
+            if (localHistory != null) {
+                return Object.entries(localHistory?.chat).map(([chatID, chatTranscript]) => ({
+                    chatID: chatID,
+                    transcript: chatTranscript,
+                }))
+            }
+
+            return []
+        })
+
         this.registerAuthenticatedRequest('chat/remoteRepos', async ({ id }) => {
             const panel = this.webPanels.getPanelOrError(id)
             await this.receiveWebviewMessage(id, {

--- a/vscode/src/jsonrpc/agent-protocol.ts
+++ b/vscode/src/jsonrpc/agent-protocol.ts
@@ -53,6 +53,10 @@ export type ClientRequests = {
     // chat id. Main difference compared to the chat/new is that we return chatId.
     'chat/web/new': [null, { panelId: string; chatId: string }]
 
+    // Deletes chat by its ID and returns newly updated chat history list
+    // Primary is used only in cody web client
+    'chat/delete': [{ chatId: string }, ChatExportResult[]]
+
     // Similar to `chat/new` except it starts a new chat session from an
     // existing transcript. The chatID matches the `chatID` property of the
     // `type: 'transcript'` ExtensionMessage that is sent via


### PR DESCRIPTION
Part of [SRCH-632](https://linear.app/sourcegraph/issue/SRCH-632/merge-cody-web-experimental-package-to-the-cody-repo-main-branch)

This is the one of PRs that come from the bigger change we did for Cody Web in this main PR https://github.com/sourcegraph/cody/pull/4605

This PR extends agent RPC API in order to delete chats from Cody Web client, currently, it's not used
anywhere in main so it's safe to merge this since it has no effect on other clients.

## Test plan
- Check that CI is passing 