### PR TITLE
Debug: make debug commands available outside of test

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -11,7 +11,7 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 ### Fixed
 
 - Edit: Fixed a case where multiple, duplicate, edit commands would be created unintentionally. [pull/5183](https://github.com/sourcegraph/cody/pull/5183)
-
+- Debug: Commands for debugging purposes (e.g., "Cody Debug: Export Logs") are available outside of development mode again. [pull/5197](https://github.com/sourcegraph/cody/pull/5197)
 ### Changed
 
 ## 1.30.3

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -270,6 +270,7 @@ const register = async (
     if (isExtensionModeDevOrTest) {
         await registerTestCommands(context, authProvider, disposables)
     }
+    registerDebugCommands(context, disposables)
     registerUpgradeHandlers(configWatcher, authProvider, disposables)
     disposables.push(new CharactersLogger())
 
@@ -583,8 +584,18 @@ async function registerTestCommands(
         // Access token - this is only used in configuration tests
         vscode.commands.registerCommand('cody.test.token', async (endpoint, token) =>
             authProvider.auth({ endpoint, token })
-        ),
-        // For debugging
+        )
+    )
+}
+
+/**
+ * Register commands used for debugging.
+ */
+async function registerDebugCommands(
+    context: vscode.ExtensionContext,
+    disposables: vscode.Disposable[]
+): Promise<void> {
+    disposables.push(
         vscode.commands.registerCommand('cody.debug.export.logs', () => exportOutputLog(context.logUri)),
         vscode.commands.registerCommand('cody.debug.outputChannel', () => openCodyOutputChannel()),
         vscode.commands.registerCommand('cody.debug.enable.all', () => enableVerboseDebugMode()),


### PR DESCRIPTION
The debug commands were recently moved to be available in test/dev mode only, most likely by accident. 

This PR fixes this issue by always registering the commands for debugging on extension start-up.

## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

Run the Export Debug Logs command and verify the command works:

![image](https://github.com/user-attachments/assets/74cc46bf-f6ac-4e99-afee-3c8f5a511323)

Before this change, the command returns an error

![image](https://github.com/user-attachments/assets/efb391e9-88f9-4990-bd1c-f844d342a9f9)

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->

Fixed issues where debug commands are not available in production.