### PR TITLE
Introduce server-side context behind feature flag

### DIFF
--- a/vscode/src/chat/chat-view/ChatsController.ts
+++ b/vscode/src/chat/chat-view/ChatsController.ts
@@ -38,7 +38,7 @@ import {
     webviewViewOrPanelViewColumn,
 } from './ChatController'
 import { chatHistory } from './ChatHistoryManager'
-import type { BaseContextFetcher } from './ContextFetcher'
+import type { ContextFetcher } from './ContextFetcher'
 
 export const CodyChatEditorViewType = 'cody.editorPanel'
 
@@ -77,7 +77,7 @@ export class ChatsController implements vscode.Disposable {
         private readonly contextRanking: ContextRankingController | null,
         private readonly symf: SymfRunner | null,
 
-        private readonly contextFetcher: BaseContextFetcher,
+        private readonly contextFetcher: ContextFetcher,
 
         private readonly guardrails: Guardrails,
         private readonly contextAPIClient: ContextAPIClient | null

--- a/vscode/src/chat/chat-view/ChatsController.ts
+++ b/vscode/src/chat/chat-view/ChatsController.ts
@@ -38,6 +38,7 @@ import {
     webviewViewOrPanelViewColumn,
 } from './ChatController'
 import { chatHistory } from './ChatHistoryManager'
+import type { BaseContextFetcher } from './ContextFetcher'
 
 export const CodyChatEditorViewType = 'cody.editorPanel'
 
@@ -70,10 +71,14 @@ export class ChatsController implements vscode.Disposable {
         private options: Options,
         private chatClient: ChatClient,
         private authProvider: AuthProvider,
+
         private readonly enterpriseContext: EnterpriseContextFactory,
         private readonly localEmbeddings: LocalEmbeddingsController | null,
         private readonly contextRanking: ContextRankingController | null,
         private readonly symf: SymfRunner | null,
+
+        private readonly contextFetcher: BaseContextFetcher,
+
         private readonly guardrails: Guardrails,
         private readonly contextAPIClient: ContextAPIClient | null
     ) {
@@ -477,6 +482,7 @@ export class ChatsController implements vscode.Disposable {
             guardrails: this.guardrails,
             startTokenReceiver: this.options.startTokenReceiver,
             contextAPIClient: this.contextAPIClient,
+            contextFetcher: this.contextFetcher,
         })
     }
 

--- a/vscode/src/chat/chat-view/ContextFetcher.ts
+++ b/vscode/src/chat/chat-view/ContextFetcher.ts
@@ -17,7 +17,7 @@ interface ContextQuery {
     repoIDs: string[]
 }
 
