### PR TITLE
fix h-scrolling in @-mention menu on narrow screens

### DIFF
--- a/lib/prompt-editor/src/plugins/atMentions/atMentions.tsx
+++ b/lib/prompt-editor/src/plugins/atMentions/atMentions.tsx
@@ -249,15 +249,11 @@ export const MentionsPlugin: FunctionComponent<{ contextWindowSizeInTokens?: num
                                 ref={ref => {
                                     refs.setFloating(ref)
                                 }}
-                                style={
-                                    x === 0 && y === 0
-                                        ? { display: 'none' }
-                                        : {
-                                              position: strategy,
-                                              top: y,
-                                              left: x,
-                                          }
-                                }
+                                style={{
+                                    position: strategy,
+                                    top: y,
+                                    left: x,
+                                }}
                                 className={clsx(styles.popover)}
                             >
                                 <MentionMenu


### PR DESCRIPTION
Fixes https://linear.app/sourcegraph/issue/SRCH-805/mention-menu-in-narrow-sidebar-chat-causes-erroneous-h-scrolling

## Test plan

In narrow sidebar, type @ and open menu a lot of times. Confirm no h-scroll.