### PR TITLE
Send `copy` extension message notification to the clients on copy button

### DIFF
--- a/vscode/src/chat/chat-view/ChatController.ts
+++ b/vscode/src/chat/chat-view/ChatController.ts
@@ -358,6 +358,7 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
                 await handleCodeFromInsertAtCursor(message.text)
                 break
             case 'copy':
+                await this.postMessage({type: 'copy', text: message.text})
                 await handleCopiedCode(message.text, message.eventType === 'Button')
                 break
             case 'smartApplySubmit':

--- a/vscode/src/chat/protocol.ts
+++ b/vscode/src/chat/protocol.ts
@@ -227,6 +227,10 @@ export type ExtensionMessage =
      * The current default model will always be the first one on the list.
      */
     | { type: 'chatModels'; models: Model[] }
+    | {
+        type: 'copy'
+        text: string
+    }
     | { type: 'enhanced-context'; enhancedContextStatus: EnhancedContextContextT }
     | ({ type: 'attribution' } & ExtensionAttributionMessage)
     | { type: 'context/remote-repos'; repos: Repo[] }


### PR DESCRIPTION
## Test plan
- to be tested together with the jetbrains part
<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
