### PR TITLE
Edit: set Cody logo as fallback provider icon

### DIFF
--- a/vscode/src/edit/input/get-items/model.ts
+++ b/vscode/src/edit/input/get-items/model.ts
@@ -21,7 +21,7 @@ const getModelProviderIcon = (provider: string): string => {
         case 'Google':
             return '$(gemini-logo)'
         default:
-            return ''
+            return '$(cody-logo)'
     }
 }
 


### PR DESCRIPTION
PR to set Cody logo as fallback provider icon when the provider is not on our list.

Small UI change to match the same behavior we use in the chat dropdown list:

![image](https://github.com/sourcegraph/cody/assets/68532117/af0e1eca-5b91-4c61-8235-568c3bce5cd3)


## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

Before

![image](https://github.com/sourcegraph/cody/assets/68532117/b6f8cf6c-8ad5-495b-a8b5-8501c5285a15)

After

![image](https://github.com/sourcegraph/cody/assets/68532117/240f17c0-cad5-4f10-a78e-c76989bfefe5)
