### PR TITLE
Remove noodle flag set to true for Cody Web

### DIFF
--- a/web/CHANGELOG.md
+++ b/web/CHANGELOG.md
@@ -1,5 +1,6 @@
-## Next
+## 0.3.7
 - Adds support for the full panel (not just chat) to the CodyWebPanel component (renamed from CodyWebChat).
+- Sets experimental.noodle flag to false (default).
 
 ## 0.3.6
 - Adds fix that chat UI doesn't include context repository as background 

--- a/web/lib/agent/agent.client.ts
+++ b/web/lib/agent/agent.client.ts
@@ -87,7 +87,6 @@ export async function createAgentClient({
             telemetryClientName,
             customHeaders: customHeaders ?? {},
             customConfiguration: {
-                'cody.experimental.noodle': true,
                 'cody.autocomplete.enabled': false,
                 'cody.experimental.urlContext': true,
                 'cody.web': true,

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sourcegraph/cody-web",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "description": "Cody standalone web app",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
context: https://linear.app/sourcegraph/issue/SRCH-821/context-is-not-being-fetched-on-vs-code-even-though-its-being-fetched
https://sourcegraph.slack.com/archives/C05D629GWJK/p1722933166623269?thread_ts=1722620916.715349&cid=C05D629GWJK

The `experimental.noodle` flag is enabled by default for Cody Web which should not be the case. Some experimental feature like chat query rewrite are therefore enabled right now.

This PR sets the `experimental.noodle` flag to false.

## Test plan

- cd web
- pnpm dev
- Submit a chat message in chat and monitor the network request to `getCodyChat` to make sure the query string is the chat message without the mention chips text.

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
