### PR TITLE
Fix open diff

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -14,6 +14,7 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 
 - Command: The "Ask Cody to Explain" command for explaining terminal output has been removed from the command palette, as it is only callable from the terminal context menu. [pull/4860](https://github.com/sourcegraph/cody/pull/4860)
 - Autocomplete: Fixed an issue where the cached retriever was attempting to open removed files. [pull/4942](https://github.com/sourcegraph/cody/pull/4942)
+- Command: Make "Open Diff" button maximize current editor if multiple are open. [pull/4957](https://github.com/sourcegraph/cody/pull/4957)
 
 ### Changed
 

--- a/vscode/src/commands/index.ts
+++ b/vscode/src/commands/index.ts
@@ -70,7 +70,7 @@ export const CodyCommandMenuItems: MenuCommandAccessor[] = [
         description: 'Auto Edit (Experimental)',
         icon: 'surround-with',
         command: { command: 'cody.command.auto-edit' },
-        keybinding: `${osIcon}Tab`,
+        keybinding: '${osIcon}Tab',
     },
     {
         key: 'commit',

--- a/vscode/src/commands/index.ts
+++ b/vscode/src/commands/index.ts
@@ -70,7 +70,7 @@ export const CodyCommandMenuItems: MenuCommandAccessor[] = [
         description: 'Auto Edit (Experimental)',
         icon: 'surround-with',
         command: { command: 'cody.command.auto-edit' },
-        keybinding: '${osIcon}Tab',
+        keybinding: `${osIcon}Tab`,
     },
     {
         key: 'commit',

--- a/vscode/src/non-stop/codelenses/provider.ts
+++ b/vscode/src/non-stop/codelenses/provider.ts
@@ -203,7 +203,7 @@ export class FixupCodeLenses implements vscode.CodeLensProvider, FixupControlApp
         }
         // show diff view between the current document and replacement
         // Add replacement content to the temp document
-
+        
         if (!isRunningInsideAgent()) {
             // Note: For VS Code, we need to accept the task before showing it as a diff here, this is because
             // we have injected empty whitespace and decorations to the document.
@@ -219,6 +219,11 @@ export class FixupCodeLenses implements vscode.CodeLensProvider, FixupControlApp
         edit.replace(tempDocUri, task.selectionRange, task.original)
         await vscode.workspace.applyEdit(edit)
         await doc.save()
+
+        // If there is more than one editor group, maximize the current group
+        if (vscode.window.tabGroups.all.length > 1) {
+            await vscode.commands.executeCommand('workbench.action.toggleMaximizeEditorGroup');
+        }
 
         // Show diff between current document and replacement content
         await vscode.commands.executeCommand(

--- a/vscode/src/non-stop/codelenses/provider.ts
+++ b/vscode/src/non-stop/codelenses/provider.ts
@@ -203,7 +203,7 @@ export class FixupCodeLenses implements vscode.CodeLensProvider, FixupControlApp
         }
         // show diff view between the current document and replacement
         // Add replacement content to the temp document
-        
+
         if (!isRunningInsideAgent()) {
             // Note: For VS Code, we need to accept the task before showing it as a diff here, this is because
             // we have injected empty whitespace and decorations to the document.
@@ -222,7 +222,7 @@ export class FixupCodeLenses implements vscode.CodeLensProvider, FixupControlApp
 
         // If there is more than one editor group, maximize the current group
         if (vscode.window.tabGroups.all.length > 1) {
-            await vscode.commands.executeCommand('workbench.action.toggleMaximizeEditorGroup');
+            await vscode.commands.executeCommand('workbench.action.toggleMaximizeEditorGroup')
         }
 
         // Show diff between current document and replacement content


### PR DESCRIPTION
Problem: When there are multiple editor groups open and vscode determines there isn't enough room, if the "open diff" button is clicked, the diff will just open up as another vertical diff, rather than the intended horizontal diff. 

https://github.com/user-attachments/assets/2dae5868-2c6f-4851-9e24-3a7b965cc4a0

This PR checks if multiple editor groups are open, if so, it maximizes the current editor. This guarantees the horizontal diff will open properly.
Video below shows this change( open diff with one editor vs with two editors)

https://github.com/user-attachments/assets/8f9faa51-829e-47dd-a3d4-167f3dadb8bb



## Test plan
- Manual testing with various number of tabs/editors/editor groups/types.
- Ran unit tests - handful failed, but they seem unrelated. Output is attached
[testoutput.txt](https://github.com/user-attachments/files/16325868/testoutput.txt)

