### PR TITLE
fix: set cody.chatInSidebar context before cody.activated

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -239,27 +239,27 @@
           "type": "webview",
           "id": "cody.chat",
           "name": "Chat",
-          "when": "!cody.activated || cody.isConsumer || cody.chatInSidebar"
+          "when": "!cody.activated || cody.chatInSidebar"
         },
         {
           "id": "cody.support.tree.view",
           "name": "Settings & Support",
-          "when": "cody.activated && !cody.isConsumer && !cody.chatInSidebar"
+          "when": "cody.activated && !cody.chatInSidebar"
         },
         {
           "id": "cody.chat.tree.view",
           "name": "Chats",
-          "when": "cody.activated && !cody.isConsumer && !cody.chatInSidebar"
+          "when": "cody.activated && !cody.chatInSidebar"
         },
         {
           "id": "cody.commands.tree.view",
           "name": "Commands",
-          "when": "cody.activated && !cody.currentFileIgnored && !cody.isConsumer && !cody.chatInSidebar"
+          "when": "cody.activated && !cody.currentFileIgnored && !cody.chatInSidebar"
         },
         {
           "id": "cody.commands.disabled.view",
           "name": "Commands",
-          "when": "cody.activated && cody.currentFileIgnored && !cody.isConsumer && !cody.chatInSidebar"
+          "when": "cody.activated && cody.currentFileIgnored && !cody.chatInSidebar"
         }
       ]
     },
@@ -267,12 +267,12 @@
       {
         "view": "cody.chat.tree.view",
         "contents": "Chat alongside your code, attach files, add additional context, and try different chat models.\n[New Chat](command:cody.chat.newPanel)",
-        "when": "cody.activated && !cody.isConsumer && !cody.chatInSidebar"
+        "when": "cody.activated && !cody.chatInSidebar"
       },
       {
         "view": "cody.commands.disabled.view",
         "contents": "Commands are disabled for this file by an admin setting. Other Cody features are also disabled.\nMore info about [Cody Context Filters](https://sourcegraph.com/docs/cody/capabilities/ignore-context#cody-ignore)",
-        "when": "cody.activated && cody.currentFileIgnored && !cody.isConsumer && !cody.chatInSidebar"
+        "when": "cody.activated && cody.currentFileIgnored && !cody.chatInSidebar"
       }
     ],
     "commands": [
@@ -476,7 +476,7 @@
         "command": "cody.chat.moveToEditor",
         "category": "Cody",
         "title": "Move Chat to Editor Panel",
-        "enablement": "cody.activated && cody.isConsumer && cody.chatInSidebar",
+        "enablement": "cody.activated && cody.chatInSidebar",
         "group": "Cody",
         "icon": "$(layout-sidebar-left-off)"
       },
@@ -484,7 +484,7 @@
         "command": "cody.chat.moveFromEditor",
         "category": "Cody",
         "title": "Move Chat from Editor to Main Cody Panel",
-        "enablement": "cody.activated && cody.isConsumer && cody.chatInSidebar && view == cody.chat",
+        "enablement": "cody.activated && cody.chatInSidebar && view == cody.chat",
         "group": "Cody",
         "icon": "$(layout-sidebar-left)"
       },
