### PR TITLE
add additional `otherCodeCompletionProviders`

### DIFF
--- a/vscode/src/completions/logger.ts
+++ b/vscode/src/completions/logger.ts
@@ -1108,11 +1108,13 @@ const otherCompletionProviders = [
     'Codeium.codeium-enterprise-updater',
     'Codeium.codeium',
     'Continue.continue',
+    'DanielSanMedium.dscodegpt', // CodeGPT: Chat & AI Agents
     'devsense.intelli-php-vscode',
     'FittenTech.Fitten-Code',
     'GitHub.copilot-nightly',
     'GitHub.copilot',
     'mutable-ai.mutable-ai',
+    'Supermaven.supermaven',
     'svipas.code-autocomplete',
     'TabbyML.vscode-tabby',
     'TabNine.tabnine-vscode-self-hosted-updater',


### PR DESCRIPTION
Adds `SuperMaven` and `CodeGPT:Chat & AI Agents` to the list of `otherCompletionProviders`.

Got the `extensionId` by right clicking the extension on VSCode and grabbing it from there.

<img width="540" alt="image" src="https://github.com/user-attachments/assets/004021c6-1ca3-42e7-955e-219751be00c7">


## Test plan
Test CI and confirm that local build runs
<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
