### PR TITLE
Cody Web: Add high-level memoization for chat/transcript UI

### DIFF
--- a/vscode/webviews/chat/Transcript.tsx
+++ b/vscode/webviews/chat/Transcript.tsx
@@ -6,8 +6,8 @@ import {
     deserializeContextItem,
     isAbortErrorOrSocketHangUp,
 } from '@sourcegraph/cody-shared'
-import isEqual from 'lodash/isEqual'
 import type { PromptEditorRefAPI } from '@sourcegraph/prompt-editor'
+import isEqual from 'lodash/isEqual'
 import { type FC, memo, useCallback, useEffect, useMemo, useRef } from 'react'
 import type { UserAccountInfo } from '../Chat'
 import type { ApiPostMessage } from '../Chat'

--- a/vscode/webviews/chat/Transcript.tsx
+++ b/vscode/webviews/chat/Transcript.tsx
@@ -6,6 +6,7 @@ import {
     deserializeContextItem,
     isAbortErrorOrSocketHangUp,
 } from '@sourcegraph/cody-shared'
+import isEqual from 'lodash/isEqual'
 import type { PromptEditorRefAPI } from '@sourcegraph/prompt-editor'
 import { type FC, memo, useCallback, useEffect, useMemo, useRef } from 'react'
 import type { UserAccountInfo } from '../Chat'
