### PR TITLE
Make the Agent debugging launch configuration work on Windows.

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -75,6 +75,7 @@
       "name": "Launch Agent port 3113",
       "program": "${workspaceFolder}/agent/dist/index.js",
       "runtimeArgs": ["--enable-source-maps", "--preserve-symlinks"],
+      "args": ["api", "jsonrpc-stdio"],
       "preLaunchTask": "Build Agent",
       "env": {
         "CODY_AGENT_DEBUG_REMOTE": "true",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -38,6 +38,9 @@
       "type": "shell",
       "label": "Build Agent",
       "command": "pnpm install && pnpm build",
+      "windows": {
+        "command": "pnpm install; pnpm build",
+      },
       "options": {
         "cwd": "${workspaceFolder}/agent"
       }


### PR DESCRIPTION
This helps debug Agent during Windows development.

## Test plan

Manual test: In VSCode on Windows, pick the "Launch Agent port 3113" launch configuration and hit Play.
