### PR TITLE
Smart Apply: Add basic UI to support other IDEs

### DIFF
--- a/vscode/src/chat/chat-view/ChatController.ts
+++ b/vscode/src/chat/chat-view/ChatController.ts
@@ -560,7 +560,8 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
     private async isSmartApplyEnabled(): Promise<boolean> {
         const config = await getFullConfig()
         if (config.isRunningInsideAgent) {
-            // Only supported in VS Code right now, until we test and iterate on the UI for other clients.
+            // Only supported in VS Code right now, until we test on other clients.
+            // TODO: Enable in other clients based on clientCapabilities
             return false
         }
 

--- a/vscode/webviews/chat/ChatMessageContent/ChatMessageContent.tsx
+++ b/vscode/webviews/chat/ChatMessageContent/ChatMessageContent.tsx
@@ -5,6 +5,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { clsx } from 'clsx'
 import type { FixupTaskID } from '../../../src/non-stop/FixupTask'
 import { CodyTaskState } from '../../../src/non-stop/state'
+import type { UserAccountInfo } from '../../Chat'
 import { type ClientActionListener, useClientActionListener } from '../../client/clientState'
 import { MarkdownFromCody } from '../../components/MarkdownFromCody'
 import type { PriorHumanMessageInfo } from '../cells/messageCell/assistant/AssistantMessageCell'
@@ -27,6 +28,7 @@ interface ChatMessageContentProps {
     displayMarkdown: string
     isMessageLoading: boolean
     humanMessage: PriorHumanMessageInfo | null
+    userInfo: UserAccountInfo
 
     copyButtonOnSubmit?: CodeBlockActionsProps['copyButtonOnSubmit']
     insertButtonOnSubmit?: CodeBlockActionsProps['insertButtonOnSubmit']
@@ -51,6 +53,7 @@ export const ChatMessageContent: React.FunctionComponent<ChatMessageContentProps
     className,
     experimentalSmartApplyEnabled,
     smartApply,
+    userInfo,
 }) => {
     const rootRef = useRef<HTMLDivElement>(null)
 
@@ -116,8 +119,10 @@ export const ChatMessageContent: React.FunctionComponent<ChatMessageContentProps
                     buttons = createButtonsExperimentalUI(
                         preText,
                         humanMessage,
+                        userInfo,
                         fileName,
                         copyButtonOnSubmit,
+                        insertButtonOnSubmit,
                         smartApplyInterceptor,
                         smartApplyId,
                         smartApplyState

--- a/vscode/webviews/chat/cells/messageCell/assistant/AssistantMessageCell.tsx
+++ b/vscode/webviews/chat/cells/messageCell/assistant/AssistantMessageCell.tsx
@@ -118,6 +118,7 @@ export const AssistantMessageCell: FunctionComponent<{
                                 humanMessage={humanMessage}
                                 experimentalSmartApplyEnabled={experimentalSmartApplyEnabled}
                                 smartApply={smartApply}
+                                userInfo={userInfo}
                             />
                         ) : (
                             isLoading && <LoadingDots />


### PR DESCRIPTION
## Description

The current smart apply implementation uses an OS-native dropdown for "Insert at Cursor" and "Save to New File". This is via a VS Code API. It works well for this initial MVP version, but obviously will not work in other clients.

This PR implements a fallback UI for other clients that is the same as the current UI for these actions.

See screenshots

**VS Code WebView**

<img width="476" alt="image" src="https://github.com/user-attachments/assets/454daeb3-c3be-4349-882b-8c00579bc225">

**Other Clients WebView**

<img width="470" alt="image" src="https://github.com/user-attachments/assets/2e2ea69e-c8ff-4cad-8597-ef06c42a7225">

## Test plan

1. Test all code block actions in VS Code mode in the webview, check they all works
1. Test all code block actions in non-VS Code mode in the webview, check they all works

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

