### PR TITLE
Autocomplete: Fix typo in setting

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -1288,7 +1288,7 @@
             }
           }
         },
-        "cody.autocomplete.experimental.hotStreakAndsmartThrottle": {
+        "cody.autocomplete.experimental.hotStreakAndSmartThrottle": {
           "type": "boolean",
           "default": false,
           "markdownDescription": "Changes the debounce time for autocomplete requests based on the amount of time since the last request."


### PR DESCRIPTION
## Description

Typo

## Test plan

1. Enable setting
2. Check smart throttle and hot streak are actually enabled

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->