### PR TITLE
Autocomplete: fix prefix computation in cache keys

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -11,6 +11,7 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 ### Fixed
 
 - Command: The "Ask Cody to Explain" command for explaining terminal output has been removed from the command palette, as it is only callable from the terminal context menu. [pull/4860](https://github.com/sourcegraph/cody/pull/4860)
+- Autocomplete: Fixed the request manager cache keys computation. [pull/4902](https://github.com/sourcegraph/cody/pull/4902)
 
 ### Changed
 

--- a/vscode/src/completions/request-manager.ts
+++ b/vscode/src/completions/request-manager.ts
@@ -347,7 +347,9 @@ class RequestCache {
     private toCacheKey(requestParams: Pick<RequestParams, 'docContext'>): CacheKey {
         const { prefix, currentLinePrefix, nextNonEmptyLine } = requestParams.docContext
 
-        const prefixWithoutCurrentLinePrefix = prefix.slice(0, -currentLinePrefix.length).trim()
+        const prefixWithoutCurrentLinePrefix = (
+            currentLinePrefix.length ? prefix.slice(0, -currentLinePrefix.length) : prefix
+        ).trim()
 
         const prevNonEmptyLines: string[] = []
         let remainingPrefix = prefixWithoutCurrentLinePrefix

--- a/vscode/src/completions/test-helpers.ts
+++ b/vscode/src/completions/test-helpers.ts
@@ -59,13 +59,24 @@ export function documentAndPosition(
     languageId?: string,
     uriString?: string
 ): { document: VSCodeTextDocument; position: VSCodePosition } {
+    const { prefix, suffix, cursorIndex } = prefixAndSuffix(textWithCursor)
+
+    const doc = document(prefix + suffix, languageId, uriString)
+    const position = doc.positionAt(cursorIndex)
+    return { document: doc, position }
+}
+
+export function prefixAndSuffix(textWithCursor: string): {
+    prefix: string
+    suffix: string
+    cursorIndex: number
+} {
     const cursorIndex = textWithCursor.indexOf(CURSOR_MARKER)
     if (cursorIndex === -1) {
         throw new Error(`The test text must include a ${CURSOR_MARKER} to denote the cursor position.`)
     }
     const prefix = textWithCursor.slice(0, cursorIndex)
     const suffix = textWithCursor.slice(cursorIndex + CURSOR_MARKER.length)
-    const doc = document(prefix + suffix, languageId, uriString)
-    const position = doc.positionAt(cursorIndex)
-    return { document: doc, position }
+
+    return { prefix, suffix, cursorIndex }
 }


### PR DESCRIPTION
The current implementation doesn't account for cases where the current line suffix is an empty string. This PR fixes it and updates unit tests. Part of https://linear.app/sourcegraph/issue/CODY-2190/[autocomplete-latency]-ab-test-hot-streak

## Test plan

Updated unit tests.
