### PR TITLE
Autocomplete: add char count to `yield` span events

### DIFF
--- a/vscode/src/completions/client.ts
+++ b/vscode/src/completions/client.ts
@@ -177,9 +177,12 @@ export function createClient(
                                     completion: parsed.completion || '',
                                     stopReason: parsed.stopReason || CompletionStopReason.StreamingChunk,
                                 }
+
                                 span.addEvent('yield', {
+                                    charCount: result.completionResponse.completion.length,
                                     stopReason: result.completionResponse.stopReason,
                                 })
+
                                 yield result
                             }
 
@@ -234,6 +237,7 @@ export function createClient(
                 } finally {
                     if (result.completionResponse) {
                         span.addEvent('return', {
+                            charCount: result.completionResponse.completion.length,
                             stopReason: result.completionResponse.stopReason,
                         })
                         span.setStatus({ code: SpanStatusCode.OK })

--- a/vscode/src/completions/providers/fireworks.ts
+++ b/vscode/src/completions/providers/fireworks.ts
@@ -621,7 +621,11 @@ class FireworksProvider extends Provider {
                                 (lastResponseField('stopReason') || CompletionStopReason.StreamingChunk),
                         }
 
-                        span.addEvent('yield', { stopReason: result.completionResponse.stopReason })
+                        span.addEvent('yield', {
+                            charCount: result.completionResponse.completion.length,
+                            stopReason: result.completionResponse.stopReason,
+                        })
+
                         yield result
 
                         chunkIndex += 1
@@ -656,7 +660,10 @@ class FireworksProvider extends Provider {
                     throw new TracedError(message, traceId)
                 } finally {
                     if (result.completionResponse) {
-                        span.addEvent('return', { stopReason: result.completionResponse.stopReason })
+                        span.addEvent('return', {
+                            charCount: result.completionResponse.completion.length,
+                            stopReason: result.completionResponse.stopReason,
+                        })
                         span.setStatus({ code: SpanStatusCode.OK })
                         span.end()
                         log?.onComplete(result.completionResponse)


### PR DESCRIPTION
Adds `charCount` to `yield` span events. This would allow us to compare the number of characters received on the client to the number of characters sampled on the Cody Gateway side.

## Test plan

CI
