### PR TITLE
Webview: update tab behavior by IDE

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -914,12 +914,12 @@
         },
         {
           "command": "cody.chat.newPanel",
-          "when": "view == cody.chat && cody.activated",
+          "when": "(cody.chatInSidebar && view != cody.chat && cody.activated) || (!cody.chatInSidebar && view == cody.chat && cody.activated)",
           "group": "navigation@2"
         },
         {
           "command": "cody.chat.history.panel",
-          "when": "view == cody.chat && cody.activated",
+          "when": "(cody.chatInSidebar && view != cody.chat && cody.activated) || (!cody.chatInSidebar && view == cody.chat && cody.activated)",
           "group": "navigation@3"
         },
         {

--- a/vscode/webviews/App.tsx
+++ b/vscode/webviews/App.tsx
@@ -265,7 +265,9 @@ export const App: React.FunctionComponent<{ vscodeAPI: VSCodeWrapper }> = ({ vsc
             className={styles.outerContainer}
         >
             {/* NOTE: Display tabs to PLG users only until Universal Cody is ready. */}
-            {userAccountInfo.isDotComUser && <TabsBar currentView={view} setView={setView} />}
+            {userAccountInfo.isDotComUser && (
+                <TabsBar currentView={view} setView={setView} IDE={config.agentIDE || CodyIDE.VSCode} />
+            )}
             {errorMessages && <ErrorBanner errors={errorMessages} setErrors={setErrorMessages} />}
             <TabContainer value={view}>
                 {view === 'chat' && (

--- a/vscode/webviews/chat/components/WelcomeMessage.tsx
+++ b/vscode/webviews/chat/components/WelcomeMessage.tsx
@@ -54,7 +54,7 @@ export const WelcomeMessage: FunctionComponent<{ IDE: CodyIDE }> = ({ IDE }) => 
                 {IDE === CodyIDE.VSCode && (
                     <>
                         <FeatureRow icon={TextIcon}>
-                            To add code context from an editor, or the file explorer, right click and use{' '}
+                            To add code context from an editor, right click and use{' '}
                             <MenuExample>Add to Cody Chat</MenuExample>
                         </FeatureRow>
                         <FeatureRow icon={MessageSquarePlusIcon}>

--- a/vscode/webviews/tabs/AccountTab.tsx
+++ b/vscode/webviews/tabs/AccountTab.tsx
@@ -70,8 +70,9 @@ export const AccountTab: React.FC<AccountTabProps> = ({ userInfo }) => {
                 <Button
                     key={a.text}
                     variant="secondary"
-                    className="tw-w-full tw-bg-popover"
+                    className="tw-w-full tw-bg-popover tw-border tw-border-border"
                     onClick={a.onClick}
+                    title={a.text}
                 >
                     {a.text}
                 </Button>

--- a/vscode/webviews/tabs/TabsBar.tsx
+++ b/vscode/webviews/tabs/TabsBar.tsx
@@ -14,11 +14,14 @@ import {
 import { getVSCodeAPI } from '../utils/VSCodeApi'
 import { View } from './types'
 
+import { CodyIDE } from '@sourcegraph/cody-shared'
+import { useCallback, useMemo } from 'react'
 import { Kbd } from '../components/Kbd'
 import { Tooltip, TooltipContent, TooltipTrigger } from '../components/shadcn/ui/tooltip'
 import styles from './TabsBar.module.css'
 
 interface TabsBarProps {
+    IDE: CodyIDE
     currentView: View
     setView: (view?: View) => void
 }
@@ -36,7 +39,38 @@ interface TabConfig {
     changesView?: boolean
 }
 
-const tabItems: TabConfig[] = [
+interface TabButtonProps {
+    Icon: IconComponent
+    view?: View
+    command?: string
+    isActive?: boolean
+    onClick: () => void
+    prominent?: boolean
+    tooltip: React.ReactNode
+}
+
+const TabButton: React.FC<TabButtonProps> = ({ Icon, isActive, onClick, tooltip, prominent }) => (
+    <Tooltip>
+        <TooltipTrigger asChild>
+            <button
+                type="button"
+                onClick={onClick}
+                className={clsx(
+                    'tw-py-3 tw-px-2 tw-opacity-80 hover:tw-opacity-100 tw-border-b-[1px] tw-border-transparent tw-transition tw-translate-y-[1px]',
+                    {
+                        '!tw-opacity-100 !tw-border-[var(--vscode-tab-activeBorderTop)]': isActive,
+                        '!tw-opacity-100': prominent,
+                    }
+                )}
+            >
+                <Icon size={16} strokeWidth={1.25} className="tw-w-8 tw-h-8" />
+            </button>
+        </TooltipTrigger>
+        <TooltipContent>{tooltip}</TooltipContent>
+    </Tooltip>
+)
+
+const BASE_TAB_ITEMS: TabConfig[] = [
     {
         view: View.Chat,
         tooltip: 'Chat',
@@ -84,48 +118,28 @@ const tabItems: TabConfig[] = [
     },
 ]
 
-interface TabButtonProps {
-    Icon: IconComponent
-    view?: View
-    command?: string
-    isActive?: boolean
-    onClick: () => void
-    prominent?: boolean
-    tooltip: React.ReactNode
-}
+const getTabItemsByIDE = (IDE: CodyIDE): TabConfig[] =>
+    IDE !== CodyIDE.VSCode
+        ? BASE_TAB_ITEMS.map((item, index) =>
+              index === BASE_TAB_ITEMS.length - 1 ? { ...item, changesView: true } : item
+          )
+        : BASE_TAB_ITEMS
 
-const TabButton: React.FC<TabButtonProps> = ({ Icon, isActive, onClick, tooltip, prominent }) => (
-    <Tooltip>
-        <TooltipTrigger asChild>
-            <button
-                type="button"
-                onClick={onClick}
-                className={clsx(
-                    'tw-py-3 tw-px-2 tw-opacity-80 hover:tw-opacity-100 tw-border-b-[1px] tw-border-transparent tw-transition tw-translate-y-[1px]',
-                    {
-                        '!tw-opacity-100 !tw-border-[var(--vscode-tab-activeBorderTop)]': isActive,
-                        '!tw-opacity-100': prominent,
-                    }
-                )}
-            >
-                <Icon size={16} strokeWidth={1.25} className="tw-w-8 tw-h-8" />
-            </button>
-        </TooltipTrigger>
-        <TooltipContent>{tooltip}</TooltipContent>
-    </Tooltip>
-)
-
-export const TabsBar: React.FC<TabsBarProps> = ({ currentView, setView }) => {
-    const handleClick = (view: View, command?: string, changesView?: boolean) => {
-        if (command) {
-            getVSCodeAPI().postMessage({ command: 'command', id: command })
-        }
-        if (changesView) {
-            setView(view)
-        }
-    }
-
+export const TabsBar: React.FC<TabsBarProps> = ({ currentView, setView, IDE }) => {
+    const tabItems = useMemo(() => getTabItemsByIDE(IDE), [IDE])
     const currentViewSubIcons = tabItems.find(tab => tab.view === currentView)?.SubIcons
+
+    const handleClick = useCallback(
+        (view: View, command?: string, changesView?: boolean) => {
+            if (command) {
+                getVSCodeAPI().postMessage({ command: 'command', id: command })
+            }
+            if (changesView) {
+                setView(view)
+            }
+        },
+        [setView]
+    )
 
     return (
         <Tabs.List


### PR DESCRIPTION
Follow up on https://github.com/sourcegraph/cody/pull/4959

- Adds a new `getTabItemsByIDE` function to conditionally configure tab items based on the IDE
- Updates the `AccountTab` component to have a border and title tooltip for JetBrains
- Removes the ability to add code context from the file explorer in the `WelcomeMessage` component

## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

Updated the Welcome message to remove the deprecated feature (add code from file tree)
![image](https://github.com/user-attachments/assets/d76fa4c9-f03a-4034-bdf6-f15df2a3cfb1)

Fixed breaking changes that do not switch view for Account tab on JetBrains and other IDEs

Do not show "New Chat" and "History" button in VS Code title menu since they are now tabs:

![image](https://github.com/user-attachments/assets/aca26499-d757-4c4d-b5d3-8faf752783ec)

Before:

![image](https://github.com/user-attachments/assets/d6cbb27c-3e34-4623-8116-4a81ad333cc7)


## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
