### PR TITLE
Chat: Default to sidebar chat and remove tree views registrations.

### DIFF
--- a/lib/shared/src/experimentation/FeatureFlagProvider.ts
+++ b/lib/shared/src/experimentation/FeatureFlagProvider.ts
@@ -77,9 +77,6 @@ export enum FeatureFlag {
     /** Whether to use server-side Context API. */
     CodyServerSideContextAPI = 'cody-server-side-context-api-enabled',
 
-    /** Chat in sidebar */
-    CodyChatInSidebar = 'cody-chat-in-sidebar',
-
     ChatPromptSelector = 'chat-prompt-selector',
 }
 

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -6,6 +6,8 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 
 ### Added
 
+Chat: Cody is now defaulted to run in the sidebar for both Enterprise and Non-Enterprise users. [pull/](https://github.com/sourcegraph/cody/pull/)
+
 ### Fixed
 
 ### Changed

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -6,7 +6,7 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 
 ### Added
 
-Chat: Cody is now defaulted to run in the sidebar for both Enterprise and Non-Enterprise users. [pull/](https://github.com/sourcegraph/cody/pull/)
+Chat: Cody is now defaulted to run in the sidebar for both Enterprise and Non-Enterprise users. [pull/5039](https://github.com/sourcegraph/cody/pull/5039)
 
 ### Fixed
 

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -238,43 +238,10 @@
         {
           "type": "webview",
           "id": "cody.chat",
-          "name": "Chat",
-          "when": "!cody.activated || cody.chatInSidebar"
-        },
-        {
-          "id": "cody.support.tree.view",
-          "name": "Settings & Support",
-          "when": "cody.activated && !cody.chatInSidebar"
-        },
-        {
-          "id": "cody.chat.tree.view",
-          "name": "Chats",
-          "when": "cody.activated && !cody.chatInSidebar"
-        },
-        {
-          "id": "cody.commands.tree.view",
-          "name": "Commands",
-          "when": "cody.activated && !cody.currentFileIgnored && !cody.chatInSidebar"
-        },
-        {
-          "id": "cody.commands.disabled.view",
-          "name": "Commands",
-          "when": "cody.activated && cody.currentFileIgnored && !cody.chatInSidebar"
+          "name": "Chat"
         }
       ]
     },
-    "viewsWelcome": [
-      {
-        "view": "cody.chat.tree.view",
-        "contents": "Chat alongside your code, attach files, add additional context, and try different chat models.\n[New Chat](command:cody.chat.newPanel)",
-        "when": "cody.activated && !cody.chatInSidebar && !cody.currentFileIgnored"
-      },
-      {
-        "view": "cody.commands.disabled.view",
-        "contents": "Commands are disabled for this file by an admin setting. Other Cody features are also disabled.\nMore info about [Cody Context Filters](https://sourcegraph.com/docs/cody/capabilities/ignore-context#cody-ignore)",
-        "when": "cody.activated && cody.currentFileIgnored && !cody.chatInSidebar"
-      }
-    ],
     "commands": [
       {
         "command": "cody.welcome",
@@ -476,7 +443,7 @@
         "command": "cody.chat.moveToEditor",
         "category": "Cody",
         "title": "Move Chat to Editor Panel",
-        "enablement": "cody.activated && cody.chatInSidebar",
+        "enablement": "cody.activated",
         "group": "Cody",
         "icon": "$(layout-sidebar-left-off)"
       },
@@ -484,7 +451,7 @@
         "command": "cody.chat.moveFromEditor",
         "category": "Cody",
         "title": "Move Chat from Editor to Main Cody Panel",
-        "enablement": "cody.activated && cody.chatInSidebar && view == cody.chat",
+        "enablement": "cody.activated && view == cody.chat",
         "group": "Cody",
         "icon": "$(layout-sidebar-left)"
       },
@@ -634,7 +601,7 @@
       {
         "command": "cody.chat.toggle",
         "key": "alt+l",
-        "when": "cody.activated && editorTextFocus && cody.chatInSidebar",
+        "when": "cody.activated && editorTextFocus",
         "args": {
           "editorFocus": true
         }
@@ -642,7 +609,7 @@
       {
         "command": "cody.chat.toggle",
         "key": "alt+l",
-        "when": "cody.activated && !editorTextFocus && cody.chatInSidebar",
+        "when": "cody.activated && !editorTextFocus",
         "args": {
           "editorFocus": false
         }
@@ -891,35 +858,18 @@
       ],
       "view/title": [
         {
-          "command": "cody.chat.newPanel",
-          "when": "view == cody.chat.tree.view && cody.activated",
-          "group": "navigation@1"
-        },
-        {
-          "command": "cody.chat.history.clear",
-          "when": "view == cody.chat.tree.view && cody.activated && cody.hasChatHistory",
-          "enablement": "cody.hasChatHistory",
-          "group": "navigation@2"
-        },
-        {
-          "command": "cody.chat.history.export",
-          "when": "view == cody.chat.tree.view && cody.activated && cody.hasChatHistory",
-          "enablement": "cody.hasChatHistory",
-          "group": "navigation@3"
-        },
-        {
           "command": "cody.menu.commands",
           "when": "view == cody.chat && cody.activated",
           "group": "navigation@1"
         },
         {
           "command": "cody.chat.newPanel",
-          "when": "(cody.chatInSidebar && view != cody.chat && cody.activated) || (!cody.chatInSidebar && view == cody.chat && cody.activated)",
+          "when": "view != cody.chat && cody.activated",
           "group": "navigation@2"
         },
         {
           "command": "cody.chat.history.panel",
-          "when": "(cody.chatInSidebar && view != cody.chat && cody.activated) || (!cody.chatInSidebar && view == cody.chat && cody.activated)",
+          "when": "view != cody.chat && cody.activated",
           "group": "navigation@3"
         },
         {
@@ -929,22 +879,22 @@
         },
         {
           "command": "cody.welcome",
-          "when": "view == cody.support.tree.view",
+          "when": "view == cody.chat",
           "group": "7_cody@0"
         },
         {
           "command": "cody.debug.export.logs",
-          "when": "view == cody.support.tree.view",
+          "when": "view == cody.chat",
           "group": "8_cody@1"
         },
         {
           "command": "cody.debug.enable.all",
-          "when": "view == cody.support.tree.view && !config.cody.debug.verbose",
+          "when": "view == cody.chat",
           "group": "8_cody@0"
         },
         {
           "command": "cody.debug.outputChannel",
-          "when": "view == cody.support.tree.view",
+          "when": "view == cody.chat",
           "group": "8_cody@2"
         },
         {
@@ -962,7 +912,7 @@
         },
         {
           "command": "cody.chat.moveFromEditor",
-          "when": "activeWebviewPanelId == cody.editorPanel && cody.activated && cody.chatInSidebar",
+          "when": "activeWebviewPanelId == cody.editorPanel && cody.activated",
           "group": "navigation@1",
           "visibility": "visible"
         },
@@ -989,28 +939,6 @@
           "when": "activeWebviewPanelId == cody.editorPanel && cody.activated",
           "group": "navigation@5",
           "visibility": "visible"
-        }
-      ],
-      "view/item/context": [
-        {
-          "command": "cody.chat.history.delete",
-          "when": "view == cody.chat.tree.view && cody.activated && cody.hasChatHistory && viewItem == cody.chats",
-          "group": "inline@2"
-        },
-        {
-          "command": "cody.menu.commands-settings",
-          "when": "view == cody.commands.tree.view && viewItem == cody.sidebar.custom-commands",
-          "group": "inline@1"
-        },
-        {
-          "command": "cody.copy.version",
-          "when": "view == cody.support.tree.view && viewItem == cody.version",
-          "group": "inline@1"
-        },
-        {
-          "command": "cody.menu.commands-settings",
-          "when": "view == cody.commands.tree.view && viewItem == cody.sidebar.custom-commands",
-          "group": "inline@1"
         }
       ],
       "terminal/context": [

--- a/vscode/src/chat/chat-view/ChatController.ts
+++ b/vscode/src/chat/chat-view/ChatController.ts
@@ -547,6 +547,9 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
             featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyExperimentalUnitTest),
         ])
 
