### PR TITLE
[wip] plug Buildkite Test Analytics 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,8 +166,14 @@ jobs:
       - run: pnpm install
       - run: xvfb-run -a pnpm -C vscode run test:e2e --shard=${{ matrix.shard }}
         if: matrix.runner == 'ubuntu'
+        env:
+          BUILDKITE_ANALYTICS_TOKEN: ${{ secrets.BUILDKITE_ANALYTICS_TOKEN }}
+          BUILDKITE_ANALYTICS_DEBUG_ENABLED: true
       - run: pnpm -C vscode run test:e2e
         if: matrix.runner != 'ubuntu'
+        env:
+          BUILDKITE_ANALYTICS_TOKEN: ${{ secrets.BUILDKITE_ANALYTICS_TOKEN }}
+          BUILDKITE_ANALYTICS_DEBUG_ENABLED: true
       - uses: actions/upload-artifact@v4
         if: ${{ failure() }}
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,9 +107,11 @@ jobs:
         if: matrix.runner == 'ubuntu'
         env:
           BUILDKITE_ANALYTICS_TOKEN: ${{ secrets.BUILDKITE_ANALYTICS_TOKEN }}
+          BUILDKITE_ANALYTICS_DEBUG_ENABLED: true
       - run: pnpm -C vscode run test:integration
         if: matrix.runner == 'windows' || matrix.runner == 'macos'
         env:
+          BUILDKITE_ANALYTICS_DEBUG_ENABLED: true
           BUILDKITE_ANALYTICS_TOKEN: ${{ secrets.BUILDKITE_ANALYTICS_TOKEN }}
 
   # Sets a variable that is used to determine the matrix to run slow tests (e2e) on.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,8 +105,12 @@ jobs:
       - run: pnpm install
       - run: xvfb-run -a pnpm -C vscode run test:integration
         if: matrix.runner == 'ubuntu'
+        env:
+          BUILDKITE_ANALYTICS_TOKEN: ${{ secrets.BUILDKITE_ANALYTICS_TOKEN }}
       - run: pnpm -C vscode run test:integration
         if: matrix.runner == 'windows' || matrix.runner == 'macos'
+        env:
+          BUILDKITE_ANALYTICS_TOKEN: ${{ secrets.BUILDKITE_ANALYTICS_TOKEN }}
 
   # Sets a variable that is used to determine the matrix to run slow tests (e2e) on.
   # Everything runs on ubuntu, only commits to main run on macos and windows.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,8 @@ jobs:
           CODY_NODE_VERSION: ${{ matrix.node }}
       - name: Upload test results to Buildkite Test Analytics
         if: success() || failure() # this enables to run on both cases, but never if the job gets cancelled.
+        env:
+          BUILDKITE_ANALYTICS_TOKEN: ${{ secrets.BUILDKITE_ANALYTICS_TOKEN }}
         run: |
           curl \
           -X POST \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,24 +60,24 @@ jobs:
       - run: pnpm run test:unit --run --reporter=default --reporter=junit --outputFile.junit=junit.xml
         env:
           CODY_NODE_VERSION: ${{ matrix.node }}
-      - name: Upload test results to Buildkite Test Analytics
-        if: success() || failure() # this enables to run on both cases, but never if the job gets cancelled.
-        env:
-          BUILDKITE_ANALYTICS_TOKEN: ${{ secrets.BUILDKITE_ANALYTICS_TOKEN }}
-        run: |
-          curl \
-          -X POST \
-          --fail-with-body \
-          -H "Authorization: Token token=\"$BUILDKITE_ANALYTICS_TOKEN\"" \
-          -F "data=@junit.xml" \
-          -F "format=junit" \
-          -F "run_env[CI]=github_actions" \
-          -F "run_env[key]=$GITHUB_ACTION-$GITHUB_RUN_NUMBER-$GITHUB_RUN_ATTEMPT" \
-          -F "run_env[number]=$GITHUB_RUN_NUMBER" \
-          -F "run_env[branch]=$GITHUB_REF" \
-          -F "run_env[commit_sha]=$GITHUB_SHA" \
-          -F "run_env[url]=https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" \
-          https://analytics-api.buildkite.com/v1/uploads
+      # - name: Upload test results to Buildkite Test Analytics
+      #   if: success() || failure() # this enables to run on both cases, but never if the job gets cancelled.
+      #   env:
+      #     BUILDKITE_ANALYTICS_TOKEN: ${{ secrets.BUILDKITE_ANALYTICS_TOKEN }}
+      #   run: |
+      #     curl \
+      #     -X POST \
+      #     --fail-with-body \
+      #     -H "Authorization: Token token=\"$BUILDKITE_ANALYTICS_TOKEN\"" \
+      #     -F "data=@junit.xml" \
+      #     -F "format=junit" \
+      #     -F "run_env[CI]=github_actions" \
+      #     -F "run_env[key]=$GITHUB_ACTION-$GITHUB_RUN_NUMBER-$GITHUB_RUN_ATTEMPT" \
+      #     -F "run_env[number]=$GITHUB_RUN_NUMBER" \
+      #     -F "run_env[branch]=$GITHUB_REF" \
+      #     -F "run_env[commit_sha]=$GITHUB_SHA" \
+      #     -F "run_env[url]=https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" \
+      #     https://analytics-api.buildkite.com/v1/uploads
 
   test-integration:
     needs: fast_tests_matrix_prep

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,9 +57,25 @@ jobs:
           restore-keys: ${{ runner.os }}-${{ matrix.node }}-pnpm-store-
       - run: pnpm install
       - run: pnpm build