@@ -634,7 +634,7 @@
       {
         "command": "cody.chat.toggle",
         "key": "alt+l",
-        "when": "cody.activated && editorTextFocus && cody.isConsumer",
+        "when": "cody.activated && editorTextFocus && cody.chatInSidebar",
         "args": {
           "editorFocus": true
         }
@@ -642,7 +642,7 @@
       {
         "command": "cody.chat.toggle",
         "key": "alt+l",
-        "when": "cody.activated && !editorTextFocus && cody.isConsumer",
+        "when": "cody.activated && !editorTextFocus && cody.chatInSidebar",
         "args": {
           "editorFocus": false
         }
@@ -823,7 +823,7 @@
         },
         {
           "command": "cody.chat.newEditorPanel",
-          "when": "cody.activated && cody.isConsumer && cody.chatInSidebar"
+          "when": "cody.activated && cody.chatInSidebar"
         }
       ],
       "editor/context": [
@@ -962,7 +962,7 @@
         },
         {
           "command": "cody.chat.moveFromEditor",
-          "when": "activeWebviewPanelId == cody.editorPanel && cody.activated && cody.isConsumer && cody.chatInSidebar",
+          "when": "activeWebviewPanelId == cody.editorPanel && cody.activated && cody.chatInSidebar",
           "group": "navigation@1",
           "visibility": "visible"
         },

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -650,7 +650,7 @@
       {
         "command": "cody.chat.newEditorPanel",
         "key": "alt+l",
-        "when": "cody.activated && editorTextFocus && !cody.chatInSidebar",
+        "when": "cody.activated && editorTextFocus",
         "args": {
           "editorFocus": true
         }
@@ -823,7 +823,7 @@
         },
         {
           "command": "cody.chat.newEditorPanel",
-          "when": "cody.activated && !cody.chatInSidebar"
+          "when": "cody.activated"
         }
       ],
       "editor/context": [

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -267,7 +267,7 @@
       {
         "view": "cody.chat.tree.view",
         "contents": "Chat alongside your code, attach files, add additional context, and try different chat models.\n[New Chat](command:cody.chat.newPanel)",
-        "when": "cody.activated && !cody.chatInSidebar"
+        "when": "cody.activated && !cody.chatInSidebar && !cody.currentFileIgnored"
       },
       {
         "view": "cody.commands.disabled.view",
@@ -650,7 +650,7 @@
       {
         "command": "cody.chat.newEditorPanel",
         "key": "alt+l",
-        "when": "cody.activated && editorTextFocus",
+        "when": "cody.activated && editorTextFocus && !cody.chatInSidebar",
         "args": {
           "editorFocus": true
         }

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -244,22 +244,22 @@
         {
           "id": "cody.support.tree.view",
           "name": "Settings & Support",
-          "when": "cody.activated && !cody.chatInSidebar"
+          "when": "cody.activated && !cody.isConsumer && !cody.chatInSidebar"
         },
         {
           "id": "cody.chat.tree.view",
           "name": "Chats",
-          "when": "cody.activated && !cody.chatInSidebar"
+          "when": "cody.activated && !cody.isConsumer && !cody.chatInSidebar"
         },
         {
           "id": "cody.commands.tree.view",
           "name": "Commands",
-          "when": "cody.activated && !cody.currentFileIgnored && !cody.chatInSidebar"
+          "when": "cody.activated && !cody.currentFileIgnored && !cody.isConsumer && !cody.chatInSidebar"
         },
         {
           "id": "cody.commands.disabled.view",
           "name": "Commands",
-          "when": "cody.activated && cody.currentFileIgnored && !cody.chatInSidebar"
+          "when": "cody.activated && cody.currentFileIgnored && !cody.isConsumer && !cody.chatInSidebar"
         }
       ]
     },
@@ -267,12 +267,12 @@
       {
         "view": "cody.chat.tree.view",
         "contents": "Chat alongside your code, attach files, add additional context, and try different chat models.\n[New Chat](command:cody.chat.newPanel)",
-        "when": "cody.activated && !cody.chatInSidebar"
+        "when": "cody.activated && !cody.isConsumer && !cody.chatInSidebar"
       },
       {
         "view": "cody.commands.disabled.view",
         "contents": "Commands are disabled for this file by an admin setting. Other Cody features are also disabled.\nMore info about [Cody Context Filters](https://sourcegraph.com/docs/cody/capabilities/ignore-context#cody-ignore)",
-        "when": "cody.activated && cody.currentFileIgnored && !cody.chatInSidebar"
+        "when": "cody.activated && cody.currentFileIgnored && !cody.isConsumer && !cody.chatInSidebar"
       }
     ],
     "commands": [
@@ -476,7 +476,7 @@
         "command": "cody.chat.moveToEditor",
         "category": "Cody",
         "title": "Move Chat to Editor Panel",
-        "enablement": "cody.activated && cody.chatInSidebar",
+        "enablement": "cody.activated && cody.isConsumer && cody.chatInSidebar",
         "group": "Cody",
         "icon": "$(layout-sidebar-left-off)"
       },
@@ -484,7 +484,7 @@
         "command": "cody.chat.moveFromEditor",
         "category": "Cody",
         "title": "Move Chat from Editor to Main Cody Panel",
