### PR TITLE
Agent: add new sidebar panel agent protocol & webview sign-in form

### DIFF
--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/agent/protocol_generated/Chat_Sidebar_NewResult.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/agent/protocol_generated/Chat_Sidebar_NewResult.kt
@@ -1,0 +1,8 @@
+@file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
+package com.sourcegraph.cody.agent.protocol_generated;
+
+data class Chat_Sidebar_NewResult(
+  val panelId: String,
+  val chatId: String,
+)
+

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/agent/protocol_generated/CodyAgentClient.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/agent/protocol_generated/CodyAgentClient.kt
@@ -64,4 +64,6 @@ interface CodyAgentClient {
   fun webview_setOptions(params: Webview_SetOptionsParams)
   @JsonNotification("webview/setHtml")
   fun webview_setHtml(params: Webview_SetHtmlParams)
+  @JsonNotification("window/didChangeContext")
+  fun window_didChangeContext(params: Window_DidChangeContextParams)
 }

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/agent/protocol_generated/CodyAgentServer.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/agent/protocol_generated/CodyAgentServer.kt
@@ -18,6 +18,8 @@ interface CodyAgentServer {
   fun chat_new(params: Null?): CompletableFuture<String>
   @JsonRequest("chat/web/new")
   fun chat_web_new(params: Null?): CompletableFuture<Chat_Web_NewResult>
+  @JsonRequest("chat/sidebar/new")
+  fun chat_sidebar_new(params: Null?): CompletableFuture<Chat_Sidebar_NewResult>
   @JsonRequest("chat/delete")
   fun chat_delete(params: Chat_DeleteParams): CompletableFuture<List<ChatExportResult>>
   @JsonRequest("chat/restore")

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/agent/protocol_generated/Window_DidChangeContextParams.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/agent/protocol_generated/Window_DidChangeContextParams.kt
@@ -1,0 +1,8 @@
+@file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
+package com.sourcegraph.cody.agent.protocol_generated;
+
+data class Window_DidChangeContextParams(
+  val key: String,
+  val value: String? = null,
+)
+

--- a/agent/src/agent.ts
+++ b/agent/src/agent.ts
@@ -1172,6 +1172,18 @@ export class Agent extends MessageHandler implements ExtensionClient {
             return { panelId, chatId }
         })
 
