### PR TITLE
Agent: Simplify chat model restoration logic

### DIFF
--- a/agent/src/agent.ts
+++ b/agent/src/agent.ts
@@ -2,12 +2,7 @@ import { spawn } from 'node:child_process'
 import path from 'node:path'
 
 import type { Polly, Request } from '@pollyjs/core'
-import {
-    type CodyCommand,
-    getDotComDefaultModels,
-    isWindows,
-    telemetryRecorder,
-} from '@sourcegraph/cody-shared'
+import { type CodyCommand, isWindows, telemetryRecorder } from '@sourcegraph/cody-shared'
 import * as vscode from 'vscode'
 import { StreamMessageReader, StreamMessageWriter, createMessageConnection } from 'vscode-jsonrpc/node'
 
@@ -1079,27 +1074,14 @@ export class Agent extends MessageHandler implements ExtensionClient {
 
         this.registerAuthenticatedRequest('chat/restore', async ({ modelID, messages, chatID }) => {
             const authStatus = await vscode.commands.executeCommand<AuthStatus>('cody.auth.status')
-            let theModel = modelID
+            const theModel = modelID
                 ? modelID
                 : ModelsService.getModels(
                       ModelUsage.Chat,
                       authStatus.isDotCom && !authStatus.userCanUpgrade
-                  ).at(0)?.model
-            if (!theModel) {
-                theModel = getDotComDefaultModels()[0].model
-            }
-
-            const chatModel = new SimpleChatModel(modelID!, [], chatID)
-            for (const message of messages) {
-                const deserializedMessage = PromptString.unsafe_deserializeChatMessage(message)
-                if (deserializedMessage.error) {
-                    chatModel.addErrorAsBotMessage(deserializedMessage.error)
-                } else if (deserializedMessage.speaker === 'assistant') {
-                    chatModel.addBotMessage(deserializedMessage)
-                } else if (deserializedMessage.speaker === 'human') {
-                    chatModel.addHumanMessage(deserializedMessage)
-                }
-            }
+                  ).at(0)?.model ?? ''
+            const chatMessages = messages?.map(m => PromptString.unsafe_deserializeChatMessage(m)) ?? []
+            const chatModel = new SimpleChatModel(theModel, chatMessages, chatID)
             await chatHistory.saveChat(authStatus, chatModel.toSerializedChatTranscript())
             return this.createChatPanel(
                 Promise.resolve({


### PR DESCRIPTION
- Remove unnecessary logic for determining the default model ID
  - We were not using `theModel` value previously
- Set default model ID to empty string if there is no model found as it should be sync again when webview is created
- Simplify the process of deserializing and adding chat messages to the chat model
- Use the provided model ID and chat messages directly to create the chat model

## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

No feature change so CI should be green. The chat/restore test should continues to be green to validate the change.