### PR TITLE
E2Ev2: Ensure consistent `cwd()`

### DIFF
--- a/vscode/e2e/utils/helpers.ts
+++ b/vscode/e2e/utils/helpers.ts
@@ -1,5 +1,9 @@
+import path from 'node:path'
 import type { TestInfo } from '@playwright/test'
 
+export const CODY_ROOT_DIR = process.env.CODY_ROOT_DIR ?? path.resolve(__dirname, '..', '..', '..')
+export const CODY_VSCODE_ROOT_DIR =
+    process.env.CODY_VSCODE_ROOT_DIR ?? path.resolve(__dirname, '..', '..')
 /**
  * Stretches the test with at most the `max` amount of ms but never more than
  * needed to finish the operation. This way you can effectively nullify the time

--- a/vscode/e2e/utils/symlink-extensions.setup.ts
+++ b/vscode/e2e/utils/symlink-extensions.setup.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs/promises'
 import path from 'node:path'
 import { test as setup } from '@playwright/test'
+import { CODY_VSCODE_ROOT_DIR } from './helpers'
 
 //TODO: make options with nice descriptions and validation
 export type SymlinkExtensions =
@@ -28,7 +29,7 @@ setup.extend<{}, SymlinkExtensions>({
         throw new TypeError('vscodeTmpDir is required to symlink extensions')
     }
     for (const extension of symlinkExtensions) {
-        const absoluteDir = path.resolve(process.cwd(), extension)
+        const absoluteDir = path.resolve(CODY_VSCODE_ROOT_DIR, extension)
         //read the package.json as json
         const packageJsonPath = await fs.readFile(path.join(absoluteDir, 'package.json'))
         const packageJson = JSON.parse(packageJsonPath.toString())

--- a/vscode/e2e/utils/tmpdir.setup.ts
+++ b/vscode/e2e/utils/tmpdir.setup.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs/promises'
 import path from 'node:path'
 import { test as setup } from '@playwright/test'
+import { CODY_VSCODE_ROOT_DIR } from './helpers'
 import type { WorkerOptions } from './vscody'
 export interface TmpDirOptions {
     clearGlobalTmpDirParent: boolean
@@ -12,10 +13,11 @@ setup.extend<{}, TmpDirOptions & WorkerOptions>({
     clearGlobalTmpDirParent: [false, { scope: 'worker', option: true }],
 })('tmpdir', async ({ globalTmpDir, clearGlobalTmpDirParent }) => {
     if (globalTmpDir) {
-        await fs.mkdir(globalTmpDir, { recursive: true })
+        const resolvedGlobalTmpDir = path.resolve(CODY_VSCODE_ROOT_DIR, globalTmpDir)
+        await fs.mkdir(resolvedGlobalTmpDir, { recursive: true })
         if (clearGlobalTmpDirParent) {
-            const parentDir = path.resolve(process.cwd(), globalTmpDir, '..')
-            const currentDirName = path.parse(globalTmpDir).name
+            const parentDir = path.resolve(resolvedGlobalTmpDir, '..')
+            const currentDirName = path.parse(resolvedGlobalTmpDir).name
             const promises = []
             for (const dirName of await fs.readdir(parentDir)) {
                 if (dirName !== currentDirName) {

--- a/vscode/e2e/utils/vscody/fixture.ts
+++ b/vscode/e2e/utils/vscody/fixture.ts
@@ -38,7 +38,7 @@ import {
     type ENTERPRISE_TESTING_CREDENTIALS,
     TESTING_CREDENTIALS,
 } from '../../../src/testutils/testing-credentials'
-import { retry, stretchTimeout } from '../helpers'
+import { CODY_VSCODE_ROOT_DIR, retry, stretchTimeout } from '../helpers'
 import {
     MITM_AUTH_TOKEN_PLACEHOLDER,
     MITM_PROXY_AUTH_AVAILABLE_HEADER,
@@ -51,18 +51,17 @@ export type Directory = string
 const DOWNLOAD_GRACE_TIME = 5 * 60 * 1000 //5 minutes
 
 // TODO(rnauta): finish all variable descriptions
+const zAbsPath = () => zod.string().transform(p => path.resolve(CODY_VSCODE_ROOT_DIR, p))
 const workerOptionsSchema = zod.object({
-    repoRootDir: zod
-        .string()
-        .describe(
-            'DEPRECATED: The .git root of this project. Might still get used for some path defaults so must be set'
-        ),
-    vscodeExtensionCacheDir: zod.string(),
-    globalTmpDir: zod.string(),
-    vscodeTmpDir: zod.string(),
-    vscodeServerTmpDir: zod.string(),
-    binaryTmpDir: zod.string(),
-    recordingDir: zod.string(),
+    repoRootDir: zAbsPath().describe(
+        'DEPRECATED: The .git root of this project. Might still get used for some path defaults so must be set'
+    ),
+    vscodeExtensionCacheDir: zAbsPath(),
+    globalTmpDir: zAbsPath(),
+    vscodeTmpDir: zAbsPath(),
+    vscodeServerTmpDir: zAbsPath(),
+    binaryTmpDir: zAbsPath(),
+    recordingDir: zAbsPath(),
     vscodeServerPortRange: zod.tuple([zod.number(), zod.number()]).default([33100, 33200]),
     mitmServerPortRange: zod.tuple([zod.number(), zod.number()]).default([34100, 34200]),
     keepRuntimeDirs: zod.enum(['all', 'failed', 'none']).default('none'),
@@ -73,7 +72,7 @@ const workerOptionsSchema = zod.object({
 const testOptionsSchema = zod.object({
     vscodeVersion: zod.string().default('stable'),
     vscodeExtensions: zod.array(zod.string().toLowerCase()).default([]),
-    templateWorkspaceDir: zod.string(),
+    templateWorkspaceDir: zAbsPath(),
     recordingMode: zod.enum([
         'passthrough',
         'record',
@@ -293,7 +292,7 @@ const implFixture = _test.extend<TestContext, WorkerContext>({
         async ({ validOptions }, use, testInfo) => {
             const dir = await fs.mkdtemp(path.resolve(validOptions.globalTmpDir, 'test-workspace-'))
 
-            await copyExt(path.resolve(process.cwd(), validOptions.templateWorkspaceDir), dir, {
+            await copyExt(path.resolve(CODY_VSCODE_ROOT_DIR, validOptions.templateWorkspaceDir), dir, {
                 overwrite: true,
                 preserveTimestamps: true,
                 dereference: true, // we can't risk the test modifying the symlink
@@ -455,7 +454,7 @@ const implFixture = _test.extend<TestContext, WorkerContext>({
     polly: [
         async ({ validOptions }, use, testInfo) => {
             const relativeTestPath = path.relative(
-                path.resolve(process.cwd(), testInfo.project.testDir),
+                path.resolve(CODY_VSCODE_ROOT_DIR, testInfo.project.testDir),
                 testInfo.file
             )
             const polly = new Polly(`${testInfo.project.name}/${relativeTestPath}/${testInfo.title}`, {
@@ -525,7 +524,7 @@ const implFixture = _test.extend<TestContext, WorkerContext>({
                 persisterOptions: {
                     keepUnusedRequests: validOptions.keepUnusedRecordings ?? true,
                     fs: {
-                        recordingsDir: path.resolve(process.cwd(), validOptions.recordingDir),
+                        recordingsDir: path.resolve(CODY_VSCODE_ROOT_DIR, validOptions.recordingDir),
                     },
                 },
             })
@@ -667,9 +666,12 @@ const implFixture = _test.extend<TestContext, WorkerContext>({
         async ({ validOptions, debugMode, serverRootDir, mitmProxy, page, polly }, use, testInfo) => {
             polly.pause()
 
-            const executableDir = path.resolve(process.cwd(), validOptions.vscodeTmpDir)
+            const executableDir = path.resolve(CODY_VSCODE_ROOT_DIR, validOptions.vscodeTmpDir)
             await fs.mkdir(executableDir, { recursive: true })
-            const serverExecutableDir = path.resolve(process.cwd(), validOptions.vscodeServerTmpDir)
+            const serverExecutableDir = path.resolve(
+                CODY_VSCODE_ROOT_DIR,
+                validOptions.vscodeServerTmpDir
+            )
             await fs.mkdir(serverExecutableDir, { recursive: true })
             // We nullify the time it takes to download VSCode as it can vary wildly!
             const [_, codeTunnelCliPath] = await stretchTimeout(
@@ -715,7 +717,7 @@ const implFixture = _test.extend<TestContext, WorkerContext>({
             if (validOptions.vscodeExtensions.length > 0) {
                 //TODO(rnauta): Add lockfile wrapper to avoid race conditions
                 const sharedExtensionsDir = path.resolve(
-                    process.cwd(),
+                    CODY_VSCODE_ROOT_DIR,
                     validOptions.vscodeExtensionCacheDir
                 )
                 if (!sharedExtensionsDir.endsWith(path.join('.vscode-server', 'extensions'))) {
@@ -785,8 +787,8 @@ const implFixture = _test.extend<TestContext, WorkerContext>({
                     ? `--inspect-brk=${extensionHostDebugPort}`
                     : `--inspect=${extensionHostDebugPort}`,
                 TESTING_DOTCOM_URL: mitmProxy.sourcegraph.dotcom.endpoint,
-                CODY_TESTING_BFG_DIR: path.resolve(process.cwd(), validOptions.binaryTmpDir),
-                CODY_TESTING_SYMF_DIR: path.resolve(process.cwd(), validOptions.binaryTmpDir),
+                CODY_TESTING_BFG_DIR: path.resolve(CODY_VSCODE_ROOT_DIR, validOptions.binaryTmpDir),
+                CODY_TESTING_SYMF_DIR: path.resolve(CODY_VSCODE_ROOT_DIR, validOptions.binaryTmpDir),
             }
             const config = {
                 url: `http://127.0.0.1:${serverPort}/`,

--- a/vscode/playwright.v2.config.ts
+++ b/vscode/playwright.v2.config.ts
@@ -1,4 +1,4 @@
-import os from 'node:os'
+import { homedir } from 'node:os'
 import { type ReporterDescription, defineConfig } from '@playwright/test'
 import { ulid } from 'ulidx'
 import type { SymlinkExtensions } from './e2e/utils/symlink-extensions.setup'
@@ -9,9 +9,7 @@ const isWin = process.platform.startsWith('win')
 const isCI = !!process.env.CI
 process.env.RUN_ID = process.env.RUN_ID || ulid()
 
-export default defineConfig<
-    WorkerOptions & TestOptions & TmpDirOptions & SymlinkExtensions & GlobalSetupOptions
->({
+export default defineConfig<WorkerOptions & TestOptions & TmpDirOptions & SymlinkExtensions>({
     workers: '50%',
     retries: 0, // NO MORE FLAKE ALLOWED! It's a slippery slope.
     forbidOnly: isCI,
@@ -32,7 +30,7 @@ export default defineConfig<
         setupClearGlobalTmpParentDir: true,
         vscodeVersion: 'stable',
         vscodeTmpDir: '../.test/global/vscode',
-        vscodeExtensionCacheDir: `${os.homedir()}/.vscode-server/extensions`,
+        vscodeExtensionCacheDir: `${homedir()}/.vscode-server/extensions`,
         vscodeServerTmpDir: '../.test/global/vscode-server',
         binaryTmpDir: '../.test/global/bin',
         waitForExtensionHostDebugger: false,


### PR DESCRIPTION
Ensures that both running Playwright directly or via a VSCode extension paths are resolved correctly.

Normally Playwright ensures that process.cwd() is relative to the Playwright config file. However when running through the VSCode extension that doesn't seem to hold.

## Test Plan

Only affects unused e2ev2 tests, no tests needed
