### PR TITLE
Autocomplete: ignore leading empty leading lines

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -10,6 +10,8 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 
 ### Changed
 
+- Autocomplete: Ignores leading empty new lines for autocomplete suggestions to reduce the number of cases when Cody doesn't suggest anything. [pull/4864](https://github.com/sourcegraph/cody/pull/4864)
+
 ## 1.28.0
 
 ### Added

--- a/vscode/src/completions/providers/fetch-and-process-completions.ts
+++ b/vscode/src/completions/providers/fetch-and-process-completions.ts
@@ -6,7 +6,7 @@ import {
 
 import { addAutocompleteDebugEvent } from '../../services/open-telemetry/debug-utils'
 import { canUsePartialCompletion } from '../can-use-partial-completion'
-import { getFirstLine } from '../text-processing'
+import { getFirstLine, removeLeadingEmptyLines } from '../text-processing'
 import { parseAndTruncateCompletion } from '../text-processing/parse-and-truncate-completion'
 import {
     type InlineCompletionItemWithAnalytics,
@@ -105,7 +105,12 @@ export async function* fetchAndProcessDynamicMultilineCompletions(
         const extractCompletion = shouldYieldFirstCompletion
             ? parseAndTruncateCompletion
             : canUsePartialCompletion
-        const rawCompletion = providerSpecificPostProcess(completion)
+
+        let rawCompletion = providerSpecificPostProcess(completion)
+
+        if (docContext.currentLinePrefix.trim() === '' && docContext.currentLineSuffix.trim() === '') {
+            rawCompletion = removeLeadingEmptyLines(rawCompletion)
+        }
 
         if (!getFirstLine(rawCompletion) && !shouldYieldFirstCompletion) {
             continue

--- a/vscode/src/completions/text-processing/utils.ts
+++ b/vscode/src/completions/text-processing/utils.ts
@@ -433,3 +433,7 @@ export function getSuffixAfterFirstNewline(suffix: PromptString): PromptString {
 
     return suffix.slice(firstNlInSuffix)
 }
+
+export function removeLeadingEmptyLines(str: string): string {
+    return str.replace(/^[\r\n]+/, '')
+}


### PR DESCRIPTION
Ignore leading empty new lines for autocomplete suggestions to reduce the number of cases when Cody doesn't suggest anything. Example use case below:

```ts
class Something {
  private one = 1

  private two = 2
  █
  private three = 3
  █
  private four = 4
  █
}
```

- Closes https://linear.app/sourcegraph/issue/CODY-3060/[autocomplete-latency]-start-completion-detection-in-the-chars-stream
- Follow up for https://github.com/sourcegraph/cody/pull/4901

## Test plan

Update unit tests, CI, and manually tested.
