### PR TITLE
Smart Apply: Add click events for telemetry

### DIFF
--- a/vscode/src/services/utils/codeblock-action-tracker.ts
+++ b/vscode/src/services/utils/codeblock-action-tracker.ts
@@ -52,10 +52,8 @@ function setLastStoredCode(
     let operation: string
     switch (eventName) {
         case 'copyButton':
-            operation = 'copy'
-            break
         case 'keyDown.Copy':
-            operation = 'paste'
+            operation = 'copy'
             break
         case 'applyButton':
             operation = 'apply'


### PR DESCRIPTION
## Description

This PR:
- Adds click events for telemetry
- Improves the type safety of this function slightly
- Correctly calls `setLastStoredCode` _before_ we apply any edits/files. This is needed as we set `insertInProgress` to gate against incorrectly checking a new insertion is a copy/paste from the clipboard.


## Test plan

1. Trigger telemetry events by clicking code block actions
2. Check that the fired telemetry is correct

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

