### PR TITLE
use the full width of the Cody chat viewport

### DIFF
--- a/lib/prompt-editor/src/PromptEditor.module.css
+++ b/lib/prompt-editor/src/PromptEditor.module.css
@@ -1,6 +1,6 @@
 :root {
-    --prompt-editor-padding-y: 0.4375rem;
-    --prompt-editor-padding-x: 0.5rem;
+    --prompt-editor-padding-y: 8px;
+    --prompt-editor-padding-x: 8px;
 }
 
 .editor {
@@ -16,11 +16,9 @@
 .editor:not(.seamless) {
     background-color: var(--vscode-input-background);
     color: var(--vscode-input-foreground);
-
     box-sizing: border-box;
     border: 1px solid transparent;
     border-radius: 2px;
-
     padding: var(--prompt-editor-padding-y) var(--prompt-editor-padding-x);
 }
 

--- a/vscode/test/e2e/chat-input.test.ts
+++ b/vscode/test/e2e/chat-input.test.ts
@@ -206,27 +206,25 @@ test.extend<DotcomUrlOverride>({ dotcomUrl: mockServer.SERVER_URL }).extend<Expe
     await firstChatInput.fill('to model1')
     await firstChatInput.press('Enter')
 
+    async function expectModelName(modelName: string): Promise<void> {
+        await expect(chatFrame.locator('[data-testid="chat-model"]').last()).toHaveText(modelName)
+    }
+
     // Verify tooltip shows the correct model
-    await chatFrame.locator('[data-testid="chat-message-model-icon"]').last().hover()
-    await expect(
-        chatFrame.locator('[data-testid="message"]').getByText('Claude 3.5 Sonnet by Anthropic')
-    ).toBeVisible()
+    await expectModelName('Claude 3.5 Sonnet')
 
     // Change model and send another message.
     await expect(modelSelect).toBeEnabled()
     await modelSelect.click()
     const modelChoices = chatFrame.getByRole('listbox', { name: 'Suggestions' })
-    await modelChoices.getByRole('option', { name: 'GPT-4o' }).click()
+    await modelChoices.getByRole('option', { name: 'Claude 3 Haiku' }).click()
     const lastChatInput = getChatInputs(chatFrame).last()
     await expect(lastChatInput).toBeFocused()
-    await expect(modelSelect).toHaveText(/^GPT-4o/)
+    await expect(modelSelect).toHaveText(/^Claude 3 Haiku/)
     await lastChatInput.fill('to model2')
     await lastChatInput.press('Enter')
-    await expect(chatFrame.locator('[data-testid="chat-message-model-icon"]')).toHaveCount(2)
-    await chatFrame.locator('[data-testid="chat-message-model-icon"]').last().hover()
-    await expect(
-        chatFrame.locator('[data-testid="message"]').getByText('GPT-4o by OpenAI')
-    ).toBeVisible()
+    await expect(chatFrame.locator('[data-testid="chat-model"]')).toHaveCount(2)
+    await expectModelName('Claude 3 Haiku')
 })
 
 test.extend<ExpectedV2Events>({

--- a/vscode/webviews/chat/Transcript.test.tsx
+++ b/vscode/webviews/chat/Transcript.test.tsx
@@ -203,7 +203,7 @@ describe('Transcript', () => {
                 ]}
             />
         )
-        expectCells([{ message: 'Foo' }, { message: 'Request Failed: some error' }])
+        expectCells([{ message: 'Foo' }, { message: 'Model\nRequest Failed: some error' }])
         expect(screen.queryByText('Try again with different context')).toBeNull()
     })
 

