### PR TITLE
helper for webview to call extension (ChatController) API and get a result

### DIFF
--- a/lib/shared/src/index.ts
+++ b/lib/shared/src/index.ts
@@ -305,3 +305,9 @@ export {
     UNKNOWN_NODES_EDITOR_STATE_FIXTURE,
 } from './lexicalEditor/fixtures'
 export { getSerializedParams } from './sourcegraph-api/completions/utils'
+export {
+    type GenericVSCodeWrapper,
+    type GenericWebviewAPIWrapper,
+    createExtensionAPIProxyInWebview,
+    handleExtensionAPICallFromWebview,
+} from './misc/rpc/proxy'

--- a/lib/shared/src/misc/rpc/proxy.ts
+++ b/lib/shared/src/misc/rpc/proxy.ts
@@ -1,0 +1,100 @@
+import { isAbortError } from '../../sourcegraph-api/errors'
+
+export interface GenericVSCodeWrapper<TWebviewMessage, TExtensionMessage> {
+    postMessage(message: TWebviewMessage): void
+    onMessage(callback: (message: TExtensionMessage) => void): () => void
+    getState(): unknown
+    setState(newState: unknown): void
+}
+
+/**
+ * Create a proxy function for use in the webview that "calls" a function in the extension host
+ * (which must be a message defined in {@link WebviewMessage}) and returns a promise for the result
+ * (which must be a message defined in {@link ExtensionMessage}).
+ *
+ * @template TWebviewMessage The webview protocol (such as {@link WebviewMessage}).
+ * @template TExtensionMessage The extension host protocol (such as {@link ExtensionMessage}).
+ */
+export function createExtensionAPIProxyInWebview<
+    TWebviewMessage extends { command: string },
+    TExtensionMessage extends { type: string },
+    TRequestName extends TWebviewMessage['command'],
+    TResponseName extends TExtensionMessage['type'],
+>(
+    api: GenericVSCodeWrapper<TWebviewMessage, TExtensionMessage>,
+    requestName: TRequestName,
+    responseName: TResponseName
+): (
+    params: Omit<Extract<TWebviewMessage, { command: TRequestName }>, 'command'>
+) => Promise<Omit<Extract<TExtensionMessage, { type: TResponseName }>, 'type'>> {
+    type TRequestParams = Omit<Extract<TWebviewMessage, { command: TRequestName }>, 'command'>
+    type TResponseValue = Omit<Extract<TExtensionMessage, { type: TResponseName }>, 'type'>
+    return (params: TRequestParams): Promise<TResponseValue> => {
+        return new Promise<TResponseValue>((resolve, reject) => {
+            api.postMessage({ command: requestName, ...params } as unknown as TWebviewMessage)
+
+            const MAX_WAIT_SECONDS = 15
+            const rejectTimeout = setTimeout(() => {
+                reject(new Error(`No ${responseName} response after ${MAX_WAIT_SECONDS}s`))
+                dispose()
+            }, MAX_WAIT_SECONDS * 1000)
+
+            const dispose = api.onMessage((message: TExtensionMessage) => {
+                if (message.type === responseName) {
+                    resolve(message as unknown as TResponseValue)
+                    dispose()
+                    clearTimeout(rejectTimeout)
+                }
+            })
+        })
+    }
+}
+
+export interface GenericWebviewAPIWrapper<TWebviewMessage, TExtensionMessage> {
+    postMessage(message: TExtensionMessage): void
+    postError(error: Error): void
+    onMessage(callback: (message: TWebviewMessage) => void): () => void
+}
+
+/**
+ * Create a handler for use in the extension host that responds to "calls" from a webview proxy
+ * function created by {@link createExtensionAPIProxyInWebview}.
+ *
+ * @template TWebviewMessage The webview protocol (such as {@link WebviewMessage}).
+ * @template TExtensionMessage The extension host protocol (such as {@link ExtensionMessage}).
+ */
+export function handleExtensionAPICallFromWebview<
+    TWebviewMessage extends { command: string },
+    TExtensionMessage extends { type: string },
+    TRequestName extends TWebviewMessage['command'],
+    TResponseName extends TExtensionMessage['type'],
+>(
+    api: GenericWebviewAPIWrapper<TWebviewMessage, TExtensionMessage>,
+    requestName: TRequestName,
+    responseName: TResponseName,
+    handler: (
+        params: Omit<Extract<TWebviewMessage, { command: TRequestName }>, 'command'>
+    ) => Promise<Omit<Extract<TExtensionMessage, { type: TResponseName }>, 'type'>>
+): { dispose: () => void } {
+    type TRequestParams = Omit<Extract<TWebviewMessage, { command: TRequestName }>, 'command'>
+    const dispose = api.onMessage(async message => {
+        if (message.command === requestName) {
+            try {
+                const response = await handler(message as unknown as TRequestParams)
+                api.postMessage({ type: responseName, ...response } as unknown as TExtensionMessage)
+            } catch (error) {
+                if (isAbortError(error)) {
+                    return
+                }
+                api.postError(
+                    error instanceof Error
+                        ? error
+                        : typeof error === 'string'
+                          ? new Error(error)
+                          : new Error(`Unknown error while handling ${requestName}`)
+                )
+            }
+        }
+    })
+    return { dispose }
+}

