### PR TITLE
Make cody-bench chat work again after ModelsService changes + upgrade LLM judge model

### DIFF
--- a/agent/src/cli/command-bench/llm-judge.ts
+++ b/agent/src/cli/command-bench/llm-judge.ts
@@ -1,4 +1,4 @@
-import { ModelsService, type PromptString } from '@sourcegraph/cody-shared'
+import type { PromptString } from '@sourcegraph/cody-shared'
 import { SourcegraphNodeCompletionsClient } from '../../../../vscode/src/completions/nodeClient'
 import type { CodyBenchOptions } from './command-bench'
 
@@ -32,7 +32,7 @@ export class LlmJudge {
                 temperature: 0,
                 topK: 1,
                 fast: true,
-                model: ModelsService.getModelByIDSubstringOrError('claude-3-opus').model,
+                model: 'anthropic/claude-3-5-sonnet-20240620',
             },
             { apiVersion: 0 }
         )


### PR DESCRIPTION
Due to some recent changes in ModelsService, the API whose usages were removed here wasn't returning any results when run inside cody-bench. Turns out we don't need them at all.

I also upgraded the LLM judge to the latest Claude 3.5 Sonnet. I know this will cause some changes in eval results, but we probably always want the best possible model as the judge.

## Test plan
Tested locally.
