### PR TITLE
CLI: Fix npm release

### DIFF
--- a/agent/CHANGELOG.md
+++ b/agent/CHANGELOG.md
@@ -10,6 +10,12 @@ This is a log of all notable changes to the Cody command-line tool. [Unreleased]
 
 ### Changed
 
+## 0.1.1
+
+### Fixed
+
+- Running `npm install -g @sourcegraph/cody-agent` should work now. It was previously crashing about a missing keytar dependency.
+
 ## 0.1.0
 
 ### Added

--- a/agent/package.json
+++ b/agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sourcegraph/cody-agent",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Cody JSON-RPC agent for consistent cross-editor support",
   "license": "Apache-2.0",
   "repository": {
@@ -24,8 +24,14 @@
     "prepublishOnly": "pnpm run build"
   },
   "bin": "dist/index.js",
-  "files": ["dist/index.js", "dist/index.js.map", "dist/*.wasm", "dist/win-ca-roots.exe"],
-  "dependencies": {
+  "files": [
+    "dist/index.js",
+    "dist/index.js.map",
+    "dist/*.wasm",
+    "dist/win-ca-roots.exe",
+    "dist/keytar-*.node"
+  ],
+  "peerDependencies": {
     "@inquirer/prompts": "^5.0.7",
     "@pollyjs/core": "^6.0.6",
     "@pollyjs/persister": "^6.0.6",
@@ -52,9 +58,7 @@
     "uuid": "^9.0.0",
     "vscode-uri": "^3.0.7",
     "win-ca": "^3.5.1",
-    "ws": "^8.16.0"
-  },
-  "devDependencies": {
+    "ws": "^8.16.0",
     "@types/dedent": "^0.7.0",
     "@types/diff": "^5.0.9",
     "@types/fast-json-stable-stringify": "^2.1.0",

--- a/agent/recordings/cody-chat_103640681/recording.har.yaml
+++ b/agent/recordings/cody-chat_103640681/recording.har.yaml
@@ -5,7 +5,7 @@ log:
     name: Polly.JS
     version: 6.0.6
   entries:
-    - _id: 3977a0844deafca78dab5498c249731c
+    - _id: f5c671311272dfe9f175bc9d89a42959
       _order: 0
       cache: {}
       request:
@@ -20,12 +20,12 @@ log:
             value: token
               REDACTED_d5e0f0a37c9821e856b923fe14e67a605e3f6c0a517d5a4f46a4e35943ee0f6d
           - name: user-agent
-            value: cody-cli / 0.1.0
+            value: cody-cli / 0.1.0-SNAPSHOT
           - name: connection
             value: keep-alive
           - name: host
             value: sourcegraph.com
-        headersSize: 341
+        headersSize: 359
         httpVersion: HTTP/1.1
         method: POST
         postData:
@@ -48,8 +48,8 @@ log:
           - name: client-name
             value: cody-cli
           - name: client-version
-            value: 0.1.0
-        url: https://sourcegraph.com/.api/completions/stream?api-version=1&client-name=cody-cli&client-version=0.1.0
+            value: 0.1.0-SNAPSHOT
+        url: https://sourcegraph.com/.api/completions/stream?api-version=1&client-name=cody-cli&client-version=0.1.0-SNAPSHOT
       response:
         bodySize: 158
         content:
@@ -65,7 +65,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Sat, 29 Jun 2024 00:12:56 GMT
+            value: Tue, 02 Jul 2024 09:56:00 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
@@ -94,7 +94,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-06-29T00:12:54.673Z
+      startedDateTime: 2024-07-02T09:55:59.385Z
       time: 0
       timings:
         blocked: -1
@@ -104,7 +104,7 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: ecca79497457a4c2bc7dadf6f0d89230
+    - _id: d0137030b958d69c4b901e901e27dae7
       _order: 0
       cache: {}
       request:
@@ -119,12 +119,12 @@ log:
             value: token
               REDACTED_d5e0f0a37c9821e856b923fe14e67a605e3f6c0a517d5a4f46a4e35943ee0f6d
           - name: user-agent
-            value: cody-cli / 0.1.0
+            value: cody-cli / 0.1.0-SNAPSHOT
           - name: connection
             value: keep-alive
           - name: host
             value: sourcegraph.com
-        headersSize: 341
+        headersSize: 359
         httpVersion: HTTP/1.1
         method: POST
         postData:
@@ -147,17 +147,17 @@ log:
           - name: client-name
             value: cody-cli
           - name: client-version
-            value: 0.1.0
-        url: https://sourcegraph.com/.api/completions/stream?api-version=1&client-name=cody-cli&client-version=0.1.0
+            value: 0.1.0-SNAPSHOT
+        url: https://sourcegraph.com/.api/completions/stream?api-version=1&client-name=cody-cli&client-version=0.1.0-SNAPSHOT
       response:
-        bodySize: 8172
+        bodySize: 6468
         content:
           mimeType: text/event-stream
-          size: 8172
+          size: 6468
           text: >+
             event: completion
 
-            data: {"completion":"Squirrel is a high-performance, open-source object-relational database (ORD) that uses an SQL dialect and is embedded within applications. It is designed to be lightweight, fast, and easy to use, making it suitable for applications that require a database but do not need the complexity and overhead of a traditional client-server database management system (DBMS).","stopReason":"end_turn"}
+            data: {"completion":"Squirrel is a high-performance, open-source object-relational database (ORD) that provides a SQL interface for storing and querying JSON data. It is designed to be embedded in applications, making it suitable for use cases such as caching, analytics, and data storage in edge computing environments.","stopReason":"end_turn"}
 
 
             event: done
@@ -167,7 +167,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Sat, 29 Jun 2024 00:12:57 GMT
+            value: Tue, 02 Jul 2024 09:56:02 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
@@ -196,7 +196,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-06-29T00:12:56.274Z
+      startedDateTime: 2024-07-02T09:56:01.007Z
       time: 0
       timings:
         blocked: -1
@@ -206,7 +206,7 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: 886c0117d06168cf2c5ef71692212297
+    - _id: 4b9ab34799ecb6bc4e4aafdfdbedced9
       _order: 0
       cache: {}
       request:
@@ -221,12 +221,12 @@ log:
             value: token
               REDACTED_d5e0f0a37c9821e856b923fe14e67a605e3f6c0a517d5a4f46a4e35943ee0f6d
           - name: user-agent
-            value: cody-cli / 0.1.0
+            value: cody-cli / 0.1.0-SNAPSHOT
           - name: connection
             value: keep-alive
           - name: host
             value: sourcegraph.com
-        headersSize: 341
+        headersSize: 359
         httpVersion: HTTP/1.1
         method: POST
         postData:
@@ -260,8 +260,8 @@ log:
           - name: client-name
             value: cody-cli
           - name: client-version
-            value: 0.1.0
-        url: https://sourcegraph.com/.api/completions/stream?api-version=1&client-name=cody-cli&client-version=0.1.0
+            value: 0.1.0-SNAPSHOT
+        url: https://sourcegraph.com/.api/completions/stream?api-version=1&client-name=cody-cli&client-version=0.1.0-SNAPSHOT
       response:
         bodySize: 1729
         content:
@@ -280,7 +280,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Sat, 29 Jun 2024 00:12:59 GMT
+            value: Tue, 02 Jul 2024 09:56:04 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
@@ -309,7 +309,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-06-29T00:12:58.735Z
+      startedDateTime: 2024-07-02T09:56:03.436Z
       time: 0
       timings:
         blocked: -1

--- a/agent/src/cli/__snapshots__/chat.test.ts.snap
+++ b/agent/src/cli/__snapshots__/chat.test.ts.snap
@@ -23,10 +23,9 @@ exports[`--context-repo (squirrel test) 1`] = `
 exitCode: 0
 stdout: >+
   Squirrel is a high-performance, open-source object-relational database (ORD)
-  that uses an SQL dialect and is embedded within applications. It is designed
-  to be lightweight, fast, and easy to use, making it suitable for applications
-  that require a database but do not need the complexity and overhead of a
-  traditional client-server database management system (DBMS).
+  that provides a SQL interface for storing and querying JSON data. It is
+  designed to be embedded in applications, making it suitable for use cases such
+  as caching, analytics, and data storage in edge computing environments.
 
 stderr: ""
 "

--- a/agent/src/cli/chat.ts
+++ b/agent/src/cli/chat.ts
@@ -92,7 +92,7 @@ export async function chatAction(options: ChatOptions): Promise<number> {
     const workspaceRootUri = vscode.Uri.file(path.resolve(options.dir))
     const clientInfo: ClientInfo = {
         name: 'cody-cli',
-        version: packageJson.version,
+        version: options.isTesting ? '0.1.0-SNAPSHOT' : packageJson.version,
         workspaceRootUri: workspaceRootUri.toString(),
         extensionConfiguration: {
             serverEndpoint: options.endpoint,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -126,70 +126,6 @@ importers:
       '@sourcegraph/telemetry':
         specifier: ^0.16.0
         version: 0.16.0
-      '@types/js-levenshtein':
-        specifier: ^1.1.1
-        version: 1.1.1
-      chalk:
-        specifier: ^5.3.0
-        version: 5.3.0
-      commander:
-        specifier: ^11.1.0
-        version: 11.1.0
-      csv-writer:
-        specifier: ^1.6.0
-        version: 1.6.0
-      dedent:
-        specifier: ^0.7.0
-        version: 0.7.0
-      easy-table:
-        specifier: ^1.2.0
-        version: 1.2.0
-      env-paths:
-        specifier: ^3.0.0
-        version: 3.0.0
-      fast-myers-diff:
-        specifier: ^3.2.0
-        version: 3.2.0
-      glob:
-        specifier: ^7.2.3
-        version: 7.2.3
-      js-levenshtein:
-        specifier: ^1.1.6
-        version: 1.1.6
-      keytar:
-        specifier: ^7.9.0
-        version: 7.9.0
-      lodash:
-        specifier: ^4.17.21
-        version: 4.17.21
-      mac-ca:
-        specifier: ^2.0.3
-        version: 2.0.3
-      minimatch:
-        specifier: ^9.0.3
-        version: 9.0.3
-      open:
-        specifier: ^8.4.2
-        version: 8.4.2
-      ora:
-        specifier: ^8.0.1
-        version: 8.0.1
-      pretty-ms:
-        specifier: ^8.0.0
-        version: 8.0.0
-      uuid:
-        specifier: ^9.0.0
-        version: 9.0.0
-      vscode-uri:
-        specifier: ^3.0.7
-        version: 3.0.7
-      win-ca:
-        specifier: ^3.5.1
-        version: 3.5.1
-      ws:
-        specifier: ^8.16.0
-        version: 8.16.0
-    devDependencies:
       '@types/dedent':
         specifier: ^0.7.0
         version: 0.7.0
@@ -205,6 +141,9 @@ importers:
       '@types/google-protobuf':
         specifier: 3.15.12
         version: 3.15.12
+      '@types/js-levenshtein':
+        specifier: ^1.1.1
+        version: 1.1.1
       '@types/lodash':
         specifier: ^4.14.195
         version: 4.17.0
@@ -226,24 +165,84 @@ importers:
       '@types/ws':
         specifier: ^8.5.10
         version: 8.5.10
+      chalk:
+        specifier: ^5.3.0
+        version: 5.3.0
+      commander:
+        specifier: ^11.1.0
+        version: 11.1.0
+      csv-writer:
+        specifier: ^1.6.0
+        version: 1.6.0
+      dedent:
+        specifier: ^0.7.0
+        version: 0.7.0
       diff:
         specifier: ^5.2.0
         version: 5.2.0
+      easy-table:
+        specifier: ^1.2.0
+        version: 1.2.0
+      env-paths:
+        specifier: ^3.0.0
+        version: 3.0.0
       esbuild:
         specifier: ^0.18.19
         version: 0.18.20
       fast-json-stable-stringify:
         specifier: ^2.1.0
         version: 2.1.0
+      fast-myers-diff:
+        specifier: ^3.2.0
+        version: 3.2.0
+      glob:
+        specifier: ^7.2.3
+        version: 7.2.3
       google-protobuf:
         specifier: ^3.21.2
         version: 3.21.2
+      js-levenshtein:
+        specifier: ^1.1.6
+        version: 1.1.6
+      keytar:
+        specifier: ^7.9.0
+        version: 7.9.0
+      lodash:
+        specifier: ^4.17.21
+        version: 4.17.21
+      mac-ca:
+        specifier: ^2.0.3
+        version: 2.0.3
+      minimatch:
+        specifier: ^9.0.3
+        version: 9.0.3
+      open:
+        specifier: ^8.4.2
+        version: 8.4.2
+      ora:
+        specifier: ^8.0.1
+        version: 8.0.1
       parse-git-diff:
         specifier: ^0.0.14
         version: 0.0.14
+      pretty-ms:
+        specifier: ^8.0.0
+        version: 8.0.0
       rimraf:
         specifier: ^5.0.5
         version: 5.0.5
+      uuid:
+        specifier: ^9.0.0
+        version: 9.0.0
+      vscode-uri:
+        specifier: ^3.0.7
+        version: 3.0.7
+      win-ca:
+        specifier: ^3.5.1
+        version: 3.5.1
+      ws:
+        specifier: ^8.16.0
+        version: 8.16.0
       yaml:
         specifier: ^2.3.4
         version: 2.3.4
@@ -2312,7 +2311,6 @@ packages:
     cpu: [arm64]
     os: [android]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/android-arm64@0.20.2:
@@ -2329,7 +2327,6 @@ packages:
     cpu: [arm]
     os: [android]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/android-arm@0.20.2:
@@ -2346,7 +2343,6 @@ packages:
     cpu: [x64]
     os: [android]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/android-x64@0.20.2:
@@ -2363,7 +2359,6 @@ packages:
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/darwin-arm64@0.20.2:
@@ -2380,7 +2375,6 @@ packages:
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/darwin-x64@0.20.2:
@@ -2397,7 +2391,6 @@ packages:
     cpu: [arm64]
     os: [freebsd]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/freebsd-arm64@0.20.2:
@@ -2414,7 +2407,6 @@ packages:
     cpu: [x64]
     os: [freebsd]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/freebsd-x64@0.20.2:
@@ -2431,7 +2423,6 @@ packages:
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/linux-arm64@0.20.2:
@@ -2448,7 +2439,6 @@ packages:
     cpu: [arm]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/linux-arm@0.20.2:
@@ -2465,7 +2455,6 @@ packages:
     cpu: [ia32]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/linux-ia32@0.20.2:
@@ -2482,7 +2471,6 @@ packages:
     cpu: [loong64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/linux-loong64@0.20.2:
@@ -2499,7 +2487,6 @@ packages:
     cpu: [mips64el]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/linux-mips64el@0.20.2:
@@ -2516,7 +2503,6 @@ packages:
     cpu: [ppc64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/linux-ppc64@0.20.2:
@@ -2533,7 +2519,6 @@ packages:
     cpu: [riscv64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/linux-riscv64@0.20.2:
@@ -2550,7 +2535,6 @@ packages:
     cpu: [s390x]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/linux-s390x@0.20.2:
@@ -2567,7 +2551,6 @@ packages:
     cpu: [x64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/linux-x64@0.20.2:
@@ -2584,7 +2567,6 @@ packages:
     cpu: [x64]
     os: [netbsd]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/netbsd-x64@0.20.2:
@@ -2601,7 +2583,6 @@ packages:
     cpu: [x64]
     os: [openbsd]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/openbsd-x64@0.20.2:
@@ -2618,7 +2599,6 @@ packages:
     cpu: [x64]
     os: [sunos]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/sunos-x64@0.20.2:
@@ -2635,7 +2615,6 @@ packages:
     cpu: [arm64]
     os: [win32]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/win32-arm64@0.20.2:
@@ -2652,7 +2631,6 @@ packages:
     cpu: [ia32]
     os: [win32]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/win32-ia32@0.20.2:
@@ -2669,7 +2647,6 @@ packages:
     cpu: [x64]
     os: [win32]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/win32-x64@0.20.2:
@@ -5936,7 +5913,6 @@ packages:
 
   /@types/dedent@0.7.0:
     resolution: {integrity: sha512-EGlKlgMhnLt/cM4DbUSafFdrkeJoC9Mvnj0PUCU7tFmTjMjNRT957kXCx0wYm3JuEq4o4ZsS5vG+NlkM2DMd2A==}
-    dev: true
 
   /@types/detect-port@1.3.5:
     resolution: {integrity: sha512-Rf3/lB9WkDfIL9eEKaSYKc+1L/rNVYBjThk22JTqQw0YozXarX8YljFAz+HCoC6h4B4KwCMsBPZHaFezwT4BNA==}
@@ -5944,7 +5920,6 @@ packages:
 
   /@types/diff@5.0.9:
     resolution: {integrity: sha512-RWVEhh/zGXpAVF/ZChwNnv7r4rvqzJ7lYNSmZSVTxjV0PBLf6Qu7RNg+SUtkpzxmiNkjCx0Xn2tPp7FIkshJwQ==}
-    dev: true
 
   /@types/doctrine@0.0.3:
     resolution: {integrity: sha512-w5jZ0ee+HaPOaX25X2/2oGR/7rgAQSYII7X7pp0m9KgBfMP7uKfMfTvcpl5Dj+eDBbpxKGiqE+flqDr6XTd2RA==}
@@ -6007,7 +5982,7 @@ packages:
     deprecated: This is a stub types definition. fast-json-stable-stringify provides its own type definitions, so you do not need this installed.
     dependencies:
       fast-json-stable-stringify: 2.1.0
-    dev: true
+    dev: false
 
   /@types/find-cache-dir@3.2.1:
     resolution: {integrity: sha512-frsJrz2t/CeGifcu/6uRo4b+SzAwT4NYCVPu1GN8IB9XTzrpPkGuV0tmh9mN+/L0PklAlsC3u5Fxt0ju00LXIw==}
@@ -6031,11 +6006,10 @@ packages:
     dependencies:
       '@types/minimatch': 5.1.2
       '@types/node': 20.12.7
-    dev: true
 
   /@types/google-protobuf@3.15.12:
     resolution: {integrity: sha512-40um9QqwHjRS92qnOaDpL7RmDK15NuZYo9HihiJRbYkMQZlWnuH8AdvbMy8/o6lgLmKbDUKa+OALCltHdbOTpQ==}
-    dev: true
+    dev: false
 
   /@types/hast@2.3.10:
     resolution: {integrity: sha512-McWspRw8xx8J9HurkVBfYj0xKoE25tOFlHGdx4MJ5xORQrMGZNqJhVQWaIbm6Oyla5kYOXtDiopzKRJzEOkwJw==}
@@ -6082,7 +6056,6 @@ packages:
 
   /@types/lodash@4.17.0:
     resolution: {integrity: sha512-t7dhREVv6dbNj0q17X12j7yDG4bD/DHYX7o5/DbDxobP0HnGPgpRz2Ej77aL7TZT3DSw13fqUTj8J4mMnqa7WA==}
-    dev: true
 
   /@types/long@4.0.2:
     resolution: {integrity: sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==}
@@ -6119,7 +6092,6 @@ packages:
 
   /@types/minimatch@5.1.2:
     resolution: {integrity: sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==}
-    dev: true
 
   /@types/minimist@1.2.5:
     resolution: {integrity: sha512-hov8bUuiLiyFPGyFPE1lwWhmzYbirOXQNNo40+y3zow8aFVTeyn3VWL0VFFfdNddA8S4Vf0Tc062rzyNr7Paag==}
@@ -6149,7 +6121,7 @@ packages:
     resolution: {integrity: sha512-FQx220y22OKNTqaByeBGqHWYz4cl94tpcxeFdvBo3wjG6XPBuZ0BNgNZRV5J5TFmmcsJ4IzsLkmGRiQbnYsBEQ==}
     dependencies:
       '@types/node': 20.12.7
-    dev: true
+    dev: false
 
   /@types/node@18.19.31:
     resolution: {integrity: sha512-ArgCD39YpyyrtFKIqMDvjz79jto5fcI/SVUs2HwB+f0dAzq68yqOdyaSivLiLugSziTpNXLQrVb7RZFmdZzbhA==}
@@ -6180,7 +6152,7 @@ packages:
     deprecated: This is a stub types definition. open provides its own type definitions, so you do not need this installed.
     dependencies:
       open: 8.4.2
-    dev: true
+    dev: false
 
   /@types/pako@2.0.3:
     resolution: {integrity: sha512-bq0hMV9opAcrmE0Byyo0fY3Ew4tgOevJmQ9grUhpXQhYfyLJ1Kqg3P33JT5fdbT2AjeAjR51zqqVjAL/HMkx7Q==}
@@ -6304,7 +6276,6 @@ packages:
 
   /@types/uuid@9.0.2:
     resolution: {integrity: sha512-kNnC1GFBLuhImSnV7w4njQkUiJi0ZXUycu1rUaouPqiKlXkh77JKgdRnTAp1x5eBwcIwbtI+3otwzuIDEuDoxQ==}
-    dev: true
 
   /@types/uuid@9.0.8:
     resolution: {integrity: sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==}
@@ -6312,14 +6283,13 @@ packages:
 
   /@types/vscode@1.80.0:
     resolution: {integrity: sha512-qK/CmOdS2o7ry3k6YqU4zD3R2AYlJfbwBoSbKpBoP+GpXNE+0NEgJOli4n0bm0diK5kfBnchgCEj4igQz/44Hg==}
-    dev: true
 
   /@types/win-ca@3.5.4:
     resolution: {integrity: sha512-WDlA6ZvTg1g9ygKcDCQb4GjEtk0RcZyx09btQea9NZqfKPl+WtyOlEwNfYMhK2E5sRCo6hMtct1EX3l04yAC1A==}
     dependencies:
       '@types/node': 20.12.7
       '@types/node-forge': 1.3.11
-    dev: true
+    dev: false
 
   /@types/wrap-ansi@3.0.0:
     resolution: {integrity: sha512-ltIpx+kM7g/MLRZfkbL7EsCEjfzCcScLpkg37eXEtx5kmrAKBkTJwd1GIAjDSL8wTpM6Hzn5YO4pSb91BEwu1g==}
@@ -6329,7 +6299,7 @@ packages:
     resolution: {integrity: sha512-vmQSUcfalpIq0R9q7uTo2lXs6eGIpt9wtnLdMv9LVpIjCA/+ufZRozlVoVelIYixx1ugCBKDhn89vnsEGOCx9A==}
     dependencies:
       '@types/node': 20.12.7
-    dev: true
+    dev: false
 
   /@ungap/structured-clone@1.2.0:
     resolution: {integrity: sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==}
@@ -8283,6 +8253,7 @@ packages:
   /diff@5.2.0:
     resolution: {integrity: sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==}
     engines: {node: '>=0.3.1'}
+    dev: false
 
   /dir-glob@3.0.1:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
@@ -8541,7 +8512,6 @@ packages:
       '@esbuild/win32-arm64': 0.18.20
       '@esbuild/win32-ia32': 0.18.20
       '@esbuild/win32-x64': 0.18.20
-    dev: true
 
   /esbuild@0.20.2:
     resolution: {integrity: sha512-WdOOppmUNU+IbZ0PaDiTst80zjnrOkyJNHoKupIcVyU8Lvla3Ugx94VzkQ32Ijqd7UhHJy75gNWDMUekcrSJ6g==}
@@ -9507,7 +9477,7 @@ packages:
 
   /google-protobuf@3.21.2:
     resolution: {integrity: sha512-3MSOYFO5U9mPGikIYCzK0SaThypfGgS6bHqrUGXG3DPHCrb+txNqeEcns1W0lkGfk0rCyNXm7xB9rMxnCiZOoA==}
-    dev: true
+    dev: false
 
   /gopd@1.0.1:
     resolution: {integrity: sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==}
@@ -12479,6 +12449,7 @@ packages:
 
   /parse-git-diff@0.0.14:
     resolution: {integrity: sha512-UHNB4IWZ0dae4Z9aKgQTAm1gTBqBpmqKwoLx2/iEaVY9hQlqstDnvdWsq5fJjF2iC6368OvAB6LWUJab5wk9VQ==}
+    dev: false
 
   /parse-json@5.2.0:
     resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
@@ -13669,7 +13640,7 @@ packages:
     hasBin: true
     dependencies:
       glob: 10.3.12
-    dev: true
+    dev: false
 
   /rollup@4.17.2:
     resolution: {integrity: sha512-/9ClTJPByC0U4zNLowV1tMBe8yMEAxewtR3cUNX5BoEpGH3dQEWpJLr6CLp0fPdYRF/fzVOgvDb1zXuakwF5kQ==}
@@ -15988,7 +15959,6 @@ packages:
   /yaml@2.3.4:
     resolution: {integrity: sha512-8aAvwVUSHpfEqTQ4w/KMlf3HcRdt50E5ODIQJBw1fQ5RL34xabzxtUlzTXVqc4rkZsPbvrXKWnABCD7kWSmocA==}
     engines: {node: '>= 14'}
-    dev: true
 
   /yaml@2.4.2:
     resolution: {integrity: sha512-B3VqDZ+JAg1nZpaEmWtTXUlBneoGx6CPM9b0TENK6aoSu5t73dItudwdgmi6tHlIZZId4dZ9skcAQ2UbcyAeVA==}


### PR DESCRIPTION
Previously, `npm install -g @sourcergraph/cody-agent` didn't work. This PR fixes the problem

* Includes keytar file in Cody cli npm release
* Uses `peerDependencies` instead of `depenencies` and `devDependencies` so users don't install transitive dependencies


## Test plan


Manually tested by running a local `verdaccio` registry and installing from there.

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
