### PR TITLE
[Cody Web]: Allow agent auth running without access token

### DIFF
--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/CodyIDE.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/CodyIDE.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
 package com.sourcegraph.cody.protocol_generated;
 
-typealias CodyIDE = String // One of: VSCode, JetBrains, Neovim, Emacs
+typealias CodyIDE = String // One of: VSCode, JetBrains, Neovim, Emacs, Web
 

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/ConfigParams.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/ConfigParams.kt
@@ -3,7 +3,7 @@ package com.sourcegraph.cody.protocol_generated;
 
 data class ConfigParams(
   val experimentalNoodle: Boolean,
-  val agentIDE: CodyIDE? = null, // Oneof: VSCode, JetBrains, Neovim, Emacs
+  val agentIDE: CodyIDE? = null, // Oneof: VSCode, JetBrains, Neovim, Emacs, Web
   val agentExtensionVersion: String? = null,
   val serverEndpoint: String,
   val uiKindIsWeb: Boolean,

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/Constants.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/Constants.kt
@@ -62,6 +62,7 @@ object Constants {
   const val JetBrains = "JetBrains"
   const val Neovim = "Neovim"
   const val Emacs = "Emacs"
+  const val Web = "Web"
   const val Idle = "Idle"
   const val Working = "Working"
   const val Inserting = "Inserting"

--- a/agent/src/AgentWorkspaceConfiguration.ts
+++ b/agent/src/AgentWorkspaceConfiguration.ts
@@ -40,6 +40,8 @@ export class AgentWorkspaceConfiguration implements vscode.WorkspaceConfiguratio
                 return CodyIDE.Emacs
             case 'neovim':
                 return CodyIDE.Neovim
+            case 'web':
+                return CodyIDE.Web
             default:
                 return undefined
         }

--- a/lib/shared/src/configuration.ts
+++ b/lib/shared/src/configuration.ts
@@ -94,6 +94,7 @@ export enum CodyIDE {
     JetBrains = 'JetBrains',
     Neovim = 'Neovim',
     Emacs = 'Emacs',
+    Web = 'Web',
 }
 
 export interface AutocompleteTimeouts {

--- a/lib/shared/src/telemetry-v2/TelemetryRecorderProvider.ts
+++ b/lib/shared/src/telemetry-v2/TelemetryRecorderProvider.ts
@@ -10,6 +10,7 @@ import {
 
 import {
     CONTEXT_SELECTION_ID,
+    type CodyIDE,
     type Configuration,
     type ConfigurationWithAccessToken,
 } from '../configuration'
@@ -23,7 +24,7 @@ import type { AuthStatusProvider } from '../auth/types'
 import { getTier } from './cody-tier'
 
 interface ExtensionDetails {
-    ide: 'VSCode' | 'JetBrains' | 'Neovim' | 'Emacs'
+    ide: CodyIDE
     ideExtensionType: 'Cody' | 'CodeSearch'
 
     /** Version number for the extension. */

--- a/lib/shared/src/telemetry/EventLogger.ts
+++ b/lib/shared/src/telemetry/EventLogger.ts
@@ -5,10 +5,11 @@ import { isError } from '../utils'
 
 import type { TelemetryEventProperties } from '.'
 import type { AuthStatus } from '../auth/types'
+import type { CodyIDE } from '../configuration'
 import { getTier } from '../telemetry-v2/cody-tier'
 
 export interface ExtensionDetails {
-    ide: 'VSCode' | 'JetBrains' | 'Neovim' | 'Emacs'
+    ide: CodyIDE
     ideVersion?: string
     ideExtensionType: 'Cody' | 'CodeSearch'
     platform: string
@@ -51,6 +52,9 @@ export class EventLogger {
                 break
             case 'Neovim':
                 this.client = 'NEOVIM_CODY_EXTENSION'
+                break
+            case 'Web':
+                this.client = 'WEB_CODY_EXTENSION'
                 break
             default:
                 throw new Error(`new IDE ${this.extensionDetails.ide} not yet accounted for`)

--- a/vscode/src/chat/chat-view/ChatPanelsManager.ts
+++ b/vscode/src/chat/chat-view/ChatPanelsManager.ts
@@ -230,11 +230,11 @@ export class ChatPanelsManager implements vscode.Disposable {
         // Enterprise context is used for remote repositories context fetching
         // in vs cody extension it should be always off if extension is connected
         // to dot com instance, but in Cody Web it should be on by default for
-        // all instances (including dot com), Cody Web client sets cody.allow-remote-context
+        // all instances (including dot com), Cody Web client sets cody.web
         // to true to enable this directly.
         const allowRemoteContext = vscode.workspace
             .getConfiguration()
-            .get<boolean>('cody.allow-remote-context', !isConsumer)
+            .get<boolean>('cody.web', !isConsumer)
 
         return new SimpleChatPanelProvider({
             ...this.options,

--- a/vscode/src/chat/chat-view/ChatPanelsManager.ts
+++ b/vscode/src/chat/chat-view/ChatPanelsManager.ts
@@ -3,6 +3,7 @@ import * as vscode from 'vscode'
 import {
     type AuthStatus,
     type ChatClient,
+    CodyIDE,
     type ConfigurationWithAccessToken,
     type FeatureFlagProvider,
     type Guardrails,
@@ -230,11 +231,10 @@ export class ChatPanelsManager implements vscode.Disposable {
         // Enterprise context is used for remote repositories context fetching
         // in vs cody extension it should be always off if extension is connected
         // to dot com instance, but in Cody Web it should be on by default for
-        // all instances (including dot com), Cody Web client sets cody.web
-        // to true to enable this directly.
-        const allowRemoteContext = vscode.workspace
-            .getConfiguration()
-            .get<boolean>('cody.web', !isConsumer)
+        // all instances (including dot com)
+        const isCodyWeb =
+            vscode.workspace.getConfiguration().get<string>('cody.advanced.agent.ide') === CodyIDE.Web
+        const allowRemoteContext = isCodyWeb || !isConsumer
 
         return new SimpleChatPanelProvider({
             ...this.options,

--- a/vscode/src/services/AuthProvider.ts
+++ b/vscode/src/services/AuthProvider.ts
@@ -227,12 +227,23 @@ export class AuthProvider implements AuthStatusProvider {
     ): Promise<AuthStatus> {
         const endpoint = config.serverEndpoint
         const token = config.accessToken
+        const isCodyWeb = vscode.workspace.getConfiguration().get<boolean>('cody.web', false)
+
         if (isOfflineMode) {
             const lastUser = localStorage.getLastStoredUser()
             return { ...offlineModeAuthStatus, ...lastUser }
         }
-        if (!token || !endpoint) {
-            return { ...defaultAuthStatus, endpoint }
+
+        // Cody Web can work without access token since authorization flow
+        // relies on cookie authentication
+        if (isCodyWeb) {
+            if (!endpoint) {
+                return { ...defaultAuthStatus, endpoint }
+            }
+        } else {
+            if (!token || !endpoint) {
+                return { ...defaultAuthStatus, endpoint }
+            }
         }
         // Cache the config and the GraphQL client
         if (this.config !== config || !this.client) {

--- a/vscode/src/services/AuthProvider.ts
+++ b/vscode/src/services/AuthProvider.ts
@@ -3,6 +3,7 @@ import * as vscode from 'vscode'
 import {
     type AuthStatus,
     type AuthStatusProvider,
+    CodyIDE,
     type ConfigurationWithAccessToken,
     DOTCOM_URL,
     LOCAL_APP_URL,
@@ -12,18 +13,17 @@ import {
     logError,
     networkErrorAuthStatus,
     offlineModeAuthStatus,
+    telemetryRecorder,
     unauthenticatedStatus,
 } from '@sourcegraph/cody-shared'
 
+import { AccountMenuOptions, openAccountMenu } from '../auth/account-menu'
+import { closeAuthProgressIndicator } from '../auth/auth-progress-indicator'
 import { CodyChatPanelViewType } from '../chat/chat-view/ChatManager'
 import { ACCOUNT_USAGE_URL, isLoggedIn as isAuthenticated, isSourcegraphToken } from '../chat/protocol'
 import { newAuthStatus } from '../chat/utils'
 import { getFullConfig } from '../configuration'
 import { logDebug } from '../log'
-
-import { telemetryRecorder } from '@sourcegraph/cody-shared'
-import { AccountMenuOptions, openAccountMenu } from '../auth/account-menu'
-import { closeAuthProgressIndicator } from '../auth/auth-progress-indicator'
 import { maybeStartInteractiveTutorial } from '../tutorial/helpers'
 import { AuthMenu, showAccessTokenInputBox, showInstanceURLInputBox } from './AuthMenus'
 import { getAuthReferralCode } from './AuthProviderSimplified'
@@ -227,7 +227,8 @@ export class AuthProvider implements AuthStatusProvider {
     ): Promise<AuthStatus> {
         const endpoint = config.serverEndpoint
         const token = config.accessToken
-        const isCodyWeb = vscode.workspace.getConfiguration().get<boolean>('cody.web', false)
+        const isCodyWeb =
+            vscode.workspace.getConfiguration().get<string>('cody.advanced.agent.ide') === CodyIDE.Web
 
         if (isOfflineMode) {
             const lastUser = localStorage.getLastStoredUser()

--- a/vscode/src/services/telemetry.ts
+++ b/vscode/src/services/telemetry.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode'
 
 import {
+    CodyIDE,
     type Configuration,
     type ConfigurationWithAccessToken,
     EventLogger,
@@ -26,7 +27,7 @@ const { platform, arch } = getOSArch()
 export const getExtensionDetails = (
     config: Pick<Configuration, 'agentIDE' | 'agentIDEVersion' | 'agentExtensionVersion'>
 ): ExtensionDetails => ({
-    ide: config.agentIDE ?? 'VSCode',
+    ide: config.agentIDE ?? CodyIDE.VSCode,
     ideVersion: config.agentIDEVersion ?? vscode.version,
     ideExtensionType: 'Cody',
     platform: platform ?? 'browser',
@@ -150,13 +151,14 @@ export const telemetryService: TelemetryService = {
 }
 
 // TODO: Clean up this name mismatch when we move to TelemetryV2
-export function logPrefix(ide: 'VSCode' | 'JetBrains' | 'Neovim' | 'Emacs' | undefined): string {
+export function logPrefix(ide: CodyIDE | undefined): string {
     return ide
         ? {
               VSCode: 'CodyVSCodeExtension',
               JetBrains: 'CodyJetBrainsPlugin',
               Emacs: 'CodyEmacsPlugin',
               Neovim: 'CodyNeovimPlugin',
+              Web: 'CodyWebClient',
           }[ide]
         : 'CodyVSCodeExtension'
 }

--- a/web/lib/agent/agent.client.ts
+++ b/web/lib/agent/agent.client.ts
@@ -71,7 +71,7 @@ export async function createAgentClient({
 
     // Initialize
     const serverInfo: ServerInfo = await rpc.sendRequest('initialize', {
-        name: 'cody-web',
+        name: 'web',
         version: '0.0.1',
         workspaceRootUri,
         extensionConfiguration: {

--- a/web/lib/agent/agent.client.ts
+++ b/web/lib/agent/agent.client.ts
@@ -82,7 +82,7 @@ export async function createAgentClient({
                 'cody.experimental.noodle': true,
                 'cody.autocomplete.enabled': false,
                 'cody.experimental.urlContext': true,
-                'cody.allow-remote-context': true,
+                'cody.web': true,
             },
         },
     })


### PR DESCRIPTION
Part of [SRCH-632](https://linear.app/sourcegraph/issue/SRCH-632/merge-cody-web-experimental-package-to-the-cody-repo-main-branch)

This is one of the PRs that come from the main change PR that I made for Cody Web here: https://github.com/sourcegraph/cody/pull/4605. 

This PR introduces the `cody.web` configuration field that allows running the cody agent 
- Without provided access token 
- Always fetching remote context (not only for sourcegraph.com instance)

This change is safe to merge because it affects only Cody Web package and has no impact 
on any other agent clients

## Test plan
- CI is passing

