### PR TITLE
skip check:manifest if OFFLINE is set

### DIFF
--- a/vscode/scripts/validate-package-json.ts
+++ b/vscode/scripts/validate-package-json.ts
@@ -5,6 +5,11 @@ import addFormats from 'ajv-formats'
 import axios from 'axios'
 
 async function main() {
+    if (process.env.OFFLINE) {
+        console.warn('Skipping validation of package.json because OFFLINE=true')
+        return
+    }
+
     const packageJson = JSON.parse(fs.readFileSync(path.join(process.cwd(), 'package.json'), 'utf-8'))
     const schemaJson = JSON.parse(
         fs.readFileSync(path.join(process.cwd(), 'package.schema.json'), 'utf-8')


### PR DESCRIPTION
I was trying to do development offline and this step was failing due to it needing internet access to download schema files. Given it is still covered by CI this enables disabling it via the usual OFFLINE environment variable.

Note: I looked a little bit into caching here, but I didn't want to over-engineer. However, it may be useful to do given this step takes 7s for me. It may be faster for you if you live closer to schemastore servers.

Test Plan: ran "pnpm run check:manifest" with and without OFFLINE=1 specified.