### PR TITLE
VS Code: Release v1.26.8

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -19,6 +19,12 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 
 - For non-Enterprise users, the sidebar for commands, chat history, and settings has been removed and replaced by the sidebar chat. [pull/4832](https://github.com/sourcegraph/cody/pull/4832)
 
+## 1.26.8
+
+### Fixed
+
+- Autocomplete: Set the default Anthropic model only for certain cases. [pull/4982](https://github.com/sourcegraph/cody/pull/4982)
+
 ## 1.26.7
 
 ### Fixed

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -3,7 +3,7 @@
   "name": "cody-ai",
   "private": true,
   "displayName": "Cody: AI Coding Assistant with Autocomplete & Chat",
-  "version": "1.26.7",
+  "version": "1.26.8",
   "publisher": "sourcegraph",
   "license": "Apache-2.0",
   "icon": "resources/cody.png",

--- a/vscode/src/completions/providers/anthropic.ts
+++ b/vscode/src/completions/providers/anthropic.ts
@@ -288,7 +288,6 @@ export function createProviderConfig({
     providerOptions,
     ...otherOptions
 }: AnthropicOptions & { providerOptions?: Partial<ProviderOptions> }): ProviderConfig {
-    const defaultClientModel = model ?? 'anthropic/claude-instant-1.2'
     return {
         create(options: ProviderOptions) {
             return new AnthropicProvider(
@@ -297,14 +296,16 @@ export function createProviderConfig({
                     ...providerOptions,
                     id: PROVIDER_IDENTIFIER,
                 },
-                { maxContextTokens, model: model ?? defaultClientModel, ...otherOptions }
+                { maxContextTokens, model, ...otherOptions }
             )
         },
         contextSizeHints: standardContextSizeHints(maxContextTokens),
         identifier: PROVIDER_IDENTIFIER,
-        model: model ?? defaultClientModel,
+        model: model ?? DEFAULT_PLG_ANTHROPIC_MODEL,
     }
 }
+
+export const DEFAULT_PLG_ANTHROPIC_MODEL = 'anthropic/claude-instant-1.2'
 
 // All the Anthropic version identifiers that are allowlisted as being able to be passed as the
 // model identifier on a Sourcegraph Server

--- a/vscode/src/completions/providers/create-provider.ts
+++ b/vscode/src/completions/providers/create-provider.ts
@@ -10,6 +10,7 @@ import * as vscode from 'vscode'
 import { logError } from '../../log'
 import {
     type AnthropicOptions,
+    DEFAULT_PLG_ANTHROPIC_MODEL,
     createProviderConfig as createAnthropicProviderConfig,
 } from './anthropic'
 import { createProviderConfig as createExperimentalOllamaProviderConfig } from './experimental-ollama'
@@ -51,7 +52,10 @@ export async function createProviderConfigFromVSCodeConfig(
             })
         }
         case 'anthropic': {
-            return createAnthropicProviderConfig({ client, model })
+            return createAnthropicProviderConfig({
+                client,
+                model: model ?? authStatus.isDotCom ? DEFAULT_PLG_ANTHROPIC_MODEL : undefined,
+            })
         }
         case 'unstable-gemini': {
             return createGeminiProviderConfig({ client, model })


### PR DESCRIPTION
Patch release to fix the enterprise issue with https://github.com/sourcegraph/cody/pull/4982

## Test plan

CI, changelog and VS Code version updatse.
