### PR TITLE
VSCode: Handle improperly aborted bfg/symf download

### DIFF
--- a/vscode/src/local-context/utils.ts
+++ b/vscode/src/local-context/utils.ts
@@ -54,6 +54,11 @@ export async function downloadFile(
     await new Promise((resolve, reject) => {
         stream.on('finish', resolve)
         stream.on('error', reject)
+        stream.on('close', () => {
+            if (!stream.writableFinished) {
+                reject(new Error('Stream closed before finishing'))
+            }
+        })
     })
 }
 


### PR DESCRIPTION
Adds a check for when the stream closes before finishing. This ensures that if the stream closes unexpectedly, an error is thrown, improving error detection and handling in the file download process.

Related to CODY-3057 and user reported https://github.com/sourcegraph/cody/issues/5000

## Test plan
In our current e2e testing setup it's hard to control exact network timings. I'll be adding additional test in the e2ev2 setup which allows much more granular network control.

For now I've manually verified that by abruptly destroying the stream does indeed resolve the promise.
