### PR TITLE
Chat: update signout button command in account tab

### DIFF
--- a/vscode/webviews/tabs/AccountTab.tsx
+++ b/vscode/webviews/tabs/AccountTab.tsx
@@ -40,7 +40,7 @@ export const AccountTab: React.FC<AccountTabProps> = ({ userInfo }) => {
         },
         {
             text: 'Sign Out',
-            onClick: () => getVSCodeAPI().postMessage({ command: 'command', id: 'cody.auth.signout' }),
+            onClick: () => getVSCodeAPI().postMessage({ command: 'auth', authKind: 'signout' }),
         },
     ]
 


### PR DESCRIPTION
Follow up on https://github.com/sourcegraph/cody/pull/5192

Update the Sign Out button command in Account Tab (only used by non-VS Code clients) to `signout` auth command that would send a notification to client on setContext change via `window/didChangeContext`.

## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

Green UI. No feature chanegs.

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
