### PR TITLE
Cody Web: Fix client-config request for Cody Web in production

### DIFF
--- a/lib/shared/src/sourcegraph-api/graphql/client.ts
+++ b/lib/shared/src/sourcegraph-api/graphql/client.ts
@@ -1353,14 +1353,18 @@ export class ClientConfigSingleton {
     }
 
     public async getConfig(): Promise<CodyClientConfig | undefined> {
-        switch (this.shouldFetch()) {
-            case 'sync':
-                return this.refreshConfig()
-            // biome-ignore lint/suspicious/noFallthroughSwitchClause: This is intentional
-            case 'async':
-                this.refreshConfig()
-            case false:
-                return this.cachedClientConfig
+        try {
+            switch (this.shouldFetch()) {
+                case 'sync':
+                    return this.refreshConfig()
+                // biome-ignore lint/suspicious/noFallthroughSwitchClause: This is intentional
+                case 'async':
+                    this.refreshConfig()
+                case false:
+                    return this.cachedClientConfig
+            }
+        } catch {
+            return
         }
     }
 

--- a/web/CHANGELOG.md
+++ b/web/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.2.7
+- Provide api to set custom headers for any network request in Cody Web (agent worker thread)
+
 ## 0.2.6
 - Don't show model-select dropdown for enterprise users who don't have server-sent models enabled
 

--- a/web/lib/agent/agent.client.ts
+++ b/web/lib/agent/agent.client.ts
@@ -28,6 +28,7 @@ interface AgentClientOptions {
     serverEndpoint: string
     accessToken: string
     workspaceRootUri: string
+    customHeaders?: Record<string, string>
     debug?: boolean
     trace?: boolean
 }
@@ -36,6 +37,7 @@ export async function createAgentClient({
     serverEndpoint,
     accessToken,
     workspaceRootUri,
+    customHeaders,
     debug = true,
     trace = false,
 }: AgentClientOptions): Promise<AgentClient> {
@@ -77,7 +79,7 @@ export async function createAgentClient({
         extensionConfiguration: {
             accessToken,
             serverEndpoint,
-            customHeaders: {},
+            customHeaders: customHeaders ?? {},
             customConfiguration: {
                 'cody.experimental.noodle': true,
                 'cody.autocomplete.enabled': false,

--- a/web/lib/components/CodyWebChatProvider.tsx
+++ b/web/lib/components/CodyWebChatProvider.tsx
@@ -66,6 +66,7 @@ interface CodyWebChatProviderProps {
     chatID?: string | null
     initialContext?: InitialContext
     onNewChatCreated?: (chatId: string) => void
+    customHeaders?: Record<string, string>
 }
 
 /**
@@ -80,6 +81,7 @@ export const CodyWebChatProvider: FC<PropsWithChildren<CodyWebChatProviderProps>
         children,
         chatID: initialChatId,
         onNewChatCreated,
+        customHeaders,
     } = props
 
     // In order to avoid multiple client creation during dev runs
@@ -111,6 +113,7 @@ export const CodyWebChatProvider: FC<PropsWithChildren<CodyWebChatProviderProps>
                     workspaceRootUri: '',
                     serverEndpoint: serverEndpoint,
                     accessToken: accessToken ?? '',
+                    customHeaders,
                 })
 
                 // Fetch existing chats from the agent chat storage
@@ -150,7 +153,7 @@ export const CodyWebChatProvider: FC<PropsWithChildren<CodyWebChatProviderProps>
                 setClient(() => error as Error)
             }
         })()
-    }, [initialChatId, accessToken, serverEndpoint, lastActiveChatID, initialContext])
+    }, [initialChatId, accessToken, serverEndpoint, lastActiveChatID, initialContext, customHeaders])
 
     const vscodeAPI = useMemo<VSCodeWrapper>(() => {
         if (client && !isErrorLike(client)) {

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cody-web-experimental",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "Cody standalone web app",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
So, with the new `client-config` handler (which is part of REST API), we've got a runtime fail in Cody Web in production. The problem is that the GET request doesn't send the Origin request header (since it's a plain get request), also we don't send custom client headers like 
```
x-requested-with: Sourcegraph
x-sourcegraph-client: https://sourcegraph.sourcegraph.com/
```

because of this lack of request headers this `client-config` fails in a runtime with 401 status. This PR exposes `customHeaders` API for Cody Web components, so consumer components in the Sourcegraph client would be able to set the proper set of headers that we have in `window.context.xhrHeaders`


## Test plan
- This change doesn't change much in cody vs code logic so here we should just make sure that CI is passing 
- Later as this PR will be merged and published to NPM I will prepare a PR where we conduct proper testing in sourcegraph client

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
