### PR TITLE
fix focus and dupe command name

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -443,7 +443,7 @@
         "command": "cody.chat.newPanel",
         "category": "Cody",
         "group": "Cody",
-        "title": "New Chat",
+        "title": "New Chat in Sidebar",
         "enablement": "cody.activated",
         "icon": "$(new-comment-icon)"
       },

--- a/vscode/src/chat/chat-view/ChatsController.ts
+++ b/vscode/src/chat/chat-view/ChatsController.ts
@@ -146,7 +146,11 @@ export class ChatsController implements vscode.Disposable {
 
             vscode.commands.registerCommand('cody.chat.newPanel', async () => {
                 localStorage.setLastUsedChatModality('sidebar')
+                const isVisible = this.panel.isVisible()
                 await this.panel.clearAndRestartSession()
+                if (!isVisible) {
+                    await vscode.commands.executeCommand('cody.chat.focus')
+                }
             }),
             vscode.commands.registerCommand('cody.chat.newEditorPanel', () => {
                 localStorage.setLastUsedChatModality('editor')


### PR DESCRIPTION
Follow-up fixes to https://github.com/sourcegraph/cody/pull/5089
- Give `New Chat *` commands unique names
- Prevent loss of focus when creating a new chat in the sidebar

## Test plan

Test locally
