### PR TITLE
Logging around openUntitledDocument for #4581

### DIFF
--- a/agent/src/TestClient.ts
+++ b/agent/src/TestClient.ts
@@ -6,7 +6,7 @@ import { createPatch } from 'diff'
 import { execSync, spawn } from 'node:child_process'
 import fspromises from 'node:fs/promises'
 import path from 'node:path'
-import { type ContextItem, type SerializedChatMessage, logError } from '@sourcegraph/cody-shared'
+import { type ContextItem, type SerializedChatMessage, logDebug, logError } from '@sourcegraph/cody-shared'
 import dedent from 'dedent'
 import { applyPatch } from 'fast-myers-diff'
 import * as vscode from 'vscode'
@@ -339,6 +339,9 @@ export class TestClient extends MessageHandler {
             return result
         })
         this.registerRequest('textDocument/openUntitledDocument', params => {
+            logDebug('#4581: textDocument/openUntitledDocument', JSON.stringify({
+                params,
+            }))
             this.workspace.loadDocument(ProtocolTextDocumentWithUri.fromDocument(params))
             this.notify('textDocument/didOpen', params)
             return Promise.resolve(true)

--- a/agent/src/vscode-shim.ts
+++ b/agent/src/vscode-shim.ts
@@ -494,6 +494,12 @@ function toUri(
 }
 
 async function openUntitledDocument(uri: Uri, content?: string, language?: string) {
+    logDebug('#4581: openUntitledDocument called: ', JSON.stringify({
+        uri: uri.toString(),
+        content,
+        language,
+    }))
+    
     if (clientInfo?.capabilities?.untitledDocuments !== 'enabled') {
         const errorMessage =
             'Client does not support untitled documents. To fix this problem, set `untitledDocuments: "enabled"` in client capabilities'


### PR DESCRIPTION
Trying to get better info around [this bug](https://github.com/sourcegraph/cody/issues/4581)

## Test plan
- Ran extension locally