### PR TITLE
Chat: Simplify the Enterprise docs in the model selector

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -17,6 +17,8 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 
 - Autocomplete: When the last completion candidate is not applicable at the current document position, it remains in the cache even after the user backspaces or deletes characters from the current line. [pull/4704](https://github.com/sourcegraph/cody/pull/4704)
 - Chat: Added a stop button and cleaned up the vertical space layout of the chat. [pull/4580](https://github.com/sourcegraph/cody/pull/4580)
+- Chat: Simplify the Enterprise docs in the model selector [pull/4745](https://github.com/sourcegraph/cody/pull/4745)
+
 
 ## 1.24.0
 

--- a/vscode/webviews/components/modelSelectField/ModelSelectField.tsx
+++ b/vscode/webviews/components/modelSelectField/ModelSelectField.tsx
@@ -216,37 +216,6 @@ export const ModelSelectField: React.FunctionComponent<{
                                 ))}
                             </CommandGroup>
                         ))}
-                        <CommandGroup heading="Enterprise Model Options">
-                            {ENTERPRISE_MODEL_OPTIONS.map(({ id, url, title }) => (
-                                <CommandLink
-                                    key={id}
-                                    href={url}
-                                    target="_blank"
-                                    rel="noreferrer"
-                                    onSelect={() => {
-                                        telemetryRecorder.recordEvent(
-                                            'cody.modelSelector',
-                                            'clickEnterpriseModelOption',
-                                            { metadata: { [id]: 1 } }
-                                        )
-                                    }}
-                                    className={styles.modelTitleWithIcon}
-                                >
-                                    <span className={styles.modelIcon}>
-                                        {/* wider than normal to fit in with provider icons */}
-                                        <BuildingIcon size={16} strokeWidth={2} />{' '}
-                                    </span>
-                                    <span className={styles.modelName}>{title}</span>
-                                    <span className={styles.rightIcon}>
-                                        <ExternalLinkIcon
-                                            size={16}
-                                            strokeWidth={1.25}
-                                            className="tw-opacity-80"
-                                        />
-                                    </span>
-                                </CommandLink>
-                            ))}
-                        </CommandGroup>
                         <CommandGroup>
                             <CommandLink
                                 href="https://sourcegraph.com/docs/cody/clients/install-vscode#supported-llm-models"
@@ -259,6 +228,34 @@ export const ModelSelectField: React.FunctionComponent<{
                                     <BookOpenIcon size={16} strokeWidth={2} />{' '}
                                 </span>
                                 <span className={styles.modelName}>Documentation</span>
+                                <span className={styles.rightIcon}>
+                                    <ExternalLinkIcon
+                                        size={16}
+                                        strokeWidth={1.25}
+                                        className="tw-opacity-80"
+                                    />
+                                </span>
+                            </CommandLink>
+                        </CommandGroup>
+                        <CommandGroup>
+                            <CommandLink
+                                key="enterprise-model-options"
+                                href={ENTERPRISE_MODEL_DOCS_PAGE}
+                                target="_blank"
+                                rel="noreferrer"
+                                onSelect={() => {
+                                    telemetryRecorder.recordEvent(
+                                        'cody.modelSelector',
+                                        'clickEnterpriseModelOption'
+                                    )
+                                }}
+                                className={styles.modelTitleWithIcon}
+                            >
+                                <span className={styles.modelIcon}>
+                                    {/* wider than normal to fit in with provider icons */}
+                                    <BuildingIcon size={16} strokeWidth={2} />{' '}
+                                </span>
+                                <span className={styles.modelName}>Enterprise Model Options</span>
                                 <span className={styles.rightIcon}>
                                     <ExternalLinkIcon
                                         size={16}
@@ -289,29 +286,6 @@ export const ModelSelectField: React.FunctionComponent<{
 
 const ENTERPRISE_MODEL_DOCS_PAGE =
     'https://sourcegraph.com/docs/cody/clients/enable-cody-enterprise?utm_source=cody.modelSelector'
-
-const ENTERPRISE_MODEL_OPTIONS: { id: string; url: string; title: string }[] = [
-    {
-        id: 'anthropic-account',
-        url: `${ENTERPRISE_MODEL_DOCS_PAGE}#use-your-organizations-anthropic-account`,
-        title: 'Anthropic account',
-    },
-    {
-        id: 'openai-account',
-        url: `${ENTERPRISE_MODEL_DOCS_PAGE}#use-your-organizations-openai-account`,
-        title: 'OpenAI account',
-    },
-    {
-        id: 'amazon-bedrock',
-        url: `${ENTERPRISE_MODEL_DOCS_PAGE}#use-amazon-bedrock-aws`,
-        title: 'Amazon Bedrock',
-    },
-    {
-        id: 'azure-openai-service',
-        url: `${ENTERPRISE_MODEL_DOCS_PAGE}#use-azure-openai-service`,
-        title: 'Azure OpenAI Service',
-    },
-]
 
 const GROUP_ORDER = [
     ModelUIGroup.Accuracy,


### PR DESCRIPTION
Declutters the model option selectors by using only a single Enterprise documentation CTA.

| Before | After |
| - | - |
| ![CleanShot 2024-07-02 at 11 31 02@2x](https://github.com/sourcegraph/cody/assets/153/35b2c258-2245-4df3-8508-d1e4291e0d10) | ![CleanShot 2024-07-02 at 11 30 33@2x](https://github.com/sourcegraph/cody/assets/153/c61a0ce3-3bfd-41b3-8049-fe62460af623) |

Closes https://linear.app/sourcegraph/issue/CODY-2316/combine-chat-model-selector-enterprise-model-options-into-a-single

## Test plan

- CI
