### PR TITLE
Cody Web: Fix mention provider fetching when user is switching between chats

### DIFF
--- a/lib/prompt-editor/src/mentions/mentionMenu/useMentionMenuData.test.tsx
+++ b/lib/prompt-editor/src/mentions/mentionMenu/useMentionMenuData.test.tsx
@@ -49,7 +49,6 @@ describe('useMentionMenuData', () => {
         ])
         vi.mocked(useChatContextMentionProviders).mockReturnValue({
             providers: mockProviders,
-            reload: () => {},
         })
         vi.mocked(useClientState).mockReturnValue({
             initialContext: [mockContextItems[0]],

--- a/lib/prompt-editor/src/plugins/atMentions/atMentions.tsx
+++ b/lib/prompt-editor/src/plugins/atMentions/atMentions.tsx
@@ -19,7 +19,8 @@ import {
     KEY_ESCAPE_COMMAND,
     type TextNode,
 } from 'lexical'
-import { type FunctionComponent, useCallback, useEffect, useRef, useState } from 'react'
+import { isEqual } from 'lodash'
+import { type FunctionComponent, memo, useCallback, useEffect, useRef, useState } from 'react'
 import styles from './atMentions.module.css'
 
 import {
@@ -75,202 +76,207 @@ function scanForMentionTriggerInLexicalInput(text: string) {
 
 export type setEditorQuery = (getNewQuery: (currentText: string) => [string, number?]) => void
 
-export const MentionsPlugin: FunctionComponent<{ contextWindowSizeInTokens?: number }> = ({
-    contextWindowSizeInTokens,
-}) => {
-    const [editor] = useLexicalComposerContext()
+export const MentionsPlugin: FunctionComponent<{ contextWindowSizeInTokens?: number }> = memo(
+    ({ contextWindowSizeInTokens }) => {
+        const [editor] = useLexicalComposerContext()
 
-    /**
-     * Total sum of tokens represented by all of the @-mentioned items.
-     */
-    const [tokenAdded, setTokenAdded] = useState<number>(0)
+        /**
+         * Total sum of tokens represented by all of the @-mentioned items.
+         */
+        const [tokenAdded, setTokenAdded] = useState<number>(0)
 
-    const { x, y, refs, strategy } = useFloating(FLOATING_OPTIONS)
+        const { x, y, refs, strategy } = useFloating(FLOATING_OPTIONS)
 
-    const remainingTokenBudget =
-        contextWindowSizeInTokens === undefined
-            ? Number.MAX_SAFE_INTEGER
-            : contextWindowSizeInTokens - tokenAdded
+        const remainingTokenBudget =
+            contextWindowSizeInTokens === undefined
+                ? Number.MAX_SAFE_INTEGER
+                : contextWindowSizeInTokens - tokenAdded
 
-    const { params, updateQuery, updateMentionMenuParams } = useMentionMenuParams()
+        const { params, updateQuery, updateMentionMenuParams } = useMentionMenuParams()
 
-    const data = useMentionMenuData(params, {
-        remainingTokenBudget,
-        limit: SUGGESTION_LIST_LENGTH_LIMIT,
-    })
-
-    const setEditorQuery = useCallback<setEditorQuery>(
-        getNewQuery => {
-            if (editor) {
-                editor.update(() => {
-                    const node = $getSelection()?.getNodes().at(-1)
-                    if (!node || !$isTextNode(node)) {
-                        return
-                    }
-
-                    const currentText = node.getTextContent()
-                    const [newText, index] = getNewQuery(currentText)
-                    if (currentText === newText) {
-                        return
-                    }
-
-                    node.setTextContent(newText)
-
-                    if (index !== undefined) {
-                        node.select(index, index)
-                    } else {
-                        // If our old text was "prefix @bar baz" and the new text is
-                        // "prefix @ baz" then our cursor should be just after @
-                        // (which is at the common prefix position)
-                        const offset = sharedPrefixLength(currentText, newText)
-                        node.select(offset, offset)
-                    }
-                })
-            }
-        },
-        [editor]
-    )
-
-    useEffect(() => {
-        // Listen for changes to ContextItemMentionNode to update the token count.
-        // This updates the token count when a mention is added or removed.
-        const unregister = editor.registerMutationListener(ContextItemMentionNode, node => {
-            const items = toSerializedPromptEditorValue(editor)?.contextItems
-            if (!items?.length) {
-                setTokenAdded(0)
-                return
-            }
-            setTokenAdded(items?.reduce((acc, item) => acc + (item.size ? item.size : 0), 0) ?? 0)
+        const data = useMentionMenuData(params, {
+            remainingTokenBudget,
+            limit: SUGGESTION_LIST_LENGTH_LIMIT,
         })
-        return unregister
-    }, [editor])
 
-    const onSelectOption = useCallback(
-        (selectedOption: MentionMenuOption, nodeToReplace: TextNode | null, closeMenu: () => void) => {
-            editor.update(() => {
-                const currentInputText = nodeToReplace?.__text
-                if (!currentInputText) {
+        const setEditorQuery = useCallback<setEditorQuery>(
+            getNewQuery => {
+                if (editor) {
+                    editor.update(() => {
+                        const node = $getSelection()?.getNodes().at(-1)
+                        if (!node || !$isTextNode(node)) {
+                            return
+                        }
+
+                        const currentText = node.getTextContent()
+                        const [newText, index] = getNewQuery(currentText)
+                        if (currentText === newText) {
+                            return
+                        }
+
+                        node.setTextContent(newText)
+
+                        if (index !== undefined) {
+                            node.select(index, index)
+                        } else {
+                            // If our old text was "prefix @bar baz" and the new text is
+                            // "prefix @ baz" then our cursor should be just after @
+                            // (which is at the common prefix position)
+                            const offset = sharedPrefixLength(currentText, newText)
+                            node.select(offset, offset)
+                        }
+                    })
+                }
+            },
+            [editor]
+        )
+
+        useEffect(() => {
+            // Listen for changes to ContextItemMentionNode to update the token count.
+            // This updates the token count when a mention is added or removed.
+            const unregister = editor.registerMutationListener(ContextItemMentionNode, node => {
+                const items = toSerializedPromptEditorValue(editor)?.contextItems
+                if (!items?.length) {
+                    setTokenAdded(0)
                     return
                 }
-
-                const selectedItem = selectedOption.item
-                const isLargeFile = selectedItem.isTooLarge
-                // When selecting a large file without range, add the selected option as text node with : at the end.
-                // This allows users to autocomplete the file path, and provide them with the options to add range.
-                if (isLargeFile && !selectedItem.range) {
-                    const textNode = $createContextItemTextNode(selectedItem)
-                    nodeToReplace.replace(textNode)
-                    const colonNode = $createTextNode(':')
-                    textNode.insertAfter(colonNode)
-                    colonNode.select()
-                } else {
-                    const mentionNode = $createContextItemMentionNode(selectedItem)
-                    nodeToReplace.replace(mentionNode)
-                    const spaceNode = $createTextNode(' ')
-                    mentionNode.insertAfter(spaceNode)
-                    spaceNode.select()
-                }
-                closeMenu()
+                setTokenAdded(items?.reduce((acc, item) => acc + (item.size ? item.size : 0), 0) ?? 0)
             })
-        },
-        [editor]
-    )
+            return unregister
+        }, [editor])
 
-    // Reposition popover when the window, editor, or popover changes size.
-    useEffect(() => {
-        const referenceEl = refs.reference.current
-        const floatingEl = refs.floating.current
-        if (!referenceEl || !floatingEl) {
-            return undefined
-        }
-        const cleanup = autoUpdate(referenceEl, floatingEl, async () => {
-            const { x, y } = await computePosition(referenceEl, floatingEl, FLOATING_OPTIONS)
-            floatingEl.style.left = `${x}px`
-            floatingEl.style.top = `${y}px`
-        })
-        return cleanup
-    }, [refs.reference.current, refs.floating.current])
+        const onSelectOption = useCallback(
+            (
+                selectedOption: MentionMenuOption,
+                nodeToReplace: TextNode | null,
+                closeMenu: () => void
+            ) => {
+                editor.update(() => {
+                    const currentInputText = nodeToReplace?.__text
+                    if (!currentInputText) {
+                        return
+                    }
 
-    // Close the menu when the editor loses focus.
-    const anchorElementRef2 = useRef<HTMLElement>()
-    useEffect(() => {
-        return editor.registerCommand(
-            BLUR_COMMAND,
-            event => {
-                // Ignore clicks in the mention menu itself.
-                const isInEditorOrMenu = Boolean(
-                    event.relatedTarget instanceof Node &&
-                        (editor.getRootElement()?.contains(event.relatedTarget) ||
-                            anchorElementRef2.current?.contains(event.relatedTarget))
-                )
-                if (isInEditorOrMenu) {
-                    // `editor.focus()` swallows clicks in the menu; this seems to work instead.
-                    editor.getRootElement()?.focus()
-                    return true
-                }
-
-                editor.dispatchCommand(
-                    KEY_ESCAPE_COMMAND,
-                    new KeyboardEvent('keydown', { key: 'Escape' })
-                )
-                return true
-            },
-            COMMAND_PRIORITY_NORMAL
-        )
-    }, [editor])
-
-    const onClose = useCallback(() => {
-        updateMentionMenuParams({ parentItem: null })
-    }, [updateMentionMenuParams])
-
-    return (
-        <LexicalTypeaheadMenuPlugin<MentionMenuOption>
-            onQueryChange={updateQuery}
-            onSelectOption={onSelectOption}
-            onClose={onClose}
-            triggerFn={scanForMentionTriggerInLexicalInput}
-            options={DUMMY_OPTIONS}
-            anchorClassName={styles.resetAnchor}
-            commandPriority={
-                COMMAND_PRIORITY_NORMAL /* so Enter keypress selects option and doesn't submit form */
-            }
-            onOpen={menuResolution => {
-                refs.setPositionReference({
-                    getBoundingClientRect: menuResolution.getRect,
+                    const selectedItem = selectedOption.item
+                    const isLargeFile = selectedItem.isTooLarge
+                    // When selecting a large file without range, add the selected option as text node with : at the end.
+                    // This allows users to autocomplete the file path, and provide them with the options to add range.
+                    if (isLargeFile && !selectedItem.range) {
+                        const textNode = $createContextItemTextNode(selectedItem)
+                        nodeToReplace.replace(textNode)
+                        const colonNode = $createTextNode(':')
+                        textNode.insertAfter(colonNode)
+                        colonNode.select()
+                    } else {
+                        const mentionNode = $createContextItemMentionNode(selectedItem)
+                        nodeToReplace.replace(mentionNode)
+                        const spaceNode = $createTextNode(' ')
+                        mentionNode.insertAfter(spaceNode)
+                        spaceNode.select()
+                    }
+                    closeMenu()
                 })
-            }}
-            menuRenderFn={(anchorElementRef, itemProps) => {
-                const { selectOptionAndCleanUp } = itemProps
-                anchorElementRef2.current = anchorElementRef.current ?? undefined
-                return (
-                    anchorElementRef.current && (
-                        <FloatingPortal root={anchorElementRef.current}>
-                            <div
-                                ref={ref => {
-                                    refs.setFloating(ref)
-                                }}
-                                style={{
-                                    position: strategy,
-                                    top: y,
-                                    left: x,
-                                }}
-                                className={clsx(styles.popover)}
-                            >
-                                <MentionMenu
-                                    params={params}
-                                    updateMentionMenuParams={updateMentionMenuParams}
-                                    setEditorQuery={setEditorQuery}
-                                    data={data}
-                                    selectOptionAndCleanUp={selectOptionAndCleanUp}
-                                />
-                            </div>
-                        </FloatingPortal>
+            },
+            [editor]
+        )
+
+        // Reposition popover when the window, editor, or popover changes size.
+        useEffect(() => {
+            const referenceEl = refs.reference.current
+            const floatingEl = refs.floating.current
+            if (!referenceEl || !floatingEl) {
+                return undefined
+            }
+            const cleanup = autoUpdate(referenceEl, floatingEl, async () => {
+                const { x, y } = await computePosition(referenceEl, floatingEl, FLOATING_OPTIONS)
+                floatingEl.style.left = `${x}px`
+                floatingEl.style.top = `${y}px`
+            })
+            return cleanup
+        }, [refs.reference.current, refs.floating.current])
+
+        // Close the menu when the editor loses focus.
+        const anchorElementRef2 = useRef<HTMLElement>()
+        useEffect(() => {
+            return editor.registerCommand(
+                BLUR_COMMAND,
+                event => {
+                    // Ignore clicks in the mention menu itself.
+                    const isInEditorOrMenu = Boolean(
+                        event.relatedTarget instanceof Node &&
+                            (editor.getRootElement()?.contains(event.relatedTarget) ||
+                                anchorElementRef2.current?.contains(event.relatedTarget))
                     )
-                )
-            }}
-        />
-    )
-}
+                    if (isInEditorOrMenu) {
+                        // `editor.focus()` swallows clicks in the menu; this seems to work instead.
+                        editor.getRootElement()?.focus()
+                        return true
+                    }
+
+                    editor.dispatchCommand(
+                        KEY_ESCAPE_COMMAND,
+                        new KeyboardEvent('keydown', { key: 'Escape' })
+                    )
+                    return true
+                },
+                COMMAND_PRIORITY_NORMAL
+            )
+        }, [editor])
+
+        const onClose = useCallback(() => {
+            updateMentionMenuParams({ parentItem: null })
+        }, [updateMentionMenuParams])
+
+        return (
+            <LexicalTypeaheadMenuPlugin<MentionMenuOption>
+                onQueryChange={updateQuery}
+                onSelectOption={onSelectOption}
+                onClose={onClose}
+                triggerFn={scanForMentionTriggerInLexicalInput}
+                options={DUMMY_OPTIONS}
+                anchorClassName={styles.resetAnchor}
+                commandPriority={
+                    COMMAND_PRIORITY_NORMAL /* so Enter keypress selects option and doesn't submit form */
+                }
+                onOpen={menuResolution => {
+                    refs.setPositionReference({
+                        getBoundingClientRect: menuResolution.getRect,
+                    })
+                }}
+                menuRenderFn={(anchorElementRef, itemProps) => {
+                    const { selectOptionAndCleanUp } = itemProps
+                    anchorElementRef2.current = anchorElementRef.current ?? undefined
+                    return (
+                        anchorElementRef.current && (
+                            <FloatingPortal root={anchorElementRef.current}>
+                                <div
+                                    ref={ref => {
+                                        refs.setFloating(ref)
+                                    }}
+                                    style={{
+                                        position: strategy,
+                                        top: y,
+                                        left: x,
+                                    }}
+                                    className={clsx(styles.popover)}
+                                >
+                                    <MentionMenu
+                                        params={params}
+                                        updateMentionMenuParams={updateMentionMenuParams}
+                                        setEditorQuery={setEditorQuery}
+                                        data={data}
+                                        selectOptionAndCleanUp={selectOptionAndCleanUp}
+                                    />
+                                </div>
+                            </FloatingPortal>
+                        )
+                    )
+                }}
+            />
+        )
+    },
+    isEqual
+)
 
 function sharedPrefixLength(s1: string, s2: string): number {
     let i = 0

--- a/vscode/webviews/Chat.tsx
+++ b/vscode/webviews/Chat.tsx
@@ -8,7 +8,6 @@ import type { VSCodeWrapper } from './utils/VSCodeApi'
 
 import { truncateTextStart } from '@sourcegraph/cody-shared/src/prompt/truncation'
 import { CHAT_INPUT_TOKEN_BUDGET } from '@sourcegraph/cody-shared/src/token/constants'
-import { useChatContextMentionProviders } from '@sourcegraph/prompt-editor'
 import styles from './Chat.module.css'
 import { WelcomeMessage } from './chat/components/WelcomeMessage'
 import { ScrollDown } from './components/ScrollDown'
@@ -43,7 +42,6 @@ export const Chat: React.FunctionComponent<React.PropsWithChildren<ChatboxProps>
     showIDESnippetActions = true,
     className,
 }) => {
-    const { reload: reloadMentionProviders } = useChatContextMentionProviders()
     const telemetryRecorder = useTelemetryRecorder()
 
     const transcriptRef = useRef(transcript)
@@ -157,11 +155,6 @@ export const Chat: React.FunctionComponent<React.PropsWithChildren<ChatboxProps>
             window.removeEventListener('focus', onFocus)
         }
     }, [])
-
-    // biome-ignore lint/correctness/useExhaustiveDependencies: needs to run when is dotcom status is changing to update openctx providers
-    useEffect(() => {
-        reloadMentionProviders()
-    }, [userInfo.isDotComUser, reloadMentionProviders])
 
     return (
         <div className={clsx(styles.container, className, 'tw-relative')}>

--- a/web/CHANGELOG.md
+++ b/web/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.3.2
+- Fixes mention providers fetching as we switch between chats 
+
 ## 0.3.1
 - Improves debounce logic for context item suggestions 
 

--- a/web/lib/components/CodyWebChatProvider.tsx
+++ b/web/lib/components/CodyWebChatProvider.tsx
@@ -29,10 +29,10 @@ import { useLocalStorage } from '../utils/use-local-storage'
  */
 const ACTIVE_CHAT_ID_KEY = 'cody-web.last-active-chat-id'
 
-// Usually CodyWebChatProvider VSCode API wrapper listens messages from Extension host
-// which matches with the current active panel id. But this message id check can be corrupted
-// by race conditions in different events that extension host is sending during switching chats.
-// Some events should be always handled by the client regardless from which active panel they
+// Usually the CodyWebChatProvider VSCode API wrapper listens only to messages from the Extension host
+// which matches the current active panel id. But this message id check can be corrupted
+// by race conditions in different events that the extension host sends during chat-switching.
+// Some events should always be handled by the client regardless of which active panel they
 // came from.
 const GLOBAL_MESSAGE_TYPES: Array<ExtensionMessage['type']> = ['allMentionProvidersMetadata']
 

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sourcegraph/cody-web",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Cody standalone web app",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
Recently, probably since we changed our logic for global contexts, I've noticed that as you switch between chats in the Cody Web sometimes the context providers like Repositories and Files just disappear from the @ menu. 

This PR fixes this by ensuring that we always listen to these events from the extension host, this PR also removes some old logic about reloading providers (it's no longer needed because providers' state became local)

## Test plan
- Check Cody Web demo (`cd web & pnpm dev`)
- Try to use the @ menu you should see set of three providers Repositories, Files and Symbols
- Change chat (or create new one) you should see the same set of providers 


