### PR TITLE
Use server proxy for web mentions in Cody Web

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ playwright
 playwright-report
 test-results
 .vscode-test/
+.envrc

--- a/lib/shared/src/sourcegraph-api/graphql/queries.ts
+++ b/lib/shared/src/sourcegraph-api/graphql/queries.ts
@@ -459,6 +459,15 @@ query GetRemoteFileQuery($repositoryName: String!, $filePath: String!, $startLin
 }
 `
 
+export const GET_URL_CONTENT_QUERY = `
+query GetURLContentQuery($url: String!) {
+    urlMentionContext(url: $url) {
+        title
+        content
+    }
+}
+`
+
 export const VIEWER_SETTINGS_QUERY = `
 query ViewerSettings {
   viewerSettings {

--- a/vscode/src/context/openctx.ts
+++ b/vscode/src/context/openctx.ts
@@ -3,6 +3,7 @@ import {
     type ConfigurationWithAccessToken,
     FeatureFlag,
     GIT_OPENCTX_PROVIDER_URI,
+    WEB_PROVIDER_URI,
     featureFlagProvider,
     graphqlClient,
     isError,
@@ -17,7 +18,7 @@ import { gitMentionsProvider } from './openctx/git'
 import LinearIssuesProvider from './openctx/linear-issues'
 import RemoteFileProvider, { createRemoteFileProvider } from './openctx/remoteFileSearch'
 import RemoteRepositorySearch, { createRemoteRepositoryProvider } from './openctx/remoteRepositorySearch'
-import WebProvider from './openctx/web'
+import { createWebProvider } from './openctx/web'
 
 export async function exposeOpenCtxClient(
     context: Pick<vscode.ExtensionContext, 'extension' | 'secrets'>,
@@ -64,11 +65,15 @@ async function getStandardOpenCtxProviders(
     config: ConfigurationWithAccessToken,
     isDotCom: boolean
 ): Promise<{ settings: any; provider: Provider; providerUri: string }[]> {
-    const providers: { settings: any; provider: Provider; providerUri: string }[] = [
+    const providers: {
+        settings: any
+        provider: Provider
+        providerUri: string
+    }[] = [
         {
             settings: true,
-            provider: WebProvider,
-            providerUri: WebProvider.providerUri,
+            provider: createWebProvider(false),
+            providerUri: WEB_PROVIDER_URI,
         },
     ]
 
@@ -120,6 +125,11 @@ function getCodyWebOpenCtxProviders() {
             settings: true,
             providerUri: RemoteFileProvider.providerUri,
             provider: createRemoteFileProvider('Files'),
+        },
+        {
+            settings: true,
+            providerUri: WEB_PROVIDER_URI,
+            provider: createWebProvider(true),
         },
     ]
 }

--- a/vscode/src/context/openctx/web.ts
+++ b/vscode/src/context/openctx/web.ts
@@ -1,35 +1,47 @@
 import type { ItemsParams, ItemsResult } from '@openctx/client'
-import { WEB_PROVIDER_URI } from '@sourcegraph/cody-shared'
+import { WEB_PROVIDER_URI, graphqlClient, isErrorLike } from '@sourcegraph/cody-shared'
 import type { OpenCtxProvider } from './types'
 
 /**
  * An OpenCtx provider that fetches the content of a URL and provides it as an item.
  */
-const WebProvider: OpenCtxProvider = {
-    providerUri: WEB_PROVIDER_URI,
+export function createWebProvider(useProxy: boolean): OpenCtxProvider {
+    return {
+        providerUri: WEB_PROVIDER_URI,
 
-    meta() {
-        return {
-            name: 'Web URLs',
-            mentions: { label: 'Type or paste a URL...' },
-        }
-    },
+        meta() {
+            return {
+                name: 'Web URLs',
+                mentions: { label: 'Type or paste a URL...' },
+            }
+        },
 
-    async mentions({ query }) {
-        const [item] = await fetchItem({ message: query }, 2000)
-        if (!item) {
-            return []
-        }
+        async mentions({ query }) {
+            const [item] = await fetchItem({ message: query }, useProxy, 2000)
+            if (!item) {
+                return []
+            }
 
-        return [{ title: item.title, uri: item.url || '', data: { content: item.ai?.content } }]
-    },
+            return [
+                {
+                    title: item.title,
+                    uri: item.url || '',
+                    data: { content: item.ai?.content },
+                },
+            ]
+        },
 
-    async items(params) {
-        return fetchItem(params)
-    },
+        async items(params) {
+            return fetchItem(params, useProxy)
+        },
+    }
 }
 
-async function fetchItem(params: ItemsParams, timeoutMs?: number): Promise<ItemsResult> {
+async function fetchItem(
+    params: ItemsParams,
+    useProxy: boolean,
+    timeoutMs?: number
+): Promise<ItemsResult> {
     if (typeof params.mention?.data?.content === 'string') {
         return [
             {
@@ -46,20 +58,33 @@ async function fetchItem(params: ItemsParams, timeoutMs?: number): Promise<Items
         return []
     }
     try {
-        const content = await fetchContentForURLContextItem(
-            url,
-            timeoutMs ? AbortSignal.timeout(timeoutMs) : undefined
-        )
-
-        if (content === null) {
-            return []
+        let title: string | null
+        let content: string
+        if (useProxy) {
+            const response = await graphqlClient.getURLContent(url)
+            if (isErrorLike(response)) {
+                return []
+            }
+            title = response.title
+            content = response.content
+        } else {
+            const response = await fetchContentForURLContextItem(
+                url,
+                timeoutMs ? AbortSignal.timeout(timeoutMs) : undefined
+            )
+            if (response === null) {
+                return []
+            }
+            content = response
+            title = tryGetHTMLDocumentTitle(content) ?? url
         }
+
         return [
             {
                 url,
-                title: tryGetHTMLDocumentTitle(content) ?? url,
+                title: title ?? url,
                 ui: { hover: { text: `Fetched from ${url}` } },
-                ai: { content: content },
+                ai: { content },
             },
         ]
     } catch (error) {
@@ -116,5 +141,3 @@ function tryGetHTMLDocumentTitle(html: string): string | undefined {
         ?.groups?.title.replaceAll(/\s+/gm, ' ')
         .trim()
 }
-
-export default WebProvider

--- a/web/CHANGELOG.md
+++ b/web/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.3.4
+- Adds support for URL mentions
+
 ## 0.3.4 
 - Adds support for remote file ranges  
 

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sourcegraph/cody-web",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "Cody standalone web app",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
This updates the web context provider to optionally use the new endpoint in the GraphQL API (introduced [here](https://github.com/sourcegraph/sourcegraph/pull/64223)) to fetch web context in cody web to get around CORS issues.

## Test plan

Tested dev build against local Sourcegraph instance. Also tested that web mentions still work in VSCode.
![screenshot-2024-08-01_14-40-53@2x](https://github.com/user-attachments/assets/d6ba00aa-459a-41c9-a6ce-eb53af55239d)
