### PR TITLE
refactor how remote repo/file providers represent context

### DIFF
--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/agent/protocol_generated/ContextItem.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/agent/protocol_generated/ContextItem.kt
@@ -42,6 +42,7 @@ data class ContextItemFile(
   val metadata: List<String>? = null,
   val type: TypeEnum, // Oneof: file
   val remoteRepositoryName: String? = null,
+  val remoteFilePath: String? = null,
 ) : ContextItem() {
 
   enum class TypeEnum {
@@ -67,6 +68,7 @@ data class ContextItemRepository(
   val metadata: List<String>? = null,
   val type: TypeEnum, // Oneof: repository
   val repoID: String,
+  val openctxProviderUri: String? = null,
 ) : ContextItem() {
 
   enum class TypeEnum {
@@ -120,6 +122,7 @@ data class ContextItemSymbol(
   val symbolName: String,
   val kind: SymbolKind, // Oneof: class, function, method
   val remoteRepositoryName: String? = null,
+  val remoteFilePath: String? = null,
 ) : ContextItem() {
 
   enum class TypeEnum {

--- a/lib/prompt-editor/src/mentions/mentionMenu/MentionMenu.tsx
+++ b/lib/prompt-editor/src/mentions/mentionMenu/MentionMenu.tsx
@@ -1,7 +1,6 @@
 import type { MenuRenderFn } from '@lexical/react/LexicalTypeaheadMenuPlugin'
 import {
     type ContextItem,
-    type ContextItemOpenCtx,
     type ContextMentionProviderMetadata,
     FILE_CONTEXT_MENTION_PROVIDER,
     FILE_RANGE_TOOLTIP_LABEL,
@@ -144,49 +143,46 @@ export const MentionMenu: FunctionComponent<
             // put in the query to search for files. Below we are doing a hack to not set the repo item as a mention
             // but instead keep the same provider selected and put the full repo name in the query. The provider will then
             // return files instead of repos if the repo name is in the query.
-            if (item.provider === 'openctx') {
-                const openCtxItem = item as ContextItemOpenCtx
-                if (
-                    openCtxItem.providerUri === REMOTE_FILE_PROVIDER_URI &&
-                    openCtxItem.mention?.data?.repoName &&
-                    !openCtxItem.mention?.data?.filePath
-                ) {
-                    // Do not set the selected item as mention if it is repo item from the remote file search provider.
-                    // Rather keep the provider in place and update the query with repo name so that the provider can
-                    // start showing the files instead.
+            if (
+                item.type === 'repository' &&
+                item.provider === 'openctx' &&
+                item.openctxProviderUri === REMOTE_FILE_PROVIDER_URI
+            ) {
+                // Do not set the selected item as mention if it is repo item from the remote file search provider.
+                // Rather keep the provider in place and update the query with repo name so that the provider can
+                // start showing the files instead.
 
-                    updateMentionMenuParams({
-                        parentItem: {
-                            id: REMOTE_FILE_PROVIDER_URI,
-                            title: 'Remote Files',
-                            queryLabel: 'Enter file path to search',
-                            emptyLabel: `No matching files found in ${openCtxItem?.mention?.data.repoName} repository`,
-                        },
-                    })
+                updateMentionMenuParams({
+                    parentItem: {
+                        id: REMOTE_FILE_PROVIDER_URI,
+                        title: 'Remote Files',
+                        queryLabel: 'Enter file path to search',
+                        emptyLabel: `No matching files found in ${item.repoName} repository`,
+                    },
+                })
 
-                    setEditorQuery(currentText => {
-                        const selection = getSelection()
+                setEditorQuery(currentText => {
+                    const selection = getSelection()
 
-                        if (!selection) {
-                            return [currentText]
-                        }
+                    if (!selection) {
+                        return [currentText]
+                    }
 
-                        const cursorPosition = selection.anchorOffset
-                        const mentionStart = cursorPosition - mentionQuery.text.length
-                        const mentionEndIndex = cursorPosition
-                        const textToInsert = `${openCtxItem.mention?.data?.repoName}:`
+                    const cursorPosition = selection.anchorOffset
+                    const mentionStart = cursorPosition - mentionQuery.text.length
+                    const mentionEndIndex = cursorPosition
+                    const textToInsert = `${item.repoName}:`
 
-                        return [
-                            currentText.slice(0, mentionStart) +
-                                textToInsert +
-                                currentText.slice(mentionEndIndex),
-                            mentionStart + textToInsert.length,
-                        ]
-                    })
+                    return [
+                        currentText.slice(0, mentionStart) +
+                            textToInsert +
+                            currentText.slice(mentionEndIndex),
+                        mentionStart + textToInsert.length,
+                    ]
+                })
 
-                    setValue(null)
-                    return
-                }
+                setValue(null)
+                return
             }
 
             selectOptionAndCleanUp(createMentionMenuOption(item))

--- a/lib/shared/src/codebase-context/messages.ts
+++ b/lib/shared/src/codebase-context/messages.ts
@@ -126,6 +126,33 @@ export type ContextItem =
     | ContextItemOpenCtx
 
 /**
+ * All types of {@link ContextItem}. If you add a new ContextItem type, add it here. If you remove a
+ * ContextItem type, remove it from here. This is type-checked by the {@link _checkContextItemTypes}
+ * type-assertion below.
+ */
+export const CONTEXT_ITEM_TYPES = [
+    'symbol',
+    'file',
+    'repository',
+    'tree',
+    'openctx',
+] as const satisfies ContextItem['type'][]
+
+/**
+ * For type-checking only, to ensure that {@link CONTEXT_ITEM_TYPES} contains the exact set of
+ * allowed {@link ContextItem['type']} values.
+ */
+// @ts-ignore
+const _checkContextItemTypes: (typeof CONTEXT_ITEM_TYPES)[number] = {} as any as ContextItem['type']
+
+/**
+ * Whether {@link type} is a valid {@link ContextItem['type']}.
+ */
+export function isContextItemType(type: string): type is ContextItem['type'] {
+    return (CONTEXT_ITEM_TYPES as string[]).includes(type)
+}
+
+/**
  * A context item that represents a repository.
  */
 export interface ContextItemRepository extends ContextItemCommon {
@@ -133,6 +160,8 @@ export interface ContextItemRepository extends ContextItemCommon {
     repoName: string
     repoID: string
     content: null
+
+    openctxProviderUri?: string
 }
 
 /**
@@ -175,6 +204,11 @@ export interface ContextItemFile extends ContextItemCommon {
      * that we need to resolve this context item mention via remote search file
      */
     remoteRepositoryName?: string
+
+    /**
+     * File path in the remote repository.
+     */
+    remoteFilePath?: string
 }
 
 /**
@@ -194,6 +228,11 @@ export interface ContextItemSymbol extends ContextItemCommon {
      * that we need to resolve this context item mention via remote search file
      */
     remoteRepositoryName?: string
+
+    /**
+     * File path in the remote repository.
+     */
+    remoteFilePath?: string
 }
 
 /** The valid kinds of a symbol. */

--- a/lib/shared/src/context/openctx/api.ts
+++ b/lib/shared/src/context/openctx/api.ts
@@ -1,10 +1,18 @@
-import type { Client, ProviderMethodOptions } from '@openctx/client'
+import type { Client, EachWithProviderUri, Mention, ProviderMethodOptions } from '@openctx/client'
 import type * as vscode from 'vscode'
+import type { MentionWithContextItemData } from './internalProvider'
 
 type OpenCtxController = Pick<
     Client<vscode.Range>,
-    'meta' | 'metaChanges__asyncGenerator' | 'mentions' | 'mentionsChanges__asyncGenerator' | 'items'
+    'meta' | 'metaChanges__asyncGenerator' | 'mentionsChanges__asyncGenerator' | 'items'
 > & {
+    /**
+     * Annotate that our internal `mentions` methods can return {@link MentionWithContextItemData}.
+     */
+    mentions: (
+        ...args: Parameters<Client<vscode.Range>['mentions']>
+    ) => Promise<EachWithProviderUri<(Mention | MentionWithContextItemData)[]>>
+
     annotationsChanges__asyncGenerator(
         doc: Pick<vscode.TextDocument, 'uri' | 'getText'>,
         opts?: ProviderMethodOptions,

--- a/lib/shared/src/context/openctx/internalProvider.ts
+++ b/lib/shared/src/context/openctx/internalProvider.ts
@@ -1,0 +1,66 @@
+import type {
+    Mention,
+    MentionsParams,
+    MentionsResult,
+    Provider,
+    ProviderSettings,
+} from '@openctx/client'
+import { isContextItemType } from '../../codebase-context/messages'
+import type { SerializedContextItem } from '../../lexicalEditor/nodes'
+
+/**
+ * An OpenCtx provider implemented internally.
+ */
+export interface InternalOpenCtxProvider extends Provider {
+    providerUri: string
+
+    /**
+     * Internal mention providers can return {@link MentionWithContextItemData} to make it easier to
+     * convert to our {@link ContextItem} type.
+     */
+    mentions?(
+        params: MentionsParams,
+        settings: ProviderSettings
+    ):
+        | MentionsResult
+        | Promise<MentionsResult>
+        | MentionWithContextItemData[]
+        | Promise<MentionWithContextItemData[]>
+}
+
+/**
+ * An OpenCtx mention whose {@link Mention.data} contains a {@link ContextItem}.
+ */
+export interface MentionWithContextItemData extends Mention {
+    data: {
+        contextItem: SerializedContextItem
+    }
+}
+
+export function isMentionWithContextItemData(mention: Mention): mention is MentionWithContextItemData {
+    if (!mention.data) {
+        return false
+    }
+    if (
+        !(
+            'contextItem' in mention.data &&
+            mention.data.contextItem &&
+            typeof mention.data.contextItem === 'object'
+        )
+    ) {
+        return false
+    }
+    if (!('uri' in mention.data.contextItem && typeof mention.data.contextItem.uri === 'string')) {
+        return false
+    }
+    if (
+        !(
+            'type' in mention.data.contextItem &&
+            typeof mention.data.contextItem.type === 'string' &&
+            isContextItemType(mention.data.contextItem.type)
+        )
+    ) {
+        return false
+    }
+    return true
+}

--- a/lib/shared/src/index.ts
+++ b/lib/shared/src/index.ts
@@ -310,6 +310,7 @@ export {
     GIT_OPENCTX_PROVIDER_URI,
 } from './context/openctx/api'
 export * from './context/openctx/context'
+export * from './context/openctx/internalProvider'
 export { type ClientStateForWebview } from './clientState'
 export * from './lexicalEditor/editorState'
 export * from './lexicalEditor/nodes'

--- a/vscode/src/chat/clientStateBroadcaster.ts
+++ b/vscode/src/chat/clientStateBroadcaster.ts
@@ -2,7 +2,9 @@ import {
     type ContextItem,
     ContextItemSource,
     type ContextItemTree,
+    REMOTE_REPOSITORY_PROVIDER_URI,
     contextFiltersProvider,
+    deserializeContextItem,
     displayLineRange,
     displayPathBasename,
     expandToLineRange,
@@ -12,7 +14,6 @@ import { getSelectionOrFileContext } from '../commands/context/selection'
 import { createRemoteRepositoryMention } from '../context/openctx/remoteRepositorySearch'
 import type { RemoteSearch } from '../context/remote-search'
 import type { ChatModel } from './chat-view/ChatModel'
-import { contextItemMentionFromOpenCtxItem } from './context/chatContext'
 import type { ExtensionMessage } from './protocol'
 
 type PostMessage = (message: Extract<ExtensionMessage, { type: 'clientState' }>) => void
@@ -119,14 +120,16 @@ export function getCorpusContextItemsForEditorState({
             if (contextFiltersProvider.isRepoNameIgnored(repo.name)) {
                 continue
             }
+            const mention = createRemoteRepositoryMention(
+                {
+                    id: repo.id,
+                    name: repo.name,
+                    url: repo.name,
+                },
+                REMOTE_REPOSITORY_PROVIDER_URI
+            )
             items.push({
-                ...contextItemMentionFromOpenCtxItem(
-                    createRemoteRepositoryMention({
-                        id: repo.id,
-                        name: repo.name,
-                        url: repo.name,
-                    })
-                ),
+                ...deserializeContextItem(mention.data.contextItem),
                 title: 'Current Repository',
                 description: repo.name,
                 source: ContextItemSource.Initial,

--- a/vscode/src/context/openctx/linear-issues.ts
+++ b/vscode/src/context/openctx/linear-issues.ts
@@ -1,7 +1,7 @@
 import linearIssues from '@openctx/provider-linear-issues'
-import type { OpenCtxProvider } from './types'
+import type { InternalOpenCtxProvider } from '@sourcegraph/cody-shared'
 
-const LinearIssuesProvider: OpenCtxProvider = {
+const LinearIssuesProvider: InternalOpenCtxProvider = {
     providerUri: 'internal-linear-issues',
     ...linearIssues,
 }

--- a/vscode/src/context/openctx/types.ts
+++ b/vscode/src/context/openctx/types.ts
@@ -1,5 +1,0 @@
-import type { Provider } from '@openctx/client'
-
-export interface OpenCtxProvider extends Provider {
-    providerUri: string
-}

--- a/vscode/src/context/openctx/web.ts
+++ b/vscode/src/context/openctx/web.ts
@@ -1,11 +1,15 @@
 import type { ItemsParams, ItemsResult } from '@openctx/client'
-import { WEB_PROVIDER_URI, graphqlClient, isErrorLike } from '@sourcegraph/cody-shared'
-import type { OpenCtxProvider } from './types'
+import {
+    type InternalOpenCtxProvider,
+    WEB_PROVIDER_URI,
+    graphqlClient,
+    isErrorLike,
+} from '@sourcegraph/cody-shared'
 
 /**
  * An OpenCtx provider that fetches the content of a URL and provides it as an item.
  */
-export function createWebProvider(useProxy: boolean): OpenCtxProvider {
+export function createWebProvider(useProxy: boolean): InternalOpenCtxProvider {
     return {
         providerUri: WEB_PROVIDER_URI,
 


### PR DESCRIPTION
Now, they just embed a ContextItem in their `mention.data.contextItem` field. This eliminates ad-hoc intermediate ways of representing a remote repo or file, of which there were a few in the codebase.

No behavior change.

## Test plan

Perform remote @-repo and @-file mentions in VS Code and Cody Web. Ensure they work. In particular, ensure the right context is fetched and that remote @-file mentions have the 2-step input (where first you pick the repo and then the file).