### PR TITLE
Command: add requires setting for auto-edit command

### DIFF
--- a/vscode/src/commands/index.ts
+++ b/vscode/src/commands/index.ts
@@ -71,6 +71,7 @@ export const CodyCommandMenuItems: MenuCommandAccessor[] = [
         icon: 'surround-with',
         command: { command: 'cody.command.auto-edit' },
         keybinding: `${osIcon}Tab`,
+        requires: { setting: 'cody.internal.unstable' },
     },
     {
         key: 'commit',


### PR DESCRIPTION
This change adds a `requires` property to the `CodyCommandMenuItems` configuration for the `cody.command.auto-edit` command. The `requires` property specifies that the `cody.internal.unstable` setting must be enabled for this command to be available.

This ensures that the auto-edit command is only accessible when the user has opted-in to using unstable Cody features.

## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

Auto Edit doesn't show up for enterprise users if they don't have the config enabled

<img width="595" alt="image" src="https://github.com/user-attachments/assets/6026162d-bf88-4833-9cc7-52d7a846f674">


## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
