### PR TITLE
extract React context/wrapper components

### DIFF
--- a/vscode/webviews/App.tsx
+++ b/vscode/webviews/App.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { type ComponentProps, useCallback, useEffect, useMemo, useState } from 'react'
 
 import styles from './App.module.css'
 
@@ -12,6 +12,7 @@ import {
     type Model,
     PromptString,
     type SerializedChatTranscript,
+    type TelemetryRecorder,
     isCodyProUser,
 } from '@sourcegraph/cody-shared'
 import type { AuthMethod, ConfigurationSubsetForWebview, LocalEnv } from '../src/chat/protocol'
@@ -26,8 +27,10 @@ import { ClientStateContextProvider, useClientActionDispatcher } from './client/
 
 import { TabContainer, TabRoot } from './components/shadcn/ui/tabs'
 import { WithContextProviders } from './mentions/providers'
+import { ChatContextClientProviderFromVSCodeAPI } from './promptEditor/plugins/atMentions/chatContextClient'
 import { AccountTab, CommandsTab, HistoryTab, SettingsTab, TabsBar, View } from './tabs'
 import type { VSCodeWrapper } from './utils/VSCodeApi'
+import { ComposedWrappers, type Wrapper } from './utils/composeWrappers'
 import { updateDisplayPathEnvInfoForWebview } from './utils/displayPathEnvInfo'
 import { TelemetryRecorderContext, createWebviewTelemetryRecorder } from './utils/telemetry'
 
