### PR TITLE
fixed(models): allow per-site preferences to be configured for ModelsService

### DIFF
--- a/agent/src/agent.ts
+++ b/agent/src/agent.ts
@@ -1073,7 +1073,7 @@ export class Agent extends MessageHandler implements ExtensionClient {
 
         this.registerAuthenticatedRequest('chat/restore', async ({ modelID, messages, chatID }) => {
             const authStatus = await vscode.commands.executeCommand<AuthStatus>('cody.auth.status')
-            modelID ??= ModelsService.getDefaultChatModel(authStatus) ?? ''
+            modelID ??= ModelsService.getDefaultChatModel() ?? ''
             const chatMessages = messages?.map(PromptString.unsafe_deserializeChatMessage) ?? []
             const chatModel = new ChatModel(modelID, chatID, chatMessages)
             await chatHistory.saveChat(authStatus, chatModel.toSerializedChatTranscript())
@@ -1086,8 +1086,7 @@ export class Agent extends MessageHandler implements ExtensionClient {
         })
 
         this.registerAuthenticatedRequest('chat/models', async ({ modelUsage }) => {
-            const authStatus = await vscode.commands.executeCommand<AuthStatus>('cody.auth.status')
-            const models = ModelsService.getModels(modelUsage, authStatus)
+            const models = ModelsService.getModels(modelUsage)
             return { models }
         })
 

--- a/lib/shared/src/models/index.ts
+++ b/lib/shared/src/models/index.ts
@@ -367,7 +367,7 @@ export class ModelsService {
         }
         // If global cache is missing, try loading from storage
         if (!ModelsService._preferences) {
-            const serialized = ModelsService.storage?.get('model-preferences')
+            const serialized = ModelsService.storage?.get(ModelsService.STORAGE_KEY)
             ModelsService._preferences = (serialized ? JSON.parse(serialized) : {}) as PerSitePreferences
         }
 

--- a/vscode/src/chat/chat-view/ChatController.ts
+++ b/vscode/src/chat/chat-view/ChatController.ts
@@ -209,7 +209,7 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
         this.remoteSearch = enterpriseContext?.createRemoteSearch() || null
         this.editor = editor
 
-        this.chatModel = new ChatModel(getDefaultModelID(authProvider.getAuthStatus()))
+        this.chatModel = new ChatModel(getDefaultModelID())
 
         this.guardrails = guardrails
         this.startTokenReceiver = startTokenReceiver
@@ -541,13 +541,13 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
     // #region top-level view action handlers
     // =======================================================================
 
-    public setAuthStatus(authStatus: AuthStatus): void {
+    public setAuthStatus(_: AuthStatus): void {
         // Run this async because this method may be called during initialization
         // and awaiting on this.postMessage may result in a deadlock
         void this.sendConfig()
 
         // Get the latest model list available to the current user to update the ChatModel.
-        this.handleSetChatModel(getDefaultModelID(authStatus))
+        this.handleSetChatModel(getDefaultModelID())
     }
 
     // When the webview sends the 'ready' message, respond by posting the view config
@@ -1114,7 +1114,7 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
         if (!authStatus?.isLoggedIn) {
             return
         }
-        const models = ModelsService.getModels(ModelUsage.Chat, authStatus)
+        const models = ModelsService.getModels(ModelUsage.Chat)
 
         void this.postMessage({
             type: 'chatModels',
@@ -1724,10 +1724,10 @@ export function revealWebviewViewOrPanel(viewOrPanel: vscode.WebviewView | vscod
     }
 }
 
-function getDefaultModelID(status: AuthStatus): string {
+function getDefaultModelID(): string {
     const pending = ''
     try {
-        return ModelsService.getDefaultChatModel(status) || pending
+        return ModelsService.getDefaultChatModel() || pending
     } catch {
         return pending
     }

--- a/vscode/src/chat/chat-view/ChatsController.ts
+++ b/vscode/src/chat/chat-view/ChatsController.ts
@@ -440,7 +440,7 @@ export class ChatsController implements vscode.Disposable {
     private createChatController(): ChatController {
         const authStatus = this.options.authProvider.getAuthStatus()
         const isConsumer = authStatus.isDotCom
-        const models = ModelsService.getModels(ModelUsage.Chat, authStatus)
+        const models = ModelsService.getModels(ModelUsage.Chat)
 
         // Enterprise context is used for remote repositories context fetching
         // in vs cody extension it should be always off if extension is connected

--- a/vscode/src/chat/protocol.ts
+++ b/vscode/src/chat/protocol.ts
@@ -290,16 +290,6 @@ export interface LocalEnv {
     uiKindIsWeb: boolean
 }
 
-export function isLoggedIn(authStatus: AuthStatus): boolean {
-    if (!authStatus.siteHasCodyEnabled) {
-        return false
-    }
-    return (
-        authStatus.authenticated &&
-        (authStatus.requiresVerifiedEmail ? authStatus.hasVerifiedEmail : true)
-    )
-}
-
 export type AuthMethod = 'dotcom' | 'github' | 'gitlab' | 'google'
 
 // Provide backward compatibility for the old token regex

--- a/vscode/src/chat/utils.test.ts
+++ b/vscode/src/chat/utils.test.ts
@@ -4,255 +4,166 @@ import { defaultAuthStatus, unauthenticatedStatus } from '@sourcegraph/cody-shar
 import { newAuthStatus } from './utils'
 
 describe('validateAuthStatus', () => {
-    const siteVersion = ''
-    const isDotCom = true
-    const verifiedEmail = true
-    const codyEnabled = true
-    const validUser = true
-    const endpoint = ''
-    const userCanUpgrade = false
-    const username = 'cody'
-    const primaryEmail = 'me@domain.test'
-    const displayName = 'Test Name'
-    const avatarURL = 'https://domain.test/avatar.png'
+    const options = {
+        ...defaultAuthStatus,
+        siteVersion: '',
+        isDotCom: true,
+        hasVerifiedEmail: true,
+        siteHasCodyEnabled: true,
+        authenticated: true,
+        endpoint: '',
+        userCanUpgrade: false,
+        username: 'cody',
+        primaryEmail: 'me@domain.test',
+        displayName: 'Test Name',
+        avatarURL: 'https://domain.test/avatar.png',
+    }
 
     it('returns auth state for invalid user on dotcom instance', () => {
-        const expected = { ...unauthenticatedStatus, endpoint }
+        const expected = { ...unauthenticatedStatus, endpoint: options.endpoint }
         expect(
-            newAuthStatus(
-                endpoint,
-                isDotCom,
-                !validUser,
-                !verifiedEmail,
-                codyEnabled,
-                userCanUpgrade,
-                siteVersion,
-                avatarURL,
-                username,
-                displayName,
-                primaryEmail
-            )
+            newAuthStatus({
+                ...options,
+                authenticated: false,
+                hasVerifiedEmail: false,
+            })
         ).toEqual(expected)
     })
 
     it('returns auth status for valid user with verified email on dotcom instance', () => {
         const expected = {
-            ...defaultAuthStatus,
+            ...options,
             authenticated: true,
             hasVerifiedEmail: true,
             showInvalidAccessTokenError: false,
             requiresVerifiedEmail: true,
             siteHasCodyEnabled: true,
             isLoggedIn: true,
-            endpoint,
-            avatarURL,
-            username,
-            displayName,
-            primaryEmail,
             codyApiVersion: 1,
         }
-        expect(
-            newAuthStatus(
-                endpoint,
-                isDotCom,
-                validUser,
-                verifiedEmail,
-                codyEnabled,
-                userCanUpgrade,
-                siteVersion,
-                avatarURL,
-                username,
-                displayName,
-                primaryEmail
-            )
-        ).toEqual(expected)
+        expect(newAuthStatus(options)).toEqual(expected)
     })
 
     it('returns auth status for valid user without verified email on dotcom instance', () => {
         const expected = {
-            ...defaultAuthStatus,
+            ...options,
             authenticated: true,
             hasVerifiedEmail: false,
             requiresVerifiedEmail: true,
             siteHasCodyEnabled: true,
-            endpoint,
-            avatarURL,
-            username,
-            displayName,
-            primaryEmail,
             codyApiVersion: 1,
         }
         expect(
-            newAuthStatus(
-                endpoint,
-                isDotCom,
-                validUser,
-                !verifiedEmail,
-                codyEnabled,
-                userCanUpgrade,
-                siteVersion,
-                avatarURL,
-                username,
-                displayName,
-                primaryEmail
-            )
+            newAuthStatus({
+                ...options,
+                hasVerifiedEmail: false,
+            })
         ).toEqual(expected)
     })
 
     it('returns auth status for valid user on enterprise instance with Cody enabled', () => {
         const expected = {
-            ...defaultAuthStatus,
+            ...options,
             authenticated: true,
             siteHasCodyEnabled: true,
+            hasVerifiedEmail: false,
             isLoggedIn: true,
             isDotCom: false,
-            endpoint,
-            avatarURL,
-            username,
-            displayName,
-            primaryEmail,
             codyApiVersion: 1,
         }
         expect(
-            newAuthStatus(
-                endpoint,
-                !isDotCom,
-                validUser,
-                verifiedEmail,
-                codyEnabled,
-                userCanUpgrade,
-                siteVersion,
-                avatarURL,
-                username,
-                displayName,
-                primaryEmail
-            )
+            newAuthStatus({
+                ...options,
+                isDotCom: false,
+                hasVerifiedEmail: false,
+            })
         ).toEqual(expected)
     })
 
     it('returns auth status for invalid user on enterprise instance with Cody enabled', () => {
-        const expected = { ...unauthenticatedStatus, endpoint }
+        const expected = { ...unauthenticatedStatus, endpoint: options.endpoint }
         expect(
-            newAuthStatus(
-                endpoint,
-                !isDotCom,
-                !validUser,
-                verifiedEmail,
-                codyEnabled,
-                userCanUpgrade,
-                siteVersion,
-                avatarURL,
-                primaryEmail,
-                displayName
-            )
+            newAuthStatus({
+                ...options,
+                isDotCom: false,
+                authenticated: false,
+                hasVerifiedEmail: false,
+                siteHasCodyEnabled: false,
+            })
         ).toEqual(expected)
     })
 
     it('returns auth status for valid user on enterprise instance with Cody disabled', () => {
         const expected = {
-            ...defaultAuthStatus,
+            ...options,
             authenticated: true,
             siteHasCodyEnabled: false,
-            endpoint,
-            avatarURL,
-            username,
-            displayName,
-            primaryEmail,
+            hasVerifiedEmail: false,
             isDotCom: false,
             codyApiVersion: 1,
         }
         expect(
-            newAuthStatus(
-                endpoint,
-                !isDotCom,
-                validUser,
-                !verifiedEmail,
-                !codyEnabled,
-                userCanUpgrade,
-                siteVersion,
-                avatarURL,
-                username,
-                displayName,
-                primaryEmail
-            )
+            newAuthStatus({
+                ...options,
+                isDotCom: false,
+                siteHasCodyEnabled: false,
+                hasVerifiedEmail: false,
+            })
         ).toEqual(expected)
     })
 
     it('returns auth status for invalid user on enterprise instance with Cody disabled', () => {
-        const expected = { ...unauthenticatedStatus, endpoint }
+        const expected = { ...unauthenticatedStatus, endpoint: options.endpoint }
         expect(
-            newAuthStatus(
-                endpoint,
-                !isDotCom,
-                !validUser,
-                verifiedEmail,
-                !codyEnabled,
-                userCanUpgrade,
-                siteVersion,
-                avatarURL,
-                username,
-                displayName,
-                primaryEmail
-            )
+            newAuthStatus({
+                ...options,
+                isDotCom: false,
+                authenticated: false,
+                hasVerifiedEmail: false,
+                siteHasCodyEnabled: false,
+            })
         ).toEqual(expected)
     })
 
     it('returns auth status for signed in user without email and displayName on enterprise instance', () => {
         const expected = {
-            ...defaultAuthStatus,
+            ...options,
             authenticated: true,
             siteHasCodyEnabled: true,
             isLoggedIn: true,
             isDotCom: false,
-            endpoint,
-            avatarURL,
-            username,
             displayName: '',
             primaryEmail: '',
+            hasVerifiedEmail: false,
             codyApiVersion: 1,
         }
         expect(
-            newAuthStatus(
-                endpoint,
-                !isDotCom,
-                validUser,
-                verifiedEmail,
-                codyEnabled,
-                userCanUpgrade,
-                siteVersion,
-                avatarURL,
-                username
-            )
+            newAuthStatus({
+                ...options,
+                displayName: '',
+                primaryEmail: '',
+                isDotCom: false,
+            })
         ).toEqual(expected)
     })
 
     it('returns API version 0 for a legacy instance', () => {
         const expected = {
-            ...defaultAuthStatus,
+            ...options,
             authenticated: true,
             siteHasCodyEnabled: true,
+            hasVerifiedEmail: false,
             isLoggedIn: true,
             isDotCom: false,
-            endpoint,
-            avatarURL,
-            username,
-            displayName: '',
-            primaryEmail: '',
             siteVersion: '5.2.0',
             codyApiVersion: 0,
         }
         expect(
-            newAuthStatus(
-                endpoint,
-                !isDotCom,
-                validUser,
-                verifiedEmail,
-                codyEnabled,
-                userCanUpgrade,
-                '5.2.0',
-                avatarURL,
-                username
-            )
+            newAuthStatus({
+                ...options,
+                isDotCom: false,
+                siteVersion: '5.2.0',
+            })
         ).toEqual(expected)
     })
 })

--- a/vscode/src/commands/scm/source-control.ts
+++ b/vscode/src/commands/scm/source-control.ts
@@ -231,9 +231,9 @@ export class CodySourceControl implements vscode.Disposable {
         this.abortController = abortController
     }
 
-    public setAuthStatus(authStatus: AuthStatus): void {
-        const models = ModelsService.getModels(ModelUsage.Chat, authStatus)
-        const preferredModel = models?.find(p => p.model.includes('claude-3-haiku'))
+    public setAuthStatus(_: AuthStatus): void {
+        const models = ModelsService.getModels(ModelUsage.Chat)
+        const preferredModel = models.find(p => p.model.includes('claude-3-haiku'))
         this.model = preferredModel ?? models[0]
     }
 

--- a/vscode/src/completions/providers/create-provider.ts
+++ b/vscode/src/completions/providers/create-provider.ts
@@ -298,7 +298,7 @@ interface AutocompleteModelInfo {
 }
 
 function getAutocompleteModelInfo(authStatus: AuthStatus): AutocompleteModelInfo | Error | undefined {
-    const model = ModelsService.getDefaultModel(ModelUsage.Autocomplete, authStatus)
+    const model = ModelsService.getDefaultModel(ModelUsage.Autocomplete)
     if (model) {
         let provider = model.provider
         if (model.clientSideConfig?.openAICompatible) {

--- a/vscode/src/edit/input/get-input.ts
+++ b/vscode/src/edit/input/get-input.ts
@@ -23,7 +23,6 @@ import { type TextChange, updateRangeMultipleChanges } from '../../non-stop/trac
 import type { AuthProvider } from '../../services/AuthProvider'
 import type { EditIntent, EditMode } from '../types'
 import { isGenerateIntent } from '../utils/edit-intent'
-import { getEditModelsForUser } from '../utils/edit-models'
 import { CURSOR_RANGE_ITEM, EXPANDED_RANGE_ITEM, SELECTION_RANGE_ITEM } from './get-items/constants'
 import { DOCUMENT_ITEM, MODEL_ITEM, RANGE_ITEM, TEST_ITEM, getEditInputItems } from './get-items/edit'
 import { getModelInputItems, getModelOptionItems } from './get-items/model'
@@ -98,7 +97,7 @@ export const getInput = async (
 
     const authStatus = authProvider.getAuthStatus()
     const isCodyPro = !authStatus.userCanUpgrade
-    const modelOptions = getEditModelsForUser(authStatus)
+    const modelOptions = ModelsService.getModels(ModelUsage.Edit)
     const modelItems = getModelOptionItems(modelOptions, isCodyPro)
     const showModelSelector = modelOptions.length > 1 && authStatus.isDotCom
 

--- a/vscode/src/edit/manager.ts
+++ b/vscode/src/edit/manager.ts
@@ -115,9 +115,7 @@ export class EditManager implements vscode.Disposable {
         // Set default edit configuration, if not provided
         // It is possible that these values may be overriden later, e.g. if the user changes them in the edit input.
         const range = getEditLineSelection(document, proposedRange)
-        const model =
-            configuration.model ||
-            ModelsService.getDefaultEditModel(this.options.authProvider.getAuthStatus())
+        const model = configuration.model || ModelsService.getDefaultEditModel()
         if (!model) {
             throw new Error('No default edit model found. Please set one.')
         }

--- a/vscode/src/edit/utils/edit-models.ts
+++ b/vscode/src/edit/utils/edit-models.ts
@@ -1,15 +1,5 @@
-import {
-    type AuthStatus,
-    type EditModel,
-    type Model,
-    ModelUsage,
-    ModelsService,
-} from '@sourcegraph/cody-shared'
+import type { AuthStatus, EditModel } from '@sourcegraph/cody-shared'
 import type { EditIntent } from '../types'
-
-export function getEditModelsForUser(authStatus: AuthStatus): Model[] {
-    return ModelsService.getModels(ModelUsage.Edit, authStatus)
-}
 
 export function getOverridenModelForIntent(
     intent: EditIntent,

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -491,13 +491,11 @@ function registerAuthCommands(authProvider: AuthProvider, disposables: vscode.Di
                 if (typeof accessToken !== 'string') {
                     throw new TypeError('accessToken is required')
                 }
-                return (
-                    await authProvider.auth({
-                        endpoint: serverEndpoint,
-                        token: accessToken,
-                        customHeaders,
-                    })
-                ).authStatus
+                return await authProvider.auth({
+                    endpoint: serverEndpoint,
+                    token: accessToken,
+                    customHeaders,
+                })
             }
         )
     )

--- a/vscode/src/models/sync.ts
+++ b/vscode/src/models/sync.ts
@@ -25,6 +25,7 @@ import { getEnterpriseContextWindow } from './utils'
  */
 export async function syncModels(authStatus: AuthStatus): Promise<void> {
     // Offline mode only support Ollama models, which would be synced seperately.
+    ModelsService.setAuthStatus(authStatus)
     if (authStatus.isOfflineMode) {
         ModelsService.setModels([])
         return

--- a/vscode/src/services/AuthProvider.ts
+++ b/vscode/src/services/AuthProvider.ts
@@ -21,7 +21,7 @@ import {
 
 import { AccountMenuOptions, openAccountMenu } from '../auth/account-menu'
 import { closeAuthProgressIndicator } from '../auth/auth-progress-indicator'
-import { ACCOUNT_USAGE_URL, isLoggedIn as isAuthenticated, isSourcegraphToken } from '../chat/protocol'
+import { ACCOUNT_USAGE_URL, isSourcegraphToken } from '../chat/protocol'
 import { newAuthStatus } from '../chat/utils'
 import { getFullConfig } from '../configuration'
 import { logDebug } from '../log'
@@ -157,7 +157,7 @@ export class AuthProvider implements AuthStatusProvider, vscode.Disposable {
                         token: newToken || null,
                     })
                 }
-                await showAuthResultMessage(selectedEndpoint, authStatus?.authStatus)
+                await showAuthResultMessage(selectedEndpoint, authStatus)
                 logDebug('AuthProvider:signinMenu', mode, selectedEndpoint)
             }
         }
@@ -174,10 +174,10 @@ export class AuthProvider implements AuthStatusProvider, vscode.Disposable {
         })
         telemetryRecorder.recordEvent('cody.auth.signin.token', 'clicked', {
             metadata: {
-                success: authState?.isLoggedIn ? 1 : 0,
+                success: authState.isLoggedIn ? 1 : 0,
             },
         })
-        await showAuthResultMessage(instanceUrl, authState?.authStatus)
+        await showAuthResultMessage(instanceUrl, authState)
     }
 
     public async signoutMenu(): Promise<void> {
@@ -254,47 +254,14 @@ export class AuthProvider implements AuthStatusProvider, vscode.Disposable {
             this.client = new SourcegraphGraphQLAPIClient(config)
         }
         // Version is for frontend to check if Cody is not enabled due to unsupported version when siteHasCodyEnabled is false
-        const [{ enabled, version }, codyLLMConfiguration, userInfo] = await Promise.all([
-            this.client.isCodyEnabled(),
-            this.client.getCodyLLMConfiguration(),
-            this.client.getCurrentUserInfo(),
-        ])
+        const [{ enabled: siteHasCodyEnabled, version: siteVersion }, codyLLMConfiguration, userInfo] =
+            await Promise.all([
+                this.client.isCodyEnabled(),
+                this.client.getCodyLLMConfiguration(),
+                this.client.getCurrentUserInfo(),
+            ])
+
         logDebug('CodyLLMConfiguration', JSON.stringify(codyLLMConfiguration))
-
-        const configOverwrites = isError(codyLLMConfiguration) ? undefined : codyLLMConfiguration
-
-        const isDotCom = this.client.isDotCom()
-
-        if (!isDotCom) {
-            const hasVerifiedEmail = false
-
-            // check first if it's a network error
-            if (isError(userInfo)) {
-                if (isNetworkError(userInfo)) {
-                    return { ...networkErrorAuthStatus, endpoint }
-                }
-                return { ...unauthenticatedStatus, endpoint }
-            }
-
-            return newAuthStatus(
-                endpoint,
-                isDotCom,
-                !isError(userInfo),
-                hasVerifiedEmail,
-                enabled,
-                /* userCanUpgrade: */ false,
-                version,
-                userInfo.avatarURL,
-                userInfo.username,
-                userInfo.displayName,
-                userInfo.primaryEmail?.email,
-                configOverwrites
-            )
-        }
-
-        // Configure AuthStatus for DotCom users
-        const isCodyEnabled = true
-
         // check first if it's a network error
         if (isError(userInfo)) {
             if (isNetworkError(userInfo)) {
@@ -303,26 +270,42 @@ export class AuthProvider implements AuthStatusProvider, vscode.Disposable {
             return { ...unauthenticatedStatus, endpoint }
         }
 
+        const configOverwrites = isError(codyLLMConfiguration) ? undefined : codyLLMConfiguration
+
+        const isDotCom = this.client.isDotCom()
+
+        if (!isDotCom) {
+            return newAuthStatus({
+                ...userInfo,
+                endpoint,
+                isDotCom,
+                siteVersion,
+                configOverwrites,
+                authenticated: true,
+                hasVerifiedEmail: false,
+                siteHasCodyEnabled,
+                userCanUpgrade: false,
+            })
+        }
+
+        // Configure AuthStatus for DotCom users
+
         const proStatus = await this.client.getCurrentUserCodySubscription()
         // Pro user without the pending status is the valid pro users
         const isActiveProUser =
             'plan' in proStatus && proStatus.plan === 'PRO' && proStatus.status !== 'PENDING'
 
-        return newAuthStatus(
+        return newAuthStatus({
+            ...userInfo,
             endpoint,
             isDotCom,
-            !!userInfo.id,
-            userInfo.hasVerifiedEmail,
-            isCodyEnabled,
-            !isActiveProUser, // UserCanUpgrade
-            version,
-            userInfo.avatarURL,
-            userInfo.username,
-            userInfo.displayName,
-            userInfo.primaryEmail?.email,
+            siteHasCodyEnabled,
+            siteVersion,
             configOverwrites,
-            userInfo.organizations
-        )
+            authenticated: !!userInfo.id,
+            userCanUpgrade: !isActiveProUser,
+            primaryEmail: userInfo.primaryEmail?.email ?? '',
+        })
     }
 
     public getAuthStatus(): AuthStatus {
@@ -342,7 +325,7 @@ export class AuthProvider implements AuthStatusProvider, vscode.Disposable {
         customHeaders?: Record<string, string> | null
         isExtensionStartup?: boolean
         isOfflineMode?: boolean
-    }): Promise<{ authStatus: AuthStatus; isLoggedIn: boolean }> {
+    }): Promise<AuthStatus> {
         const config = {
             serverEndpoint: formatURL(endpoint) ?? '',
             accessToken: token,
@@ -351,38 +334,34 @@ export class AuthProvider implements AuthStatusProvider, vscode.Disposable {
 
         try {
             const authStatus = await this.makeAuthStatus(config, isOfflineMode)
-            const isLoggedIn = isAuthenticated(authStatus)
-            authStatus.isLoggedIn = isLoggedIn
 
             if (!isOfflineMode) {
                 await this.storeAuthInfo(config.serverEndpoint, config.accessToken)
             }
 
             await this.setAuthStatus(authStatus)
-            await vscode.commands.executeCommand('setContext', 'cody.activated', isLoggedIn)
+            await vscode.commands.executeCommand('setContext', 'cody.activated', authStatus.isLoggedIn)
 
             // If the extension is authenticated on startup, it can't be a user's first
             // ever authentication. We store this to prevent logging first-ever events
             // for already existing users.
-            if (isExtensionStartup && isLoggedIn) {
+            if (isExtensionStartup && authStatus.isLoggedIn) {
                 await this.setHasAuthenticatedBefore()
-            } else if (isLoggedIn) {
+            } else if (authStatus.isLoggedIn) {
                 this.handleFirstEverAuthentication()
             }
 
-            return { authStatus, isLoggedIn }
+            return authStatus
         } catch (error) {
             logDebug('AuthProvider:auth', 'failed', error)
 
             // Try to reload auth status in case of network error, else return default auth status
-            return await this.reloadAuthStatus().catch(() => {
-                return { authStatus: unauthenticatedStatus, isLoggedIn: false }
-            })
+            return await this.reloadAuthStatus().catch(() => unauthenticatedStatus)
         }
     }
 
     // Set auth status in case of reload
-    public async reloadAuthStatus(): Promise<{ authStatus: AuthStatus; isLoggedIn: boolean }> {
+    public async reloadAuthStatus(): Promise<AuthStatus> {
         await vscode.commands.executeCommand('setContext', 'cody.activated', false)
 
         this.config = await getFullConfig()

--- a/vscode/src/services/tree-views/TreeViewProvider.test.ts
+++ b/vscode/src/services/tree-views/TreeViewProvider.test.ts
@@ -14,15 +14,6 @@ vi.mock('vscode', () => ({
 }))
 
 describe('TreeViewProvider', () => {
-    const siteVersion = ''
-    const verifiedEmail = true
-    const codyEnabled = true
-    const validUser = true
-    const username = 'someuser'
-    const primaryEmail = 'me@domain.test'
-    const displayName = 'Test Name'
-    const avatarURL = 'https://domain.test/avatar.png'
-
     let tree: TreeViewProvider
 
     /**
@@ -50,19 +41,19 @@ describe('TreeViewProvider', () => {
     }): Promise<void> {
         const nextUpdate = waitForTreeUpdate()
         tree.setAuthStatus(
-            newAuthStatus(
-                endpoint.toString(),
-                isDotCom(endpoint.toString()),
-                validUser,
-                verifiedEmail,
-                codyEnabled,
-                upgradeAvailable,
-                siteVersion,
-                avatarURL,
-                username,
-                displayName,
-                primaryEmail
-            )
+            newAuthStatus({
+                endpoint: endpoint.toString(),
+                isDotCom: isDotCom(endpoint.toString()),
+                authenticated: true,
+                hasVerifiedEmail: true,
+                siteHasCodyEnabled: true,
+                userCanUpgrade: upgradeAvailable,
+                siteVersion: '',
+                username: 'someuser',
+                primaryEmail: 'me@domain.test',
+                displayName: 'Test Name',
+                avatarURL: 'https://domain.test/avatar.png',
+            })
         )
         return nextUpdate
     }


### PR DESCRIPTION
@abeatrix found a bug with the model defaults when switching accounts. This scopes selections and defaults per endpoint, so that (mostly for us internally) you won't end up submitting a chat with a model that doesn't exist because you've switched accounts.

I also:
* Refactored the cache in ModelsService to make it simpler
* Stored the auth status in ModelsService because we're already calling it on every status update and it simplifies call sites
* Refactored newAuthStatus

## Test plan
Updated unit tests
<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
