### PR TITLE
Fix cody web telemetry and multiple llm checks

### DIFF
--- a/lib/shared/src/sourcegraph-api/graphql/client.ts
+++ b/lib/shared/src/sourcegraph-api/graphql/client.ts
@@ -1427,11 +1427,6 @@ export class ClientConfigSingleton {
                     return this.fetchClientConfigLegacy()
                 }
 
-                // Otherwise we use our centralized client config endpoint.
-                if (!graphqlClient.hasAccessToken())
-                    throw new Error(
-                        'unable to fetch /.api/client-config, client is not authenticated yet'
-                    )
                 return graphqlClient
                     .fetchHTTP<CodyClientConfig>('client-config', 'GET', '/.api/client-config')
                     .then(clientConfig => {

--- a/lib/shared/src/sourcegraph-api/rest/client.ts
+++ b/lib/shared/src/sourcegraph-api/rest/client.ts
@@ -22,14 +22,16 @@ export class RestClient {
      */
     constructor(
         private endpointUrl: string,
-        private accessToken: string
+        private accessToken?: string
     ) {}
 
     // Make an authenticated HTTP request to the Sourcegraph instance.
     // "name" is a developer-friendly term to label the request's trace span.
     private getRequest<T>(name: string, urlSuffix: string): Promise<T | Error> {
         const headers = new Headers()
-        headers.set('Authorization', `token ${this.accessToken}`)
+        if (this.accessToken) {
+            headers.set('Authorization', `token ${this.accessToken}`)
+        }
         addCustomUserAgent(headers)
         addTraceparent(headers)
 

--- a/vscode/src/models/sync.test.ts
+++ b/vscode/src/models/sync.test.ts
@@ -134,7 +134,9 @@ describe('syncModels from the server', () => {
         vi.restoreAllMocks()
     })
 
-    it('throws if no creds are available', async () => {
+    // Cody Web can be run without access token since it relies on cookie auth info
+    // skip this tests since these checks have been removed to make Cody Web working
+    it.skip('throws if no creds are available', async () => {
         await expect(async () => {
             const authStatus = {
                 ...defaultAuthStatus,

--- a/vscode/src/models/sync.ts
+++ b/vscode/src/models/sync.ts
@@ -142,9 +142,6 @@ async function fetchServerSideModels(endpoint: string): Promise<Model[]> {
 
     // Get the user's access token, assumed to be already saved in the secret store.
     const userAccessToken = await secretStorage.getToken(endpoint)
-    if (!userAccessToken) {
-        throw new Error('no userAccessToken available. Unable to fetch models.')
-    }
 
     // Fetch the data via REST API.
     // NOTE: We may end up exposing this data via GraphQL, it's still TBD.

--- a/vscode/src/services/telemetry-v2.ts
+++ b/vscode/src/services/telemetry-v2.ts
@@ -119,10 +119,13 @@ export async function createOrUpdateTelemetryRecorderProvider(
         )
     }
 
+    const isCodyWeb = config.agentIDE === CodyIDE.Web
+
     /**
      * On first initialization, also record some initial events.
+     * Skip any init events for Cody Web use case.
      */
-    if (initialize) {
+    if (initialize && !isCodyWeb) {
         if (newAnonymousUser) {
             /**
              * New user

--- a/web/CHANGELOG.md
+++ b/web/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.5
+- Don't send vscode-related init telemetry events 
+- Fix enterprise LLM selector appearance checks for Cody Web 
+
 ## 0.2.4
 - Fix Markdown links for cody web 
 

--- a/web/lib/components/CodyWebChat.tsx
+++ b/web/lib/components/CodyWebChat.tsx
@@ -8,8 +8,9 @@ import {
     type ContextItem,
     type ContextItemRepository,
     ContextItemSource,
-    type Model,
+    Model,
     PromptString,
+    isEnterpriseUser,
     isErrorLike,
     setDisplayPathEnvInfo,
 } from '@sourcegraph/cody-shared'
@@ -96,12 +97,22 @@ export const CodyWebChat: FC<CodyWebChatProps> = props => {
                 case 'chatModels':
                     // The default model will always be the first one on the list.
                     setChatModels(message.models)
+                    setUserAccountInfo(
+                        info =>
+                            info && {
+                                ...info,
+                                isOldStyleEnterpriseUser:
+                                    !info.isDotComUser &&
+                                    !message.models.some(Model.isNewStyleEnterprise),
+                            }
+                    )
                     break
                 case 'config':
                     setUserAccountInfo({
                         isCodyProUser: !message.authStatus.userCanUpgrade,
                         isDotComUser: message.authStatus.isDotCom,
-                        isOldStyleEnterpriseUser: !message.authStatus.isDotCom,
+                        // Default to assuming they are a single model enterprise
+                        isOldStyleEnterpriseUser: isEnterpriseUser(message.authStatus),
                         user: message.authStatus,
                         ide: CodyIDE.Web,
                     })

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cody-web-experimental",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "Cody standalone web app",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
Fixes https://linear.app/sourcegraph/issue/SRCH-732/telemetry-send-extension-related-events-in-cody-web

Also, this PR fixes problems with different `isOldStyleEnterpriseUser` definitions; this field controls LLM selector appearance for enterprise customers, and prior to this PR, it was a bit different compared to the check we have for VSCode Cody extension chat.  

Note that at the moment, there is no enterprise test instance where we can test this locally (since S2 doesn't support server-side models yet), but @jamesmcnamara tested it manually, so this PR pretty much relies on his prior testing. 

## Test plan
- CI is green

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
