### PR TITLE
Cody Web: fix cody web context ignore and file resolution

### DIFF
--- a/lib/shared/src/codebase-context/messages.ts
+++ b/lib/shared/src/codebase-context/messages.ts
@@ -158,6 +158,12 @@ export interface ContextItemOpenCtx extends ContextItemCommon {
  */
 export interface ContextItemFile extends ContextItemCommon {
     type: 'file'
+
+    /**
+     * Name of remote repository, this is how mention resolve logic checks
+     * that we need to resolve this context item mention via remote search file
+     */
+    remoteRepositoryName?: string
 }
 
 /**
@@ -171,6 +177,12 @@ export interface ContextItemSymbol extends ContextItemCommon {
 
     /** The kind of symbol, used for presentation only (not semantically meaningful). */
     kind: SymbolKind
+
+    /**
+     * Name of remote repository, this is how mention resolve logic checks
+     * that we need to resolve this context item mention via remote search file
+     */
+    remoteRepositoryName?: string
 }
 
 /** The valid kinds of a symbol. */

--- a/lib/shared/src/common/uri.ts
+++ b/lib/shared/src/common/uri.ts
@@ -1,42 +1,13 @@
-import { URI } from 'vscode-uri'
+import type { URI } from 'vscode-uri'
 
 import { pathFunctionsForURI } from './path'
 
 export const SUPPORTED_URI_SCHEMAS = new Set([
     'file',
     'untitled',
-    'remote-file',
     'vscode-notebook',
     'vscode-notebook-cell',
 ])
