### PR TITLE
openctx: merge in "openctx.providers" from Sourcegraph instance

### DIFF
--- a/lib/shared/src/context/openctx/api.ts
+++ b/lib/shared/src/context/openctx/api.ts
@@ -15,12 +15,11 @@ export const openCtx: OpenCtx = {}
  * disposed and replaced.
  */
 export function setOpenCtx({ client, disposable }: OpenCtx): void {
-    const { client: oldClient, disposable: oldDisposable } = openCtx
+    const { disposable: oldDisposable } = openCtx
 
     openCtx.client = client
     openCtx.disposable = disposable
 
-    oldClient?.dispose()
     oldDisposable?.dispose()
 }
 

--- a/lib/shared/src/sourcegraph-api/graphql/client.ts
+++ b/lib/shared/src/sourcegraph-api/graphql/client.ts
@@ -48,6 +48,7 @@ import {
     REPOSITORY_SEARCH_QUERY,
     REPO_NAME_QUERY,
     SEARCH_ATTRIBUTION_QUERY,
+    VIEWER_SETTINGS_QUERY,
 } from './queries'
 import { buildGraphQLUrl } from './url'
 
@@ -490,6 +491,10 @@ interface EvaluatedFeatureFlagsResponse {
 
 interface EvaluateFeatureFlagResponse {
     evaluateFeatureFlag: boolean
+}
+
+interface ViewerSettingsResponse {
+    viewerSettings: { final: string }
 }
 
 function extractDataOrError<T, R>(response: APIResponse<T> | Error, extract: (data: T) => R): R | Error {
@@ -1276,6 +1281,14 @@ export class SourcegraphGraphQLAPIClient {
                 flagName,
             }
         ).then(response => extractDataOrError(response, data => data.evaluateFeatureFlag))
+    }
+
+    public async viewerSettings(): Promise<Record<string, any> | Error> {
+        const response = await this.fetchSourcegraphAPI<APIResponse<ViewerSettingsResponse>>(
+            VIEWER_SETTINGS_QUERY,
+            {}
+        )
+        return extractDataOrError(response, data => JSON.parse(data.viewerSettings.final))
     }
 
     public fetchSourcegraphAPI<T>(

--- a/lib/shared/src/sourcegraph-api/graphql/queries.ts
+++ b/lib/shared/src/sourcegraph-api/graphql/queries.ts
@@ -458,3 +458,11 @@ query GetRemoteFileQuery($repositoryName: String!, $filePath: String!, $startLin
   }
 }
 `
+
+export const VIEWER_SETTINGS_QUERY = `
+query ViewerSettings {
+  viewerSettings {
+    final
+  }
+}
+`

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -433,8 +433,8 @@ importers:
         specifier: ^0.0.6
         version: 0.0.6
       '@openctx/vscode-lib':
-        specifier: ^0.0.14
-        version: 0.0.14
+        specifier: ^0.0.17
+        version: 0.0.17
       '@opentelemetry/api':
         specifier: ^1.7.0
         version: 1.7.0
@@ -3490,6 +3490,17 @@ packages:
       picomatch: 3.0.1
       rxjs: 7.8.1
 
+  /@openctx/client@0.0.22:
+    resolution: {integrity: sha512-qqOKrmYafBnbrmp7QzWM1ItUEYTqyqkEBet/Ih3E5kDbE8/JTT5H99Kt0AG7okTxGcBWJElHDcqe+4FmLqhk3g==}
+    dependencies:
+      '@openctx/protocol': 0.0.16
+      '@openctx/provider': 0.0.15
+      '@openctx/schema': 0.0.12
+      lru-cache: 10.2.2
+      picomatch: 3.0.1
+      rxjs: 7.8.1
+    dev: false
+
   /@openctx/protocol@0.0.15:
     resolution: {integrity: sha512-mT1iIb+tAdY0SUwFoM8xscvrC9c5wbCQ3hbzQgI5LKaXIULmPdQa478MtGxNto2zfp8QD6VKrySsKbzQ3JFfrA==}
     dependencies:
@@ -3543,6 +3554,15 @@ packages:
       '@openctx/client': 0.0.20
       '@openctx/ui-common': 0.0.11
       rxjs: 7.8.1
+    dev: true
+
+  /@openctx/vscode-lib@0.0.17:
+    resolution: {integrity: sha512-KunSkK0pYZI00cEq6vZJ6kWFLF7VEG02MkI5TvxH6PqM4QmiJfOCrq3pZmiMJ3RrdQPSMpYfXLeYo4ct+aYGXw==}
+    dependencies:
+      '@openctx/client': 0.0.22
+      '@openctx/ui-common': 0.0.11
+      rxjs: 7.8.1
+    dev: false
 
   /@opentelemetry/api-logs@0.45.1:
     resolution: {integrity: sha512-zVGq/k70l+kB/Wuv3O/zhptP2hvDhEbhDu9EtHde1iWZJf3FedeYS/nWVcMBkkyPAjS/JKNk86WN4CBQLGUuOw==}

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -1315,7 +1315,7 @@
     "@anthropic-ai/sdk": "^0.20.8",
     "@mdi/js": "^7.2.96",
     "@openctx/provider-linear-issues": "^0.0.6",
-    "@openctx/vscode-lib": "^0.0.14",
+    "@openctx/vscode-lib": "^0.0.17",
     "@opentelemetry/api": "^1.7.0",
     "@opentelemetry/core": "^1.18.1",
     "@opentelemetry/exporter-trace-otlp-http": "^0.45.1",


### PR DESCRIPTION
If "openctx.providers" is configured in a users settings on a Sourcegraph instance, it will merge that in. This allows admins and users to set the configuration and automatically have it included in Cody.

The implementation prefers the vscode settings for a provider, but will merge the list of remote and local providers. This is hidden behind the noddle configuration so we can dogfood this.

Test Plan: added a provider to my sourcegraph settings and it appeared in Cody.

See the loom for demo https://www.loom.com/share/c861edd7ad17452aae9056019d9771e8

Fixes https://linear.app/sourcegraph/issue/SPLF-173/openctx-configuration-via-sourcegraph-instance-settings