### PR TITLE
Commands: filter commands based on client capabilities

### DIFF
--- a/agent/src/agent.ts
+++ b/agent/src/agent.ts
@@ -479,9 +479,9 @@ export class Agent extends MessageHandler implements ExtensionClient {
             process.exit(0)
         })
 
-        this.registerNotification('workspaceFolder/didChange', async params => {
-            if (this.workspace.workspaceRootUri?.toString() !== params.uri) {
-                const newWorkspaceUri = vscode.Uri.parse(params.uri)
+        this.registerNotification('workspaceFolder/didChange', async ({ uri }) => {
+            if (uri && this.workspace.workspaceRootUri?.toString() !== uri) {
+                const newWorkspaceUri = vscode.Uri.parse(uri)
                 this.workspace.workspaceRootUri = newWorkspaceUri
 
                 const currentWorkspaceFolders = vscode_shim.workspaceFolders ?? []

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -28,7 +28,7 @@ import {
     CODY_OLLAMA_DOCS_URL,
 } from './chat/protocol'
 import { CodeActionProvider } from './code-actions/CodeActionProvider'
-import { executeCodyCommand, setCommandController } from './commands/CommandsController'
+import { commandControllerInit, executeCodyCommand } from './commands/CommandsController'
 import { GhostHintDecorator } from './commands/GhostHintDecorator'
 import {
     executeDocCommand,
@@ -303,7 +303,7 @@ async function initializeSingletons(
     // user's model choices
     ModelsService.setStorage(localStorage)
     disposables.push(upstreamHealthProvider, contextFiltersProvider)
-    setCommandController(platform.createCommandsProvider?.())
+    commandControllerInit(platform.createCommandsProvider?.(), platform.extensionClient.capabilities)
     repoNameResolver.init(authProvider)
     await configWatcher.onChange(
         async config => {

--- a/vscode/webviews/components/MarkdownFromCody.tsx
+++ b/vscode/webviews/components/MarkdownFromCody.tsx
@@ -83,7 +83,7 @@ const URL_PROCESSORS: Record<CodyIDE, UrlTransform> = {
     [CodyIDE.Neovim]: defaultUrlProcessor,
     [CodyIDE.Emacs]: defaultUrlProcessor,
     [CodyIDE.VSCode]: wrapLinksWithCodyOpenCommand,
-    [CodyIDE.VisualStudio]: wrapLinksWithCodyOpenCommand,
+    [CodyIDE.VisualStudio]: defaultUrlProcessor,
 }
 
 export const MarkdownFromCody: FunctionComponent<{ className?: string; children: string }> = ({


### PR DESCRIPTION
## Description

This change updates the `CommandsController` to handle edit commands based on the client's capabilities. If the client's edit capability is set to `'none'`, the controller will disable all edit commands and throw an error if an edit command is attempted.

The changes include:
- Add a new `isEditEnabled` flag to track the edit capability
- Update `init` method to set the `isEditEnabled` flag based on the client capabilities
- Filter out edit commands from the command list if edit is disabled
- Throw an error if an edit command is executed and edit is disabled

## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

1. Start Cody with edit capability set to `'none'`
2. Verify that edit commands are not shown in the command list
3. Attempt to execute an edit command and verify that an error is thrown


With Edit enabled:

<img width="772" alt="image" src="https://github.com/user-attachments/assets/b9610f67-3c04-4904-a72d-27d29b9c39f2">

edit === "none"

<img width="801" alt="image" src="https://github.com/user-attachments/assets/228278fe-d1f3-4a4f-b710-d63684b2f8d6">



## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
