### PR TITLE
Guardrails: update webview on auth change

### DIFF
--- a/vscode/src/chat/chat-view/ChatController.ts
+++ b/vscode/src/chat/chat-view/ChatController.ts
@@ -565,6 +565,21 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
 
         // Get the latest model list available to the current user to update the ChatModel.
         this.handleSetChatModel(getDefaultModelID())
+
+        // Get the latest feature config and send to webview.
+        ClientConfigSingleton.getInstance()
+            .getConfig()
+            .then(
+                async clientConfig =>
+                    await this.postMessage({
+                        type: 'setConfigFeatures',
+                        configFeatures: {
+                            chat: !!clientConfig?.chatEnabled,
+                            attribution: !!clientConfig?.attributionEnabled,
+                            serverSentModels: !!clientConfig?.modelsAPIEnabled,
+                        },
+                    })
+            )
     }
 
     // When the webview sends the 'ready' message, respond by posting the view config

--- a/vscode/test/e2e/attribution.test.ts
+++ b/vscode/test/e2e/attribution.test.ts
@@ -7,8 +7,7 @@ import { type DotcomUrlOverride, test as baseTest } from './helpers'
 
 const test = baseTest.extend<DotcomUrlOverride>({ dotcomUrl: mockServer.SERVER_URL })
 
-// TODO: Currently TIMEOUT - to be fixed by @keegancsmith in pull/4964
-test.skip('attribution search enabled in chat', async ({ page, sidebar }) => {
+test('attribution search enabled in chat', async ({ page, sidebar }) => {
     await fetch(`${mockServer.SERVER_URL}/.test/attribution/enable`, { method: 'POST' })
     await sidebarSignin(page, sidebar)
     const chatFrame = getChatSidebarPanel(page)


### PR DESCRIPTION
Previously we do not update the value for attributions in webview on auth change, so when we updated the test to use sidebar chat instead of panel chat, the test for attributions failed.

## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

Green CI.

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
