### PR TITLE
revert chatInSidebar at start

### DIFF
--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -95,12 +95,12 @@ export async function start(
     context: vscode.ExtensionContext,
     platform: PlatformContext
 ): Promise<vscode.Disposable> {
-    const isExtensionTestMode = context.extensionMode === vscode.ExtensionMode.Test
     const isExtensionModeDevOrTest =
-        context.extensionMode === vscode.ExtensionMode.Development || isExtensionTestMode
+        context.extensionMode === vscode.ExtensionMode.Development ||
+        context.extensionMode === vscode.ExtensionMode.Test
 
     // HACK to improve e2e test latency
-    if (isExtensionTestMode) {
+    if (vscode.workspace.getConfiguration().get<boolean>('cody.internal.chatInSidebar')) {
         await vscode.commands.executeCommand('setContext', 'cody.chatInSidebar', true)
     }
 
@@ -117,7 +117,7 @@ export async function start(
 
     const disposables: vscode.Disposable[] = []
 
-    const authProvider = AuthProvider.create(await getFullConfig(), isExtensionTestMode)
+    const authProvider = AuthProvider.create(await getFullConfig(), isExtensionModeDevOrTest)
     const configWatcher = await BaseConfigWatcher.create(authProvider, disposables)
     await configWatcher.onChange(
         async config => {

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -117,7 +117,7 @@ export async function start(
 
     const disposables: vscode.Disposable[] = []
 
-    const authProvider = AuthProvider.create(await getFullConfig(), isExtensionModeDevOrTest)
+    const authProvider = AuthProvider.create(await getFullConfig())
     const configWatcher = await BaseConfigWatcher.create(authProvider, disposables)
     await configWatcher.onChange(
         async config => {

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -100,7 +100,7 @@ export async function start(
         context.extensionMode === vscode.ExtensionMode.Development || isExtensionTestMode
 
     // HACK to improve e2e test latency
-    if (!isExtensionTestMode) {
+    if (isExtensionTestMode) {
         await vscode.commands.executeCommand('setContext', 'cody.chatInSidebar', true)
     }
 

--- a/vscode/src/services/AuthProvider.ts
+++ b/vscode/src/services/AuthProvider.ts
@@ -52,17 +52,14 @@ export class AuthProvider implements AuthStatusProvider, vscode.Disposable {
         return AuthProvider._instance
     }
 
-    public static create(config: AuthConfig, isTesting: boolean): AuthProvider {
+    public static create(config: AuthConfig): AuthProvider {
         if (!AuthProvider._instance) {
-            AuthProvider._instance = new AuthProvider(config, isTesting)
+            AuthProvider._instance = new AuthProvider(config)
         }
         return AuthProvider._instance
     }
 
-    private constructor(
-        private config: AuthConfig,
-        private isTesting: boolean
-    ) {
+    private constructor(private config: AuthConfig) {
         this.status.endpoint = 'init'
         this.loadEndpointHistory()
     }
@@ -346,7 +343,7 @@ export class AuthProvider implements AuthStatusProvider, vscode.Disposable {
 
             // Set context for the extension to render views based on auth status.
             // isConsumer should be set before activated to avoid flickering.
-            const isConsumer = this.isTesting || (authStatus.isLoggedIn && authStatus.isDotCom)
+            const isConsumer = authStatus.isLoggedIn && authStatus.isDotCom
             await vscode.commands.executeCommand('setContext', 'cody.chatInSidebar', isConsumer)
             await vscode.commands.executeCommand('setContext', 'cody.activated', authStatus.isLoggedIn)
 


### PR DESCRIPTION
Fix typo made in https://github.com/sourcegraph/cody/pull/4952
Revert the start event check since those are unnecessary.

## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

Green CI since everything should behave the same with the change (as they were unnecessary)

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