-
-/**
- * Custom/synthetic URI for remote files, primary used for
- * resolving remote files for any web clients
- */
-export function createRemoteFileURI(repository: string, path: string): URI {
-    return URI.from({
-        scheme: 'remote-file',
-        authority: repository,
-        path: path.startsWith('/') ? path : `/${path}`,
-    })
-}
-
-export function isRemoteFileURI(uri: URI) {
-    return uri.scheme === 'remote-file'
-}
-
-interface ParsedRemoteFileData {
-    repository: string
-    path: string
-}
-
-export function parseRemoteFileURI(uri: URI): ParsedRemoteFileData {
-    return {
-        path: uri.path,
-        repository: uri.authority,
-    }
-}
 
 /**
  * dirname, but operates on a {@link URI}.

--- a/lib/shared/src/index.ts
+++ b/lib/shared/src/index.ts
@@ -115,9 +115,6 @@ export {
     uriExtname,
     uriParseNameAndExtension,
     SUPPORTED_URI_SCHEMAS,
-    createRemoteFileURI,
-    isRemoteFileURI,
-    parseRemoteFileURI,
     type FileURI,
 } from './common/uri'
 export { NoopEditor } from './editor'

--- a/vscode/src/editor/utils/editor-context.ts
+++ b/vscode/src/editor/utils/editor-context.ts
@@ -14,17 +14,14 @@ import {
     type SymbolKind,
     TokenCounter,
     contextFiltersProvider,
-    createRemoteFileURI,
     displayPath,
     graphqlClient,
     isCodyIgnoredFile,
     isDefined,
     isErrorLike,
-    isRemoteFileURI,
     isWindows,
     logError,
     openCtx,
-    parseRemoteFileURI,
     toRangeData,
 } from '@sourcegraph/cody-shared'
 
@@ -83,7 +80,9 @@ export async function getFileContextFiles(
             type: 'file',
             size: item.file.byteSize,
             source: ContextItemSource.User,
-            uri: createRemoteFileURI(item.repository.name, item.file.path),
+            remoteRepositoryName: item.repository.name,
+            isIgnored: contextFiltersProvider.isRepoNameIgnored(item.repository.name),
+            uri: URI.file(item.repository.name + item.file.path),
         }))
     }
 
@@ -174,7 +173,9 @@ export async function getSymbolContextFiles(
         return symbolsOrError.flatMap<ContextItemSymbol>(item =>
             item.symbols.map(symbol => ({
                 type: 'symbol',
-                uri: createRemoteFileURI(item.repository.name, symbol.location.resource.path),
+                remoteRepositoryName: item.repository.name,
+                uri: URI.file(item.repository.name + symbol.location.resource.path),
+                isIgnored: contextFiltersProvider.isRepoNameIgnored(item.repository.name),
                 source: ContextItemSource.User,
                 symbolName: symbol.name,
                 // TODO [VK] Support other symbols kind
@@ -417,8 +418,10 @@ async function resolveFileOrSymbolContextItem(
     contextItem: ContextItemFile | ContextItemSymbol,
     editor: Editor
 ): Promise<ContextItemWithContent> {
-    if (isRemoteFileURI(contextItem.uri)) {
-        const { repository, path } = parseRemoteFileURI(contextItem.uri)
+    if (contextItem.remoteRepositoryName) {
+        // Get only actual file path without repository name
+        const repository = contextItem.remoteRepositoryName
+        const path = contextItem.uri.path.slice(repository.length + 1, contextItem.uri.path.length)
 
         // TODO [VK]: Support ranges for symbol context items
         const resultOrError = await graphqlClient.getFileContent(repository, path)

--- a/web/CHANGELOG.md
+++ b/web/CHANGELOG.md
@@ -1,4 +1,9 @@
 
+## 0.2.2
+- Fixes remote repository context as you switch between chats
+- Adds support for context ignore for remote repositories files
+- Fixes link rendering in the mention menu/suggestion panel
+
 ## 0.2.1 
 
 - Fixes remote files and remote symbols files link

--- a/web/lib/components/CodyWebChat.tsx
+++ b/web/lib/components/CodyWebChat.tsx
@@ -10,7 +10,6 @@ import {
     ContextItemSource,
     type Model,
     PromptString,
-    createRemoteFileURI,
     isErrorLike,
     setDisplayPathEnvInfo,
 } from '@sourcegraph/cody-shared'
@@ -179,7 +178,8 @@ export const CodyWebChat: FC<CodyWebChatProps> = props => {
             mentions.push({
                 type: 'file',
                 isIgnored: false,
-                uri: createRemoteFileURI(repositories[0].name, fileURL),
+                remoteRepositoryName: repositories[0].name,
+                uri: URI.file(repositories[0].name + fileURL),
                 source: ContextItemSource.Initial,
             })
         }

--- a/web/lib/components/CodyWebChatProvider.tsx
+++ b/web/lib/components/CodyWebChatProvider.tsx
@@ -227,6 +227,13 @@ export const CodyWebChatProvider: FC<PropsWithChildren<CodyWebChatProviderProps>
             setActiveWebviewPanelID(panelId)
             setLastActiveChatID(chatId)
 
+            await agent.rpc.sendRequest('webview/receiveMessage', {
+                id: activeWebviewPanelIDRef.current,
+                message: { chatID: chatId, command: 'restoreHistory' },
+            })
+
+            // Set initial context after we restore history so context won't be
+            // overridden by the previous chat session context
             if (initialContext?.repositories.length) {
                 await agent.rpc.sendRequest('webview/receiveMessage', {
                     id: activeWebviewPanelIDRef.current,
@@ -236,11 +243,6 @@ export const CodyWebChatProvider: FC<PropsWithChildren<CodyWebChatProviderProps>
                     },
                 })
             }
-
-            await agent.rpc.sendRequest('webview/receiveMessage', {
-                id: activeWebviewPanelIDRef.current,
-                message: { chatID: chatId, command: 'restoreHistory' },
-            })
 
             if (onNewChatCreated) {
                 onNewChatCreated(chatId)

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cody-web-experimental",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Cody standalone web app",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
Fixes https://linear.app/sourcegraph/issue/CODY-2769/files-in-excluded-repos-can-still-be-mentioned-in-standalone-chat

Prior to this PR remote file resolution which is used in Cody Web didn't respect cody context filters excluding repository checks, this PR adds this

Also, before we relied on special URIs to distinguish between remote and local files, it compromised URI rendering since those special URIs had ugly "remote-file" prefixes. Now the context item has a remoteRepositoryName field, which doesn't require work with a special URI anymore.

These PR changes don't affect the VSCode extension or any other clients. The logic in the VSCode extension that has been changed by this PR is used only by Cody Web, so it is safe to merge without comprehensive testing in all other clients.

## Test plan
- Manual testing (go to demo and try to mention remote files
- CI checks around VSCode extension

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
