### PR TITLE
chore(codyconfig): made CodyClientConfig optional

### DIFF
--- a/agent/recordings/defaultClient_631904893/recording.har.yaml
+++ b/agent/recordings/defaultClient_631904893/recording.har.yaml
@@ -5,7 +5,7 @@ log:
     name: Polly.JS
     version: 6.0.6
   entries:
-    - _id: 2e7862e0c501fbdd157a5733d068fd52
+    - _id: 8ffa79cf5668b64b3fd5ad5674e1d846
       _order: 0
       cache: {}
       request:
@@ -15,7 +15,7 @@ log:
           - _fromType: array
             name: authorization
             value: token
-              REDACTED_0ba08837494d00e3943c46999589eb29a210ba8063f084fff511c8e4d1503909
+              REDACTED_d5e0f0a37c9821e856b923fe14e67a605e3f6c0a517d5a4f46a4e35943ee0f6d
           - _fromType: array
             name: content-type
             value: application/json; charset=utf-8
@@ -30,26 +30,28 @@ log:
             value: gzip,deflate
           - name: host
             value: sourcegraph.com
-        headersSize: 301
+        headersSize: 289
         httpVersion: HTTP/1.1
         method: GET
         queryString: []
         url: https://sourcegraph.com/.api/client-config
       response:
-        bodySize: 22
+        bodySize: 188
         content:
+          encoding: base64
           mimeType: text/plain; charset=utf-8
-          size: 22
-          text: |
-            Invalid access token.
+          size: 188
+          text: "[\"H4sIAAAAAAAAA2zMsQoCMRCE4T5PsVztE9hJsLjOznrPrBjI7koyQeW4d7dRBEn9z3xrI\
+            CKaLp5eR+OlSJr2hNpl9wk3xjBwh0fXexHI+NkbXKOrsqU2NoCal47s9utXLu07aMoV\
+            0Q3yxDlb8sfQUU9S2uE0/ylhC28AAAD//wMAK/Ow9eAAAAA=\"]"
         cookies: []
         headers:
           - name: date
-            value: Tue, 09 Jul 2024 02:18:43 GMT
+            value: Tue, 09 Jul 2024 20:48:01 GMT
           - name: content-type
             value: text/plain; charset=utf-8
-          - name: content-length
-            value: "22"
+          - name: transfer-encoding
+            value: chunked
           - name: connection
             value: keep-alive
           - name: access-control-allow-credentials
@@ -59,7 +61,8 @@ log:
           - name: cache-control
             value: no-cache, max-age=0
           - name: vary
-            value: Cookie,Accept-Encoding,Authorization
+            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
+              X-Requested-With,Cookie
           - name: x-content-type-options
             value: nosniff
           - name: x-frame-options
@@ -68,12 +71,14 @@ log:
             value: 1; mode=block
           - name: strict-transport-security
             value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1263
+          - name: content-encoding
+            value: gzip
+        headersSize: 1342
         httpVersion: HTTP/1.1
         redirectURL: ""
-        status: 401
-        statusText: Unauthorized
-      startedDateTime: 2024-07-09T02:18:42.792Z
+        status: 200
+        statusText: OK
+      startedDateTime: 2024-07-09T20:48:01.761Z
       time: 0
       timings:
         blocked: -1
@@ -3843,211 +3848,6 @@ log:
         status: 200
         statusText: OK
       startedDateTime: 2024-06-27T23:22:53.211Z