--- a/vscode/webviews/chat/Transcript.tsx
+++ b/vscode/webviews/chat/Transcript.tsx
@@ -58,7 +58,7 @@ export const Transcript: FC<TranscriptProps> = props => {
     )
 
     return (
-        <div className="tw-px-8 tw-pt-6 tw-pb-12 tw-flex tw-flex-col tw-gap-10">
+        <div className="tw-px-6 tw-pt-8 tw-pb-12 tw-flex tw-flex-col tw-gap-8">
             {interactions.map((interaction, i) => (
                 <TranscriptInteraction
                     // biome-ignore lint/suspicious/noArrayIndexKey: <explanation>

--- a/vscode/webviews/chat/cells/Cell.tsx
+++ b/vscode/webviews/chat/cells/Cell.tsx
@@ -1,15 +1,13 @@
 import { clsx } from 'clsx'
 import type React from 'react'
 import type { FunctionComponent, PropsWithChildren } from 'react'
-import { MESSAGE_CELL_AVATAR_SIZE } from './messageCell/BaseMessageCell'
 
 /**
  * A cell is a row in a chat, which can be a human message, assistant message, context, notice, etc.
  */
 export const Cell: FunctionComponent<
     PropsWithChildren<{
-        style?: 'human' | 'context' | 'assistant'
-        gutterIcon: React.ReactNode
+        header: React.ReactNode
         containerClassName?: string
         contentClassName?: string
         'aria-current'?: boolean
@@ -17,8 +15,7 @@ export const Cell: FunctionComponent<
         'data-testid'?: string
     }>
 > = ({
-    style,
-    gutterIcon,
+    header,
     containerClassName,
     contentClassName,
     'aria-current': ariaCurrent,
@@ -27,18 +24,13 @@ export const Cell: FunctionComponent<
     children,
 }) => (
     <div
-        className={clsx('tw-flex tw-gap-4', containerClassName)}
+        className={clsx('tw-flex tw-flex-col tw-gap-4', containerClassName)}
         role="row"
         aria-current={ariaCurrent}
         aria-disabled={ariaDisabled}
         data-testid={dataTestID}
     >
-        <div
-            className="tw-flex tw-pt-[2px] tw-items-top tw-justify-center"
-            style={{ width: `${MESSAGE_CELL_AVATAR_SIZE}px` }}
-        >
-            {gutterIcon}
-        </div>
+        <header className="tw-flex tw-gap-4 tw-items-center">{header}</header>
         <div className={clsx('tw-flex-1 tw-overflow-hidden', contentClassName)}>{children}</div>
     </div>
 )

--- a/vscode/webviews/chat/cells/contextCell/ContextCell.tsx
+++ b/vscode/webviews/chat/cells/contextCell/ContextCell.tsx
@@ -104,125 +104,134 @@ export const ContextCell: FunctionComponent<{
         } = useConfig()
 
         return contextItemsToDisplay === undefined || contextItemsToDisplay.length !== 0 ? (
-            <Cell
-                style="context"
-                gutterIcon={
-                    <SourcegraphLogo
-                        width={NON_HUMAN_CELL_AVATAR_SIZE}
-                        height={NON_HUMAN_CELL_AVATAR_SIZE}
-                    />
-                }
-                containerClassName={className}
-                contentClassName="tw-flex tw-flex-col tw-gap-4 tw-overflow-hidden tw-max-w-full"
-                data-testid="context"
+            <Accordion
+                type="single"
+                collapsible
+                defaultValue={(__storybook__initialOpen && 'item-1') || undefined}
+                asChild={true}
             >
-                {contextItems === undefined ? (
-                    <LoadingDots />
-                ) : (
-                    <Accordion
-                        type="single"
-                        collapsible
-                        className="tw-pt-1.5"
-                        defaultValue={(__storybook__initialOpen && 'item-1') || undefined}
-                    >
-                        <AccordionItem value="item-1">
+                <AccordionItem value="item-1" asChild>
+                    <Cell
+                        header={
                             <AccordionTrigger
                                 onClick={logContextOpening}
                                 onKeyUp={logContextOpening}
                                 title={contextItemCountLabel}
+                                className="tw-flex tw-items-center tw-gap-4"
                             >
+                                <SourcegraphLogo
+                                    width={NON_HUMAN_CELL_AVATAR_SIZE}
+                                    height={NON_HUMAN_CELL_AVATAR_SIZE}
+                                />
                                 <span className="tw-flex tw-items-baseline">
-                                    <span className="tw-font-medium">Context </span>
+                                    Context
                                     <span className="tw-opacity-60 tw-text-sm tw-ml-2">
                                         &mdash; {contextItemCountLabel}
                                     </span>
                                 </span>
                             </AccordionTrigger>
-                            <AccordionContent>
-                                {internalDebugContext && contextAlternatives && (
-                                    <div>
-                                        <button onClick={prevSelectedAlternative} type="button">
-                                            &larr;
-                                        </button>
-                                        <button onClick={nextSelectedAlternative} type="button">
-                                            &rarr;
-                                        </button>{' '}
-                                        Ranking mechanism:{' '}
-                                        {selectedAlternative === undefined
-                                            ? 'actual'
-                                            : `${contextAlternatives[selectedAlternative].strategy}: (${
-                                                  (selectedAlternative ?? -1) + 1
-                                              } of ${contextAlternatives.length})`}
-                                    </div>
-                                )}
-                                <ul className="tw-list-none tw-flex tw-flex-col tw-gap-2 tw-pt-2">
-                                    {contextItemsToDisplay?.map((item, i) => (
-                                        <li
-                                            // biome-ignore lint/suspicious/noArrayIndexKey: stable order
-                                            key={i}
-                                            data-testid="context-item"
-                                        >
-                                            <FileLink
-                                                uri={item.uri}
-                                                repoName={item.repoName}
-                                                revision={item.revision}
-                                                source={item.source}
-                                                range={item.range}
-                                                title={item.title}
-                                                isTooLarge={item.isTooLarge}
-                                                isTooLargeReason={item.isTooLargeReason}
-                                                isIgnored={item.isIgnored}
-                                                className={clsx(styles.contextItem, MENTION_CLASS_NAME)}
-                                                linkClassName={styles.contextItemLink}
-                                            />
-                                            {internalDebugContext &&
-                                                item.metadata &&
-                                                item.metadata.length > 0 && (
-                                                    <span className={styles.contextItemMetadata}>
-                                                        {item.metadata.join(', ')}
-                                                    </span>
-                                                )}
-                                        </li>
-                                    ))}
-                                    {!isForFirstMessage && (
-                                        <span
-                                            className={clsx(
-                                                styles.contextItem,
-                                                'tw-flex tw-items-center tw-gap-2'
-                                            )}
-                                        >
-                                            <MessagesSquareIcon size={14} className="tw-ml-1" />
-                                            <span>Prior messages and context in this conversation</span>
-                                        </span>
+                        }
+                        containerClassName={className}
+                        contentClassName="tw-flex tw-flex-col tw-gap-4 tw-overflow-hidden tw-max-w-full"
+                        data-testid="context"
+                    >
+                        {contextItems === undefined ? (
+                            <LoadingDots />
+                        ) : (
+                            <>
+                                <AccordionContent>
+                                    {internalDebugContext && contextAlternatives && (
+                                        <div>
+                                            <button onClick={prevSelectedAlternative} type="button">
+                                                &larr;
+                                            </button>
+                                            <button onClick={nextSelectedAlternative} type="button">
+                                                &rarr;
+                                            </button>{' '}
+                                            Ranking mechanism:{' '}
+                                            {selectedAlternative === undefined
+                                                ? 'actual'
+                                                : `${
+                                                      contextAlternatives[selectedAlternative].strategy
+                                                  }: (${(selectedAlternative ?? -1) + 1} of ${
+                                                      contextAlternatives.length
+                                                  })`}
+                                        </div>
                                     )}
-                                    <li>
-                                        <Tooltip>
-                                            <TooltipTrigger asChild>
-                                                <span
+                                    <ul className="tw-list-none tw-flex tw-flex-col tw-gap-2 tw-pt-2">
+                                        {contextItemsToDisplay?.map((item, i) => (
+                                            <li
+                                                // biome-ignore lint/suspicious/noArrayIndexKey: stable order
+                                                key={i}
+                                                data-testid="context-item"
+                                            >
+                                                <FileLink
+                                                    uri={item.uri}
+                                                    repoName={item.repoName}
+                                                    revision={item.revision}
+                                                    source={item.source}
+                                                    range={item.range}
+                                                    title={item.title}
+                                                    isTooLarge={item.isTooLarge}
+                                                    isTooLargeReason={item.isTooLargeReason}
+                                                    isIgnored={item.isIgnored}
                                                     className={clsx(
                                                         styles.contextItem,
-                                                        'tw-flex tw-items-center tw-gap-2'
+                                                        MENTION_CLASS_NAME
                                                     )}
-                                                >
-                                                    <BrainIcon size={14} className="tw-ml-1" />
-                                                    <span>Public knowledge</span>
-                                                </span>
-                                            </TooltipTrigger>
-                                            <TooltipContent side="bottom">
+                                                    linkClassName={styles.contextItemLink}
+                                                />
+                                                {internalDebugContext &&
+                                                    item.metadata &&
+                                                    item.metadata.length > 0 && (
+                                                        <span className={styles.contextItemMetadata}>
+                                                            {item.metadata.join(', ')}
+                                                        </span>
+                                                    )}
+                                            </li>
+                                        ))}
+                                        {!isForFirstMessage && (
+                                            <span
+                                                className={clsx(
+                                                    styles.contextItem,
+                                                    'tw-flex tw-items-center tw-gap-2'
+                                                )}
+                                            >
+                                                <MessagesSquareIcon size={14} className="tw-ml-1" />
                                                 <span>
-                                                    Information and general reasoning capabilities
-                                                    trained into the model{' '}
-                                                    {model && <code>{model}</code>}
+                                                    Prior messages and context in this conversation
                                                 </span>
-                                            </TooltipContent>
-                                        </Tooltip>
-                                    </li>
-                                </ul>
-                            </AccordionContent>
-                        </AccordionItem>
-                    </Accordion>
-                )}
-            </Cell>
+                                            </span>
+                                        )}
+                                        <li>
+                                            <Tooltip>
+                                                <TooltipTrigger asChild>
+                                                    <span
+                                                        className={clsx(
+                                                            styles.contextItem,
+                                                            'tw-flex tw-items-center tw-gap-2'
+                                                        )}
+                                                    >
+                                                        <BrainIcon size={14} className="tw-ml-1" />
+                                                        <span>Public knowledge</span>
+                                                    </span>
+                                                </TooltipTrigger>
+                                                <TooltipContent side="bottom">
+                                                    <span>
+                                                        Information and general reasoning capabilities
+                                                        trained into the model{' '}
+                                                        {model && <code>{model}</code>}
+                                                    </span>
+                                                </TooltipContent>
+                                            </Tooltip>
+                                        </li>
+                                    </ul>
+                                </AccordionContent>
+                            </>
+                        )}
+                    </Cell>
+                </AccordionItem>
+            </Accordion>
         ) : null
     },
     isEqual

--- a/vscode/webviews/chat/cells/messageCell/BaseMessageCell.tsx
+++ b/vscode/webviews/chat/cells/messageCell/BaseMessageCell.tsx
@@ -1,4 +1,3 @@
-import type { ChatMessage } from '@sourcegraph/cody-shared'
 import type { FunctionComponent } from 'react'
 import { Cell } from '../Cell'
 
@@ -6,16 +5,19 @@ import { Cell } from '../Cell'
  * The base component for messages.
  */
 export const BaseMessageCell: FunctionComponent<{
-    speaker: ChatMessage['speaker']
     speakerIcon?: React.ReactNode
+    speakerTitle?: React.ReactNode
     content: React.ReactNode
     contentClassName?: string
     footer?: React.ReactNode
     className?: string
-}> = ({ speaker, speakerIcon, content, contentClassName, footer, className }) => (
+}> = ({ speakerIcon, speakerTitle, content, contentClassName, footer, className }) => (
     <Cell
-        style={speaker === 'human' ? 'human' : 'assistant'}
-        gutterIcon={speakerIcon}
+        header={
+            <>
+                {speakerIcon} <span className="tw-mt-[-1px] tw-font-semibold">{speakerTitle}</span>
+            </>
+        }
         containerClassName={className}
         contentClassName={contentClassName}
         data-testid="message"
@@ -25,4 +27,4 @@ export const BaseMessageCell: FunctionComponent<{
     </Cell>
 )
 
-export const MESSAGE_CELL_AVATAR_SIZE = 24
+export const MESSAGE_CELL_AVATAR_SIZE = 20

--- a/vscode/webviews/chat/cells/messageCell/assistant/AssistantMessageCell.tsx
+++ b/vscode/webviews/chat/cells/messageCell/assistant/AssistantMessageCell.tsx
@@ -15,7 +15,6 @@ import isEqual from 'lodash/isEqual'
 import { type FunctionComponent, type RefObject, memo, useMemo } from 'react'
 import type { ApiPostMessage, UserAccountInfo } from '../../../../Chat'
 import { chatModelIconComponent } from '../../../../components/ChatModelIcon'
-import { Tooltip, TooltipContent, TooltipTrigger } from '../../../../components/shadcn/ui/tooltip'
 import {
     ChatMessageContent,
     type CodeBlockActionsProps,
@@ -79,21 +78,13 @@ export const AssistantMessageCell: FunctionComponent<{
 
         return (
             <BaseMessageCell
-                speaker={message.speaker}
-                speakerIcon={
-                    chatModel && ModelIcon ? (
-                        <span>
-                            <Tooltip>
-                                <TooltipTrigger
-                                    className="tw-cursor-default"
-                                    data-testid="chat-message-model-icon"
-                                >
-                                    <ModelIcon size={NON_HUMAN_CELL_AVATAR_SIZE} />
-                                </TooltipTrigger>
-                                <TooltipContent side="bottom">{`${chatModel.title} by ${chatModel.provider}`}</TooltipContent>
-                            </Tooltip>
-                        </span>
-                    ) : null
+                speakerIcon={ModelIcon ? <ModelIcon size={NON_HUMAN_CELL_AVATAR_SIZE} /> : null}
+                speakerTitle={
+                    <span data-testid="chat-model">
+                        {chatModel
+                            ? chatModel.title ?? `Model ${chatModel.model} by ${chatModel.provider}`
+                            : 'Model'}
+                    </span>
                 }
                 content={
                     <>

--- a/vscode/webviews/chat/cells/messageCell/human/HumanMessageCell.tsx
+++ b/vscode/webviews/chat/cells/messageCell/human/HumanMessageCell.tsx
@@ -67,14 +67,14 @@ export const HumanMessageCell: FunctionComponent<{
 
         return (
             <BaseMessageCell
-                speaker="human"
                 speakerIcon={
                     <UserAvatar
                         user={userInfo.user}
                         size={MESSAGE_CELL_AVATAR_SIZE}
-                        className="tw-mt-[2px]"
+                        sourcegraphGradientBorder={true}
                     />
                 }
+                speakerTitle={userInfo.user.displayName ?? userInfo.user.username}
                 content={
                     <HumanMessageEditor
                         userInfo={userInfo}

--- a/vscode/webviews/chat/cells/messageCell/human/editor/HumanMessageEditor.module.css
+++ b/vscode/webviews/chat/cells/messageCell/human/editor/HumanMessageEditor.module.css
@@ -1,6 +1,5 @@
 :root {
-    --human-message-editor-toolbar-height: 22px;
-    --human-message-editor-gap: 4px;
+    --human-message-editor-gap: 0;
     --human-message-editor-cell-spacing-bottom: 6px;
 }
 
@@ -14,18 +13,15 @@
     outline: solid 1px var(--vscode-input-border);
     outline-offset: -1px;
     cursor: text;
-    padding-bottom: var(--prompt-editor-padding-y);
 
     .editor {
         scrollbar-gutter: stable;
         padding: var(--prompt-editor-padding-y) var(--prompt-editor-padding-x);
-        padding-bottom: 0;
     }
 }
 
 .toolbar {
-    min-height: var(--human-message-editor-toolbar-height);
-    padding: 0 var(--prompt-editor-padding-x);
+    padding: calc(0.75*var(--prompt-editor-padding-y)) var(--prompt-editor-padding-x);
     margin-left: -2px;
     overflow: hidden;
 }
@@ -38,6 +34,7 @@
         opacity: 0;
         margin-top: 0;
         pointer-events: none;
+        padding: 0;
     }
 }
 

--- a/vscode/webviews/chat/cells/messageCell/human/editor/HumanMessageEditor.tsx
+++ b/vscode/webviews/chat/cells/messageCell/human/editor/HumanMessageEditor.tsx
@@ -324,7 +324,7 @@ export const HumanMessageEditor: FunctionComponent<{
                     focusEditor={focusEditor}
                     appendTextToEditor={appendTextToEditor}
                     hidden={!focused && isSent}
-                    className={clsx('tw-transition-all', styles.toolbar)}
+                    className={styles.toolbar}
                 />
             )}
         </div>

--- a/vscode/webviews/chat/cells/messageCell/human/editor/toolbar/Toolbar.tsx
+++ b/vscode/webviews/chat/cells/messageCell/human/editor/toolbar/Toolbar.tsx
@@ -65,7 +65,7 @@ export const Toolbar: FunctionComponent<{
             aria-hidden={hidden}
             hidden={hidden}
             className={clsx(
-                'tw-flex tw-items-center tw-justify-between tw-flex-wrap-reverse tw-gap-2 [&_>_*]:tw-flex-shrink-0',
+                'tw-flex tw-items-center tw-justify-between tw-flex-wrap-reverse tw-border-t tw-border-t-border tw-gap-2 [&_>_*]:tw-flex-shrink-0',
                 className
             )}
             onMouseDown={onMaybeGapClick}
@@ -74,7 +74,10 @@ export const Toolbar: FunctionComponent<{
             <div className="tw-flex tw-items-center">
                 {/* Can't use tw-gap-1 because the popover creates an empty element when open. */}
                 {onMentionClick && (
-                    <AddContextButton onClick={onMentionClick} className="tw-opacity-60 tw-mr-2" />
+                    <AddContextButton
+                        onClick={onMentionClick}
+                        className="tw-opacity-60 focus-visible:tw-opacity-100 hover:tw-opacity-100 tw-mr-2"
+                    />
                 )}
                 <PromptSelectFieldToolbarItem
                     focusEditor={focusEditor}

--- a/vscode/webviews/chat/components/WelcomeMessage.tsx
+++ b/vscode/webviews/chat/components/WelcomeMessage.tsx
@@ -53,7 +53,7 @@ export const WelcomeMessage: FunctionComponent<{ IDE: CodyIDE; setView: (view: V
     const dispatchClientAction = useClientActionDispatcher()
 
     return (
-        <div className="tw-flex-1 tw-flex tw-flex-col tw-items-start tw-w-full tw-pt-4 tw-px-8 tw-gap-10 sm:tw-pl-21 tw-transition-all">
+        <div className="tw-flex-1 tw-flex tw-flex-col tw-items-start tw-w-full tw-pt-4 tw-px-6 tw-gap-10 tw-transition-all">
             <CollapsiblePanel
                 storageKey="prompts"
                 title="Prompts & Commands"

--- a/vscode/webviews/components/UserAvatar.module.css
+++ b/vscode/webviews/components/UserAvatar.module.css
@@ -8,3 +8,12 @@
     justify-content: center;
     height: fit-content;
 }
+
+.sourcegraph-gradient-border {
+    --gradient-border-width: 1px;
+
+    border-radius: 50%;
+    padding: 1px;
+    background-clip: padding-box;
+    background-image: linear-gradient(180deg, #00CBEC 0%, #A112FF 50%, #FF5543 100%);
+}

--- a/vscode/webviews/components/UserAvatar.story.tsx
+++ b/vscode/webviews/components/UserAvatar.story.tsx
@@ -7,7 +7,7 @@ import { UserAvatar } from './UserAvatar'
 const meta: Meta<typeof UserAvatar> = {
     title: 'cody/UserAvatar',
     component: UserAvatar,
-    decorators: [VSCodeStandaloneComponent],
+    decorators: [story => <div className="tw-m-5">{story()}</div>, VSCodeStandaloneComponent],
     args: {
         size: 30,
     },
@@ -48,5 +48,17 @@ export const Text2Letters: Story = {
             endpoint: '',
             primaryEmail: '',
         },
+    },
+}
+
+export const SourcegraphGradientBorder: Story = {
+    args: {
+        user: {
+            username: 'sqs',
+            avatarURL: 'https://avatars.githubusercontent.com/u/1976',
+            endpoint: '',
+            primaryEmail: '',
+        },
+        sourcegraphGradientBorder: true,
     },
 }

--- a/vscode/webviews/components/UserAvatar.tsx
+++ b/vscode/webviews/components/UserAvatar.tsx
@@ -6,13 +6,42 @@ import styles from './UserAvatar.module.css'
 interface Props {
     user: NonNullable<UserAccountInfo['user']>
     size: number
+    sourcegraphGradientBorder?: boolean
     className?: string
 }
+
+const SOURCEGRAPH_GRADIENT_BORDER_SIZE = 1 /* px */
 
 /**
  * UserAvatar displays the avatar of a user.
  */
-export const UserAvatar: FunctionComponent<Props> = ({ user, size, className }) => {
+export const UserAvatar: FunctionComponent<Props> = ({
+    user,
+    size,
+    sourcegraphGradientBorder,
+    className,
+}) => {
+    const inner = (
+        <InnerUserAvatar
+            user={user}
+            size={sourcegraphGradientBorder ? size - SOURCEGRAPH_GRADIENT_BORDER_SIZE * 2 : size}
+            className={sourcegraphGradientBorder ? undefined : className}
+        />
+    )
+    return sourcegraphGradientBorder ? (
+        <div className={clsx(styles.sourcegraphGradientBorder, 'tw-inline-flex', className)}>
+            {inner}
+        </div>
+    ) : (
+        inner
+    )
+}
+
+const InnerUserAvatar: FunctionComponent<Omit<Props, 'sourcegraphGradientBorder'>> = ({
+    user,
+    size,
+    className,
+}) => {
     const title = user.displayName || user.username
 
     if (user?.avatarURL) {
@@ -32,7 +61,7 @@ export const UserAvatar: FunctionComponent<Props> = ({ user, size, className }) 
 
         return (
             <img
-                className={clsx(styles.userAvatar, className)}
+                className={styles.userAvatar}
                 src={url}
                 role="presentation"
                 title={title}

--- a/vscode/webviews/components/shadcn/ui/accordion.tsx
+++ b/vscode/webviews/components/shadcn/ui/accordion.tsx
@@ -22,13 +22,13 @@ const AccordionTrigger = React.forwardRef<
         <AccordionPrimitive.Trigger
             ref={ref}
             className={cn(
-                'tw-flex tw-gap-1 tw-items-center tw-justify-between tw-transition-all [&[data-state=open]>svg]:tw-rotate-90',
+                'tw-flex tw-gap-1 tw-items-center tw-justify-between tw-transition-all [&[data-state=open]>svg.lucide]:tw-rotate-90',
                 className
             )}
             {...props}
         >
-            <ChevronRight className="tw-h-8 tw-w-8 tw-shrink-0 tw-transition-transform tw-duration-150" />
             {children}
+            <ChevronRight className="tw-h-8 tw-w-8 tw-shrink-0 tw-transition-transform tw-duration-150 tw-text-muted-foreground" />
         </AccordionPrimitive.Trigger>
     </AccordionPrimitive.Header>
 ))


### PR DESCRIPTION
Many people have asked for Cody chat to use the full width in the viewport. This is especially important now that we often show chat in a narrow sidebar instead of an editor panel.

Example request: https://x.com/riipandi/status/1825414693860856206 (this was just now, there have been many others)

This is a partial impl of this Figma: https://www.figma.com/design/f078wFMKsIOaEwj7Iwj5xy/%E2%AC%9C%EF%B8%8F--Unified-Cody?node-id=4157-66156&t=UY3VI8o9wD53jilb-0.

![image](https://github.com/user-attachments/assets/0b60b5f9-1c3d-47b4-a7cb-23e51ba2443b)


Fixes https://linear.app/sourcegraph/issue/SRCH-930/chat-should-use-full-viewport-width

## Test plan

Use Cody chat on a narrow screen.

## Changelog

The chat UI now uses the full width of its viewport, which is helpful when using chat in a narrow editor sidebar.