### PR TITLE
CLI: fix bug in `--show-context`

### DIFF
--- a/agent/CHANGELOG.md
+++ b/agent/CHANGELOG.md
@@ -10,6 +10,12 @@ This is a log of all notable changes to the Cody command-line tool. [Unreleased]
 
 ### Changed
 
+## 5.5.11
+
+### Fixed
+
+- The `cody chat --show-context` flag now correctly prints out the used context for `--context-repo` and `--context-file`.
+
 ## 5.5.10
 
 ### Fixed

--- a/agent/package.json
+++ b/agent/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sourcegraph/cody",
-  "version": "5.5.10",
-  "description": "Cody JSON-RPC agent for consistent cross-editor support",
+  "version": "5.5.11",
+  "description": "Cody CLI is the same technology that powers Cody in the IDE but available from the command-line.",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/agent/src/cli/__snapshots__/command-chat.test.ts.snap
+++ b/agent/src/cli/__snapshots__/command-chat.test.ts.snap
@@ -1,10 +1,16 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`--context-file (animal test) 1`] = `
-"command: cody chat chat --context-file animal.ts -m implement a cow. Only print
-  the code without any explanation.
+"command: cody chat chat --context-file animal.ts --show-context -m implement a
+  cow. Only print the code without any explanation.
 exitCode: 0
 stdout: |+
+  > Context items:
+
+  > 1. WORKING_DIRECTORY/animal.ts
+
+
+
   Here's a simple implementation of a cow in Python:
 
   \`\`\`python

--- a/agent/src/cli/command-chat.test.ts
+++ b/agent/src/cli/command-chat.test.ts
@@ -70,7 +70,7 @@ describe('cody chat', () => {
         return {
             command: 'cody chat ' + params.args.join(' '),
             exitCode,
-            stdout: stdout.buffer,
+            stdout: stdout.buffer.replaceAll(tmp.rootPath, 'WORKING_DIRECTORY'),
             stderr: stderr.buffer,
         }
     }
@@ -111,6 +111,7 @@ describe('cody chat', () => {
                         'chat',
                         '--context-repo',
                         'github.com/sourcegraph/sourcegraph',
+                        '--show-context',
                         '-m',
                         'what is squirrel? Explain as briefly as possible.',
                     ],
@@ -127,6 +128,7 @@ describe('cody chat', () => {
                         'chat',
                         '--context-file',
                         'animal.ts',
+                        '--show-context',
                         '-m',
                         'implement a cow. Only print the code without any explanation.',
                     ],

--- a/agent/src/cli/command-chat.ts
+++ b/agent/src/cli/command-chat.ts
@@ -281,9 +281,9 @@ export async function chatAction(options: ChatOptions): Promise<number> {
     spinner.clear()
 
     if (options.showContext) {
-        const contextFiles = response.messages.flatMap(m => m.contextFiles ?? [])
+        const reponseContextFiles = response.messages.flatMap(m => m.contextFiles ?? [])
         streams.log('> Context items:\n')
-        for (const [i, item] of contextFiles.entries()) {
+        for (const [i, item] of reponseContextFiles.entries()) {
             const uri = vscode.Uri.from(item.uri as any)
             const endpoint = serverInfo.authStatus.endpoint ?? options.endpoint
             // Workaround for strange URI authority resopnse, reported in

--- a/agent/src/cli/command-chat.ts
+++ b/agent/src/cli/command-chat.ts
@@ -281,10 +281,16 @@ export async function chatAction(options: ChatOptions): Promise<number> {
     spinner.clear()
 
     if (options.showContext) {
-        const contextFiles = reply.contextFiles ?? []
+        const contextFiles = response.messages.flatMap(m => m.contextFiles ?? [])
         streams.log('> Context items:\n')
         for (const [i, item] of contextFiles.entries()) {
-            streams.log(`> ${i + 1}. ${item.uri.fsPath}\n`)
+            const uri = vscode.Uri.from(item.uri as any)
+            const endpoint = serverInfo.authStatus.endpoint ?? options.endpoint
+            // Workaround for strange URI authority resopnse, reported in
+            // https://sourcegraph.slack.com/archives/C05AGQYD528/p1721382757890889
+            const remoteURL = new URL(uri.path, endpoint).toString()
+            const displayText = uri.scheme === 'file' ? uri.fsPath : remoteURL
+            streams.log(`> ${i + 1}. ${displayText}\n`)
         }
         streams.log('\n')
     }

--- a/agent/src/vscode-shim.ts
+++ b/agent/src/vscode-shim.ts
@@ -929,6 +929,9 @@ const _commands: Partial<typeof vscode.commands> = {
     },
 }
 
+_commands?.registerCommand?.('workbench.action.reloadWindow', () => {
+    // Do nothing
+})
 _commands?.registerCommand?.('setContext', (key, value) => {
     if (typeof key !== 'string') {
         throw new TypeError(`setContext: first argument must be string. Got: ${key}`)


### PR DESCRIPTION
Previously, the `--show-context` option in the `cody chat` command didn't actually print out context. This PR fixes the issue for both local files and remote repo files.



## Test plan
See updated test case for `--context-file`. I manually tested it works with `--context-repo` because the test case is skipped due to [CODY-2960 : Re-enable `--context-repo` integration test](https://linear.app/sourcegraph/issue/CODY-2960/re-enable-context-repo-integration-test)

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
