### PR TITLE
Fix context files urls

### DIFF
--- a/lib/shared/src/sourcegraph-api/graphql/url.ts
+++ b/lib/shared/src/sourcegraph-api/graphql/url.ts
@@ -1,3 +1,5 @@
+import { trimEnd } from 'lodash'
+
 const GRAPHQL_URI = '/.api/graphql'
 
 interface BuildGraphQLUrlOptions {
@@ -10,5 +12,5 @@ interface BuildGraphQLUrlOptions {
 export const buildGraphQLUrl = ({ request, baseUrl }: BuildGraphQLUrlOptions): string => {
     const nameMatch = request ? request.match(/^\s*(?:query|mutation)\s+(\w+)/) : ''
     const apiURL = `${GRAPHQL_URI}${nameMatch ? `?${nameMatch[1]}` : ''}`
-    return baseUrl ? new URL(apiURL, baseUrl).href : apiURL
+    return baseUrl ? new URL(trimEnd(baseUrl, '/') + apiURL).href : apiURL
 }


### PR DESCRIPTION
A recent change brok the urls. This PR reverts the original behaviour.

The recent change: https://github.com/sourcegraph/cody/pull/4706#discussion_r1658684268
Slack thread: https://sourcegraph.slack.com/archives/C05AGQYD528/p1721382757890889

## Test plan
- chat context file items looks properly for remote files 