### PR TITLE
Chat: Cody chat buttons are visible in Cody views only

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -11,11 +11,13 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 ### Changed
 
 ## 1.28.1
+
 Chat: Cody is now defaulted to run in the sidebar for both Enterprise and Non-Enterprise users. [pull/5039](https://github.com/sourcegraph/cody/pull/5039)
 
 ### Fixed
 
 - Edit: Fixed an issue where we would generate an inefficient diff due to a mismatch in the end-of-line sequence between the user and the LLM. [pull/5069](https://github.com/sourcegraph/cody/pull/5069)
+- Chat: Fixed an issue where buttons to start a new Cody chat and show Chat History were visible in non-Cody views. [pull/](https://github.com/sourcegraph/cody/pull/)
 
 ### Changed
 

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -17,7 +17,7 @@ Chat: Cody is now defaulted to run in the sidebar for both Enterprise and Non-En
 ### Fixed
 
 - Edit: Fixed an issue where we would generate an inefficient diff due to a mismatch in the end-of-line sequence between the user and the LLM. [pull/5069](https://github.com/sourcegraph/cody/pull/5069)
-- Chat: Fixed an issue where buttons to start a new Cody chat and show Chat History were visible in non-Cody views. [pull/](https://github.com/sourcegraph/cody/pull/)
+- Chat: Fixed an issue where buttons to start a new Cody chat and show Chat History were visible in non-Cody views. [pull/5106](https://github.com/sourcegraph/cody/pull/5106)
 
 ### Changed
 

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -485,7 +485,7 @@
         "title": "Delete All Chats",
         "group": "Cody",
         "icon": "$(trash)",
-        "enablement": "cody.activated && cody.hasChatHistory"
+        "enablement": "cody.activated"
       },
       {
         "command": "cody.chat.history.delete",
@@ -493,7 +493,7 @@
         "title": "Delete Chat",
         "group": "Cody",
         "icon": "$(trash)",
-        "enablement": "cody.activated && cody.hasChatHistory"
+        "enablement": "cody.activated"
       },
       {
         "command": "cody.chat.history.export",
@@ -501,7 +501,7 @@
         "title": "Export Chats as JSON",
         "group": "Cody",
         "icon": "$(arrow-circle-down)",
-        "enablement": "cody.activated && cody.hasChatHistory"
+        "enablement": "cody.activated"
       },
       {
         "command": "cody.chat.history.panel",
@@ -509,7 +509,7 @@
         "title": "Chat History",
         "group": "Cody",
         "icon": "$(list-unordered)",
-        "enablement": "cody.activated && cody.hasChatHistory"
+        "enablement": "cody.activated"
       },
       {
         "command": "cody.search.index-update",
@@ -876,16 +876,6 @@
           "group": "navigation@1"
         },
         {
-          "command": "cody.chat.newPanel",
-          "when": "view != cody.chat && cody.activated",
-          "group": "navigation@2"
-        },
-        {
-          "command": "cody.chat.history.panel",
-          "when": "view != cody.chat && cody.activated",
-          "group": "navigation@3"
-        },
-        {
           "command": "cody.welcome",
           "when": "view == cody.chat",
           "group": "7_cody@0"
@@ -938,7 +928,7 @@
         },
         {
           "command": "cody.chat.view.popOut",
-          "when": "activeWebviewPanelId == cody.editorPanel && cody.activated && !isAuxiliaryEditorPart",
+          "when": "view == cody.chat && cody.activated && !isAuxiliaryEditorPart",
           "group": "navigation@4",
           "visibility": "visible"
         },


### PR DESCRIPTION
CLOSE https://linear.app/sourcegraph/issue/CODY-3141/new-chat-and-chat-history-icons-appearing-in-various-places-in-vs-code

Fixed an issue where buttons to start a new Cody chat and show Chat History were visible in non-Cody views.

Also removed the `cody.hasChatHistory` when clause since those are no longer being set and is invokable via the chat UI instead of sidebar tree views.

## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

Log into Cody as PLG users and open Chat and a new chat in Editor to verify the History button and New Chat button only shows up in the Editor Chat Panel:

![Screenshot 2024-08-05 at 6 22 58 AM](https://github.com/user-attachments/assets/78f26837-5e22-4c4d-91ab-68a2147a1bed)

Verify the same thing with Enterprise users:

![Screenshot 2024-08-05 at 6 22 21 AM](https://github.com/user-attachments/assets/5310f269-b002-4afb-835e-614a687ec34b)


Open other extension panels and verify those buttons are not showing up in non-Cody panels:

![image](https://github.com/user-attachments/assets/415b994e-f223-4986-a726-23f4c11f502b)


## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->

Fixed an issue where buttons to start a new Cody chat and show Chat History were visible in non-Cody views.