### PR TITLE
adding deepseek-v2 and deepseek fine-tuned model for A/B test

### DIFF
--- a/lib/shared/src/completions/types.ts
+++ b/lib/shared/src/completions/types.ts
@@ -38,6 +38,10 @@ export interface DocumentContext extends DocumentDependentContext, LinesContext 
     maxSuffixLength: number
 }
 
+export interface GitContext {
+    repoName: string
+}
+
 export interface DocumentDependentContext {
     prefix: string
     suffix: string

--- a/lib/shared/src/experimentation/FeatureFlagProvider.ts
+++ b/lib/shared/src/experimentation/FeatureFlagProvider.ts
@@ -21,6 +21,7 @@ export enum FeatureFlag {
     // Enable various feature flags to experiment with FIM trained fine-tuned models via Fireworks
     CodyAutocompleteFIMModelExperimentBaseFeatureFlag = 'cody-autocomplete-fim-model-experiment-flag',
     CodyAutocompleteFIMModelExperimentControl = 'cody-autocomplete-fim-model-experiment-control',
+    CodyAutocompleteFIMModelExperimentCurrentBest = 'cody-autocomplete-fim-model-experiment-current-best',
     CodyAutocompleteFIMModelExperimentVariant1 = 'cody-autocomplete-fim-model-experiment-variant-1',
     CodyAutocompleteFIMModelExperimentVariant2 = 'cody-autocomplete-fim-model-experiment-variant-2',
     CodyAutocompleteFIMModelExperimentVariant3 = 'cody-autocomplete-fim-model-experiment-variant-3',

--- a/lib/shared/src/prompt/prompt-string.ts
+++ b/lib/shared/src/prompt/prompt-string.ts
@@ -6,7 +6,7 @@ import type { ContextFiltersProvider } from '../cody-ignore/context-filters-prov
 import type { TerminalOutputArguments } from '../commands/types'
 import { markdownCodeBlockLanguageIDForFilename } from '../common/languages'
 import type { RangeData } from '../common/range'
-import type { AutocompleteContextSnippet, DocumentContext } from '../completions/types'
+import type { AutocompleteContextSnippet, DocumentContext, GitContext } from '../completions/types'
 import type { ConfigGetter } from '../configuration'
 import type { ActiveTextEditorDiagnostic } from '../editor'
 import { createGitDiff } from '../editor/create-git-diff'
@@ -339,6 +339,13 @@ export class PromptString {
                 'symbol' in contextSnippet
                     ? internal_createPromptString(contextSnippet.symbol, ref)
                     : undefined,
+        }
+    }
+
+    public static fromAutocompleteGitContext(gitContext: GitContext, uri: vscode.Uri) {
+        const ref = [uri]
+        return {
+            repoName: internal_createPromptString(gitContext.repoName, ref),
         }
     }
 

--- a/vscode/src/completions/get-completion-provider.ts
+++ b/vscode/src/completions/get-completion-provider.ts
@@ -1,4 +1,4 @@
-import type { DocumentContext } from '@sourcegraph/cody-shared'
+import type { DocumentContext, GitContext } from '@sourcegraph/cody-shared'
 
 import { completionProviderConfig } from './completion-provider-config'
 import { type InlineCompletionsParams, TriggerKind } from './get-inline-completions'
@@ -12,6 +12,7 @@ interface GetCompletionProvidersParams
     > {
     docContext: DocumentContext
     completionLogId: CompletionLogID
+    gitContext?: GitContext
 }
 
 export function getCompletionProvider(params: GetCompletionProvidersParams): Provider {
@@ -23,6 +24,7 @@ export function getCompletionProvider(params: GetCompletionProvidersParams): Pro
         docContext,
         firstCompletionTimeout,
         completionLogId,
+        gitContext,
     } = params
 
     const sharedProviderOptions: Omit<ProviderOptions, 'id' | 'n' | 'multiline'> = {
@@ -34,6 +36,7 @@ export function getCompletionProvider(params: GetCompletionProvidersParams): Pro
         // For now the value is static and based on the average multiline completion latency.
         firstCompletionTimeout,
         completionLogId,
+        gitContext,
     }
 
     // Show more if manually triggered (but only showing 1 is faster, so we use it

--- a/vscode/src/completions/get-inline-completions.ts
+++ b/vscode/src/completions/get-inline-completions.ts
@@ -392,6 +392,13 @@ async function doGetInlineCompletions(
 
     tracer?.({ context: contextResult })
 
+    let gitContext = undefined
+    if (gitIdentifiersForFile?.gitUrl) {
+        gitContext = {
+            repoName: gitIdentifiersForFile.gitUrl,
+        }
+    }
+
     const completionProvider = getCompletionProvider({
         document,
         position,
@@ -400,6 +407,7 @@ async function doGetInlineCompletions(
         docContext,
         firstCompletionTimeout,
         completionLogId: logId,
+        gitContext,
     })
 
     tracer?.({

--- a/vscode/src/completions/providers/create-provider.ts
+++ b/vscode/src/completions/providers/create-provider.ts
@@ -14,11 +14,12 @@ import {
 } from './anthropic'
 import { createProviderConfig as createExperimentalOllamaProviderConfig } from './experimental-ollama'
 import {
-    DEEPSEEK_CODER_1P3_B,
+    CODE_QWEN_7B,
     DEEPSEEK_CODER_7B,
+    DEEPSEEK_CODER_V2_LITE_BASE,
+    FIREWORKS_DEEPSEEK_7B_LANG_LOG_FINETUNED,
+    FIREWORKS_DEEPSEEK_7B_LANG_STACK_FINETUNED,
     FIREWORKS_FIM_FINE_TUNED_MODEL_HYBRID,
-    FIREWORKS_FIM_FINE_TUNED_MODEL_HYBRID_WITH_200MS_DELAY,
-    FIREWORKS_FIM_LANG_SPECIFIC_MODEL_MIXTRAL,
     type FireworksOptions,
     createProviderConfig as createFireworksProviderConfig,
 } from './fireworks'
@@ -174,43 +175,46 @@ async function resolveFIMModelExperimentFromFeatureFlags(): ReturnType<
     /**
      * The traffic allocated to the fine-tuned-base feature flag is further split between multiple feature flag in function.
      */
-    const [fimModelControl, fimModelVariant1, fimModelVariant2, fimModelVariant3, fimModelVariant4] =
-        await Promise.all([
-            featureFlagProvider.evaluateFeatureFlag(
-                FeatureFlag.CodyAutocompleteFIMModelExperimentControl
-            ),
-            featureFlagProvider.evaluateFeatureFlag(
-                FeatureFlag.CodyAutocompleteFIMModelExperimentVariant1
-            ),
-            featureFlagProvider.evaluateFeatureFlag(
-                FeatureFlag.CodyAutocompleteFIMModelExperimentVariant2
-            ),
-            featureFlagProvider.evaluateFeatureFlag(
-                FeatureFlag.CodyAutocompleteFIMModelExperimentVariant3
-            ),
-            featureFlagProvider.evaluateFeatureFlag(
-                FeatureFlag.CodyAutocompleteFIMModelExperimentVariant4
-            ),
-        ])
+    const [
+        fimModelControl,
+        fimModelVariant1,
+        fimModelVariant2,
+        fimModelVariant3,
+        fimModelVariant4,
+        fimModelCurrentBest,
+    ] = await Promise.all([
+        featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteFIMModelExperimentControl),
+        featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteFIMModelExperimentVariant1),
+        featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteFIMModelExperimentVariant2),
+        featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteFIMModelExperimentVariant3),
+        featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteFIMModelExperimentVariant4),
+        featureFlagProvider.evaluateFeatureFlag(
+            FeatureFlag.CodyAutocompleteFIMModelExperimentCurrentBest
+        ),
+    ])
+
     if (fimModelVariant1) {
         // Variant 1: Current production model with +200msec latency to quantity the effect of latency increase while keeping same quality
-        return { provider: 'fireworks', model: FIREWORKS_FIM_FINE_TUNED_MODEL_HYBRID_WITH_200MS_DELAY }
+        return { provider: 'fireworks', model: DEEPSEEK_CODER_V2_LITE_BASE }
     }
     if (fimModelVariant2) {
-        return { provider: 'fireworks', model: FIREWORKS_FIM_LANG_SPECIFIC_MODEL_MIXTRAL }
+        return { provider: 'fireworks', model: FIREWORKS_DEEPSEEK_7B_LANG_LOG_FINETUNED }
     }
     if (fimModelVariant3) {
-        return { provider: 'fireworks', model: DEEPSEEK_CODER_1P3_B }
+        return { provider: 'fireworks', model: CODE_QWEN_7B }
     }
     if (fimModelVariant4) {
+        return { provider: 'fireworks', model: FIREWORKS_DEEPSEEK_7B_LANG_STACK_FINETUNED }
+    }
+    if (fimModelCurrentBest) {
         return { provider: 'fireworks', model: DEEPSEEK_CODER_7B }
     }
     if (fimModelControl) {
         // Current production model
-        return { provider: 'fireworks', model: FIREWORKS_FIM_FINE_TUNED_MODEL_HYBRID }
+        return { provider: 'fireworks', model: 'starcoder-hybrid' }
     }
     // Extra free traffic - redirect to the current production model which could be different than control
