### PR TITLE
Chat: update welcome message to be IDE based

### DIFF
--- a/vscode/webviews/App.tsx
+++ b/vscode/webviews/App.tsx
@@ -6,6 +6,7 @@ import {
     type AuthStatus,
     type ChatMessage,
     type ClientStateForWebview,
+    CodyIDE,
     GuardrailsPost,
     type Model,
     PromptString,
@@ -102,6 +103,7 @@ export const App: React.FunctionComponent<{ vscodeAPI: VSCodeWrapper }> = ({ vsc
                             // with E2E tests where change the DOTCOM_URL via the env variable TESTING_DOTCOM_URL.
                             isDotComUser: message.authStatus.isDotCom,
                             user: message.authStatus,
+                            ide: message.config.agentIDE || CodyIDE.VSCode,
                         })
                         setView(message.authStatus.isLoggedIn ? 'chat' : 'login')
                         updateDisplayPathEnvInfoForWebview(message.workspaceFolderUris)

--- a/vscode/webviews/Chat.tsx
+++ b/vscode/webviews/Chat.tsx
@@ -2,7 +2,7 @@ import { clsx } from 'clsx'
 import type React from 'react'
 import { useCallback, useEffect, useMemo } from 'react'
 
-import type { AuthStatus, ChatMessage, Guardrails } from '@sourcegraph/cody-shared'
+import type { AuthStatus, ChatMessage, CodyIDE, Guardrails } from '@sourcegraph/cody-shared'
 import { Transcript, focusLastHumanMessageEditor } from './chat/Transcript'
 import type { VSCodeWrapper } from './utils/VSCodeApi'
 
@@ -180,7 +180,7 @@ export const Chat: React.FunctionComponent<React.PropsWithChildren<ChatboxProps>
                 postMessage={postMessage}
                 guardrails={guardrails}
             />
-            {transcript.length === 0 && showWelcomeMessage && <WelcomeMessage />}
+            {transcript.length === 0 && showWelcomeMessage && <WelcomeMessage IDE={userInfo.ide} />}
             <ScrollDown scrollableParent={scrollableParent} onClick={focusLastHumanMessageEditor} />
         </div>
     )
@@ -190,6 +190,7 @@ export interface UserAccountInfo {
     isDotComUser: boolean
     isCodyProUser: boolean
     user: Pick<AuthStatus, 'username' | 'displayName' | 'avatarURL'>
+    ide: CodyIDE
 }
 
 export type ApiPostMessage = (message: any) => void

--- a/vscode/webviews/chat/components/WelcomeMessage.test.tsx
+++ b/vscode/webviews/chat/components/WelcomeMessage.test.tsx
@@ -1,3 +1,4 @@
+import { CodyIDE } from '@sourcegraph/cody-shared'
 import { fireEvent, render, screen } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, test } from 'vitest'
 import { WelcomeMessage, localStorageKey } from './WelcomeMessage'
