### PR TITLE
Autocomplete: Add extended version of smart throttle

### DIFF
--- a/lib/shared/src/configuration.ts
+++ b/lib/shared/src/configuration.ts
@@ -77,6 +77,7 @@ export interface Configuration {
     autocompleteExperimentalFireworksOptions?: FireworksOptions
     autocompleteExperimentalMultiModelCompletions?: MultimodelSingleModelConfig[]
     autocompleteExperimentalSmartThrottle?: boolean
+    autocompleteExperimentalSmartThrottleExtended?: boolean
 
     /**
      * Hidden settings

--- a/lib/shared/src/experimentation/FeatureFlagProvider.ts
+++ b/lib/shared/src/experimentation/FeatureFlagProvider.ts
@@ -42,6 +42,7 @@ export enum FeatureFlag {
     CodyAutocompleteHotStreak = 'cody-autocomplete-hot-streak',
     // Enable smart-throttling for more aggressive request cancellation and lower initial latencies
     CodyAutocompleteSmartThrottle = 'cody-autocomplete-smart-throttle',
+    CodyAutocompleteSmartThrottleExtended = 'cody-autocomplete-smart-throttle-extended',
 
     // When enabled, it will extend the number of languages considered for context (e.g. React files
     // will be able to use CSS files as context).

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -7,7 +7,7 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 ### Added
 
 - Chat: Chat has been added back to the VS Code sidebar (after being removed about 6 months ago). By default, new chats open in the sidebar. New chats can still be opened in an editor panel with the `New Chat in Sidebar` command. Currently open chats can be moved from the sidebar into an editor panel and vice versa.
-- Autocomplete: Added an extended experimental throttling mechanism that should decrease latency. [TODO]
+- Autocomplete: Added an extended experimental throttling mechanism that should decrease latency. [pull/4852](https://github.com/sourcegraph/cody/pull/4852)
 
 ### Fixed
 

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -7,6 +7,7 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 ### Added
 
 - Chat: Chat has been added back to the VS Code sidebar (after being removed about 6 months ago). By default, new chats open in the sidebar. New chats can still be opened in an editor panel with the `New Chat in Sidebar` command. Currently open chats can be moved from the sidebar into an editor panel and vice versa.
+- Autocomplete: Added an extended experimental throttling mechanism that should decrease latency. [TODO]
 
 ### Fixed
 

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -1212,6 +1212,11 @@
           "default": false,
           "markdownDescription": "Changes the debounce time for autocomplete requests based on the amount of time since the last request."
         },
+        "cody.autocomplete.experimental.smartThrottleExtended": {
+          "type": "boolean",
+          "default": false,
+          "markdownDescription": "Changes the (extended) debounce time for autocomplete requests based on the amount of time since the last request."
+        },
         "openctx.enable": {
           "type": "boolean",
           "markdownDescription": "Enable OpenCtx providers for Cody.",

--- a/vscode/src/completions/completion-provider-config.ts
+++ b/vscode/src/completions/completion-provider-config.ts
@@ -16,6 +16,7 @@ class CompletionProviderConfig {
         FeatureFlag.CodyAutocompleteTracing,
         FeatureFlag.CodyAutocompleteContextExtendLanguagePool,
         FeatureFlag.CodyAutocompleteSmartThrottle,
+        FeatureFlag.CodyAutocompleteSmartThrottleExtended,
         FeatureFlag.CodyAutocompleteLatencyExperimentBasedFeatureFlag,
     ] as const
 
@@ -73,22 +74,31 @@ class CompletionProviderConfig {
         }
     }
 
-    private getLatencyExperimentGroup(): 'hot-streak' | 'smart-throttle' | 'control' {
+    private getLatencyExperimentGroup():
+        | 'hot-streak'
+        | 'smart-throttle'
+        | 'smart-throttle-extended'
+        | 'control' {
         // The desired distribution:
-        // - Hot-streak 33%
-        // - Smart-throttle 33%
-        // - Control group 33%
+        // - Hot-streak 25%
+        // - Smart-throttle 25%
+        // - Smart-throttle-extended 25%
+        // - Control group 25%
         //
-        // The rollout values to set;
-        // - CodyAutocompleteLatencyExperimentBasedFeatureFlag 66%
-        // - CodyAutocompleteHotStreak 50%
-        // - CodyAutocompleteSmartThrottle 100%
+        // The rollout values to set:
+        // - CodyAutocompleteLatencyExperimentBasedFeatureFlag 75%
+        // - CodyAutocompleteHotStreak 33%
+        // - CodyAutocompleteSmartThrottle 66%
+        // - CodyAutocompleteSmartThrottleExtended 100%
         if (this.getPrefetchedFlag(FeatureFlag.CodyAutocompleteLatencyExperimentBasedFeatureFlag)) {
             if (this.getPrefetchedFlag(FeatureFlag.CodyAutocompleteHotStreak)) {
                 return 'hot-streak'
             }
 
             if (this.getPrefetchedFlag(FeatureFlag.CodyAutocompleteSmartThrottle)) {
+                if (this.getPrefetchedFlag(FeatureFlag.CodyAutocompleteSmartThrottleExtended)) {
+                    return 'smart-throttle-extended'
+                }
                 return 'smart-throttle'
             }
         }
@@ -107,6 +117,13 @@ class CompletionProviderConfig {
         return (
             this.config.autocompleteExperimentalSmartThrottle ||
             this.getLatencyExperimentGroup() === 'smart-throttle'
+        )
+    }
+
+    public get smartThrottleExtended(): boolean {
+        return (
+            this.config.autocompleteExperimentalSmartThrottleExtended ||
+            this.getLatencyExperimentGroup() === 'smart-throttle-extended'
         )
     }
 }

--- a/vscode/src/completions/completion-provider-config.ts
+++ b/vscode/src/completions/completion-provider-config.ts
@@ -89,7 +89,7 @@ class CompletionProviderConfig {
         // - CodyAutocompleteLatencyExperimentBasedFeatureFlag 75%
         // - CodyAutocompleteHotStreak 33%
         // - CodyAutocompleteSmartThrottle 66%
-        // - CodyAutocompleteSmartThrottleExtended 100%
+        // - CodyAutocompleteSmartThrottleExtended 50%
         if (this.getPrefetchedFlag(FeatureFlag.CodyAutocompleteLatencyExperimentBasedFeatureFlag)) {
             if (this.getPrefetchedFlag(FeatureFlag.CodyAutocompleteHotStreak)) {
                 return 'hot-streak'

--- a/vscode/src/completions/inline-completion-item-provider.ts
+++ b/vscode/src/completions/inline-completion-item-provider.ts
@@ -158,8 +158,11 @@ export class InlineCompletionItemProvider
             )
         )
 
-        if (completionProviderConfig.smartThrottle) {
-            this.smartThrottleService = new SmartThrottleService()
+        if (completionProviderConfig.smartThrottle || completionProviderConfig.smartThrottleExtended) {
+            this.smartThrottleService = new SmartThrottleService(
+                // Use an extended throttle timeout of 500ms for the extended throttle.
+                completionProviderConfig.smartThrottleExtended ? 500 : undefined
+            )
             this.disposables.push(this.smartThrottleService)
         }
 

--- a/vscode/src/completions/smart-throttle.test.ts
+++ b/vscode/src/completions/smart-throttle.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { getCurrentDocContext } from './get-current-doc-context'
 import { TriggerKind } from './get-inline-completions'
 import type { RequestParams } from './request-manager'
-import { SmartThrottleService, THROTTLE_TIMEOUT } from './smart-throttle'
+import { DEFAULT_THROTTLE_TIMEOUT, SmartThrottleService } from './smart-throttle'
 import { documentAndPosition } from './test-helpers'
 
 describe('SmartThrottleService', () => {
@@ -63,7 +63,7 @@ describe('SmartThrottleService', () => {
         expect(thirdThrottledRequest?.abortSignal?.aborted).toBe(false)
 
         // The third request will be promoted if enough time passes since the last promotion
-        vi.advanceTimersByTime(THROTTLE_TIMEOUT + 10)
+        vi.advanceTimersByTime(DEFAULT_THROTTLE_TIMEOUT + 10)
 
         const fourthThrottledRequest = await service.throttle(createRequest('foo█'), TriggerKind.Manual)
 

--- a/vscode/src/completions/smart-throttle.ts
+++ b/vscode/src/completions/smart-throttle.ts
@@ -6,8 +6,8 @@ import { forkSignal, sleep } from './utils'
 
 // The throttle timeout is relatively high so that we do not keep a lot of concurrent requests. 250
 // is chosen as it will keep about 2 requests concurrent with our current median latency of about
-// 500ms.
-export const THROTTLE_TIMEOUT = 250
+// 500ms
+export const DEFAULT_THROTTLE_TIMEOUT = 250
 
 // A smart throttle service for autocomplete requests. The idea is to move beyond a simple debounce
 // based timeout and start a bunch of requests immediately. Additionally, we also want to be more
@@ -29,6 +29,12 @@ export class SmartThrottleService implements vscode.Disposable {
     // The timestamp when the latest tail request was prompted to a throttled-request. When it
     // exceeds the throttle timeout, a tail request will be promoted again.
     private lastThrottlePromotion = 0
+
+    private THROTTLE_TIMEOUT: number
+
+    constructor(timeout = DEFAULT_THROTTLE_TIMEOUT) {
+        this.THROTTLE_TIMEOUT = timeout
+    }
 
     async throttle(request: RequestParams, triggerKind: TriggerKind): Promise<RequestParams | null> {
         return wrapInActiveSpan('autocomplete.smartThrottle', async () => {
@@ -53,7 +59,7 @@ export class SmartThrottleService implements vscode.Disposable {
             // Case 2: The last throttled promotion is more than the throttle timeout ago. In this case,
             //         promote the last tail request to a throttled request and continue with the third
             //         case.
-            if (now - this.lastThrottlePromotion > THROTTLE_TIMEOUT && this.tailRequest) {
+            if (now - this.lastThrottlePromotion > this.THROTTLE_TIMEOUT && this.tailRequest) {
                 // Setting tailRequest to null will make sure the throttled request can no longer be
                 // cancelled by this logic.
                 this.tailRequest = null

--- a/vscode/src/configuration.test.ts
+++ b/vscode/src/configuration.test.ts
@@ -102,6 +102,8 @@ describe('getConfiguration', () => {
                         return 1500
                     case 'cody.autocomplete.experimental.smartThrottle':
                         return false
+                    case 'cody.autocomplete.experimental.smartThrottleExtended':
+                        return false
                     default:
                         throw new Error(`unexpected key: ${key}`)
                 }
@@ -153,6 +155,7 @@ describe('getConfiguration', () => {
             },
             autocompleteFirstCompletionTimeout: 1500,
             autocompleteExperimentalSmartThrottle: false,
+            autocompleteExperimentalSmartThrottleExtended: false,
             testingModelConfig: undefined,
             experimentalChatContextRanker: false,
         } satisfies Configuration)

--- a/vscode/src/configuration.ts
+++ b/vscode/src/configuration.ts
@@ -170,6 +170,10 @@ export function getConfiguration(
             'autocomplete.experimental.smartThrottle',
             false
         ),
+        autocompleteExperimentalSmartThrottleExtended: getHiddenSetting(
+            'autocomplete.experimental.smartThrottleExtended',
+            false
+        ),
 
         // Note: In spirit, we try to minimize agent-specific code paths in the VSC extension.
         // We currently use this flag for the agent to provide more helpful error messages

--- a/vscode/src/testutils/mocks.ts
+++ b/vscode/src/testutils/mocks.ts
@@ -921,6 +921,7 @@ export const DEFAULT_VSCODE_SETTINGS = {
     },
     autocompleteFirstCompletionTimeout: 3500,
     autocompleteExperimentalSmartThrottle: false,
+    autocompleteExperimentalSmartThrottleExtended: false,
     testingModelConfig: undefined,
     experimentalChatContextRanker: false,
 } satisfies Configuration


### PR DESCRIPTION
## Description

This PR adds an extended version of the smart-throttle, that increases the `THROTTLE_TIMEOUT` from 250 to 500ms. This will help us assess if the additional requests by the smart throttle are causing increased latency. This experiment should result in _fewer_ in-flight requests

## Test plan

1. Enable smart throttle experiment
2. Expect to see in-flight requests and smart abort
3. Also covered by https://github.com/sourcegraph/cody/pull/4735

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
