### PR TITLE
fixed(web): removed `fs-extra`

### DIFF
--- a/agent/src/agent.ts
+++ b/agent/src/agent.ts
@@ -1,4 +1,5 @@
 import { spawn } from 'node:child_process'
+import { copyFileSync } from 'node:fs'
 import path from 'node:path'
 
 import type { Polly, Request } from '@pollyjs/core'
@@ -36,7 +37,6 @@ import type * as agent_protocol from '../../vscode/src/jsonrpc/agent-protocol'
 import { mkdirSync, statSync } from 'node:fs'
 import { PassThrough } from 'node:stream'
 import type { Har } from '@pollyjs/persister'
-import { copySync } from 'fs-extra'
 import levenshtein from 'js-levenshtein'
 import * as uuid from 'uuid'
 import type { MessageConnection } from 'vscode-jsonrpc'
@@ -117,7 +117,7 @@ function copyExtensionRelativeResources(extensionPath: string, extensionClient: 
         }
         try {
             mkdirSync(path.dirname(target), { recursive: true })
-            copySync(source, target)
+            copyFileSync(source, target)
         } catch (err) {
             logDebug('copyExtensionRelativeResources', `Failed to copy ${source} to dist ${target}`, err)
         }


### PR DESCRIPTION
There's a current bug somewhere (I think in Vite?) that tries to externalize node dependencies, and print out a warning message. But when it loads the dependencies of `fs-extra`, specifically `graceful-fs` it comes in as a symbol instead of string, which can't be interpolated and it crashes.
![image](https://github.com/user-attachments/assets/b1c78ea2-0c59-4657-8d47-2ae4e03987e1)

Our only use of it is to copy a file, which we can do with `fs` so it is unneeded.
## Test plan
Compiles and runs in browser.
