### PR TITLE
suppress ÷ on alt-/ in the chat input

### DIFF
--- a/vscode/webviews/App.tsx
+++ b/vscode/webviews/App.tsx
@@ -173,7 +173,7 @@ export const App: React.FunctionComponent<{ vscodeAPI: VSCodeWrapper }> = ({ vsc
     useEffect(() => {
         // On macOS, suppress the '¬' character emitted by default for alt+L
         const handleKeyDown = (event: KeyboardEvent) => {
-            const suppressedKeys = ['¬', 'Ò', '¿']
+            const suppressedKeys = ['¬', 'Ò', '¿', '÷']
             if (event.altKey && suppressedKeys.includes(event.key)) {
                 event.preventDefault()
             }


### PR DESCRIPTION
Avoid emitting a `÷` in the chat input when the user hits `alt-/` (this happens on macOS, as alt is used for emitting unicode)

<img width="454" alt="image" src="https://github.com/user-attachments/assets/92fd8e89-d6f7-43a5-8d3c-b1d0aef95284">


## Test plan

Test locally
