### PR TITLE
E2E V2: Basic authenticated flow

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -731,6 +731,9 @@ importers:
       http-proxy-middleware:
         specifier: ^3.0.0
         version: 3.0.0
+      kill-sync:
+        specifier: ^1.0.3
+        version: 1.0.3
       mocha:
         specifier: ^10.2.0
         version: 10.2.0
@@ -10725,6 +10728,10 @@ packages:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
     dependencies:
       json-buffer: 3.0.1
+    dev: true
+
+  /kill-sync@1.0.3:
+    resolution: {integrity: sha512-3UKwyIpWxg2WGrYyN3f+Fh68QZ4WApTHWwEnyeDK96HSRy9In9UQvanCwIsaLQV7gOzczotBeoX8jgPNZ1g2Zw==}
     dev: true
 
   /kind-of@3.2.2:

--- a/recordings/vscode/e2e_2083974793/auth-test-ts_1102405082/Pre-Authenticated_3817348620/recording.har.yaml
+++ b/recordings/vscode/e2e_2083974793/auth-test-ts_1102405082/Pre-Authenticated_3817348620/recording.har.yaml
@@ -1,0 +1,1669 @@
+log:
+  _recordingName: e2e/auth.test.ts/Pre-Authenticated
+  creator:
+    comment: persister:fs
+    name: Polly.JS
+    version: 6.0.6
+  entries:
+    - _id: 70e01b727101a2f5b1c146b8f9ff43bb
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 242
+        cookies: []
+        headers:
+          - name: transfer-encoding
+            value: chunked
+          - name: host
+            value: sourcegraph.com
+          - name: connection
+            value: close
+          - name: traceparent
+            value: 00-aa5649b79b6786280e68d47efc5266d2-30c81fb22d2423a8-01
+          - name: authorization
+            value: token
+              REDACTED_5313821e901984ba7bbf1999deafb5f6f722c05ed13b6dfa6cffbd6128089e39
+          - name: accept-encoding
+            value: identity
+          - name: content-type
+            value: application/json
+          - name: x-mitm-proxy-name
+            value: sourcegraph.dotcom
+          - name: x-mitm-auth-token-name
+            value: sourcegraph.dotcom
+        headersSize: 576
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json
+          params: []
+          textJSON:
+            maxTokensToSample: 4000
+            messages:
+              - speaker: system
+                text: You are Cody, an AI coding assistant from Sourcegraph.
+              - speaker: human
+                text: hello
+            model: anthropic/claude-3-sonnet-20240229
+            temperature: 0.2
+            topK: -1
+            topP: -1
+        queryString:
+          - name: api-version
+            value: "1"
+          - name: client-name
+            value: vscode
+          - name: client-version
+            value: 1.24.1
+        url: https://sourcegraph.com/.api/completions/stream?api-version=1&client-name=vscode&client-version=1.24.1
+      response:
+        bodySize: 913
+        content:
+          mimeType: text/event-stream
+          size: 913
+          text: >+
+            event: completion
+
+            data: {"completion":"Hello! I'm Claude, an AI assistant created by Anthropic. How can I help you today?","stopReason":"end_turn"}
+
+
+            event: done
+
+            data: {}
+
+        cookies: []
+        headers:
+          - name: date
+            value: Thu, 04 Jul 2024 16:53:59 GMT
+          - name: content-type
+            value: text/event-stream
+          - name: transfer-encoding
+            value: chunked
+          - name: connection
+            value: close
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache
+          - name: vary
+            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
+              X-Requested-With,Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+        headersSize: 1279
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: 2024-07-04T16:53:57.901Z
+      time: 0
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 0
+    - _id: aaf424160c7b949a3bee5ce788bf182c
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 217
+        cookies: []
+        headers:
+          - name: connection
+            value: close
+          - name: host
+            value: sourcegraph.com
+          - name: accept-encoding
+            value: identity
+          - name: user-agent
+            value: node-fetch/1.0 (+https://github.com/bitinn/node-fetch)
+          - name: content-length
+            value: "217"
+          - name: accept
+            value: "*/*"
+          - name: content-type
+            value: application/json; charset=utf-8
+          - name: authorization
+            value: token
+              REDACTED_5313821e901984ba7bbf1999deafb5f6f722c05ed13b6dfa6cffbd6128089e39
+          - name: x-mitm-proxy-name
+            value: sourcegraph.dotcom
+          - name: x-mitm-auth-token-name
+            value: sourcegraph.dotcom
+        headersSize: 556
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json; charset=utf-8
+          params: []
+          textJSON:
+            query: |-
+              
+              query CodyConfigFeaturesResponse {
+                  site {
+                      codyConfigFeatures {
+                          chat
+                          autoComplete
+                          commands
+                          attribution
+                      }
+                  }
+              }
+            variables: {}
+        queryString:
+          - name: CodyConfigFeaturesResponse
+            value: null
+        url: https://sourcegraph.com/.api/graphql?CodyConfigFeaturesResponse
+      response:
+        bodySize: 110
+        content:
+          mimeType: application/json
+          size: 110
+          text: "{\"data\":{\"site\":{\"codyConfigFeatures\":{\"chat\":true,\"autoComplete\
+            \":true,\"commands\":true,\"attribution\":false}}}}"
+        cookies: []
+        headers:
+          - name: date
+            value: Thu, 04 Jul 2024 16:53:33 GMT
+          - name: content-type
+            value: application/json
+          - name: content-length
+            value: "110"
+          - name: connection
+            value: close
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache, max-age=0
+          - name: vary
+            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
+              X-Requested-With,Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+        headersSize: 1297
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: 2024-07-04T16:53:33.577Z
+      time: 0
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 0
+    - _id: 97d1abafdf0933c23295cc7d7b7ea7f9
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 144
+        cookies: []
+        headers:
+          - name: connection
+            value: close
+          - name: host
+            value: sourcegraph.com
+          - name: accept-encoding
+            value: identity
+          - name: user-agent
+            value: node-fetch/1.0 (+https://github.com/bitinn/node-fetch)
+          - name: content-length
+            value: "144"
+          - name: accept
+            value: "*/*"
+          - name: content-type
+            value: application/json; charset=utf-8
+          - name: authorization
+            value: token
+              REDACTED_5313821e901984ba7bbf1999deafb5f6f722c05ed13b6dfa6cffbd6128089e39
+          - name: x-mitm-proxy-name
+            value: sourcegraph.dotcom
+          - name: x-mitm-auth-token-name
+            value: sourcegraph.dotcom
+        headersSize: 544
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json; charset=utf-8
+          params: []
+          textJSON:
+            query: |-
+              
+              query ContextFilters {
+                  site {
+                      codyContextFilters(version: V1) {
+                          raw
+                      }
+                  }
+              }
+            variables: {}
+        queryString:
+          - name: ContextFilters
+            value: null
+        url: https://sourcegraph.com/.api/graphql?ContextFilters
+      response:
+        bodySize: 53
+        content:
+          mimeType: application/json
+          size: 53
+          text: "{\"data\":{\"site\":{\"codyContextFilters\":{\"raw\":null}}}}"
+        cookies: []
+        headers:
+          - name: date
+            value: Thu, 04 Jul 2024 16:53:33 GMT
+          - name: content-type
+            value: application/json
+          - name: content-length
+            value: "53"
+          - name: connection
+            value: close
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache, max-age=0
+          - name: vary
+            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
+              X-Requested-With,Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+        headersSize: 1296
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: 2024-07-04T16:53:33.206Z
+      time: 0
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 0
+    - _id: 28c346c4c160958f92e8f989a1737e5e
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 318
+        cookies: []
+        headers:
+          - name: connection
+            value: close
+          - name: host
+            value: sourcegraph.com
+          - name: accept-encoding
+            value: identity
+          - name: user-agent
+            value: node-fetch/1.0 (+https://github.com/bitinn/node-fetch)
+          - name: content-length
+            value: "318"
+          - name: accept
+            value: "*/*"
+          - name: content-type
+            value: application/json; charset=utf-8
+          - name: authorization
+            value: token
+              REDACTED_5313821e901984ba7bbf1999deafb5f6f722c05ed13b6dfa6cffbd6128089e39
+          - name: x-mitm-proxy-name
+            value: sourcegraph.dotcom
+          - name: x-mitm-auth-token-name
+            value: sourcegraph.dotcom
+        headersSize: 561
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json; charset=utf-8
+          params: []
+          textJSON:
+            query: |-
+              
+              query CurrentSiteCodyLlmConfiguration {
+                  site {
+                      codyLLMConfiguration {
+                          chatModel
+                          chatModelMaxTokens
+                          fastChatModel
+                          fastChatModelMaxTokens
+                          completionModel
+                          completionModelMaxTokens
+                      }
+                  }
+              }
+            variables: {}
+        queryString:
+          - name: CurrentSiteCodyLlmConfiguration
+            value: null
+        url: https://sourcegraph.com/.api/graphql?CurrentSiteCodyLlmConfiguration
+      response:
+        bodySize: 275
+        content:
+          mimeType: application/json
+          size: 275
+          text: "{\"data\":{\"site\":{\"codyLLMConfiguration\":{\"chatModel\":\"anthropic\
+            /claude-3-sonnet-20240229\",\"chatModelMaxTokens\":12000,\"fastChat\
+            Model\":\"anthropic/claude-3-haiku-20240307\",\"fastChatModelMaxTok\
+            ens\":12000,\"completionModel\":\"fireworks/starcoder\",\"completio\
+            nModelMaxTokens\":9000}}}}"
+        cookies: []
+        headers:
+          - name: date
+            value: Thu, 04 Jul 2024 16:53:32 GMT
+          - name: content-type
+            value: application/json
+          - name: content-length
+            value: "275"
+          - name: connection
+            value: close
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache, max-age=0
+          - name: vary
+            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
+              X-Requested-With,Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+        headersSize: 1297
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: 2024-07-04T16:53:32.181Z
+      time: 0
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 0
+    - _id: a4d641ac3093a4efbffe59352b351757
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 165
+        cookies: []
+        headers:
+          - name: connection
+            value: close
+          - name: host
+            value: sourcegraph.com
+          - name: accept-encoding
+            value: identity
+          - name: user-agent
+            value: node-fetch/1.0 (+https://github.com/bitinn/node-fetch)
+          - name: content-length
+            value: "165"
+          - name: accept
+            value: "*/*"
+          - name: content-type
+            value: application/json; charset=utf-8
+          - name: authorization
+            value: token
+              REDACTED_5313821e901984ba7bbf1999deafb5f6f722c05ed13b6dfa6cffbd6128089e39
+          - name: x-mitm-proxy-name
+            value: sourcegraph.dotcom
+          - name: x-mitm-auth-token-name
+            value: sourcegraph.dotcom
+        headersSize: 561
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json; charset=utf-8
+          params: []
+          textJSON:
+            query: |-
+              
+              query CurrentSiteCodyLlmConfiguration {
+                  site {
+                      codyLLMConfiguration {
+                          smartContextWindow
+                      }
+                  }
+              }
+            variables: {}
+        queryString:
+          - name: CurrentSiteCodyLlmConfiguration
+            value: null
+        url: https://sourcegraph.com/.api/graphql?CurrentSiteCodyLlmConfiguration
+      response:
+        bodySize: 75
+        content:
+          mimeType: application/json
+          size: 75
+          text: "{\"data\":{\"site\":{\"codyLLMConfiguration\":{\"smartContextWindow\":\"\
+            enabled\"}}}}"
+        cookies: []
+        headers:
+          - name: date
+            value: Thu, 04 Jul 2024 16:53:32 GMT
+          - name: content-type
+            value: application/json
+          - name: content-length
+            value: "75"
+          - name: connection
+            value: close
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache, max-age=0
+          - name: vary
+            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
+              X-Requested-With,Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+        headersSize: 1296
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: 2024-07-04T16:53:32.184Z
+      time: 0
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 0
+    - _id: 06568f66a76daea32430b82552305046
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 150
+        cookies: []
+        headers:
+          - name: connection
+            value: close
+          - name: host
+            value: sourcegraph.com
+          - name: accept-encoding
+            value: identity
+          - name: user-agent
+            value: node-fetch/1.0 (+https://github.com/bitinn/node-fetch)
+          - name: content-length
+            value: "150"
+          - name: accept
+            value: "*/*"
+          - name: content-type
+            value: application/json; charset=utf-8
+          - name: authorization
+            value: token
+              REDACTED_5313821e901984ba7bbf1999deafb5f6f722c05ed13b6dfa6cffbd6128089e39
+          - name: x-mitm-proxy-name
+            value: sourcegraph.dotcom
+          - name: x-mitm-auth-token-name
+            value: sourcegraph.dotcom
+        headersSize: 556
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json; charset=utf-8
+          params: []
+          textJSON:
+            query: |-
+              
+              query CurrentSiteCodyLlmProvider {
+                  site {
+                      codyLLMConfiguration {
+                          provider
+                      }
+                  }
+              }
+            variables: {}
+        queryString:
+          - name: CurrentSiteCodyLlmProvider
+            value: null
+        url: https://sourcegraph.com/.api/graphql?CurrentSiteCodyLlmProvider
+      response:
+        bodySize: 69
+        content:
+          mimeType: application/json
+          size: 69
+          text: "{\"data\":{\"site\":{\"codyLLMConfiguration\":{\"provider\":\"sourcegraph\
+            \"}}}}"
+        cookies: []
+        headers:
+          - name: date
+            value: Thu, 04 Jul 2024 16:53:32 GMT
+          - name: content-type
+            value: application/json
+          - name: content-length
+            value: "69"
+          - name: connection
+            value: close
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache, max-age=0
+          - name: vary
+            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
+              X-Requested-With,Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+        headersSize: 1296
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: 2024-07-04T16:53:32.182Z
+      time: 0
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 0
+    - _id: d1e9e9d8ae116eb7e71823b775d35828
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 341
+        cookies: []
+        headers:
+          - name: connection
+            value: close
+          - name: host
+            value: sourcegraph.com
+          - name: accept-encoding
+            value: identity
+          - name: user-agent
+            value: node-fetch/1.0 (+https://github.com/bitinn/node-fetch)
+          - name: content-length
+            value: "341"
+          - name: accept
+            value: "*/*"
+          - name: content-type
+            value: application/json; charset=utf-8
+          - name: authorization
+            value: token
+              REDACTED_5313821e901984ba7bbf1999deafb5f6f722c05ed13b6dfa6cffbd6128089e39
+          - name: x-mitm-proxy-name
+            value: sourcegraph.dotcom
+          - name: x-mitm-auth-token-name
+            value: sourcegraph.dotcom
+        headersSize: 541
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json; charset=utf-8
+          params: []
+          textJSON:
+            query: |-
+              
+              query CurrentUser {
+                  currentUser {
+                      id
+                      hasVerifiedEmail
+                      displayName
+                      username
+                      avatarURL
+                      primaryEmail {
+                          email
+                      }
+                      organizations {
+                          nodes {
+                              id
+                              name
+                          }
+                      }
+                  }
+              }
+            variables: {}
+        queryString:
+          - name: CurrentUser
+            value: null
+        url: https://sourcegraph.com/.api/graphql?CurrentUser
+      response:
+        bodySize: 334
+        content:
+          mimeType: application/json
+          size: 334
+          text: "{\"data\":{\"currentUser\":{\"id\":\"VXNlcjozNDQ1Mjc=\",\"hasVerifiedEma\
+            il\":true,\"displayName\":\"SourcegraphBot-9000\",\"username\":\"so\
+            urcegraphbot9k-fnwmu\",\"avatarURL\":\"https://lh3.googleuserconten\
+            t.com/a/ACg8ocKFaqbYeuBkbj5dFEzx8bXV8a7i3sVbKCNPV7G0uyvk=s96-c\",\"\
+            primaryEmail\":{\"email\":\"sourcegraphbot9k@gmail.com\"},\"organiz\
+            ations\":{\"nodes\":[]}}}}"
+        cookies: []
+        headers:
+          - name: date
+            value: Thu, 04 Jul 2024 16:53:32 GMT
+          - name: content-type
+            value: application/json
+          - name: content-length
+            value: "334"
+          - name: connection
+            value: close
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache, max-age=0
+          - name: vary
+            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
+              X-Requested-With,Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+        headersSize: 1297
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: 2024-07-04T16:53:32.185Z
+      time: 0
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 0
+    - _id: 9fdf3418a505d251116e020fda591c55
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 268
+        cookies: []
+        headers:
+          - name: connection
+            value: close
+          - name: host
+            value: sourcegraph.com
+          - name: accept-encoding
+            value: identity
+          - name: user-agent
+            value: node-fetch/1.0 (+https://github.com/bitinn/node-fetch)
+          - name: content-length
+            value: "268"
+          - name: accept
+            value: "*/*"
+          - name: content-type
+            value: application/json; charset=utf-8
+          - name: authorization
+            value: token
+              REDACTED_5313821e901984ba7bbf1999deafb5f6f722c05ed13b6dfa6cffbd6128089e39
+          - name: x-mitm-proxy-name
+            value: sourcegraph.dotcom
+          - name: x-mitm-auth-token-name
+            value: sourcegraph.dotcom
+        headersSize: 557
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json; charset=utf-8
+          params: []
+          textJSON:
+            query: |-
+              
+              query CurrentUserCodySubscription {
+                  currentUser {
+                      codySubscription {
+                          status
+                          plan
+                          applyProRateLimits
+                          currentPeriodStartAt
+                          currentPeriodEndAt
+                      }
+                  }
+              }
+            variables: {}
+        queryString:
+          - name: CurrentUserCodySubscription
+            value: null
+        url: https://sourcegraph.com/.api/graphql?CurrentUserCodySubscription
+      response:
+        bodySize: 194
+        content:
+          mimeType: application/json
+          size: 194
+          text: "{\"data\":{\"currentUser\":{\"codySubscription\":{\"status\":\"ACTIVE\",\
+            \"plan\":\"PRO\",\"applyProRateLimits\":true,\"currentPeriodStartAt\
+            \":\"2024-06-14T22:11:32Z\",\"currentPeriodEndAt\":\"2024-07-14T22:\
+            11:32Z\"}}}}"
+        cookies: []
+        headers:
+          - name: date
+            value: Thu, 04 Jul 2024 16:53:32 GMT
+          - name: content-type
+            value: application/json
+          - name: content-length
+            value: "194"
+          - name: connection
+            value: close
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache, max-age=0
+          - name: vary
+            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
+              X-Requested-With,Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+        headersSize: 1297
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: 2024-07-04T16:53:32.465Z
+      time: 0
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 0
+    - _id: 8c9afe1aa82ba249333811c3abcc1ddf
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 443
+        cookies: []
+        headers:
+          - name: connection
+            value: close
+          - name: host
+            value: sourcegraph.com
+          - name: accept-encoding
+            value: identity
+          - name: user-agent
+            value: node-fetch/1.0 (+https://github.com/bitinn/node-fetch)
+          - name: content-length
+            value: "443"
+          - name: accept
+            value: "*/*"
+          - name: content-type
+            value: application/json; charset=utf-8
+          - name: authorization
+            value: token
+              REDACTED_5313821e901984ba7bbf1999deafb5f6f722c05ed13b6dfa6cffbd6128089e39
+          - name: x-mitm-proxy-name
+            value: sourcegraph.dotcom
+          - name: x-mitm-auth-token-name
+            value: sourcegraph.dotcom
+        headersSize: 624
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json; charset=utf-8
+          params: []
+          textJSON:
+            query: |
+              
+              mutation RecordTelemetryEvents($events: [TelemetryEventInput!]!) {
+              	telemetry {
+              		recordEvents(events: $events) {
+              			alwaysNil
+              		}
+              	}
+              }
+            variables:
+              events:
+                - action: savedLogin
+                  feature: cody.extension
+                  parameters:
+                    metadata:
+                      - key: contextSelection
+                        value: 10
+                      - key: tier
+                        value: 1
+                    version: 0
+                  source:
+                    client: VSCode.Cody
+                    clientVersion: 1.24.1
+                  timestamp: 2024-07-04T16:53:32.154Z
+        queryString:
+          - name: RecordTelemetryEvents
+            value: null
+        url: https://sourcegraph.com/.api/graphql?RecordTelemetryEvents
+      response:
+        bodySize: 58
+        content:
+          mimeType: application/json
+          size: 58
+          text: "{\"data\":{\"telemetry\":{\"recordEvents\":{\"alwaysNil\":null}}}}"
+        cookies: []
+        headers:
+          - name: date
+            value: Thu, 04 Jul 2024 16:53:32 GMT
+          - name: content-type
+            value: application/json
+          - name: content-length
+            value: "58"
+          - name: connection
+            value: close
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache, max-age=0
+          - name: vary
+            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
+              X-Requested-With,Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+        headersSize: 1296
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: 2024-07-04T16:53:32.467Z
+      time: 0
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 0
+    - _id: a9c39c1ca32ea2a9e36eda635f3470fd
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 1507
+        cookies: []
+        headers:
+          - name: connection
+            value: close
+          - name: host
+            value: sourcegraph.com
+          - name: accept-encoding
+            value: identity
+          - name: user-agent
+            value: node-fetch/1.0 (+https://github.com/bitinn/node-fetch)
+          - name: content-length
+            value: "1507"
+          - name: accept
+            value: "*/*"
+          - name: traceparent
+            value: 00-aa5649b79b6786280e68d47efc5266d2-54fa8285255e5b7f-01
+          - name: content-type
+            value: application/json; charset=utf-8
+          - name: authorization
+            value: token
+              REDACTED_5313821e901984ba7bbf1999deafb5f6f722c05ed13b6dfa6cffbd6128089e39
+          - name: x-mitm-proxy-name
+            value: sourcegraph.dotcom
+          - name: x-mitm-auth-token-name
+            value: sourcegraph.dotcom
+        headersSize: 695
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json; charset=utf-8
+          params: []
+          textJSON:
+            query: |
+              
+              mutation RecordTelemetryEvents($events: [TelemetryEventInput!]!) {
+              	telemetry {
+              		recordEvents(events: $events) {
+              			alwaysNil
+              		}
+              	}
+              }
+            variables:
+              events:
+                - action: submitted
+                  feature: cody.chat-question
+                  parameters:
+                    metadata:
+                      - key: recordsPrivateMetadataTranscript
+                        value: 1
+                      - key: addEnhancedContext
+                        value: 0
+                      - key: mentionsTotal
+                        value: 0
+                      - key: mentionsOfRepository
+                        value: 0
+                      - key: mentionsOfTree
+                        value: 0
+                      - key: mentionsOfWorkspaceRootTree
+                        value: 0
+                      - key: mentionsOfFile
+                        value: 0
+                      - key: mentionsInInitialContext
+                        value: 0
+                      - key: mentionsInInitialContextOfRepository
+                        value: 0
+                      - key: mentionsInInitialContextOfTree
+                        value: 0
+                      - key: mentionsInInitialContextOfWorkspaceRootTree
+                        value: 0
+                      - key: mentionsInInitialContextOfFile
+                        value: 0
+                      - key: mentionsByUser
+                        value: 0
+                      - key: mentionsByUserOfRepository
+                        value: 0
+                      - key: mentionsByUserOfTree
+                        value: 0
+                      - key: mentionsByUserOfWorkspaceRootTree
+                        value: 0
+                      - key: mentionsByUserOfFile
+                        value: 0
+                      - key: contextSelection
+                        value: 10
+                      - key: tier
+                        value: 1
+                    privateMetadata:
+                      addEnhancedContext: false
+                      chatModel: anthropic/claude-3-sonnet-20240229
+                      gitMetadata: ""
+                      promptText: hello
+                      requestID: 9e3f6a35-98b1-40ed-952e-ba8eb0eca183
+                      sessionID: Thu, 04 Jul 2024 16:53:34 GMT
+                      source: chat
+                      traceId: aa5649b79b6786280e68d47efc5266d2
+                    version: 0
+                  source:
+                    client: VSCode.Cody
+                    clientVersion: 1.24.1
+                  timestamp: 2024-07-04T16:53:57.880Z
+        queryString:
+          - name: RecordTelemetryEvents
+            value: null
+        url: https://sourcegraph.com/.api/graphql?RecordTelemetryEvents
+      response:
+        bodySize: 58
+        content:
+          mimeType: application/json
+          size: 58
+          text: "{\"data\":{\"telemetry\":{\"recordEvents\":{\"alwaysNil\":null}}}}"
+        cookies: []
+        headers:
+          - name: date
+            value: Thu, 04 Jul 2024 16:53:58 GMT
+          - name: content-type
+            value: application/json
+          - name: content-length
+            value: "58"
+          - name: connection
+            value: close
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache, max-age=0
+          - name: vary
+            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
+              X-Requested-With,Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+        headersSize: 1296
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: 2024-07-04T16:53:57.888Z
+      time: 0
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 0
+    - _id: 9256611d35ee1299ab2d95c5978f3ee3
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 577
+        cookies: []
+        headers:
+          - name: connection
+            value: close
+          - name: host
+            value: sourcegraph.com
+          - name: accept-encoding
+            value: identity
+          - name: user-agent
+            value: node-fetch/1.0 (+https://github.com/bitinn/node-fetch)
+          - name: content-length
+            value: "577"
+          - name: accept
+            value: "*/*"
+          - name: content-type
+            value: application/json; charset=utf-8
+          - name: authorization
+            value: token
+              REDACTED_5313821e901984ba7bbf1999deafb5f6f722c05ed13b6dfa6cffbd6128089e39
+          - name: x-mitm-proxy-name
+            value: sourcegraph.dotcom
+          - name: x-mitm-auth-token-name
+            value: sourcegraph.dotcom
+        headersSize: 624
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json; charset=utf-8
+          params: []
+          textJSON:
+            query: |
+              
+              mutation RecordTelemetryEvents($events: [TelemetryEventInput!]!) {
+              	telemetry {
+              		recordEvents(events: $events) {
+              			alwaysNil
+              		}
+              	}
+              }
+            variables:
+              events:
+                - action: submit
+                  feature: cody.humanMessageEditor
+                  parameters:
+                    metadata:
+                      - key: isFirstMessage
+                        value: 1
+                      - key: isEdit
+                        value: 0
+                      - key: messageLength
+                        value: 5
+                      - key: contextItems
+                        value: 0
+                      - key: contextSelection
+                        value: 10
+                      - key: tier
+                        value: 1
+                    version: 0
+                  source:
+                    client: VSCode.Cody
+                    clientVersion: 1.24.1
+                  timestamp: 2024-07-04T16:53:57.884Z
+        queryString:
+          - name: RecordTelemetryEvents
+            value: null
+        url: https://sourcegraph.com/.api/graphql?RecordTelemetryEvents
+      response:
+        bodySize: 58
+        content:
+          mimeType: application/json
+          size: 58
+          text: "{\"data\":{\"telemetry\":{\"recordEvents\":{\"alwaysNil\":null}}}}"
+        cookies: []
+        headers:
+          - name: date
+            value: Thu, 04 Jul 2024 16:53:58 GMT
+          - name: content-type
+            value: application/json
+          - name: content-length
+            value: "58"
+          - name: connection
+            value: close
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache, max-age=0
+          - name: vary
+            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
+              X-Requested-With,Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+        headersSize: 1296
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: 2024-07-04T16:53:57.891Z
+      time: 0
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 0
+    - _id: 730d503811a5d0a4b5420cb351e035a2
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 836
+        cookies: []
+        headers:
+          - name: connection
+            value: close
+          - name: host
+            value: sourcegraph.com
+          - name: accept-encoding
+            value: identity
+          - name: user-agent
+            value: node-fetch/1.0 (+https://github.com/bitinn/node-fetch)
+          - name: content-length
+            value: "836"
+          - name: accept
+            value: "*/*"
+          - name: traceparent
+            value: 00-aa5649b79b6786280e68d47efc5266d2-6fab518c9fc23cc2-01
+          - name: content-type
+            value: application/json; charset=utf-8
+          - name: authorization
+            value: token
+              REDACTED_5313821e901984ba7bbf1999deafb5f6f722c05ed13b6dfa6cffbd6128089e39
+          - name: x-mitm-proxy-name
+            value: sourcegraph.dotcom
+          - name: x-mitm-auth-token-name
+            value: sourcegraph.dotcom
+        headersSize: 694
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json; charset=utf-8
+          params: []
+          textJSON:
+            query: |
+              
+              mutation RecordTelemetryEvents($events: [TelemetryEventInput!]!) {
+              	telemetry {
+              		recordEvents(events: $events) {
+              			alwaysNil
+              		}
+              	}
+              }
+            variables:
+              events:
+                - action: executed
+                  feature: cody.chat-question
+                  parameters:
+                    metadata:
+                      - key: recordsPrivateMetadataTranscript
+                        value: 1
+                      - key: contextSelection
+                        value: 10
+                      - key: tier
+                        value: 1
+                    privateMetadata:
+                      privateContextStats:
+                        excluded: 0
+                        included: 0
+                      promptText: hello
+                      properties:
+                        addEnhancedContext: false
+                        chatModel: anthropic/claude-3-sonnet-20240229
+                        requestID: 9e3f6a35-98b1-40ed-952e-ba8eb0eca183
+                        sessionID: Thu, 04 Jul 2024 16:53:34 GMT
+                        source: chat
+                        traceId: aa5649b79b6786280e68d47efc5266d2
+                    version: 0
+                  source:
+                    client: VSCode.Cody
+                    clientVersion: 1.24.1
+                  timestamp: 2024-07-04T16:53:57.892Z
+        queryString:
+          - name: RecordTelemetryEvents
+            value: null
+        url: https://sourcegraph.com/.api/graphql?RecordTelemetryEvents
+      response:
+        bodySize: 58
+        content:
+          mimeType: application/json
+          size: 58
+          text: "{\"data\":{\"telemetry\":{\"recordEvents\":{\"alwaysNil\":null}}}}"
+        cookies: []
+        headers:
+          - name: date
+            value: Thu, 04 Jul 2024 16:53:58 GMT
+          - name: content-type
+            value: application/json
+          - name: content-length
+            value: "58"
+          - name: connection
+            value: close
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache, max-age=0
+          - name: vary
+            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
+              X-Requested-With,Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+        headersSize: 1296
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: 2024-07-04T16:53:57.899Z
+      time: 0
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 0
+    - _id: 3eef1de00f5883b4237009389e4ba8ea
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 779
+        cookies: []
+        headers:
+          - name: connection
+            value: close
+          - name: host
+            value: sourcegraph.com
+          - name: accept-encoding
+            value: identity
+          - name: user-agent
+            value: node-fetch/1.0 (+https://github.com/bitinn/node-fetch)
+          - name: content-length
+            value: "779"
+          - name: accept
+            value: "*/*"
+          - name: traceparent
+            value: 00-aa5649b79b6786280e68d47efc5266d2-6fab518c9fc23cc2-01
+          - name: content-type
+            value: application/json; charset=utf-8
+          - name: authorization
+            value: token
+              REDACTED_5313821e901984ba7bbf1999deafb5f6f722c05ed13b6dfa6cffbd6128089e39
+          - name: x-mitm-proxy-name
+            value: sourcegraph.dotcom
+          - name: x-mitm-auth-token-name
+            value: sourcegraph.dotcom
+        headersSize: 694
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json; charset=utf-8
+          params: []
+          textJSON:
+            query: |
+              
+              mutation RecordTelemetryEvents($events: [TelemetryEventInput!]!) {
+              	telemetry {
+              		recordEvents(events: $events) {
+              			alwaysNil
+              		}
+              	}
+              }
+            variables:
+              events:
+                - action: noCode
+                  feature: cody.chatResponse
+                  parameters:
+                    interactionID: 9e3f6a35-98b1-40ed-952e-ba8eb0eca183
+                    metadata:
+                      - key: charCount
+                        value: 0
+                      - key: lineCount
+                        value: 0
+                      - key: recordsPrivateMetadataTranscript
+                        value: 1
+                      - key: contextSelection
+                        value: 10
+                      - key: tier
+                        value: 1
+                    privateMetadata:
+                      chatModel: anthropic/claude-3-sonnet-20240229
+                      responseText: Hello! I'm Claude, an AI assistant created by Anthropic. How can I
+                        help you today?
+                    version: 2
+                  source:
+                    client: VSCode.Cody
+                    clientVersion: 1.24.1
+                  timestamp: 2024-07-04T16:53:59.157Z
+        queryString:
+          - name: RecordTelemetryEvents
+            value: null
+        url: https://sourcegraph.com/.api/graphql?RecordTelemetryEvents
+      response:
+        bodySize: 58
+        content:
+          mimeType: application/json
+          size: 58
+          text: "{\"data\":{\"telemetry\":{\"recordEvents\":{\"alwaysNil\":null}}}}"
+        cookies: []
+        headers:
+          - name: date
+            value: Thu, 04 Jul 2024 16:53:59 GMT
+          - name: content-type
+            value: application/json
+          - name: content-length
+            value: "58"
+          - name: connection
+            value: close
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache, max-age=0
+          - name: vary
+            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
+              X-Requested-With,Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+        headersSize: 1296
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: 2024-07-04T16:53:59.162Z
+      time: 0
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 0
+    - _id: 0acb1c08896d50db0e004b8b62e4dbc3
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 164
+        cookies: []
+        headers:
+          - name: connection
+            value: close
+          - name: host
+            value: sourcegraph.com
+          - name: accept-encoding
+            value: identity
+          - name: user-agent
+            value: node-fetch/1.0 (+https://github.com/bitinn/node-fetch)
+          - name: content-length
+            value: "164"
+          - name: accept
+            value: "*/*"
+          - name: content-type
+            value: application/json; charset=utf-8
+          - name: authorization
+            value: token
+              REDACTED_5313821e901984ba7bbf1999deafb5f6f722c05ed13b6dfa6cffbd6128089e39
+          - name: x-mitm-proxy-name
+            value: sourcegraph.dotcom
+          - name: x-mitm-auth-token-name
+            value: sourcegraph.dotcom
+        headersSize: 548
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json; charset=utf-8
+          params: []
+          textJSON:
+            query: |-
+              
+              query SiteIdentification {
+              	site {
+              		siteID
+              		productSubscription {
+              			license {
+              				hashedKey
+              			}
+              		}
+              	}
+              }
+            variables: {}
+        queryString:
+          - name: SiteIdentification
+            value: null
+        url: https://sourcegraph.com/.api/graphql?SiteIdentification
+      response:
+        bodySize: 160
+        content:
+          mimeType: application/json
+          size: 160
+          text: "{\"data\":{\"site\":{\"siteID\":\"SourcegraphWeb\",\"productSubscription\
+            \":{\"license\":{\"hashedKey\":\"9c71b123f8fdef24486dea4e56674ec324\
+            52725c5165d53bd44fb6742a39aaf5\"}}}}}"
+        cookies: []
+        headers:
+          - name: date
+            value: Thu, 04 Jul 2024 16:53:32 GMT
+          - name: content-type
+            value: application/json
+          - name: content-length
+            value: "160"
+          - name: connection
+            value: close
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache, max-age=0
+          - name: vary
+            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
+              X-Requested-With,Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+        headersSize: 1297
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: 2024-07-04T16:53:32.174Z
+      time: 0
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 0
+    - _id: a4f06f44ac6627e56ffe62ff40b4aaa9
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 101
+        cookies: []
+        headers:
+          - name: connection
+            value: close
+          - name: host
+            value: sourcegraph.com
+          - name: accept-encoding
+            value: identity
+          - name: user-agent
+            value: node-fetch/1.0 (+https://github.com/bitinn/node-fetch)
+          - name: content-length
+            value: "101"
+          - name: accept
+            value: "*/*"
+          - name: content-type
+            value: application/json; charset=utf-8
+          - name: authorization
+            value: token
+              REDACTED_5313821e901984ba7bbf1999deafb5f6f722c05ed13b6dfa6cffbd6128089e39
+          - name: x-mitm-proxy-name
+            value: sourcegraph.dotcom
+          - name: x-mitm-auth-token-name
+            value: sourcegraph.dotcom
+        headersSize: 548
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json; charset=utf-8
+          params: []
+          textJSON:
+            query: |-
+              
+              query SiteProductVersion {
+                  site {
+                      productVersion
+                  }
+              }
+            variables: {}
+        queryString:
+          - name: SiteProductVersion
+            value: null
+        url: https://sourcegraph.com/.api/graphql?SiteProductVersion
+      response:
+        bodySize: 73
+        content:
+          mimeType: application/json
+          size: 73
+          text: "{\"data\":{\"site\":{\"productVersion\":\"280965_2024-07-04_5.4-ae5c9050\
+            940a\"}}}"
+        cookies: []
+        headers:
+          - name: date
+            value: Thu, 04 Jul 2024 16:53:32 GMT
+          - name: content-type
+            value: application/json
+          - name: content-length
+            value: "73"
+          - name: connection
+            value: close
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache, max-age=0
+          - name: vary
+            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
+              X-Requested-With,Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+        headersSize: 1296
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: 2024-07-04T16:53:32.180Z
+      time: 0
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 0
+  pages: []
+  version: "1.2"

--- a/recordings/vscode/e2e_2083974793/example-test-ts_2069432700/Show-off-v2-features_1731159314/recording.har.yaml
+++ b/recordings/vscode/e2e_2083974793/example-test-ts_2069432700/Show-off-v2-features_1731159314/recording.har.yaml
@@ -5,7 +5,7 @@ log:
     name: Polly.JS
     version: 6.0.6
   entries:
-    - _id: fd79a8c38d53d2648b1b68d15d1f77c6
+    - _id: 051eb84896f9d8791ff36989d0ffc2d3
       _order: 0
       cache: {}
       request:
@@ -17,7 +17,7 @@ log:
           - name: host
             value: sourcegraph.com
           - name: accept-encoding
-            value: gzip,deflate
+            value: identity
           - name: user-agent
             value: node-fetch/1.0 (+https://github.com/bitinn/node-fetch)
           - name: content-length
@@ -26,7 +26,9 @@ log:
             value: "*/*"
           - name: content-type
             value: application/json; charset=utf-8
-        headersSize: 303
+          - name: x-mitm-proxy-name
+            value: sourcegraph.dotcom
+        headersSize: 385
         httpVersion: HTTP/1.1
         method: POST
         postData:
@@ -51,30 +53,20 @@ log:
             value: null
         url: https://sourcegraph.com/.api/graphql?CodyConfigFeaturesResponse
       response:
-        bodySize: 152
+        bodySize: 110
         content:
-          encoding: base64
           mimeType: application/json
-          size: 152
-          text: "[\"H4sIAAAAAAAAAzyLwQqAIBAF/2XPfYFXof/YdC0h3dDnIcR/Dws6DQwznTyDyXSqETLp1\
-            N9Wc4j7KoxWpL72YJBBabIQN6jVdJ0yj885TYmzr38DlLg1RM1kAp9VxhjjAQAA//8D\
-            AIfOLkJuAAAA\"]"
-          textDecoded:
-            data:
-              site:
-                codyConfigFeatures:
-                  attribution: false
-                  autoComplete: true
-                  chat: true
-                  commands: true
+          size: 110
+          text: "{\"data\":{\"site\":{\"codyConfigFeatures\":{\"chat\":true,\"autoComplete\
+            \":true,\"commands\":true,\"attribution\":false}}}}"
         cookies: []
         headers:
           - name: date
-            value: Tue, 02 Jul 2024 14:12:04 GMT
+            value: Thu, 04 Jul 2024 22:58:03 GMT
           - name: content-type
             value: application/json
-          - name: transfer-encoding
-            value: chunked
+          - name: content-length
+            value: "110"
           - name: connection
             value: close
           - name: access-control-allow-credentials
@@ -94,14 +86,12 @@ log:
             value: 1; mode=block
           - name: strict-transport-security
             value: max-age=31536000; includeSubDomains; preload
-          - name: content-encoding
-            value: gzip
-        headersSize: 1328
+        headersSize: 1297
         httpVersion: HTTP/1.1
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-07-02T14:12:04.040Z
+      startedDateTime: 2024-07-04T22:58:03.431Z
       time: 0
       timings:
         blocked: -1
@@ -111,7 +101,7 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: 09b59ac55ce3c40d6f9ab8c79846a2c6
+    - _id: 6b179f7e96514dd2aba8fdc1249351e3
       _order: 0
       cache: {}
       request:
@@ -123,7 +113,7 @@ log:
           - name: host
             value: sourcegraph.com
           - name: accept-encoding
-            value: gzip,deflate
+            value: identity
           - name: user-agent
             value: node-fetch/1.0 (+https://github.com/bitinn/node-fetch)
           - name: content-length
@@ -132,7 +122,9 @@ log:
             value: "*/*"
           - name: content-type
             value: application/json; charset=utf-8
-        headersSize: 291
+          - name: x-mitm-proxy-name
+            value: sourcegraph.dotcom
+        headersSize: 373
         httpVersion: HTTP/1.1
         method: POST
         postData:
@@ -154,110 +146,19 @@ log:
             value: null
         url: https://sourcegraph.com/.api/graphql?ContextFilters
       response:
-        bodySize: 111
+        bodySize: 53
         content:
-          encoding: base64
           mimeType: application/json
-          size: 111
-          text: "[\"H4sIAAAAAAAAA6pWSkksSVSyqlY=\",\"Ks4sSQXRyfkplc75eSWpFSVumTklqUXFINGi\
-            xHIlq7zSnJza2tpaAAAAAP//AwA2LshlNQAAAA==\"]"
+          size: 53
+          text: "{\"data\":{\"site\":{\"codyContextFilters\":{\"raw\":null}}}}"
         cookies: []
         headers:
           - name: date
-            value: Tue, 02 Jul 2024 14:12:03 GMT
-          - name: content-type
-            value: application/json
-          - name: transfer-encoding
-            value: chunked
-          - name: connection
-            value: close
-          - name: access-control-allow-credentials
-            value: "true"
-          - name: access-control-allow-origin
-            value: ""
-          - name: cache-control
-            value: no-cache, max-age=0
-          - name: vary
-            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
-              X-Requested-With,Cookie
-          - name: x-content-type-options
-            value: nosniff
-          - name: x-frame-options
-            value: DENY
-          - name: x-xss-protection
-            value: 1; mode=block
-          - name: strict-transport-security
-            value: max-age=31536000; includeSubDomains; preload
-          - name: content-encoding
-            value: gzip
-        headersSize: 1328
-        httpVersion: HTTP/1.1
-        redirectURL: ""
-        status: 200
-        statusText: OK
-      startedDateTime: 2024-07-02T14:12:03.358Z
-      time: 0
-      timings:
-        blocked: -1
-        connect: -1
-        dns: -1
-        receive: 0
-        send: 0
-        ssl: -1
-        wait: 0
-    - _id: 0b63afd2aa308ea31206484848de021f
-      _order: 0
-      cache: {}
-      request:
-        bodySize: 183
-        cookies: []
-        headers:
-          - name: connection
-            value: close
-          - name: host
-            value: sourcegraph.com
-          - name: accept-encoding
-            value: gzip,deflate
-          - name: user-agent
-            value: node-fetch/1.0 (+https://github.com/bitinn/node-fetch)
-          - name: content-length
-            value: "183"
-          - name: accept
-            value: "*/*"
-          - name: content-type
-            value: application/json; charset=utf-8
-        headersSize: 296
-        httpVersion: HTTP/1.1
-        method: POST
-        postData:
-          mimeType: application/json; charset=utf-8
-          params: []
-          textJSON:
-            query: |2
-              
-                  query EvaluateFeatureFlag($flagName: String!) {
-                      evaluateFeatureFlag(flagName: $flagName)
-                  }
-            variables:
-              flagName: cody-use-sourcegraph-embeddings
-        queryString:
-          - name: EvaluateFeatureFlag
-            value: null
-        url: https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag
-      response:
-        bodySize: 37
-        content:
-          mimeType: application/json
-          size: 37
-          text: "{\"data\":{\"evaluateFeatureFlag\":null}}"
-        cookies: []
-        headers:
-          - name: date
-            value: Tue, 02 Jul 2024 14:12:02 GMT
+            value: Thu, 04 Jul 2024 22:58:03 GMT
           - name: content-type
             value: application/json
           - name: content-length
-            value: "37"
+            value: "53"
           - name: connection
             value: close
           - name: access-control-allow-credentials
@@ -282,7 +183,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-07-02T14:12:02.463Z
+      startedDateTime: 2024-07-04T22:58:03.074Z
       time: 0
       timings:
         blocked: -1
@@ -292,448 +193,7 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: 97bed95811980e1a8d1c114065f65cdf
-      _order: 0
-      cache: {}
-      request:
-        bodySize: 177
-        cookies: []
-        headers:
-          - name: connection
-            value: close
-          - name: host
-            value: sourcegraph.com
-          - name: accept-encoding
-            value: gzip,deflate
-          - name: user-agent
-            value: node-fetch/1.0 (+https://github.com/bitinn/node-fetch)
-          - name: content-length
-            value: "177"
-          - name: accept
-            value: "*/*"
-          - name: content-type
-            value: application/json; charset=utf-8
-        headersSize: 296
-        httpVersion: HTTP/1.1
-        method: POST
-        postData:
-          mimeType: application/json; charset=utf-8
-          params: []
-          textJSON:
-            query: |2
-              
-                  query EvaluateFeatureFlag($flagName: String!) {
-                      evaluateFeatureFlag(flagName: $flagName)
-                  }
-            variables:
-              flagName: cody-autocomplete-tracing
-        queryString:
-          - name: EvaluateFeatureFlag
-            value: null
-        url: https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag
-      response:
-        bodySize: 37
-        content:
-          mimeType: application/json
-          size: 37
-          text: "{\"data\":{\"evaluateFeatureFlag\":null}}"
-        cookies: []
-        headers:
-          - name: date
-            value: Tue, 02 Jul 2024 14:12:02 GMT
-          - name: content-type
-            value: application/json
-          - name: content-length
-            value: "37"
-          - name: connection
-            value: close
-          - name: access-control-allow-credentials
-            value: "true"
-          - name: access-control-allow-origin
-            value: ""
-          - name: cache-control
-            value: no-cache, max-age=0
-          - name: vary
-            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
-              X-Requested-With,Cookie
-          - name: x-content-type-options
-            value: nosniff
-          - name: x-frame-options
-            value: DENY
-          - name: x-xss-protection
-            value: 1; mode=block
-          - name: strict-transport-security
-            value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1296
-        httpVersion: HTTP/1.1
-        redirectURL: ""
-        status: 200
-        statusText: OK
-      startedDateTime: 2024-07-02T14:12:02.464Z
-      time: 0
-      timings:
-        blocked: -1
-        connect: -1
-        dns: -1
-        receive: 0
-        send: 0
-        ssl: -1
-        wait: 0
-    - _id: a3d3d0f7feb229a85bd641be136a8edd
-      _order: 0
-      cache: {}
-      request:
-        bodySize: 181
-        cookies: []
-        headers:
-          - name: connection
-            value: close
-          - name: host
-            value: sourcegraph.com
-          - name: accept-encoding
-            value: gzip,deflate
-          - name: user-agent
-            value: node-fetch/1.0 (+https://github.com/bitinn/node-fetch)
-          - name: content-length
-            value: "181"
-          - name: accept
-            value: "*/*"
-          - name: content-type
-            value: application/json; charset=utf-8
-        headersSize: 296
-        httpVersion: HTTP/1.1
-        method: POST
-        postData:
-          mimeType: application/json; charset=utf-8
-          params: []
-          textJSON:
-            query: |2
-              
-                  query EvaluateFeatureFlag($flagName: String!) {
-                      evaluateFeatureFlag(flagName: $flagName)
-                  }
-            variables:
-              flagName: cody-embeddings-auto-indexing
-        queryString:
-          - name: EvaluateFeatureFlag
-            value: null
-        url: https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag
-      response:
-        bodySize: 37
-        content:
-          mimeType: application/json
-          size: 37
-          text: "{\"data\":{\"evaluateFeatureFlag\":null}}"
-        cookies: []
-        headers:
-          - name: date
-            value: Tue, 02 Jul 2024 14:12:03 GMT
-          - name: content-type
-            value: application/json
-          - name: content-length
-            value: "37"
-          - name: connection
-            value: close
-          - name: access-control-allow-credentials
-            value: "true"
-          - name: access-control-allow-origin
-            value: ""
-          - name: cache-control
-            value: no-cache, max-age=0
-          - name: vary
-            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
-              X-Requested-With,Cookie
-          - name: x-content-type-options
-            value: nosniff
-          - name: x-frame-options
-            value: DENY
-          - name: x-xss-protection
-            value: 1; mode=block
-          - name: strict-transport-security
-            value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1296
-        httpVersion: HTTP/1.1
-        redirectURL: ""
-        status: 200
-        statusText: OK
-      startedDateTime: 2024-07-02T14:12:02.749Z
-      time: 0
-      timings:
-        blocked: -1
-        connect: -1
-        dns: -1
-        receive: 0
-        send: 0
-        ssl: -1
-        wait: 0
-    - _id: 0b8e788d38a93fd0c53c921e768bff46
-      _order: 0
-      cache: {}
-      request:
-        bodySize: 177
-        cookies: []
-        headers:
-          - name: connection
-            value: close
-          - name: host
-            value: sourcegraph.com
-          - name: accept-encoding
-            value: gzip,deflate
-          - name: user-agent
-            value: node-fetch/1.0 (+https://github.com/bitinn/node-fetch)
-          - name: content-length
-            value: "177"
-          - name: accept
-            value: "*/*"
-          - name: traceparent
-            value: 00-f0577df6943a2bfaaffc899734ad881e-924cb5ce9934c0cc-01
-          - name: content-type
-            value: application/json; charset=utf-8
-        headersSize: 366
-        httpVersion: HTTP/1.1
-        method: POST
-        postData:
-          mimeType: application/json; charset=utf-8
-          params: []
-          textJSON:
-            query: |2
-              
-                  query EvaluateFeatureFlag($flagName: String!) {
-                      evaluateFeatureFlag(flagName: $flagName)
-                  }
-            variables:
-              flagName: cody-interactive-tutorial
-        queryString:
-          - name: EvaluateFeatureFlag
-            value: null
-        url: https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag
-      response:
-        bodySize: 37
-        content:
-          mimeType: application/json
-          size: 37
-          text: "{\"data\":{\"evaluateFeatureFlag\":null}}"
-        cookies: []
-        headers:
-          - name: date
-            value: Tue, 02 Jul 2024 14:12:03 GMT
-          - name: content-type
-            value: application/json
-          - name: content-length
-            value: "37"
-          - name: connection
-            value: close
-          - name: access-control-allow-credentials
-            value: "true"
-          - name: access-control-allow-origin
-            value: ""
-          - name: cache-control
-            value: no-cache, max-age=0
-          - name: vary
-            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
-              X-Requested-With,Cookie
-          - name: x-content-type-options
-            value: nosniff
-          - name: x-frame-options
-            value: DENY
-          - name: x-xss-protection
-            value: 1; mode=block
-          - name: strict-transport-security
-            value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1296
-        httpVersion: HTTP/1.1
-        redirectURL: ""
-        status: 200
-        statusText: OK
-      startedDateTime: 2024-07-02T14:12:03.713Z
-      time: 0
-      timings:
-        blocked: -1
-        connect: -1
-        dns: -1
-        receive: 0
-        send: 0
-        ssl: -1
-        wait: 0
-    - _id: 4ec84765b3d45b8a8f6392da0304fa77
-      _order: 0
-      cache: {}
-      request:
-        bodySize: 178
-        cookies: []
-        headers:
-          - name: connection
-            value: close
-          - name: host
-            value: sourcegraph.com
-          - name: accept-encoding
-            value: gzip,deflate
-          - name: user-agent
-            value: node-fetch/1.0 (+https://github.com/bitinn/node-fetch)
-          - name: content-length
-            value: "178"
-          - name: accept
-            value: "*/*"
-          - name: traceparent
-            value: 00-f3df72a135c611acb86086fc824e6e1f-b32eb6211074902f-01
-          - name: content-type
-            value: application/json; charset=utf-8
-        headersSize: 366
-        httpVersion: HTTP/1.1
-        method: POST
-        postData:
-          mimeType: application/json; charset=utf-8
-          params: []
-          textJSON:
-            query: |2
-              
-                  query EvaluateFeatureFlag($flagName: String!) {
-                      evaluateFeatureFlag(flagName: $flagName)
-                  }
-            variables:
-              flagName: cody-chat-context-preamble
-        queryString:
-          - name: EvaluateFeatureFlag
-            value: null
-        url: https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag
-      response:
-        bodySize: 37
-        content:
-          mimeType: application/json
-          size: 37
-          text: "{\"data\":{\"evaluateFeatureFlag\":null}}"
-        cookies: []
-        headers:
-          - name: date
-            value: Tue, 02 Jul 2024 14:12:03 GMT
-          - name: content-type
-            value: application/json
-          - name: content-length
-            value: "37"
-          - name: connection
-            value: close
-          - name: access-control-allow-credentials
-            value: "true"
-          - name: access-control-allow-origin
-            value: ""
-          - name: cache-control
-            value: no-cache, max-age=0
-          - name: vary
-            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
-              X-Requested-With,Cookie
-          - name: x-content-type-options
-            value: nosniff
-          - name: x-frame-options
-            value: DENY
-          - name: x-xss-protection
-            value: 1; mode=block
-          - name: strict-transport-security
-            value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1296
-        httpVersion: HTTP/1.1
-        redirectURL: ""
-        status: 200
-        statusText: OK
-      startedDateTime: 2024-07-02T14:12:03.727Z
-      time: 0
-      timings:
-        blocked: -1
-        connect: -1
-        dns: -1
-        receive: 0
-        send: 0
-        ssl: -1
-        wait: 0
-    - _id: 62498f2d11167bd2d5d002a799a49338
-      _order: 0
-      cache: {}
-      request:
-        bodySize: 147
-        cookies: []
-        headers:
-          - name: connection
-            value: close
-          - name: host
-            value: sourcegraph.com
-          - name: accept-encoding
-            value: gzip,deflate
-          - name: user-agent
-            value: node-fetch/1.0 (+https://github.com/bitinn/node-fetch)
-          - name: content-length
-            value: "147"
-          - name: accept
-            value: "*/*"
-          - name: content-type
-            value: application/json; charset=utf-8
-        headersSize: 289
-        httpVersion: HTTP/1.1
-        method: POST
-        postData:
-          mimeType: application/json; charset=utf-8
-          params: []
-          textJSON:
-            query: |2
-              
-                  query FeatureFlags {
-                      evaluatedFeatureFlags() {
-                          name
-                          value
-                        }
-                  }
-            variables: {}
-        queryString:
-          - name: FeatureFlags
-            value: null
-        url: https://sourcegraph.com/.api/graphql?FeatureFlags
-      response:
-        bodySize: 37
-        content:
-          mimeType: application/json
-          size: 37
-          text: "{\"data\":{\"evaluatedFeatureFlags\":[]}}"
-        cookies: []
-        headers:
-          - name: date
-            value: Tue, 02 Jul 2024 14:12:02 GMT
-          - name: content-type
-            value: application/json
-          - name: content-length
-            value: "37"
-          - name: connection
-            value: close
-          - name: access-control-allow-credentials
-            value: "true"
-          - name: access-control-allow-origin
-            value: ""
-          - name: cache-control
-            value: no-cache, max-age=0
-          - name: vary
-            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
-              X-Requested-With,Cookie
-          - name: x-content-type-options
-            value: nosniff
-          - name: x-frame-options
-            value: DENY
-          - name: x-xss-protection
-            value: 1; mode=block
-          - name: strict-transport-security
-            value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1296
-        httpVersion: HTTP/1.1
-        redirectURL: ""
-        status: 200
-        statusText: OK
-      startedDateTime: 2024-07-02T14:12:02.205Z
-      time: 0
-      timings:
-        blocked: -1
-        connect: -1
-        dns: -1
-        receive: 0
-        send: 0
-        ssl: -1
-        wait: 0
-    - _id: 8d297306aeea324b87ef494954016fba
+    - _id: fe37074003dfdb90bbb037aa8cb2344c
       _order: 0
       cache: {}
       request:
@@ -745,7 +205,7 @@ log:
           - name: host
             value: sourcegraph.com
           - name: accept-encoding
-            value: gzip,deflate
+            value: identity
           - name: user-agent
             value: node-fetch/1.0 (+https://github.com/bitinn/node-fetch)
           - name: content-length
@@ -754,7 +214,9 @@ log:
             value: "*/*"
           - name: content-type
             value: application/json; charset=utf-8
-        headersSize: 295
+          - name: x-mitm-proxy-name
+            value: sourcegraph.dotcom
+        headersSize: 377
         httpVersion: HTTP/1.1
         method: POST
         postData:
@@ -779,23 +241,21 @@ log:
             value: null
         url: https://sourcegraph.com/.api/graphql?SiteIdentification
       response:
-        bodySize: 219
+        bodySize: 160
         content:
-          encoding: base64
           mimeType: application/json
-          size: 219
-          text: "[\"H4sIAAAAAAAAAzTLsQ6CMBCA4Xc=\",\"udmF9q4FZhfjyOB87V2liQHSlsEQ391g4r/8\
-            03eAcGMYD6i56f+3K4wwrXuJ+iy8zQ8NcIGtrLLHNu2hxpK3ltflBK8cdak/O3OdVe7\
-            6hhGG6LvQGZv6JJoMYu9EGZWc86jRGiTjDUXqHAnZIIgpOI+G7cCcCD5nXwAAAP//Aw\
-            AY9rt+oAAAAA==\"]"
+          size: 160
+          text: "{\"data\":{\"site\":{\"siteID\":\"SourcegraphWeb\",\"productSubscription\
+            \":{\"license\":{\"hashedKey\":\"9c71b123f8fdef24486dea4e56674ec324\
+            52725c5165d53bd44fb6742a39aaf5\"}}}}}"
         cookies: []
         headers:
           - name: date
-            value: Tue, 02 Jul 2024 14:12:02 GMT
+            value: Thu, 04 Jul 2024 22:58:03 GMT
           - name: content-type
             value: application/json
-          - name: transfer-encoding
-            value: chunked
+          - name: content-length
+            value: "160"
           - name: connection
             value: close
           - name: access-control-allow-credentials
@@ -815,14 +275,12 @@ log:
             value: 1; mode=block
           - name: strict-transport-security
             value: max-age=31536000; includeSubDomains; preload
-          - name: content-encoding
-            value: gzip
-        headersSize: 1328
+        headersSize: 1297
         httpVersion: HTTP/1.1
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-07-02T14:12:02.158Z
+      startedDateTime: 2024-07-04T22:58:02.759Z
       time: 0
       timings:
         blocked: -1
@@ -832,7 +290,7 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: 203c1896021c3a09dfe619120ea1b725
+    - _id: df9bbe44d51a47ebe6840a3b9fba1c29
       _order: 0
       cache: {}
       request:
@@ -844,7 +302,7 @@ log:
           - name: host
             value: sourcegraph.com
           - name: accept-encoding
-            value: gzip,deflate
+            value: identity
           - name: user-agent
             value: node-fetch/1.0 (+https://github.com/bitinn/node-fetch)
           - name: content-length
@@ -853,7 +311,9 @@ log:
             value: "*/*"
           - name: content-type
             value: application/json; charset=utf-8
-        headersSize: 368
+          - name: x-mitm-proxy-name
+            value: sourcegraph.dotcom
+        headersSize: 450
         httpVersion: HTTP/1.1
         method: POST
         postData:
@@ -873,22 +333,20 @@ log:
             value: null
         url: https://sourcegraph.com/.api/graphql?SiteProductVersion
       response:
-        bodySize: 139
+        bodySize: 73
         content:
-          encoding: base64
           mimeType: application/json
-          size: 139
-          text: "[\"H4sIAAAAAAAAA6pWSkksSVSyqlY=\",\"Ks4sSQXRBUX5KaXJJWGpRcWZ+XlKVkpGFgZm\
-            pgbxRgZGJroG5roGRvGmeia6hkmWJqaWyYlJ5kbJSrW1tQAAAAD//wMA1rHtQ0kAAAA=\
-            \"]"
+          size: 73
+          text: "{\"data\":{\"site\":{\"productVersion\":\"280965_2024-07-04_5.4-ae5c9050\
+            940a\"}}}"
         cookies: []
         headers:
           - name: date
-            value: Tue, 02 Jul 2024 14:12:02 GMT
+            value: Thu, 04 Jul 2024 22:58:03 GMT
           - name: content-type
             value: application/json
-          - name: transfer-encoding
-            value: chunked
+          - name: content-length
+            value: "73"
           - name: connection
             value: close
           - name: access-control-allow-credentials
@@ -908,14 +366,12 @@ log:
             value: 1; mode=block
           - name: strict-transport-security
             value: max-age=31536000; includeSubDomains; preload
-          - name: content-encoding
-            value: gzip
-        headersSize: 1328
+        headersSize: 1296
         httpVersion: HTTP/1.1
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-07-02T14:12:02.161Z
+      startedDateTime: 2024-07-04T22:58:02.790Z
       time: 0
       timings:
         blocked: -1

--- a/vscode/e2e/auth.test.ts
+++ b/vscode/e2e/auth.test.ts
@@ -1,0 +1,32 @@
+import { expect } from '@playwright/test'
+import { fixture as test, uix } from './utils/vscody'
+
+test.describe('Auth', () => {
+    test.use({
+        templateWorkspaceDir: 'test/fixtures/workspace',
+    })
+    test('Pre-Authenticated', async ({
+        page,
+        mitmProxy,
+        vscodeUI,
+        polly,
+        executeCommand,
+        workspaceDir,
+    }) => {
+        await uix.cody.preAuthenticate({ workspaceDir })
+        await uix.vscode.startSession({ page, vscodeUI, executeCommand, workspaceDir })
+        await uix.cody.waitForStartup()
+
+        await executeCommand('workbench.view.extension.cody')
+
+        const sidebar = uix.vscode.Sidebar.get({ page })
+
+        await sidebar.locator
+            .locator('div[aria-label="Settings & Support"]')
+            .locator('div[aria-label="Account"]')
+            .click()
+
+        await expect(page.getByText('Signed in as SourcegraphBot')).toBeVisible()
+        await expect(page.getByText('Plan: Cody Pro')).toBeVisible()
+    })
+})

--- a/vscode/e2e/example.test.ts
+++ b/vscode/e2e/example.test.ts
@@ -7,13 +7,13 @@ test.describe('Demonstrations', () => {
     })
     test('Show off v2 features', async ({
         page,
-        sourcegraphMitM,
+        mitmProxy,
         vscodeUI,
         polly,
         executeCommand,
         workspaceDir,
     }) => {
-        polly.server.host(sourcegraphMitM.target, () => {
+        polly.server.host(mitmProxy.sourcegraph.dotcom.proxyTarget, () => {
             polly.server
                 .post('/.api/graphql')
                 .filter(req => 'RecordTelemetryEvents' in req.query)
@@ -51,7 +51,7 @@ test.describe('Demonstrations', () => {
         ).toBeVisible()
     })
 
-    test('also works', async ({ page, sourcegraphMitM, vscodeUI, executeCommand }) => {
+    test('also works', async ({ page, mitmProxy, vscodeUI, executeCommand }) => {
         await uix.cody.dummy()
     })
 })

--- a/vscode/e2e/utils/tmpdir.setup.ts
+++ b/vscode/e2e/utils/tmpdir.setup.ts
@@ -1,0 +1,32 @@
+import fs from 'node:fs/promises'
+import path from 'node:path'
+import { test as setup } from '@playwright/test'
+import type { WorkerOptions } from './vscody'
+export interface TmpDirOptions {
+    clearGlobalTmpDirParent: boolean
+}
+
+// biome-ignore lint/complexity/noBannedTypes: <explanation>
+setup.extend<{}, TmpDirOptions & WorkerOptions>({
+    globalTmpDir: ['', { scope: 'worker', option: true }],
+    clearGlobalTmpDirParent: [false, { scope: 'worker', option: true }],
+})('tmpdir', async ({ globalTmpDir, clearGlobalTmpDirParent }) => {
+    if (globalTmpDir) {
+        await fs.mkdir(globalTmpDir, { recursive: true })
+        if (clearGlobalTmpDirParent) {
+            const parentDir = path.resolve(process.cwd(), globalTmpDir, '..')
+            const currentDirName = path.parse(globalTmpDir).name
+            const promises = []
+            for (const dirName of await fs.readdir(parentDir)) {
+                if (dirName !== currentDirName) {
+                    promises.push(
+                        fs.rm(path.resolve(parentDir, dirName), { recursive: true, force: true })
+                    )
+                }
+            }
+            if (promises.length > 0) {
+                await Promise.all(promises)
+            }
+        }
+    }
+})

--- a/vscode/e2e/utils/vscody/constants.ts
+++ b/vscode/e2e/utils/vscody/constants.ts
@@ -1,0 +1,5 @@
+export const MITM_AUTH_TOKEN_PLACEHOLDER = '<__MITM_AUTH_TOKEN__>'
+export const MITM_PROXY_SERVICE_NAME_HEADER = 'x-mitm-proxy-name'
+export const MITM_PROXY_SERVICE_ENDPOINT_HEADER = 'x-mitm-proxy-endpoint'
+export const MITM_PROXY_AUTH_AVAILABLE_HEADER = 'x-mitm-auth-available'
+export const MITM_PROXY_AUTH_TOKEN_NAME_HEADER = 'x-mitm-auth-token-name'

--- a/vscode/e2e/utils/vscody/fixture.ts
+++ b/vscode/e2e/utils/vscody/fixture.ts
@@ -6,14 +6,13 @@ import type { Dirent } from 'node:fs'
 import fs from 'node:fs/promises'
 import 'node:http'
 import 'node:https'
-import type { AddressInfo } from 'node:net'
+import type { Server as HTTPServer } from 'node:http'
 import path from 'node:path'
 import { EventEmitter } from 'node:stream'
-
 import pspawn from '@npmcli/promise-spawn'
-import { type TestInfo, test as _test, expect, mergeTests } from '@playwright/test'
+import { test as _test, expect, mergeTests } from '@playwright/test'
 import NodeHttpAdapter from '@pollyjs/adapter-node-http'
-import { type EXPIRY_STRATEGY, type MODE, Polly } from '@pollyjs/core'
+import { type EXPIRY_STRATEGY, type MODE, Polly, Timing } from '@pollyjs/core'
 import type { ArrayContainsAll } from '@sourcegraph/cody-shared/src/utils'
 import {
     ConsoleReporter,
@@ -23,16 +22,29 @@ import {
 } from '@vscode/test-electron'
 import { downloadAndUnzipVSCode } from '@vscode/test-electron/out/download'
 import express from 'express'
+import jsonStableStringify from 'fast-json-stable-stringify'
 import { copy as copyExt } from 'fs-extra'
-import { createProxyMiddleware } from 'http-proxy-middleware'
-import type { loggerPlugin as ProxyMiddlewarePlugin } from 'http-proxy-middleware'
+import { createProxyMiddleware, proxyEventsPlugin } from 'http-proxy-middleware'
+import type { OnProxyEvent } from 'http-proxy-middleware/dist/types'
+import killSync from 'kill-sync'
+import { onExit } from 'signal-exit'
 import zod from 'zod'
 
 import { waitForLock } from '../../../src/lockfile'
-import { CodyPersister } from '../../../src/testutils/CodyPersister'
-import { defaultMatchRequestsBy } from '../../../src/testutils/polly'
+import { CodyPersister, redactAuthorizationHeader } from '../../../src/testutils/CodyPersisterV2'
+import {
+    type DOTCOM_TESTING_CREDENTIALS,
+    type ENTERPRISE_TESTING_CREDENTIALS,
+    TESTING_CREDENTIALS,
+} from '../../../src/testutils/testing-credentials'
 import { retry, stretchTimeout } from '../helpers'
-
+import {
+    MITM_AUTH_TOKEN_PLACEHOLDER,
+    MITM_PROXY_AUTH_AVAILABLE_HEADER,
+    MITM_PROXY_AUTH_TOKEN_NAME_HEADER,
+    MITM_PROXY_SERVICE_ENDPOINT_HEADER,
+    MITM_PROXY_SERVICE_NAME_HEADER,
+} from './constants'
 export type Directory = string
 
 const DOWNLOAD_GRACE_TIME = 5 * 60 * 1000 //5 minutes
@@ -51,6 +63,7 @@ const workerOptionsSchema = zod.object({
     binaryTmpDir: zod.string(),
     recordingDir: zod.string(),
     vscodeServerPortRange: zod.tuple([zod.number(), zod.number()]).default([33100, 33200]),
+    mitmServerPortRange: zod.tuple([zod.number(), zod.number()]).default([34100, 34200]),
     keepRuntimeDirs: zod.enum(['all', 'failed', 'none']).default('none'),
     allowGlobalVSCodeModification: zod.boolean().default(false),
 })
@@ -76,6 +89,21 @@ const testOptionsSchema = zod.object({
 export type TestOptions = zod.infer<typeof testOptionsSchema>
 export type WorkerOptions = zod.infer<typeof workerOptionsSchema>
 
+export interface MitMProxyConfig {
+    sourcegraph: {
+        dotcom: {
+            readonly endpoint: string
+            readonly proxyTarget: string
+            readonly authName: keyof typeof DOTCOM_TESTING_CREDENTIALS
+        }
+        enterprise: {
+            readonly endpoint: string
+            readonly proxyTarget: string
+            readonly authName: keyof typeof ENTERPRISE_TESTING_CREDENTIALS
+        }
+    }
+}
+
 export interface WorkerContext {
     validWorkerOptions: WorkerOptions
 }
@@ -87,11 +115,14 @@ export interface TestContext {
     serverRootDir: Directory
     validOptions: TestOptions & WorkerOptions
     polly: Polly
-    sourcegraphMitM: { endpoint: string; target: string }
+    mitmProxy: MitMProxyConfig
+    //sourcegraphMitM: { endpoint: string; target: string }
     workspaceDir: Directory
     //TODO(rnauta): Make the typing inferred from VSCode directly
     executeCommand: <T = any>(commandId: string, ...args: any[]) => Promise<T | undefined>
 }
+
+type ProxyReqHandler = (...args: Parameters<Exclude<OnProxyEvent['proxyReq'], undefined>>) => boolean
 
 function schemaOptions<T extends zod.ZodObject<any>, S extends 'worker' | 'test'>(o: T, s: S) {
     return Object.fromEntries(
@@ -99,6 +130,19 @@ function schemaOptions<T extends zod.ZodObject<any>, S extends 'worker' | 'test'
     ) as unknown as { [k in keyof T]: [T[k], { scope: S; option: true }] }
 }
 
+const SPAWNED_PIDS = new Set<number | undefined>()
+onExit(
+    () => {
+        console.log('KILLLING')
+        for (const pid of SPAWNED_PIDS.values()) {
+            if (pid !== undefined) {
+                console.log('KILLING', pid)
+                killSync(pid, 'SIGKILL', true)
+            }
+        }
+    },
+    { alwaysLast: true }
+)
 // We split out the options fixutre from the implementation fixture so that in
 // the implementaiton fixture we don't accidentally use any options directly,
 // instead having to use validated options
@@ -122,6 +166,7 @@ const optionsFixture: ReturnType<
                 vscodeExtensionCacheDir,
                 keepRuntimeDirs,
                 vscodeServerPortRange,
+                mitmServerPortRange,
                 allowGlobalVSCodeModification,
             },
             use
@@ -137,6 +182,7 @@ const optionsFixture: ReturnType<
                     vscodeExtensionCacheDir,
                     keepRuntimeDirs,
                     vscodeServerPortRange,
+                    mitmServerPortRange,
                     allowGlobalVSCodeModification,
                 } satisfies { [key in keyof WorkerOptions]-?: WorkerOptions[key] },
                 {}
@@ -252,9 +298,8 @@ const implFixture = _test.extend<TestContext, WorkerContext>({
         },
     ],
     //#region Polly & Proxies
-    sourcegraphMitM: [
-        // biome-ignore lint/correctness/noEmptyPattern: <explanation>
-        async ({}, use, testInfo) => {
+    mitmProxy: [
+        async ({ validWorkerOptions }, use, testInfo) => {
             const app = express()
             //TODO: Credentials & Configuration TODO: I can see a use-case where
             //you can switch endpoints dynamically. For instance wanting to try
@@ -262,42 +307,140 @@ const implFixture = _test.extend<TestContext, WorkerContext>({
             //probably do that already using env variables in the workspace
             //config but it's not a super smooth experience yet. If you run into
             //this please give me a ping so we can brainstorm.
-            const target = 'https://sourcegraph.com'
+            const allocatedPorts = rangeOffset(
+                [testInfo.parallelIndex * 2, 2],
+                validWorkerOptions.mitmServerPortRange
+            )
+            const [sgDotComPort, sgEnterprisePort] = allocatedPorts
+            //TODO: we can provide additional endpoints here
+            const state: {
+                authName: {
+                    enterprise: MitMProxyConfig['sourcegraph']['enterprise']['authName']
+                    dotcom: MitMProxyConfig['sourcegraph']['dotcom']['authName']
+                }
+            } = { authName: { enterprise: 's2', dotcom: 'dotcom' } }
+
+            const config: MitMProxyConfig = {
+                sourcegraph: {
+                    dotcom: {
+                        get authName() {
+                            return state.authName.dotcom
+                        },
+                        endpoint: `http://127.0.0.1:${sgEnterprisePort}`,
+                        get proxyTarget() {
+                            return TESTING_CREDENTIALS[state.authName.dotcom].serverEndpoint
+                        },
+                    },
+                    enterprise: {
+                        get authName() {
+                            return state.authName.enterprise
+                        },
+                        endpoint: `http://127.0.0.1:${sgDotComPort}`,
+                        get proxyTarget() {
+                            return TESTING_CREDENTIALS[state.authName.enterprise].serverEndpoint
+                        },
+                    },
+                },
+            }
+
+            // Proxy Middleware has some internal Try/Catch wrapping so not all
+            // errors make it out into the test. By creating a manual signal we
+            // can ensure that errors inside the middleware always bubble up to
+            // a failed test.
             const testFailureSignal = new EventEmitter<{ error: [Error] }>()
             testFailureSignal.on('error', err => {
+                if (err.name === 'PollyError') {
+                    if (err.message.includes('`recordIfMissing` is `false`')) {
+                        console.error('Missing recording')
+                    }
+                } else {
+                    console.error('Error inside MitM proxy', err.message)
+                }
                 throw err
+                // process.nextTick(() => {
+                // })
             })
-            const middleware = createProxyMiddleware({
-                target,
+
+            const proxyReqHandlers = [
+                sourcegraphProxyReqHandler('dotcom', config),
+                sourcegraphProxyReqHandler('enterprise', config),
+            ]
+            const proxyMiddleware = createProxyMiddleware({
                 changeOrigin: true,
                 ejectPlugins: true,
-                plugins: [failOrRetryRecordingOnError(testFailureSignal, testInfo)],
-            })
-            app.use(middleware)
-            let server: ReturnType<typeof app.listen> = null as any
-            const serverInfo = await new Promise<AddressInfo>((resolve, reject) => {
-                server = app.listen(0, '127.0.0.1', () => {
-                    const address = server.address()
-                    if (address === null || typeof address === 'string') {
-                        reject('address is not a valid object')
-                    } else {
-                        resolve(address)
+                prependPath: false,
+                plugins: [proxyEventsPlugin],
+                router: req => {
+                    try {
+                        const hostPrefix = `http://${req.headers.host}`
+                        if (hostPrefix.startsWith(config.sourcegraph.dotcom.endpoint)) {
+                            return new URL(req.url ?? '', config.sourcegraph.dotcom.proxyTarget)
+                        }
+                        if (hostPrefix.startsWith(config.sourcegraph.enterprise.endpoint)) {
+                            return new URL(req.url ?? '', config.sourcegraph.enterprise.proxyTarget)
+                        }
+                        throw new Error('Unknown host prefix')
+                    } catch (err) {
+                        testFailureSignal.emit('error', err as Error)
+                        return undefined
                     }
-                })
+                },
+                on: {
+                    error: err => {
+                        testFailureSignal.emit('error', err as Error)
+                    },
+                    proxyReq: (proxyReq, req, res, options) => {
+                        try {
+                            for (const handler of proxyReqHandlers) {
+                                const handlerRes = handler(proxyReq, req, res, options)
+                                if (handlerRes) {
+                                    return
+                                }
+                            }
+                            throw new Error('No proxy request handler found')
+                        } catch (err) {
+                            testFailureSignal.emit('error', err as Error)
+                        }
+                    },
+                },
             })
+            app.use(proxyMiddleware)
+            const servers: HTTPServer<any, any>[] = []
+            const serverPromises = []
+            for (const port of allocatedPorts) {
+                serverPromises.push(
+                    new Promise((resolve, reject) => {
+                        const server = app.listen(port, '127.0.0.1', () => {
+                            server.listening ? resolve(void 0) : reject("server didn't start")
+                        })
+                        servers.push(server)
+                    })
+                )
+            }
 
-            await use({
-                endpoint: `http://${serverInfo.address}:${serverInfo.port}`,
-                target,
-            })
+            const cleanupServers = () => {
+                return Promise.allSettled(
+                    servers.map(server => {
+                        server.closeAllConnections()
+                        return new Promise<void>(resolve => server.close(() => resolve(void 0)))
+                    })
+                )
+            }
 
-            server.closeAllConnections()
-            await new Promise(resolve => server.close(resolve))
+            try {
+                await Promise.all(serverPromises)
+            } catch (e) {
+                await cleanupServers()
+                throw e
+            }
+
+            await use(config)
+            await cleanupServers()
         },
         { scope: 'test' },
     ],
     polly: [
-        async ({ validOptions, sourcegraphMitM }, use, testInfo) => {
+        async ({ validOptions }, use, testInfo) => {
             const relativeTestPath = path.relative(
                 path.resolve(process.cwd(), testInfo.project.testDir),
                 testInfo.file
@@ -310,7 +453,62 @@ const implFixture = _test.extend<TestContext, WorkerContext>({
                 adapters: ['node-http'],
                 recordFailedRequests: true,
                 logLevel: 'SILENT',
-                matchRequestsBy: defaultMatchRequestsBy,
+                timing: Timing.relative(1.0), //TODO: Configuration for fuzzy/flake testing
+                matchRequestsBy: {
+                    //TODO: Think of a clever way that we can require order on some types of requests
+                    order: false,
+                    method: true,
+                    url(url, req) {
+                        const parsed = new URL(url)
+                        parsed.searchParams.delete('client-version')
+                        const mitmProxy = getFirstOrValue(req.headers[MITM_PROXY_SERVICE_NAME_HEADER])
+                        if (mitmProxy) {
+                            parsed.hostname = `${mitmProxy}.proxy`
+                            parsed.port = ''
+                            parsed.protocol = 'http:'
+                        }
+                        //todo: replace host with semantic name if available
+                        return parsed.toString()
+                    },
+                    // Canonicalize JSON bodies so that we can replay the recording even if the JSON strings
+                    // differ by semantically meaningless things like object key enumeration order.
+                    body(body, req) {
+                        const contentType = getFirstOrValue(req.getHeader('content-type'))?.toLowerCase()
+                        if (contentType === 'application/json') {
+                            return jsonStableStringify(JSON.parse(body))
+                        }
+                        //TODO: Remove client version variables
+                        if (!contentType && typeof body === 'string') {
+                            const trimmedBody = body.trim()
+                            if (
+                                (trimmedBody.startsWith('{') && trimmedBody.endsWith('}')) ||
+                                (trimmedBody.startsWith('[') && trimmedBody.endsWith(']'))
+                            ) {
+                                let json: any = null
+                                try {
+                                    //only allow this to fail silently
+                                    json = JSON.parse(trimmedBody)
+                                } catch {}
+                                return jsonStableStringify(json)
+                            }
+                        }
+                        // TODO: We want to handle site identification requests so that we can seamlessly switch proxied backends
+                        // these are base64, chunked, gzip encoded responses though so we'll get to that
+                        return body
+                    },
+                    headers(headers, req) {
+                        const matchHeaders: Record<string, string> = {}
+                        const auth = getFirstOrValue(headers.authorization)
+                        const authName = getFirstOrValue(headers[MITM_PROXY_AUTH_TOKEN_NAME_HEADER])
+                        if (authName) {
+                            matchHeaders[MITM_PROXY_AUTH_TOKEN_NAME_HEADER] = authName
+                        } else if (auth) {
+                            matchHeaders.authorization = redactAuthorizationHeader(auth)
+                        }
+
+                        return matchHeaders
+                    },
+                },
                 persisterOptions: {
                     keepUnusedRequests: validOptions.keepUnusedRecordings ?? true,
                     fs: {
@@ -321,54 +519,145 @@ const implFixture = _test.extend<TestContext, WorkerContext>({
 
             polly.server
                 .any()
-                .filter(req => !req.url.startsWith(sourcegraphMitM.target))
+                .filter(req => !req.getHeader(MITM_PROXY_SERVICE_NAME_HEADER))
                 .intercept((req, res, interceptor) => {
+                    console.log('NOT HANDLING REQUEST', req.url)
                     interceptor.stopPropagation()
                     interceptor.passthrough()
                 })
-            polly.server.host(sourcegraphMitM.target, () => {
-                polly.server
-                    .post('/.api/graphql')
-                    .filter(req => 'RecordTelemetryEvents' in req.query)
-                    .on('request', (req, inter) => {
-                        //TODO(rnauta): Store telemetry & allow for custom validation (if needed)
-                    })
 
-                // NOTE: this might seem counter intuitive that the user could
-                // override these functions given that PollyJS calls them in the
-                // order they were defined. However, these intercept handlers
-                // don't work like normal middleware in that it's the first to
-                // respond. Instead if you call sendStatus(400) in a subsequent
-                // handler you change the resoponse. So although handlers are
-                // called in the order they are defined, it's the last handler
-                // to modify the response that actually dictates the response.
-                // This took me ages to figure out, and feels like a terrible
-                // API...why they didn't just go with normal well-understood
-                // middleware API 🤷‍♂️
-                polly.server
-                    .post('/.api/graphql')
-                    .filter(
-                        req => 'RecordTelemetryEvents' in req.query || 'LogEventMutation' in req.query
+            //TODO(rnauta): we probably make some helpers so that we can verify it's a proxy request from a particular service
+            // Sourcegraph Handlers
+            polly.server
+                .any()
+                .filter(req => {
+                    return !!getFirstOrValue(req.getHeader(MITM_PROXY_SERVICE_NAME_HEADER))?.startsWith(
+                        'sourcegraph'
                     )
-                    .intercept((req, res, interceptor) => {
-                        res.send('{}')
-                        res.status(200)
+                })
+                .on('response', (req, res) => {
+                    if (res.statusCode === 401) {
+                        // check if we simply didn't have the correct auth available
+                        const authAvailable = req.hasHeader(MITM_PROXY_AUTH_AVAILABLE_HEADER)
+                        const authSet = req.hasHeader(MITM_PROXY_AUTH_TOKEN_NAME_HEADER)
+
+                        if (authSet && !authAvailable) {
+                            throw new Error(
+                                "TESTING_CREDENTIALS haven't been set. TODO: Give an action to run next"
+                            )
+                        }
+                    }
+                })
+
+            if (true as unknown) {
+                // TODO: Make it configurable if we setup default handlers
+                polly.server
+                    .any()
+                    .filter(req => {
+                        return (
+                            !!getFirstOrValue(req.getHeader(MITM_PROXY_SERVICE_NAME_HEADER))?.startsWith(
+                                'sourcegraph'
+                            ) && req.pathname.startsWith('/-/debug/otlp/v1/traces')
+                        )
+                    })
+                    .intercept((req, res) => {
+                        //TODO(rnauta): forward this to a local otlp server & include with attachments
+                        // ideally combined with local or even remote sourcegraph traces too
+                        console.log('INTERCEPTED TRACING')
+                        res.status(201).json({ partialSuccess: {} })
                     })
 
-                polly.server.get('/healthz').intercept((req, res, interceptor) => {
-                    res.sendStatus(200)
-                })
-            })
+                polly.server
+                    .any()
+                    .filter(req => {
+                        return (
+                            !!getFirstOrValue(req.getHeader(MITM_PROXY_SERVICE_NAME_HEADER))?.startsWith(
+                                'sourcegraph'
+                            ) &&
+                            req.pathname.startsWith('/.api/graphql') &&
+                            'LogEventMutation' in req.query
+                        )
+                    })
+                    .intercept((req, res) => {
+                        console.log('INTERCEPTED A LOG MUTATION EVENT')
+                        res.status(200).json({ data: { logEvent: null } })
+                    })
+
+                polly.server
+                    .any()
+                    .filter(req => {
+                        return (
+                            !!getFirstOrValue(req.getHeader(MITM_PROXY_SERVICE_NAME_HEADER))?.startsWith(
+                                'sourcegraph'
+                            ) &&
+                            req.pathname.startsWith('/.api/graphql') &&
+                            'RecordTelemetryEvents' in req.query
+                        )
+                    })
+                    .intercept((req, res) => {
+                        console.log('INTERCEPTED A RecordTelemetryEvent')
+                        res.status(200).json({
+                            data: { telemetry: { recordEvents: { alwaysNil: null } } },
+                        })
+                    })
+
+                polly.server
+                    .any()
+                    .filter(req => {
+                        return (
+                            !!getFirstOrValue(req.getHeader(MITM_PROXY_SERVICE_NAME_HEADER))?.startsWith(
+                                'sourcegraph'
+                            ) &&
+                            req.pathname.startsWith('/.api/graphql') &&
+                            'EvaluateFeatureFlag' in req.query
+                        )
+                    })
+                    .intercept((req, res) => {
+                        //TODO(rnauta): impeement this
+                        console.log('INTERCEPTED FEATURE FLAG EVENT')
+                        res.status(200).json({ data: { evaluateFeatureFlag: null } })
+                    })
+                polly.server
+                    .any()
+                    .filter(req => {
+                        return (
+                            !!getFirstOrValue(req.getHeader(MITM_PROXY_SERVICE_NAME_HEADER))?.startsWith(
+                                'sourcegraph'
+                            ) &&
+                            req.pathname.startsWith('/.api/graphql') &&
+                            'FeatureFlags' in req.query
+                        )
+                    })
+                    .intercept((req, res) => {
+                        console.log('intercepted feature flag get')
+                        res.status(200).json({ data: { evaluatedFeatureFlags: [] } })
+                    })
+
+                polly.server
+                    .any()
+                    .filter(req => {
+                        return req.pathname.startsWith('/healthz')
+                    })
+                    .intercept((req, res, interceptor) => {
+                        console.log('INTERCEPTED HEALTH CHECK')
+                        res.sendStatus(200)
+                    })
+            }
 
             await use(polly)
-            await polly.flush()
+            //NOTE: Be careful where you include Polly in this fixture. Because
+            //right now it's one of the first things released after a test
+            //meaning that requests outside of the test (such as shutting down
+            //etc) are not recorded/intercepted. If you'd include it in a
+            //component that lives longer the cleanup might not happen directly
+            //after the test finishes
             await polly.stop()
         },
         { scope: 'test' },
     ],
     //#region vscode agent
     vscodeUI: [
-        async ({ validOptions, serverRootDir, sourcegraphMitM, page }, use, testInfo) => {
+        async ({ validOptions, serverRootDir, mitmProxy, page, polly }, use, testInfo) => {
             const executableDir = path.resolve(process.cwd(), validOptions.vscodeTmpDir)
             await fs.mkdir(executableDir, { recursive: true })
             const serverExecutableDir = path.resolve(process.cwd(), validOptions.vscodeServerTmpDir)
@@ -402,7 +691,7 @@ const implFixture = _test.extend<TestContext, WorkerContext>({
                         'workbench.welcomePage.walkthroughs.openOnInstall': false,
                         'workbench.colorTheme': 'Default Dark Modern',
                         // sane defaults
-                        'cody.debug.verbose': true,
+                        'cody.debug.verbose': false,
                     },
                     null,
                     2
@@ -470,12 +759,7 @@ const implFixture = _test.extend<TestContext, WorkerContext>({
 
             // We can now start the server
             const connectionToken = '0000-0000'
-            const serverPort = validOptions.vscodeServerPortRange[0] + testInfo.parallelIndex
-            if (serverPort > validOptions.vscodeServerPortRange[1]) {
-                throw new Error(
-                    'Port range is exhausted. Either reduce the amount of workers or increase the port range.'
-                )
-            }
+            const serverPort = rangeOffset(testInfo.parallelIndex, validOptions.vscodeServerPortRange)
             const args = [
                 'serve-web',
                 `--user-data-dir=${userDataDir}`,
@@ -492,7 +776,7 @@ const implFixture = _test.extend<TestContext, WorkerContext>({
                 ...(['stable', 'insiders'].includes(validOptions.vscodeVersion)
                     ? { VSCODE_CLI_QUALITY: validOptions.vscodeVersion }
                     : { VSCODE_CLI_COMMIT: validOptions.vscodeVersion }),
-                TESTING_DOTCOM_URL: sourcegraphMitM.endpoint,
+                TESTING_DOTCOM_URL: mitmProxy.sourcegraph.dotcom.endpoint,
                 CODY_TESTING_BFG_DIR: path.resolve(process.cwd(), validOptions.binaryTmpDir),
                 CODY_TESTING_SYMF_DIR: path.resolve(process.cwd(), validOptions.binaryTmpDir),
             }
@@ -501,6 +785,7 @@ const implFixture = _test.extend<TestContext, WorkerContext>({
                 stdio: ['inherit', 'ignore', 'inherit'],
                 detached: false,
             })
+            SPAWNED_PIDS.add(codeProcess.pid)
 
             const config = { url: `http://127.0.0.1:${serverPort}/`, token: connectionToken }
             await stretchTimeout(() => waitForVSCodeServer({ url: config.url, serverExecutableDir }), {
@@ -509,7 +794,7 @@ const implFixture = _test.extend<TestContext, WorkerContext>({
             })
 
             await use(config)
-
+            polly.pause()
             // Turn of logging browser logging and navigate away from the UI
             // Otherwise we needlessly add a bunch of noisy error logs
             if (page.url().startsWith(config.url)) {
@@ -523,13 +808,10 @@ const implFixture = _test.extend<TestContext, WorkerContext>({
                 await page.goto('about:blank')
                 await page.waitForLoadState('domcontentloaded')
             }
-            const exitPromise = new Promise(resolve => {
-                codeProcess.on('exit', () => {
-                    resolve(void 0)
-                })
-            })
-            codeProcess.kill()
-            await exitPromise
+            if (codeProcess.pid) {
+                killSync(codeProcess.pid, 'SIGTERM', true)
+                SPAWNED_PIDS.delete(codeProcess.pid)
+            }
         },
         { scope: 'test' },
     ],
@@ -692,17 +974,68 @@ async function getFilesRecursive(dir: string): Promise<Array<Dirent>> {
     return files
 }
 
-function failOrRetryRecordingOnError(
-    emitter: EventEmitter<{ error: [Error] }>,
-    testInfo: TestInfo
-): typeof ProxyMiddlewarePlugin {
-    return (proxyServer, options) => {
-        //TODO(rnauta): retry with different settings if user accepts in cli prompt
-        proxyServer.on('error', (err, req, res) => {
-            emitter.emit('error', err)
-        })
+function sourcegraphProxyReqHandler(
+    variant: 'enterprise' | 'dotcom',
+    config: MitMProxyConfig
+): ProxyReqHandler {
+    return (proxyReq, req, res, options) => {
+        if (config.sourcegraph[variant].proxyTarget.startsWith((options.target as URL).origin)) {
+            const name = `sourcegraph.${variant}`
+            proxyReq.setHeader('accept-encoding', 'identity') //makes it easier to debug
+            proxyReq.setHeader(MITM_PROXY_SERVICE_ENDPOINT_HEADER, config.sourcegraph[variant].endpoint)
+            proxyReq.setHeader(MITM_PROXY_SERVICE_NAME_HEADER, name)
+            if (TESTING_CREDENTIALS[config.sourcegraph[variant].authName].token) {
+                proxyReq.setHeader(MITM_PROXY_AUTH_AVAILABLE_HEADER, name)
+            }
+            const authReplacement =
+                TESTING_CREDENTIALS[config.sourcegraph[variant].authName].token ??
+                TESTING_CREDENTIALS[config.sourcegraph[variant].authName].redactedToken
+
+            const headers = proxyReq.getHeaders()
+            if (headers.authorization) {
+                // can be used to match without worrying about the specific token value
+                const before = getFirstOrValue(headers.authorization)
+                const after = before.replace(MITM_AUTH_TOKEN_PLACEHOLDER, authReplacement)
+                if (before !== after) {
+                    // this means we set the token. This allows you to still
+                    // manually specify some other token in your test. For
+                    // instance to try and see what happens with an incorrect
+                    // token
+                    proxyReq.setHeader(MITM_PROXY_AUTH_TOKEN_NAME_HEADER, name)
+                }
+
+                proxyReq.setHeader('authorization', after)
+            }
+            return true
+        }
+        return false
     }
 }
+
+function getFirstOrValue<T>(input: T | Array<T>): T {
+    return Array.isArray(input) ? input[0] : input
+}
+
+/**
+ * Returns the lower bound + offset or errors if the number is outside of the range
+ */
+function rangeOffset<LENGTH extends number = number>(
+    offset: [number, LENGTH],
+    range: [number, number]
+): FixedLengthTuple<number, LENGTH>
+function rangeOffset(offset: number, range: [number, number]): number
+function rangeOffset(_offset: number | [number, number], range: [number, number]): number | number[] {
+    const [offset, take] = Array.isArray(_offset) ? _offset : [_offset, -1]
+    const anchor = range[0] + offset
+    if (take < 0) {
+        return anchor
+    }
+    return Array.from({ length: take }, (_, i) => anchor + i)
+}
+
+type FixedLengthTuple<T, N extends number, R extends readonly T[] = []> = R['length'] extends N
+    ? R
+    : FixedLengthTuple<T, N, readonly [T, ...R]>
 
 // A custom version of the VS Code download reporter that silences matching installation
 // notifications as these otherwise are emitted on every test run

--- a/vscode/e2e/utils/vscody/fixture.ts
+++ b/vscode/e2e/utils/vscody/fixture.ts
@@ -133,10 +133,8 @@ function schemaOptions<T extends zod.ZodObject<any>, S extends 'worker' | 'test'
 const SPAWNED_PIDS = new Set<number | undefined>()
 onExit(
     () => {
-        console.log('KILLLING')
         for (const pid of SPAWNED_PIDS.values()) {
             if (pid !== undefined) {
-                console.log('KILLING', pid)
                 killSync(pid, 'SIGKILL', true)
             }
         }
@@ -560,7 +558,6 @@ const implFixture = _test.extend<TestContext, WorkerContext>({
                     .intercept((req, res) => {
                         //TODO(rnauta): forward this to a local otlp server & include with attachments
                         // ideally combined with local or even remote sourcegraph traces too
-                        console.log('INTERCEPTED TRACING')
                         res.status(201).json({ partialSuccess: {} })
                     })
 
@@ -576,7 +573,7 @@ const implFixture = _test.extend<TestContext, WorkerContext>({
                         )
                     })
                     .intercept((req, res) => {
-                        console.log('INTERCEPTED A LOG MUTATION EVENT')
+                        //TODO: Implement this
                         res.status(200).json({ data: { logEvent: null } })
                     })
 
@@ -592,7 +589,7 @@ const implFixture = _test.extend<TestContext, WorkerContext>({
                         )
                     })
                     .intercept((req, res) => {
-                        console.log('INTERCEPTED A RecordTelemetryEvent')
+                        //TODO: implement this
                         res.status(200).json({
                             data: { telemetry: { recordEvents: { alwaysNil: null } } },
                         })
@@ -611,7 +608,6 @@ const implFixture = _test.extend<TestContext, WorkerContext>({
                     })
                     .intercept((req, res) => {
                         //TODO(rnauta): impeement this
-                        console.log('INTERCEPTED FEATURE FLAG EVENT')
                         res.status(200).json({ data: { evaluateFeatureFlag: null } })
                     })
                 polly.server
@@ -626,7 +622,7 @@ const implFixture = _test.extend<TestContext, WorkerContext>({
                         )
                     })
                     .intercept((req, res) => {
-                        console.log('intercepted feature flag get')
+                        //TODO: implement this
                         res.status(200).json({ data: { evaluatedFeatureFlags: [] } })
                     })
 
@@ -636,7 +632,7 @@ const implFixture = _test.extend<TestContext, WorkerContext>({
                         return req.pathname.startsWith('/healthz')
                     })
                     .intercept((req, res, interceptor) => {
-                        console.log('INTERCEPTED HEALTH CHECK')
+                        //TODO: implement this
                         res.sendStatus(200)
                     })
             }
@@ -728,17 +724,8 @@ const implFixture = _test.extend<TestContext, WorkerContext>({
                             ...process.env,
                             // VSCODE_EXTENSIONS: sharedExtensionsDir, This doesn't work either
                         },
-                        stdio: ['inherit', 'inherit', 'inherit'],
+                        stdio: ['inherit', 'ignore', 'inherit'],
                     })
-                } catch (e) {
-                    console.log('I AM HERE')
-                    if (
-                        typeof e === 'string' &&
-                        e.includes('code version use stable --install-dir /path/to/installation')
-                    ) {
-                    }
-                    console.error(e)
-                    throw e
                 } finally {
                     releaseLock()
                 }
@@ -938,7 +925,7 @@ async function downloadOrWaitForVSCode({
                 throw new Error('Global VSCode path modification is not allowed')
             }
             await pspawn(tunnelPath, ['version', 'use', 'stable', '--install-dir', installPath], {
-                stdio: ['inherit', 'inherit', 'inherit'],
+                stdio: ['inherit', 'ignore', 'inherit'],
             })
         } else if (res.code !== 0) {
             throw new Error(JSON.stringify(res))

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -1466,6 +1466,7 @@
     "fs-extra": "^11.2.0",
     "fuzzysort": "^2.0.4",
     "http-proxy-middleware": "^3.0.0",
+    "kill-sync": "^1.0.3",
     "mocha": "^10.2.0",
     "ovsx": "^0.8.2",
     "pako": "^2.1.0",

--- a/vscode/src/testutils/CodyPersisterV2.ts
+++ b/vscode/src/testutils/CodyPersisterV2.ts
@@ -1,0 +1,203 @@
+// TODO: This potentially introduces some breaking behaviour compared to the previous one.
+// When the playwright E2E lands properly we should re-record all agent tests
+// with this updated recorder.
+
+import crypto from 'node:crypto'
+
+import type { Har, HarEntry } from '@pollyjs/persister'
+import FSPersister from '@pollyjs/persister-fs'
+
+import { isError, parseEvents } from '@sourcegraph/cody-shared'
+import { PollyYamlWriter } from './PollyYamlWriter'
+import { decodeCompressedBase64 } from './base64'
+
+const AUTH_HEADER_REGEX = /^(?<prefix>token|bearer)\s+(?<redacted>REDACTED_)?(?<token>.*?)\s*$/im
+/**
+ * SHA-256 digests a Sourcegraph access token so that it's value is redacted but
+ * remains uniquely identifyable. The token needs to be uniquely identifiable so
+ * that we can correctly replay HTTP responses based on the access token.
+ */
+export function redactAuthorizationHeader(header: string): string {
+    const match = AUTH_HEADER_REGEX.exec(header)
+    if (match) {
+        if (match.groups?.redacted) {
+            return header
+        }
+        const tokenHash = sha256(`prefix${match.groups?.token}`)
+        return `${match.groups?.prefix} REDACTED_${tokenHash}`
+    }
+    return header
+}
+
+function sha256(input: string): string {
+    return crypto.createHash('sha256').update(input).digest('hex')
+}
+
+/**
+ * The default file system persister with the following customizations
+ *
+ * - Replaces Cody access tokens with the string "REDACTED" because we don't
+ *   want to commit the access token into git.
+ * - To avoid diff churn/conflicts:
+ *   - Sets date headers to a known static date
+ *   - Removes cookies
+ *   - Sets dates/timing information stored by Polly to static values
+ */
+export class CodyPersister extends FSPersister {
+    // HACK: `FSPersister` has a private `api` property that writes the
+    // recording.har file using JSON format. We override the `api` property here
+    // with a custom implementation that uses YAML format instead. This property
+    // is intentionally marked as public even if it's not used anywhere.
+    public api: PollyYamlWriter
+
+    constructor(polly: any) {
+        super(polly)
+        if (!this.options.recordingsDir) {
+            throw new Error('No recording directory provided')
+        }
+        this.api = new PollyYamlWriter(this.options.recordingsDir)
+    }
+    public static get id(): string {
+        return 'fs'
+    }
+
+    public async onFindRecording(recordingId: string): Promise<Har | null> {
+        const har = await super.onFindRecording(recordingId)
+        if (har === null) {
+            return har
+        }
+        for (const entry of har.log.entries) {
+            const postData = entry?.request?.postData
+            if (
+                postData !== undefined &&
+                postData?.text === undefined &&
+                (postData as any)?.textJSON !== undefined
+            ) {
+                // Format `postData.textJSON` back into the escaped string for the `.text` format.
+                postData.text = JSON.stringify((postData as any).textJSON)
+                ;(postData as any).textJSON = undefined
+            }
+        }
+        return har
+    }
+
+    public onSaveRecording(recordingId: string, recording: Har): Promise<void> {
+        const entries = recording.log.entries
+        recording.log.entries.sort((a, b) => a.request.url.localeCompare(b.request.url))
+        for (const entry of entries) {
+            if (entry.request?.postData?.text?.startsWith('{')) {
+                // Format `postData.text` as a JSON object instead of escaped string.
+                // This makes it much easier to review the har file locally.
+                const postData: any = entry.request.postData
+                postData.textJSON = JSON.parse(entry.request.postData.text)
+                postData.text = undefined
+            }
+            // Clean up the entries to reduce the size of the diff when re-recording
+            // and to remove any access tokens.
+            const headers = [...entry.request.headers, ...entry.response.headers]
+            for (const header of headers) {
+                switch (header.name.toLowerCase()) {
+                    case 'authorization':
+                        header.value = redactAuthorizationHeader(header.value)
+                        break
+                    // We should not harcode the dates to minimize diffs because
+                    // that breaks the expiration feature in Polly.
+                }
+            }
+
+            // Remove any headers and cookies we don't need at all.
+            entry.request.headers = this.filterHeaders(entry.request.headers)
+            entry.response.headers = this.filterHeaders(entry.response.headers)
+            entry.response.content.text
+            entry.request.cookies.length = 0
+            entry.response.cookies.length = 0
+            entry.response.content.text = postProcessResponseText(entry)
+
+            // And other misc fields.
+            entry.time = 0
+            entry.timings = {
+                blocked: -1,
+                connect: -1,
+                dns: -1,
+                receive: 0,
+                send: 0,
+                ssl: -1,
+                wait: 0,
+            }
+            const responseContent = entry.response.content
+            if (
+                responseContent?.encoding === 'base64' &&
+                responseContent?.mimeType === 'application/json' &&
+                responseContent.text
+            ) {
+                // The GraphQL responses are base64+gzip encoded. We decode them
+                // in a sibling `textDecoded` property so we can more easily review
+                // in in pull requests.
+                try {
+                    const text = JSON.parse(responseContent.text)[0]
+                    const decodedBase64 = decodeCompressedBase64(text)
+                    ;(responseContent as any).textDecoded = decodedBase64
+                } catch {
+                    // Ignored: uncomment below to debug. It's fine to ignore this error because we only
+                    // make a best-effort to decode the gzip+base64 encoded JSON payload. It's not needed
+                    // for the HTTP replay to work correctly because we leave the `.text` property unchanged.
+                    // console.error('base64 decode error', error)
+                }
+            }
+        }
+        return super.onSaveRecording(recordingId, recording)
+    }
+
+    private filterHeaders(
+        headers: { name: string; value: string }[]
+    ): { name: string; value: string }[] {
+        const removeHeaderNames = new Set([
+            'set-cookie',
+            'server',
+            'via',
+            'x-sourcegraph-actor-anonymous-uid',
+            //TODO(rnauta): leaky abstraction, how to configure this on the other end
+            'x-mitm-proxy-endpoint',
+            'x-mitm-auth-available',
+        ])
+        const removeHeaderPrefixes = ['x-trace', 'cf-']
+        return headers.filter(
+            header =>
+                !removeHeaderNames.has(header.name) &&
+                removeHeaderPrefixes.every(prefix => !header.name.startsWith(prefix))
+        )
+    }
+}
+function postProcessResponseText(entry: HarEntry): string | undefined {
+    const { text } = entry.response.content
+    if (text === undefined) {
+        return undefined
+    }
+    if (
+        !entry.request.url.includes('/.api/completions/stream') &&
+        !entry.request.url.includes('/completions/code')
+    ) {
+        return text
+    }
+    const parseResult = parseEvents(text)
+    if (isError(parseResult)) {
+        return text
+    }
+    const hasError = parseResult.events.some(event => event.type === 'error')
+    if (hasError) {
+        return text
+    }
+
+    const [completionEvent, doneEvent] = parseResult.events.slice(-2)
+    if (completionEvent.type !== 'completion' || doneEvent.type !== 'done') {
+        return text
+    }
+
+    const lines = text.split('\n')
+    const lastCompletionEvent = lines.lastIndexOf('event: completion')
+    if (lastCompletionEvent >= 0) {
+        return lines.slice(lastCompletionEvent).join('\n')
+    }
+
+    return text
+}

--- a/vscode/src/testutils/testing-credentials.ts
+++ b/vscode/src/testutils/testing-credentials.ts
@@ -33,7 +33,7 @@ export function dotcomCredentials(): TestingCredentials {
 
 // See instructions in agent/scripts/export-cody-http-recording-tokens.sh for
 // how to update the `redacted` tokens when the access token changes.
-export const TESTING_CREDENTIALS = {
+export const DOTCOM_TESTING_CREDENTIALS = {
     dotcom: {
         token: process.env.SRC_DOTCOM_PRO_ACCESS_TOKEN,
         redactedToken: 'REDACTED_d5e0f0a37c9821e856b923fe14e67a605e3f6c0a517d5a4f46a4e35943ee0f6d',
@@ -44,6 +44,9 @@ export const TESTING_CREDENTIALS = {
         redactedToken: 'REDACTED_e2ef220aa0a2f84113dc065a7fd9c7a620f17455d0aca3690d312676518dc48f',
         serverEndpoint: DOTCOM_URL.toString(),
     } satisfies TestingCredentials,
+}
+
+export const ENTERPRISE_TESTING_CREDENTIALS = {
     enterprise: {
         token: process.env.SRC_ENTERPRISE_ACCESS_TOKEN,
         redactedToken: 'REDACTED_b20717265e7ab1d132874d8ff0be053ab9c1dacccec8dce0bbba76888b6a0a69',
@@ -54,4 +57,10 @@ export const TESTING_CREDENTIALS = {
         redactedToken: 'REDACTED_964f5256e709a8c5c151a63d8696d5c7ac81604d179405864d88ff48a9232364',
         serverEndpoint: 'https://sourcegraph.sourcegraph.com/',
     } satisfies TestingCredentials,
+}
+
+export const TESTING_CREDENTIALS: typeof ENTERPRISE_TESTING_CREDENTIALS &
+    typeof DOTCOM_TESTING_CREDENTIALS = {
+    ...DOTCOM_TESTING_CREDENTIALS,
+    ...ENTERPRISE_TESTING_CREDENTIALS,
 }


### PR DESCRIPTION
Fixes CODY-2727, CODY-2728, CODY-2764, CODY-2735

This is far from the final implementation but it sets up some solid primitives to continue work from.

We now essentially allow the configuration of multiple proxy endpoints. For now there are just two SourceGraph variants but we can effectively have as many proxies as we want (Ollama, FastPath, etc.) Note that the "implementation" of these variants can easily be switched out during a test. This is so that later we can leverage this for debugging by allowing a user to seamlessly switch between production and local variants without invalidating all recorded messages.

For the Sourcegraph proxies we now also have several default Polly handlers setup. For some of those, such as telemetry, we can both send a fixed response as well as record the values in some data-structure that will allow for easy validation during a test (which will be implemented as a UIX helper so that it's opt-in).

Next; you could already configure if you want to record missing messages. But we now also check if the TESTING_CREDENTIALS have actually been loaded when a request being recorded fails so that we can show more helpful error messages.

And the above changes (and some more minor ones) come together with the basic Auth UIX helper to allow starting a VSCode session as a authenticated user.

![CleanShot 2024-07-05 at 01 33 13@2x](https://github.com/sourcegraph/cody/assets/3949285/98d7042e-ff6f-4e7c-85f1-246f12d39912)


TODO:
- [ ] Modify proxy config within test

## Test plan

This doesn't affect any production code yet so existing tests are adequate.

For testing the auth I've ran `CODY_RECORD_IF_MISSING=false pnpm run test:e2e2` to verify that all tests pass and that the recordings are up-to-date.
