### PR TITLE
Chat UI: Tab bar available to all users

### DIFF
--- a/vscode/webviews/App.tsx
+++ b/vscode/webviews/App.tsx
@@ -280,9 +280,8 @@ export const App: React.FunctionComponent<{ vscodeAPI: VSCodeWrapper }> = ({ vsc
                     orientation="vertical"
                     className={styles.outerContainer}
                 >
-                    {/* NOTE: Display tabs to PLG users only until Universal Cody is ready. */}
                     {/* Shows tab bar for sidebar chats only. */}
-                    {userAccountInfo.isDotComUser && config.webviewType === 'editor' ? null : (
+                    {config.webviewType === 'editor' ? null : (
                         <TabsBar
                             currentView={view}
                             setView={setView}


### PR DESCRIPTION
FOLLOW UP on https://github.com/sourcegraph/cody/pull/5039

Made a change couple days again in https://github.com/sourcegraph/cody/pull/5039 to make sidebar chat the default for both DotCom and Enterprise users in prepare for the next release, but missed to remove the condition about the nav bar for enterprise users. This PR removes the condition to check if the user is Enterprise users or not, and display the nav bar for everyone until the chat is in the Editor panel.

## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

1. log into s2
2. open a new chat in the editor
3. confirm the nav bar is showing up in the sidebar 
4. confirm the nav bar is not showing up in the editor panel

![image](https://github.com/user-attachments/assets/b4b0bba7-155c-40c1-9a1d-db20af26231e)


## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
