### PR TITLE
Agent: new protocol to create chat sidebar panel

### DIFF
--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/agent/protocol_generated/Chat_Sidebar_NewResult.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/agent/protocol_generated/Chat_Sidebar_NewResult.kt
@@ -1,0 +1,8 @@
+@file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
+package com.sourcegraph.cody.agent.protocol_generated;
+
+data class Chat_Sidebar_NewResult(
+  val panelId: String,
+  val chatId: String,
+)
+

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/agent/protocol_generated/CodyAgentServer.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/agent/protocol_generated/CodyAgentServer.kt
@@ -18,6 +18,8 @@ interface CodyAgentServer {
   fun chat_new(params: Null?): CompletableFuture<String>
   @JsonRequest("chat/web/new")
   fun chat_web_new(params: Null?): CompletableFuture<Chat_Web_NewResult>
+  @JsonRequest("chat/sidebar/new")
+  fun chat_sidebar_new(params: Null?): CompletableFuture<Chat_Sidebar_NewResult>
   @JsonRequest("chat/delete")
   fun chat_delete(params: Chat_DeleteParams): CompletableFuture<List<ChatExportResult>>
   @JsonRequest("chat/restore")

--- a/agent/src/agent.ts
+++ b/agent/src/agent.ts
@@ -1141,6 +1141,18 @@ export class Agent extends MessageHandler implements ExtensionClient {
             return { panelId, chatId }
         })
 
+        this.registerAuthenticatedRequest('chat/sidebar/new', async () => {
+            const panelId = await this.createChatPanel(
+                Promise.resolve({
+                    type: 'chat',
+                    session: await vscode.commands.executeCommand('cody.chat.newPanel'),
+                })
+            )
+
+            const chatId = this.webPanels.panels.get(panelId)?.chatID ?? ''
+            return { panelId, chatId }
+        })
+
         this.registerAuthenticatedRequest('chat/restore', async ({ modelID, messages, chatID }) => {
             const authStatus = await vscode.commands.executeCommand<AuthStatus>('cody.auth.status')
             modelID ??= ModelsService.getDefaultChatModel() ?? ''

--- a/vscode/src/chat/chat-view/ChatsController.ts
+++ b/vscode/src/chat/chat-view/ChatsController.ts
@@ -153,6 +153,7 @@ export class ChatsController implements vscode.Disposable {
                 if (!isVisible) {
                     await vscode.commands.executeCommand('cody.chat.focus')
                 }
+                return this.panel
             }),
             vscode.commands.registerCommand('cody.chat.newEditorPanel', () => {
                 localStorage.setLastUsedChatModality('editor')

--- a/vscode/src/jsonrpc/agent-protocol.ts
+++ b/vscode/src/jsonrpc/agent-protocol.ts
@@ -53,6 +53,12 @@ export type ClientRequests = {
     // chat id. Main difference compared to the chat/new is that we return chatId.
     'chat/web/new': [null, { panelId: string; chatId: string }]
 
+    // Start a new chat session and returns panel id and chat id that later can
+    // be used to reference to the session with panel id and restore chat with
+    // chat id. Main difference compared to the chat/web/new is that the chat
+    // this created has sidebar view type v.s. editor view type.
+    'chat/sidebar/new': [null, { panelId: string; chatId: string }]
+
     // Deletes chat by its ID and returns newly updated chat history list
     // Primary is used only in cody web client
     'chat/delete': [{ chatId: string }, ChatExportResult[]]


### PR DESCRIPTION
This change adds a new JSONRPC endpoint `chat/sidebar/new` that allows creating a new chat panel with a sidebar view type, in addition to the existing `chat/new`  and `chat/web/new` endpoint that creates a chat panel with an editor view type.

The new endpoint returns the panel ID and chat ID that can be used to reference the session and restore the chat.

This change also updates the `ChatsController` to return the created panel when using the `cody.chat.newPanel` command.

## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

Try calling the `chat/sidebar/new` from a client when creating a webview to confirm the webview is showing up as "sidebar" view type that has the nav bar on top.

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->

Adds a new JSONRPC endpoint `chat/sidebar/new` that allows creating a new chat panel with a sidebar view type.