### PR TITLE
CLI: fix --endpoint and --access-token options

### DIFF
--- a/agent/src/cli/command-chat.ts
+++ b/agent/src/cli/command-chat.ts
@@ -55,12 +55,12 @@ Enterprise Only:
         // --help does not document you can pass arguments, it will just
         // silently work.
         .option(
-            '--endpoint',
+            '--endpoint <url>',
             'Sourcegraph instance URL',
             process.env.SRC_ENDPOINT ?? 'https://sourcegraph.com'
         )
         .option(
-            '--access-token',
+            '--access-token <token>',
             'Sourcegraph access token. ' + loginInstruction,
             process.env.SRC_ACCESS_TOKEN ?? ''
         )


### PR DESCRIPTION
Previously, passing the `--endpoint` or `--access-token` options crashed the CLI tool because it got parsed as a boolean `true`. This PR fixes the problem by adding the correct Commander.js syntax to the option declaration.

Reported https://linear.app/sourcegraph/issue/CODY-2742/-context-repo-is-not-working#comment-a0d5b6b5

## Test plan

Manually tested with
```
❯ pnpm agent chat --context-repo github.com/sourcegraph/cody -m 'what is the agent?' --endpoint ...
```
It no longer crashes with the stack trace
```
at __node_internal_captureLargerStackTrace (node:internal/errors:496:5)
    at new NodeError (node:internal/errors:405:5)
    at new URL (node:internal/url:778:13)
    at buildGraphQLUrl (/Users/jan/repos/cody/lib/shared/src/sourcegraph-api/graphql/url.ts:13:22)
    at SourcegraphGraphQLAPIClient.fetchSourcegraphAPI (/Users/jan/repos/cody/lib/shared/src/sourcegraph-api/graphql/client.ts:1181:21)
    at SourcegraphGraphQLAPIClient.getSiteVersion (/Users/jan/repos/cody/lib/shared/src/sourcegraph-api/graphql/client.ts:544:21)
    at GraphQLTelemetryExporter.setLegacyEventsStateOnce (/Users/jan/repos/cody/lib/shared/src/sourcegraph-api/telemetry/GraphQLTelemetryExporter.ts:44:51)
    at GraphQLTelemetryExporter.exportEvents (/Users/jan/repos/cody/lib/shared/src/sourcegraph-api/telemetry/GraphQLTelemetryExporter.ts:94:20)
    at SimpleSubmitter.submit (/Users/jan/repos/cody/node_modules/.pnpm/@sourcegraph+telemetry@0.16.0/node_modules/@sourcegraph/telemetry/src/index.ts:284:8)
    at EventRecorder.recordEvent (/
```

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
