### PR TITLE
VS Code: make config features getter sync and properly dispose scheduled fetches

### DIFF
--- a/lib/shared/src/guardrails/client.ts
+++ b/lib/shared/src/guardrails/client.ts
@@ -9,7 +9,7 @@ export class SourcegraphGuardrailsClient implements Guardrails {
 
     public async searchAttribution(snippet: string): Promise<Attribution | Error> {
         // Short-circuit attribution search if turned off in site config.
-        const configFeatures = await ConfigFeaturesSingleton.getInstance().getConfigFeatures()
+        const configFeatures = ConfigFeaturesSingleton.getInstance().getConfigFeatures()
         if (!configFeatures.attribution) {
             return new Error('Attribution search is turned off.')
         }

--- a/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
+++ b/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
@@ -1518,7 +1518,7 @@ export class SimpleChatPanelProvider
         // Used for keeping sidebar chat view closed when webview panel is enabled
         await vscode.commands.executeCommand('setContext', CodyChatPanelViewType, true)
 
-        const configFeatures = await ConfigFeaturesSingleton.getInstance().getConfigFeatures()
+        const configFeatures = ConfigFeaturesSingleton.getInstance().getConfigFeatures()
         void this.postMessage({
             type: 'setConfigFeatures',
             configFeatures: {

--- a/vscode/src/commands/execute/ask.ts
+++ b/vscode/src/commands/execute/ask.ts
@@ -22,7 +22,7 @@ export interface ExecuteChatArguments extends Omit<WebviewSubmitMessage, 'text' 
  * This is also called by all the default commands (e.g., explain).
  */
 export const executeChat = async (args: ExecuteChatArguments): Promise<ChatSession | undefined> => {
-    const { chat, commands } = await ConfigFeaturesSingleton.getInstance().getConfigFeatures()
+    const { chat, commands } = ConfigFeaturesSingleton.getInstance().getConfigFeatures()
     const isCommand = Boolean(args.command)
     if ((!isCommand && !chat) || (isCommand && !commands)) {
         void vscode.window.showErrorMessage(

--- a/vscode/src/completions/inline-completion-item-provider.ts
+++ b/vscode/src/completions/inline-completion-item-provider.ts
@@ -228,7 +228,7 @@ export class InlineCompletionItemProvider
             }
             this.lastCompletionRequest = completionRequest
 
-            const configFeatures = await ConfigFeaturesSingleton.getInstance().getConfigFeatures()
+            const configFeatures = ConfigFeaturesSingleton.getInstance().getConfigFeatures()
 
             if (!configFeatures.autoComplete) {
                 // If ConfigFeatures exists and autocomplete is disabled then raise

--- a/vscode/src/edit/manager.ts
+++ b/vscode/src/edit/manager.ts
@@ -91,7 +91,7 @@ export class EditManager implements vscode.Disposable {
             source = DEFAULT_EVENT_SOURCE,
             telemetryMetadata,
         } = args
-        const configFeatures = await ConfigFeaturesSingleton.getInstance().getConfigFeatures()
+        const configFeatures = ConfigFeaturesSingleton.getInstance().getConfigFeatures()
         if (!configFeatures.commands) {
             void vscode.window.showErrorMessage(
                 'This feature has been disabled by your Sourcegraph site admin.'

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -255,6 +255,7 @@ const register = async (
         disposables
     )
     disposables.push(chatManager)
+    disposables.push(ConfigFeaturesSingleton.getInstance())
 
     const sourceControl = new CodySourceControl(chatClient)
     const statusBar = createStatusBar()
@@ -357,7 +358,7 @@ const register = async (
         id: DefaultCodyCommands | PromptString,
         args?: Partial<CodyCommandArgs>
     ): Promise<CommandResult | undefined> => {
-        const { commands } = await ConfigFeaturesSingleton.getInstance().getConfigFeatures()
+        const { commands } = ConfigFeaturesSingleton.getInstance().getConfigFeatures()
         if (!commands) {
             void vscode.window.showErrorMessage(
                 'This feature has been disabled by your Sourcegraph site admin.'


### PR DESCRIPTION
I noticed the async call on the critical path of the autocomplete pipeline and went to check if it slows us down. It turns out it can be made synchronous, which this PR does. Plus, it adds logic to clean `setInterval` calls properly.

## Test plan

CI
