### PR TITLE
symf: regenerate index more frequently

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -12,6 +12,8 @@ Chat: Added ability to remove individual chats from chat history in the sidebar.
 
 ### Changed
 
+- Chat: the local search index is now rebuilt more frequently when many files are changed since the last index (such as when the user checks out a revision that differs from the current revision).
+
 ## 1.28.1
 
 Chat: Cody is now defaulted to run in the sidebar for both Enterprise and Non-Enterprise users. [pull/5039](https://github.com/sourcegraph/cody/pull/5039)

--- a/vscode/src/local-context/download-symf.ts
+++ b/vscode/src/local-context/download-symf.ts
@@ -10,7 +10,7 @@ import { captureException } from '../services/sentry/sentry'
 import { downloadFile, fileExists, unzip } from './utils'
 
 export type SymfVersionString = SemverString<'v'>
-const symfVersion: SymfVersionString = 'v0.0.13'
+const symfVersion: SymfVersionString = 'v0.0.14'
 
 export const _config = {
     //delay before trying to re-lock a active file

--- a/vscode/src/local-context/symf.ts
+++ b/vscode/src/local-context/symf.ts
@@ -216,8 +216,7 @@ export class SymfRunner implements IndexedKeywordContextFetcher, vscode.Disposab
     }
 
     /**
-     * Check index freshness and reindex if needed. Currently reindexes daily if changes
-     * have been detected.
+     * Check index freshness and reindex if needed.
      */
     public async reindexIfStale(scopeDir: FileURI): Promise<void> {
         logDebug('SymfRunner', 'reindexIfStale', scopeDir.fsPath)

--- a/vscode/src/local-context/symf.ts
+++ b/vscode/src/local-context/symf.ts
@@ -33,12 +33,16 @@ import { getSymfPath } from './download-symf'
 import { rewriteKeywordQuery } from './rewrite-keyword-query'
 
 const execFile = promisify(_execFile)
-const oneDayMillis = 1000 * 60 * 60 * 24
 
-interface CorpusDiff {
+export interface CorpusDiff {
     maybeChangedFiles?: boolean
     changedFiles?: string[]
+
+    // milliseconds elapsed since last index
     millisElapsed?: number
+
+    // milliseconds of last indexing duration
+    lastTimeToIndexMillis?: number
 }
 
 function parseJSONToCorpusDiff(json: string): CorpusDiff {
@@ -226,10 +230,8 @@ export class SymfRunner implements IndexedKeywordContextFetcher, vscode.Disposab
                 })
                 return
             }
-            if (
-                (diff.millisElapsed === undefined || diff.millisElapsed > oneDayMillis) &&
-                (diff.maybeChangedFiles || (diff.changedFiles && diff.changedFiles.length > 0))
-            ) {
+
+            if (shouldReindex(diff)) {
                 // reindex targeting a temporary directory
                 // atomically replace index
                 await this.ensureIndex(scopeDir, {
@@ -857,4 +859,68 @@ class IndexManager implements vscode.Disposable {
             this.currentlyRefreshing.delete(scopeDir.toString())
         }
     }
+}
+
+/**
+ * Determines whether the search index should be refreshed based on whether we're past a staleness threshold
+ * that depends on the time since last index, time it took to create the last index, and the number of files changed.
+ */
+export function shouldReindex(diff: CorpusDiff): boolean {
+    if (diff.millisElapsed === undefined) {
+        return true
+    }
+
+    const numChangedFiles = diff.changedFiles
+        ? diff.changedFiles.length
+        : diff.maybeChangedFiles
+          ? 9999999
+          : 0
+    if (numChangedFiles === 0) {
+        return false
+    }
+
+    const stalenessThresholds = [
+        {
+            // big change thresholds
+            changedFiles: 20,
+            thresholds: [
+                { lastTimeToIndexMillis: 1000 * 60 * 5, maxMillisStale: 30 * 1000 }, // 5m -> 30s
+                { lastTimeToIndexMillis: 1000 * 60 * 5, maxMillisStale: 60 * 1000 }, // 10m -> 1m
+            ],
+        },
+        {
+            // small change thresholds
+            changedFiles: 0,
+            thresholds: [
+                { lastTimeToIndexMillis: 1000 * 30, maxMillisStale: 1000 * 60 * 5 }, // 30s -> 5m
+                { lastTimeToIndexMillis: 1000 * 60, maxMillisStale: 1000 * 60 * 15 }, // 1m -> 15m
+                { lastTimeToIndexMillis: 1000 * 60 * 5, maxMillisStale: 1000 * 60 * 60 }, // 5m -> 1h
+                { lastTimeToIndexMillis: 1000 * 60 * 10, maxMillisStale: 1000 * 60 * 60 * 2 }, // 10m -> 2h
+            ],
+        },
+    ]
+
+    const fallbackThreshold = 1000 * 60 * 60 * 24 // 1 day
+
+    let t0 = undefined
+    for (const thresh of stalenessThresholds) {
+        if (numChangedFiles >= thresh.changedFiles) {
+            t0 = thresh
+            break
+        }
+    }
+    if (!t0) {
+        // should never happen given last changedFiles is 0
+        return diff.millisElapsed >= fallbackThreshold
+    }
+    if (diff.lastTimeToIndexMillis === undefined) {
+        return true
+    }
+
+    for (const thresh of t0.thresholds) {
+        if (diff.lastTimeToIndexMillis <= thresh.lastTimeToIndexMillis) {
+            return diff.millisElapsed >= thresh.maxMillisStale
+        }
+    }
+    return diff.millisElapsed >= fallbackThreshold
 }


### PR DESCRIPTION
The local search index is now rebuilt more frequently when many files are changed since the last index (such as when the user checks out a revision that differs from the current revision).

The frequency of update is dependent on:
- # files changed since last index
- time since last index
- time it took for last index

## Test plan

Test locally. See unit test.
