### PR TITLE
Chat: remove isFreeUser model check and simplify model selection

### DIFF
--- a/lib/shared/src/models/index.ts
+++ b/lib/shared/src/models/index.ts
@@ -1,4 +1,4 @@
-import { type AuthStatus, isCodyProUser, isEnterpriseUser, isFreeUser } from '../auth/types'
+import { type AuthStatus, isCodyProUser, isEnterpriseUser } from '../auth/types'
 import { fetchLocalOllamaModels } from '../llm-providers/ollama/utils'
 import { logDebug } from '../logger'
 import { CHAT_INPUT_TOKEN_BUDGET, CHAT_OUTPUT_TOKEN_BUDGET } from '../token/constants'
@@ -283,9 +283,6 @@ export class ModelsService {
         // Free users can only use the default free model, so we just find the first model they can use
         const models = ModelsService.getModelsByType(type)
         const firstModelUserCanUse = models.find(m => ModelsService.canUserUseModel(authStatus, m))
-        if (!authStatus.authenticated || isFreeUser(authStatus)) {
-            return firstModelUserCanUse
-        }
         const current = ModelsService.defaultModels.get(type)
         if (current && ModelsService.canUserUseModel(authStatus, current)) {
             return current
@@ -338,7 +335,7 @@ export class ModelsService {
             return tier !== 'enterprise'
         }
 
-        return tier === 'free'
+        return true
     }
 
     private static resolveModel(modelID: Model | string): Model | undefined {

--- a/lib/shared/src/models/index.ts
+++ b/lib/shared/src/models/index.ts
@@ -335,7 +335,7 @@ export class ModelsService {
             return tier !== 'enterprise'
         }
 
-        return true
+        return tier === 'free'
     }
 
     private static resolveModel(modelID: Model | string): Model | undefined {

--- a/vscode/webviews/App.tsx
+++ b/vscode/webviews/App.tsx
@@ -204,16 +204,12 @@ export const App: React.FunctionComponent<{ vscodeAPI: VSCodeWrapper }> = ({ vsc
 
     const onCurrentChatModelChange = useCallback(
         (selected: Model): void => {
-            if (!chatModels || !setChatModels) {
-                return
-            }
             vscodeAPI.postMessage({
                 command: 'chatModel',
                 model: selected.model,
             })
-            setChatModels([selected].concat(chatModels.filter(m => m.model !== selected.model)))
         },
-        [chatModels, vscodeAPI]
+        [vscodeAPI]
     )
     const chatModelContext = useMemo<ChatModelContext>(
         () => ({ chatModels, onCurrentChatModelChange }),


### PR DESCRIPTION
Right now we are limiting FreeUser to use first model only which is incorrect.  Removing the check fixed the issue where non-Cody Pro users are unable to use other free models


## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

Build from this branch and log in to Cody as Cody Free user, try selecting a model


### Demo

I can select a model that's not 3.5 Sonnet:

![image](https://github.com/user-attachments/assets/f055c546-8118-45a0-8038-a7d41a924711)


Also tried logging in as dotcom pro users to confirm the model selection is working as expected:

![image](https://github.com/user-attachments/assets/9a86a7a9-b950-4323-bb86-14967495537c)
