### PR TITLE
persist open/closed state of CollapsiblePanel

### DIFF
--- a/vscode/webviews/chat/components/CustomCommandsList.tsx
+++ b/vscode/webviews/chat/components/CustomCommandsList.tsx
@@ -21,7 +21,7 @@ export const CustomCommandsList: FunctionComponent<{
     }
 
     return (
-        <CollapsiblePanel title="Custom Commands" initialOpen={initialOpen}>
+        <CollapsiblePanel storageKey="customCommands" title="Custom Commands" initialOpen={initialOpen}>
             {customCommandsList.map(({ key, prompt, description }) => (
                 <Button
                     key={key}

--- a/vscode/webviews/chat/components/DefaultCommandsList.tsx
+++ b/vscode/webviews/chat/components/DefaultCommandsList.tsx
@@ -36,7 +36,7 @@ export const DefaultCommandsList: FunctionComponent<{
     )
 
     return (
-        <CollapsiblePanel title="Commands" initialOpen={initialOpen}>
+        <CollapsiblePanel storageKey="defaultCommands" title="Commands" initialOpen={initialOpen}>
             {commandList.map(({ key, title, icon: Icon }) => (
                 <Button
                     key={key}

--- a/vscode/webviews/chat/components/WelcomeMessage.test.tsx
+++ b/vscode/webviews/chat/components/WelcomeMessage.test.tsx
@@ -5,9 +5,9 @@ import { WelcomeMessage } from './WelcomeMessage'
 
 describe('WelcomeMessage', () => {
     function openCollapsiblePanels(): void {
-        const collapsibleTriggers = screen.getAllByTestId('collapsible-trigger')
-        for (const trigger of collapsibleTriggers) {
-            fireEvent.click(trigger)
+        const closedPanelButtons = document.querySelectorAll('button[data-state="closed"]')
+        for (const button of closedPanelButtons) {
+            fireEvent.click(button)
         }
     }
     test('renders for CodyIDE.VSCode', () => {

--- a/vscode/webviews/chat/components/WelcomeMessage.tsx
+++ b/vscode/webviews/chat/components/WelcomeMessage.tsx
@@ -47,7 +47,7 @@ export const WelcomeMessage: FunctionComponent<{ IDE: CodyIDE }> = ({ IDE }) => 
     return (
         <div className="tw-flex-1 tw-flex tw-flex-col tw-items-start tw-w-full tw-pt-4 tw-px-8 tw-gap-10 sm:tw-pl-21 tw-transition-all">
             <DefaultCommandsList IDE={IDE} initialOpen={false} />
-            <CollapsiblePanel title="Chat Help">
+            <CollapsiblePanel storageKey="chatHelp" title="Chat Help">
                 <FeatureRow icon={AtSignIcon}>
                     Type <Kbd macOS="@" linuxAndWindows="@" /> to add context to your chat
                 </FeatureRow>

--- a/vscode/webviews/components/CollapsiblePanel.tsx
+++ b/vscode/webviews/components/CollapsiblePanel.tsx
@@ -1,10 +1,12 @@
 import clsx from 'clsx'
 import { ChevronsDownUpIcon, ChevronsUpDownIcon } from 'lucide-react'
-import React from 'react'
+import type React from 'react'
+import { useState } from 'react'
 import { Button } from './shadcn/ui/button'
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from './shadcn/ui/collapsible'
 
 interface CollapsiblePanelProps {
+    storageKey: string
     title: string
     children: React.ReactNode
     className?: string
@@ -12,12 +14,13 @@ interface CollapsiblePanelProps {
 }
 
 export const CollapsiblePanel: React.FC<CollapsiblePanelProps> = ({
+    storageKey,
     title,
     children,
     className,
     initialOpen,
 }) => {
-    const [isOpen, setIsOpen] = React.useState(initialOpen)
+    const [isOpen, setIsOpen] = useCollapsiblePanelOpenState(storageKey, initialOpen)
 
     const Icon = isOpen ? ChevronsDownUpIcon : ChevronsUpDownIcon
 
@@ -28,10 +31,14 @@ export const CollapsiblePanel: React.FC<CollapsiblePanelProps> = ({
             className={clsx('tw-w-full tw-flex tw-flex-col tw-gap-3', className)}
         >
             <div className="tw-flex tw-justify-between">
-                <h4 className="tw-text tw-font-medium tw-text-muted-foreground">{title}</h4>
                 <CollapsibleTrigger asChild>
-                    <Button variant="ghost" size="icon" data-testid="collapsible-trigger">
-                        <Icon className="tw-h-8 tw-w-8 tw-text" size={16} strokeWidth="1.25" />
+                    <Button variant="ghost" data-testid="collapsible-trigger">
+                        <h4 className="tw-text tw-font-medium tw-text-muted-foreground">{title}</h4>
+                        <Icon
+                            className="tw-h-8 tw-w-8 tw-text-muted-foreground"
+                            size={16}
+                            strokeWidth="1.25"
+                        />
                     </Button>
                 </CollapsibleTrigger>
             </div>
@@ -42,4 +49,25 @@ export const CollapsiblePanel: React.FC<CollapsiblePanelProps> = ({
             </CollapsibleContent>
         </Collapsible>
     )
+}
+
+function useCollapsiblePanelOpenState(
+    storageKey: string,
+    initialOpen = false
+): [boolean, (isOpen: boolean) => void] {
+    const fullStorageKey = `cody.collapsiblePanel.${storageKey}`
+    const value = localStorage.getItem(fullStorageKey)
+    const storedValue = value === null ? initialOpen : value === 'true'
+    const [isOpen, setIsOpen] = useState(storedValue ?? initialOpen)
+    return [
+        isOpen,
+        (isOpen: boolean) => {
+            setIsOpen(isOpen)
+            if (isOpen === initialOpen) {
+                localStorage.removeItem(fullStorageKey)
+            } else {
+                localStorage.setItem(fullStorageKey, isOpen ? 'true' : 'false')
+            }
+        },
+    ]
 }

--- a/vscode/webviews/tabs/HistoryTab.tsx
+++ b/vscode/webviews/tabs/HistoryTab.tsx
@@ -27,7 +27,12 @@ export const HistoryTab: React.FC<HistoryTabProps> = ({ userHistory }) => {
     return (
         <div className="tw-flex tw-flex-col tw-gap-8 tw-px-8 tw-py-6">
             {Array.from(chatByPeriod, ([period, chats]) => (
-                <CollapsiblePanel key={period} title={period} initialOpen={true}>
+                <CollapsiblePanel
+                    key={period}
+                    storageKey={`history.${period}`}
+                    title={period}
+                    initialOpen={true}
+                >
                     {chats.map(({ interactions, id }) => {
                         const lastMessage =
                             interactions[interactions.length - 1]?.humanMessage?.text?.trim()


### PR DESCRIPTION
Now these friends stay open or closed, the last way you left them, across chat sessions and editor restarts:

<img width="495" alt="image" src="https://github.com/user-attachments/assets/2e2ea994-bed8-404d-b75e-e1b5ac1cfa73">


## Test plan

Collapse and reload editor. Confirm state.