### PR TITLE
Consume context from OpenCtx for chat message based on selectors

### DIFF
--- a/lib/shared/src/context/openctx/context.ts
+++ b/lib/shared/src/context/openctx/context.ts
@@ -11,10 +11,11 @@ export const getContextForChatMessage = async (message: string): Promise<Context
 
     const providers = await openCtxClient.meta({})
 
-    const matchingProviders = providers.filter(p =>
-        p.items?.messageSelectors
-            ?.map(({ pattern }) => message.match(new RegExp(pattern)))
-            .some(matches => matches?.length)
+    const matchingProviders = providers.filter(
+        p =>
+            p.items?.messageSelectors?.filter(
+                ({ pattern }) => message.match(new RegExp(pattern))?.length
+            )?.length
     )
 
     const items = (
@@ -35,8 +36,6 @@ export const getContextForChatMessage = async (message: string): Promise<Context
                     provider: 'openctx',
                 }) as ContextItemOpenCtx
         )
-
-    logDebug('items items ', JSON.stringify(items))
 
     return items
 }

--- a/lib/shared/src/context/openctx/context.ts
+++ b/lib/shared/src/context/openctx/context.ts
@@ -4,40 +4,50 @@ import { openCtx } from './api'
 
 // getContextForChatMessage returns context items for a given chat message from the OpenCtx providers.
 export const getContextForChatMessage = async (message: string): Promise<ContextItemOpenCtx[]> => {
-    const openCtxClient = openCtx.client
-    if (!openCtxClient) {
+    try {
+        const openCtxClient = openCtx.client
+        if (!openCtxClient) {
+            return []
+        }
+
+        // get list of all configured OpenCtx providers.
+        const providers = await openCtxClient.meta({})
+
+        // filter providers that have message selectors configured and match the message text.
+        const matchingProviders = providers.filter(
+            p =>
+                p.items?.messageSelectors?.filter(({ pattern }) => {
+                    try {
+                        return message.match(new RegExp(pattern))?.length
+                    } catch {
+                        return []
+                    }
+                })?.length
+        )
+
+        // get list of items from each matching provider.
+        const items = (
+            await Promise.all(
+                matchingProviders.map(({ providerUri }) =>
+                    openCtxClient.items({ message }, { providerUri }).catch(() => [])
+                )
+            )
+        ).flat()
+
+        return items
+            .filter(item => item.ai?.content)
+            .map(
+                item =>
+                    ({
+                        type: 'openctx',
+                        title: item.title,
+                        uri: URI.parse(item.url || item.providerUri),
+                        providerUri: item.providerUri,
+                        content: item.ai?.content || '',
+                        provider: 'openctx',
+                    }) as ContextItemOpenCtx
+            )
+    } catch {
         return []
     }
-
-    // get list of all configured OpenCtx providers.
-    const providers = await openCtxClient.meta({})
-
-    // filter providers that have message selectors configured and match the message text.
-    const matchingProviders = providers.filter(
-        p =>
-            p.items?.messageSelectors?.filter(
-                ({ pattern }) => message.match(new RegExp(pattern))?.length
-            )?.length
-    )
-
-    // get list of items from each matching provider.
-    const items = (
-        await Promise.all(
-            matchingProviders.map(({ providerUri }) => openCtxClient.items({ message }, { providerUri }))
-        )
-    ).flat()
-
-    return items
-        .filter(item => item.ai?.content)
-        .map(
-            item =>
-                ({
-                    type: 'openctx',
-                    title: item.title,
-                    uri: URI.parse(item.url || item.providerUri),
-                    providerUri: item.providerUri,
-                    content: item.ai?.content || '',
-                    provider: 'openctx',
-                }) as ContextItemOpenCtx
-        )
 }

--- a/lib/shared/src/context/openctx/context.ts
+++ b/lib/shared/src/context/openctx/context.ts
@@ -1,0 +1,42 @@
+import { URI } from 'vscode-uri'
+import type { ContextItemOpenCtx } from '../../codebase-context/messages'
+import { logDebug } from '../../logger'
+import { openCtx } from './api'
+
+export const getContextForChatMessage = async (message: string): Promise<ContextItemOpenCtx[]> => {
+    const openCtxClient = openCtx.client
+    if (!openCtxClient) {
+        return []
+    }
+
+    const providers = await openCtxClient.meta({})
+
+    const matchingProviders = providers.filter(p =>
+        p.items?.messageSelectors
+            ?.map(({ pattern }) => message.match(new RegExp(pattern)))
+            .some(matches => matches?.length)
+    )
+
+    const items = (
+        await Promise.all(
+            matchingProviders.map(({ providerUri }) => openCtxClient.items({ message }, { providerUri }))
+        )
+    )
+        .flat()
+        .filter(item => item.ai?.content)
+        .map(
+            item =>
+                ({
+                    type: 'openctx',
+                    title: item.title,
+                    uri: URI.parse(item.url || item.providerUri),
+                    providerUri: item.providerUri,
+                    content: item.ai?.content || '',
+                    provider: 'openctx',
+                }) as ContextItemOpenCtx
+        )
+
+    logDebug('items items ', JSON.stringify(items))
+
+    return items
+}

--- a/lib/shared/src/index.ts
+++ b/lib/shared/src/index.ts
@@ -305,6 +305,7 @@ export {
     REMOTE_FILE_PROVIDER_URI,
     WEB_PROVIDER_URI,
 } from './context/openctx/api'
+export * from './context/openctx/context'
 export { type ClientStateForWebview } from './clientState'
 export * from './lexicalEditor/editorState'
 export * from './lexicalEditor/nodes'

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "vitest": "^1.5.0"
   },
   "dependencies": {
-    "@openctx/client": "^0.0.19",
+    "@openctx/client": "^0.0.20",
     "ignore": "^5.3.1",
     "mac-ca": "^2.0.3",
     "react": "18.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,8 +18,8 @@ importers:
   .:
     dependencies:
       '@openctx/client':
-        specifier: ^0.0.19
-        version: 0.0.19
+        specifier: ^0.0.20
+        version: 0.0.20
       ignore:
         specifier: ^5.3.1
         version: 5.3.1
@@ -433,8 +433,8 @@ importers:
         specifier: ^0.0.6
         version: 0.0.6
       '@openctx/vscode-lib':
-        specifier: ^0.0.13
-        version: 0.0.13
+        specifier: ^0.0.14
+        version: 0.0.14
       '@opentelemetry/api':
         specifier: ^1.7.0
         version: 1.7.0
@@ -842,8 +842,8 @@ importers:
   web:
     devDependencies:
       '@openctx/vscode-lib':
-        specifier: ^0.0.13
-        version: 0.0.13
+        specifier: ^0.0.14
+        version: 0.0.14
       '@sourcegraph/cody':
         specifier: workspace:*
         version: link:../agent
@@ -3480,11 +3480,11 @@ packages:
       which: 4.0.0
     dev: true
 
-  /@openctx/client@0.0.19:
-    resolution: {integrity: sha512-zyfCojoQlkqsNwEJERdCpAs1ytJnAQ/bFEfPM0wv6npkGDpjG0pagQonx7wY7gR2g1+gRDonS29hYeRU/i98lQ==}
+  /@openctx/client@0.0.20:
+    resolution: {integrity: sha512-mLfFBO/OpQfCD/fi03gX+1efxzEQp9X0HkJR05E3dagm3WMiGT3bqqWB8U9eN/9ajpA/H92MD0Gg00rhSKsusw==}
     dependencies:
-      '@openctx/protocol': 0.0.15
-      '@openctx/provider': 0.0.14
+      '@openctx/protocol': 0.0.16
+      '@openctx/provider': 0.0.15
       '@openctx/schema': 0.0.12
       lru-cache: 10.2.2
       picomatch: 3.0.1
@@ -3492,6 +3492,12 @@ packages:
 
   /@openctx/protocol@0.0.15:
     resolution: {integrity: sha512-mT1iIb+tAdY0SUwFoM8xscvrC9c5wbCQ3hbzQgI5LKaXIULmPdQa478MtGxNto2zfp8QD6VKrySsKbzQ3JFfrA==}
+    dependencies:
+      '@openctx/schema': 0.0.12
+    dev: false
+
+  /@openctx/protocol@0.0.16:
+    resolution: {integrity: sha512-W8kRJPpbYVCK0vfel4NByq7wfpTwa1+1TpsA79X12Eta+PstPqCbMUEGjwTeruilzVpIdros26rm4nCsx7MctA==}
     dependencies:
       '@openctx/schema': 0.0.12
 
@@ -3511,6 +3517,14 @@ packages:
       '@openctx/protocol': 0.0.15
       '@openctx/schema': 0.0.12
       picomatch: 3.0.1
+    dev: false
+
+  /@openctx/provider@0.0.15:
+    resolution: {integrity: sha512-7jEBI7EcExFOKk1OE91YJhYxLlqzFGWDuu01YHd6CBmq0Eo5IxezEosUn7FvKnTyA0ywoRpT27PI9OX0Lqu/Ag==}
+    dependencies:
+      '@openctx/protocol': 0.0.16
+      '@openctx/schema': 0.0.12
+      picomatch: 3.0.1
 
   /@openctx/schema@0.0.12:
     resolution: {integrity: sha512-YEqmuasaOeAtcrhlN3/D6r+76J/omRbSBUPbv4azKQA7CDvG9MnfgV1Gv8JbFSz33XzI1h9wGbPi5uzb6o6peQ==}
@@ -3523,10 +3537,10 @@ packages:
       sanitize-html: 2.13.0
       xss: 1.0.15
 
-  /@openctx/vscode-lib@0.0.13:
-    resolution: {integrity: sha512-lE26bXFVV8FQgayhBcFgdq+W4PrksB07TZmW/E3s9CTaEVUqMh/OW8o0Zo6R928Zsph+VibYsh/DTRHaavBGHA==}
+  /@openctx/vscode-lib@0.0.14:
+    resolution: {integrity: sha512-60nWaP28NgVP9wpq0Ap/Swfm1JJjKZLVYi9URK8BhdLW3RN3TivIrBIDN75Hf2eGbJ5s2XLI+WmTSlETzwOTkQ==}
     dependencies:
-      '@openctx/client': 0.0.19
+      '@openctx/client': 0.0.20
       '@openctx/ui-common': 0.0.11
       rxjs: 7.8.1
 

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -1395,7 +1395,7 @@
     "@anthropic-ai/sdk": "^0.20.8",
     "@mdi/js": "^7.2.96",
     "@openctx/provider-linear-issues": "^0.0.6",
-    "@openctx/vscode-lib": "^0.0.13",
+    "@openctx/vscode-lib": "^0.0.14",
     "@opentelemetry/api": "^1.7.0",
     "@opentelemetry/core": "^1.18.1",
     "@opentelemetry/exporter-trace-otlp-http": "^0.45.1",

--- a/vscode/src/chat/chat-view/ChatController.ts
+++ b/vscode/src/chat/chat-view/ChatController.ts
@@ -32,6 +32,7 @@ import {
     Typewriter,
     allMentionProvidersMetadata,
     featureFlagProvider,
+    getContextForChatMessage,
     graphqlClient,
     handleExtensionAPICallFromWebview,
     hydrateAfterPostMessage,
@@ -828,24 +829,31 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
                   })
                 : inputTextWithoutContextChips
 