@@ -63,10 +64,8 @@ export const Transcript: FC<TranscriptProps> = props => {
                     key={`${chatID}-${i}`}
                     chatID={chatID}
                     chatEnabled={chatEnabled}
-                    transcript={transcript}
                     userInfo={userInfo}
                     interaction={interaction}
-                    messageInProgress={messageInProgress}
                     guardrails={guardrails}
                     postMessage={postMessage}
                     isTranscriptError={isTranscriptError}
@@ -142,7 +141,7 @@ export function transcriptToInteractionPairs(
     return pairs
 }
 
-interface TranscriptInteractionProps extends TranscriptProps {
+interface TranscriptInteractionProps extends Omit<TranscriptProps, 'transcript' | 'messageInProgress'> {
     interaction: Interaction
     isFirstInteraction: boolean
     isLastInteraction: boolean
@@ -250,7 +249,7 @@ const TranscriptInteraction: FC<TranscriptInteractionProps> = memo(props => {
             )}
         </>
     )
-})
+}, isEqual)
 
 // TODO(sqs): Do this the React-y way.
 export function focusLastHumanMessageEditor(): void {

--- a/vscode/webviews/chat/Transcript.tsx
+++ b/vscode/webviews/chat/Transcript.tsx
@@ -7,14 +7,7 @@ import {
     isAbortErrorOrSocketHangUp,
 } from '@sourcegraph/cody-shared'
 import type { PromptEditorRefAPI } from '@sourcegraph/prompt-editor'
-import {
-    type ComponentProps,
-    type FunctionComponent,
-    useCallback,
-    useEffect,
-    useMemo,
-    useRef,
-} from 'react'
+import { type FC, memo, useCallback, useEffect, useMemo, useRef } from 'react'
 import type { UserAccountInfo } from '../Chat'
 import type { ApiPostMessage } from '../Chat'
 import { getVSCodeAPI } from '../utils/VSCodeApi'
@@ -26,19 +19,37 @@ import {
 } from './cells/messageCell/assistant/AssistantMessageCell'
 import { HumanMessageCell } from './cells/messageCell/human/HumanMessageCell'
 
-export const Transcript: React.FunctionComponent<{
+interface TranscriptProps {
     chatID: string
+    chatEnabled: boolean
     transcript: ChatMessage[]
+    userInfo: UserAccountInfo
     messageInProgress: ChatMessage | null
+
+    guardrails?: Guardrails
+    postMessage?: ApiPostMessage
+    isTranscriptError?: boolean
+
     feedbackButtonsOnSubmit: (text: string) => void
     copyButtonOnSubmit: CodeBlockActionsProps['copyButtonOnSubmit']
     insertButtonOnSubmit?: CodeBlockActionsProps['insertButtonOnSubmit']
-    isTranscriptError?: boolean
-    userInfo: UserAccountInfo
-    chatEnabled: boolean
-    postMessage?: ApiPostMessage
-    guardrails?: Guardrails
-}> = ({ chatID, transcript, messageInProgress, ...props }) => {
+}
+
+export const Transcript: FC<TranscriptProps> = props => {
+    const {
+        chatID,
+        chatEnabled,
+        transcript,
+        userInfo,
+        messageInProgress,
+        guardrails,
+        postMessage,
+        isTranscriptError,
+        feedbackButtonsOnSubmit,
+        copyButtonOnSubmit,
+        insertButtonOnSubmit,
+    } = props
+
     const interactions = useMemo(
         () => transcriptToInteractionPairs(transcript, messageInProgress),
         [transcript, messageInProgress]
@@ -48,13 +59,20 @@ export const Transcript: React.FunctionComponent<{
         <div className="tw-px-8 tw-py-6 tw-pt-8 tw-mt-2 tw-flex tw-flex-col tw-gap-10">
             {interactions.map((interaction, i) => (
                 <TranscriptInteraction
-                    chatID={chatID}
                     // biome-ignore lint/suspicious/noArrayIndexKey: <explanation>
                     key={`${chatID}-${i}`}
-                    {...props}
+                    chatID={chatID}
+                    chatEnabled={chatEnabled}
                     transcript={transcript}
-                    messageInProgress={messageInProgress}
+                    userInfo={userInfo}
                     interaction={interaction}
+                    messageInProgress={messageInProgress}
+                    guardrails={guardrails}
+                    postMessage={postMessage}
+                    isTranscriptError={isTranscriptError}
+                    feedbackButtonsOnSubmit={feedbackButtonsOnSubmit}
+                    copyButtonOnSubmit={copyButtonOnSubmit}
+                    insertButtonOnSubmit={insertButtonOnSubmit}
                     isFirstInteraction={i === 0}
                     isLastInteraction={i === interactions.length - 1}
                     isLastSentInteraction={
@@ -124,24 +142,33 @@ export function transcriptToInteractionPairs(
     return pairs
 }
 
-const TranscriptInteraction: FunctionComponent<
-    ComponentProps<typeof Transcript> & {
-        interaction: Interaction
-        isFirstInteraction: boolean
-        isLastInteraction: boolean
-        isLastSentInteraction: boolean
-        priorAssistantMessageIsLoading: boolean
-    }
-> = ({
-    interaction: { humanMessage, assistantMessage },
-    isFirstInteraction,
-    isLastInteraction,
-    isLastSentInteraction,
-    priorAssistantMessageIsLoading,
-    isTranscriptError,
-    ...props
-}) => {
+interface TranscriptInteractionProps extends TranscriptProps {
+    interaction: Interaction
+    isFirstInteraction: boolean
+    isLastInteraction: boolean
+    isLastSentInteraction: boolean
+    priorAssistantMessageIsLoading: boolean
+}
+
+const TranscriptInteraction: FC<TranscriptInteractionProps> = memo(props => {
+    const {
+        interaction: { humanMessage, assistantMessage },
+        isFirstInteraction,
+        isLastInteraction,
+        isLastSentInteraction,
+        priorAssistantMessageIsLoading,
+        isTranscriptError,
+        userInfo,
+        chatEnabled,
+        feedbackButtonsOnSubmit,
+        postMessage,
+        guardrails,
+        insertButtonOnSubmit,
+        copyButtonOnSubmit,
+    } = props
+
     const humanEditorRef = useRef<PromptEditorRefAPI | null>(null)
+
     useEffect(() => {
         return getVSCodeAPI().onMessage(message => {
             if (message.type === 'updateEditorState') {
@@ -174,8 +201,9 @@ const TranscriptInteraction: FunctionComponent<
     return (
         <>
             <HumanMessageCell
-                {...props}
                 key={humanMessage.index}
+                userInfo={userInfo}
+                chatEnabled={chatEnabled}
                 message={humanMessage}
                 isFirstMessage={humanMessage.index === 0}
                 isSent={!humanMessage.isUnsentFollowup}
@@ -199,8 +227,14 @@ const TranscriptInteraction: FunctionComponent<
             {assistantMessage && !isContextLoading && (
                 <AssistantMessageCell
                     key={assistantMessage.index}
-                    {...props}
+                    userInfo={userInfo}
+                    chatEnabled={chatEnabled}
                     message={assistantMessage}
+                    feedbackButtonsOnSubmit={feedbackButtonsOnSubmit}
+                    copyButtonOnSubmit={copyButtonOnSubmit}
+                    insertButtonOnSubmit={insertButtonOnSubmit}
+                    postMessage={postMessage}
+                    guardrails={guardrails}
                     humanMessage={makeHumanMessageInfo(
                         { humanMessage, assistantMessage },
                         humanEditorRef
@@ -216,7 +250,7 @@ const TranscriptInteraction: FunctionComponent<
             )}
         </>
     )
-}
+})
 
 // TODO(sqs): Do this the React-y way.
 export function focusLastHumanMessageEditor(): void {

--- a/vscode/webviews/chat/cells/contextCell/ContextCell.tsx
+++ b/vscode/webviews/chat/cells/contextCell/ContextCell.tsx
@@ -3,7 +3,7 @@ import { pluralize } from '@sourcegraph/cody-shared'
 import { MENTION_CLASS_NAME } from '@sourcegraph/prompt-editor'
 import { clsx } from 'clsx'
 import { BrainIcon, MessagesSquareIcon } from 'lucide-react'
-import type React from 'react'
+import { type FunctionComponent, memo } from 'react'
 import { FileLink } from '../../../components/FileLink'
 import {
     Accordion,
@@ -22,7 +22,7 @@ import styles from './ContextCell.module.css'
 /**
  * A component displaying the context for a human message.
  */
-export const ContextCell: React.FunctionComponent<{
+export const ContextCell: FunctionComponent<{
     contextItems: ContextItem[] | undefined
     model?: Model['model']
     isForFirstMessage: boolean
@@ -30,7 +30,7 @@ export const ContextCell: React.FunctionComponent<{
 
     /** For use in storybooks only. */
     __storybook__initialOpen?: boolean
-}> = ({ contextItems, model, isForFirstMessage, className, __storybook__initialOpen }) => {
+}> = memo(({ contextItems, model, isForFirstMessage, className, __storybook__initialOpen }) => {
     const usedContext: ContextItem[] = []
     const excludedAtContext: ContextItem[] = []
     if (contextItems) {
@@ -156,4 +156,4 @@ export const ContextCell: React.FunctionComponent<{
             )}
         </Cell>
     ) : null
-}
+})

--- a/vscode/webviews/chat/cells/contextCell/ContextCell.tsx
+++ b/vscode/webviews/chat/cells/contextCell/ContextCell.tsx
@@ -2,6 +2,7 @@ import type { ContextItem, Model } from '@sourcegraph/cody-shared'
 import { pluralize } from '@sourcegraph/cody-shared'
 import { MENTION_CLASS_NAME } from '@sourcegraph/prompt-editor'
 import { clsx } from 'clsx'
+import isEqual from 'lodash/isEqual'
 import { BrainIcon, MessagesSquareIcon } from 'lucide-react'
 import { type FunctionComponent, memo } from 'react'
 import { FileLink } from '../../../components/FileLink'
@@ -156,4 +157,4 @@ export const ContextCell: FunctionComponent<{
             )}
         </Cell>
     ) : null
-})
+}, isEqual)

--- a/vscode/webviews/chat/cells/messageCell/assistant/AssistantMessageCell.tsx
+++ b/vscode/webviews/chat/cells/messageCell/assistant/AssistantMessageCell.tsx
@@ -9,6 +9,7 @@ import {
     reformatBotMessageForChat,
     serializedPromptEditorStateFromChatMessage,
 } from '@sourcegraph/cody-shared'
+import isEqual from 'lodash/isEqual'
 import type { PromptEditorRefAPI } from '@sourcegraph/prompt-editor'
 import { type FunctionComponent, type RefObject, memo, useMemo } from 'react'
 import type { ApiPostMessage, UserAccountInfo } from '../../../../Chat'
@@ -143,7 +144,8 @@ export const AssistantMessageCell: FunctionComponent<{
                 }
             />
         )
-    }
+    },
+    isEqual
 )
 
 export const NON_HUMAN_CELL_AVATAR_SIZE =

--- a/vscode/webviews/chat/cells/messageCell/assistant/AssistantMessageCell.tsx
+++ b/vscode/webviews/chat/cells/messageCell/assistant/AssistantMessageCell.tsx
@@ -10,7 +10,7 @@ import {
     serializedPromptEditorStateFromChatMessage,
 } from '@sourcegraph/cody-shared'
 import type { PromptEditorRefAPI } from '@sourcegraph/prompt-editor'
-import { type FunctionComponent, type RefObject, useMemo } from 'react'
+import { type FunctionComponent, type RefObject, memo, useMemo } from 'react'
 import type { ApiPostMessage, UserAccountInfo } from '../../../../Chat'
 import { chatModelIconComponent } from '../../../../components/ChatModelIcon'
 import { Tooltip, TooltipContent, TooltipTrigger } from '../../../../components/shadcn/ui/tooltip'
@@ -44,105 +44,107 @@ export const AssistantMessageCell: FunctionComponent<{
 
     postMessage?: ApiPostMessage
     guardrails?: Guardrails
-}> = ({
-    message,
-    humanMessage,
-    userInfo,
-    chatEnabled,
-    isLoading,
-    showFeedbackButtons,
-    feedbackButtonsOnSubmit,
-    copyButtonOnSubmit,
-    insertButtonOnSubmit,
-    postMessage,
-    guardrails,
-}) => {
-    const displayMarkdown = useMemo(
-        () => reformatBotMessageForChat(message.text ?? ps``).toString(),
-        [message]
-    )
+}> = memo(
+    ({
+        message,
+        humanMessage,
+        userInfo,
+        chatEnabled,
+        isLoading,
+        showFeedbackButtons,
+        feedbackButtonsOnSubmit,
+        copyButtonOnSubmit,
+        insertButtonOnSubmit,
+        postMessage,
+        guardrails,
+    }) => {
+        const displayMarkdown = useMemo(
+            () => reformatBotMessageForChat(message.text ?? ps``).toString(),
+            [message]
+        )
 
-    const chatModel = useChatModelByID(message.model)
-    const ModelIcon = chatModel ? chatModelIconComponent(chatModel.model) : null
-    const isAborted = isAbortErrorOrSocketHangUp(message.error)
+        const chatModel = useChatModelByID(message.model)
+        const ModelIcon = chatModel ? chatModelIconComponent(chatModel.model) : null
+        const isAborted = isAbortErrorOrSocketHangUp(message.error)
 
-    return (
-        <BaseMessageCell
-            speaker={message.speaker}
-            speakerIcon={
-                chatModel && ModelIcon ? (
-                    <span>
-                        <Tooltip>
-                            <TooltipTrigger
-                                className="tw-cursor-default"
-                                data-testid="chat-message-model-icon"
-                            >
-                                <ModelIcon size={NON_HUMAN_CELL_AVATAR_SIZE} />
-                            </TooltipTrigger>
-                            <TooltipContent side="bottom">{`${chatModel.title} by ${chatModel.provider}`}</TooltipContent>
-                        </Tooltip>
-                    </span>
-                ) : null
-            }
-            content={
-                <>
-                    {message.error && !isAborted ? (
-                        typeof message.error === 'string' ? (
-                            <RequestErrorItem error={message.error} />
-                        ) : (
-                            <ErrorItem
-                                error={message.error}
-                                userInfo={userInfo}
-                                postMessage={postMessage}
+        return (
+            <BaseMessageCell
+                speaker={message.speaker}
+                speakerIcon={
+                    chatModel && ModelIcon ? (
+                        <span>
+                            <Tooltip>
+                                <TooltipTrigger
+                                    className="tw-cursor-default"
+                                    data-testid="chat-message-model-icon"
+                                >
+                                    <ModelIcon size={NON_HUMAN_CELL_AVATAR_SIZE} />
+                                </TooltipTrigger>
+                                <TooltipContent side="bottom">{`${chatModel.title} by ${chatModel.provider}`}</TooltipContent>
+                            </Tooltip>
+                        </span>
+                    ) : null
+                }
+                content={
+                    <>
+                        {message.error && !isAborted ? (
+                            typeof message.error === 'string' ? (
+                                <RequestErrorItem error={message.error} />
+                            ) : (
+                                <ErrorItem
+                                    error={message.error}
+                                    userInfo={userInfo}
+                                    postMessage={postMessage}
+                                />
+                            )
+                        ) : null}
+                        {displayMarkdown ? (
+                            <ChatMessageContent
+                                displayMarkdown={displayMarkdown}
+                                isMessageLoading={isLoading}
+                                copyButtonOnSubmit={copyButtonOnSubmit}
+                                insertButtonOnSubmit={insertButtonOnSubmit}
+                                guardrails={guardrails}
                             />
-                        )
-                    ) : null}
-                    {displayMarkdown ? (
-                        <ChatMessageContent
-                            displayMarkdown={displayMarkdown}
-                            isMessageLoading={isLoading}
-                            copyButtonOnSubmit={copyButtonOnSubmit}
-                            insertButtonOnSubmit={insertButtonOnSubmit}
-                            guardrails={guardrails}
-                        />
-                    ) : (
-                        isLoading && <LoadingDots />
-                    )}
-                </>
-            }
-            footer={
-                chatEnabled &&
-                humanMessage && (
-                    <div className="tw-py-3 tw-flex tw-flex-col tw-gap-2">
-                        {isAborted && (
-                            <div className="tw-text-sm tw-text-muted-foreground tw-mt-4">
-                                Output stream stopped
-                            </div>
+                        ) : (
+                            isLoading && <LoadingDots />
                         )}
-                        <div className="tw-flex tw-items-center tw-divide-x tw-transition tw-divide-muted tw-opacity-65 hover:tw-opacity-100">
-                            {showFeedbackButtons && feedbackButtonsOnSubmit && (
-                                <FeedbackButtons
-                                    feedbackButtonsOnSubmit={feedbackButtonsOnSubmit}
-                                    className="tw-pr-4"
-                                />
+                    </>
+                }
+                footer={
+                    chatEnabled &&
+                    humanMessage && (
+                        <div className="tw-py-3 tw-flex tw-flex-col tw-gap-2">
+                            {isAborted && (
+                                <div className="tw-text-sm tw-text-muted-foreground tw-mt-4">
+                                    Output stream stopped
+                                </div>
                             )}
-                            {!isLoading && (!message.error || isAborted) && (
-                                <ContextFocusActions
-                                    humanMessage={humanMessage}
-                                    className={
-                                        showFeedbackButtons && feedbackButtonsOnSubmit
-                                            ? 'tw-pl-5'
-                                            : undefined
-                                    }
-                                />
-                            )}
+                            <div className="tw-flex tw-items-center tw-divide-x tw-transition tw-divide-muted tw-opacity-65 hover:tw-opacity-100">
+                                {showFeedbackButtons && feedbackButtonsOnSubmit && (
+                                    <FeedbackButtons
+                                        feedbackButtonsOnSubmit={feedbackButtonsOnSubmit}
+                                        className="tw-pr-4"
+                                    />
+                                )}
+                                {!isLoading && (!message.error || isAborted) && (
+                                    <ContextFocusActions
+                                        humanMessage={humanMessage}
+                                        className={
+                                            showFeedbackButtons && feedbackButtonsOnSubmit
+                                                ? 'tw-pl-5'
+                                                : undefined
+                                        }
+                                    />
+                                )}
+                            </div>
                         </div>
-                    </div>
-                )
-            }
-        />
-    )
-}
+                    )
+                }
+            />
+        )
+    }
+)
 
 export const NON_HUMAN_CELL_AVATAR_SIZE =
     MESSAGE_CELL_AVATAR_SIZE * 0.83 /* make them "look" the same size as the human avatar icons */

--- a/vscode/webviews/chat/cells/messageCell/assistant/AssistantMessageCell.tsx
+++ b/vscode/webviews/chat/cells/messageCell/assistant/AssistantMessageCell.tsx
@@ -9,8 +9,8 @@ import {
     reformatBotMessageForChat,
     serializedPromptEditorStateFromChatMessage,
 } from '@sourcegraph/cody-shared'
-import isEqual from 'lodash/isEqual'
 import type { PromptEditorRefAPI } from '@sourcegraph/prompt-editor'
+import isEqual from 'lodash/isEqual'
 import { type FunctionComponent, type RefObject, memo, useMemo } from 'react'
 import type { ApiPostMessage, UserAccountInfo } from '../../../../Chat'
 import { chatModelIconComponent } from '../../../../components/ChatModelIcon'

--- a/vscode/webviews/chat/cells/messageCell/human/HumanMessageCell.tsx
+++ b/vscode/webviews/chat/cells/messageCell/human/HumanMessageCell.tsx
@@ -3,6 +3,7 @@ import {
     type SerializedPromptEditorValue,
     serializedPromptEditorStateFromChatMessage,
 } from '@sourcegraph/cody-shared'
+import isEqual from 'lodash/isEqual'
 import type { PromptEditorRefAPI } from '@sourcegraph/prompt-editor'
 import { type FunctionComponent, memo, useMemo } from 'react'
 import type { UserAccountInfo } from '../../../../Chat'
@@ -96,5 +97,6 @@ export const HumanMessageCell: FunctionComponent<{
                 className={className}
             />
         )
-    }
+    },
+    isEqual
 )

--- a/vscode/webviews/chat/cells/messageCell/human/HumanMessageCell.tsx
+++ b/vscode/webviews/chat/cells/messageCell/human/HumanMessageCell.tsx
@@ -4,7 +4,7 @@ import {
     serializedPromptEditorStateFromChatMessage,
 } from '@sourcegraph/cody-shared'
 import type { PromptEditorRefAPI } from '@sourcegraph/prompt-editor'
-import { type FunctionComponent, useMemo } from 'react'
+import { type FunctionComponent, memo, useMemo } from 'react'
 import type { UserAccountInfo } from '../../../../Chat'
 import { UserAvatar } from '../../../../components/UserAvatar'
 import { BaseMessageCell, MESSAGE_CELL_AVATAR_SIZE } from '../BaseMessageCell'
@@ -40,59 +40,61 @@ export const HumanMessageCell: FunctionComponent<{
 
     /** For use in storybooks only. */
     __storybook__focus?: boolean
-}> = ({
-    message,
-    userInfo,
-    chatEnabled = true,
-    isFirstMessage,
-    isSent,
-    isPendingPriorResponse,
-    onChange,
-    onSubmit,
-    onStop,
-    isFirstInteraction,
-    isLastInteraction,
-    isEditorInitiallyFocused,
-    className,
-    editorRef,
-    __storybook__focus,
-}) => {
-    const messageJSON = JSON.stringify(message)
-    const initialEditorState = useMemo(
-        () => serializedPromptEditorStateFromChatMessage(JSON.parse(messageJSON)),
-        [messageJSON]
-    )
+}> = memo(
+    ({
+        message,
+        userInfo,
+        chatEnabled = true,
+        isFirstMessage,
+        isSent,
+        isPendingPriorResponse,
+        onChange,
+        onSubmit,
+        onStop,
+        isFirstInteraction,
+        isLastInteraction,
+        isEditorInitiallyFocused,
+        className,
+        editorRef,
+        __storybook__focus,
+    }) => {
+        const messageJSON = JSON.stringify(message)
+        const initialEditorState = useMemo(
+            () => serializedPromptEditorStateFromChatMessage(JSON.parse(messageJSON)),
+            [messageJSON]
+        )
 
-    return (
-        <BaseMessageCell
-            speaker="human"
-            speakerIcon={
-                <UserAvatar
-                    user={userInfo.user}
-                    size={MESSAGE_CELL_AVATAR_SIZE}
-                    className="tw-mt-[2px]"
-                />
-            }
-            content={
-                <HumanMessageEditor
-                    userInfo={userInfo}
-                    initialEditorState={initialEditorState}
-                    placeholder={isFirstMessage ? 'Ask...' : 'Ask a followup...'}
-                    isFirstMessage={isFirstMessage}
-                    isSent={isSent}
-                    isPendingPriorResponse={isPendingPriorResponse}
-                    onChange={onChange}
-                    onSubmit={onSubmit}
-                    onStop={onStop}
-                    disabled={!chatEnabled}
-                    isFirstInteraction={isFirstInteraction}
-                    isLastInteraction={isLastInteraction}
-                    isEditorInitiallyFocused={isEditorInitiallyFocused}
-                    editorRef={editorRef}
-                    __storybook__focus={__storybook__focus}
-                />
-            }
-            className={className}
-        />
-    )
-}
+        return (
+            <BaseMessageCell
+                speaker="human"
+                speakerIcon={
+                    <UserAvatar
+                        user={userInfo.user}
+                        size={MESSAGE_CELL_AVATAR_SIZE}
+                        className="tw-mt-[2px]"
+                    />
+                }
+                content={
+                    <HumanMessageEditor
+                        userInfo={userInfo}
+                        initialEditorState={initialEditorState}
+                        placeholder={isFirstMessage ? 'Ask...' : 'Ask a followup...'}
+                        isFirstMessage={isFirstMessage}
+                        isSent={isSent}
+                        isPendingPriorResponse={isPendingPriorResponse}
+                        onChange={onChange}
+                        onSubmit={onSubmit}
+                        onStop={onStop}
+                        disabled={!chatEnabled}
+                        isFirstInteraction={isFirstInteraction}
+                        isLastInteraction={isLastInteraction}
+                        isEditorInitiallyFocused={isEditorInitiallyFocused}
+                        editorRef={editorRef}
+                        __storybook__focus={__storybook__focus}
+                    />
+                }
+                className={className}
+            />
+        )
+    }
+)

--- a/vscode/webviews/chat/cells/messageCell/human/HumanMessageCell.tsx
+++ b/vscode/webviews/chat/cells/messageCell/human/HumanMessageCell.tsx
@@ -3,8 +3,8 @@ import {
     type SerializedPromptEditorValue,
     serializedPromptEditorStateFromChatMessage,
 } from '@sourcegraph/cody-shared'
-import isEqual from 'lodash/isEqual'
 import type { PromptEditorRefAPI } from '@sourcegraph/prompt-editor'
+import isEqual from 'lodash/isEqual'
 import { type FunctionComponent, memo, useMemo } from 'react'
 import type { UserAccountInfo } from '../../../../Chat'
 import { UserAvatar } from '../../../../components/UserAvatar'

--- a/web/CHANGELOG.md
+++ b/web/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.2.10
+- Add better rendering memoization (fixes problem with long-history chats) 
+
 ## 0.2.9 
 - Add support for custom headers in Rest API service
 (fixes problem with fetching remote LLM models for Cody Web) 

--- a/web/lib/components/CodyWebChatProvider.tsx
+++ b/web/lib/components/CodyWebChatProvider.tsx
@@ -296,22 +296,32 @@ export const CodyWebChatProvider: FC<PropsWithChildren<CodyWebChatProviderProps>
         [client, vscodeAPI, setLastActiveChatID]
     )
 
+    const contextInfo = useMemo(
+        () => ({
+            client,
+            vscodeAPI,
+            activeWebviewPanelID,
+            activeChatID: lastActiveChatID,
+            setLastActiveChatID,
+            initialContext,
+            createChat,
+            selectChat,
+        }),
+        [
+            client,
+            vscodeAPI,
+            activeWebviewPanelID,
+            lastActiveChatID,
+            setLastActiveChatID,
+            initialContext,
+            createChat,
+            selectChat,
+        ]
+    )
+
     return (
-        <AppWrapper>
-            <CodyWebChatContext.Provider
-                value={{
-                    client,
-                    vscodeAPI,
-                    activeWebviewPanelID,
-                    activeChatID: lastActiveChatID,
-                    setLastActiveChatID,
-                    initialContext,
-                    createChat,
-                    selectChat,
-                }}
-            >
-                {children}
-            </CodyWebChatContext.Provider>
+        <AppWrapper vscodeAPI={vscodeAPI}>
+            <CodyWebChatContext.Provider value={contextInfo}>{children}</CodyWebChatContext.Provider>
         </AppWrapper>
     )
 }

--- a/web/lib/components/CodyWebChatProvider.tsx
+++ b/web/lib/components/CodyWebChatProvider.tsx
@@ -320,7 +320,7 @@ export const CodyWebChatProvider: FC<PropsWithChildren<CodyWebChatProviderProps>
     )
 
     return (
-        <AppWrapper vscodeAPI={vscodeAPI}>
+        <AppWrapper>
             <CodyWebChatContext.Provider value={contextInfo}>{children}</CodyWebChatContext.Provider>
         </AppWrapper>
     )

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cody-web-experimental",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "description": "Cody standalone web app",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
Attempt to fix https://linear.app/sourcegraph/issue/SRCH-724/prinova-found-an-issue-on-cody-web

The problem that some customers have is somewhere in the react rendering pipeline, I couldn't reproduce this problem from the issue on my machine but I noticed that even though we have `useCallback` and `useMemo` hooks in high-level components we still don't use memoization on components level for anything, this means that the whole chate (all messages) would be re-rendered if one of messages has been changed (by re-rendering I mean react reconciliation). 

This PR 
- Removes props drilling from high-level components (it's easy to track dependencies graph when we don't spread the whole props object to each component)
- Adds `memo()` wrappers for heavy UI components such as transcript interactions and its children UI like human input, assistant message, ..etc) 

Note: I chained this PR with un-related to this PR telemetry fix just to avoid double package versions in NPM (I will merge them in sequence as they will be reviewed)

## Test plan
- Standard high-level manual checks (changes in this PR don't change anything with the current feature set, standard e2e checks should be enough to catch possible regressions)
