### PR TITLE
Shipment of deepseek-v2-lite-base on autocomplete for PLG users

### DIFF
--- a/lib/shared/src/experimentation/FeatureFlagProvider.ts
+++ b/lib/shared/src/experimentation/FeatureFlagProvider.ts
@@ -17,6 +17,8 @@ export enum FeatureFlag {
     CodyAutocompleteStarCoder2Hybrid = 'cody-autocomplete-starcoder2-hybrid',
     // Enable the FineTuned model as the default model via Fireworks
     CodyAutocompleteFIMFineTunedModelHybrid = 'cody-autocomplete-fim-fine-tuned-model-hybrid',
+    // Enable the deepseek-v2 as the default model via Fireworks
+    CodyAutocompleteDeepseekV2LiteBase = 'cody-autocomplete-deepseek-v2-lite-base',
 
     // Enable various feature flags to experiment with FIM trained fine-tuned models via Fireworks
     CodyAutocompleteFIMModelExperimentBaseFeatureFlag = 'cody-autocomplete-fim-model-experiment-flag',

--- a/vscode/src/completions/providers/create-provider.test.ts
+++ b/vscode/src/completions/providers/create-provider.test.ts
@@ -1,5 +1,3 @@
-import { describe, expect, it } from 'vitest'
-
 import {
     type AuthStatus,
     type CodeCompletionsClient,
@@ -10,7 +8,9 @@ import {
     defaultAuthStatus,
     graphqlClient,
 } from '@sourcegraph/cody-shared'
-
+import { beforeAll, describe, expect, it } from 'vitest'
+import type * as vscode from 'vscode'
+import { localStorage } from '../../services/LocalStorageProvider'
 import { DEFAULT_VSCODE_SETTINGS } from '../../testutils/mocks'
 
 import { createProviderConfig } from './create-provider'
@@ -53,6 +53,13 @@ describe('createProviderConfig', () => {
     })
 
     describe('if completions provider field is not defined in VSCode settings', () => {
+        beforeAll(async () => {
+            localStorage.setStorage({
+                get: () => null,
+                update: () => {},
+            } as any as vscode.Memento)
+        })
+
         it('returns "anthropic" if completions provider is not configured', async () => {
             const provider = await createProviderConfig(
                 getVSCodeConfigurationWithAccessToken({
@@ -85,7 +92,7 @@ describe('createProviderConfig', () => {
                 dummyAuthStatus
             )
             expect(provider?.identifier).toBe('fireworks')
-            expect(provider?.model).toBe('starcoder-hybrid')
+            expect(provider?.model).toBe('deepseek-coder-v2-lite-base')
         })
 
         it('returns "experimental-openaicompatible" provider config and corresponding model if specified', async () => {
@@ -241,7 +248,7 @@ describe('createProviderConfig', () => {
                 },
                 {
                     codyLLMConfig: { provider: 'fireworks' },
-                    expected: { provider: 'fireworks', model: 'starcoder-hybrid' },
+                    expected: { provider: 'fireworks', model: 'deepseek-coder-v2-lite-base' },
                 },
 
                 // unknown-provider

--- a/vscode/src/completions/providers/create-provider.ts
+++ b/vscode/src/completions/providers/create-provider.ts
@@ -32,6 +32,7 @@ import { createProviderConfig as createGeminiProviderConfig } from './google'
 import { createProviderConfig as createOpenAICompatibleProviderConfig } from './openaicompatible'
 import type { ProviderConfig } from './provider'
 import { createProviderConfig as createUnstableOpenAIProviderConfig } from './unstable-openai'
+import { localStorage } from '../../services/LocalStorageProvider'
 
 export async function createProviderConfigFromVSCodeConfig(
     client: CodeCompletionsClient,
@@ -48,12 +49,14 @@ export async function createProviderConfigFromVSCodeConfig(
             })
         }
         case 'fireworks': {
+            const { anonymousUserID } = await localStorage.anonymousUserID()
             return createFireworksProviderConfig({
                 client,
                 model: config.autocompleteAdvancedModel ?? model ?? null,
                 timeouts: config.autocompleteTimeouts,
                 authStatus,
                 config,
+                anonymousUserID
             })
         }
         case 'anthropic': {
@@ -135,12 +138,14 @@ export async function createProviderConfig(
             })
 
         case 'fireworks':
+            const { anonymousUserID } = await localStorage.anonymousUserID()
             return createFireworksProviderConfig({
                 client,
                 timeouts: config.autocompleteTimeouts,
                 model: modelId ?? null,
                 authStatus,
                 config,
+                anonymousUserID,
             })
         case 'experimental-openaicompatible':
             // TODO(slimsag): self-hosted-models: deprecate and remove this once customers are upgraded

--- a/vscode/src/completions/providers/fireworks.ts
+++ b/vscode/src/completions/providers/fireworks.ts
@@ -187,7 +187,16 @@ class FireworksProvider extends Provider {
 
     constructor(
         options: ProviderOptions,
-        { model, maxContextTokens, client, timeouts, config, authStatus, anonymousUserID }: Required<Omit<FireworksOptions, 'anonymousUserID'>> & { anonymousUserID?: string }    ) {
+        {
+            model,
+            maxContextTokens,
+            client,
+            timeouts,
+            config,
+            authStatus,
+            anonymousUserID,
+        }: Required<Omit<FireworksOptions, 'anonymousUserID'>> & { anonymousUserID?: string }
+    ) {
         super(options)
         this.timeouts = timeouts
         if (model === FIREWORKS_FIM_FINE_TUNED_MODEL_HYBRID_WITH_200MS_DELAY) {
@@ -539,7 +548,7 @@ class FireworksProvider extends Provider {
                     ],
                     stream: true,
                     languageId: self.options.document.languageId,
-                    anonymousUserID: self.anonymousUserID
+                    anonymousUserID: self.anonymousUserID,
                 }
 
                 const headers = new Headers(self.getCustomHeaders())
@@ -725,7 +734,9 @@ export function createProviderConfig({
 }): ProviderConfig {
     const clientModel =
         model === null || model === ''
-            ? (otherOptions.authStatus.isDotCom ? DEEPSEEK_CODER_V2_LITE_BASE : 'starcoder-hybrid')
+            ? otherOptions.authStatus.isDotCom
+                ? DEEPSEEK_CODER_V2_LITE_BASE
+                : 'starcoder-hybrid'
             : ['starcoder-hybrid', 'starcoder2-hybrid'].includes(model)
               ? (model as FireworksModel)
               : Object.prototype.hasOwnProperty.call(MODEL_MAP, model)

--- a/vscode/src/completions/providers/fireworks.ts
+++ b/vscode/src/completions/providers/fireworks.ts
@@ -722,7 +722,7 @@ export function createProviderConfig({
 }): ProviderConfig {
     const clientModel =
         model === null || model === ''
-            ? 'starcoder-hybrid'
+            ? DEEPSEEK_CODER_V2_LITE_BASE
             : ['starcoder-hybrid', 'starcoder2-hybrid'].includes(model)
               ? (model as FireworksModel)
               : Object.prototype.hasOwnProperty.call(MODEL_MAP, model)


### PR DESCRIPTION
## Context
1. This PR adds a feature flag `cody-autocomplete-deepseek-v2-lite-base` to ship the deepseek-v2-lite-base model. For now, the model will be shipped for all the PLG users.
2. Sends a `anonymousUserId` fields in the fireworks payload. This payload is send to fireworks so that each user can be redirected to the same deployment and can leverage prompt caching.

## Test plan
1. Override myself in the feature flag and ensure we are hitting `deepseek` model when on dotCom instance.
2. Override myself in the feature flag and ensure we are hitting `starcoder` model when on S2 instance.
3. Checked that we pass `anonymousUserId` correctly to CG.

## Changelog
1. Shipping `deepseek-coder-v2-lite-base` as the default autocomplete model for PLG users.
2. Add `anonymousUserId` in the CG payload to leverage fireworks prompt caching.
