### PR TITLE
Autocomplete: always resolve something on document open calls

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -14,6 +14,7 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 
 - Command: The "Ask Cody to Explain" command for explaining terminal output has been removed from the command palette, as it is only callable from the terminal context menu. [pull/4860](https://github.com/sourcegraph/cody/pull/4860)
 - Command: Make "Open Diff" button maximize current editor if multiple are open. [pull/4957](https://github.com/sourcegraph/cody/pull/4957)
+- Autocomplete: Fixed an issue where autocomplete context requests were never resolved. [pull/4961](https://github.com/sourcegraph/cody/pull/4961)
 
 ### Changed
 
@@ -22,6 +23,7 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 ## 1.26.6
 
 ### Fixed
+
 - Autocomplete: Fixed an issue where the cached retriever was attempting to open removed files. [pull/4942](https://github.com/sourcegraph/cody/pull/4942)
 
 ## 1.26.5

--- a/vscode/src/completions/context/retrievers/cached-retriever.ts
+++ b/vscode/src/completions/context/retrievers/cached-retriever.ts
@@ -177,6 +177,7 @@ export abstract class CachedRetriever implements ContextRetriever {
         if (uri.scheme !== 'file') {
             return Promise.resolve(undefined)
         }
+
         this.addDependency(uri.toString())
         return this.workspace.openTextDocument(uri)
     }

--- a/vscode/src/completions/context/retrievers/cached-retriever.ts
+++ b/vscode/src/completions/context/retrievers/cached-retriever.ts
@@ -171,11 +171,11 @@ export abstract class CachedRetriever implements ContextRetriever {
         return this.window.tabGroups
     }
 
-    openTextDocument = (uri: vscode.Uri): Thenable<vscode.TextDocument> => {
+    openTextDocument = (uri: vscode.Uri): Thenable<vscode.TextDocument | undefined> => {
         // Returns undefined if the uri is not a file system uri, which includes untitled files.
         // Trying to open a removed file will re-create the file and return a new document.
         if (uri.scheme !== 'file') {
-            return new Promise(() => undefined)
+            return Promise.resolve(undefined)
         }
         this.addDependency(uri.toString())
         return this.workspace.openTextDocument(uri)

--- a/vscode/src/completions/context/retrievers/jaccard-similarity/jaccard-similarity-retriever.ts
+++ b/vscode/src/completions/context/retrievers/jaccard-similarity/jaccard-similarity-retriever.ts
@@ -198,7 +198,8 @@ export class JaccardSimilarityRetriever extends CachedRetriever implements Conte
                     }
 
                     try {
-                        return [await this.openTextDocument(uri)]
+                        const doc = await this.openTextDocument(uri)
+                        return doc ? [doc] : []
                     } catch (error) {
                         console.error(error)
                         return []
@@ -221,7 +222,9 @@ export class JaccardSimilarityRetriever extends CachedRetriever implements Conte
                 .map(async item => {
                     try {
                         const document = await this.openTextDocument(item.document.uri)
-                        addDocument(document)
+                        if (document) {
+                            addDocument(document)
+                        }
                     } catch (error) {
                         console.error(error)
                     }

--- a/vscode/src/completions/context/retrievers/jaccard-similarity/jaccard-similarity-retriever.ts
+++ b/vscode/src/completions/context/retrievers/jaccard-similarity/jaccard-similarity-retriever.ts
@@ -5,7 +5,7 @@ import { getContextRange } from '../../../doc-context-getters'
 import type { ContextRetriever, ContextRetrieverOptions } from '../../../types'
 import { type DocumentHistory, VSCodeDocumentHistory } from './history'
 
-import { FeatureFlag } from '@sourcegraph/cody-shared'
+import { FeatureFlag, isDefined } from '@sourcegraph/cody-shared'
 import { completionProviderConfig } from '../../../completion-provider-config'
 import { lastNLines } from '../../../text-processing'
 import { shouldBeUsedAsContext } from '../../utils'
@@ -162,9 +162,21 @@ export class JaccardSimilarityRetriever extends CachedRetriever implements Conte
         // Use tabs API to get current docs instead of `vscode.workspace.textDocuments`.
         // See related discussion: https://github.com/microsoft/vscode/issues/15178
         // See more info about the API: https://code.visualstudio.com/api/references/vscode-api#Tab
+        //
+        // Use only file-URIs
         const allUris: vscode.Uri[] = this.tabGroups.all
-            .flatMap(({ tabs }) => tabs.map(tab => (tab.input as any)?.uri))
-            .filter(Boolean)
+            .flatMap(({ tabs }) =>
+                tabs.map(tab => {
+                    const maybeDoc = tab.input as vscode.TextDocument | undefined
+
+                    if (maybeDoc?.uri && maybeDoc?.uri.scheme === 'file') {
+                        return maybeDoc.uri
+                    }
+
+                    return undefined
+                })
+            )
+            .filter(isDefined)
 
         // To define an upper-bound for the number of files to take into consideration, we consider all
         // active editor tabs and the 5 tabs (7 when there are no split views) that are open around it


### PR DESCRIPTION
Follow-up for https://github.com/sourcegraph/cody/pull/4942, which causes some autocomplete never to be resolved because we return a pending promise for non-file document URIs in the cached context retriever. This PR changes this behavior by returning a promise resolved with `undefined` in such cases.

## Test plan

CI and manually verified by opening user JSON settings in VS Code alongside "normal" files and forcing autocomplete requests.
