### PR TITLE
openctx: call disposable when replacing openctx controller

### DIFF
--- a/lib/shared/src/context/openctx/api.ts
+++ b/lib/shared/src/context/openctx/api.ts
@@ -1,19 +1,27 @@
 import type { Client } from '@openctx/client'
 import type * as vscode from 'vscode'
 
-type OpenCtxClient = Pick<Client<vscode.Range>, 'meta' | 'mentions' | 'items'>
+type OpenCtxClient = Pick<Client<vscode.Range>, 'meta' | 'mentions' | 'items' | 'dispose'>
 
-class OpenCtx {
-    constructor(public client: OpenCtxClient | undefined) {}
+interface OpenCtx {
+    client?: OpenCtxClient
+    disposable?: vscode.Disposable
 }
 
-export const openCtx = new OpenCtx(undefined)
+export const openCtx: OpenCtx = {}
 
 /**
- * Set the handle to the OpenCtx client.
+ * Set the handle to the OpenCtx. If there is an existing handle it will be
+ * disposed and replaced.
  */
-export function setOpenCtxClient(client: OpenCtxClient): void {
-    openCtx.client = client
+export function setOpenCtx(newOpenCtx: OpenCtx): void {
+    const old = { ...openCtx }
+
+    openCtx.client = newOpenCtx.client
+    openCtx.disposable = newOpenCtx.disposable
+
+    old.client?.dispose()
+    old.disposable?.dispose()
 }
 
 export const REMOTE_REPOSITORY_PROVIDER_URI = 'internal-remote-repository-search'

--- a/lib/shared/src/index.ts
+++ b/lib/shared/src/index.ts
@@ -300,7 +300,7 @@ export * from './token'
 export * from './token/constants'
 export * from './configuration'
 export {
-    setOpenCtxClient,
+    setOpenCtx,
     openCtx,
     REMOTE_REPOSITORY_PROVIDER_URI,
     REMOTE_FILE_PROVIDER_URI,

--- a/vscode/src/context/openctx.ts
+++ b/vscode/src/context/openctx.ts
@@ -4,7 +4,7 @@ import {
     FeatureFlag,
     GIT_OPENCTX_PROVIDER_URI,
     featureFlagProvider,
-    setOpenCtxClient,
+    setOpenCtx,
 } from '@sourcegraph/cody-shared'
 import * as vscode from 'vscode'
 
@@ -33,16 +33,19 @@ export async function exposeOpenCtxClient(
         const createController =
             createOpenCtxController ?? (await import('@openctx/vscode-lib')).createController
 
-        setOpenCtxClient(
-            createController({
-                extensionId: context.extension.id,
-                secrets: context.secrets,
-                outputChannel,
-                features: {},
-                providers,
-                preloadDelay: 5 * 1000, // 5 seconds
-            }).controller
-        )
+        const controller = createController({
+            extensionId: context.extension.id,
+            secrets: context.secrets,
+            outputChannel,
+            features: {},
+            providers,
+            preloadDelay: 5 * 1000, // 5 seconds
+        })
+
+        setOpenCtx({
+            client: controller.controller,
+            disposable: controller.disposable,
+        })
     } catch (error) {
         logDebug('openctx', `Failed to load OpenCtx client: ${error}`)
     }


### PR DESCRIPTION
We call the setOpenCtx everytime the config or authed account changes. Previously we correctly would replace the OpenCtx client when that happened, but we did not call dispose on the old client or the observable disposables created by vscode-lib.

Test Plan: at mentioned remote repos and got s2 repos. Switched to dotcom and got dotcom repos instead. So switching still works.