### PR TITLE
update hedges prevention preamble in prompt-mixin

### DIFF
--- a/lib/shared/src/prompt/prompt-mixin.ts
+++ b/lib/shared/src/prompt/prompt-mixin.ts
@@ -9,7 +9,7 @@ const CONTEXT_PREAMBLE = ps`You have access to the provided codebase context. `
 /**
  * The preamble for preventing known models from hedging.
  */
-const HEDGES_PREVENTION = ps`Provide a high-level overview answer positively without apologizing. `
+const HEDGES_PREVENTION = ps`Answer positively without apologizing. `
 
 /**
  * Prompt mixins elaborate every prompt presented to the LLM.


### PR DESCRIPTION
Simplify the preamble for preventing hedging and verified with the updated data in: https://github.com/sourcegraph/cody-leaderboard/pull/12/commits/88eb291906c6b602e999fa5dcf0d0bd85e96002b

## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

![image](https://github.com/sourcegraph/cody/assets/68532117/569f12c9-673f-42ea-9998-e64f039022cf)
