### PR TITLE
refactor context-fetching

### DIFF
--- a/lib/shared/src/index.ts
+++ b/lib/shared/src/index.ts
@@ -285,7 +285,7 @@ export {
     type ContextMentionProviderMetadata,
 } from './mentions/api'
 export { TokenCounter } from './token/counter'
-export { ENHANCED_CONTEXT_ALLOCATION } from './token/constants'
+export { CORPUS_CONTEXT_ALLOCATION as ENHANCED_CONTEXT_ALLOCATION } from './token/constants'
 export { tokensToChars, charsToTokens } from './token/utils'
 export * from './prompt/prompt-string'
 export { getCompletionsModelConfig } from './llm-providers/utils'

--- a/lib/shared/src/token/constants.ts
+++ b/lib/shared/src/token/constants.ts
@@ -14,10 +14,10 @@ export const FAST_CHAT_INPUT_TOKEN_BUDGET = 4096
 export const CHAT_OUTPUT_TOKEN_BUDGET = 4000
 
 /**
- * Enhanced context takes up to 60% of the total context window for chat.
+ * Corpus context takes up to 60% of the total context window for chat.
  * The % is the same for both fast and regular chat models.
  */
-export const ENHANCED_CONTEXT_ALLOCATION = 0.6
+export const CORPUS_CONTEXT_ALLOCATION = 0.6
 
 /**
  * NOTE: Reserved for models with large context windows and good recall.

--- a/lib/shared/src/token/index.ts
+++ b/lib/shared/src/token/index.ts
@@ -17,7 +17,7 @@ export interface ChatContextTokenUsage {
     /**
      * Tokens used by non-user-specified context messages.
      */
