### PR TITLE
Chat: use Context Preamble by default

### DIFF
--- a/lib/shared/src/experimentation/FeatureFlagProvider.ts
+++ b/lib/shared/src/experimentation/FeatureFlagProvider.ts
@@ -61,9 +61,6 @@ export enum FeatureFlag {
     /** Automatically start indexing using embeddings. */
     CodyEmbeddingsAutoIndexing = 'cody-embeddings-auto-indexing',
 
-    /** Enable Context Preamble for open-end chat questions. */
-    CodyChatContextPreamble = 'cody-chat-context-preamble',
-
     /** Whether to use generated metadata to power embeddings. */
     CodyEmbeddingsGenerateMetadata = 'cody-embeddings-generate-metadata',
 

--- a/lib/shared/src/prompt/prompt-mixin.ts
+++ b/lib/shared/src/prompt/prompt-mixin.ts
@@ -1,5 +1,4 @@
 import type { ChatMessage } from '../chat/transcript/messages'
-import { FeatureFlag, featureFlagProvider } from '../experimentation/FeatureFlagProvider'
 import { PromptString, ps } from './prompt-string'
 
 /**
@@ -17,7 +16,7 @@ const HEDGES_PREVENTION = ps`Answer positively without apologizing. `
  */
 export class PromptMixin {
     private static mixins: PromptMixin[] = []
-    private static defaultMixin: PromptMixin = new PromptMixin(ps``)
+    private static defaultMixin: PromptMixin = new PromptMixin(CONTEXT_PREAMBLE)
 
     /**
      * Prepends all mixins to `humanMessage`. Modifies and returns `humanMessage`.
@@ -43,28 +42,6 @@ export class PromptMixin {
             }
         }
         return humanMessage
-    }
-
-    /**
-     * Sets the default prompt mixin determined by evaluating the CodyChatContextPreamble feature flag.
-     * Always enable the context preamble in testing and development mode.
-     *
-     * If the feature flag is enabled, set the context preamble as the default mixin.
-     * If the feature flag is disabled or an error occurs, the default mixin will be an empty prompt.
-     */
-    public static async updateContextPreamble(isExtensionModeDevOrTest = false): Promise<void> {
-        try {
-            const enabled =
-                isExtensionModeDevOrTest ||
-                (await featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyChatContextPreamble))
-            PromptMixin.defaultMixin = new PromptMixin(enabled ? CONTEXT_PREAMBLE : ps``)
-        } catch {
-            PromptMixin.resetDefaultPromptMixin()
-        }
-    }
-
-    private static resetDefaultPromptMixin(): void {
-        PromptMixin.defaultMixin = new PromptMixin(ps``)
     }
 
     /**


### PR DESCRIPTION
Follow up on https://linear.app/sourcegraph/issue/CODY-2507/evaluate-claude-35-sonnet-as-new-default

As mentioned in the linked issue, we were able to verify the context preamble has improved chat quality. This PR is to remove the CodyChatContextPreamble feature flag so that the Context Preamble is always used by default. This also applies to Enterprise users as they do not have access to feature flags.

The CodyChatContextPreamble feature flag has been removed, and the context preamble is now always enabled by default in the PromptMixin. This simplifies the code and removes the need for the feature flag.

BREAKING CHANGE: The CodyChatContextPreamble feature flag has been removed. The context preamble is now always enabled by default when context is used.

## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

Green CI, as all existing features should remain unchanged. All our tests should not affected by this change because the same preamble was enabled for all tests.