### PR TITLE
lazily import js-tiktoken to cut ~6mb from initial bundle size

### DIFF
--- a/agent/src/cli/command-chat.ts
+++ b/agent/src/cli/command-chat.ts
@@ -3,7 +3,7 @@ import ora, { type Ora, spinners } from 'ora'
 import path from 'node:path'
 
 import type { Polly } from '@pollyjs/core'
-import { type ContextItem, ModelUsage, TokenCounter } from '@sourcegraph/cody-shared'
+import { type ContextItem, ModelUsage, TokenCounterUtils } from '@sourcegraph/cody-shared'
 import { Command } from 'commander'
 
 import Table from 'easy-table'
@@ -306,7 +306,7 @@ export async function chatAction(options: ChatOptions): Promise<number> {
     spinner.prefixText = ''
     const elapsed = performance.now() - start
     const replyText = reply.text ?? ''
-    const tokens = TokenCounter.encode(replyText).length
+    const tokens = (await TokenCounterUtils.encode(replyText)).length
     const tokensPerSecond = tokens / (elapsed / 1000)
     spinner.text = spinner.text.trim() + ` (${Math.round(tokensPerSecond)} tokens/second)`
     spinner.clear()

--- a/lib/shared/package.json
+++ b/lib/shared/package.json
@@ -28,7 +28,7 @@
     "diff": "^5.2.0",
     "fast-xml-parser": "^4.3.2",
     "isomorphic-fetch": "^3.0.0",
-    "js-tiktoken": "^1.0.10",
+    "js-tiktoken": "^1.0.14",
     "lexical": "^0.17.0",
     "lodash": "^4.17.21",
     "lru-cache": "^10.0.0",

--- a/lib/shared/src/index.ts
+++ b/lib/shared/src/index.ts
@@ -184,7 +184,6 @@ export {
 export { PromptMixin, newPromptMixin } from './prompt/prompt-mixin'
 export * from './prompt/templates'
 export {
-    truncateText,
     truncateTextNearestLine,
     truncatePromptStringStart,
     truncatePromptString,
@@ -285,7 +284,7 @@ export {
     SYMBOL_CONTEXT_MENTION_PROVIDER,
     type ContextMentionProviderMetadata,
 } from './mentions/api'
-export { TokenCounter } from './token/counter'
+export { TokenCounter, getTokenCounterUtils, TokenCounterUtils } from './token/counter'
 export { CORPUS_CONTEXT_ALLOCATION as ENHANCED_CONTEXT_ALLOCATION } from './token/constants'
 export { tokensToChars, charsToTokens } from './token/utils'
 export * from './prompt/prompt-string'

--- a/lib/shared/src/prompt/truncation.test.ts
+++ b/lib/shared/src/prompt/truncation.test.ts
@@ -1,51 +1,25 @@
-import { truncateText, truncateTextStart } from './truncation'
+import { truncateTextStart } from './truncation'
 
 import { describe, expect, it } from 'vitest'
 
-describe('truncateText', () => {
-    it('truncates text to max tokens', () => {
-        const text = 'Hello world, this is a test string for truncation'
-        const maxTokens = 5
-        const truncated = truncateText(text, maxTokens)
-
-        expect(truncated).toBe('Hello world, this is')
-    })
-
-    it('returns original text if tokens are less than max', () => {
-        const text = 'Hello'
-        const maxTokens = 10
-        const truncated = truncateText(text, maxTokens)
-
-        expect(truncated).toBe('Hello')
-    })
-
-    it('handles empty text', () => {
-        const text = ''
-        const maxTokens = 5
-        const truncated = truncateText(text, maxTokens)
-
-        expect(truncated).toBe('')
-    })
-})
-
 describe('truncateTextStart', () => {
-    it('truncates text to the specified number of tokens', () => {
+    it('truncates text to the specified number of tokens', async () => {
         const text = 'Hello world, this is a test string'
-        const truncated = truncateTextStart(text, 5)
+        const truncated = await truncateTextStart(text, 5)
 
         expect(truncated).toBe('this is a test string')
     })
 
-    it('returns original text if tokens is greater than text length', () => {
+    it('returns original text if tokens is greater than text length', async () => {
         const text = 'Hello'
-        const truncated = truncateTextStart(text, 10)
+        const truncated = await truncateTextStart(text, 10)
 
         expect(truncated).toBe('Hello')
     })
 
-    it('truncates to the end of the last token if maxTokens is mid-token', () => {
+    it('truncates to the end of the last token if maxTokens is mid-token', async () => {
         const text = 'Hello world test string'
-        const truncated = truncateTextStart(text, 2)
+        const truncated = await truncateTextStart(text, 2)
 
         expect(truncated).toBe('test string')
     })

--- a/lib/shared/src/prompt/truncation.ts
+++ b/lib/shared/src/prompt/truncation.ts
@@ -1,21 +1,17 @@
 import type { RangeData } from '../common/range'
-import { TokenCounter } from '../token/counter'
+import { getTokenCounterUtils } from '../token/counter'
 
 import type { PromptString } from './prompt-string'
 
-/**
- * Truncates text to the given number of tokens, keeping the start of the text.
- */
-export function truncateText(text: string, maxTokens: number): string {
-    const encoded = TokenCounter.encode(text)
-    return encoded.length <= maxTokens ? text : TokenCounter.decode(encoded.slice(0, maxTokens)).trim()
-}
-
-export function truncatePromptString(text: PromptString, maxTokens: number): PromptString {
-    const encoded = TokenCounter.encode(text.toString())
+export async function truncatePromptString(
+    text: PromptString,
+    maxTokens: number
+): Promise<PromptString> {
+    const tokenCounterUtils = await getTokenCounterUtils()
+    const encoded = tokenCounterUtils.encode(text.toString())
     return encoded.length <= maxTokens
         ? text
-        : text.slice(0, TokenCounter.decode(encoded.slice(0, maxTokens))?.length).trim()
+        : text.slice(0, tokenCounterUtils.decode(encoded.slice(0, maxTokens))?.length).trim()
 }
 
 /**
@@ -57,13 +53,21 @@ export function truncateTextNearestLine(
 /**
  * Truncates text to the given number of tokens, keeping the end of the text.
  */
-export function truncateTextStart(text: string, maxTokens: number): string {
-    const encoded = TokenCounter.encode(text)
-    return encoded.length <= maxTokens ? text : TokenCounter.decode(encoded.slice(-maxTokens)).trim()
+export async function truncateTextStart(text: string, maxTokens: number): Promise<string> {
+    const tokenCounterUtils = await getTokenCounterUtils()
+    const encoded = tokenCounterUtils.encode(text)
+    return encoded.length <= maxTokens
+        ? text
+        : tokenCounterUtils.decode(encoded.slice(-maxTokens)).trim()
 }
 
-export function truncatePromptStringStart(text: PromptString, maxTokens: number): PromptString {
-    const encoded = TokenCounter.encode(text.toString())
+export async function truncatePromptStringStart(
+    text: PromptString,
+    maxTokens: number
+): Promise<PromptString> {
+    const tokenCounterUtils = await getTokenCounterUtils()
+
+    const encoded = tokenCounterUtils.encode(text.toString())
 
     if (encoded.length <= maxTokens) {
         return text
@@ -73,6 +77,6 @@ export function truncatePromptStringStart(text: PromptString, maxTokens: number)
     // considered unsafe. Instead, we use the string representation to get the updated
     // character count
 
-    const decoded = TokenCounter.decode(encoded.slice(-maxTokens))
+    const decoded = tokenCounterUtils.decode(encoded.slice(-maxTokens))
     return text.slice(-decoded.length - 1).trim()
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -375,8 +375,8 @@ importers:
         specifier: ^3.0.0
         version: 3.0.0
       js-tiktoken:
-        specifier: ^1.0.10
-        version: 1.0.10
+        specifier: ^1.0.14
+        version: 1.0.14
       lexical:
         specifier: ^0.17.0
         version: 0.17.0
@@ -11679,8 +11679,8 @@ packages:
     resolution: {integrity: sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g==}
     engines: {node: '>=0.10.0'}
 
-  /js-tiktoken@1.0.10:
-    resolution: {integrity: sha512-ZoSxbGjvGyMT13x6ACo9ebhDha/0FHdKA+OsQcMOWcm1Zs7r90Rhk5lhERLzji+3rA7EKpXCgwXcM5fF3DMpdA==}
+  /js-tiktoken@1.0.14:
+    resolution: {integrity: sha512-Pk3l3WOgM9joguZY2k52+jH82RtABRgB5RdGFZNUGbOKGMVlNmafcPA3b0ITcCZPu1L9UclP1tne6aw7ZI4Myg==}
     dependencies:
       base64-js: 1.5.1
     dev: false

--- a/vscode/src/chat/chat-view/prompt.test.ts
+++ b/vscode/src/chat/chat-view/prompt.test.ts
@@ -54,7 +54,7 @@ describe('DefaultPrompter', () => {
     })
 
     it('prompt context items are ordered in reverse order of relevance', async () => {
-        const p = new PromptBuilder({ input: 10_000, output: 10_000 })
+        const p = await PromptBuilder.create({ input: 10_000, output: 10_000 })
         const contextItems: ContextItem[] = [
             {
                 type: 'file',

--- a/vscode/src/chat/chat-view/prompt.ts
+++ b/vscode/src/chat/chat-view/prompt.ts
@@ -47,7 +47,7 @@ export class DefaultPrompter {
         options?: { experimentalSmartApplyEnabled?: boolean }
     ): Promise<PromptInfo> {
         return wrapInActiveSpan('chat.prompter', async () => {
-            const promptBuilder = new PromptBuilder(chat.contextWindow)
+            const promptBuilder = await PromptBuilder.create(chat.contextWindow)
             const preInstruction: PromptString | undefined = PromptString.fromConfig(
                 vscode.workspace.getConfiguration('cody.chat'),
                 'preInstruction',

--- a/vscode/src/commands/context/directory.ts
+++ b/vscode/src/commands/context/directory.ts
@@ -1,7 +1,7 @@
 import {
     type ContextItem,
     ContextItemSource,
-    TokenCounter,
+    TokenCounterUtils,
     contextFiltersProvider,
     logError,
     toRangeData,
@@ -65,7 +65,7 @@ export async function getContextFileFromDirectory(directory?: URI): Promise<Cont
                 const bytes = await vscode.workspace.fs.readFile(fileUri)
                 const content = new TextDecoder('utf-8').decode(bytes)
                 const range = new vscode.Range(0, 0, content.split('\n').length - 1 || 0, 0)
-                const size = TokenCounter.countTokens(content)
+                const size = await TokenCounterUtils.countTokens(content)
 
                 contextFiles.push({
                     type: 'file',

--- a/vscode/src/commands/context/file-path.ts
+++ b/vscode/src/commands/context/file-path.ts
@@ -1,7 +1,7 @@
 import {
     type ContextItem,
     ContextItemSource,
-    TokenCounter,
+    TokenCounterUtils,
     contextFiltersProvider,
     logError,
     toRangeData,
@@ -45,7 +45,7 @@ export async function getContextFileFromUri(
             if (!content.trim()) {
                 throw new Error('No file content')
             }
-            const size = TokenCounter.countTokens(content)
+            const size = await TokenCounterUtils.countTokens(content)
 
             return {
                 type: 'file',

--- a/vscode/src/commands/context/git-api.ts
+++ b/vscode/src/commands/context/git-api.ts
@@ -1,6 +1,11 @@
 import * as vscode from 'vscode'
 
-import { type ContextItem, ContextItemSource, TokenCounter, displayPath } from '@sourcegraph/cody-shared'
+import {
+    type ContextItem,
+    ContextItemSource,
+    TokenCounterUtils,
+    displayPath,
+} from '@sourcegraph/cody-shared'
 import { logError } from '../../log'
 import type { Repository } from '../../repository/builtinGitExtension'
 import { doesFileExist } from '../utils/workspace-files'
@@ -24,7 +29,7 @@ export async function getContextFilesFromGitApi(
 
     const contextItems = [...diffContext, ...logContext]
     if (template) {
-        contextItems.push(getGitCommitTemplateContextFile(template))
+        contextItems.push(await getGitCommitTemplateContextFile(template))
     }
     return contextItems
 }
@@ -94,7 +99,7 @@ async function getContextFilesFromGitDiff(gitRepo: Repository): Promise<ContextI
                 // Using the uri by file enables Cody Ignore checks during prompt-building step.
                 uri,
                 source: ContextItemSource.Terminal,
-                size: TokenCounter.countTokens(content),
+                size: await TokenCounterUtils.countTokens(content),
             })
         }
 
@@ -138,7 +143,7 @@ async function getContextFilesFromGitLog(gitRepo: Repository, maxEntries = 5): P
                 title: command,
                 uri: vscode.Uri.file('GIT_LOG'),
                 source: ContextItemSource.Terminal,
-                size: TokenCounter.countTokens(content),
+                size: await TokenCounterUtils.countTokens(content),
             },
         ]
     } catch (error) {
@@ -153,7 +158,7 @@ async function getContextFilesFromGitLog(gitRepo: Repository, maxEntries = 5): P
  * @param template - The git commit template.
  * @returns The context item containing the git commit template information.
  */
-function getGitCommitTemplateContextFile(template: string): ContextItem {
+async function getGitCommitTemplateContextFile(template: string): Promise<ContextItem> {
     const content = `Here is my git commit template:\n\n${template}`
     return {
         type: 'file',
@@ -161,7 +166,7 @@ function getGitCommitTemplateContextFile(template: string): ContextItem {
         title: 'Git Commit Template',
         uri: vscode.Uri.file('COMMIT_TEMPLATE'),
         source: ContextItemSource.Terminal,
-        size: TokenCounter.countTokens(content),
+        size: await TokenCounterUtils.countTokens(content),
     }
 }
 

--- a/vscode/src/commands/context/selection.ts
+++ b/vscode/src/commands/context/selection.ts
@@ -1,6 +1,6 @@
 import {
     type ContextItem,
-    TokenCounter,
+    TokenCounterUtils,
     contextFiltersProvider,
     isCodyIgnoredFile,
     logError,
@@ -47,7 +47,7 @@ export async function getContextFileFromCursor(
             const selection = activeSelection ?? visibleRange
 
             const content = document.getText(selection)
-            const size = TokenCounter.countTokens(content)
+            const size = await TokenCounterUtils.countTokens(content)
 
             return {
                 type: 'file',
@@ -90,7 +90,7 @@ export async function getContextFileFromSelection(): Promise<ContextItem[]> {
                     content,
                     source: ContextItemSource.Selection,
                     range: toRangeData(selection),
-                    size: TokenCounter.countTokens(content),
+                    size: await TokenCounterUtils.countTokens(content),
                 } satisfies ContextItemFile,
             ]
         } catch (error) {
@@ -129,7 +129,7 @@ export async function getSelectionOrFileContext(): Promise<ContextItem[]> {
                 content,
                 source: ContextItemSource.Selection,
                 range: range && toRangeData(range),
-                size: TokenCounter.countTokens(content),
+                size: await TokenCounterUtils.countTokens(content),
             } satisfies ContextItemFile,
         ]
     })

--- a/vscode/src/commands/context/shell.ts
+++ b/vscode/src/commands/context/shell.ts
@@ -10,7 +10,7 @@ import path from 'node:path/posix'
 import {
     type ContextItem,
     ContextItemSource,
-    TokenCounter,
+    TokenCounterUtils,
     wrapInActiveSpan,
 } from '@sourcegraph/cody-shared'
 
@@ -43,7 +43,7 @@ export async function getContextFileFromShell(command: string): Promise<ContextI
             }
 
             const content = outputWrapper.replace('{command}', command).replace('{output}', output)
-            const size = TokenCounter.countTokens(content)
+            const size = await TokenCounterUtils.countTokens(content)
 
             return [
                 {

--- a/vscode/src/commands/scm/source-control.ts
+++ b/vscode/src/commands/scm/source-control.ts
@@ -208,7 +208,7 @@ export class CodySourceControl implements vscode.Disposable {
         const text = COMMIT_COMMAND_PROMPTS.instruction.replace('{COMMIT_TEMPLATE}', templatePrompt)
         const transcript: ChatMessage[] = [{ speaker: 'human', text }]
 
-        const promptBuilder = new PromptBuilder(contextWindow)
+        const promptBuilder = await PromptBuilder.create(contextWindow)
         promptBuilder.tryAddToPrefix(preamble)
         promptBuilder.tryAddMessages(transcript.reverse())
 

--- a/vscode/src/commands/utils/create-context-file.ts
+++ b/vscode/src/commands/utils/create-context-file.ts
@@ -1,4 +1,4 @@
-import { type ContextItem, ContextItemSource, TokenCounter } from '@sourcegraph/cody-shared'
+import { type ContextItem, ContextItemSource, TokenCounterUtils } from '@sourcegraph/cody-shared'
 
 import * as vscode from 'vscode'
 import type { URI } from 'vscode-uri'
@@ -6,7 +6,7 @@ import type { URI } from 'vscode-uri'
 export async function createContextFile(file: URI, content: string): Promise<ContextItem | undefined> {
     try {
         const range = new vscode.Range(0, 0, content.split('\n').length, 0)
-        const size = TokenCounter.countTokens(content)
+        const size = await TokenCounterUtils.countTokens(content)
 
         return {
             type: 'file',

--- a/vscode/src/edit/prompt/context.ts
+++ b/vscode/src/edit/prompt/context.ts
@@ -44,8 +44,8 @@ const getContextFromIntent = async ({
     selectionRange,
     editor,
 }: GetContextFromIntentOptions): Promise<ContextMessage[]> => {
-    const truncatedPrecedingText = truncatePromptStringStart(prefix.text, MAX_CURRENT_FILE_TOKENS)
-    const truncatedFollowingText = truncatePromptString(suffix.text, MAX_CURRENT_FILE_TOKENS)
+    const truncatedPrecedingText = await truncatePromptStringStart(prefix.text, MAX_CURRENT_FILE_TOKENS)
+    const truncatedFollowingText = await truncatePromptString(suffix.text, MAX_CURRENT_FILE_TOKENS)
 
     // Disable no case declarations because we get better type checking with a switch case
     switch (intent) {

--- a/vscode/src/edit/prompt/index.ts
+++ b/vscode/src/edit/prompt/index.ts
@@ -8,7 +8,7 @@ import {
     type EditProvider,
     type Message,
     PromptString,
-    TokenCounter,
+    TokenCounterUtils,
     getModelInfo,
     getSimplePreamble,
     modelsService,
@@ -84,7 +84,7 @@ export const buildInteraction = async ({
     )
     const precedingText = PromptString.fromDocumentText(document, prefixRange)
     const selectedText = PromptString.fromDocumentText(document, task.selectionRange)
-    const tokenCount = TokenCounter.countPromptString(selectedText)
+    const tokenCount = await TokenCounterUtils.countPromptString(selectedText)
     if (tokenCount > contextWindow) {
         throw new Error("The amount of text selected exceeds Cody's current capacity.")
     }
@@ -104,7 +104,7 @@ export const buildInteraction = async ({
             instruction: task.instruction,
             document,
         })
-    const promptBuilder = new PromptBuilder(modelsService.getContextWindowByID(model))
+    const promptBuilder = await PromptBuilder.create(modelsService.getContextWindowByID(model))
 
     const preamble = getSimplePreamble(model, codyApiVersion, prompt.system)
     promptBuilder.tryAddToPrefix(preamble)

--- a/vscode/src/edit/prompt/smart-apply.ts
+++ b/vscode/src/edit/prompt/smart-apply.ts
@@ -5,7 +5,7 @@ import {
     type EditModel,
     type Message,
     PromptString,
-    TokenCounter,
+    TokenCounterUtils,
     getSimplePreamble,
     modelsService,
     ps,
@@ -70,13 +70,13 @@ export const getPrompt = async (
 ): Promise<{ messages: Message[]; prefix: string }> => {
     const documentRange = new vscode.Range(0, 0, document.lineCount - 1, 0)
     const documentText = PromptString.fromDocumentText(document, documentRange)
-    const tokenCount = TokenCounter.countPromptString(documentText)
+    const tokenCount = await TokenCounterUtils.countPromptString(documentText)
     const contextWindow = modelsService.getContextWindowByID(model)
     if (tokenCount > contextWindow.input) {
         throw new Error("The amount of text in this document exceeds Cody's current capacity.")
     }
 
-    const promptBuilder = new PromptBuilder(contextWindow)
+    const promptBuilder = await PromptBuilder.create(contextWindow)
     const preamble = getSimplePreamble(model, codyApiVersion, SMART_APPLY_SELECTION_PROMPT.system)
     promptBuilder.tryAddToPrefix(preamble)
 

--- a/vscode/src/editor/utils/editor-context.ts
+++ b/vscode/src/editor/utils/editor-context.ts
@@ -13,7 +13,7 @@ import {
     type PromptString,
     type RangeData,
     type SymbolKind,
-    TokenCounter,
+    TokenCounterUtils,
     contextFiltersProvider,
     displayPath,
     graphqlClient,
@@ -387,10 +387,12 @@ async function resolveContextItem(
         : item.type === 'file' || item.type === 'symbol'
           ? [await resolveFileOrSymbolContextItem(item, editor, signal)]
           : []
-    return resolvedItems.map(resolvedItem => ({
-        ...resolvedItem,
-        size: resolvedItem.size ?? TokenCounter.countTokens(resolvedItem.content),
-    }))
+    return await Promise.all(
+        resolvedItems.map(async resolvedItem => ({
+            ...resolvedItem,
+            size: resolvedItem.size ?? (await TokenCounterUtils.countTokens(resolvedItem.content)),
+        }))
+    )
 }
 
 async function resolveContextMentionProviderContextItem(
@@ -463,7 +465,7 @@ async function resolveFileOrSymbolContextItem(
                 content: resultOrError,
                 repoName: repository,
                 source: ContextItemSource.Unified,
-                size: TokenCounter.countTokens(resultOrError),
+                size: await TokenCounterUtils.countTokens(resultOrError),
             }
         }
     }
@@ -476,6 +478,6 @@ async function resolveFileOrSymbolContextItem(
     return {
         ...contextItem,
         content,
-        size: contextItem.size ?? TokenCounter.countTokens(content),
+        size: contextItem.size ?? (await TokenCounterUtils.countTokens(content)),
     }
 }

--- a/vscode/src/prompt-builder/index.test.ts
+++ b/vscode/src/prompt-builder/index.test.ts
@@ -18,8 +18,8 @@ describe('PromptBuilder', () => {
 
     const preamble: Message[] = [{ speaker: 'system', text: ps`preamble` }]
 
-    it('throws an error when trying to add corpus context before chat input', () => {
-        const builder = new PromptBuilder({ input: 100, output: 100 })
+    it('throws an error when trying to add corpus context before chat input', async () => {
+        const builder = await PromptBuilder.create({ input: 100, output: 100 })
         builder.tryAddToPrefix(preamble)
         const file: ContextItem = {
             type: 'file',
@@ -30,8 +30,8 @@ describe('PromptBuilder', () => {
         expect(() => builder.tryAddContext('corpus', [file])).rejects.toThrowError()
     })
 
-    it('throws an error when trying to add User Context before chat input', () => {
-        const builder = new PromptBuilder({ input: 100, output: 100 })
+    it('throws an error when trying to add User Context before chat input', async () => {
+        const builder = await PromptBuilder.create({ input: 100, output: 100 })
         builder.tryAddToPrefix(preamble)
         const file: ContextItem = {
             type: 'file',
@@ -42,9 +42,9 @@ describe('PromptBuilder', () => {
         expect(() => builder.tryAddContext('user', [file])).rejects.toThrowError()
     })
 
-    describe('tryAddToPrefix', () => {
-        it('should add messages to prefix if within token limit', () => {
-            const builder = new PromptBuilder({ input: 20, output: 100 })
+    describe('tryAddToPrefix', async () => {
+        it('should add messages to prefix if within token limit', async () => {
+            const builder = await PromptBuilder.create({ input: 20, output: 100 })
             const preambleTranscript: ChatMessage[] = [{ speaker: 'human', text: ps`Hi!` }]
 
             expect(builder.tryAddToPrefix(preambleTranscript)).toBe(true)
@@ -52,8 +52,8 @@ describe('PromptBuilder', () => {
             // expect(mockUpdateUsage).toHaveBeenCalledWith('preamble', messages)
         })
 
-        it('should not add messages to prefix if not within token limit', () => {
-            const builder = new PromptBuilder({ input: 1, output: 100 })
+        it('should not add messages to prefix if not within token limit', async () => {
+            const builder = await PromptBuilder.create({ input: 1, output: 100 })
             const preambleTranscript: ChatMessage[] = [{ speaker: 'human', text: ps`Hi!` }]
 
             expect(builder.tryAddToPrefix(preambleTranscript)).toBe(false)
@@ -61,15 +61,15 @@ describe('PromptBuilder', () => {
         })
     })
 
-    describe('tryAddMessages', () => {
-        it('throws error when tryAddMessages before tryAddPrefix', () => {
-            const builder = new PromptBuilder({ input: 100, output: 100 })
+    describe('tryAddMessages', async () => {
+        it('throws error when tryAddMessages before tryAddPrefix', async () => {
+            const builder = await PromptBuilder.create({ input: 100, output: 100 })
             const transcript: ChatMessage[] = [{ speaker: 'human', text: ps`Hi!` }]
             expect(() => builder.tryAddMessages(transcript.reverse())).toThrowError()
         })
 
-        it('adds single valid transcript', () => {
-            const builder = new PromptBuilder({ input: 100, output: 100 })
+        it('adds single valid transcript', async () => {
+            const builder = await PromptBuilder.create({ input: 100, output: 100 })
             const transcript: ChatMessage[] = [{ speaker: 'human', text: ps`Hi!` }]
             builder.tryAddToPrefix(preamble)
             builder.tryAddMessages(transcript.reverse())
@@ -79,8 +79,8 @@ describe('PromptBuilder', () => {
             expect(messages[1].speaker).toBe('human')
         })
 
-        it('throw on transcript starts with assistant', () => {
-            const builder = new PromptBuilder({ input: 100, output: 100 })
+        it('throw on transcript starts with assistant', async () => {
+            const builder = await PromptBuilder.create({ input: 100, output: 100 })
             const transcript: ChatMessage[] = [{ speaker: 'assistant', text: ps`Hi!` }]
             builder.tryAddToPrefix(preamble)
             expect(() => {
@@ -88,8 +88,8 @@ describe('PromptBuilder', () => {
             }).toThrowError()
         })
 
-        it('adds valid transcript in reverse order', () => {
-            const builder = new PromptBuilder({ input: 1000, output: 100 })
+        it('adds valid transcript in reverse order', async () => {
+            const builder = await PromptBuilder.create({ input: 1000, output: 100 })
             const transcript: ChatMessage[] = [
                 { speaker: 'human', text: ps`Hi assistant!` },
                 { speaker: 'assistant', text: ps`Hello there!` },
@@ -107,8 +107,8 @@ describe('PromptBuilder', () => {
             expect(messages[2].speaker === messages[4].speaker).toBeTruthy()
         })
 
-        it('throws on consecutive speakers order', () => {
-            const builder = new PromptBuilder({ input: 1000, output: 100 })
+        it('throws on consecutive speakers order', async () => {
+            const builder = await PromptBuilder.create({ input: 1000, output: 100 })
             const invalidTranscript: ChatMessage[] = [
                 { speaker: 'human', text: ps`Hi there!` },
                 { speaker: 'human', text: ps`Hello there!` },
@@ -121,8 +121,8 @@ describe('PromptBuilder', () => {
             }).toThrowError()
         })
 
-        it('throws on transcript with human speakers only', () => {
-            const builder = new PromptBuilder({ input: 1000, output: 100 })
+        it('throws on transcript with human speakers only', async () => {
+            const builder = await PromptBuilder.create({ input: 1000, output: 100 })
             const invalidTranscript: ChatMessage[] = [
                 { speaker: 'human', text: ps`1` },
                 { speaker: 'human', text: ps`2` },
@@ -135,8 +135,8 @@ describe('PromptBuilder', () => {
             }).toThrowError()
         })
 
-        it('stops adding message-pairs when limit has been reached', () => {
-            const builder = new PromptBuilder({ input: 20, output: 100 })
+        it('stops adding message-pairs when limit has been reached', async () => {
+            const builder = await PromptBuilder.create({ input: 20, output: 100 })
             builder.tryAddToPrefix(preamble)
             const longTranscript: ChatMessage[] = [
                 { speaker: 'human', text: ps`Hi assistant!` },
@@ -156,7 +156,7 @@ describe('PromptBuilder', () => {
         })
     })
 
-    describe('tryAddContext', () => {
+    describe('tryAddContext', async () => {
         const chatTranscript: Message[] = [
             { speaker: 'human', text: ps`Hi!` },
             { speaker: 'assistant', text: ps`Hi!` },
@@ -170,7 +170,7 @@ describe('PromptBuilder', () => {
         }
 
         it('should not allow context prompt to exceed context window', async () => {
-            const builder = new PromptBuilder({ input: 10, output: 100 })
+            const builder = await PromptBuilder.create({ input: 10, output: 100 })
             builder.tryAddToPrefix(preamble)
             builder.tryAddMessages([...chatTranscript].reverse())
 
@@ -193,7 +193,7 @@ describe('PromptBuilder', () => {
         })
 
         it('should not contain duplicated context', async () => {
-            const builder = new PromptBuilder({ input: 100, output: 100 })
+            const builder = await PromptBuilder.create({ input: 100, output: 100 })
             builder.tryAddToPrefix(preamble)
             builder.tryAddMessages([...chatTranscript].reverse())
 
@@ -209,7 +209,7 @@ describe('PromptBuilder', () => {
         })
 
         it('should not contain non-unique context (context with overlapping ranges)', async () => {
-            const builder = new PromptBuilder({ input: 100, output: 100 })
+            const builder = await PromptBuilder.create({ input: 100, output: 100 })
             builder.tryAddToPrefix(preamble)
             builder.tryAddMessages([...chatTranscript].reverse())
 
@@ -230,7 +230,7 @@ describe('PromptBuilder', () => {
         })
 
         it('should not contain context that is too large', async () => {
-            const builder = new PromptBuilder({ input: 50, output: 50 })
+            const builder = await PromptBuilder.create({ input: 50, output: 50 })
             builder.tryAddToPrefix(preamble)
             builder.tryAddMessages([...chatTranscript].reverse())
 
@@ -263,7 +263,7 @@ describe('PromptBuilder', () => {
         })
 
         it('should remove context with overlapping ranges when full file is provided', async () => {
-            const builder = new PromptBuilder({ input: 50, output: 50 })
+            const builder = await PromptBuilder.create({ input: 50, output: 50 })
             builder.tryAddToPrefix(preamble)
             builder.tryAddMessages([...chatTranscript].reverse())
 
@@ -291,7 +291,7 @@ describe('PromptBuilder', () => {
         })
 
         it('should not remove user-added with overlapping ranges even when full file is provided', async () => {
-            const builder = new PromptBuilder({ input: 55, output: 50 })
+            const builder = await PromptBuilder.create({ input: 55, output: 50 })
             builder.tryAddToPrefix(preamble)
             builder.tryAddMessages([...chatTranscript].reverse())
 
@@ -319,7 +319,7 @@ describe('PromptBuilder', () => {
         })
 
         it('should deduplicate context from different token usage types', async () => {
-            const builder = new PromptBuilder({ input: 55, output: 50 })
+            const builder = await PromptBuilder.create({ input: 55, output: 50 })
             builder.tryAddToPrefix(preamble)
             builder.tryAddMessages([...chatTranscript].reverse())
 
@@ -355,7 +355,7 @@ describe('PromptBuilder', () => {
         })
 
         it('preserves context items content', async () => {
-            const builder = new PromptBuilder({ input: 100, output: 100 })
+            const builder = await PromptBuilder.create({ input: 100, output: 100 })
             builder.tryAddToPrefix(preamble)
             builder.tryAddMessages([...chatTranscript].reverse())
 

--- a/vscode/src/prompt-builder/index.ts
+++ b/vscode/src/prompt-builder/index.ts
@@ -35,11 +35,14 @@ export class PromptBuilder {
      */
     public contextItems: ContextItem[] = []
 
-    private tokenCounter: TokenCounter
-
-    constructor(contextWindow: ModelContextWindow) {
-        this.tokenCounter = new TokenCounter(contextWindow)
+    /**
+     * Convenience constructor because loading the tokenizer is async due to its large size.
+     */
+    public static async create(contextWindow: ModelContextWindow): Promise<PromptBuilder> {
+        return new PromptBuilder(await TokenCounter.create(contextWindow))
     }
+
+    private constructor(private readonly tokenCounter: TokenCounter) {}
 
     public build(): Message[] {
         if (this.contextItems.length > 0) {

--- a/vscode/test/e2e/chat-input.test.ts
+++ b/vscode/test/e2e/chat-input.test.ts
@@ -251,14 +251,18 @@ test.extend<ExpectedV2Events>({
     const [chatFrame, lastChatInput, firstChatInput, chatInputs] = await createEmptyChatPanel(page)
 
     // Submit three new messages
+    await expect(chatInputs).toHaveCount(1)
     await lastChatInput.fill('One')
     await lastChatInput.press('Enter')
+    await page.waitForTimeout(250)
     await expect(chatFrame.getByText('One')).toBeVisible()
     await lastChatInput.fill('Two')
     await lastChatInput.press('Enter')
+    await page.waitForTimeout(250)
     await expect(chatFrame.getByText('Two')).toBeVisible()
     await lastChatInput.fill('Three')
     await lastChatInput.press('Enter')
+    await page.waitForTimeout(250)
     await expect(chatFrame.getByText('Three')).toBeVisible()
 
     // Click on the first input to get into the editing mode


### PR DESCRIPTION
`js-tiktoken` is a very large JavaScript library. This changes how we use it, cutting ~6mb from the initial bundle size (3mb for each of the webviews and agent).

- Now, we only import `cl100k_base` and not the other tokenizers. These were being tree-shaken anyway, but this protects us from regressions there.
- We now lazily import the `cl100k_base` data, which means all token counting functions are now async. In the webviews and on the web, this results in a significant speedup in page load (~6mb smaller initial bundle and ~25% faster DOMContentLoaded).



## Test plan

n/a