### PR TITLE
Remove context chips from context retriever queries

### DIFF
--- a/lib/shared/src/lexicalEditor/editorState.ts
+++ b/lib/shared/src/lexicalEditor/editorState.ts
@@ -200,6 +200,26 @@ export function contextItemsFromPromptEditorValue(
     return contextItems
 }
 
+export function inputTextWithoutContextChipsFromPromptEditorState(
+    state: SerializedPromptEditorState
+): string {
+    const editorState: typeof state.lexicalEditorState = JSON.parse(
+        JSON.stringify(state.lexicalEditorState)
+    )
+    const queue: SerializedLexicalNode[] = [editorState.root]
+    while (queue.length > 0) {
+        const node = queue.shift()
+        if (node && 'children' in node && Array.isArray(node.children)) {
+            node.children = node.children.filter(child => !isSerializedContextItemMentionNode(child))
+            for (const child of node.children as SerializedLexicalNode[]) {
+                queue.push(child)
+            }
+        }
+    }
+
+    return textContentFromSerializedLexicalNode(editorState.root).trimStart()
+}
+
 export function filterContextItemsFromPromptEditorValue(
     value: SerializedPromptEditorValue,
     keep: (item: SerializedContextItem) => boolean


### PR DESCRIPTION
This approach supersedes the one from #4920 and is more elegant. We reconstruct the editor state at query time and remove all context chips from the text, then use that text for querying context retrievers.

## Test plan

Tested locally - context retriever queries for symf/bfg no longer include repo or @-mentions. 