-export class BaseContextFetcher implements vscode.Disposable {
+export class ContextFetcher implements vscode.Disposable {
     constructor(
         private symf: SymfRunner | undefined,
         private llms: SourcegraphCompletionsClient
@@ -28,7 +28,6 @@ export class BaseContextFetcher implements vscode.Disposable {
     }
 
     public async fetchContext(query: ContextQuery): Promise<ContextItem[]> {
-        // TODO(beyang): replace with single server-side call
         const rewritten = await rewriteKeywordQuery(this.llms, query.userQuery)
         const result = await graphqlClient.contextSearch(query.repoIDs, rewritten)
         if (isError(result)) {
@@ -37,11 +36,6 @@ export class BaseContextFetcher implements vscode.Disposable {
         return result?.flatMap(r => contextSearchResultToContextItem(r) ?? []) ?? []
     }
 }
-
-// TODO(beyang): merge current PLG and enterprise LLM context into this class,
-// further simplifying ChatController
-// - toggle the new context on with a feature flag
-// - then revisit the server side
 
 function contextSearchResultToContextItem(result: ContextSearchResult): ContextItem | undefined {
     if (result.startLine < 0 || result.endLine < 0) {

--- a/vscode/src/chat/chat-view/ContextFetcher.ts
+++ b/vscode/src/chat/chat-view/ContextFetcher.ts
@@ -1,0 +1,66 @@
+import {
+    type ContextItem,
+    ContextItemSource,
+    type ContextSearchResult,
+    type PromptString,
+    type SourcegraphCompletionsClient,
+    graphqlClient,
+} from '@sourcegraph/cody-shared'
+import { isError } from 'lodash'
+import * as vscode from 'vscode'
+import { rewriteKeywordQuery } from '../../local-context/rewrite-keyword-query'
+import type { SymfRunner } from '../../local-context/symf'
+import { logDebug } from '../../log'
+
+interface ContextQuery {
+    userQuery: PromptString
+    repoIDs: string[]
+}
+
+export class BaseContextFetcher implements vscode.Disposable {
+    constructor(
+        private symf: SymfRunner | undefined,
+        private llms: SourcegraphCompletionsClient
+    ) {}
+
+    public dispose(): void {
+        this.symf?.dispose()
+    }
+
+    public async fetchContext(query: ContextQuery): Promise<ContextItem[]> {
+        // TODO(beyang): replace with single server-side call
+        const rewritten = await rewriteKeywordQuery(this.llms, query.userQuery)
+        const result = await graphqlClient.contextSearch(query.repoIDs, rewritten)
+        if (isError(result)) {
+            throw result
+        }
+        return result?.flatMap(r => contextSearchResultToContextItem(r) ?? []) ?? []
+    }
+}
+
+// TODO(beyang): merge current PLG and enterprise LLM context into this class,
+// further simplifying ChatController
+// - toggle the new context on with a feature flag
+// - then revisit the server side
+
+function contextSearchResultToContextItem(result: ContextSearchResult): ContextItem | undefined {
+    if (result.startLine < 0 || result.endLine < 0) {
+        logDebug(
+            'ContextFetcher',
+            'ignoring server context result with invalid range',
+            result.repoName,
+            result.uri.toString()
+        )
+        return undefined
+    }
+    return {
+        type: 'file',
+        content: result.content,
+        range: new vscode.Range(result.startLine, 0, result.endLine, 0),
+        uri: result.uri,
+        source: ContextItemSource.Unified,
+        repoName: result.repoName,
+        title: result.path,
+        revision: result.commit,
+    }
+}

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -19,7 +19,7 @@ import {
 import type { CommandResult } from './CommandResult'
 import type { MessageProviderOptions } from './chat/MessageProvider'
 import { ChatsController, CodyChatEditorViewType } from './chat/chat-view/ChatsController'
-import { BaseContextFetcher } from './chat/chat-view/ContextFetcher'
+import { ContextFetcher } from './chat/chat-view/ContextFetcher'
 import type { ContextAPIClient } from './chat/context/contextAPIClient'
 import {
     ACCOUNT_LIMITS_INFO_URL,
@@ -196,7 +196,7 @@ const register = async (
     if (symfRunner) {
         disposables.push(symfRunner)
     }
-    const contextFetcher = new BaseContextFetcher(symfRunner, completionsClient)
+    const contextFetcher = new ContextFetcher(symfRunner, completionsClient)
 
     // Initialize enterprise context
     const enterpriseContextFactory = new EnterpriseContextFactory(completionsClient)
@@ -748,7 +748,7 @@ interface RegisterChatOptions {
     contextRanking?: ContextRankingController
     symfRunner?: SymfRunner
     contextAPIClient?: ContextAPIClient
-    contextFetcher: BaseContextFetcher
+    contextFetcher: ContextFetcher
 }
 
 function registerChat(

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -19,6 +19,7 @@ import {
 import type { CommandResult } from './CommandResult'
 import type { MessageProviderOptions } from './chat/MessageProvider'
 import { ChatsController, CodyChatEditorViewType } from './chat/chat-view/ChatsController'
+import { BaseContextFetcher } from './chat/chat-view/ContextFetcher'
 import type { ContextAPIClient } from './chat/context/contextAPIClient'
 import {
     ACCOUNT_LIMITS_INFO_URL,
@@ -195,6 +196,7 @@ const register = async (
     if (symfRunner) {
         disposables.push(symfRunner)
     }
+    const contextFetcher = new BaseContextFetcher(symfRunner, completionsClient)
 
     // Initialize enterprise context
     const enterpriseContextFactory = new EnterpriseContextFactory(completionsClient)
@@ -218,6 +220,7 @@ const register = async (
             contextRanking,
             symfRunner,
             contextAPIClient,
+            contextFetcher,
         },
         disposables
     )
@@ -745,6 +748,7 @@ interface RegisterChatOptions {
     contextRanking?: ContextRankingController
     symfRunner?: SymfRunner
     contextAPIClient?: ContextAPIClient
+    contextFetcher: BaseContextFetcher
 }
 
 function registerChat(
@@ -760,6 +764,7 @@ function registerChat(
         contextRanking,
         symfRunner,
         contextAPIClient,
+        contextFetcher,
     }: RegisterChatOptions,
     disposables: vscode.Disposable[]
 ): {
@@ -784,6 +789,7 @@ function registerChat(
         localEmbeddings || null,
         contextRanking || null,
         symfRunner || null,
+        contextFetcher,
         guardrails,
         contextAPIClient || null
     )


### PR DESCRIPTION
This change introduces an internal flag `cody.internal.serverSideContext` to toggle on using the server-side context API. Without this flag, behavior is unchanged.

Code-structure-wise, this factors out all context fetching into the `ChatController.fetchContext` method, which includes both the legacy and new server-side context, the latter of which is contained in the new `ContextFetcher` class. This should help ease the transition.

## Security

The flagged new `unsafe_` invocation is just a relocation of an existing call.

## Test plan

Behavior is unchanged. Test locally.
