### PR TITLE
Autocomplete: increase autocomplete request manager cache size

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -21,6 +21,7 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 - Chat: Added a stop button and cleaned up the vertical space layout of the chat. [pull/4580](https://github.com/sourcegraph/cody/pull/4580)
 - Autocomplete: Added a caching layer to Jaccard Similarity to reduce the load of context gathering during autocompletion. [pull/4608](https://github.com/sourcegraph/cody/pull/4608)
 - Chat: Simplify the Enterprise docs in the model selector [pull/4745](https://github.com/sourcegraph/cody/pull/4745)
+- Autocomplete: Increase request manager cache size. [pull/4778](https://github.com/sourcegraph/cody/pull/4778)
 
 ## 1.24.1
 

--- a/vscode/src/completions/request-manager.ts
+++ b/vscode/src/completions/request-manager.ts
@@ -305,7 +305,7 @@ interface RequestCacheItem {
 }
 class RequestCache {
     private cache = new LRUCache<string, RequestCacheItem>({
-        max: 50,
+        max: 250,
     })
 
     private toCacheKey(key: Pick<RequestParams, 'docContext'>): string {


### PR DESCRIPTION
- Increases the request manager cache size from 50 to 250 to better leverage it because we plan to send more requests in the upcoming A/B tests.
- Closes https://linear.app/sourcegraph/issue/CODY-2750/[autocomplete-latency]-increase-request-manager-cache-size

## Test plan

CI
