### PR TITLE
Chat: Show file name for code snippets 

### DIFF
--- a/vscode/src/chat/chat-view/ChatController.ts
+++ b/vscode/src/chat/chat-view/ChatController.ts
@@ -391,7 +391,7 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
                 await handleCopiedCode(message.text, message.eventType === 'Button')
                 break
             case 'smartApply':
-                await handleSmartApply(message.code, message.instruction)
+                await handleSmartApply(message.code, message.instruction, message.fileName || undefined)
                 break
             case 'openURI':
                 vscode.commands.executeCommand('vscode.open', message.uri)

--- a/vscode/src/chat/chat-view/prompt.ts
+++ b/vscode/src/chat/chat-view/prompt.ts
@@ -67,12 +67,14 @@ export class DefaultPrompter {
             //
             // Adding the preamble before the final build step ensures it is included in the final prompt but not displayed in the UI.
             // It also allows adding the preamble only when there is context to display, without wasting tokens on the same preamble repeatedly.
-            if (
+
+            PromptMixin.setContextPreamble(
                 !this.isCommand &&
-                Boolean(this.explicitContext.length || historyItems.length || this.getEnhancedContext)
-            ) {
-                reverseTranscript[0] = PromptMixin.mixInto(reverseTranscript[0], chat.modelID)
-            }
+                    Boolean(
+                        this.explicitContext.length || historyItems.length || this.getEnhancedContext
+                    )
+            )
+            reverseTranscript[0] = PromptMixin.mixInto(reverseTranscript[0], chat.modelID)
 
             const messagesIgnored = promptBuilder.tryAddMessages(reverseTranscript)
             if (messagesIgnored) {

--- a/vscode/src/chat/protocol.ts
+++ b/vscode/src/chat/protocol.ts
@@ -133,6 +133,7 @@ export type WebviewMessage =
           command: 'smartApply'
           instruction?: string
           code: string
+          fileName?: string | undefined | null
       }
     | {
           command: 'auth'

--- a/vscode/webviews/Chat.tsx
+++ b/vscode/webviews/Chat.tsx
@@ -121,13 +121,14 @@ export const Chat: React.FunctionComponent<React.PropsWithChildren<ChatboxProps>
             return
         }
 
-        return (text: string, instruction?: PromptString) => {
+        return (text: string, instruction?: PromptString, fileName?: string) => {
             // Log the event type and text to telemetry in chat view
             vscodeAPI.postMessage({
                 command: 'smartApply',
                 instruction: instruction?.toString(),
                 // remove the additional /n added by the text area at the end of the text
                 code: text.replace(/\n$/, ''),
+                fileName,
             })
         }
     }, [vscodeAPI, showIDESnippetActions])

