### PR TITLE
CLI: disable autocomplete and clean up logs

### DIFF
--- a/agent/src/agent.ts
+++ b/agent/src/agent.ts
@@ -1315,6 +1315,10 @@ export class Agent extends MessageHandler implements ExtensionClient {
         return this.clientInfo?.version || '0.0.0'
     }
 
+    get capabilities(): agent_protocol.ClientCapabilities | undefined {
+        return this.clientInfo?.capabilities ?? undefined
+    }
+
     /**
      * Gets provided extension objects. This may only be called after
      * registration is complete.

--- a/agent/src/cli/command-chat.test.ts
+++ b/agent/src/cli/command-chat.test.ts
@@ -49,7 +49,8 @@ describe('cody chat', () => {
         const stdout = new StringBufferStream()
         const stderr = new StringBufferStream()
         options.streams = new Streams(stdout, stderr)
-        options.debug = true
+        // Uncomment below to see output channel logs from Cody
+        // options.debug = true
         const exitCode = await chatAction(options)
         if (exitCode !== (params.expectedExitCode ?? 0)) {
             const extraHint =

--- a/agent/src/cli/command-chat.ts
+++ b/agent/src/cli/command-chat.ts
@@ -125,11 +125,15 @@ export async function chatAction(options: ChatOptions): Promise<number> {
         name: codyCliClientName,
         version: options.isTesting ? '6.0.0-SNAPSHOT' : packageJson.version,
         workspaceRootUri: workspaceRootUri.toString(),
+        capabilities: {
+            completions: 'none',
+        },
         extensionConfiguration: {
             serverEndpoint: options.endpoint,
             accessToken: options.accessToken,
             customHeaders: {},
             customConfiguration: {
+                'cody.internal.autocomplete.entirelyDisabled': true,
                 'cody.experimental.symf.enabled': false,
                 'cody.experimental.telemetry.enabled': options.isTesting ? false : undefined,
             },
@@ -138,6 +142,12 @@ export async function chatAction(options: ChatOptions): Promise<number> {
     spinner.text = 'Initializing...'
     const { serverInfo, client, messageHandler } = await newEmbeddedAgentClient(clientInfo, activate)
     const { models } = await client.request('chat/models', { modelUsage: ModelUsage.Chat })
+
+    if (options.debug) {
+        messageHandler.registerNotification('debug/message', message => {
+            console.log(`${message.channel}: ${message.message}`)
+        })
+    }
 
     messageHandler.registerNotification('webview/postMessage', message => {
         if (message.message.type === 'transcript') {

--- a/vscode/src/commands/services/custom-commands.ts
+++ b/vscode/src/commands/services/custom-commands.ts
@@ -164,7 +164,7 @@ export class CustomCommandsManager implements vscode.Disposable {
                 )
             }
         } catch (error) {
-            console.error('CustomCommandsProvider:build', 'failed', { verbose: error })
+            logError('CustomCommandsProvider:build', 'failed', { verbose: error })
         }
         return this.customCommandsMap
     }

--- a/vscode/src/extension-client.ts
+++ b/vscode/src/extension-client.ts
@@ -1,5 +1,6 @@
 import type { Disposable } from 'vscode'
 import type { EnterpriseContextFactory } from './context/enterprise-context-factory'
+import type { ClientCapabilities } from './jsonrpc/agent-protocol'
 import { FixupCodeLenses } from './non-stop/codelenses/provider'
 import type { FixupActor, FixupFileCollection } from './non-stop/roles'
 import type { FixupControlApplicator } from './non-stop/strategies'
@@ -32,6 +33,7 @@ export interface ExtensionClient {
 
     get clientName(): string
     get clientVersion(): string
+    get capabilities(): ClientCapabilities | undefined
 }
 
 /**
@@ -45,5 +47,6 @@ export function defaultVSCodeExtensionClient(): ExtensionClient {
         createFixupControlApplicator: files => new FixupCodeLenses(files),
         clientName: 'vscode',
         clientVersion: version,
+        capabilities: undefined,
     }
 }

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -522,7 +522,7 @@ function registerUpgradeHandlers(
             if (ws.focused && authStatus.isDotCom && authStatus.isLoggedIn) {
                 const res = await graphqlClient.getCurrentUserCodyProEnabled()
                 if (res instanceof Error) {
-                    console.error(res)
+                    logError('onDidChangeWindowState', 'getCurrentUserCodyProEnabled', res)
                     return
                 }
                 // Re-auth if user's cody pro status has changed
@@ -628,7 +628,7 @@ function registerAutocomplete(
                     disposeAutocomplete()
                     if (
                         config.isRunningInsideAgent &&
-                        !process.env.CODY_SUPPRESS_AGENT_AUTOCOMPLETE_WARNING
+                        platform.extensionClient.capabilities?.completions !== 'none'
                     ) {
                         throw new Error(
                             'The setting `config.autocomplete` evaluated to `false`. It must be true when running inside the agent. ' +
@@ -670,7 +670,7 @@ function registerAutocomplete(
                 )
             })
             .catch(error => {
-                console.error('Error creating inline completion item provider:', error)
+                logError('registerAutocomplete', 'Error creating inline completion item provider', error)
             })
         return setupAutocompleteQueue
     }

--- a/web/lib/agent/agent.client.ts
+++ b/web/lib/agent/agent.client.ts
@@ -76,6 +76,9 @@ export async function createAgentClient({
         name: 'web',
         version: '0.0.1',
         workspaceRootUri,
+        capabilities: {
+            completions: 'none',
+        },
         extensionConfiguration: {
             accessToken,
             serverEndpoint,

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -14,7 +14,6 @@ const fakeProcessEnv: Record<string, string | boolean> = {
     NODE_ENV: 'production',
     NODE_DEBUG: false,
     TESTING_DOTCOM_URL: 'https://sourcegraph.com',
-    CODY_SUPPRESS_AGENT_AUTOCOMPLETE_WARNING: true,
     CODY_WEB_DONT_SET_SOME_HEADERS: true,
     LSP_LIGHT_LOGGING_ENABLED: false,
     LSP_LIGHT_CACHE_DISABLED: false,


### PR DESCRIPTION
Fixes CODY-2945

Previously, the `cody chat` command enabled autocomplete providers even if we don't use autocomplete. This resulted in noisy console logs in errors related to loading autocomplete. This PR fixes the problem by entirely disabling autocomplete from `cody chat`.

Example console output before this PR

![CleanShot 2024-07-18 at 10 53 27@2x](https://github.com/user-attachments/assets/1ae8d61a-2d6b-4e09-9821-72264331d328)


## Test plan
Green CI.
<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
