### PR TITLE
Use fuzzysort for remote files

### DIFF
--- a/lib/shared/package.json
+++ b/lib/shared/package.json
@@ -27,6 +27,7 @@
     "dedent": "^0.7.0",
     "diff": "^5.2.0",
     "fast-xml-parser": "^4.3.2",
+    "fuzzysort": "^2.0.4",
     "isomorphic-fetch": "^3.0.0",
     "js-tiktoken": "^1.0.10",
     "lexical": "^0.16.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -300,6 +300,9 @@ importers:
       fast-xml-parser:
         specifier: ^4.3.2
         version: 4.3.2
+      fuzzysort:
+        specifier: ^2.0.4
+        version: 2.0.4
       isomorphic-fetch:
         specifier: ^3.0.0
         version: 3.0.0
@@ -6074,6 +6077,7 @@ packages:
 
   /@types/lodash@4.17.0:
     resolution: {integrity: sha512-t7dhREVv6dbNj0q17X12j7yDG4bD/DHYX7o5/DbDxobP0HnGPgpRz2Ej77aL7TZT3DSw13fqUTj8J4mMnqa7WA==}
+    dev: false
 
   /@types/long@4.0.2:
     resolution: {integrity: sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==}
@@ -9210,7 +9214,6 @@ packages:
 
   /fuzzysort@2.0.4:
     resolution: {integrity: sha512-Api1mJL+Ad7W7vnDZnWq5pGaXJjyencT+iKGia2PlHUcSsSzWwIQ3S1isiMpwpavjYtGd2FzhUIhnnhOULZgDw==}
-    dev: true
 
   /gauge@4.0.4:
     resolution: {integrity: sha512-f9m+BEN5jkg6a0fZjleidjN51VE1X+mPFQ2DJ0uv1V39oCLCbsGe6yjbBnp7eK7z/+GAon99a3nHuqbuuthyPg==}


### PR DESCRIPTION
In @vovakulikov 's demo of Cody Web today, I noticed that he @-mentioned `insight.go`, which didn't match any files. He corrected it to `insights.go`, which did match a file, and continued the demo.

Seeing that made me think that we should add the ability to more fuzzily match remote files, similar to how we match local files (@-mentioning `chatcontext` will match `.../chat/.../context...`, `...chatContext...`, `...chat-context...`, and perhaps more)

This PR attempts to add fuzziness to the file search by expanding the path into `OR` elements in the GQL query and querying for 300 results rather than 30. Those 300 are fed through `fuzzysorter`, comparing them to the entered path and returning the top 30.

Alternate approach to #4755.

Neither approach completely recreates the local file experience because it can't apply `fuzzysort` to all of the files. From experimentation, it looks like `fuzzysort` uses a trie or similar to match paths containing parts of the entered file name. For example, mentioning `chatcontext` surfaces paths containing either `chat` or `context` or `chatcontext` because `fuzzysort` is able to apply its heuristics to all of the local files.

But either approach does help with some misspellings.

## Test plan

run locally (`cde web && pnpm install && pnpm dev`) and experiment with @-mentions. I've been using `internal/databse/insight` (purposeful misspelling), adding `.go` also.
Use your creativity to come up with different options.

