### PR TITLE
Fix @openctx/vscode-lib initialization for Cody Web

### DIFF
--- a/lib/shared/src/sourcegraph-api/completions/browserClient.ts
+++ b/lib/shared/src/sourcegraph-api/completions/browserClient.ts
@@ -124,4 +124,8 @@ if (isRunningInWebWorker) {
 
         document: self.document,
     }
+    // HACK: @openctx/vscode-lib uses global object to share vscode API, it breaks cody web since
+    // global doesn't exist in web worker context, for more details see openctx issue here
+    // https://github.com/sourcegraph/openctx/issues/169
+    ;(self as any).global = {}
 }

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -88,7 +88,6 @@ export default defineProjectWithDefaults(__dirname, {
     build: {
         // Turn off minification since it breaks json-rpc in inline web-worker in Safari
         minify: false,
-        emptyOutDir: false,
         outDir: 'dist',
         assetsDir: '.',
         reportCompressedSize: false,


### PR DESCRIPTION
`@openctx/vscode-lib` uses global. sets under the hood which breaks Cody Web use case since we're importing vscode-lib within web worker context where we don't have global object. 

This PR adds hack/workaround for Cody Web, proper fix should happen in `@openctx/vscode-lib` here https://github.com/sourcegraph/openctx/issues/169

## Test plan
- Run cody web demo
- Check that you can see and use repositories and files mentions providers

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
