### PR TITLE
change default keybinding for creating chat in editor to Shift+Alt+L

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -22,14 +22,9 @@ Chat: Cody is now defaulted to run in the sidebar for both Enterprise and Non-En
 - Autocomplete: Ignores leading empty new lines for autocomplete suggestions to reduce the number of cases when Cody doesn't suggest anything. [pull/4864](https://github.com/sourcegraph/cody/pull/4864)
 - Autocomplete: Preload completions on cursor movement. [pull/4901](https://github.com/sourcegraph/cody/pull/4901)
 - Chat: The shortcuts for starting starting and toggling the chat have changed:
-  - `Alt+L`: think of this as the muscle-memory "chat" shortcut
-    - From text editor: opens/focuses the chat sidebar panel
-    - From text editor with active selection: adds the active selection to chat
-    - From chat sidebar: focuses the last editor panel
-    - From chat editor: no-op
-  - `Shift+Alt+L`:
-    - From text editor: opens a new chat editor panel
-    - Anywhere else: starts a new chat in the sidebar
+  - `Alt+L`: Toggles between the chat view and the last text editor. If a chat view doesn't exist, it opens a new one. From a text editor with an active selection, it adds the active selection to the chat.
+  - `Shift+Alt+L`: starts a new chat session.
+  - The `cody.chat.defaultLocation` setting controls the default location of chat sessions. The values are "sidebar", "editor", or "sticky". The default is "sticky", which defaults to the sidebar but switches whenever the user moves the chat to the editor panel, or vice versa.
 
 ## 1.28.0
 

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -21,6 +21,15 @@ Chat: Cody is now defaulted to run in the sidebar for both Enterprise and Non-En
 
 - Autocomplete: Ignores leading empty new lines for autocomplete suggestions to reduce the number of cases when Cody doesn't suggest anything. [pull/4864](https://github.com/sourcegraph/cody/pull/4864)
 - Autocomplete: Preload completions on cursor movement. [pull/4901](https://github.com/sourcegraph/cody/pull/4901)
+- Chat: The shortcuts for starting starting and toggling the chat have changed:
+  - `Alt+L`: think of this as the muscle-memory "chat" shortcut
+    - From text editor: opens/focuses the chat sidebar panel
+    - From text editor with active selection: adds the active selection to chat
+    - From chat sidebar: focuses the last editor panel
+    - From chat editor: no-op
+  - `Shift+Alt+L`:
+    - From text editor: opens a new chat editor panel
+    - Anywhere else: starts a new chat in the sidebar
 
 ## 1.28.0
 

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -424,6 +424,14 @@
         "enablement": "!cody.activated"
       },
       {
+        "command": "cody.chat.new",
+        "category": "Cody",
+        "title": "New Chat",
+        "enablement": "cody.activated",
+        "group": "Cody",
+        "icon": "$(new-comment-icon)"
+      },
+      {
         "command": "cody.chat.newEditorPanel",
         "category": "Cody",
         "title": "New Chat in Editor",
@@ -443,7 +451,8 @@
         "command": "cody.chat.moveFromEditor",
         "category": "Cody",
         "title": "Move Chat from Editor to Main Cody Panel",
-        "enablement": "cody.activated && view == cody.chat",
+        "when": "cody.activated && view == cody.chat",
+        "enablement": "cody.activated",
         "group": "Cody",
         "icon": "$(layout-sidebar-left)"
       },
@@ -582,12 +591,12 @@
       },
 
       {
-        "command": "cody.chat.newPanel",
+        "command": "cody.chat.new",
         "key": "shift+alt+/",
         "when": "cody.activated"
       },
       {
-        "command": "cody.chat.newPanel",
+        "command": "cody.chat.new",
         "key": "shift+alt+l",
         "when": "cody.activated"
       },
@@ -622,23 +631,6 @@
         "when": "cody.activated && !editorTextFocus",
         "args": {
           "editorFocus": false
-        }
-      },
-
-      {
-        "command": "cody.chat.newEditorPanel",
-        "key": "shift+alt+l",
-        "when": "cody.activated && editorTextFocus",
-        "args": {
-          "editorFocus": true
-        }
-      },
-      {
-        "command": "cody.chat.newEditorPanel",
-        "key": "shift+alt+/",
-        "when": "cody.activated && editorTextFocus",
-        "args": {
-          "editorFocus": true
         }
       },
 
@@ -1045,6 +1037,18 @@
           "type": "string",
           "markdownDescription": "A custom instruction to be included at the start of all chat messages (e.g. \"Answer all my questions in Spanish.\")",
           "examples": ["Answer all my questions in Spanish."]
