### PR TITLE
Cody Web: fix cody web UI flashes problem

### DIFF
--- a/web/lib/components/CodyWebChat.tsx
+++ b/web/lib/components/CodyWebChat.tsx
@@ -1,4 +1,4 @@
-import { type FC, useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { type FC, useCallback, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import { URI } from 'vscode-uri'
 
 import {
@@ -60,8 +60,10 @@ export interface CodyWebChatProps {
 export const CodyWebChat: FC<CodyWebChatProps> = props => {
     const { className } = props
 
-    const { vscodeAPI, client, activeChatID, initialContext } = useWebAgentClient()
+    const { vscodeAPI, client, activeChatID, activeWebviewPanelID, initialContext } = useWebAgentClient()
     const dispatchClientAction = useClientActionDispatcher()
+
+    const [initialization, setInitialization] = useState<'init' | 'completed'>('init')
 
     const rootElementRef = useRef<HTMLDivElement>(null)
     const [isTranscriptError, setIsTranscriptError] = useState<boolean>(false)
@@ -70,7 +72,7 @@ export const CodyWebChat: FC<CodyWebChatProps> = props => {
     const [userAccountInfo, setUserAccountInfo] = useState<UserAccountInfo>()
     const [chatModels, setChatModels] = useState<Model[]>()
 
-    useEffect(() => {
+    useLayoutEffect(() => {
         vscodeAPI.onMessage(message => {
             switch (message.type) {
                 case 'transcript': {
@@ -108,15 +110,26 @@ export const CodyWebChat: FC<CodyWebChatProps> = props => {
         })
     }, [vscodeAPI, dispatchClientAction])
 
-    useEffect(() => {
-        // Notify the extension host that we are ready to receive events.
-        vscodeAPI.postMessage({ command: 'ready' })
-        vscodeAPI.postMessage({ command: 'initialized' })
-
-        if (activeChatID) {
-            vscodeAPI.postMessage({ command: 'restoreHistory', chatID: activeChatID })
+    useLayoutEffect(() => {
+        if (initialization === 'completed') {
+            return
         }
-    }, [vscodeAPI, activeChatID])
+
+        if (client && !isErrorLike(client) && activeChatID && activeWebviewPanelID) {
+            // Notify the extension host that we are ready to receive events.
+            vscodeAPI.postMessage({ command: 'ready' })
+            vscodeAPI.postMessage({ command: 'initialized' })
+
+            client.rpc
+                .sendRequest('webview/receiveMessage', {
+                    id: activeWebviewPanelID,
+                    message: { command: 'restoreHistory', chatID: activeChatID },
+                })
+                .then(() => {
+                    setInitialization('completed')
+                })
+        }
+    }, [initialization, vscodeAPI, activeChatID, activeWebviewPanelID, client])
 
     // Deprecated V1 telemetry
     const telemetryService = useMemo(() => createWebviewTelemetryService(vscodeAPI), [vscodeAPI])
@@ -180,7 +193,11 @@ export const CodyWebChat: FC<CodyWebChatProps> = props => {
     console.log({ client, userAccountInfo, chatModels, activeChatID })
     return (
         <div className={className} data-cody-web-chat={true} ref={rootElementRef}>
-            {client && userAccountInfo && chatModels && activeChatID ? (
+            {client &&
+            userAccountInfo &&
+            chatModels &&
+            activeChatID &&
+            initialization === 'completed' ? (
                 isErrorLike(client) ? (
                     <p>Error: {client.message}</p>
                 ) : (

--- a/web/lib/components/CodyWebChatProvider.tsx
+++ b/web/lib/components/CodyWebChatProvider.tsx
@@ -1,6 +1,5 @@
 import {
     type FC,
-    type MutableRefObject,
     type PropsWithChildren,
     createContext,
     useCallback,
@@ -38,7 +37,7 @@ interface AgentClient {
 interface CodyWebChatContextData {
     client: AgentClient | Error | null
     activeChatID: string | null
-    activeWebviewPanelID: MutableRefObject<string>
+    activeWebviewPanelID: string
     vscodeAPI: VSCodeWrapper
     initialContext: InitialContext | undefined
     setLastActiveChatID: (chatID: string | null) => void
@@ -49,7 +48,7 @@ interface CodyWebChatContextData {
 export const CodyWebChatContext = createContext<CodyWebChatContextData>({
     client: null,
     activeChatID: null,
-    activeWebviewPanelID: { current: '' },
+    activeWebviewPanelID: '',
     initialContext: undefined,
 
     // Null casting is just to avoid unnecessary null type checks in
@@ -86,14 +85,17 @@ export const CodyWebChatProvider: FC<PropsWithChildren<CodyWebChatProviderProps>
     // In order to avoid multiple client creation during dev runs
     // since useEffect can be fired multiple times during dev builds
     const isClientInitialized = useRef(false)
-    const activeWebviewPanelID = useRef<string>('')
+    const activeWebviewPanelIDRef = useRef<string>('')
     const onMessageCallbacksRef = useRef<((message: ExtensionMessage) => void)[]>([])
 
+    const [activeWebviewPanelID, setActiveWebviewPanelID] = useState<string>('')
     const [client, setClient] = useState<AgentClient | Error | null>(null)
     const [lastActiveChatID, setLastActiveChatID] = useLocalStorage<string | null>(
         ACTIVE_CHAT_ID_KEY,
         null
     )
+
+    activeWebviewPanelIDRef.current = activeWebviewPanelID
 
     // TODO [VK] Memoize agent client creation to avoid re-creating client
     useEffect(() => {
@@ -116,15 +118,16 @@ export const CodyWebChatProvider: FC<PropsWithChildren<CodyWebChatProviderProps>
                     fullHistory: true,
                 })
 
+                const initialChat = chatHistory.find(chat => chat.chatID === initialChatId)
+
                 // In case of no chats we should create initial empty chat
                 // Also when we have a context
-                if (chatHistory.length === 0 || initialChatId === null) {
+                if (chatHistory.length === 0 || (initialChatId !== undefined && !initialChat)) {
                     await createChat(client)
                 } else {
                     // Activate either last active chat by ID from local storage or
                     // set the last created chat from the history
                     const lastUsedChat = chatHistory.find(chat => chat.chatID === lastActiveChatID)
-                    const initialChat = chatHistory.find(chat => chat.chatID === initialChatId)
                     const lastActiveChat =
                         initialChat ?? lastUsedChat ?? chatHistory[chatHistory.length - 1]
 
@@ -133,7 +136,7 @@ export const CodyWebChatProvider: FC<PropsWithChildren<CodyWebChatProviderProps>
 
                 if (initialContext?.repositories.length) {
                     await client.rpc.sendRequest('webview/receiveMessage', {
-                        id: activeWebviewPanelID.current,
+                        id: activeWebviewPanelIDRef.current,
                         message: {
                             command: 'context/choose-remote-search-repo',
                             explicitRepos: initialContext?.repositories ?? [],
@@ -154,7 +157,7 @@ export const CodyWebChatProvider: FC<PropsWithChildren<CodyWebChatProviderProps>
             client.rpc.onNotification(
                 'webview/postMessage',
                 ({ id, message }: { id: string; message: ExtensionMessage }) => {
-                    if (activeWebviewPanelID.current === id) {
+                    if (activeWebviewPanelIDRef.current === id) {
                         for (const callback of onMessageCallbacksRef.current) {
                             callback(hydrateAfterPostMessage(message, uri => URI.from(uri as any)))
                         }
@@ -162,7 +165,6 @@ export const CodyWebChatProvider: FC<PropsWithChildren<CodyWebChatProviderProps>
                 }
             )
         }
-
         const vscodeAPI: VSCodeWrapper = {
             postMessage: message => {
                 if (client && !isErrorLike(client)) {
@@ -178,7 +180,7 @@ export const CodyWebChatProvider: FC<PropsWithChildren<CodyWebChatProviderProps>
                     }
 
                     void client.rpc.sendRequest('webview/receiveMessage', {
-                        id: activeWebviewPanelID.current,
+                        id: activeWebviewPanelIDRef.current,
                         message,
                     })
                 }
@@ -216,15 +218,18 @@ export const CodyWebChatProvider: FC<PropsWithChildren<CodyWebChatProviderProps>
                 return
             }
 
-            const { panelID, chatID } = await agent.rpc.sendRequest<{ panelID: string; chatID: string }>(
-                'chat/new'
+            const { panelId, chatId } = await agent.rpc.sendRequest<{ panelId: string; chatId: string }>(
+                'chat/web/new'
             )
-            activeWebviewPanelID.current = panelID
-            setLastActiveChatID(chatID)
+
+            activeWebviewPanelIDRef.current = panelId
+
+            setActiveWebviewPanelID(panelId)
+            setLastActiveChatID(chatId)
 
             if (initialContext?.repositories.length) {
                 await agent.rpc.sendRequest('webview/receiveMessage', {
-                    id: activeWebviewPanelID.current,
+                    id: activeWebviewPanelIDRef.current,
                     message: {
                         command: 'context/choose-remote-search-repo',
                         explicitRepos: initialContext?.repositories ?? [],
@@ -232,8 +237,13 @@ export const CodyWebChatProvider: FC<PropsWithChildren<CodyWebChatProviderProps>
                 })
             }
 
+            await agent.rpc.sendRequest('webview/receiveMessage', {
+                id: activeWebviewPanelIDRef.current,
+                message: { chatID: chatId, command: 'restoreHistory' },
+            })
+
             if (onNewChatCreated) {
-                onNewChatCreated(chatID)
+                onNewChatCreated(chatId)
             }
         },
         [client, onNewChatCreated, setLastActiveChatID, initialContext]
@@ -251,7 +261,7 @@ export const CodyWebChatProvider: FC<PropsWithChildren<CodyWebChatProviderProps>
             // Restore chat with chat history (transcript data) and set the newly
             // restored panel ID to be able to listen event from only this panel
             // in the vscode API
-            activeWebviewPanelID.current = await agent.rpc.sendRequest('chat/restore', {
+            const nextPanelId = await agent.rpc.sendRequest<string>('chat/restore', {
                 chatID: chat.chatID,
                 messages: chat.transcript.interactions.flatMap(interaction =>
                     // Ignore incomplete messages from bot, this might be possible
@@ -259,6 +269,9 @@ export const CodyWebChatProvider: FC<PropsWithChildren<CodyWebChatProviderProps>
                     [interaction.humanMessage, interaction.assistantMessage].filter(message => message)
                 ),
             })
+
+            activeWebviewPanelIDRef.current = nextPanelId
+            setActiveWebviewPanelID(nextPanelId)
 
             // Make sure that agent will reset the internal state and
             // sends all necessary events with transcript to switch active chat

--- a/web/lib/components/CodyWebHistory.tsx
+++ b/web/lib/components/CodyWebHistory.tsx
@@ -24,8 +24,7 @@ interface CodyWebHistoryProps {
 export const CodyWebHistory: FC<CodyWebHistoryProps> = props => {
     const { children } = props
 
-    const { client, vscodeAPI, activeChatID, setLastActiveChatID, createChat, selectChat } =
-        useWebAgentClient()
+    const { client, vscodeAPI, activeChatID, createChat, selectChat } = useWebAgentClient()
 
     const [chats, setChats] = useState<ChatExportResult[]>([])
 
@@ -56,26 +55,12 @@ export const CodyWebHistory: FC<CodyWebHistoryProps> = props => {
                         receivedChats.push({ chatID, transcript })
                     }
 
-                    setChats(chats => {
-                        // Select only new chats that haven't been received before
-                        // New chats means that we may have new chat blank item in the chats
-                        // in this case we should replace them with real chats and update
-                        // last active chat id
-                        const newChats = receivedChats.filter(
-                            chat => !chats.find(currentChat => currentChat.chatID === chat.chatID)
-                        )
-
-                        if (newChats.length > 0) {
-                            setLastActiveChatID(newChats[newChats.length - 1].chatID)
-                        }
-
-                        return receivedChats
-                    })
+                    setChats(receivedChats)
                     return
                 }
             }
         })
-    }, [vscodeAPI, setLastActiveChatID])
+    }, [vscodeAPI])
 
     const deleteChat = async (chat: ChatExportResult): Promise<void> => {
         if (!client || isErrorLike(client)) {
@@ -89,10 +74,8 @@ export const CodyWebHistory: FC<CodyWebHistoryProps> = props => {
 
         // Delete chat from the agent's store
         const newChatsList = await client.rpc.sendRequest<ChatExportResult[]>('chat/delete', {
-            chatID: chat.chatID,
+            chatId: chat.chatID,
         })
-
-        setChats(newChatsList)
 
         // this means that we deleted not selected chat, so we can skip checks
         // about zero chat list case and selected chat was deleted case


### PR DESCRIPTION
Based on https://github.com/sourcegraph/cody/pull/4756
Closes [SRCH-632](https://linear.app/sourcegraph/issue/SRCH-632/merge-cody-web-experimental-package-to-the-cody-repo-main-branch)

After this change we will be able to publish Cody Web package from main again.

This PR fixes UI-flash problems when we switch chats or set the initial chat transcript. 
Previously, the CodyWebChat component didn't wait for any restoring event and render
all available transcripts right away, this caused problems when you opened the chat and 
could see how we render empty chat only then render actual transcript UI. 
 
This PR makes CodyWebChat wait for the actual current chat restoration and fixes the problem 
with flashing. 
 
**Tech note:** I'm not happy with the current approach with refs and panel and chat ids states but for now it seems as a reasonable fix. Later I will refactor the provider state in a way that cody web chat component  wouldn't subscribe in vscode API 

## Test plan
- CI is green 
- Check that when you open the cody web demo (`cd ./web` and `pnpm dev`) you should see
no flashes while we set the initial chat (the last visited chat) 

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
