### PR TITLE
Cody Web: Allow to set custom telemetry client name

### DIFF
--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/agent/protocol_generated/ExtensionConfiguration.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/agent/protocol_generated/ExtensionConfiguration.kt
@@ -11,6 +11,7 @@ data class ExtensionConfiguration(
   val autocompleteAdvancedModel: String? = null,
   val debug: Boolean? = null,
   val verboseDebug: Boolean? = null,
+  val telemetryClientName: String? = null,
   val codebase: String? = null,
   val eventProperties: EventProperties? = null,
   val customConfiguration: Map<String, Any>? = null,

--- a/agent/src/AgentWorkspaceConfiguration.ts
+++ b/agent/src/AgentWorkspaceConfiguration.ts
@@ -73,6 +73,8 @@ export class AgentWorkspaceConfiguration implements vscode.WorkspaceConfiguratio
                 // that we don't want to submit vscode-specific events when
                 // running inside the agent.
                 return 'agent'
+            case 'cody.telemetry.clientName':
+                return extensionConfig?.telemetryClientName
             case 'cody.autocomplete.enabled':
                 return true
             case 'cody.autocomplete.advanced.provider':

--- a/lib/shared/src/configuration.ts
+++ b/lib/shared/src/configuration.ts
@@ -27,6 +27,7 @@ export interface Configuration {
     debugFilter: RegExp | null
     debugVerbose: boolean
     telemetryLevel: 'all' | 'off' | 'agent'
+    telemetryClientName?: string
     useContext: ConfigurationUseContext
     customHeaders: Record<string, string>
     chatPreInstruction: PromptString

--- a/lib/shared/src/index.ts
+++ b/lib/shared/src/index.ts
@@ -247,6 +247,7 @@ export {
     NoOpTelemetryRecorderProvider,
     TelemetryRecorderProvider,
     noOpTelemetryRecorder,
+    type ExtensionDetails,
 } from './telemetry-v2/TelemetryRecorderProvider'
 export type { TelemetryRecorder } from './telemetry-v2/TelemetryRecorderProvider'
 export * from './telemetry-v2/singleton'

--- a/vscode/src/configuration.test.ts
+++ b/vscode/src/configuration.test.ts
@@ -49,6 +49,8 @@ describe('getConfiguration', () => {
                         return /.*/
                     case 'cody.telemetry.level':
                         return 'off'
+                    case 'cody.telemetry.clientName':
+                        return undefined
                     case 'cody.chat.preInstruction':
                         return 'My name is Jeff.'
                     case 'cody.edit.preInstruction':

--- a/vscode/src/configuration.ts
+++ b/vscode/src/configuration.ts
@@ -197,6 +197,8 @@ export function getConfiguration(
             'autocomplete.advanced.timeout.firstCompletion',
             3_500
         ),
+
+        telemetryClientName: getHiddenSetting<string | undefined>('telemetry.clientName'),
         testingModelConfig:
             isTesting && hasValidLocalEmbeddingsConfig()
                 ? {

--- a/vscode/src/jsonrpc/agent-protocol.ts
+++ b/vscode/src/jsonrpc/agent-protocol.ts
@@ -529,7 +529,7 @@ export interface ExtensionConfiguration {
     autocompleteAdvancedModel?: string | undefined | null
     debug?: boolean | undefined | null
     verboseDebug?: boolean | undefined | null
-    telemetryClientName?: string
+    telemetryClientName?: string | undefined | null
     codebase?: string | undefined | null
 
     /**

--- a/vscode/src/jsonrpc/agent-protocol.ts
+++ b/vscode/src/jsonrpc/agent-protocol.ts
@@ -529,6 +529,7 @@ export interface ExtensionConfiguration {
     autocompleteAdvancedModel?: string | undefined | null
     debug?: boolean | undefined | null
     verboseDebug?: boolean | undefined | null
+    telemetryClientName?: string
     codebase?: string | undefined | null
 
     /**

--- a/vscode/src/uninstall/serializeConfig.ts
+++ b/vscode/src/uninstall/serializeConfig.ts
@@ -1,10 +1,9 @@
 import * as fs from 'node:fs'
 import * as os from 'node:os'
 import * as path from 'node:path'
-import type { AuthStatus, ConfigurationWithAccessToken } from '@sourcegraph/cody-shared'
+import type { AuthStatus, ConfigurationWithAccessToken, ExtensionDetails } from '@sourcegraph/cody-shared'
 
 import { Platform, getOSArch } from '../os'
-import type { ExtensionDetails } from '../services/telemetry-v2'
 
 const CONFIG_FILE = 'config.json'
 

--- a/vscode/src/uninstall/serializeConfig.ts
+++ b/vscode/src/uninstall/serializeConfig.ts
@@ -1,7 +1,11 @@
 import * as fs from 'node:fs'
 import * as os from 'node:os'
 import * as path from 'node:path'
-import type { AuthStatus, ConfigurationWithAccessToken, ExtensionDetails } from '@sourcegraph/cody-shared'
+import type {
+    AuthStatus,
+    ConfigurationWithAccessToken,
+    ExtensionDetails,
+} from '@sourcegraph/cody-shared'
 
 import { Platform, getOSArch } from '../os'
 

--- a/web/CHANGELOG.md
+++ b/web/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.2.8
+- Adds new prop to set custom client telemetry name (telemetryClientName)
+
 ## 0.2.7
 - Provide api to set custom headers for any network request in Cody Web (agent worker thread)
 

--- a/web/demo/App.tsx
+++ b/web/demo/App.tsx
@@ -36,6 +36,7 @@ export const App: FC = () => {
         <CodyWebChatProvider
             accessToken={ACCESS_TOKEN}
             serverEndpoint="https://sourcegraph.com"
+            telemetryClientName="codydemo.testing"
             initialContext={MOCK_INITIAL_DOT_COM_CONTEXT}
         >
             <div className={styles.root}>

--- a/web/lib/agent/agent.client.ts
+++ b/web/lib/agent/agent.client.ts
@@ -28,6 +28,7 @@ interface AgentClientOptions {
     serverEndpoint: string
     accessToken: string
     workspaceRootUri: string
+    telemetryClientName?: string
     customHeaders?: Record<string, string>
     debug?: boolean
     trace?: boolean
@@ -38,6 +39,7 @@ export async function createAgentClient({
     accessToken,
     workspaceRootUri,
     customHeaders,
+    telemetryClientName,
     debug = true,
     trace = false,
 }: AgentClientOptions): Promise<AgentClient> {
@@ -82,6 +84,7 @@ export async function createAgentClient({
         extensionConfiguration: {
             accessToken,
             serverEndpoint,
+            telemetryClientName,
             customHeaders: customHeaders ?? {},
             customConfiguration: {
                 'cody.experimental.noodle': true,

--- a/web/lib/components/CodyWebChatProvider.tsx
+++ b/web/lib/components/CodyWebChatProvider.tsx
@@ -64,9 +64,10 @@ interface CodyWebChatProviderProps {
     serverEndpoint: string
     accessToken: string | null
     chatID?: string | null
+    telemetryClientName?: string
     initialContext?: InitialContext
-    onNewChatCreated?: (chatId: string) => void
     customHeaders?: Record<string, string>
+    onNewChatCreated?: (chatId: string) => void
 }
 
 /**
@@ -78,6 +79,7 @@ export const CodyWebChatProvider: FC<PropsWithChildren<CodyWebChatProviderProps>
         serverEndpoint,
         accessToken,
         initialContext,
+        telemetryClientName,
         children,
         chatID: initialChatId,
         onNewChatCreated,
@@ -110,10 +112,11 @@ export const CodyWebChatProvider: FC<PropsWithChildren<CodyWebChatProviderProps>
 
             try {
                 const client = await createAgentClient({
+                    customHeaders,
+                    telemetryClientName,
                     workspaceRootUri: '',
                     serverEndpoint: serverEndpoint,
                     accessToken: accessToken ?? '',
-                    customHeaders,
                 })
 
                 // Fetch existing chats from the agent chat storage
@@ -153,7 +156,15 @@ export const CodyWebChatProvider: FC<PropsWithChildren<CodyWebChatProviderProps>
                 setClient(() => error as Error)
             }
         })()
-    }, [initialChatId, accessToken, serverEndpoint, lastActiveChatID, initialContext, customHeaders])
+    }, [
+        initialChatId,
+        accessToken,
+        serverEndpoint,
+        lastActiveChatID,
+        initialContext,
+        customHeaders,
+        telemetryClientName,
+    ])
 
     const vscodeAPI = useMemo<VSCodeWrapper>(() => {
         if (client && !isErrorLike(client)) {

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cody-web-experimental",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "description": "Cody standalone web app",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
Closes https://linear.app/sourcegraph/issue/SRCH-568/create-telemetry-spec-or-look-at-usage-numbers-for-usage-of-cody-in

This PR exposes a custom telemetry client API so consumers of the Cody Web (Sourcegraph client) would be able to set this name directly, it's needed because we should make Cody Web send events with the same clients in which we're running it, (on dotcom it would be `dotcom.web` on enterprise instance it would be `server.web`)

## Test plan
- Run code web demo and check that events have `testing.cody` client name in event's metadata
