### PR TITLE
Fuzz remote filename for @-mentions

### DIFF
--- a/lib/shared/src/sourcegraph-api/graphql/client.ts
+++ b/lib/shared/src/sourcegraph-api/graphql/client.ts
@@ -7,7 +7,6 @@ import type { TelemetryEventInput } from '@sourcegraph/telemetry'
 
 import { escapeRegExp } from 'lodash'
 import semver from 'semver'
-import { isErrorLike } from '../../common'
 import type { ConfigurationWithAccessToken } from '../../configuration'
 import { logDebug, logError } from '../../logger'
 import { addTraceparent, wrapInActiveSpan } from '../../tracing'

--- a/lib/shared/src/sourcegraph-api/graphql/client.ts
+++ b/lib/shared/src/sourcegraph-api/graphql/client.ts
@@ -1,4 +1,4 @@
-import * as path from 'path'
+import * as path from 'node:path'
 import type { Response as NodeResponse } from 'node-fetch'
 import { URI } from 'vscode-uri'
 import { fetch } from '../../fetch'

--- a/vscode/src/editor/utils/editor-context.ts
+++ b/vscode/src/editor/utils/editor-context.ts
@@ -50,7 +50,10 @@ const lowScoringPathSegments = ['bin']
  */
 const throttledFindFiles = throttle(() => findWorkspaceFiles(), 10000)
 
-const debouncedRemoteFindFiles = debouncePromise(graphqlClient.getRemoteFiles.bind(graphqlClient), 500)
+const debouncedRemoteFindFiles = debouncePromise(
+    graphqlClient.getRemoteFilesWithFuzzyRetry.bind(graphqlClient),
+    500
+)
 const debouncedRemoteFindSymbols = debouncePromise(
     graphqlClient.getRemoteSymbols.bind(graphqlClient),
     500


### PR DESCRIPTION
In @vovakulikov 's demo of Cody Web today, I noticed that he @-mentioned `insight.go`, which didn't match any files. He corrected it to `insights.go`, which did match a file, and continued the demo.

Seeing that made me think that we should add the ability to more fuzzily match remote files, similar to how we match local files (@-mentioning `chatcontext` will match `.../chat/.../context...`, `...chatContext...`, `...chat-context...`, and perhaps more)

This PR adds some fuzziness to the filename as an example of one way to approach this. Perhaps it's the correct approach, and maybe we want to expand it to the whole path so it behaves more similarly to matching local files, but this is a start. It's a small start to avoid adding a lot of latency or noise to remote file mentioning.

Compare to #4761 

https://github.com/sourcegraph/cody/assets/129280/10ebe9c1-a413-4fd1-835a-256262e051aa

## Test plan

@-mention files that don't exist (my test go-to is `internal/database/insight.go`) and see that it returns a list of files 