+        this.registerAuthenticatedRequest('chat/sidebar/new', async () => {
+            const panelId = await this.createChatPanel(
+                Promise.resolve({
+                    type: 'chat',
+                    session: await vscode.commands.executeCommand('cody.chat.newPanel'),
+                })
+            )
+
+            const chatId = this.webPanels.panels.get(panelId)?.chatID ?? ''
+            return { panelId, chatId }
+        })
+
         // TODO: JetBrains no longer uses this, consider deleting it.
         this.registerAuthenticatedRequest('chat/restore', async ({ modelID, messages, chatID }) => {
             const authStatus = await vscode.commands.executeCommand<AuthStatus>('cody.auth.status')

--- a/agent/src/vscode-shim.ts
+++ b/agent/src/vscode-shim.ts
@@ -950,6 +950,7 @@ _commands?.registerCommand?.('setContext', (key, value) => {
         throw new TypeError(`setContext: first argument must be string. Got: ${key}`)
     }
     context.set(key, value)
+    agent?.notify('window/didChangeContext', { key, value })
 })
 _commands?.registerCommand?.('vscode.executeFoldingRangeProvider', async uri => {
     const promises: vscode.FoldingRange[] = []

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -480,6 +480,9 @@ importers:
       '@radix-ui/react-dialog':
         specifier: ^1.0.5
         version: 1.0.5(@types/react-dom@18.2.25)(@types/react@18.2.79)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-form':
+        specifier: ^0.1.0
+        version: 0.1.0(@types/react-dom@18.2.25)(@types/react@18.2.79)(react-dom@18.2.0)(react@18.2.0)
       '@radix-ui/react-popover':
         specifier: ^1.0.7
         version: 1.0.7(@types/react-dom@18.2.25)(@types/react@18.2.79)(react-dom@18.2.0)(react@18.2.0)
@@ -4600,6 +4603,31 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
     dev: false
 
+  /@radix-ui/react-form@0.1.0(@types/react-dom@18.2.25)(@types/react@18.2.79)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-1/oVYPDjbFILOLIarcGcMKo+y6SbTVT/iUKVEw59CF4offwZgBgC3ZOeSBewjqU0vdA6FWTPWTN63obj55S/tQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+    dependencies:
+      '@radix-ui/primitive': 1.1.0
+      '@radix-ui/react-compose-refs': 1.1.0(@types/react@18.2.79)(react@18.2.0)
+      '@radix-ui/react-context': 1.1.0(@types/react@18.2.79)(react@18.2.0)
+      '@radix-ui/react-id': 1.1.0(@types/react@18.2.79)(react@18.2.0)
+      '@radix-ui/react-label': 2.1.0(@types/react-dom@18.2.25)(@types/react@18.2.79)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-primitive': 2.0.0(@types/react-dom@18.2.25)(@types/react@18.2.79)(react-dom@18.2.0)(react@18.2.0)
+      '@types/react': 18.2.79
+      '@types/react-dom': 18.2.25
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    dev: false
+
   /@radix-ui/react-id@1.0.1(@types/react@18.2.37)(react@18.2.0):
     resolution: {integrity: sha512-tI7sT/kqYp8p96yGWY1OAnLHrqDgzHefRBKQ2YAkBS5ja7QLcZ9Z/uY7bEjPUatf8RomoXM8/1sMj1IJaE5UzQ==}
     peerDependencies:
@@ -4642,6 +4670,26 @@ packages:
       '@radix-ui/react-use-layout-effect': 1.1.0(@types/react@18.2.79)(react@18.2.0)
       '@types/react': 18.2.79
       react: 18.2.0
+    dev: false
+
+  /@radix-ui/react-label@2.1.0(@types/react-dom@18.2.25)(@types/react@18.2.79)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-peLblDlFw/ngk3UWq0VnYaOLy6agTZZ+MUO/WhVfm14vJGML+xH4FAl2XQGLqdefjNb7ApRg6Yn7U42ZhmYXdw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+    dependencies:
+      '@radix-ui/react-primitive': 2.0.0(@types/react-dom@18.2.25)(@types/react@18.2.79)(react-dom@18.2.0)(react@18.2.0)
+      '@types/react': 18.2.79
+      '@types/react-dom': 18.2.25
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
     dev: false
 
   /@radix-ui/react-popover@1.0.7(@types/react-dom@18.2.25)(@types/react@18.2.79)(react-dom@18.2.0)(react@18.2.0):

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -54,7 +54,12 @@
     "version-bump:patch": "RELEASE_TYPE=patch ts-node-transpile-only ./scripts/version-bump.ts",
     "version-bump:dry-run": "RELEASE_TYPE=prerelease ts-node-transpile-only ./scripts/version-bump.ts"
   },
-  "categories": ["Programming Languages", "Machine Learning", "Snippets", "Education"],
+  "categories": [
+    "Programming Languages",
+    "Machine Learning",
+    "Snippets",
+    "Education"
+  ],
   "keywords": [
     "ai",
     "openai",
@@ -107,7 +112,11 @@
   },
   "main": "./dist/extension.node.js",
   "browser": "./dist/extension.web.js",
-  "activationEvents": ["onLanguage", "onStartupFinished", "onWebviewPanel:cody.editorPanel"],
+  "activationEvents": [
+    "onLanguage",
+    "onStartupFinished",
+    "onWebviewPanel:cody.editorPanel"
+  ],
   "contributes": {
     "walkthroughs": [
       {
@@ -723,13 +732,17 @@
       },
       {
         "command": "cody.supercompletion.jumpTo",
-        "args": ["next"],
+        "args": [
+          "next"
+        ],
         "key": "shift+ctrl+down",
         "when": "cody.activated && !editorReadonly && cody.hasActionableSupercompletion"
       },
       {
         "command": "cody.supercompletion.jumpTo",
-        "args": ["previous"],
+        "args": [
+          "previous"
+        ],
         "key": "shift+ctrl+up",
         "when": "cody.activated && !editorReadonly && cody.hasActionableSupercompletion"
       }
@@ -991,12 +1004,20 @@
           "order": 2,
           "type": "string",
           "markdownDescription": "A Git repository URL to use instead of allowing Cody to infer the Git repository from the workspace.",
-          "examples": ["https://github.com/sourcegraph/cody", "ssh://git@github.com/sourcegraph/cody"]
+          "examples": [
+            "https://github.com/sourcegraph/cody",
+            "ssh://git@github.com/sourcegraph/cody"
+          ]
         },
         "cody.useContext": {
           "order": 99,
           "type": "string",
-          "enum": ["embeddings", "keyword", "blended", "none"],
+          "enum": [
+            "embeddings",
+            "keyword",
+            "blended",
+            "none"
+          ],
           "default": "blended",
           "markdownDescription": "Controls which context providers Cody uses for chat, commands and inline edits. Use 'blended' for best results. For debugging other context sources, 'embeddings' will use an embeddings-based index if available. 'keyword' will use a search-based index. 'none' will not use embeddings or search-based indexes."
         },
@@ -1042,12 +1063,18 @@
           "order": 6,
           "type": "string",
           "markdownDescription": "A custom instruction to be included at the start of all chat messages (e.g. \"Answer all my questions in Spanish.\")",
-          "examples": ["Answer all my questions in Spanish."]
+          "examples": [
+            "Answer all my questions in Spanish."
+          ]
         },
         "cody.chat.defaultLocation": {
           "order": 6,
           "type": "string",
-          "enum": ["sticky", "sidebar", "editor"],
+          "enum": [
+            "sticky",
+            "sidebar",
+            "editor"
+          ],
           "markdownDescription": "Controls where the Cody chat view opens when the user invokes the `Cody: New Chat` command, or the Alt+L and Alt+/ shortcuts.",
           "enumDescriptions": [
             "Opens in the last-activated view location, which is set whenever the user explicitly chooses to open chat in a given location",
@@ -1060,7 +1087,9 @@
           "order": 7,
           "type": "string",
           "markdownDescription": "A custom instruction to be included at the end of all instructions for edit commands (e.g. \"Write all unit tests with Jest instead of detected framework.\")",
-          "examples": ["Write all unit tests with Jest instead of detected framework."]
+          "examples": [
+            "Write all unit tests with Jest instead of detected framework."
+          ]
         },
         "cody.codeActions.enabled": {
           "order": 11,
@@ -1106,8 +1135,14 @@
         "cody.telemetry.level": {
           "order": 99,
           "type": "string",
-          "enum": ["all", "off"],
-          "enumDescriptions": ["Sends usage data and errors.", "Disables all extension telemetry."],
+          "enum": [
+            "all",
+            "off"
+          ],
+          "enumDescriptions": [
+            "Sends usage data and errors.",
+            "Disables all extension telemetry."
+          ],
           "markdownDescription": "Controls the telemetry about Cody usage and errors. See [Cody usage and privacy notice](https://about.sourcegraph.com/terms/cody-notice).",
           "default": "all"
         },
@@ -1136,7 +1171,11 @@
         "cody.autocomplete.advanced.model": {
           "type": "string",
           "default": null,
-          "enum": [null, "starcoder-16b", "starcoder-7b"],
+          "enum": [
+            null,
+            "starcoder-16b",
+            "starcoder-7b"
+          ],
           "markdownDescription": "Overwrite the  model used for code autocompletion inference. This is only supported with the `fireworks` provider"
         },
         "cody.autocomplete.completeSuggestWidgetSelection": {
@@ -1156,7 +1195,10 @@
         },
         "cody.experimental.foldingRanges": {
           "type": "string",
-          "enum": ["lsp", "indentation-based"],
+          "enum": [
+            "lsp",
+            "indentation-based"
+          ],
           "enumDescriptions": [
             "Use folding ranges that are enabled by default in VS Code, and are usually powered by LSP",
             "Use custom implementation of folding ranges that is indentation based. This is the implementation that is used by other Cody clients like the JetBrains plugin"
@@ -1167,7 +1209,13 @@
         "cody.autocomplete.experimental.graphContext": {
           "type": "string",
           "default": null,
-          "enum": [null, "bfg", "bfg-mixed", "tsc", "tsc-mixed"],
+          "enum": [
+            null,
+            "bfg",
+            "bfg-mixed",
+            "tsc",
+            "tsc-mixed"
+          ],
           "markdownDescription": "Use the code graph to retrieve context for autocomplete requests."
         },
         "cody.autocomplete.experimental.fireworksOptions": {
@@ -1347,7 +1395,9 @@
     "untrustedWorkspaces": {
       "supported": "limited",
       "description": "Cody only uses providers (configured in `openctx.providers`) from trusted workspaces because providers may execute arbitrary code.",
-      "restrictedConfigurations": ["openctx.providers"]
+      "restrictedConfigurations": [
+        "openctx.providers"
+      ]
     }
   },
   "dependencies": {
@@ -1368,6 +1418,7 @@
     "@radix-ui/react-accordion": "^1.2.0",
     "@radix-ui/react-collapsible": "^1.1.0",
     "@radix-ui/react-dialog": "^1.0.5",
+    "@radix-ui/react-form": "^0.1.0",
     "@radix-ui/react-popover": "^1.0.7",
     "@radix-ui/react-slot": "^1.0.2",
     "@radix-ui/react-tabs": "^1.1.0",

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -54,12 +54,7 @@
     "version-bump:patch": "RELEASE_TYPE=patch ts-node-transpile-only ./scripts/version-bump.ts",
     "version-bump:dry-run": "RELEASE_TYPE=prerelease ts-node-transpile-only ./scripts/version-bump.ts"
   },
-  "categories": [
-    "Programming Languages",
-    "Machine Learning",
-    "Snippets",
-    "Education"
-  ],
+  "categories": ["Programming Languages", "Machine Learning", "Snippets", "Education"],
   "keywords": [
     "ai",
     "openai",
@@ -112,11 +107,7 @@
   },
   "main": "./dist/extension.node.js",
   "browser": "./dist/extension.web.js",
-  "activationEvents": [
-    "onLanguage",
-    "onStartupFinished",
-    "onWebviewPanel:cody.editorPanel"
-  ],
+  "activationEvents": ["onLanguage", "onStartupFinished", "onWebviewPanel:cody.editorPanel"],
   "contributes": {
     "walkthroughs": [
       {
@@ -732,17 +723,13 @@
       },
       {
         "command": "cody.supercompletion.jumpTo",
-        "args": [
-          "next"
-        ],
+        "args": ["next"],
         "key": "shift+ctrl+down",
         "when": "cody.activated && !editorReadonly && cody.hasActionableSupercompletion"
       },
       {
         "command": "cody.supercompletion.jumpTo",
-        "args": [
-          "previous"
-        ],
+        "args": ["previous"],
         "key": "shift+ctrl+up",
         "when": "cody.activated && !editorReadonly && cody.hasActionableSupercompletion"
       }
@@ -1004,20 +991,12 @@
           "order": 2,
           "type": "string",
           "markdownDescription": "A Git repository URL to use instead of allowing Cody to infer the Git repository from the workspace.",
-          "examples": [
-            "https://github.com/sourcegraph/cody",
-            "ssh://git@github.com/sourcegraph/cody"
-          ]
+          "examples": ["https://github.com/sourcegraph/cody", "ssh://git@github.com/sourcegraph/cody"]
         },
         "cody.useContext": {
           "order": 99,
           "type": "string",
-          "enum": [
-            "embeddings",
-            "keyword",
-            "blended",
-            "none"
-          ],
+          "enum": ["embeddings", "keyword", "blended", "none"],
           "default": "blended",
           "markdownDescription": "Controls which context providers Cody uses for chat, commands and inline edits. Use 'blended' for best results. For debugging other context sources, 'embeddings' will use an embeddings-based index if available. 'keyword' will use a search-based index. 'none' will not use embeddings or search-based indexes."
         },
@@ -1063,18 +1042,12 @@
           "order": 6,
           "type": "string",
           "markdownDescription": "A custom instruction to be included at the start of all chat messages (e.g. \"Answer all my questions in Spanish.\")",
-          "examples": [
-            "Answer all my questions in Spanish."
-          ]
+          "examples": ["Answer all my questions in Spanish."]
         },
         "cody.chat.defaultLocation": {
           "order": 6,
           "type": "string",
-          "enum": [
-            "sticky",
-            "sidebar",
-            "editor"
-          ],
+          "enum": ["sticky", "sidebar", "editor"],
           "markdownDescription": "Controls where the Cody chat view opens when the user invokes the `Cody: New Chat` command, or the Alt+L and Alt+/ shortcuts.",
           "enumDescriptions": [
             "Opens in the last-activated view location, which is set whenever the user explicitly chooses to open chat in a given location",
@@ -1087,9 +1060,7 @@
           "order": 7,
           "type": "string",
           "markdownDescription": "A custom instruction to be included at the end of all instructions for edit commands (e.g. \"Write all unit tests with Jest instead of detected framework.\")",
-          "examples": [
-            "Write all unit tests with Jest instead of detected framework."
-          ]
+          "examples": ["Write all unit tests with Jest instead of detected framework."]
         },
         "cody.codeActions.enabled": {
           "order": 11,
@@ -1135,14 +1106,8 @@
         "cody.telemetry.level": {
           "order": 99,
           "type": "string",
-          "enum": [
-            "all",
-            "off"
-          ],
-          "enumDescriptions": [
-            "Sends usage data and errors.",
-            "Disables all extension telemetry."
-          ],
+          "enum": ["all", "off"],
+          "enumDescriptions": ["Sends usage data and errors.", "Disables all extension telemetry."],
           "markdownDescription": "Controls the telemetry about Cody usage and errors. See [Cody usage and privacy notice](https://about.sourcegraph.com/terms/cody-notice).",
           "default": "all"
         },
@@ -1171,11 +1136,7 @@
         "cody.autocomplete.advanced.model": {
           "type": "string",
           "default": null,
-          "enum": [
-            null,
-            "starcoder-16b",
-            "starcoder-7b"
-          ],
+          "enum": [null, "starcoder-16b", "starcoder-7b"],
           "markdownDescription": "Overwrite the  model used for code autocompletion inference. This is only supported with the `fireworks` provider"
         },
         "cody.autocomplete.completeSuggestWidgetSelection": {
@@ -1195,10 +1156,7 @@
         },
         "cody.experimental.foldingRanges": {
           "type": "string",
-          "enum": [
-            "lsp",
-            "indentation-based"
-          ],
+          "enum": ["lsp", "indentation-based"],
           "enumDescriptions": [
             "Use folding ranges that are enabled by default in VS Code, and are usually powered by LSP",
             "Use custom implementation of folding ranges that is indentation based. This is the implementation that is used by other Cody clients like the JetBrains plugin"
@@ -1209,13 +1167,7 @@
         "cody.autocomplete.experimental.graphContext": {
           "type": "string",
           "default": null,
-          "enum": [
-            null,
-            "bfg",
-            "bfg-mixed",
-            "tsc",
-            "tsc-mixed"
-          ],
+          "enum": [null, "bfg", "bfg-mixed", "tsc", "tsc-mixed"],
           "markdownDescription": "Use the code graph to retrieve context for autocomplete requests."
         },
         "cody.autocomplete.experimental.fireworksOptions": {
@@ -1395,9 +1347,7 @@
     "untrustedWorkspaces": {
       "supported": "limited",
       "description": "Cody only uses providers (configured in `openctx.providers`) from trusted workspaces because providers may execute arbitrary code.",
-      "restrictedConfigurations": [
-        "openctx.providers"
-      ]
+      "restrictedConfigurations": ["openctx.providers"]
     }
   },
   "dependencies": {

--- a/vscode/src/chat/chat-view/ChatController.ts
+++ b/vscode/src/chat/chat-view/ChatController.ts
@@ -494,6 +494,15 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
                     }
                     break
                 }
+                if (message.authKind === 'signin' && message.endpoint && message.value) {
+                    await this.authProvider.auth({ endpoint: message.endpoint, token: message.value })
+                    break
+                }
+                if (message.authKind === 'signout') {
+                    await this.authProvider.signoutMenu()
+                    this.setWebviewView(View.Login)
+                    break
+                }
                 // cody.auth.signin or cody.auth.signout
                 await vscode.commands.executeCommand(`cody.auth.${message.authKind}`)
                 break

--- a/vscode/src/jsonrpc/agent-protocol.ts
+++ b/vscode/src/jsonrpc/agent-protocol.ts
@@ -53,6 +53,12 @@ export type ClientRequests = {
     // chat id. Main difference compared to the chat/new is that we return chatId.
     'chat/web/new': [null, { panelId: string; chatId: string }]
 
+    // Start a new chat session and returns panel id and chat id that later can
+    // be used to reference to the session with panel id and restore chat with
+    // chat id. Main difference compared to the chat/new and chat/web/new is that
+    // the panel has sidebar webview type instead of editor webview type.
+    'chat/sidebar/new': [null, { panelId: string; chatId: string }]
+
     // Deletes chat by its ID and returns newly updated chat history list
     // Primary is used only in cody web client
     'chat/delete': [{ chatId: string }, ChatExportResult[]]
@@ -476,6 +482,10 @@ export type ServerNotifications = {
     'webview/setIconPath': [{ handle: string; iconPathUri?: string | null | undefined }]
     'webview/setOptions': [{ handle: string; options: DefiniteWebviewOptions }]
     'webview/setHtml': [{ handle: string; html: string }]
+
+    // When the when-claude context has changed.
+    // For example, 'cody.activated' is set based on user's latest authentication status.
+    'window/didChangeContext': [{ key: string; value?: string | undefined | null }]
 }
 
 export interface WebviewCreateWebviewPanelOptions {

--- a/vscode/webviews/App.tsx
+++ b/vscode/webviews/App.tsx
@@ -252,6 +252,8 @@ export const App: React.FunctionComponent<{ vscodeAPI: VSCodeWrapper }> = ({ vsc
                         simplifiedLoginRedirect={loginRedirect}
                         uiKindIsWeb={config.uiKindIsWeb}
                         vscodeAPI={vscodeAPI}
+                        codyIDE={userAccountInfo?.ide ?? CodyIDE.VSCode}
+                        authStatus={authStatus}
                     />
                 </div>
             ) : (

--- a/vscode/webviews/OnboardingExperiment.story.tsx
+++ b/vscode/webviews/OnboardingExperiment.story.tsx
@@ -1,16 +1,9 @@
 import type { Meta, StoryObj } from '@storybook/react'
 
+import { CodyIDE } from '@sourcegraph/cody-shared'
 import { LoginSimplified } from './OnboardingExperiment'
 import { VSCodeSidebar } from './storybook/VSCodeStoryDecorator'
 import type { VSCodeWrapper } from './utils/VSCodeApi'
-
-const meta: Meta<typeof LoginSimplified> = {
-    title: 'cody/Onboarding',
-    component: LoginSimplified,
-    decorators: [VSCodeSidebar],
-}
-
-export default meta
 
 const vscodeAPI: VSCodeWrapper = {
     postMessage: () => {},
@@ -19,14 +12,32 @@ const vscodeAPI: VSCodeWrapper = {
     setState: () => {},
 }
 
-export const Login: StoryObj<typeof LoginSimplified> = {
-    render: () => (
-        <LoginSimplified simplifiedLoginRedirect={() => {}} uiKindIsWeb={false} vscodeAPI={vscodeAPI} />
-    ),
+const meta: Meta<typeof LoginSimplified> = {
+    title: 'cody/Onboarding',
+    component: LoginSimplified,
+    decorators: [VSCodeSidebar],
+    args: {
+        simplifiedLoginRedirect: () => {},
+        uiKindIsWeb: false,
+        vscodeAPI: vscodeAPI,
+        codyIDE: CodyIDE.VSCode,
+    },
+}
+
+export default meta
+
+type Story = StoryObj<typeof LoginSimplified>
+
+export const Login: Story = {
+    args: {
+        uiKindIsWeb: false,
+        codyIDE: CodyIDE.VSCode,
+    },
 }
 
 export const LoginWeb: StoryObj<typeof LoginSimplified> = {
-    render: () => (
-        <LoginSimplified simplifiedLoginRedirect={() => {}} uiKindIsWeb={true} vscodeAPI={vscodeAPI} />
-    ),
+    args: {
+        uiKindIsWeb: true,
+        codyIDE: CodyIDE.Web,
+    },
 }

--- a/vscode/webviews/components/ClientSignInForm.module.css
+++ b/vscode/webviews/components/ClientSignInForm.module.css
@@ -1,0 +1,41 @@
+.container {
+    width: 100%;
+    max-width: 300px;
+    background: var(--vscode-sideBar-background);
+    color: var(--vscode-sideBar-foreground);
+    border: 1px solid var(--vscode-widget-border);
+    box-shadow: 0 2px 16px 0 var(--vscode-widget-shadow);
+    border-radius: 4px;
+    margin-bottom: var(--spacing);
+    padding: var(--spacing);
+}
+
+.section {
+    width: 100%;
+    display: flex;
+    gap: 0.5rem;
+    align-items: flex-start;
+    flex-direction: column;
+}
+
+.button {
+    width: 100%;
+    box-sizing: border-box;
+    justify-content: center;
+    padding: 0.25rem;
+    margin-left: auto;
+    margin-right: auto;
+    margin-top: var(--spacing);
+}
+
+.input {
+    width: 100%;
+    padding: 0.25rem;
+    color: var(--vscode-input-foreground);
+    background-color: var(--vscode-input-background);
+    border: 1px solid var(--vscode-input-border);
+}
+
+.warning {
+    color: var(--vscode-inputValidation-warningBorder);
+}

--- a/vscode/webviews/components/ClientSignInForm.tsx
+++ b/vscode/webviews/components/ClientSignInForm.tsx
@@ -1,0 +1,109 @@
+import { VSCodeButton } from '@vscode/webview-ui-toolkit/react'
+import type React from 'react'
+import styles from './ClientSignInForm.module.css'
+
+import type { AuthStatus } from '@sourcegraph/cody-shared'
+import { useCallback, useState } from 'react'
+import { isSourcegraphToken } from '../../src/chat/protocol'
+import { getVSCodeAPI } from '../utils/VSCodeApi'
+import { Form, FormControl, FormField, FormLabel, FormMessage } from './shadcn/ui/form'
+import { cn } from './shadcn/utils'
+
+interface ClientSignInFormProps {
+    authStatus?: AuthStatus
+    className?: string
+}
+
+/**
+ * A temporary sign-in form for clients that do not support sign-in through quickpick.
+ *
+ * The form allows the user to enter the Sourcegraph instance URL and an access token.
+ * It validates the input and sends the authentication information to the VSCode extension
+ * when the user clicks the "Sign In with Access Token" button.
+ *
+ * @param className - An optional CSS class name to apply to the form container.
+ * @param authStatus - The current authentication status, which may include an error message.
+ * @returns A React component that renders the sign-in form.
+ */
+export const ClientSignInForm: React.FC<ClientSignInFormProps> = ({ className, authStatus }) => {
+    const [formData, setFormData] = useState({
+        endpoint: authStatus?.endpoint ?? '',
+        accessToken: '',
+    })
+
+    const handleInputChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+        const { name, value } = e.target
+        setFormData(prev => ({ ...prev, [name]: value }))
+    }, [])
+
+    const onSubmitClick = useCallback(() => {
+        getVSCodeAPI().postMessage({
+            command: 'auth',
+            authKind: 'signin',
+            endpoint: formData.endpoint,
+            value: formData.accessToken,
+        })
+    }, [formData])
+
+    return (
+        <Form
+            className={cn(
+                'tw-flex-col tw-w-grid tw-grid-cols-6 tw-gap-4 tw-flex',
+                styles.container,
+                className
+            )}
+        >
+            <FormField name="endpoint" className={styles.section}>
+                <FormLabel title="Sourcegraph Instance URL" />
+                <FormControl
+                    className={styles.input}
+                    type="url"
+                    name="endpoint"
+                    placeholder="https://company.sourcegraph.com"
+                    value={formData.endpoint}
+                    required
+                    onChange={handleInputChange}
+                />
+                <FormMessage match={() => isInvalidURL(formData.endpoint)} className={styles.warning}>
+                    Not a valid URL.
+                </FormMessage>
+            </FormField>
+            <FormField
+                name="accessToken"
+                className={styles.section}
+                serverInvalid={authStatus?.showNetworkError}
+            >
+                <FormLabel title="Access Token" />
+                <FormControl
+                    className={styles.input}
+                    type="password"
+                    name="accessToken"
+                    placeholder="Enter your access token"
+                    value={formData.accessToken}
+                    onChange={handleInputChange}
+                    required
+                />
+                <FormMessage
+                    className={styles.warning}
+                    match={() => !isSourcegraphToken(formData.accessToken)}
+                >
+                    Please enter a valid access token.
+                </FormMessage>
+            </FormField>
+            <VSCodeButton className={styles.button} type="button" onClick={onSubmitClick}>
+                Sign In with Access Token
+            </VSCodeButton>
+        </Form>
+    )
+}
+
+ClientSignInForm.displayName = 'Sign In Form'
+
+const isInvalidURL = (url: string): boolean => {
+    try {
+        new URL(url)
+        return false
+    } catch {
+        return true
+    }
+}

--- a/vscode/webviews/components/shadcn/ui/form.tsx
+++ b/vscode/webviews/components/shadcn/ui/form.tsx
@@ -1,0 +1,30 @@
+import * as FormUI from '@radix-ui/react-form'
+import * as React from 'react'
+import { cn } from '../utils'
+
+const FormRoot = FormUI.Root
+
+const FormField = FormUI.Field
+const FormControl = FormUI.Control
+const FormMessage = FormUI.Message
+const FormSubmit = FormUI.Submit
+
+const Form = React.forwardRef<
+    React.ElementRef<typeof FormUI.Root>,
+    React.ComponentPropsWithoutRef<typeof FormUI.Root>
+>(({ className, title, ...props }, ref) => (
+    <FormRoot name={title} className={className} {...props}>
+        {props.children}
+    </FormRoot>
+))
+
+const FormLabel = React.forwardRef<
+    React.ElementRef<typeof FormUI.Label>,
+    React.ComponentPropsWithoutRef<typeof FormUI.Label>
+>(({ className, title, ...props }, ref) => (
+    <FormUI.Label className={cn('tw-text-accent-foreground', className)} {...props}>
+        {title ?? props.children}
+    </FormUI.Label>
+))
+
+export { Form, FormField, FormLabel, FormSubmit, FormControl, FormMessage }


### PR DESCRIPTION
Part of https://linear.app/sourcegraph/issue/CODY-3208/user-friendly-login-for-plg-and-enterprise https://linear.app/sourcegraph/issue/CODY-3055/web-based-login-ui-may-spuriously-appear

- Add a new `chat/sidebar/new` request to the agent protocol that creates a new chat panel with a sidebar webview type
- Update the `vscode-shim` to notify the agent when the window context changes, e.g. when the user's authentication status changes
- Update the `ChatController` to handle `signin` and `signout` messages from the webview
- Add a new `ClientSignInForm` component for clients that don't support the sign-in quickpick

These changes address the following issues:
- 'chat/sidebar/new' enables clients to start a new sidebar chat. The current 'chat/new' starts an editor chat where the nav bar is removed from the chat view
- Clicking on the sign-out button on the client Account page will sign users out and send a `window/didChangeContext` notification to clients, this allows JetBrains  and other clients to display the login page / chat view based on the value using by the webview. Part of https://linear.app/sourcegraph/issue/CODY-3055/web-based-login-ui-may-spuriously-appear

NOTE: Reason I didn't create a new field for client capability is because we will eventually move into a unified authentication page, which is currently in-design. The sign-in form in this is just a temporary workaround for clients that do not have access to quick pick or on sign out.

## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

1. cd into vscode directory and run `pnpm storybook`
2. adjust the `codyIDE` value to confirm the current Login form for VS Code and Web remains unchanged
3. Verified the Login form only shows up for codyIDE that is not VS Code and Web

![image](https://github.com/user-attachments/assets/73b33361-c2f5-42c6-add2-b54cb34fbd9f)

codyIDE = VisualStudio / JetBrains / Eclipse
![image](https://github.com/user-attachments/assets/6e36c642-441e-48fc-829d-b092d855a7c0)

codyIDE = VSCode
![image](https://github.com/user-attachments/assets/179a472e-bf45-40e0-a270-0ee5317aa102)


## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
