### PR TITLE
fix a bug where the current file would not show up when searching for @-file mentions

### DIFF
--- a/lib/prompt-editor/src/mentions/mentionMenu/MentionMenu.tsx
+++ b/lib/prompt-editor/src/mentions/mentionMenu/MentionMenu.tsx
@@ -120,18 +120,6 @@ export const MentionMenu: FunctionComponent<
         [data.providers, params.query, setEditorQuery, updateMentionMenuParams, mentionQuery]
     )
 
-    const onInitialContextItemSelect = useCallback(
-        (value: string): void => {
-            const item = data.initialContextItems?.find(item => commandRowValue(item) === value)
-            if (!item) {
-                throw new Error(`No item found with value ${value}`)
-            }
-
-            selectOptionAndCleanUp(createMentionMenuOption(item))
-        },
-        [data.initialContextItems, selectOptionAndCleanUp]
-    )
-
     const onCommandSelect = useCallback(
         (commandSelected: string): void => {
             const item = data.items?.find(item => commandRowValue(item) === commandSelected)
@@ -198,18 +186,14 @@ export const MentionMenu: FunctionComponent<
     // `value` in state, but when the options change, our state `value` may refer to a row that no
     // longer exists in the list. In that case, we want the first row to be selected.
     const firstProviderRow = data.providers.at(0)
-    const firstInitialContextItemRow = data.initialContextItems?.at(0)
     const firstItemRow = data.items?.at(0)
-    const firstRow = params.parentItem
-        ? firstItemRow
-        : firstProviderRow ?? firstInitialContextItemRow ?? firstItemRow
+    const firstRow = params.parentItem ? firstItemRow : firstProviderRow ?? firstItemRow
 
     const valueRow = useMemo(
         () =>
             data.providers.find(provider => commandRowValue(provider) === value) ??
-            data.initialContextItems?.find(item => commandRowValue(item) === value) ??
             data.items?.find(item => commandRowValue(item) === value),
-        [data.providers, data.items, data.initialContextItems, value]
+        [data.providers, data.items, value]
     )
     const effectiveValueRow = valueRow ?? firstRow
 
@@ -253,27 +237,6 @@ export const MentionMenu: FunctionComponent<
                 {providers.length > 0 && (
                     <CommandGroup className={COMMAND_GROUP_CLASS_NAME}>{providers}</CommandGroup>
                 )}
-
-                {!params.parentItem &&
-                    data.initialContextItems &&
-                    data.initialContextItems.length > 0 && (
-                        <CommandGroup className={COMMAND_GROUP_CLASS_NAME}>
-                            {data.initialContextItems.map(item => (
-                                <CommandItem
-                                    key={commandRowValue(item)}
-                                    value={commandRowValue(item)}
-                                    onSelect={onInitialContextItemSelect}
-                                    className={clsx(
-                                        styles.item,
-                                        styles.contextItem,
-                                        COMMAND_ROW_CLASS_NAME
-                                    )}
-                                >
-                                    <MentionMenuContextItemContent query={mentionQuery} item={item} />
-                                </CommandItem>
-                            ))}
-                        </CommandGroup>
-                    )}
 
                 {(heading || (data.items && data.items.length > 0)) && (
                     <CommandGroup heading={heading} className={COMMAND_GROUP_CLASS_NAME}>

--- a/lib/prompt-editor/src/plugins/atMentions/util.ts
+++ b/lib/prompt-editor/src/plugins/atMentions/util.ts
@@ -1,4 +1,4 @@
-import { type ContextItem, ContextItemSource } from '@sourcegraph/cody-shared'
+import type { ContextItem } from '@sourcegraph/cody-shared'
 
 export function contextItemID(item: ContextItem): string {
     return JSON.stringify([
@@ -11,18 +11,4 @@ export function contextItemID(item: ContextItem): string {
             ? `${item.range.start.line}:${item.range.start.character}-${item.range.end.line}:${item.range.end.character}`
             : '',
     ])
-}
-
-export function prepareContextItemForMentionMenu(
-    item: ContextItem,
-    remainingTokenBudget: number
-): ContextItem {
-    return {
-        ...item,
-
-        isTooLarge: item.size !== undefined ? item.size > remainingTokenBudget : item.isTooLarge,
-
-        // All @-mentions should have a source of `User`.
-        source: ContextItemSource.User,
-    }
 }

--- a/vscode/webviews/promptEditor/MentionMenu.story.tsx
+++ b/vscode/webviews/promptEditor/MentionMenu.story.tsx
@@ -56,13 +56,11 @@ function toParams(query: string, parentItem?: ContextMentionProviderMetadata): M
 
 function toData(
     items: ContextItem[] | undefined,
-    providers: ContextMentionProviderMetadata[] = [],
-    initialContextItems: MentionMenuData['initialContextItems'] = []
+    providers: ContextMentionProviderMetadata[] = []
 ): MentionMenuData {
     return {
         items,
         providers,
-        initialContextItems,
     }
 }
 
@@ -71,6 +69,26 @@ export const Default: StoryObj<typeof MentionMenu> = {
         params: toParams(''),
         data: toData(
             [
+                {
+                    type: 'tree',
+                    isWorkspaceRoot: true,
+                    name: 'my-repo',
+                    description: 'my-repo',
+                    title: 'Current Repository',
+                    source: ContextItemSource.Initial,
+                    content: null,
+                    uri: URI.file('a/b'),
+                    icon: 'folder',
+                },
+                {
+                    uri: URI.file('a/b/initial.go'),
+                    type: 'file',
+                    description: 'initial.go:8-13',
+                    title: 'Current Selection',
+                    source: ContextItemSource.Initial,
+                    range: { start: { line: 7, character: 5 }, end: { line: 12, character: 9 } },
+                    icon: 'list-selection',
+                },
                 {
                     uri: URI.file('a/b/x.go'),
                     type: 'file',
@@ -100,29 +118,7 @@ export const Default: StoryObj<typeof MentionMenu> = {
                     uri: URI.file(`/${'sub-dir/'.repeat(50)}/}/src/LoginDialog.tsx`),
                 },
             ],
-            [FILE_CONTEXT_MENTION_PROVIDER, SYMBOL_CONTEXT_MENTION_PROVIDER],
-            [
-                {
-                    type: 'tree',
-                    isWorkspaceRoot: true,
-                    name: 'my-repo',
-                    description: 'my-repo',
-                    title: 'Current Repository',
-                    source: ContextItemSource.Initial,
-                    content: null,
-                    uri: URI.file('a/b'),
-                    icon: 'folder',
-                },
-                {
-                    uri: URI.file('a/b/initial.go'),
-                    type: 'file',
-                    description: 'initial.go:8-13',
-                    title: 'Current Selection',
-                    source: ContextItemSource.Initial,
-                    range: { start: { line: 7, character: 5 }, end: { line: 12, character: 9 } },
-                    icon: 'list-selection',
-                },
-            ]
+            [FILE_CONTEXT_MENTION_PROVIDER, SYMBOL_CONTEXT_MENTION_PROVIDER]
         ),
     },
 }


### PR DESCRIPTION
This was unintentionally caused by https://github.com/sourcegraph/cody/pull/5057. The intent was to not show 2 mention items `Current File: foo.ts` and `foo.ts`, but it meant that if you typed `@foo` then neither would show up.

Also simplify how initial context is passed to MentionMenu. Just include it in `items` so we don't spread responsibility for displaying and filtering it across multiple components.

A future improvement would be to move all of this logic to the backend (extension host) and just give the UI the fully filtered list.


## Test plan

Open a new Cody chat. Type `@` and then the name of the currently open file in your editor. Confirm that Cody shows `Current File: ...` as an option.

## Changelog

- Fixed a bug in chat where the current file would not show up when @-mentioning a file and searching for it by name.