### PR TITLE
Cody Web: Fixes config features event

### DIFF
--- a/vscode/src/chat/chat-view/ChatController.ts
+++ b/vscode/src/chat/chat-view/ChatController.ts
@@ -583,6 +583,8 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
     // When the webview sends the 'ready' message, respond by posting the view config
     private async handleReady(): Promise<void> {
         await this.sendConfig()
+        await this.postConfigFeatures()
+
         // Update the chat model providers again to ensure the correct token limit is set on ready
         this.handleSetChatModel(this.chatModel.modelID)
     }

--- a/web/CHANGELOG.md
+++ b/web/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.0
+- Rename package to @sourcegraph/cody-web 
+- Fixes problem when cody agent publishes setConfigFeatures too early 
+
 ## 0.2.10
 - Add better rendering memoization (fixes problem with long-history chats) 
 

--- a/web/README.md
+++ b/web/README.md
@@ -2,7 +2,7 @@
 
 **Status:** experimental (currently is used by Sourcegraph Web client)
 
-The `cody-web-experimental` package implements a standalone web app/components for Cody Web.
+The `@sourcegraph/cody-web` package implements a standalone web app/components for Cody Web.
 
 To run demo standalone web app: 
 - Run `pnpm dev` 
@@ -17,8 +17,8 @@ IndexDB tables for http://localhost:5777 domain.
 
 ## How to run within Sourcegraph client 
 
-- Build `cody-web-experimental` package by running `pnpm build`
+- Build `@sourcegraph/cody-web` package by running `pnpm build`
 - Register package local link with `pnpm link --global`
-- Go to the Sourcegraph repository and create a link with `pnpm link cody-web-experimental --global`
+- Go to the Sourcegraph repository and create a link with `pnpm link @sourcegraph/cody-web --global`
 - Run Sourcegraph `sg start` or `sg start web-standalone`
 

--- a/web/lib/components/CodyWebChat.tsx
+++ b/web/lib/components/CodyWebChat.tsx
@@ -213,13 +213,17 @@ export const CodyWebChat: FC<CodyWebChatProps> = props => {
         ]
     )
 
+    const isLoading =
+        !client ||
+        !userAccountInfo ||
+        !chatModels ||
+        !activeChatID ||
+        !exportedFeatureFlags ||
+        initialization !== 'completed'
+
     return (
         <div className={className} data-cody-web-chat={true} ref={setRootElement}>
-            {client &&
-            userAccountInfo &&
-            chatModels &&
-            activeChatID &&
-            initialization === 'completed' ? (
+            {!isLoading ? (
                 isErrorLike(client) ? (
                     <p>Error: {client.message}</p>
                 ) : (
@@ -244,7 +248,7 @@ export const CodyWebChat: FC<CodyWebChatProps> = props => {
                     </ChatEnvironmentContext.Provider>
                 )
             ) : (
-                <div className={styles.loading}>Loading Cody Agent...</div>
+                <div className={styles.loading}>Loading Cody Client...</div>
             )}
         </div>
     )

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "cody-web-experimental",
-  "version": "0.2.10",
+  "name": "@sourcegraph/cody-web",
+  "version": "0.3.0",
   "description": "Cody standalone web app",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
At the moment, I think we recently did some work around adding the `useFeatureFlag` hook. 
Cody Controller was sending the `setConfigFeatures` event too early before we init in Cody Web component, and because of this we render transcript UI with no feature flag info and hence `useFeatureFlag ` was failing with `useFeatureFlags must be used within a FeatureFlagsProvider`

This PR simply adds `setConfigFeatures` to the ready event handler so it would be sent after Chat UI is ready. 

Also, in this PR I changed the name of the cody web package to make it more standard and move out of my personal NPM account to sourcegraph organization. 

## Test plan
- Run Cody Web demo `cd web & pnpm dev`
- Open Dev tools and remove all tables in your IndexDB for the demo domain
- Refresh the page
- You should see chat UI with no history and no messages 

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
