### PR TITLE
When substituting the config.codebase for a git remote name, make it look like one

### DIFF
--- a/agent/package.json
+++ b/agent/package.json
@@ -17,7 +17,7 @@
     "build-minify": "pnpm run build --minify",
     "agent": "pnpm run build && node --enable-source-maps dist/index.js",
     "agent:skip-root-build": "pnpm run build:agent && node --enable-source-maps dist/index.js",
-    "agent:debug": "pnpm run build && CODY_AGENT_TRACE_PATH=/tmp/agent.json CODY_AGENT_DEBUG_REMOTE=true node --enable-source-maps ./dist/index.js",
+    "agent:debug": "pnpm run build && CODY_AGENT_TRACE_PATH=/tmp/agent.json CODY_AGENT_DEBUG_REMOTE=true node --enable-source-maps ./dist/index.js api jsonrpc-stdio",
     "build-ts": "tsc --build",
     "test-agent-binary": "esbuild ./scripts/test-agent-binary.ts --bundle --platform=node --alias:vscode=./src/vscode-shim.ts --outdir=dist && node ./dist/test-agent-binary.js",
     "test": "vitest",

--- a/lib/shared/src/utils.ts
+++ b/lib/shared/src/utils.ts
@@ -14,9 +14,14 @@ export function convertGitCloneURLToCodebaseName(cloneURL: string): string | nul
     if (isError(result)) {
         if (result.message) {
             if (result.cause) {
-                logError('convertGitCloneURLToCodebaseName', result.message, result.cause)
+                logError(
+                    'convertGitCloneURLToCodebaseName',
+                    result.message,
+                    result.cause,
+                    result.stack?.concat('\n')
+                )
             } else {
-                logError('convertGitCloneURLToCodebaseName', result.message)
+                logError('convertGitCloneURLToCodebaseName', result.message, result.stack?.concat('\n'))
             }
         }
         return null

--- a/vscode/src/repository/git-metadata-for-editor.test.ts
+++ b/vscode/src/repository/git-metadata-for-editor.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest'
+import { fakeGitURLFromCodebase } from './git-metadata-for-editor'
+
+describe('fakeGitURLFromCodebase', () => {
+    it('returns undefined when codebaseName is undefined', () => {
+        expect(fakeGitURLFromCodebase(undefined)).toBeUndefined()
+    })
+
+    it('returns the codebaseName as a URL string when it is a valid URL', () => {
+        expect(fakeGitURLFromCodebase('https://github.com/sourcegraph/cody')).toBe(
+            'https://github.com/sourcegraph/cody'
+        )
+    })
+
+    it('converts a codebase name without a scheme to a git URL', () => {
+        expect(fakeGitURLFromCodebase('example.com/foo/bar')).toBe('git@example.com:foo/bar')
+    })
+
+    it('handles a codebase name with multiple slashes', () => {
+        expect(fakeGitURLFromCodebase('example.com/foo/bar/baz')).toBe('git@example.com:foo/bar/baz')
+    })
+
+    it('handles a codebase name with a single path component', () => {
+        expect(fakeGitURLFromCodebase('example.com/foo')).toBe('git@example.com:foo')
+    })
+})


### PR DESCRIPTION
`config.codebase` is picked up from the workspace root, but it is a Sourcegraph repository name (for example, `github.com/sourcegraph/cody`) not a git remote URL (for example, `https://github.com/sourcegraph/cody.git`.)

This cheesily reformats `config.codebase` to look like a git remote URL. Keeping the real fetch URL instead of making one up would be better, but doing this local rewrite for now to try to ease customer pain in CODY-2846.

Related: sourcegraph/cody#4924

## Test plan

Automated test:

```
pnpm -C vscode test:unit
```

Manual test:

1. Set up sourcegraph/jetbrains
2. `CODY_DIR=/absolute/path/to/cody ./gradlew :runIDE -PforceAgentBuild=true`
3. Open multiple files, some inside a git repository, some outside.
4. Logs with `convertGitCloneURLToCodebaseName` should NOT appear.
