### PR TITLE
Context: disable local embeddings by default

### DIFF
--- a/vscode/src/extension.node.ts
+++ b/vscode/src/extension.node.ts
@@ -39,17 +39,16 @@ export function activate(
     // Create the default client for VSCode.
     extensionClient ||= defaultVSCodeExtensionClient()
 
-    // NOTE: local embeddings are only going to be supported in VSC for now.
-    // Until we revisit this decision, we disable local embeddings for all agent
-    // clients like the JetBrains plugin.
-    let isLocalEmbeddingsDisabled = vscode.workspace
+    // Local embeddings are disabled by default since we are now moving towards
+    // server-side embeddings. One important side-effect of disabling local
+    // embeddings is that we no longer download the cody-engine binary from
+    // github.com, which has been problematic for some enterprise customers.
+    // We still keep the functionality in the codebase for now in case
+    // we want to revert the decision (for example, only do local embeddings
+    // for Cody Pro users until we have Multitenancy).
+    const isLocalEmbeddingsEnabled = vscode.workspace
         .getConfiguration()
-        .get<boolean>('cody.advanced.agent.running', false)
-
-    // Optional override for local testing.
-    isLocalEmbeddingsDisabled = vscode.workspace
-        .getConfiguration()
-        .get<boolean>('cody.experimental.localEmbeddings.disabled', isLocalEmbeddingsDisabled)
+        .get<boolean>('cody.experimental.localEmbeddings.enabled', false)
 
     const isSymfEnabled = vscode.workspace
         .getConfiguration()
@@ -60,10 +59,10 @@ export function activate(
         .get<boolean>('cody.experimental.telemetry.enabled', true)
 
     return activateCommon(context, {
-        createLocalEmbeddingsController: isLocalEmbeddingsDisabled
-            ? undefined
-            : (config: LocalEmbeddingsConfig): Promise<LocalEmbeddingsController> =>
-                  createLocalEmbeddingsController(context, config),
+        createLocalEmbeddingsController: isLocalEmbeddingsEnabled
+            ? (config: LocalEmbeddingsConfig): Promise<LocalEmbeddingsController> =>
+                  createLocalEmbeddingsController(context, config)
+            : undefined,
         createCompletionsClient: (...args) => new SourcegraphNodeCompletionsClient(...args),
         createCommandsProvider: () => new CommandsProvider(),
         createSymfRunner: isSymfEnabled ? (...args) => new SymfRunner(...args) : undefined,


### PR DESCRIPTION
Fixes CODY-3199

Previously, local embeddings were enabled by default. This was problematic for several reasons:

* Local embeddings could go out of sync and hurt context quality because they returned outdated chunks.
* Local embeddings required downloading the `cody-engine` binary from github.com, which was problematic for some enterprise customers.

This PR disables local embeddings by default addressing both problems.


## Test plan

* Run `rm -rf '/Users/olafurpg/Library/Application Support/Code/User/globalStorage/sourcegraph.cody-ai/cody-engine'` (adjust path to your computer)
* Remove `cody.experimental.localEmbeddings.disabled` user setting from your VS Code installation
* Run a local build of this plugin
* After the extension has finished activating, confirm that the path `'/Users/olafurpg/Library/Application Support/Code/User/globalStorage/sourcegraph.cody-ai/cody-engine'` still doesn't exist
* Set user setting `"cody.experimental.localEmbeddings.enabled": true`, reload VS Code, confirm that it downloads the cody-engine binary during activation.

## Changelog

* Local embeddings are now disabled by default. To enable local embeddings, add the user setting `"cody.experimental.localEmbeddings.enabled": true`.

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
