### PR TITLE
Agent: add vscode-shim support for open commands

### DIFF
--- a/agent/src/vscode-shim.ts
+++ b/agent/src/vscode-shim.ts
@@ -46,6 +46,7 @@ import {
 
 import { emptyDisposable } from '../../vscode/src/testutils/emptyDisposable'
 
+import open from 'open'
 import { AgentDiagnostics } from './AgentDiagnostics'
 import { AgentQuickPick } from './AgentQuickPick'
 import { AgentTabGroups } from './AgentTabGroups'
@@ -934,6 +935,13 @@ _commands?.registerCommand?.('vscode.executeDocumentSymbolProvider', uri => {
 _commands?.registerCommand?.('vscode.executeFormatDocumentProvider', uri => {
     return Promise.resolve([])
 })
+_commands?.registerCommand?.('vscode.open', async (uri: vscode.Uri) => {
+    const result = toUri(uri?.path)
+    if (result) {
+        return _window.showTextDocument(result)
+    }
+    return open(uri.toString())
+})
 
 function promisify(value: any): Promise<any> {
     return value instanceof Promise ? value : Promise.resolve(value)
@@ -949,6 +957,10 @@ const _env: Partial<typeof vscode.env> = {
     clipboard: {
         readText: () => Promise.resolve(''),
         writeText: () => Promise.resolve(),
+    },
+    openExternal: async (uri: vscode.Uri) => {
+        open(uri.toString())
+        return true
     },
 }
 export const env = _env as typeof vscode.env

--- a/agent/src/vscode-shim.ts
+++ b/agent/src/vscode-shim.ts
@@ -958,9 +958,13 @@ const _env: Partial<typeof vscode.env> = {
         readText: () => Promise.resolve(''),
         writeText: () => Promise.resolve(),
     },
-    openExternal: async (uri: vscode.Uri) => {
-        open(uri.toString())
-        return true
+    openExternal: (uri: vscode.Uri): Thenable<boolean> => {
+        try {
+            open(uri.toString())
+            return Promise.resolve(true)
+        } catch {
+            return Promise.resolve(false)
+        }
     },
 }
 export const env = _env as typeof vscode.env


### PR DESCRIPTION
close https://linear.app/sourcegraph/issue/CODY-2799/implement-vscodeopen-command-in-shims-to-get-local-context-link

This change adds support for the `vscode.open` command in the vscode-shim. The `vscode.open` command is used to open a URI in the default application. The implementation first tries to open the URI as a text document, and if that fails, it falls back to using the `open` library to open the URI in the default application.

Additionally, the `env.openExternal` function has been implemented to open a URI in the default external application.

These changes ensure that the vscode-shim provides a more complete implementation of the VSCode API, allowing for better integration with VSCode-based applications.


## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

Can open context link from chat in JetBrains

![vscodeopen](https://github.com/user-attachments/assets/3e5ed1dd-5ad7-423b-b56c-639a2ec503d6)


## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
