### PR TITLE
fix(local_e2e): diagnose properly access token issues

### DIFF
--- a/agent/src/local-e2e/README.md
+++ b/agent/src/local-e2e/README.md
@@ -56,6 +56,7 @@ instance is running, saving that file will reload the instance.
 ## Running the tests 
 
 1. In your Sourcegraph folder, run `sg start dotcom-cody-e2e`.
+  1. To ensure the default site-admin is available (mandatory), still in the Sourcegraph folder you can run `sg db default-site-admin`.
 1. Back to the Cody repo, run `pnpm run test:local-e2e`
 
 ## FAQ 
@@ -86,3 +87,8 @@ configurable? Please remember that sane defaults that works out of the box are r
 
 Perhaps try resetting the Redis instance, i.e. in the Sourcegraph folder, run `sg db reset-redis` and 
 try again.
+
+### What does `sg db default-site-admin` do exactly? 
+
+It creates if necessary a site-admin user in your local instance, which always have the same email, username, 
+password and more importantly, the same access token (`sgf_f0f0f0f0...`).


### PR DESCRIPTION
As I was about to record a loom video showcasing this, I noticed that when the access token is rejected, it wasn't handle as well as it should; which is now fixed. Also adjust the docs a bit. 

Before:

![CleanShot 2024-07-12 at 15 08 02@2x](https://github.com/user-attachments/assets/6e11e61c-3c6b-48f0-91b6-f6efbeb85aea)


After: 

![CleanShot 2024-07-12 at 15 09 16@2x](https://github.com/user-attachments/assets/b721ae69-78a9-4dfe-a873-32d443cdd52a)


## Test plan

CI + local 

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
