### PR TITLE
graphql: use ETIMEDOUT for request timeouts

### DIFF
--- a/lib/shared/src/sourcegraph-api/graphql/client.ts
+++ b/lib/shared/src/sourcegraph-api/graphql/client.ts
@@ -1284,7 +1284,7 @@ export class SourcegraphGraphQLAPIClient {
                 .then(response => response.json() as T)
                 .catch(error => {
                     if (error.name === 'AbortError') {
-                        return new Error(`EHOSTUNREACH: Request timed out after ${timeout}ms (${url})`)
+                        return new Error(`ETIMEDOUT: Request timed out after ${timeout}ms (${url})`)
                     }
                     return new Error(`accessing Sourcegraph GraphQL API: ${error} (${url})`)
                 })
@@ -1378,7 +1378,7 @@ export class SourcegraphGraphQLAPIClient {
                 .then(response => response.json() as T)
                 .catch(error => {
                     if (error.name === 'AbortError') {
-                        return new Error(`EHOSTUNREACH: Request timed out after ${timeout}ms (${url})`)
+                        return new Error(`ETIMEDOUT: Request timed out after ${timeout}ms (${url})`)
                     }
                     return new Error(`accessing Sourcegraph HTTP API: ${error} (${url})`)
                 })

--- a/vscode/src/services/AuthProvider.ts
+++ b/vscode/src/services/AuthProvider.ts
@@ -533,7 +533,8 @@ export function isNetworkError(error: Error): boolean {
         message.includes('ENOTFOUND') ||
         message.includes('ECONNREFUSED') ||
         message.includes('ECONNRESET') ||
-        message.includes('EHOSTUNREACH')
+        message.includes('EHOSTUNREACH') ||
+        message.includes('ETIMEDOUT')
     )
 }
 


### PR DESCRIPTION
The EHOSTUNREACH error was misleading, since we only know the request timed out and not that the host was unreachable. I believe we used EHOSTUNREACH since the original thing we where debugging was unexpected behaviour when using a proxy. This was introduced in https://github.com/sourcegraph/cody/pull/4243

ETIMEDOUT isn't exactly correct since we aren't getting a TCP layer timeout. However, I am using the errno approach so the isNetworkError code still works.

Note: the autocomplete code uses specific error types to encode these behaviours which we should switch to. However, that is a bigger change and I wasn't sure how it would work given the RPC stuff between extension worker, webview, etc.

Test Plan: CI

Part of CODY-2959