### PR TITLE
don't show file 2x in mention menu

### DIFF
--- a/lib/prompt-editor/src/mentions/mentionMenu/useMentionMenuData.test.tsx
+++ b/lib/prompt-editor/src/mentions/mentionMenu/useMentionMenuData.test.tsx
@@ -1,0 +1,65 @@
+import {
+    type ContextItem,
+    ContextItemSource,
+    type ContextMentionProviderMetadata,
+} from '@sourcegraph/cody-shared'
+import { renderHook } from '@testing-library/react'
+import { describe, expect, test, vi } from 'vitest'
+import { URI } from 'vscode-uri'
+import { useClientState } from '../../clientState'
+import {
+    useChatContextItems,
+    useChatContextMentionProviders,
+} from '../../plugins/atMentions/chatContextClient'
+import { useMentionMenuData } from './useMentionMenuData'
+
+vi.mock('../../plugins/atMentions/chatContextClient')
+vi.mock('../../clientState')
+
+describe('useMentionMenuData', () => {
+    test('items do not include values from initialContextItems', async () => {
+        const mockContextItems: ContextItem[] = [
+            {
+                uri: URI.parse('file1.ts'),
+                type: 'file',
+                isTooLarge: undefined,
+                source: ContextItemSource.User,
+            },
+            {
+                uri: URI.parse('file2.ts'),
+                type: 'file',
+                isTooLarge: undefined,
+                source: ContextItemSource.User,
+            },
+            {
+                uri: URI.parse('file3.ts'),
+                type: 'file',
+                isTooLarge: undefined,
+                source: ContextItemSource.User,
+            },
+        ]
+        const mockProviders: ContextMentionProviderMetadata[] = [
+            { title: 'My Provider', id: 'my-provider', queryLabel: '', emptyLabel: '' },
+        ]
+
+        vi.mocked(useChatContextItems).mockReturnValue([
+            mockContextItems[0],
+            mockContextItems[1],
+            mockContextItems[2],
+        ])
+        vi.mocked(useChatContextMentionProviders).mockReturnValue({
+            providers: mockProviders,
+            reload: () => {},
+        })
+        vi.mocked(useClientState).mockReturnValue({
+            initialContext: [mockContextItems[0]],
+        })
+
+        const { result } = renderHook(() =>
+            useMentionMenuData({ query: '', parentItem: null }, { remainingTokenBudget: 100, limit: 10 })
+        )
+        expect(result.current.providers).toEqual(mockProviders)
+        expect(result.current.initialContextItems).toEqual([mockContextItems[0]])
+        expect(result.current.items).toEqual<ContextItem[]>([mockContextItems[1], mockContextItems[2]])
+    })
+})

--- a/lib/prompt-editor/src/mentions/mentionMenu/useMentionMenuData.ts
+++ b/lib/prompt-editor/src/mentions/mentionMenu/useMentionMenuData.ts
@@ -70,6 +70,15 @@ export function useMentionMenuData(
                       ),
             items: results
                 ?.slice(0, limit)
+                .filter(
+                    // If an item is in the initial context, don't show it twice.
+                    item =>
+                        !clientState.initialContext.some(
+                            initialItem =>
+                                initialItem.uri.toString() === item.uri.toString() &&
+                                initialItem.type === item.type
+                        )
+                )
                 .map(item => prepareContextItemForMentionMenu(item, remainingTokenBudget)),
             initialContextItems: clientState.initialContext.filter(item =>
                 queryLower


### PR DESCRIPTION
In the chat @-mention menu, often the current file was shown twice: once at the top because it's part of initial context, and once below because it's an open tab. This caused a glitch where it would be highlighted in 2 places in the mention menu and would prevent navigating down with the arrow key. Now it's only shown once.

![image](https://github.com/user-attachments/assets/8a276c5c-5228-441f-8f74-f0c23d16f3e8)


Fix https://linear.app/sourcegraph/issue/CODY-2749/mention-menu-glitches-when-you-try-to-navigate-with-the-updown-arrows

## Test plan

Open mention menu and confirm only shown once.

## Changelog

- Fixes a bug where the same file was sometimes shown twice in the @-mention menu, causing a glitch in arrow-key navigation.