### PR TITLE
fix: use backticks for correct string template syntax

### DIFF
--- a/vscode/src/commands/index.ts
+++ b/vscode/src/commands/index.ts
@@ -70,7 +70,7 @@ export const CodyCommandMenuItems: MenuCommandAccessor[] = [
         description: 'Auto Edit (Experimental)',
         icon: 'surround-with',
         command: { command: 'cody.command.auto-edit' },
-        keybinding: '${osIcon}Tab',
+        keybinding: `${osIcon}Tab`,
     },
     {
         key: 'commit',


### PR DESCRIPTION
This Cody Command has `''` instead of ``` `` ```, so the `osIcon` is not expanded.

![Screenshot 2024-07-22 at 19 54 50](https://github.com/user-attachments/assets/3ab6aad9-62cb-4705-9285-bd59cf28a61c)


## Test plan

N/A
