### PR TITLE
Autocomplete: an extra abort call for API request

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -10,6 +10,7 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 - Edit: Added support for users' to edit the applied edit before the diff view is removed. [pull/4684](https://github.com/sourcegraph/cody/pull/4684)
 - Autocomplete: Added experimental support for Gemini 1.5 Flash as the autocomplete model. To enable this experimental feature, update the `autocomplete.advanced.provider` configuration setting to `unstable-gemini`. Prerequisite: Your Sourcegraph instance (v5.5.0+) must first be configured to use Gemini 1.5 Flash as the autocomplete model. [pull/4743](https://github.com/sourcegraph/cody/pull/4743)
 - Autocomplete: Fixed hot-streak cache keys for long documents. [pull/4817](https://github.com/sourcegraph/cody/pull/4817)
+- Autocomplete: Added an extra abort call to ensure request cancellation. [pull/4818](https://github.com/sourcegraph/cody/pull/4818)
 
 ### Fixed
 

--- a/vscode/src/completions/providers/fetch-and-process-completions.ts
+++ b/vscode/src/completions/providers/fetch-and-process-completions.ts
@@ -14,6 +14,7 @@ import {
     processCompletion,
 } from '../text-processing/process-inline-completions'
 
+import { trace } from '@opentelemetry/api'
 import { getDynamicMultilineDocContext } from './dynamic-multiline'
 import { type HotStreakExtractor, createHotStreakExtractor } from './hot-streak'
 import type { ProviderOptions } from './provider'
@@ -226,6 +227,13 @@ export async function* fetchAndProcessDynamicMultilineCompletions(
                 })
             }
         }
+    }
+
+    trace.getActiveSpan()?.addEvent('completion_stream_end')
+
+    // An extra abort call to ensure the API request is canceled when we reach this point.
+    if (!abortController.signal.aborted) {
+        abortController.abort()
     }
 
     return undefined


### PR DESCRIPTION
Added an extra abort call to ensure all requests are canceled when we exit the post-processing stage of the completion generation.

## Test plan

CI
