### PR TITLE
Agent: Fix setContext command args value always undefined

### DIFF
--- a/agent/src/vscode-shim.ts
+++ b/agent/src/vscode-shim.ts
@@ -917,15 +917,12 @@ const _commands: Partial<typeof vscode.commands> = {
             }
         })
     },
-    executeCommand: (command, args) => {
+    executeCommand: (command, ...args) => {
         const registered = registeredCommands.get(command)
         if (registered) {
             try {
                 if (args) {
-                    if (typeof args === 'object' && typeof args[Symbol.iterator] === 'function') {
-                        return promisify(registered.callback(...args))
-                    }
-                    return promisify(registered.callback(args))
+                    return promisify(registered.callback(...args))
                 }
                 return promisify(registered.callback())
             } catch (error) {
@@ -945,12 +942,13 @@ const _commands: Partial<typeof vscode.commands> = {
 _commands?.registerCommand?.('workbench.action.reloadWindow', () => {
     // Do nothing
 })
-_commands?.registerCommand?.('setContext', (key, value) => {
+_commands?.registerCommand?.('setContext', (...args) => {
+    const [key, value] = args
     if (typeof key !== 'string') {
         throw new TypeError(`setContext: first argument must be string. Got: ${key}`)
     }
     context.set(key, value)
-    agent?.notify('window/didChangeContext', { key, value })
+    agent?.notify('window/didChangeContext', { key, value: `${value}` })
 })
 _commands?.registerCommand?.('vscode.executeFoldingRangeProvider', async uri => {
     const promises: vscode.FoldingRange[] = []

--- a/agent/src/vscode-shim.ts
+++ b/agent/src/vscode-shim.ts
@@ -942,13 +942,12 @@ const _commands: Partial<typeof vscode.commands> = {
 _commands?.registerCommand?.('workbench.action.reloadWindow', () => {
     // Do nothing
 })
-_commands?.registerCommand?.('setContext', (...args) => {
-    const [key, value] = args
+_commands?.registerCommand?.('setContext', (key, value) => {
     if (typeof key !== 'string') {
         throw new TypeError(`setContext: first argument must be string. Got: ${key}`)
     }
     context.set(key, value)
-    agent?.notify('window/didChangeContext', { key, value: `${value}` })
+    agent?.notify('window/didChangeContext', { key, value: value.toString() })
 })
 _commands?.registerCommand?.('vscode.executeFoldingRangeProvider', async uri => {
     const promises: vscode.FoldingRange[] = []

--- a/agent/src/vscode-shim.ts
+++ b/agent/src/vscode-shim.ts
@@ -921,9 +921,18 @@ const _commands: Partial<typeof vscode.commands> = {
         const registered = registeredCommands.get(command)
         if (registered) {
             try {
-                if (args) {
+                // Handle the case where a single object is passed
+                if (args.length === 1) {
+                    if (typeof args[0] === 'object' && typeof args[0][Symbol.iterator] === 'function') {
+                        return promisify(registered.callback(...args[0]))
+                    }
+                    return promisify(registered.callback(args[0]))
+                }
+                // Handle multiple arguments or a single non-object argument
+                if (args?.length > 1) {
                     return promisify(registered.callback(...args))
                 }
+                // Handle command with no argument
                 return promisify(registered.callback())
             } catch (error) {
                 console.error(error)

--- a/vscode/src/chat/chat-view/ChatController.ts
+++ b/vscode/src/chat/chat-view/ChatController.ts
@@ -570,7 +570,7 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
             this.webviewPanelOrView?.viewType === 'cody.editorPanel' ? 'editor' : 'sidebar'
 
         return {
-            agentIDE: config.isRunningInsideAgent ? config.agentIDE : CodyIDE.VSCode,
+            agentIDE: config.agentIDE ?? CodyIDE.VSCode,
             agentExtensionVersion: config.isRunningInsideAgent
                 ? config.agentExtensionVersion
                 : VSCEVersion,

--- a/vscode/src/chat/chat-view/ChatController.ts
+++ b/vscode/src/chat/chat-view/ChatController.ts
@@ -1909,4 +1909,5 @@ export async function addWebviewViewHTML(
     view.webview.html = decoded
         .replaceAll('./', `${resources.toString()}/`)
         .replaceAll("'self'", view.webview.cspSource)
+        .replaceAll('{cspSource}', view.webview.cspSource)
 }

--- a/vscode/webviews/OnboardingExperiment.tsx
+++ b/vscode/webviews/OnboardingExperiment.tsx
@@ -76,8 +76,8 @@ export const LoginSimplified: React.FunctionComponent<React.PropsWithoutRef<Logi
     const otherSignInClick = (): void => {
         vscodeAPI.postMessage({ command: 'auth', authKind: 'signin' })
     }
-    const isCodyWeb = uiKindIsWeb || codyIDE === CodyIDE.Web
-    const isNonVSCodeIDE = !isCodyWeb && codyIDE !== CodyIDE.VSCode
+    const isNonVSCodeIDE = codyIDE !== CodyIDE.Web && codyIDE !== CodyIDE.VSCode
+    const isCodyWebUI = (uiKindIsWeb || codyIDE === CodyIDE.Web) && !isNonVSCodeIDE
     return (
         <div className={styles.container}>
             <div className={styles.sectionsContainer}>
@@ -86,11 +86,11 @@ export const LoginSimplified: React.FunctionComponent<React.PropsWithoutRef<Logi
                     <h1>Cody Free or Cody Pro</h1>
                     <div className={styles.buttonWidthSizer}>
                         <div className={styles.buttonStack}>
-                            {isCodyWeb || isNonVSCodeIDE ? (
+                            {isCodyWebUI || isNonVSCodeIDE ? (
                                 <WebLogin
                                     telemetryRecorder={telemetryRecorder}
                                     vscodeAPI={vscodeAPI}
-                                    isCodyWeb={isCodyWeb}
+                                    isCodyWeb={isCodyWebUI}
                                 />
                             ) : (
                                 <>
@@ -141,7 +141,7 @@ export const LoginSimplified: React.FunctionComponent<React.PropsWithoutRef<Logi
                         </div>
                     </div>
                 </div>
-                {isCodyWeb || codyIDE === CodyIDE.VSCode ? (
+                {isCodyWebUI || codyIDE === CodyIDE.VSCode ? (
                     <div className={styles.section}>
                         <h1>Cody Enterprise</h1>
                         <div className={styles.buttonWidthSizer}>


### PR DESCRIPTION
Fix an issue with vscode shim where the args value of setContext command always returned undefined, due to args was not being deconstructed properly during the "executeCommand" step.

Also updated the logic for displaying the new sign-in form for non-vscode IDE clients

## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

'window/didChangeContext' should now show the correct key-value pair for notifying authStatus change:

![Screenshot 2024-08-13 154449](https://github.com/user-attachments/assets/d7a13bff-bb06-4e79-8b8e-da6a7d51c113)

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->

NA