-      - run: pnpm run test:unit --run
+      - run: pnpm run test:unit --run --reporter=default --reporter=junit --outputFile.junit=junit.xml
         env:
           CODY_NODE_VERSION: ${{ matrix.node }}
+      - name: Upload test results to Buildkite Test Analytics
+        if: success() || failure() # this enables to run on both cases, but never if the job gets cancelled.
+        run: |
+          curl \
+          -X POST \
+          --fail-with-body \
+          -H "Authorization: Token token=\"$BUILDKITE_ANALYTICS_TOKEN\"" \
+          -F "data=@junit.xml" \
+          -F "format=junit" \
+          -F "run_env[CI]=github_actions" \
+          -F "run_env[key]=$GITHUB_ACTION-$GITHUB_RUN_NUMBER-$GITHUB_RUN_ATTEMPT" \
+          -F "run_env[number]=$GITHUB_RUN_NUMBER" \
+          -F "run_env[branch]=$GITHUB_REF" \
+          -F "run_env[commit_sha]=$GITHUB_SHA" \
+          -F "run_env[url]=https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" \
+          https://analytics-api.buildkite.com/v1/uploads
 
   test-integration:
     needs: fast_tests_matrix_prep

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -796,6 +796,9 @@ importers:
       mocha:
         specifier: ^10.2.0
         version: 10.2.0
+      mocha-multi-reporters:
+        specifier: ^1.5.1
+        version: 1.5.1(mocha@10.2.0)
       node-fetch:
         specifier: ^2.6.4
         version: 2.7.0
@@ -12616,6 +12619,19 @@ packages:
       pathe: 1.1.2
       pkg-types: 1.1.1
       ufo: 1.5.3
+    dev: true
+
+  /mocha-multi-reporters@1.5.1(mocha@10.2.0):
+    resolution: {integrity: sha512-Yb4QJOaGLIcmB0VY7Wif5AjvLMUFAdV57D2TWEva1Y0kU/3LjKpeRVmlMIfuO1SVbauve459kgtIizADqxMWPg==}
+    engines: {node: '>=6.0.0'}
+    peerDependencies:
+      mocha: '>=3.1.2'
+    dependencies:
+      debug: 4.3.5
+      lodash: 4.17.21
+      mocha: 10.2.0
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /mocha@10.2.0:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -760,6 +760,9 @@ importers:
       ajv-formats:
         specifier: ^3.0.1
         version: 3.0.1(ajv@8.14.0)
+      buildkite-test-collector:
+        specifier: ^1.7.2
+        version: 1.7.2
       chokidar:
         specifier: ^3.6.0
         version: 3.6.0
@@ -7470,6 +7473,16 @@ packages:
       - debug
     dev: false
 
+  /axios@1.7.3:
+    resolution: {integrity: sha512-Ar7ND9pU99eJ9GpoGQKhKf58GpUOgnzuaB7ueNQ5BMi0p+LZ5oaEnfF999fAArcTIBwXTCHAmGcHOZJaWPq9Nw==}
+    dependencies:
+      follow-redirects: 1.15.6(debug@4.3.5)
+      form-data: 4.0.0
+      proxy-from-env: 1.1.0
+    transitivePeerDependencies:
+      - debug
+    dev: true
+
   /azure-devops-node-api@11.2.0:
     resolution: {integrity: sha512-XdiGPhrpaT5J8wdERRKs5g8E0Zy1pvOYTli7z9E8nmOn3YGp4FhtjhrOyFmX/8veWCwdI69mCHKJw6l+4J/bHA==}
     dependencies:
