### PR TITLE
Add metadata to context items

### DIFF
--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/agent/protocol_generated/ContextItem.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/agent/protocol_generated/ContextItem.kt
@@ -39,6 +39,7 @@ data class ContextItemFile(
   val isTooLargeReason: String? = null,
   val provider: String? = null,
   val icon: String? = null,
+  val metadata: List<String>? = null,
   val type: TypeEnum, // Oneof: file
   val remoteRepositoryName: String? = null,
 ) : ContextItem() {
@@ -63,6 +64,7 @@ data class ContextItemRepository(
   val isTooLargeReason: String? = null,
   val provider: String? = null,
   val icon: String? = null,
+  val metadata: List<String>? = null,
   val type: TypeEnum, // Oneof: repository
   val repoID: String,
 ) : ContextItem() {
@@ -87,6 +89,7 @@ data class ContextItemTree(
   val isTooLargeReason: String? = null,
   val provider: String? = null,
   val icon: String? = null,
+  val metadata: List<String>? = null,
   val type: TypeEnum, // Oneof: tree
   val isWorkspaceRoot: Boolean,
   val name: String,
@@ -112,6 +115,7 @@ data class ContextItemSymbol(
   val isTooLargeReason: String? = null,
   val provider: String? = null,
   val icon: String? = null,
+  val metadata: List<String>? = null,
   val type: TypeEnum, // Oneof: symbol
   val symbolName: String,
   val kind: SymbolKind, // Oneof: class, function, method
@@ -138,6 +142,7 @@ data class ContextItemOpenCtx(
   val isTooLargeReason: String? = null,
   val provider: String? = null,
   val icon: String? = null,
+  val metadata: List<String>? = null,
   val type: TypeEnum, // Oneof: openctx
   val providerUri: String,
   val mention: MentionParams? = null,

--- a/lib/shared/src/codebase-context/messages.ts
+++ b/lib/shared/src/codebase-context/messages.ts
@@ -72,6 +72,12 @@ interface ContextItemCommon {
      * Lucid icon name for the context item
      */
     icon?: string
+
+    /**
+     * Optional metadata about where this context item came from or how it was scored, which
+     * can help a user or dev working on Cody understand why this item is appearing in context.
+     */
+    metadata?: string[]
 }
 
 /**

--- a/lib/shared/src/configuration.ts
+++ b/lib/shared/src/configuration.ts
@@ -68,7 +68,7 @@ export interface Configuration {
      * Unstable Features for internal testing only
      */
     internalUnstable: boolean
-    internalDebugContext: boolean
+    internalDebugContext?: boolean
 
     /**
      * Experimental autocomplete

--- a/lib/shared/src/configuration.ts
+++ b/lib/shared/src/configuration.ts
@@ -68,6 +68,7 @@ export interface Configuration {
      * Unstable Features for internal testing only
      */
     internalUnstable: boolean
+    internalDebugContext: boolean
 
     /**
      * Experimental autocomplete

--- a/lib/shared/src/local-context/index.ts
+++ b/lib/shared/src/local-context/index.ts
@@ -27,4 +27,6 @@ export interface Result {
     file: URI
     range: Range
     summary: string
+    blugeScore: number
+    heuristicBoostID?: string
 }

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -1267,12 +1267,6 @@
           "type": "boolean",
           "markdownDescription": "[INTERNAL ONLY] Enable all unstable experimental features.",
           "default": false
-        },
-        "cody.internal.showContextAlternatives": {
-          "order": 999,
-          "type": "boolean",
-          "markdownDescription": "[INTERNAL ONLY] Show alternative context lists in chat",
-          "default": false
         }
       }
     },

--- a/vscode/src/chat/chat-view/ChatController.ts
+++ b/vscode/src/chat/chat-view/ChatController.ts
@@ -565,6 +565,7 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
             experimentalNoodle: config.experimentalNoodle,
             experimentalSmartApply,
             webviewType,
+            internalDebugContext: config.internalDebugContext,
         }
     }
 
@@ -1259,18 +1260,10 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
         )
         abortSignal.throwIfAborted()
 
-        // Update UI based on prompt construction
-        // Includes the excluded context items to display in the UI
-        if (vscode.workspace.getConfiguration().get<boolean>('cody.internal.showContextAlternatives')) {
-            this.chatModel.setLastMessageContext(
-                [...context.used, ...context.ignored],
-                contextAlternatives
-            )
-        } else {
-            this.chatModel.setLastMessageContext([...context.used, ...context.ignored])
-        }
+        // Update UI based on prompt construction. Includes the excluded context items to display in the UI
+        this.chatModel.setLastMessageContext([...context.used, ...context.ignored], contextAlternatives)
 
-        // this is not awaited, so we kick the call off but don't block on it returning
+        // This is not awaited, so we kick the call off but don't block on it returning
         this.contextAPIClient?.recordContext(requestID, context.used, context.ignored)
 
         if (sendTelemetry) {

--- a/vscode/src/chat/chat-view/ContextRetriever.ts
+++ b/vscode/src/chat/chat-view/ContextRetriever.ts
@@ -245,6 +245,7 @@ export class ContextRetriever implements vscode.Disposable {
                         range,
                         source: ContextItemSource.Search,
                         content: text,
+                        metadata: ['source:symf-live'],
                     }
                 })
             )
@@ -313,7 +314,11 @@ export class ContextRetriever implements vscode.Disposable {
         if (isError(remoteResult)) {
             throw remoteResult
         }
-        return remoteResult?.flatMap(r => contextSearchResultToContextItem(r) ?? []) ?? []
+        const finalResults = remoteResult?.flatMap(r => contextSearchResultToContextItem(r) ?? []) ?? []
+        for (const r of finalResults) {
+            r.metadata = (r.metadata ?? []).concat(['source:sourcegraph'])
+        }
+        return finalResults
     }
 
     private async retrieveIndexedContextLocally(

--- a/vscode/src/chat/chat-view/context.ts
+++ b/vscode/src/chat/chat-view/context.ts
@@ -241,12 +241,21 @@ export async function searchSymf(
                         logError('ChatController.searchSymf', `Error getting file contents: ${error}`)
                         return []
                     }
+
+                    const metadata: string[] = [
+                        'source:symf-index',
+                        'score:' + result.blugeScore.toFixed(0),
+                    ]
+                    if (result.heuristicBoostID) {
+                        metadata.push('boost:' + result.heuristicBoostID)
+                    }
                     return {
                         type: 'file',
                         uri: result.file,
                         range,
                         source: ContextItemSource.Search,
                         content: text,
+                        metadata,
                     }
                 }
             )

--- a/vscode/src/chat/protocol.ts
+++ b/vscode/src/chat/protocol.ts
@@ -275,7 +275,11 @@ export interface ExtensionTranscriptMessage {
 export interface ConfigurationSubsetForWebview
     extends Pick<
         ConfigurationWithAccessToken,
-        'experimentalNoodle' | 'serverEndpoint' | 'agentIDE' | 'agentExtensionVersion'
+        | 'experimentalNoodle'
+        | 'serverEndpoint'
+        | 'agentIDE'
+        | 'agentExtensionVersion'
+        | 'internalDebugContext'
     > {
     experimentalSmartApply: boolean
     webviewType?: WebviewType | undefined | null

--- a/vscode/src/configuration.test.ts
+++ b/vscode/src/configuration.test.ts
@@ -90,6 +90,8 @@ describe('getConfiguration', () => {
                         return undefined
                     case 'cody.internal.unstable':
                         return false
+                    case 'cody.internal.debug.context':
+                        return false
                     case 'cody.experimental.supercompletions':
                         return false
                     case 'cody.experimental.noodle':
@@ -134,6 +136,7 @@ describe('getConfiguration', () => {
             isRunningInsideAgent: false,
             agentIDE: undefined,
             internalUnstable: false,
+            internalDebugContext: false,
             debugVerbose: true,
             debugFilter: /.*/,
             telemetryLevel: 'off',

--- a/vscode/src/configuration.ts
+++ b/vscode/src/configuration.ts
@@ -135,7 +135,7 @@ export function getConfiguration(
          */
 
         internalUnstable: getHiddenSetting('internal.unstable', isTesting),
-        internalDebugContext: getHiddenSetting('internal.debugContext', false),
+        internalDebugContext: getHiddenSetting('internal.debug.context', false),
 
         autocompleteExperimentalGraphContext,
         experimentalCommitMessage: getHiddenSetting('experimental.commitMessage', true),

--- a/vscode/src/configuration.ts
+++ b/vscode/src/configuration.ts
@@ -135,6 +135,7 @@ export function getConfiguration(
          */
 
         internalUnstable: getHiddenSetting('internal.unstable', isTesting),
+        internalDebugContext: getHiddenSetting('internal.debugContext', false),
 
         autocompleteExperimentalGraphContext,
         experimentalCommitMessage: getHiddenSetting('experimental.commitMessage', true),

--- a/vscode/src/local-context/symf.ts
+++ b/vscode/src/local-context/symf.ts
@@ -597,7 +597,19 @@ function parseSymfStdout(stdout: string): Result[] {
     }
     const results = JSON.parse(stdout) as RawSymfResult[]
     return results.map(result => {
-        const { fqname, name, type, doc, exported, lang, file: fsPath, range, summary } = result
+        const {
+            fqname,
+            name,
+            type,
+            doc,
+            exported,
+            lang,
+            file: fsPath,
+            range,
+            summary,
+            blugeScore,
+            heuristicBoostID,
+        } = result
 
         const { row: startRow, col: startColumn } = range.startPoint
         const { row: endRow, col: endColumn } = range.endPoint
@@ -626,6 +638,8 @@ function parseSymfStdout(stdout: string): Result[] {
                     col: endColumn,
                 },
             },
+            blugeScore,
+            heuristicBoostID,
         } satisfies Result
     })
 }

--- a/vscode/src/testutils/mocks.ts
+++ b/vscode/src/testutils/mocks.ts
@@ -915,6 +915,7 @@ export const DEFAULT_VSCODE_SETTINGS = {
     debugFilter: null,
     telemetryLevel: 'all',
     internalUnstable: false,
+    internalDebugContext: false,
     autocompleteAdvancedProvider: null,
     autocompleteAdvancedModel: null,
     autocompleteCompleteSuggestWidgetSelection: true,

--- a/vscode/webviews/chat/cells/contextCell/ContextCell.module.css
+++ b/vscode/webviews/chat/cells/contextCell/ContextCell.module.css
@@ -3,6 +3,12 @@
     padding: 2px 4px 2px 2px;
 }
 
+.context-item-metadata {
+    color: var(--vscode-disabledForeground);
+    padding-left: 0.1rem;
+    text-wrap: nowrap;
+}
+
 .context-item-link {
     background: none;
     border: none;

--- a/vscode/webviews/chat/cells/contextCell/ContextCell.tsx
+++ b/vscode/webviews/chat/cells/contextCell/ContextCell.tsx
@@ -16,6 +16,7 @@ import {
 import { Tooltip, TooltipContent, TooltipTrigger } from '../../../components/shadcn/ui/tooltip'
 import { SourcegraphLogo } from '../../../icons/SourcegraphLogo'
 import { getVSCodeAPI } from '../../../utils/VSCodeApi'
+import { useConfig } from '../../../utils/useConfig'
 import { LoadingDots } from '../../components/LoadingDots'
 import { Cell } from '../Cell'
 import { NON_HUMAN_CELL_AVATAR_SIZE } from '../messageCell/assistant/AssistantMessageCell'
@@ -98,6 +99,10 @@ export const ContextCell: FunctionComponent<{
             })
         }
 
+        const {
+            config: { internalDebugContext },
+        } = useConfig()
+
         return contextItemsToDisplay === undefined || contextItemsToDisplay.length !== 0 ? (
             <Cell
                 style="context"
@@ -134,7 +139,7 @@ export const ContextCell: FunctionComponent<{
                                 </span>
                             </AccordionTrigger>
                             <AccordionContent>
-                                {contextAlternatives && (
+                                {internalDebugContext && contextAlternatives && (
                                     <div>
                                         <button onClick={prevSelectedAlternative} type="button">
                                             &larr;
@@ -170,6 +175,13 @@ export const ContextCell: FunctionComponent<{
                                                 className={clsx(styles.contextItem, MENTION_CLASS_NAME)}
                                                 linkClassName={styles.contextItemLink}
                                             />
+                                            {internalDebugContext &&
+                                                item.metadata &&
+                                                item.metadata.length > 0 && (
+                                                    <span className={styles.contextItemMetadata}>
+                                                        {item.metadata.join(', ')}
+                                                    </span>
+                                                )}
                                         </li>
                                     ))}
                                     {!isForFirstMessage && (


### PR DESCRIPTION
Context items now include optional metadata about their source or scoring, which can help developers understand why certain items are appearing in the context. This change adds a `metadata` field to the `ContextItemCommon` interface and populates it for context items from Sourcegraph search, the local symbol index, and live search results.

You can view these by setting `"cody.internal.debug.context": true` in settings. The `cody.internal.showContextAlternatives` has been removed and replaced by this one.

## Test plan

Test locally, doesn't affect prod.
