### PR TITLE
Config: JSON Generated Schema & Singleton

### DIFF
--- a/lib/shared/src/configuration.ts
+++ b/lib/shared/src/configuration.ts
@@ -20,6 +20,7 @@ export interface ConfigGetter<T> {
     get<T>(section: string, defaultValue?: T): T
 }
 
+// TODO: Question...why do we have this duplicated here? I'd like it to live in ONE place.
 // Should we share VS Code specific config via cody-shared?
 export interface Configuration {
     proxy?: string | null

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -787,6 +787,9 @@ importers:
       http-proxy-middleware:
         specifier: ^3.0.0
         version: 3.0.0
+      json-schema-to-zod:
+        specifier: ^2.3.1
+        version: 2.3.1
       kill-sync:
         specifier: ^1.0.3
         version: 1.0.3
@@ -11243,6 +11246,11 @@ packages:
     resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
     dev: true
 
+  /json-schema-to-zod@2.3.1:
+    resolution: {integrity: sha512-mxj4nDqbh6H0PPslVwG8z0w9uvckSyin/j4BMD818l/3E1Ie4L6x77itCVJ29ejZI67cUgBoZGsUB69WGc6b/g==}
+    hasBin: true
+    dev: true
+
   /json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
     dev: true
@@ -11372,8 +11380,8 @@ packages:
       strip-json-comments: 5.0.1
       summary: 2.1.0
       typescript: 5.4.2
-      zod: 3.22.4
-      zod-validation-error: 3.3.0(zod@3.22.4)
+      zod: 3.23.8
+      zod-validation-error: 3.3.0(zod@3.23.8)
     dev: true
 
   /known-css-properties@0.29.0:
@@ -16902,17 +16910,13 @@ packages:
     engines: {node: '>=12.20'}
     dev: true
 
-  /zod-validation-error@3.3.0(zod@3.22.4):
+  /zod-validation-error@3.3.0(zod@3.23.8):
     resolution: {integrity: sha512-Syib9oumw1NTqEv4LT0e6U83Td9aVRk9iTXPUQr1otyV1PuXQKOvOwhMNqZIq5hluzHP2pMgnOmHEo7kPdI2mw==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       zod: ^3.18.0
     dependencies:
-      zod: 3.22.4
-    dev: true
-
-  /zod@3.22.4:
-    resolution: {integrity: sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==}
+      zod: 3.23.8
     dev: true
 
   /zod@3.23.8:

--- a/vscode/config.hidden.json
+++ b/vscode/config.hidden.json
@@ -1,0 +1,5 @@
+{
+  "type": "object",
+  "title": "Cody Hidden",
+  "properties": {}
+}

--- a/vscode/example.package.json
+++ b/vscode/example.package.json
@@ -1,0 +1,14 @@
+"openctx.providers": {
+          "type": "object",
+          "markdownDescription": "OpenCtx providers configuration.",
+          "default": {},
+          "scope": "resource",
+          "properties": {
+            "A": {
+              "type": "string"
+            },
+            "B": {
+              "type": "string"
+            }
+          }
+        },

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -10,6 +10,7 @@
   "description": "AI coding assistant that uses search and codebase context to help you write code faster. Cody brings autocomplete, chat, and commands to VS Code, so you can generate code, write unit tests, create docs, and explain complex code using AI. Choose from the latest LLMs, including GPT-4o and Claude 3.",
   "scripts": {
     "postinstall": "pnpm download-wasm && pnpm copy-win-ca-roots",
+    "generate:config-schema": "ts-node-transpile-only ./scripts/generate-config-schema.ts && biome check --apply-unsafe src/config-v2.ts",
     "dev": "pnpm run -s dev:desktop",
     "dev:insiders": "pnpm run -s dev:desktop:insiders",
     "start:dev:desktop": "NODE_ENV=development code --extensionDevelopmentPath=$PWD --disable-extension=sourcegraph.cody-ai --disable-extension=github.copilot --inspect-extensions=9333 --new-window . --goto ./src/completions/inline-completion-item-provider.ts:16:5",
@@ -1430,6 +1431,7 @@
     "fs-extra": "^11.2.0",
     "fuzzysort": "^2.0.4",
     "http-proxy-middleware": "^3.0.0",
+    "json-schema-to-zod": "^2.3.1",
     "kill-sync": "^1.0.3",
     "mocha": "^10.2.0",
     "node-fetch": "^2.6.4",

--- a/vscode/scripts/generate-config-schema.ts
+++ b/vscode/scripts/generate-config-schema.ts
@@ -1,0 +1,51 @@
+import assert from 'node:assert'
+import * as fs from 'node:fs/promises'
+import * as path from 'node:path'
+import dedent from 'dedent'
+import jsonSchemaToZod from 'json-schema-to-zod'
+// import { z } from 'zod'
+
+const ROOT_DIR = path.join(__dirname, '..')
+async function main() {
+    //TODO: pass target file as arg
+    const targetFilePath = path.join(ROOT_DIR, 'src', 'config-v2.ts')
+    const targetFile = await fs.readFile(targetFilePath, 'utf-8')
+
+    const packageJson = JSON.parse(await fs.readFile(path.join(ROOT_DIR, 'package.json'), 'utf-8'))
+    const publicConfigs = packageJson?.contributes?.configuration
+    assert(publicConfigs)
+    const publicSchema = jsonSchemaToZod(publicConfigs)
+
+    const hiddenConfigs = JSON.parse(
+        await fs.readFile(path.join(ROOT_DIR, 'config.hidden.json'), 'utf-8')
+    )
+    const hiddenSchema = jsonSchemaToZod(hiddenConfigs)
+    const schemaBlock = dedent(
+        `
+    /** START_GENERATED_ZOD_SCHEMA **/
+    /*
+    * This block is automatically populated by the scripts/generate-config-schema.ts script.
+    * Do not edit this block manually.
+    */
+    const publicSchema = ${publicSchema}
+    const hiddenSchema = ${hiddenSchema}
+    /** END_GENERATED_ZOD_SCHEMA **/
+    `
+    )
+
+    const targetBlock = targetFile.match(
+        /\/\*\* START_GENERATED_ZOD_SCHEMA \*\*\/.*\/\*\* END_GENERATED_ZOD_SCHEMA \*\*\//s
+    )
+    assert(targetBlock)
+
+    const patchedFile = targetFile
+        .slice(0, targetBlock.index)
+        .concat(schemaBlock)
+        .concat(targetFile.slice(targetBlock.index! + targetBlock[0].length))
+    await fs.writeFile(targetFilePath, patchedFile)
+}
+
+main().catch(err => {
+    console.error(err)
+    process.exit(1)
+})

--- a/vscode/src/config-v2.ts
+++ b/vscode/src/config-v2.ts
@@ -1,0 +1,321 @@
+import { DOTCOM_URL } from '@sourcegraph/cody-shared'
+import _ from 'lodash'
+import * as vscode from 'vscode'
+import { z } from 'zod'
+import type { ConfigWatcher, OnChangeOptions } from './configwatcher'
+import { logError } from './log'
+import type { AuthProvider } from './services/AuthProvider'
+import { getAccessToken } from './services/SecretStorageProvider'
+
+/**
+ * TODO: We can handle deprecations & migrations quite gracefully by simply
+ * generating a mapping for them. Should do so in a future PR
+ */
+
+/**
+ * TODO: We can easily add additional config validation, sanitization and
+ * dependency based defaults using refinements:
+ * ```
+ * export const passwordValidationSchema = z.object({
+ *   password: z.string(),
+ *   confirmPassword: z.string(),
+ * }).refine(
+ *   (data) => data.password === data.confirmPassword, {
+ *     message: "Passwords do not match",
+ *     path: ["confirmPassword"],
+ * });
+ * ```
+ */
+
+/** START_GENERATED_ZOD_SCHEMA **/
+/*
+ * This block is automatically populated by the scripts/generate-config-schema.ts script.
+ * Do not edit this block manually.
+ */
+const publicSchema = z.object({
+    'cody.serverEndpoint': z.string().describe('URL to the Sourcegraph instance.').optional(),
+    'cody.codebase': z.string().optional(),
+    'cody.useContext': z.enum(['embeddings', 'keyword', 'blended', 'none']).default('blended'),
+    'cody.customHeaders': z.record(z.any()).default({}),
+    'cody.autocomplete.enabled': z.boolean().default(true),
+    'cody.autocomplete.languages': z.record(z.any()).default({ '*': true }),
+    'cody.commandCodeLenses': z.boolean().default(false),
+    'cody.chat.preInstruction': z.string().optional(),
+    'cody.edit.preInstruction': z.string().optional(),
+    'cody.codeActions.enabled': z.boolean().default(true),
+    'cody.commandHints.enabled': z.boolean().default(true),
+    'cody.experimental.tracing': z.boolean().default(false),
+    'cody.experimental.commitMessage': z.boolean().default(false),
+    'cody.experimental.minion.anthropicKey': z.string().default(''),
+    'cody.debug.verbose': z.boolean().optional(),
+    'cody.debug.filter': z.string().optional(),
+    'cody.telemetry.level': z.enum(['all', 'off']).default('all'),
+    'cody.autocomplete.advanced.provider': z
+        .union([
+            z.literal(null),
+            z.literal('anthropic'),
+            z.literal('fireworks'),
+            z.literal('unstable-gemini'),
+            z.literal('unstable-openai'),
+            z.literal('experimental-ollama'),
+            z.literal('experimental-openaicompatible'),
+        ])
+        .default(null),
+    'cody.autocomplete.advanced.serverEndpoint': z.string().optional(),
+    'cody.autocomplete.advanced.accessToken': z.string().optional(),
+    'cody.autocomplete.advanced.model': z
+        .union([z.literal(null), z.literal('starcoder-16b'), z.literal('starcoder-7b')])
+        .default(null),
+    'cody.autocomplete.completeSuggestWidgetSelection': z.boolean().default(true),
+    'cody.autocomplete.formatOnAccept': z.boolean().default(false),
+    'cody.autocomplete.disableInsideComments': z.boolean().default(false),
+    'cody.experimental.foldingRanges': z.enum(['lsp', 'indentation-based']).default('all'),
+    'cody.autocomplete.experimental.graphContext': z
+        .union([
+            z.literal(null),
+            z.literal('bfg'),
+            z.literal('bfg-mixed'),
+            z.literal('tsc'),
+            z.literal('tsc-mixed'),
+        ])
+        .default(null),
+    'cody.autocomplete.experimental.fireworksOptions': z
+        .object({
+            url: z
+                .string()
+                .describe('The URL of the Fireworks API.')
+                .default('https://api.fireworks.ai/inference/v1/completions'),
+            token: z.string().describe('The access token of the Fireworks API.').optional(),
+            model: z
+                .string()
+                .describe('The model ID can be acquired from `firectl list deployments`')
+                .default('accounts/sourcegraph/models/starcoder2-7b'),
+            parameters: z
+                .object({
+                    temperature: z.any().optional(),
+                    top_k: z.any().optional(),
+                    top_p: z.any().optional(),
+                    stop: z.array(z.string()).default([]),
+                })
+                .describe('Parameters for querying the the model.')
+                .optional(),
+        })
+        .optional(),
+    'cody.autocomplete.experimental.ollamaOptions': z
+        .object({
+            url: z.string().describe('The URL of the Ollama API.').default('http://localhost:11434'),
+            model: z.string().default('deepseek-coder:6.7b-base-q4_K_M'),
+            parameters: z
+                .object({
+                    num_ctx: z.any().optional(),
+                    temperature: z.any().optional(),
+                    top_k: z.any().optional(),
+                    top_p: z.any().optional(),
+                })
+                .describe(
+                    'Parameters for how Ollama will run the model. See Ollama [PARAMETER documentation](https://github.com/jmorganca/ollama/blob/main/docs/api.md#generate-request-with-options).'
+                )
+                .optional(),
+        })
+        .default({ url: 'http://localhost:11434', model: 'deepseek-coder:6.7b-base-q4_K_M' }),
+    'cody.autocomplete.experimental.hotStreakAndSmartThrottle': z.boolean().default(false),
+    'openctx.enable': z.boolean().default(true),
+    'openctx.providers': z.object({ A: z.string().optional(), B: z.string().optional() }).default({}),
+    'cody.internal.unstable': z.boolean().default(false),
+})
+const hiddenSchema = z.object({})
+/** END_GENERATED_ZOD_SCHEMA **/
+
+/**
+ * This cooerces things like 'false', '0' into False
+ */
+const stringBool = () =>
+    z
+        .string()
+        .transform(s => JSON.stringify(s))
+        .pipe(z.boolean())
+//TODO: I'd like to parse this from environment variables so that we don't have a bunch of `process.env` statements floating around
+const envSchema = z.object({
+    _env: z.object({
+        CODY_TESTING: stringBool().default('false'),
+        TESTING_DOTCOM_URL: z.string().optional(),
+    }),
+})
+
+// We don't auto generate this because there's no underlying config for it
+const secretSchema = z.object({
+    _secret: z.object({
+        serverEndpoint: z.string(),
+        accessToken: z.string().nullable().default(null),
+    }),
+})
+
+// Note: secrets are stored in secret storage not in any exposed config file for
+// now they are essentially only the auth token but I can imagine OpenCtx
+// secrets etc might need to be store here too and we provide some UI/UX around
+// setting them.
+export type SecretConfig = z.infer<typeof secretSchema>
+export type HiddenConfig = z.infer<typeof hiddenSchema>
+export type PublicConfig = z.infer<typeof publicSchema>
+
+export type Config = z.infer<typeof schema>
+
+const schema = publicSchema
+    .merge(hiddenSchema)
+    .merge(secretSchema)
+    .merge(envSchema)
+    .refine(data => {
+        // basic default
+        data._secret.serverEndpoint =
+            data._secret.serverEndpoint ??
+            (localStorage?.getEndpoint() ||
+                (data._env.CODY_TESTING ? 'http://localhost:49300/' : DOTCOM_URL.href))
+
+        // sanitize codebase
+        if (data['cody.codebase']) {
+            const protocolRegexp = /^(https?):\/\//
+            const trailingSlashRegexp = /\/$/
+            data['cody.codebase'] = data['cody.codebase']
+                .replace(protocolRegexp, '')
+                .trim()
+                .replace(trailingSlashRegexp, '')
+        }
+    })
+const defaultConfig = schema.parse({})
+
+class ZodConfigError extends Error {
+    constructor(public result: ReturnType<typeof schema.safeParse>) {
+        super('Could not safely parse conifg')
+        this.name = 'ZodConfigError'
+    }
+}
+
+export class ConfigWatcherV2 implements ConfigWatcher<Config> {
+    private configChangeEvent = new vscode.EventEmitter()
+    private disposables: vscode.Disposable[] = [this.configChangeEvent]
+
+    private currentPublicData: object = getPublicData()
+    private currentHiddenData: object = getHiddenData()
+    private currentEnvData: object = getEnvData()
+    private currentSecretData: object = {}
+
+    private currentConfig: Config = parseWithDefaults({
+        ...this.currentPublicData,
+        ...this.currentHiddenData,
+        _env: this.currentEnvData,
+        _secret: this.currentSecretData,
+    })
+
+    public static async create(authProvider: AuthProvider, disposables: vscode.Disposable[]) {
+        const watcher = new ConfigWatcherV2()
+        disposables.push(watcher)
+
+        disposables.push(
+            vscode.workspace.onDidChangeConfiguration(async event => {
+                if (!event.affectsConfiguration('cody')) {
+                    return
+                }
+                watcher.currentPublicData = getPublicData()
+                watcher.currentHiddenData = getHiddenData()
+                await watcher.refresh()
+            })
+        )
+        disposables.push(
+            authProvider.onChange(async () => {
+                watcher.currentSecretData = { _secret: await getSecretData() }
+                await watcher.refresh()
+            })
+        )
+        return watcher
+    }
+
+    get(): Config {
+        return this.currentConfig
+    }
+
+    async onChange(
+        callback: (config: Config) => Promise<void>,
+        disposables: vscode.Disposable[],
+        { runImmediately }: OnChangeOptions = { runImmediately: false }
+    ): Promise<void> {
+        disposables.push()
+        if (runImmediately) {
+            await callback(this.currentConfig)
+        }
+    }
+
+    dispose() {
+        for (const d of this.disposables) {
+            d.dispose()
+        }
+        this.disposables = []
+    }
+
+    private async refresh() {
+        const nextConfig = parseWithDefaults({
+            ...this.currentPublicData,
+            ...this.currentHiddenData,
+            _secret: this.currentSecretData,
+            _env: this.currentEnvData,
+        })
+        if (JSON.stringify(this.currentConfig) !== JSON.stringify(nextConfig)) {
+            this.currentConfig = nextConfig
+            this.configChangeEvent.fire(nextConfig)
+        }
+    }
+}
+
+function getPublicData(): object {
+    const globalConfig = vscode.workspace.getConfiguration()
+    return Object.fromEntries(Object.keys(publicSchema.shape).map(key => [key, globalConfig.get(key)]))
+}
+
+function getHiddenData(): object {
+    const globalConfig = vscode.workspace.getConfiguration()
+    return Object.fromEntries(Object.keys(hiddenSchema.shape).map(key => [key, globalConfig.get(key)]))
+}
+
+function getEnvData(): object {
+    return Object.fromEntries(
+        Object.keys(envSchema.shape._env.shape).map(key => [key, process.env[key]])
+    )
+}
+
+async function getSecretData(): Promise<object> {
+    return {
+        accessToken: getAccessToken(),
+    }
+}
+
+function parseWithDefaults(json: string | object): Config {
+    try {
+        let parsedJson = json
+        if (typeof parsedJson === 'string') {
+            parsedJson = JSON.parse(parsedJson)
+        }
+        let result = schema.safeParse(parsedJson)
+        if (result.success) {
+            return result.data
+        }
+        const errorPaths = result.error.issues.map(issue => issue.path)
+        // we unset the values for all error paths so that we can hopefully revert back to
+        // safe defaults
+
+        for (const path of errorPaths) {
+            logError('Configuration', `${path.join('.')} is not valid config, setting to default`)
+            _.unset(parsedJson, path)
+        }
+
+        result = schema.safeParse(parsedJson)
+        if (!result.success) {
+            throw new ZodConfigError(result)
+        }
+
+        return result.data
+    } catch (e) {
+        if (e instanceof ZodConfigError) {
+            logError('Configuration', `Error parsing config ${e.result.error?.format()}`)
+        }
+        return defaultConfig
+    }
+}

--- a/vscode/src/configwatcher.ts
+++ b/vscode/src/configwatcher.ts
@@ -3,7 +3,7 @@ import * as vscode from 'vscode'
 import { getFullConfig } from './configuration'
 import type { AuthProvider } from './services/AuthProvider'
 
-interface OnChangeOptions {
+export interface OnChangeOptions {
     runImmediately: boolean
 }
 

--- a/vscode/src/editor/utils/document-sections.ts
+++ b/vscode/src/editor/utils/document-sections.ts
@@ -245,6 +245,8 @@ async function defaultGetFoldingRanges(uri: vscode.Uri): Promise<vscode.FoldingR
     // setting `"cody.experimental.foldingRanges": "indentation-based"` and
     // reload VS Code. Beyond feature parity between all clients, this implementation
     // can be used to write test cases without mocking, which is a nice benefit.
+
+    //TODO: Example then here the config isn't dependency injected ?!?
     if (
         vscode.workspace.getConfiguration().get<string>('cody.experimental.foldingRanges', 'lsp') ===
         'indentation-based'

--- a/vscode/src/minion/MinionOrchestrator.ts
+++ b/vscode/src/minion/MinionOrchestrator.ts
@@ -63,7 +63,7 @@ export class MinionOrchestrator implements vscode.Disposable {
         )
 
         const assetRoot = vscode.Uri.joinPath(this.extensionUri, 'dist', 'webviews')
-
+        //TODO: Example then here the config isn't dependency injected ?!?
         const config = await getFullConfig()
         const anthropicKey = config.experimentalMinionAnthropicKey
         const anthropic = new Anthropic({ apiKey: anthropicKey })


### PR DESCRIPTION
WIP:  A proposal to make some DX changes to the config

### PoC
- Use literal strings for getting config values.
    - Much easier to search / grep
    - 1-on-1 relation between package.json & code
- Use zod schema validation
   - generated from source of truth...JSON Schema
   - config is always valid
   - gracefully handle migrations, deprecations and fallbacks
- Place env variables in single point.
   - all configuration in a single inspectable object
   - derived flags can be computed values
   - validation

### Open Questions
- Move to singleton config object?
   - Live in shared lib?
   - Some have injected config / some look up in workspace etc.
   - How to handle listeners

## Test plan
CI