### PR TITLE
Autocomplete: fix hot-streak cache keys for long documents

### DIFF
--- a/lib/shared/src/completions/types.ts
+++ b/lib/shared/src/completions/types.ts
@@ -31,6 +31,11 @@ export interface DocumentContext extends DocumentDependentContext, LinesContext 
      */
     injectedCompletionText?: string
     positionWithoutInjectedCompletionText?: vscode.Position
+    /**
+     * Required to manipulate the document context after it was created.
+     */
+    maxPrefixLength: number
+    maxSuffixLength: number
 }
 
 export interface DocumentDependentContext {

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -9,6 +9,7 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 - Ollama: Added support for running Cody offline with local Ollama models. [pull/4691](https://github.com/sourcegraph/cody/pull/4691)
 - Edit: Added support for users' to edit the applied edit before the diff view is removed. [pull/4684](https://github.com/sourcegraph/cody/pull/4684)
 - Autocomplete: Added experimental support for Gemini 1.5 Flash as the autocomplete model. To enable this experimental feature, update the `autocomplete.advanced.provider` configuration setting to `unstable-gemini`. Prerequisite: Your Sourcegraph instance (v5.5.0+) must first be configured to use Gemini 1.5 Flash as the autocomplete model. [pull/4743](https://github.com/sourcegraph/cody/pull/4743)
+- Autocomplete: Fixed hot-streak cache keys for long documents. [pull/4817](https://github.com/sourcegraph/cody/pull/4817)
 
 ### Fixed
 

--- a/vscode/src/completions/get-current-doc-context.test.ts
+++ b/vscode/src/completions/get-current-doc-context.test.ts
@@ -41,6 +41,8 @@ describe('getCurrentDocContext', () => {
                 line: 0,
             },
             injectedPrefix: null,
+            maxPrefixLength: 100,
+            maxSuffixLength: 100,
             position: { character: 2, line: 1 },
         })
     })
@@ -61,6 +63,8 @@ describe('getCurrentDocContext', () => {
                 line: 1,
             },
             injectedPrefix: null,
+            maxPrefixLength: 100,
+            maxSuffixLength: 100,
             position: { character: 2, line: 2 },
         })
     })
@@ -81,6 +85,8 @@ describe('getCurrentDocContext', () => {
                 line: 0,
             },
             injectedPrefix: null,
+            maxPrefixLength: 100,
+            maxSuffixLength: 100,
             position: { character: 13, line: 0 },
         })
     })
@@ -101,6 +107,8 @@ describe('getCurrentDocContext', () => {
                 line: 1,
             },
             injectedPrefix: null,
+            maxPrefixLength: 100,
+            maxSuffixLength: 100,
             position: { character: 13, line: 1 },
         })
     })
@@ -129,6 +137,8 @@ describe('getCurrentDocContext', () => {
             multilineTrigger: null,
             multilineTriggerPosition: null,
             injectedPrefix: 'ssert',
+            maxPrefixLength: 100,
+            maxSuffixLength: 100,
             position: { character: 9, line: 0 },
         })
     })
@@ -158,6 +168,8 @@ describe('getCurrentDocContext', () => {
             multilineTrigger: null,
             multilineTriggerPosition: null,
             injectedPrefix: 'log',
+            maxPrefixLength: 100,
+            maxSuffixLength: 100,
             position: { character: 8, line: 1 },
         })
     })
@@ -186,6 +198,8 @@ describe('getCurrentDocContext', () => {
             multilineTrigger: null,
             multilineTriggerPosition: null,
             injectedPrefix: null,
+            maxPrefixLength: 100,
+            maxSuffixLength: 100,
             position: { character: 7, line: 0 },
         })
     })
@@ -393,6 +407,8 @@ describe('insertCompletionIntoDocContext', () => {
             multilineTrigger: null,
             multilineTriggerPosition: null,
             injectedPrefix: null,
+            maxPrefixLength: 140,
+            maxSuffixLength: 60,
             position: { character: 24, line: 2 },
             positionWithoutInjectedCompletionText: docContext.position,
         })
