### PR TITLE
Agent: update webview build script

### DIFF
--- a/agent/package.json
+++ b/agent/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "build:root": "pnpm -C .. run -s build",
     "build:agent": "node src/esbuild.mjs",
-    "build:webviews": "pnpm -C ../vscode _build:webviews --mode production && cp -R ../vscode/dist/webviews dist/webviews",
+    "build:webviews": "pnpm -C ../vscode _build:webviews --mode production --outDir ../../agent/dist/webviews",
     "build": "pnpm run -s build:root && pnpm run -s build:webviews && pnpm run -s build:agent",
     "build-minify": "pnpm run build --minify",
     "agent": "pnpm run build && node --enable-source-maps dist/index.js",


### PR DESCRIPTION
- Update the `build:webviews` script to output the built webviews directly to the `agent/dist/webviews` directory instead of copying them over

The change was commit accidentally in the last PR. It works the same but using --outDir simplify the build process and ensures the webviews are properly included in the agent distribution on machines where the cp command doesn't work


## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

Confirmed running pnpm:webviews create the webviews dir in agent/dist

![image](https://github.com/user-attachments/assets/6bb02704-ed55-4cc3-a907-03e16435db3a)


## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->

NA