-      time: 0
-      timings:
-        blocked: -1
-        connect: -1
-        dns: -1
-        receive: 0
-        send: 0
-        ssl: -1
-        wait: 0
-    - _id: 4d7b84f278a68f81a65e407b527c4a0e
-      _order: 0
-      cache: {}
-      request:
-        bodySize: 217
-        cookies: []
-        headers:
-          - _fromType: array
-            name: authorization
-            value: token
-              REDACTED_4a92106dd3be39a589d6e2d0a6e32b705744d4007d74518fdfd1dbf953176dc6
-          - _fromType: array
-            name: content-type
-            value: application/json; charset=utf-8
-          - _fromType: array
-            name: user-agent
-            value: defaultClient / v1
-          - _fromType: array
-            name: accept
-            value: "*/*"
-          - _fromType: array
-            name: content-length
-            value: "217"
-          - _fromType: array
-            name: accept-encoding
-            value: gzip,deflate
-          - name: host
-            value: sourcegraph.com
-        headersSize: 332
-        httpVersion: HTTP/1.1
-        method: POST
-        postData:
-          mimeType: application/json; charset=utf-8
-          params: []
-          textJSON:
-            query: |-
-              
-              query CodyConfigFeaturesResponse {
-                  site {
-                      codyConfigFeatures {
-                          chat
-                          autoComplete
-                          commands
-                          attribution
-                      }
-                  }
-              }
-            variables: {}
-        queryString:
-          - name: CodyConfigFeaturesResponse
-            value: null
-        url: https://sourcegraph.com/.api/graphql?CodyConfigFeaturesResponse
-      response:
-        bodySize: 22
-        content:
-          mimeType: text/plain; charset=utf-8
-          size: 22
-          text: |
-            Invalid access token.
-        cookies: []
-        headers:
-          - name: date
-            value: Wed, 03 Jul 2024 06:24:14 GMT
-          - name: content-type
-            value: text/plain; charset=utf-8
-          - name: content-length
-            value: "22"
-          - name: connection
-            value: keep-alive
-          - name: access-control-allow-credentials
-            value: "true"
-          - name: access-control-allow-origin
-            value: ""
-          - name: cache-control
-            value: no-cache, max-age=0
-          - name: vary
-            value: Cookie,Accept-Encoding,Authorization
-          - name: x-content-type-options
-            value: nosniff
-          - name: x-frame-options
-            value: DENY
-          - name: x-xss-protection
-            value: 1; mode=block
-          - name: strict-transport-security
-            value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1263
-        httpVersion: HTTP/1.1
-        redirectURL: ""
-        status: 401
-        statusText: Unauthorized
-      startedDateTime: 2024-07-03T06:24:13.717Z
-      time: 0
-      timings:
-        blocked: -1
-        connect: -1
-        dns: -1
-        receive: 0
-        send: 0
-        ssl: -1
-        wait: 0
-    - _id: 12581f1c735a04aeb88af7a54cd007b2
-      _order: 0
-      cache: {}
-      request:
-        bodySize: 217
-        cookies: []
-        headers:
-          - _fromType: array
-            name: authorization
-            value: token
-              REDACTED_d5e0f0a37c9821e856b923fe14e67a605e3f6c0a517d5a4f46a4e35943ee0f6d
-          - _fromType: array
-            name: content-type
-            value: application/json; charset=utf-8
-          - _fromType: array
-            name: user-agent
-            value: defaultClient / v1
-          - _fromType: array
-            name: accept
-            value: "*/*"
-          - _fromType: array
-            name: content-length
-            value: "217"
-          - _fromType: array
-            name: accept-encoding
-            value: gzip,deflate
-          - name: host
-            value: sourcegraph.com
-        headersSize: 332
-        httpVersion: HTTP/1.1
-        method: POST
-        postData:
-          mimeType: application/json; charset=utf-8
-          params: []
-          textJSON:
-            query: |-
-              
-              query CodyConfigFeaturesResponse {
-                  site {
-                      codyConfigFeatures {
-                          chat
-                          autoComplete
-                          commands
-                          attribution
-                      }
-                  }
-              }
-            variables: {}
-        queryString:
-          - name: CodyConfigFeaturesResponse
-            value: null
-        url: https://sourcegraph.com/.api/graphql?CodyConfigFeaturesResponse
-      response:
-        bodySize: 162
-        content:
-          encoding: base64
-          mimeType: application/json
-          size: 162
-          text: "[\"H4sIAAAAAAAAAzyLwQqA\",\"IBAF/2XPfYFXof/YdC0h3dDnIcR/Dws6DQwznTyDyXSq\
-            ETLp1N9Wc4j7KoxWpL72YJBBabIQN6jVdJ0yj885TYmzr38DlLg1RM1kAp9VxhjjAQA\
-            A//8=\",\"AwCHzi5CbgAAAA==\"]"
-        cookies: []
-        headers:
-          - name: date
-            value: Wed, 03 Jul 2024 06:24:15 GMT
-          - name: content-type
-            value: application/json
-          - name: transfer-encoding
-            value: chunked
-          - name: connection
-            value: keep-alive
-          - name: access-control-allow-credentials
-            value: "true"
-          - name: access-control-allow-origin
-            value: ""
-          - name: cache-control
-            value: no-cache, max-age=0
-          - name: vary
-            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
-              X-Requested-With,Cookie
-          - name: x-content-type-options
-            value: nosniff
-          - name: x-frame-options
-            value: DENY
-          - name: x-xss-protection
-            value: 1; mode=block
-          - name: strict-transport-security
-            value: max-age=31536000; includeSubDomains; preload
-          - name: content-encoding
-            value: gzip
-        headersSize: 1333
-        httpVersion: HTTP/1.1
-        redirectURL: ""
-        status: 200
-        statusText: OK
-      startedDateTime: 2024-07-03T06:24:14.717Z
       time: 0
       timings:
         blocked: -1

