### PR TITLE
Auth: fix AuthStatus update handling

### DIFF
--- a/agent/src/agent.ts
+++ b/agent/src/agent.ts
@@ -1087,8 +1087,8 @@ export class Agent extends MessageHandler implements ExtensionClient {
 
         this.registerAuthenticatedRequest('chat/models', async ({ modelUsage }) => {
             const authStatus = await vscode.commands.executeCommand<AuthStatus>('cody.auth.status')
-            const providers = ModelsService.getModels(modelUsage, authStatus)
-            return { models: providers ?? [] }
+            const models = ModelsService.getModels(modelUsage, authStatus)
+            return { models }
         })
 
         this.registerAuthenticatedRequest('chat/export', async input => {

--- a/agent/src/index.test.ts
+++ b/agent/src/index.test.ts
@@ -102,11 +102,17 @@ describe('Agent', () => {
     // Context files ends with 'Ignored.ts' will be excluded by .cody/ignore
     const ignoredUri = workspace.file('src', 'isIgnored.ts')
 
-    it('extensionConfiguration/change (handle errors)', async () => {
+    it('extensionConfiguration/change & chat/models (handle errors)', async () => {
         // Send two config change notifications because this is what the
         // JetBrains client does and there was a bug where everything worked
         // fine as long as we didn't send the second unauthenticated config
         // change.
+        const initModelName = 'anthropic/claude-3-5-sonnet-20240620'
+        const {
+            models: [initModel],
+        } = await client.request('chat/models', { modelUsage: ModelUsage.Chat })
+        expect(initModel.model).toStrictEqual(initModelName)
+
         const invalid = await client.request('extensionConfiguration/change', {
             ...client.info.extensionConfiguration,
             anonymousUserID: 'abcde1234',
@@ -117,6 +123,9 @@ describe('Agent', () => {
             customHeaders: {},
         })
         expect(invalid?.isLoggedIn).toBeFalsy()
+        const invalidModels = await client.request('chat/models', { modelUsage: ModelUsage.Chat })
+        expect(invalidModels.models).toStrictEqual([])
+
         const valid = await client.request('extensionConfiguration/change', {
             ...client.info.extensionConfiguration,
             anonymousUserID: 'abcde1234',
@@ -125,6 +134,12 @@ describe('Agent', () => {
             customHeaders: {},
         })
         expect(valid?.isLoggedIn).toBeTruthy()
+
+        const reauthenticatedModels = await client.request('chat/models', {
+            modelUsage: ModelUsage.Chat,
+        })
+        expect(reauthenticatedModels.models).not.toStrictEqual([])
+        expect(reauthenticatedModels.models[0].model).toStrictEqual(initModelName)
 
         // Please don't update the recordings to use a different account without consulting #team-cody-core.
         // When changing an account, you also need to update the REDACTED_ hash above.

--- a/vscode/src/chat/chat-view/ChatController.ts
+++ b/vscode/src/chat/chat-view/ChatController.ts
@@ -535,7 +535,7 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
         void this.sendConfig()
 
         // Get the latest model list available to the current user to update the ChatModel.
-        this.handleSetChatModel(getDefaultModelID(this.authProvider.getAuthStatus()))
+        this.handleSetChatModel(getDefaultModelID(authStatus))
     }
 
     // When the webview sends the 'ready' message, respond by posting the view config

--- a/vscode/src/services/AuthProvider.ts
+++ b/vscode/src/services/AuthProvider.ts
@@ -357,7 +357,7 @@ export class AuthProvider implements AuthStatusProvider, vscode.Disposable {
                 await this.storeAuthInfo(config.serverEndpoint, config.accessToken)
             }
 
-            this.setAuthStatus(authStatus)
+            await this.setAuthStatus(authStatus)
             await vscode.commands.executeCommand('setContext', 'cody.activated', isLoggedIn)
 
             // If the extension is authenticated on startup, it can't be a user's first
@@ -393,7 +393,7 @@ export class AuthProvider implements AuthStatusProvider, vscode.Disposable {
     }
 
     // Set auth status and share it with chatview
-    private setAuthStatus(authStatus: AuthStatus): void {
+    private async setAuthStatus(authStatus: AuthStatus): Promise<void> {
         if (this.status === authStatus) {
             return
         }
@@ -402,7 +402,7 @@ export class AuthProvider implements AuthStatusProvider, vscode.Disposable {
         if (authStatus.endpoint === 'init') {
             return
         }
-        void this.updateAuthStatus(authStatus)
+        await this.updateAuthStatus(authStatus)
     }
 
     private async updateAuthStatus(authStatus: AuthStatus): Promise<void> {


### PR DESCRIPTION
Makes sure we await the this.updateAuthStatus(authStatus) step in this.setAuthStatus(authStatus) during authStatus change to make sure Models are synced accordingly. This fixes the issue introduced by the recent refactor where we have moved the syncModels step into `setAuthStatus` from the authProvider listener. 

Previously, we skip waiting for this.updateAuthStatus(authStatus) in authProvider.setAuthStatus(authStatus) step because we didn't want to wait for the token to be stored inside the local storage.

## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

Green CI - a new unit test is added to an agent to ensure this behaviour is respected in the future.