### PR TITLE
Chat: update stylesheet for visual studio

### DIFF
--- a/agent/src/vscode-shim.ts
+++ b/agent/src/vscode-shim.ts
@@ -970,6 +970,9 @@ _commands?.registerCommand?.('vscode.executeDocumentSymbolProvider', uri => {
     // location.
     return Promise.resolve([])
 })
+_commands?.registerCommand?.('vscode.executeWorkspaceSymbolProvider', query => {
+    return Promise.resolve([])
+})
 _commands?.registerCommand?.('vscode.executeFormatDocumentProvider', uri => {
     return Promise.resolve([])
 })

--- a/vscode/webviews/Chat.module.css
+++ b/vscode/webviews/Chat.module.css
@@ -2,7 +2,7 @@
     height: 100%;
     display: flex;
     flex-direction: column;
-    overflow: scroll;
+    overflow: auto;
 }
 
 .chat-disabled {

--- a/vscode/webviews/OnboardingExperiment.tsx
+++ b/vscode/webviews/OnboardingExperiment.tsx
@@ -51,7 +51,7 @@ const WebLogin: React.FunctionComponent<
                         event.stopPropagation()
                     }}
                 >
-                    Add the Access Token to VS Code
+                    Add Access Token to Cody
                 </a>
             </li>
         </ol>