-        "enablement": "cody.activated && cody.chatInSidebar && view == cody.chat",
+        "enablement": "cody.activated && cody.isConsumer && cody.chatInSidebar && view == cody.chat",
         "group": "Cody",
         "icon": "$(layout-sidebar-left)"
       },
@@ -823,7 +823,7 @@
         },
         {
           "command": "cody.chat.newEditorPanel",
-          "when": "cody.activated && cody.chatInSidebar"
+          "when": "cody.activated && cody.isConsumer && cody.chatInSidebar"
         }
       ],
       "editor/context": [
@@ -962,7 +962,7 @@
         },
         {
           "command": "cody.chat.moveFromEditor",
-          "when": "activeWebviewPanelId == cody.editorPanel && cody.activated && cody.chatInSidebar",
+          "when": "activeWebviewPanelId == cody.editorPanel && cody.activated && cody.isConsumer && cody.chatInSidebar",
           "group": "navigation@1",
           "visibility": "visible"
         },

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -823,7 +823,7 @@
         },
         {
           "command": "cody.chat.newEditorPanel",
-          "when": "cody.activated && cody.chatInSidebar"
+          "when": "cody.activated && !cody.chatInSidebar"
         }
       ],
       "editor/context": [

--- a/vscode/src/chat/chat-view/ChatsController.ts
+++ b/vscode/src/chat/chat-view/ChatsController.ts
@@ -121,9 +121,6 @@ export class ChatsController implements vscode.Disposable {
             username: authStatus.username,
         }
 
-        const isConsumer = authStatus.isLoggedIn && authStatus.isDotCom
-        vscode.commands.executeCommand('setContext', 'cody.isConsumer', isConsumer)
-
         this.panel.setAuthStatus(authStatus)
         this.supportTreeViewProvider.setAuthStatus(authStatus)
         this.historyTreeViewProvider.updateTree(authStatus)

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -95,6 +95,10 @@ export async function start(
     context: vscode.ExtensionContext,
     platform: PlatformContext
 ): Promise<vscode.Disposable> {
+    const isExtensionTextMode = context.extensionMode === vscode.ExtensionMode.Test
+    const isExtensionModeDevOrTest =
+        context.extensionMode === vscode.ExtensionMode.Development || isExtensionTextMode
+
     // HACK to improve e2e test latency
     if (vscode.workspace.getConfiguration().get<boolean>('cody.internal.chatInSidebar')) {
         await vscode.commands.executeCommand('setContext', 'cody.chatInSidebar', true)
@@ -113,11 +117,8 @@ export async function start(
 
     const disposables: vscode.Disposable[] = []
 
-    const authProvider = AuthProvider.create(await getFullConfig())
+    const authProvider = AuthProvider.create(await getFullConfig(), isExtensionTextMode)
     const configWatcher = await BaseConfigWatcher.create(authProvider, disposables)
-    const isExtensionModeDevOrTest =
-        context.extensionMode === vscode.ExtensionMode.Development ||
-        context.extensionMode === vscode.ExtensionMode.Test
     await configWatcher.onChange(
         async config => {
             await configureEventsInfra(config, isExtensionModeDevOrTest, authProvider)

--- a/vscode/src/services/AuthProvider.ts
+++ b/vscode/src/services/AuthProvider.ts
@@ -52,14 +52,17 @@ export class AuthProvider implements AuthStatusProvider, vscode.Disposable {
         return AuthProvider._instance
     }
 
-    public static create(config: AuthConfig): AuthProvider {
+    public static create(config: AuthConfig, isTesting: boolean): AuthProvider {
         if (!AuthProvider._instance) {
-            AuthProvider._instance = new AuthProvider(config)
+            AuthProvider._instance = new AuthProvider(config, isTesting)
         }
         return AuthProvider._instance
     }
 
-    private constructor(private config: AuthConfig) {
+    private constructor(
+        private config: AuthConfig,
+        private isTesting: boolean
+    ) {
         this.status.endpoint = 'init'
         this.loadEndpointHistory()
     }
@@ -343,7 +346,7 @@ export class AuthProvider implements AuthStatusProvider, vscode.Disposable {
 
             // Set context for the extension to render views based on auth status.
             // isConsumer should be set before activated to avoid flickering.
-            const isConsumer = authStatus.isLoggedIn && authStatus.isDotCom
+            const isConsumer = authStatus.isLoggedIn && authStatus.isDotCom && !this.isTesting
             await vscode.commands.executeCommand('setContext', 'cody.chatInSidebar', isConsumer)
             await vscode.commands.executeCommand('setContext', 'cody.activated', authStatus.isLoggedIn)
 

--- a/vscode/src/services/AuthProvider.ts
+++ b/vscode/src/services/AuthProvider.ts
@@ -363,7 +363,7 @@ export class AuthProvider implements AuthStatusProvider, vscode.Disposable {
             // Set context for the extension to render views based on auth status.
             // isConsumer should be set before activated to avoid flickering.
             const isConsumer = authStatus.isLoggedIn && authStatus.isDotCom
-            await vscode.commands.executeCommand('setContext', 'cody.isConsumer', isConsumer)
+            await vscode.commands.executeCommand('setContext', 'cody.chatInSidebar', isConsumer)
             await vscode.commands.executeCommand('setContext', 'cody.activated', isLoggedIn)
 
             // If the extension is authenticated on startup, it can't be a user's first

--- a/vscode/src/services/AuthProvider.ts
+++ b/vscode/src/services/AuthProvider.ts
@@ -359,6 +359,11 @@ export class AuthProvider implements AuthStatusProvider, vscode.Disposable {
             }
 
             await this.setAuthStatus(authStatus)
+
+            // Set context for the extension to render views based on auth status.
+            // isConsumer should be set before activated to avoid flickering.
+            const isConsumer = authStatus.isLoggedIn && authStatus.isDotCom
+            await vscode.commands.executeCommand('setContext', 'cody.isConsumer', isConsumer)
             await vscode.commands.executeCommand('setContext', 'cody.activated', isLoggedIn)
 
             // If the extension is authenticated on startup, it can't be a user's first

--- a/vscode/src/services/AuthProvider.ts
+++ b/vscode/src/services/AuthProvider.ts
@@ -346,7 +346,7 @@ export class AuthProvider implements AuthStatusProvider, vscode.Disposable {
 
             // Set context for the extension to render views based on auth status.
             // isConsumer should be set before activated to avoid flickering.
-            const isConsumer = authStatus.isLoggedIn && authStatus.isDotCom && !this.isTesting
+            const isConsumer = this.isTesting || (authStatus.isLoggedIn && authStatus.isDotCom)
             await vscode.commands.executeCommand('setContext', 'cody.chatInSidebar', isConsumer)
             await vscode.commands.executeCommand('setContext', 'cody.activated', authStatus.isLoggedIn)
 

--- a/vscode/test/e2e/attribution.test.ts
+++ b/vscode/test/e2e/attribution.test.ts
@@ -2,7 +2,7 @@ import { expect } from '@playwright/test'
 
 import * as mockServer from '../fixtures/mock-server'
 
-import { createEmptyChatPanel, sidebarSignin } from './common'
+import { getChatInputs, getChatSidebarPanel, sidebarSignin } from './common'
 import { type DotcomUrlOverride, test as baseTest } from './helpers'
 
 const test = baseTest.extend<DotcomUrlOverride>({ dotcomUrl: mockServer.SERVER_URL })
@@ -10,7 +10,8 @@ const test = baseTest.extend<DotcomUrlOverride>({ dotcomUrl: mockServer.SERVER_U
 test('attribution search enabled in chat', async ({ page, sidebar }) => {
     await fetch(`${mockServer.SERVER_URL}/.test/attribution/enable`, { method: 'POST' })
     await sidebarSignin(page, sidebar)
-    const [chatFrame, chatInput] = await createEmptyChatPanel(page)
+    const chatFrame = getChatSidebarPanel(page)
+    const chatInput = getChatInputs(chatFrame)
     await chatInput.fill('show me a code snippet')
     await chatInput.press('Enter')
     await expect(chatFrame.getByTestId('attribution-indicator')).toBeVisible()
@@ -19,7 +20,8 @@ test('attribution search enabled in chat', async ({ page, sidebar }) => {
 test('attribution search disabled in chat', async ({ page, sidebar }) => {
     await fetch(`${mockServer.SERVER_URL}/.test/attribution/disable`, { method: 'POST' })
     await sidebarSignin(page, sidebar)
-    const [chatFrame, chatInput] = await createEmptyChatPanel(page)
+    const chatFrame = getChatSidebarPanel(page)
+    const chatInput = getChatInputs(chatFrame)
     await chatInput.fill('show me a code snippet')
     await chatInput.press('Enter')
     await expect(chatFrame.getByTestId('attribution-indicator')).toBeHidden()

--- a/vscode/test/e2e/attribution.test.ts
+++ b/vscode/test/e2e/attribution.test.ts
@@ -7,7 +7,8 @@ import { type DotcomUrlOverride, test as baseTest } from './helpers'
 
 const test = baseTest.extend<DotcomUrlOverride>({ dotcomUrl: mockServer.SERVER_URL })
 
-test('attribution search enabled in chat', async ({ page, sidebar }) => {
+// TODO: Currently TIMEOUT - to be fixed by @keegancsmith in pull/4964
+test.skip('attribution search enabled in chat', async ({ page, sidebar }) => {
     await fetch(`${mockServer.SERVER_URL}/.test/attribution/enable`, { method: 'POST' })
     await sidebarSignin(page, sidebar)
     const chatFrame = getChatSidebarPanel(page)

--- a/vscode/test/e2e/chat-input.test.ts
+++ b/vscode/test/e2e/chat-input.test.ts
@@ -1,6 +1,13 @@
 import { type Locator, expect } from '@playwright/test'
 import * as mockServer from '../fixtures/mock-server'
-import { createEmptyChatPanel, focusChatInputAtEnd, sidebarExplorer, sidebarSignin } from './common'
+import {
+    createEmptyChatPanel,
+    focusChatInputAtEnd,
+    getChatInputs,
+    getChatSidebarPanel,
+    sidebarExplorer,
+    sidebarSignin,
+} from './common'
 import { type DotcomUrlOverride, type ExpectedV2Events, executeCommandInPalette, test } from './helpers'
 
 test.extend<ExpectedV2Events>({
@@ -95,7 +102,8 @@ test.extend<DotcomUrlOverride>({ dotcomUrl: mockServer.SERVER_URL })(
         await page.bringToFront()
 
         await sidebarSignin(page, sidebar)
-        const [chatPanel, lastChatInput] = await createEmptyChatPanel(page)
+        const chatPanel = getChatSidebarPanel(page)
+        const lastChatInput = getChatInputs(chatPanel).last()
 
         function nthHumanMessageRow(n: number): Locator {
             return chatPanel
@@ -187,7 +195,8 @@ test.extend<DotcomUrlOverride>({ dotcomUrl: mockServer.SERVER_URL }).extend<Expe
 
     await sidebarSignin(page, sidebar)
 
-    const [chatFrame, lastChatInput, firstChatInput] = await createEmptyChatPanel(page)
+    const chatFrame = getChatSidebarPanel(page)
+    const firstChatInput = getChatInputs(chatFrame).first()
 
     const modelSelect = chatFrame.getByRole('combobox', { name: 'Select a model' }).last()
 
@@ -208,6 +217,7 @@ test.extend<DotcomUrlOverride>({ dotcomUrl: mockServer.SERVER_URL }).extend<Expe
     await modelSelect.click()
     const modelChoices = chatFrame.getByRole('listbox', { name: 'Suggestions' })
     await modelChoices.getByRole('option', { name: 'GPT-4o' }).click()
+    const lastChatInput = getChatInputs(chatFrame).last()
     await expect(lastChatInput).toBeFocused()
     await expect(modelSelect).toHaveText(/^GPT-4o/)
     await lastChatInput.fill('to model2')

--- a/vscode/test/e2e/chat-rateLimit.test.ts
+++ b/vscode/test/e2e/chat-rateLimit.test.ts
@@ -2,7 +2,7 @@ import { expect } from '@playwright/test'
 
 import * as mockServer from '../fixtures/mock-server'
 
-import { createEmptyChatPanel, sidebarSignin } from './common'
+import { getChatInputs, getChatSidebarPanel, sidebarSignin } from './common'
 import { type DotcomUrlOverride, type ExpectedV2Events, test as baseTest } from './helpers'
 
 const test = baseTest.extend<DotcomUrlOverride>({ dotcomUrl: mockServer.SERVER_URL })
@@ -28,7 +28,8 @@ test.extend<ExpectedV2Events>({
     })
 
     await sidebarSignin(page, sidebar)
-    const [chatFrame, chatInput] = await createEmptyChatPanel(page)
+    const chatFrame = getChatSidebarPanel(page)
+    const chatInput = getChatInputs(chatFrame).last()
     await chatInput.fill('test message')
     await chatInput.press('Enter')
 
@@ -56,7 +57,8 @@ test.extend<ExpectedV2Events>({
     })
 
     await sidebarSignin(page, sidebar)
-    const [chatFrame, chatInput] = await createEmptyChatPanel(page)
+    const chatFrame = getChatSidebarPanel(page)
+    const chatInput = getChatInputs(chatFrame).last()
     await chatInput.fill('test message')
     await chatInput.press('Enter')
 
@@ -84,7 +86,8 @@ test.extend<ExpectedV2Events>({
     })
 
     await sidebarSignin(page, sidebar)
-    const [chatFrame, chatInput] = await createEmptyChatPanel(page)
+    const chatFrame = getChatSidebarPanel(page)
+    const chatInput = getChatInputs(chatFrame).last()
     await chatInput.fill('test message')
     await chatInput.press('Enter')
 

--- a/vscode/test/e2e/initial-context.test.ts
+++ b/vscode/test/e2e/initial-context.test.ts
@@ -5,6 +5,8 @@ import {
     chatInputMentions,
     clickEditorTab,
     createEmptyChatPanel,
+    getChatInputs,
+    getChatSidebarPanel,
     openFileInEditorTab,
     selectLineRangeInEditorTab,
     sidebarSignin,
@@ -15,7 +17,8 @@ testWithGitRemote.extend<DotcomUrlOverride>({ dotcomUrl: mockServer.SERVER_URL }
     'initial context - self-serve repo',
     async ({ page, sidebar }) => {
         await sidebarSignin(page, sidebar)
-        const [, lastChatInput] = await createEmptyChatPanel(page)
+        const chatFrame = getChatSidebarPanel(page)
+        const lastChatInput = getChatInputs(chatFrame).last()
 
         // The current repository should be initially present in the chat input.
         await expect(chatInputMentions(lastChatInput)).toHaveText(['myrepo'])
@@ -67,7 +70,8 @@ testWithGitRemote.extend<DotcomUrlOverride>({ dotcomUrl: mockServer.SERVER_URL }
         await sidebarSignin(page, sidebar)
         await openFileInEditorTab(page, 'main.c')
 
-        const [chatPanel, , firstChatInput] = await createEmptyChatPanel(page)
+        const chatPanel = getChatSidebarPanel(page)
+        const firstChatInput = getChatInputs(chatPanel).first()
         await expect(chatInputMentions(firstChatInput)).toHaveText(['myrepo', 'main.c'])
         await firstChatInput.pressSequentially('xyz')
         await firstChatInput.press('Enter')

--- a/vscode/webviews/chat/components/CustomCommandsList.tsx
+++ b/vscode/webviews/chat/components/CustomCommandsList.tsx
@@ -22,7 +22,9 @@ export const CustomCommandsList: FunctionComponent<{ commands: CodyCommand[]; ID
             key={key}
             variant="text"
             size="none"
-            onClick={() => getVSCodeAPI().postMessage({ command: 'command', id: key })}
+            onClick={() =>
+                getVSCodeAPI().postMessage({ command: 'command', id: 'cody.action.command', arg: key })
+            }
             className="tw-px-2 hover:tw-bg-button-background-hover"
             title={description ?? prompt}
         >


### PR DESCRIPTION
- Sets the `cody.isConsumer` context before setting `cody.activated` to avoid flickering
- Moves the `cody.isConsumer` context setting from `ChatsController` to `AuthProvider` to centralize auth status handling
- Also fixed Custom Commands not working when invoked from Custom Commands list

Issue: The non-consumer view / non-chatInSidebar view is displayed before  the sidebar chat is rendered, this is because cody.activated is currently set before cody.isConsumer && cody.chatInSidebar are set:

https://github.com/user-attachments/assets/3c22c044-a61a-4eb2-b1ff-08dbfaed7274


## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

E2E tests are updated

## After

https://github.com/user-attachments/assets/fecd2705-c6b2-4cc3-8074-b04f50f78a59

