### PR TITLE
Anthropic shouldn't be in list of autocomplete options

### DIFF
--- a/lib/shared/src/configuration.ts
+++ b/lib/shared/src/configuration.ts
@@ -41,7 +41,6 @@ export interface Configuration {
     autocomplete: boolean
     autocompleteLanguages: Record<string, boolean>
     autocompleteAdvancedProvider:
-        | 'anthropic'
         | 'fireworks'
         | 'unstable-openai'
         | 'experimental-openaicompatible'


### PR DESCRIPTION
Addresses [this bug](https://github.com/sourcegraph/cody/issues/4639)


## Testing

Bug replicated
![Screenshot from 2024-07-03 19-44-29](https://github.com/sourcegraph/cody/assets/42585006/0c02bc63-5ef3-4c3c-88fa-850cc4b457a4)

After changes, anthropic option removed.
![Screenshot from 2024-07-03 19-46-26](https://github.com/sourcegraph/cody/assets/42585006/a67f2a46-df5c-4e83-9b11-31bb5498c3c8)
