### PR TITLE
Cody Web: Add range support for remote file mentions

### DIFF
--- a/lib/prompt-editor/src/plugins/atMentions/atMentions.tsx
+++ b/lib/prompt-editor/src/plugins/atMentions/atMentions.tsx
@@ -164,11 +164,14 @@ export const MentionsPlugin: FunctionComponent<{ contextWindowSizeInTokens?: num
                     if (isLargeFile && !selectedItem.range) {
                         const textNode = $createContextItemTextNode(selectedItem)
                         nodeToReplace.replace(textNode)
-                        const colonNode = $createTextNode(':')
+
                         // Keep at symbol because we're still in the editing mode
                         // (since ranges haven't been presented yet)
                         textNode.insertBefore($createTextNode('@'))
+
+                        const colonNode = $createTextNode(':')
                         textNode.insertAfter(colonNode)
+
                         colonNode.select()
                     } else {
                         const mentionNode = $createContextItemMentionNode(selectedItem)

--- a/lib/prompt-editor/src/plugins/atMentions/atMentions.tsx
+++ b/lib/prompt-editor/src/plugins/atMentions/atMentions.tsx
@@ -165,6 +165,9 @@ export const MentionsPlugin: FunctionComponent<{ contextWindowSizeInTokens?: num
                         const textNode = $createContextItemTextNode(selectedItem)
                         nodeToReplace.replace(textNode)
                         const colonNode = $createTextNode(':')
+                        // Keep at symbol because we're still in the editing mode
+                        // (since ranges haven't been presented yet)
+                        textNode.insertBefore($createTextNode('@'))
                         textNode.insertAfter(colonNode)
                         colonNode.select()
                     } else {

--- a/vscode/src/chat/context/chatContext.ts
+++ b/vscode/src/chat/context/chatContext.ts
@@ -42,12 +42,17 @@ export async function getChatContextItemsForMention(
         case FILE_CONTEXT_MENTION_PROVIDER.id: {
             telemetryRecorder?.withProvider(mentionQuery.provider)
             const files = mentionQuery.text
-                ? await getFileContextFiles(mentionQuery.text, MAX_RESULTS, remoteRepositoriesNames)
+                ? await getFileContextFiles(
+                      mentionQuery.text,
+                      mentionQuery.range,
+                      MAX_RESULTS,
+                      remoteRepositoriesNames
+                  )
                 : await getOpenTabsContextFile()
 
             // If a range is provided, that means user is trying to mention a specific line range.
             // We will get the content of the file for that range to display file size warning if needed.
-            if (mentionQuery.range && files.length > 0) {
+            if (mentionQuery.range && files.length > 0 && (remoteRepositoriesNames?.length ?? 0) === 0) {
                 const item = await getContextFileFromUri(
                     files[0].uri,
                     new vscode.Range(mentionQuery.range.start.line, 0, mentionQuery.range.end.line, 0)

--- a/vscode/src/chat/context/chatContext.ts
+++ b/vscode/src/chat/context/chatContext.ts
@@ -42,12 +42,12 @@ export async function getChatContextItemsForMention(
         case FILE_CONTEXT_MENTION_PROVIDER.id: {
             telemetryRecorder?.withProvider(mentionQuery.provider)
             const files = mentionQuery.text
-                ? await getFileContextFiles(
-                      mentionQuery.text,
-                      mentionQuery.range,
-                      MAX_RESULTS,
-                      remoteRepositoriesNames
-                  )
+                ? await getFileContextFiles({
+                      query: mentionQuery.text,
+                      range: mentionQuery.range,
+                      maxResults: MAX_RESULTS,
+                      repositoriesNames: remoteRepositoriesNames,
+                  })
                 : await getOpenTabsContextFile()
 
             // If a range is provided, that means user is trying to mention a specific line range.

--- a/vscode/src/edit/input/get-matching-context.ts
+++ b/vscode/src/edit/input/get-matching-context.ts
@@ -12,7 +12,7 @@ interface FixupMatchingContext {
 }
 
 export async function getMatchingContext(mentionQuery: MentionQuery): Promise<FixupMatchingContext[]> {
-    const results = await getChatContextItemsForMention(mentionQuery, new AbortController().signal)
+    const results = await getChatContextItemsForMention({ mentionQuery })
     return results.map(result => {
         return {
             key: getLabelForContextItem(result),

--- a/vscode/src/editor/utils/editor-context.test.ts
+++ b/vscode/src/editor/utils/editor-context.test.ts
@@ -45,7 +45,7 @@ describe('getFileContextFiles', () => {
     }
 
     async function runSearch(query: string, maxResults: number): Promise<(string | undefined)[]> {
-        const results = await getFileContextFiles(query, maxResults)
+        const results = await getFileContextFiles(query, undefined, maxResults)
 
         return results.map(f => uriBasename(f.uri))
     }

--- a/vscode/src/editor/utils/editor-context.test.ts
+++ b/vscode/src/editor/utils/editor-context.test.ts
@@ -45,7 +45,11 @@ describe('getFileContextFiles', () => {
     }
 
     async function runSearch(query: string, maxResults: number): Promise<(string | undefined)[]> {
-        const results = await getFileContextFiles(query, undefined, maxResults)
+        const results = await getFileContextFiles({
+            query,
+            maxResults,
+            range: undefined,
+        })
 
         return results.map(f => uriBasename(f.uri))
     }

--- a/web/CHANGELOG.md
+++ b/web/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.3.4 
+- Adds support for remote file ranges  
+
 ## 0.3.3
 - Disables Ollama local models fetching 
 

--- a/web/lib/components/CodyWebChat.tsx
+++ b/web/lib/components/CodyWebChat.tsx
@@ -179,6 +179,12 @@ export const CodyWebChat: FC<CodyWebChatProps> = props => {
             mentions.push({
                 type: 'file',
                 isIgnored: false,
+                range: initialContext?.fileRange
+                    ? {
+                          start: { line: initialContext.fileRange.startLine, character: 0 },
+                          end: { line: initialContext.fileRange.endLine + 1, character: 0 },
+                      }
+                    : undefined,
                 remoteRepositoryName: repositories[0].name,
                 uri: URI.file(repositories[0].name + fileURL),
                 source: ContextItemSource.Initial,

--- a/web/lib/types.ts
+++ b/web/lib/types.ts
@@ -6,4 +6,5 @@ export interface Repository {
 export type InitialContext = {
     repositories: Repository[]
     fileURL?: string
+    fileRange?: { startLine: number; endLine: number }
 }

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sourcegraph/cody-web",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "Cody standalone web app",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
Part of https://linear.app/sourcegraph/issue/SRCH-561/add-support-for-file-ranges-in-cody-web

This PR adds support for file ranges in remote file mentions, prior to this there was a problem that after you submitted too large a file the mention wasn't properly added (The @ sign was removed and `:` range column was added but nothing more) This PR fixes this too, (I think this problem existed in VSCode too, but I couldn't find a too large file in VSCode build) 

## Test plan
- Check that mentioning too big files requires `:` ranges flow and check that this flow works properly with Cody Web demo

