### PR TITLE
make @-mention menu feel more stable

### DIFF
--- a/lib/prompt-editor/src/config.ts
+++ b/lib/prompt-editor/src/config.ts
@@ -25,9 +25,7 @@ export interface PromptEditorConfig {
         CommandInput: typeof Command.Input
         CommandList: typeof Command.List
         CommandEmpty: typeof Command.Empty
-        CommandLoading: typeof Command.Loading
         CommandGroup: typeof Command.Group
-        CommandSeparator: typeof Command.Separator
         CommandItem: typeof Command.Item
     }
 }

--- a/lib/prompt-editor/src/mentions/mentionMenu/MentionMenu.module.css
+++ b/lib/prompt-editor/src/mentions/mentionMenu/MentionMenu.module.css
@@ -4,13 +4,7 @@
     outline: none;
 }
 
-.container [cmdk-empty], .container [cmdk-loading] {
-    padding: 0.325rem 0.5rem;
-}
-
 .item {
-    line-height: 1.2;
-
     &.context-item {
         display: flex;
         flex-direction: column;

--- a/lib/prompt-editor/src/mentions/mentionMenu/MentionMenu.test.tsx
+++ b/lib/prompt-editor/src/mentions/mentionMenu/MentionMenu.test.tsx
@@ -4,16 +4,7 @@ import {
     displayPathBasename,
 } from '@sourcegraph/cody-shared'
 import { fireEvent, render, screen } from '@testing-library/react'
-import {
-    Command,
-    CommandEmpty,
-    CommandGroup,
-    CommandInput,
-    CommandItem,
-    CommandList,
-    CommandLoading,
-    CommandSeparator,
-} from 'cmdk'
+import { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList } from 'cmdk'
 import type { ComponentProps, FunctionComponent } from 'react'
 import { type Mock, describe, expect, test, vi } from 'vitest'
 import { URI } from 'vscode-uri'
@@ -68,9 +59,7 @@ const CONFIG: PromptEditorConfig = {
         CommandInput,
         CommandList,
         CommandEmpty,
-        CommandLoading,
         CommandGroup,
-        CommandSeparator,
         CommandItem,
     },
 }
@@ -86,7 +75,7 @@ describe('MentionMenu', () => {
                     <MentionMenu {...PROPS} data={{ items: undefined, providers: [PROVIDER_P1] }} />,
                     { wrapper: Wrapper }
                 )
-                expectMenu(container, ['>provider p1', '#Loading...'])
+                expectMenu(container, ['>provider p1'])
             })
 
             test('empty items', () => {

--- a/lib/prompt-editor/src/mentions/mentionMenu/MentionMenu.tsx
+++ b/lib/prompt-editor/src/mentions/mentionMenu/MentionMenu.tsx
@@ -197,11 +197,17 @@ export const MentionMenu: FunctionComponent<
     // We use `cmdk` Command as a controlled component, so we need to supply its `value`. We track
     // `value` in state, but when the options change, our state `value` may refer to a row that no
     // longer exists in the list. In that case, we want the first row to be selected.
-    const firstRow = data.initialContextItems?.at(0) ?? data.providers.at(0) ?? data.items?.at(0)
+    const firstProviderRow = data.providers.at(0)
+    const firstInitialContextItemRow = data.initialContextItems?.at(0)
+    const firstItemRow = data.items?.at(0)
+    const firstRow = params.parentItem
+        ? firstItemRow
+        : firstProviderRow ?? firstInitialContextItemRow ?? firstItemRow
+
     const valueRow = useMemo(
         () =>
-            data.initialContextItems?.find(item => commandRowValue(item) === value) ??
             data.providers.find(provider => commandRowValue(provider) === value) ??
+            data.initialContextItems?.find(item => commandRowValue(item) === value) ??
             data.items?.find(item => commandRowValue(item) === value),
         [data.providers, data.items, data.initialContextItems, value]
     )
@@ -210,15 +216,7 @@ export const MentionMenu: FunctionComponent<
     const heading = getItemsHeading(params.parentItem, mentionQuery)
 
     const {
-        commandComponents: {
-            Command,
-            CommandEmpty,
-            CommandGroup,
-            CommandItem,
-            CommandList,
-            CommandLoading,
-            CommandSeparator,
-        },
+        commandComponents: { Command, CommandEmpty, CommandGroup, CommandItem, CommandList },
     } = usePromptEditorConfig()
 
     const providers = data.providers.map(provider => (
@@ -227,7 +225,7 @@ export const MentionMenu: FunctionComponent<
             key={commandRowValue(provider)}
             value={commandRowValue(provider)}
             onSelect={onProviderSelect}
-            className={styles.item}
+            className={clsx(styles.item, COMMAND_ROW_CLASS_NAME)}
         >
             <MentionMenuProviderItemContent provider={provider} />
         </CommandItem>
@@ -239,21 +237,29 @@ export const MentionMenu: FunctionComponent<
             shouldFilter={false}
             value={effectiveValueRow ? commandRowValue(effectiveValueRow) : undefined}
             onValueChange={setValue}
-            className={styles.container}
+            className={clsx(styles.container, COMMAND_CLASS_NAME)}
             label="@-mention context"
             ref={ref}
         >
             <CommandList>
+                {providers.length > 0 && (
+                    <CommandGroup className={COMMAND_GROUP_CLASS_NAME}>{providers}</CommandGroup>
+                )}
+
                 {!params.parentItem &&
                     data.initialContextItems &&
                     data.initialContextItems.length > 0 && (
-                        <CommandGroup>
+                        <CommandGroup className={COMMAND_GROUP_CLASS_NAME}>
                             {data.initialContextItems.map(item => (
                                 <CommandItem
                                     key={commandRowValue(item)}
                                     value={commandRowValue(item)}
                                     onSelect={onInitialContextItemSelect}
-                                    className={clsx(styles.item, styles.contextItem)}
+                                    className={clsx(
+                                        styles.item,
+                                        styles.contextItem,
+                                        COMMAND_ROW_CLASS_NAME
+                                    )}
                                 >
                                     <MentionMenuContextItemContent query={mentionQuery} item={item} />
                                 </CommandItem>
@@ -261,18 +267,15 @@ export const MentionMenu: FunctionComponent<
                         </CommandGroup>
                     )}
 
-                {providers.length > 0 && <CommandGroup>{providers}</CommandGroup>}
-
                 {(heading || (data.items && data.items.length > 0)) && (
-                    <CommandGroup heading={heading}>
-                        {heading && data.items && data.items.length > 0 && <CommandSeparator />}
+                    <CommandGroup heading={heading} className={COMMAND_GROUP_CLASS_NAME}>
                         {data.items?.map(item => (
                             <CommandItem
                                 key={commandRowValue(item)}
                                 value={commandRowValue(item)}
                                 disabled={item.isIgnored}
                                 onSelect={onCommandSelect}
-                                className={clsx(styles.item, styles.contextItem)}
+                                className={clsx(styles.item, styles.contextItem, COMMAND_ROW_CLASS_NAME)}
                             >
                                 <MentionMenuContextItemContent query={mentionQuery} item={item} />
                             </CommandItem>
@@ -280,10 +283,10 @@ export const MentionMenu: FunctionComponent<
                     </CommandGroup>
                 )}
 
-                {data.items === undefined ? (
-                    <CommandLoading>Loading...</CommandLoading>
-                ) : data.items.length === 0 ? (
-                    <CommandEmpty>{getEmptyLabel(params.parentItem, mentionQuery)}</CommandEmpty>
+                {data.items && data.items.length === 0 ? (
+                    <CommandEmpty className={clsx(COMMAND_ROW_CLASS_NAME, COMMAND_ROW_TEXT_CLASS_NAME)}>
+                        {getEmptyLabel(params.parentItem, mentionQuery)}
+                    </CommandEmpty>
                 ) : null}
             </CommandList>
         </Command>
@@ -342,3 +345,28 @@ function getItemsHeading(
     }
     return parentItem.title ?? parentItem.id
 }
+
+/**
+ * This max-height value MUST be an integer multiple of the {@link COMMAND_ROW_CLASS_NAME} height
+ * plus 2px (for the top and bottom border).
+ */
+const COMMAND_CLASS_NAME = '!tw-max-h-[392px]'
+
+/**
+ * Use the same padding and text size for all command rows so that there is no partially obscured
+ * row (i.e., each row is the same height, and the height of the Command is an integer multiple of
+ * the row height).
+ *
+ * If you change this, also update {@link COMMAND_GROUP_CLASS_NAME}'s `[&_[cmd-group-heading]]:`
+ * styles.
+ */
+const COMMAND_ROW_CLASS_NAME = '!tw-p-3 !tw-text-md !tw-leading-[1.2] !tw-h-[30px] !tw-rounded-none'
+
+const COMMAND_ROW_TEXT_CLASS_NAME = '!tw-text-muted-foreground'
+
+/**
+ * Don't add padding around groups or show borders below groups, because that makes the total height not an integer multiple of
+ * the row height.
+ */
+const COMMAND_GROUP_CLASS_NAME =
+    '!tw-p-0 !tw-border-b-0 [&_[cmdk-group-heading]]:!tw-p-3 [&_[cmdk-group-heading]]:!tw-text-md [&_[cmdk-group-heading]]:!tw-leading-[1.2] [&_[cmdk-group-heading]]:!tw-h-[30px]'

--- a/lib/prompt-editor/src/mentions/mentionMenu/MentionMenuItem.module.css
+++ b/lib/prompt-editor/src/mentions/mentionMenu/MentionMenuItem.module.css
@@ -10,7 +10,7 @@
 
 .row {
     display: flex;
-    align-items: end;
+    align-items: center;
     gap: 0.35rem;
 }
 

--- a/lib/prompt-editor/src/plugins/atMentions/atMentions.module.css
+++ b/lib/prompt-editor/src/plugins/atMentions/atMentions.module.css
@@ -5,9 +5,7 @@
     box-shadow: 0 0 8px 2px var(--vscode-widget-shadow);
     border-radius: 3px;
 
-    min-width: 20vw;
-    width: 400px;
-    max-width: 90vw;
+    width: clamp(200px, 100vw, 400px);
 }
 
 .reset-anchor {

--- a/vscode/src/chat/clientStateBroadcaster.ts
+++ b/vscode/src/chat/clientStateBroadcaster.ts
@@ -56,7 +56,7 @@ export function startClientStateBroadcaster({
                             url: repo.name,
                         })
                     ),
-                    title: 'Repository',
+                    title: 'Current Repository',
                     description: repo.name,
                     source: ContextItemSource.Initial,
                     icon: 'folder',
@@ -70,7 +70,7 @@ export function startClientStateBroadcaster({
                 const item = {
                     type: 'tree',
                     uri: workspaceFolder.uri,
-                    title: 'Repository',
+                    title: 'Current Repository',
                     name: workspaceFolder.name,
                     description: workspaceFolder.name,
                     isWorkspaceRoot: true,

--- a/vscode/webviews/components/shadcn/ui/command.tsx
+++ b/vscode/webviews/components/shadcn/ui/command.tsx
@@ -43,7 +43,7 @@ const CommandList = React.forwardRef<
 >(({ className, ...props }, ref) => (
     <CommandPrimitive.List
         ref={ref}
-        className={cn('tw-max-h-[400px] tw-overflow-y-auto tw-overflow-x-hidden', className)}
+        className={cn('tw-max-h-[500px] tw-overflow-y-auto tw-overflow-x-hidden', className)}
         {...props}
     />
 ))

--- a/vscode/webviews/promptEditor/MentionMenu.story.tsx
+++ b/vscode/webviews/promptEditor/MentionMenu.story.tsx
@@ -4,6 +4,7 @@ import { URI } from 'vscode-uri'
 import {
     type ContextItem,
     type ContextItemOpenCtx,
+    ContextItemSource,
     type ContextMentionProviderMetadata,
     FILE_CONTEXT_MENTION_PROVIDER,
     SYMBOL_CONTEXT_MENTION_PROVIDER,
@@ -24,7 +25,7 @@ const meta: Meta<typeof MentionMenu> = {
     // Render something that looks like the editor to make the storybook look nicer.
     render: args => {
         return (
-            <div>
+            <div style={{ margin: '20px' }}>
                 <div
                     style={{
                         border: 'solid 1px var(--vscode-input-border)',
@@ -55,11 +56,13 @@ function toParams(query: string, parentItem?: ContextMentionProviderMetadata): M
 
 function toData(
     items: ContextItem[] | undefined,
-    providers: ContextMentionProviderMetadata[] = []
+    providers: ContextMentionProviderMetadata[] = [],
+    initialContextItems: MentionMenuData['initialContextItems'] = []
 ): MentionMenuData {
     return {
-        providers,
         items,
+        providers,
+        initialContextItems,
     }
 }
 
@@ -97,7 +100,29 @@ export const Default: StoryObj<typeof MentionMenu> = {
                     uri: URI.file(`/${'sub-dir/'.repeat(50)}/}/src/LoginDialog.tsx`),
                 },
             ],
-            [FILE_CONTEXT_MENTION_PROVIDER, SYMBOL_CONTEXT_MENTION_PROVIDER]
+            [FILE_CONTEXT_MENTION_PROVIDER, SYMBOL_CONTEXT_MENTION_PROVIDER],
+            [
+                {
+                    type: 'tree',
+                    isWorkspaceRoot: true,
+                    name: 'my-repo',
+                    description: 'my-repo',
+                    title: 'Current Repository',
+                    source: ContextItemSource.Initial,
+                    content: null,
+                    uri: URI.file('a/b'),
+                    icon: 'folder',
+                },
+                {
+                    uri: URI.file('a/b/initial.go'),
+                    type: 'file',
+                    description: 'initial.go:8-13',
+                    title: 'Current Selection',
+                    source: ContextItemSource.Initial,
+                    range: { start: { line: 7, character: 5 }, end: { line: 12, character: 9 } },
+                    icon: 'list-selection',
+                },
+            ]
         ),
     },
 }
@@ -122,7 +147,14 @@ export const WithExperimentalProviders: StoryObj<typeof MentionMenu> = {
     },
 }
 
-export const Loading: StoryObj<typeof MentionMenu> = {
+export const LoadingNoProvider: StoryObj<typeof MentionMenu> = {
+    args: {
+        params: toParams('', undefined),
+        data: toData(undefined),
+    },
+}
+
+export const LoadingSingleProvider: StoryObj<typeof MentionMenu> = {
     args: {
         params: toParams('', FILE_CONTEXT_MENTION_PROVIDER),
         data: toData(undefined),

--- a/vscode/webviews/promptEditor/config.ts
+++ b/vscode/webviews/promptEditor/config.ts
@@ -8,8 +8,6 @@ import {
     CommandInput,
     CommandItem,
     CommandList,
-    CommandLoading,
-    CommandSeparator,
 } from '../components/shadcn/ui/command'
 import { Tooltip, TooltipContent, TooltipTrigger } from '../components/shadcn/ui/tooltip'
 import { getVSCodeAPI } from '../utils/VSCodeApi'
@@ -38,9 +36,7 @@ export const promptEditorConfig: PromptEditorConfig = {
         CommandInput: CommandInput,
         CommandList: CommandList,
         CommandEmpty: CommandEmpty,
-        CommandLoading: CommandLoading,
         CommandGroup: CommandGroup,
-        CommandSeparator: CommandSeparator,
         CommandItem: CommandItem,
     },
 }

--- a/vscode/webviews/tailwind.config.mjs
+++ b/vscode/webviews/tailwind.config.mjs
@@ -5,7 +5,7 @@ const plugin = require('tailwindcss/plugin')
 export default {
     content: {
         relative: true,
-        files: ['**/*.{ts,tsx}'],
+        files: ['**/*.{ts,tsx}', '../../lib/**/**/*.{ts,tsx}'],
     },
     prefix: 'tw-',
     theme: {

--- a/web/index.html
+++ b/web/index.html
@@ -6,7 +6,7 @@
         <link rel="shortcut icon" href="data:" type="image/x-icon" />
         <title>Cody</title>
     </head>
-    <body class="theme-dark">
+    <body class="theme-dark" data-cody-web-chat>
         <div id="root"></div>
         <script type="module" src="demo/index.tsx"></script>
     </body>

--- a/web/tailwind.config.mjs
+++ b/web/tailwind.config.mjs
@@ -4,6 +4,11 @@ export default {
     ...webviewTailwindConfig,
     content: {
         relative: true,
-        files: ['demo/*.{ts,tsx}', '../vscode/webviews/**/*.{ts,tsx}', 'lib/**/*.{ts,tsx}'],
+        files: [
+            'demo/*.{ts,tsx}',
+            '../vscode/webviews/**/*.{ts,tsx}',
+            'lib/**/*.{ts,tsx}',
+            '../lib/prompt-editor/**/*.{ts,tsx}',
+        ],
     },
 }


### PR DESCRIPTION
The @-mention menu does not feel "stable" or "solid" enough IMO. Here are changes that make it feel more "stable".

- Make all rows the same height, and make the total height an integer multiple of the row height so that no row is ever partially obscured. This also means removing horizontal separators between groups and making the text rows (such as the "empty" message and group headings) use the same font size as results.
- Remove "Loading...". This causes jitter in every case, and it only helps in rare cases where loading takes a long time.
- Fix an issue in the horizontal positioning.
- Fix an issue where navigating into the `Files ->` menu would not select the first item

### Before

<img width="410" alt="image" src="https://github.com/user-attachments/assets/618d89d3-6d44-40e5-88bc-4e5225ed4c59">

### After
<img width="384" alt="image" src="https://github.com/user-attachments/assets/34dba229-ca1b-49fd-9e23-6b553ace38c9">


## Test plan

Storybooks, and run in debug mode and try using it.