### PR TITLE
show tab labels on wide screens

### DIFF
--- a/vscode/webviews/tabs/TabsBar.tsx
+++ b/vscode/webviews/tabs/TabsBar.tsx
@@ -41,6 +41,7 @@ interface TabConfig {
         tooltipExtra?: React.ReactNode
 
         title: string
+        alwaysShowTitle?: boolean
         Icon: IconComponent
         command: string
         arg?: string | undefined | null
@@ -56,6 +57,7 @@ interface TabButtonProps {
     onClick: () => void
     prominent?: boolean
     title: string
+    alwaysShowTitle?: boolean
 
     /** Extra content to display in the tooltip (in addition to the title). */
     tooltipExtra?: React.ReactNode
@@ -64,7 +66,19 @@ interface TabButtonProps {
 }
 
 const TabButton = forwardRef<HTMLButtonElement, TabButtonProps>(
-    ({ Icon, isActive, onClick, title, tooltipExtra, prominent, 'data-testid': dataTestId }, ref) => (
+    (
+        {
+            Icon,
+            isActive,
+            onClick,
+            title,
+            alwaysShowTitle,
+            tooltipExtra,
+            prominent,
+            'data-testid': dataTestId,
+        },
+        ref
+    ) => (
         <Tooltip>
             <TooltipTrigger asChild>
                 <button
@@ -81,7 +95,7 @@ const TabButton = forwardRef<HTMLButtonElement, TabButtonProps>(
                     data-testid={dataTestId}
                 >
                     <Icon size={16} strokeWidth={1.25} className="tw-w-8 tw-h-8" />
-                    <span className="tw-hidden md:tw-inline">{title}</span>
+                    <span className={alwaysShowTitle ? '' : 'tw-hidden md:tw-inline'}>{title}</span>
                 </button>
             </TooltipTrigger>
             <TooltipContent className="md:tw-hidden">
@@ -104,6 +118,7 @@ export const TabsBar: React.FC<TabsBarProps> = ({ currentView, setView, IDE }) =
                         SubIcons: [
                             {
                                 title: 'New Chat',
+                                alwaysShowTitle: true,
                                 tooltipExtra: (
                                     <>
                                         {IDE !== CodyIDE.Web && (
@@ -213,19 +228,22 @@ export const TabsBar: React.FC<TabsBarProps> = ({ currentView, setView, IDE }) =
                 ))}
             </div>
             <div className="tw-flex tw-gap-4">
-                {currentViewSubIcons?.map(({ Icon, command, title, tooltipExtra, arg }) => (
-                    <TabButton
-                        key={command}
-                        Icon={Icon}
-                        title={title}
-                        tooltipExtra={tooltipExtra}
-                        command={command}
-                        onClick={() =>
-                            getVSCodeAPI().postMessage({ command: 'command', id: command, arg })
-                        }
-                        prominent
-                    />
-                ))}
+                {currentViewSubIcons?.map(
+                    ({ Icon, command, title, alwaysShowTitle, tooltipExtra, arg }) => (
+                        <TabButton
+                            key={command}
+                            Icon={Icon}
+                            title={title}
+                            alwaysShowTitle={alwaysShowTitle}
+                            tooltipExtra={tooltipExtra}
+                            command={command}
+                            onClick={() =>
+                                getVSCodeAPI().postMessage({ command: 'command', id: command, arg })
+                            }
+                            prominent
+                        />
+                    )
+                )}
             </div>
         </Tabs.List>
     )

--- a/vscode/webviews/tabs/TabsBar.tsx
+++ b/vscode/webviews/tabs/TabsBar.tsx
@@ -34,10 +34,13 @@ type IconComponent = React.ForwardRefExoticComponent<
 interface TabConfig {
     Icon: IconComponent
     view: View
-    tooltip: React.ReactNode
+    title: string
     command?: string
     SubIcons?: {
-        tooltip: React.ReactNode
+        /** Extra content to display in the tooltip (in addition to the title). */
+        tooltipExtra?: React.ReactNode
+
+        title: string
         Icon: IconComponent
         command: string
         arg?: string | undefined | null
@@ -52,12 +55,16 @@ interface TabButtonProps {
     isActive?: boolean
     onClick: () => void
     prominent?: boolean
-    tooltip: React.ReactNode
+    title: string
+
+    /** Extra content to display in the tooltip (in addition to the title). */
+    tooltipExtra?: React.ReactNode
+
     'data-testid'?: string
 }
 
 const TabButton = forwardRef<HTMLButtonElement, TabButtonProps>(
-    ({ Icon, isActive, onClick, tooltip, prominent, 'data-testid': dataTestId }, ref) => (
+    ({ Icon, isActive, onClick, title, tooltipExtra, prominent, 'data-testid': dataTestId }, ref) => (
         <Tooltip>
             <TooltipTrigger asChild>
                 <button
@@ -65,7 +72,7 @@ const TabButton = forwardRef<HTMLButtonElement, TabButtonProps>(
                     onClick={onClick}
                     ref={ref}
                     className={clsx(
-                        'tw-py-3 tw-px-2 tw-opacity-80 hover:tw-opacity-100 tw-border-b-[1px] tw-border-transparent tw-transition tw-translate-y-[1px]',
+                        'tw-flex tw-gap-3 tw-items-center tw-leading-none tw-py-3 tw-px-2 tw-opacity-80 hover:tw-opacity-100 tw-border-b-[1px] tw-border-transparent tw-transition tw-translate-y-[1px]',
                         {
                             '!tw-opacity-100 !tw-border-[var(--vscode-tab-activeBorderTop)]': isActive,
                             '!tw-opacity-100': prominent,
@@ -74,9 +81,12 @@ const TabButton = forwardRef<HTMLButtonElement, TabButtonProps>(
                     data-testid={dataTestId}
                 >
                     <Icon size={16} strokeWidth={1.25} className="tw-w-8 tw-h-8" />
+                    <span className="tw-hidden md:tw-inline">{title}</span>
                 </button>
             </TooltipTrigger>
-            <TooltipContent>{tooltip}</TooltipContent>
+            <TooltipContent className="md:tw-hidden">
+                {title} {tooltipExtra}
+            </TooltipContent>
         </Tooltip>
     )
 )
@@ -89,13 +99,13 @@ export const TabsBar: React.FC<TabsBarProps> = ({ currentView, setView, IDE }) =
                 [
                     {
                         view: View.Chat,
-                        tooltip: 'Chat',
+                        title: 'Chat',
                         Icon: MessagesSquareIcon,
                         SubIcons: [
                             {
-                                tooltip: (
+                                title: 'New Chat',
+                                tooltipExtra: (
                                     <>
-                                        New Chat{' '}
                                         {IDE !== CodyIDE.Web && (
                                             <Kbd macOS="shift+opt+l" linuxAndWindows="shift+alt+l" />
                                         )}
@@ -106,7 +116,7 @@ export const TabsBar: React.FC<TabsBarProps> = ({ currentView, setView, IDE }) =
                             },
                             IDE !== CodyIDE.Web
                                 ? {
-                                      tooltip: 'Open in Editor',
+                                      title: 'Open in Editor',
                                       Icon: ColumnsIcon,
                                       command: 'cody.chat.moveToEditor',
                                   }
@@ -116,18 +126,18 @@ export const TabsBar: React.FC<TabsBarProps> = ({ currentView, setView, IDE }) =
                     },
                     {
                         view: View.History,
-                        tooltip: 'Chat History',
+                        title: 'History',
                         Icon: HistoryIcon,
                         SubIcons: [
                             IDE !== CodyIDE.Web
                                 ? {
-                                      tooltip: 'Export History',
+                                      title: 'Export History',
                                       Icon: DownloadIcon,
                                       command: 'cody.chat.history.export',
                                   }
                                 : null,
                             {
-                                tooltip: 'Clear History',
+                                title: 'Clear Chat History',
                                 Icon: Trash2Icon,
                                 command: 'cody.chat.history.clear',
                                 // We don't have a way to request user confirmation in Cody Web
@@ -140,14 +150,14 @@ export const TabsBar: React.FC<TabsBarProps> = ({ currentView, setView, IDE }) =
                     },
                     {
                         view: View.Prompts,
-                        tooltip: 'Prompts & Commands',
+                        title: IDE === CodyIDE.Web ? 'Prompts' : 'Prompts & Commands',
                         Icon: BookTextIcon,
                         changesView: true,
                     },
                     IDE !== CodyIDE.Web
                         ? {
                               view: View.Settings,
-                              tooltip: 'Settings',
+                              title: 'Settings',
                               Icon: SettingsIcon,
                               command: 'cody.status-bar.interacted',
                           }
@@ -155,7 +165,7 @@ export const TabsBar: React.FC<TabsBarProps> = ({ currentView, setView, IDE }) =
                     IDE !== CodyIDE.Web
                         ? {
                               view: View.Account,
-                              tooltip: 'Account',
+                              title: 'Account',
                               Icon: CircleUserIcon,
                               command: 'cody.auth.account',
                               changesView: IDE !== CodyIDE.VSCode,
@@ -188,12 +198,12 @@ export const TabsBar: React.FC<TabsBarProps> = ({ currentView, setView, IDE }) =
             )}
         >
             <div className="tw-flex tw-gap-1">
-                {tabItems.map(({ Icon, view, command, tooltip, changesView }) => (
+                {tabItems.map(({ Icon, view, command, title, changesView }) => (
                     <Tabs.Trigger key={view} value={view} asChild={true}>
                         <TabButton
                             Icon={Icon}
                             view={view}
-                            tooltip={tooltip}
+                            title={title}
                             command={command}
                             isActive={currentView === view}
                             onClick={() => handleClick(view, command, changesView)}
@@ -203,11 +213,12 @@ export const TabsBar: React.FC<TabsBarProps> = ({ currentView, setView, IDE }) =
                 ))}
             </div>
             <div className="tw-flex tw-gap-4">
-                {currentViewSubIcons?.map(({ Icon, command, tooltip, arg }) => (
+                {currentViewSubIcons?.map(({ Icon, command, title, tooltipExtra, arg }) => (
                     <TabButton
                         key={command}
                         Icon={Icon}
-                        tooltip={tooltip}
+                        title={title}
+                        tooltipExtra={tooltipExtra}
                         command={command}
                         onClick={() =>
                             getVSCodeAPI().postMessage({ command: 'command', id: command, arg })


### PR DESCRIPTION
If the screen is 768px wide or wider, then the Cody chat panel tabs will show text labels. This means that the standalone Cody Web chat screen will show text labels for most users, which fixes https://linear.app/sourcegraph/issue/CODY-3171/history-tab-is-hard-to-find-on-cody-web.


https://github.com/user-attachments/assets/7790d9ff-af8e-4e6f-929a-ea3210be1f2d



## Test plan

Make screen (or containing panel) narrow and wide. When it's wide, confirm tooltips are NOT shown but tab titles are visible. When narrow, confirm tab titles are NOT shown but tooltips are.