### PR TITLE
Cody Web: fix cody web remote files link uri

### DIFF
--- a/vscode/src/editor/utils/editor-context.ts
+++ b/vscode/src/editor/utils/editor-context.ts
@@ -426,12 +426,11 @@ async function resolveFileOrSymbolContextItem(
         if (!isErrorLike(resultOrError)) {
             return {
                 ...contextItem,
-                uri: URI.from({
-                    scheme: '',
-                    authority: '',
-                    path: `${repository}${path}`,
-                }),
+                title: path,
+                uri: URI.parse(`${graphqlClient.endpoint}${repository}/-/blob/${path}`),
                 content: resultOrError,
+                repoName: repository,
+                source: ContextItemSource.Unified,
                 size: contextItem.size ?? TokenCounter.countTokens(resultOrError),
             }
         }

--- a/web/CHANGELOG.md
+++ b/web/CHANGELOG.md
@@ -1,4 +1,8 @@
 
+## 0.2.1 
+
+- Fixes remote files and remote symbols files link
+
 ## 0.2.0
 
 Initial release includes

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cody-web-experimental",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Cody standalone web app",
   "license": "Apache-2.0",
   "repository": {

--- a/web/package.json
+++ b/web/package.json
@@ -1,5 +1,4 @@
 {
-  "private": true,
   "name": "cody-web-experimental",
   "version": "0.2.0",
   "description": "Cody standalone web app",


### PR DESCRIPTION
Fixes https://linear.app/sourcegraph/issue/SRCH-633/links-in-the-prompt-has-incorrect-url-in-cody-web

This affects only cody web package and has no impact on other clients

## Test plan
- Start a new chat and include files and remote repositories via mentions
- Check that links in the Context list have proper URL

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
