### PR TITLE
Chat context: disable symf for enterprise accounts

### DIFF
--- a/vscode/src/external-services.ts
+++ b/vscode/src/external-services.ts
@@ -67,7 +67,7 @@ export async function configureExternalServices(
     const completionsClient = platform.createCompletionsClient(initialConfig, logger)
     const codeCompletionsClient = createCodeCompletionsClient(initialConfig, logger)
 
-    const symfRunner = platform.createSymfRunner?.(context, completionsClient)
+    const symfRunner = platform.createSymfRunner?.(context, completionsClient, authProvider)
 
     if (initialConfig.codebase && isError(await graphqlClient.getRepoId(initialConfig.codebase))) {
         logDebug(


### PR DESCRIPTION
Previously, the extension would download and run local indexing with symf for all accounts including enterprise accounts. This PR changes the behavior so that symf only starts running after the user has authenticated with a non-enterprise accounts. This is an important step towards removing all network traffic to other hosts besides the connected Sourcegraph instance.


## Test plan
We don't have agent integration tests for symf so this needs to be manually tested. You don't have to do all of these steps but these are cases I tried to cover.

* Clear local symf caches: `rm -rf '/Users/olafurpg/Library/Application Support/Code/User/globalStorage/sourcegraph.cody-ai/symf/'`
* Confirm you don't have this user setting enabled `"cody.experimental.symf.enabled": false`
* Authenticate to S2
* Clone and open Shopify/liquid repo
* Confirm that opening the repo does not trigger symf download
* Clear the local cache, sign out of Cody, reload window
* Open the repo and confirm that symf does not get downloaded
* Sign into Cody Pro account and confirm that symf starts downloading after authenticating
* Clear the cache, sign out, reload, sign into S2 and confirm that symf does not start downloading
* Switch to a Cody Pro account and confirm that symf gets downloaded and the repo is indexed, and you can ask "@liquid what is liquid?" to get a relevant answer about the repo
* Clear the local symf cache again
* Repeat steps with latest Cody release and confirm that symf does get downloaded when opening the directory with an enterprise account

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

## Changelog

* Cody no longer runs local codebase indexing unless you are authenticated with a non-enterprise account. For enteprise accounts, this means that Cody will no longer send a network request to github.com to download a `symf` binary.
<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
