### PR TITLE
In app notifications for Prompts and Prompt Library

### DIFF
--- a/lib/shared/src/token/constants.ts
+++ b/lib/shared/src/token/constants.ts
@@ -9,6 +9,7 @@ export const CHAT_INPUT_TOKEN_BUDGET = 7000
 export const FAST_CHAT_INPUT_TOKEN_BUDGET = 4096
 
 /**
+ /**
  * The default output token limit for chat models.
  */
 export const CHAT_OUTPUT_TOKEN_BUDGET = 4000

--- a/vscode/webviews/chat/components/DefaultCommandsList.tsx
+++ b/vscode/webviews/chat/components/DefaultCommandsList.tsx
@@ -35,7 +35,7 @@ export const DefaultCommandsList: FunctionComponent<{
     )
 
     return (
-        <CollapsiblePanel title="Commands" initialOpen={initialOpen}>
+        <CollapsiblePanel title="Prompts" initialOpen={initialOpen}>
             {commandList.map(({ key, title, icon: Icon, href}) => (
                 <Button
                     key={key}

--- a/vscode/webviews/chat/components/DefaultCommandsList.tsx
+++ b/vscode/webviews/chat/components/DefaultCommandsList.tsx
@@ -14,16 +14,15 @@ import { View } from '../../tabs/types'
 import { getVSCodeAPI } from '../../utils/VSCodeApi'
 
 const commonCommandList = [
-    { key: 'cody.command.edit-code', title: 'Edit Code', icon: PencilLineIcon },
-    { key: 'cody.command.document-code', title: 'Document Code', icon: BookIcon },
-    { key: 'cody.command.explain-code', title: 'Explain Code', icon: FileQuestionIcon },
-    { key: 'cody.command.unit-tests', title: 'Generate Unit Tests', icon: GavelIcon },
-    { key: 'cody.command.smell-code', title: 'Find Code Smells', icon: TextSearchIcon },
+    { key: 'cody.command.edit-code', title: 'Edit Code', icon: PencilLineIcon, href: null},
+    { key: 'cody.command.document-code', title: 'Document Code', icon: BookIcon, href: null},
+    { key: 'cody.command.explain-code', title: 'Explain Code', icon: FileQuestionIcon, href: null},
+    { key: 'cody.command.unit-tests', title: 'Generate Unit Tests', icon: GavelIcon, href: null},
+    { key: 'cody.command.smell-code', title: 'Find Code Smells', icon: TextSearchIcon, href: null},
 ]
 
 const vscodeCommandList = [
-    { key: 'cody.menu.custom-commands', title: 'Custom Commands', icon: PencilRulerIcon },
-]
+    { key: 'cody.menu.custom-commands', title: 'Custom Commands', icon: PencilRulerIcon, href: <a href="https://sourcegraph.com">Import to Prompt Library</a>},]
 
 export const DefaultCommandsList: FunctionComponent<{
     IDE?: CodyIDE
@@ -37,18 +36,21 @@ export const DefaultCommandsList: FunctionComponent<{
 
     return (
         <CollapsiblePanel title="Commands" initialOpen={initialOpen}>
-            {commandList.map(({ key, title, icon: Icon }) => (
+            {commandList.map(({ key, title, icon: Icon, href}) => (
                 <Button
                     key={key}
                     variant="ghost"
-                    className="tw-text-left"
+                    className="tw-text-left tw-flex tw-flex-wrap tw-items-center tw-justify-between tw-gap-2"
                     onClick={() => {
                         getVSCodeAPI().postMessage({ command: 'command', id: key })
                         setView?.(View.Chat)
                     }}
                 >
-                    <Icon className="tw-w-8 tw-h-8 tw-opacity-80" size={16} strokeWidth="1.25" />
-                    <span className="tw-truncate tw-w-full">{title}</span>
+                    <div className="tw-flex tw-items-center tw-gap-2 tw-flex-grow">
+                        <Icon className="tw-w-8 tw-h-8 tw-opacity-80 tw-shrink-0" size={16} strokeWidth="1.25" />
+                        <span className="tw-truncate">{title}</span>
+                    </div>
+                    {href && <span className="tw-text-sm tw-text-blue-500">{href}</span>}
                 </Button>
             ))}
         </CollapsiblePanel>

--- a/vscode/webviews/chat/components/DefaultCommandsList.tsx
+++ b/vscode/webviews/chat/components/DefaultCommandsList.tsx
@@ -22,8 +22,7 @@ const commonCommandList = [
 ]
 
 const vscodeCommandList = [
-    { key: 'cody.menu.custom-commands', title: 'Custom Commands', icon: PencilRulerIcon, href: <a href="https://sourcegraph.com">Import to Prompt Library</a>},]
-
+    { key: 'cody.menu.custom-commands', title: 'Custom Commands. To be replaced by Prompts soon', icon: PencilRulerIcon, href: <a href="https://sourcegraph.com">Import any of your existing Custom Commands to your Prompt Library</a>},]
 export const DefaultCommandsList: FunctionComponent<{
     IDE?: CodyIDE
     setView?: (view: View) => void

--- a/vscode/webviews/chat/components/WelcomeMessage.tsx
+++ b/vscode/webviews/chat/components/WelcomeMessage.tsx
@@ -3,6 +3,7 @@ import {
     AtSignIcon,
     type LucideProps,
     MessageSquarePlusIcon,
+    PencilRulerIcon,
     SettingsIcon,
     TextIcon,
 } from 'lucide-react'
@@ -46,6 +47,14 @@ export const WelcomeMessage: FunctionComponent<{ IDE: CodyIDE }> = ({ IDE }) => 
 
     return (
         <div className="tw-flex-1 tw-flex tw-flex-col tw-items-start tw-w-full tw-pt-4 tw-px-8 tw-gap-10 sm:tw-pl-21 tw-transition-all">
+            <CollapsiblePanel title="Commands are now Prompts!">
+                <FeatureRow icon={PencilRulerIcon}>
+                    Prompts (formerly known as Commands) allow you to quickly chat with Cody with repeatable prompts. 
+                    <br/>Learn more <a href="https://sourcegraph.com/prompts">here</a> 
+                    <br/>Create your own Prompts in the <a href="https://sourcegraph.com/prompts">Prompt Library</a>
+
+                </FeatureRow>
+            </CollapsiblePanel>
             <DefaultCommandsList IDE={IDE} initialOpen={false} />
             <CollapsiblePanel title="Chat Help">
                 <FeatureRow icon={AtSignIcon}>

--- a/vscode/webviews/chat/components/WelcomeMessage.tsx
+++ b/vscode/webviews/chat/components/WelcomeMessage.tsx
@@ -47,10 +47,11 @@ export const WelcomeMessage: FunctionComponent<{ IDE: CodyIDE }> = ({ IDE }) => 
 
     return (
         <div className="tw-flex-1 tw-flex tw-flex-col tw-items-start tw-w-full tw-pt-4 tw-px-8 tw-gap-10 sm:tw-pl-21 tw-transition-all">
-            <CollapsiblePanel title="Commands are now Prompts!">
+            <CollapsiblePanel title="Commands are now Prompts!" initialOpen={true}>
                 <FeatureRow icon={PencilRulerIcon}>
                     Prompts (formerly known as Commands) allow you to quickly chat with Cody with repeatable prompts. 
-                    <br/>Learn more <a href="https://sourcegraph.com/prompts">here</a> 
+                    Read our <a href="https://sourcegraph.com/prompts">docs</a> to learn more.
+                    <br/> 
                     <br/>Create your own Prompts in the <a href="https://sourcegraph.com/prompts">Prompt Library</a>
 
                 </FeatureRow>


### PR DESCRIPTION
Fulfills:
* https://linear.app/sourcegraph/issue/PROD-171/we-surface-this-importer-tool-in-the-vs-code-app
* https://linear.app/sourcegraph/issue/PROD-170/show-a-tooltip-that-notifies-the-user-commands-are-now-prompts-when

Does the following:
* Create a dialogue that notifies the user that Commands are now Prompts
* Adds a hyper link to the Prompt Library importer so users with Custom Commands can import their prompts

Still need to do:

- [ ] Polish the copy
- [ ] Update the "Import" hyperlink to the right link @sqs 
- [ ] Update the "Learn more" hyperlink to the correct docs location
- [ ] Determine if Edit, Document, and Generate Unit Tests should _not_ be in the "Prompts" drawer, since they're not technically Prompts. 

![Screenshot 2024-07-31 at 5 00 07 PM](https://github.com/user-attachments/assets/2592e180-7453-4869-aca8-a06ff4edd236)


## Test plan
QA on local

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
