### PR TITLE
noodle: new lines in the generate unit test prompt template

### DIFF
--- a/lib/shared/src/lexicalEditor/editorState.test.ts
+++ b/lib/shared/src/lexicalEditor/editorState.test.ts
@@ -50,7 +50,7 @@ describe('textContentFromSerializedLexicalNode', () => {
                 wrapMention
             )
         ).toBe(
-            'Your task is to generate a suit of multiple unit tests for the functions defined inside the <<file1.go>> file. Use the <<mention the testing framework>> framework to generate the unit tests. Follow the example tests from the <<mention an example test file>> test file. Include unit tests for the following cases: <<list test cases>>. Ensure that the unit tests cover all the edge cases and validate the expected functionality of the functions'
+            'Your task is to generate a suit of multiple unit tests for the functions defined inside the <<file1.go>> file.\n\nUse the <<mention the testing framework>> framework to generate the unit tests. Follow the example tests from the <<mention an example test file>> test file. Include unit tests for the following cases: <<list test cases>>.\n\nEnsure that the unit tests cover all the edge cases and validate the expected functionality of the functions'
         )
     })
 })

--- a/lib/shared/src/lexicalEditor/fixtures.ts
+++ b/lib/shared/src/lexicalEditor/fixtures.ts
@@ -164,7 +164,7 @@ export const GENERATE_UNIT_TEST_EDITOR_STATE_FIXTURE: SerializedPromptEditorStat
                             style: '',
                             type: 'text',
                             version: 1,
-                            text: ' file. Use the ',
+                            text: ' file.\n\nUse the ',
                         },
                         {
                             type: 'templateInput',
@@ -212,7 +212,7 @@ export const GENERATE_UNIT_TEST_EDITOR_STATE_FIXTURE: SerializedPromptEditorStat
                             style: '',
                             type: 'text',
                             version: 1,
-                            text: '. Ensure that the unit tests cover all the edge cases and validate the expected functionality of the functions',
+                            text: '.\n\nEnsure that the unit tests cover all the edge cases and validate the expected functionality of the functions',
                         },
                     ],
                 } as SerializedLexicalNode,

--- a/vscode/src/commands/execute/test-chat-experimental.ts
+++ b/vscode/src/commands/execute/test-chat-experimental.ts
@@ -40,7 +40,7 @@ async function chatMessageTemplate(): Promise<ChatMessage | undefined> {
     const prompt = ps`Your task is to generate a suit of multiple unit tests for the functions defined inside the ${selectedCodePromptWithExtraFiles(
         contextFile,
         []
-    )} file. Use the {{mention the testing framework}} framework to generate the unit tests. Follow the example tests from the {{mention an example test file}} test file. Include unit tests for the following cases: {{list test cases}}. Ensure that the unit tests cover all the edge cases and validate the expected functionality of the functions`
+    )} file.\n\nUse the {{mention the testing framework}} framework to generate the unit tests. Follow the example tests from the {{mention an example test file}} test file. Include unit tests for the following cases: {{list test cases}}.\n\nEnsure that the unit tests cover all the edge cases and validate the expected functionality of the functions`
 
     return {
         speaker: 'human',


### PR DESCRIPTION
This makes it easier to read.

Test Plan: click the generate unit test button and view it in storybook.

#### storybook screenshot
<img width="1206" alt="Screenshot 2024-07-24 at 10 01 30" src="https://github.com/user-attachments/assets/0a8c92bc-b775-428b-8013-8c0566ff4cfd">

#### vscode screenshot
<img width="560" alt="Screenshot 2024-07-24 at 09 58 09" src="https://github.com/user-attachments/assets/d19f1708-5e92-4e04-a236-07ca6b55275e">
