### PR TITLE
Chat UI: update loading dots color to adapt to theme

### DIFF
--- a/vscode/webviews/chat/components/LoadingDots.module.css
+++ b/vscode/webviews/chat/components/LoadingDots.module.css
@@ -10,7 +10,7 @@
     width: 0.25rem !important;
     height: 0.25rem !important;
     border-radius: 100%;
-    background-color: #fff;
+    background-color: var(--vscode-input-foreground);
     opacity: 0.25;
 }
 


### PR DESCRIPTION
CLOSE https://linear.app/sourcegraph/issue/CODY-2792/busy-dots-arent-themed-correctly

- replace hard-coded background-color for LoadingDots
- use input foreground color for loading dots

## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

Start Cody from this branch in debug mode to confirm the loading dots when waiting for Cody's reply are updated when you change editor theme

![image](https://github.com/sourcegraph/cody/assets/68532117/e48ce7cf-f70a-43d3-84a9-58cd2681a965)
