### PR TITLE
fixed/dropdown: enterprise users can use any model available

### DIFF
--- a/vscode/webviews/components/modelSelectField/ModelSelectField.story.tsx
+++ b/vscode/webviews/components/modelSelectField/ModelSelectField.story.tsx
@@ -73,14 +73,6 @@ export const EnterpriseUser: Story = {
             isDotComUser: false,
             isCodyProUser: false,
         },
-    },
-}
-
-export const NewStyleEnterpriseUser: Story = {
-    args: {
-        userInfo: {
-            isDotComUser: false,
-            isCodyProUser: false,
-        },
+        serverSentModelsEnabled: true,
     },
 }

--- a/vscode/webviews/components/modelSelectField/ModelSelectField.tsx
+++ b/vscode/webviews/components/modelSelectField/ModelSelectField.tsx
@@ -279,7 +279,7 @@ function modelAvailability(
     if (!userInfo.isDotComUser && !serverSentModelsEnabled) {
         return 'not-selectable-on-enterprise'
     }
-    if (isCodyProModel(model) && !userInfo.isCodyProUser) {
+    if (isCodyProModel(model) && userInfo.isDotComUser && !userInfo.isCodyProUser) {
         return 'needs-cody-pro'
     }
     return 'available'


### PR DESCRIPTION
[CODY-3138](https://linear.app/sourcegraph/issue/CODY-3138)

Previously we did not allow enterprise users to use cody pro models that were enabled on their instance. Here we refine that test to check only if it's a free user.

## Test plan
Manual test

## Changelog
Fix bug where enterprise users were stopped from using enabled, server-sent models.