### PR TITLE
Chat: update webview content security policy template

### DIFF
--- a/vscode/src/chat/chat-view/ChatController.ts
+++ b/vscode/src/chat/chat-view/ChatController.ts
@@ -1889,5 +1889,5 @@ export async function addWebviewViewHTML(
     // 2. Update URIs for content security policy to only allow specific scripts to be run
     view.webview.html = decoded
         .replaceAll('./', `${resources.toString()}/`)
-        .replaceAll('{cspSource}', view.webview.cspSource)
+        .replaceAll("'self'", view.webview.cspSource)
 }

--- a/vscode/webviews/index.html
+++ b/vscode/webviews/index.html
@@ -6,7 +6,7 @@
         <!-- This content security policy also implicitly disables inline scripts and styles. -->
         <meta
             http-equiv="Content-Security-Policy"
-            content="default-src 'none'; img-src {cspSource} https: data:; script-src {cspSource}; style-src {cspSource}; font-src data: {cspSource};"
+            content="default-src 'none'; img-src 'self' https: data:; script-src 'self'; style-src 'self'; font-src data: 'self';"
         />
         <!-- DO NOT REMOVE: THIS FILE IS THE ENTRY FILE FOR CODY WEBVIEW -->
         <title>Cody</title>


### PR DESCRIPTION
- Update the content security policy in the chat webview template file index.html to use `'self'` instead of `{cspSource}` to allow the webview to load resources from the same origin by default without needing to specific cspSource

This change allows clients to run the webview with the template file by default


## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

Green UI - This  change should not have impact with any current features or webviews setup

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
