### PR TITLE
Edit: Collapse selections to cursor position after prompt

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -22,6 +22,7 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 - Autocomplete: Added a caching layer to Jaccard Similarity to reduce the load of context gathering during autocompletion. [pull/4608](https://github.com/sourcegraph/cody/pull/4608)
 - Chat: Simplify the Enterprise docs in the model selector [pull/4745](https://github.com/sourcegraph/cody/pull/4745)
 - Autocomplete: Increase request manager cache size. [pull/4778](https://github.com/sourcegraph/cody/pull/4778)
+- Edit: We now collapse the selection down to the cursor position after an edit is triggered. [pull/4781](https://github.com/sourcegraph/cody/pull/4781)
 
 ## 1.24.1
 

--- a/vscode/src/non-stop/FixupController.ts
+++ b/vscode/src/non-stop/FixupController.ts
@@ -414,7 +414,11 @@ export class FixupController
         )
 
         // Return focus to the editor
-        void vscode.window.showTextDocument(document)
+        const editor = await vscode.window.showTextDocument(document)
+
+        // Collapse selection to cursor position
+        const cursor = editor.selection.active
+        editor.selection = new vscode.Selection(cursor, cursor)
 
         return task
     }


### PR DESCRIPTION
## Description

Small QOL improvement: We don't need the selection to showcase the range, now we have decorations that do the same. And even for clients that don't show decorations, the selection is likely no longer helpful after this point

**Before:**

https://github.com/sourcegraph/cody/assets/9516420/849b5bc1-0507-4938-bd82-5377c8154236

**After**

https://github.com/sourcegraph/cody/assets/9516420/bb4c9473-826d-49e7-977d-20928cb6453f



## Test plan

1. Make edits with selections
2. Expect selection to collapse

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
