### PR TITLE
CLI: fix enhanced context

### DIFF
--- a/agent/package.json
+++ b/agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sourcegraph/cody",
-  "version": "0.2.0",
+  "version": "5.5.9",
   "description": "Cody JSON-RPC agent for consistent cross-editor support",
   "license": "Apache-2.0",
   "repository": {

--- a/agent/recordings/cody-chat_103640681/recording.har.yaml
+++ b/agent/recordings/cody-chat_103640681/recording.har.yaml
@@ -5,7 +5,7 @@ log:
     name: Polly.JS
     version: 6.0.6
   entries:
-    - _id: 8ffa79cf5668b64b3fd5ad5674e1d846
+    - _id: f9539d6a991b9b1e5cf123556c80a1a7
       _order: 0
       cache: {}
       request:
@@ -15,13 +15,13 @@ log:
           - _fromType: array
             name: authorization
             value: token
-              REDACTED_d5e0f0a37c9821e856b923fe14e67a605e3f6c0a517d5a4f46a4e35943ee0f6d
+              REDACTED_964f5256e709a8c5c151a63d8696d5c7ac81604d179405864d88ff48a9232364
           - _fromType: array
             name: content-type
             value: application/json; charset=utf-8
           - _fromType: array
             name: user-agent
-            value: cody-cli / 0.1.0-SNAPSHOT
+            value: jetbrains / 6.0.0-SNAPSHOT
           - _fromType: array
             name: accept
             value: "*/*"
@@ -29,32 +29,33 @@ log:
             name: accept-encoding
             value: gzip,deflate
           - name: host
-            value: sourcegraph.com
-        headersSize: 296
+            value: sourcegraph.sourcegraph.com
+        headersSize: 321
         httpVersion: HTTP/1.1
         method: GET
         queryString: []
-        url: https://sourcegraph.com/.api/client-config
+        url: https://sourcegraph.sourcegraph.com/.api/client-config
       response:
-        bodySize: 188
+        bodySize: 191
         content:
           encoding: base64
           mimeType: text/plain; charset=utf-8
-          size: 188
-          text:
-            "[\"H4sIAAAAAAAAA2zMsQoCMRCE4T5PsVztE9hJsLjOznrPrBjI7koyQeW4d7dRBEn9z3xrI\
-            CKaLp5eR+OlSJr2hNpl9wk3xjBwh0fXexHI+NkbXKOrsqU2NoCal47s9utXLu07aMoV\
-            0Q3yxDlb8sfQUU9S2uE0/ylhC28AAAD//wMAK/Ow9eAAAAA=\"]"
+          size: 191
+          text: "[\"H4sIAAAAAAAAA2zMsQpCMQyF4b1PEe7sE7hJcXBzc861EQtNI80pKnLf3UVwyfz953wSE\
+            dFytfI+dl6blGVPGFN2P7gzQuAJy6aPJpB4OR2m2VS5F48/gFHXiWo9dFceyNYhL1xq\
+            L/YMM7UizQ/n019v3FzSlr4AAAD//w==\",\"AwCYZZ0K3wAAAA==\"]"
         cookies: []
         headers:
           - name: date
-            value: Mon, 08 Jul 2024 17:50:26 GMT
+            value: Tue, 16 Jul 2024 15:14:58 GMT
           - name: content-type
             value: text/plain; charset=utf-8
           - name: transfer-encoding
             value: chunked
           - name: connection
             value: keep-alive
+          - name: retry-after
+            value: "523"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -62,8 +63,8 @@ log:
           - name: cache-control
             value: no-cache, max-age=0
           - name: vary
-            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
-              X-Requested-With,Cookie
+            value: Accept-Encoding, Authorization, Cookie, Authorization, X-Requested-With,
+              Cookie
           - name: x-content-type-options
             value: nosniff
           - name: x-frame-options
@@ -74,12 +75,12 @@ log:
             value: max-age=31536000; includeSubDomains; preload
           - name: content-encoding
             value: gzip
-        headersSize: 1342
+        headersSize: 1365
         httpVersion: HTTP/1.1
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-07-08T17:50:26.534Z
+      startedDateTime: 2024-07-16T15:14:57.806Z
       time: 0
       timings:
         blocked: -1
@@ -89,7 +90,7 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: c68bea7a0faa81ae058bce23fac124b5
+    - _id: 67bca6fe77aa075277907719042acf02
       _order: 0
       cache: {}
       request:
@@ -102,14 +103,14 @@ log:
             value: gzip;q=0
           - name: authorization
             value: token
-              REDACTED_d5e0f0a37c9821e856b923fe14e67a605e3f6c0a517d5a4f46a4e35943ee0f6d
+              REDACTED_964f5256e709a8c5c151a63d8696d5c7ac81604d179405864d88ff48a9232364
           - name: user-agent
-            value: cody-cli / 0.1.0-SNAPSHOT
+            value: jetbrains / 6.0.0-SNAPSHOT
           - name: connection
             value: keep-alive
           - name: host
-            value: sourcegraph.com
-        headersSize: 359
+            value: sourcegraph.sourcegraph.com
+        headersSize: 385
         httpVersion: HTTP/1.1
         method: POST
         postData:
@@ -130,10 +131,10 @@ log:
           - name: api-version
             value: "1"
           - name: client-name
-            value: cody-cli
+            value: jetbrains
           - name: client-version
-            value: 0.1.0-SNAPSHOT
-        url: https://sourcegraph.com/.api/completions/stream?api-version=1&client-name=cody-cli&client-version=0.1.0-SNAPSHOT
+            value: 6.0.0-SNAPSHOT
+        url: https://sourcegraph.sourcegraph.com/.api/completions/stream?api-version=1&client-name=jetbrains&client-version=6.0.0-SNAPSHOT
       response:
         bodySize: 158
         content:
@@ -149,13 +150,15 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Tue, 09 Jul 2024 17:21:41 GMT
+            value: Tue, 16 Jul 2024 15:14:59 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
             value: chunked
           - name: connection
             value: keep-alive
+          - name: retry-after
+            value: "522"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -163,8 +166,8 @@ log:
           - name: cache-control
             value: no-cache
           - name: vary
-            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
-              X-Requested-With,Cookie
+            value: Accept-Encoding, Authorization, Cookie, Authorization, X-Requested-With,
+              Cookie
           - name: x-content-type-options
             value: nosniff
           - name: x-frame-options
@@ -173,12 +176,12 @@ log:
             value: 1; mode=block
           - name: strict-transport-security
             value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1299
+        headersSize: 1322
         httpVersion: HTTP/1.1
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-07-09T17:21:40.750Z
+      startedDateTime: 2024-07-16T15:14:58.201Z
       time: 0
       timings:
         blocked: -1
@@ -188,11 +191,11 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: 1d3952e3688b246fc425495697c0078b
+    - _id: d51be7c2ebb3eb4d805d0fcf8c2dbdbf
       _order: 0
       cache: {}
       request:
-        bodySize: 288
+        bodySize: 14528
         cookies: []
         headers:
           - name: content-type
@@ -201,14 +204,14 @@ log:
             value: gzip;q=0
           - name: authorization
             value: token
-              REDACTED_d5e0f0a37c9821e856b923fe14e67a605e3f6c0a517d5a4f46a4e35943ee0f6d
+              REDACTED_964f5256e709a8c5c151a63d8696d5c7ac81604d179405864d88ff48a9232364
           - name: user-agent
-            value: cody-cli / 0.1.0-SNAPSHOT
+            value: jetbrains / 6.0.0-SNAPSHOT
           - name: connection
             value: keep-alive
           - name: host
-            value: sourcegraph.com
-        headersSize: 359
+            value: sourcegraph.sourcegraph.com
+        headersSize: 385
         httpVersion: HTTP/1.1
         method: POST
         postData:
@@ -220,7 +223,653 @@ log:
               - speaker: system
                 text: You are Cody, an AI coding assistant from Sourcegraph.
               - speaker: human
-                text: what is squirrel? Explain as briefly as possible.
+                text: >-
+                  Codebase context from file
+                  /cmd/symbols/internal/squirrel/README.md in repository
+                  github.com/sourcegraph/sourcegraph:
+
+                  ```markdown
+
+                  # Squirrel
+
+
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: >-
+                  Codebase context from file
+                  /doc/dev/background-information/sql/index.md in repository
+                  github.com/sourcegraph/sourcegraph:
+
+                  ```markdown
+
+                  # SQL
+
+
+                  Guidance and documentation about writing database interactions within the Sourcegraph application.
+
+
+                  - [Migrations overview](migrations_overview.md)
+
+                  - [Migrations](migrations.md)
+
+                  - High-performance guides
+                    - [Batch operations](batch_operations.md)
+                    - [Materialized cache](materialized_cache.md)
+                  - [Locking behavior](locking_behavior.md)
+
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: >-
+                  Codebase context from file
+                  /.github/PULL_REQUEST_TEMPLATE/developer_insights.md in
+                  repository github.com/sourcegraph/sourcegraph:
+
+                  ```markdown
+
+                  <!-- Describe the purpose of the PR so that if you looked at it in 6 months time it would be clear from the overview why this was created -->
+
+                  ## Overview
+
+                  Insert description here...
+
+
+                  <!-- Insert before and after screenshot(s) that makes it easy to identify the changes made -->
+
+                  ## Screenshots
+
+                  | BEFORE             |  AFTER |
+
+                  :-------------------------:|:-------------------------:
+                   Insert image here | Insert image here  
+
+
+                  <!-- Update the implementation steps that should be completed to implement the feature/bug fix/tech debt cleanup -->
+
+                  ## Progress
+
+                  - [ ] Implementation progress milestones
+                    - [ ] Milestone X
+                      - [ ] Task 1
+                      - [ ] Task 2
+                    - [ ] Milestone Y
+                    - [ ] Milestone Z
+                    - [ ] Milestone ...
+                  - [ ] Documentation text/screenshots updated (if relevant)
+
+                  - [ ] Changelog updated (if user-facing)
+
+                  - [ ] Approved by a frontend engineer (if touching frontend code)
+
+                  - [ ] Approved by a backend engineer (if touching backend code)
+
+                  - [ ] Approved by a designer (if it touches the UI)
+
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: >-
+                  Codebase context from file /dev/clustering/README.md in
+                  repository github.com/sourcegraph/sourcegraph:
+
+                  ```markdown
+
+                  # Text Clustering
+
+
+                  This directory contains Python code to cluster text data using sentence embeddings and KMeans clustering.
+
+
+                  ## Overview
+
+
+                  The `cluster.py` script takes in a TSV file with a text field, generates sentence embeddings using the SentenceTransformers library, clusters the embeddings with KMeans, and outputs a TSV file with cluster assignments.
+
+
+                  The goal is to group similar text snippets together into a predefined number of clusters.
+
+
+                  ## Usage
+
+
+                  Ensure the required packges are installed:
+
+
+                  ```
+
+                  pip install -r requirements.txt
+
+                  ```
+
+
+                  The script accepts the following arguments:
+
+
+                  | Argument       | Description                                      | Default    |
+
+                  | -------------- | ------------------------------------------------ | ---------- |
+
+                  | `--input`      | Path to input TSV file                           | _Required_ |
+
+                  | `--text_field` | Name of text field in the tsv file to operate on | "text"     |
+
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: >-
+                  Codebase context from file
+                  /doc/dev/background-information/observability/index.md in
+                  repository github.com/sourcegraph/sourcegraph:
+
+                  ```markdown
+
+
+                  This documentation is for generalized, usecase-agnostic development of Sourcegraph's observability.
+
+                  Sourcegraph employees should also refer to the [handbook's observability section](https://handbook.sourcegraph.com/engineering/observability) for Sourcegraph-specific documentation.
+
+
+                  > NOTE: For how to *use* Sourcegraph's observability and an overview of our observability features, refer to the [observability for site administrators documentation](../../../admin/observability/index.md).
+
+
+                  ## Overview
+
+
+                  Observability at Sourcegraph includes:
+
+
+                  | | Description | Examples |
+
+                  |:--|------------|--------|
+
+                  | **Monitoring** | how you know _when_ something is wrong | Dashboards & metrics, alerting, health checks |
+
+                  | **Debugging** | how you debug _what_ is wrong | Tracing, logging |
+
+
+                  ## Concepts
+
+
+                  - [Sourcegraph monitoring pillars](https://handbook.sourcegraph.com/engineering/observability/monitoring_pillars)
+
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: >-
+                  Codebase context from file
+                  /cmd/symbols/internal/squirrel/service_test.go in repository
+                  github.com/sourcegraph/sourcegraph:
+
+                  ```go
+
+                  package squirrel
+
+
+                  import (
+                  	"context"
+                  	"os"
+                  	"path/filepath"
+                  	"slices"
+                  	"sort"
+                  	"testing"
+
+                  	"github.com/fatih/color"
+                  	"github.com/google/go-cmp/cmp"
+                  	"github.com/grafana/regexp"
+
+                  	"github.com/sourcegraph/sourcegraph/internal/search"
+                  	"github.com/sourcegraph/sourcegraph/internal/search/result"
+                  	"github.com/sourcegraph/sourcegraph/internal/types"
+                  )
+
+
+                  func init() {
+                  	if _, ok := os.LookupEnv("NO_COLOR"); !ok {
+                  		color.NoColor = false
+                  	}
+                  }
+
+
+                  func TestNonLocalDefinition(t *testing.T) {
+                  	repoDirs, err := os.ReadDir("test_repos")
+                  	fatalIfErrorLabel(t, err, "reading test_repos")
+
+                  	annotations := []annotation{}
+
+                  	readFile := func(ctx context.Context, path types.RepoCommitPath) ([]byte, error) {
+                  		return os.ReadFile(filepath.Join("test_repos", path.Repo, path.Path))
+                  	}
+
+                  	tempSquirrel := New(readFile, nil)
+                  	allSymbols := []result.Symbol{}
+
+                  	for _, repoDir := range repoDirs {
+                  		if !repoDir.IsDir() {
+                  			t.Fatalf("unexpected file %s", repoDir.Name())
+                  		}
+
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: >-
+                  Codebase context from file
+                  /cmd/symbols/internal/squirrel/service.go in repository
+                  github.com/sourcegraph/sourcegraph:
+
+                  ```go
+
+                  package squirrel
+
+
+                  import (
+                  	"context"
+                  	"fmt"
+                  	"os"
+                  	"runtime"
+                  	"strconv"
+                  	"strings"
+
+                  	"github.com/fatih/color"
+                  	sitter "github.com/smacker/go-tree-sitter"
+
+                  	symbolsTypes "github.com/sourcegraph/sourcegraph/cmd/symbols/internal/types"
+                  	"github.com/sourcegraph/sourcegraph/internal/types"
+                  	"github.com/sourcegraph/sourcegraph/lib/errors"
+                  )
+
+
+                  // How to read a file.
+
+                  type readFileFunc func(context.Context, types.RepoCommitPath) ([]byte, error)
+
+
+                  // SquirrelService uses tree-sitter and the symbols service to analyze and traverse files to find
+
+                  // symbols.
+
+                  type SquirrelService struct {
+                  	readFile            readFileFunc
+                  	symbolSearch        symbolsTypes.SearchFunc
+                  	breadcrumbs         Breadcrumbs
+                  	parser              *sitter.Parser
+                  	closables           []func()
+                  	errorOnParseFailure bool
+                  	depth               int
+                  }
+
+
+                  // New creates a new SquirrelService.
+
+                  func New(readFile readFileFunc, symbolSearch symbolsTypes.SearchFunc) *SquirrelService {
+                  	return &SquirrelService{
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: >-
+                  Codebase context from file
+                  /cmd/symbols/internal/squirrel/CODENOTIFY in repository
+                  github.com/sourcegraph/sourcegraph:
+
+                  ```
+
+                  ** @varungandhi-src
+
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: >-
+                  Codebase context from file
+                  /cmd/symbols/internal/api/handler_cgo.go in repository
+                  github.com/sourcegraph/sourcegraph:
+
+                  ```go
+                  	"github.com/sourcegraph/sourcegraph/internal/grpc/chunk"
+                  	proto "github.com/sourcegraph/sourcegraph/internal/symbols/v1"
+                  	internaltypes "github.com/sourcegraph/sourcegraph/internal/types"
+                  	"github.com/sourcegraph/sourcegraph/lib/errors"
+                  )
+
+
+                  func convertSquirrelErrorToGrpcError(err error) *status.Status {
+                  	if errors.Is(err, squirrel.UnrecognizedFileExtensionError) {
+                  		return status.New(codes.InvalidArgument, err.Error())
+                  	}
+                  	if errors.Is(err, squirrel.UnsupportedLanguageError) {
+                  		return status.New(codes.Unimplemented, err.Error())
+                  	}
+                  	return nil
+                  }
+
+
+                  // LocalCodeIntel returns local code intelligence for the given file and commit
+
+                  func (s *grpcService) LocalCodeIntel(request *proto.LocalCodeIntelRequest, ss proto.SymbolsService_LocalCodeIntelServer) error {
+                  	squirrelService := squirrel.New(s.readFileFunc, nil)
+                  	defer squirrelService.Close()
+
+                  	args := request.GetRepoCommitPath().ToInternal()
+
+                  	ctx := ss.Context()
+                  	payload, err := squirrelService.LocalCodeIntel(ctx, args)
+                  	if err != nil {
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: >-
+                  Codebase context from file
+                  /cmd/symbols/internal/squirrel/test_repos/python/sub/example3.py
+                  in repository github.com/sourcegraph/sourcegraph:
+
+                  ```python
+
+                  #   v py.example3.f def
+
+                  def f():
+
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: >-
+                  Codebase context from file
+                  /cmd/symbols/internal/squirrel/test_repos/starlark/bzl_library.bzl
+                  in repository github.com/sourcegraph/sourcegraph:
+
+                  ```bzl
+
+                  #   vvvvvvvvvvv bzl_library def
+
+                  def bzl_library():
+
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: >-
+                  Codebase context from file
+                  /cmd/symbols/internal/squirrel/test_repos/java1/src/sub/Sample2.java
+                  in repository github.com/sourcegraph/sourcegraph:
+
+                  ```java
+
+                  package sub;
+
+
+                  //    vv C3 def
+
+                  class C3 {
+                      //         vv f3 def
+                      static int f3;
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: >-
+                  Codebase context from file
+                  /cmd/symbols/internal/squirrel/test_repos/starlark/WORKSPACE
+                  in repository github.com/sourcegraph/sourcegraph:
+
+                  ```
+
+                  #                          vvvvvvvvvvvvv bzl_library ref
+
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: >-
+                  Codebase context from file
+                  /cmd/symbols/internal/squirrel/test_repos/starlark/BUILD in
+                  repository github.com/sourcegraph/sourcegraph:
+
+                  ```
+
+                  #                          vvvvvvvvvvvvv bzl_library ref
+
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: >-
+                  Codebase context from file
+                  /cmd/symbols/internal/squirrel/test_repos/starlark/BUILD.bazel
+                  in repository github.com/sourcegraph/sourcegraph:
+
+                  ```bazel
+
+                  #                          vvvvvvvvvvvvv bzl_library ref
+
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: >-
+                  Codebase context from file
+                  /cmd/symbols/internal/squirrel/hover_test.go in repository
+                  github.com/sourcegraph/sourcegraph:
+
+                  ```go
+
+                  package squirrel
+
+
+                  import (
+                  	"context"
+                  	"strings"
+                  	"testing"
+
+                  	"github.com/sourcegraph/sourcegraph/internal/types"
+                  	"github.com/sourcegraph/sourcegraph/lib/errors"
+                  )
+
+
+                  func TestHover(t *testing.T) {
+                  	java := `
+                  class C {
+                  	void m() {
+                  		// not a comment line
+
+                  		// comment line 1
+                  		// comment line 2
+                  		int x = 5;
+                  	}
+                  }
+
+                  `
+
+                  	golang := `
+                  func main() {
+                  	// not a comment line
+
+                  	// comment line 1
+                  	// comment line 2
+                  	var x int
+                  }
+
+                  `
+
+                  	csharp := `
+                  namespace Foo {
+                      class Bar {
+                          static void Baz(int p) {
+                  			// not a comment line
+
+                  			// comment line 1
+                  			// comment line 2
+                  			var x = 5;
+                  		}
+                  	}
+                  }
+
+                  `
+
+                  	tests := []struct {
+                  		path     string
+                  		contents string
+                  		want     string
+                  	}{
+                  		{"test.java", java, "comment line 1/ncomment line 2/n"},
+                  		{"test.go", golang, "comment line 1/ncomment line 2/n"},
+                  		{"test.cs", csharp, "comment line 1/ncomment line 2/n"},
+                  	}
+
+                  	readFile := func(ctx context.Context, path types.RepoCommitPath) ([]byte, error) {
+                  		for _, test := range tests {
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: >-
+                  Codebase context from file
+                  /cmd/symbols/internal/squirrel/test_repos/starlark/sample.bzl
+                  in repository github.com/sourcegraph/sourcegraph:
+
+                  ```bzl
+
+                  #                          vvvvvvvvvvvvv bzl_library ref
+
+                  load("//:bzl_library.bzl", "bzl_library")
+
+                  load("//:bzl_library.bzl", custom_bzl_library = "bzl_library")
+
+
+                  #   vvvvv _impl def
+
+                  def _impl():
+                      pass
+
+                  #                  vvvvv _impl ref
+
+                  bzl_library(impl = _impl)
+
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: >-
+                  Codebase context from file
+                  /cmd/symbols/internal/squirrel/test_repos/python/example2.py
+                  in repository github.com/sourcegraph/sourcegraph:
+
+                  ```python
+
+                  import example as a1
+
+                  import example
+
+                  from example import C1, C1 as a2
+
+                  from .sub.example3 import f as a3
+
+
+                  #        vv py.C1 ref
+
+                  #                    vv py.C1 ref
+
+                  #                        vv py.C1 ref
+
+                  #                            vv py.C1 ref
+
+                  #                                vv py.example3.f ref
+
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: >-
+                  Codebase context from file
+                  /cmd/symbols/internal/squirrel/test_repos/java1/src/sub/sub2/Sample3.java
+                  in repository github.com/sourcegraph/sourcegraph:
+
+                  ```java
+
+                  package sub.subsub;
+
+
+                  //     vvv src/sub path
+
+                  //         vv C1 ref
+
+                  import sub.C1;
+
+
+                  class C4 extends C1 {
+                      //  vv C4.f1 def
+                      int f1;
+
+                      void m() {
+                          //      vv C1 ref
+                          //                   vv C4.f1 ref
+                          //                              vv f1 ref
+                          int y = C1.f1 + this.f1 + super.f1;
+                      }
+
+                      //          vv m5 def
+                      static void m5(Integer i) { }
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: >-
+                  Codebase context from file
+                  /cmd/symbols/internal/squirrel/BUILD.bazel in repository
+                  github.com/sourcegraph/sourcegraph:
+
+                  ```bazel
+
+                  load("//dev:go_defs.bzl", "go_test")
+
+                  load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+
+                  go_library(
+                      name = "squirrel",
+                      srcs = [
+                          "breadcrumbs.go",
+                          "hover.go",
+                          "lang_java.go",
+                          "lang_python.go",
+                          "lang_starlark.go",
+                          "languages.go",
+                          "local_code_intel.go",
+                          "service.go",
+                          "util.go",
+                      ],
+                      embedsrcs = ["language-file-extensions.json"],
+                      importpath = "github.com/sourcegraph/sourcegraph/cmd/symbols/internal/squirrel",
+                      tags = [TAG_PLATFORM_SEARCH],
+                      visibility = ["//cmd/symbols:__subpackages__"],
+                      deps = [
+                          "//cmd/symbols/internal/types",
+                          "//internal/api",
+                          "//internal/jsonc",
+                          "//internal/search",
+                          "//internal/search/result",
+                          "//internal/types",
+                          "//lib/errors",
+                          "@com_github_fatih_color//:color",
+                          "@com_github_grafana_regexp//:regexp",
+                          "@com_github_smacker_go_tree_sitter//:go-tree-sitter",
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: >-
+                  You have access to the provided codebase context. Answer
+                  positively without apologizing. 
+
+
+                  Question: what is squirrel? Explain as briefly as possible.
             model: anthropic/claude-3-5-sonnet-20240620
             temperature: 0.2
             topK: -1
@@ -229,19 +878,19 @@ log:
           - name: api-version
             value: "1"
           - name: client-name
-            value: cody-cli
+            value: jetbrains
           - name: client-version
-            value: 0.1.0-SNAPSHOT
-        url: https://sourcegraph.com/.api/completions/stream?api-version=1&client-name=cody-cli&client-version=0.1.0-SNAPSHOT
+            value: 6.0.0-SNAPSHOT
+        url: https://sourcegraph.sourcegraph.com/.api/completions/stream?api-version=1&client-name=jetbrains&client-version=6.0.0-SNAPSHOT
       response:
-        bodySize: 1632
+        bodySize: 5611
         content:
           mimeType: text/event-stream
-          size: 1632
+          size: 5611
           text: >+
             event: completion
 
-            data: {"completion":"Squirrel is a lightweight, high-performance SQL database engine written in Rust. It's designed to be embedded into other applications.","stopReason":"end_turn"}
+            data: {"completion":"Squirrel is a service within the Sourcegraph codebase that uses tree-sitter and the symbols service to analyze and traverse files to find symbols. It provides functionality for local code intelligence, including symbol search and hover information.","stopReason":"end_turn"}
 
 
             event: done
@@ -251,13 +900,15 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Tue, 09 Jul 2024 17:21:43 GMT
+            value: Tue, 16 Jul 2024 15:15:04 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
             value: chunked
           - name: connection
             value: keep-alive
+          - name: retry-after
+            value: "518"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -265,8 +916,8 @@ log:
           - name: cache-control
             value: no-cache
           - name: vary
-            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
-              X-Requested-With,Cookie
+            value: Accept-Encoding, Authorization, Cookie, Authorization, X-Requested-With,
+              Cookie
           - name: x-content-type-options
             value: nosniff
           - name: x-frame-options
@@ -275,12 +926,12 @@ log:
             value: 1; mode=block
           - name: strict-transport-security
             value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1299
+        headersSize: 1322
         httpVersion: HTTP/1.1
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-07-09T17:21:42.055Z
+      startedDateTime: 2024-07-16T15:15:02.212Z
       time: 0
       timings:
         blocked: -1
@@ -290,7 +941,7 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: fe8c88d62fa50b2521ec23515930f597
+    - _id: 2f4aa689ed4f58ea997875a6b3a87186
       _order: 0
       cache: {}
       request:
@@ -303,14 +954,14 @@ log:
             value: gzip;q=0
           - name: authorization
             value: token
-              REDACTED_d5e0f0a37c9821e856b923fe14e67a605e3f6c0a517d5a4f46a4e35943ee0f6d
+              REDACTED_964f5256e709a8c5c151a63d8696d5c7ac81604d179405864d88ff48a9232364
           - name: user-agent
-            value: cody-cli / 0.1.0-SNAPSHOT
+            value: jetbrains / 6.0.0-SNAPSHOT
           - name: connection
             value: keep-alive
           - name: host
-            value: sourcegraph.com
-        headersSize: 359
+            value: sourcegraph.sourcegraph.com
+        headersSize: 385
         httpVersion: HTTP/1.1
         method: POST
         postData:
@@ -334,7 +985,7 @@ log:
               - speaker: human
                 text: >-
                   You have access to the provided codebase context. Answer
-                  positively without apologizing.
+                  positively without apologizing. 
 
 
                   Question: implement a cow. Only print the code without any explanation.
@@ -346,10 +997,10 @@ log:
           - name: api-version
             value: "1"
           - name: client-name
-            value: cody-cli
+            value: jetbrains
           - name: client-version
-            value: 0.1.0-SNAPSHOT
-        url: https://sourcegraph.com/.api/completions/stream?api-version=1&client-name=cody-cli&client-version=0.1.0-SNAPSHOT
+            value: 6.0.0-SNAPSHOT
+        url: https://sourcegraph.sourcegraph.com/.api/completions/stream?api-version=1&client-name=jetbrains&client-version=6.0.0-SNAPSHOT
       response:
         bodySize: 3437
         content:
@@ -368,13 +1019,15 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Tue, 09 Jul 2024 17:21:44 GMT
+            value: Tue, 16 Jul 2024 15:15:07 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
             value: chunked
           - name: connection
             value: keep-alive
+          - name: retry-after
+            value: "514"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -382,8 +1035,8 @@ log:
           - name: cache-control
             value: no-cache
           - name: vary
-            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
-              X-Requested-With,Cookie
+            value: Accept-Encoding, Authorization, Cookie, Authorization, X-Requested-With,
+              Cookie
           - name: x-content-type-options
             value: nosniff
           - name: x-frame-options
@@ -392,12 +1045,12 @@ log:
             value: 1; mode=block
           - name: strict-transport-security
             value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1299
+        headersSize: 1322
         httpVersion: HTTP/1.1
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-07-09T17:21:43.572Z
+      startedDateTime: 2024-07-16T15:15:06.230Z
       time: 0
       timings:
         blocked: -1
@@ -407,7 +1060,121 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: 9d0e130a38eaf9d3cd8d9512afc14b87
+    - _id: 6d68e70caae8b436c57cef420e5762cc
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 916
+        cookies: []
+        headers:
+          - name: content-type
+            value: application/json
+          - name: accept-encoding
+            value: gzip;q=0
+          - name: authorization
+            value: token
+              REDACTED_964f5256e709a8c5c151a63d8696d5c7ac81604d179405864d88ff48a9232364
+          - name: user-agent
+            value: jetbrains / 6.0.0-SNAPSHOT
+          - name: connection
+            value: keep-alive
+          - name: host
+            value: sourcegraph.sourcegraph.com
+        headersSize: 371
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json
+          params: []
+          textJSON:
+            fast: true
+            maxTokensToSample: 400
+            messages:
+              - speaker: human
+                text: You are Cody, an AI coding assistant from Sourcegraph.
+              - speaker: assistant
+                text: I am Cody, an AI coding assistant from Sourcegraph.
+              - speaker: human
+                text: "You are helping the user search over a codebase. List some filename
+                  fragments that would match files relevant to read to answer
+                  the user's query. Present your results in a *single* XML list
+                  in the following format: <keywords><keyword><value>a single
+                  keyword</value><variants>a space separated list of synonyms
+                  and variants of the keyword, including acronyms,
+                  abbreviations, and expansions</variants><weight>a numerical
+                  weight between 0.0 and 1.0 that indicates the importance of
+                  the keyword</weight></keyword></keywords>. Here is the user
+                  query: <userQuery>what is squirrel? Explain as briefly as
+                  possible.</userQuery>"
+              - speaker: assistant
+            temperature: 0
+            topK: 1
+        queryString:
+          - name: client-name
+            value: jetbrains
+          - name: client-version
+            value: 6.0.0-SNAPSHOT
+        url: https://sourcegraph.sourcegraph.com/.api/completions/stream?client-name=jetbrains&client-version=6.0.0-SNAPSHOT
+      response:
+        bodySize: 8530
+        content:
+          mimeType: text/event-stream
+          size: 8530
+          text: >+
+            event: completion
+
+            data: {"completion":"\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrels sciuridae rodent\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eoverview\u003c/value\u003e\n\u003cvariants\u003esummary brief explanation\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003c/keywords\u003e","stopReason":"end_turn"}
+
+
+            event: done
+
+            data: {}
+
+        cookies: []
+        headers:
+          - name: date
+            value: Tue, 16 Jul 2024 15:15:01 GMT
+          - name: content-type
+            value: text/event-stream
+          - name: transfer-encoding
+            value: chunked
+          - name: connection
+            value: keep-alive
+          - name: retry-after
+            value: "520"
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache
+          - name: vary
+            value: Accept-Encoding, Authorization, Cookie, Authorization, X-Requested-With,
+              Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+        headersSize: 1322
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: 2024-07-16T15:15:00.436Z
+      time: 0
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 0
+    - _id: 204d8b5f0f47e53e25b515318b0b5aa6
       _order: 0
       cache: {}
       request:
@@ -417,13 +1184,13 @@ log:
           - _fromType: array
             name: authorization
             value: token
-              REDACTED_d5e0f0a37c9821e856b923fe14e67a605e3f6c0a517d5a4f46a4e35943ee0f6d
+              REDACTED_964f5256e709a8c5c151a63d8696d5c7ac81604d179405864d88ff48a9232364
           - _fromType: array
             name: content-type
             value: application/json; charset=utf-8
           - _fromType: array
             name: user-agent
-            value: cody-cli / 0.0.5b
+            value: jetbrains / 6.0.0-SNAPSHOT
           - _fromType: array
             name: accept
             value: "*/*"
@@ -434,8 +1201,8 @@ log:
             name: accept-encoding
             value: gzip,deflate
           - name: host
-            value: sourcegraph.com
-        headersSize: 319
+            value: sourcegraph.sourcegraph.com
+        headersSize: 352
         httpVersion: HTTP/1.1
         method: POST
         postData:
@@ -443,7 +1210,7 @@ log:
           params: []
           textJSON:
             query: |-
-
+              
               query ContextFilters {
                   site {
                       codyContextFilters(version: V1) {
@@ -455,20 +1222,20 @@ log:
         queryString:
           - name: ContextFilters
             value: null
-        url: https://sourcegraph.com/.api/graphql?ContextFilters
+        url: https://sourcegraph.sourcegraph.com/.api/graphql?ContextFilters
       response:
-        bodySize: 111
+        bodySize: 163
         content:
           encoding: base64
           mimeType: application/json
-          size: 111
-          text:
-            "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqzixJBdHJ+SmVzvl5JakVJW6ZOSWpRcUg0aLEciWrv\
-            NKcnNra2loAAAAA//8=\",\"AwA2LshlNQAAAA==\"]"
+          size: 163
+          text: "[\"H4sIAAAAAAAAAxTIQQqAIBBG4bvMMqgDuA1aRvtoMehPBJOKTmSIdw/f5oNXybEymUr5U\
+            nRtcN8cvKLocoki5X4Tvx0UK48Dmb1SQgwr39hYFcmToWkQ9ueIwncUTAO1o/V+AAAA\
+            //8=\",\"AwBK/4wNZQAAAA==\"]"
         cookies: []
         headers:
           - name: date
-            value: Thu, 27 Jun 2024 01:53:46 GMT
+            value: Tue, 16 Jul 2024 15:14:58 GMT
           - name: content-type
             value: application/json
           - name: transfer-encoding
@@ -476,7 +1243,7 @@ log:
           - name: connection
             value: keep-alive
           - name: retry-after
-            value: "142"
+            value: "523"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -484,8 +1251,8 @@ log:
           - name: cache-control
             value: no-cache, max-age=0
           - name: vary
-            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
-              X-Requested-With,Cookie
+            value: Accept-Encoding, Authorization, Cookie, Authorization, X-Requested-With,
+              Cookie
           - name: x-content-type-options
             value: nosniff
           - name: x-frame-options
@@ -496,12 +1263,12 @@ log:
             value: max-age=31536000; includeSubDomains; preload
           - name: content-encoding
             value: gzip
-        headersSize: 1440
+        headersSize: 1356
         httpVersion: HTTP/1.1
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-06-27T01:53:45.861Z
+      startedDateTime: 2024-07-16T15:14:57.815Z
       time: 0
       timings:
         blocked: -1
@@ -511,7 +1278,7 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: 460fa85fef77ffa15bb82fa3a88049a3
+    - _id: 6c3ed4b248638d9fb396d62dbb213764
       _order: 0
       cache: {}
       request:
@@ -521,13 +1288,13 @@ log:
           - _fromType: array
             name: authorization
             value: token
-              REDACTED_d5e0f0a37c9821e856b923fe14e67a605e3f6c0a517d5a4f46a4e35943ee0f6d
+              REDACTED_964f5256e709a8c5c151a63d8696d5c7ac81604d179405864d88ff48a9232364
           - _fromType: array
             name: content-type
             value: application/json; charset=utf-8
           - _fromType: array
             name: user-agent
-            value: cody-cli / 0.0.5b
+            value: jetbrains / 6.0.0-SNAPSHOT
           - _fromType: array
             name: accept
             value: "*/*"
@@ -538,8 +1305,8 @@ log:
             name: accept-encoding
             value: gzip,deflate
           - name: host
-            value: sourcegraph.com
-        headersSize: 336
+            value: sourcegraph.sourcegraph.com
+        headersSize: 369
         httpVersion: HTTP/1.1
         method: POST
         postData:
@@ -547,7 +1314,7 @@ log:
           params: []
           textJSON:
             query: |-
-
+              
               query CurrentSiteCodyLlmConfiguration {
                   site {
                       codyLLMConfiguration {
@@ -564,23 +1331,22 @@ log:
         queryString:
           - name: CurrentSiteCodyLlmConfiguration
             value: null
-        url: https://sourcegraph.com/.api/graphql?CurrentSiteCodyLlmConfiguration
+        url: https://sourcegraph.sourcegraph.com/.api/graphql?CurrentSiteCodyLlmConfiguration
       response:
         bodySize: 248
         content:
           encoding: base64
           mimeType: application/json
           size: 248
-          text:
-            "[\"H4sIAAAAAAAAA3zOwQqCQBAG4HeZs+K0BqFXr3rrBYbdMRdtJ3ZXKmTfPSyiSOg08PP/H\
-            7OAoUhQLxBs5PVqMfe27RpxvT3NnqIV98wHip0YnqAGcnHwcrG60BPNhvMyD+Icx1yh\
-            2qNSFWSfQUe3o4zsAtQ7hYgZ9BRi898byI7ziyvxAD+bLanlfJl4ffaN9tbzVfwYihD\
-            JazHsYdP7gipETCmlBwAAAP//AwBQeP+1EwEAAA==\"]"
+          text: "[\"H4sIAAAAAAAAA3zOTQrCMBAF4LvMuqFj6g9222278wJDktrQmilJikrJ3aWKKBZcDTze+\
+            5gZNEWCcoZgo1muYn2v66Zi19rz5Clads+8o9iwNgOUQC52nkercjXQpI0oxE4Eds5E\
+            IVFucS8Rss+koduJe+MClBuJiBm0FGL1X+zI9tOLK/AAP5s1qfgyDmZ594221psr+z7\
+            kIZJXrI2HVe8LOiJiSik9AAAA//8DABY6yDgVAQAA\"]"
           textDecoded:
             data:
               site:
                 codyLLMConfiguration:
-                  chatModel: anthropic/claude-3-sonnet-20240229
+                  chatModel: anthropic/claude-3-5-sonnet-20240620
                   chatModelMaxTokens: 12000
                   completionModel: fireworks/starcoder
                   completionModelMaxTokens: 9000
@@ -589,7 +1355,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Thu, 27 Jun 2024 01:53:45 GMT
+            value: Tue, 16 Jul 2024 15:14:57 GMT
           - name: content-type
             value: application/json
           - name: transfer-encoding
@@ -597,7 +1363,7 @@ log:
           - name: connection
             value: keep-alive
           - name: retry-after
-            value: "143"
+            value: "523"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -605,8 +1371,8 @@ log:
           - name: cache-control
             value: no-cache, max-age=0
           - name: vary
-            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
-              X-Requested-With,Cookie
+            value: Accept-Encoding, Authorization, Cookie, Authorization, X-Requested-With,
+              Cookie
           - name: x-content-type-options
             value: nosniff
           - name: x-frame-options
@@ -617,12 +1383,12 @@ log:
             value: max-age=31536000; includeSubDomains; preload
           - name: content-encoding
             value: gzip
-        headersSize: 1440
+        headersSize: 1356
         httpVersion: HTTP/1.1
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-06-27T01:53:44.877Z
+      startedDateTime: 2024-07-16T15:14:57.338Z
       time: 0
       timings:
         blocked: -1
@@ -632,7 +1398,7 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: 7edf90ea650cb304fe26f9d57bd79477
+    - _id: 52e634de5eece217f6acfdb021459c17
       _order: 0
       cache: {}
       request:
@@ -642,13 +1408,13 @@ log:
           - _fromType: array
             name: authorization
             value: token
-              REDACTED_d5e0f0a37c9821e856b923fe14e67a605e3f6c0a517d5a4f46a4e35943ee0f6d
+              REDACTED_964f5256e709a8c5c151a63d8696d5c7ac81604d179405864d88ff48a9232364
           - _fromType: array
             name: content-type
             value: application/json; charset=utf-8
           - _fromType: array
             name: user-agent
-            value: cody-cli / 0.0.5b
+            value: jetbrains / 6.0.0-SNAPSHOT
           - _fromType: array
             name: accept
             value: "*/*"
@@ -659,8 +1425,8 @@ log:
             name: accept-encoding
             value: gzip,deflate
           - name: host
-            value: sourcegraph.com
-        headersSize: 336
+            value: sourcegraph.sourcegraph.com
+        headersSize: 369
         httpVersion: HTTP/1.1
         method: POST
         postData:
@@ -668,7 +1434,7 @@ log:
           params: []
           textJSON:
             query: |-
-
+              
               query CurrentSiteCodyLlmConfiguration {
                   site {
                       codyLLMConfiguration {
@@ -680,25 +1446,20 @@ log:
         queryString:
           - name: CurrentSiteCodyLlmConfiguration
             value: null
-        url: https://sourcegraph.com/.api/graphql?CurrentSiteCodyLlmConfiguration
+        url: https://sourcegraph.sourcegraph.com/.api/graphql?CurrentSiteCodyLlmConfiguration
       response:
-        bodySize: 132
+        bodySize: 139
         content:
           encoding: base64
           mimeType: application/json
-          size: 132
-          text:
-            "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqzixJBdHJ+SmVPj6+zvl5aZnppUWJJZn5eWD53MSiE\
-            uf8vJLUipLwzLyU/HIlK6XUvMSknNQUpdra2loAAAAA//8DAOgINKVLAAAA\"]"
-          textDecoded:
-            data:
-              site:
-                codyLLMConfiguration:
-                  smartContextWindow: enabled
+          size: 139
+          text: "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqzixJBdHJ+SmVPj6+zvl5aZnppUWJJZn5eWD53MSiE\
+            uf8vJLUipLwzLyU/HIlK6XUvMSknNQUpdra2loAAAAA//8=\",\"AwDoCDSlSwAAAA==\
+            \"]"
         cookies: []
         headers:
           - name: date
-            value: Thu, 27 Jun 2024 01:53:45 GMT
+            value: Tue, 16 Jul 2024 15:14:57 GMT
           - name: content-type
             value: application/json
           - name: transfer-encoding
@@ -706,7 +1467,7 @@ log:
           - name: connection
             value: keep-alive
           - name: retry-after
-            value: "143"
+            value: "523"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -714,8 +1475,8 @@ log:
           - name: cache-control
             value: no-cache, max-age=0
           - name: vary
-            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
-              X-Requested-With,Cookie
+            value: Accept-Encoding, Authorization, Cookie, Authorization, X-Requested-With,
+              Cookie
           - name: x-content-type-options
             value: nosniff
           - name: x-frame-options
@@ -726,12 +1487,12 @@ log:
             value: max-age=31536000; includeSubDomains; preload
           - name: content-encoding
             value: gzip
-        headersSize: 1440
+        headersSize: 1356
         httpVersion: HTTP/1.1
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-06-27T01:53:44.900Z
+      startedDateTime: 2024-07-16T15:14:57.377Z
       time: 0
       timings:
         blocked: -1
@@ -741,7 +1502,7 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: d890a82b3cc2fe4d514f289e8fe6d158
+    - _id: 244eaabe52a621e08a73e8b374901225
       _order: 0
       cache: {}
       request:
@@ -751,13 +1512,13 @@ log:
           - _fromType: array
             name: authorization
             value: token
-              REDACTED_d5e0f0a37c9821e856b923fe14e67a605e3f6c0a517d5a4f46a4e35943ee0f6d
+              REDACTED_964f5256e709a8c5c151a63d8696d5c7ac81604d179405864d88ff48a9232364
           - _fromType: array
             name: content-type
             value: application/json; charset=utf-8
           - _fromType: array
             name: user-agent
-            value: cody-cli / 0.0.5b
+            value: jetbrains / 6.0.0-SNAPSHOT
           - _fromType: array
             name: accept
             value: "*/*"
@@ -768,8 +1529,8 @@ log:
             name: accept-encoding
             value: gzip,deflate
           - name: host
-            value: sourcegraph.com
-        headersSize: 331
+            value: sourcegraph.sourcegraph.com
+        headersSize: 364
         httpVersion: HTTP/1.1
         method: POST
         postData:
@@ -777,7 +1538,7 @@ log:
           params: []
           textJSON:
             query: |-
-
+              
               query CurrentSiteCodyLlmProvider {
                   site {
                       codyLLMConfiguration {
@@ -789,15 +1550,14 @@ log:
         queryString:
           - name: CurrentSiteCodyLlmProvider
             value: null
-        url: https://sourcegraph.com/.api/graphql?CurrentSiteCodyLlmProvider
+        url: https://sourcegraph.sourcegraph.com/.api/graphql?CurrentSiteCodyLlmProvider
       response:
         bodySize: 128
         content:
           encoding: base64
           mimeType: application/json
           size: 128
-          text:
-            "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqzixJBdHJ+SmVPj6+zvl5aZnppUWJJZn5eSDxgqL8s\
+          text: "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqzixJBdHJ+SmVPj6+zvl5aZnppUWJJZn5eSDxgqL8s\
             syU1CIlK6Xi/NKi5NT0osSCDKXa2tpaAAAAAP//AwAfFAXARQAAAA==\"]"
           textDecoded:
             data:
@@ -807,7 +1567,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Thu, 27 Jun 2024 01:53:45 GMT
+            value: Tue, 16 Jul 2024 15:14:57 GMT
           - name: content-type
             value: application/json
           - name: transfer-encoding
@@ -815,7 +1575,7 @@ log:
           - name: connection
             value: keep-alive
           - name: retry-after
-            value: "143"
+            value: "523"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -823,8 +1583,8 @@ log:
           - name: cache-control
             value: no-cache, max-age=0
           - name: vary
-            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
-              X-Requested-With,Cookie
+            value: Accept-Encoding, Authorization, Cookie, Authorization, X-Requested-With,
+              Cookie
           - name: x-content-type-options
             value: nosniff
           - name: x-frame-options
@@ -835,12 +1595,12 @@ log:
             value: max-age=31536000; includeSubDomains; preload
           - name: content-encoding
             value: gzip
-        headersSize: 1440
+        headersSize: 1356
         httpVersion: HTTP/1.1
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-06-27T01:53:44.878Z
+      startedDateTime: 2024-07-16T15:14:57.357Z
       time: 0
       timings:
         blocked: -1
@@ -850,7 +1610,7 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: 3fec40886d87367e761715c3159e6590
+    - _id: 350edf6da2666f3846b30731d7d8c2f7
       _order: 0
       cache: {}
       request:
@@ -860,13 +1620,13 @@ log:
           - _fromType: array
             name: authorization
             value: token
-              REDACTED_d5e0f0a37c9821e856b923fe14e67a605e3f6c0a517d5a4f46a4e35943ee0f6d
+              REDACTED_964f5256e709a8c5c151a63d8696d5c7ac81604d179405864d88ff48a9232364
           - _fromType: array
             name: content-type
             value: application/json; charset=utf-8
           - _fromType: array
             name: user-agent
-            value: cody-cli / 0.0.5b
+            value: jetbrains / 6.0.0-SNAPSHOT
           - _fromType: array
             name: accept
             value: "*/*"
@@ -877,8 +1637,8 @@ log:
             name: accept-encoding
             value: gzip,deflate
           - name: host
-            value: sourcegraph.com
-        headersSize: 316
+            value: sourcegraph.sourcegraph.com
+        headersSize: 349
         httpVersion: HTTP/1.1
         method: POST
         postData:
@@ -886,7 +1646,7 @@ log:
           params: []
           textJSON:
             query: |-
-
+              
               query CurrentUser {
                   currentUser {
                       id
@@ -909,155 +1669,32 @@ log:
         queryString:
           - name: CurrentUser
             value: null
-        url: https://sourcegraph.com/.api/graphql?CurrentUser
-      response:
-        bodySize: 376
-        content:
-          encoding: base64
-          mimeType: application/json
-          size: 376
-          text:
-            "[\"H4sIAAAAAAAAA2RPy07CQBT9l7tuaQ1R2klIFAQXaOMjNBjj4nZ6aaePmToPFJr+O2kwc\
-            eHunJzHvaeHHC0C64E7rUnarSE9UpEDg3SXNLxSp+T+5eqp4nPwoESTkhZ7QfmqRdEA\
-            s9qRB7kwXYPHBFsCBm/KaU6Fxq5cKOvHYRiCB86QlheD+TNkysa1v5ffrQMP8IAW9fb\
-            1ERiU1naGBUFTTieFUkVDYwNX0pK0E67aAIO7ZREpvlnjV/ZOblFn1XW+Xp1+omyXRj\
-            gTU5Nmm2XynM4eQnc81HMT3/gcPOi0aFEff0f0QBfw77PbYhTGazB4oHSBUpzQCiXNG\
-            JMqJwPs43MYhuEMAAD//wMASoyTP04BAAA=\"]"
-          textDecoded:
-            data:
-              currentUser:
-                avatarURL: https://lh3.googleusercontent.com/a/ACg8ocKFaqbYeuBkbj5dFEzx8bXV8a7i3sVbKCNPV7G0uyvk=s96-c
-                displayName: SourcegraphBot-9000
-                hasVerifiedEmail: true
-                id: VXNlcjozNDQ1Mjc=
-                organizations:
-                  nodes: []
-                primaryEmail:
-                  email: sourcegraphbot9k@gmail.com
-                username: sourcegraphbot9k-fnwmu
-        cookies: []
-        headers:
-          - name: date
-            value: Thu, 27 Jun 2024 01:53:45 GMT
-          - name: content-type
-            value: application/json
-          - name: transfer-encoding
-            value: chunked
-          - name: connection
-            value: keep-alive
-          - name: retry-after
-            value: "143"
-          - name: access-control-allow-credentials
-            value: "true"
-          - name: access-control-allow-origin
-            value: ""
-          - name: cache-control
-            value: no-cache, max-age=0
-          - name: vary
-            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
-              X-Requested-With,Cookie
-          - name: x-content-type-options
-            value: nosniff
-          - name: x-frame-options
-            value: DENY
-          - name: x-xss-protection
-            value: 1; mode=block
-          - name: strict-transport-security
-            value: max-age=31536000; includeSubDomains; preload
-          - name: content-encoding
-            value: gzip
-        headersSize: 1440
-        httpVersion: HTTP/1.1
-        redirectURL: ""
-        status: 200
-        statusText: OK
-      startedDateTime: 2024-06-27T01:53:44.920Z
-      time: 0
-      timings:
-        blocked: -1
-        connect: -1
-        dns: -1
-        receive: 0
-        send: 0
-        ssl: -1
-        wait: 0
-    - _id: 84b962509b12000d0eef7c8a8fa655f3
-      _order: 0
-      cache: {}
-      request:
-        bodySize: 268
-        cookies: []
-        headers:
-          - _fromType: array
-            name: authorization
-            value: token
-              REDACTED_d5e0f0a37c9821e856b923fe14e67a605e3f6c0a517d5a4f46a4e35943ee0f6d
-          - _fromType: array
-            name: content-type
-            value: application/json; charset=utf-8
-          - _fromType: array
-            name: user-agent
-            value: cody-cli / 0.0.5b
-          - _fromType: array
-            name: accept
-            value: "*/*"
-          - _fromType: array
-            name: content-length
-            value: "268"
-          - _fromType: array
-            name: accept-encoding
-            value: gzip,deflate
-          - name: host
-            value: sourcegraph.com
-        headersSize: 332
-        httpVersion: HTTP/1.1
-        method: POST
-        postData:
-          mimeType: application/json; charset=utf-8
-          params: []
-          textJSON:
-            query: |-
-
-              query CurrentUserCodySubscription {
-                  currentUser {
-                      codySubscription {
-                          status
-                          plan
-                          applyProRateLimits
-                          currentPeriodStartAt
-                          currentPeriodEndAt
-                      }
-                  }
-              }
-            variables: {}
-        queryString:
-          - name: CurrentUserCodySubscription
-            value: null
-        url: https://sourcegraph.com/.api/graphql?CurrentUserCodySubscription
+        url: https://sourcegraph.sourcegraph.com/.api/graphql?CurrentUser
       response:
         bodySize: 228
         content:
           encoding: base64
           mimeType: application/json
           size: 228
-          text:
-            "[\"H4sIAAAAAAAAA1zMsQrCMBSF4Xc5c4U2FoVsRToIgqWtDm6xyRCoSbi5GUrJu4uCoI7n5\
-            +Os0IoV5IopERnHl2joPb1ehnSPE9nA1rtXi6w4RUg0h/F4bVEgzMpBouvPKKBCmJeO\
-            fK/YnOzDcoRkSqb4fHeGrNcDK+KGISFKUW/K3aaqRyFkVcmtuOFPt05/2f2vzTnnJwA\
-            AAP//AwBuKtnYwgAAAA==\"]"
+          text: "[\"H4sIAAAAAAAAAzSOuwrCQBBF/2XqLawXLO0kgpggiMWQncTRzWyY2Qgx7L9LfJTncricB\
+            QJmBL9AO6mS5NpIV+QAHppzFdt72hxOjy04uKE1pNwxhd2AHMF3GI0cBLYx4lzhQOBl\
+            itHBZKTyYWhTmDNZZunBAT4xo9bH/d8clQfU+ff43ZL2KPzCzElszZEUyMBfrqWU8gY\
+            AAP//AwAAXh5NtQAAAA==\"]"
           textDecoded:
             data:
               currentUser:
-                codySubscription:
-                  applyProRateLimits: true
-                  currentPeriodEndAt: 2024-07-14T22:11:32Z
-                  currentPeriodStartAt: 2024-06-14T22:11:32Z
-                  plan: PRO
-                  status: ACTIVE
+                avatarURL: null
+                displayName: null
+                hasVerifiedEmail: false
+                id: VXNlcjo0OTk=
+                organizations:
+                  nodes: []
+                primaryEmail: null
+                username: codytesting
         cookies: []
         headers:
           - name: date
-            value: Thu, 27 Jun 2024 01:53:45 GMT
+            value: Tue, 16 Jul 2024 15:14:57 GMT
           - name: content-type
             value: application/json
           - name: transfer-encoding
@@ -1065,7 +1702,7 @@ log:
           - name: connection
             value: keep-alive
           - name: retry-after
-            value: "143"
+            value: "523"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -1073,8 +1710,8 @@ log:
           - name: cache-control
             value: no-cache, max-age=0
           - name: vary
-            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
-              X-Requested-With,Cookie
+            value: Accept-Encoding, Authorization, Cookie, Authorization, X-Requested-With,
+              Cookie
           - name: x-content-type-options
             value: nosniff
           - name: x-frame-options
@@ -1085,12 +1722,12 @@ log:
             value: max-age=31536000; includeSubDomains; preload
           - name: content-encoding
             value: gzip
-        headersSize: 1440
+        headersSize: 1356
         httpVersion: HTTP/1.1
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-06-27T01:53:45.238Z
+      startedDateTime: 2024-07-16T15:14:57.396Z
       time: 0
       timings:
         blocked: -1
@@ -1100,7 +1737,207 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: e3e9d3db6d23d195bf9fcf9d8e2fe36f
+    - _id: 26ecc9d2f361f4c40e9a9bf4b2f8bea8
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 735
+        cookies: []
+        headers:
+          - _fromType: array
+            name: authorization
+            value: token
+              REDACTED_964f5256e709a8c5c151a63d8696d5c7ac81604d179405864d88ff48a9232364
+          - _fromType: array
+            name: content-type
+            value: application/json; charset=utf-8
+          - _fromType: array
+            name: user-agent
+            value: jetbrains / 6.0.0-SNAPSHOT
+          - _fromType: array
+            name: accept
+            value: "*/*"
+          - _fromType: array
+            name: content-length
+            value: "735"
+          - _fromType: array
+            name: accept-encoding
+            value: gzip,deflate
+          - name: host
+            value: sourcegraph.sourcegraph.com
+        headersSize: 352
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json; charset=utf-8
+          params: []
+          textJSON:
+            query: >-
+              
+              query GetCodyContext($repos: [ID!]!, $query: String!, $codeResultsCount: Int!, $textResultsCount: Int!) {
+              	getCodyContext(repos: $repos, query: $query, codeResultsCount: $codeResultsCount, textResultsCount: $textResultsCount) {
+                      ...on FileChunkContext {
+                          blob {
+                              path
+                              repository {
+                                id
+                                name
+                              }
+                              commit {
+                                oid
+                              }
+                              url
+                            }
+                            startLine
+                            endLine
+                            chunkContent
+                      }
+                  }
+              }
+            variables:
+              codeResultsCount: 15
+              query: overview squirrel
+              repos:
+                - UmVwb3NpdG9yeTozOTk=
+              textResultsCount: 5
+        queryString:
+          - name: GetCodyContext
+            value: null
+        url: https://sourcegraph.sourcegraph.com/.api/graphql?GetCodyContext
+      response:
+        bodySize: 5426
+        content:
+          encoding: base64
+          mimeType: application/json
+          size: 5426
+          text: "[\"H4sIAAAAAAAA/+w7gXLbuI6/gtXOzTk5W9o0bd+udzKzbZru5l7a9CXuu3tXZVRKgmS+S\
+            KSWpJykTf79BiRly46dJu3ezd1sPJ2pDQIgCIAACDKfg5wZFow/ByWafZlf7Uth8NIE\
+            4w+fg7SSKQ01zEyDcZDVeaSv6lRWOuLCoBKsivTvLVcKq+jk4MWrNwdhnQfDQGEjNTd\
+            SXRE5z4Nx8L7++0W6+7bJf/3pCify0/HkfC8YBoLVGIyDkptpm4aZrCMtW5VhqVgz7X\
+            8PboZBJuuaG2IpLU98nuY/PsOn6V+eZc+znR8xYz/uPNn96Qf2Y8qePn/2Y7aLu5gWR\
+            NuqKhgH0Zcn+uW+XKNRRAqK7quWm2GgDVPmiAsMxj8MAxS5+/5kGGTTVpxb3QsTjIPv\
+            4dQziEUsgpvhLWPkMotynEUpy85LJVuRj7gopKqZ4VJE+vcq4iLHyz+hQR6ims1G2fl\
+            hnVX+dkQG+bXlORMZAhM55DJraxTGcgeWytbAheKGixJoc6VMI1jHYBmhaLjgZsoFmC\
+            nC6WKdwJqm4pllE9IsI/jwhpeKOSI5QzXjeHE2qOfApAOGdb61QtDH64Z/4+V01KCyy\
+            iD5y5bnqGMBMIIPL5nJpiAbnHNICZIsII6PRX7DDCrOKv4Jc8hYNsWzQd2DJRY2l+tI\
+            ZuekkBSnbMalOhtUDpJ0EIe6ztVD5yPRu/dHR8nJwd/eH5xOksnBm3dHLyYHZGmsSMS\
+            EC83LqdF/Qpf/GhXdEY+e3XL9uP3hh93su9EIXqHOFE/Rum/TqkZqBFnYn+9OQEswU2\
+            aAF3AlW6ikPMccCGCAC3gOtRRmqsHwGgl2IdsqhxQhq5ApKJSsLavOs+FiegVmyjVcM\
+            A2ZQmYwh9HICoSx+P57OPaosTgUGpWB3IrY2P04RYVhaPfTYg0eL8VCKreJWWFQgc4U\
+            otBTaQZ6y62jZueoSVBk+gqMBJ6jMLy4slJmUyZK1FCzHJeFOp2z0rG4hpcHr49PDqD\
+            /uQZ48XpycALXsRiPNn3G13eMxaJbCq9ZiXaxcL0GBnb9PQ28b3JmnA153VS4CGDaYK\
+            Pd2vV0bhxJSKR50kBHYMkLZKZVGKVtCQW/jAxmU8gxNdaiom2W9fJOyVKh1jYqwBkcL\
+            s/e+GGoeYXaSDGPTnAGbzoY/CcBO/CE6XPYuQV5so7wH+uA/7UOaJ3GAV8tRXgqj6KF\
+            p2horS5zGPACFFY4Y8JsdbT71kMqWS6htRrVqGAZF+Uc80XTKDnDHNIrYLQRaO/lgKL\
+            kAlFZOiPbbEpxdD6cyRw3sKD8t5lDN3oHgxw1L4Un5MbRorZmf3+4IVpT5s2qVlMqEO\
+            WftyzcqIc74u7TNSXHBC8N7M8Z0TaeUDjMucKMdAmZFIZxoeHdlZlKYS1K+9TPbh3WV\
+            iLQarK8RuKeIWCdYp5zUWobA//6BpnQsBDaRs2lAEtzI3z0KGFz9RFcqAXj4qQABpPT\
+            v0PBK7R1DjA3f8GxyodQoqBiAvVaKZx8ti7yoxPFhKZyBZWGiqeKqathJ6LzxB69ndA\
+            tY2iXJFvTtEbfEqpTDdPk4bS3dditrpSsAq5Jg1Q9NqB5zSvm9agFbxo0NFyimaKi0k\
+            4Cg0ZhjgUXmINo6xQVJcVO0E6T7zUrkb4fCN0qF38VUqmPOTRUr6IGpqhe1IZVFeZjw\
+            v748WMsGt50YBipjszJbi6Nx3Jr8EZhWYaNcWoqZFXJC9IvU6UNZ9ryvoYX/vc8L73q\
+            5c97fYikYG1lWVwTz+VEBauAL3+WSBzPj6MRF01rPnaTvg==\",\"Y2ZqExJBFxa+S8\
+            7kxGs7mfMksybWPT/CNbxltStn5k4LvlQ3eub4G+mLZAQp4BrigJDjAPzqv+K4JlONa\
+            sZSXnFz9Xhwe5CSluPpk/4R7qfbdawPnksZnWsopPKxyZ5ehpShM6ZxxEohteEZ+CLa\
+            bhRZ9A9u/6phSbQwFv1jHdZNJa+QQp6rp1ilJSgsKDRL61ofpkzkqZTnq6xAoz0zng2\
+            mxjR6HEUdZthTtDVCl+Up2Szx2LKL60k00g1mvKA19dWwqJER3h5PDsbwWiqYyguScr\
+            vVuH3Xol0VLRZ1uyxAtmoFyReLeriy/hUsqUBzg8DymguujWJGqhWrnQ3CMHL/LNoG9\
+            9hal8SOlyU3S8dwLrKqzbGLjsvh8BoOLhmVrNrGj/FodN2PWvMfNrhsb7+RgjYvF+X2\
+            NlxbZdKp6FzIC0gupigS0LJGYysyOuMoKUqakulpKpnKNZBFnjyHGo3iGaW1CpXhohz\
+            CFFlFuWyK2bkTB7a3X2HaluXqhDlBaUZmkv48E2Vr0CFU0hIRF6utfSls6vB9iL5+6v\
+            maoOFVxZT+Fu+MFuwSz25DYXl3n41Y8gwTg9qEpfyzhc6HKWdzCfp091bIpLKEDpK61\
+            5HkdSOVgUEsYhMHmesZx4H7KXX3jSwXUc6kLx1QVzzDOYqWak5I4lGJG9hIZOK+RQpm\
+            +DTKZCVVh94bLaUsK4xKOcrqJsrqZh2OYgUTLFJY4mWzdpIN1uhpFJnKpmuY35MyUqj\
+            bynwNA3PVOK1tkeBFKzLggpvBFnwmZryAZAjyHMZ7IHV4JOV52xyI2SAO3h4n+8dHxy\
+            dxsPUzfCfPHUFsrDLDt3Kf/oc9KFilqTg1N7G4mU8yQW3eSnEkM1a9ogKXUyAcGNj25\
+            gonXgTacK+40kNApbwcJ8jyV1wNnHETuyfjgJZgCmZYdVgcKCXVEUuxGhhLOYQ4UMhy\
+            exRYIRKxYUJI43ui4z34cLYAfL5xKET9miq18R7QGgaZuQTvpKG/4BhCY6tH0mp4go3\
+            ct/uaSsotGHw4S68MWnGk2uoUptC0SnTLohkGnXOH/y65WFmlm8Iy918t9y2vYvrPYN\
+            10nX6S9i1eDDrphyB4ZZFZVZ26ve1W7JwodLBu0ZQ0E8qr1giEqJgosQPobhG8gO88L\
+            DzUZJv5+mJjwtdklWIQB63AywYzg7mrev/FrqijpDJ54JbiF/PVIfsxWm/Wy+ZAvfv8\
+            2wN1Ua+J2aoVhtc4j89GZVLMej/ppH2/EK25oUP2cpyrWXaOikK1UYgjh9Px80qZ0K6\
+            Ee8XHtaqcx8qvDrL3JKx4GtkYsYjMUQS/uZqZNjIwu3vCWBBr6Pb2a4qsLjSthqV7RS\
+            Q/URc6Tp3H0KFFQ0+ttiinAttrCLxrkXRMsOrqk+t+G8VmqDRaWW3no+Ait1N4ym4Bq\
+            zNqo9rMdPHfh93ep7/ghYFPbTLscPpGD91Qh54SfabaOtVzli8XMEJpmNKols/52275\
+            4Ts7RlhZJTVLaXGLz4czawEbxKxaj4UleM141SqEVEraQybHxkxXOglcGJ8ko4iitr+\
+            Z0MBA4MWqmkKfS/vhfUk1Q1hSzAaNbMH2qv694m1ecieFFYzPXxOZ949fHbw9nhy+/s\
+            djZN6gl82R+fa98fY2/DJjqhUlE/mUj7TKHmAV1nB7rqpQJVkpH9PlRrUs22Sn3wra/\
+            cvtVtADc0OpmiyyPFyCaJQ08n5JauFJfhWzHcejGzD3T3h/ZK6yQYnSOyrTxQ1bj0/k\
+            r6rJ7NcBFfO+Dt7WhplWh6f2v/nBw3END/XAlu/ddgnfC4WZLAX/hDbSHVwaFJpLcbC\
+            urA==\",\"9rwpRmYyRx0eihmreN61p23uC51MiyL67vl121D9g/kRE2XLSrzfzO/F/\
+            I4T8w3zelrBq0UisIekfZnjoTBYgUPRUBHYXcuQ9aqKl/bmg0p2ys4ln6FwVTazN3K0\
+            Cb11Bhq2yfN8ON9amWOg8PcWtYFt647h8uiJGxyC1uDG/TnCc0uW0QmKasvp0+lIr+S\
+            b8d5CvaQvHS6nse7Iktv23gp1uF9JjYPuIKdKe57xKwh/RbNc9Qy2wok89O7eUdFRjo\
+            TQXcXk8nfDrirJ8vnRc3XmFa1l5nIIJMDWwoXguz0SH74qYy7OfVFjb+Ei3aYRul7hb\
+            thcPcbsh6nrYa/lAGbQXIVzBgXkWMQixwKKwdb4Gy1KglRMnUfppyrxl5Bh+ql6tOlD\
+            FfZgqy4+0OO1sG4P+O12/iebsZ1Iq8x646n1pSchQR8t/XCVbbb1Ha2LNv3Z51Jrfdj\
+            fdbbOKqY1/frs3vk4BPBYhceyp0nDDM8o0UKx+/MftfP/4/jkr6fvXuwfPHrC/VV1x+\
+            Patbt9w2c22xQGFBn9jzHwy/eHR68ejXs/Nf2/M2yYsk/4mK8fpKz/q0aeyhmqx3veL\
+            6vmjgR8u0f14MuD/k3AF+5u/9daGRPU5jfSwbrrSSpK6Gj4cV5NOPhM8hzqxS1YFIGQ\
+            Bpg9h6MwUHGBflU02AfDznrwE3/XJgxcwh48+3lxrfrRsSplxUTp5bHC14yLToo7ZFg\
+            rwdr5Z0zB5bxT7efN9JSpxs9LG0I3LEN4LWVXWjnlvGSqA/SqKqurl+zTgFbW9C4O71\
+            TaRrVtVFwnfKc633NZ0iDZ11+I9m8hYmMvdp3Q/sWsvey2nq6XgBfMv3pcAG88k8/Op\
+            W0pGwdDoP+HEAcry4jFivixiIOb4TKPUhIHZ/Gv5ZHZ61dnvYfx+B++FPf3ziTk4tLZ\
+            2eZbOynztKTtueLxyP1AXT3wj9u+NoVXkuWDOIii8cpxnzw2DnpA+4jjTvSs1UbWSX+\
+            OvTU8YjHvDkDC66ZadATsT9sLINEbpnWHvm5Vntquo99LsNA9N/pV79Fud7h8c+rJYz\
+            PwQap6kBP7isXTA9PAduZ1jIfGwv6RWYfjB/d3hrC/YymeeIxQt+m8pdjhFRZld8mnZ\
+            rb5uL/j3GjtRroHygPQHoi6QO81SL/9iLXc+9Ft+sQ3gHYfe2bforc7PP72g/Ze54z8\
+            dbmBRjEO/EQ2tc8HvEt07uOdm5js71gGvkR+CnhpUOSaUHu9N6J9GhY7i76bbbg5Wsu\
+            8V1V3E3Zz9yZeHVr1WTfJl1GXqVZJSDZKJPs7xO3f7N+Tum+6bVCFVm5CvOnE708ym0\
+            H97FaD0S3w2eBQGCxRAd+Cz0T/8C312KG4h2LueAl3ux0xLzFynI1LmeRY6EVBUkp7R\
+            O4XI79wmdh5EtVWqJNSRlEpxzkWS2TLJcgCMHCeQQax5cr8EB0Mvc+oTMMefFi4ZBz0\
+            3ja5E0J/0J7kb4PpBJFQkNgw5PLnhsGuRFw/3LIS1whi766TTOaY2Lvr2xiL54orA63\
+            hS+hn/n/7B3tzjcwnHxW8whF2bwR0+E8tRRx0VC5E2fPJ3jc8DbxlGsNKK8jkxa/Ju6\
+            MXk9fHJ2+S04MXJ/u/dVPPuOb+b0WsxFGf9ThJdJv6MKyTZCFxjs0to0d3PlgcLqP23\
+            7psHiQ1ZZuHuyfrd4/PH6ZvQlsvYb8RszT0SybrxNkose9CE/suNIrG/n3oRmz/TD9x\
+            z/SjaNy9199I4Z+UJrSvFWLiHv9F0Xj1jemQovPZzc1/BwAA//84ilWu9UYAAA==\"]"
+        cookies: []
+        headers:
+          - name: date
+            value: Tue, 16 Jul 2024 15:15:02 GMT
+          - name: content-type
+            value: application/json
+          - name: transfer-encoding
+            value: chunked
+          - name: connection
+            value: keep-alive
+          - name: retry-after
+            value: "519"
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache, max-age=0
+          - name: content-encoding
+            value: gzip
+          - name: vary
+            value: Accept-Encoding, Authorization, Cookie, Authorization, X-Requested-With,
+              Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+        headersSize: 1356
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: 2024-07-16T15:15:01.805Z
+      time: 0
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 0
+    - _id: b4499992cdf92807c09248d1e216cbdb
       _order: 0
       cache: {}
       request:
@@ -1110,13 +1947,13 @@ log:
           - _fromType: array
             name: authorization
             value: token
-              REDACTED_d5e0f0a37c9821e856b923fe14e67a605e3f6c0a517d5a4f46a4e35943ee0f6d
+              REDACTED_964f5256e709a8c5c151a63d8696d5c7ac81604d179405864d88ff48a9232364
           - _fromType: array
             name: content-type
             value: application/json; charset=utf-8
           - _fromType: array
             name: user-agent
-            value: cody-cli / 0.0.5b
+            value: jetbrains / 6.0.0-SNAPSHOT
           - _fromType: array
             name: accept
             value: "*/*"
@@ -1127,8 +1964,8 @@ log:
             name: accept-encoding
             value: gzip,deflate
           - name: host
-            value: sourcegraph.com
-        headersSize: 317
+            value: sourcegraph.sourcegraph.com
+        headersSize: 350
         httpVersion: HTTP/1.1
         method: POST
         postData:
@@ -1136,7 +1973,7 @@ log:
           params: []
           textJSON:
             query: |
-
+              
               query Repositories($names: [String!]!, $first: Int!) {
                   repositories(names: $names, first: $first) {
                     nodes {
@@ -1152,27 +1989,20 @@ log:
         queryString:
           - name: Repositories
             value: null
-        url: https://sourcegraph.com/.api/graphql?Repositories
+        url: https://sourcegraph.sourcegraph.com/.api/graphql?Repositories
       response:
-        bodySize: 180
+        bodySize: 175
         content:
           encoding: base64
           mimeType: application/json
-          size: 180
-          text:
-            "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqSi3IL84syS/KTC0G8fPyU0CM6GqlvMTcVCUrpfTMk\
-            ozSJL3k/Fz94vzSouTU9KLEggxktpKOUmaKkpVSaG5YeZKxX0GKu2Vlakh+lV9Werl/\
-            iKehr6OtrVJtbG1tLQAAAP//AwAClJdVdwAAAA==\"]"
-          textDecoded:
-            data:
-              repositories:
-                nodes:
-                  - id: UmVwb3NpdG9yeTozNjgwOTI1MA==
-                    name: github.com/sourcegraph/sourcegraph
+          size: 175
+          text: "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqSi3IL84syS/KTC0G8fPyU0CM6GqlvMTcVCUrpfTMk\
+            ozSJL3k/Fz94vzSouTU9KLEggxktpKOUmaKkpVSaG5YeZKxX0GKu2Vlakh+lX9Itq1S\
+            bWxtbS0AAAD//w==\",\"AwARSH8wbwAAAA==\"]"
         cookies: []
         headers:
           - name: date
-            value: Thu, 27 Jun 2024 01:53:49 GMT
+            value: Tue, 16 Jul 2024 15:15:00 GMT
           - name: content-type
             value: application/json
           - name: transfer-encoding
@@ -1180,7 +2010,7 @@ log:
           - name: connection
             value: keep-alive
           - name: retry-after
-            value: "138"
+            value: "520"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -1188,8 +2018,8 @@ log:
           - name: cache-control
             value: no-cache, max-age=0
           - name: vary
-            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
-              X-Requested-With,Cookie
+            value: Accept-Encoding, Authorization, Cookie, Authorization, X-Requested-With,
+              Cookie
           - name: x-content-type-options
             value: nosniff
           - name: x-frame-options
@@ -1200,12 +2030,12 @@ log:
             value: max-age=31536000; includeSubDomains; preload
           - name: content-encoding
             value: gzip
-        headersSize: 1440
+        headersSize: 1356
         httpVersion: HTTP/1.1
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-06-27T01:53:49.334Z
+      startedDateTime: 2024-07-16T15:15:00.245Z
       time: 0
       timings:
         blocked: -1
@@ -1215,7 +2045,7 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: 2aa42833ae189b030c5bc322f1d27b0c
+    - _id: e83b435a530574a277932bc0a0cad82a
       _order: 0
       cache: {}
       request:
@@ -1225,13 +2055,13 @@ log:
           - _fromType: array
             name: authorization
             value: token
-              REDACTED_d5e0f0a37c9821e856b923fe14e67a605e3f6c0a517d5a4f46a4e35943ee0f6d
+              REDACTED_964f5256e709a8c5c151a63d8696d5c7ac81604d179405864d88ff48a9232364
           - _fromType: array
             name: content-type
             value: application/json; charset=utf-8
           - _fromType: array
             name: user-agent
-            value: cody-cli / 0.0.5b
+            value: jetbrains / 6.0.0-SNAPSHOT
           - _fromType: array
             name: accept
             value: "*/*"
@@ -1242,8 +2072,8 @@ log:
             name: accept-encoding
             value: gzip,deflate
           - name: host
-            value: sourcegraph.com
-        headersSize: 323
+            value: sourcegraph.sourcegraph.com
+        headersSize: 356
         httpVersion: HTTP/1.1
         method: POST
         postData:
@@ -1251,7 +2081,7 @@ log:
           params: []
           textJSON:
             query: |-
-
+              
               query SiteProductVersion {
                   site {
                       productVersion
@@ -1261,24 +2091,23 @@ log:
         queryString:
           - name: SiteProductVersion
             value: null
-        url: https://sourcegraph.com/.api/graphql?SiteProductVersion
+        url: https://sourcegraph.sourcegraph.com/.api/graphql?SiteProductVersion
       response:
         bodySize: 136
         content:
           encoding: base64
           mimeType: application/json
           size: 136
-          text:
-            "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqzixJBdEFRfkppcklYalFxZn5eUpWSkYWBgZGZvFGB\
-            kYmugZmukbm8aZ6JrqGxknGhqbJ5smmpmZKtbW1AAAAAP//AwAok7tZSQAAAA==\"]"
+          text: "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqzixJBdEFRfkppcklYalFxZn5eUpWSkYWRqbGxvFGB\
+            kYmugbmuoZm8aZ6prqJBomGFolmBqmWBiZKtbW1AAAAAP//AwBtpsiNSQAAAA==\"]"
           textDecoded:
             data:
               site:
-                productVersion: 280026_2024-06-27_5.4-13b315c7c556
+                productVersion: 282533_2024-07-16_5.5-a0a18a60e904
         cookies: []
         headers:
           - name: date
-            value: Thu, 27 Jun 2024 01:53:45 GMT
+            value: Tue, 16 Jul 2024 15:14:57 GMT
           - name: content-type
             value: application/json
           - name: transfer-encoding
@@ -1286,7 +2115,7 @@ log:
           - name: connection
             value: keep-alive
           - name: retry-after
-            value: "143"
+            value: "523"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -1294,8 +2123,8 @@ log:
           - name: cache-control
             value: no-cache, max-age=0
           - name: vary
-            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
-              X-Requested-With,Cookie
+            value: Accept-Encoding, Authorization, Cookie, Authorization, X-Requested-With,
+              Cookie
           - name: x-content-type-options
             value: nosniff
           - name: x-frame-options
@@ -1306,12 +2135,12 @@ log:
             value: max-age=31536000; includeSubDomains; preload
           - name: content-encoding
             value: gzip
-        headersSize: 1440
+        headersSize: 1356
         httpVersion: HTTP/1.1
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-06-27T01:53:44.876Z
+      startedDateTime: 2024-07-16T15:14:57.299Z
       time: 0
       timings:
         blocked: -1

--- a/agent/src/cli/__snapshots__/command-chat.test.ts.snap
+++ b/agent/src/cli/__snapshots__/command-chat.test.ts.snap
@@ -24,8 +24,10 @@ exports[`--context-repo (squirrel test) 1`] = `
   what is squirrel? Explain as briefly as possible.
 exitCode: 0
 stdout: >+
-  Squirrel is a lightweight, high-performance SQL database engine written in
-  Rust. It's designed to be embedded into other applications.
+  Squirrel is a service within the Sourcegraph codebase that uses tree-sitter
+  and the symbols service to analyze and traverse files to find symbols. It
+  provides functionality for local code intelligence, including symbol search
+  and hover information.
 
 stderr: ""
 "

--- a/agent/src/cli/codyCliClientName.ts
+++ b/agent/src/cli/codyCliClientName.ts
@@ -1,0 +1,22 @@
+// Context https://github.com/sourcegraph/sourcegraph/pull/63855
+// The Sourcegraph Enterprise backend rejects requests from unknown clients on
+// the assumption that they may not support context filters. This logic is flawed because
+// it has both false positives and false negatives.
+//
+// - False negatives: upcoming Cody clients (CLI, Eclipse, Visual Studio)
+//   already support context filters out of the box thanks to using the Cody agent
+//   but they can't send requests unless we add a special case to them. It may
+//   require months for these clients to wait for all Enterprise instances to
+//   upgrade to a version that adds exceptions for their name.
+// - False positive: a malicious client can always fake that it's "jetbrains"
+//   with a valid version number even if the client doesn't respect context
+//   filters. This gives a false sense of security because it doesn't prevent
+//   malicious traffic from bypassing context filters. In fact, I am leaning
+//   towards using the
+//
+// To bypass this server check, the Cody CLI needs to fake its name to be
+// "jetbrains" and declare a version number above 5.5.8. We can change the name
+// back to cody-cli once all Enterprise instances have upgraded to a release
+// that includes this PR https://github.com/sourcegraph/sourcegraph/pull/63855
+
+export const codyCliClientName = 'jetbrains'

--- a/agent/src/cli/command-chat.test.ts
+++ b/agent/src/cli/command-chat.test.ts
@@ -21,7 +21,7 @@ interface ChatCommandResult {
 }
 
 describe('cody chat', () => {
-    const credentials = TESTING_CREDENTIALS.dotcom
+    const credentials = TESTING_CREDENTIALS.s2
     let polly: Polly
     const agentDirectory = getAgentDir()
     const tmp = new TestWorkspace(path.join(agentDirectory, 'src', '__tests__', 'cody-cli-chat'))
@@ -51,12 +51,18 @@ describe('cody chat', () => {
         options.debug = true
         const exitCode = await chatAction(options)
         if (exitCode !== (params.expectedExitCode ?? 0)) {
+            const extraHint =
+                stdout.buffer.length === 0 && stderr.buffer.length === 0
+                    ? 'Stdout and stderr are empty even if the process exited with a non-zero code. ' +
+                      'Comment out the --silent option from the test file to try to get more debugging information.'
+                    : undefined
             throw new Error(
                 YAML.stringify({
                     exitCode,
                     expectedExitCode: params.expectedExitCode,
                     stdout: stdout.buffer,
                     stderr: stderr.buffer,
+                    extraHint,
                 })
             )
         }
@@ -93,8 +99,7 @@ describe('cody chat', () => {
         ).toMatchSnapshot()
     }, 10_000)
 
-    // Only works for Sourcegraph Enterprise users. Blocked by CODY-2884.
-    it.skip('--context-repo (squirrel test)', async () => {
+    it('--context-repo (squirrel test)', async () => {
         expect(
             YAML.stringify(
                 await runCommand({

--- a/agent/src/cli/command-chat.ts
+++ b/agent/src/cli/command-chat.ts
@@ -13,8 +13,10 @@ import packageJson from '../../package.json'
 import { newEmbeddedAgentClient } from '../agent'
 import type { ClientInfo } from '../protocol-alias'
 import { Streams } from './Streams'
+import { codyCliClientName } from './codyCliClientName'
 import { AuthenticatedAccount } from './command-auth/AuthenticatedAccount'
 import { notLoggedIn } from './command-auth/messages'
+import { isNonEmptyArray } from './isNonEmptyArray'
 
 declare const process: { pkg: { entrypoint: string } } & NodeJS.Process
 export interface ChatOptions {
@@ -120,8 +122,8 @@ export async function chatAction(options: ChatOptions): Promise<number> {
     }
     const workspaceRootUri = vscode.Uri.file(path.resolve(options.dir))
     const clientInfo: ClientInfo = {
-        name: 'cody-cli',
-        version: options.isTesting ? '0.1.0-SNAPSHOT' : packageJson.version,
+        name: codyCliClientName,
+        version: options.isTesting ? '6.0.0-SNAPSHOT' : packageJson.version,
         workspaceRootUri: workspaceRootUri.toString(),
         extensionConfiguration: {
             serverEndpoint: options.endpoint,
@@ -204,6 +206,7 @@ export async function chatAction(options: ChatOptions): Promise<number> {
         )
         return 1
     }
+    const addEnhancedContext = isNonEmptyArray(options.contextRepo)
     const response = await client.request('chat/submitMessage', {
         id,
         message: {
@@ -211,7 +214,7 @@ export async function chatAction(options: ChatOptions): Promise<number> {
             submitType: 'user',
             text: messageText,
             contextFiles,
-            addEnhancedContext: false,
+            addEnhancedContext,
         },
     })
 

--- a/agent/src/cli/isNonEmptyArray.ts
+++ b/agent/src/cli/isNonEmptyArray.ts
@@ -1,0 +1,3 @@
+export function isNonEmptyArray<T>(arr: undefined | null | T[]): arr is T[] {
+    return Array.isArray(arr) && arr.length > 0
+}

--- a/vscode/src/testutils/CodyPersister.ts
+++ b/vscode/src/testutils/CodyPersister.ts
@@ -188,7 +188,7 @@ function postProcessResponseText(entry: HarEntry): string | undefined {
     }
 
     const [completionEvent, doneEvent] = parseResult.events.slice(-2)
-    if (completionEvent.type !== 'completion' || doneEvent.type !== 'done') {
+    if (completionEvent?.type !== 'completion' || doneEvent?.type !== 'done') {
         return text
     }
 


### PR DESCRIPTION
Fixes CODY-2742

Previously, the `--context-repo` option did not work with the CLI because of two issues:

- The CLI used the client name "cody-cli", which Sourcegraph Enterprise rejects due to a problem that is described in the PR https://github.com/sourcegraph/sourcegraph/pull/63855 To work around this problem, the CLI will use the client name "jetbrains" for time being.
- The `addEnhancedOptions` was set to false in `chat/submitMessage`. We now set this option to `true` when `--context-repo` or `--context-file` is enabled.


## Test plan
See updated test case that fixes the Squirrel test. This change required using S2 credentials instead of dotcom.


<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