+        },
+        "cody.chat.defaultLocation": {
+          "order": 6,
+          "type": "string",
+          "enum": ["sticky", "sidebar", "editor"],
+          "markdownDescription": "Controls where the Cody chat view opens when the user invokes the `Cody: New Chat` command, or the Alt+L and Alt+/ shortcuts.",
+          "enumDescriptions": [
+            "Opens in the last-activated view location, which is set whenever the user explicitly chooses to open chat in a given location",
+            "Opens in the sidebar",
+            "Opens in an editor panel"
+          ],
+          "default": "sticky"
         },
         "cody.edit.preInstruction": {
           "order": 7,

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -582,39 +582,6 @@
       },
 
       {
-        "command": "cody.chat.toggle",
-        "key": "alt+l",
-        "when": "cody.activated && editorTextFocus",
-        "args": {
-          "editorFocus": true
-        }
-      },
-      {
-        "command": "cody.chat.toggle",
-        "key": "alt+l",
-        "when": "cody.activated && !editorTextFocus",
-        "args": {
-          "editorFocus": false
-        }
-      },
-      {
-        "command": "cody.chat.toggle",
-        "key": "alt+/",
-        "when": "cody.activated && editorTextFocus",
-        "args": {
-          "editorFocus": true
-        }
-      },
-      {
-        "command": "cody.chat.toggle",
-        "key": "alt+/",
-        "when": "cody.activated && !editorTextFocus",
-        "args": {
-          "editorFocus": false
-        }
-      },
-
-      {
         "command": "cody.chat.newPanel",
         "key": "shift+alt+/",
         "when": "cody.activated"
@@ -623,6 +590,39 @@
         "command": "cody.chat.newPanel",
         "key": "shift+alt+l",
         "when": "cody.activated"
+      },
+
+      {
+        "command": "cody.chat.toggle",
+        "key": "alt+l",
+        "when": "cody.activated && editorTextFocus",
+        "args": {
+          "editorFocus": true
+        }
+      },
+      {
+        "command": "cody.chat.toggle",
+        "key": "alt+l",
+        "when": "cody.activated && !editorTextFocus",
+        "args": {
+          "editorFocus": false
+        }
+      },
+      {
+        "command": "cody.chat.toggle",
+        "key": "alt+/",
+        "when": "cody.activated && editorTextFocus",
+        "args": {
+          "editorFocus": true
+        }
+      },
+      {
+        "command": "cody.chat.toggle",
+        "key": "alt+/",
+        "when": "cody.activated && !editorTextFocus",
+        "args": {
+          "editorFocus": false
+        }
       },
 
       {

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -580,16 +580,7 @@
         "key": "alt+l",
         "when": "!cody.activated"
       },
-      {
-        "command": "cody.chat.newPanel",
-        "key": "alt+/",
-        "when": "cody.activated"
-      },
-      {
-        "command": "cody.chat.newPanel",
-        "key": "alt+shift+l",
-        "when": "cody.activated"
-      },
+
       {
         "command": "cody.chat.toggle",
         "key": "alt+l",
@@ -607,13 +598,50 @@
         }
       },
       {
-        "command": "cody.chat.newEditorPanel",
-        "key": "alt+l",
+        "command": "cody.chat.toggle",
+        "key": "alt+/",
         "when": "cody.activated && editorTextFocus",
         "args": {
           "editorFocus": true
         }
       },
+      {
+        "command": "cody.chat.toggle",
+        "key": "alt+/",
+        "when": "cody.activated && !editorTextFocus",
+        "args": {
+          "editorFocus": false
+        }
+      },
+
+      {
+        "command": "cody.chat.newPanel",
+        "key": "shift+alt+/",
+        "when": "cody.activated"
+      },
+      {
+        "command": "cody.chat.newPanel",
+        "key": "shift+alt+l",
+        "when": "cody.activated"
+      },
+
+      {
+        "command": "cody.chat.newEditorPanel",
+        "key": "shift+alt+l",
+        "when": "cody.activated && editorTextFocus",
+        "args": {
+          "editorFocus": true
+        }
+      },
+      {
+        "command": "cody.chat.newEditorPanel",
+        "key": "shift+alt+/",
+        "when": "cody.activated && editorTextFocus",
+        "args": {
+          "editorFocus": true
+        }
+      },
+
       {
         "command": "cody.mention.selection",
         "key": "alt+/",
@@ -624,6 +652,7 @@
         "key": "alt+l",
         "when": "cody.activated && editorTextFocus && editorHasSelection"
       },
