### PR TITLE
Chat: Allow both the submitting and "next" input to cancel the submission.

### DIFF
--- a/vscode/webviews/chat/Transcript.tsx
+++ b/vscode/webviews/chat/Transcript.tsx
@@ -77,6 +77,9 @@ export const Transcript: FC<TranscriptProps> = props => {
                     isLastSentInteraction={
                         i === interactions.length - 2 && interaction.assistantMessage !== null
                     }
+                    assistantMessageIsLoading={Boolean(
+                        messageInProgress && interactions.at(i)?.assistantMessage?.isLoading
+                    )}
                     priorAssistantMessageIsLoading={Boolean(
                         messageInProgress && interactions.at(i - 1)?.assistantMessage?.isLoading
                     )}
@@ -146,6 +149,7 @@ interface TranscriptInteractionProps extends Omit<TranscriptProps, 'transcript' 
     isFirstInteraction: boolean
     isLastInteraction: boolean
     isLastSentInteraction: boolean
+    assistantMessageIsLoading: boolean
     priorAssistantMessageIsLoading: boolean
 }
 
@@ -155,6 +159,7 @@ const TranscriptInteraction: FC<TranscriptInteractionProps> = memo(props => {
         isFirstInteraction,
         isLastInteraction,
         isLastSentInteraction,
+        assistantMessageIsLoading,
         priorAssistantMessageIsLoading,
         isTranscriptError,
         userInfo,
@@ -206,6 +211,7 @@ const TranscriptInteraction: FC<TranscriptInteractionProps> = memo(props => {
                 message={humanMessage}
                 isFirstMessage={humanMessage.index === 0}
                 isSent={!humanMessage.isUnsentFollowup}
+                isPendingResponse={assistantMessageIsLoading}
                 isPendingPriorResponse={priorAssistantMessageIsLoading}
                 onSubmit={humanMessage.isUnsentFollowup ? onFollowupSubmit : onEditSubmit}
                 onStop={onStop}

--- a/vscode/webviews/chat/cells/messageCell/human/HumanMessageCell.tsx
+++ b/vscode/webviews/chat/cells/messageCell/human/HumanMessageCell.tsx
@@ -25,6 +25,9 @@ export const HumanMessageCell: FunctionComponent<{
     /** Whether this editor is for a message that has been sent already. */
     isSent: boolean
 
+    /** Wether this editor has an in-progress assistant reposponse */
+    isPendingResponse: boolean
+
     /** Whether this editor is for a followup message to a still-in-progress assistant response. */
     isPendingPriorResponse: boolean
 
@@ -48,6 +51,7 @@ export const HumanMessageCell: FunctionComponent<{
         chatEnabled = true,
         isFirstMessage,
         isSent,
+        isPendingResponse,
         isPendingPriorResponse,
         onChange,
         onSubmit,
@@ -82,6 +86,7 @@ export const HumanMessageCell: FunctionComponent<{
                         placeholder={isFirstMessage ? 'Ask...' : 'Ask a followup...'}
                         isFirstMessage={isFirstMessage}
                         isSent={isSent}
+                        isPendingResponse={isPendingResponse}
                         isPendingPriorResponse={isPendingPriorResponse}
                         onChange={onChange}
                         onSubmit={onSubmit}

--- a/vscode/webviews/chat/cells/messageCell/human/editor/HumanMessageEditor.test.tsx
+++ b/vscode/webviews/chat/cells/messageCell/human/editor/HumanMessageEditor.test.tsx
@@ -161,6 +161,7 @@ function renderWithMocks(props: Partial<ComponentProps<typeof HumanMessageEditor
         initialEditorState: FILE_MENTION_EDITOR_STATE_FIXTURE,
         placeholder: 'my-placeholder',
         isFirstMessage: true,
+        isPendingResponse: false,
         isPendingPriorResponse: false,
         isSent: false,
         onChange,

--- a/vscode/webviews/chat/cells/messageCell/human/editor/HumanMessageEditor.tsx
+++ b/vscode/webviews/chat/cells/messageCell/human/editor/HumanMessageEditor.tsx
@@ -38,6 +38,9 @@ export const HumanMessageEditor: FunctionComponent<{
     /** Whether this editor is for a message that has been sent already. */
     isSent: boolean
 
+    /** Wether this editor has an in-progress assistant reposponse */
+    isPendingResponse: boolean
+
     /** Whether this editor is for a followup message to a still-in-progress assistant response. */
     isPendingPriorResponse: boolean
 
@@ -62,6 +65,7 @@ export const HumanMessageEditor: FunctionComponent<{
     placeholder,
     isFirstMessage,
     isSent,
+    isPendingResponse,
     isPendingPriorResponse,
     disabled = false,
     onChange,
@@ -93,11 +97,12 @@ export const HumanMessageEditor: FunctionComponent<{
         [onChange]
     )
 
-    const submitState: SubmitButtonState = isPendingPriorResponse
-        ? 'waitingResponseComplete'
-        : isEmptyEditorValue
-          ? 'emptyEditorValue'
-          : 'submittable'
+    const submitState: SubmitButtonState =
+        isPendingPriorResponse || isPendingResponse
+            ? 'waitingResponseComplete'
+            : isEmptyEditorValue
+              ? 'emptyEditorValue'
+              : 'submittable'
 
     const onSubmitClick = useCallback(() => {
         if (submitState === 'emptyEditorValue') {
@@ -278,7 +283,7 @@ export const HumanMessageEditor: FunctionComponent<{
                 'tw-transition',
                 className
             )}
-            data-keep-toolbar-open={isLastInteraction || undefined}
+            data-keep-toolbar-open={isPendingPriorResponse || isPendingResponse}
             onMouseDown={onMaybeGapClick}
             onClick={onMaybeGapClick}
             onFocus={onFocus}


### PR DESCRIPTION
Right now after submitting a message you have to chase the "stop" button around as text is generated. This change ensures that both the submitting and follow up field give a way to cancel the message.

Not the most elegant fix, but patches a frustration @dominiccooney and @abeatrix shared until we can maybe think of something more slick.

![CleanShot 2024-08-02 at 11.44.28@2x.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/onbAacT3LuCgMVcIIUAU/867624eb-8287-4002-866f-773ef5a2d69d.png)

## Test plan
CI