### PR TITLE
Add lenses and edit retry support to agent

### DIFF
--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/agent/protocol_generated/CodyAgentServer.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/agent/protocol_generated/CodyAgentServer.kt
@@ -54,6 +54,10 @@ interface CodyAgentServer {
   fun editTask_undo(params: EditTask_UndoParams): CompletableFuture<Null?>
   @JsonRequest("editTask/cancel")
   fun editTask_cancel(params: EditTask_CancelParams): CompletableFuture<Null?>
+  @JsonRequest("editTask/retry")
+  fun editTask_retry(params: EditTask_RetryParams): CompletableFuture<EditTask>
+  @JsonRequest("editTask/getTaskDetails")
+  fun editTask_getTaskDetails(params: EditTask_GetTaskDetailsParams): CompletableFuture<EditTask>
   @JsonRequest("editTask/getFoldingRanges")
   fun editTask_getFoldingRanges(params: GetFoldingRangeParams): CompletableFuture<GetFoldingRangeResult>
   @JsonRequest("command/execute")

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/agent/protocol_generated/EditCommands_CodeParams.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/agent/protocol_generated/EditCommands_CodeParams.kt
@@ -7,6 +7,7 @@ data class EditCommands_CodeParams(
   val instruction: String,
   val model: String? = null,
   val mode: ModeEnum? = null, // Oneof: edit, insert
+  val range: Range? = null,
 ) {
 
   enum class ModeEnum {

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/agent/protocol_generated/EditTask.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/agent/protocol_generated/EditTask.kt
@@ -7,5 +7,7 @@ data class EditTask(
   val error: CodyError? = null,
   val selectionRange: Range,
   val instruction: String? = null,
+  val model: String? = null,
+  val originalText: String? = null,
 )
 

--- a/agent/src/AgentFixupControls.ts
+++ b/agent/src/AgentFixupControls.ts
@@ -43,7 +43,9 @@ export class AgentFixupControls extends FixupCodeLenses {
         return Promise.resolve(undefined)
     }
 
-    // FixupControlApplicator
+    public getTask(id: FixupTaskID): FixupTask | undefined {
+        return this.fixups.taskForId(id)
+    }
 
     didUpdateTask(task: FixupTask): void {
         super.didUpdateTask(task)
@@ -66,6 +68,7 @@ export class AgentFixupControls extends FixupCodeLenses {
             selectionRange: task.selectionRange,
             instruction: task.instruction?.toString().trim(),
             model: task.model.toString().trim(),
+            originalText: task.original,
         }
     }
 }

--- a/agent/src/AgentFixupControls.ts
+++ b/agent/src/AgentFixupControls.ts
@@ -1,15 +1,17 @@
 import type { FixupFile } from '../../vscode/src/non-stop/FixupFile'
 import type { FixupTask, FixupTaskID } from '../../vscode/src/non-stop/FixupTask'
 import type { FixupActor, FixupFileCollection } from '../../vscode/src/non-stop/roles'
-import type { FixupControlApplicator } from '../../vscode/src/non-stop/strategies'
 import { type Agent, errorToCodyError } from './agent'
 import type { EditTask } from './protocol-alias'
+import {FixupCodeLenses} from "../../vscode/src/non-stop/codelenses/provider";
 
-export class AgentFixupControls implements FixupControlApplicator {
+export class AgentFixupControls extends FixupCodeLenses {
     constructor(
         private readonly fixups: FixupActor & FixupFileCollection,
         private readonly notify: typeof Agent.prototype.notify
-    ) {}
+    ) {
+        super(fixups)
+    }
 
     public accept(id: FixupTaskID): void {
         const task = this.fixups.taskForId(id)
@@ -35,9 +37,11 @@ export class AgentFixupControls implements FixupControlApplicator {
     // FixupControlApplicator
 
     didUpdateTask(task: FixupTask): void {
+        super.didUpdateTask(task)
         this.notify('editTask/didUpdate', AgentFixupControls.serialize(task))
     }
     didDeleteTask(task: FixupTask): void {
+        super.didDeleteTask(task)
         this.notify('editTask/didDelete', AgentFixupControls.serialize(task))
     }
 

--- a/agent/src/AgentFixupControls.ts
+++ b/agent/src/AgentFixupControls.ts
@@ -1,9 +1,10 @@
+import type { QuickPickInput } from '../../vscode/src/edit/input/get-input'
 import type { FixupFile } from '../../vscode/src/non-stop/FixupFile'
 import type { FixupTask, FixupTaskID } from '../../vscode/src/non-stop/FixupTask'
+import { FixupCodeLenses } from '../../vscode/src/non-stop/codelenses/provider'
 import type { FixupActor, FixupFileCollection } from '../../vscode/src/non-stop/roles'
 import { type Agent, errorToCodyError } from './agent'
 import type { EditTask } from './protocol-alias'
-import {FixupCodeLenses} from "../../vscode/src/non-stop/codelenses/provider";
 
 export class AgentFixupControls extends FixupCodeLenses {
     constructor(
@@ -34,6 +35,14 @@ export class AgentFixupControls extends FixupCodeLenses {
         }
     }
 
+    public retry(id: FixupTaskID, previousInput: QuickPickInput): Promise<FixupTask | undefined> {
+        const task = this.fixups.taskForId(id)
+        if (task) {
+            return this.fixups.retry(task, 'code-lens', previousInput)
+        }
+        return Promise.resolve(undefined)
+    }
+
     // FixupControlApplicator
 
     didUpdateTask(task: FixupTask): void {
@@ -56,6 +65,7 @@ export class AgentFixupControls extends FixupCodeLenses {
             error: errorToCodyError(task.error),
             selectionRange: task.selectionRange,
             instruction: task.instruction?.toString().trim(),
+            model: task.model.toString().trim(),
         }
     }
 }

--- a/agent/src/TestClient.ts
+++ b/agent/src/TestClient.ts
@@ -475,10 +475,8 @@ export class TestClient extends MessageHandler {
         const task = await this.request('editCommands/document', null)
         await this.taskHasReachedAppliedPhase(task)
         const lenses = this.codeLenses.get(uri.toString()) ?? []
-        if (lenses.length > 0) {
-            throw new Error(
-                `Code lenses are not supported in this mode ${JSON.stringify(lenses, null, 2)}`
-            )
+        if (lenses.length !== 2) {
+            throw new Error(`Expected accept code lenses for ${uri}, but found ${lenses.length}`)
         }
 
         await this.request('editTask/accept', { id: task.id })
@@ -497,10 +495,8 @@ export class TestClient extends MessageHandler {
         const task = await this.request('editCommands/test', null)
         await this.taskHasReachedAppliedPhase(task)
         const lenses = this.codeLenses.get(uri.toString()) ?? []
-        if (lenses.length > 0) {
-            throw new Error(
-                `Code lenses are not supported in this mode ${JSON.stringify(lenses, null, 2)}`
-            )
+        if (lenses.length !== 2) {
+            throw new Error(`Expected accept code lenses for ${uri}, but found ${lenses.length}`)
         }
 
         await this.request('editTask/accept', { id: task.id })
@@ -722,8 +718,8 @@ export class TestClient extends MessageHandler {
     public async acceptEditTask(uri: vscode.Uri, task: EditTask): Promise<void> {
         await this.taskHasReachedAppliedPhase(task)
         const lenses = this.codeLenses.get(uri.toString()) ?? []
-        if (lenses.length !== 0) {
-            throw new Error(`Expected no code lenses for ${uri}, but found ${lenses.length}`)
+        if (lenses.length !== 2) {
+            throw new Error(`Expected accept code lenses for ${uri}, but found ${lenses.length}`)
         }
         await this.request('editTask/accept', { id: task.id })
     }

--- a/agent/src/TestClient.ts
+++ b/agent/src/TestClient.ts
@@ -256,6 +256,7 @@ export class TestClient extends MessageHandler {
         })
         this.registerNotification('codeLenses/display', async params => {
             this.codeLenses.set(params.uri, params.codeLenses)
+            this.codeLensUpdate.fire(params.codeLenses)
         })
 
         this.registerRequest('workspace/edit', async params => {
@@ -473,13 +474,7 @@ export class TestClient extends MessageHandler {
     public async documentCode(uri: vscode.Uri): Promise<string> {
         await this.openFile(uri, { removeCursor: false })
         const task = await this.request('editCommands/document', null)
-        await this.taskHasReachedAppliedPhase(task)
-        const lenses = this.codeLenses.get(uri.toString()) ?? []
-        if (lenses.length !== 2) {
-            throw new Error(`Expected accept code lenses for ${uri}, but found ${lenses.length}`)
-        }
-
-        await this.request('editTask/accept', { id: task.id })
+        await this.acceptEditTask(uri, task)
         return this.workspace.getDocument(uri)?.content ?? ''
     }
 
@@ -493,13 +488,7 @@ export class TestClient extends MessageHandler {
         })
 
         const task = await this.request('editCommands/test', null)
-        await this.taskHasReachedAppliedPhase(task)
-        const lenses = this.codeLenses.get(uri.toString()) ?? []
-        if (lenses.length !== 2) {
-            throw new Error(`Expected accept code lenses for ${uri}, but found ${lenses.length}`)
-        }
-
-        await this.request('editTask/accept', { id: task.id })
+        await this.acceptEditTask(uri, task)
         return this.getTestEdit()
     }
 
@@ -575,6 +564,28 @@ export class TestClient extends MessageHandler {
         return `ID_${freshID}`
     }
 
+    public acceptLensWasShown(uri: Uri): Promise<void> {
+        const lenses = this.codeLenses.get(uri.toString()) ?? []
+        if (lenses.find(l => l.command?.command === 'cody.fixup.codelens.accept')) {
+            return Promise.resolve()
+        }
+
+        let disposables: vscode.Disposable[]
+        return new Promise<void>((resolve, reject) => {
+            disposables = [
+                this.onCodeLensUpdate(codeLenses => {
+                    if (codeLenses.find(l => l.command?.command === 'cody.fixup.codelens.accept')) {
+                        return resolve()
+                    }
+                }),
+            ]
+        }).finally(() => {
+            for (const disposable of disposables) {
+                disposable.dispose()
+            }
+        })
+    }
+
     /**
      * Promise that resolves when the provided task has reached the 'applied' state.
      */
@@ -637,6 +648,8 @@ export class TestClient extends MessageHandler {
     }
 
     public codeLenses = new Map<string, ProtocolCodeLens[]>()
+    public codeLensUpdate = new vscode.EventEmitter<ProtocolCodeLens[]>()
+    public onCodeLensUpdate = this.codeLensUpdate.event
     public taskUpdate = new vscode.EventEmitter<EditTask>()
     public onDidUpdateTask = this.taskUpdate.event
     public taskDelete = new vscode.EventEmitter<EditTask>()
@@ -717,10 +730,7 @@ export class TestClient extends MessageHandler {
 
     public async acceptEditTask(uri: vscode.Uri, task: EditTask): Promise<void> {
         await this.taskHasReachedAppliedPhase(task)
-        const lenses = this.codeLenses.get(uri.toString()) ?? []
-        if (lenses.length !== 2) {
-            throw new Error(`Expected accept code lenses for ${uri}, but found ${lenses.length}`)
-        }
+        await this.acceptLensWasShown(uri)
         await this.request('editTask/accept', { id: task.id })
     }
 

--- a/agent/src/agent.ts
+++ b/agent/src/agent.ts
@@ -1005,6 +1005,15 @@ export class Agent extends MessageHandler implements ExtensionClient {
             return null
         })
 
+        this.registerAuthenticatedRequest('editTask/getTaskDetails', async ({ id }) => {
+            const task = this.fixups?.getTask(id)
+            if (task) {
+                return AgentFixupControls.serialize(task)
+            }
+
+            return Promise.reject('No task with id' + id)
+        })
+
         this.registerAuthenticatedRequest('editTask/retry', params => {
             const instruction = PromptString.unsafe_fromUserQuery(params.instruction)
             const models = getModelOptionItems(ModelsService.getModels(ModelUsage.Edit), true)

--- a/agent/src/agent.ts
+++ b/agent/src/agent.ts
@@ -1011,7 +1011,7 @@ export class Agent extends MessageHandler implements ExtensionClient {
                 return AgentFixupControls.serialize(task)
             }
 
-            return Promise.reject('No task with id' + id)
+            return Promise.reject(`No task with id ${id}`)
         })
 
         this.registerAuthenticatedRequest('editTask/retry', params => {

--- a/agent/src/agent.ts
+++ b/agent/src/agent.ts
@@ -2,7 +2,7 @@ import { spawn } from 'node:child_process'
 import path from 'node:path'
 
 import type { Polly, Request } from '@pollyjs/core'
-import { type CodyCommand, isWindows, telemetryRecorder } from '@sourcegraph/cody-shared'
+import { type CodyCommand, ModelUsage, isWindows, telemetryRecorder } from '@sourcegraph/cody-shared'
 import * as vscode from 'vscode'
 import { StreamMessageReader, StreamMessageWriter, createMessageConnection } from 'vscode-jsonrpc/node'
 
@@ -43,6 +43,8 @@ import { loadTscRetriever } from '../../vscode/src/completions/context/retriever
 import { supportedTscLanguages } from '../../vscode/src/completions/context/retrievers/tsc/supportedTscLanguages'
 import type { CompletionItemID } from '../../vscode/src/completions/logger'
 import { type ExecuteEditArguments, executeEdit } from '../../vscode/src/edit/execute'
+import type { QuickPickInput } from '../../vscode/src/edit/input/get-input'
+import { getModelOptionItems } from '../../vscode/src/edit/input/get-items/model'
 import { getEditSmartSelection } from '../../vscode/src/edit/utils/edit-selection'
 import type { ExtensionClient, ExtensionObjects } from '../../vscode/src/extension-client'
 import { IndentationBasedFoldingRangeProvider } from '../../vscode/src/lsp/foldingRanges'
@@ -1001,6 +1003,23 @@ export class Agent extends MessageHandler implements ExtensionClient {
         this.registerAuthenticatedRequest('editTask/cancel', async ({ id }) => {
             this.fixups?.cancel(id)
             return null
+        })
+
+        this.registerAuthenticatedRequest('editTask/retry', params => {
+            const instruction = PromptString.unsafe_fromUserQuery(params.instruction)
+            const models = getModelOptionItems(ModelsService.getModels(ModelUsage.Edit), true)
+            const previousInput: QuickPickInput = {
+                instruction: instruction,
+                userContextFiles: [],
+                model: models.find(item => item.modelTitle === params.model)?.model ?? models[0].model,
+                range: vscodeRange(params.range),
+                intent: 'edit',
+                mode: params.mode,
+            }
+
+            if (!this.fixups) return Promise.reject()
+            const retryResult = this.fixups.retry(params.id, previousInput)
+            return this.createEditTask(retryResult.then(task => task && { type: 'edit', task }))
         })
 
         this.registerAuthenticatedRequest(

--- a/agent/src/edit.test.ts
+++ b/agent/src/edit.test.ts
@@ -35,7 +35,7 @@ describe('Edit', () => {
         })
         await client.taskHasReachedAppliedPhase(task)
         const lenses = client.codeLenses.get(uri.toString()) ?? []
-        expect(lenses).toHaveLength(0)
+        expect(lenses).toHaveLength(2)
         await client.request('editTask/accept', { id: task.id })
         const newContent = client.workspace.getDocument(uri)?.content
         expect(trimEndOfLine(newContent)).toMatchInlineSnapshot(

--- a/vscode/src/edit/input/get-input.ts
+++ b/vscode/src/edit/input/get-input.ts
@@ -34,7 +34,7 @@ import { getMatchingContext } from './get-matching-context'
 import { createQuickPick } from './quick-pick'
 import { fetchDocumentSymbols, getLabelForContextItem, removeAfterLastAt } from './utils'
 
-interface QuickPickInput {
+export interface QuickPickInput {
     /** The user provided instruction */
     instruction: PromptString
     /** Any user provided context, from @ or @# */

--- a/vscode/src/jsonrpc/agent-protocol.ts
+++ b/vscode/src/jsonrpc/agent-protocol.ts
@@ -104,6 +104,7 @@ export type ClientRequests = {
             instruction: string
             model?: string | undefined | null
             mode?: 'edit' | 'insert' | undefined | null
+            range?: Range | undefined | null
         },
         EditTask,
     ]
@@ -117,6 +118,16 @@ export type ClientRequests = {
     'editTask/undo': [{ id: FixupTaskID }, null]
     // Discards the task. Applicable to tasks in any state.
     'editTask/cancel': [{ id: FixupTaskID }, null]
+    'editTask/retry': [
+        {
+            id: FixupTaskID
+            instruction: string
+            model: string
+            mode: 'edit' | 'insert'
+            range: Range
+        },
+        EditTask,
+    ]
 
     // Utility for clients that don't have language-neutral folding-range support.
     // Provides a list of all the computed folding ranges in the specified document.
@@ -803,6 +814,7 @@ export interface EditTask {
     error?: CodyError | undefined | null
     selectionRange: Range
     instruction?: string | undefined | null
+    model?: string | undefined | null
 }
 
 export interface CodyError {

--- a/vscode/src/jsonrpc/agent-protocol.ts
+++ b/vscode/src/jsonrpc/agent-protocol.ts
@@ -128,6 +128,7 @@ export type ClientRequests = {
         },
         EditTask,
     ]
+    'editTask/getTaskDetails': [{ id: FixupTaskID }, EditTask]
 
     // Utility for clients that don't have language-neutral folding-range support.
     // Provides a list of all the computed folding ranges in the specified document.
@@ -815,6 +816,7 @@ export interface EditTask {
     selectionRange: Range
     instruction?: string | undefined | null
     model?: string | undefined | null
+    originalText?: string | undefined | null
 }
 
 export interface CodyError {

--- a/vscode/src/non-stop/FixupController.ts
+++ b/vscode/src/non-stop/FixupController.ts
@@ -221,16 +221,6 @@ export class FixupController
      * meaning any associated UI and behaviour is updated.
      */
     public registerDiscardOnRestoreListener(task: FixupTask): void {
-        // Triggering an auto-discard or auto-accept can lead to race conditions in the Agent, as the
-        // Agent doesn't get notified when the Accept lens is displayed, so it doesn't actually know when it
-        // is safe to discard/accept.
-        // Fixing it properly will require us to send some sort of notification back to the Agent after we finish
-        // applying the changes. https://github.com/sourcegraph/cody-issues/issues/315 is one example of a bug
-        // caused by auto-accepting here, but there were others as well.
-        if (isRunningInsideAgent()) {
-            return
-        }
-
         const listener = vscode.workspace.onDidChangeTextDocument(async event => {
             if (task.state !== CodyTaskState.Applied) {
                 // Task is not in the applied state, this is likely due to it
@@ -1012,7 +1002,7 @@ export class FixupController
 
     // Handles changes to the source document in the fixup selection
     public textDidChange(task: FixupTask): void {
-        if (task.state === CodyTaskState.Applied && task.mode === 'insert' && !isRunningInsideAgent()) {
+        if (task.state === CodyTaskState.Applied && task.mode === 'insert') {
             // For insertion tasks we accept as soon as the user makes a change
             // within the task range. This is a case where the user is more likely to want
             // to keep in the flow of writing their code, and would not benefit from editing

--- a/vscode/src/non-stop/FixupController.ts
+++ b/vscode/src/non-stop/FixupController.ts
@@ -26,7 +26,7 @@ import {
 } from '@sourcegraph/cody-shared/src/chat/transcript/messages'
 import { PersistenceTracker } from '../common/persistence-tracker'
 import { lines } from '../completions/text-processing'
-import { getInput } from '../edit/input/get-input'
+import { type QuickPickInput, getInput } from '../edit/input/get-input'
 import { isStreamedIntent } from '../edit/utils/edit-intent'
 import { getOverridenModelForIntent } from '../edit/utils/edit-models'
 import type { ExtensionClient } from '../extension-client'
@@ -279,21 +279,27 @@ export class FixupController
 
     // Undo the specified task, then prompt for a new set of instructions near
     // the same region and start a new task.
-    public async retry(task: FixupTask, source: EventSource): Promise<FixupTask | undefined> {
+    public async retry(
+        task: FixupTask,
+        source: EventSource,
+        previousInput?: QuickPickInput
+    ): Promise<FixupTask | undefined> {
         const document = await vscode.workspace.openTextDocument(task.fixupFile.uri)
         // Prompt the user for a new instruction, and create a new fixup
-        const input = await getInput(
-            document,
-            this.authProvider,
-            {
-                initialInputValue: task.instruction,
-                initialRange: task.selectionRange,
-                initialSelectedContextItems: task.userContextItems,
-                initialModel: task.model,
-                initialIntent: task.intent,
-            },
-            source
-        )
+        const input =
+            previousInput ??
+            (await getInput(
+                document,
+                this.authProvider,
+                {
+                    initialInputValue: task.instruction,
+                    initialRange: task.selectionRange,
+                    initialSelectedContextItems: task.userContextItems,
+                    initialModel: task.model,
+                    initialIntent: task.intent,
+                },
+                source
+            ))
         if (!input) {
             return
         }

--- a/vscode/src/non-stop/codelenses/items.ts
+++ b/vscode/src/non-stop/codelenses/items.ts
@@ -99,7 +99,7 @@ function getWorkingLens(codeLensRange: vscode.Range, id: string): vscode.CodeLen
     lens.command = {
         title: '$(sync~spin) Cody is working...',
         command: 'cody.chat.focus',
-        arguments: [id]
+        arguments: [id],
     }
     return lens
 }
@@ -109,7 +109,7 @@ function getInsertingLens(codeLensRange: vscode.Range, id: string): vscode.CodeL
     lens.command = {
         title: '$(sync~spin) Inserting...',
         command: 'cody.chat.focus',
-        arguments: [id]
+        arguments: [id],
     }
     return lens
 }
@@ -119,7 +119,7 @@ function getApplyingLens(codeLensRange: vscode.Range, id: string): vscode.CodeLe
     lens.command = {
         title: '$(sync~spin) Applying...',
         command: 'cody.chat.focus',
-        arguments: [id]
+        arguments: [id],
     }
     return lens
 }
@@ -188,12 +188,12 @@ function getAcceptLens(codeLensRange: vscode.Range, id: string): vscode.CodeLens
     return lens
 }
 
-function getUnitTestLens(codeLensRange: vscode.Range,  id: string): vscode.CodeLens {
+function getUnitTestLens(codeLensRange: vscode.Range, id: string): vscode.CodeLens {
     const lens = new vscode.CodeLens(codeLensRange)
     lens.command = {
         title: '$(sync~spin) Generating tests...',
         command: 'cody.chat.focus',
-        arguments: [id]
+        arguments: [id],
     }
     return lens
 }

--- a/vscode/src/non-stop/codelenses/items.ts
+++ b/vscode/src/non-stop/codelenses/items.ts
@@ -14,18 +14,18 @@ export function getLensesForTask(task: FixupTask): vscode.CodeLens[] {
     switch (task.state) {
         case CodyTaskState.Pending:
         case CodyTaskState.Working: {
-            const title = getWorkingLens(codeLensRange)
+            const title = getWorkingLens(codeLensRange, task.id)
             const cancel = getCancelLens(codeLensRange, task.id)
             return [title, cancel]
         }
         case CodyTaskState.Inserting: {
             if (isTest) {
-                return [getUnitTestLens(codeLensRange)]
+                return [getUnitTestLens(codeLensRange, task.id)]
             }
-            return [getInsertingLens(codeLensRange), getCancelLens(codeLensRange, task.id)]
+            return [getInsertingLens(codeLensRange, task.id), getCancelLens(codeLensRange, task.id)]
         }
         case CodyTaskState.Applying: {
-            const title = getApplyingLens(codeLensRange)
+            const title = getApplyingLens(codeLensRange, task.id)
             const cancel = getCancelLens(codeLensRange, task.id)
             return [title, cancel]
         }
@@ -94,29 +94,32 @@ function getErrorLens(codeLensRange: vscode.Range, task: FixupTask): vscode.Code
     return lens
 }
 
-function getWorkingLens(codeLensRange: vscode.Range): vscode.CodeLens {
+function getWorkingLens(codeLensRange: vscode.Range, id: string): vscode.CodeLens {
     const lens = new vscode.CodeLens(codeLensRange)
     lens.command = {
         title: '$(sync~spin) Cody is working...',
         command: 'cody.chat.focus',
+        arguments: [id]
     }
     return lens
 }
 
-function getInsertingLens(codeLensRange: vscode.Range): vscode.CodeLens {
+function getInsertingLens(codeLensRange: vscode.Range, id: string): vscode.CodeLens {
     const lens = new vscode.CodeLens(codeLensRange)
     lens.command = {
         title: '$(sync~spin) Inserting...',
         command: 'cody.chat.focus',
+        arguments: [id]
     }
     return lens
 }
 
-function getApplyingLens(codeLensRange: vscode.Range): vscode.CodeLens {
+function getApplyingLens(codeLensRange: vscode.Range, id: string): vscode.CodeLens {
     const lens = new vscode.CodeLens(codeLensRange)
     lens.command = {
         title: '$(sync~spin) Applying...',
         command: 'cody.chat.focus',
+        arguments: [id]
     }
     return lens
 }
@@ -185,11 +188,12 @@ function getAcceptLens(codeLensRange: vscode.Range, id: string): vscode.CodeLens
     return lens
 }
 
-function getUnitTestLens(codeLensRange: vscode.Range): vscode.CodeLens {
+function getUnitTestLens(codeLensRange: vscode.Range,  id: string): vscode.CodeLens {
     const lens = new vscode.CodeLens(codeLensRange)
     lens.command = {
         title: '$(sync~spin) Generating tests...',
         command: 'cody.chat.focus',
+        arguments: [id]
     }
     return lens
 }

--- a/vscode/src/non-stop/roles.ts
+++ b/vscode/src/non-stop/roles.ts
@@ -1,6 +1,7 @@
 import type * as vscode from 'vscode'
 
 import type { EventSource } from '@sourcegraph/cody-shared'
+import type { QuickPickInput } from '../edit/input/get-input'
 import type { FixupFile } from './FixupFile'
 import type { FixupTask, FixupTaskID } from './FixupTask'
 import type { CodyTaskState } from './utils'
@@ -37,8 +38,13 @@ export interface FixupActor {
      * a new task to try again. Only applicable to tasks in the "applied" state.
      * @param task the task to retry.
      * @param source the source of the retry, for event logging.
+     * @param previousInput the previous input, if any.
      */
-    retry(task: FixupTask, source: EventSource): Promise<FixupTask | undefined>
+    retry(
+        task: FixupTask,
+        source: EventSource,
+        previousInput?: QuickPickInput
+    ): Promise<FixupTask | undefined>
 }
 
 /**

--- a/vscode/src/non-stop/strategies.ts
+++ b/vscode/src/non-stop/strategies.ts
@@ -17,12 +17,3 @@ export interface FixupControlApplicator extends vscode.Disposable {
     // API here.
     visibleFilesWithTasksMaybeChanged(files: readonly FixupFile[]): void
 }
-
-// A FixupControlApplicator which does not present any controls for fixup
-// tasks.
-export class NullFixupControlApplicator implements FixupControlApplicator {
-    public didUpdateTask(task: FixupTask): void {}
-    public didDeleteTask(task: FixupTask): void {}
-    public visibleFilesWithTasksMaybeChanged(files: readonly FixupFile[]): void {}
-    public dispose(): void {}
-}


### PR DESCRIPTION
Fixes CODY-2802

## Changes

1. Added support for receiving lenses notifications through agent (plus some fixes for tests)
2. Added two new endpoints: `editTask/getTaskDetails` and `editTask/retry`

## Test plan

Full manual QA together with [corresponding JetBrainsPR](https://github.com/sourcegraph/jetbrains/pull/1955)