### PR TITLE
Upload image UI

### DIFF
--- a/vscode/webviews/chat/cells/messageCell/human/editor/toolbar/Toolbar.tsx
+++ b/vscode/webviews/chat/cells/messageCell/human/editor/toolbar/Toolbar.tsx
@@ -1,14 +1,13 @@
 import { type Model, ModelsService } from '@sourcegraph/cody-shared'
 import clsx from 'clsx'
-import { PaperclipIcon } from 'lucide-react'
 import { type FunctionComponent, useCallback } from 'react'
 import type { UserAccountInfo } from '../../../../../../Chat'
 import { ModelSelectField } from '../../../../../../components/modelSelectField/ModelSelectField'
-import { ToolbarButton } from '../../../../../../components/shadcn/ui/toolbar'
 import { getVSCodeAPI } from '../../../../../../utils/VSCodeApi'
 import { useChatModelContext } from '../../../../../models/chatModelContext'
 import { AddContextButton } from './AddContextButton'
 import { SubmitButton, type SubmitButtonState } from './SubmitButton'
+import { UploadImageButton } from './UploadImageButton'
 
 /**
  * The toolbar for the human message editor.
@@ -74,12 +73,10 @@ export const Toolbar: FunctionComponent<{
                     <AddContextButton onClick={onMentionClick} className="tw-opacity-60" />
                 )}
                 {currentModel && ModelsService.isMultiModalModel(currentModel?.model) && (
-                    <ToolbarButton
-                        variant="secondary"
-                        tooltip="Upload an image"
-                        iconStart={PaperclipIcon}
+                    // todo(tim): add support for passing in chatModel.images[0] if present (and make onClick remove it)
+                    <UploadImageButton
+                        className="tw-opacity-60"
                         onClick={() => getVSCodeAPI().postMessage({ command: 'chat/upload-image' })}
-                        aria-label="Upload image"
                     />
                 )}
                 <span>

--- a/vscode/webviews/chat/cells/messageCell/human/editor/toolbar/UploadImageButton.story.tsx
+++ b/vscode/webviews/chat/cells/messageCell/human/editor/toolbar/UploadImageButton.story.tsx
@@ -1,0 +1,40 @@
+import { useArgs } from '@storybook/preview-api'
+import type { Meta, StoryObj } from '@storybook/react'
+import { VSCodeStandaloneComponent } from '../../../../../../storybook/VSCodeStoryDecorator'
+import { UploadImageButton } from './UploadImageButton'
+
+const meta: Meta<typeof UploadImageButton> = {
+    title: 'ui/UploadImageButton',
+    component: UploadImageButton,
+
+    args: {
+        uploadedImageUri: undefined,
+    },
+
+    decorators: [VSCodeStandaloneComponent],
+}
+
+export default meta
+
+export const Default: StoryObj<typeof meta> = {
+    render: () => {
+        const [args, setArgs] = useArgs()
+        return (
+            <UploadImageButton
+                {...args}
+                onClick={() => {
+                    setArgs({
+                        // Toggle between submittable and busy
+                        uploadedImageUri: args.uploadedImageUri ? undefined : 'some/image/image.png',
+                    })
+                }}
+            />
+        )
+    },
+}
+
+export const WithImageAttached: StoryObj<typeof meta> = {
+    args: {
+        uploadedImageUri: 'some/image/image-with-a-super-super-super-long-path.svg',
+    },
+}

--- a/vscode/webviews/chat/cells/messageCell/human/editor/toolbar/UploadImageButton.tsx
+++ b/vscode/webviews/chat/cells/messageCell/human/editor/toolbar/UploadImageButton.tsx
@@ -1,0 +1,43 @@
+import { ImageIcon, XIcon } from 'lucide-react'
+import { Button } from '../../../../../../components/shadcn/ui/button'
+import { Tooltip, TooltipContent, TooltipTrigger } from '../../../../../../components/shadcn/ui/tooltip'
+
+export const UploadImageButton = ({
+    className,
+    uploadedImageUri,
+    onClick,
+}: { className?: string; uploadedImageUri?: string; onClick: () => void }) =>
+    !uploadedImageUri ? (
+        <Tooltip>
+            <TooltipTrigger asChild>
+                <Button
+                    variant="ghost"
+                    size="icon"
+                    onClick={onClick}
+                    aria-label="Upload an image"
+                    className={className}
+                >
+                    <ImageIcon className="tw-w-8 tw-h-8" strokeWidth={1.25} />
+                </Button>
+            </TooltipTrigger>
+            <TooltipContent side="bottom">Upload an image</TooltipContent>
+        </Tooltip>
+    ) : (
+        <Tooltip>
+            <TooltipTrigger asChild>
+                <Button
+                    variant="ghost"
+                    size="sm"
+                    aria-label="Upload an image"
+                    className={className}
+                    onClick={onClick}
+                >
+                    <span className="tw-max-w-[10em] tw-overflow-hidden tw-text-ellipsis" title="">
+                        {uploadedImageUri ? uploadedImageUri.split(/[\/\\]/).pop() : ''}
+                    </span>
+                    <XIcon strokeWidth={1.25} className="tw-h-8 tw-w-8" />
+                </Button>
+            </TooltipTrigger>
+            <TooltipContent>Remove attached image</TooltipContent>
+        </Tooltip>
+    )

--- a/vscode/webviews/components/modelSelectField/ModelSelectField.module.css
+++ b/vscode/webviews/components/modelSelectField/ModelSelectField.module.css
@@ -31,6 +31,10 @@
     margin-left: auto;
 }
 
+.supports-image-upload-icon {
+    margin-left: auto;
+}
+
 .badge  {
     margin-left: auto;
     line-height: 16px;
@@ -46,12 +50,16 @@
     opacity: 0.75;
 }
 
+.supports-image-upload-icon + .badge {
+    margin-left: 0;
+}
+
 /* Show minimal form in the button. */
 button > .model-title-with-icon {
     .model-name {
         font-weight: normal;
     }
-    .model-icon, .model-provider, .badge {
+    .model-icon, .model-provider, .badge, .supports-image-upload-icon {
         display: none;
     }
 }

--- a/vscode/webviews/components/modelSelectField/ModelSelectField.tsx
+++ b/vscode/webviews/components/modelSelectField/ModelSelectField.tsx
@@ -1,6 +1,6 @@
-import { type Model, ModelUIGroup } from '@sourcegraph/cody-shared'
+import { type Model, ModelUIGroup, ModelsService } from '@sourcegraph/cody-shared'
 import { clsx } from 'clsx'
-import { BookOpenIcon, BuildingIcon, ExternalLinkIcon } from 'lucide-react'
+import { BookOpenIcon, BuildingIcon, ExternalLinkIcon, ImageIcon } from 'lucide-react'
 import { type FunctionComponent, type ReactNode, useCallback, useMemo } from 'react'
 import type { UserAccountInfo } from '../../Chat'
 import { getVSCodeAPI } from '../../utils/VSCodeApi'
@@ -121,6 +121,7 @@ export const ModelSelectField: React.FunctionComponent<{
                             showIcon={true}
                             showProvider={true}
                             modelAvailability={availability}
+                            supportsImageUpload={ModelsService.isMultiModalModel(m.model)}
                         />
                     ),
                     // needs-cody-pro models should be clickable (not disabled) so the user can
@@ -340,7 +341,8 @@ const ModelTitleWithIcon: FunctionComponent<{
     showIcon?: boolean
     showProvider?: boolean
     modelAvailability?: ModelAvailability
-}> = ({ model, showIcon, showProvider, modelAvailability }) => (
+    supportsImageUpload?: boolean
+}> = ({ model, showIcon, showProvider, modelAvailability, supportsImageUpload }) => (
     <span
         className={clsx(styles.modelTitleWithIcon, {
             [styles.disabled]: modelAvailability !== 'available',
@@ -348,6 +350,11 @@ const ModelTitleWithIcon: FunctionComponent<{
     >
         {showIcon && <ChatModelIcon model={model.model} className={styles.modelIcon} />}
         <span className={styles.modelName}>{model.title}</span>
+        {supportsImageUpload && (
+            <span className={styles.supportsImageUploadIcon} title="Supports image upload">
+                <ImageIcon size={16} strokeWidth={1.25} className="tw-opacity-80" />
+            </span>
+        )}
         {modelAvailability === 'needs-cody-pro' && (
             <span className={clsx(styles.badge, styles.badgePro)}>Cody Pro</span>
         )}


### PR DESCRIPTION
@abeatrix some UI changes for image upload:

* New icon, given it only supports image upload (not CSV etc that some other LLM uploads do)
* Button state (and Storybook) for when an image is uploaded, with UI for removing
* Badge in the model selector for showing models that support image upload

https://github.com/sourcegraph/cody/assets/153/41cdb4c0-b08c-4128-96eb-9e080c8f9a71

https://github.com/sourcegraph/cody/assets/153/2e7ab980-c0e6-410c-8caf-adebf47d5868

## Test plan

- CI
