### PR TITLE
Agent: Revert breaking protocol change

### DIFF
--- a/vscode/src/chat/chat-view/ChatController.ts
+++ b/vscode/src/chat/chat-view/ChatController.ts
@@ -338,11 +338,16 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
             case 'get-chat-models':
                 this.postChatModels()
                 break
-            case 'getUserContext':
-                await this.handleGetUserContextFilesCandidates({
+            case 'getUserContext': {
+                const result = await this.handleGetUserContextFilesCandidates({
                     query: parseMentionQuery(message.query, null),
                 })
+                await this.postMessage({
+                    type: 'userContextFiles',
+                    userContextFiles: result.userContextFiles,
+                })
                 break
+            }
             case 'insert':
                 await handleCodeFromInsertAtCursor(message.text)
                 break


### PR DESCRIPTION
There was a unintentional protocol change to a legacy `getUserContext` message where it didn't trigger the associated `userContextFiles` message. This message was still being used by Jetbrains causing [CODY-3196](https://linear.app/sourcegraph/issue/CODY-3169/sourcegraphjetbrains1990-jetbrains-file-tagging-is-not-working)

This reverts the change and ensures that the correct messages are triggered. As a follow up [CODY-3172](https://linear.app/sourcegraph/issue/CODY-3172/cascading-messages-arent-type-checked) will ensure that these class of issues are properly (type-)checked and tested.

## Test plan
- Current tests pass
- Verified locally that with the change JetBrains once again shows context files
- Deferred testing of the actual testing of the message handler until CODY-3172