### PR TITLE
Edit: Correctly guard against duplicate in-progress edits

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -10,6 +10,8 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 
 ### Fixed
 
+- Edit: Fixed a case where multiple, duplicate, edit commands would be created unintentionally. [pull/5183](https://github.com/sourcegraph/cody/pull/5183)
+
 ### Changed
 
 ## 1.30.3

--- a/vscode/src/edit/manager.ts
+++ b/vscode/src/edit/manager.ts
@@ -188,8 +188,8 @@ export class EditManager implements vscode.Disposable {
         const activeTask = this.controller.tasksForFile(task.fixupFile).find(activeTask => {
             return (
                 ACTIVE_TASK_STATES.includes(activeTask.state) &&
-                activeTask.instruction === task!.instruction &&
-                activeTask.selectionRange.isEqual(task!.selectionRange)
+                activeTask.instruction.toString() === task.instruction.toString() &&
+                activeTask.selectionRange.isEqual(task.selectionRange)
             )
         })
 


### PR DESCRIPTION
## Description

Edit `instruction` is no longer a `string`, but a `PromptString` object.

This meant that our equality check failed, the two strings were identical, but not considered the same due to how object equality works in JS

## Test plan

1. Select some code
1. Open the Cody sidebar
1. Hit "Document Code" or "Generate Unit Test" multiple times
1. Confirm that only one "Document Code" or "Generate Unit Test" command runs 

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->