### PR TITLE
VS Code: Release 1.30.1

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -14,6 +14,17 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 
 - Chat: Improved how Cody associates code to existing files in chat responses. [pull/5038](https://github.com/sourcegraph/cody/pull/5038)
 - Chat: Added an experimental simpler code block UI, that can accomodate the "Smart Apply" button. [pull/5038](https://github.com/sourcegraph/cody/pull/5038)
+
+## 1.30.1
+
+### Added
+
+Autocomplete: Add a feature flag for DeepSeek-coder-v2 lite base model. [pull/5151](https://github.com/sourcegraph/cody/pull/5079)
+
+### Fixed
+
+### Changed
+
 ## 1.30.0
 
 ### Added

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -3,7 +3,7 @@
   "name": "cody-ai",
   "private": true,
   "displayName": "Cody: AI Coding Assistant with Autocomplete & Chat",
-  "version": "1.30.0",
+  "version": "1.30.1",
   "publisher": "sourcegraph",
   "license": "Apache-2.0",
   "icon": "resources/cody.png",


### PR DESCRIPTION
Patch release follow-up based on https://github.com/sourcegraph/cody/blob/main/vscode/CONTRIBUTING.md

## Test plan
version/CHANGELOG only

## Changelog
Autocomplete: Add a feature flag for DeepSeek-coder-v2 lite base model. [pull/5151](https://github.com/sourcegraph/cody/pull/5079)