### PR TITLE
changed(model dropdown): removed enterprise-model options link for enterprise users

### DIFF
--- a/vscode/webviews/components/modelSelectField/ModelSelectField.tsx
+++ b/vscode/webviews/components/modelSelectField/ModelSelectField.tsx
@@ -217,34 +217,36 @@ export const ModelSelectField: React.FunctionComponent<{
                                 </span>
                             </CommandLink>
                         </CommandGroup>
-                        <CommandGroup>
-                            <CommandLink
-                                key="enterprise-model-options"
-                                href={ENTERPRISE_MODEL_DOCS_PAGE}
-                                target="_blank"
-                                rel="noreferrer"
-                                onSelect={() => {
-                                    telemetryRecorder.recordEvent(
-                                        'cody.modelSelector',
-                                        'clickEnterpriseModelOption'
-                                    )
-                                }}
-                                className={styles.modelTitleWithIcon}
-                            >
-                                <span className={styles.modelIcon}>
-                                    {/* wider than normal to fit in with provider icons */}
-                                    <BuildingIcon size={16} strokeWidth={2} />{' '}
-                                </span>
-                                <span className={styles.modelName}>Enterprise Model Options</span>
-                                <span className={styles.rightIcon}>
-                                    <ExternalLinkIcon
-                                        size={16}
-                                        strokeWidth={1.25}
-                                        className="tw-opacity-80"
-                                    />
-                                </span>
-                            </CommandLink>
-                        </CommandGroup>
+                        {userInfo.isDotComUser && (
+                            <CommandGroup>
+                                <CommandLink
+                                    key="enterprise-model-options"
+                                    href={ENTERPRISE_MODEL_DOCS_PAGE}
+                                    target="_blank"
+                                    rel="noreferrer"
+                                    onSelect={() => {
+                                        telemetryRecorder.recordEvent(
+                                            'cody.modelSelector',
+                                            'clickEnterpriseModelOption'
+                                        )
+                                    }}
+                                    className={styles.modelTitleWithIcon}
+                                >
+                                    <span className={styles.modelIcon}>
+                                        {/* wider than normal to fit in with provider icons */}
+                                        <BuildingIcon size={16} strokeWidth={2} />{' '}
+                                    </span>
+                                    <span className={styles.modelName}>Enterprise Model Options</span>
+                                    <span className={styles.rightIcon}>
+                                        <ExternalLinkIcon
+                                            size={16}
+                                            strokeWidth={1.25}
+                                            className="tw-opacity-80"
+                                        />
+                                    </span>
+                                </CommandLink>
+                            </CommandGroup>
+                        )}
                     </CommandList>
                 </Command>
             )}


### PR DESCRIPTION
[CODY-3084](https://linear.app/sourcegraph/issue/CODY-3084)
Removes a less-than-useful link for enterprise users in the LLM dropdown.

## Test plan
Manually tested.

## Changelog
* Removed "Enterprise Model Options" link in the LLM dropdown for enterprise clients
<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
