### PR TITLE
Add 300ms debounce for at-mention query input

### DIFF
--- a/lib/prompt-editor/src/mentions/mentionMenu/useMentionMenuData.ts
+++ b/lib/prompt-editor/src/mentions/mentionMenu/useMentionMenuData.ts
@@ -1,5 +1,6 @@
 import type { ContextItem, ContextMentionProviderMetadata } from '@sourcegraph/cody-shared'
-import { useMemo, useState } from 'react'
+import { debounce } from 'lodash'
+import { useCallback, useMemo, useState } from 'react'
 import { useClientState } from '../../clientState'
 import {
     useChatContextItems,
@@ -19,13 +20,18 @@ export function useMentionMenuParams(): {
 } {
     const [params, setParams] = useState<MentionMenuParams>({ query: null, parentItem: null })
 
+    const updateQuery = useCallback(
+        debounce((query: string | null) => setParams(prev => ({ ...prev, query })), 300),
+        []
+    )
+
     return useMemo(
         () => ({
             params,
-            updateQuery: query => setParams(prev => ({ ...prev, query })),
+            updateQuery,
             updateMentionMenuParams: update => setParams(prev => ({ ...prev, ...update })),
         }),
-        [params]
+        [params, updateQuery]
     )
 }
 

--- a/vscode/test/e2e/chat-atFile.test.ts
+++ b/vscode/test/e2e/chat-atFile.test.ts
@@ -86,7 +86,8 @@ test.extend<ExpectedV2Events>({
     // Space before @ is required unless it's at position 0
     await chatInput.fill('Explain@mj')
     await expect(chatPanelFrame.getByRole('option', { name: 'Main.java' })).not.toBeVisible()
-    await chatInput.fill('@mj')
+    await chatInput.fill('')
+    await chatInput.pressSequentially('@mj', { delay: 350 })
     await expect(chatPanelFrame.getByRole('option', { name: 'Main.java' })).toBeVisible()
     await chatInput.fill('clear')
 
@@ -226,7 +227,8 @@ test.extend<ExpectedV2Events>({
     const [chatPanelFrame, , firstChatInput] = await createEmptyChatPanel(page)
 
     // Send a message with an @-mention.
-    await firstChatInput.fill('Explain @mj')
+    await firstChatInput.fill('Explain ')
+    await firstChatInput.pressSequentially('@mj', { delay: 350 })
     await chatPanelFrame.getByRole('option', { name: 'Main.java' }).click()
     await expect(firstChatInput).toHaveText('Explain Main.java ')
     await firstChatInput.press('Enter')

--- a/vscode/test/e2e/common.ts
+++ b/vscode/test/e2e/common.ts
@@ -156,7 +156,7 @@ export async function openMentionsForProvider(
     chatInput: Locator,
     provider: string
 ): Promise<void> {
-    await chatInput.press('@')
+    await chatInput.pressSequentially('@', { delay: 350 })
     await frame.getByRole('option', { name: provider }).click()
 }
 


### PR DESCRIPTION
closes: https://linear.app/sourcegraph/issue/SRCH-775/debounce-requests-for-openctx-providers

There is no debounce for @-mention query input, which causes a continuous search for context items and telemetry event requests for every keystroke. 

This PR adds a 300ms debounce which reduces the redundant requests by many folds. 

## Test plan
- cd web
- pnpm dev
- play with @-mentions and check for API calls in network tab. They should not be triggered for every keystroke when you type quickly. 


## Changelog

- Added a 300ms debounce for at-mention query input.
