### PR TITLE
Remove the redundant and confusing logging about the completions provider used by Cody

### DIFF
--- a/vscode/src/completions/inline-completion-item-provider.ts
+++ b/vscode/src/completions/inline-completion-item-provider.ts
@@ -184,11 +184,6 @@ export class InlineCompletionItemProvider
         const chatHistory = localStorage.getChatHistory(this.config.authStatus)?.chat
         this.isProbablyNewInstall = !chatHistory || Object.entries(chatHistory).length === 0
 
-        logDebug(
-            'CodyCompletionProvider:initialized',
-            [this.config.providerConfig.identifier, this.config.providerConfig.model].join('/')
-        )
-
         this.disposables.push(this.contextMixer)
         if (!this.config.noInlineAccept) {
             // We don't want to accept and log items when we are doing completion comparison from different models.


### PR DESCRIPTION
During the testing phase for [Enterprise model selection training](https://docs.google.com/document/d/19AC8KF4Q3pz9VtvCg_qUY6PWaXe_V2hk_yQKDmikyZw/edit#heading=h.qi3klszb0l6o) we found this in the logs 


This confused people for so long because it makes people think that AWS bedrock is using `claude-instant-1.2` model which we don't use anymore 
<img width="623" alt="image" src="https://github.com/user-attachments/assets/738b8f7f-0c06-4bb5-b8db-db8321eb56af">

The problem here is that we use this in logging for BYOK models only on the client side because its a fallback model [added here](https://github.com/sourcegraph/cody/blob/d51edf2cf306fc5052186b2f8916d907d119bb74/vscode/src/completions/providers/create-provider.ts#L96). This fallback model is the HARDCODED base model of claude-instant-1.2 but its not actually used on the client and all the real requests for completions go to claude haiku or whichever model we are using at the moment for completions with the BYOK customers. 

This logging also causes other problems because it uses some hardcoded logic with fallbacks in place to retrieve the model name and so we end up in scenarios like the one below where we just see that open ai is being used and it doesn't tell you the actual model being used 

<img width="527" alt="image" src="https://github.com/user-attachments/assets/8025d526-4893-493d-8402-407733c5b9d1">


I think we should just get rid of this logging mechanism because right now thanks to the changes from @slimsag we just make a GQL request to get the logs of the providers used so we get a log like this 
```
█ CodyLLMConfiguration: {"chatModel":"claude-3-opus-20240229","chatModelMaxTokens":12000,"fastChatModel":"claude-3-haiku-20240307","fastChatModelMaxTokens":12000,"completionModel":"claude-3-haiku-20240307","completionModelMaxTokens":12000,"provider":"anthropic","smartContextWindow":true}
█ ClientConfigSingleton: refreshing configuration
█ ClientConfigSingleton: refreshed {"codyEnabled":true,"chatEnabled":true,"autoCompleteEnabled":true,"customCommandsEnabled":true,"attributionEnabled":false,"smartContextWindowEnabled":true,"modelsAPIEnabled":false}
```
Its best to just have one source of the logs of the actual model used.

NOTE: 
1.I am aware that I can probably do a much deeper refactor where I can get rid of a lot of code in an around this stuff because the new changes from stephen make it possible but right now I don't have the time to focus on that
2. The code related to the strange fallback mechanism originally came in this PR https://github.com/sourcegraph/cody/pull/2783

## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