-    return { provider: 'fireworks', model: FIREWORKS_FIM_FINE_TUNED_MODEL_HYBRID }
+    return { provider: 'fireworks', model: 'starcoder-hybrid' }
 }
 
 async function resolveDefaultModelFromVSCodeConfigOrFeatureFlags(

--- a/vscode/src/completions/providers/fim-prompt-utils.ts
+++ b/vscode/src/completions/providers/fim-prompt-utils.ts
@@ -49,13 +49,17 @@ export class DeepSeekPromptExtractor implements FIMModelSpecificPromptExtractor 
 
     getInfillingPrompt(param: FIMInfillingPromptParams): PromptString {
         // Deepseek paper: https://arxiv.org/pdf/2401.14196
-        return ps`${param.intro}\n#${param.filename}\n<｜fim▁begin｜>${param.prefix}<｜fim▁hole｜>${param.suffix}<｜fim▁end｜>`
+        const prompt = ps`${param.intro}\n#${param.filename}\n<｜fim▁begin｜>${param.prefix}<｜fim▁hole｜>${param.suffix}<｜fim▁end｜>`
+        if (param.repoName) {
+            return ps`<repo_name>${param.repoName}\n${prompt}`
+        }
+        return prompt
     }
 }
 
 export class FinetunedModelV1PromptExtractor implements FIMModelSpecificPromptExtractor {
     getContextPrompt(param: FIMContextPromptParams): PromptString {
-        // Fine-tuned model have a additional <file_sep> tag.
+        // Fine-tuned model has a additional <file_sep> tag.
         return ps`<file_sep>Here is a reference snippet of code from ${PromptString.fromDisplayPath(
             param.filename
         )}\n${param.content}`
@@ -74,7 +78,7 @@ export class CodeQwenModelPromptExtractor implements FIMModelSpecificPromptExtra
     // https://github.com/QwenLM/CodeQwen1.5?tab=readme-ov-file#2-file-level-code-completion-fill-in-the-middle
 
     getContextPrompt(param: FIMContextPromptParams): PromptString {
-        // Fine-tuned model have a additional <file_sep> tag.
+        // Fine-tuned model has a additional <file_sep> tag.
         return ps`<file_sep>${PromptString.fromDisplayPath(param.filename)}\n${param.content}`
     }
 

--- a/vscode/src/completions/providers/fireworks.ts
+++ b/vscode/src/completions/providers/fireworks.ts
@@ -84,7 +84,7 @@ export const FIREWORKS_FIM_LANG_SPECIFIC_MODEL_MIXTRAL = 'fim-lang-specific-mode
 
 export const FIREWORKS_DEEPSEEK_7B_LANG_STACK_FINETUNED =
     'fim-lang-specific-model-deepseek-stack-trained'
-export const FIREWORKS_DEEPSEEK_7B_LANG_LOG_FINETUNED = 'fim-lang-specific-model-deepseek-logs-trained  '
+export const FIREWORKS_DEEPSEEK_7B_LANG_LOG_FINETUNED = 'fim-lang-specific-model-deepseek-logs-trained'
 
 // Huggingface link (https://huggingface.co/deepseek-ai/deepseek-coder-1.3b-base)
 export const DEEPSEEK_CODER_1P3_B = 'deepseek-coder-1p3b'

--- a/vscode/src/completions/providers/provider.ts
+++ b/vscode/src/completions/providers/provider.ts
@@ -4,6 +4,7 @@ import {
     type AutocompleteContextSnippet,
     type CompletionParameters,
     type DocumentContext,
+    type GitContext,
     tokensToChars,
 } from '@sourcegraph/cody-shared'
 
@@ -81,6 +82,11 @@ export interface ProviderOptions {
 
     // feature flags
     hotStreak?: boolean
+
+    /**
+     * Git related context information. Currently only supports a repo name, which is used by various FIM models in prompt.
+     */
+    gitContext?: GitContext
 }
 
 export abstract class Provider {

--- a/vscode/src/repository/git-metadata-for-editor.ts
+++ b/vscode/src/repository/git-metadata-for-editor.ts
@@ -1,3 +1,4 @@
+import { convertGitCloneURLToCodebaseName } from '@sourcegraph/cody-shared'
 import * as vscode from 'vscode'
 import { getConfiguration } from '../configuration'
 import { getEditor } from '../editor/active-editor'
@@ -29,11 +30,15 @@ class GitMetadataForCurrentEditor {
 
         const config = getConfiguration()
         const currentFile = getEditor()?.active?.document?.uri
-        const gitUrl =
+        const remoteGitUrl =
             config.codebase ||
             (currentFile
                 ? (await repoNameResolver.getRepoRemoteUrlsFromWorkspaceUri(currentFile))[0]
                 : config.codebase)
+
+        const gitUrl = remoteGitUrl
+            ? convertGitCloneURLToCodebaseName(remoteGitUrl) || undefined
+            : undefined
         if (currentFile) {
             const commit = gitCommitIdFromGitExtension(currentFile)
             newGitIdentifiersForFile = {


### PR DESCRIPTION
## Context
These are the changes for the autocomplete experiment. Following are the variant details, along with the hypothesis. (cc: @rishabhmehrotra)

1. `Control`: This is the current production model.
2. `Current-best`: The best model we have on autocomplete till now.
3. `Variant-1 `: DeeSeek-v2 lite base.
4. `Variant-2`: Deepseek Fine-tuned model on stack-dedup.
5. `Variant-3`: CodeQwen 1.5 - 7B
6. `Variant-4`: Deepseek Fine-tuned model trained on symbol context.

Offline evaluation: https://docs.google.com/spreadsheets/d/1i0Hz-Db-_ZKT3xAfjKtwTn2amGjKPBONyPCp4iEdUas/edit#gid=0
Backend PR: https://github.com/sourcegraph/sourcegraph/pull/63702

## Test plan
**Local Testing**
1. Start the debugger and Change my user-id among variants.
2. Observe the payload and model we are triggering for each variant combination.
