### PR TITLE
Agent: add support for Visual Studio IDE in AgentWorkspaceConfiguration

### DIFF
--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/CodyIDE.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/CodyIDE.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
 package com.sourcegraph.cody.protocol_generated;
 
-typealias CodyIDE = String // One of: VSCode, JetBrains, Neovim, Emacs, Web
+typealias CodyIDE = String // One of: VSCode, JetBrains, Neovim, Emacs, Web, VisualStudio
 

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/ConfigParams.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/ConfigParams.kt
@@ -3,7 +3,7 @@ package com.sourcegraph.cody.protocol_generated;
 
 data class ConfigParams(
   val experimentalNoodle: Boolean,
-  val agentIDE: CodyIDE? = null, // Oneof: VSCode, JetBrains, Neovim, Emacs, Web
+  val agentIDE: CodyIDE? = null, // Oneof: VSCode, JetBrains, Neovim, Emacs, Web, VisualStudio
   val agentExtensionVersion: String? = null,
   val serverEndpoint: String,
   val experimentalUnitTest: Boolean,

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/Constants.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/Constants.kt
@@ -13,6 +13,7 @@ object Constants {
   const val Neovim = "Neovim"
   const val Emacs = "Emacs"
   const val Web = "Web"
+  const val VisualStudio = "VisualStudio"
   const val history = "history"
   const val transcript = "transcript"
   const val view = "view"

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/ExtensionMessage.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/ExtensionMessage.kt
@@ -50,7 +50,7 @@ data class ConfigExtensionMessage(
 
 data class Ui_themeExtensionMessage(
   val type: TypeEnum, // Oneof: ui/theme
-  val agentIDE: CodyIDE, // Oneof: VSCode, JetBrains, Neovim, Emacs, Web
+  val agentIDE: CodyIDE, // Oneof: VSCode, JetBrains, Neovim, Emacs, Web, VisualStudio
   val cssVariables: CodyIDECssVariables,
 ) : ExtensionMessage() {
 

--- a/agent/src/AgentWorkspaceConfiguration.ts
+++ b/agent/src/AgentWorkspaceConfiguration.ts
@@ -42,6 +42,8 @@ export class AgentWorkspaceConfiguration implements vscode.WorkspaceConfiguratio
                 return CodyIDE.Neovim
             case 'web':
                 return CodyIDE.Web
+            case 'visualstudio':
+                return CodyIDE.VisualStudio
             default:
                 return undefined
         }

--- a/lib/shared/src/configuration.ts
+++ b/lib/shared/src/configuration.ts
@@ -98,6 +98,7 @@ export enum CodyIDE {
     Neovim = 'Neovim',
     Emacs = 'Emacs',
     Web = 'Web',
+    VisualStudio = 'VisualStudio',
 }
 
 export interface AutocompleteTimeouts {

--- a/vscode/webviews/components/MarkdownFromCody.tsx
+++ b/vscode/webviews/components/MarkdownFromCody.tsx
@@ -82,6 +82,7 @@ const URL_PROCESSORS: Record<CodyIDE, UrlTransform> = {
     [CodyIDE.Neovim]: defaultUrlProcessor,
     [CodyIDE.Emacs]: defaultUrlProcessor,
     [CodyIDE.VSCode]: wrapLinksWithCodyOpenCommand,
+    [CodyIDE.VisualStudio]: wrapLinksWithCodyOpenCommand,
 }
 
 export const MarkdownFromCody: FunctionComponent<{ className?: string; children: string }> = ({


### PR DESCRIPTION
This change adds support for the Visual Studio IDE in the AgentWorkspaceConfiguration class. A new case has been added to the `getIDE()` method to handle the 'visualstudio' configuration value and return the corresponding CodyIDE.VisualStudio enum value.

Additionally, the CodyIDE enum in the shared configuration.ts file has been updated to include the VisualStudio value.

## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

Green CI as this PR is adding a new value to the enum object that is not being used by other clients yet.

Also there is no feature change.