### PR TITLE
bundle size improvements

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -934,6 +934,9 @@ importers:
       util:
         specifier: ^0.12.5
         version: 0.12.5
+      vite-bundle-analyzer:
+        specifier: ^0.10.5
+        version: 0.10.5
       vite-plugin-svgr:
         specifier: ^4.2.0
         version: 4.2.0(typescript@5.5.4)(vite@5.4.0)
@@ -16918,6 +16921,10 @@ packages:
       unist-util-stringify-position: 4.0.0
       vfile-message: 4.0.2
     dev: false
+
+  /vite-bundle-analyzer@0.10.5:
+    resolution: {integrity: sha512-gxIFQ6ifoQjDXaVWJmXHwI2VEVqyz6FXHKicNpTe4Pr2MAka6NQVRcmgznziRzbl9rhMP0qIc5Be8PxfGXUhgQ==}
+    dev: true
 
   /vite-node@1.6.0(@types/node@20.12.7):
     resolution: {integrity: sha512-de6HJgzC+TFzOu0NTC4RAIsyf/DY/ibWDYQUcuEA84EMHhcefTUGkjFHKKEJhQN4A+6I0u++kr3l36ZF2d7XRw==}

--- a/vscode/webviews/components/MarkdownFromCody.tsx
+++ b/vscode/webviews/components/MarkdownFromCody.tsx
@@ -1,5 +1,5 @@
 import { CodyIDE } from '@sourcegraph/cody-shared'
-import { all } from 'lowlight'
+import { common } from 'lowlight'
 import type { ComponentProps, FunctionComponent } from 'react'
 import { useMemo } from 'react'
 import Markdown, { defaultUrlTransform } from 'react-markdown'
@@ -135,7 +135,7 @@ function markdownPluginProps(): Pick<
                 {
                     detect: true,
                     languages: Object.fromEntries(
-                        Object.entries(all).filter(([language]) => LANGUAGES.includes(language))
+                        Object.entries(common).filter(([language]) => LANGUAGES.includes(language))
                     ),
 
                     // `ignoreMissing: true` is required to avoid errors when trying to highlight

--- a/web/lib/agent/agent.client.ts
+++ b/web/lib/agent/agent.client.ts
@@ -15,7 +15,7 @@ import {
 // cody repository
 
 // @ts-ignore
-import AgentWorker from './agent.worker.ts?worker&inline'
+import AgentWorker from './agent.worker.ts?worker'
 
 // TODO(sqs): dedupe with agentClient.ts in [experimental Cody CLI](https://github.com/sourcegraph/cody/pull/3418)
 export interface AgentClient {

--- a/web/package.json
+++ b/web/package.json
@@ -40,6 +40,7 @@
     "tailwind-merge": "^2.3.0",
     "tailwindcss": "^3.4.3",
     "util": "^0.12.5",
+    "vite-bundle-analyzer": "^0.10.5",
     "vite-plugin-svgr": "^4.2.0",
     "vscode-uri": "^3.0.8"
   }

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -1,6 +1,6 @@
 import { resolve } from 'node:path'
-
 import react from '@vitejs/plugin-react-swc'
+import { analyzer } from 'vite-bundle-analyzer'
 import svgr from 'vite-plugin-svgr'
 
 // @ts-ignore
@@ -29,6 +29,7 @@ export default defineProjectWithDefaults(__dirname, {
         // @ts-ignore
         react({ devTarget: 'esnext' }),
         svgr() as any,
+        process.env.ANALYZE ? analyzer({ analyzerMode: 'server' }) : undefined,
     ],
     resolve: {
         alias: [
@@ -100,7 +101,7 @@ export default defineProjectWithDefaults(__dirname, {
         minify: false,
         outDir: 'dist',
         assetsDir: '.',
-        reportCompressedSize: false,
+        reportCompressedSize: true,
         lib: {
             formats: ['cjs'],
             entry: resolve(__dirname, 'lib/index.ts'),


### PR DESCRIPTION
- only import 37 common langs' highlighting support. Saves ~1MB on the bundle size, at the expense of losing syntax-highlighting support for languages like: isbl, mathematica, gcl, 1c, sqf, maxima, pgsql, x86asm, mel, arduino.
- import web worker in separate file
- add vite-bundle-analyzer

## Test plan

CI