### PR TITLE
Cody Web: Use deep links only in vscode extension

### DIFF
--- a/vscode/webviews/chat/ChatEnvironmentContext.ts
+++ b/vscode/webviews/chat/ChatEnvironmentContext.ts
@@ -1,16 +1,12 @@
+import { CodyIDE } from '@sourcegraph/cody-shared'
 import { createContext, useContext } from 'react'
 
-export enum ChatClientType {
-    Web = 'web',
-    VsCode = 'vscode',
-}
-
 interface ChatEnvironmentContextData {
-    clientType: ChatClientType
+    clientType: CodyIDE
 }
 
 export const ChatEnvironmentContext = createContext<ChatEnvironmentContextData>({
-    clientType: ChatClientType.VsCode,
+    clientType: CodyIDE.VSCode,
 })
 
 export function useChatEnvironment() {

--- a/vscode/webviews/chat/ChatEnvironmentContext.ts
+++ b/vscode/webviews/chat/ChatEnvironmentContext.ts
@@ -1,0 +1,18 @@
+import { createContext, useContext } from 'react'
+
+export enum ChatClientType {
+    Web = 'web',
+    VsCode = 'vscode',
+}
+
+interface ChatEnvironmentContextData {
+    clientType: ChatClientType
+}
+
+export const ChatEnvironmentContext = createContext<ChatEnvironmentContextData>({
+    clientType: ChatClientType.VsCode,
+})
+
+export function useChatEnvironment() {
+    return useContext(ChatEnvironmentContext)
+}

--- a/vscode/webviews/components/MarkdownFromCody.tsx
+++ b/vscode/webviews/components/MarkdownFromCody.tsx
@@ -1,3 +1,4 @@
+import { CodyIDE } from '@sourcegraph/cody-shared'
 import { all } from 'lowlight'
 import type { ComponentProps, FunctionComponent } from 'react'
 import { useMemo } from 'react'
@@ -6,7 +7,7 @@ import type { UrlTransform } from 'react-markdown/lib'
 import rehypeHighlight, { type Options as RehypeHighlightOptions } from 'rehype-highlight'
 import rehypeSanitize, { type Options as RehypeSanitizeOptions, defaultSchema } from 'rehype-sanitize'
 import remarkGFM from 'remark-gfm'
-import { ChatClientType, useChatEnvironment } from '../chat/ChatEnvironmentContext'
+import { useChatEnvironment } from '../chat/ChatEnvironmentContext'
 
 /**
  * Supported URIs to render as links in outputted markdown.
@@ -75,9 +76,12 @@ function wrapLinksWithCodyOpenCommand(url: string): string {
     return `command:_cody.vscode.open?${encodedURL}`
 }
 
-const URL_PROCESSORS: Record<ChatClientType, UrlTransform> = {
-    [ChatClientType.Web]: defaultUrlProcessor,
-    [ChatClientType.VsCode]: wrapLinksWithCodyOpenCommand,
+const URL_PROCESSORS: Record<CodyIDE, UrlTransform> = {
+    [CodyIDE.Web]: defaultUrlProcessor,
+    [CodyIDE.JetBrains]: defaultUrlProcessor,
+    [CodyIDE.Neovim]: defaultUrlProcessor,
+    [CodyIDE.Emacs]: defaultUrlProcessor,
+    [CodyIDE.VSCode]: wrapLinksWithCodyOpenCommand,
 }
 
 export const MarkdownFromCody: FunctionComponent<{ className?: string; children: string }> = ({

--- a/vscode/webviews/components/MarkdownFromCody.tsx
+++ b/vscode/webviews/components/MarkdownFromCody.tsx
@@ -1,9 +1,12 @@
 import { all } from 'lowlight'
 import type { ComponentProps, FunctionComponent } from 'react'
+import { useMemo } from 'react'
 import Markdown, { defaultUrlTransform } from 'react-markdown'
+import type { UrlTransform } from 'react-markdown/lib'
 import rehypeHighlight, { type Options as RehypeHighlightOptions } from 'rehype-highlight'
 import rehypeSanitize, { type Options as RehypeSanitizeOptions, defaultSchema } from 'rehype-sanitize'
 import remarkGFM from 'remark-gfm'
+import { ChatClientType, useChatEnvironment } from '../chat/ChatEnvironmentContext'
 
 /**
  * Supported URIs to render as links in outputted markdown.
@@ -50,6 +53,16 @@ const ALLOWED_ELEMENTS = [
     'br',
 ]
 
+function defaultUrlProcessor(url: string): string {
+    const processedURL = defaultUrlTransform(url)
+
+    if (!ALLOWED_URI_REGEXP.test(processedURL)) {
+        return ''
+    }
+
+    return processedURL
+}
+
 /**
  * Transform URLs to opens links in assistant responses using the `_cody.vscode.open` command.
  */
@@ -62,18 +75,24 @@ function wrapLinksWithCodyOpenCommand(url: string): string {
     return `command:_cody.vscode.open?${encodedURL}`
 }
 
+const URL_PROCESSORS: Record<ChatClientType, UrlTransform> = {
+    [ChatClientType.Web]: defaultUrlProcessor,
+    [ChatClientType.VsCode]: wrapLinksWithCodyOpenCommand,
+}
+
 export const MarkdownFromCody: FunctionComponent<{ className?: string; children: string }> = ({
     className,
     children,
-}) => (
-    <Markdown
-        className={className}
-        {...markdownPluginProps()}
-        urlTransform={wrapLinksWithCodyOpenCommand}
-    >
-        {children}
-    </Markdown>
-)
+}) => {
+    const { clientType } = useChatEnvironment()
+    const urlTransform = useMemo(() => URL_PROCESSORS[clientType], [clientType])
+
+    return (
+        <Markdown className={className} {...markdownPluginProps()} urlTransform={urlTransform}>
+            {children}
+        </Markdown>
+    )
+}
 
 let _markdownPluginProps: ReturnType<typeof markdownPluginProps> | undefined
 function markdownPluginProps(): Pick<

