### PR TITLE
E2Ev2: Fix credentials bug

### DIFF
--- a/vscode/e2e/utils/credentials.setup.ts
+++ b/vscode/e2e/utils/credentials.setup.ts
@@ -1,11 +1,14 @@
 import { test as setup } from '@playwright/test'
 import * as dotenv from 'dotenv'
-import { CREDENTIALS_ENVFILE_PATH, updateEnvFile } from './credentials-envfile'
+import { CREDENTIALS_ENVFILE_PATH, updateEnvFile } from './vscody/credentials-envfile'
 
 // biome-ignore lint/complexity/noBannedTypes: <explanation>
 // biome-ignore lint/correctness/noEmptyPattern: <explanation>
 setup.extend<{}>({})('credentials', async ({}) => {
     try {
+        // NOTE: VSCode Playwright UI will abort the running test when it
+        // detects a file change. So you'll in some cases have to click the run
+        // test butotn twice. Every other case seems to work fine.
         if (updateEnvFile()) {
             dotenv.config({ path: CREDENTIALS_ENVFILE_PATH })
         }

--- a/vscode/e2e/utils/vscody/credentials-envfile.ts
+++ b/vscode/e2e/utils/vscody/credentials-envfile.ts
@@ -2,7 +2,7 @@ import { execSync } from 'node:child_process'
 import fs from 'node:fs'
 import path from 'node:path'
 import dedent from 'dedent'
-import { CODY_VSCODE_ROOT_DIR } from './helpers'
+import { CODY_VSCODE_ROOT_DIR } from '../helpers'
 
 const existingRegex = /^([^=]+)=(.*)$/m
 export const CREDENTIALS_ENVFILE_PATH = path.join(CODY_VSCODE_ROOT_DIR, '.credentials.env')
@@ -64,13 +64,15 @@ export function updateEnvFile(): boolean {
     const values = withMissingValues(existingValues)
 
     let hasChanges = false
-    for (const [name, value] of values) {
-        if (existingValues.get(name) !== value) {
+    for (const name of Array.from(values.keys())) {
+        if (existingValues.get(name) !== values.get(name)) {
+            console.log(`Updating ${name}`, values.get(name), existingValues.get(name))
             hasChanges = true
         }
     }
+
     if (!hasChanges) {
-        false
+        return false
     }
 
     const content = dedent(`

--- a/vscode/e2e/utils/vscody/fixture.ts
+++ b/vscode/e2e/utils/vscody/fixture.ts
@@ -33,12 +33,13 @@ import { onExit } from 'signal-exit'
 import zod from 'zod'
 import { waitForLock } from '../../../src/lockfile'
 import { CodyPersister, redactAuthorizationHeader } from '../../../src/testutils/CodyPersisterV2'
-import {
-    type DOTCOM_TESTING_CREDENTIALS,
-    type ENTERPRISE_TESTING_CREDENTIALS,
-    TESTING_CREDENTIALS,
+import type {
+    DOTCOM_TESTING_CREDENTIALS,
+    ENTERPRISE_TESTING_CREDENTIALS,
 } from '../../../src/testutils/testing-credentials'
+import { TESTING_CREDENTIALS } from '../../../src/testutils/testing-credentials'
 import { CODY_VSCODE_ROOT_DIR, retry, stretchTimeout } from '../helpers'
+
 import {
     MITM_AUTH_TOKEN_PLACEHOLDER,
     MITM_PROXY_AUTH_AVAILABLE_HEADER,

--- a/vscode/e2e/utils/vscody/fixture.ts
+++ b/vscode/e2e/utils/vscody/fixture.ts
@@ -96,12 +96,12 @@ export interface MitMProxyConfig {
         dotcom: {
             readonly endpoint: string
             readonly proxyTarget: string
-            readonly authName: keyof typeof DOTCOM_TESTING_CREDENTIALS
+            authName: keyof typeof DOTCOM_TESTING_CREDENTIALS
         }
         enterprise: {
             readonly endpoint: string
             readonly proxyTarget: string
-            readonly authName: keyof typeof ENTERPRISE_TESTING_CREDENTIALS
+            authName: keyof typeof ENTERPRISE_TESTING_CREDENTIALS
         }
     }
 }
@@ -146,6 +146,7 @@ onExit(
     },
     { alwaysLast: true }
 )
+
 // We split out the options fixutre from the implementation fixture so that in
 // the implementaiton fixture we don't accidentally use any options directly,
 // instead having to use validated options
@@ -340,6 +341,9 @@ const implFixture = _test.extend<TestContext, WorkerContext>({
                         get authName() {
                             return state.authName.dotcom
                         },
+                        set authName(value: MitMProxyConfig['sourcegraph']['dotcom']['authName']) {
+                            state.authName.dotcom = value
+                        },
                         endpoint: `http://127.0.0.1:${sgEnterprisePort}`,
                         get proxyTarget() {
                             return TESTING_CREDENTIALS[state.authName.dotcom].serverEndpoint
@@ -348,6 +352,9 @@ const implFixture = _test.extend<TestContext, WorkerContext>({
                     enterprise: {
                         get authName() {
                             return state.authName.enterprise
+                        },
+                        set authName(value: MitMProxyConfig['sourcegraph']['enterprise']['authName']) {
+                            state.authName.enterprise = value
                         },
                         endpoint: `http://127.0.0.1:${sgDotComPort}`,
                         get proxyTarget() {
@@ -382,9 +389,11 @@ const implFixture = _test.extend<TestContext, WorkerContext>({
                 ejectPlugins: true,
                 prependPath: false,
                 preserveHeaderKeyCase: false,
+                secure: false,
                 plugins: [proxyEventsPlugin],
                 router: req => {
                     try {
+                        //TODO: convert this to a regex instead
                         const hostPrefix = `http://${req.headers.host}`
                         if (hostPrefix.startsWith(config.sourcegraph.dotcom.endpoint)) {
                             return new URL(req.url ?? '', config.sourcegraph.dotcom.proxyTarget)

--- a/vscode/playwright.v2.config.ts
+++ b/vscode/playwright.v2.config.ts
@@ -3,16 +3,17 @@ import * as path from 'node:path'
 import { type ReporterDescription, defineConfig } from '@playwright/test'
 import * as dotenv from 'dotenv'
 import { ulid } from 'ulidx'
-import { CREDENTIALS_ENVFILE_PATH } from './e2e/utils/credentials-envfile'
 import { CODY_VSCODE_ROOT_DIR } from './e2e/utils/helpers'
 import type { SymlinkExtensions } from './e2e/utils/symlink-extensions.setup'
 import type { TmpDirOptions } from './e2e/utils/tmpdir.setup'
 import type { TestOptions, WorkerOptions } from './e2e/utils/vscody'
+import { CREDENTIALS_ENVFILE_PATH } from './e2e/utils/vscody/credentials-envfile'
 
 // Using dotenv files makes it work nicely in VSCode without having to restart the editor
 // to load new environment variables.
 dotenv.config({ path: path.resolve(CODY_VSCODE_ROOT_DIR, '.env') })
 dotenv.config({ path: CREDENTIALS_ENVFILE_PATH })
+
 const isWin = process.platform.startsWith('win')
 const isCI = !!process.env.CI
 process.env.RUN_ID = process.env.RUN_ID || ulid()
@@ -88,7 +89,7 @@ export default defineConfig<WorkerOptions & TestOptions & TmpDirOptions & Symlin
             name: 'utils',
             testDir: './e2e/utils',
             testMatch: ['**/*.test.ts'],
-            dependencies: ['tmpdir', 'symlink-extensions'],
+            dependencies: ['tmpdir', 'symlink-extensions', ...(isCI ? [] : ['credentials'])],
         },
         {
             name: 'e2e',


### PR DESCRIPTION
For some reason the import when mixed with types ends up imported not as the exported const but as the entire module. 🤷 


## Test plan

Only unused testing framework is affected. No tests required.