+        const webviewType =
+            this.webviewPanelOrView?.viewType === 'cody.editorPanel' ? 'editor' : 'sidebar'
+
         return {
             agentIDE: config.isRunningInsideAgent ? config.agentIDE : CodyIDE.VSCode,
             agentExtensionVersion: config.isRunningInsideAgent
@@ -556,7 +559,7 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
             serverEndpoint: config.serverEndpoint,
             experimentalNoodle: config.experimentalNoodle,
             experimentalUnitTest,
-            webviewType: this.webviewPanelOrView?.viewType === 'cody.editorPanel' ? 'editor' : 'sidebar',
+            webviewType,
         }
     }
 
@@ -1509,7 +1512,8 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
      */
     public async createWebviewViewOrPanel(
         activePanelViewColumn?: vscode.ViewColumn,
-        lastQuestion?: string
+        lastQuestion?: string,
+        viewType = CodyChatEditorViewType
     ): Promise<vscode.WebviewView | vscode.WebviewPanel> {
         // Checks if the webview view or panel already exists and is visible.
         // If so, returns early to avoid creating a duplicate.
@@ -1517,7 +1521,6 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
             return this.webviewPanelOrView
         }
 
-        const viewType = CodyChatEditorViewType
         const panelTitle =
             chatHistory.getChat(this.authProvider.getAuthStatus(), this.chatModel.sessionID)
                 ?.chatTitle || getChatPanelTitle(lastQuestion)
