### PR TITLE
Ensure normalized URI is used

### DIFF
--- a/agent/src/AgentDiagnostics.ts
+++ b/agent/src/AgentDiagnostics.ts
@@ -1,13 +1,14 @@
 import type * as vscode from 'vscode'
+import { UriString } from './vscode-shim'
 
 export class AgentDiagnostics {
-    private diagnostics = new Map<string, vscode.Diagnostic[]>()
-    public publish(newDiagnostics: Map<string, vscode.Diagnostic[]>): void {
+    private diagnostics = new Map<UriString, readonly vscode.Diagnostic[]>()
+    public publish(newDiagnostics: Map<UriString, readonly vscode.Diagnostic[]>): void {
         for (const [key, value] of newDiagnostics.entries()) {
             this.diagnostics.set(key, value)
         }
     }
-    public forUri(uri: vscode.Uri): vscode.Diagnostic[] {
-        return this.diagnostics.get(uri.toString()) ?? []
+    public forUri(uri: vscode.Uri): readonly vscode.Diagnostic[] {
+        return this.diagnostics.get(UriString.fromUri(uri)) ?? []
     }
 }

--- a/agent/src/vscode-shim.ts
+++ b/agent/src/vscode-shim.ts
@@ -475,7 +475,7 @@ const defaultTreeView: vscode.TreeView<any> = {
 }
 
 function toUri(
-    uriOrString: string | vscode.Uri | { language?: string; content?: string } | undefined
+    uriOrString: string | UriString | vscode.Uri | { language?: string; content?: string } | undefined
 ): Uri | undefined {
     if (typeof uriOrString === 'string') {
         return Uri.parse(uriOrString)
@@ -495,6 +495,14 @@ function toUri(
         })
     }
     return
+}
+
+// This opaque type prevents strings from being mistakenly used as URIs.
+export type UriString = string & { __tag: 'vscode.Uri' }
+export namespace UriString {
+    export function fromUri(uri: vscode.Uri): UriString {
+        return uri.toString() as UriString
+    }
 }
 
 function outputChannel(name: string): vscode.LogOutputChannel {


### PR DESCRIPTION
VSCode URIs can sometimes be %-encoded. The JetBrains client doesn't entirely correctly handle this yet meaning that sometimes the URI used to publish diagnostics differed from the URI to fetch code-actions.

This meant that on paths with special characters (Such as most Windows paths or paths with spaces) diagnostics weren't correctly returned.

Now we ensure that only normalized strings are used by first converting them back to a Uri.

Fixes CODY-3217

> Note: There's a follow up action item to improve URI normalization in the Bindings (de)serializer (CODY-3223)

## Test plan
- Added additional opaque `UriString` type to ensure no unintended strings are passed in to Diagnostics anymore
- CI