### PR TITLE
Command: experimental auto-edit command

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -340,6 +340,14 @@
         "when": "cody.activated && cody.isGeneratingCommit"
       },
       {
+        "command": "cody.command.auto-edit",
+        "category": "Cody Command",
+        "group": "Cody Command",
+        "title": "Auto Edit Code at Cursor",
+        "icon": "$(surround-with)",
+        "enablement": "cody.activated && config.cody.internal.unstable"
+      },
+      {
         "command": "cody.auth.signout",
         "category": "Cody",
         "title": "Sign Out",
@@ -620,6 +628,11 @@
         "command": "cody.command.edit-code",
         "key": "alt+k",
         "when": "cody.activated && !editorReadonly"
+      },
+      {
+        "command": "cody.command.auto-edit",
+        "key": "alt+tab",
+        "when": "cody.activated && !editorReadonly && config.cody.internal.unstable"
       },
       {
         "command": "cody.tutorial.edit",

--- a/vscode/src/commands/execute/auto-edit.ts
+++ b/vscode/src/commands/execute/auto-edit.ts
@@ -1,0 +1,55 @@
+import * as vscode from 'vscode'
+
+import { logDebug, ps } from '@sourcegraph/cody-shared'
+import { wrapInActiveSpan } from '@sourcegraph/cody-shared'
+import type { EditCommandResult } from '../../CommandResult'
+import { type ExecuteEditArguments, executeEdit } from '../../edit/execute'
+import { getEditor } from '../../editor/active-editor'
+import type { CodyCommandArgs } from '../types'
+
+/**
+ * Executes Edit command at current cursor position without manually-provided instruction.
+ * It prompts the LLM to provide the completed code to insert at the current cursor position,
+ * or if a selection is detected, edit the selected code instead.
+ *
+ * @param args - Optional arguments for the command, including the URI of the document to operate on and the selection range.
+ * @returns The result of the edit command, or `undefined` if the command could not be executed.
+ */
+export async function executeAutoEditCommand(
+    args?: Partial<CodyCommandArgs>
+): Promise<EditCommandResult | undefined> {
+    return wrapInActiveSpan('command.fim', async span => {
+        span.setAttribute('sampled', true)
+        logDebug('executeAutoEditCommand', 'executing', { verbose: args })
+
+        const editor = args?.uri ? await vscode.window.showTextDocument(args.uri) : getEditor()?.active
+        if (!editor?.document) {
+            throw new Error('No active editor or document')
+        }
+
+        if (args?.range) {
+            editor.selection = new vscode.Selection(args.range.start, args.range.end)
+        }
+
+        const isLineEmpty = editor.document.lineAt(editor.selection.start.line).isEmptyOrWhitespace
+        const isSelectionEmpty = editor.selection.isEmpty && isLineEmpty
+
+        return {
+            type: 'edit',
+            task: await executeEdit({
+                configuration: {
+                    instruction: isSelectionEmpty ? fim : edit,
+                    intent: isSelectionEmpty ? 'add' : 'edit',
+                    mode: isSelectionEmpty ? 'insert' : 'edit',
+                },
+                source: args?.source,
+            } satisfies ExecuteEditArguments),
+        }
+    })
+}
+
+// Prompt for fill-in code
+const fim = ps`Based on the surrounding code and inline instructions (if any), generate the completed code that can be added to the current cursor position marked with <|cursor|>. If no updates are needed, add a comment for the code after the cursor instead. The response should only contain code that can be inserted at the current position WITHOUT including the code before and after the cursor. For example, when adding a docstring for a block of code, only include the docstring in the response.`
+
+// Prompt for editing selected code
+const edit = ps`Based on the surrounding code and inline instructions (if any), generate the completed code that can replace the current selection. Delete code that no longer applies. If no updates are needed, add comments for the code instead. The response should only contain code that can be inserted at the current position WITHOUT including the code before and after the cursor. For example, when adding a docstring, only include the docstring in the response.`

--- a/vscode/src/commands/index.ts
+++ b/vscode/src/commands/index.ts
@@ -66,6 +66,13 @@ export const CodyCommandMenuItems: MenuCommandAccessor[] = [
         mode: 'ask',
     },
     {
+        key: 'auto',
+        description: 'Auto Edit (Experimental)',
+        icon: 'surround-with',
+        command: { command: 'cody.command.auto-edit' },
+        keybinding: '${osIcon}Tab',
+    },
+    {
         key: 'commit',
         description: 'Generate Commit Message (Experimental)',
         icon: 'git-commit',

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -38,6 +38,7 @@ import {
     executeTestChatCommand,
     executeTestEditCommand,
 } from './commands/execute'
+import { executeAutoEditCommand } from './commands/execute/auto-edit'
 import { CodySourceControl } from './commands/scm/source-control'
 import type { CodyCommandArgs } from './commands/types'
 import { newCodyCommandArgs } from './commands/utils/get-commands'
@@ -358,6 +359,7 @@ const register = async (
         vscode.commands.registerCommand('cody.command.unit-tests', a => executeTestEditCommand(a)),
         vscode.commands.registerCommand('cody.command.tests-cases', a => executeTestCaseEditCommand(a)),
         vscode.commands.registerCommand('cody.command.explain-output', a => executeExplainOutput(a)),
+        vscode.commands.registerCommand('cody.command.auto-edit', a => executeAutoEditCommand(a)),
         sourceControl // Generate Commit Message command
     )
 

--- a/vscode/test/e2e/command-edit.test.ts
+++ b/vscode/test/e2e/command-edit.test.ts
@@ -3,12 +3,7 @@ import { expect } from '@playwright/test'
 import * as mockServer from '../fixtures/mock-server'
 
 import { openFileInEditorTab, sidebarExplorer, sidebarSignin } from './common'
-import {
-    type DotcomUrlOverride,
-    type ExpectedV2Events,
-    test as baseTest,
-    executeCommandInPalette,
-} from './helpers'
+import { type DotcomUrlOverride, type ExpectedV2Events, test as baseTest } from './helpers'
 
 const test = baseTest.extend<DotcomUrlOverride>({ dotcomUrl: mockServer.SERVER_URL })
 
@@ -80,9 +75,9 @@ test.extend<ExpectedV2Events>({
     await expect(page.getByText('appleName')).toBeVisible()
     await expect(page.getByText('bananaName')).not.toBeVisible()
 
-    // create another edit from the sidebar Edit button
+    // create another edit using shortcut
     await page.getByText('appleName').click()
-    await executeCommandInPalette(page, 'Cody Commands: Edit code')
+    await page.keyboard.press('Alt+K')
     await expect(page.getByText(inputTitle)).toBeVisible()
     await inputBox.focus()
     await inputBox.fill(instruction)


### PR DESCRIPTION
proof of concept: a new command that triggers multi-line autocompletes but uses the inline-edit.

Loom: https://www.loom.com/share/eb82aab84d7d423381e6f16d46c3a2e8?sid=660401f3-0388-4cc1-9379-609111c25bf0

Currently behind the `cody.internal.unstable` configuration for internal testing purposes.

## Demo

![image](https://github.com/sourcegraph/cody/assets/68532117/f321a0da-2052-4439-9e6f-20bc9c696c4b)

![image](https://github.com/sourcegraph/cody/assets/68532117/53e0191b-8af4-4880-b555-59c2e5e810d9)

![image](https://github.com/sourcegraph/cody/assets/68532117/e8d69e3f-1431-4afc-8d10-d229a9176d8a)


## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

1. Start Cody from this branch
2. Enable `cody.internal.unstable` in your VS Code User Settings 
3. Open a file in your editor and place your cursor in a position where you would usually want to trigger multi-line autocompletes
4. Press `Option+Tab` to execute the command
5. Verify the command works as intended