### PR TITLE
chat: pass in editor to TemplateInputNode

### DIFF
--- a/vscode/webviews/promptEditor/nodes/TemplateInputComponent.tsx
+++ b/vscode/webviews/promptEditor/nodes/TemplateInputComponent.tsx
@@ -1,4 +1,3 @@
-import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext'
 import { useLexicalNodeSelection } from '@lexical/react/useLexicalNodeSelection'
 import { mergeRegister } from '@lexical/utils'
 import {
@@ -6,6 +5,7 @@ import {
     CLICK_COMMAND,
     COMMAND_PRIORITY_LOW,
     KEY_DOWN_COMMAND,
+    type LexicalEditor,
     type NodeKey,
 } from 'lexical'
 import { useCallback, useEffect, useMemo, useRef } from 'react'
@@ -14,12 +14,12 @@ import { $isTemplateInputNode, type TemplateInputNode } from './TemplateInputNod
 import { useIsFocused } from './mentionUtils'
 
 export const TemplateInputComponent: React.FC<{
+    editor: LexicalEditor
     nodeKey: NodeKey
     node: TemplateInputNode
     className: string
     focusedClassName: string
-}> = ({ nodeKey, node, className, focusedClassName }) => {
-    const [editor] = useLexicalComposerContext()
+}> = ({ editor, nodeKey, node, className, focusedClassName }) => {
     const isEditorFocused = useIsFocused()
     const [isSelected, setSelected, clearSelection] = useLexicalNodeSelection(nodeKey)
     const ref = useRef<HTMLSpanElement>(null)

--- a/vscode/webviews/promptEditor/nodes/TemplateInputNode.tsx
+++ b/vscode/webviews/promptEditor/nodes/TemplateInputNode.tsx
@@ -13,8 +13,6 @@ import {
 import { TemplateInputComponent } from './TemplateInputComponent'
 import styles from './TemplateInputNode.module.css'
 
-export type TemplateInputState = 'unset' | 'focused' | 'set'
-
 export class TemplateInputNode extends DecoratorNode<JSX.Element> {
     static getType(): typeof TEMPLATE_INPUT_NODE_TYPE {
         return TEMPLATE_INPUT_NODE_TYPE
@@ -44,9 +42,10 @@ export class TemplateInputNode extends DecoratorNode<JSX.Element> {
         return this.templateInput.placeholder
     }
 
-    decorate(_editor: LexicalEditor, _config: EditorConfig): JSX.Element {
+    decorate(editor: LexicalEditor, _config: EditorConfig): JSX.Element {
         return (
             <TemplateInputComponent
+                editor={editor}
                 nodeKey={this.getKey()}
                 node={this}
                 className={`${styles.templateInputNode}`}


### PR DESCRIPTION
Minor change I had in a stash. We should just pass in the editor we are given rather than relying on useLexicalComposerContext.

Additionally removed unused TemplateInputState.

Test Plan: viewed the generate unit test fixture in storybook