### PR TITLE
Add `otherCompletionProviders` to metadata 

### DIFF
--- a/vscode/src/completions/logger.ts
+++ b/vscode/src/completions/logger.ts
@@ -441,6 +441,13 @@ function writeCompletionEvent<SubFeature extends string, Action extends string, 
             params.metadata.source = mappedSource
         }
 
+        // for each completionsProviders, add it to metadata showing it's enabled
+        if (params.privateMetadata?.otherCompletionProviders) {
+            for (const key of params.privateMetadata.otherCompletionProviders) {
+                params.metadata[`otherCompletionProviders.${key}`] = 1
+            }
+        }
+
         // Need to convert since CompletionIntent only refers to a type
         const CompletionIntentEnum: Record<CompletionIntent, CompletionIntent> = Object.keys(
             CompletionIntentTelemetryMetadataMapping


### PR DESCRIPTION
PR adds all the values from string array: `otherCompletionProviders` in `privateMetadata` to `metadata` so that we can collect this data on all instances. 

Goes through string array and adds each completionsProvider to the `metadata` as `otherCompletionProviders.{completionProvider} : 1`. Sample Payload below:

<img width="449" alt="image (41)" src="https://github.com/user-attachments/assets/7e542fb7-11d5-4091-b384-94af3b79fa8b">

## Test plan
Tested locally and confirming that `privateMetadata` does not change and `metadata` includes the new fields.

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
