### PR TITLE
CLI: only support --context-repo on dotcom accounts

### DIFF
--- a/agent/src/cli/command-chat.test.ts
+++ b/agent/src/cli/command-chat.test.ts
@@ -93,7 +93,8 @@ describe('cody chat', () => {
         ).toMatchSnapshot()
     }, 10_000)
 
-    it('--context-repo (squirrel test)', async () => {
+    // Only works for Sourcegraph Enterprise users. Blocked by CODY-2884.
+    it.skip('--context-repo (squirrel test)', async () => {
         expect(
             YAML.stringify(
                 await runCommand({

--- a/agent/src/cli/command-chat.ts
+++ b/agent/src/cli/command-chat.ts
@@ -50,7 +50,7 @@ export const chatCommand = () =>
         .option('--model <model>', 'Chat model to use')
         .option(
             '--context-repo <repos...>',
-            'Names of repositories to use as context. Example: github.com/sourcegraph/cody'
+            '(Sourcegraph Enterprise only) Names of repositories to use as context. Example: github.com/sourcegraph/cody.'
         )
         .option('--context-file <files...>', 'Local files to include in the context')
         .option('--show-context', 'Show context items in reply', false)
@@ -145,6 +145,13 @@ export async function chatAction(options: ChatOptions): Promise<number> {
     }
 
     if (options.contextRepo && options.contextRepo.length > 0) {
+        if (serverInfo.authStatus?.isDotCom) {
+            spinner.fail(
+                'The --context-repo option is only available for Sourcegraph Enterprise users. ' +
+                    'Please sign into an Enterprise instance with the command: cody auth logout && cody auth login --web'
+            )
+            return 1
+        }
         const { repos } = await client.request('graphql/getRepoIds', {
             names: options.contextRepo,
             first: options.contextRepo.length,


### PR DESCRIPTION
Fixes CODY-2742

Previously, the CLI tried to support `--context-repo` on dotcom accounts even if remote repo context doesn't work on dotcom. This PR changes the behavior to report an error message if the user tries to pass --context-repo with a dotcom account.


## Test plan
Manually tested with
```
❯ pnpm agent chat --context-repo github.com/sourcegraph/cody -m 'what is the agent?'

> @sourcegraph/cody@ agent /Users/olafurpg/dev/sourcegraph/cody
> pnpm -C agent agent "chat" "--context-repo" "github.com/sourcegraph/cody" "-m" "what is the agent?"


> @sourcegraph/cody@0.2.0 agent /Users/olafurpg/dev/sourcegraph/cody/agent
> pnpm run build && node --enable-source-maps dist/index.js "chat" "--context-repo" "github.com/sourcegraph/cody" "-m" "what is the agent?"


> @sourcegraph/cody@0.2.0 build /Users/olafurpg/dev/sourcegraph/cody/agent
> pnpm run -s build:root && pnpm run -s build:agent

✖ The --context-repo option is only available for Sourcegraph Enterprise users. Please sign into an Enterprise instance with the command: cody auth logout && cody auth login --web
```

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