@@ -12,7 +13,7 @@ afterEach(() => {
 
 describe('WelcomeMessage', () => {
     test('renders', () => {
-        render(<WelcomeMessage />)
+        render(<WelcomeMessage IDE={CodyIDE.VSCode} />)
 
         // Initial render
         expect(screen.getByText(/Customize chat settings/)).toBeInTheDocument()
@@ -30,7 +31,7 @@ describe('WelcomeMessage', () => {
 
     test('renders as collapsed if localstorage is set', () => {
         window.localStorage.setItem(localStorageKey, 'true')
-        render(<WelcomeMessage />)
+        render(<WelcomeMessage IDE={CodyIDE.VSCode} />)
         expect(screen.getByRole('button', { name: 'Cody Chat Help' })).toBeInTheDocument()
     })
 })

--- a/vscode/webviews/chat/components/WelcomeMessage.tsx
+++ b/vscode/webviews/chat/components/WelcomeMessage.tsx
@@ -85,21 +85,28 @@ export const WelcomeMessage: FunctionComponent<{
                 <FeatureRow icon={AtSignIcon}>
                     Type <Kbd macOS="@" linuxAndWindows="@" /> to add context to your chat
                 </FeatureRow>
-                <FeatureRow icon={TextIcon}>
-                    To add code context from an editor, or the file explorer, right click and use{' '}
-                    <MenuExample>Add to Cody Chat</MenuExample>
-                </FeatureRow>
+                {/* IDE Specificed message - VS Code */}
+                {IDE === CodyIDE.VSCode && (
+                    <FeatureRow icon={TextIcon}>
+                        To add code context from an editor, or the file explorer, right click and use{' '}
+                        <MenuExample>Add to Cody Chat</MenuExample>
+                    </FeatureRow>
+                )}
+                {/* IDE Specificed message - VS Code */}
                 {IDE === CodyIDE.VSCode && (
                     <FeatureRow icon={NewChatIcon}>
                         Start a new chat using <Kbd macOS="opt+/" linuxAndWindows="alt+/" /> or the{' '}
                         <CodyIcon character="H" /> button in the top right of any file
                     </FeatureRow>
                 )}
-                <FeatureRow icon={SettingsIcon}>
-                    Customize chat settings with the{' '}
-                    <i className="codicon codicon-settings-gear tw-translate-y-[3px] tw-mx-1" /> button,
-                    or see the <a href="https://sourcegraph.com/docs/cody">documentation</a>
-                </FeatureRow>
+                {/* IDE Specificed message - VS Code */}
+                {IDE === CodyIDE.VSCode && (
+                    <FeatureRow icon={SettingsIcon}>
+                        Customize chat settings with the{' '}
+                        <i className="codicon codicon-settings-gear tw-translate-y-[3px] tw-mx-1" />{' '}
+                        button, or see the <a href="https://sourcegraph.com/docs/cody">documentation</a>
+                    </FeatureRow>
+                )}
             </div>
         </div>
     )

--- a/vscode/webviews/chat/components/WelcomeMessage.tsx
+++ b/vscode/webviews/chat/components/WelcomeMessage.tsx
@@ -1,3 +1,4 @@
+import { CodyIDE } from '@sourcegraph/cody-shared'
 import { AtSignIcon, HelpCircleIcon, SettingsIcon, TextIcon, XIcon } from 'lucide-react'
 import { type FunctionComponent, type ReactElement, useCallback, useState } from 'react'
 import { Kbd } from '../../components/Kbd'
@@ -34,7 +35,9 @@ const NewChatIcon: FunctionComponent = (props): ReactElement => (
 
 export const localStorageKey = 'chat.welcome-message-dismissed'
 
-export const WelcomeMessage: FunctionComponent = () => {
+export const WelcomeMessage: FunctionComponent<{
+    IDE: CodyIDE
+}> = ({ IDE }) => {
     const [showMessage, setShowMessage] = useState<boolean>(
         localStorage.getItem(localStorageKey) !== 'true'
     )
@@ -86,10 +89,12 @@ export const WelcomeMessage: FunctionComponent = () => {
                     To add code context from an editor, or the file explorer, right click and use{' '}
                     <MenuExample>Add to Cody Chat</MenuExample>
                 </FeatureRow>
-                <FeatureRow icon={NewChatIcon}>
-                    Start a new chat using <Kbd macOS="opt+/" linuxAndWindows="alt+/" /> or the{' '}
-                    <CodyIcon character="H" /> button in the top right of any file
-                </FeatureRow>
+                {IDE === CodyIDE.VSCode && (
+                    <FeatureRow icon={NewChatIcon}>
+                        Start a new chat using <Kbd macOS="opt+/" linuxAndWindows="alt+/" /> or the{' '}
+                        <CodyIcon character="H" /> button in the top right of any file
+                    </FeatureRow>
+                )}
                 <FeatureRow icon={SettingsIcon}>
                     Customize chat settings with the{' '}
                     <i className="codicon codicon-settings-gear tw-translate-y-[3px] tw-mx-1" /> button,

--- a/vscode/webviews/chat/components/WelcomeMessage.tsx
+++ b/vscode/webviews/chat/components/WelcomeMessage.tsx
@@ -52,7 +52,8 @@ export const WelcomeMessage: FunctionComponent<{
         setShowMessage(true)
     }, [])
 
-    if (!showMessage) {
+    // NOTE: The current welcome message only applies to VS Code client.
+    if (!showMessage || IDE !== CodyIDE.VSCode) {
         return (
             <div className="tw-flex-1 tw-flex tw-relative tw-min-h-12">
                 <div className="tw-absolute tw-bottom-0 tw-w-full tw-flex tw-justify-end tw-pb-8 tw-pr-8">
@@ -85,28 +86,19 @@ export const WelcomeMessage: FunctionComponent<{
                 <FeatureRow icon={AtSignIcon}>
                     Type <Kbd macOS="@" linuxAndWindows="@" /> to add context to your chat
                 </FeatureRow>
-                {/* IDE Specificed message - VS Code */}
-                {IDE === CodyIDE.VSCode && (
-                    <FeatureRow icon={TextIcon}>
-                        To add code context from an editor, or the file explorer, right click and use{' '}
-                        <MenuExample>Add to Cody Chat</MenuExample>
-                    </FeatureRow>
-                )}
-                {/* IDE Specificed message - VS Code */}
-                {IDE === CodyIDE.VSCode && (
-                    <FeatureRow icon={NewChatIcon}>
-                        Start a new chat using <Kbd macOS="opt+/" linuxAndWindows="alt+/" /> or the{' '}
-                        <CodyIcon character="H" /> button in the top right of any file
-                    </FeatureRow>
-                )}
-                {/* IDE Specificed message - VS Code */}
-                {IDE === CodyIDE.VSCode && (
-                    <FeatureRow icon={SettingsIcon}>
-                        Customize chat settings with the{' '}
-                        <i className="codicon codicon-settings-gear tw-translate-y-[3px] tw-mx-1" />{' '}
-                        button, or see the <a href="https://sourcegraph.com/docs/cody">documentation</a>
-                    </FeatureRow>
-                )}
+                <FeatureRow icon={TextIcon}>
+                    To add code context from an editor, or the file explorer, right click and use{' '}
+                    <MenuExample>Add to Cody Chat</MenuExample>
+                </FeatureRow>
+                <FeatureRow icon={NewChatIcon}>
+                    Start a new chat using <Kbd macOS="opt+/" linuxAndWindows="alt+/" /> or the{' '}
+                    <CodyIcon character="H" /> button in the top right of any file
+                </FeatureRow>
+                <FeatureRow icon={SettingsIcon}>
+                    Customize chat settings with the{' '}
+                    <i className="codicon codicon-settings-gear tw-translate-y-[3px] tw-mx-1" /> button,
+                    or see the <a href="https://sourcegraph.com/docs/cody">documentation</a>
+                </FeatureRow>
             </div>
         </div>
     )

--- a/vscode/webviews/chat/fixtures.ts
+++ b/vscode/webviews/chat/fixtures.ts
@@ -2,6 +2,7 @@ import { URI } from 'vscode-uri'
 
 import {
     type ChatMessage,
+    CodyIDE,
     ContextItemSource,
     FILE_MENTION_EDITOR_STATE_FIXTURE,
     ps,
@@ -148,4 +149,5 @@ export const FIXTURE_USER_ACCOUNT_INFO: UserAccountInfo = {
         displayName: 'Quinn Slack',
         avatarURL: 'https://avatars.githubusercontent.com/u/1976',
     },
+    ide: CodyIDE.VSCode,
 }

--- a/web/lib/components/CodyWebChat.tsx
+++ b/web/lib/components/CodyWebChat.tsx
@@ -207,7 +207,7 @@ export const CodyWebChat: FC<CodyWebChatProps> = props => {
                                         <Chat
                                             chatID={activeChatID}
                                             chatEnabled={true}
-                                            showWelcomeMessage={true}
+                                            showWelcomeMessage={false}
                                             showIDESnippetActions={false}
                                             userInfo={userAccountInfo}
                                             messageInProgress={messageInProgress}

--- a/web/lib/components/CodyWebChat.tsx
+++ b/web/lib/components/CodyWebChat.tsx
@@ -4,6 +4,7 @@ import { URI } from 'vscode-uri'
 import {
     type ChatMessage,
     type ClientStateForWebview,
+    CodyIDE,
     type ContextItem,
     type ContextItemRepository,
     ContextItemSource,
@@ -100,6 +101,7 @@ export const CodyWebChat: FC<CodyWebChatProps> = props => {
                         isCodyProUser: !message.authStatus.userCanUpgrade,
                         isDotComUser: message.authStatus.isDotCom,
                         user: message.authStatus,
+                        ide: CodyIDE.Web,
                     })
                     break
                 case 'clientAction':

--- a/web/lib/components/CodyWebChat.tsx
+++ b/web/lib/components/CodyWebChat.tsx
@@ -207,7 +207,7 @@ export const CodyWebChat: FC<CodyWebChatProps> = props => {
                                         <Chat
                                             chatID={activeChatID}
                                             chatEnabled={true}
-                                            showWelcomeMessage={false}
+                                            showWelcomeMessage={true}
                                             showIDESnippetActions={false}
                                             userInfo={userAccountInfo}
                                             messageInProgress={messageInProgress}


### PR DESCRIPTION
CLOSE: https://linear.app/sourcegraph/issue/CODY-2291/port-chat-ux-vscode-isms-to-jetbrains

This change adds the IDE information (VSCode or other) to the user account info object. This allows the WelcomeMessage component to conditionally render certain features based on the IDE being used. This is because most of the current welcome messages (`New Chat` and `Config`) only applies to VS Code and not other clients:

![Screenshot 2024-07-05 at 12 05 04 PM](https://github.com/sourcegraph/cody/assets/68532117/719c742d-1619-4b97-a623-db9605e5a6ef)

The changes include:
- Adding the `ide` property to the `UserAccountInfo` interface in `Chat.tsx`
- Passing the `ide` value from the App component to the Chat component
- Updating the `WelcomeMessage` component to conditionally render the "Start a new chat" feature based on the IDE


## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

Verify the following:
- The New Chat and Settings items in the welcome message should display on VS Code

![image](https://github.com/sourcegraph/cody/assets/68532117/797b9f26-7af5-42c5-b6a5-469e58b572e7)

- The New Chat and Settings items in the welcome message should not show up in other clients (e.g. JetBrains, web)
  - Tested with Cody Web demo:
  
![image](https://github.com/sourcegraph/cody/assets/68532117/66487527-5b4b-40cf-a631-70e968acbcf3)


