### PR TITLE
Fix ScrollDown button for cody web case

### DIFF
--- a/vscode/webviews/Chat.tsx
+++ b/vscode/webviews/Chat.tsx
@@ -23,6 +23,7 @@ interface ChatboxProps {
     isTranscriptError: boolean
     userInfo: UserAccountInfo
     guardrails?: Guardrails
+    scrollableParent?: HTMLElement | null
     showWelcomeMessage?: boolean
     showIDESnippetActions?: boolean
     className?: string
@@ -39,6 +40,7 @@ export const Chat: React.FunctionComponent<React.PropsWithChildren<ChatboxProps>
     chatEnabled = true,
     userInfo,
     guardrails,
+    scrollableParent,
     showWelcomeMessage = true,
     showIDESnippetActions = true,
     className,
@@ -185,7 +187,7 @@ export const Chat: React.FunctionComponent<React.PropsWithChildren<ChatboxProps>
                 guardrails={guardrails}
             />
             {transcript.length === 0 && showWelcomeMessage && <WelcomeMessage />}
-            <ScrollDown onClick={focusLastHumanMessageEditor} />
+            <ScrollDown scrollableParent={scrollableParent} onClick={focusLastHumanMessageEditor} />
         </div>
     )
 }

--- a/vscode/webviews/components/ScrollDown.tsx
+++ b/vscode/webviews/components/ScrollDown.tsx
@@ -1,46 +1,88 @@
 import { ArrowDownIcon } from 'lucide-react'
-import { type FunctionComponent, useCallback, useEffect, useState } from 'react'
+import { type FC, useCallback, useEffect, useMemo, useState } from 'react'
 import { Button } from './shadcn/ui/button'
 
 const MARGIN = 200 /* px */
+
+interface Scroller {
+    root: HTMLElement | Window
+    getObserveElement: () => Element
+    getScrollTop: () => number
+    getScrollHeight: () => number
+    getClientHeight: () => number
+}
+
+// Chat UI could be run in different modes, in VSCode the whole chat
+// is rendered within scrollable iframe and it scroll down button should
+// listen and work with window updates,In Cody Web (and possible in other
+// clients) chat might be rendered in arbitrary scollable element.
+// This Scroller API helps to observe complexity of both cases and provides
+// unified API to work with different root elements.
+function createScrollerAPI(element: HTMLElement | null | undefined): Scroller {
+    if (element) {
+        return {
+            root: element,
+            getObserveElement: () => element.children[0],
+            getScrollTop: () => element.scrollTop,
+            getScrollHeight: () => element.scrollHeight,
+            getClientHeight: () => element.getBoundingClientRect().height,
+        }
+    }
+
+    return {
+        root: window,
+        getObserveElement: () => window.document.body,
+        getScrollTop: () => window.scrollY,
+        getScrollHeight: () => window.document.body.scrollHeight,
+        getClientHeight: () => window.innerHeight,
+    }
+}
+
+interface ScrollDownProps {
+    scrollableParent?: HTMLElement | null
+    onClick?: () => void
+}
 
 /**
  * A component that displays a down arrow at the bottom of the viewport to inform the user that
  * there is more content if they scroll down.
  */
