### PR TITLE
chore(ci): fix reported branch name in BKA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,14 +140,20 @@ jobs:
           key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
           restore-keys: ${{ runner.os }}-pnpm-store-
       - run: pnpm install
-      - run: xvfb-run -a pnpm -C vscode run test:e2e --shard=${{ matrix.shard }}
+      - run: GITHUB_REF=$BRANCH_NAME xvfb-run -a pnpm -C vscode run test:e2e --shard=${{ matrix.shard }}
         if: matrix.runner == 'ubuntu'
         env:
           BUILDKITE_ANALYTICS_TOKEN: ${{ secrets.BUILDKITE_ANALYTICS_TOKEN }}
-      - run: pnpm -C vscode run test:e2e
+          # This is required because the test collector from Buildkite is imprecise when it
+          # comes to infer the branch name on GitHub action.
+          BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
+      - run: GITHUB_REF=$BRANCH_NAME pnpm -C vscode run test:e2e
         if: matrix.runner != 'ubuntu'
         env:
           BUILDKITE_ANALYTICS_TOKEN: ${{ secrets.BUILDKITE_ANALYTICS_TOKEN }}
+          # This is required because the test collector from Buildkite is imprecise when it
+          # comes to infer the branch name on GitHub action.
+          BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
       - uses: actions/upload-artifact@v4
         if: ${{ failure() }}
         with:


### PR DESCRIPTION
https://github.com/buildkite/test-collector-javascript/blob/9d29eb099a89bdab9e2b0d3420cc0e111fb0c0bc/util/ci.js#L72-L81 is really imprecise and doesn't account for all variants the value can take. This PR fixes it on our side until they do on their side. 

If we don't have this, we can't filter properly the results in the UI and `main` stats gets merged in the rest, completely throwing off the value of these analytics (while it's useful to track those in all branches, the timings and flakiness really matter solely on `main`). 

## Test plan

Tested on this PR + CI 

<img width="1177" alt="image" src="https://github.com/user-attachments/assets/8cbf1ec6-275f-407b-a8b7-a37ecaa1ca46">
