### PR TITLE
Chat: add IDE-specific avatar alt text

### DIFF
--- a/vscode/webviews/chat/cells/messageCell/human/HumanMessageCell.tsx
+++ b/vscode/webviews/chat/cells/messageCell/human/HumanMessageCell.tsx
@@ -71,6 +71,7 @@ export const HumanMessageCell: FunctionComponent<{
                     user={userInfo.user}
                     size={MESSAGE_CELL_AVATAR_SIZE}
                     className="tw-mt-[2px]"
+                    ide={userInfo.ide}
                 />
             }
             content={

--- a/vscode/webviews/components/UserAvatar.module.css
+++ b/vscode/webviews/components/UserAvatar.module.css
@@ -1,10 +1,14 @@
-.user-avatar {
+.user-avatar, .user-avatar-text{
     isolation: isolate;
     display: inline-flex;
     border-radius: 50%;
-    background-color: var(--vscode-inputOption-activeBackground);
-    color: var(--vscode-inputOption-activeForeground);
     align-items: center;
     justify-content: center;
-    height: fit-content;
+    width: 1.5rem;
+    height: 1.5rem;
+}
+
+.user-avatar-text {
+    background-color: var(--vscode-inputOption-activeBackground);
+    color: var(--vscode-inputOption-activeForeground);
 }

--- a/vscode/webviews/components/UserAvatar.story.tsx
+++ b/vscode/webviews/components/UserAvatar.story.tsx
@@ -44,3 +44,12 @@ export const Text2Letters: Story = {
         },
     },
 }
+
+export const InvalidAvatarURL: Story = {
+    args: {
+        user: {
+            username: 'long-username-example',
+            avatarURL: 'https://example.com/invalid-avatar-url.png',
+        },
+    },
+}

--- a/vscode/webviews/components/UserAvatar.tsx
+++ b/vscode/webviews/components/UserAvatar.tsx
@@ -1,3 +1,4 @@
+import { CodyIDE } from '@sourcegraph/cody-shared'
 import { clsx } from 'clsx'
 import type { FunctionComponent } from 'react'
 import type { UserAccountInfo } from '../Chat'
@@ -7,13 +8,15 @@ interface Props {
     user: NonNullable<UserAccountInfo['user']>
     size: number
     className?: string
+    ide?: CodyIDE
 }
 
 /**
  * UserAvatar displays the avatar of a user.
  */
-export const UserAvatar: FunctionComponent<Props> = ({ user, size, className }) => {
+export const UserAvatar: FunctionComponent<Props> = ({ user, size, className, ide }) => {
     const title = user.displayName || user.username
+    const altText = ide === CodyIDE.VSCode ? `Avatar for ${user.username}` : ''
 
     if (user?.avatarURL) {
         let url = user.avatarURL
@@ -36,18 +39,13 @@ export const UserAvatar: FunctionComponent<Props> = ({ user, size, className }) 
                 src={url}
                 role="presentation"
                 title={title}
-                alt={`Avatar for ${user.username}`}
-                width={size}
-                height={size}
+                alt={altText}
             />
         )
     }
+
     return (
-        <div
-            title={title}
-            className={clsx(styles.userAvatar, className)}
-            style={{ width: `${size}px`, height: `${size}px` }}
-        >
+        <div title={title} className={clsx(styles.userAvatarText, className)}>
             <span className={styles.initials}>
                 {getInitials(user?.displayName || user?.username || '')}
             </span>


### PR DESCRIPTION
Add a new story to the UserAvatar component to test the behavior when the avatar URL is invalid.

This helps to validate instances that we see on JB

![image](https://github.com/sourcegraph/cody/assets/68532117/dba973c9-7a0b-4d73-88e3-b95ef0d3f781)


add IDE-specific avatar alt text

- Add `ide` prop to `UserAvatar` component to support IDE-specific alt text
- Update `HumanMessageCell` to pass `userInfo.ide` to `UserAvatar`
- Update `UserAvatar` to render different alt text based on the IDE


## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

Storybook: add story for invalid avatar URL.

Start Storybook (`pnpm run storybook`) to verify the new component is showing up:

![image](https://github.com/sourcegraph/cody/assets/68532117/885bc573-d775-429c-89be-37c690de1d50)

