### PR TITLE
Lowercase the version flag of Cody CLI

### DIFF
--- a/agent/src/cli/command-root.ts
+++ b/agent/src/cli/command-root.ts
@@ -10,7 +10,7 @@ import { version } from '../../package.json'
 
 export const rootCommand = new Command()
     .name('cody')
-    .version(version)
+    .version(version, '-v, --version')
     .description(
         'The Cody cli supports running Cody in headless mode and interacting with it via JSON-RPC. Run `cody chat -m "Hello" to get started.'
     )


### PR DESCRIPTION
The most common flags for CLI applications to show the current version are --version and -v (lowercase).

This PR makes Cody CLI consistent with that convention.

## Test plan

Run manually
```
❯ pnpm agent -v
...
5.5.10
```