### PR TITLE
VS Code: Reload window on first activation event 

### DIFF
--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -97,7 +97,7 @@ export async function start(
 ): Promise<vscode.Disposable> {
     // NOTE: Hack to ensure the window is reloaded when extension is restarted after upgrade
     //  to get the updated sidebar chat UI. Can be removed after the next release (1.28).
-    if (!context.globalState.get('newSidebarChatUI_isReloaded', false)) {
+    if (!context.globalState.get('newSidebarChatUI_isReloaded', false) && process.env.CODY_TESTING !== 'true') {
         // First activation, set the flag and then reload the window
         await context.globalState.update('newSidebarChatUI_isReloaded', true)
         await vscode.commands.executeCommand('workbench.action.reloadWindow')

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -95,6 +95,14 @@ export async function start(
     context: vscode.ExtensionContext,
     platform: PlatformContext
 ): Promise<vscode.Disposable> {
+    // NOTE: Hack to ensure the window is reloaded when extension is activiated for the first time on restart extensions click.
+    // TODO: Can be removed after 1.28.0 is released.
+    if (version === '1.28.0' && !context.globalState.get('1_28_isReloaded', false)) {
+        // First activation, set the flag and then reload the window
+        await context.globalState.update('1_28_isReloaded', true)
+        await vscode.commands.executeCommand('workbench.action.reloadWindow')
+    }
+
     const isExtensionTestMode = context.extensionMode === vscode.ExtensionMode.Test
     const isExtensionModeDevOrTest =
         context.extensionMode === vscode.ExtensionMode.Development || isExtensionTestMode

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -97,7 +97,10 @@ export async function start(
 ): Promise<vscode.Disposable> {
     // NOTE: Hack to ensure the window is reloaded when extension is restarted after upgrade
     //  to get the updated sidebar chat UI. Can be removed after the next release (1.28).
-    if (!context.globalState.get('newSidebarChatUI_isReloaded', false) && process.env.CODY_TESTING !== 'true') {
+    if (
+        !context.globalState.get('newSidebarChatUI_isReloaded', false) &&
+        process.env.CODY_TESTING !== 'true'
+    ) {
         // First activation, set the flag and then reload the window
         await context.globalState.update('newSidebarChatUI_isReloaded', true)
         await vscode.commands.executeCommand('workbench.action.reloadWindow')

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -95,11 +95,11 @@ export async function start(
     context: vscode.ExtensionContext,
     platform: PlatformContext
 ): Promise<vscode.Disposable> {
-    // NOTE: Hack to ensure the window is reloaded when extension is activiated for the first time on restart extensions click.
-    // TODO: Can be removed after 1.28.0 is released.
-    if (version === '1.28.0' && !context.globalState.get('1_28_isReloaded', false)) {
+    // NOTE: Hack to ensure the window is reloaded when extension is restarted after upgrade
+    //  to get the updated sidebar chat UI. Can be removed after the next release (1.28).
+    if (!context.globalState.get('newSidebarChatUI_isReloaded', false)) {
         // First activation, set the flag and then reload the window
-        await context.globalState.update('1_28_isReloaded', true)
+        await context.globalState.update('newSidebarChatUI_isReloaded', true)
         await vscode.commands.executeCommand('workbench.action.reloadWindow')
     }
 


### PR DESCRIPTION
CLOSE https://linear.app/sourcegraph/issue/CODY-3007/new-sidebar-ui-does-not-get-picked-up-on-extension-reload

Add a condition to check if `newSidebarChatUI_isReloaded` has been set before or not.

If not, reload the window to ensure the new webview is registered before the extension host is activated. 

After discussing with @kalanchan and @vovakulikov , we think this is a better approach than showing the CTA to ask users to reload without knowing if the user has reloaded or not.

## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

Green CI - The extension should not be affected by this change and work as expected.

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
