### PR TITLE
Edit/Smart Apply: Correctly handle `add` insertion ranges

### DIFF
--- a/vscode/src/edit/output/response-transformer.test.ts
+++ b/vscode/src/edit/output/response-transformer.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, it } from 'vitest'
-import type { FixupTask } from '../../non-stop/FixupTask'
 import { responseTransformer } from './response-transformer'
 import { RESPONSE_TEST_FIXTURES } from './test-fixtures'
 
@@ -8,7 +7,7 @@ describe('responseTransformer', () => {
         'responseTransformer with %s',
         (name, fixture) => {
             it(`should correctly transform response for ${name}`, () => {
-                const result = responseTransformer(fixture.response, {} as FixupTask, true)
+                const result = responseTransformer(fixture.response, fixture.task, true)
                 expect(result).toEqual(fixture.expected)
             })
         }

--- a/vscode/src/edit/output/response-transformer.ts
+++ b/vscode/src/edit/output/response-transformer.ts
@@ -30,7 +30,6 @@ const MARKDOWN_CODE_BLOCK_REGEX = new RegExp(
     'g'
 )
 
-
 const LEADING_SPACES_AND_NEW_LINES = /^\s*\n/
 const LEADING_SPACES = /^[ ]+/
 
@@ -45,7 +44,7 @@ export function responseTransformer(
     isMessageInProgress: boolean
 ): string {
     const strippedText = text
-        // Strip specific XML tags referenced in the prompt, e.g. 
+        // Strip specific XML tags referenced in the prompt, e.g. <CODE511>
         .replaceAll(PROMPT_TOPIC_REGEX, '')
         // Strip Markdown syntax for code blocks, e.g. ```typescript.
         .replaceAll(MARKDOWN_CODE_BLOCK_REGEX, block =>
@@ -56,9 +55,12 @@ export function responseTransformer(
     // - For `add` insertions, the LLM will attempt to continue the code from the position of the cursor, we handle the `insertionPoint`
     //   but we should preserve new lines as they may be valuable for spacing
     // - For other edits, we already trim the selection to exclude padded whitespace, we only want the start of the incoming text
-    const trimmedText = task.intent === 'add' ? strippedText.replace(LEADING_SPACES, '') : strippedText.replace(LEADING_SPACES_AND_NEW_LINES, '')
+    const trimmedText =
+        task.intent === 'add'
+            ? strippedText.replace(LEADING_SPACES, '')
+            : strippedText.replace(LEADING_SPACES_AND_NEW_LINES, '')
 
-    // Strip the response of any remaining HTML entities such as < and >
+    // Strip the response of any remaining HTML entities such as &lt; and &gt;
     const decodedText = decode(trimmedText)
 
     if (!isMessageInProgress) {

--- a/vscode/src/edit/output/test-fixtures.ts
+++ b/vscode/src/edit/output/test-fixtures.ts
@@ -1,34 +1,43 @@
+import type { FixupTask } from '../../non-stop/FixupTask'
 import { PROMPT_TOPICS } from '../prompt/constants'
 
 interface ResponseTestFixture {
     response: string
     expected: string
+    task: FixupTask
 }
 
 const CLEAN_RESPONSE = `export function logDebug<T extends string>(filterLabel: string, text: string, ...args: unknown[]): void {
     log<T>('error', filterLabel, text, ...args)
 }`
 
+const DEFAULT_TASK = {} as FixupTask
+
 export const RESPONSE_TEST_FIXTURES: Record<string, ResponseTestFixture> = {
     clean: {
         response: CLEAN_RESPONSE,
         expected: CLEAN_RESPONSE,
+        task: DEFAULT_TASK,
     },
     withTags: {
         response: `<${PROMPT_TOPICS.OUTPUT}>` + CLEAN_RESPONSE + `</${PROMPT_TOPICS.OUTPUT}>`,
         expected: CLEAN_RESPONSE,
+        task: DEFAULT_TASK,
     },
     withIncorrectNumberedTag: {
         response: '<CODE123>' + CLEAN_RESPONSE + '</CODE789>',
         expected: CLEAN_RESPONSE,
+        task: DEFAULT_TASK,
     },
     withMarkdownSyntax: {
         response: '```\n' + CLEAN_RESPONSE + '```',
         expected: CLEAN_RESPONSE,
+        task: DEFAULT_TASK,
     },
     withMarkdownSyntaxAndLang: {
         response: '```typescript\n' + CLEAN_RESPONSE + '```',
         expected: CLEAN_RESPONSE,
+        task: DEFAULT_TASK,
     },
     withMarkdownSyntaxAndTags: {
         response:
@@ -38,9 +47,22 @@ export const RESPONSE_TEST_FIXTURES: Record<string, ResponseTestFixture> = {
             `</${PROMPT_TOPICS.OUTPUT}>` +
             '```',
         expected: CLEAN_RESPONSE,
+        task: DEFAULT_TASK,
     },
     withHtmlEntities: {
         response: CLEAN_RESPONSE.replace(/</g, '&lt;').replace(/>/g, '&gt;'),
         expected: CLEAN_RESPONSE,
+        task: DEFAULT_TASK,
+    },
+    withLeadingSpaces: {
+        response: '   \n\n' + CLEAN_RESPONSE,
+        expected: CLEAN_RESPONSE,
+        task: DEFAULT_TASK,
+    },
+    withLeadingSpacesAndAddIntent: {
+        response: '   \n\n' + CLEAN_RESPONSE,
+        // Leading new lines are valuable information for `add`
+        expected: '\n\n' + CLEAN_RESPONSE,
+        task: { ...DEFAULT_TASK, intent: 'add' } as FixupTask,
     },
 }

--- a/vscode/src/non-stop/FixupTask.ts
+++ b/vscode/src/non-stop/FixupTask.ts
@@ -78,15 +78,7 @@ export class FixupTask {
     ) {
         this.id = Date.now().toString(36).replaceAll(/\d+/g, '')
         this.instruction = instruction.replace(/^\/(edit|fix)/, ps``).trim()
-        // We always expand the range to encompass all characters from the selection lines
-        // This is so we can calculate an optimal diff, and the LLM has the best chance at understanding
-        // the indentation in the returned code.
-        this.selectionRange = new vscode.Range(
-            selectionRange.start.line,
-            0,
-            selectionRange.end.line,
-            document.lineAt(selectionRange.end.line).range.end.character
-        )
+        this.selectionRange = this.getDefaultSelectionRange(selectionRange)
         this.originalRange = this.selectionRange
     }
 
@@ -108,5 +100,22 @@ export class FixupTask {
      */
     public get state(): CodyTaskState {
         return this.state_
+    }
+
+    private getDefaultSelectionRange(proposedRange: vscode.Range): vscode.Range {
+        if (this.intent === 'add') {
+            // We are only adding new code, no need to expand the range
+            return proposedRange
+        }
+
+        // For all other Edits, we always expand the range to encompass all characters from the selection lines
+        // This is so we can calculate an optimal diff, and the LLM has the best chance at understanding
+        // the indentation in the returned code.
+        return new vscode.Range(
+            proposedRange.start.line,
+            0,
+            proposedRange.end.line,
+            this.document.lineAt(proposedRange.end.line).range.end.character
+        )
     }
 }


### PR DESCRIPTION
closes CODY-3243

## Description

Initially reported here: https://sourcegraph.slack.com/archives/C05MW2TMYAV/p1723448811005809

Fixes a bug with Smart Apply where:
- Cody wants to `insert` a change to the bottom of the file, but that file doesn't have an empty final line

This uncovered two aspects that I've fixed here:
- Chat responses don't typically include line spacing, but we do need it here. I've added logic to manually inject a whitespace line if the final line is non-empty.
- The `responseTransformer` for the `add` command doesn't work effectively. New lines _are_ valuable information here that the LLM is more likely to provide, as we're essentially asking it to continue from the previous cursor position with an instruction.

## Test plan

1. Create edits with the `add` intent, check that they appear correctly
2. Create smart applies that add to the bottom of a file with a non-empty final line, check it appears correctly
