### PR TITLE
Webview: adjust LoadingPage layout to fill the full viewport height

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -14,6 +14,7 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 
 - Edit: Fixed an issue where, when unable to detect the indentation of a file, Cody would remove all indentation from a response. [pull/4704](https://github.com/sourcegraph/cody/pull/4704)
 - Edit: Fixed an issue where Cody would sometimes remove unintended parts of the code when an edit was accepted on save. [pull/4720](https://github.com/sourcegraph/cody/pull/4720)
+- Chat: The loading dots in the loading page are now centered correctly. [pull/4808](https://github.com/sourcegraph/cody/pull/4808)
 
 ### Changed
 

--- a/vscode/webviews/LoadingPage.module.css
+++ b/vscode/webviews/LoadingPage.module.css
@@ -2,7 +2,7 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    height: 100%;
+    height: 100vh;
 }
 
 .dots-holder {

--- a/vscode/webviews/LoadingPage.tsx
+++ b/vscode/webviews/LoadingPage.tsx
@@ -1,10 +1,8 @@
 import styles from './LoadingPage.module.css'
 
 export const LoadingPage: React.FunctionComponent = () => (
-    <div className="outer-container">
-        <div className={styles.container}>
-            <LoadingDots />
-        </div>
+    <div className={styles.container}>
+        <LoadingDots />
     </div>
 )
 


### PR DESCRIPTION
Minor UI fix: adjust LoadingPage layout to use the full viewport height.

## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

### Before

![Screenshot 2024-07-08 at 11 02 13 AM](https://github.com/sourcegraph/cody/assets/68532117/941c502e-3ec6-4af5-a613-33d22363fc75)

### After

![Screenshot 2024-07-08 at 11 01 43 AM](https://github.com/sourcegraph/cody/assets/68532117/f9822507-e51b-4357-8e19-daddd7607127)
