### PR TITLE
Pass custom headers to rest API client

### DIFF
--- a/lib/shared/src/index.ts
+++ b/lib/shared/src/index.ts
@@ -150,7 +150,8 @@ export {
 } from './experimentation/FeatureFlagProvider'
 export { GuardrailsPost, summariseAttribution } from './guardrails'
 export type { Attribution, Guardrails } from './guardrails'
-export { SourcegraphGuardrailsClient, type GuardrailsClientConfig } from './guardrails/client'
+export { SourcegraphGuardrailsClient } from './guardrails/client'
+export type { GuardrailsClientConfig } from './guardrails/client'
 export {
     CompletionStopReason,
     type CodeCompletionsClient,

--- a/lib/shared/src/sourcegraph-api/rest/client.ts
+++ b/lib/shared/src/sourcegraph-api/rest/client.ts
@@ -32,7 +32,7 @@ export class RestClient {
     // Make an authenticated HTTP request to the Sourcegraph instance.
     // "name" is a developer-friendly term to label the request's trace span.
     private getRequest<T>(name: string, urlSuffix: string): Promise<T | Error> {
-        const headers = new Headers(this.customHeaders as HeadersInit)
+        const headers = new Headers(this.customHeaders)
         if (this.accessToken) {
             headers.set('Authorization', `token ${this.accessToken}`)
         }

--- a/lib/shared/src/sourcegraph-api/rest/client.ts
+++ b/lib/shared/src/sourcegraph-api/rest/client.ts
@@ -20,16 +20,19 @@ export class RestClient {
     /**
      * @param endpointUrl URL to the sourcegraph instance, e.g. "https://sourcegraph.acme.com".
      * @param accessToken User access token to contact the sourcegraph instance.
+     * @param customHeaders Custom headers (primary is used by Cody Web case when Sourcegraph client
+     * providers set of custom headers to make sure that auth flow will work properly
      */
     constructor(
         private endpointUrl: string,
-        private accessToken?: string
+        private accessToken: string | undefined,
+        private customHeaders: Record<string, string>
     ) {}
 
     // Make an authenticated HTTP request to the Sourcegraph instance.
     // "name" is a developer-friendly term to label the request's trace span.
     private getRequest<T>(name: string, urlSuffix: string): Promise<T | Error> {
-        const headers = new Headers()
+        const headers = new Headers(this.customHeaders as HeadersInit)
         if (this.accessToken) {
             headers.set('Authorization', `token ${this.accessToken}`)
         }

--- a/vscode/src/models/sync.ts
+++ b/vscode/src/models/sync.ts
@@ -151,8 +151,6 @@ async function fetchServerSideModels(endpoint: string): Promise<ServerModelConfi
     const userAccessToken = await secretStorage.getToken(endpoint)
     const customHeaders = getConfiguration().customHeaders ?? {}
 
-    console.log('customHeaders', customHeaders)
-
     // Fetch the data via REST API.
     // NOTE: We may end up exposing this data via GraphQL, it's still TBD.
     const client = new RestClient(endpoint, userAccessToken, customHeaders)

--- a/web/CHANGELOG.md
+++ b/web/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.9 
+- Add support for custom headers in Rest API service
+(fixes problem with fetching remote LLM models for Cody Web) 
+
 ## 0.2.8
 - Adds new prop to set custom client telemetry name (telemetryClientName)
 

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cody-web-experimental",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "description": "Cody standalone web app",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
Fixes https://linear.app/sourcegraph/issue/SRCH-801/supported-llm-rest-api-handler-fails-in-cody-web-client

This PR passes client custom headers to the rest API client to make it work on Cody Web side with Sourcegrph client. 

## Test plan
- At this point, we just need to ensure that CI is passing 
- For full testing, you should 
   - build cody web `cd web` and `pnpm build`
   - link it with `pnpm link --global` running from web directory 
   - go to the sourcegraph repo and update the package.json `cody-web-experimental` package to `0.2.9` version
   - run sg start web-standalone with `SOURCEGRAPH_API_URL: https://sg02.sourcegraphcloud.com` (the staging where we have remote LLMs enabled)
   - Go to the Cody Web page and check that `.api/modelconfig/supported-models.json` call has custom client request headers like `X-Requested-With: Sourcegraph`

