### PR TITLE
E2E: ensure input boxes are visible before filling in auth

### DIFF
--- a/vscode/test/e2e/chat-history.test.ts
+++ b/vscode/test/e2e/chat-history.test.ts
@@ -26,6 +26,9 @@ test.extend<ExpectedV2Events>({
 
     const [chatPanelFrame, chatInput] = await createEmptyChatPanel(page)
 
+    // Ensure the chat view is ready before we start typing
+    await expect(chatPanelFrame.getByText('to add context to your chat')).toBeVisible()
+
     await chatInput.fill('Hey')
     await chatInput.press('Enter')
 

--- a/vscode/test/e2e/common.ts
+++ b/vscode/test/e2e/common.ts
@@ -15,8 +15,11 @@ export const sidebarSignin = async (
     await focusSidebar(page)
     await sidebar.getByRole('button', { name: 'Sign In to Your Enterprise Instance' }).click()
     await page.getByRole('option', { name: 'Sign In with URL and Access Token' }).click()
+    // Ensure the correct input box has showed up before we start filling in the forms.
+    await expect(page.getByText('Enter the URL of the')).toBeVisible()
     await page.getByRole('combobox', { name: 'input' }).fill(SERVER_URL)
     await page.getByRole('combobox', { name: 'input' }).press('Enter')
+    await expect(page.getByText('Paste your access token')).toBeVisible()
     await page.getByRole('combobox', { name: 'input' }).fill(VALID_TOKEN)
     await page.getByRole('combobox', { name: 'input' }).press('Enter')
 


### PR DESCRIPTION
- Adds checks to ensure the correct input boxes are visible before filling in the URL and access token fields during the sign-in flow

This attempted some of the failing E2E tests on main where the filling step is performed before the input box has shown up based on the recordings we got from the failed tests.

Example captured from recordings:

1. After we have input the URL:

![image](https://github.com/sourcegraph/cody/assets/68532117/d990fdfc-e9b1-4ef6-820a-7e5e1735eb56)

2. We did not enter the token (because the token step was performed before the input box is ready):

![image](https://github.com/sourcegraph/cody/assets/68532117/12c883d3-15b4-4ad7-9f27-b975a6c2e4ba)

3. This means we weren't able to login for the test:

![image](https://github.com/sourcegraph/cody/assets/68532117/c1af1318-9b88-469c-96bb-fb0320e1259c)

Example 2:

![image](https://github.com/sourcegraph/cody/assets/68532117/70160129-9019-4544-983b-5faf1e3caeac)

![image](https://github.com/sourcegraph/cody/assets/68532117/61068de1-6adf-4487-b2bc-b8f352ce110d)


## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

Green CI.