### PR TITLE
load CommandsProvider in web

### DIFF
--- a/vscode/src/commands/menus/items/menu.ts
+++ b/vscode/src/commands/menus/items/menu.ts
@@ -9,7 +9,7 @@ import { type CommandMenuButton, CommandMenuButtons } from './buttons'
 
 import { platform } from 'node:os'
 
-export { CommandMenuButton } from './buttons'
+export { type CommandMenuButton } from './buttons'
 export { CommandMenuSeperator } from './seperators'
 export { CommandMenuOption } from './options'
 

--- a/vscode/src/commands/services/provider.ts
+++ b/vscode/src/commands/services/provider.ts
@@ -2,8 +2,6 @@ import { type CodyCommand, type ContextItem, isFileURI } from '@sourcegraph/cody
 
 import * as vscode from 'vscode'
 import { CodyCommandMenuItems } from '..'
-import { getContextFileFromGitLog } from '../context/git-log'
-import { getContextFileFromShell } from '../context/shell'
 import { executeExplainHistoryCommand } from '../execute/explain-history'
 import { showCommandMenu } from '../menus'
 import type { CodyCommandArgs } from '../types'
@@ -99,6 +97,7 @@ export class CommandsProvider implements vscode.Disposable {
      * Used for retreiving context for the command field in custom command
      */
     public async runShell(shell: string): Promise<ContextItem[]> {
+        const { getContextFileFromShell } = await import('../context/shell')
         return getContextFileFromShell(shell)
     }
 
@@ -127,6 +126,7 @@ export class CommandsProvider implements vscode.Disposable {
         if (!isFileURI(uri)) {
             throw new Error('history only supported on local file paths')
         }
+        const { getContextFileFromGitLog } = await import('../context/git-log')
         return getContextFileFromGitLog(uri, options)
     }
 

--- a/web/lib/agent/agent.worker.ts
+++ b/web/lib/agent/agent.worker.ts
@@ -1,12 +1,12 @@
 import { createController } from '@openctx/vscode-lib'
 import { Agent } from '@sourcegraph/cody/src/agent'
+import { CommandsProvider } from 'cody-ai/src/commands/services/provider'
+import { createActivation } from 'cody-ai/src/extension.web'
 import {
     BrowserMessageReader,
     BrowserMessageWriter,
     createMessageConnection,
 } from 'vscode-jsonrpc/browser'
-
-import { createActivation } from 'cody-ai/src/extension.web'
 import { IndexDBStorage } from './index-db-storage'
 
 const conn = createMessageConnection(new BrowserMessageReader(self), new BrowserMessageWriter(self))
@@ -18,6 +18,8 @@ const agent = new Agent({
         // since it relies on DOM API which is not available in web-worker
         createSentryService: undefined,
         createStorage: () => IndexDBStorage.create(),
+
+        createCommandsProvider: () => new CommandsProvider(),
 
         // Import createController from openctx lib synchronously because
         // dynamic import don't work in web worker when we use it in direct

--- a/web/lib/agent/shims/os.ts
+++ b/web/lib/agent/shims/os.ts
@@ -6,4 +6,8 @@ export function arch(): unknown {
     return 'n/a'
 }
 
-export default { platform, arch }
+export function homedir(): unknown {
+    return ''
+}
+
+export default { platform, arch, homedir }


### PR DESCRIPTION
This makes Cody Web more similar to Cody in the editor. The commands provider will be used in the future for providing a nice transition path from Commands to Prompt Library; it is not per se desirable functionality we want.



## Test plan

CI