### PR TITLE
Autocomplete: set the default anthropic model only for certain cases

### DIFF
--- a/vscode/src/completions/providers/anthropic.ts
+++ b/vscode/src/completions/providers/anthropic.ts
@@ -288,7 +288,6 @@ export function createProviderConfig({
     providerOptions,
     ...otherOptions
 }: AnthropicOptions & { providerOptions?: Partial<ProviderOptions> }): ProviderConfig {
-    const defaultClientModel = model ?? 'anthropic/claude-instant-1.2'
     return {
         create(options: ProviderOptions) {
             return new AnthropicProvider(
@@ -297,14 +296,16 @@ export function createProviderConfig({
                     ...providerOptions,
                     id: PROVIDER_IDENTIFIER,
                 },
-                { maxContextTokens, model: model ?? defaultClientModel, ...otherOptions }
+                { maxContextTokens, model, ...otherOptions }
             )
         },
         contextSizeHints: standardContextSizeHints(maxContextTokens),
         identifier: PROVIDER_IDENTIFIER,
-        model: model ?? defaultClientModel,
+        model: model ?? DEFAULT_PLG_ANTHROPIC_MODEL,
     }
 }
+
+export const DEFAULT_PLG_ANTHROPIC_MODEL = 'anthropic/claude-instant-1.2'
 
 // All the Anthropic version identifiers that are allowlisted as being able to be passed as the
 // model identifier on a Sourcegraph Server

--- a/vscode/src/completions/providers/create-provider.ts
+++ b/vscode/src/completions/providers/create-provider.ts
@@ -13,6 +13,7 @@ import * as vscode from 'vscode'
 import { logError } from '../../log'
 import {
     type AnthropicOptions,
+    DEFAULT_PLG_ANTHROPIC_MODEL,
     createProviderConfig as createAnthropicProviderConfig,
 } from './anthropic'
 import { createProviderConfig as createExperimentalOllamaProviderConfig } from './experimental-ollama'
@@ -56,7 +57,10 @@ export async function createProviderConfigFromVSCodeConfig(
             })
         }
         case 'anthropic': {
-            return createAnthropicProviderConfig({ client, model })
+            return createAnthropicProviderConfig({
+                client,
+                model: model ?? authStatus.isDotCom ? DEFAULT_PLG_ANTHROPIC_MODEL : undefined,
+            })
         }
         case 'gemini':
         case 'unstable-gemini': {


### PR DESCRIPTION
- Fixes the issue when enterprise instances use the non-deployed Anthropic model as a default value. Now we set the default Anthropic model only for DotCom users and only in cases where the autocomplete provider is set to Anthropic in local settings. It keeps [the original issue](https://github.com/sourcegraph/cody/issues/4639) fixed and also addresses the enterprise problem.
- Slack investigation [here](https://sourcegraph.slack.com/archives/C07CVL78MDF/p1721694416152009).
- Follow-up issues:
    - Write unit/integration tests for `ModelsService` and autocomplete: https://linear.app/sourcegraph/issue/CODY-3030/write-test-for-modelsservice-usage-with-autocomplete-on-the-client
    - Update terminology by removing multiple entities named `provider`: https://linear.app/sourcegraph/issue/CODY-3031/update-terminology-by-removing-multiple-entities-named-provider-in
    - Update the logic to pass model IDs to the Anthropic provider for all the cases where sourcegraph is a provider: https://linear.app/sourcegraph/issue/CODY-3032/update-the-logic-to-pass-model-ids-to-anthropic-provider-for-all-the

## Test plan

For PLG:

1. Connect to DotCom using Cody VS Code
2. Set autocomplete provider to Anthropic `"cody.autocomplete.advanced.provider": "anthropic"`
3. Generate a completion.

For enterprises:

1. Connect to https://sg02.sourcegraphcloud.com/
2. Generate a completion.