### PR TITLE
make alt+l toggle chat, rather than create a new chat

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -604,11 +604,6 @@
         "when": "cody.activated"
       },
       {
-        "command": "cody.chat.focus",
-        "key": "alt+l",
-        "when": "cody.activated && editorTextFocus"
-      },
-      {
         "command": "cody.chat.toggle",
         "key": "alt+l",
         "when": "cody.activated && editorTextFocus",

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -422,13 +422,6 @@
         "enablement": "cody.activated && config.cody.autocomplete.experimental.multiModelCompletions && config.cody.autocomplete.enabled && !editorReadonly && !editorHasSelection && !inlineSuggestionsVisible"
       },
       {
-        "command": "cody.chat.focusView",
-        "category": "Cody",
-        "group": "Cody",
-        "title": "Focus on Chat View",
-        "enablement": "cody.activated"
-      },
-      {
         "command": "cody.chat.signIn",
         "category": "Cody",
         "group": "Cody",
@@ -607,8 +600,29 @@
       },
       {
         "command": "cody.chat.newPanel",
-        "key": "alt+l",
+        "key": "alt+shift+l",
         "when": "cody.activated"
+      },
+      {
+        "command": "cody.chat.focus",
+        "key": "alt+l",
+        "when": "cody.activated && editorTextFocus"
+      },
+      {
+        "command": "cody.chat.toggle",
+        "key": "alt+l",
+        "when": "cody.activated && editorTextFocus",
+        "args": {
+          "editorFocus": true
+        }
+      },
+      {
+        "command": "cody.chat.toggle",
+        "key": "alt+l",
+        "when": "cody.activated && !editorTextFocus",
+        "args": {
+          "editorFocus": false
+        }
       },
       {
         "command": "cody.mention.selection",

--- a/vscode/src/chat/chat-view/ChatsController.ts
+++ b/vscode/src/chat/chat-view/ChatsController.ts
@@ -147,9 +147,6 @@ export class ChatsController implements vscode.Disposable {
             vscode.commands.registerCommand('cody.action.chat', args =>
                 this.submitChatInNewEditor(args)
             ),
-            vscode.commands.registerCommand('cody.chat.focusView', () =>
-                vscode.commands.executeCommand('cody.chat.focus')
-            ),
             vscode.commands.registerCommand('cody.chat.signIn', () =>
                 vscode.commands.executeCommand('cody.chat.focus')
             ),
@@ -157,6 +154,16 @@ export class ChatsController implements vscode.Disposable {
                 await this.panel.clearAndRestartSession()
                 await vscode.commands.executeCommand('cody.chat.focus')
             }),
+            vscode.commands.registerCommand(
+                'cody.chat.toggle',
+                async (ops: { editorFocus: boolean }) => {
+                    if (ops.editorFocus) {
+                        await vscode.commands.executeCommand('cody.chat.focus')
+                    } else {
+                        await vscode.commands.executeCommand('workbench.action.focusActiveEditorGroup')
+                    }
+                }
+            ),
             vscode.commands.registerCommand('cody.chat.newEditorPanel', () =>
                 this.getOrCreateEditorChatController()
             ),
@@ -201,6 +208,9 @@ export class ChatsController implements vscode.Disposable {
     private async sendEditorContextToChat(uri?: URI): Promise<void> {
         telemetryRecorder.recordEvent('cody.addChatContext', 'clicked')
         const provider = await this.getActiveChatController()
+        if (provider === this.panel) {
+            await vscode.commands.executeCommand('cody.chat.focus')
+        }
         await provider.handleGetUserEditorContext(uri)
     }
 

--- a/vscode/webviews/App.tsx
+++ b/vscode/webviews/App.tsx
@@ -162,6 +162,19 @@ export const App: React.FunctionComponent<{ vscodeAPI: VSCodeWrapper }> = ({ vsc
     )
 
     useEffect(() => {
+        // On macOS, suppress the '¬' character emitted by default for alt+L
+        const handleKeyDown = (event: KeyboardEvent) => {
+            if (event.altKey && event.key === '¬') {
+                event.preventDefault()
+            }
+        }
+        window.addEventListener('keydown', handleKeyDown)
+        return () => {
+            window.removeEventListener('keydown', handleKeyDown)
+        }
+    }, [])
+
+    useEffect(() => {
         // Notify the extension host that we are ready to receive events
         vscodeAPI.postMessage({ command: 'ready' })
     }, [vscodeAPI])


### PR DESCRIPTION
https://github.com/user-attachments/assets/db166dc0-538e-44ca-9760-8416d0d737f8

Enable the user to build some good muscle memory:

* `Alt+L` toggles between chat and editor
* `Alt+Shift+L` creates a new chat session in the chat panel
* `Alt+L` with an editor selection still adds the selection to the current chat context (but it now shows the chat panel if it is hidden)

## Test plan

Tested locally