@@ -225,86 +228,87 @@ export const App: React.FunctionComponent<{ vscodeAPI: VSCodeWrapper }> = ({ vsc
         [chatModels, onCurrentChatModelChange, serverSentModelsEnabled]
     )
 
+    const wrappers = useMemo<Wrapper[]>(
+        () => getAppWrappers(vscodeAPI, telemetryRecorder, chatModelContext, clientState),
+        [vscodeAPI, telemetryRecorder, chatModelContext, clientState]
+    )
+
     // Wait for all the data to be loaded before rendering Chat View
     if (!view || !authStatus || !config || !userHistory) {
         return <LoadingPage />
     }
 
-    if (authStatus.showNetworkError) {
-        return (
-            <div className={styles.outerContainer}>
-                <TelemetryRecorderContext.Provider value={telemetryRecorder}>
+    return (
+        <ComposedWrappers wrappers={wrappers}>
+            {authStatus.showNetworkError ? (
+                <div className={styles.outerContainer}>
                     <ConnectionIssuesPage
                         configuredEndpoint={authStatus.endpoint}
                         vscodeAPI={vscodeAPI}
                     />
-                </TelemetryRecorderContext.Provider>
-            </div>
-        )
-    }
-
-    if (view === 'login' || !authStatus.isLoggedIn || !userAccountInfo) {
-        return (
-            <div className={styles.outerContainer}>
-                <TelemetryRecorderContext.Provider value={telemetryRecorder}>
+                </div>
+            ) : view === 'login' || !authStatus.isLoggedIn || !userAccountInfo ? (
+                <div className={styles.outerContainer}>
                     <LoginSimplified
                         simplifiedLoginRedirect={loginRedirect}
                         uiKindIsWeb={config?.uiKindIsWeb}
                         vscodeAPI={vscodeAPI}
                     />
-                </TelemetryRecorderContext.Provider>
-            </div>
-        )
-    }
-
-    return (
-        <TabRoot
-            defaultValue={View.Chat}
-            value={view}
-            orientation="vertical"
-            className={styles.outerContainer}
-        >
-            {/* NOTE: Display tabs to PLG users only until Universal Cody is ready. */}
-            {/* Shows tab bar for sidebar chats only. */}
-            {userAccountInfo.isDotComUser && config.webviewType !== 'editor' && (
-                <TabsBar currentView={view} setView={setView} IDE={config.agentIDE || CodyIDE.VSCode} />
+                </div>
+            ) : (
+                <TabRoot
+                    defaultValue={View.Chat}
+                    value={view}
+                    orientation="vertical"
+                    className={styles.outerContainer}
+                >
+                    {/* NOTE: Display tabs to PLG users only until Universal Cody is ready. */}
+                    {/* Shows tab bar for sidebar chats only. */}
+                    {userAccountInfo.isDotComUser && config.webviewType !== 'editor' && (
+                        <TabsBar
+                            currentView={view}
+                            setView={setView}
+                            IDE={config.agentIDE || CodyIDE.VSCode}
+                        />
+                    )}
+                    {errorMessages && (
+                        <ErrorBanner errors={errorMessages} setErrors={setErrorMessages} />
+                    )}
+                    <TabContainer value={view}>
+                        {view === 'chat' && (
+                            <>
+                                <Notices
+                                    probablyNewInstall={isNewInstall}
+                                    IDE={config.agentIDE}
+                                    version={config.agentExtensionVersion}
+                                />
+                                <Chat
+                                    chatID={chatID}
+                                    chatEnabled={chatEnabled}
+                                    userInfo={userAccountInfo}
+                                    messageInProgress={messageInProgress}
+                                    transcript={transcript}
+                                    vscodeAPI={vscodeAPI}
+                                    isTranscriptError={isTranscriptError}
+                                    guardrails={attributionEnabled ? guardrails : undefined}
+                                    experimentalUnitTestEnabled={config.experimentalUnitTest}
+                                />
+                            </>
+                        )}
+                        {view === 'history' && <HistoryTab userHistory={userHistory} />}
+                        {view === 'commands' && (
+                            <CommandsTab
+                                setView={setView}
+                                IDE={config.agentIDE}
+                                commands={commandList}
+                            />
+                        )}
+                        {view === 'account' && <AccountTab userInfo={userAccountInfo} />}
+                        {view === 'settings' && <SettingsTab userInfo={userAccountInfo} />}
+                    </TabContainer>
+                </TabRoot>
             )}
-            {errorMessages && <ErrorBanner errors={errorMessages} setErrors={setErrorMessages} />}
-            <TabContainer value={view}>
-                {view === 'chat' && (
-                    <ChatModelContextProvider value={chatModelContext}>
-                        <WithContextProviders>
-                            <TelemetryRecorderContext.Provider value={telemetryRecorder}>
-                                <ClientStateContextProvider value={clientState}>
-                                    <Notices
-                                        probablyNewInstall={isNewInstall}
-                                        IDE={config.agentIDE}
-                                        version={config.agentExtensionVersion}
-                                    />
-                                    <Chat
-                                        chatID={chatID}
-                                        chatEnabled={chatEnabled}
-                                        userInfo={userAccountInfo}
-                                        messageInProgress={messageInProgress}
-                                        transcript={transcript}
-                                        vscodeAPI={vscodeAPI}
-                                        isTranscriptError={isTranscriptError}
-                                        guardrails={attributionEnabled ? guardrails : undefined}
-                                        experimentalUnitTestEnabled={config.experimentalUnitTest}
-                                    />
-                                </ClientStateContextProvider>
-                            </TelemetryRecorderContext.Provider>
-                        </WithContextProviders>
-                    </ChatModelContextProvider>
-                )}
-                {view === 'history' && <HistoryTab userHistory={userHistory} />}
-                {view === 'commands' && (
-                    <CommandsTab setView={setView} IDE={config.agentIDE} commands={commandList} />
-                )}
-                {view === 'account' && <AccountTab userInfo={userAccountInfo} />}
-                {view === 'settings' && <SettingsTab userInfo={userAccountInfo} />}
-            </TabContainer>
-        </TabRoot>
+        </ComposedWrappers>
     )
 }
 
@@ -326,3 +330,30 @@ const ErrorBanner: React.FunctionComponent<{ errors: string[]; setErrors: (error
             ))}
         </div>
     )
+
+export function getAppWrappers(
+    vscodeAPI: VSCodeWrapper,
+    telemetryRecorder: TelemetryRecorder,
+    chatModelContext: ChatModelContext,
+    clientState: ClientStateForWebview
+): Wrapper[] {
+    return [
+        {
+            component: ChatContextClientProviderFromVSCodeAPI,
+            props: { vscodeAPI },
+        } satisfies Wrapper<any, ComponentProps<typeof ChatContextClientProviderFromVSCodeAPI>>,
+        {
+            provider: TelemetryRecorderContext.Provider,
+            value: telemetryRecorder,
+        } satisfies Wrapper<ComponentProps<typeof TelemetryRecorderContext.Provider>['value']>,
+        {
+            provider: ChatModelContextProvider,
+            value: chatModelContext,
+        } satisfies Wrapper<ComponentProps<typeof ChatModelContextProvider>['value']>,
+        { component: WithContextProviders },
+        {
+            provider: ClientStateContextProvider,
+            value: clientState,
+        } satisfies Wrapper<ComponentProps<typeof ClientStateContextProvider>['value']>,
+    ]
+}

--- a/vscode/webviews/AppWrapper.tsx
+++ b/vscode/webviews/AppWrapper.tsx
@@ -1,54 +1,48 @@
-import type { TelemetryRecorder } from '@sourcegraph/cody-shared'
-import type { FunctionComponent, ReactNode } from 'react'
+import { type ComponentProps, type FunctionComponent, type ReactNode, useMemo } from 'react'
 import { ClientActionListenersContextProvider, ClientStateContextProvider } from './client/clientState'
 import { TooltipProvider } from './components/shadcn/ui/tooltip'
-import {
-    ChatContextClientProviderForTestsOnly,
-    ChatContextClientProviderFromVSCodeAPI,
-} from './promptEditor/plugins/atMentions/chatContextClient'
+import { ChatContextClientProviderForTestsOnly } from './promptEditor/plugins/atMentions/chatContextClient'
 import { dummyChatContextClient } from './promptEditor/plugins/atMentions/fixtures'
-import type { VSCodeWrapper } from './utils/VSCodeApi'
+import { ComposedWrappers, type Wrapper } from './utils/composeWrappers'
 import { TelemetryRecorderContext } from './utils/telemetry'
 
-const AppWrapperCommon = ({
-    vscodeAPI,
-    children,
-}: { vscodeAPI: VSCodeWrapper | null; children: ReactNode }): ReactNode => {
-    return (
-        // (tim): The default delayDuration of 300 felt a little low to go from
-        // the left to the right of the panel. I increased it to 600, but any
-        // higher feels too "sticky"
-        <TooltipProvider disableHoverableContent={true} delayDuration={600}>
-            <ClientActionListenersContextProvider>
-                <ChatContextClientProviderFromVSCodeAPI vscodeAPI={vscodeAPI}>
-                    {children}
-                </ChatContextClientProviderFromVSCodeAPI>
-            </ClientActionListenersContextProvider>
-        </TooltipProvider>
-    )
-}
-
-/**
- * Wrapper for {@link App} so that we can add more React context providers without requiring big,
- * hard-to-review whitespace diffs in {@link App}.
- */
-export const AppWrapper: FunctionComponent<{ vscodeAPI: VSCodeWrapper; children: ReactNode }> =
-    AppWrapperCommon
+export const AppWrapper: FunctionComponent<{ children: ReactNode }> = ({ children }) => (
+    <ComposedWrappers wrappers={COMMON_WRAPPERS}>{children}</ComposedWrappers>
+)
 
 /**
  * For use in tests only.
  */
-export const TestAppWrapper: FunctionComponent<{ children: ReactNode }> = ({ children }) => (
-    <AppWrapperCommon vscodeAPI={null}>
-        <TelemetryRecorderContext.Provider value={NOOP_TELEMETRY_RECORDER}>
-            <ClientStateContextProvider value={{ initialContext: [] }}>
-                <ChatContextClientProviderForTestsOnly value={dummyChatContextClient}>
-                    {children}
-                </ChatContextClientProviderForTestsOnly>
-            </ClientStateContextProvider>
-        </TelemetryRecorderContext.Provider>
-    </AppWrapperCommon>
-)
-const NOOP_TELEMETRY_RECORDER: TelemetryRecorder = {
-    recordEvent: () => {},
+export const TestAppWrapper: FunctionComponent<{ children: ReactNode }> = ({ children }) => {
+    const wrappers = useMemo<Wrapper[]>(
+        () => [
+            ...COMMON_WRAPPERS,
+            {
+                provider: TelemetryRecorderContext.Provider,
+                value: {
+                    recordEvent: () => {},
+                },
+            } satisfies Wrapper<ComponentProps<typeof TelemetryRecorderContext.Provider>['value']>,
+            {
+                provider: ClientStateContextProvider,
+                value: { initialContext: [] },
+            } satisfies Wrapper<ComponentProps<typeof ClientStateContextProvider>['value']>,
+            {
+                provider: ChatContextClientProviderForTestsOnly,
+                value: dummyChatContextClient,
+            } satisfies Wrapper<ComponentProps<typeof ChatContextClientProviderForTestsOnly>['value']>,
+        ],
+        []
+    )
+    return <ComposedWrappers wrappers={wrappers}>{children}</ComposedWrappers>
 }
+
+const COMMON_WRAPPERS: Wrapper[] = [
+    {
+        component: TooltipProvider,
+        props: { disableHoverableContent: true, delayDuration: 600 },
+    } satisfies Wrapper<any, ComponentProps<typeof TooltipProvider>>,
+    {
+        component: ClientActionListenersContextProvider,
+    },
+]

--- a/vscode/webviews/index.tsx
+++ b/vscode/webviews/index.tsx
@@ -8,12 +8,10 @@ import './index.css'
 import { AppWrapper } from './AppWrapper'
 import { getVSCodeAPI } from './utils/VSCodeApi'
 
-const vscodeAPI = getVSCodeAPI()
-
 ReactDOM.createRoot(document.querySelector('#root') as HTMLElement).render(
     <React.StrictMode>
-        <AppWrapper vscodeAPI={vscodeAPI}>
-            <App vscodeAPI={vscodeAPI} />
+        <AppWrapper>
+            <App vscodeAPI={getVSCodeAPI()} />
         </AppWrapper>
     </React.StrictMode>
 )

--- a/vscode/webviews/storybook/VSCodeStoryDecorator.tsx
+++ b/vscode/webviews/storybook/VSCodeStoryDecorator.tsx
@@ -13,8 +13,6 @@ import '../../node_modules/@vscode/codicons/dist/codicon.css'
 import { TestAppWrapper } from '../AppWrapper'
 import { type ChatModelContext, ChatModelContextProvider } from '../chat/models/chatModelContext'
 import { WithContextProviders } from '../mentions/providers'
-import { ChatContextClientProviderForTestsOnly } from '../promptEditor/plugins/atMentions/chatContextClient'
-import { dummyChatContextClient } from '../promptEditor/plugins/atMentions/fixtures'
 import { TelemetryRecorderContext, createWebviewTelemetryRecorder } from '../utils/telemetry'
 import styles from './VSCodeStoryDecorator.module.css'
 
@@ -87,13 +85,11 @@ export function VSCodeDecorator(className: string | undefined, style?: CSSProper
         return (
             <div className={clsx(styles.container, className)} style={style}>
                 <TestAppWrapper>
-                    <ChatContextClientProviderForTestsOnly value={dummyChatContextClient}>
-                        <ChatModelContextProvider value={useDummyChatModelContext()}>
-                            <TelemetryRecorderContext.Provider value={telemetryRecorder}>
-                                {story()}
-                            </TelemetryRecorderContext.Provider>
-                        </ChatModelContextProvider>
-                    </ChatContextClientProviderForTestsOnly>
+                    <ChatModelContextProvider value={useDummyChatModelContext()}>
+                        <TelemetryRecorderContext.Provider value={telemetryRecorder}>
+                            {story()}
+                        </TelemetryRecorderContext.Provider>
+                    </ChatModelContextProvider>
                 </TestAppWrapper>
             </div>
         )

--- a/vscode/webviews/utils/composeWrappers.tsx
+++ b/vscode/webviews/utils/composeWrappers.tsx
@@ -1,0 +1,35 @@
+import type { FunctionComponent, ReactNode } from 'react'
+
+/**
+ * A wrapper component, used with {@link ComposedWrappers}.
+ */
+export type Wrapper<V = any, P extends { children: ReactNode } = any> =
+    | {
+          provider: React.Provider<V>
+          value: V
+      }
+    | { component: React.ComponentType<P>; props?: Omit<P, 'children'> }
+
+/**
+ * A React component that composes wrappers (which can be React context providers or other
+ * components) from an array, which is nicer than a deeply nested JSX syntax tree that would
+ * otherwise be needed.
+ */
+export const ComposedWrappers: FunctionComponent<{ wrappers: Wrapper[]; children: ReactNode }> = ({
+    wrappers,
+    children,
+}) => {
+    return composeWrappers(wrappers, children)
+}
+function composeWrappers(wrappers: Wrapper[], children: ReactNode): ReactNode {
+    return wrappers.reduce((acc, wrapper) => {
+        if ('provider' in wrapper) {
+            return <wrapper.provider value={wrapper.value}>{acc}</wrapper.provider>
+        }
+        return (
+            <wrapper.component key={0} {...wrapper.props}>
+                {acc}
+            </wrapper.component>
+        )
+    }, children)
+}

--- a/web/lib/components/CodyWebChat.tsx
+++ b/web/lib/components/CodyWebChat.tsx
@@ -14,30 +14,22 @@ import {
     setDisplayPathEnvInfo,
 } from '@sourcegraph/cody-shared'
 
+import { getAppWrappers } from 'cody-ai/webviews/App'
 import { Chat, type UserAccountInfo } from 'cody-ai/webviews/Chat'
 import { ChatEnvironmentContext } from 'cody-ai/webviews/chat/ChatEnvironmentContext'
-import {
-    type ChatModelContext,
-    ChatModelContextProvider,
-} from 'cody-ai/webviews/chat/models/chatModelContext'
-import {
-    ClientStateContextProvider,
-    useClientActionDispatcher,
-} from 'cody-ai/webviews/client/clientState'
-import { WithContextProviders } from 'cody-ai/webviews/mentions/providers'
+import type { ChatModelContext } from 'cody-ai/webviews/chat/models/chatModelContext'
+import { useClientActionDispatcher } from 'cody-ai/webviews/client/clientState'
 import {
     ChatMentionContext,
     type ChatMentionsSettings,
 } from 'cody-ai/webviews/promptEditor/plugins/atMentions/chatContextClient'
-import {
-    TelemetryRecorderContext,
-    createWebviewTelemetryRecorder,
-} from 'cody-ai/webviews/utils/telemetry'
+import { createWebviewTelemetryRecorder } from 'cody-ai/webviews/utils/telemetry'
 
 import { useWebAgentClient } from './CodyWebChatProvider'
 
 // Include global Cody Web styles to the styles bundle
 import '../global-styles/styles.css'
+import { ComposedWrappers, type Wrapper } from 'cody-ai/webviews/utils/composeWrappers'
 import styles from './CodyWebChat.module.css'
 
 const CONTEXT_MENTIONS_SETTINGS: ChatMentionsSettings = {
@@ -195,6 +187,11 @@ export const CodyWebChat: FC<CodyWebChatProps> = props => {
 
     const envVars = useMemo(() => ({ clientType: CodyIDE.Web }), [])
 
+    const wrappers = useMemo<Wrapper[]>(
+        () => getAppWrappers(vscodeAPI, telemetryRecorder, chatModelContext, clientState),
+        [vscodeAPI, telemetryRecorder, chatModelContext, clientState]
+    )
+
     return (
         <div className={className} data-cody-web-chat={true} ref={setRootElement}>
             {client &&
@@ -207,27 +204,21 @@ export const CodyWebChat: FC<CodyWebChatProps> = props => {
                 ) : (
                     <ChatEnvironmentContext.Provider value={envVars}>
                         <ChatMentionContext.Provider value={CONTEXT_MENTIONS_SETTINGS}>
-                            <TelemetryRecorderContext.Provider value={telemetryRecorder}>
-                                <ChatModelContextProvider value={chatModelContext}>
-                                    <ClientStateContextProvider value={clientState}>
-                                        <WithContextProviders>
-                                            <Chat
-                                                chatID={activeChatID}
-                                                chatEnabled={true}
-                                                showWelcomeMessage={false}
-                                                showIDESnippetActions={false}
-                                                userInfo={userAccountInfo}
-                                                messageInProgress={messageInProgress}
-                                                transcript={transcript}
-                                                vscodeAPI={vscodeAPI}
-                                                isTranscriptError={isTranscriptError}
-                                                scrollableParent={rootElement}
-                                                className={styles.chat}
-                                            />
-                                        </WithContextProviders>
-                                    </ClientStateContextProvider>
-                                </ChatModelContextProvider>
-                            </TelemetryRecorderContext.Provider>
+                            <ComposedWrappers wrappers={wrappers}>
+                                <Chat
+                                    chatID={activeChatID}
+                                    chatEnabled={true}
+                                    showWelcomeMessage={false}
+                                    showIDESnippetActions={false}
+                                    userInfo={userAccountInfo}
+                                    messageInProgress={messageInProgress}
+                                    transcript={transcript}
+                                    vscodeAPI={vscodeAPI}
+                                    isTranscriptError={isTranscriptError}
+                                    scrollableParent={rootElement}
+                                    className={styles.chat}
+                                />
+                            </ComposedWrappers>
                         </ChatMentionContext.Provider>
                     </ChatEnvironmentContext.Provider>
                 )

--- a/web/lib/components/CodyWebChatProvider.tsx
+++ b/web/lib/components/CodyWebChatProvider.tsx
@@ -297,7 +297,7 @@ export const CodyWebChatProvider: FC<PropsWithChildren<CodyWebChatProviderProps>
     )
 
     return (
-        <AppWrapper vscodeAPI={vscodeAPI}>
+        <AppWrapper>
             <CodyWebChatContext.Provider
                 value={{
                     client,


### PR DESCRIPTION
This makes it easier to add new React context or other wrappers without making the JSX tree even more deeply nested. It also eliminates duplication.



## Test plan

CI, `pnpm -C web dev`