--- a/web/CHANGELOG.md
+++ b/web/CHANGELOG.md
@@ -1,11 +1,12 @@
+## 0.2.4
+- Fix Markdown links for cody web 
 
-## 0.2.2
+## 0.2.3
 - Fixes remote repository context as you switch between chats
 - Adds support for context ignore for remote repositories files
 - Fixes link rendering in the mention menu/suggestion panel
 
-## 0.2.1 
-
+## 0.2.1
 - Fixes remote files and remote symbols files link
 
 ## 0.2.0

--- a/web/lib/components/CodyWebChat.tsx
+++ b/web/lib/components/CodyWebChat.tsx
@@ -15,6 +15,7 @@ import {
 } from '@sourcegraph/cody-shared'
 
 import { Chat, type UserAccountInfo } from 'cody-ai/webviews/Chat'
+import { ChatClientType, ChatEnvironmentContext } from 'cody-ai/webviews/chat/ChatEnvironmentContext'
 import {
     type ChatModelContext,
     ChatModelContextProvider,
@@ -189,6 +190,8 @@ export const CodyWebChat: FC<CodyWebChatProps> = props => {
         }
     }, [initialContext])
 
+    const envVars = useMemo(() => ({ clientType: ChatClientType.Web }), [])
+
     return (
         <div className={className} data-cody-web-chat={true} ref={setRootElement}>
             {client &&
@@ -199,29 +202,31 @@ export const CodyWebChat: FC<CodyWebChatProps> = props => {
                 isErrorLike(client) ? (
                     <p>Error: {client.message}</p>
                 ) : (
-                    <ChatMentionContext.Provider value={CONTEXT_MENTIONS_SETTINGS}>
-                        <TelemetryRecorderContext.Provider value={telemetryRecorder}>
-                            <ChatModelContextProvider value={chatModelContext}>
-                                <ClientStateContextProvider value={clientState}>
-                                    <WithContextProviders>
-                                        <Chat
-                                            chatID={activeChatID}
-                                            chatEnabled={true}
-                                            showWelcomeMessage={false}
-                                            showIDESnippetActions={false}
-                                            userInfo={userAccountInfo}
-                                            messageInProgress={messageInProgress}
-                                            transcript={transcript}
-                                            vscodeAPI={vscodeAPI}
-                                            isTranscriptError={isTranscriptError}
-                                            scrollableParent={rootElement}
-                                            className={styles.chat}
-                                        />
-                                    </WithContextProviders>
-                                </ClientStateContextProvider>
-                            </ChatModelContextProvider>
-                        </TelemetryRecorderContext.Provider>
-                    </ChatMentionContext.Provider>
+                    <ChatEnvironmentContext.Provider value={envVars}>
+                        <ChatMentionContext.Provider value={CONTEXT_MENTIONS_SETTINGS}>
+                            <TelemetryRecorderContext.Provider value={telemetryRecorder}>
+                                <ChatModelContextProvider value={chatModelContext}>
+                                    <ClientStateContextProvider value={clientState}>
+                                        <WithContextProviders>
+                                            <Chat
+                                                chatID={activeChatID}
+                                                chatEnabled={true}
+                                                showWelcomeMessage={false}
+                                                showIDESnippetActions={false}
+                                                userInfo={userAccountInfo}
+                                                messageInProgress={messageInProgress}
+                                                transcript={transcript}
+                                                vscodeAPI={vscodeAPI}
+                                                isTranscriptError={isTranscriptError}
+                                                scrollableParent={rootElement}
+                                                className={styles.chat}
+                                            />
+                                        </WithContextProviders>
+                                    </ClientStateContextProvider>
+                                </ChatModelContextProvider>
+                            </TelemetryRecorderContext.Provider>
+                        </ChatMentionContext.Provider>
+                    </ChatEnvironmentContext.Provider>
                 )
             ) : (
                 <div className={styles.loading}>Loading Cody Agent...</div>

--- a/web/lib/components/CodyWebChat.tsx
+++ b/web/lib/components/CodyWebChat.tsx
@@ -15,7 +15,7 @@ import {
 } from '@sourcegraph/cody-shared'
 
 import { Chat, type UserAccountInfo } from 'cody-ai/webviews/Chat'
-import { ChatClientType, ChatEnvironmentContext } from 'cody-ai/webviews/chat/ChatEnvironmentContext'
+import { ChatEnvironmentContext } from 'cody-ai/webviews/chat/ChatEnvironmentContext'
 import {
     type ChatModelContext,
     ChatModelContextProvider,
@@ -190,7 +190,7 @@ export const CodyWebChat: FC<CodyWebChatProps> = props => {
         }
     }, [initialContext])
 
-    const envVars = useMemo(() => ({ clientType: ChatClientType.Web }), [])
+    const envVars = useMemo(() => ({ clientType: CodyIDE.Web }), [])
 
     return (
         <div className={className} data-cody-web-chat={true} ref={setRootElement}>

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cody-web-experimental",
-  "version": "0.2.2",
+  "version": "0.2.4",
   "description": "Cody standalone web app",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
Fixes https://linear.app/sourcegraph/issue/SRCH-633/links-in-the-prompt-has-incorrect-url-in-cody-web

Initially, I thought that I fixed problems with links in this PR https://github.com/sourcegraph/cody/pull/4809 but cody can render links in answers too via the markdown component. This PR simply disables vscode deep links when we render chat UI components for Cody Web case. 

Original logic about link building stays untouched, we provide simpler URL transform only for cody web case, safe to merge. 

## Test plan
- Check that markdown links still work properly in vscode exntesion.

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
