### PR TITLE
Cody: Temporarily disable 3.5 Sonnet

### DIFF
--- a/lib/shared/src/models/dotcom.ts
+++ b/lib/shared/src/models/dotcom.ts
@@ -34,6 +34,17 @@ const expandedContextWindow: ModelContextWindow = {
  * @deprecated This will be replaced with server-sent models
  */
 export const DEFAULT_DOT_COM_MODELS = [
+    // Note: GPT-4o is temporary set to the default model due to INC-319
+    // #inc-319-cody-connection-closed-without-receiving-any-events
+    {
+        title: 'GPT-4o',
+        model: 'openai/gpt-4o',
+        provider: 'OpenAI',
+        usage: [ModelUsage.Chat, ModelUsage.Edit],
+        contextWindow: expandedContextWindow,
+        tags: [ModelTag.Gateway, ModelTag.Pro, ModelTag.Recommended, ModelTag.Accuracy],
+    },
+
     // --------------------------------
     // Anthropic models
     // --------------------------------
@@ -73,14 +84,6 @@ export const DEFAULT_DOT_COM_MODELS = [
     // --------------------------------
     // OpenAI models
     // --------------------------------
-    {
-        title: 'GPT-4o',
-        model: 'openai/gpt-4o',
-        provider: 'OpenAI',
-        usage: [ModelUsage.Chat, ModelUsage.Edit],
-        contextWindow: expandedContextWindow,
-        tags: [ModelTag.Gateway, ModelTag.Pro, ModelTag.Recommended, ModelTag.Accuracy],
-    },
     {
         title: 'GPT-4 Turbo',
         model: 'openai/gpt-4-turbo',

--- a/lib/shared/src/models/dotcom.ts
+++ b/lib/shared/src/models/dotcom.ts
@@ -52,7 +52,7 @@ export const DEFAULT_DOT_COM_MODELS = [
         title: 'Claude 3.5 Sonnet',
         model: 'anthropic/claude-3-5-sonnet-20240620',
         provider: 'Anthropic',
-        usage: [ModelUsage.Chat, ModelUsage.Edit],
+        usage: [], // Temporarily disabled due to INC-319: #inc-319-cody-connection-closed-without-receiving-any-events
         contextWindow: expandedContextWindow,
         tags: [ModelTag.Gateway, ModelTag.Accuracy, ModelTag.Recommended, ModelTag.Free],
     },

--- a/vscode/src/edit/utils/edit-models.ts
+++ b/vscode/src/edit/utils/edit-models.ts
@@ -19,7 +19,7 @@ export function getOverridenModelForIntent(
             // TODO: Make the model usage more visible to users outside of the normal edit flow. This means
             // we could let the user provide any model they want for `fix`.
             // Issue: https://github.com/sourcegraph/cody/issues/3512
-            return 'anthropic/claude-3-5-sonnet-20240620'
+            return 'openai/gpt-4o'
         case 'doc':
             // Doc is a case where we can sacrifice LLM performnace for improved latency and get comparable results.
             return 'anthropic/claude-3-haiku-20240307'


### PR DESCRIPTION
## Description

This PR:
- Temporarily disables 3.5 Sonnet
- Temporarily sets the default model for chat and fix to GPT-4o

## Test plan

1. Execute chats and fixes, check the model used is not 3.5 Sonnet
2. Check that 3.5 Sonnet is not available

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
