### PR TITLE
fix more @-mention menu glitchiness by fixing height

### DIFF
--- a/lib/prompt-editor/src/BaseEditor.module.css
+++ b/lib/prompt-editor/src/BaseEditor.module.css
@@ -1,20 +1,4 @@
-.editor-shell {
-    position: relative;
-}
-
-.editor-shell .editor-container {
-    position: relative;
-    display: block;
-}
-
-.editor-scroller {
-    border: 0;
-    display: flex;
-    outline: 0;
-}
-
 .editor {
-    flex: auto;
     position: relative;
 }
 

--- a/lib/prompt-editor/src/BaseEditor.tsx
+++ b/lib/prompt-editor/src/BaseEditor.tsx
@@ -60,22 +60,15 @@ export const BaseEditor: FunctionComponent<Props> = ({
     )
 
     return (
-        <div className={clsx(styles.editorShell, className)}>
-            <div className={styles.editorContainer}>
+        <div className={className}>
+            <div className={styles.editor}>
                 <LexicalComposer initialConfig={initialConfig}>
                     <RichTextPlugin
                         contentEditable={
-                            <div className={styles.editorScroller}>
-                                <div className={styles.editor}>
-                                    <ContentEditable
-                                        className={clsx(
-                                            styles.contentEditable,
-                                            contentEditableClassName
-                                        )}
-                                        ariaLabel={ariaLabel}
-                                    />
-                                </div>
-                            </div>
+                            <ContentEditable
+                                className={clsx(styles.contentEditable, contentEditableClassName)}
+                                ariaLabel={ariaLabel}
+                            />
                         }
                         placeholder={<div className={styles.placeholder}>{placeholder}</div>}
                         ErrorBoundary={LexicalErrorBoundary}

--- a/lib/prompt-editor/src/mentions/mentionMenu/MentionMenu.module.css
+++ b/lib/prompt-editor/src/mentions/mentionMenu/MentionMenu.module.css
@@ -1,7 +1,6 @@
 .container {
-    border: 1px solid var(--vscode-widget-border);
-    border-radius: 3px;
     outline: none;
+    border-radius: 0;
 }
 
 .item {

--- a/lib/prompt-editor/src/mentions/mentionMenu/MentionMenu.tsx
+++ b/lib/prompt-editor/src/mentions/mentionMenu/MentionMenu.tsx
@@ -58,7 +58,10 @@ export const MentionMenu: FunctionComponent<
 
     const [value, setValue] = useState<string | null>(null)
 
-    const mentionQuery = parseMentionQuery(params.query ?? '', params.parentItem)
+    const mentionQuery = useMemo(
+        () => parseMentionQuery(params.query ?? '', params.parentItem),
+        [params.query, params.parentItem]
+    )
 
     useEffect(() => {
         if (__storybook__focus) {

--- a/lib/prompt-editor/src/plugins/atMentions/atMentions.module.css
+++ b/lib/prompt-editor/src/plugins/atMentions/atMentions.module.css
@@ -1,15 +1,27 @@
+.popover-dimensions {
+    margin-top: 20px; /* show on the line below the cursor */
+    width: clamp(200px, 65vw, 440px);
+
+    --max-items: 12;
+    --mention-item-height: 30px;
+    height: min(calc(var(--max-items)*var(--mention-item-height) + 2px), 90vh);
+
+    display: flex;
+    align-items: start;
+    .popover {
+        flex: 1;
+    }
+}
+:global(.typeahead-flipped) .popover-dimensions {
+    align-items: end;
+}
+
 .popover {
     overflow: auto;
     background: var(--vscode-sideBar-background);
     color: var(--vscode-sideBar-foreground);
     box-shadow: 0 0 8px 2px var(--vscode-widget-shadow);
+    border: 1px solid var(--vscode-dropdown-border);
     border-radius: 3px;
-
-    margin-top: 20px; /* show on the line below the cursor */
-
-    width: clamp(200px, 65vw, 440px);
-    --max-items: 12;
-    --mention-item-height: 30px;
-    /* Max height is either 12 items, or 90vh. */
-    max-height: min(calc(var(--max-items)*var(--mention-item-height) + 2px), 90vh);
+    max-height: calc(var(--max-items)*var(--mention-item-height) + 2px);
 }

--- a/lib/prompt-editor/src/plugins/atMentions/atMentions.tsx
+++ b/lib/prompt-editor/src/plugins/atMentions/atMentions.tsx
@@ -217,14 +217,20 @@ export const MentionsPlugin: FunctionComponent<{ contextWindowSizeInTokens?: num
                     return (
                         anchorElementRef.current &&
                         createPortal(
-                            <div className={clsx(styles.popover)}>
-                                <MentionMenu
-                                    params={params}
-                                    updateMentionMenuParams={updateMentionMenuParams}
-                                    setEditorQuery={setEditorQuery}
-                                    data={data}
-                                    selectOptionAndCleanUp={selectOptionAndCleanUp}
-                                />
+                            // Use an outer container that is always the same height, which is the
+                            // max height of the visible menu. This ensures that the menu does not
+                            // flip orientation as the user is typing if it suddenly has less
+                            // results. It also makes the positioning less glitchy.
+                            <div className={clsx(styles.popoverDimensions)}>
+                                <div className={styles.popover}>
+                                    <MentionMenu
+                                        params={params}
+                                        updateMentionMenuParams={updateMentionMenuParams}
+                                        setEditorQuery={setEditorQuery}
+                                        data={data}
+                                        selectOptionAndCleanUp={selectOptionAndCleanUp}
+                                    />
+                                </div>
                             </div>,
                             anchorElementRef.current
                         )

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
   },
   "pnpm": {
     "overrides": {
-      "@lexical/react": "https://storage.googleapis.com/sourcegraph-assets/npm/lexical-react-sourcegraph-fork-e9a8d498.tgz"
+      "@lexical/react": "https://storage.googleapis.com/sourcegraph-assets/npm/lexical-react-sourcegraph-fork-31065486.tgz"
     },
     "packageExtensions": {
       "@vscode/webview-ui-toolkit": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,7 @@ neverBuiltDependencies:
   - playwright
 
 overrides:
-  '@lexical/react': https://storage.googleapis.com/sourcegraph-assets/npm/lexical-react-sourcegraph-fork-e9a8d498.tgz
+  '@lexical/react': https://storage.googleapis.com/sourcegraph-assets/npm/lexical-react-sourcegraph-fork-31065486.tgz
 
 packageExtensionsChecksum: bc809394d179d8460f9d473fc54e379a
 
@@ -290,8 +290,8 @@ importers:
         specifier: ^0.17.0
         version: 0.17.0
       '@lexical/react':
-        specifier: https://storage.googleapis.com/sourcegraph-assets/npm/lexical-react-sourcegraph-fork-e9a8d498.tgz
-        version: '@storage.googleapis.com/sourcegraph-assets/npm/lexical-react-sourcegraph-fork-e9a8d498.tgz(react-dom@18.2.0)(react@18.2.0)(yjs@13.6.18)'
+        specifier: https://storage.googleapis.com/sourcegraph-assets/npm/lexical-react-sourcegraph-fork-31065486.tgz
+        version: '@storage.googleapis.com/sourcegraph-assets/npm/lexical-react-sourcegraph-fork-31065486.tgz(react-dom@18.2.0)(react@18.2.0)(yjs@13.6.18)'
       '@lexical/text':
         specifier: ^0.17.0
         version: 0.17.0
@@ -17621,9 +17621,9 @@ packages:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
     dev: false
 
-  '@storage.googleapis.com/sourcegraph-assets/npm/lexical-react-sourcegraph-fork-e9a8d498.tgz(react-dom@18.2.0)(react@18.2.0)(yjs@13.6.18)':
-    resolution: {tarball: https://storage.googleapis.com/sourcegraph-assets/npm/lexical-react-sourcegraph-fork-e9a8d498.tgz}
-    id: '@storage.googleapis.com/sourcegraph-assets/npm/lexical-react-sourcegraph-fork-e9a8d498.tgz'
+  '@storage.googleapis.com/sourcegraph-assets/npm/lexical-react-sourcegraph-fork-31065486.tgz(react-dom@18.2.0)(react@18.2.0)(yjs@13.6.18)':
+    resolution: {tarball: https://storage.googleapis.com/sourcegraph-assets/npm/lexical-react-sourcegraph-fork-31065486.tgz}
+    id: '@storage.googleapis.com/sourcegraph-assets/npm/lexical-react-sourcegraph-fork-31065486.tgz'
     name: '@lexical/react'
     version: 0.17.0
     peerDependencies:


### PR DESCRIPTION
See code comments. Now, the orientation won't flip, and sometimes it flipped the wrong way if it was 0px tall for a brief period (and then did not re-detect the available height after it filled in with content).

## Test plan

In the Chat storybook, type `@` and ensure the menu is not obscured.

In the web demo or the Transcript storybook, type `@a` and then delete so you just have `@`. The menu should be positioned correctly.

## Changelog

Fixed glitches in the positioning of the @-mention menu.