--- a/lib/shared/src/guardrails/client.ts
+++ b/lib/shared/src/guardrails/client.ts
@@ -10,7 +10,7 @@ export class SourcegraphGuardrailsClient implements Guardrails {
     public async searchAttribution(snippet: string): Promise<Attribution | Error> {
         // Short-circuit attribution search if turned off in site config.
         const clientConfig = await ClientConfigSingleton.getInstance().getConfig()
-        if (!clientConfig.attributionEnabled) {
+        if (!clientConfig?.attributionEnabled) {
             return new Error('Attribution search is turned off.')
         }
         const result = await this.client.searchAttribution(snippet)

--- a/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
+++ b/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
@@ -1563,18 +1563,17 @@ export class SimpleChatPanelProvider
         // Used for keeping sidebar chat view closed when webview panel is enabled
         await vscode.commands.executeCommand('setContext', CodyChatPanelViewType, true)
 
-        const clientConfig = await ClientConfigSingleton.getInstance()
-            .getConfig()
-            // In the event of an error, ClientConfigSingleton already logged it internally but it
-            // means we were unable to fetch the client configuration - most likely because we are
-            // not authenticated yet. We need to be able to display the chat panel (which is where
-            // all login functionality is) in this case, so we fallback to some default values:
-            .catch(e => ({ chatEnabled: true, attributionEnabled: false }))
+        const clientConfig = await ClientConfigSingleton.getInstance().getConfig()
+
         void this.postMessage({
             type: 'setConfigFeatures',
             configFeatures: {
-                chat: clientConfig.chatEnabled,
-                attribution: clientConfig.attributionEnabled,
+                // If clientConfig is undefined means we were unable to fetch the client configuration -
+                // most likely because we are not authenticated yet. We need to be able to display the
+                // chat panel (which is where all login functionality is) in this case, so we fallback
+                // to some default values:
+                chat: clientConfig?.chatEnabled ?? true,
+                attribution: clientConfig?.attributionEnabled ?? false,
             },
         })
 

--- a/vscode/src/commands/execute/ask.ts
+++ b/vscode/src/commands/execute/ask.ts
@@ -22,9 +22,12 @@ export interface ExecuteChatArguments extends Omit<WebviewSubmitMessage, 'text' 
  * This is also called by all the default commands (e.g., explain).
  */
 export const executeChat = async (args: ExecuteChatArguments): Promise<ChatSession | undefined> => {
-    const { chatEnabled, customCommandsEnabled } = await ClientConfigSingleton.getInstance().getConfig()
+    const clientConfig = await ClientConfigSingleton.getInstance().getConfig()
     const isCommand = Boolean(args.command)
-    if ((!isCommand && !chatEnabled) || (isCommand && !customCommandsEnabled)) {
+    if (
+        (!isCommand && !clientConfig?.chatEnabled) ||
+        (isCommand && !clientConfig?.customCommandsEnabled)
+    ) {
         void vscode.window.showErrorMessage(
             'This feature has been disabled by your Sourcegraph site admin.'
         )

--- a/vscode/src/commands/services/runner.ts
+++ b/vscode/src/commands/services/runner.ts
@@ -76,7 +76,7 @@ export class CommandRunner implements vscode.Disposable {
 
         // Conditions checks
         const clientConfig = await ClientConfigSingleton.getInstance().getConfig()
-        if (!clientConfig.customCommandsEnabled) {
+        if (!clientConfig?.customCommandsEnabled) {
             const disabledMsg = 'This feature has been disabled by your Sourcegraph site admin.'
             void vscode.window.showErrorMessage(disabledMsg)
             this.span.end()

--- a/vscode/src/completions/inline-completion-item-provider.ts
+++ b/vscode/src/completions/inline-completion-item-provider.ts
@@ -230,7 +230,7 @@ export class InlineCompletionItemProvider
 
             const clientConfig = await ClientConfigSingleton.getInstance().getConfig()
 
-            if (!clientConfig.autoCompleteEnabled) {
+            if (clientConfig && !clientConfig.autoCompleteEnabled) {
                 // If ConfigFeatures exists and autocomplete is disabled then raise
                 // the error banner for autocomplete config turned off
                 const error = new Error('AutocompleteConfigTurnedOff')

--- a/vscode/src/edit/manager.ts
+++ b/vscode/src/edit/manager.ts
@@ -92,7 +92,7 @@ export class EditManager implements vscode.Disposable {
             telemetryMetadata,
         } = args
         const clientConfig = await ClientConfigSingleton.getInstance().getConfig()
-        if (!clientConfig.customCommandsEnabled) {
+        if (!clientConfig?.customCommandsEnabled) {
             void vscode.window.showErrorMessage(
                 'This feature has been disabled by your Sourcegraph site admin.'
             )

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -361,8 +361,8 @@ const register = async (
         id: DefaultCodyCommands | PromptString,
         args?: Partial<CodyCommandArgs>
     ): Promise<CommandResult | undefined> => {
-        const { customCommandsEnabled } = await ClientConfigSingleton.getInstance().getConfig()
-        if (!customCommandsEnabled) {
+        const clientConfig = await ClientConfigSingleton.getInstance().getConfig()
+        if (!clientConfig?.customCommandsEnabled) {
             void vscode.window.showErrorMessage(
                 'This feature has been disabled by your Sourcegraph site admin.'
             )

--- a/vscode/src/models/sync.ts
+++ b/vscode/src/models/sync.ts
@@ -37,8 +37,8 @@ export async function syncModels(authStatus: AuthStatus): Promise<void> {
 
     // Fetch the LLM models and configuration server-side. See:
     // https://linear.app/sourcegraph/project/server-side-cody-model-selection-cca47c48da6d
-    const { modelsAPIEnabled } = await ClientConfigSingleton.getInstance().getConfig()
-    if (modelsAPIEnabled) {
+    const clientConfig = await ClientConfigSingleton.getInstance().getConfig()
+    if (clientConfig?.modelsAPIEnabled) {
         logDebug('ModelsService', 'new models API enabled')
         const serverSideModels = await fetchServerSideModels(authStatus.endpoint || '')
         ModelsService.setModels(serverSideModels)


### PR DESCRIPTION
Here are the changes that make the return type of `ClientConfigSingleton` potentially undefined, and avoids fetching if the user is not authenticated.

## Test plan
Green CI
<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
