### PR TITLE
Chat UI: (fix) do not display menu border on hide

### DIFF
--- a/vscode/webviews/components/shadcn/ui/collapsible.tsx
+++ b/vscode/webviews/components/shadcn/ui/collapsible.tsx
@@ -25,7 +25,7 @@ const Collapsible: React.FC<CollapsibleProps> = ({ title, items, className, clos
             className={clsx('tw-w-full tw-flex tw-flex-col tw-gap-2 tw-self-stretch', className)}
         >
             <CollapsibleTitle title={title} />
-            <CollapsibleMenu content={items} />
+            {isOpen && <CollapsibleMenu content={items} />}
         </_Collapsible>
     )
 }


### PR DESCRIPTION
Update to show CollapsibleMenu when isOpen is set to true, else, do not show the CollapsibleMenu element at all.

## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

Collapse the Commands / Chat Help menu and confirm the border box is gone

![image](https://github.com/user-attachments/assets/96f39f5d-7b29-42fe-998d-d6a80a522602)

### Before

![image](https://github.com/user-attachments/assets/7c8fffdf-e94e-49eb-8a08-5a99502b85b3)


## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
