### PR TITLE
Agent: fix name of workspace root

### DIFF
--- a/agent/src/vscode-shim.ts
+++ b/agent/src/vscode-shim.ts
@@ -176,7 +176,7 @@ export function setWorkspaceDocuments(newWorkspaceDocuments: WorkspaceDocuments)
                 .includes(newWorkspaceDocuments.workspaceRootUri.toString())
         ) {
             workspaceFolders.push({
-                name: 'Workspace Root',
+                name: path.basename(newWorkspaceDocuments.workspaceRootUri.fsPath),
                 uri: newWorkspaceDocuments.workspaceRootUri,
                 index: 0,
             })


### PR DESCRIPTION
Previously, the name of the workspace in the Eclipse chat UI was "Workspace Root" instead of the basename of the folder like it is in VS Code. This PR fixes the problem.

Fixes CODY-2986

## Test plan

Confirmed that the directory name is now listed in the chat UI, just like in VS Code

![image](https://github.com/user-attachments/assets/a29a09c9-22ba-4cdc-8cab-b650ca60e522)
![image](https://github.com/user-attachments/assets/f45cd18c-2dc5-4b0b-ac48-fa3dbf610088)

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
