### PR TITLE
Smart Apply: Disable retry lens

### DIFF
--- a/vscode/src/non-stop/codelenses/items.ts
+++ b/vscode/src/non-stop/codelenses/items.ts
@@ -37,7 +37,7 @@ export function getLensesForTask(task: FixupTask): vscode.CodeLens[] {
 
             // Optional:
             // Retries only makes sense if the user created the prompt
-            const canRetry = task.intent !== 'fix' && task.intent !== 'doc' && !isTest
+            const canRetry = task.intent !== 'fix' && task.intent !== 'doc' && !isTest && !isChatEdit
             const retryLens = canRetry ? getRetryLens(codeLensRange, task.id) : null
 
             // Diffs only if there's code that's changed


### PR DESCRIPTION
## Description

"Retry" is not relevant to smart apply

## Test plan

1. Execute a smart apply
2. Observe the code lens in the document
3. Check that "Retry" is not visible

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
