### PR TITLE
Code Lenses: disable "Edit & Retry" for non-user prompts

### DIFF
--- a/vscode/src/non-stop/codelenses/items.ts
+++ b/vscode/src/non-stop/codelenses/items.ts
@@ -37,8 +37,7 @@ export function getLensesForTask(task: FixupTask): vscode.CodeLens[] {
 
             // Optional:
             // Retries only makes sense if the user created the prompt
-            // TODO: Are there other actions that shouldn't offer a retry?
-            const canRetry = task.source !== 'code-action:fix' && !isTest
+            const canRetry = task.intent !== 'fix' && task.intent !== 'doc' && !isTest
             const retryLens = canRetry ? getRetryLens(codeLensRange, task.id) : null
 
             // Diffs only if there's code that's changed


### PR DESCRIPTION
Before the "Edit & Retry" lens was shown after using the "Ask Cody to Fix" code action. Although it worked this would then show a prompt that the user never wrote which is confusing.

Now we don't show the Edit & Retry lens and only allow Accept/Reject.

## Test plan
CI
Manually verified that the Edit & Retry lens no longer shows up