### PR TITLE
Chat: update chat model selection and default model on auth sync

### DIFF
--- a/vscode/src/chat/chat-view/ChatController.ts
+++ b/vscode/src/chat/chat-view/ChatController.ts
@@ -533,6 +533,14 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
         // Run this async because this method may be called during initialization
         // and awaiting on this.postMessage may result in a deadlock
         void this.sendConfig()
+
+        // Get the latest model list available to the current user to update the ChatModel.
+        const authStatus = this.authProvider.getAuthStatus()
+        const models = ModelsService.getModels(
+            ModelUsage.Chat,
+            authStatus.isDotCom && !authStatus.userCanUpgrade
+        )
+        this.handleSetChatModel(getDefaultModelID(this.authProvider, models))
     }
 
     // When the webview sends the 'ready' message, respond by posting the view config
@@ -876,6 +884,7 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
     private async handleSetChatModel(modelID: string): Promise<void> {
         this.chatModel.updateModel(modelID)
         await chatModel.set(modelID)
+        this.postChatModels()
     }
 
     private async handleGetAllMentionProvidersMetadata(): Promise<void> {

--- a/vscode/src/chat/chat-view/ChatPanelsManager.ts
+++ b/vscode/src/chat/chat-view/ChatPanelsManager.ts
@@ -116,10 +116,7 @@ export class ChatPanelsManager implements vscode.Disposable {
         await vscode.commands.executeCommand('setContext', CodyChatPanelViewType, authStatus.isLoggedIn)
         this.supportTreeViewProvider.syncAuthStatus(authStatus)
 
-        // Notify all existing panel providers about the auth status change.
-        for (const provider of this.panelProviders) {
-            provider.syncAuthStatus()
-        }
+        this.sidebarProvider.syncAuthStatus()
     }
 
     public async getNewChatPanel(): Promise<ChatController> {
@@ -197,6 +194,7 @@ export class ChatPanelsManager implements vscode.Disposable {
         })
 
         this.activePanelProvider = provider
+        this.panelProviders.push(provider)
         return provider
     }
 
@@ -217,7 +215,7 @@ export class ChatPanelsManager implements vscode.Disposable {
             vscode.workspace.getConfiguration().get<string>('cody.advanced.agent.ide') === CodyIDE.Web
         const allowRemoteContext = isCodyWeb || !isConsumer
 
-        const controller = new ChatController({
+        return new ChatController({
             ...this.options,
             chatClient: this.chatClient,
             localEmbeddings: isConsumer ? this.localEmbeddings : null,
@@ -228,8 +226,6 @@ export class ChatPanelsManager implements vscode.Disposable {
             guardrails: this.guardrails,
             startTokenReceiver: this.options.startTokenReceiver,
         })
-        this.panelProviders.push(controller)
-        return controller
     }
 
     public async clearHistory(chatID?: string): Promise<void> {


### PR DESCRIPTION
This PR fixes an issue where submitting a question in sidebar chat view does not display the correct icon associated with the selected model as the model ID was not updated in the ChatModel previously on auth change because the chat provider can only be created when the user is logged in, which is no longer the case for the sidebar chat view.

Changes:
- Update the ChatModel based on the available chat model list for the current user on auth status change.


## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

1. Start Cody from this branch
2. In the sidebar chat, send Cody a question without changing the model
3. Verify the response from Cody is showing the logo associated with the model shown in your model dropdown list.

### After

![Screenshot 2024-07-11 at 9 54 46 AM](https://github.com/sourcegraph/cody/assets/68532117/e8c82fbd-9e57-409b-bb22-6c491cf2652c)

### Before

The response from Cody is not showing the correct logo associated with the model shown in the chat input box. Hovering over the logo shows that the model ID is "{pending}":

![image](https://github.com/sourcegraph/cody/assets/68532117/a26c12ba-7eb7-430d-98df-6d1642af81a4)
