### PR TITLE
Get settings schema endpoint

### DIFF
--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/agent/protocol_generated/CodyAgentServer.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/agent/protocol_generated/CodyAgentServer.kt
@@ -122,6 +122,8 @@ interface CodyAgentServer {
   fun extensionConfiguration_change(params: ExtensionConfiguration): CompletableFuture<AuthStatus?>
   @JsonRequest("extensionConfiguration/status")
   fun extensionConfiguration_status(params: Null?): CompletableFuture<AuthStatus?>
+  @JsonRequest("extensionConfiguration/getSettingsSchema")
+  fun extensionConfiguration_getSettingsSchema(params: Null?): CompletableFuture<String>
   @JsonRequest("textDocument/change")
   fun textDocument_change(params: ProtocolTextDocument): CompletableFuture<TextDocument_ChangeResult>
   @JsonRequest("attribution/search")

--- a/agent/src/agent.ts
+++ b/agent/src/agent.ts
@@ -509,12 +509,12 @@ export class Agent extends MessageHandler implements ExtensionClient {
 
         this.registerRequest('extensionConfiguration/getSettingsSchema', async () => {
             return JSON.stringify({
-                "$schema": "http://json-schema.org/draft-07/schema#",
-                "title": "Schema for Cody settings in the Cody VSCode Extension.",
-                "description": "This prevents invalid Cody specific configuration in the settings file.",
-                "type": "object",
-                "allOf": [{"$ref": "https://json.schemastore.org/package"}],
-                "properties": packageJson.contributes.configuration.properties
+                $schema: 'http://json-schema.org/draft-07/schema#',
+                title: 'Schema for Cody settings in the Cody VSCode Extension.',
+                description: 'This prevents invalid Cody specific configuration in the settings file.',
+                type: 'object',
+                allOf: [{ $ref: 'https://json.schemastore.org/package' }],
+                properties: packageJson.contributes.configuration.properties,
             })
         })
 

--- a/agent/src/agent.ts
+++ b/agent/src/agent.ts
@@ -5,6 +5,7 @@ import type { Polly, Request } from '@pollyjs/core'
 import { type CodyCommand, ModelUsage, isWindows, telemetryRecorder } from '@sourcegraph/cody-shared'
 import * as vscode from 'vscode'
 import { StreamMessageReader, StreamMessageWriter, createMessageConnection } from 'vscode-jsonrpc/node'
+import packageJson from '../../vscode/package.json'
 
 import {
     type AuthStatus,
@@ -504,6 +505,17 @@ export class Agent extends MessageHandler implements ExtensionClient {
         this.registerRequest('extensionConfiguration/status', async () => {
             const result = await this.authenticationPromise
             return result ?? null
+        })
+
+        this.registerRequest('extensionConfiguration/getSettingsSchema', async () => {
+            return JSON.stringify({
+                "$schema": "http://json-schema.org/draft-07/schema#",
+                "title": "Schema for Cody settings in the Cody VSCode Extension.",
+                "description": "This prevents invalid Cody specific configuration in the settings file.",
+                "type": "object",
+                "allOf": [{"$ref": "https://json.schemastore.org/package"}],
+                "properties": packageJson.contributes.configuration.properties
+            })
         })
 
         this.registerNotification('progress/cancel', ({ id }) => {

--- a/vscode/src/jsonrpc/agent-protocol.ts
+++ b/vscode/src/jsonrpc/agent-protocol.ts
@@ -233,6 +233,9 @@ export type ClientRequests = {
     // Returns the current authentication status without making changes to it.
     'extensionConfiguration/status': [null, AuthStatus | null]
 
+    // Returns the json schema of the extension confi
+    'extensionConfiguration/getSettingsSchema': [null, string]
+
     'textDocument/change': [ProtocolTextDocument, { success: boolean }]
 
     // Run attribution search for a code snippet displayed in chat.


### PR DESCRIPTION
## Changes

This PR adds `extensionConfiguration/getSettingsSchema` endpoint which generates json schema file useful for validating cody settings and for documentation purposes.

## Test plan

1. Build Jenkins [PR #1972](https://github.com/sourcegraph/jetbrains/pull/1972)  with CODY_DIR set to this PR branch.
2. Run action `Open Cody Settings Editor` (you can use `shift shift` to find it)
3. Change some Cody settings. E.g. you can try to disable autocomplete:
`"cody.autocomplete.enabled": true`
4. Hit `Ctrl + S` to trigger the config update
5. Try to use autocomplete in some other file and make sure it does not work.
6. Revert your changes and make sure autocomplete is enabled again.
