### PR TITLE
fix: support tree view for non-plg users only

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -244,7 +244,7 @@
         {
           "id": "cody.support.tree.view",
           "name": "Settings & Support",
-          "when": "cody.activated && (!cody.isConsumer || !cody.devOrTest)"
+          "when": "cody.activated && !cody.chatInSidebar"
         },
         {
           "id": "cody.chat.tree.view",


### PR DESCRIPTION
Overlooked this when clause in the last commit that is causing the support sidebar to show up

![image](https://github.com/user-attachments/assets/8aaa382c-84a1-4dce-bf08-a652d5f8518c)

this PR updates the when clause to match the ones for the commands tree view so that it would work as expected

## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

support sidebar not showing up

![image](https://github.com/user-attachments/assets/3e8bf186-c707-453d-85f0-6bba10b5156a)