@@ -433,6 +449,8 @@ describe('insertCompletionIntoDocContext', () => {
             multilineTrigger: null,
             multilineTriggerPosition: null,
             injectedPrefix: null,
+            maxPrefixLength: 140,
+            maxSuffixLength: 60,
             // Note: The position is always moved at the end of the line that the text was inserted
             position: { character: "    console.log('hello', 'world')".length, line: 1 },
             positionWithoutInjectedCompletionText: docContext.position,
@@ -478,6 +496,8 @@ describe('insertCompletionIntoDocContext', () => {
             multilineTrigger: null,
             multilineTriggerPosition: null,
             injectedPrefix: null,
+            maxPrefixLength: 140,
+            maxSuffixLength: 60,
             // Note: The position is always moved at the end of the line that the text was inserted
             position: { character: '    }, 2)'.length, line: 4 },
             positionWithoutInjectedCompletionText: docContext.position,

--- a/vscode/src/completions/get-current-doc-context.ts
+++ b/vscode/src/completions/get-current-doc-context.ts
@@ -63,8 +63,7 @@ export function getCurrentDocContext(params: GetCurrentDocContextParams): Docume
 
     const prefixLines = lines(completePrefixWithContextCompletion)
     const suffixLines = lines(completeSuffix)
-
-    const prefix = getPrefix(offset, maxPrefixLength, prefixLines)
+    const prefix = getPrefix({ offset, maxPrefixLength, prefixLines })
 
     let totalSuffix = 0
     let endLine = 0
@@ -90,7 +89,15 @@ export function getCurrentDocContext(params: GetCurrentDocContextParams): Docume
     })
 }
 
-function getPrefix(offset: number, maxPrefixLength: number, prefixLines: string[]): string {
+interface GetPrefixParams {
+    offset: number
+    maxPrefixLength: number
+    prefixLines: string[]
+}
+
+function getPrefix(params: GetPrefixParams): string {
+    const { offset, maxPrefixLength, prefixLines } = params
+
     let prefix: string
     if (offset > maxPrefixLength) {
         let total = 0
@@ -183,11 +190,11 @@ export function insertIntoDocContext(params: InsertIntoDocContextParams): Docume
     })
 
     const updatedDocumentText = prefix + insertText
-    const updatedPrefix = getPrefix(
-        updatedDocumentText.length,
+    const updatedPrefix = getPrefix({
+        offset: updatedDocumentText.length,
         maxPrefixLength,
-        lines(updatedDocumentText)
-    )
+        prefixLines: lines(updatedDocumentText),
+    })
 
     const updatedDocContext = getDerivedDocContext({
         maxPrefixLength,

--- a/vscode/src/completions/get-current-doc-context.ts
+++ b/vscode/src/completions/get-current-doc-context.ts
@@ -64,6 +64,33 @@ export function getCurrentDocContext(params: GetCurrentDocContextParams): Docume
     const prefixLines = lines(completePrefixWithContextCompletion)
     const suffixLines = lines(completeSuffix)
 
+    const prefix = getPrefix(offset, maxPrefixLength, prefixLines)
+
+    let totalSuffix = 0
+    let endLine = 0
+    for (let i = 0; i < suffixLines.length; i++) {
+        if (totalSuffix + suffixLines[i].length > maxSuffixLength) {
+            break
+        }
+        endLine = i + 1
+        totalSuffix += suffixLines[i].length
+    }
+    const suffix = suffixLines.slice(0, endLine).join('\n')
+
+    return getDerivedDocContext({
+        maxPrefixLength,
+        maxSuffixLength,
+        position,
+        languageId: document.languageId,
+        documentDependentContext: {
+            prefix,
+            suffix,
+            injectedPrefix,
+        },
+    })
+}
+
+function getPrefix(offset: number, maxPrefixLength: number, prefixLines: string[]): string {
     let prefix: string
     if (offset > maxPrefixLength) {
         let total = 0
@@ -80,32 +107,15 @@ export function getCurrentDocContext(params: GetCurrentDocContextParams): Docume
         prefix = prefixLines.join('\n')
     }
 
-    let totalSuffix = 0
-    let endLine = 0
-    for (let i = 0; i < suffixLines.length; i++) {
-        if (totalSuffix + suffixLines[i].length > maxSuffixLength) {
-            break
-        }
-        endLine = i + 1
-        totalSuffix += suffixLines[i].length
-    }
-    const suffix = suffixLines.slice(0, endLine).join('\n')
-
-    return getDerivedDocContext({
-        position,
-        languageId: document.languageId,
-        documentDependentContext: {
-            prefix,
-            suffix,
-            injectedPrefix,
-        },
-    })
+    return prefix
 }
 
 interface GetDerivedDocContextParams {
     languageId: string
     position: vscode.Position
     documentDependentContext: DocumentDependentContext
+    maxPrefixLength: number
+    maxSuffixLength: number
 }
 
 /**
@@ -113,7 +123,7 @@ interface GetDerivedDocContextParams {
  * Used if the document context needs to be calculated for the updated text but there's no `document` instance for that.
  */
 function getDerivedDocContext(params: GetDerivedDocContextParams): DocumentContext {
-    const { position, documentDependentContext, languageId } = params
+    const { position, documentDependentContext, languageId, maxPrefixLength, maxSuffixLength } = params
     const linesContext = getLinesContext(documentDependentContext)
 
     const { multilineTrigger, multilineTriggerPosition } = detectMultiline({
@@ -130,6 +140,8 @@ function getDerivedDocContext(params: GetDerivedDocContextParams): DocumentConte
     return {
         ...documentDependentContext,
         ...linesContext,
+        maxPrefixLength,
+        maxSuffixLength,
         position,
         multilineTrigger,
         multilineTriggerPosition,
@@ -160,7 +172,7 @@ export function insertIntoDocContext(params: InsertIntoDocContextParams): Docume
         insertText,
         languageId,
         docContext,
-        docContext: { position, prefix, suffix, currentLineSuffix },
+        docContext: { position, prefix, suffix, currentLineSuffix, maxPrefixLength, maxSuffixLength },
     } = params
 
     const updatedPosition = getPositionAfterTextInsertion(position, insertText)
@@ -170,11 +182,20 @@ export function insertIntoDocContext(params: InsertIntoDocContextParams): Docume
         text: insertText,
     })
 
+    const updatedDocumentText = prefix + insertText
+    const updatedPrefix = getPrefix(
+        updatedDocumentText.length,
+        maxPrefixLength,
+        lines(updatedDocumentText)
+    )
+
     const updatedDocContext = getDerivedDocContext({
+        maxPrefixLength,
+        maxSuffixLength,
         languageId,
         position: updatedPosition,
         documentDependentContext: {
-            prefix: prefix + insertText,
+            prefix: updatedPrefix,
             // Remove the characters that are being replaced by the completion
             // to reduce the chances of breaking the parse tree with redundant symbols.
             suffix: suffix.slice(getMatchingSuffixLength(insertText, currentLineSuffix)),

--- a/vscode/src/completions/get-inline-completions-tests/helpers.ts
+++ b/vscode/src/completions/get-inline-completions-tests/helpers.ts
@@ -163,8 +163,8 @@ export function params(
     const docContext = getCurrentDocContext({
         document,
         position,
-        maxPrefixLength: 1000,
-        maxSuffixLength: 1000,
+        maxPrefixLength: providerConfig.contextSizeHints.prefixChars,
+        maxSuffixLength: providerConfig.contextSizeHints.suffixChars,
         context: takeSuggestWidgetSelectionIntoAccount
             ? {
                   triggerKind: 0,

--- a/vscode/src/completions/get-inline-completions-tests/hot-streak.test.ts
+++ b/vscode/src/completions/get-inline-completions-tests/hot-streak.test.ts
@@ -25,8 +25,12 @@ describe('[getInlineCompletions] hot streak', () => {
 
     describe('static multiline', () => {
         it('caches hot streaks completions that are streamed in', async () => {
+            const thousandConsoleLogLines = 'console.log(1)\n'.repeat(1000)
+
             let request = await getInlineCompletionsWithInlinedChunks(
-                `function myFunction() {
+                `const a = 10_000
+                ${thousandConsoleLogLines}
+                function myFunction() {
                     console.log(1)
                     █console.log(2)
                     █console.log(3)
@@ -34,7 +38,10 @@ describe('[getInlineCompletions] hot streak', () => {
                     █
                 }`,
                 {
-                    configuration: { autocompleteExperimentalHotStreak: true },
+                    configuration: {
+                        autocompleteExperimentalHotStreak: true,
+                        autocompleteAdvancedProvider: 'fireworks',
+                    },
                     delayBetweenChunks: 50,
                 }
             )

--- a/vscode/src/completions/get-inline-completions-tests/hot-streak.test.ts
+++ b/vscode/src/completions/get-inline-completions-tests/hot-streak.test.ts
@@ -28,7 +28,7 @@ describe('[getInlineCompletions] hot streak', () => {
             const thousandConsoleLogLines = 'console.log(1)\n'.repeat(1000)
 
             let request = await getInlineCompletionsWithInlinedChunks(
-                `const a = 10_000
+                `const shouldNotBeInTheDocumentPrefix = 10_000
                 ${thousandConsoleLogLines}
                 function myFunction() {
                     console.log(1)
@@ -45,6 +45,10 @@ describe('[getInlineCompletions] hot streak', () => {
                     delayBetweenChunks: 50,
                 }
             )
+
+            // Use long document text that is much longer than `contextHits.maxPrefixLength`
+            // to test the hot streak behavior in long documents.
+            expect(request.docContext.prefix.includes('shouldNotBeInTheDocumentPrefix')).toBeFalsy()
 
             await vi.runAllTimersAsync()
             // Wait for hot streak completions be yielded and cached.

--- a/vscode/src/completions/inline-completion-item-provider-config-singleton.ts
+++ b/vscode/src/completions/inline-completion-item-provider-config-singleton.ts
@@ -24,7 +24,7 @@ export interface CodyCompletionItemProviderConfig {
     completeSuggestWidgetSelection?: boolean
 
     // Flag to check if the current request is also triggered for multiple providers.
-    // When true it means the inlineCompletion are triggerd for multiple model for comparison purpose.
+    // When true it means the inlineCompletion are triggered for multiple model for comparison purpose.
     // Check `createInlineCompletionItemFromMultipleProviders` method in create-inline-completion-item-provider for more detail.
     noInlineAccept?: boolean
 }

--- a/vscode/src/completions/inline-completion-item-provider.test.ts
+++ b/vscode/src/completions/inline-completion-item-provider.test.ts
@@ -187,6 +187,8 @@ describe('InlineCompletionItemProvider', () => {
               "currentLinePrefix": "const foo = ",
               "currentLineSuffix": "",
               "injectedPrefix": null,
+              "maxPrefixLength": 4300,
+              "maxSuffixLength": 716,
               "multilineTrigger": null,
               "multilineTriggerPosition": null,
               "nextNonEmptyLine": "console.log(1)",

--- a/vscode/src/completions/text-processing/utils.ts
+++ b/vscode/src/completions/text-processing/utils.ts
@@ -369,19 +369,24 @@ export function getNextNonEmptyLine(suffix: string): string {
     )
 }
 
-export function getPrevNonEmptyLine(prefix: string): string {
+export function getPrevNonEmptyLineIndex(prefix: string): number | null {
     const prevLf = prefix.lastIndexOf('\n')
     const prevCrLf = prefix.lastIndexOf('\r\n')
     // There is no prev line
     if (prevLf === -1 && prevCrLf === -1) {
+        return null
+    }
+
+    return prevCrLf >= 0 ? prevCrLf : prevLf
+}
+
+export function getPrevNonEmptyLine(prefix: string): string {
+    const prevNonEmptyLineIndex = getPrevNonEmptyLineIndex(prefix)
+    if (prevNonEmptyLineIndex === null) {
         return ''
     }
-    return (
-        findLast(
-            lines(prefix.slice(0, prevCrLf >= 0 ? prevCrLf : prevLf)),
-            line => line.trim().length > 0
-        ) ?? ''
-    )
+
+    return findLast(lines(prefix.slice(0, prevNonEmptyLineIndex)), line => line.trim().length > 0) ?? ''
 }
 
 export function lines(text: string): string[] {


### PR DESCRIPTION
- We do not account for long documents that hit the document context prefix limit. That causes request manager cache keys to be incorrect for preloaded hot-streak completions. This PR fixes this issue by taking into account `maxPrefixLength`.
- Closes https://linear.app/sourcegraph/issue/CODY-2815/[autocomplete-latency]-fix-cache-keys-for-hot-streak-completions-in

## Test plan

1. Updated unit tests
2. Verified manually in `src/completions/inline-completion-item-provider.ts` by removing code before the `logDebug` in the `logIgnored` function and generating a completion. The first completion should be an if statement and right after it should be the preloaded hot streak completion where we assigned the value to `lasIgnoredUriLogged`. Hot Streak should be enabled: `"cody.autocomplete.experimental.hotStreak": true,`.