-            const context = getEnhancedContext({
-                strategy: contextStrategy,
-                editor: this.editor,
-                input: { text: rewrite, mentions },
-                addEnhancedContext,
-                providers: {
-                    localEmbeddings: this.localEmbeddings,
-                    symf: this.symf,
-                    remoteSearch: this.remoteSearch,
-                },
-                contextRanking: this.contextRanking,
-            })
+            const context = Promise.all([
+                getEnhancedContext({
+                    strategy: contextStrategy,
+                    editor: this.editor,
+                    input: { text: rewrite, mentions },
+                    addEnhancedContext,
+                    providers: {
+                        localEmbeddings: this.localEmbeddings,
+                        symf: this.symf,
+                        remoteSearch: this.remoteSearch,
+                    },
+                    contextRanking: this.contextRanking,
+                }),
+                getContextForChatMessage(text.toString()),
+            ])
             // add a callback, but return the original context
             context.then(c =>
-                this.contextAPIClient?.rankContext(requestID, inputTextWithoutContextChips.toString(), c)
+                this.contextAPIClient?.rankContext(
+                    requestID,
+                    inputTextWithoutContextChips.toString(),
+                    c.flat()
+                )
             )
 
-            return context
+            return (await context).flat()
         }
 
         const remoteRepoIDs = remoteRepositoryIDsFromHumanInput({ text, mentions })

--- a/web/package.json
+++ b/web/package.json
@@ -41,6 +41,6 @@
     "@types/lodash": "4.14.195",
     "util": "^0.12.5",
     "vscode-uri": "^3.0.7",
-    "@openctx/vscode-lib": "^0.0.13"
+    "@openctx/vscode-lib": "^0.0.14"
   }
 }


### PR DESCRIPTION
This PR is a follow-up of https://github.com/sourcegraph/openctx/pull/178. 

When a chat message is submitted, it calls the OpenCtx providers with matching selectors to get context items and include them in the context. 

## Test plan

Include the Hello World OpenCtx provider:  "https://openctx.org/npm/@openctx/provider-hello-world": true

Send any message in chat, there should be a openctx context item in the list. 

## Changelog

- Cody will now bring in context from OpenCtx providers for a chat message on submission. 
