### PR TITLE
Edit: Strip trailing CR characters when computing diff

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -683,8 +683,8 @@ importers:
         specifier: ^0.7.0
         version: 0.7.0
       '@types/diff':
-        specifier: ^5.0.9
-        version: 5.0.9
+        specifier: ^5.2.1
+        version: 5.2.1
       '@types/express':
         specifier: ^4.17.17
         version: 4.17.17
@@ -6451,6 +6451,10 @@ packages:
 
   /@types/diff@5.0.9:
     resolution: {integrity: sha512-RWVEhh/zGXpAVF/ZChwNnv7r4rvqzJ7lYNSmZSVTxjV0PBLf6Qu7RNg+SUtkpzxmiNkjCx0Xn2tPp7FIkshJwQ==}
+    dev: true
+
+  /@types/diff@5.2.1:
+    resolution: {integrity: sha512-uxpcuwWJGhe2AR1g8hD9F5OYGCqjqWnBUQFD8gMZsDbv8oPHzxJF6iMO6n8Tk0AdzlxoaaoQhOYlIg/PukVU8g==}
     dev: true
 
   /@types/doctrine@0.0.3:

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -10,6 +10,8 @@ Chat: Cody is now defaulted to run in the sidebar for both Enterprise and Non-En
 
 ### Fixed
 
+- Edit: Fixed an issue where we would generate an inefficient diff due to a mismatch in the end-of-line sequence between the user and the LLM. [pull/5069](https://github.com/sourcegraph/cody/pull/5069)
+
 ### Changed
 
 - Autocomplete: Ignores leading empty new lines for autocomplete suggestions to reduce the number of cases when Cody doesn't suggest anything. [pull/4864](https://github.com/sourcegraph/cody/pull/4864)

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -1395,7 +1395,7 @@
     "@storybook/preview-api": "^8.0.5",
     "@types/crypto-js": "^4.2.2",
     "@types/dedent": "^0.7.0",
-    "@types/diff": "^5.0.9",
+    "@types/diff": "^5.2.1",
     "@types/express": "^4.17.17",
     "@types/fs-extra": "^11.0.4",
     "@types/glob": "^8.0.0",

--- a/vscode/src/non-stop/line-diff.ts
+++ b/vscode/src/non-stop/line-diff.ts
@@ -1,4 +1,4 @@
-import { diffLines } from 'diff'
+import { type LinesOptions, diffLines } from 'diff'
 import * as vscode from 'vscode'
 
 interface InsertionEdit {
@@ -37,7 +37,15 @@ export function computeDiff(
 
     let startLine = range.start.line
     const applicableDiff: Edit[] = []
-    const diff = diffLines(original, replacement)
+    const diff = diffLines(
+        original,
+        replacement,
+        {
+            // Handle cases where we generate an incorrect diff due to a mismatch in the end of line sequence between
+            // the LLM and the original code in the users' editor.
+            stripTrailingCr: true,
+        } as LinesOptions // @types/diff is not currently up to date
+    )
 
     for (const change of diff) {
         const count = change.count || 0


### PR DESCRIPTION
## Description

Fixes an issue where we would generate incorrect diffs due to trailing CR characters in the users' selected code, and this not being matched by the response from the LLM.

## Test plan

1. Enable end of line sequence CRLF (e.g. in VS Code)
2. Start an edit
3. Check that the diff only shows what changed

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