-export const ScrollDown: FunctionComponent<{ onClick?: () => void }> = ({ onClick: parentOnClick }) => {
+export const ScrollDown: FC<ScrollDownProps> = props => {
+    const { scrollableParent, onClick: parentOnClick } = props
     const [canScrollDown, setCanScrollDown] = useState(false)
+
+    const scrollerAPI = useMemo(() => createScrollerAPI(scrollableParent), [scrollableParent])
 
     useEffect(() => {
         function handleScroll() {
-            const scrollPosition = window.scrollY
-            const scrollHeight = window.document.body.scrollHeight
-            const clientHeight = window.innerHeight
+            const scrollPosition = scrollerAPI.getScrollTop()
+            const scrollHeight = scrollerAPI.getScrollHeight()
+            const clientHeight = scrollerAPI.getClientHeight()
             setCanScrollDown(scrollPosition + clientHeight < scrollHeight - MARGIN)
         }
         handleScroll()
-        window.addEventListener('scroll', handleScroll)
-        window.addEventListener('resize', handleScroll)
+        scrollerAPI.root.addEventListener('scroll', handleScroll)
+        scrollerAPI.root.addEventListener('resize', handleScroll)
 
         const resizeObserver = new ResizeObserver(() => {
             handleScroll()
         })
-        resizeObserver.observe(window.document.body)
+        resizeObserver.observe(scrollerAPI.getObserveElement())
 
         return () => {
-            window.removeEventListener('scroll', handleScroll)
-            window.removeEventListener('resize', handleScroll)
+            scrollerAPI.root.removeEventListener('scroll', handleScroll)
+            scrollerAPI.root.removeEventListener('resize', handleScroll)
             resizeObserver.disconnect()
         }
-    }, [])
+    }, [scrollerAPI])
 
     const onClick = useCallback(() => {
         setCanScrollDown(false) // immediately hide to avoid jitter
-        window.scrollTo({
-            top: window.document.body.scrollHeight,
+        scrollerAPI.root.scrollTo({
+            top: scrollerAPI.getScrollHeight(),
         })
         parentOnClick?.()
-    }, [parentOnClick])
+    }, [parentOnClick, scrollerAPI])
 
     return canScrollDown ? (
         <div className="tw-sticky tw-bottom-0 tw-w-full tw-text-center tw-py-4">

--- a/vscode/webviews/components/ScrollDown.tsx
+++ b/vscode/webviews/components/ScrollDown.tsx
@@ -13,9 +13,9 @@ interface Scroller {
 }
 
 // Chat UI could be run in different modes, in VSCode the whole chat
-// is rendered within scrollable iframe and it scroll down button should
+// is rendered within scrollable iframe, and it scrolls down button should
 // listen and work with window updates,In Cody Web (and possible in other
-// clients) chat might be rendered in arbitrary scollable element.
+// clients) chat might be rendered in arbitrary scrollable element.
 // This Scroller API helps to observe complexity of both cases and provides
 // unified API to work with different root elements.
 function createScrollerAPI(element: HTMLElement | null | undefined): Scroller {

--- a/web/lib/components/CodyWebChat.tsx
+++ b/web/lib/components/CodyWebChat.tsx
@@ -1,4 +1,4 @@
-import { type FC, useCallback, useLayoutEffect, useMemo, useRef, useState } from 'react'
+import { type FC, useCallback, useLayoutEffect, useMemo, useState } from 'react'
 import { URI } from 'vscode-uri'
 
 import {
@@ -65,7 +65,7 @@ export const CodyWebChat: FC<CodyWebChatProps> = props => {
 
     const [initialization, setInitialization] = useState<'init' | 'completed'>('init')
 
-    const rootElementRef = useRef<HTMLDivElement>(null)
+    const [rootElement, setRootElement] = useState<HTMLElement | null>()
     const [isTranscriptError, setIsTranscriptError] = useState<boolean>(false)
     const [messageInProgress, setMessageInProgress] = useState<ChatMessage | null>(null)
     const [transcript, setTranscript] = useState<ChatMessage[]>([])
@@ -190,9 +190,8 @@ export const CodyWebChat: FC<CodyWebChatProps> = props => {
         }
     }, [initialContext])
 
-    console.log({ client, userAccountInfo, chatModels, activeChatID })
     return (
-        <div className={className} data-cody-web-chat={true} ref={rootElementRef}>
+        <div className={className} data-cody-web-chat={true} ref={setRootElement}>
             {client &&
             userAccountInfo &&
             chatModels &&
@@ -217,7 +216,7 @@ export const CodyWebChat: FC<CodyWebChatProps> = props => {
                                             vscodeAPI={vscodeAPI}
                                             telemetryService={telemetryService}
                                             isTranscriptError={isTranscriptError}
-                                            // scrollableParent={rootElementRef.current}
+                                            scrollableParent={rootElement}
                                             className={styles.chat}
                                         />
                                     </WithContextProviders>


### PR DESCRIPTION
Fixes https://linear.app/sourcegraph/issue/SRCH-670/fix-scroll-to-bottom-button-for-cody-web

Fixes scroll down button for arbitrary scrollable container 

## Test plan
- Check that the scroll-down button works properly in the VSCode extension
- Check that the scroll-down button works in the cody web demo (`cd web` and `pnpm dev`)