--- a/vscode/src/chat/chat-view/ChatController.ts
+++ b/vscode/src/chat/chat-view/ChatController.ts
@@ -18,6 +18,7 @@ import {
     type DefaultChatCommands,
     type EventSource,
     FeatureFlag,
+    type GenericWebviewAPIWrapper,
     type Guardrails,
     type MentionQuery,
     type Message,
@@ -32,6 +33,7 @@ import {
     allMentionProvidersMetadata,
     featureFlagProvider,
     graphqlClient,
+    handleExtensionAPICallFromWebview,
     hydrateAfterPostMessage,
     inputTextWithoutContextChipsFromPromptEditorState,
     isAbortErrorOrSocketHangUp,
@@ -51,7 +53,10 @@ import {
 
 import type { Span } from '@opentelemetry/api'
 import { captureException } from '@sentry/core'
-import { isContextWindowLimitError } from '@sourcegraph/cody-shared/src/sourcegraph-api/errors'
+import {
+    isAbortError,
+    isContextWindowLimitError,
+} from '@sourcegraph/cody-shared/src/sourcegraph-api/errors'
 import type { TelemetryEventParameters } from '@sourcegraph/telemetry'
 import type { URI } from 'vscode-uri'
 import { version as VSCEVersion } from '../../../package.json'
@@ -189,7 +194,7 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
     private readonly startTokenReceiver: typeof startTokenReceiver | undefined
     private readonly contextAPIClient: ContextAPIClient | null
 
-    private contextFilesQueryCancellation?: vscode.CancellationTokenSource
+    private contextFilesQueryAbortController?: AbortController
     private allMentionProvidersMetadataQueryCancellation?: vscode.CancellationTokenSource
 
     private disposables: vscode.Disposable[] = []
@@ -345,13 +350,12 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
                 this.postChatModels()
                 break
             case 'getUserContext':
-                await this.handleGetUserContextFilesCandidates(parseMentionQuery(message.query, null))
+                await this.handleGetUserContextFilesCandidates({
+                    query: parseMentionQuery(message.query, null),
+                })
                 break
             case 'getAllMentionProvidersMetadata':
                 await this.handleGetAllMentionProvidersMetadata()
-                break
-            case 'queryContextItems':
-                await this.handleGetUserContextFilesCandidates(message.query)
                 break
             case 'insert':
                 await handleCodeFromInsertAtCursor(message.text)
@@ -530,8 +534,6 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
                 await this.experimentalSetUnitTestPrompt()
                 break
             }
-            default:
-                this.postError(new Error(`Invalid request type from Webview Panel: ${message.command}`))
         }
     }
 