--- a/vscode/webviews/tabs/TabsBar.tsx
+++ b/vscode/webviews/tabs/TabsBar.tsx
@@ -126,7 +126,7 @@ export const TabsBar: React.FC<TabsBarProps> = ({ currentView, setView, IDE }) =
                                 alwaysShowTitle: true,
                                 tooltipExtra: (
                                     <>
-                                        {IDE !== CodyIDE.Web && (
+                                        {IDE === CodyIDE.VSCode && (
                                             <Kbd macOS="shift+opt+l" linuxAndWindows="shift+alt+l" />
                                         )}
                                     </>

--- a/vscode/webviews/themes/visual-studio.css
+++ b/vscode/webviews/themes/visual-studio.css
@@ -22,9 +22,9 @@ html[data-ide='VisualStudio'] {
     --vscode-button-background: var(--visualstudio-filetabbackground);
     --vscode-button-hoverBackground: var(--visualstudio-filetabselectedbackground);
     --vscode-button-foreground: var(--visualstudio-filetabparenttext);
-    --vscode-button-secondaryHoverBackground: var(--visualstudio-editorexpansionlink);
-    --vscode-button-secondaryBackground: var(--visualstudio-editorexpansionlink);
-    --vscode-button-secondaryForeground: var(--visualstudio-editorexpansionfill);
+    --vscode-button-secondaryHoverBackground: var(--visualstudio-filetabprovisionalhover);
+    --vscode-button-secondaryBackground: var(--visualstudio-filetabbackground);
+    --vscode-button-secondaryForeground: var(--visualstudio-filetabinactivetext);
     --vscode-button-separator: var(--visualstudio-filetabprimaryseparator);
     --vscode-charts-blue: var(--visualstudio-vizsurfacesoftbluedark);
     --vscode-charts-foreground: var(--visualstudio-);
@@ -107,7 +107,7 @@ html[data-ide='VisualStudio'] {
     --vscode-editor-findMatchHighlightBorder: var(--visualstudio-);
     --vscode-editor-findRangeHighlightBorder: var(--visualstudio-);
     --vscode-editor-focusedStackFrameHighlightBackground: var(--visualstudio-);
-    --vscode-editor-foreground: var(--visualstudio-);
+    --vscode-editor-foreground: var(--visualstudio-toolwindowtext);
     --vscode-editor-hoverHighlightBackground: var(--visualstudio-);
     --vscode-editor-inactiveSelectionBackground: var(--visualstudio-);
     --vscode-editor-inlineValuesBackground: var(--visualstudio-);
@@ -251,7 +251,7 @@ html[data-ide='VisualStudio'] {
     --vscode-editorWidget-background: var(--visualstudio-);
     --vscode-editorWidget-border: var(--visualstudio-);
     --vscode-editorWidget-foreground: var(--visualstudio-);
-    --vscode-errorForeground: var(--visualstudio-);
+    --vscode-errorForeground: var(--visualstudio-toolwindowvalidationerrortext);
     --vscode-extensionBadge-remoteBackground: var(--visualstudio-);
     --vscode-extensionBadge-remoteForeground: var(--visualstudio-);
     --vscode-extensionButton-separator: var(--visualstudio-);
@@ -276,19 +276,20 @@ html[data-ide='VisualStudio'] {
     --vscode-inputValidation-warningBorder: var(--visualstudio-);
     --vscode-interactive-activeCodeBorder: var(--visualstudio-);
     --vscode-interactive-inactiveCodeBorder: var(--visualstudio-);
-    --vscode-keybindingLabel-background: var(--visualstudio-);
-    --vscode-keybindingLabel-border: var(--visualstudio-);
-    --vscode-keybindingLabel-bottomBorder: var(--visualstudio-);
-    --vscode-keybindingLabel-foreground: var(--visualstudio-);
+    --vscode-keybindingLabel-background: var(--visualstudio-helpsearchbackground);
+    --vscode-keybindingLabel-border: var(--visualstudio-helpsearchborder);
+    --vscode-keybindingLabel-bottomBorder: var(--visualstudio-helpsearchfilterborder);
+    --vscode-keybindingLabel-foreground: var(--visualstudio-helpsearchtext);
     --vscode-list-deemphasizedForeground: var(--visualstudio-);
     --vscode-list-filterMatchBorder: var(--visualstudio-);
     --vscode-list-focusHighlightForeground: var(--visualstudio-);
     --vscode-list-focusOutline: var(--visualstudio-);
     --vscode-list-highlightForeground: var(--visualstudio-);
     --vscode-list-hoverBackground: var(--visualstudio-);
-    --vscode-list-invalidItemForeground: var(--visualstudio-);
-    --vscode-list-activeSelectionForeground: var(--visualstudio-);
-    --vscode-list-activeSelectionBackground: var(--visualstudio-);
+    --vscode-list-invalidItemForeground: var(--visualstudio-toolwindowvalidationerrortext);
+    --vscode-list-inactiveSelectionBackground: var(--visualstudio-sortbackground);
+    --vscode-list-activeSelectionForeground: var(--visualstudio-sorttext);
+    --vscode-list-activeSelectionBackground: var(--visualstudio-sortbackground);
     --vscode-listFilterWidget-background: var(--visualstudio-);
     --vscode-listFilterWidget-noMatchesOutline: var(--visualstudio-);
     --vscode-listFilterWidget-outline: var(--visualstudio-);
@@ -394,15 +395,15 @@ html[data-ide='VisualStudio'] {
     --vscode-remoteHub-decorations-modifiedForegroundColor: var(--visualstudio-);
     --vscode-remoteHub-decorations-submoduleForegroundColor: var(--visualstudio-);
     --vscode-remoteHub-decorations-workspaceRepositoriesView-hasUncommittedChangesForegroundColor: var(--visualstudio-);
-    --vscode-scm-historyItemStatisticsBorder: var(--visualstudio-);
+    --vscode-scm-historyItemStatisticsBorder: var(--visualstudio-scrollbararrowglyph);
     --vscode-scrollbar-shadow: var(--visualstudio-scrollbarthumbglyph);
-    --vscode-scrollbarSlider-activeBackground: var(--visualstudio-scrollbarbackground);
+    --vscode-scrollbarSlider-activeBackground: var(--visualstudio-scrollbarthumbpressedbackground);
     --vscode-scrollbarSlider-background: var(--visualstudio-scrollbarbackground);
-    --vscode-scrollbarSlider-hoverBackground: var(--visualstudio-scrollbarbackground);
+    --vscode-scrollbarSlider-hoverBackground: var(--visualstudio-scrollbarthumbmouseoverbackground);
     --vscode-search-resultsInfoForeground: var(--visualstudio-);
     --vscode-searchEditor-findMatchBorder: var(--visualstudio-);
     --vscode-searchEditor-textInputBorder: var(--visualstudio-);
-    --vscode-selection-background: var(--visualstudio-);
+    --vscode-selection-background: var(--visualstudio-ComboBoxSelection);
     --vscode-settings-checkboxBackground: var(--visualstudio-);
     --vscode-settings-checkboxBorder: var(--visualstudio-);
     --vscode-settings-checkboxForeground: var(--visualstudio-);
@@ -593,7 +594,7 @@ html[data-ide='VisualStudio'] {
     --vscode-widget-shadow: var(--visualstudio-buttonshadow);
 
     /* Mimic rules injected by VSCode */
-    scrollbar-color: var(--visualstudio-scrollbarthumbbackground);
+    scrollbar-color: var(--vscode-scrollbarSlider-background) var(--vscode-editor-background);
 
 }
 


### PR DESCRIPTION
- Add empty mock of "vscode.executeWorkspaceSymbolProvider" to vs code shim.
- Display New Chat keybinding for VS Code only as the shortcut only works for VS Code. In the future we should allow clients to send a list of shortcuts and display those instead. Part of https://linear.app/sourcegraph/issue/CODY-3046/web-ui-displays-vscode-shortcuts-not-jetbrains-ones
- Update stylesheet for Visual Studio
- In Login page, remove mention of VS Code, replace "Add the Access Token to VS Code" with "Add Access Token to Cody" - CLOSE https://linear.app/sourcegraph/issue/CODY-2920/sign-in-screen-mentions-vscode-doesnt-have-pretty-buttons
- Also fixed a minor regression on main where scrollbar is always shown by default:

<img width="477" alt="image" src="https://github.com/user-attachments/assets/d5db19de-1df3-4470-92a8-38be7676cd5d">

## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

Green CI - since all changes are mostly UI specified and should not change any current behavior.

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->

Chat: remove scrollbar from showing when not needed.