### PR TITLE
Autocomplete: fuzzy cache matches

### DIFF
--- a/vscode/src/completions/get-inline-completions-tests/analytics.test.ts
+++ b/vscode/src/completions/get-inline-completions-tests/analytics.test.ts
@@ -54,7 +54,7 @@ describe('[getInlineCompletions] completion event', () => {
         )
 
         // Get `suggestionId` from `CompletionLogger.loaded` call.
-        const suggestionId: CompletionLogger.CompletionLogID = spy.mock.calls[0][0]
+        const suggestionId: CompletionLogger.CompletionLogID = spy.mock.calls[0][0].logId
         const completionEvent = CompletionLogger.getCompletionEvent(suggestionId)
 
         return omit(completionEvent, [
@@ -114,6 +114,7 @@ describe('[getInlineCompletions] completion event', () => {
                     "totalChars": 0,
                   },
                   "id": "stable-uuid",
+                  "isFuzzyMatch": false,
                   "languageId": "typescript",
                   "multiline": true,
                   "multilineMode": "block",
@@ -175,6 +176,7 @@ describe('[getInlineCompletions] completion event', () => {
                     "totalChars": 0,
                   },
                   "id": "stable-uuid",
+                  "isFuzzyMatch": false,
                   "languageId": "typescript",
                   "multiline": false,
                   "multilineMode": null,

--- a/vscode/src/completions/get-inline-completions.ts
+++ b/vscode/src/completions/get-inline-completions.ts
@@ -113,6 +113,7 @@ export interface InlineCompletionsResult {
 export enum InlineCompletionsResultSource {
     Network = 'Network',
     Cache = 'Cache',
+    FuzzyCache = 'FuzzyCache',
     HotStreak = 'HotStreak',
     CacheAfterRequestStart = 'CacheAfterRequestStart',
 

--- a/vscode/src/completions/get-inline-completions.ts
+++ b/vscode/src/completions/get-inline-completions.ts
@@ -113,7 +113,6 @@ export interface InlineCompletionsResult {
 export enum InlineCompletionsResultSource {
     Network = 'Network',
     Cache = 'Cache',
-    FuzzyCache = 'FuzzyCache',
     HotStreak = 'HotStreak',
     CacheAfterRequestStart = 'CacheAfterRequestStart',
 
@@ -319,10 +318,17 @@ async function doGetInlineCompletions(
         isCacheEnabled: triggerKind !== TriggerKind.Manual,
     })
     if (cachedResult) {
-        const { completions, source } = cachedResult
+        const { completions, source, isFuzzyMatch } = cachedResult
 
         CompletionLogger.start(logId)
-        CompletionLogger.loaded(logId, requestParams, completions, source, isDotComUser)
+        CompletionLogger.loaded({
+            logId,
+            requestParams,
+            completions,
+            source,
+            isFuzzyMatch,
+            isDotComUser,
+        })
 
         return {
             logId,
@@ -438,7 +444,15 @@ async function doGetInlineCompletions(
         gitUrl: gitIdentifiersForFile?.gitUrl,
         commit: gitIdentifiersForFile?.commit,
     }
-    CompletionLogger.loaded(logId, requestParams, completions, source, isDotComUser, inlineContextParams)
+    CompletionLogger.loaded({
+        logId,
+        requestParams,
+        completions,
+        source,
+        isDotComUser,
+        inlineContextParams,
+        isFuzzyMatch: false,
+    })
 
     return {
         logId,

--- a/vscode/src/completions/inline-completion-item-provider.ts
+++ b/vscode/src/completions/inline-completion-item-provider.ts
@@ -826,7 +826,7 @@ function onlyCompletionWidgetSelectionChanged(
     return prevSelectedCompletionInfo.text !== nextSelectedCompletionInfo.text
 }
 
-let lasIgnoredUriLogged: string | undefined = undefined
+let lastIgnoredUriLogged: string | undefined = undefined
 function logIgnored(uri: vscode.Uri, reason: CodyIgnoreType, isManualCompletion: boolean) {
     // Only show a notification for actively triggered autocomplete requests.
     if (isManualCompletion) {
@@ -834,10 +834,10 @@ function logIgnored(uri: vscode.Uri, reason: CodyIgnoreType, isManualCompletion:
     }
 
     const string = uri.toString()
-    if (lasIgnoredUriLogged === string) {
+    if (lastIgnoredUriLogged === string) {
         return
     }
-    lasIgnoredUriLogged = string
+    lastIgnoredUriLogged = string
     logDebug(
         'CodyCompletionProvider:ignored',
         'Cody is disabled in file ' + uri.toString() + ' (' + reason + ')'

--- a/vscode/src/completions/logger.test.ts
+++ b/vscode/src/completions/logger.test.ts
@@ -63,13 +63,14 @@ describe('logger', () => {
 
         CompletionLogger.start(id)
         CompletionLogger.networkRequestStarted(id, defaultContextSummary)
-        CompletionLogger.loaded(
-            id,
-            defaultRequestParams,
-            [item],
-            InlineCompletionsResultSource.Network,
-            false
-        )
+        CompletionLogger.loaded({
+            logId: id,
+            requestParams: defaultRequestParams,
+            completions: [item],
+            source: InlineCompletionsResultSource.Network,
+            isFuzzyMatch: false,
+            isDotComUser: false,
+        })
         CompletionLogger.suggested(id)
         CompletionLogger.accepted(id, document, item, range(0, 0, 0, 0), false)
 
@@ -94,13 +95,14 @@ describe('logger', () => {
         const id1 = CompletionLogger.create(defaultArgs)
         CompletionLogger.start(id1)
         CompletionLogger.networkRequestStarted(id1, defaultContextSummary)
-        CompletionLogger.loaded(
-            id1,
-            defaultRequestParams,
-            [item],
-            InlineCompletionsResultSource.Network,
-            false
-        )
+        CompletionLogger.loaded({
+            logId: id1,
+            requestParams: defaultRequestParams,
+            completions: [item],
+            source: InlineCompletionsResultSource.Network,
+            isFuzzyMatch: false,
+            isDotComUser: false,
+        })
         CompletionLogger.suggested(id1)
 
         const loggerItem = CompletionLogger.getCompletionEvent(id1)
@@ -110,13 +112,14 @@ describe('logger', () => {
         const id2 = CompletionLogger.create(defaultArgs)
         CompletionLogger.start(id2)
         CompletionLogger.networkRequestStarted(id2, defaultContextSummary)
-        CompletionLogger.loaded(
-            id2,
-            defaultRequestParams,
-            [item],
-            InlineCompletionsResultSource.Cache,
-            false
-        )
+        CompletionLogger.loaded({
+            logId: id2,
+            requestParams: defaultRequestParams,
+            completions: [item],
+            source: InlineCompletionsResultSource.Cache,
+            isFuzzyMatch: false,
+            isDotComUser: false,
+        })
         CompletionLogger.suggested(id2)
         CompletionLogger.accepted(id2, document, item, range(0, 0, 0, 0), false)
 
@@ -133,13 +136,14 @@ describe('logger', () => {
         const id3 = CompletionLogger.create(defaultArgs)
         CompletionLogger.start(id3)
         CompletionLogger.networkRequestStarted(id3, defaultContextSummary)
-        CompletionLogger.loaded(
-            id3,
-            defaultRequestParams,
-            [item],
-            InlineCompletionsResultSource.Cache,
-            false
-        )
+        CompletionLogger.loaded({
+            logId: id3,
+            requestParams: defaultRequestParams,
+            completions: [item],
+            source: InlineCompletionsResultSource.Cache,
+            isFuzzyMatch: false,
+            isDotComUser: false,
+        })
         CompletionLogger.suggested(id3)
 
         const loggerItem3 = CompletionLogger.getCompletionEvent(id3)

--- a/vscode/src/completions/logger.ts
+++ b/vscode/src/completions/logger.ts
@@ -146,6 +146,11 @@ interface SharedEventPayload extends InteractionIDPayload {
      */
     source?: InlineCompletionsResultSource
 
+    /**
+     * True if a completion was fuzzy-matched by the request manager cache.
+     */
+    isFuzzyMatch?: boolean
+
     /** Eventual artificial delay that was used to throttle unwanted completions. */
     artificialDelay?: number
 
@@ -542,15 +547,29 @@ export function networkRequestStarted(
     }
 }
 
-export function loaded(
-    id: CompletionLogID,
-    params: RequestParams,
-    items: InlineCompletionItemWithAnalytics[],
-    source: InlineCompletionsResultSource,
-    isDotComUser: boolean,
-    inlineContextParams: InlineContextItemsParams | undefined = undefined
-): void {
-    const event = activeSuggestionRequests.get(id)
+interface LoadedParams {
+    logId: CompletionLogID
+    requestParams: RequestParams
+    completions: InlineCompletionItemWithAnalytics[]
+    source: InlineCompletionsResultSource
+    isDotComUser: boolean
+    isFuzzyMatch: boolean
+    inlineContextParams?: InlineContextItemsParams
+}
+
+export function loaded(params: LoadedParams): void {
+    const {
+        logId,
+        requestParams,
+        completions,
+        source,
+        isDotComUser,
+        isFuzzyMatch,
+        inlineContextParams = undefined,
+    } = params
+
+    const event = activeSuggestionRequests.get(logId)
+
     if (!event) {
         return
     }
@@ -559,27 +578,28 @@ export function loaded(
 
     // Check if we already have a completion id for the loaded completion item
     const recentCompletionKey =
-        items.length > 0 ? getRecentCompletionsKey(params, items[0].insertText) : ''
+        completions.length > 0 ? getRecentCompletionsKey(requestParams, completions[0].insertText) : ''
 
     const completionAnalyticsId =
         recentCompletions.get(recentCompletionKey) ?? (uuid.v4() as CompletionAnalyticsID)
 
     recentCompletions.set(recentCompletionKey, completionAnalyticsId)
     event.params.id = completionAnalyticsId
+    event.params.isFuzzyMatch = isFuzzyMatch
 
     if (!event.loadedAt) {
         event.loadedAt = performance.now()
     }
     if (event.items.length === 0) {
-        event.items = items.map(item => completionItemToItemInfo(item, isDotComUser))
+        event.items = completions.map(item => completionItemToItemInfo(item, isDotComUser))
     }
 
-    if (!event.params.resolvedModel && items[0]?.resolvedModel) {
-        event.params.resolvedModel = items[0]?.resolvedModel
+    if (!event.params.resolvedModel && completions[0]?.resolvedModel) {
+        event.params.resolvedModel = completions[0]?.resolvedModel
     }
 
-    if (!event.params.responseHeaders && items[0]?.responseHeaders) {
-        event.params.responseHeaders = items[0]?.responseHeaders
+    if (!event.params.responseHeaders && completions[0]?.responseHeaders) {
+        event.params.responseHeaders = completions[0]?.responseHeaders
     }
 
     // 🚨 SECURITY: included only for DotCom users & Public github Repos.
@@ -603,10 +623,10 @@ export function loaded(
             gitUrl: inlineContextParams.gitUrl,
             commit: inlineContextParams.commit,
             filePath: inlineContextParams.filePath,
-            prefix: params.docContext.prefix,
-            suffix: params.docContext.suffix,
-            triggerLine: params.position.line,
-            triggerCharacter: params.position.character,
+            prefix: requestParams.docContext.prefix,
+            suffix: requestParams.docContext.suffix,
+            triggerLine: requestParams.position.line,
+            triggerCharacter: requestParams.position.character,
             context: inlineContextParams.context.map(snippet => ({
                 content: snippet.content,
                 startLine: snippet.startLine,

--- a/vscode/src/completions/request-manager.test.ts
+++ b/vscode/src/completions/request-manager.test.ts
@@ -232,7 +232,7 @@ describe('RequestManager', () => {
                 const prefix2 = 'function foo() {\n  const x = 1\n  const y = 2\n  console.'
                 const { completions, source } = checkCache(prefix2)!
 
-                expect(source).toBe(InlineCompletionsResultSource.Cache)
+                expect(source).toBe(InlineCompletionsResultSource.FuzzyCache)
                 expect(completions[0].insertText).toBe('log(x + y)')
             })
 
@@ -247,7 +247,7 @@ describe('RequestManager', () => {
                     'function bar() {\n  const a = 1;\n  const b = 2;\n  const c = 4;\n  console.'
                 const { completions, source } = await checkCache(prefix2)!
 
-                expect(source).toBe(InlineCompletionsResultSource.Cache)
+                expect(source).toBe(InlineCompletionsResultSource.FuzzyCache)
                 expect(completions[0].insertText).toBe('log(x + y + z)')
             })
 
@@ -260,7 +260,7 @@ describe('RequestManager', () => {
                 const prefix2 = 'function foo() {\n  const x = 1\n\n  const y = 2\n\n\n  console.'
                 const { completions, source } = checkCache(prefix2)!
 
-                expect(source).toBe(InlineCompletionsResultSource.Cache)
+                expect(source).toBe(InlineCompletionsResultSource.FuzzyCache)
                 expect(completions[0].insertText).toBe('log(x + y)')
             })
         })

--- a/vscode/src/completions/request-manager.test.ts
+++ b/vscode/src/completions/request-manager.test.ts
@@ -204,8 +204,9 @@ describe('RequestManager', () => {
             setTimeout(() => provider1.yield(["'hello')"]), 0)
             await createRequest(prefix, provider1)
 
-            const { completions, source } = checkCache(prefix)!
+            const { completions, source, isFuzzyMatch } = checkCache(prefix)!
 
+            expect(isFuzzyMatch).toBe(false)
             expect(source).toBe(InlineCompletionsResultSource.Cache)
             expect(completions[0].insertText).toBe("'hello')")
         })
@@ -223,20 +224,21 @@ describe('RequestManager', () => {
                 expect(checkCache(prefix2)).toBe(null)
             })
 
-            it('matches when semicolons are added', async () => {
+            it('fuzzy matches when semicolons are added', async () => {
                 const prefix1 = 'function foo() {\n  const x = 1;\n  const y = 2;\n  console.'
                 const provider1 = createProvider(prefix1)
                 setTimeout(() => provider1.yield(['log(x + y)']), 0)
                 await createRequest(prefix1, provider1)
 
                 const prefix2 = 'function foo() {\n  const x = 1\n  const y = 2\n  console.'
-                const { completions, source } = checkCache(prefix2)!
+                const { completions, source, isFuzzyMatch } = checkCache(prefix2)!
 
-                expect(source).toBe(InlineCompletionsResultSource.FuzzyCache)
+                expect(source).toBe(InlineCompletionsResultSource.Cache)
+                expect(isFuzzyMatch).toBe(true)
                 expect(completions[0].insertText).toBe('log(x + y)')
             })
 
-            it('matches when previous lines are similar and within the fuzzy match distance', async () => {
+            it('fuzzy matches when previous lines are similar and within the fuzzy match distance', async () => {
                 const prefix1 =
                     'function foo() {\n  const x = 1;\n  const y = 2;\n  const z = 3;\n  console.'
                 const provider1 = createProvider(prefix1)
@@ -245,22 +247,24 @@ describe('RequestManager', () => {
 
                 const prefix2 =
                     'function bar() {\n  const a = 1;\n  const b = 2;\n  const c = 4;\n  console.'
-                const { completions, source } = await checkCache(prefix2)!
+                const { completions, source, isFuzzyMatch } = await checkCache(prefix2)!
 
-                expect(source).toBe(InlineCompletionsResultSource.FuzzyCache)
+                expect(source).toBe(InlineCompletionsResultSource.Cache)
+                expect(isFuzzyMatch).toBe(true)
                 expect(completions[0].insertText).toBe('log(x + y + z)')
             })
 
-            it('matches when new lines are added', async () => {
+            it('fuzzy matches when new lines are added', async () => {
                 const prefix1 = 'function foo() {\n  const x = 1;\n  const y = 2;\n  console.'
                 const provider1 = createProvider(prefix1)
                 setTimeout(() => provider1.yield(['log(x + y)']), 0)
                 await createRequest(prefix1, provider1)
 
                 const prefix2 = 'function foo() {\n  const x = 1\n\n  const y = 2\n\n\n  console.'
-                const { completions, source } = checkCache(prefix2)!
+                const { completions, source, isFuzzyMatch } = checkCache(prefix2)!
 
-                expect(source).toBe(InlineCompletionsResultSource.FuzzyCache)
+                expect(source).toBe(InlineCompletionsResultSource.Cache)
+                expect(isFuzzyMatch).toBe(true)
                 expect(completions[0].insertText).toBe('log(x + y)')
             })
         })

--- a/vscode/src/completions/request-manager.ts
+++ b/vscode/src/completions/request-manager.ts
@@ -11,6 +11,7 @@ import {
 
 import { addAutocompleteDebugEvent } from '../services/open-telemetry/debug-utils'
 
+import levenshtein from 'js-levenshtein'
 import { logDebug } from '../log'
 import { completionProviderConfig } from './completion-provider-config'
 import {
@@ -22,7 +23,7 @@ import { isLocalCompletionsProvider } from './providers/experimental-ollama'
 import { STOP_REASON_HOT_STREAK } from './providers/hot-streak'
 import type { CompletionProviderTracer, Provider } from './providers/provider'
 import { reuseLastCandidate } from './reuse-last-candidate'
-import { lines, removeIndentation } from './text-processing'
+import { getPrevNonEmptyLineIndex, lines, removeIndentation } from './text-processing'
 import {
     type InlineCompletionItemWithAnalytics,
     processInlineCompletions,
@@ -303,25 +304,124 @@ interface RequestCacheItem {
     completions: InlineCompletionItemWithAnalytics[]
     source: InlineCompletionsResultSource
 }
+
+interface CacheKey {
+    prefixWithoutLastNLines: string
+    prevNonEmptyLines: string[]
+    currentLinePrefix: string
+    nextNonEmptyLine: string
+}
+
+type CacheEntry = { key: CacheKey; value: RequestCacheItem }
+
 class RequestCache {
-    private cache = new LRUCache<string, RequestCacheItem>({
+    private cache = new LRUCache<string, CacheEntry>({
         max: 250,
     })
 
-    private toCacheKey(key: Pick<RequestParams, 'docContext'>): string {
-        return `${key.docContext.prefix}█${key.docContext.nextNonEmptyLine}`
+    /**
+     * The base allowed Levenshtein distance between lines to match.
+     */
+    private levenshteinBaseThreshold = 3
+    /**
+     * The maximum allowed Levenshtein distance between lines to match.
+     */
+    private levenshteinMaxThreshold = 5
+    /**
+     * The number of lines to fuzzy match.
+     */
+    private fuzzyPrefixMatchLineCount = 5
+
+    private toCacheKey(requestParams: Pick<RequestParams, 'docContext'>): CacheKey {
+        const { prefix, currentLinePrefix, nextNonEmptyLine } = requestParams.docContext
+
+        const prefixWithoutCurrentLinePrefix = prefix.slice(0, -currentLinePrefix.length).trim()
+
+        const prevNonEmptyLines: string[] = []
+        let remainingPrefix = prefixWithoutCurrentLinePrefix
+
+        for (let i = 0; i < this.fuzzyPrefixMatchLineCount; i++) {
+            let lastNewLineIndex = getPrevNonEmptyLineIndex(remainingPrefix)
+            if (lastNewLineIndex === null) {
+                lastNewLineIndex = 0
+            }
+
+            const prevNonEmptyLine = remainingPrefix.slice(lastNewLineIndex)
+            prevNonEmptyLines.unshift(prevNonEmptyLine)
+            remainingPrefix = remainingPrefix.slice(0, -prevNonEmptyLine.length).trim()
+
+            if (lastNewLineIndex === 0) {
+                break
+            }
+        }
+
+        return {
+            prefixWithoutLastNLines: remainingPrefix,
+            prevNonEmptyLines,
+            currentLinePrefix,
+            nextNonEmptyLine,
+        }
     }
 
-    public get(key: RequestParams): RequestCacheItem | undefined {
-        return this.cache.get(this.toCacheKey(key))
+    private serializeCacheKey(key: CacheKey): string {
+        return `${key.prefixWithoutLastNLines}\n${key.prevNonEmptyLines.join('\n')}\n${
+            key.currentLinePrefix
+        }█${key.nextNonEmptyLine}`
     }
 
-    public set(key: Pick<RequestParams, 'docContext'>, item: RequestCacheItem): void {
-        this.cache.set(this.toCacheKey(key), item)
+    private getDynamicThreshold(str: string): number {
+        // Empirically picked number to increase the maximum threshold for long strings.
+        const lengthFactor = Math.floor(str.length / 20)
+        return Math.min(this.levenshteinBaseThreshold + lengthFactor, this.levenshteinMaxThreshold)
     }
 
-    public delete(key: RequestParams): void {
-        this.cache.delete(this.toCacheKey(key))
+    public get(requestParams: RequestParams): RequestCacheItem | undefined {
+        const cacheKey = this.toCacheKey(requestParams)
+        const cacheKeyString = this.serializeCacheKey(cacheKey)
+
+        const exactMatch = this.cache.get(cacheKeyString)
+        if (exactMatch) {
+            return exactMatch.value
+        }
+
+        // If no exact match found, look for a close match using levenshtein distance.
+        // This is useful for cases when previous lines have minor changes
+        // like added semicolons or extra spaces.
+        for (const entry of this.cache.values() as Generator<CacheEntry | undefined>) {
+            if (
+                entry &&
+                entry.key.prefixWithoutLastNLines === cacheKey.prefixWithoutLastNLines &&
+                entry.key.currentLinePrefix === cacheKey.currentLinePrefix &&
+                entry.key.nextNonEmptyLine === cacheKey.nextNonEmptyLine &&
+                entry.key.prevNonEmptyLines.length === cacheKey.prevNonEmptyLines.length
+            ) {
+                const allLinesMatch = entry.key.prevNonEmptyLines.every((line, index) => {
+                    const threshold = this.getDynamicThreshold(line)
+                    const distance = levenshtein(line, cacheKey.prevNonEmptyLines[index])
+                    return distance <= threshold
+                })
+
+                if (allLinesMatch) {
+                    return {
+                        ...entry.value,
+                        source: InlineCompletionsResultSource.FuzzyCache,
+                    }
+                }
+            }
+        }
+
+        return undefined
+    }
+
+    public set(requestParams: Pick<RequestParams, 'docContext'>, item: RequestCacheItem): void {
+        const cacheKey = this.toCacheKey(requestParams)
+        const hashKey = this.serializeCacheKey(cacheKey)
+        this.cache.set(hashKey, { key: cacheKey, value: item })
+    }
+
+    public delete(requestParams: RequestParams): void {
+        const hashKey = this.serializeCacheKey(this.toCacheKey(requestParams))
+        this.cache.delete(hashKey)
     }
 }
 


### PR DESCRIPTION
This PR adds fuzzy matching to the autocomplete request manager cache. Fuzzy matching allows for approximate cache key matching, which should increase the cache hit ratio for all autocomplete requests. It should be especially useful for hot streak completions where we pre-generate multiple suggestions upfront. Currently, these completions are discarded if users slightly tweak the suggested code, even by adding a semicolon or an extra space. The fuzzy-matcher fixes this inefficiency. 

- We use the Levenshtein distance to measure the similarity between strings.
- The matching threshold is dynamically adjusted based on the length of the string, allowing for more flexibility with longer strings while maintaining precision for shorter ones.
- The fuzzy matching is applied to multiple previous context lines, not just the current line. This provides a more robust matching system for minor changes across numerous lines.
- ~~The new completion source `InlineCompletionsResultSource.FuzzyCache` is added to analyze the impact of this change in production.~~
- The new `isFuzzyMatch` analytics field is added to autocomplete events to analyze the impact of this change in production.

Closes https://linear.app/sourcegraph/issue/CODY-2838/[autocomplete-latency]-implement-fuzzy-matcher-to-autocomplete-cache

## Test plan

Unit tests and manually verified that it plays nicely with hot streak completions (add semicolons or extra lines after the accepted completion and observe that the hot streak completion still matches).
