### PR TITLE
TS Build: add project reference on lib/shared from prompt-editor

### DIFF
--- a/lib/prompt-editor/tsconfig.json
+++ b/lib/prompt-editor/tsconfig.json
@@ -18,4 +18,9 @@
   "include": [
     "src"
   ],
+  "references": [
+    {
+      "path": "../shared"
+    },
+  ]
 }


### PR DESCRIPTION
Previously, the prompt-editor project depended on
`@sourcegraph/cody-shared` but the prompt-editor tsconfig.json build didn't have a project reference on `lib/shared/tsconfig.json`. Adding this project reference might reduce the risk of race conditions resulting in cryptic build errors.

Context https://sourcegraph.slack.com/archives/C05AGQYD528/p1722911641411329


## Test plan
Green CI.
<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
