### PR TITLE
Sidebar: use release blog post URL for release notes

### DIFF
--- a/vscode/src/chat/protocol.ts
+++ b/vscode/src/chat/protocol.ts
@@ -261,6 +261,7 @@ export interface ConfigurationSubsetForWebview
  * URLs for the Sourcegraph instance and app.
  */
 export const CODY_DOC_URL = new URL('https://sourcegraph.com/docs/cody')
+export const SG_BLOG_URL = new URL('https://sourcegraph.com/blog/')
 
 // Community and support
 export const DISCORD_URL = new URL('https://discord.gg/s2qDtYGnAE')

--- a/vscode/src/release.test.ts
+++ b/vscode/src/release.test.ts
@@ -41,14 +41,14 @@ describe('getReleaseTypeByIDE', () => {
 })
 
 describe('getReleaseNotesURLByIDE', () => {
-    it('returns GitHub release notes for VS Code stable builds', () => {
+    it('returns stable release blog post URL for VS Code stable builds', () => {
         expect(getReleaseNotesURLByIDE('4.2.1', CodyIDE.VSCode)).toEqual(
-            'https://github.com/sourcegraph/cody/releases/tag/vscode-v4.2.1'
+            'https://sourcegraph.com/blog/cody-vscode-4-2-0-release'
         )
     })
-    it('returns changelog for VS Code insiders builds', () => {
+    it('returns stable release blog post URL for VS Code insiders builds', () => {
         expect(getReleaseNotesURLByIDE('4.3.1689391131', CodyIDE.VSCode)).toEqual(
-            'https://github.com/sourcegraph/cody/blob/main/vscode/CHANGELOG.md'
+            'https://sourcegraph.com/blog/cody-vscode-4-2-0-release'
         )
     })
 

--- a/vscode/src/release.test.ts
+++ b/vscode/src/release.test.ts
@@ -42,13 +42,20 @@ describe('getReleaseTypeByIDE', () => {
 
 describe('getReleaseNotesURLByIDE', () => {
     it('returns stable release blog post URL for VS Code stable builds', () => {
-        expect(getReleaseNotesURLByIDE('4.2.1', CodyIDE.VSCode)).toEqual(
-            'https://sourcegraph.com/blog/cody-vscode-4-2-0-release'
+        expect(getReleaseNotesURLByIDE('1.24.0', CodyIDE.VSCode)).toEqual(
+            'https://sourcegraph.com/blog/cody-vscode-1-24-0-release'
         )
     })
+
+    it('returns stable release blog post URL for VS Code patch release', () => {
+        expect(getReleaseNotesURLByIDE('1.24.2', CodyIDE.VSCode)).toEqual(
+            'https://sourcegraph.com/blog/cody-vscode-1-24-0-release'
+        )
+    })
+
     it('returns stable release blog post URL for VS Code insiders builds', () => {
-        expect(getReleaseNotesURLByIDE('4.3.1689391131', CodyIDE.VSCode)).toEqual(
-            'https://sourcegraph.com/blog/cody-vscode-4-2-0-release'
+        expect(getReleaseNotesURLByIDE('1.25.1720624657', CodyIDE.VSCode)).toEqual(
+            'https://sourcegraph.com/blog/cody-vscode-1-24-0-release'
         )
     })
 

--- a/vscode/src/release.ts
+++ b/vscode/src/release.ts
@@ -1,4 +1,5 @@
 import { CodyIDE } from '@sourcegraph/cody-shared'
+import { SG_BLOG_URL } from './chat/protocol'
 
 type ReleaseType = 'stable' | 'insiders'
 
@@ -45,9 +46,7 @@ export function getReleaseNotesURLByIDE(version: string, IDE: CodyIDE): string {
 
     switch (IDE) {
         case CodyIDE.VSCode:
-            return isStable
-                ? `https://github.com/sourcegraph/cody/releases/tag/vscode-v${version}`
-                : 'https://github.com/sourcegraph/cody/blob/main/vscode/CHANGELOG.md'
+            return getReleaseBlogPostURL(version, IDE)
 
         case CodyIDE.JetBrains:
             return isStable
@@ -55,6 +54,32 @@ export function getReleaseNotesURLByIDE(version: string, IDE: CodyIDE): string {
                 : 'https://github.com/sourcegraph/jetbrains/releases'
 
         default:
-            throw new Error('IDE not supported')
+            throw new Error(`No release note for ${IDE}.`)
     }
+}
+
+/**
+ * Gets the release blog post URL for the given IDE and version.
+ *
+ * This function constructs the release blog post URL for the given IDE and version.
+ * For VS Code, it constructs the blog URL based on the version number.
+ *
+ * @param version - The version of the IDE.
+ * @param IDE - The IDE to get the release blog post URL for.
+ * @returns The release blog post URL for the given IDE and version.
+ */
+function getReleaseBlogPostURL(version: string, IDE: CodyIDE): string {
+    const blogURL = new URL(SG_BLOG_URL)
+
+    if (IDE === CodyIDE.VSCode) {
+        // Examples of version:
+        // 1.24.3 (stable), 1.25.123143 (pre-release)
+        const versionNums = version.split('.')
+        // NOTE: We do not generate blog post for pre-releases (odd minor number).
+        const minor = Number(versionNums[1]) % 2 === 0 ? versionNums[1] : `${Number(versionNums[1]) - 1}`
+        // Example: https://sourcegraph.com/blog/cody-vscode-1-24-0-release
+        blogURL.pathname += `cody-vscode-${versionNums[0]}-${minor}-0-release`
+    }
+
+    return blogURL.href
 }


### PR DESCRIPTION
CLOSE https://linear.app/sourcegraph/issue/CODY-2832

- Changes the behavior of `getReleaseNotesURLByIDE` to always return the release blog post URL for VS Code.
- Adds a new `getReleaseBlogPostURL` function to construct the release blog post URL based on the version number.
- Updates the unit tests to reflect the new behavior.

## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

Verify clicking on the following options will redirect you to the release blog post instead of github release notes:
- "Release Notes" option in the sidebar 
- Upgraded notification in Chat pop-up

https://github.com/sourcegraph/cody/assets/68532117/b4e8537f-87b6-4598-ae2c-eb4fc877f00b

