### PR TITLE
Windows Self-signed Certificates: use `inject: '+'`

### DIFF
--- a/vscode/src/certs.js
+++ b/vscode/src/certs.js
@@ -32,7 +32,7 @@ export function registerLocalCertificates(context) {
         const ca = require('win-ca/api')
         const rootsExe = path.join(context.extensionUri.fsPath, 'dist', 'win-ca-roots.exe')
         ca.exe(rootsExe)
-        ca({ fallback: true })
+        ca({ fallback: true, inject: '+' })
     } catch (e) {
         console.warn('Error installing Windows certs', e)
     }


### PR DESCRIPTION
Previously, some users were unable to run Cody on Windows with HTTPS proxies and self-signed certificates. This PR is an attempt to fix that problem by enabling the `inject: '+'` feature in the `win-ca` npm package, which has the following documentation:

```
new experimental mode: `tls.createSecureContext()` is patched and
certificates are used along with built-in ones. This mode should affect
all secure connections, not just https module.
```

Related CODY-2626

## Test plan

I manually verified that I'm able to use the plugin on the latest Insiders with a local build of the extension. However, this might not mean much because I'm unable to reproduce the original issue even when I don't reference the bundled `win-ca-roots.exe` file. Either way, this change is probably worth a shot and we can revert it if we get user reports about network issues.

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