+
       {
         "command": "cody.tutorial.chat",
         "key": "alt+l",

--- a/vscode/src/chat/chat-view/ChatController.ts
+++ b/vscode/src/chat/chat-view/ChatController.ts
@@ -537,7 +537,8 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
     private async getConfigForWebview(): Promise<ConfigurationSubsetForWebview & LocalEnv> {
         const config = await getFullConfig()
 
-        const webviewType = this.webviewPanelOrView?.webview ? 'sidebar' : 'editor'
+        const webviewType =
+            this.webviewPanelOrView?.viewType === 'cody.editorPanel' ? 'editor' : 'sidebar'
 
         return {
             agentIDE: config.isRunningInsideAgent ? config.agentIDE : CodyIDE.VSCode,

--- a/vscode/src/services/LocalStorageProvider.ts
+++ b/vscode/src/services/LocalStorageProvider.ts
@@ -22,6 +22,8 @@ interface PersistedUserLocalHistory {
     chat: ChatHistory
 }
 
+export type ChatLocation = 'editor' | 'sidebar'
+
 class LocalStorage {
     // Bump this on storage changes so we don't handle incorrectly formatted data
     protected readonly KEY_LOCAL_HISTORY = 'cody-local-chatHistory-v2'
@@ -32,6 +34,7 @@ class LocalStorage {
     public readonly LAST_USED_USERNAME = 'SOURCEGRAPH_CODY_USERNAME'
     protected readonly CODY_ENDPOINT_HISTORY = 'SOURCEGRAPH_CODY_ENDPOINT_HISTORY'
     protected readonly CODY_ENROLLMENT_HISTORY = 'SOURCEGRAPH_CODY_ENROLLMENTS'
+    protected readonly LAST_USED_CHAT_MODALITY = 'cody-last-used-chat-modality'
 
     /**
      * Should be set on extension activation via `localStorage.setStorage(context.globalState)`
@@ -224,6 +227,14 @@ class LocalStorage {
 
     public getConfig(): ConfigurationWithAccessToken | null {
         return this.get(this.KEY_CONFIG)
+    }
+
+    public setLastUsedChatModality(modality: 'sidebar' | 'editor'): void {
+        this.set(this.LAST_USED_CHAT_MODALITY, modality)
+    }
+
+    public getLastUsedChatModality(): 'sidebar' | 'editor' {
+        return this.storage?.get(this.LAST_USED_CHAT_MODALITY) ?? 'sidebar'
     }
 
     public get<T>(key: string): T | null {

--- a/vscode/test/e2e/chat-keyboard-shortcuts.test.ts
+++ b/vscode/test/e2e/chat-keyboard-shortcuts.test.ts
@@ -17,10 +17,10 @@ test('chat keyboard shortcuts for sidebar chat', async ({ page, sidebar }) => {
     const chatPanel = getChatEditorPanel(page)
     const chatInput = getChatInputs(chatPanel).first()
 
-    // Alt+L with no selection opens a new chat (with file mention).
+    // Shift+Alt+L with no selection opens a new chat in an editor panel (with file mention).
     await openFileInEditorTab(page, 'buzz.ts')
     await clickEditorTab(page, 'buzz.ts')
-    await page.keyboard.press('Alt+L')
+    await page.keyboard.press('Shift+Alt+L')
     await expect(chatInput).toContainText('buzz.ts', { timeout: 3_000 })
 
     await executeCommandInPalette(page, 'View: Close Primary Sidebar')
@@ -37,7 +37,8 @@ test('chat keyboard shortcuts for sidebar chat', async ({ page, sidebar }) => {
     await page.keyboard.press('Alt+L')
     await expect(chatInput).toContainText('buzz.ts buzz.ts:3-5 x buzz.ts:7-9 ')
 
-    // Alt+L in the chat (after sending) opens a new chat.
+    // Alt+Shift+L in the chat (after sending) opens a new chat.
     await chatInput.press('Enter')
+    await page.keyboard.press('Shift+Alt+L')
     await expect(chatMessageRows(chatPanel).nth(2)).toContainText(/hello from the assistant/)
 })

--- a/vscode/test/e2e/chat-keyboard-shortcuts.test.ts
+++ b/vscode/test/e2e/chat-keyboard-shortcuts.test.ts
@@ -1,9 +1,8 @@
 import { expect } from '@playwright/test'
 import {
-    chatMessageRows,
     clickEditorTab,
-    getChatEditorPanel,
     getChatInputs,
+    getChatSidebarPanel,
     openFileInEditorTab,
     selectLineRangeInEditorTab,
     sidebarSignin,
@@ -14,31 +13,19 @@ test('chat keyboard shortcuts for sidebar chat', async ({ page, sidebar }) => {
     await page.bringToFront()
     await sidebarSignin(page, sidebar)
 
-    const chatPanel = getChatEditorPanel(page)
-    const chatInput = getChatInputs(chatPanel).first()
+    const chatSidebar = getChatSidebarPanel(page)
+    const chatSidebarInput = getChatInputs(chatSidebar).first()
 
     // Shift+Alt+L with no selection opens a new chat in an editor panel (with file mention).
     await openFileInEditorTab(page, 'buzz.ts')
     await clickEditorTab(page, 'buzz.ts')
     await page.keyboard.press('Shift+Alt+L')
-    await expect(chatInput).toContainText('buzz.ts', { timeout: 3_000 })
+    await expect(chatSidebarInput).toContainText('buzz.ts', { timeout: 3_000 })
 
     await executeCommandInPalette(page, 'View: Close Primary Sidebar')
 
     // Alt+L with a selection opens a new chat (with selection mention).
     await selectLineRangeInEditorTab(page, 3, 5)
     await page.keyboard.press('Alt+L')
-    await expect(chatInput).toContainText('buzz.ts buzz.ts:3-5 ')
-
-    // Alt+L with an existing chat appends a selection mention.
-    await chatInput.press('x')
-    await clickEditorTab(page, 'buzz.ts')
-    await selectLineRangeInEditorTab(page, 7, 9)
-    await page.keyboard.press('Alt+L')
-    await expect(chatInput).toContainText('buzz.ts buzz.ts:3-5 x buzz.ts:7-9 ')
-
-    // Alt+Shift+L in the chat (after sending) opens a new chat.
-    await chatInput.press('Enter')
-    await page.keyboard.press('Shift+Alt+L')
-    await expect(chatMessageRows(chatPanel).nth(2)).toContainText(/hello from the assistant/)
+    await expect(chatSidebarInput).toContainText('buzz.ts buzz.ts:3-5 ')
 })

--- a/vscode/webviews/App.tsx
+++ b/vscode/webviews/App.tsx
@@ -176,7 +176,8 @@ export const App: React.FunctionComponent<{ vscodeAPI: VSCodeWrapper }> = ({ vsc
     useEffect(() => {
         // On macOS, suppress the '¬' character emitted by default for alt+L
         const handleKeyDown = (event: KeyboardEvent) => {
-            if (event.altKey && event.key === '¬') {
+            const suppressedKeys = ['¬', 'Ò', '¿']
+            if (event.altKey && suppressedKeys.includes(event.key)) {
                 event.preventDefault()
             }
         }

--- a/vscode/webviews/tabs/TabsBar.tsx
+++ b/vscode/webviews/tabs/TabsBar.tsx
@@ -84,7 +84,7 @@ const BASE_TAB_ITEMS: TabConfig[] = [
                     </>
                 ),
                 Icon: MessageSquarePlusIcon,
-                command: 'cody.chat.newPanel',
+                command: 'cody.chat.new',
             },
             {
                 tooltip: 'Open in Editor',

--- a/vscode/webviews/tabs/TabsBar.tsx
+++ b/vscode/webviews/tabs/TabsBar.tsx
@@ -80,7 +80,7 @@ const BASE_TAB_ITEMS: TabConfig[] = [
             {
                 tooltip: (
                     <>
-                        New Chat <Kbd macOS="opt+/" linuxAndWindows="alt+/" />
+                        New Chat <Kbd macOS="shift+opt+l" linuxAndWindows="shift+alt+l" />
                     </>
                 ),
                 Icon: MessageSquarePlusIcon,


### PR DESCRIPTION
`Alt+L` now toggles between editor and sidebar chat:

- `Alt+L`: think of this as the muscle-memory "chat" shortcut
  - From text editor: opens/focuses the chat sidebar panel
  - From text editor with active selection: adds the active selection to chat
  - From chat sidebar: focuses the last editor panel
  - From chat editor: no-op
- `Shift+Alt+L`:
  - From text editor: opens a new chat editor panel
  - Anywhere else: starts a new chat in the sidebar

This is in line with our goal of using `Alt-{J,K,L}` as the standard shortcuts in Cody.

There is still a bit of jank when invoking `Shift+Alt+L` from a chat editor panel, because this will open a new chat in the *sidebar*. But fixing this will require a bit more work in the form of adding a VS Code context to detect when focus is in chat in an editor panel.

## Test plan

Test the shortcuts locally