@@ -7811,6 +7824,19 @@ packages:
     dependencies:
       readable-stream: 3.6.2
     dev: false
+
+  /buildkite-test-collector@1.7.2:
+    resolution: {integrity: sha512-o+bDN5ynqCt5JkGa362X4BXtGxpHGIPrNvFPJkL36rEgeZxb1xnTTtfvWWfVydrjqmL2JPX91zIr8Bcq6+0Tag==}
+    engines: {npm: '>=7.0.0'}
+    dependencies:
+      axios: 1.7.3
+      dotenv: 16.4.5
+      request-spy: 0.0.10
+      strip-ansi: 6.0.1
+      uuid: 8.3.2
+    transitivePeerDependencies:
+      - debug
+    dev: true
 
   /bytes@3.0.0:
     resolution: {integrity: sha512-pMhOfFDPiv9t5jjIXkHosWmkSyQbvsgEVNkz0ERHbuLh2T/7j4Mqqpz523Fe8MVY89KC6Sh/QfS2sM+SjgFDcw==}
@@ -12624,6 +12650,10 @@ packages:
     resolution: {integrity: sha512-ySViT69/76t8VhE1xXHK6Ch4NcDd26gx0MzKXLO+F7NOtnqH68d9zF94nT8ZWSxXh8ELOERsnJO/sWt1xZYw5A==}
     dev: false
 
+  /monkeypatch@1.0.0:
+    resolution: {integrity: sha512-6tG0IrCUUIBuAspnbdmOAd+D/AptB/ya9JLujp88NIAuFuTGdGvCKtDkc6pwNOcIJ6nKLm3FjJlaCdx8vr3r2w==}
+    dev: true
+
   /morgan@1.10.0:
     resolution: {integrity: sha512-AbegBVI4sh6El+1gNwvD5YIck7nSA36weD7xvIxG4in80j/UoK8AEGaWnnz8v1GxonMCltmlNs5ZKbGvl9b1XQ==}
     engines: {node: '>= 0.8.0'}
@@ -13753,7 +13783,6 @@ packages:
 
   /proxy-from-env@1.1.0:
     resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
-    dev: false
 
   /psl@1.9.0:
     resolution: {integrity: sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag==}
@@ -14360,6 +14389,12 @@ packages:
     resolution: {integrity: sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w==}
     engines: {node: '>=0.10'}
     dev: false
+
+  /request-spy@0.0.10:
+    resolution: {integrity: sha512-va+4vLamK9Pwu/WJnJrQcTjCjYdIcl0KDKOKEkfvNmer4f+K+OhgbpU4DCiPyzBGnTpYXbrVLrnD8O5fS/cmKA==}
+    dependencies:
+      monkeypatch: 1.0.0
+    dev: true
 
   /require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
@@ -16228,6 +16263,11 @@ packages:
   /utils-merge@1.0.1:
     resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
     engines: {node: '>= 0.4.0'}
+
+  /uuid@8.3.2:
+    resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    hasBin: true
+    dev: true
 
   /uuid@9.0.0:
     resolution: {integrity: sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==}

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -54,7 +54,12 @@
     "version-bump:patch": "RELEASE_TYPE=patch ts-node-transpile-only ./scripts/version-bump.ts",
     "version-bump:dry-run": "RELEASE_TYPE=prerelease ts-node-transpile-only ./scripts/version-bump.ts"
   },
-  "categories": ["Programming Languages", "Machine Learning", "Snippets", "Education"],
+  "categories": [
+    "Programming Languages",
+    "Machine Learning",
+    "Snippets",
+    "Education"
+  ],
   "keywords": [
     "ai",
     "openai",
@@ -107,7 +112,11 @@
   },
   "main": "./dist/extension.node.js",
   "browser": "./dist/extension.web.js",
