### PR TITLE
Add window/showSaveDialog to the protocol

### DIFF
--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/agent/protocol_generated/CodyAgentClient.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/agent/protocol_generated/CodyAgentClient.kt
@@ -12,6 +12,8 @@ interface CodyAgentClient {
   // ========
   @JsonRequest("window/showMessage")
   fun window_showMessage(params: ShowWindowMessageParams): CompletableFuture<String?>
+  @JsonRequest("window/showSaveDialog")
+  fun window_showSaveDialog(params: Null?): CompletableFuture<String?>
   @JsonRequest("textDocument/edit")
   fun textDocument_edit(params: TextDocumentEditParams): CompletableFuture<Boolean>
   @JsonRequest("textDocument/openUntitledDocument")

--- a/agent/src/vscode-shim.ts
+++ b/agent/src/vscode-shim.ts
@@ -755,8 +755,12 @@ const _window: typeof vscode.window = {
         throw new Error('Not implemented: vscode.window.showOpenDialog')
     },
     showSaveDialog: () => {
-        console.log(new Error().stack)
-        throw new Error('Not implemented: vscode.window.showSaveDialog')
+        if (agent) {
+            return agent.request('window/showSaveDialog', null).then(result => {
+                return result ? Uri.parse(result) : undefined
+            })
+        }
+        return Promise.resolve(undefined)
     },
     showInputBox: () => {
         console.log(new Error().stack)

--- a/vscode/src/jsonrpc/agent-protocol.ts
+++ b/vscode/src/jsonrpc/agent-protocol.ts
@@ -323,6 +323,7 @@ export type ClientRequests = {
 // ================
 export type ServerRequests = {
     'window/showMessage': [ShowWindowMessageParams, string | null]
+    'window/showSaveDialog': [null, string | undefined | null]
 
     'textDocument/edit': [TextDocumentEditParams, boolean]
     'textDocument/openUntitledDocument': [UntitledTextDocument, ProtocolTextDocument | undefined | null]


### PR DESCRIPTION
Needed for https://linear.app/sourcegraph/issue/CODY-2801/implement-vscodewindowshowsavedialog-to-get-save-file-button
JetBrains part: https://github.com/sourcegraph/jetbrains/pull/2040

## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
Use the test plan from: https://github.com/sourcegraph/jetbrains/pull/2040


## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
