### PR TITLE
pass AbortSignals in more places

### DIFF
--- a/lib/shared/src/context/openctx/context.ts
+++ b/lib/shared/src/context/openctx/context.ts
@@ -3,7 +3,10 @@ import type { ContextItemOpenCtx } from '../../codebase-context/messages'
 import { openCtx } from './api'
 
 // getContextForChatMessage returns context items for a given chat message from the OpenCtx providers.
-export const getContextForChatMessage = async (message: string): Promise<ContextItemOpenCtx[]> => {
+export const getContextForChatMessage = async (
+    message: string,
+    signal?: AbortSignal
+): Promise<ContextItemOpenCtx[]> => {
     try {
         const openCtxClient = openCtx.client
         if (!openCtxClient) {
@@ -12,6 +15,7 @@ export const getContextForChatMessage = async (message: string): Promise<Context
 
         // get list of all configured OpenCtx providers.
         const providers = await openCtxClient.meta({})
+        signal?.throwIfAborted()
 
         // filter providers that have message selectors configured and match the message text.
         const matchingProviders = providers.filter(
@@ -33,6 +37,8 @@ export const getContextForChatMessage = async (message: string): Promise<Context
                 )
             )
         ).flat()
+        // TODO(sqs): add abort signal to openCtxClient.items API
+        signal?.throwIfAborted()
 
         return items
             .filter(item => item.ai?.content)

--- a/lib/shared/src/guardrails/client.ts
+++ b/lib/shared/src/guardrails/client.ts
@@ -37,7 +37,7 @@ export class SourcegraphGuardrailsClient implements Guardrails {
         const timeout =
             (this.config.experimentalGuardrailsTimeoutSeconds ?? defaultTimeoutSeconds) * 1000
 
-        const result = await this.client.searchAttribution(snippet, timeout)
+        const result = await this.client.searchAttribution(snippet, AbortSignal.timeout(timeout))
 
         if (isError(result)) {
             return result

--- a/vscode/src/context/remote-search.ts
+++ b/vscode/src/context/remote-search.ts
@@ -121,12 +121,16 @@ export class RemoteSearch implements ContextStatusProvider {
         return Array.from(new Set([...this.reposAuto.keys(), ...this.reposManual.keys()]))
     }
 
-    public async query(query: PromptString, repoIDs: string[]): Promise<ContextSearchResult[]> {
+    public async query(
+        query: PromptString,
+        repoIDs: string[],
+        signal?: AbortSignal
+    ): Promise<ContextSearchResult[]> {
         if (repoIDs.length === 0) {
             return []
         }
-        const rewritten = await rewriteKeywordQuery(this.completions, query)
-        const result = await graphqlClient.contextSearch(repoIDs, rewritten)
+        const rewritten = await rewriteKeywordQuery(this.completions, query, signal)
+        const result = await graphqlClient.contextSearch(repoIDs, rewritten, signal)
         if (isError(result)) {
             throw result
         }

--- a/vscode/src/local-context/symf.ts
+++ b/vscode/src/local-context/symf.ts
@@ -117,7 +117,8 @@ export class SymfRunner implements IndexedKeywordContextFetcher, vscode.Disposab
     public async getLiveResults(
         userQuery: PromptString,
         keywordQuery: string,
-        files: string[]
+        files: string[],
+        signal?: AbortSignal
     ): Promise<Result[]> {
         const symfPath = await this.mustSymfPath()
         const args = [
@@ -137,8 +138,12 @@ export class SymfRunner implements IndexedKeywordContextFetcher, vscode.Disposab
                 maxBuffer: 1024 * 1024 * 1024,
                 timeout: 1000 * 30, // timeout in 30 seconds
             })
+            signal?.throwIfAborted() // TODO(sqs): abort exec call
             return parseSymfStdout(stdout)
         } catch (error) {
+            if (isAbortError(error)) {
+                throw error
+            }
             throw toSymfError(error)
         }
     }

--- a/vscode/src/repository/repo-name-resolver.ts
+++ b/vscode/src/repository/repo-name-resolver.ts
@@ -47,7 +47,10 @@ export class RepoNameResolver {
      * If found, gets repo names from the repository.
      * if not found, walks the file system upwards until it finds a `.git` folder.
      */
-    public getRepoNamesFromWorkspaceUri = async (uri: vscode.Uri): Promise<string[]> => {
+    public getRepoNamesFromWorkspaceUri = async (
+        uri: vscode.Uri,
+        signal?: AbortSignal
+    ): Promise<string[]> => {
         if (!isFileURI(uri)) {
             return []
         }
@@ -57,7 +60,7 @@ export class RepoNameResolver {
         }
 
         try {
-            const remoteUrls = await this.getRepoRemoteUrlsFromWorkspaceUri(uri)
+            const remoteUrls = await this.getRepoRemoteUrlsFromWorkspaceUri(uri, signal)
 
             if (remoteUrls.length !== 0) {
                 const repoNames = await this.getRepoNamesFromRemoteUrls(remoteUrls)
@@ -72,7 +75,10 @@ export class RepoNameResolver {
         return []
     }
 
-    public getRepoRemoteUrlsFromWorkspaceUri = async (uri: vscode.Uri): Promise<string[]> => {
+    public getRepoRemoteUrlsFromWorkspaceUri = async (
+        uri: vscode.Uri,
+        signal?: AbortSignal
+    ): Promise<string[]> => {
         if (!isFileURI(uri)) {
             return []
         }
@@ -81,7 +87,7 @@ export class RepoNameResolver {
             let remoteUrls = gitRemoteUrlsFromGitExtension(uri)
 
             if (remoteUrls === undefined || remoteUrls.length === 0) {
-                remoteUrls = await gitRemoteUrlsFromParentDirs(uri)
+                remoteUrls = await gitRemoteUrlsFromParentDirs(uri, signal)
             }
 
             return remoteUrls || []


### PR DESCRIPTION
AbortSignals let us cancel potentially resource-intensive tasks when their result is no longer needed. Now we pass them around in more places.

Many methods in the GraphQL client now accept AbortSignals. This preserves the timeouts and timeout-related error behavior.

## Test plan

Test with an added 6-second-plus sleep and ensure that the error thrown is an ETIMEDOUT.