### PR TITLE
Chat: fix overflow property for pre elements in chat messages

### DIFF
--- a/vscode/webviews/chat/ChatMessageContent.module.css
+++ b/vscode/webviews/chat/ChatMessageContent.module.css
@@ -117,7 +117,7 @@
 .content pre {
     font-family: var(--vscode-editor-font-family);
     font-size: var(--vscode-editor-font-size);
-    overflow: scroll;
+    overflow: auto;
 }
 
 .content pre,


### PR DESCRIPTION
CLOSE https://linear.app/sourcegraph/issue/CODY-3023/bug-code-markdown-in-chat-has-wrong-spacing

Change the overflow property of pre elements in chat messages from 'scroll' to 'auto' to improve the user experience. This modification allows the browser to determine when scrollbars are necessary, potentially reducing visual clutter when the content doesn't require scrolling.


## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

Scroll bar will only show up if needed, and there is no weird spacing when scroll bar is not needed:

![Screenshot 2024-07-22 at 11 34 22 AM](https://github.com/user-attachments/assets/139ab9a0-9e50-434c-a550-cc4cf35641dd)

### Before

There is a weird spacing on the left and bottom of the code snippet:

![image](https://github.com/user-attachments/assets/6b6a812b-8858-4b03-b335-c8bc46896572)

![image](https://github.com/user-attachments/assets/c5ed2008-43e4-4997-a40b-7018f7afd587)

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
