### PR TITLE
Web: update chat model handling

### DIFF
--- a/vscode/src/chat/protocol.ts
+++ b/vscode/src/chat/protocol.ts
@@ -184,6 +184,9 @@ export type ExtensionMessage =
       }
     | { type: 'clientState'; value: ClientStateForWebview }
     | { type: 'clientAction'; addContextItemsToLastHumanInput: ContextItem[] }
+    /**
+     * The current default model will always be the first one on the list.
+     */
     | { type: 'chatModels'; models: Model[] }
     | { type: 'enhanced-context'; enhancedContextStatus: EnhancedContextContextT }
     | ({ type: 'attribution' } & ExtensionAttributionMessage)

--- a/web/lib/components/CodyWebChat.tsx
+++ b/web/lib/components/CodyWebChat.tsx
@@ -94,6 +94,7 @@ export const CodyWebChat: FC<CodyWebChatProps> = props => {
                     setIsTranscriptError(message.isTranscriptError)
                     break
                 case 'chatModels':
+                    // The default model will always be the first one on the list.
                     setChatModels(message.models)
                     break
                 case 'config':
@@ -141,14 +142,12 @@ export const CodyWebChat: FC<CodyWebChatProps> = props => {
             if (!chatModels || !setChatModels) {
                 return
             }
+            // Notify the host about the manual change,
+            // and the host will return the updated change models via onMessage.
             vscodeAPI.postMessage({
                 command: 'chatModel',
                 model: selected.model,
             })
-            const updatedChatModels = chatModels.map(m =>
-                m.model === selected.model ? { ...m, default: true } : { ...m, default: false }
-            )
-            setChatModels(updatedChatModels)
         },
         [chatModels, vscodeAPI]
     )


### PR DESCRIPTION
- Add a comment to clarify that the default chat model is always the first one in the list
- Refactor chat model update logic to notify the host about manual changes, and let the host return the updated chat models


## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

Green CI, as there should not be any behaviour change.