### PR TITLE
CLI: replace keytar with custom solution

### DIFF
--- a/agent/CHANGELOG.md
+++ b/agent/CHANGELOG.md
@@ -10,8 +10,19 @@ This is a log of all notable changes to the Cody command-line tool. [Unreleased]
 
 ### Changed
 
-## 0.1.1
+## 0.1.2
 
+### Changed
+
+- The "service account name" for storing secrets is now formatted as "Cody:
+  $SERVER_ENDPOINT ($USERNAME)" instead of "Cody" making it easier to
+  understand what account/endpoint is stored there.
+
+### Fixed
+
+- Running `cody-agent help` should work now. It was previously crashing about a missing keytar dependencies.
+
+## 0.1.1
 ### Fixed
 
 - Running `npm install -g @sourcegraph/cody-agent` should work now. It was previously crashing about a missing keytar dependency.

--- a/agent/package.json
+++ b/agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sourcegraph/cody-agent",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Cody JSON-RPC agent for consistent cross-editor support",
   "license": "Apache-2.0",
   "repository": {
@@ -24,13 +24,7 @@
     "prepublishOnly": "pnpm run build"
   },
   "bin": "dist/index.js",
-  "files": [
-    "dist/index.js",
-    "dist/index.js.map",
-    "dist/*.wasm",
-    "dist/win-ca-roots.exe",
-    "dist/keytar-*.node"
-  ],
+  "files": ["dist/index.js", "dist/index.js.map", "dist/*.wasm", "dist/win-ca-roots.exe"],
   "peerDependencies": {
     "@inquirer/prompts": "^5.0.7",
     "@pollyjs/core": "^6.0.6",
@@ -48,7 +42,6 @@
     "fast-myers-diff": "^3.2.0",
     "glob": "^7.2.3",
     "js-levenshtein": "^1.1.6",
-    "keytar": "^7.9.0",
     "lodash": "^4.17.21",
     "mac-ca": "^2.0.3",
     "minimatch": "^9.0.3",

--- a/agent/src/cli/auth/AuthenticatedAccount.ts
+++ b/agent/src/cli/auth/AuthenticatedAccount.ts
@@ -39,23 +39,24 @@ export class AuthenticatedAccount {
         return this.account.serverEndpoint
     }
 
-    public static async fromUserSettings(spinner?: Ora): Promise<AuthenticatedAccount | undefined> {
+    public static async fromUserSettings(spinner: Ora): Promise<AuthenticatedAccount | undefined> {
         const settings = loadUserSettings()
         if (!settings.activeAccountID) {
             return undefined
         }
         const account = settings.accounts?.find(({ id }) => id === settings.activeAccountID)
         if (!account) {
-            spinner?.fail(`Failed to find active account ${settings.activeAccountID}`)
+            spinner.fail(`Failed to find active account ${settings.activeAccountID}`)
             return undefined
         }
-        return AuthenticatedAccount.fromUnauthenticated(account)
+        return AuthenticatedAccount.fromUnauthenticated(spinner, account)
     }
 
     public static async fromUnauthenticated(
+        spinner: Ora,
         account: Account
     ): Promise<AuthenticatedAccount | undefined> {
-        const accessToken = await readCodySecret(account)
+        const accessToken = await readCodySecret(spinner, account)
         if (!accessToken) {
             return undefined
         }

--- a/agent/src/cli/auth/command-accounts.ts
+++ b/agent/src/cli/auth/command-accounts.ts
@@ -20,7 +20,7 @@ export const accountsCommand = new Command('accounts')
             }
             const t = new Table()
             for (const account of settings.accounts ?? []) {
-                const authenticated = await AuthenticatedAccount.fromUnauthenticated(account)
+                const authenticated = await AuthenticatedAccount.fromUnauthenticated(spinner, account)
                 t.cell(chalk.bold('Name'), account.id)
                 t.cell(chalk.bold('Instance'), account.serverEndpoint)
                 const isActiveAccount = account.id === settings.activeAccountID

--- a/agent/src/cli/auth/command-login.ts
+++ b/agent/src/cli/auth/command-login.ts
@@ -119,7 +119,7 @@ export async function loginAction(
     })
     const userInfo = await client.getCurrentUserInfo()
     if (isError(userInfo)) {
-        spinner.fail('Failed to get username from GraphQL')
+        spinner.fail('Failed to get username from GraphQL. Error: ' + String(userInfo))
         return undefined
     }
     const oldSettings = loadUserSettings()

--- a/agent/src/cli/auth/command-login.ts
+++ b/agent/src/cli/auth/command-login.ts
@@ -124,7 +124,7 @@ export async function loginAction(
     }
     const oldSettings = loadUserSettings()
     const id = uniqueID(userInfo.username, oldSettings)
-    const account: Account = { id, serverEndpoint }
+    const account: Account = { id, username: userInfo.username, serverEndpoint }
     const oldAccounts = oldSettings?.accounts
         ? oldSettings.accounts.filter(({ id }) => id !== account.id)
         : []

--- a/agent/src/cli/auth/command-login.ts
+++ b/agent/src/cli/auth/command-login.ts
@@ -32,6 +32,9 @@ export const loginCommand = new Command('login')
     .action(async (options: LoginOptions) => {
         const spinner = ora('Logging in...').start()
         const account = await AuthenticatedAccount.fromUserSettings(spinner)
+        if (!spinner.isSpinning) {
+            process.exit(1)
+        }
         const userInfo = await account?.getCurrentUserInfo()
         if (!isError(userInfo) && userInfo?.username) {
             spinner.succeed('You are already logged in as ' + userInfo.username)
@@ -128,7 +131,7 @@ export async function loginAction(
     const oldAccounts = oldSettings?.accounts
         ? oldSettings.accounts.filter(({ id }) => id !== account.id)
         : []
-    await writeCodySecret(account, token)
+    await writeCodySecret(spinner, account, token)
     const newAccounts = [account, ...oldAccounts]
     const newSettings: UserSettings = { accounts: newAccounts, activeAccountID: account.id }
     writeUserSettings(newSettings)

--- a/agent/src/cli/auth/command-logout.ts
+++ b/agent/src/cli/auth/command-logout.ts
@@ -13,7 +13,6 @@ export const logoutCommand = new Command('logout')
                 spinner.fail('You are already logged out')
                 process.exit(1)
             }
-            await removeCodySecret(settings.activeAccountID)
             const account = settings.accounts.find(account => account.id === settings.activeAccountID)
             if (!account) {
                 spinner.fail(
@@ -23,6 +22,7 @@ export const logoutCommand = new Command('logout')
                 )
                 process.exit(1)
             }
+            await removeCodySecret(account)
             const newAccounts = settings.accounts.filter(
                 account => account.id !== settings.activeAccountID
             )

--- a/agent/src/cli/auth/command-logout.ts
+++ b/agent/src/cli/auth/command-logout.ts
@@ -27,7 +27,7 @@ export const logoutCommand = new Command('logout')
                 account => account.id !== settings.activeAccountID
             )
             writeUserSettings({ accounts: newAccounts })
-            spinner.succeed(`Logged out of account ${account.id} on ${account.serverEndpoint}`)
+            spinner.succeed(`Logged out of account ${account.username} on ${account.serverEndpoint}`)
             process.exit(0)
         } catch (error) {
             if (error instanceof Error) {

--- a/agent/src/cli/auth/command-logout.ts
+++ b/agent/src/cli/auth/command-logout.ts
@@ -22,7 +22,7 @@ export const logoutCommand = new Command('logout')
                 )
                 process.exit(1)
             }
-            await removeCodySecret(account)
+            await removeCodySecret(spinner, account)
             const newAccounts = settings.accounts.filter(
                 account => account.id !== settings.activeAccountID
             )

--- a/agent/src/cli/auth/messages.ts
+++ b/agent/src/cli/auth/messages.ts
@@ -1,5 +1,8 @@
 import type { Ora } from 'ora'
 
 export function notLoggedIn(spinner: Ora): void {
+    if (!spinner.isSpinning) {
+        return
+    }
     spinner.fail('Not logged in. To fix this problem, run:\n\tcody auth login --web')
 }

--- a/agent/src/cli/auth/secrets.ts
+++ b/agent/src/cli/auth/secrets.ts
@@ -1,42 +1,162 @@
-import keytar from 'keytar'
+import { exec } from 'node:child_process'
+import { promisify } from 'node:util'
 import { logDebug } from '../../../../vscode/src/log'
 import type { Account } from './settings'
 
 // This file deals with reading/writing/removing Cody access tokens from the
 // operating system's secret storage (Keychain on macOS, Credential Value on
-// Windows, etc.).
+// Windows, etc.). Originally, we used the `keytar` npm dependency to interact
+// with the OS secret storage. However, Keytar is unmaintained and it was
+// complicated to distribute anyways because you had to distribute native
+// modules for each supported OS. The current implementation shells out to the
+// `security` command on macOS, `powershell` on Windows, and `secret-tool` on
+// Linux. Users can always set the `CODY_ACCESS_TOKEN` environment variable if
+// they don't want to use this functionality.
+//
+// The biggest problem with this approach is that users will most likely select
+// "Always allow" when prompted if the "system" tool can access the Cody
+// secrets. This means that any other tool on the computer can shell out to
+// `system` to read the same secret. However, we chose to go with this approach
+// regardless of this risk based on the following observations:
+// - The user can chose not to let Cody manage its secrets. This is an optional feature.
+// - Storing the secret as a global environment variable also isn't secure.
+// - The `gh` cli tool uses the same approach (shelling out to `security` on macOS),
+//   meaning that any tool on my computer can read my GitHub access token by shelling out
+//   to `security` without me knowing.
+// - It's marginally more secure to build a native module instead of using
+//   `system` because a malicious user can also load the native module instead
+//   of shelling out to `system` to fake that it's Cody cli.
 
-const codyServiceName = 'Cody'
-
-function keytarServiceName(account: Account): string {
-    const host = new URL(account.serverEndpoint).host
-    return `${account.id} on ${host}`
-}
 export async function writeCodySecret(account: Account, secret: string): Promise<void> {
+    const keychain = getKeychainOperations(account)
     try {
-        await keytar.setPassword(codyServiceName, keytarServiceName(account), secret)
+        await keychain.writeSecret(secret)
     } catch (error) {
-        logDebug('keytar-storage', 'Error storing secret:', error)
+        logDebug('keychain-storage', 'Error storing secret:', error)
     }
 }
 
 export async function readCodySecret(account: Account) {
+    const keychain = getKeychainOperations(account)
     try {
-        const secret = await keytar.getPassword(codyServiceName, keytarServiceName(account))
+        const secret = await keychain.readSecret()
         if (secret) {
             return secret
         }
         return null
     } catch (error) {
-        logDebug('keytar-storage', 'Error retrieving secret:', error)
+        logDebug('keychain-storage', 'Error retrieving secret:', error)
         return null
     }
 }
 
-export async function removeCodySecret(account: string) {
+export async function removeCodySecret(account: Account) {
+    const keychain = getKeychainOperations(account)
     try {
-        await keytar.deletePassword(codyServiceName, account)
+        await keychain.deleteSecret()
     } catch (error) {
-        logDebug('keytar-storage', 'Error deleting secret:', error)
+        logDebug('keychain-storage', 'Error deleting secret:', error)
+    }
+}
+
+const execAsync = promisify(exec)
+function getKeychainOperations(account: Account): KeychainOperations {
+    switch (process.platform) {
+        case 'darwin':
+            return new MacOSKeychain(account)
+        case 'win32':
+            return new WindowsCredentialManager(account)
+        case 'linux':
+            return new LinuxSecretService(account)
+        default:
+            throw new Error(`Unsupported platform: ${process.platform}`)
+    }
+}
+
+/**
+ * Uses each operating system's native keychain to store the Cody access token.
+ * - `security` on macOS
+ * - `powershell -command '...StoredCredential ...` on Windows
+ * - `secret-tool` on Linux
+ */
+abstract class KeychainOperations {
+    constructor(public account: Account) {}
+    protected service(): string {
+        const host = new URL(this.account.serverEndpoint).host
+        return `Cody: ${host} (${this.account.id})`
+    }
+    abstract readSecret(): Promise<string>
+    abstract writeSecret(secret: string): Promise<void>
+    abstract deleteSecret(): Promise<void>
+}
+
+class MacOSKeychain extends KeychainOperations {
+    async readSecret(): Promise<string> {
+        const { stdout } = await execAsync(
+            `security find-generic-password -s "${this.service()}" -a "${this.account.username}" -w`
+        )
+        return stdout.trim()
+    }
+
+    async writeSecret(secret: string): Promise<void> {
+        await execAsync(
+            `security add-generic-password -s "${this.service()}" -a "${
+                this.account.username
+            }" -w "${secret}"`
+        )
+    }
+
+    async deleteSecret(): Promise<void> {
+        await execAsync(
+            `security delete-generic-password -s "${this.service()}" -a "${this.account.username}"`
+        )
+    }
+}
+
+class WindowsCredentialManager extends KeychainOperations {
+    async readSecret(): Promise<string> {
+        const { stdout } = await execAsync(
+            `powershell -command "& {(Get-StoredCredential -Target '${this.service()}:${
+                this.account.username
+            }').Password | ConvertFrom-SecureString -AsPlainText}"`
+        )
+        return stdout.trim()
+    }
+
+    async writeSecret(secret: string): Promise<void> {
+        await execAsync(
+            `powershell -command "& {New-StoredCredential -Target '${this.service()}:${
+                this.account.username
+            }' -UserName '${this.account.username}' -Password '${secret}' -Persist LocalMachine}"`
+        )
+    }
+
+    async deleteSecret(): Promise<void> {
+        await execAsync(
+            `powershell -command "& {Remove-StoredCredential -Target '${this.service()}:${
+                this.account.username
+            }'}"`
+        )
+    }
+}
+
+class LinuxSecretService extends KeychainOperations {
+    async readSecret(): Promise<string> {
+        const { stdout } = await execAsync(
+            `secret-tool lookup service ${this.service()} account ${this.account.username}`
+        )
+        return stdout.trim()
+    }
+
+    async writeSecret(secret: string): Promise<void> {
+        await execAsync(
+            `echo "${secret}" | secret-tool store --label="${this.service()}" service ${this.service()} account ${
+                this.account.username
+            }`
+        )
+    }
+
+    async deleteSecret(): Promise<void> {
+        await execAsync(`secret-tool clear service ${this.service()} account ${this.account.username}`)
     }
 }

--- a/agent/src/cli/auth/secrets.ts
+++ b/agent/src/cli/auth/secrets.ts
@@ -144,20 +144,22 @@ class WindowsCredentialManager extends KeychainOperations {
 class LinuxSecretService extends KeychainOperations {
     async readSecret(): Promise<string> {
         const { stdout } = await execAsync(
-            `secret-tool lookup service ${this.service()} account ${this.account.username}`
+            `secret-tool lookup service '${this.service()}' account '${this.account.username}'`
         )
         return stdout.trim()
     }
 
     async writeSecret(secret: string): Promise<void> {
         await execAsync(
-            `echo "${secret}" | secret-tool store --label="${this.service()}" service ${this.service()} account ${
+            `echo "${secret}" | secret-tool store --label="${this.service()}" service '${this.service()}' account ${
                 this.account.username
             }`
         )
     }
 
     async deleteSecret(): Promise<void> {
-        await execAsync(`secret-tool clear service ${this.service()} account ${this.account.username}`)
+        await execAsync(
+            `secret-tool clear service '${this.service()}' account '${this.account.username}'`
+        )
     }
 }

--- a/agent/src/cli/auth/secrets.ts
+++ b/agent/src/cli/auth/secrets.ts
@@ -115,10 +115,11 @@ class MacOSKeychain extends KeychainOperations {
 
 class WindowsCredentialManager extends KeychainOperations {
     async readSecret(): Promise<string> {
+        const powershellCommand = `(Get-StoredCredential -Target "${this.service()}:${
+            this.account.username
+        }").GetNetworkCredential().Password`
         const { stdout } = await execAsync(
-            `powershell -command "& {(Get-StoredCredential -Target '${this.service()}:${
-                this.account.username
-            }').Password | ConvertFrom-SecureString -AsPlainText}"`
+            `powershell -Command "${powershellCommand.replace(/"/g, '\\"')}"`
         )
         return stdout.trim()
     }

--- a/agent/src/cli/auth/secrets.ts
+++ b/agent/src/cli/auth/secrets.ts
@@ -167,7 +167,7 @@ To fix this problem, run the command below to install the missing dependencies:
   Install-Module -Name CredentialManager
 ${alternativelyMessage}`
     private target(): string {
-        return `${this.service()}:${this.account.username}`
+        return `${this.service()}:${this.account.username}`.replaceAll('"', '_')
     }
     async readSecret(): Promise<string> {
         const powershellCommand = `(Get-StoredCredential -Target "${this.target()}").GetNetworkCredential().Password`

--- a/agent/src/cli/auth/secrets.ts
+++ b/agent/src/cli/auth/secrets.ts
@@ -60,7 +60,6 @@ export async function removeCodySecret(spinner: Ora, account: Account) {
 }
 
 function getKeychainOperations(spinner: Ora, account: Account): KeychainOperations {
-    registerCommandNotFoundHandler()
     switch (process.platform) {
         case 'darwin':
             return new MacOSKeychain(spinner, account)

--- a/agent/src/cli/chat.ts
+++ b/agent/src/cli/chat.ts
@@ -58,11 +58,12 @@ export const chatCommand = () =>
         .option('--debug', 'Enable debug logging', false)
         .action(async (options: ChatOptions) => {
             if (!options.accessToken) {
-                const spinner = ora().start()
+                const spinner = ora().start('Loading access token')
                 const account = await AuthenticatedAccount.fromUserSettings(spinner)
                 if (!spinner.isSpinning) {
                     process.exit(1)
                 }
+                spinner.stop()
                 if (account) {
                     options.accessToken = account.accessToken
                     options.endpoint = account.serverEndpoint

--- a/agent/src/cli/chat.ts
+++ b/agent/src/cli/chat.ts
@@ -58,7 +58,11 @@ export const chatCommand = () =>
         .option('--debug', 'Enable debug logging', false)
         .action(async (options: ChatOptions) => {
             if (!options.accessToken) {
-                const account = await AuthenticatedAccount.fromUserSettings()
+                const spinner = ora().start()
+                const account = await AuthenticatedAccount.fromUserSettings(spinner)
+                if (!spinner.isSpinning) {
+                    process.exit(1)
+                }
                 if (account) {
                     options.accessToken = account.accessToken
                     options.endpoint = account.serverEndpoint

--- a/agent/src/esbuild.mjs
+++ b/agent/src/esbuild.mjs
@@ -58,7 +58,6 @@ async function buildAgent(minify) {
         logLevel: 'error',
         external: ['typescript'],
         minify: minify,
-        loader: { '.node': 'copy' },
 
         alias: {
             vscode: path.resolve(process.cwd(), 'src', 'vscode-shim.ts'),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -204,9 +204,6 @@ importers:
       js-levenshtein:
         specifier: ^1.1.6
         version: 1.1.6
-      keytar:
-        specifier: ^7.9.0
-        version: 7.9.0
       lodash:
         specifier: ^4.17.21
         version: 4.17.21
@@ -7113,6 +7110,7 @@ packages:
       buffer: 5.7.1
       inherits: 2.0.4
       readable-stream: 3.6.2
+    dev: true
 
   /bluebird@3.4.7:
     resolution: {integrity: sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA==}
@@ -7259,6 +7257,7 @@ packages:
     dependencies:
       base64-js: 1.5.1
       ieee754: 1.2.1
+    dev: true
 
   /buffer@6.0.3:
     resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
@@ -7515,6 +7514,7 @@ packages:
 
   /chownr@1.1.4:
     resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
+    dev: true
 
   /chownr@2.0.0:
     resolution: {integrity: sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==}
@@ -8079,6 +8079,8 @@ packages:
     requiresBuild: true
     dependencies:
       mimic-response: 3.1.0
+    dev: true
+    optional: true
 
   /dedent@0.7.0:
     resolution: {integrity: sha512-Q6fKUPqnAHAyhiUgFU7BUzLiv0kd8saH9al7tnu5Q/okj6dnupxyTgFIBjVzJATdfIAm9NAsvXNzjaKa+bxVyA==}
@@ -8130,6 +8132,8 @@ packages:
     resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
     engines: {node: '>=4.0.0'}
     requiresBuild: true
+    dev: true
+    optional: true
 
   /deep-freeze@0.0.1:
     resolution: {integrity: sha512-Z+z8HiAvsGwmjqlphnHW5oz6yWlOwu6EQfFTjmeTWlDeda3FS2yv3jhq35TX/ewmsnqB+RX2IdsIOyjJCQN5tg==}
@@ -8265,6 +8269,8 @@ packages:
     resolution: {integrity: sha512-bwy0MGW55bG41VqxxypOsdSdGqLwXPI/focwgTYCFMbdUiBAxLg9CFzG08sz2aqzknwiX7Hkl0bQENjg8iLByw==}
     engines: {node: '>=8'}
     requiresBuild: true
+    dev: true
+    optional: true
 
   /detect-node-es@1.1.0:
     resolution: {integrity: sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==}
@@ -8766,6 +8772,8 @@ packages:
     resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
     engines: {node: '>=6'}
     requiresBuild: true
+    dev: true
+    optional: true
 
   /exponential-backoff@3.1.1:
     resolution: {integrity: sha512-dX7e/LHVJ6W3DE1MHWi9S1EYzDESENfLrYohG2G++ovZrYOkm4Knwa0mc1cn84xJOR4KEU0WSchhLbd0UklbHw==}
@@ -9189,6 +9197,7 @@ packages:
 
   /fs-constants@1.0.0:
     resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
+    dev: true
 
   /fs-extra@10.1.0:
     resolution: {integrity: sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==}
@@ -9377,6 +9386,8 @@ packages:
   /github-from-package@0.0.0:
     resolution: {integrity: sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==}
     requiresBuild: true
+    dev: true
+    optional: true
 
   /github-slugger@2.0.0:
     resolution: {integrity: sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==}
@@ -10032,6 +10043,7 @@ packages:
 
   /ini@1.3.8:
     resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
+    dev: true
 
   /ini@4.1.2:
     resolution: {integrity: sha512-AMB1mvwR1pyBFY/nSevUX6y8nJWS63/SzUKD3JyQn97s4xgIdgQPT75IRouIiBAN4yLQBUShNYVW0+UG25daCw==}
@@ -10720,6 +10732,8 @@ packages:
     dependencies:
       node-addon-api: 4.3.0
       prebuild-install: 7.1.2
+    dev: true
+    optional: true
 
   /keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
@@ -11807,6 +11821,8 @@ packages:
     resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
     engines: {node: '>=10'}
     requiresBuild: true
+    dev: true
+    optional: true
 
   /min-indent@1.0.1:
     resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
@@ -11926,6 +11942,7 @@ packages:
 
   /mkdirp-classic@0.5.3:
     resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
+    dev: true
 
   /mkdirp@0.5.6:
     resolution: {integrity: sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==}
@@ -12070,6 +12087,8 @@ packages:
   /napi-build-utils@1.0.2:
     resolution: {integrity: sha512-ONmRUqK7zj7DWX0D9ADe03wbwOBZxNAfF20PlGfCWQcD3+/MakShIHrMqx9YwPTfxDdF1zLeL+RGZiR9kGMLdg==}
     requiresBuild: true
+    dev: true
+    optional: true
 
   /negotiator@0.6.3:
     resolution: {integrity: sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==}
@@ -12112,10 +12131,14 @@ packages:
     requiresBuild: true
     dependencies:
       semver: 7.6.0
+    dev: true
+    optional: true
 
   /node-addon-api@4.3.0:
     resolution: {integrity: sha512-73sE9+3UaLYYFmDsFZnqCInzPyh3MqIwZO9cw58yIqAZhONrrabrYyYe3TuIqtIiOuTXVhsGau8hcrhhwSsDIQ==}
     requiresBuild: true
+    dev: true
+    optional: true
 
   /node-dir@0.1.17:
     resolution: {integrity: sha512-tmPX422rYgofd4epzrNoOXiE8XFZYOcCq1vD7MAXCDO+O+zndlA2ztdKKMa+EeuBG5tHETpr4ml4RGgpqDCCAg==}
@@ -12889,6 +12912,8 @@ packages:
       simple-get: 4.0.1
       tar-fs: 2.1.1
       tunnel-agent: 0.6.0
+    dev: true
+    optional: true
 
   /prelude-ls@1.1.2:
     resolution: {integrity: sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w==}
@@ -13110,6 +13135,7 @@ packages:
     dependencies:
       end-of-stream: 1.4.4
       once: 1.4.0
+    dev: true
 
   /pumpify@1.5.1:
     resolution: {integrity: sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==}
@@ -13192,6 +13218,8 @@ packages:
       ini: 1.3.8
       minimist: 1.2.8
       strip-json-comments: 2.0.1
+    dev: true
+    optional: true
 
   /re2js@0.4.1:
     resolution: {integrity: sha512-Kxb+OKXrEPowP4bXAF07NDXtgYX07S8HeVGgadx5/D/R41LzWg1kgTD2szIv2iHJM3vrAPnDKaBzfUE/7QWX9w==}
@@ -14036,6 +14064,8 @@ packages:
   /simple-concat@1.0.1:
     resolution: {integrity: sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==}
     requiresBuild: true
+    dev: true
+    optional: true
 
   /simple-get@4.0.1:
     resolution: {integrity: sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==}
@@ -14044,6 +14074,8 @@ packages:
       decompress-response: 6.0.0
       once: 1.4.0
       simple-concat: 1.0.1
+    dev: true
+    optional: true
 
   /sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
@@ -14416,6 +14448,8 @@ packages:
     resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
     engines: {node: '>=0.10.0'}
     requiresBuild: true
+    dev: true
+    optional: true
 
   /strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
@@ -14724,6 +14758,7 @@ packages:
       mkdirp-classic: 0.5.3
       pump: 3.0.0
       tar-stream: 2.2.0
+    dev: true
 
   /tar-fs@3.0.6:
     resolution: {integrity: sha512-iokBDQQkUyeXhgPYaZxmczGPhnhXZ0CmrqI+MOb/WFGS9DW5wnfrLgtjUJBvz50vQ3qfRwJ62QVoCFu8mPVu5w==}
@@ -14744,6 +14779,7 @@ packages:
       fs-constants: 1.0.0
       inherits: 2.0.4
       readable-stream: 3.6.2
+    dev: true
 
   /tar-stream@3.1.7:
     resolution: {integrity: sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==}
@@ -15042,6 +15078,8 @@ packages:
     requiresBuild: true
     dependencies:
       safe-buffer: 5.2.1
+    dev: true
+    optional: true
 
   /tunnel@0.0.6:
     resolution: {integrity: sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==}

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -6,6 +6,7 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 
 ### Added
 
+
 - Ollama: Added support for running Cody offline with local Ollama models. [pull/4691](https://github.com/sourcegraph/cody/pull/4691)
 - Edit: Added support for users' to edit the applied edit before the diff view is removed. [pull/4684](https://github.com/sourcegraph/cody/pull/4684)
 

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -6,7 +6,6 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 
 ### Added
 
-
 - Ollama: Added support for running Cody offline with local Ollama models. [pull/4691](https://github.com/sourcegraph/cody/pull/4691)
 - Edit: Added support for users' to edit the applied edit before the diff view is removed. [pull/4684](https://github.com/sourcegraph/cody/pull/4684)
 


### PR DESCRIPTION
Previously, we used Keytar to write/read/delete secrets. This was problematic for two reasons:

- Keytar has been unmaintained since 2022
- Keytar required native Node modules that meant `cody-agent` was crashing on macOS when using a release that was built on Linux (in CI)

This PR addresses both problems by replacing keytar with a custom solution that shells out to different secret managers (`security` on macOS, `secret-tool` on Linux, and `powershell` on
 Windows). See comment in `secrets.ts` for a more detailed reasoning why
we went with this approach.


## Test plan

Manually tested on macOS/Linux/Windows.

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
