### PR TITLE
many various code cleanups and removals

### DIFF
--- a/agent/src/agent.ts
+++ b/agent/src/agent.ts
@@ -430,6 +430,13 @@ export class Agent extends MessageHandler implements ExtensionClient {
                     this.globalState
                 )
 
+                this.authenticationPromise = clientInfo.extensionConfiguration
+                    ? this.handleConfigChanges(clientInfo.extensionConfiguration, {
+                          forceAuthentication: true,
+                      })
+                    : this.authStatus()
+                const authStatus = await this.authenticationPromise
+
                 const webviewKind = clientInfo.capabilities?.webview || 'agentic'
                 const nativeWebviewConfig = clientInfo.capabilities?.webviewNativeConfig
                 if (webviewKind === 'native') {
@@ -446,13 +453,6 @@ export class Agent extends MessageHandler implements ExtensionClient {
                 } else {
                     this.registerWebviewHandlers()
                 }
-
-                this.authenticationPromise = clientInfo.extensionConfiguration
-                    ? this.handleConfigChanges(clientInfo.extensionConfiguration, {
-                          forceAuthentication: true,
-                      })
-                    : this.authStatus()
-                const authStatus = await this.authenticationPromise
 
                 return {
                     name: 'cody-agent',

--- a/lib/shared/src/auth/types.ts
+++ b/lib/shared/src/auth/types.ts
@@ -42,7 +42,7 @@ export interface AuthStatusProvider {
     getAuthStatus(): AuthStatus
 }
 
-export const defaultAuthStatus = {
+export const defaultAuthStatus: AuthStatus = {
     endpoint: '',
     isDotCom: true,
     isLoggedIn: false,
@@ -59,9 +59,9 @@ export const defaultAuthStatus = {
     displayName: '',
     avatarURL: '',
     codyApiVersion: 0,
-} satisfies AuthStatus
+}
 
-export const unauthenticatedStatus = {
+export const unauthenticatedStatus: AuthStatus = {
     endpoint: '',
     isDotCom: true,
     isLoggedIn: false,
@@ -78,9 +78,9 @@ export const unauthenticatedStatus = {
     displayName: '',
     avatarURL: '',
     codyApiVersion: 0,
-} satisfies AuthStatus
+}
 
-export const networkErrorAuthStatus = {
+export const networkErrorAuthStatus: Omit<AuthStatus, 'endpoint'> = {
     isDotCom: false,
     showInvalidAccessTokenError: false,
     authenticated: false,
@@ -97,9 +97,9 @@ export const networkErrorAuthStatus = {
     displayName: '',
     avatarURL: '',
     codyApiVersion: 0,
-} satisfies Omit<AuthStatus, 'endpoint'>
+}
 
-export const offlineModeAuthStatus = {
+export const offlineModeAuthStatus: AuthStatus = {
     endpoint: '',
     isDotCom: true,
     isLoggedIn: true,
@@ -117,7 +117,7 @@ export const offlineModeAuthStatus = {
     displayName: '',
     avatarURL: '',
     codyApiVersion: 0,
-} satisfies AuthStatus
+}
 
 export function isCodyProUser(authStatus: AuthStatus): boolean {
     return authStatus.isDotCom && !authStatus.userCanUpgrade

--- a/lib/shared/src/cody-ignore/context-filters-provider.ts
+++ b/lib/shared/src/cody-ignore/context-filters-provider.ts
@@ -97,7 +97,7 @@ export class ContextFiltersProvider implements vscode.Disposable {
 
     async init(getRepoNamesFromWorkspaceUri: GetRepoNamesFromWorkspaceUri) {
         this.getRepoNamesFromWorkspaceUri = getRepoNamesFromWorkspaceUri
-        this.dispose()
+        this.reset()
         this.startRefetchTimer(await this.fetchContextFilters())
     }
 
@@ -226,7 +226,7 @@ export class ContextFiltersProvider implements vscode.Disposable {
         return false
     }
 
-    public dispose(): void {
+    private reset(): void {
         this.lastFetchDelay = 0
         this.lastResultLifetime = undefined
         this.lastContextFiltersResponse = null
@@ -239,7 +239,11 @@ export class ContextFiltersProvider implements vscode.Disposable {
         }
     }
 
-    private hasAllowEverythingFilters() {
+    public dispose(): void {
+        this.reset()
+    }
+
+    private hasAllowEverythingFilters(): boolean {
         return (
             graphqlClient.isDotCom() ||
             this.lastContextFiltersResponse === INCLUDE_EVERYTHING_CONTEXT_FILTERS

--- a/lib/shared/src/configuration.ts
+++ b/lib/shared/src/configuration.ts
@@ -107,6 +107,8 @@ export interface AutocompleteTimeouts {
     singleline?: number
 }
 
+export type ConfigurationWithEndpoint = Omit<ConfigurationWithAccessToken, 'accessToken'>
+
 export interface ConfigurationWithAccessToken extends Configuration {
     serverEndpoint: string
     /** The access token, which is stored in the secret storage (not configuration). */

--- a/lib/shared/src/sourcegraph-api/graphql/client.ts
+++ b/lib/shared/src/sourcegraph-api/graphql/client.ts
@@ -8,7 +8,7 @@ import { escapeRegExp } from 'lodash'
 import semver from 'semver'
 import type { AuthStatus } from '../../auth/types'
 import { dependentAbortController, onAbort } from '../../common/abortController'
-import type { ConfigurationWithAccessToken } from '../../configuration'
+import type { Configuration, ConfigurationWithAccessToken } from '../../configuration'
 import { logDebug, logError } from '../../logger'
 import { addTraceparent, wrapInActiveSpan } from '../../tracing'
 import { isError } from '../../utils'
@@ -542,7 +542,7 @@ export type GraphQLAPIClientConfig = Pick<
     ConfigurationWithAccessToken,
     'serverEndpoint' | 'accessToken' | 'customHeaders'
 > &
-    Pick<Partial<ConfigurationWithAccessToken>, 'telemetryLevel'>
+    Pick<Partial<Configuration>, 'telemetryLevel'>
 
 export let customUserAgent: string | undefined
 export function addCustomUserAgent(headers: Headers): void {

--- a/lib/shared/src/sourcegraph-api/graphql/client.ts
+++ b/lib/shared/src/sourcegraph-api/graphql/client.ts
@@ -558,7 +558,7 @@ const QUERY_TO_NAME_REGEXP = /^\s*(?:query|mutation)\s+(\w+)/m
 
 export class SourcegraphGraphQLAPIClient {
     private dotcomUrl = DOTCOM_URL
-    public anonymousUserID: string | undefined
+    private anonymousUserID: string | undefined
 
     /**
      * Should be set on extension activation via `localStorage.onConfigurationChange(config)`
@@ -583,15 +583,6 @@ export class SourcegraphGraphQLAPIClient {
 
     public setConfig(newConfig: GraphQLAPIClientConfig): void {
         this._config = newConfig
-    }
-
-    /**
-     * Tells if the underlying configuration contains an access token, i.e. if requests made right
-     * now would likely be authenticated. This can be used to avoid making requests that would
-     * otherwise just fail due to requiring auth.
-     */
-    public hasAccessToken(): boolean {
-        return !!this._config?.accessToken
     }
 
     /**

--- a/lib/shared/src/sourcegraph-api/telemetry/GraphQLTelemetryExporter.ts
+++ b/lib/shared/src/sourcegraph-api/telemetry/GraphQLTelemetryExporter.ts
@@ -23,7 +23,7 @@ export class GraphQLTelemetryExporter implements TelemetryExporter {
 
     constructor(
         public client: SourcegraphGraphQLAPIClient,
-        anonymousUserID: string,
+        private anonymousUserID: string,
         /**
          * logEvent mode to use if exporter needs to use a legacy export mode.
          */
@@ -98,7 +98,6 @@ export class GraphQLTelemetryExporter implements TelemetryExporter {
          * if setLegacyEventsStateOnce determines we need to do so.
          */
         if (this.exportMode === 'legacy') {
-            console.log({ legacyBackcompatLogEventMode: this.legacyBackcompatLogEventMode })
             const resultOrError = await Promise.all(
                 events.map(event =>
                     this.client.logEvent(
@@ -114,7 +113,7 @@ export class GraphQLTelemetryExporter implements TelemetryExporter {
                                     [curr.key]: curr.value,
                                 })),
                             argument: JSON.stringify(event.parameters.privateMetadata),
-                            userCookieID: this.client.anonymousUserID || '',
+                            userCookieID: this.anonymousUserID || '',
                             connectedSiteID: this.legacySiteIdentification?.siteid,
                             hashedLicenseKey: this.legacySiteIdentification?.hashedLicenseKey,
                         },

--- a/lib/shared/src/telemetry-v2/TelemetryRecorderProvider.ts
+++ b/lib/shared/src/telemetry-v2/TelemetryRecorderProvider.ts
@@ -126,7 +126,7 @@ export class MockServerTelemetryRecorderProvider extends BaseTelemetryRecorderPr
 > {
     constructor(
         extensionDetails: ExtensionDetails,
-        config: ConfigurationWithAccessToken,
+        config: Configuration,
         authStatusProvider: AuthStatusProvider,
         anonymousUserID: string
     ) {

--- a/vscode/src/chat/protocol.ts
+++ b/vscode/src/chat/protocol.ts
@@ -196,6 +196,11 @@ export type ExtensionMessage =
           type: 'config'
           config: ConfigurationSubsetForWebview & LocalEnv
           authStatus: AuthStatus
+          configFeatures: {
+              chat: boolean
+              attribution: boolean
+              serverSentModels: boolean
+          }
           workspaceFolderUris: string[]
       }
     | { type: 'ui/theme'; agentIDE: CodyIDE; cssVariables: CodyIDECssVariables }
@@ -225,14 +230,6 @@ export type ExtensionMessage =
     | { type: 'enhanced-context'; enhancedContextStatus: EnhancedContextContextT }
     | ({ type: 'attribution' } & ExtensionAttributionMessage)
     | { type: 'context/remote-repos'; repos: Repo[] }
-    | {
-          type: 'setConfigFeatures'
-          configFeatures: {
-              chat: boolean
-              attribution: boolean
-              serverSentModels: boolean
-          }
-      }
     | {
           type: 'queryPrompts/response'
           result?: Prompt[] | null | undefined

--- a/vscode/src/chat/protocol.ts
+++ b/vscode/src/chat/protocol.ts
@@ -4,7 +4,7 @@ import type {
     AuthStatus,
     ClientStateForWebview,
     CodyIDE,
-    ConfigurationWithAccessToken,
+    ConfigurationWithEndpoint,
     ContextItem,
     EnhancedContextContextT,
     MentionQuery,
@@ -288,7 +288,7 @@ export interface ExtensionTranscriptMessage {
  */
 export interface ConfigurationSubsetForWebview
     extends Pick<
-        ConfigurationWithAccessToken,
+        ConfigurationWithEndpoint,
         | 'experimentalNoodle'
         | 'serverEndpoint'
         | 'agentIDE'

--- a/vscode/src/completions/providers/fireworks.ts
+++ b/vscode/src/completions/providers/fireworks.ts
@@ -7,6 +7,7 @@ import {
     type CompletionResponse,
     type CompletionResponseGenerator,
     CompletionStopReason,
+    type Configuration,
     type ConfigurationWithAccessToken,
     NetworkError,
     PromptString,
@@ -199,7 +200,7 @@ class FireworksProvider extends Provider {
         'userCanUpgrade' | 'isDotCom' | 'endpoint' | 'isFireworksTracingEnabled'
     >
     private isLocalInstance: boolean
-    private fireworksConfig?: ConfigurationWithAccessToken['autocompleteExperimentalFireworksOptions']
+    private fireworksConfig?: Configuration['autocompleteExperimentalFireworksOptions']
     private promptExtractor: FIMModelSpecificPromptExtractor
     // Todo: This variable is used to introduce an additional delay to collect the data on impact of latency on user experience.
     // Todo: Delete this variable once the data is collected.

--- a/vscode/src/extension.common.ts
+++ b/vscode/src/extension.common.ts
@@ -4,7 +4,7 @@ import type {
     CompletionLogger,
     CompletionsClientConfig,
     Configuration,
-    ConfigurationWithAccessToken,
+    ConfigurationWithEndpoint,
     SourcegraphCompletionsClient,
 } from '@sourcegraph/cody-shared'
 import type { startTokenReceiver } from './auth/token-receiver'
@@ -46,7 +46,7 @@ export interface PlatformContext {
         config: CompletionsClientConfig,
         logger?: CompletionLogger
     ) => SourcegraphCompletionsClient
-    createSentryService?: (config: Pick<ConfigurationWithAccessToken, 'serverEndpoint'>) => SentryService
+    createSentryService?: (config: Pick<ConfigurationWithEndpoint, 'serverEndpoint'>) => SentryService
     createOpenTelemetryService?: (config: OpenTelemetryServiceConfig) => OpenTelemetryService
     startTokenReceiver?: typeof startTokenReceiver
     onConfigurationChange?: (configuration: Configuration) => void

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -4,7 +4,9 @@ import {
     type ChatClient,
     ClientConfigSingleton,
     type CodeCompletionsClient,
+    type Configuration,
     type ConfigurationWithAccessToken,
+    type ConfigurationWithEndpoint,
     type DefaultCodyCommands,
     type Guardrails,
     ModelsService,
@@ -406,7 +408,7 @@ async function registerOtherCommands(disposables: vscode.Disposable[]) {
 }
 
 function registerCodyCommands(
-    config: ConfigWatcher<ConfigurationWithAccessToken>,
+    config: ConfigWatcher<Configuration>,
     statusBar: CodyStatusBar,
     sourceControl: CodySourceControl,
     chatClient: ChatClient,
@@ -514,7 +516,7 @@ function registerAuthCommands(authProvider: AuthProvider, disposables: vscode.Di
 }
 
 function registerUpgradeHandlers(
-    configWatcher: ConfigWatcher<ConfigurationWithAccessToken>,
+    configWatcher: ConfigWatcher<Configuration>,
     authProvider: AuthProvider,
     disposables: vscode.Disposable[]
 ): void {
@@ -622,7 +624,7 @@ async function tryRegisterTutorial(
  * the returned promise is awaited in parallel with other tasks.
  */
 function registerAutocomplete(
-    configWatcher: ConfigWatcher<ConfigurationWithAccessToken>,
+    configWatcher: ConfigWatcher<ConfigurationWithEndpoint>,
     platform: PlatformContext,
     authProvider: AuthProvider,
     statusBar: CodyStatusBar,
@@ -704,7 +706,7 @@ function registerAutocomplete(
 
 async function registerMinion(
     context: vscode.ExtensionContext,
-    config: ConfigWatcher<ConfigurationWithAccessToken>,
+    config: ConfigWatcher<Configuration>,
     authProvider: AuthProvider,
     symfRunner: SymfRunner | undefined,
     disposables: vscode.Disposable[]

--- a/vscode/src/services/cody-ignore.ts
+++ b/vscode/src/services/cody-ignore.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode'
 
 import {
     CODY_IGNORE_POSIX_GLOB,
-    type ConfigurationWithAccessToken,
+    type Configuration,
     type IgnoreFileContent,
     ignores,
 } from '@sourcegraph/cody-shared'
@@ -19,7 +19,7 @@ const utf8 = new TextDecoder('utf-8')
  *
  * NOTE: Execute ONCE at extension activation time.
  */
-export function setUpCodyIgnore(config: ConfigurationWithAccessToken): vscode.Disposable[] {
+export function setUpCodyIgnore(config: Configuration): vscode.Disposable[] {
     if (TestSupport.instance) {
         TestSupport.instance.ignoreHelper.set(ignores)
     }

--- a/vscode/src/services/sentry/sentry.ts
+++ b/vscode/src/services/sentry/sentry.ts
@@ -2,7 +2,7 @@ import type { init as browserInit } from '@sentry/browser'
 import type { init as nodeInit } from '@sentry/node'
 
 import {
-    type ConfigurationWithAccessToken,
+    type ConfigurationWithEndpoint,
     NetworkError,
     isAbortError,
     isAuthError,
@@ -21,14 +21,14 @@ export type SentryOptions = NonNullable<Parameters<typeof nodeInit | typeof brow
 export abstract class SentryService {
     constructor(
         protected config: Pick<
-            ConfigurationWithAccessToken,
+            ConfigurationWithEndpoint,
             'serverEndpoint' | 'isRunningInsideAgent' | 'agentIDE'
         >
     ) {
         this.prepareReconfigure()
     }
 
-    public onConfigurationChange(newConfig: Pick<ConfigurationWithAccessToken, 'serverEndpoint'>): void {
+    public onConfigurationChange(newConfig: Pick<ConfigurationWithEndpoint, 'serverEndpoint'>): void {
         this.config = newConfig
         this.prepareReconfigure()
     }

--- a/vscode/webviews/App.story.tsx
+++ b/vscode/webviews/App.story.tsx
@@ -40,6 +40,7 @@ const dummyVSCodeAPI: VSCodeWrapper = {
                 siteVersion: '5.1.0',
                 endpoint: 'https://example.com',
             },
+            configFeatures: { attribution: true, chat: true, serverSentModels: true },
             workspaceFolderUris: [],
         })
         cb({ type: 'chatModels', models: getDotComDefaultModels() })

--- a/vscode/webviews/App.tsx
+++ b/vscode/webviews/App.tsx
@@ -12,10 +12,8 @@ import {
     PromptString,
     type SerializedChatTranscript,
     type TelemetryRecorder,
-    isCodyProUser,
 } from '@sourcegraph/cody-shared'
 import type { AuthMethod, ConfigurationSubsetForWebview, LocalEnv } from '../src/chat/protocol'
-import type { UserAccountInfo } from './Chat'
 import { LoadingPage } from './LoadingPage'
 import { LoginSimplified } from './OnboardingExperiment'
 import { ConnectionIssuesPage } from './Troubleshooting'
@@ -42,7 +40,6 @@ export const App: React.FunctionComponent<{ vscodeAPI: VSCodeWrapper }> = ({ vsc
     const [transcript, setTranscript] = useState<ChatMessage[]>([])
 
     const [authStatus, setAuthStatus] = useState<AuthStatus | null>(null)
-    const [userAccountInfo, setUserAccountInfo] = useState<UserAccountInfo>()
 
     const [userHistory, setUserHistory] = useState<SerializedChatTranscript[]>()
 
@@ -101,14 +98,6 @@ export const App: React.FunctionComponent<{ vscodeAPI: VSCodeWrapper }> = ({ vsc
                     case 'config':
                         setConfig(message.config)
                         setAuthStatus(message.authStatus)
-                        setUserAccountInfo({
-                            isCodyProUser: isCodyProUser(message.authStatus),
-                            // Receive this value from the extension backend to make it work
-                            // with E2E tests where change the DOTCOM_URL via the env variable TESTING_DOTCOM_URL.
-                            isDotComUser: message.authStatus.isDotCom,
-                            user: message.authStatus,
-                            ide: message.config.agentIDE ?? CodyIDE.VSCode,
-                        })
                         setView(message.authStatus.isLoggedIn ? View.Chat : View.Login)
                         updateDisplayPathEnvInfoForWebview(message.workspaceFolderUris)
                         // Get chat models
@@ -252,8 +241,7 @@ export const App: React.FunctionComponent<{ vscodeAPI: VSCodeWrapper }> = ({ vsc
                         simplifiedLoginRedirect={loginRedirect}
                         uiKindIsWeb={config.uiKindIsWeb}
                         vscodeAPI={vscodeAPI}
-                        codyIDE={userAccountInfo?.ide ?? CodyIDE.VSCode}
-                        authStatus={authStatus}
+                        codyIDE={config.config.agentIDE ?? CodyIDE.VSCode}
                     />
                 </div>
             ) : (
@@ -265,7 +253,6 @@ export const App: React.FunctionComponent<{ vscodeAPI: VSCodeWrapper }> = ({ vsc
                     setErrorMessages={setErrorMessages}
                     attributionEnabled={attributionEnabled}
                     chatEnabled={chatEnabled}
-                    userInfo={userAccountInfo}
                     messageInProgress={messageInProgress}
                     transcript={transcript}
                     vscodeAPI={vscodeAPI}

--- a/vscode/webviews/App.tsx
+++ b/vscode/webviews/App.tsx
@@ -3,7 +3,6 @@ import { type ComponentProps, useCallback, useEffect, useMemo, useState } from '
 import styles from './App.module.css'
 
 import {
-    type AuthStatus,
     type ChatMessage,
     type ClientStateForWebview,
     CodyIDE,
@@ -13,7 +12,7 @@ import {
     type SerializedChatTranscript,
     type TelemetryRecorder,
 } from '@sourcegraph/cody-shared'
-import type { AuthMethod, ConfigurationSubsetForWebview, LocalEnv } from '../src/chat/protocol'
+import type { AuthMethod } from '../src/chat/protocol'
 import { LoadingPage } from './LoadingPage'
 import { LoginSimplified } from './OnboardingExperiment'
 import { ConnectionIssuesPage } from './Troubleshooting'
@@ -33,13 +32,11 @@ import { TelemetryRecorderContext, createWebviewTelemetryRecorder } from './util
 import { type Config, ConfigProvider } from './utils/useConfig'
 
 export const App: React.FunctionComponent<{ vscodeAPI: VSCodeWrapper }> = ({ vscodeAPI }) => {
-    const [config, setConfig] = useState<(LocalEnv & ConfigurationSubsetForWebview) | null>(null)
-    const [view, setView] = useState<View | undefined>()
+    const [config, setConfig] = useState<Config | null>(null)
+    const [view, setView] = useState<View>()
     const [messageInProgress, setMessageInProgress] = useState<ChatMessage | null>(null)
 
     const [transcript, setTranscript] = useState<ChatMessage[]>([])
-
-    const [authStatus, setAuthStatus] = useState<AuthStatus | null>(null)
 
     const [userHistory, setUserHistory] = useState<SerializedChatTranscript[]>()
 
@@ -47,10 +44,6 @@ export const App: React.FunctionComponent<{ vscodeAPI: VSCodeWrapper }> = ({ vsc
     const [isTranscriptError, setIsTranscriptError] = useState<boolean>(false)
 
     const [chatModels, setChatModels] = useState<Model[]>()
-
-    const [chatEnabled, setChatEnabled] = useState<boolean>(true)
-    const [attributionEnabled, setAttributionEnabled] = useState<boolean>(false)
-    const [serverSentModelsEnabled, setServerSentModelsEnabled] = useState<boolean>(false)
 
     const [clientState, setClientState] = useState<ClientStateForWebview>({
         initialContext: [],
@@ -96,19 +89,13 @@ export const App: React.FunctionComponent<{ vscodeAPI: VSCodeWrapper }> = ({ vsc
                         break
                     }
                     case 'config':
-                        setConfig(message.config)
-                        setAuthStatus(message.authStatus)
+                        setConfig(message)
                         setView(message.authStatus.isLoggedIn ? View.Chat : View.Login)
                         updateDisplayPathEnvInfoForWebview(message.workspaceFolderUris)
                         // Get chat models
                         if (message.authStatus.isLoggedIn) {
                             vscodeAPI.postMessage({ command: 'get-chat-models' })
                         }
-                        break
-                    case 'setConfigFeatures':
-                        setChatEnabled(message.configFeatures.chat)
-                        setAttributionEnabled(message.configFeatures.attribution)
-                        setServerSentModelsEnabled(message.configFeatures.serverSentModels)
                         break
                     case 'history':
                         setUserHistory(Object.values(message.localHistory?.chat ?? {}))
@@ -205,41 +192,38 @@ export const App: React.FunctionComponent<{ vscodeAPI: VSCodeWrapper }> = ({ vsc
         [vscodeAPI]
     )
     const chatModelContext = useMemo<ChatModelContext>(
-        () => ({ chatModels, onCurrentChatModelChange, serverSentModelsEnabled }),
-        [chatModels, onCurrentChatModelChange, serverSentModelsEnabled]
+        () => ({
+            chatModels,
+            onCurrentChatModelChange,
+            serverSentModelsEnabled: config?.configFeatures.serverSentModels,
+        }),
+        [chatModels, onCurrentChatModelChange, config]
     )
 
     const wrappers = useMemo<Wrapper[]>(
-        () =>
-            getAppWrappers(
-                vscodeAPI,
-                telemetryRecorder,
-                chatModelContext,
-                clientState,
-                config && authStatus ? { config, authStatus } : undefined
-            ),
-        [vscodeAPI, telemetryRecorder, chatModelContext, clientState, config, authStatus]
+        () => getAppWrappers(vscodeAPI, telemetryRecorder, chatModelContext, clientState, config),
+        [vscodeAPI, telemetryRecorder, chatModelContext, clientState, config]
     )
 
     // Wait for all the data to be loaded before rendering Chat View
-    if (!view || !authStatus || !config || !userHistory) {
+    if (!view || !config || !userHistory) {
         return <LoadingPage />
     }
 
     return (
         <ComposedWrappers wrappers={wrappers}>
-            {authStatus.showNetworkError ? (
+            {config.authStatus.showNetworkError ? (
                 <div className={styles.outerContainer}>
                     <ConnectionIssuesPage
-                        configuredEndpoint={authStatus.endpoint}
+                        configuredEndpoint={config.authStatus.endpoint}
                         vscodeAPI={vscodeAPI}
                     />
                 </div>
-            ) : view === View.Login || !authStatus.isLoggedIn || !userAccountInfo ? (
+            ) : view === View.Login || !config.authStatus.isLoggedIn ? (
                 <div className={styles.outerContainer}>
                     <LoginSimplified
                         simplifiedLoginRedirect={loginRedirect}
-                        uiKindIsWeb={config.uiKindIsWeb}
+                        uiKindIsWeb={config.config.uiKindIsWeb}
                         vscodeAPI={vscodeAPI}
                         codyIDE={config.config.agentIDE ?? CodyIDE.VSCode}
                     />
@@ -248,18 +232,18 @@ export const App: React.FunctionComponent<{ vscodeAPI: VSCodeWrapper }> = ({ vsc
                 <CodyPanel
                     view={view}
                     setView={setView}
-                    config={config}
+                    config={config.config}
                     errorMessages={errorMessages}
                     setErrorMessages={setErrorMessages}
-                    attributionEnabled={attributionEnabled}
-                    chatEnabled={chatEnabled}
+                    attributionEnabled={config.configFeatures.attribution}
+                    chatEnabled={config.configFeatures.chat}
                     messageInProgress={messageInProgress}
                     transcript={transcript}
                     vscodeAPI={vscodeAPI}
                     isTranscriptError={isTranscriptError}
                     guardrails={guardrails}
                     userHistory={userHistory}
-                    experimentalSmartApplyEnabled={config.experimentalSmartApply}
+                    experimentalSmartApplyEnabled={config.config.experimentalSmartApply}
                 />
             )}
         </ComposedWrappers>
@@ -271,7 +255,7 @@ export function getAppWrappers(
     telemetryRecorder: TelemetryRecorder,
     chatModelContext: ChatModelContext,
     clientState: ClientStateForWebview,
-    config: Config | undefined
+    config: Config | null
 ): Wrapper[] {
     return [
         {

--- a/vscode/webviews/AppWrapperForTest.tsx
+++ b/vscode/webviews/AppWrapperForTest.tsx
@@ -86,6 +86,11 @@ export const AppWrapperForTest: FunctionComponent<{ children: ReactNode }> = ({ 
                             endpoint: 'https://sourcegraph.example.com',
                         } satisfies Partial<AuthStatus> as any,
                         config: {} as any,
+                        configFeatures: {
+                            chat: true,
+                            serverSentModels: true,
+                            attribution: true,
+                        },
                     },
                 },
             } satisfies Wrapper<any, ComponentProps<typeof ConfigProvider>>,

--- a/vscode/webviews/Chat.story.tsx
+++ b/vscode/webviews/Chat.story.tsx
@@ -2,7 +2,7 @@ import { asyncGeneratorWithValues } from '@sourcegraph/cody-shared'
 import { ExtensionAPIProviderForTestsOnly, MOCK_API } from '@sourcegraph/prompt-editor'
 import type { Meta, StoryObj } from '@storybook/react'
 import { Chat } from './Chat'
-import { FIXTURE_TRANSCRIPT, FIXTURE_USER_ACCOUNT_INFO } from './chat/fixtures'
+import { FIXTURE_TRANSCRIPT } from './chat/fixtures'
 import { FIXTURE_COMMANDS, makePromptsAPIWithData } from './components/promptList/fixtures'
 import { VSCodeWebview } from './storybook/VSCodeStoryDecorator'
 
@@ -22,7 +22,6 @@ const meta: Meta<typeof Chat> = {
         transcript: FIXTURE_TRANSCRIPT.simple2,
         messageInProgress: null,
         chatEnabled: true,
-        userInfo: FIXTURE_USER_ACCOUNT_INFO,
         vscodeAPI: {
             postMessage: () => {},
             onMessage: () => () => {},

--- a/vscode/webviews/Chat.tsx
+++ b/vscode/webviews/Chat.tsx
@@ -18,6 +18,7 @@ import { WelcomeMessage } from './chat/components/WelcomeMessage'
 import { ScrollDown } from './components/ScrollDown'
 import type { View } from './tabs'
 import { useTelemetryRecorder } from './utils/telemetry'
+import { useUserAccountInfo } from './utils/useConfig'
 
 interface ChatboxProps {
     chatEnabled: boolean
@@ -25,7 +26,6 @@ interface ChatboxProps {
     transcript: ChatMessage[]
     vscodeAPI: Pick<VSCodeWrapper, 'postMessage' | 'onMessage'>
     isTranscriptError: boolean
-    userInfo: UserAccountInfo
     guardrails?: Guardrails
     scrollableParent?: HTMLElement | null
     showWelcomeMessage?: boolean
@@ -40,7 +40,6 @@ export const Chat: React.FunctionComponent<React.PropsWithChildren<ChatboxProps>
     vscodeAPI,
     isTranscriptError,
     chatEnabled = true,
-    userInfo,
     guardrails,
     scrollableParent,
     showWelcomeMessage = true,
@@ -52,6 +51,8 @@ export const Chat: React.FunctionComponent<React.PropsWithChildren<ChatboxProps>
 
     const transcriptRef = useRef(transcript)
     transcriptRef.current = transcript
+
+    const userInfo = useUserAccountInfo()
 
     const feedbackButtonsOnSubmit = useCallback(
         (text: string) => {

--- a/vscode/webviews/CodyPanel.tsx
+++ b/vscode/webviews/CodyPanel.tsx
@@ -21,7 +21,6 @@ export const CodyPanel: FunctionComponent<
     } & Pick<
         ComponentProps<typeof Chat>,
         | 'chatEnabled'
-        | 'userInfo'
         | 'messageInProgress'
         | 'transcript'
         | 'vscodeAPI'
@@ -40,7 +39,6 @@ export const CodyPanel: FunctionComponent<
     setErrorMessages,
     attributionEnabled,
     chatEnabled,
-    userInfo,
     messageInProgress,
     transcript,
     vscodeAPI,
@@ -68,7 +66,6 @@ export const CodyPanel: FunctionComponent<
                 {view === View.Chat && (
                     <Chat
                         chatEnabled={chatEnabled}
-                        userInfo={userInfo}
                         messageInProgress={messageInProgress}
                         transcript={transcript}
                         vscodeAPI={vscodeAPI}
@@ -83,8 +80,8 @@ export const CodyPanel: FunctionComponent<
                 )}
                 {view === View.History && <HistoryTab userHistory={userHistory} />}
                 {view === View.Prompts && <PromptsTab setView={setView} />}
-                {view === View.Account && <AccountTab userInfo={userInfo} />}
-                {view === View.Settings && <SettingsTab userInfo={userInfo} />}
+                {view === View.Account && <AccountTab />}
+                {view === View.Settings && <SettingsTab />}
             </TabContainer>
         </TabRoot>
     )

--- a/vscode/webviews/OnboardingExperiment.tsx
+++ b/vscode/webviews/OnboardingExperiment.tsx
@@ -1,6 +1,6 @@
 import { VSCodeButton } from '@vscode/webview-ui-toolkit/react'
 
-import { type AuthStatus, CodyIDE, type TelemetryRecorder } from '@sourcegraph/cody-shared'
+import { CodyIDE, type TelemetryRecorder } from '@sourcegraph/cody-shared'
 
 import type { AuthMethod } from '../src/chat/protocol'
 
@@ -13,13 +13,13 @@ import type { VSCodeWrapper } from './utils/VSCodeApi'
 import styles from './OnboardingExperiment.module.css'
 import { ClientSignInForm } from './components/ClientSignInForm'
 import { useTelemetryRecorder } from './utils/telemetry'
+import { useConfig } from './utils/useConfig'
 
 interface LoginProps {
     simplifiedLoginRedirect: (method: AuthMethod) => void
     uiKindIsWeb: boolean
     vscodeAPI: VSCodeWrapper
     codyIDE: CodyIDE
-    authStatus?: AuthStatus
 }
 
 const WebLogin: React.FunctionComponent<
@@ -70,8 +70,8 @@ export const LoginSimplified: React.FunctionComponent<React.PropsWithoutRef<Logi
     uiKindIsWeb,
     vscodeAPI,
     codyIDE,
-    authStatus,
 }) => {
+    const authStatus = useConfig().authStatus
     const telemetryRecorder = useTelemetryRecorder()
     const otherSignInClick = (): void => {
         vscodeAPI.postMessage({ command: 'auth', authKind: 'signin' })

--- a/vscode/webviews/tabs/AccountTab.tsx
+++ b/vscode/webviews/tabs/AccountTab.tsx
@@ -2,18 +2,15 @@ import { CodyIDE } from '@sourcegraph/cody-shared'
 import { useCallback } from 'react'
 import { URI } from 'vscode-uri'
 import { ACCOUNT_USAGE_URL } from '../../src/chat/protocol'
-import type { UserAccountInfo } from '../Chat'
 import { MESSAGE_CELL_AVATAR_SIZE } from '../chat/cells/messageCell/BaseMessageCell'
 import { UserAvatar } from '../components/UserAvatar'
 import { Button } from '../components/shadcn/ui/button'
 import { getVSCodeAPI } from '../utils/VSCodeApi'
-
-interface AccountTabProps {
-    userInfo: UserAccountInfo
-}
+import { useUserAccountInfo } from '../utils/useConfig'
 
 // TODO: Implement the AccountTab component once the design is ready.
-export const AccountTab: React.FC<AccountTabProps> = ({ userInfo }) => {
+export const AccountTab: React.FC = () => {
+    const userInfo = useUserAccountInfo()
     const { user, isCodyProUser, isDotComUser, ide } = userInfo
     const { displayName, username, primaryEmail, endpoint } = user
 

--- a/vscode/webviews/tabs/SettingsTab.tsx
+++ b/vscode/webviews/tabs/SettingsTab.tsx
@@ -1,17 +1,8 @@
-import type { UserAccountInfo } from '../Chat'
 import { Button } from '../components/shadcn/ui/button'
 import { getVSCodeAPI } from '../utils/VSCodeApi'
 
-interface SettingsTabProps {
-    userInfo: UserAccountInfo
-}
-
 // Placeholder for the settings tab - Not yet implemented.
-export const SettingsTab: React.FC<SettingsTabProps> = ({ userInfo }) => {
-    if (userInfo) {
-        return null
-    }
-
+export const SettingsTab: React.FC = () => {
     return (
         <div className="tw-overflow-auto tw-flex tw-flex-col tw-gap-4 tw-px-8 tw-mt-4">
             <Button

--- a/vscode/webviews/utils/useConfig.tsx
+++ b/vscode/webviews/utils/useConfig.tsx
@@ -1,3 +1,4 @@
+import { CodyIDE, isCodyProUser } from '@sourcegraph/cody-shared'
 import {
     type ComponentProps,
     type FunctionComponent,
@@ -6,6 +7,7 @@ import {
     useContext,
 } from 'react'
 import type { ExtensionMessage } from '../../src/chat/protocol'
+import type { UserAccountInfo } from '../Chat'
 
 export interface Config
     extends Pick<Extract<ExtensionMessage, { type: 'config' }>, 'config' | 'authStatus'> {}
@@ -32,4 +34,16 @@ export function useConfig(allowUndefined?: 'allow-undefined'): Config | undefine
         throw new Error('useConfig must be used within a ConfigProvider')
     }
     return config
+}
+
+export function useUserAccountInfo(): UserAccountInfo {
+    const value = useConfig()
+    return {
+        isCodyProUser: isCodyProUser(value.authStatus),
+        // Receive this value from the extension backend to make it work
+        // with E2E tests where change the DOTCOM_URL via the env variable TESTING_DOTCOM_URL.
+        isDotComUser: value.authStatus.isDotCom,
+        user: value.authStatus,
+        ide: value.config.agentIDE ?? CodyIDE.VSCode,
+    }
 }

--- a/vscode/webviews/utils/useConfig.tsx
+++ b/vscode/webviews/utils/useConfig.tsx
@@ -10,9 +10,12 @@ import type { ExtensionMessage } from '../../src/chat/protocol'
 import type { UserAccountInfo } from '../Chat'
 
 export interface Config
-    extends Pick<Extract<ExtensionMessage, { type: 'config' }>, 'config' | 'authStatus'> {}
+    extends Pick<
+        Extract<ExtensionMessage, { type: 'config' }>,
+        'config' | 'authStatus' | 'configFeatures'
+    > {}
 
-const ConfigContext = createContext<Config | undefined>(undefined)
+const ConfigContext = createContext<Config | null>(null)
 
 /**
  * React context provider whose `value` is the {@link Config}.
@@ -26,11 +29,9 @@ export const ConfigProvider: FunctionComponent<{
 /**
  * React hook for getting the {@link Config}.
  */
-export function useConfig(): Config
-export function useConfig(allowUndefined: 'allow-undefined'): Config | undefined
-export function useConfig(allowUndefined?: 'allow-undefined'): Config | undefined {
+export function useConfig(): Config {
     const config = useContext(ConfigContext)
-    if (!config && allowUndefined !== 'allow-undefined') {
+    if (!config) {
         throw new Error('useConfig must be used within a ConfigProvider')
     }
     return config

--- a/web/lib/components/CodyWebPanel.tsx
+++ b/web/lib/components/CodyWebPanel.tsx
@@ -18,7 +18,6 @@ import {
 
 import { ChatMentionContext, type ChatMentionsSettings } from '@sourcegraph/prompt-editor'
 import { getAppWrappers } from 'cody-ai/webviews/App'
-import type { UserAccountInfo } from 'cody-ai/webviews/Chat'
 import { ChatEnvironmentContext } from 'cody-ai/webviews/chat/ChatEnvironmentContext'
 import type { ChatModelContext } from 'cody-ai/webviews/chat/models/chatModelContext'
 import { useClientActionDispatcher } from 'cody-ai/webviews/client/clientState'
@@ -61,7 +60,6 @@ export const CodyWebPanel: FC<CodyWebPanelProps> = props => {
     const [isTranscriptError, setIsTranscriptError] = useState<boolean>(false)
     const [messageInProgress, setMessageInProgress] = useState<ChatMessage | null>(null)
     const [transcript, setTranscript] = useState<ChatMessage[]>([])
-    const [userAccountInfo, setUserAccountInfo] = useState<UserAccountInfo>()
     const [chatModels, setChatModels] = useState<Model[]>()
     const [serverSentModelsEnabled, setServerSentModelsEnabled] = useState<boolean>(false)
     const [config, setConfig] = useState<(LocalEnv & ConfigurationSubsetForWebview) | null>(null)
@@ -103,12 +101,6 @@ export const CodyWebPanel: FC<CodyWebPanelProps> = props => {
                 case 'config':
                     setConfig(message.config)
                     setAuthStatus(message.authStatus)
-                    setUserAccountInfo({
-                        isCodyProUser: !message.authStatus.userCanUpgrade,
-                        isDotComUser: message.authStatus.isDotCom,
-                        user: message.authStatus,
-                        ide: CodyIDE.Web,
-                    })
                     break
                 case 'clientAction':
                     dispatchClientAction(message)
@@ -199,7 +191,7 @@ export const CodyWebPanel: FC<CodyWebPanelProps> = props => {
         [vscodeAPI, telemetryRecorder, chatModelContext, clientState, config, authStatus]
     )
 
-    const isLoading = !client || !userAccountInfo || !chatModels || !config || !view || !userHistory
+    const isLoading = !client || !chatModels || !config || !view || !userHistory
 
     return (
         <div className={className} data-cody-web-chat={true}>
@@ -221,7 +213,6 @@ export const CodyWebPanel: FC<CodyWebPanelProps> = props => {
                                     chatEnabled={true}
                                     showWelcomeMessage={true}
                                     showIDESnippetActions={true}
-                                    userInfo={userAccountInfo}
                                     messageInProgress={messageInProgress}
                                     transcript={transcript}
                                     vscodeAPI={vscodeAPI}


### PR DESCRIPTION
These were some small fixes that were piling up on one of my branches. No user-facing behavior change.

- perform auth in agent slightly earlier
- don't call it dispose if it's called multiple times and doesn't invalidate the instance
- use minimal Config type when access token is not needed
- SourcegraphGraphQLAPIClient cleanup
- use types instead of `satisfies`
- merge configFeatures webview RPC message into existing config message
- rm FeatureFlagProvider endpoint arg
- get userAccountInfo through React context

## Test plan

CI, run locally and ensure no errors