### PR TITLE
Disable Ollama local models in Cody Web

### DIFF
--- a/lib/shared/src/models/index.ts
+++ b/lib/shared/src/models/index.ts
@@ -1,4 +1,5 @@
 import { type AuthStatus, isCodyProUser, isEnterpriseUser } from '../auth/types'
+import { CodyIDE, type Configuration } from '../configuration'
 import { fetchLocalOllamaModels } from '../llm-providers/ollama/utils'
 import { logDebug, logError } from '../logger'
 import { CHAT_INPUT_TOKEN_BUDGET, CHAT_OUTPUT_TOKEN_BUDGET } from '../token/constants'
@@ -382,9 +383,12 @@ export class ModelsService {
         return empty
     }
 
-    public static async onConfigChange(): Promise<void> {
+    public static async onConfigChange(config: Configuration): Promise<void> {
         try {
-            ModelsService.localModels = await fetchLocalOllamaModels()
+            const isCodyWeb = config.agentIDE === CodyIDE.Web
+
+            // Disable Ollama local models for cody web
+            ModelsService.localModels = !isCodyWeb ? await fetchLocalOllamaModels() : []
         } catch {
             ModelsService.localModels = []
         }

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -316,7 +316,7 @@ async function initializeSingletons(
             graphqlClient.setConfig(config)
             promises.push(featureFlagProvider.refresh())
             promises.push(contextFiltersProvider.init(repoNameResolver.getRepoNamesFromWorkspaceUri))
-            ModelsService.onConfigChange()
+            void ModelsService.onConfigChange(config)
             upstreamHealthProvider.onConfigurationChange(config)
 
             await Promise.all(promises).then()

--- a/web/CHANGELOG.md
+++ b/web/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.3.3
+- Disables Ollama local models fetching 
+
 ## 0.3.2
 - Fixes mention providers fetching as we switch between chats 
 

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sourcegraph/cody-web",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Cody standalone web app",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
Local Ollama models don't make sense much for Cody Web at the moment; disable it for now to avoid any confusion when users see a request to the local host from the source.com

## Test plan
- Check Cody Web demo, make sure that we don't call ollama local models handler `api/tags`
