### PR TITLE
Command : remove "Ask Cody to Explain" from command palette

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -10,6 +10,8 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 
 ### Fixed
 
+- Command: The "Ask Cody to Explain" command for explaining terminal output has been removed from the command palette, as it is only callable from the terminal context menu. [pull/4860](https://github.com/sourcegraph/cody/pull/4860)
+
 ### Changed
 
 ## 1.26.2

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -266,7 +266,8 @@
         "command": "cody.command.explain-output",
         "title": "Ask Cody to Explain",
         "category": "Cody Command",
-        "icon": "$(cody-logo)"
+        "icon": "$(cody-logo)",
+        "enablement": "cody.activated && terminalTabsSingularSelection"
       },
       {
         "command": "cody.command.edit-code",
@@ -770,6 +771,10 @@
           "command": "cody.chat.view.popOut",
           "when": "false",
           "_comment": "Hidden because it is only a wrapper around the workspace pop out command and would place any editor tab (not just Cody chat) in a new window."
+        },
+        {
+          "command": "cody.command.explain-output",
+          "when": "false"
         }
       ],
       "editor/context": [


### PR DESCRIPTION
CLOSE https://linear.app/sourcegraph/issue/CODY-2861/vscode-outdated-cody-command-ask-cody-to-explain-throws-error

Current issue:

<img width="952" alt="image" src="https://github.com/user-attachments/assets/21a0cb70-2768-4876-8bf0-9d8ab74581a5">


The command is actually a valid command, but it only works when you highlight some text in your terminal and right click on it:
![image](https://github.com/user-attachments/assets/f1b88b34-a04b-4a4d-8eb9-5d592f6d670d)

The command is not expected to show up in the command palette menu, which is now fixed by this PR by setting the when condition to `false` for the command in the menu field.


## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

Confirm the command is still available when you select some text in your terminal and right-click:

![Screenshot 2024-07-12 at 11 59 46 AM](https://github.com/user-attachments/assets/d5073401-1832-4831-a2bd-1f632794728c)

Confirm the command is no longer available in the command palette menu:

![Screenshot 2024-07-12 at 12 00 01 PM](https://github.com/user-attachments/assets/965af002-e8b8-4a24-bca4-0d990f231325)