@@ -960,11 +962,15 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
         }
     }
 
-    private async handleGetUserContextFilesCandidates(query: MentionQuery): Promise<void> {
+    private async handleGetUserContextFilesCandidates({
+        query,
+    }: { query: MentionQuery }): Promise<
+        Omit<Extract<ExtensionMessage, { type: 'userContextFiles' }>, 'type'>
+    > {
         // Cancel previously in-flight query.
-        const cancellation = new vscode.CancellationTokenSource()
-        this.contextFilesQueryCancellation?.cancel()
-        this.contextFilesQueryCancellation = cancellation
+        const abortController = new AbortController()
+        this.contextFilesQueryAbortController?.abort()
+        this.contextFilesQueryAbortController = abortController
 
         const source = 'chat'
 
@@ -993,7 +999,7 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
         try {
             const items = await getChatContextItemsForMention(
                 query,
-                cancellation.token,
+                abortController.signal,
                 scopedTelemetryRecorder,
                 // Pass possible remote repository context in order to resolve files
                 // for this remote repositories and not for local one, Cody Web case
@@ -1002,27 +1008,19 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
                     ? this.remoteSearch?.getRepos('all')?.map(repo => repo.name)
                     : undefined
             )
+            abortController.signal.throwIfAborted()
 
-            if (cancellation.token.isCancellationRequested) {
-                return
-            }
             const { input, context } = this.chatModel.contextWindow
             const userContextFiles = items.map(f => ({
                 ...f,
                 isTooLarge: f.size ? f.size > (context?.user || input) : undefined,
             }))
-            void this.postMessage({
-                type: 'userContextFiles',
-                userContextFiles,
-            })
+            return { userContextFiles }
         } catch (error) {
-            if (cancellation.token.isCancellationRequested) {
-                return
+            if (isAbortError(error)) {
+                throw error // rethrow as-is so it gets ignored by our caller
             }
-            cancellation.cancel()
-            this.postError(new Error(`Error retrieving context files: ${error}`))
-        } finally {
-            cancellation.dispose()
+            throw new Error(`Error retrieving context files: ${error}`)
         }
     }
 
@@ -1608,6 +1606,22 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
                 this.onDidReceiveMessage(
                     hydrateAfterPostMessage(message, uri => vscode.Uri.from(uri as any))
                 )
+            )
+        )
+        const webviewAPIWrapper: GenericWebviewAPIWrapper<WebviewMessage, ExtensionMessage> = {
+            postMessage: this.postMessage.bind(this),
+            postError: this.postError.bind(this),
+            onMessage: callback => {
+                const disposable = viewOrPanel.webview.onDidReceiveMessage(callback)
+                return () => disposable.dispose()
+            },
+        }
+        this.disposables.push(
+            handleExtensionAPICallFromWebview(
+                webviewAPIWrapper,
+                'queryContextItems',
+                'userContextFiles',
+                this.handleGetUserContextFilesCandidates.bind(this)
             )
         )
 

