### PR TITLE
Allow clients to redefine untitled files protocol during their creation

### DIFF
--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/agent/protocol_generated/CodyAgentClient.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/agent/protocol_generated/CodyAgentClient.kt
@@ -15,7 +15,7 @@ interface CodyAgentClient {
   @JsonRequest("textDocument/edit")
   fun textDocument_edit(params: TextDocumentEditParams): CompletableFuture<Boolean>
   @JsonRequest("textDocument/openUntitledDocument")
-  fun textDocument_openUntitledDocument(params: UntitledTextDocument): CompletableFuture<Boolean>
+  fun textDocument_openUntitledDocument(params: UntitledTextDocument): CompletableFuture<ProtocolTextDocument?>
   @JsonRequest("textDocument/show")
   fun textDocument_show(params: TextDocument_ShowParams): CompletableFuture<Boolean>
   @JsonRequest("workspace/edit")

--- a/agent/src/TestClient.ts
+++ b/agent/src/TestClient.ts
@@ -340,9 +340,9 @@ export class TestClient extends MessageHandler {
             return result
         })
         this.registerRequest('textDocument/openUntitledDocument', params => {
-            this.workspace.loadDocument(ProtocolTextDocumentWithUri.fromDocument(params))
+            const doc = this.workspace.loadDocument(ProtocolTextDocumentWithUri.fromDocument(params))
             this.notify('textDocument/didOpen', params)
-            return Promise.resolve(true)
+            return Promise.resolve(doc.protocolDocument.underlying)
         })
         this.registerRequest('textDocument/edit', async params => {
             this.textDocumentEditParams.push(params)

--- a/vscode/src/extension-client.ts
+++ b/vscode/src/extension-client.ts
@@ -1,4 +1,5 @@
-import type { Disposable } from 'vscode'
+import type { Disposable, TextDocument, Uri } from 'vscode'
+import type vscode from 'vscode'
 import type { EnterpriseContextFactory } from './context/enterprise-context-factory'
 import type { ClientCapabilities } from './jsonrpc/agent-protocol'
 import { FixupCodeLenses } from './non-stop/codelenses/provider'
@@ -31,6 +32,12 @@ export interface ExtensionClient {
      */
     createFixupControlApplicator(fixups: FixupActor & FixupFileCollection): FixupControlApplicator
 
+    /**
+     * Opens a new document, creating appropriate file is required by a protocol.
+     * This method allows client to change the URI, so the caller should inspect returned TextDocument.
+     */
+    openNewDocument(workspace: typeof vscode.workspace, uri: Uri): Thenable<TextDocument | undefined>
+
     get clientName(): string
     get clientVersion(): string
     get capabilities(): ClientCapabilities | undefined
@@ -45,6 +52,7 @@ export function defaultVSCodeExtensionClient(): ExtensionClient {
             dispose: () => {},
         }),
         createFixupControlApplicator: files => new FixupCodeLenses(files),
+        openNewDocument: (workspace, uri) => workspace.openTextDocument(uri),
         clientName: 'vscode',
         clientVersion: version,
         capabilities: undefined,

--- a/vscode/src/jsonrpc/agent-protocol.ts
+++ b/vscode/src/jsonrpc/agent-protocol.ts
@@ -311,7 +311,7 @@ export type ServerRequests = {
     'window/showMessage': [ShowWindowMessageParams, string | null]
 
     'textDocument/edit': [TextDocumentEditParams, boolean]
-    'textDocument/openUntitledDocument': [UntitledTextDocument, boolean]
+    'textDocument/openUntitledDocument': [UntitledTextDocument, ProtocolTextDocument | undefined | null]
     'textDocument/show': [
         {
             uri: string


### PR DESCRIPTION
Closes https://linear.app/sourcegraph/issue/CODY-2004/bug-cody-recreates-the-file-that-was-created-by-generate-unit-tests

## Changes

Some IDEs (maybe even most IDEs except VSC) does not have notion of unsaved files.
Keeping two different models in IDE and in the agent is problematic and leads to hard to track errors.
It is easier to let client be honest and notify agent about real protocol which it is using (most likely `file://` instead of `untitled://`).

As a result that change slightly modifies behaviour of the `openTextDocument`. 
One could now call `openTextDocument` with `untitled://abc` parameter, and as a result get a `TextDocument` which uri points to `file://abc` (or any other path, really).

## Test plan

1. Build [JetBrains branch ](https://github.com/sourcegraph/jetbrains/pull/1903)with this PR using CODY_DIR env var
2. Ask cody to generate tests for some file which does not have tests yet
3. Accept the changes
4. Delete that newly created file
5. Perform autocomplete in some other file
6. Make sure test file was not recreated

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
