### PR TITLE
fix Cody Web dev build

### DIFF
--- a/.config/viteShared.ts
+++ b/.config/viteShared.ts
@@ -12,7 +12,7 @@ const defaultProjectConfig: UserWorkspaceConfig = {
             // Build from TypeScript sources so we don't need to run `tsc -b` in the background
             // during dev.
             {
-                find: /^(@sourcegraph\/(?:cody-[\w-]|prompt-editor)+)$/,
+                find: /^(@sourcegraph\/(?:cody-[\w-]+|prompt-editor))$/,
                 replacement: '$1/src/index.ts',
             },
         ],

--- a/web/lib/agent/agent.client.ts
+++ b/web/lib/agent/agent.client.ts
@@ -1,4 +1,4 @@
-import type { ServerInfo } from 'cody-ai/src/jsonrpc/agent-protocol'
+import type { ClientInfo, ServerInfo } from 'cody-ai/src/jsonrpc/agent-protocol'
 import {
     BrowserMessageReader,
     BrowserMessageWriter,
@@ -80,6 +80,7 @@ export async function createAgentClient({
         workspaceRootUri,
         capabilities: {
             completions: 'none',
+            webview: 'agentic',
         },
         extensionConfiguration: {
             accessToken,
@@ -92,7 +93,7 @@ export async function createAgentClient({
                 'cody.web': true,
             },
         },
-    })
+    } satisfies ClientInfo)
 
     await rpc.sendNotification('initialized', null)
 

--- a/web/lib/agent/shims/fs-extra.ts
+++ b/web/lib/agent/shims/fs-extra.ts
@@ -1,0 +1,7 @@
+export default function (): unknown {
+    return {}
+}
+
+export function copySync(): void {
+    throw new Error('not implemented')
+}

--- a/web/lib/agent/shims/open.ts
+++ b/web/lib/agent/shims/open.ts
@@ -1,0 +1,1 @@
+export default {}

--- a/web/lib/agent/shims/worker_threads.ts
+++ b/web/lib/agent/shims/worker_threads.ts
@@ -1,0 +1,1 @@
+export default {}

--- a/web/lib/components/CodyWebPanelProvider.tsx
+++ b/web/lib/components/CodyWebPanelProvider.tsx
@@ -120,7 +120,7 @@ export const CodyWebPanelProvider: FunctionComponent<PropsWithChildren<CodyWebPa
             const { panelId, chatId } = await agent.rpc.sendRequest<{
                 panelId: string
                 chatId: string
-            }>('chat/web/new')
+            }>('chat/web/new', null)
 
             activeWebviewPanelIDRef.current = panelId
 

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -28,7 +28,7 @@ export default defineProjectWithDefaults(__dirname, {
     plugins: [
         // @ts-ignore
         react({ devTarget: 'esnext' }),
-        svgr(),
+        svgr() as any,
     ],
     resolve: {
         alias: [

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -56,6 +56,12 @@ export default defineProjectWithDefaults(__dirname, {
             { find: /^(node:)?events$/, replacement: resolve(__dirname, 'node_modules/events') },
             { find: /^(node:)?util$/, replacement: resolve(__dirname, 'node_modules/util') },
             { find: /^(node:)?buffer$/, replacement: resolve(__dirname, 'node_modules/buffer') },
+            { find: /^fs-extra$/, replacement: resolve(__dirname, 'lib/agent/shims/fs-extra.ts') },
+            { find: /^open$/, replacement: resolve(__dirname, 'lib/agent/shims/open.ts') },
+            {
+                find: /^worker_threads$/,
+                replacement: resolve(__dirname, 'lib/agent/shims/worker_threads.ts'),
+            },
 
             // Autocomplete isn't used on web. Omitting it cuts the bundle size by ~5 MB.
             {


### PR DESCRIPTION
This makes `pnpm -C web dev` work again. This is just for the local dev build of Cody Web, and we separately test before bringing it into the main web app.

- fix shared vite config to use sources instead of built monorepo packages
- explicitly pass null argument to fix Cody Web
- specify Cody Web capabilities.webview agentic
- fix "stack too deep" error in typechecking
- add shim for new agent dep to unbreak Cody Web;5B

## Test plan

Run `pnpm -C web dev` and confirm the chat screen loads.