-    enhanced: number
+    corpus: number
 }
 
 export interface TokenUsage extends ChatContextTokenUsage {
@@ -32,5 +32,5 @@ export interface TokenUsage extends ChatContextTokenUsage {
 }
 
 export type TokenUsageType = ChatTokenUsageType | ContextTokenUsageType
-export type ChatTokenUsageType = 'preamble' | 'input'
-export type ContextTokenUsageType = 'user' | 'enhanced'
+export type ChatTokenUsageType = Exclude<keyof TokenUsage, keyof ChatContextTokenUsage>
+export type ContextTokenUsageType = keyof ChatContextTokenUsage

--- a/vscode/src/chat/chat-view/context.ts
+++ b/vscode/src/chat/chat-view/context.ts
@@ -20,8 +20,9 @@ import {
     uriBasename,
     wrapInActiveSpan,
 } from '@sourcegraph/cody-shared'
-import { compact, flatten, isError, zip } from 'lodash'
+import { isError } from 'lodash'
 import type { RemoteSearch } from '../../context/remote-search'
+import { resolveContextItems } from '../../editor/utils/editor-context'
 import type { VSCodeEditor } from '../../editor/vscode-editor'
 import type { LocalEmbeddingsController } from '../../local-context/local-embeddings'
 import type { SymfRunner } from '../../local-context/symf'
@@ -106,12 +107,6 @@ export async function codebaseRootsFromHumanInput(
     return [...remoteRepos, ...localRoots]
 }
 
-export function remoteRepositoryIDsFromHumanInput(input: HumanInput): string[] {
-    return input.mentions
-        .filter((item): item is ContextItemRepository => item.type === 'repository')
-        .map(repo => repo.repoID)
-}
-
 export async function remoteRepositoryURIsForLocalTrees(input: HumanInput): Promise<string[]> {
     const trees: ContextItemTree[] = input.mentions.filter(
         (item): item is ContextItemTree => item.type === 'tree'
@@ -123,11 +118,17 @@ export async function remoteRepositoryURIsForLocalTrees(input: HumanInput): Prom
     return Array.from(new Set(groups.flat()))
 }
 
-function shouldSearchInLocalWorkspace(input: HumanInput): boolean {
-    return input.mentions.some(item => item.type === 'tree')
-}
-
-interface GetEnhancedContextOptions {
+/**
+ * Resolve all @-mentions, including special @-mentions that refer to corpuses (not individual
+ * documents) like `@repository` and `@directory`, for which context search is performed.
+ */
+export async function resolveContext({
+    strategy,
+    editor,
+    input,
+    providers: { remoteSearch, symf, localEmbeddings },
+    signal,
+}: {
     strategy: ConfigurationUseContext
     editor: VSCodeEditor
     input: HumanInput
@@ -136,60 +137,79 @@ interface GetEnhancedContextOptions {
         symf: SymfRunner | null
         remoteSearch: RemoteSearch | null
     }
-    addEnhancedContext: boolean
     signal?: AbortSignal
-    // TODO(@philipp-spiess): Add abort controller to be able to cancel expensive retrievers
-}
-export async function getEnhancedContext({
-    strategy,
-    editor,
-    input,
-    providers,
-    addEnhancedContext,
-    signal,
-}: GetEnhancedContextOptions): Promise<ContextItem[]> {
-    return wrapInActiveSpan('chat.enhancedContext', async () => {
+}): Promise<ContextItem[]> {
+    return wrapInActiveSpan('chat.resolveCorpusContextMentions', async () => {
         // use user attention context only if config is set to none
         if (strategy === 'none') {
-            logDebug('ChatController', 'getEnhancedContext > none')
+            logDebug('ChatController', 'resolveContext > none')
             return getVisibleEditorContext(editor)
         }
 
-        const embeddingsContextItemsPromise =
-            strategy !== 'keyword' && (addEnhancedContext || shouldSearchInLocalWorkspace(input))
-                ? retrieveContextGracefully(
-                      searchEmbeddingsLocal(providers.localEmbeddings, input.text),
-                      'local-embeddings'
-                  )
-                : []
+        const repoMentions = input.mentions.filter(
+            (item): item is ContextItemRepository => item.type === 'repository'
+        )
+        const treeMentions = input.mentions.filter(
+            (item): item is ContextItemTree => item.type === 'tree'
+        )
+        const otherMentions = input.mentions.filter(
+            (item): item is Exclude<ContextItem, ContextItemRepository | ContextItemTree> =>
+                item.type !== 'repository' && item.type !== 'tree'
+        )
 
-        //  Get search (symf or remote search) context if config is not set to 'embeddings' only
-        const remoteSearchContextItemsPromise =
-            providers.remoteSearch && strategy !== 'embeddings'
+        // Right now, repo mentions are always remote (remoteSearch), and tree mentions are always
+        // local (symf or embeddings).
+
+        // Remote search:
+        const repoContextSearchResults =
+            remoteSearch && repoMentions.length > 0
                 ? retrieveContextGracefully(
-                      searchRemote(providers.remoteSearch, input, addEnhancedContext, signal),
+                      searchRemote(
+                          remoteSearch,
+                          input.text,
+                          repoMentions.map(m => m.repoID),
+                          signal
+                      ),
                       'remote-search'
                   )
                 : []
-        const localSearchContextItemsPromise =
-            providers.symf &&
-            strategy !== 'embeddings' &&
-            (addEnhancedContext || shouldSearchInLocalWorkspace(input))
-                ? retrieveContextGracefully(searchSymf(providers.symf, editor, input.text), 'symf')
-                : []
 
-        // Retrieve items from all context sources
-        const searchContextBySource = [
-            await embeddingsContextItemsPromise,
-            await remoteSearchContextItemsPromise,
-            await localSearchContextItemsPromise,
-        ]
+        // Symf search:
+        const treeContextSymfSearchResults =
+            symf && strategy !== 'embeddings' && treeMentions.length > 0
+                ? Promise.all(
+                      treeMentions.map(tree =>
+                          retrieveContextGracefully(
+                              searchSymf(symf, editor, tree.uri, input.text),
+                              `symf ${tree.name}`
+                          )
+                      )
+                  ).then(v => v.flat())
+                : Promise.resolve([])
 
-        // Interleave items from context sources, excluding undefined items inserted by lodash's zip
-        const searchContext = compact(flatten(zip(...searchContextBySource)))
+        // Embeddings search. Note that this is hard-coded to only work on a single workspace root
+        // and is not scoped to a dir, so we just run it once. TODO: Make it scoped to a dir.
+        const treeContextEmbeddingsSearchResults =
+            localEmbeddings && strategy !== 'keyword' && treeMentions.length > 0
+                ? retrieveContextGracefully(
+                      searchEmbeddingsLocal(localEmbeddings, input.text),
+                      'local-embeddings'
+                  )
+                : Promise.resolve([])
 
-        const priorityContext = await getPriorityContext(input.text, editor, searchContext)
-        return priorityContext.concat(searchContext)
+        // Other @-mentions:
+        const otherMentionsResolved = resolveContextItems(editor, otherMentions, input.text, signal)
+
+        const allContext: ContextItem[] = (
+            await Promise.all([
+                repoContextSearchResults,
+                treeContextSymfSearchResults,
+                treeContextEmbeddingsSearchResults,
+                otherMentionsResolved,
+            ])
+        ).flat()
+        const priorityContext = await getPriorityContext(input.text, editor, allContext)
+        return priorityContext.concat(allContext)
     })
 }
 
@@ -224,19 +244,16 @@ export async function getContextStrategy(
 }
 
 async function searchRemote(
-    remoteSearch: RemoteSearch | null,
-    input: HumanInput,
-    allReposForEnhancedContext: boolean,
+    remoteSearch: RemoteSearch,
+    input: PromptString,
+    repoIDs: string[],
     signal?: AbortSignal
 ): Promise<ContextItem[]> {
     return wrapInActiveSpan('chat.context.search.remote', async () => {
         if (!remoteSearch) {
             return []
         }
-        const repoIDs = allReposForEnhancedContext
-            ? remoteSearch.getRepoIdSet()
-            : remoteRepositoryIDsFromHumanInput(input)
-        return (await remoteSearch.query(input.text, repoIDs, signal)).map(result => {
+        return (await remoteSearch.query(input, repoIDs, signal)).map(result => {
             return {
                 type: 'file',
                 content: result.content,
@@ -257,6 +274,7 @@ async function searchRemote(
 async function searchSymf(
     symf: SymfRunner | null,
     editor: VSCodeEditor,
+    workspaceRoot: vscode.Uri,
     userText: PromptString,
     blockOnIndex = false
 ): Promise<ContextItem[]> {
@@ -264,8 +282,7 @@ async function searchSymf(
         if (!symf) {
             return []
         }
-        const workspaceRoot = editor.getWorkspaceRootUri()
-        if (!workspaceRoot || !isFileURI(workspaceRoot)) {
+        if (!isFileURI(workspaceRoot)) {
             return []
         }
 
@@ -315,16 +332,12 @@ async function searchSymf(
 }
 
 async function searchEmbeddingsLocal(
-    localEmbeddings: LocalEmbeddingsController | null,
+    localEmbeddings: LocalEmbeddingsController,
     text: PromptString,
     numResults: number = NUM_CODE_RESULTS + NUM_TEXT_RESULTS
 ): Promise<ContextItem[]> {
     return wrapInActiveSpan('chat.context.embeddings.local', async span => {
-        if (!localEmbeddings) {
-            return []
-        }
-
-        logDebug('ChatController', 'getEnhancedContext > searching local embeddings')
+        logDebug('ChatController', 'resolveContext > searching local embeddings')
         const contextItems: ContextItem[] = []
         const embeddingsResults = await localEmbeddings.getContext(text, numResults)
         span.setAttribute('numResults', embeddingsResults.length)
@@ -503,16 +516,16 @@ function extractQuestion(input: string): string | undefined {
 
 async function retrieveContextGracefully<T>(promise: Promise<T[]>, strategy: string): Promise<T[]> {
     try {
-        logDebug('ChatController', `getEnhancedContext > ${strategy} (start)`)
+        logDebug('ChatController', `resolveContext > ${strategy} (start)`)
         return await promise
     } catch (error) {
         if (isAbortError(error)) {
-            logError('ChatController', `getEnhancedContext > ${strategy}' (aborted)`)
+            logError('ChatController', `resolveContext > ${strategy}' (aborted)`)
             throw error
         }
-        logError('ChatController', `getEnhancedContext > ${strategy}' (error)`, error)
+        logError('ChatController', `resolveContext > ${strategy}' (error)`, error)
         return []
     } finally {
-        logDebug('ChatController', `getEnhancedContext > ${strategy} (end)`)
+        logDebug('ChatController', `resolveContext > ${strategy} (end)`)
     }
 }

--- a/vscode/src/chat/chat-view/prompt.test.ts
+++ b/vscode/src/chat/chat-view/prompt.test.ts
@@ -31,7 +31,7 @@ describe('DefaultPrompter', () => {
         const chat = new ChatModel('a-model-id')
         chat.addHumanMessage({ text: ps`Hello` })
 
-        const { prompt, context } = await new DefaultPrompter([]).makePrompt(chat, 0)
+        const { prompt, context } = await new DefaultPrompter([], []).makePrompt(chat, 0)
 
         expect(prompt).toEqual<Message[]>([
             {
@@ -70,7 +70,7 @@ describe('DefaultPrompter', () => {
         const chat = new ChatModel('a-model-id')
         chat.addHumanMessage({ text: ps`Hello` })
 
-        const { prompt, context } = await new DefaultPrompter([]).makePrompt(chat, 0)
+        const { prompt, context } = await new DefaultPrompter([], []).makePrompt(chat, 0)
 
         expect(prompt).toEqual<Message[]>([
             {
@@ -107,18 +107,17 @@ describe('DefaultPrompter', () => {
                 {
                     uri: vscode.Uri.file('user1.go'),
                     type: 'file',
-                    content: 'import vscode',
+                    content: 'package vscode',
                     source: ContextItemSource.User,
                 },
             ],
-            () =>
-                Promise.resolve([
-                    {
-                        uri: vscode.Uri.file('enhanced1.ts'),
-                        type: 'file',
-                        content: 'import vscode',
-                    },
-                ])
+            [
+                {
+                    uri: vscode.Uri.file('enhanced1.ts'),
+                    type: 'file',
+                    content: 'import vscode',
+                },
+            ]
         ).makePrompt(chat, 0)
 
         chat.setLastMessageContext(info.context.used)
@@ -141,18 +140,17 @@ describe('DefaultPrompter', () => {
                 {
                     uri: vscode.Uri.file('user2.go'),
                     type: 'file',
-                    content: 'import vscode',
+                    content: 'package vscode',
                     source: ContextItemSource.User,
                 },
             ],
-            () =>
-                Promise.resolve([
-                    {
-                        uri: vscode.Uri.file('enhanced2.ts'),
-                        type: 'file',
-                        content: 'import vscode',
-                    },
-                ])
+            [
+                {
+                    uri: vscode.Uri.file('enhanced2.ts'),
+                    type: 'file',
+                    content: 'import vscode',
+                },
+            ]
         ).makePrompt(chat, 0)
 
         checkPrompt(info.prompt, [
@@ -173,13 +171,17 @@ describe('DefaultPrompter', () => {
     })
 
     function checkPrompt(prompt: Message[], expectedPrefixes: string[]): void {
-        expect(prompt.length).toBe(expectedPrefixes.length)
         for (let i = 0; i < expectedPrefixes.length; i++) {
             const actual = prompt[i].text?.toString()
             const expected = expectedPrefixes[i]
             if (!actual?.includes(expected)) {
-                expect.fail(`Message mismatch: expected ${actual} to include ${expectedPrefixes[i]}`)
+                expect.fail(
+                    `Message mismatch: expected ${JSON.stringify(actual)} to include ${JSON.stringify(
+                        expectedPrefixes[i]
+                    )}`
+                )
             }
         }
+        expect(prompt.length).toBe(expectedPrefixes.length)
     }
 })

--- a/vscode/src/local-context/rewrite-chat-query.ts
+++ b/vscode/src/local-context/rewrite-chat-query.ts
@@ -2,7 +2,7 @@ import { XMLParser } from 'fast-xml-parser'
 
 import {
     type ChatClient,
-    type ContextItemWithContent,
+    type ContextItem,
     ModelsService,
     PromptString,
     getSimplePreamble,
@@ -22,7 +22,7 @@ export async function rewriteChatQuery({
     chatModel,
 }: {
     query: PromptString
-    contextItems: ContextItemWithContent[]
+    contextItems: ContextItem[]
     chatClient: ChatClient
     chatModel: ChatModel
 }): Promise<PromptString> {

--- a/vscode/src/prompt-builder/index.test.ts
+++ b/vscode/src/prompt-builder/index.test.ts
@@ -18,7 +18,7 @@ describe('PromptBuilder', () => {
 
     const preamble: Message[] = [{ speaker: 'system', text: ps`preamble` }]
 
-    it('throws an error when trying to add Enhanced Context before chat input', () => {
+    it('throws an error when trying to add corpus context before chat input', () => {
         const builder = new PromptBuilder({ input: 100, output: 100 })
         builder.tryAddToPrefix(preamble)
         const file: ContextItem = {
@@ -27,7 +27,7 @@ describe('PromptBuilder', () => {
             content: 'foobar',
             size: 100,
         }
-        expect(() => builder.tryAddContext('enhanced', [file])).rejects.toThrowError()
+        expect(() => builder.tryAddContext('corpus', [file])).rejects.toThrowError()
     })
 
     it('throws an error when trying to add User Context before chat input', () => {
@@ -183,7 +183,7 @@ describe('PromptBuilder', () => {
                 },
             ]
 
-            const { limitReached, ignored } = await builder.tryAddContext('enhanced', contextItems)
+            const { limitReached, ignored } = await builder.tryAddContext('corpus', contextItems)
             expect(limitReached).toBeTruthy()
             expect(ignored).toEqual(contextItems)
             expect(builder.contextItems).toEqual([])
@@ -249,7 +249,7 @@ describe('PromptBuilder', () => {
                 isTooLarge: true,
             }
 
-            const { limitReached, ignored } = await builder.tryAddContext('enhanced', [
+            const { limitReached, ignored } = await builder.tryAddContext('corpus', [
                 innerRange,
                 outerRange,
                 innerRange,
@@ -346,9 +346,9 @@ describe('PromptBuilder', () => {
             expect(history.limitReached).toBeFalsy()
             expect(history.added).toStrictEqual([fullFile])
 
-            const enhanced = await builder.tryAddContext('enhanced', [selection, fullFile])
-            expect(enhanced.limitReached).toBeFalsy()
-            expect(enhanced.added).toStrictEqual([])
+            const corpus = await builder.tryAddContext('corpus', [selection, fullFile])
+            expect(corpus.limitReached).toBeFalsy()
+            expect(corpus.added).toStrictEqual([])
 
             // The final context items should only contain the selection and full file.
             expect(builder.contextItems).toStrictEqual([selection, fullFile])

--- a/vscode/src/prompt-builder/utils.ts
+++ b/vscode/src/prompt-builder/utils.ts
@@ -63,7 +63,7 @@ export function getContextItemTokenUsageType(item: ContextItem): ContextTokenUsa
         case 'selection':
             return 'user'
         default:
-            return 'enhanced'
+            return 'corpus'
     }
 }
 


### PR DESCRIPTION
Now, the context-fetching code looks at the mentions to determine which repo(s) to search in. For example, if there is an @-mention of a repository, then that repository is searched. These special @-mentions are called "corpus" mentions because they need to be expanded specially (unlike file @-mentions that refer to just a single document).

This is better than the previous way, which:

1. still used the "enhanced context" concept (a coarse boolean) instead of reading the context @-mentions (such as `@repository`) to determine the behavior
2. was built in a way that made support for multiple workspaces hard

There is no (intended or known) behavior change. Note that none of the agent snapshot tests needed changing.

## Test plan

Test context-fetching on PLG and enterprise. Ensure that PLG uses symf and embeddings, and enterprise uses remote context search.