--- a/vscode/webviews/chat/ChatMessageContent.module.css
+++ b/vscode/webviews/chat/ChatMessageContent.module.css
@@ -209,4 +209,5 @@ body[data-vscode-theme-kind='vscode-light'] .content pre > code {
 
 .file-name-container {
     font-size: small;
+    color: var(--vscode-input-placeholderForeground);
 }

--- a/vscode/webviews/chat/ChatMessageContent.module.css
+++ b/vscode/webviews/chat/ChatMessageContent.module.css
@@ -1,18 +1,12 @@
-.footer-container {
+.buttons-container {
     display: flex;
-    flex-wrap: wrap;
-    justify-content: space-between;
+    align-items: center;
     border-style: solid;
     border-width: 1px;
     border-color: var(--vscode-sideBarSectionHeader-border);
     border-bottom-left-radius: 2px;
     border-bottom-right-radius: 2px;
     padding: 4px;
-}
-
-.buttons-container {
-    display: flex;
-    align-items: center;
 }
 
 .buttons {
@@ -153,7 +147,6 @@
     background-color: var(--code-background);
     color: var(--code-foreground);
     margin-bottom: 0;
-    position: relative;
 }
 body[data-vscode-theme-kind='vscode-light'] .content pre,
 body[data-vscode-theme-kind='vscode-light'] .content pre > code {
@@ -210,4 +203,5 @@ body[data-vscode-theme-kind='vscode-light'] .content pre > code {
 .file-name-container {
     font-size: small;
     color: var(--vscode-input-placeholderForeground);
+    margin-left: auto;
 }

--- a/vscode/webviews/chat/ChatMessageContent.module.css
+++ b/vscode/webviews/chat/ChatMessageContent.module.css
@@ -1,12 +1,18 @@
-.buttons-container {
+.footer-container {
     display: flex;
-    align-items: center;
+    flex-wrap: wrap;
+    justify-content: space-between;
     border-style: solid;
     border-width: 1px;
     border-color: var(--vscode-sideBarSectionHeader-border);
     border-bottom-left-radius: 2px;
     border-bottom-right-radius: 2px;
     padding: 4px;
+}
+
+.buttons-container {
+    display: flex;
+    align-items: center;
 }
 
 .buttons {
@@ -147,6 +153,7 @@
     background-color: var(--code-background);
     color: var(--code-foreground);
     margin-bottom: 0;
+    position: relative;
 }
 body[data-vscode-theme-kind='vscode-light'] .content pre,
 body[data-vscode-theme-kind='vscode-light'] .content pre > code {
@@ -198,4 +205,8 @@ body[data-vscode-theme-kind='vscode-light'] .content pre > code {
     margin-block: 1rem;
     padding-inline-start: 2rem;
     list-style: revert;
+}
+
+.file-name-container {
+    font-size: small;
 }

--- a/vscode/webviews/chat/ChatMessageContent.tsx
+++ b/vscode/webviews/chat/ChatMessageContent.tsx
@@ -446,7 +446,7 @@ export const ChatMessageContent: React.FunctionComponent<ChatMessageContentProps
                 const fileName = !isMessageLoading ? preText.match(/FileName: (.*?)\n/)?.[1] : undefined
 
                 // Remove everything between the <FILENAME> tags and the tags.
-                const codeblockText = preText.replace(/FileName: (.*?)\n/, '').trimStart()
+                const codeblockText = fileName ? preText.replace(/^(.*?)FileName: (.*?)\n/, '') : preText
 
                 const buttons = createButtons(
                     codeblockText,

--- a/vscode/webviews/chat/ChatMessageContent.tsx
+++ b/vscode/webviews/chat/ChatMessageContent.tsx
@@ -49,6 +49,7 @@ function createButtons(
         return createButtonsV2(
             preText,
             humanMessage,
+            fileName,
             copyButtonOnSubmit,
             insertButtonOnSubmit,
             smartApplyButtonOnSubmit
@@ -134,6 +135,7 @@ function createButtons(
 function createButtonsV2(
     preText: string,
     humanMessage: PriorHumanMessageInfo | null,
+    fileName?: string,
     copyButtonOnSubmit?: CodeBlockActionsProps['copyButtonOnSubmit'],
     insertButtonOnSubmit?: CodeBlockActionsProps['insertButtonOnSubmit'],
     smartApplyButtonOnSubmit?: CodeBlockActionsProps['smartApplyButtonOnSubmit']
@@ -141,7 +143,10 @@ function createButtonsV2(
     // The container will contain the buttons and the <pre> element with the code.
     // This allows us to position the buttons independent of the code.
     const container = document.createElement('div')
-    container.className = styles.buttonsContainer
+    container.className = styles.footerContainer
+
+    const buttonsContainer = document.createElement('div')
+    buttonsContainer.className = styles.buttonsContainer
     if (!copyButtonOnSubmit) {
         return container
     }
@@ -153,14 +158,16 @@ function createButtonsV2(
     buttons.append(copyButton)
 
     if (smartApplyButtonOnSubmit) {
-        const applyButton = createApplyButton(preText, humanMessage, smartApplyButtonOnSubmit)
+        const applyButton = createApplyButton(preText, humanMessage, smartApplyButtonOnSubmit, fileName)
         buttons.append(applyButton)
     }
 
     const actionsDropdown = createActionsDropdown(preText)
     buttons.append(actionsDropdown)
 
-    container.append(buttons)
+    // Display the buttons in the codeblock footer.
+    buttonsContainer.append(buttons)
+    container.append(buttonsContainer)
 
     return container
 }
@@ -268,7 +275,8 @@ function createCopyButton(
 function createApplyButton(
     preText: string,
     humanMessage: PriorHumanMessageInfo | null,
-    onApply: CodeBlockActionsProps['smartApplyButtonOnSubmit']
+    onApply: CodeBlockActionsProps['smartApplyButtonOnSubmit'],
+    fileName?: string
 ): HTMLElement {
     const button = document.createElement('button')
     button.innerHTML = 'Apply'
@@ -280,7 +288,7 @@ function createApplyButton(
     iconContainer.innerHTML = SparkleIcon
     button.prepend(iconContainer)
 
-    button.addEventListener('click', () => onApply(preText, humanMessage?.text))
+    button.addEventListener('click', () => onApply(preText, humanMessage?.text, fileName))
 
     return button
 }

--- a/vscode/webviews/chat/ChatMessageContent.tsx
+++ b/vscode/webviews/chat/ChatMessageContent.tsx
@@ -140,7 +140,6 @@ function createButtonsV2(
     // This allows us to position the buttons independent of the code.
     const container = document.createElement('div')
     container.className = styles.buttonsContainer
-
     if (!copyButtonOnSubmit) {
         return container
     }
@@ -159,8 +158,6 @@ function createButtonsV2(
     const actionsDropdown = createActionsDropdown(preText)
     buttons.append(actionsDropdown)
 
-    // Display the buttons in the codeblock footer.
-    // buttonsContainer.append(buttons)
     container.append(buttons)
 
     return container

--- a/vscode/webviews/chat/ChatMessageContent.tsx
+++ b/vscode/webviews/chat/ChatMessageContent.tsx
@@ -57,10 +57,8 @@ function createButtons(
     }
 
     const container = document.createElement('div')
-    container.className = styles.footerContainer
+    container.className = styles.buttonContainer
 
-    const buttonsContainer = document.createElement('div')
-    buttonsContainer.className = styles.buttonsContainer
     if (!copyButtonOnSubmit) {
         return container
     }
@@ -125,9 +123,7 @@ function createButtons(
         )
     }
 
-    // Display the buttons in the codeblock footer.
-    buttonsContainer.append(buttons)
-    container.append(buttonsContainer)
+    container.append(buttons)
 
     return container
 }
@@ -143,10 +139,8 @@ function createButtonsV2(
     // The container will contain the buttons and the <pre> element with the code.
     // This allows us to position the buttons independent of the code.
     const container = document.createElement('div')
-    container.className = styles.footerContainer
+    container.className = styles.buttonsContainer
 
-    const buttonsContainer = document.createElement('div')
-    buttonsContainer.className = styles.buttonsContainer
     if (!copyButtonOnSubmit) {
         return container
     }
@@ -166,8 +160,8 @@ function createButtonsV2(
     buttons.append(actionsDropdown)
 
     // Display the buttons in the codeblock footer.
-    buttonsContainer.append(buttons)
-    container.append(buttonsContainer)
+    // buttonsContainer.append(buttons)
+    container.append(buttons)
 
     return container
 }


### PR DESCRIPTION

![image](https://github.com/user-attachments/assets/68b2b156-eaae-4ff4-bf96-3f77d4c53dde)

- Updates preamble to have LLM include file name for each code snippets in responses
- Displays full file name for each code snippet when available

This enables smart apply to work beyond current opened file.

## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

- Ask cody to produce some code and verify the file name shows up at the bottom of the code blocks
- Click smartapply should apply those code snippets to the associated file

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
