### PR TITLE
Cody Web: Expose internal create chat API from Cody Web root component

### DIFF
--- a/web/CHANGELOG.md
+++ b/web/CHANGELOG.md
@@ -1,5 +1,6 @@
-## 0.3.4
+## 0.3.5
 - Adds support for URL mentions
+- Adds support for ref-like API in CodyWebChatProvider level
 
 ## 0.3.4 
 - Adds support for remote file ranges  

--- a/web/demo/App.tsx
+++ b/web/demo/App.tsx
@@ -2,7 +2,7 @@ import type { FC } from 'react'
 
 import {
     CodyWebChat,
-    type CodyWebChatContextRef,
+    type CodyWebChatContextClient,
     CodyWebChatProvider,
     CodyWebHistory,
     type Repository,
@@ -54,7 +54,7 @@ if (!accessToken) {
 }
 
 export const App: FC = () => {
-    const rootRef = useRef<CodyWebChatContextRef>(null)
+    const rootRef = useRef<CodyWebChatContextClient>(null)
 
     return (
         <CodyWebChatProvider

--- a/web/demo/App.tsx
+++ b/web/demo/App.tsx
@@ -1,10 +1,18 @@
 import type { FC } from 'react'
 
-import { CodyWebChat, CodyWebChatProvider, CodyWebHistory, type Repository, getChatTitle } from '../lib'
+import {
+    CodyWebChat,
+    type CodyWebChatContextRef,
+    CodyWebChatProvider,
+    CodyWebHistory,
+    type Repository,
+    getChatTitle,
+} from '../lib'
 
 // Include highlights styles for demo purpose, clients like
 // Sourcegraph import highlights styles themselves
 import '../../vscode/webviews/utils/highlight.css'
+import { useRef } from 'react'
 import styles from './App.module.css'
 
 const DOTCOM_SERVER_ENDPOINT = 'https://sourcegraph.com'
@@ -46,8 +54,11 @@ if (!accessToken) {
 }
 
 export const App: FC = () => {
+    const rootRef = useRef<CodyWebChatContextRef>(null)
+
     return (
         <CodyWebChatProvider
+            ref={rootRef}
             accessToken={accessToken}
             serverEndpoint={serverEndpoint}
             telemetryClientName="codydemo.testing"
@@ -87,7 +98,7 @@ export const App: FC = () => {
                                         <button
                                             type="button"
                                             className={styles.createChat}
-                                            onClick={() => input.createNewChat()}
+                                            onClick={() => rootRef.current?.createNewChat()}
                                         >
                                             Create new chat +
                                         </button>

--- a/web/lib/components/CodyWebChatProvider.tsx
+++ b/web/lib/components/CodyWebChatProvider.tsx
@@ -68,7 +68,7 @@ export const CodyWebChatContext = createContext<CodyWebChatContextData>({
     selectChat: () => Promise.resolve(),
 })
 
-export interface CodyWebChatContextRef {
+export interface CodyWebChatContextClient {
     createNewChat: () => Promise<void>
 }
 
@@ -80,6 +80,7 @@ interface CodyWebChatProviderProps {
     initialContext?: InitialContext
     customHeaders?: Record<string, string>
     onNewChatCreated?: (chatId: string) => void
+    onClientCreated?: (client: CodyWebChatContextClient) => void
 }
 
 /**
@@ -87,7 +88,7 @@ interface CodyWebChatProviderProps {
  * agent client and maintains active web panel ID, chat history and vscodeAPI.
  */
 export const CodyWebChatProvider = forwardRef<
-    CodyWebChatContextRef,
+    CodyWebChatContextClient,
     PropsWithChildren<CodyWebChatProviderProps>
 >((props, ref) => {
     const {
@@ -97,8 +98,9 @@ export const CodyWebChatProvider = forwardRef<
         telemetryClientName,
         children,
         chatID: initialChatId,
-        onNewChatCreated,
         customHeaders,
+        onNewChatCreated,
+        onClientCreated,
     } = props
 
     // In order to avoid multiple client creation during dev runs
@@ -320,6 +322,10 @@ export const CodyWebChatProvider = forwardRef<
         }),
         [createChat]
     )
+
+    useEffect(() => {
+        onClientCreated?.({ createNewChat: createChat })
+    }, [onClientCreated, createChat])
 
     const contextInfo = useMemo(
         () => ({

--- a/web/lib/components/CodyWebChatProvider.tsx
+++ b/web/lib/components/CodyWebChatProvider.tsx
@@ -1,10 +1,11 @@
 import {
-    type FC,
     type PropsWithChildren,
     createContext,
+    forwardRef,
     useCallback,
     useContext,
     useEffect,
+    useImperativeHandle,
     useMemo,
     useRef,
     useState,
@@ -67,6 +68,10 @@ export const CodyWebChatContext = createContext<CodyWebChatContextData>({
     selectChat: () => Promise.resolve(),
 })
 
+export interface CodyWebChatContextRef {
+    createNewChat: () => Promise<void>
+}
+
 interface CodyWebChatProviderProps {
     serverEndpoint: string
     accessToken: string | null
@@ -81,7 +86,10 @@ interface CodyWebChatProviderProps {
  * The root store/provider node for the Cody Web chat, creates and shares
  * agent client and maintains active web panel ID, chat history and vscodeAPI.
  */
-export const CodyWebChatProvider: FC<PropsWithChildren<CodyWebChatProviderProps>> = props => {
+export const CodyWebChatProvider = forwardRef<
+    CodyWebChatContextRef,
+    PropsWithChildren<CodyWebChatProviderProps>
+>((props, ref) => {
     const {
         serverEndpoint,
         accessToken,
@@ -305,6 +313,14 @@ export const CodyWebChatProvider: FC<PropsWithChildren<CodyWebChatProviderProps>
         [client, vscodeAPI, setLastActiveChatID]
     )
 
+    useImperativeHandle(
+        ref,
+        () => ({
+            createNewChat: createChat,
+        }),
+        [createChat]
+    )
+
     const contextInfo = useMemo(
         () => ({
             client,
@@ -333,7 +349,7 @@ export const CodyWebChatProvider: FC<PropsWithChildren<CodyWebChatProviderProps>
             <CodyWebChatContext.Provider value={contextInfo}>{children}</CodyWebChatContext.Provider>
         </AppWrapper>
     )
-}
+})
 
 export function useWebAgentClient(): CodyWebChatContextData {
     return useContext(CodyWebChatContext)

--- a/web/lib/index.ts
+++ b/web/lib/index.ts
@@ -1,4 +1,4 @@
-export { CodyWebChatProvider, type CodyWebChatContextRef } from './components/CodyWebChatProvider'
+export { CodyWebChatProvider, type CodyWebChatContextClient } from './components/CodyWebChatProvider'
 export { CodyWebChat, type CodyWebChatProps } from './components/CodyWebChat'
 export { CodyWebHistory, getChatTitle, type ChatExportResult } from './components/CodyWebHistory'
 

--- a/web/lib/index.ts
+++ b/web/lib/index.ts
@@ -1,4 +1,4 @@
-export { CodyWebChatProvider } from './components/CodyWebChatProvider'
+export { CodyWebChatProvider, type CodyWebChatContextRef } from './components/CodyWebChatProvider'
 export { CodyWebChat, type CodyWebChatProps } from './components/CodyWebChat'
 export { CodyWebHistory, getChatTitle, type ChatExportResult } from './components/CodyWebHistory'
 


### PR DESCRIPTION
Part of [SRCH-720](https://linear.app/sourcegraph/issue/SRCH-720/new-chat-button-in-side-panel-view)

This PR simply exposes the internal CodyWebProvider API so a consumer would be able to call it proactively (in this particular case to trigger chat creation outside of CodyWebProvider children components)

## Test plan
- No manual testing is required (pure tech PR) 
