### PR TITLE
CLI: fail fast if `--context-repo` does not have a matching name

### DIFF
--- a/agent/CHANGELOG.md
+++ b/agent/CHANGELOG.md
@@ -10,6 +10,13 @@ This is a log of all notable changes to the Cody command-line tool. [Unreleased]
 
 ### Changed
 
+## 5.5.10
+
+### Fixed
+
+- Running `cody chat` should no longer report errors related to autocomplete
+- Running `cody chat --context-repo REPO` now reports a helpful error if the provided repo does not exist on the instance.
+
 ## 5.5.9
 
 ### Added

--- a/agent/package.json
+++ b/agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sourcegraph/cody",
-  "version": "5.5.9",
+  "version": "5.5.10",
   "description": "Cody JSON-RPC agent for consistent cross-editor support",
   "license": "Apache-2.0",
   "repository": {

--- a/agent/src/cli/command-chat.ts
+++ b/agent/src/cli/command-chat.ts
@@ -192,6 +192,28 @@ export async function chatAction(options: ChatOptions): Promise<number> {
             names: options.contextRepo,
             first: options.contextRepo.length,
         })
+
+        const invalidRepos: string[] = []
+        for (const repo of options.contextRepo) {
+            if (!repos.some(r => r.name === repo)) {
+                invalidRepos.push(repo)
+            }
+        }
+
+        if (invalidRepos.length > 0) {
+            const reposString = invalidRepos.join(', ')
+            const errorMessage =
+                invalidRepos.length > 1
+                    ? `The repositories ${invalidRepos} do not exist on the instance. `
+                    : `The repository '${reposString}' does not exist on the instance. `
+            spinner.fail(
+                errorMessage +
+                    'The name needs to match exactly the name of the repo as it appears on your Sourcegraph instance. ' +
+                    'Please check the spelling and try again.'
+            )
+            return 1
+        }
+
         await client.request('webview/receiveMessage', {
             id,
             message: {


### PR DESCRIPTION
Fixes CODY-2947

Previously, the CLI would silently continue even if `--context-repo` had a spelling or referenced a repo that doesn't exist on the instance. Now, the CLI fails fast with a helpful error message.


## Test plan

Manually tested.
```
❯ pnpm agent chat --context-repo sourcegraph/cody --context-repo github.com/sourcegraph/jetbrains -m 'what is the agent'
...
 ✖ The repository sourcegraph/cody does not exist on the instance. The name needs to match exactly the name of the repo as it appears on your Sourcegraph instance. Please check the spelling and try again.
```
<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
