### PR TITLE
do not clobber other @-mentions when initial context changes

### DIFF
--- a/lib/prompt-editor/src/initialContext.test.ts
+++ b/lib/prompt-editor/src/initialContext.test.ts
@@ -1,0 +1,81 @@
+import {
+    $createParagraphNode,
+    $createTextNode,
+    $getRoot,
+    type LexicalEditor,
+    createEditor,
+} from 'lexical'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { isEditorContentOnlyInitialContext } from './initialContext'
+import { RICH_EDITOR_NODES } from './nodes'
+import { $createContextItemMentionNode } from './nodes/ContextItemMentionNode'
+
+describe('isEditorContentOnlyInitialContext', () => {
+    let editor: LexicalEditor
+
+    beforeEach(() => {
+        editor = createEditor({ nodes: RICH_EDITOR_NODES })
+    })
+
+    it('should return true when content is only initial context', () => {
+        editor.update(
+            () => {
+                const root = $getRoot()
+                const paragraph = $createParagraphNode()
+                paragraph.append(
+                    $createContextItemMentionNode(
+                        { type: 'file', uri: 'test.ts' },
+                        { isFromInitialContext: true }
+                    ),
+                    $createTextNode(' ')
+                )
+                root.append(paragraph)
+            },
+            { discrete: true }
+        )
+        expect(isEditorContentOnlyInitialContext(editor)).toBe(true)
+    })
+
+    it('should return false when content includes non-initial context', () => {
+        editor.update(
+            () => {
+                const root = $getRoot()
+                const paragraph = $createParagraphNode()
+                paragraph.append(
+                    $createContextItemMentionNode(
+                        { type: 'file', uri: 'test1.ts' },
+                        { isFromInitialContext: true }
+                    ),
+                    $createTextNode(' '),
+                    $createContextItemMentionNode(
+                        { type: 'file', uri: 'test2.ts' },
+                        { isFromInitialContext: false }
+                    ),
+                    $createTextNode(' ')
+                )
+                root.append(paragraph)
+            },
+            { discrete: true }
+        )
+        expect(isEditorContentOnlyInitialContext(editor)).toBe(false)
+    })
+
+    it('should return false when content includes additional text', () => {
+        editor.update(
+            () => {
+                const root = $getRoot()
+                const paragraph = $createParagraphNode()
+                const contextItem = $createContextItemMentionNode(
+                    { type: 'file', uri: 'test.ts' },
+                    { isFromInitialContext: true }
+                )
+                const space = $createTextNode(' ')
+                const additionalText = $createTextNode('Additional text')
+                paragraph.append(contextItem, space, additionalText)
+                root.append(paragraph)
+            },
+            { discrete: true }
+        )
+        expect(isEditorContentOnlyInitialContext(editor)).toBe(false)
+    })
+})

--- a/lib/prompt-editor/src/initialContext.ts
+++ b/lib/prompt-editor/src/initialContext.ts
@@ -1,5 +1,14 @@
 import type { ContextItem } from '@sourcegraph/cody-shared'
-import { $createTextNode, $getRoot, type LexicalEditor, TextNode } from 'lexical'
+import {
+    $createTextNode,
+    $getRoot,
+    ElementNode,
+    type LexicalEditor,
+    type LexicalNode,
+    ParagraphNode,
+    RootNode,
+    TextNode,
+} from 'lexical'
 import { $createContextItemMentionNode, ContextItemMentionNode } from './nodes/ContextItemMentionNode'
 
 export function lexicalNodesForContextItems(
@@ -18,16 +27,40 @@ export function lexicalNodesForContextItems(
 }
 
 export function isEditorContentOnlyInitialContext(editor: LexicalEditor): boolean {
+    function walk(node: LexicalNode, fn: (node: LexicalNode) => boolean): void {
+        if (!fn(node)) {
+            return
+        }
+        if (node instanceof ElementNode) {
+            for (const child of node.getChildren()) {
+                walk(child, fn)
+            }
+        }
+        return
+    }
+
     return editor.getEditorState().read(() => {
         const root = $getRoot()
-        return (
-            root
-                .getAllTextNodes()
-                .every(
-                    node =>
-                        (node instanceof ContextItemMentionNode && node.isFromInitialContext) ||
-                        (node instanceof TextNode && node.getTextContent() === ' ')
-                ) && /\S $/.test(root.getTextContent())
-        )
+        let onlyInitialContext = true
+        walk(root, node => {
+            if (!onlyInitialContext) {
+                return false // no need to traverse anymore
+            }
+
+            if (node instanceof ContextItemMentionNode) {
+                if (!node.isFromInitialContext) {
+                    onlyInitialContext = false
+                }
+            } else if (node instanceof TextNode) {
+                if (node.getTextContent().trim() !== '') {
+                    onlyInitialContext = false
+                }
+            } else if (!(node instanceof ParagraphNode || node instanceof RootNode)) {
+                onlyInitialContext = false
+            }
+
+            return onlyInitialContext
+        })
+        return onlyInitialContext
     })
 }

--- a/lib/shared/src/lexicalEditor/editorState.ts
+++ b/lib/shared/src/lexicalEditor/editorState.ts
@@ -370,8 +370,8 @@ function lexicalEditorStateFromPromptString(
 }
 
 /**
- * walks the tree calling callbackfn for each node. callbackfn is called in
- * "pre-order". IE a parent is called before its children are called in order.
+ * Walk the tree calling {@link callbackfn} for each node. {@link callbackfn} is called in
+ * "pre-order"; i.e., a parent is called before its children are called in order.
  */
 function forEachPreOrder(
     node: SerializedLexicalNode,


### PR DESCRIPTION
If you manually @-mention a file in Cody chat and then change your current editor selection, your manual @-mention is clobbered. This was a bug introduced when we changed the @-mention nodes from Lexical TextNodes to DecoratorNode-based nodes. Now we need to traverse the tree and check all nodes instead of just checking the TextNodes.



## Test plan

As described above.

## Changelog

- Fix a chat issue where manually entered @-mentions would be clobbered if you changed your selection or active file in the editor.