### PR TITLE
Autocomplete: Merge the `smart-throttle` and `hot-streak` experiments

### DIFF
--- a/lib/shared/src/configuration.ts
+++ b/lib/shared/src/configuration.ts
@@ -71,13 +71,11 @@ export interface Configuration {
     /**
      * Experimental autocomplete
      */
-    autocompleteExperimentalHotStreak?: boolean
     autocompleteExperimentalGraphContext: 'lsp-light' | 'bfg' | 'bfg-mixed' | 'tsc' | 'tsc-mixed' | null
     autocompleteExperimentalOllamaOptions: OllamaOptions
     autocompleteExperimentalFireworksOptions?: FireworksOptions
     autocompleteExperimentalMultiModelCompletions?: MultimodelSingleModelConfig[]
-    autocompleteExperimentalSmartThrottle?: boolean
-    autocompleteExperimentalSmartThrottleExtended?: boolean
+    autocompleteExperimentalHotStreakAndSmartThrottle?: boolean
 
     /**
      * Hidden settings

--- a/lib/shared/src/experimentation/FeatureFlagProvider.ts
+++ b/lib/shared/src/experimentation/FeatureFlagProvider.ts
@@ -35,14 +35,12 @@ export enum FeatureFlag {
     // Enable latency adjustments based on accept/reject streaks
     CodyAutocompleteUserLatency = 'cody-autocomplete-user-latency',
 
-    // Used to run multiple latency experiments in parallel
-    CodyAutocompleteLatencyExperimentBasedFeatureFlag = 'cody-autocomplete-latency-experiment-flag',
-    // Continue generations after a single-line completion and use the response to see the next line
-    // if the first completion is accepted.
-    CodyAutocompleteHotStreak = 'cody-autocomplete-hot-streak',
-    // Enable smart-throttling for more aggressive request cancellation and lower initial latencies
-    CodyAutocompleteSmartThrottle = 'cody-autocomplete-smart-throttle',
-    CodyAutocompleteSmartThrottleExtended = 'cody-autocomplete-smart-throttle-extended',
+    // - Hot Streak:
+    //              Continue generations after a single-line completion and use the response to see the next line
+    //              if the first completion is accepted.
+    // - Smart Throttle:
+    //              Enable smart-throttling for more aggressive request cancellation and lower initial latencies
+    CodyAutocompleteHotStreakAndSmartThrottle = 'cody-autocomplete-hot-streak-and-smart-throttle',
 
     // When enabled, it will extend the number of languages considered for context (e.g. React files
     // will be able to use CSS files as context).

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -1210,11 +1210,6 @@
           "markdownDescription": "Determines the algorithm Cody uses to detect folding ranges. Cody uses folding ranges for several features like the 'Document code' command",
           "default": "all"
         },
-        "cody.autocomplete.experimental.hotStreak": {
-          "type": "boolean",
-          "default": false,
-          "markdownDescription": "Preload follow-up completions"
-        },
         "cody.autocomplete.experimental.graphContext": {
           "type": "string",
           "default": null,
@@ -1293,15 +1288,10 @@
             }
           }
         },
-        "cody.autocomplete.experimental.smartThrottle": {
+        "cody.autocomplete.experimental.hotStreakAndsmartThrottle": {
           "type": "boolean",
           "default": false,
           "markdownDescription": "Changes the debounce time for autocomplete requests based on the amount of time since the last request."
-        },
-        "cody.autocomplete.experimental.smartThrottleExtended": {
-          "type": "boolean",
-          "default": false,
-          "markdownDescription": "Changes the (extended) debounce time for autocomplete requests based on the amount of time since the last request."
         },
         "openctx.enable": {
           "type": "boolean",

--- a/vscode/src/completions/completion-provider-config.ts
+++ b/vscode/src/completions/completion-provider-config.ts
@@ -11,13 +11,10 @@ class CompletionProviderConfig {
 
     private flagsToResolve = [
         FeatureFlag.CodyAutocompleteContextBfgMixed,
-        FeatureFlag.CodyAutocompleteHotStreak,
         FeatureFlag.CodyAutocompleteUserLatency,
         FeatureFlag.CodyAutocompleteTracing,
         FeatureFlag.CodyAutocompleteContextExtendLanguagePool,
-        FeatureFlag.CodyAutocompleteSmartThrottle,
-        FeatureFlag.CodyAutocompleteSmartThrottleExtended,
-        FeatureFlag.CodyAutocompleteLatencyExperimentBasedFeatureFlag,
+        FeatureFlag.CodyAutocompleteHotStreakAndSmartThrottle,
     ] as const
 
     private get config() {
@@ -74,38 +71,15 @@ class CompletionProviderConfig {
         }
     }
 
-    private getLatencyExperimentGroup():
-        | 'hot-streak'
-        | 'smart-throttle'
-        | 'smart-throttle-extended'
-        | 'control' {
+    private getLatencyExperimentGroup(): 'hot-streak-and-smart-throttle' | 'control' {
         // The desired distribution:
-        // - Hot-streak 25%
-        // - Smart-throttle 25%
-        // - Smart-throttle-extended 25%
-        // - Control group 25%
+        // - Hot-streak + Smart-throttle 50%
+        // - Control group 50%
         //
         // The rollout values to set:
-        // - CodyAutocompleteLatencyExperimentBasedFeatureFlag 75%
-        // - CodyAutocompleteHotStreak 33%
-        // - CodyAutocompleteSmartThrottle 100%
-        // - CodyAutocompleteSmartThrottleExtended 50%
-        if (this.getPrefetchedFlag(FeatureFlag.CodyAutocompleteLatencyExperimentBasedFeatureFlag)) {
-            // 75% of users get here
-            if (this.getPrefetchedFlag(FeatureFlag.CodyAutocompleteHotStreak)) {
-                // 25% of remaining users get here (33% of 75%)
-                return 'hot-streak'
-            }
-
-            if (this.getPrefetchedFlag(FeatureFlag.CodyAutocompleteSmartThrottle)) {
-                // 50% of remaining users get here (100% of 50%)
-                if (this.getPrefetchedFlag(FeatureFlag.CodyAutocompleteSmartThrottleExtended)) {
-                    // 25% of remaining users get here (50% of 50%)
-                    return 'smart-throttle-extended'
-                }
-                // Remaining 25% of users get here
-                return 'smart-throttle'
-            }
+        // - CodyAutocompleteHotStreakAndSmartThrottle 50%
+        if (this.getPrefetchedFlag(FeatureFlag.CodyAutocompleteHotStreakAndSmartThrottle)) {
+            return 'hot-streak-and-smart-throttle'
         }
 
         return 'control'
@@ -113,22 +87,15 @@ class CompletionProviderConfig {
 
     public get hotStreak(): boolean {
         return (
-            this.config.autocompleteExperimentalHotStreak ||
-            this.getLatencyExperimentGroup() === 'hot-streak'
+            this.config.autocompleteExperimentalHotStreakAndSmartThrottle ||
+            this.getLatencyExperimentGroup() === 'hot-streak-and-smart-throttle'
         )
     }
 
     public get smartThrottle(): boolean {
         return (
-            this.config.autocompleteExperimentalSmartThrottle ||
-            this.getLatencyExperimentGroup() === 'smart-throttle'
-        )
-    }
-
-    public get smartThrottleExtended(): boolean {
-        return (
-            this.config.autocompleteExperimentalSmartThrottleExtended ||
-            this.getLatencyExperimentGroup() === 'smart-throttle-extended'
+            this.config.autocompleteExperimentalHotStreakAndSmartThrottle ||
+            this.getLatencyExperimentGroup() === 'hot-streak-and-smart-throttle'
         )
     }
 }

--- a/vscode/src/completions/get-inline-completions-tests/hot-streak.test.ts
+++ b/vscode/src/completions/get-inline-completions-tests/hot-streak.test.ts
@@ -39,7 +39,7 @@ describe('[getInlineCompletions] hot streak', () => {
                 }`,
                 {
                     configuration: {
-                        autocompleteExperimentalHotStreak: true,
+                        autocompleteExperimentalHotStreakAndSmartThrottle: true,
                         autocompleteAdvancedProvider: 'fireworks',
                     },
                     delayBetweenChunks: 50,
@@ -73,7 +73,7 @@ describe('[getInlineCompletions] hot streak', () => {
                     console.log(4)
                     █
                 }`,
-                { configuration: { autocompleteExperimentalHotStreak: true } }
+                { configuration: { autocompleteExperimentalHotStreakAndSmartThrottle: true } }
             )
 
             expect(request.items[0].insertText).toEqual('console.log(2)')
@@ -98,7 +98,7 @@ describe('[getInlineCompletions] hot streak', () => {
                     console.log(4)
                     return foo█
                 }`,
-                { configuration: { autocompleteExperimentalHotStreak: true } }
+                { configuration: { autocompleteExperimentalHotStreakAndSmartThrottle: true } }
             )
 
             await request.completionResponseGeneratorPromise
@@ -135,7 +135,7 @@ describe('[getInlineCompletions] hot streak', () => {
                 }`,
                 {
                     configuration: {
-                        autocompleteExperimentalHotStreak: true,
+                        autocompleteExperimentalHotStreakAndSmartThrottle: true,
                     },
                 }
             )
@@ -166,7 +166,7 @@ describe('[getInlineCompletions] hot streak', () => {
                 const`,
                 {
                     configuration: {
-                        autocompleteExperimentalHotStreak: true,
+                        autocompleteExperimentalHotStreakAndSmartThrottle: true,
                     },
                     delayBetweenChunks: 20,
                     providerOptions: {

--- a/vscode/src/completions/inline-completion-item-provider-e2e.test.ts
+++ b/vscode/src/completions/inline-completion-item-provider-e2e.test.ts
@@ -174,7 +174,9 @@ describe('InlineCompletionItemProvider E2E', () => {
         let getCompletionProviderSpy: MockInstance
 
         beforeAll(async () => {
-            await initCompletionProviderConfig({ autocompleteExperimentalSmartThrottle: true })
+            await initCompletionProviderConfig({
+                autocompleteExperimentalHotStreakAndSmartThrottle: true,
+            })
             localStorage.setStorage({
                 get: () => null,
                 update: () => {},

--- a/vscode/src/completions/inline-completion-item-provider.ts
+++ b/vscode/src/completions/inline-completion-item-provider.ts
@@ -159,11 +159,8 @@ export class InlineCompletionItemProvider
             )
         )
 
-        if (completionProviderConfig.smartThrottle || completionProviderConfig.smartThrottleExtended) {
-            this.smartThrottleService = new SmartThrottleService(
-                // Use an extended throttle timeout of 500ms for the extended throttle.
-                completionProviderConfig.smartThrottleExtended ? 500 : undefined
-            )
+        if (completionProviderConfig.smartThrottle) {
+            this.smartThrottleService = new SmartThrottleService()
             this.disposables.push(this.smartThrottleService)
         }
 

--- a/vscode/src/completions/smart-throttle.test.ts
+++ b/vscode/src/completions/smart-throttle.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { getCurrentDocContext } from './get-current-doc-context'
 import { TriggerKind } from './get-inline-completions'
 import type { RequestParams } from './request-manager'
-import { DEFAULT_THROTTLE_TIMEOUT, SmartThrottleService } from './smart-throttle'
+import { SmartThrottleService, THROTTLE_TIMEOUT } from './smart-throttle'
 import { documentAndPosition } from './test-helpers'
 
 const stale = () => {
@@ -115,7 +115,7 @@ describe('SmartThrottleService', () => {
 
         // The third request will be promoted if enough time passes since the last promotion
         // It will also be marked as stale.
-        vi.advanceTimersByTime(DEFAULT_THROTTLE_TIMEOUT + 10)
+        vi.advanceTimersByTime(THROTTLE_TIMEOUT + 10)
 
         const fourthStaleMock = stale()
         const fourthThrottledRequest = await service.throttle(

--- a/vscode/src/completions/smart-throttle.ts
+++ b/vscode/src/completions/smart-throttle.ts
@@ -7,7 +7,7 @@ import { forkSignal, sleep } from './utils'
 // The throttle timeout is relatively high so that we do not keep a lot of concurrent requests. 250
 // is chosen as it will keep about 2 requests concurrent with our current median latency of about
 // 500ms
-export const DEFAULT_THROTTLE_TIMEOUT = 250
+export const THROTTLE_TIMEOUT = 250
 
 // A smart throttle service for autocomplete requests. The idea is to move beyond a simple debounce
 // based timeout and start a bunch of requests immediately. Additionally, we also want to be more
@@ -29,12 +29,6 @@ export class SmartThrottleService implements vscode.Disposable {
     // The timestamp when the latest tail request was prompted to a throttled-request. When it
     // exceeds the throttle timeout, a tail request will be promoted again.
     private lastThrottlePromotion = 0
-
-    private THROTTLE_TIMEOUT: number
-
-    constructor(timeout = DEFAULT_THROTTLE_TIMEOUT) {
-        this.THROTTLE_TIMEOUT = timeout
-    }
 
     async throttle(
         request: RequestParams,
@@ -63,7 +57,7 @@ export class SmartThrottleService implements vscode.Disposable {
             // Case 2: The last throttled promotion is more than the throttle timeout ago. In this case,
             //         promote the last tail request to a throttled request and continue with the third
             //         case.
-            if (now - this.lastThrottlePromotion > this.THROTTLE_TIMEOUT && this.tailRequest) {
+            if (now - this.lastThrottlePromotion > THROTTLE_TIMEOUT && this.tailRequest) {
                 // Mark the tailRequest as stale, this means we will not mark it as a completion to be suggested
                 // Instead we the incoming request will benefit from the cached response, if still relevant.
                 this.tailRequest.stale()

--- a/vscode/src/configuration.test.ts
+++ b/vscode/src/configuration.test.ts
@@ -67,8 +67,6 @@ describe('getConfiguration', () => {
                         return true
                     case 'cody.autocomplete.disableInsideComments':
                         return false
-                    case 'cody.autocomplete.experimental.hotStreak':
-                        return false
                     case 'cody.autocomplete.experimental.fireworksOptions':
                         return undefined
                     case 'cody.autocomplete.experimental.multiModelCompletions':
@@ -100,9 +98,7 @@ describe('getConfiguration', () => {
                         return undefined
                     case 'cody.autocomplete.advanced.timeout.firstCompletion':
                         return 1500
-                    case 'cody.autocomplete.experimental.smartThrottle':
-                        return false
-                    case 'cody.autocomplete.experimental.smartThrottleExtended':
+                    case 'cody.autocomplete.experimental.hotStreakAndSmartThrottle':
                         return false
                     default:
                         throw new Error(`unexpected key: ${key}`)
@@ -143,7 +139,6 @@ describe('getConfiguration', () => {
             autocompleteFormatOnAccept: true,
             autocompleteDisableInsideComments: false,
             autocompleteExperimentalFireworksOptions: undefined,
-            autocompleteExperimentalHotStreak: false,
             autocompleteExperimentalGraphContext: 'bfg',
             autocompleteExperimentalOllamaOptions: {
                 model: 'codellama:7b-code',
@@ -154,8 +149,7 @@ describe('getConfiguration', () => {
                 singleline: undefined,
             },
             autocompleteFirstCompletionTimeout: 1500,
-            autocompleteExperimentalSmartThrottle: false,
-            autocompleteExperimentalSmartThrottleExtended: false,
+            autocompleteExperimentalHotStreakAndSmartThrottle: false,
             testingModelConfig: undefined,
             experimentalChatContextRanker: false,
         } satisfies Configuration)

--- a/vscode/src/configuration.ts
+++ b/vscode/src/configuration.ts
@@ -147,10 +147,6 @@ export function getConfiguration(
 
         experimentalChatContextRanker: getHiddenSetting('experimental.chatContextRanker', false),
 
-        autocompleteExperimentalHotStreak: getHiddenSetting(
-            'autocomplete.experimental.hotStreak',
-            false
-        ),
         autocompleteExperimentalOllamaOptions: getHiddenSetting(
             'autocomplete.experimental.ollamaOptions',
             {
@@ -166,12 +162,8 @@ export function getConfiguration(
             'autocomplete.experimental.multiModelCompletions',
             undefined
         ),
-        autocompleteExperimentalSmartThrottle: getHiddenSetting(
-            'autocomplete.experimental.smartThrottle',
-            false
-        ),
-        autocompleteExperimentalSmartThrottleExtended: getHiddenSetting(
-            'autocomplete.experimental.smartThrottleExtended',
+        autocompleteExperimentalHotStreakAndSmartThrottle: getHiddenSetting(
+            'autocomplete.experimental.hotStreakAndSmartThrottle',
             false
         ),
 

--- a/vscode/src/testutils/mocks.ts
+++ b/vscode/src/testutils/mocks.ts
@@ -910,7 +910,6 @@ export const DEFAULT_VSCODE_SETTINGS = {
     autocompleteCompleteSuggestWidgetSelection: true,
     autocompleteFormatOnAccept: true,
     autocompleteDisableInsideComments: false,
-    autocompleteExperimentalHotStreak: false,
     autocompleteExperimentalGraphContext: null,
     autocompleteExperimentalOllamaOptions: {
         model: 'codellama:7b-code',
@@ -921,8 +920,7 @@ export const DEFAULT_VSCODE_SETTINGS = {
         singleline: undefined,
     },
     autocompleteFirstCompletionTimeout: 3500,
-    autocompleteExperimentalSmartThrottle: false,
-    autocompleteExperimentalSmartThrottleExtended: false,
+    autocompleteExperimentalHotStreakAndSmartThrottle: false,
     testingModelConfig: undefined,
     experimentalChatContextRanker: false,
 } satisfies Configuration


### PR DESCRIPTION
## Description

This PR enables the `hot-streak` and `smart-throttle` experiments together.

This is under a new feature flag:
`cody-autocomplete-hot-streak-and-smart-throttle`

## Test plan

1. Enable the setting for this
2. Check that hot streak and smart throttle are enabled
3. Enable the flag for this
4. Check hot streak and smart throttle are enabled

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