-  "activationEvents": ["onLanguage", "onStartupFinished", "onWebviewPanel:cody.editorPanel"],
+  "activationEvents": [
+    "onLanguage",
+    "onStartupFinished",
+    "onWebviewPanel:cody.editorPanel"
+  ],
   "contributes": {
     "walkthroughs": [
       {
@@ -696,13 +705,17 @@
       },
       {
         "command": "cody.supercompletion.jumpTo",
-        "args": ["next"],
+        "args": [
+          "next"
+        ],
         "key": "shift+ctrl+down",
         "when": "cody.activated && !editorReadonly && cody.hasActionableSupercompletion"
       },
       {
         "command": "cody.supercompletion.jumpTo",
-        "args": ["previous"],
+        "args": [
+          "previous"
+        ],
         "key": "shift+ctrl+up",
         "when": "cody.activated && !editorReadonly && cody.hasActionableSupercompletion"
       }
@@ -964,12 +977,20 @@
           "order": 2,
           "type": "string",
           "markdownDescription": "A Git repository URL to use instead of allowing Cody to infer the Git repository from the workspace.",
-          "examples": ["https://github.com/sourcegraph/cody", "ssh://git@github.com/sourcegraph/cody"]
+          "examples": [
+            "https://github.com/sourcegraph/cody",
+            "ssh://git@github.com/sourcegraph/cody"
+          ]
         },
         "cody.useContext": {
           "order": 99,
           "type": "string",
-          "enum": ["embeddings", "keyword", "blended", "none"],
+          "enum": [
+            "embeddings",
+            "keyword",
+            "blended",
+            "none"
+          ],
           "default": "blended",
           "markdownDescription": "Controls which context providers Cody uses for chat, commands and inline edits. Use 'blended' for best results. For debugging other context sources, 'embeddings' will use an embeddings-based index if available. 'keyword' will use a search-based index. 'none' will not use embeddings or search-based indexes."
         },
@@ -1015,13 +1036,17 @@
           "order": 6,
           "type": "string",
           "markdownDescription": "A custom instruction to be included at the start of all chat messages (e.g. \"Answer all my questions in Spanish.\")",
-          "examples": ["Answer all my questions in Spanish."]
+          "examples": [
+            "Answer all my questions in Spanish."
+          ]
         },
         "cody.edit.preInstruction": {
           "order": 7,
           "type": "string",
           "markdownDescription": "A custom instruction to be included at the end of all instructions for edit commands (e.g. \"Write all unit tests with Jest instead of detected framework.\")",
-          "examples": ["Write all unit tests with Jest instead of detected framework."]
+          "examples": [
+            "Write all unit tests with Jest instead of detected framework."
+          ]
         },
         "cody.codeActions.enabled": {
           "order": 11,
@@ -1067,8 +1092,14 @@
         "cody.telemetry.level": {
           "order": 99,
           "type": "string",
-          "enum": ["all", "off"],
-          "enumDescriptions": ["Sends usage data and errors.", "Disables all extension telemetry."],
+          "enum": [
+            "all",
+            "off"
+          ],
+          "enumDescriptions": [
+            "Sends usage data and errors.",
+            "Disables all extension telemetry."
+          ],
           "markdownDescription": "Controls the telemetry about Cody usage and errors. See [Cody usage and privacy notice](https://about.sourcegraph.com/terms/cody-notice).",
           "default": "all"
         },
@@ -1097,7 +1128,11 @@
         "cody.autocomplete.advanced.model": {
           "type": "string",
           "default": null,
-          "enum": [null, "starcoder-16b", "starcoder-7b"],
+          "enum": [
+            null,
+            "starcoder-16b",
+            "starcoder-7b"
+          ],
           "markdownDescription": "Overwrite the  model used for code autocompletion inference. This is only supported with the `fireworks` provider"
         },
         "cody.autocomplete.completeSuggestWidgetSelection": {
@@ -1117,7 +1152,10 @@
         },
         "cody.experimental.foldingRanges": {
           "type": "string",
-          "enum": ["lsp", "indentation-based"],
+          "enum": [
+            "lsp",
+            "indentation-based"
+          ],
           "enumDescriptions": [
             "Use folding ranges that are enabled by default in VS Code, and are usually powered by LSP",
             "Use custom implementation of folding ranges that is indentation based. This is the implementation that is used by other Cody clients like the JetBrains plugin"
@@ -1128,7 +1166,13 @@
         "cody.autocomplete.experimental.graphContext": {
           "type": "string",
           "default": null,
-          "enum": [null, "bfg", "bfg-mixed", "tsc", "tsc-mixed"],
+          "enum": [
+            null,
+            "bfg",
+            "bfg-mixed",
+            "tsc",
+            "tsc-mixed"
+          ],
           "markdownDescription": "Use the code graph to retrieve context for autocomplete requests."
         },
         "cody.autocomplete.experimental.fireworksOptions": {
@@ -1308,7 +1352,9 @@
     "untrustedWorkspaces": {
       "supported": "limited",
       "description": "Cody only uses providers (configured in `openctx.providers`) from trusted workspaces because providers may execute arbitrary code.",
-      "restrictedConfigurations": ["openctx.providers"]
+      "restrictedConfigurations": [
+        "openctx.providers"
+      ]
     }
   },
   "dependencies": {
@@ -1426,6 +1472,7 @@
     "ajv": "^8.14.0",
     "ajv-errors": "^3.0.0",
     "ajv-formats": "^3.0.1",
+    "buildkite-test-collector": "^1.7.2",
     "chokidar": "^3.6.0",
     "concurrently": "^8.2.0",
     "dedent": "^0.7.0",

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -1484,6 +1484,7 @@
     "http-proxy-middleware": "^3.0.0",
     "kill-sync": "^1.0.3",
     "mocha": "^10.2.0",
+    "mocha-multi-reporters": "^1.5.1",
     "node-fetch": "^2.6.4",
     "ovsx": "^0.8.2",
     "pako": "^2.1.0",

--- a/vscode/playwright.config.ts
+++ b/vscode/playwright.config.ts
@@ -12,7 +12,7 @@ export default defineConfig({
     expect: {
         timeout: isWin || isCI ? 5000 : 2000,
     },
-    reporter: isCI ? 'github' : 'list',
+    reporter: isCI ? [['github'], ['buildkite-test-collector/playwright/reporter']] : [['list']],
     globalSetup: require.resolve('./test/e2e/utils/setup'),
     globalTeardown: require.resolve('./test/e2e/utils/teardown'),
 })

--- a/vscode/playwright.v2.config.ts
+++ b/vscode/playwright.v2.config.ts
@@ -103,6 +103,6 @@ export default defineConfig<
         ['line', { printSteps: true, includeProjectInTestName: true }],
         ['html', { outputFolder: '.test-reports', fileName: 'report.html', open: 'never' }],
         ['json', { outputFile: '.test-reports/report.json', open: 'never' }],
-        ...(isCI ? [['github', {}] satisfies ReporterDescription] : []),
+        ...(isCI ? [['github', {}] satisfies ReporterDescription, ['buildkite-test-collector/playwright/reporter'] satisfies ReporterDescription] : []),
     ],
 })

--- a/vscode/test/integration/runner.ts
+++ b/vscode/test/integration/runner.ts
@@ -9,6 +9,10 @@ export function run(testsRoot: string): Promise<void> {
         color: true,
         timeout: 15000,
         grep: process.env.TEST_PATTERN ? new RegExp(process.env.TEST_PATTERN, 'i') : undefined,
+        reporter: "mocha-multi-reporters",
+        reporterOptions: {
+            "reporterEnabled": "spec, buildkite-test-collector/mocha/reporter",
+        }
     })
 
     return new Promise((resolve, reject) => {

--- a/vscode/test/integration/runner.ts
+++ b/vscode/test/integration/runner.ts
@@ -11,7 +11,7 @@ export function run(testsRoot: string): Promise<void> {
         grep: process.env.TEST_PATTERN ? new RegExp(process.env.TEST_PATTERN, 'i') : undefined,
         reporter: "mocha-multi-reporters",
         reporterOptions: {
-            "reporterEnabled": "spec, buildkite-test-collector/mocha/reporter",
+            "reporterEnabled": "spec, @buildkite-test-collector/mocha/reporter",
         }
     })
 


### PR DESCRIPTION
I initially added them on the unit tests, but due to the matrix testing and the vast amount of unit tests (and subtests), it yields about 2k tests per run, which is going to eat up the quota very quickly (we've got 6M in total / year).

With that in mind, I think it might be better to start with just integration and e2e, which are the ones that are usually important to monitor. Not that the unit ones aren't, but they're naturally more stable. 

I didn't plug the integration ones, they fail because the required mocha-multi-reporter module can't find the buildkite test analytics reporter (see https://github.com/sourcegraph/cody/actions/runs/10215434987/job/28264855049#step:8:54). 

I'll reach out on Slack about this to get some early feedback and possibly find some help for the integration ones if they're deem worthy of being tracked as well. 

## Test plan

See https://buildkite.com/organizations/sourcegraph/analytics/suites/cody/runs/6af3d32c-7f7c-8b76-83ee-4a325422d5a7#slowest

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
