### PR TITLE
guardrails: experimental configuration of timeouts

### DIFF
--- a/lib/shared/src/configuration.ts
+++ b/lib/shared/src/configuration.ts
@@ -63,6 +63,7 @@ export interface Configuration {
     experimentalCommitMessage: boolean
     experimentalNoodle: boolean
     experimentalMinionAnthropicKey: string | undefined
+    experimentalGuardrailsTimeoutSeconds: number | undefined
 
     /**
      * Unstable Features for internal testing only

--- a/lib/shared/src/guardrails/client.ts
+++ b/lib/shared/src/guardrails/client.ts
@@ -7,10 +7,25 @@ import { ClientConfigSingleton } from '../sourcegraph-api/graphql/client'
 // 10s timeout is enough to serve most attribution requests.
 // It's a better user experience for chat attribution to wait
 // a few seconds more and get attribution result.
-const timeout = 10000
+const defaultTimeoutSeconds = 10
+
+/**
+ * This defines the user controllable configuration. Note: enablement is
+ * controlled serverside.
+ */
+export interface GuardrailsClientConfig {
+    experimentalGuardrailsTimeoutSeconds: number | undefined
+}
 
 export class SourcegraphGuardrailsClient implements Guardrails {
-    constructor(private client: SourcegraphGraphQLAPIClient) {}
+    constructor(
+        private client: SourcegraphGraphQLAPIClient,
+        private config: GuardrailsClientConfig
+    ) {}
+
+    public onConfigurationChange(newConfig: GuardrailsClientConfig): void {
+        this.config = newConfig
+    }
 
     public async searchAttribution(snippet: string): Promise<Attribution | Error> {
         // Short-circuit attribution search if turned off in site config.
@@ -18,6 +33,10 @@ export class SourcegraphGuardrailsClient implements Guardrails {
         if (!clientConfig?.attributionEnabled) {
             return new Error('Attribution search is turned off.')
         }
+
+        const timeout =
+            (this.config.experimentalGuardrailsTimeoutSeconds ?? defaultTimeoutSeconds) * 1000
+
         const result = await this.client.searchAttribution(snippet, timeout)
 
         if (isError(result)) {

--- a/lib/shared/src/index.ts
+++ b/lib/shared/src/index.ts
@@ -145,7 +145,7 @@ export {
 } from './experimentation/FeatureFlagProvider'
 export { GuardrailsPost, summariseAttribution } from './guardrails'
 export type { Attribution, Guardrails } from './guardrails'
-export { SourcegraphGuardrailsClient } from './guardrails/client'
+export { SourcegraphGuardrailsClient, GuardrailsClientConfig } from './guardrails/client'
 export {
     CompletionStopReason,
     type CodeCompletionsClient,

--- a/vscode/src/configuration.test.ts
+++ b/vscode/src/configuration.test.ts
@@ -102,6 +102,8 @@ describe('getConfiguration', () => {
                         return 1500
                     case 'cody.autocomplete.experimental.hotStreakAndSmartThrottle':
                         return false
+                    case 'cody.experimental.guardrailsTimeoutSeconds':
+                        return undefined
                     default:
                         throw new Error(`unexpected key: ${key}`)
                 }
@@ -154,6 +156,7 @@ describe('getConfiguration', () => {
             autocompleteExperimentalHotStreakAndSmartThrottle: false,
             testingModelConfig: undefined,
             experimentalChatContextRanker: false,
+            experimentalGuardrailsTimeoutSeconds: undefined,
         } satisfies Configuration)
     })
 })

--- a/vscode/src/configuration.ts
+++ b/vscode/src/configuration.ts
@@ -147,6 +147,8 @@ export function getConfiguration(
 
         experimentalChatContextRanker: getHiddenSetting('experimental.chatContextRanker', false),
 
+        experimentalGuardrailsTimeoutSeconds: getHiddenSetting('experimental.guardrailsTimeoutSeconds'),
+
         autocompleteExperimentalOllamaOptions: getHiddenSetting(
             'autocomplete.experimental.ollamaOptions',
             {

--- a/vscode/src/external-services.ts
+++ b/vscode/src/external-services.ts
@@ -5,6 +5,7 @@ import {
     type CodeCompletionsClient,
     type ConfigurationWithAccessToken,
     type Guardrails,
+    type GuardrailsClientConfig,
     type SourcegraphCompletionsClient,
     SourcegraphGuardrailsClient,
     featureFlagProvider,
@@ -48,7 +49,8 @@ type ExternalServicesConfiguration = Pick<
     | 'experimentalTracing'
 > &
     LocalEmbeddingsConfig &
-    ContextRankerConfig
+    ContextRankerConfig &
+    GuardrailsClientConfig
 
 export async function configureExternalServices(
     context: vscode.ExtensionContext,
@@ -87,7 +89,7 @@ export async function configureExternalServices(
 
     const chatClient = new ChatClient(completionsClient, () => authProvider.getAuthStatus())
 
-    const guardrails = new SourcegraphGuardrailsClient(graphqlClient)
+    const guardrails = new SourcegraphGuardrailsClient(graphqlClient, initialConfig)
 
     const contextAPIClient = new ContextAPIClient(graphqlClient, featureFlagProvider)
 
@@ -105,6 +107,7 @@ export async function configureExternalServices(
             openTelemetryService?.onConfigurationChange(newConfig)
             completionsClient.onConfigurationChange(newConfig)
             codeCompletionsClient.onConfigurationChange(newConfig)
+            guardrails.onConfigurationChange(newConfig)
             void localEmbeddings?.setAccessToken(newConfig.serverEndpoint, newConfig.accessToken)
             void contextRanking?.setAccessToken(newConfig.serverEndpoint, newConfig.accessToken)
         },

--- a/vscode/src/testutils/mocks.ts
+++ b/vscode/src/testutils/mocks.ts
@@ -923,4 +923,5 @@ export const DEFAULT_VSCODE_SETTINGS = {
     autocompleteExperimentalHotStreakAndSmartThrottle: false,
     testingModelConfig: undefined,
     experimentalChatContextRanker: false,
+    experimentalGuardrailsTimeoutSeconds: undefined,
 } satisfies Configuration


### PR DESCRIPTION
We are currently experiencing long response times from guardrails servers. We have a hardcoded timeout of 10s. Until the issue is resolved we want to provide a way to workaround the timeout. It is marked experimental since I don't expect this setting to remain in the config forever. Instead when we invest more in the guardrails product I would expect this to live server side (along with other parts of the configuration for it).

Note the configuration key is "cody.experimental.guardrailsTimeoutSeconds"

Test Plan: hardcoded guardrails on to test against s2. Then configured the following and tested guardrails by asking chat to generate a sort implementation of more than 10 lines:
- unconfigured :: default timeout of 10s used
- 0.1 timeout :: timed out
- 40 :: no timeout

Context in https://linear.app/sourcegraph/issue/CODY-2959/cody-guardrail-timeout-on-large-block-of-code#comment-dd245410