### PR TITLE
Chat UI: add button for Move to Editor

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -473,14 +473,6 @@
         "icon": "$(new-comment-icon)"
       },
       {
-        "command": "cody.chat.moveToEditor",
-        "category": "Cody",
-        "title": "Move Chat to Editor Panel",
-        "enablement": "cody.activated && cody.chatInSidebar",
-        "group": "Cody",
-        "icon": "$(layout-sidebar-left-off)"
-      },
-      {
         "command": "cody.chat.moveFromEditor",
         "category": "Cody",
         "title": "Move Chat from Editor to Main Cody Panel",
@@ -921,11 +913,6 @@
           "command": "cody.chat.history.panel",
           "when": "(cody.chatInSidebar && view != cody.chat && cody.activated) || (!cody.chatInSidebar && view == cody.chat && cody.activated)",
           "group": "navigation@3"
-        },
-        {
-          "command": "cody.chat.moveToEditor",
-          "when": "view == cody.chat && cody.activated",
-          "group": "navigation@4"
         },
         {
           "command": "cody.welcome",

--- a/vscode/webviews/tabs/TabsBar.tsx
+++ b/vscode/webviews/tabs/TabsBar.tsx
@@ -2,6 +2,7 @@ import * as Tabs from '@radix-ui/react-tabs'
 import clsx from 'clsx'
 import {
     CircleUserIcon,
+    ColumnsIcon,
     DownloadIcon,
     HistoryIcon,
     type LucideProps,
@@ -84,6 +85,11 @@ const BASE_TAB_ITEMS: TabConfig[] = [
                 ),
                 Icon: MessageSquarePlusIcon,
                 command: 'cody.chat.newPanel',
+            },
+            {
+                tooltip: 'Open in Editor',
+                Icon: ColumnsIcon,
+                command: 'cody.chat.moveToEditor',
             },
         ],
         changesView: true,


### PR DESCRIPTION
CLOSE https://www.figma.com/design/f078wFMKsIOaEwj7Iwj5xy/Unified-Cody?node-id=2798-35343&t=ZxGguMkLYWrDAm7f-0

add button for Move (sidebar chat) to Editor from editor menu to sidebar chat tab bar for unified cody: https://www.figma.com/design/f078wFMKsIOaEwj7Iwj5xy/Unified-Cody?node-id=2798-35343&t=ZxGguMkLYWrDAm7f-0

![image](https://github.com/user-attachments/assets/fc19b75f-0c02-4467-a28a-3091e463e141)

## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

After:

![image](https://github.com/user-attachments/assets/027805ce-3179-4dc1-a433-ed947bb5bc89)


## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
