### PR TITLE
Clarify experimental Generate Unit Test command

### DIFF
--- a/vscode/webviews/chat/components/GenerateUnitTestsButton.tsx
+++ b/vscode/webviews/chat/components/GenerateUnitTestsButton.tsx
@@ -2,6 +2,7 @@ import { VSCodeButton } from '@vscode/webview-ui-toolkit/react'
 import type React from 'react'
 import { useCallback } from 'react'
 import type { ApiPostMessage } from '../../Chat'
+import { Tooltip, TooltipContent, TooltipTrigger } from '../../components/shadcn/ui/tooltip'
 
 interface GenerateUnitTestsButtonProps {
     postMessage: ApiPostMessage
@@ -16,16 +17,38 @@ export const GenerateUnitTestsButton: React.FC<GenerateUnitTestsButtonProps> = (
 
     return (
         <div className="tw-mx-auto">
-            <VSCodeButton
-                appearance="secondary"
-                onClick={handleGenerateUnitTest}
-                title="(Sourcegraph Employee Only) Leave feedback in #wg-improve-generate-unit-tests"
-            >
-                Generate Unit Tests
-                <div className="tw-text-muted-foreground" style={{ marginLeft: '0.75em' }}>
-                    EXPERIMENTAL
-                </div>
-            </VSCodeButton>
+            <Tooltip disableHoverableContent={false}>
+                <TooltipTrigger asChild>
+                    <VSCodeButton appearance="secondary" onClick={handleGenerateUnitTest}>
+                        Generate Unit Tests
+                        <div className="tw-ml-3 tw-text-sm tw-text-muted-foreground">
+                            (Experiment - Staff Only)
+                        </div>
+                    </VSCodeButton>
+                </TooltipTrigger>
+                <TooltipContent>
+                    <div className="tw-text-left tw-flex tw-flex-col tw-gap-2">
+                        <p>A new prompt-library-based approach to Generate Unit Test ⚡️</p>
+                        <p>
+                            Please use this instead of the existing command and post feedback to{' '}
+                            <a href="https://sourcegraph.slack.com/archives/C078JDXUC3U">
+                                #wg-improve-generate-unit-tests
+                            </a>
+                        </p>
+                        <p className="tw-text-muted-foreground">
+                            To disable, set{' '}
+                            <code className="tw-px-1 tw-border tw-border-current-25 tw-rounded">
+                                cody.experimentalUnitTestEnabled
+                            </code>{' '}
+                            to{' '}
+                            <code className="tw-px-1 tw-border tw-border-current-25 tw-rounded">
+                                false
+                            </code>{' '}
+                            in your user settings.
+                        </p>
+                    </div>
+                </TooltipContent>
+            </Tooltip>
         </div>
     )
 }


### PR DESCRIPTION
For the experimental generate unit test button, this adds a tooltip with:
- what it is
- a clickable link to Slack
- how to disable

It also updates the muted label to point out it's internal only for now.

<img src="https://github.com/user-attachments/assets/71ffd5e6-7fa2-452d-8888-ccddb65c7cb8" width="385">

Future ideal: move it into the standard Command List, as it's quite intrusively placed where it is now.

## Test plan

- CI

## Changelog

- N/A — internal only