### PR TITLE
JB: Update keybindingLabel color

### DIFF
--- a/vscode/webviews/themes/jetbrains.css
+++ b/vscode/webviews/themes/jetbrains.css
@@ -273,10 +273,10 @@ html[data-ide='JetBrains'] {
     --vscode-inputValidation-warningBorder: var(--jetbrains-InputValidation-warningBorder);
     --vscode-interactive-activeCodeBorder: var(--jetbrains-Interactive-activeCodeBorder);
     --vscode-interactive-inactiveCodeBorder: var(--jetbrains-Interactive-inactiveCodeBorder);
-    --vscode-keybindingLabel-background: var(--jetbrains-KeybindingLabel-background);
-    --vscode-keybindingLabel-border: var(--jetbrains-KeybindingLabel-border);
-    --vscode-keybindingLabel-bottomBorder: var(--jetbrains-KeybindingLabel-bottomBorder);
-    --vscode-keybindingLabel-foreground: var(--jetbrains-KeybindingLabel-foreground);
+    --vscode-keybindingLabel-background: var(--jetbrains-TextField-background);
+    --vscode-keybindingLabel-border: var(--jetbrains-TextField-background);
+    --vscode-keybindingLabel-bottomBorder: var(--jetbrains-TextField-background);
+    --vscode-keybindingLabel-foreground: var(--jetbrains-TextField-foreground);
     --vscode-list-deemphasizedForeground: var(--jetbrains-MenuItem-disabledForeground);
     --vscode-list-filterMatchBorder: var(--jetbrains-MenuItem-acceleratorForeground);
     --vscode-list-focusHighlightForeground: var(--jetbrains-MenuItem-selectionForeground);


### PR DESCRIPTION
Fix the keybinding label border and background color for jb

Currently showing up with border but no background color 

<img width="502" alt="image" src="https://github.com/user-attachments/assets/9b2437fe-c701-4509-aa16-d6314422d25c">

## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

TBC as the latest jb branch is not working for me.

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
