### PR TITLE
fix squished "new chat" and user avatar icons

### DIFF
--- a/vscode/webviews/chat/cells/Cell.tsx
+++ b/vscode/webviews/chat/cells/Cell.tsx
@@ -30,7 +30,7 @@ export const Cell: FunctionComponent<
         aria-disabled={ariaDisabled}
         data-testid={dataTestID}
     >
-        <header className="tw-flex tw-gap-4 tw-items-center">{header}</header>
+        <header className="tw-flex tw-gap-4 tw-items-center [&_>_*]:tw-flex-shrink-0">{header}</header>
         <div className={clsx('tw-flex-1 tw-overflow-hidden', contentClassName)}>{children}</div>
     </div>
 )

--- a/vscode/webviews/tabs/TabsBar.tsx
+++ b/vscode/webviews/tabs/TabsBar.tsx
@@ -221,7 +221,7 @@ export const TabsBar: React.FC<TabsBarProps> = ({ currentView, setView, IDE, onD
                 styles.tabsContainer
             )}
         >
-            <div className="tw-flex tw-gap-1">
+            <div className="tw-flex tw-gap-1 [&_>_*]:tw-flex-shrink-0">
                 {tabItems.map(({ Icon, view, command, title, changesView }) => (
                     <Tabs.Trigger key={view} value={view} asChild={true}>
                         <TabButton
@@ -236,7 +236,7 @@ export const TabsBar: React.FC<TabsBarProps> = ({ currentView, setView, IDE, onD
                     </Tabs.Trigger>
                 ))}
             </div>
-            <div className="tw-flex tw-gap-4">
+            <div className="tw-flex tw-gap-4 [&_>_*]:tw-flex-shrink-0">
                 {currentViewSubIcons?.map(
                     ({ Icon, command, title, alwaysShowTitle, tooltipExtra, arg, callback }) => (
                         <TabButton


### PR DESCRIPTION
Fixes https://linear.app/sourcegraph/issue/CODY-3381/fix-new-chat-button-display-issue-when-window-narrows

<img width="255" alt="image" src="https://github.com/user-attachments/assets/4d306a43-b0d0-4d1c-a831-8935e2d05bad">


## Test plan

Make App or Chat storybook narrow and ensure icons do not get smaller