### PR TITLE
Agent: get `index.test.ts` passing locally

### DIFF
--- a/agent/src/index.test.ts
+++ b/agent/src/index.test.ts
@@ -116,7 +116,8 @@ describe('Agent', () => {
         })
         expect(invalid?.isLoggedIn).toBeFalsy()
         const invalidModels = await client.request('chat/models', { modelUsage: ModelUsage.Chat })
-        expect(invalidModels.models).toStrictEqual([])
+        const remoteInvalidModels = invalidModels.models.filter(model => model.provider !== 'Ollama')
+        expect(remoteInvalidModels).toStrictEqual([])
 
         const valid = await client.request('extensionConfiguration/change', {
             ...client.info.extensionConfiguration,


### PR DESCRIPTION
This PR reverts the changes to `index.test.ts` from the PR https://github.com/sourcegraph/cody/pull/4911

The command `pnpm run test agent/src/index.test.ts` does not pass for me locally after that PR got merged. Removing the updated assertions makes the tests pass again. The `index.test.ts` file is problematic because it tests some cases where there are dependencies between the tests. I've been slowly grinding through moving most of the tests out of this file with the eventual goal of ideally removing it. We should not add new assertions or test cases to this file.


## Test plan

Green CI.

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