@@ -1671,7 +1674,9 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
             await vscode.commands.executeCommand('setContext', 'cody.activated', false)
             return
         }
-        const viewOrPanel = this._webviewPanelOrView ?? (await this.createWebviewViewOrPanel())
+        const viewOrPanel =
+            this._webviewPanelOrView ??
+            (await this.createWebviewViewOrPanel(undefined, undefined, 'cody.chat'))
 
         revealWebviewViewOrPanel(viewOrPanel)
 

--- a/vscode/src/chat/chat-view/ChatsController.ts
+++ b/vscode/src/chat/chat-view/ChatsController.ts
@@ -111,6 +111,7 @@ export class ChatsController implements vscode.Disposable {
     }
 
     public registerViewsAndCommands() {
+        this.disposables.push(this.panel)
         this.disposables.push(
             vscode.window.registerWebviewViewProvider('cody.chat', this.panel, {
                 webviewOptions: { retainContextWhenHidden: true },

--- a/vscode/src/chat/chat-view/ChatsController.ts
+++ b/vscode/src/chat/chat-view/ChatsController.ts
@@ -111,7 +111,6 @@ export class ChatsController implements vscode.Disposable {
     }
 
     public registerViewsAndCommands() {
-        this.disposables.push(this.panel)
         this.disposables.push(
             vscode.window.registerWebviewViewProvider('cody.chat', this.panel, {
                 webviewOptions: { retainContextWhenHidden: true },

--- a/vscode/src/commands/CommandsController.ts
+++ b/vscode/src/commands/CommandsController.ts
@@ -1,4 +1,4 @@
-import * as vscode from 'vscode'
+import type * as vscode from 'vscode'
 
 import { logDebug } from '../log'
 
@@ -32,13 +32,6 @@ class CommandsController implements vscode.Disposable {
         if (provider) {
             this.provider = provider
             this.disposables.push(this.provider)
-            this.disposables.push(
-                this.provider,
-                vscode.window.registerTreeDataProvider(
-                    'cody.commands.tree.view',
-                    this.provider.treeViewProvider
-                )
-            )
         }
     }
 

--- a/vscode/src/commands/services/custom-commands.ts
+++ b/vscode/src/commands/services/custom-commands.ts
@@ -10,8 +10,6 @@ import { isMacOS } from '@sourcegraph/cody-shared'
 import { CustomCommandType } from '@sourcegraph/cody-shared'
 import { URI, Utils } from 'vscode-uri'
 import { getConfiguration } from '../../configuration'
-import type { TreeViewProvider } from '../../services/tree-views/TreeViewProvider'
-import { getCommandTreeItems } from '../../services/tree-views/commands'
 import { showNewCustomCommandMenu } from '../menus'
 import { type CodyCommandsFile, ConfigFiles } from '../types'
 import { createFileWatchers, tryCreateCodyJSON, writeToCodyJSON } from '../utils/config-file'
@@ -40,7 +38,7 @@ export class CustomCommandsManager implements vscode.Disposable {
         return workspaceFolder ? Utils.joinPath(workspaceFolder.uri, this.configFileName) : undefined
     }
 
-    constructor(private sidebar: TreeViewProvider) {
+    constructor() {
         // TODO (bee) Migrate to use .cody/commands.json for VS Code
         // Right now agent is using .cody/commands.json for Custom Commands,
         // .vscode/cody.json in VS Code.
@@ -134,7 +132,6 @@ export class CustomCommandsManager implements vscode.Disposable {
             logError('CustomCommandsProvider:refresh', 'failed', { verbose: error })
         }
 
-        this.sidebar.setTreeNodes(getCommandTreeItems([...this.customCommandsMap.values()]))
         return { commands: this.customCommandsMap }
     }
 

--- a/vscode/src/commands/services/provider.ts
+++ b/vscode/src/commands/services/provider.ts
@@ -1,13 +1,7 @@
-import {
-    type CodyCommand,
-    type ContextItem,
-    featureFlagProvider,
-    isFileURI,
-} from '@sourcegraph/cody-shared'
+import { type CodyCommand, type ContextItem, isFileURI } from '@sourcegraph/cody-shared'
 
 import * as vscode from 'vscode'
 import { CodyCommandMenuItems } from '..'
-import { TreeViewProvider } from '../../services/tree-views/TreeViewProvider'
 import { getContextFileFromGitLog } from '../context/git-log'
 import { getContextFileFromShell } from '../context/shell'
 import { executeExplainHistoryCommand } from '../execute/explain-history'
@@ -27,8 +21,7 @@ const vscodeDefaultCommands = getDefaultCommandsMap(CodyCommandMenuItems as Cody
 export class CommandsProvider implements vscode.Disposable {
     private disposables: vscode.Disposable[] = []
     protected readonly defaultCommands = vscodeDefaultCommands
-    public treeViewProvider = new TreeViewProvider('command', featureFlagProvider)
-    protected customCommandsStore = new CustomCommandsManager(this.treeViewProvider)
+    protected customCommandsStore = new CustomCommandsManager()
 
     // The commands grouped with default commands and custom commands
     private allCommands = new Map<string, CodyCommand>()
@@ -44,13 +37,6 @@ export class CommandsProvider implements vscode.Disposable {
             vscode.commands.registerCommand('cody.menu.custom-commands', a => this?.menu('custom', a)),
             vscode.commands.registerCommand('cody.menu.commands-settings', a => this?.menu('config', a)),
             vscode.commands.registerCommand('cody.commands.open.doc', () => openCustomCommandDocsLink())
-        )
-
-        // Tree View
-        this.disposables.push(
-            vscode.window.registerTreeDataProvider('cody.commands.tree.view', this.treeViewProvider),
-            // Update the custom commands when the tree view is refreshed
-            this.treeViewProvider.onDidChangeTreeData(() => this.getCustomCommands())
         )
 
         this.disposables.push(

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -111,11 +111,6 @@ export async function start(
         context.extensionMode === vscode.ExtensionMode.Development ||
         context.extensionMode === vscode.ExtensionMode.Test
 
-    // HACK to improve e2e test latency
-    if (vscode.workspace.getConfiguration().get<boolean>('cody.internal.chatInSidebar')) {
-        await vscode.commands.executeCommand('setContext', 'cody.chatInSidebar', true)
-    }
-
     // Set internal storage fields for storage provider singletons
     localStorage.setStorage(
         platform.createStorage ? await platform.createStorage() : context.globalState

--- a/vscode/src/services/AuthProvider.ts
+++ b/vscode/src/services/AuthProvider.ts
@@ -339,6 +339,8 @@ export class AuthProvider implements AuthStatusProvider, vscode.Disposable {
                 await this.storeAuthInfo(config.serverEndpoint, config.accessToken)
             }
 
+            await vscode.commands.executeCommand('setContext', 'cody.activated', authStatus.isLoggedIn)
+
             await this.setAuthStatus(authStatus)
 
             // If the extension is authenticated on startup, it can't be a user's first
@@ -373,9 +375,6 @@ export class AuthProvider implements AuthStatusProvider, vscode.Disposable {
 
     // Set auth status and share it with chatview
     private async setAuthStatus(authStatus: AuthStatus): Promise<void> {
-        // Set Editor Context for extension activation.
-        await vscode.commands.executeCommand('setContext', 'cody.activated', authStatus.isLoggedIn)
-
         if (this.status === authStatus) {
             return
         }

--- a/vscode/src/services/AuthProvider.ts
+++ b/vscode/src/services/AuthProvider.ts
@@ -341,12 +341,6 @@ export class AuthProvider implements AuthStatusProvider, vscode.Disposable {
 
             await this.setAuthStatus(authStatus)
 
-            // Set context for the extension to render views based on auth status.
-            // isConsumer should be set before activated to avoid flickering.
-            const isConsumer = authStatus.isLoggedIn && authStatus.isDotCom
-            await vscode.commands.executeCommand('setContext', 'cody.chatInSidebar', isConsumer)
-            await vscode.commands.executeCommand('setContext', 'cody.activated', authStatus.isLoggedIn)
-
             // If the extension is authenticated on startup, it can't be a user's first
             // ever authentication. We store this to prevent logging first-ever events
             // for already existing users.
@@ -379,6 +373,9 @@ export class AuthProvider implements AuthStatusProvider, vscode.Disposable {
 
     // Set auth status and share it with chatview
     private async setAuthStatus(authStatus: AuthStatus): Promise<void> {
+        // Set Editor Context for extension activation.
+        await vscode.commands.executeCommand('setContext', 'cody.activated', authStatus.isLoggedIn)
+
         if (this.status === authStatus) {
             return
         }

--- a/vscode/test/e2e/chat-history.test.ts
+++ b/vscode/test/e2e/chat-history.test.ts
@@ -1,5 +1,5 @@
 import { expect } from '@playwright/test'
-import { createEmptyChatPanel, focusSidebar, sidebarSignin } from './common'
+import { getChatInputs, getChatSidebarPanel, sidebarSignin } from './common'
 import { type ExpectedV2Events, test } from './helpers'
 
 test.extend<ExpectedV2Events>({
@@ -16,21 +16,23 @@ test.extend<ExpectedV2Events>({
         'cody.chat-question:executed',
         'cody.chatResponse:noCode',
     ],
-})('restore chat from sidebar history view - plg', async ({ page, sidebar }) => {
+})('restore chat from sidebar history view', async ({ page, sidebar }) => {
     await sidebarSignin(page, sidebar)
 
-    const [chatPanelFrame, chatInput] = await createEmptyChatPanel(page)
+    const sidebarChat = getChatSidebarPanel(page)
+
+    const sidebarTabHistoryIcon = sidebarChat.locator('[id="radix-\\:r0\\:-trigger-history"]')
 
     // Ensure the chat view is ready before we start typing
-    await expect(chatPanelFrame.getByText('to add context to your chat')).toBeVisible()
+    await expect(sidebarTabHistoryIcon).toBeVisible()
 
+    const chatInput = getChatInputs(sidebarChat).first()
     await chatInput.fill('Hey')
     await chatInput.press('Enter')
 
-    await focusSidebar(page)
-    await chatPanelFrame.locator('[id="radix-\\:r0\\:-trigger-history"]').getByRole('button').click()
+    await sidebarTabHistoryIcon.getByRole('button').click()
 
-    const newHistoryItem = chatPanelFrame.getByRole('button', { name: 'Hey' })
+    const newHistoryItem = sidebarChat.getByRole('button', { name: 'Hey' })
     await expect(newHistoryItem).toBeVisible()
     await newHistoryItem.click()
 })

--- a/vscode/test/e2e/chat-history.test.ts
+++ b/vscode/test/e2e/chat-history.test.ts
@@ -1,6 +1,6 @@
 import { expect } from '@playwright/test'
 import { createEmptyChatPanel, focusSidebar, sidebarSignin } from './common'
-import { type ExpectedV2Events, executeCommandInPalette, test } from './helpers'
+import { type ExpectedV2Events, test } from './helpers'
 
 test.extend<ExpectedV2Events>({
     // list of events we expect this test to log, add to this list as needed
@@ -16,16 +16,8 @@ test.extend<ExpectedV2Events>({
         'cody.chat-question:executed',
         'cody.chatResponse:noCode',
     ],
-})('restore chat from quickPick', async ({ page, sidebar }) => {
-    // Sign into Cody
+})('restore chat from sidebar history view - plg', async ({ page, sidebar }) => {
     await sidebarSignin(page, sidebar)
-
-    const getHeyTreeItem = async () => {
-        await executeCommandInPalette(page, 'Cody: Chat History')
-
-        // locator('#quickInput_list
-        return page.locator('#quickInput_list').getByLabel('Hey, today')
-    }
 
     const [chatPanelFrame, chatInput] = await createEmptyChatPanel(page)
 
@@ -35,45 +27,10 @@ test.extend<ExpectedV2Events>({
     await chatInput.fill('Hey')
     await chatInput.press('Enter')
 
-    // TODO(beyang): fix bug that prevents immediate history propagation
-    await new Promise(resolve => setTimeout(resolve, 1_000))
+    await focusSidebar(page)
+    await chatPanelFrame.locator('[id="radix-\\:r0\\:-trigger-history"]').getByRole('button').click()
 
-    // Check if chat shows up in sidebar chat history tree view
-    await expect(await getHeyTreeItem()).toBeVisible()
+    const newHistoryItem = chatPanelFrame.getByRole('button', { name: 'Hey' })
+    await expect(newHistoryItem).toBeVisible()
+    await newHistoryItem.click()
 })
-
-// TODO: Re-enable this test once we have enabled sidebar chat by default for all users.
-// or update the test so that we can run tests in plg and enterprise mode.
-test.extend<ExpectedV2Events>({
-    // list of events we expect this test to log, add to this list as needed
-    expectedV2Events: [
-        'cody.extension:installed',
-        'cody.codyIgnore:hasFile',
-        'cody.auth.login:clicked',
-        'cody.auth.signin.menu:clicked',
-        'cody.auth.login:firstEver',
-        'cody.auth.signin.token:clicked',
-        'cody.auth:connected',
-        'cody.chat-question:submitted',
-        'cody.chat-question:executed',
-        'cody.chatResponse:noCode',
-    ],
-})
-    .skip('restore chat from sidebar history view - plg', async ({ page, sidebar }) => {
-        await sidebarSignin(page, sidebar)
-
-        const [chatPanelFrame, chatInput] = await createEmptyChatPanel(page)
-
-        // Ensure the chat view is ready before we start typing
-        await expect(chatPanelFrame.getByText('to add context to your chat')).toBeVisible()
-
-        await chatInput.fill('Hey')
-        await chatInput.press('Enter')
-
-        await focusSidebar(page)
-        await chatPanelFrame.locator('[id="radix-\\:r0\\:-trigger-history"]').getByRole('button').click()
-
-        const newHistoryItem = chatPanelFrame.getByRole('button', { name: 'Hey' })
-        await expect(newHistoryItem).toBeVisible()
-        await newHistoryItem.click()
-    })

--- a/vscode/test/e2e/chat-keyboard-shortcuts.test.ts
+++ b/vscode/test/e2e/chat-keyboard-shortcuts.test.ts
@@ -4,14 +4,13 @@ import {
     clickEditorTab,
     getChatEditorPanel,
     getChatInputs,
-    getChatSidebarPanel,
     openFileInEditorTab,
     selectLineRangeInEditorTab,
     sidebarSignin,
 } from './common'
 import { executeCommandInPalette, test } from './helpers'
 
-test('chat keyboard shortcuts for editor chat - enterprise', async ({ page, sidebar }) => {
+test('chat keyboard shortcuts for sidebar chat', async ({ page, sidebar }) => {
     await page.bringToFront()
     await sidebarSignin(page, sidebar)
 
@@ -20,57 +19,23 @@ test('chat keyboard shortcuts for editor chat - enterprise', async ({ page, side
 
     // Alt+L with no selection opens a new chat (with file mention).
     await openFileInEditorTab(page, 'buzz.ts')
-    await page.keyboard.press('Alt+L')
-    await expect(page.getByLabel('New Chat, Editor Group').getByText('New Chat')).toBeVisible()
-    await expect(chatInput).toContainText('buzz.ts')
-
-    await executeCommandInPalette(page, 'View: Close Primary Sidebar')
-
-    // Alt+L with a selection opens a new chat (with selection mention).
-    await openFileInEditorTab(page, 'buzz.ts')
-    await selectLineRangeInEditorTab(page, 3, 5)
-    await page.keyboard.press('Alt+L')
-    await expect(chatInput).toContainText('buzz.ts:3-5 ')
-
-    // Alt+L with an existing chat appends a selection mention.
-    await chatInput.press('x')
     await clickEditorTab(page, 'buzz.ts')
-    await selectLineRangeInEditorTab(page, 7, 9)
-    await page.keyboard.press('Alt+L')
-    await expect(chatInput).toContainText('buzz.ts:3-5 x buzz.ts:7-9 ')
-
-    // Alt+L in the chat (after sending) opens a new chat.
-    await chatInput.press('Enter')
-    await expect(chatMessageRows(chatPanel).nth(2)).toContainText(/hello from the assistant/)
-})
-
-// TODO: Re-enable this test once we have enabled sidebar chat by default for all users.
-test.skip('chat keyboard shortcuts for sidebar chat - plg', async ({ page, sidebar }) => {
-    await page.bringToFront()
-    await sidebarSignin(page, sidebar)
-
-    const chatPanel = getChatSidebarPanel(page)
-    const chatInput = getChatInputs(chatPanel).first()
-
-    // Alt+L with no selection opens a new chat (with file mention).
-    await openFileInEditorTab(page, 'buzz.ts')
     await page.keyboard.press('Alt+L')
     await expect(chatInput).toContainText('buzz.ts', { timeout: 3_000 })
 
     await executeCommandInPalette(page, 'View: Close Primary Sidebar')
 
     // Alt+L with a selection opens a new chat (with selection mention).
-    await openFileInEditorTab(page, 'buzz.ts')
     await selectLineRangeInEditorTab(page, 3, 5)
     await page.keyboard.press('Alt+L')
-    await expect(chatInput).toContainText('buzz.ts:3-5 ')
+    await expect(chatInput).toContainText('buzz.ts buzz.ts:3-5 ')
 
     // Alt+L with an existing chat appends a selection mention.
     await chatInput.press('x')
     await clickEditorTab(page, 'buzz.ts')
     await selectLineRangeInEditorTab(page, 7, 9)
     await page.keyboard.press('Alt+L')
-    await expect(chatInput).toContainText('buzz.ts:3-5 x buzz.ts:7-9 ')
+    await expect(chatInput).toContainText('buzz.ts buzz.ts:3-5 x buzz.ts:7-9 ')
 
     // Alt+L in the chat (after sending) opens a new chat.
     await chatInput.press('Enter')

--- a/vscode/test/e2e/helpers.ts
+++ b/vscode/test/e2e/helpers.ts
@@ -93,7 +93,6 @@ export const test = base
         extraWorkspaceSettings: {
             // NOTE: Enable unstable features for testing.
             'cody.internal.unstable': true,
-            'cody.internal.chatInSidebar': true,
         },
     })
     // By default, treat https://sourcegraph.com as "dotcom".

--- a/vscode/webviews/App.tsx
+++ b/vscode/webviews/App.tsx
@@ -285,7 +285,7 @@ export const App: React.FunctionComponent<{ vscodeAPI: VSCodeWrapper }> = ({ vsc
                 >
                     {/* NOTE: Display tabs to PLG users only until Universal Cody is ready. */}
                     {/* Shows tab bar for sidebar chats only. */}
-                    {userAccountInfo.isDotComUser && config.webviewType !== 'editor' && (
+                    {userAccountInfo.isDotComUser && config.webviewType === 'editor' ? null : (
                         <TabsBar
                             currentView={view}
                             setView={setView}


### PR DESCRIPTION
CLOSE https://linear.app/sourcegraph/issue/CODY-3075/vs-code-enterprise

This PR updates the chat experience for everyone to start with Sidebar chat that is currently available to PLG users only.

- Remove all the tree view registrations events.
- Remove all the constrain that start sidebar chats for DotCom users only.
- Update E2E tests to run in sidebar views and editor views for keyboard shortcut test.
- The rest of the chat behavior should stay the same.

## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

- Sign into S2 and confirm you no longer see the old chat experience that render tree views for commands, support and chat history.
- Verify the sidebar starts at Chat view

![image](https://github.com/user-attachments/assets/5456f61a-432d-4b0d-8d34-48be698b71d6)


Green CI since no features should be changed by this PR, and everything should work as currently do.

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->

Default to sidebar chat for both Enterprise and non-Enterprise users.