### PR TITLE
hide "New Chat in Sidebar" command

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -10,6 +10,12 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 
 ### Changed
 
+## 1.26.1
+
+### Fixed
+
+- A no-op command `New Chat in Sidebar` was removed. (This will be added back with functionality in the next minor stable release version.)
+
 ## 1.26.0
 
 ### Added

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -3,7 +3,7 @@
   "name": "cody-ai",
   "private": true,
   "displayName": "Cody: AI Coding Assistant with Autocomplete & Chat",
-  "version": "1.26.0",
+  "version": "1.26.1",
   "publisher": "sourcegraph",
   "license": "Apache-2.0",
   "icon": "resources/cody.png",
@@ -456,7 +456,7 @@
         "command": "cody.chat.panel.sidebar.new",
         "category": "Cody",
         "title": "New Chat in Sidebar",
-        "enablement": "cody.activated",
+        "enablement": "false",
         "group": "Cody",
         "icon": "$(new-comment-icon)"
       },


### PR DESCRIPTION
Removes a no-op command `New Chat in Sidebar` that was added prematurely. (This will be added back with functionality in the next minor stable release version.)

![image](https://github.com/sourcegraph/cody/assets/1646931/0b23a368-ea73-4a44-a293-be3150ad8be0)


## Test plan

Tested locally