### PR TITLE
Experimental: fetch context from both remote and locally modified source files

### DIFF
--- a/vscode/src/chat/chat-view/ContextFetcher.ts
+++ b/vscode/src/chat/chat-view/ContextFetcher.ts
@@ -1,3 +1,4 @@
+import path from 'node:path'
 import {
     type ContextItem,
     ContextItemSource,
@@ -5,20 +6,29 @@ import {
     type PromptString,
     type SourcegraphCompletionsClient,
     graphqlClient,
+    isFileURI,
 } from '@sourcegraph/cody-shared'
 import { isError } from 'lodash'
 import * as vscode from 'vscode'
+import type { VSCodeEditor } from '../../editor/vscode-editor'
 import { rewriteKeywordQuery } from '../../local-context/rewrite-keyword-query'
 import type { SymfRunner } from '../../local-context/symf'
-import { logDebug } from '../../log'
+import { logDebug, logError } from '../../log'
+import { gitLocallyModifiedFiles } from '../../repository/git-extension-api'
+import type { Root } from './context'
 
 interface ContextQuery {
     userQuery: PromptString
-    repoIDs: string[]
+    roots: Root[]
+}
+
+interface RewrittenQuery extends ContextQuery {
+    rewritten: string
 }
 
 export class ContextFetcher implements vscode.Disposable {
     constructor(
+        private editor: VSCodeEditor,
         private symf: SymfRunner | undefined,
         private llms: SourcegraphCompletionsClient
     ) {}
@@ -29,7 +39,77 @@ export class ContextFetcher implements vscode.Disposable {
 
     public async fetchContext(query: ContextQuery): Promise<ContextItem[]> {
         const rewritten = await rewriteKeywordQuery(this.llms, query.userQuery)
-        const result = await graphqlClient.contextSearch(query.repoIDs, rewritten)
+        const rewrittenQuery = {
+            ...query,
+            rewritten,
+        }
+
+        // Fetch context from locally edited files
+        const localRoots: vscode.Uri[] = []
+        for (const root of query.roots) {
+            if (!root.local) {
+                continue
+            }
+            localRoots.push(root.local)
+        }
+        const changedFilesByRoot = await Promise.all(
+            localRoots.map(root => gitLocallyModifiedFiles(root))
+        )
+        const changedFiles = changedFilesByRoot.flat()
+
+        const [liveContext, indexedContext] = await Promise.all([
+            this.fetchLiveContext(rewrittenQuery, changedFiles),
+            this.fetchIndexedContext(rewrittenQuery),
+        ])
+
+        const { keep: filteredIndexedContext } = filterLocallyModifiedFilesOutOfRemoteContext(
+            query.roots,
+            changedFilesByRoot,
+            indexedContext
+        )
+
+        return [...liveContext, ...filteredIndexedContext]
+    }
+
+    private async fetchLiveContext(query: RewrittenQuery, files: string[]): Promise<ContextItem[]> {
+        if (!this.symf) {
+            logDebug('ContextFetcher', 'symf not available, skipping live context')
+            return []
+        }
+        const results = await this.symf.getLiveResults(query.userQuery, query.rewritten, files)
+        return (
+            await Promise.all(
+                results.map(async (r): Promise<ContextItem | ContextItem[]> => {
+                    const range = new vscode.Range(
+                        r.range.startPoint.row,
+                        r.range.startPoint.col,
+                        r.range.endPoint.row,
+                        r.range.endPoint.col
+                    )
+                    let text: string | undefined
+                    try {
+                        text = await this.editor.getTextEditorContentForFile(r.file, range)
+                    } catch (error) {
+                        logError('ChatController.searchSymf', `Error getting file contents: ${error}`)
+                        return []
+                    }
+                    return {
+                        type: 'file',
+                        uri: r.file,
+                        range,
+                        source: ContextItemSource.Search,
+                        content: text,
+                    }
+                })
+            )
+        ).flat()
+    }
+
+    private async fetchIndexedContext(query: RewrittenQuery): Promise<ContextItem[]> {
+        const repoIDs = query.roots
+            .flatMap(r => r.remoteRepo?.id)
+            .filter((id): id is string => id !== undefined)
+        const result = await graphqlClient.contextSearch(repoIDs, query.rewritten)
         if (isError(result)) {
             throw result
         }
@@ -57,4 +137,54 @@ function contextSearchResultToContextItem(result: ContextSearchResult): ContextI
         title: result.path,
         revision: result.commit,
     }
+}
+
+/**
+ * Return a filtered list of remoteContextItems with the local files from
+ * each root removed.
+ */
+export function filterLocallyModifiedFilesOutOfRemoteContext(
+    roots: Root[],
+    localFilesByRoot: string[][],
+    remoteContextItems: ContextItem[]
+): { keep: ContextItem[]; remove: ContextItem[] } {
+    // Construct map from repo name to local files to filter out of remote context
+    const repoNameToLocalFiles: Map<string, Set<string>> = new Map()
+    for (let i = 0; i < roots.length; i++) {
+        const remoteRepo = roots[i].remoteRepo
+        if (!remoteRepo) {
+            continue
+        }
+
+        const localRoot = roots[i].local
+        if (!localRoot || !isFileURI(localRoot)) {
+            continue
+        }
+
+        const relLocalFiles: Set<string> = new Set()
+        for (const localFile of localFilesByRoot[i]) {
+            relLocalFiles.add(path.relative(localRoot.fsPath, localFile))
+        }
+        repoNameToLocalFiles.set(remoteRepo.name, relLocalFiles)
+    }
+
+    const keep: ContextItem[] = []
+    const remove: ContextItem[] = []
+    for (const item of remoteContextItems) {
+        if (!item.repoName) {
+            keep.push(item)
+            continue
+        }
+        const localFiles = repoNameToLocalFiles.get(item.repoName)
+        if (!localFiles) {
+            keep.push(item)
+            continue
+        }
+        if (item.type === 'file' && item.title && localFiles.has(item.title)) {
+            remove.push(item)
+            continue
+        }
+        keep.push(item)
+    }
+    return { keep, remove }
 }

--- a/vscode/src/chat/chat-view/context.test.ts
+++ b/vscode/src/chat/chat-view/context.test.ts
@@ -1,0 +1,84 @@
+import type { ContextItem } from '@sourcegraph/cody-shared'
+import { describe, expect, it } from 'vitest'
+import * as vscode from 'vscode'
+import { filterLocallyModifiedFilesOutOfRemoteContext } from './ContextFetcher'
+import type { Root } from './context'
+
+describe('filterLocallyModifiedFilesOutOfRemoteContext', () => {
+    it('filters out local context files', () => {
+        const testCases: {
+            roots: Root[]
+            localModifiedFilesByRoot: string[][]
+            remoteContextItems: ContextItem[]
+            expectedFilteredRemoteContextItems: ContextItem[]
+        }[] = [
+            {
+                roots: [
+                    {
+                        local: vscode.Uri.file('/tmp/my/repo'),
+                        remoteRepo: {
+                            name: 'github.com/my/repo',
+                            id: '==myrepoid',
+                        },
+                    },
+                ],
+                localModifiedFilesByRoot: [['/tmp/my/repo/README.md']],
+                remoteContextItems: [
+                    {
+                        // Should be filtered out
+                        type: 'file',
+                        title: 'README.md',
+                        repoName: 'github.com/my/repo',
+                        uri: vscode.Uri.parse('https://example.com/1'),
+                    },
+                    {
+                        // Doesn't match relative file path
+                        type: 'file',
+                        title: 'main.go',
+                        repoName: 'github.com/my/repo',
+                        uri: vscode.Uri.parse('https://example.com/2'),
+                    },
+                    {
+                        // Doesn't match repo name
+                        type: 'file',
+                        title: 'README.md',
+                        repoName: 'github.com/my/other-repo',
+                        uri: vscode.Uri.parse('https://example.com/3'),
+                    },
+                ],
+                expectedFilteredRemoteContextItems: [
+                    {
+                        // Doesn't match relative file path
+                        type: 'file',
+                        title: 'main.go',
+                        repoName: 'github.com/my/repo',
+                        uri: vscode.Uri.parse('https://example.com/2'),
+                    },
+                    {
+                        // Doesn't match repo name
+                        type: 'file',
+                        title: 'README.md',
+                        repoName: 'github.com/my/other-repo',
+                        uri: vscode.Uri.parse('https://example.com/3'),
+                    },
+                ],
+            },
+        ]
+
+        for (const testCase of testCases) {
+            const {
+                roots,
+                localModifiedFilesByRoot: localFilesByRoot,
+                remoteContextItems,
+                expectedFilteredRemoteContextItems: expected,
+            } = testCase
+            const { keep: filteredContextItems } = filterLocallyModifiedFilesOutOfRemoteContext(
+                roots,
+                localFilesByRoot,
+                remoteContextItems
+            )
+
+            expect(filteredContextItems).toEqual(expected)
+        }
+    })
+})

--- a/vscode/src/external-services.ts
+++ b/vscode/src/external-services.ts
@@ -72,7 +72,7 @@ export async function configureExternalServices(
     const completionsClient = platform.createCompletionsClient(initialConfig, logger)
     const codeCompletionsClient = createCodeCompletionsClient(initialConfig, logger)
 
-    const symfRunner = platform.createSymfRunner?.(context, config, completionsClient)
+    const symfRunner = platform.createSymfRunner?.(context, completionsClient)
 
     if (initialConfig.codebase && isError(await graphqlClient.getRepoId(initialConfig.codebase))) {
         logDebug(

--- a/vscode/src/local-context/download-symf.ts
+++ b/vscode/src/local-context/download-symf.ts
@@ -10,7 +10,7 @@ import { captureException } from '../services/sentry/sentry'
 import { downloadFile, fileExists, unzip } from './utils'
 
 export type SymfVersionString = SemverString<'v'>
-const symfVersion: SymfVersionString = 'v0.0.12'
+const symfVersion: SymfVersionString = 'v0.0.13'
 
 export const _config = {
     //delay before trying to re-lock a active file

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -202,7 +202,6 @@ const register = async (
     if (symfRunner) {
         disposables.push(symfRunner)
     }
-    const contextFetcher = new ContextFetcher(symfRunner, completionsClient)
 
     // Initialize enterprise context
     const enterpriseContextFactory = new EnterpriseContextFactory(completionsClient)
@@ -212,6 +211,7 @@ const register = async (
     }, disposables)
 
     const editor = new VSCodeEditor()
+    const contextFetcher = new ContextFetcher(editor, symfRunner, completionsClient)
 
     const { chatsController } = registerChat(
         {

--- a/vscode/src/repository/git-extension-api.ts
+++ b/vscode/src/repository/git-extension-api.ts
@@ -71,6 +71,32 @@ export function gitRemoteUrlsFromGitExtension(uri: vscode.Uri): string[] | undef
 }
 
 /**
+ * Gets the list of locally modified files in the Git repository for the given URI.
+ * This is defined as the list of files modified since the merge base of the current
+ * branch with its upstream. If the upstream doesn't exist, then we use the list of
+ * files modified since the last commit.
+ */
+export async function gitLocallyModifiedFiles(uri: vscode.Uri): Promise<string[]> {
+    const repo = vscodeGitAPI?.getRepository(uri)
+    if (!repo) {
+        throw new Error(`repository does not exist at ${uri.toString}`)
+    }
+
+    if (!repo.state.HEAD?.commit) {
+        throw new Error('could not get locally modified files, HEAD commit was undefined')
+    }
+    let diffBase = repo.state.HEAD.commit
+    if (repo.state.HEAD?.upstream) {
+        diffBase = await repo.getMergeBase(repo.state.HEAD.upstream.name, repo.state.HEAD.commit)
+    }
+
+    const changes = await repo?.diffWith(diffBase)
+    const modifiedFileURIs = changes.map(change => change.renameUri ?? change.uri)
+
+    return modifiedFileURIs.map(u => u.fsPath)
+}
+
+/**
  * ❗️ The Git extension API instance is only available in the VS Code extension. ️️❗️
  * TODO: implement agent support in https://github.com/sourcegraph/cody/issues/4139
  */


### PR DESCRIPTION
This modifies behavior when the `cody.internal.serverSideContext` setting is true. If this setting is not set, there should be no behavior changes.

- Remote context is fetched from Sourcegraph, the latest HEAD revision of the repository (which is how enterprise context currently works)
- Local context is fetched from files changed since the merge base of the current local working state and the upstream of the current branch. If the upstream doesn't exist, then the changes since last local commit are used.
- Context from the locally edited files is removed from the remote context to avoid duplication/staleness.
- Currently the local context is limited to 5 entries and concatenated with the remote context. In the future, we should rerank these context items together.

https://github.com/user-attachments/assets/8389821a-1a9a-4a80-866c-4a7040ce4c71

## Test plan

- Set `"cody.internal.serverSideContext": true` in settings
- Make a local change to a file. Then close the file, @-mention the repository, and ask a question about the change you just made *without* @-mentioning the specific file. The answer should answer correctly about the local change.