--- a/vscode/src/chat/context/chatContext.ts
+++ b/vscode/src/chat/context/chatContext.ts
@@ -20,7 +20,7 @@ import {
 
 export async function getChatContextItemsForMention(
     mentionQuery: MentionQuery,
-    cancellationToken: vscode.CancellationToken,
+    signal: AbortSignal,
     // Logging: log when the at-mention starts, and then log when we know the type (after the 1st
     // character is typed). Don't log otherwise because we would be logging prefixes of the same
     // query repeatedly, which is not needed.

--- a/vscode/src/edit/input/get-matching-context.ts
+++ b/vscode/src/edit/input/get-matching-context.ts
@@ -1,5 +1,4 @@
 import type { ContextItem, MentionQuery } from '@sourcegraph/cody-shared'
-import * as vscode from 'vscode'
 
 import { getChatContextItemsForMention } from '../../chat/context/chatContext'
 import { getLabelForContextItem } from './utils'
@@ -13,8 +12,7 @@ interface FixupMatchingContext {
 }
 
 export async function getMatchingContext(mentionQuery: MentionQuery): Promise<FixupMatchingContext[]> {
-    const token = new vscode.CancellationTokenSource()?.token
-    const results = await getChatContextItemsForMention(mentionQuery, token)
+    const results = await getChatContextItemsForMention(mentionQuery, new AbortController().signal)
     return results.map(result => {
         return {
             key: getLabelForContextItem(result),

--- a/vscode/webviews/AppWrapper.tsx
+++ b/vscode/webviews/AppWrapper.tsx
@@ -2,30 +2,52 @@ import type { TelemetryRecorder } from '@sourcegraph/cody-shared'
 import type { FunctionComponent, ReactNode } from 'react'
 import { ClientActionListenersContextProvider, ClientStateContextProvider } from './client/clientState'
 import { TooltipProvider } from './components/shadcn/ui/tooltip'
+import {
+    ChatContextClientProviderForTestsOnly,
+    ChatContextClientProviderFromVSCodeAPI,
+} from './promptEditor/plugins/atMentions/chatContextClient'
+import { dummyChatContextClient } from './promptEditor/plugins/atMentions/fixtures'
+import type { VSCodeWrapper } from './utils/VSCodeApi'
 import { TelemetryRecorderContext } from './utils/telemetry'
 
-export const AppWrapper: FunctionComponent<{ children: ReactNode }> = ({ children }) => {
+const AppWrapperCommon = ({
+    vscodeAPI,
+    children,
+}: { vscodeAPI: VSCodeWrapper | null; children: ReactNode }): ReactNode => {
     return (
         // (tim): The default delayDuration of 300 felt a little low to go from
         // the left to the right of the panel. I increased it to 600, but any
         // higher feels too "sticky"
         <TooltipProvider disableHoverableContent={true} delayDuration={600}>
-            <ClientActionListenersContextProvider>{children}</ClientActionListenersContextProvider>
+            <ClientActionListenersContextProvider>
+                <ChatContextClientProviderFromVSCodeAPI vscodeAPI={vscodeAPI}>
+                    {children}
+                </ChatContextClientProviderFromVSCodeAPI>
+            </ClientActionListenersContextProvider>
         </TooltipProvider>
     )
 }
 
 /**
+ * Wrapper for {@link App} so that we can add more React context providers without requiring big,
+ * hard-to-review whitespace diffs in {@link App}.
+ */
+export const AppWrapper: FunctionComponent<{ vscodeAPI: VSCodeWrapper; children: ReactNode }> =
+    AppWrapperCommon
+
+/**
  * For use in tests only.
  */
 export const TestAppWrapper: FunctionComponent<{ children: ReactNode }> = ({ children }) => (
-    <AppWrapper>
+    <AppWrapperCommon vscodeAPI={null}>
         <TelemetryRecorderContext.Provider value={NOOP_TELEMETRY_RECORDER}>
             <ClientStateContextProvider value={{ initialContext: [] }}>
-                {children}
+                <ChatContextClientProviderForTestsOnly value={dummyChatContextClient}>
+                    {children}
+                </ChatContextClientProviderForTestsOnly>
             </ClientStateContextProvider>
         </TelemetryRecorderContext.Provider>
-    </AppWrapper>
+    </AppWrapperCommon>
 )
 const NOOP_TELEMETRY_RECORDER: TelemetryRecorder = {
     recordEvent: () => {},

--- a/vscode/webviews/index.tsx
+++ b/vscode/webviews/index.tsx
@@ -8,10 +8,12 @@ import './index.css'
 import { AppWrapper } from './AppWrapper'
 import { getVSCodeAPI } from './utils/VSCodeApi'
 
+const vscodeAPI = getVSCodeAPI()
+
 ReactDOM.createRoot(document.querySelector('#root') as HTMLElement).render(
     <React.StrictMode>
-        <AppWrapper>
-            <App vscodeAPI={getVSCodeAPI()} />
+        <AppWrapper vscodeAPI={vscodeAPI}>
+            <App vscodeAPI={vscodeAPI} />
         </AppWrapper>
     </React.StrictMode>
 )

--- a/vscode/webviews/minion/MinionApp.story.tsx
+++ b/vscode/webviews/minion/MinionApp.story.tsx
@@ -1,8 +1,8 @@
+import type { GenericVSCodeWrapper } from '@sourcegraph/cody-shared'
 import type { Meta, StoryObj } from '@storybook/react'
 import { URI } from 'vscode-uri'
 import type { MinionTranscriptItem } from '../../src/minion/action'
 import { VSCodeWebview } from '../storybook/VSCodeStoryDecorator'
-import type { GenericVSCodeWrapper } from '../utils/VSCodeApi'
 import { MinionApp } from './MinionApp'
 import type { MinionExtensionMessage, MinionWebviewMessage } from './webview_protocol'
 

--- a/vscode/webviews/minion/MinionApp.tsx
+++ b/vscode/webviews/minion/MinionApp.tsx
@@ -7,11 +7,11 @@ import type {
     PlanStepsStatus,
     Step,
 } from '../../src/minion/action'
-import type { GenericVSCodeWrapper } from '../utils/VSCodeApi'
 
 import './MinionApp.css'
 import {
     type ClientStateForWebview,
+    type GenericVSCodeWrapper,
     type RangeData,
     type SerializedPromptEditorValue,
     markdownCodeBlockLanguageIDForFilename,

--- a/vscode/webviews/promptEditor/plugins/atMentions/chatContextClient.test.tsx
+++ b/vscode/webviews/promptEditor/plugins/atMentions/chatContextClient.test.tsx
@@ -3,7 +3,11 @@ import { renderHook } from '@testing-library/react'
 import React from 'react'
 import { describe, expect, test } from 'vitest'
 import { URI } from 'vscode-uri'
-import { type ChatContextClient, WithChatContextClient, useChatContextItems } from './chatContextClient'
+import {
+    type ChatContextClient,
+    ChatContextClientProviderForTestsOnly,
+    useChatContextItems,
+} from './chatContextClient'
 
 describe('useChatContextItems', () => {
     test('returns filtered providers and items based on query', async () => {
@@ -14,12 +18,12 @@ describe('useChatContextItems', () => {
             resolve = resolve_
         })
         const client: ChatContextClient = {
-            getChatContextItems: () => itemsPromise,
+            getChatContextItems: async () => ({ userContextFiles: await itemsPromise }),
         }
 
         const { result } = renderHook(() => useChatContextItems('q', null), {
             wrapper: ({ children }) =>
-                React.createElement(WithChatContextClient, { value: client }, children),
+                React.createElement(ChatContextClientProviderForTestsOnly, { value: client }, children),
         })
 
         expect(result.current).toBe(undefined)

--- a/vscode/webviews/promptEditor/plugins/atMentions/chatContextClient.tsx
+++ b/vscode/webviews/promptEditor/plugins/atMentions/chatContextClient.tsx
@@ -3,11 +3,13 @@ import {
     type ContextMentionProviderMetadata,
     FILE_CONTEXT_MENTION_PROVIDER,
     type MentionQuery,
+    createExtensionAPIProxyInWebview,
     parseMentionQuery,
 } from '@sourcegraph/cody-shared'
 import { LRUCache } from 'lru-cache'
 import {
     type FunctionComponent,
+    type ReactNode,
     createContext,
     useContext,
     useEffect,
@@ -15,7 +17,8 @@ import {
     useRef,
     useState,
 } from 'react'
-import { getVSCodeAPI } from '../../../utils/VSCodeApi'
+import type { ExtensionMessage } from '../../../../src/chat/protocol'
+import type { VSCodeWrapper } from '../../../utils/VSCodeApi'
 
 export interface ChatMentionsSettings {
     resolutionMode: 'remote' | 'local'
@@ -26,48 +29,41 @@ export const ChatMentionContext = createContext<ChatMentionsSettings>({
 })
 
 export interface ChatContextClient {
-    getChatContextItems(query: MentionQuery): Promise<ContextItem[]>
+    getChatContextItems(params: { query: MentionQuery }): Promise<{
+        userContextFiles?: ContextItem[] | null | undefined
+    }>
 }
 
-const ChatContextClientContext: React.Context<ChatContextClient> = createContext({
-    getChatContextItems(query: MentionQuery): Promise<ContextItem[]> {
-        // Adapt the VS Code webview messaging API to be RPC-like for ease of use by our callers.
-        return new Promise<ContextItem[]>((resolve, reject) => {
-            const vscodeApi = getVSCodeAPI()
-            vscodeApi.postMessage({ command: 'queryContextItems', query })
+const ChatContextClientContext = createContext<ChatContextClient | undefined>(undefined)
 
-            const RESPONSE_MESSAGE_TYPE = 'userContextFiles' as const
+export const ChatContextClientProviderFromVSCodeAPI: FunctionComponent<{
+    vscodeAPI: VSCodeWrapper | null
+    children: ReactNode
+}> = ({ vscodeAPI, children }) => {
+    const value = useMemo<ChatContextClient | null>(
+        () =>
+            vscodeAPI
+                ? {
+                      getChatContextItems: createExtensionAPIProxyInWebview(
+                          vscodeAPI,
+                          'queryContextItems',
+                          'userContextFiles'
+                      ),
+                  }
+                : null,
+        [vscodeAPI]
+    )
+    return value ? (
+        <ChatContextClientContext.Provider value={value}>{children}</ChatContextClientContext.Provider>
+    ) : (
+        <>{children}</>
+    )
+}
 
-            // Clean up after a while to avoid resource exhaustion in case there is a bug
-            // somewhere.
-            const MAX_WAIT_SECONDS = 15
-            const rejectTimeout = !query.includeRemoteRepositories
-                ? setTimeout(() => {
-                      reject(
-                          new Error(`no ${RESPONSE_MESSAGE_TYPE} response after ${MAX_WAIT_SECONDS}s`)
-                      )
-                      dispose()
-                  }, MAX_WAIT_SECONDS * 1000)
-                : ''
-
-            // Wait for the response. We assume the first message of the right type is the response to
-            // our call.
-            const dispose = vscodeApi.onMessage(message => {
-                if (message.type === RESPONSE_MESSAGE_TYPE) {
-                    resolve(message.userContextFiles ?? [])
-                    dispose()
-                    clearTimeout(rejectTimeout)
-                }
-            })
-        })
-    },
-})
-
-export const WithChatContextClient: FunctionComponent<
-    React.PropsWithChildren<{ value: ChatContextClient }>
-> = ({ value, children }) => (
-    <ChatContextClientContext.Provider value={value}>{children}</ChatContextClientContext.Provider>
-)
+/**
+ * @internal Used in tests only.
+ */
+export const ChatContextClientProviderForTestsOnly = ChatContextClientContext.Provider
 
 /** Hook to get the chat context items for the given query. */
 export function useChatContextItems(
@@ -76,6 +72,11 @@ export function useChatContextItems(
 ): ContextItem[] | undefined {
     const mentionSettings = useContext(ChatMentionContext)
     const unmemoizedClient = useContext(ChatContextClientContext)
+    if (!unmemoizedClient) {
+        throw new Error(
+            'useChatContextItems must be used within a ChatContextClientProvider or ChatContextClientProviderFromVSCodeAPI'
+        )
+    }
 
     const chatContextClient = useMemo(
         () =>
@@ -121,15 +122,15 @@ export function useChatContextItems(
 
         if (chatContextClient) {
             chatContextClient
-                .getChatContextItems(mentionQuery)
-                .then(mentions => {
+                .getChatContextItems({ query: mentionQuery })
+                .then(result => {
                     // Since remote mention search debounce and batches all mention
                     // search requests we shouldn't invalidate any old responses like
                     // we do for local search.
                     if (invalidated && !mentionQuery.includeRemoteRepositories) {
                         return
                     }
-                    setResults(mentions)
+                    setResults(result.userContextFiles ?? [])
                 })
                 .catch(error => {
                     setResults(undefined)
@@ -145,16 +146,19 @@ export function useChatContextItems(
 }
 
 function memoizeChatContextClient(client: ChatContextClient): ChatContextClient {
-    const cache = new LRUCache<string, ContextItem[]>({ max: 10 })
+    const cache = new LRUCache<
+        string,
+        Omit<Extract<ExtensionMessage, { type: 'userContextFiles' }>, 'type'>
+    >({ max: 10 })
     return {
-        async getChatContextItems(query: MentionQuery): Promise<ContextItem[]> {
-            const key = JSON.stringify(query)
+        async getChatContextItems(params) {
+            const key = JSON.stringify(params)
             const cached = cache.get(key)
             if (cached !== undefined) {
                 return cached
             }
 
-            const result = await client.getChatContextItems(query)
+            const result = await client.getChatContextItems(params)
             cache.set(key, result)
             return result
         },

--- a/vscode/webviews/promptEditor/plugins/atMentions/fixtures.ts
+++ b/vscode/webviews/promptEditor/plugins/atMentions/fixtures.ts
@@ -13,24 +13,26 @@ import type { ChatContextClient } from './chatContextClient'
  * @internal
  */
 export const dummyChatContextClient: ChatContextClient = {
-    async getChatContextItems(query) {
+    async getChatContextItems({ query }) {
         await new Promise<void>(resolve => setTimeout(resolve, 250))
 
         const queryTextLower = query.text.toLowerCase()
-        return query.provider === SYMBOL_CONTEXT_MENTION_PROVIDER.id
-            ? DUMMY_SYMBOLS.filter(
-                  f =>
-                      f.symbolName.toLowerCase().includes(queryTextLower) ||
-                      f.uri.path.includes(queryTextLower)
-              )
-            : query.provider === null || query.provider === FILE_CONTEXT_MENTION_PROVIDER.id
-              ? DUMMY_FILES.filter(f => f.uri.path.includes(queryTextLower))
-              : [
-                    {
-                        type: 'file',
-                        uri: URI.file(`sample-${query.provider}-result`),
-                    } satisfies ContextItem,
-                ].filter(f => f.uri.path.includes(queryTextLower))
+        const results =
+            query.provider === SYMBOL_CONTEXT_MENTION_PROVIDER.id
+                ? DUMMY_SYMBOLS.filter(
+                      f =>
+                          f.symbolName.toLowerCase().includes(queryTextLower) ||
+                          f.uri.path.includes(queryTextLower)
+                  )
+                : query.provider === null || query.provider === FILE_CONTEXT_MENTION_PROVIDER.id
+                  ? DUMMY_FILES.filter(f => f.uri.path.includes(queryTextLower))
+                  : [
+                        {
+                            type: 'file',
+                            uri: URI.file(`sample-${query.provider}-result`),
+                        } satisfies ContextItem,
+                    ].filter(f => f.uri.path.includes(queryTextLower))
+        return { userContextFiles: results }
     },
 }
 

--- a/vscode/webviews/storybook/VSCodeStoryDecorator.tsx
+++ b/vscode/webviews/storybook/VSCodeStoryDecorator.tsx
@@ -10,11 +10,10 @@ import { clsx } from 'clsx'
 import { type CSSProperties, useState } from 'react'
 import { URI } from 'vscode-uri'
 import '../../node_modules/@vscode/codicons/dist/codicon.css'
-import { AppWrapper } from '../AppWrapper'
+import { TestAppWrapper } from '../AppWrapper'
 import { type ChatModelContext, ChatModelContextProvider } from '../chat/models/chatModelContext'
-import { ClientStateContextProvider } from '../client/clientState'
 import { WithContextProviders } from '../mentions/providers'
-import { WithChatContextClient } from '../promptEditor/plugins/atMentions/chatContextClient'
+import { ChatContextClientProviderForTestsOnly } from '../promptEditor/plugins/atMentions/chatContextClient'
 import { dummyChatContextClient } from '../promptEditor/plugins/atMentions/fixtures'
 import { TelemetryRecorderContext, createWebviewTelemetryRecorder } from '../utils/telemetry'
 import styles from './VSCodeStoryDecorator.module.css'
@@ -87,17 +86,15 @@ export function VSCodeDecorator(className: string | undefined, style?: CSSProper
 
         return (
             <div className={clsx(styles.container, className)} style={style}>
-                <AppWrapper>
-                    <WithChatContextClient value={dummyChatContextClient}>
+                <TestAppWrapper>
+                    <ChatContextClientProviderForTestsOnly value={dummyChatContextClient}>
                         <ChatModelContextProvider value={useDummyChatModelContext()}>
                             <TelemetryRecorderContext.Provider value={telemetryRecorder}>
-                                <ClientStateContextProvider value={{ initialContext: [] }}>
-                                    {story()}
-                                </ClientStateContextProvider>
+                                {story()}
                             </TelemetryRecorderContext.Provider>
                         </ChatModelContextProvider>
-                    </WithChatContextClient>
-                </AppWrapper>
+                    </ChatContextClientProviderForTestsOnly>
+                </TestAppWrapper>
             </div>
         )
     }

--- a/vscode/webviews/utils/VSCodeApi.ts
+++ b/vscode/webviews/utils/VSCodeApi.ts
@@ -1,6 +1,6 @@
 import { URI } from 'vscode-uri'
 
-import { hydrateAfterPostMessage } from '@sourcegraph/cody-shared'
+import { type GenericVSCodeWrapper, hydrateAfterPostMessage } from '@sourcegraph/cody-shared'
 
 import type { ExtensionMessage, WebviewMessage } from '../../src/chat/protocol'
 
@@ -37,13 +37,6 @@ export function getVSCodeAPI(): VSCodeWrapper {
 
 export function setVSCodeWrapper(value: VSCodeWrapper): void {
     api = value
-}
-
-export interface GenericVSCodeWrapper<W, E> {
-    postMessage(message: W): void
-    onMessage(callback: (message: E) => void): () => void
-    getState(): unknown
-    setState(newState: unknown): void
 }
 
 let genericApi: GenericVSCodeWrapper<any, any>

--- a/web/lib/components/CodyWebChat.tsx
+++ b/web/lib/components/CodyWebChat.tsx
@@ -111,6 +111,7 @@ export const CodyWebChat: FC<CodyWebChatProps> = props => {
                     break
                 case 'setConfigFeatures':
                     setServerSentModelsEnabled(!!message.configFeatures.serverSentModels)
+                    break
             }
         })
     }, [vscodeAPI, dispatchClientAction])

--- a/web/lib/components/CodyWebChatProvider.tsx
+++ b/web/lib/components/CodyWebChatProvider.tsx
@@ -297,7 +297,7 @@ export const CodyWebChatProvider: FC<PropsWithChildren<CodyWebChatProviderProps>
     )
 
     return (
-        <AppWrapper>
+        <AppWrapper vscodeAPI={vscodeAPI}>
             <CodyWebChatContext.Provider
                 value={{
                     client,


### PR DESCRIPTION
This is a useful pattern that we use for fetching @-mention context. This helper makes it easy to add more. In the future we can adopt a real RPC protocol for exthost<->webview communication, and this helper will make that eventuality easier.

## Test plan

e2e tests. Also try a lot of @-mentions in chat and see if any behavior changes.