### PR TITLE
fix lack of type import that broke storybooks

### DIFF
--- a/lib/shared/src/index.ts
+++ b/lib/shared/src/index.ts
@@ -145,7 +145,7 @@ export {
 } from './experimentation/FeatureFlagProvider'
 export { GuardrailsPost, summariseAttribution } from './guardrails'
 export type { Attribution, Guardrails } from './guardrails'
-export { SourcegraphGuardrailsClient, GuardrailsClientConfig } from './guardrails/client'
+export { SourcegraphGuardrailsClient, type GuardrailsClientConfig } from './guardrails/client'
 export {
     CompletionStopReason,
     type CodeCompletionsClient,


### PR DESCRIPTION
With an error about `./guardrails/client.ts` not having a `GuardrailsClientConfig` export.



## Test plan

CI