### PR TITLE
Smart Apply: Handle request errors

### DIFF
--- a/vscode/src/edit/prompt/smart-apply.ts
+++ b/vscode/src/edit/prompt/smart-apply.ts
@@ -150,7 +150,6 @@ export async function promptModelForOriginalCode(
                 break
             }
             case 'error': {
-                console.log('GOT AN ERROR', message.error)
                 throw message.error
             }
         }
@@ -189,8 +188,10 @@ export async function getSmartApplySelection(
             client,
             codyApiVersion
         )
-    } catch (error) {
-        // Cody told us we need to replace some code, but we couldn't find where to replace it
+    } catch (error: any) {
+        // We erred when asking the LLM to produce the original code.
+        // Surface this error back to the user
+        vscode.window.showErrorMessage(`Error: ${error.message}`)
         return null
     }
 

--- a/vscode/src/edit/prompt/smart-apply.ts
+++ b/vscode/src/edit/prompt/smart-apply.ts
@@ -149,6 +149,10 @@ export async function promptModelForOriginalCode(
                 void multiplexer.notifyTurnComplete()
                 break
             }
+            case 'error': {
+                console.log('GOT AN ERROR', message.error)
+                throw message.error
+            }
         }
     }
 
@@ -175,14 +179,20 @@ export async function getSmartApplySelection(
     client: ChatClient,
     codyApiVersion: number
 ): Promise<SmartSelection | null> {
-    const originalCode = await promptModelForOriginalCode(
-        instruction,
-        replacement,
-        document,
-        model,
-        client,
-        codyApiVersion
-    )
+    let originalCode: string
+    try {
+        originalCode = await promptModelForOriginalCode(
+            instruction,
+            replacement,
+            document,
+            model,
+            client,
+            codyApiVersion
+        )
+    } catch (error) {
+        // Cody told us we need to replace some code, but we couldn't find where to replace it
+        return null
+    }
 
     if (originalCode.trim().length === 0 || originalCode.trim() === 'INSERT') {
         // Insert flow. Cody thinks that this code should be inserted into the document.

--- a/vscode/src/edit/prompt/smart-apply.ts
+++ b/vscode/src/edit/prompt/smart-apply.ts
@@ -188,10 +188,13 @@ export async function getSmartApplySelection(
             client,
             codyApiVersion
         )
-    } catch (error: any) {
+    } catch (error: unknown) {
         // We erred when asking the LLM to produce the original code.
         // Surface this error back to the user
-        vscode.window.showErrorMessage(`Error: ${error.message}`)
+        if (error instanceof Error) {
+            vscode.window.showErrorMessage(`Error: ${error.message}`)
+        }
+
         return null
     }
 

--- a/vscode/src/edit/prompt/smart-apply.ts
+++ b/vscode/src/edit/prompt/smart-apply.ts
@@ -146,7 +146,7 @@ export async function promptModelForOriginalCode(
                 break
             }
             case 'complete': {
-                void multiplexer.notifyTurnComplete()
+                await multiplexer.notifyTurnComplete()
                 break
             }
             case 'error': {
@@ -191,10 +191,9 @@ export async function getSmartApplySelection(
     } catch (error: unknown) {
         // We erred when asking the LLM to produce the original code.
         // Surface this error back to the user
-        if (error instanceof Error) {
-            vscode.window.showErrorMessage(`Error: ${error.message}`)
-        }
-
+        vscode.window.showErrorMessage(
+            `Error: ${error instanceof Error ? error.message : 'An unknown error occurred'}`
+        )
         return null
     }
 


### PR DESCRIPTION
## Description

Adds request error handling to the smart apply feature

Note: This is feature flagged and only enable for internal dogfooding right now

So if we get a network request or anything, we show it to the user. Previously we would end up just assuming we wanted to `insert`

## Test plan

1. Trigger a smart apply
2. Force a network error
3. Check the error message is shown to the user

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
