### PR TITLE
Model: Claude 3.5 Sonnet as the default model for chat and commands

### DIFF
--- a/lib/shared/src/models/dotcom.ts
+++ b/lib/shared/src/models/dotcom.ts
@@ -13,6 +13,10 @@ const basicContextWindow: ModelContextWindow = {
     input: CHAT_INPUT_TOKEN_BUDGET,
     output: CHAT_OUTPUT_TOKEN_BUDGET,
 }
+
+/**
+ * Has a higher context window with a separate limit for user-context.
+ */
 const expandedContextWindow: ModelContextWindow = {
     input: EXTENDED_CHAT_INPUT_TOKEN_BUDGET,
     output: CHAT_OUTPUT_TOKEN_BUDGET,
@@ -33,28 +37,26 @@ export const DEFAULT_DOT_COM_MODELS = [
     // Anthropic models
     // --------------------------------
     {
-        title: 'Claude 3 Sonnet',
-        model: 'anthropic/claude-3-sonnet-20240229',
+        title: 'Claude 3.5 Sonnet',
+        model: 'anthropic/claude-3-5-sonnet-20240620',
         provider: 'Anthropic',
         default: true,
         codyProOnly: false,
         usage: [ModelUsage.Chat, ModelUsage.Edit],
-        // Has a higher context window with a separate limit for user-context.
         contextWindow: expandedContextWindow,
         deprecated: false,
-        uiGroup: ModelUIGroup.Balanced,
+        uiGroup: ModelUIGroup.Accuracy,
     },
     {
-        title: 'Claude 3.5 Sonnet',
-        model: 'anthropic/claude-3-5-sonnet-20240620',
+        title: 'Claude 3 Sonnet',
+        model: 'anthropic/claude-3-sonnet-20240229',
         provider: 'Anthropic',
         default: false,
         codyProOnly: false,
         usage: [ModelUsage.Chat, ModelUsage.Edit],
-        // Has a higher context window with a separate limit for user-context.
         contextWindow: expandedContextWindow,
         deprecated: false,
-        uiGroup: ModelUIGroup.Accuracy,
+        uiGroup: ModelUIGroup.Balanced,
     },
     {
         title: 'Claude 3 Opus',
@@ -63,7 +65,6 @@ export const DEFAULT_DOT_COM_MODELS = [
         default: false,
         codyProOnly: true,
         usage: [ModelUsage.Chat, ModelUsage.Edit],
-        // Has a higher context window with a separate limit for user-context.
         contextWindow: expandedContextWindow,
         deprecated: false,
         uiGroup: ModelUIGroup.Accuracy,
@@ -90,7 +91,6 @@ export const DEFAULT_DOT_COM_MODELS = [
         default: false,
         codyProOnly: true,
         usage: [ModelUsage.Chat, ModelUsage.Edit],
-        // Has a higher context window with a separate limit for user-context.
         contextWindow: expandedContextWindow,
         deprecated: false,
         uiGroup: ModelUIGroup.Accuracy,

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -26,6 +26,7 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 - Chat: Simplify the Enterprise docs in the model selector [pull/4745](https://github.com/sourcegraph/cody/pull/4745)
 - Edit: We now collapse the selection down to the cursor position after an edit is triggered. [pull/4781](https://github.com/sourcegraph/cody/pull/4781)
 - Autocomplete: requests timeout decreased from 15s to 7s. [pull/4813](https://github.com/sourcegraph/cody/pull/4813)
+- Chat & Edit: Claude 3.5 Sonnet is now the default model for Chat and Commands. [pull/xxxx](https://github.com/sourcegraph/cody/pull/xxxx)
 
 ## 1.24.2
 


### PR DESCRIPTION
CLOSE https://linear.app/sourcegraph/issue/CODY-2507/evaluate-claude-35-sonnet-as-new-default

![image](https://github.com/sourcegraph/cody/assets/68532117/67520e75-20c1-4e46-b4aa-e8499546f267)

Update Claude 3.5 Sonnet to be the default model for chat and commands (including edit).

This change only affects new users as the default model for existing users is the model last used by the user.

## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

- Start Cody from this branch in as a separate instance to micmic new install.
- Verify the default model is set to Claude 3.5 Sonnet for both Chat and Inline-Edit.


### After

![image](https://github.com/sourcegraph/cody/assets/68532117/5c3631a1-7b2f-48f9-bb5b-78618725d812)


### Before

![image](https://github.com/sourcegraph/cody/assets/68532117/8d6dc197-6580-45ee-8a26-83ef3e089ee6)
