### PR TITLE
use latest node 20 release, start testing in node 22

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,13 +31,15 @@ jobs:
       matrix:
         runner: ${{ fromJson(needs.fast_tests_matrix_prep.outputs.matrix) }}
         # Run on the most recently supported version of node for all bots.
-        node: [20]
+        node: [22]
         include:
           # Additionally, run the oldest supported version on Ubuntu. We don't
           # need to run this on all platforms as we're only verifying we don't
           # call any APIs not available in this version.
           - runner: ubuntu
             node: 18 # VS Code started using Node 18 in Aug 2023 in v1.82: https://code.visualstudio.com/updates/v1_82#_engineering
+          - runner: ubuntu
+            node: 22 # The next active version of Node.js. Electron (VS Code) doesn't use it yet, but it will soon, and `agent` will run on Node 22 on many people's machines.
     runs-on: ${{ matrix.runner }}-latest
     timeout-minutes: 10
     steps:

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-nodejs 20.4.0
+nodejs 20.16.0
 pnpm 8.6.7


### PR DESCRIPTION
Node 20.4.0 was old. It was behind what VS Code uses in Electron, and it was different from what the Kotlin bindings repo uses, which caused that step to fail locally.

Also, Node 20 enters maintenance (not active) phase soon: https://nodejs.org/en/about/previous-releases. Node 22 is the current release, so let's start running some CI jobs using it.

We could probably move to Node 22 now, but there is no reason to, and there's a slight benefit to having our main Node version match what VS Code uses (via Electron).



## Test plan

CI