### PR TITLE
Smart Apply: Enable by default

### DIFF
--- a/agent/recordings/cody-chat_103640681/recording.har.yaml
+++ b/agent/recordings/cody-chat_103640681/recording.har.yaml
@@ -187,11 +187,11 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: b33f9ea19dd116f2ef31b76450455f55
+    - _id: 981e59f977afc47f300f9c5268dda27e
       _order: 0
       cache: {}
       request:
-        bodySize: 532
+        bodySize: 808
         cookies: []
         headers:
           - name: content-type
@@ -230,6 +230,13 @@ log:
                 text: Ok.
               - speaker: human
                 text: >-
+                  When generating fenced code blocks in Markdown, ensure you
+                  include the full file path in the tag. The structure should be
+                  ```language:path/to/file
+
+                  ```. You should only do this when generating a code block, the user does not need to be made aware of this in any other way.
+
+
                   You have access to the provided codebase context. 
 
 
@@ -247,14 +254,14 @@ log:
             value: 6.0.0-SNAPSHOT
         url: https://sourcegraph.sourcegraph.com/.api/completions/stream?api-version=1&client-name=jetbrains&client-version=6.0.0-SNAPSHOT
       response:
-        bodySize: 1297
+        bodySize: 2960
         content:
           mimeType: text/event-stream
-          size: 1297
+          size: 2960
           text: >+
             event: completion
 
-            data: {"completion":"```typescript\nclass Cow implements StrangeAnimal {\n    makesSound(): 'coo' | 'moo' {\n        return 'moo';\n    }\n}\n```","stopReason":"end_turn"}
+            data: {"completion":"Here's the implementation of a cow without any explanation:\n\n```typescript:animal.ts\nclass Cow implements StrangeAnimal {\n    makesSound(): 'coo' | 'moo' {\n        return 'moo';\n    }\n}\n```","stopReason":"end_turn"}
 
 
             event: done
@@ -264,7 +271,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Tue, 13 Aug 2024 19:01:34 GMT
+            value: Tue, 20 Aug 2024 12:54:22 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
@@ -293,7 +300,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-08-13T19:01:33.443Z
+      startedDateTime: 2024-08-20T12:54:21.365Z
       time: 0
       timings:
         blocked: -1

--- a/agent/recordings/defaultClient_631904893/recording.har.yaml
+++ b/agent/recordings/defaultClient_631904893/recording.har.yaml
@@ -725,11 +725,11 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: d30452695a5fef843d6895d066e114c0
+    - _id: 6708edf060eea32900e3ab691c3a2fdd
       _order: 0
       cache: {}
       request:
-        bodySize: 2378
+        bodySize: 2499
         cookies: []
         headers:
           - name: content-type
@@ -742,7 +742,7 @@ log:
           - name: user-agent
             value: defaultClient / v1
           - name: traceparent
-            value: 00-47a03e267857d6be84db01763e80e784-4cd03c4f8fad4718-01
+            value: 00-a90409f6df14c81302f6fce99c4d4e83-fcb35bc3514ca9cc-01
           - name: connection
             value: keep-alive
           - name: host
@@ -850,7 +850,7 @@ log:
                   include the full file path in the tag. The structure should be
                   ```language:path/to/file
 
-                  ```
+                  ```. You should only do this when generating a code block, the user does not need to be made aware of this in any other way.
 
 
                   You have access to the provided codebase context. Answer positively without apologizing. 
@@ -870,14 +870,14 @@ log:
             value: v1
         url: https://sourcegraph.com/.api/completions/stream?api-version=1&client-name=defaultclient&client-version=v1
       response:
-        bodySize: 10812
+        bodySize: 9837
         content:
           mimeType: text/event-stream
-          size: 10812
+          size: 9837
           text: >+
             event: completion
 
-            data: {"completion":"Certainly! Here's a Dog class that implements the Animal interface based on the context provided:\n\n```typescript:src/animal.ts\nexport class Dog implements Animal {\n    name: string;\n    isMammal: boolean = true;\n\n    constructor(name: string) {\n        this.name = name;\n    }\n\n    makeAnimalSound(): string {\n        return \"Woof!\";\n    }\n}\n```\n\nThis implementation satisfies the Animal interface requirements as defined in your workspace.","stopReason":"end_turn"}
+            data: {"completion":"Certainly! Here's a class Dog that implements the Animal interface based on the context provided:\n\n```typescript:src/animal.ts\nexport class Dog implements Animal {\n    name: string;\n    isMammal: boolean = true;\n\n    constructor(name: string) {\n        this.name = name;\n    }\n\n    makeAnimalSound(): string {\n        return \"Woof!\";\n    }\n}\n```\n\nThis Dog class fully implements the Animal interface as defined in your workspace.","stopReason":"end_turn"}
 
 
             event: done
@@ -887,7 +887,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Thu, 15 Aug 2024 09:56:17 GMT
+            value: Tue, 20 Aug 2024 12:54:19 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
@@ -916,7 +916,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-08-15T09:56:14.930Z
+      startedDateTime: 2024-08-20T12:54:15.927Z
       time: 0
       timings:
         blocked: -1
@@ -926,11 +926,11 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: 35cda81684e898d6636a8a975f08f96f
+    - _id: d0047a496b38593dace459f14e17cd22
       _order: 0
       cache: {}
       request:
-        bodySize: 2281
+        bodySize: 2402
         cookies: []
         headers:
           - name: content-type
@@ -943,7 +943,7 @@ log:
           - name: user-agent
             value: defaultClient / v1
           - name: traceparent
-            value: 00-11c5a1fa4e45fc234239bc3b84a03311-7c2b6fcfcd26fb64-01
+            value: 00-008bf8855286e9701569068e0cab6096-d88ee60a80abc4b8-01
           - name: connection
             value: keep-alive
           - name: host
@@ -1051,7 +1051,7 @@ log:
                   include the full file path in the tag. The structure should be
                   ```language:path/to/file
 
-                  ```
+                  ```. You should only do this when generating a code block, the user does not need to be made aware of this in any other way.
 
 
                   You have access to the provided codebase context. Answer positively without apologizing. 
@@ -1071,14 +1071,14 @@ log:
             value: v1
         url: https://sourcegraph.com/.api/completions/stream?api-version=1&client-name=defaultclient&client-version=v1
       response:
-        bodySize: 22028
+        bodySize: 39212
         content:
           mimeType: text/event-stream
-          size: 22028
+          size: 39212
           text: >+
             event: completion
 
-            data: {"completion":"Based on the provided codebase context, Squirrel is an interface defined in the file src/squirrel.ts. Here's what we know about it:\n\n```typescript:src/squirrel.ts\n/**\n * Squirrel is an interface that mocks something completely unrelated to squirrels.\n * It is related to the implementation of precise code navigation in Sourcegraph.\n */\nexport interface Squirrel {}\n```\n\nSquirrel is an empty interface that, despite its name, is not actually related to squirrels. Instead, it's used as part of the implementation for precise code navigation in Sourcegraph. The interface itself doesn't define any properties or methods, serving as a placeholder or mock for some functionality related to code navigation.","stopReason":"end_turn"}
+            data: {"completion":"Based on the codebase context provided, Squirrel is an interface defined in the file src/squirrel.ts. Here's what we know about it:\n\n```typescript:src/squirrel.ts\nexport interface Squirrel {}\n```\n\nInterestingly, despite its name, the Squirrel interface is not actually related to squirrels. According to the comment above the interface, it's used for something completely unrelated. Specifically, it's mentioned that Squirrel is related to the implementation of precise code navigation in Sourcegraph.\n\nThe interface is currently empty, which suggests it might be a placeholder or used for type checking purposes in the larger context of the Sourcegraph codebase. Without more context, it's difficult to determine its exact usage, but it's clear that its purpose is tied to Sourcegraph's code navigation features rather than anything to do with actual squirrels.","stopReason":"end_turn"}
 
 
             event: done
@@ -1088,7 +1088,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Thu, 15 Aug 2024 09:56:21 GMT
+            value: Tue, 20 Aug 2024 12:54:59 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
@@ -1117,7 +1117,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-08-15T09:56:18.436Z
+      startedDateTime: 2024-08-20T12:54:56.381Z
       time: 0
       timings:
         blocked: -1

--- a/agent/src/cli/__snapshots__/command-chat.test.ts.snap
+++ b/agent/src/cli/__snapshots__/command-chat.test.ts.snap
@@ -11,7 +11,9 @@ stdout: |+
 
 
 
-  \`\`\`typescript
+  Here's the implementation of a cow without any explanation:
+
+  \`\`\`typescript:animal.ts
   class Cow implements StrangeAnimal {
       makesSound(): 'coo' | 'moo' {
           return 'moo';

--- a/agent/src/index.test.ts
+++ b/agent/src/index.test.ts
@@ -455,7 +455,7 @@ describe('Agent', () => {
             // is not a git directory and symf reports some git-related error.
             expect(trimEndOfLine(lastMessage?.text ?? '')).toMatchInlineSnapshot(
                 `
-              "Certainly! Here's a Dog class that implements the Animal interface based on the context provided:
+              "Certainly! Here's a class Dog that implements the Animal interface based on the context provided:
 
               \`\`\`typescript:src/animal.ts
               export class Dog implements Animal {
@@ -472,7 +472,7 @@ describe('Agent', () => {
               }
               \`\`\`
 
-              This implementation satisfies the Animal interface requirements as defined in your workspace."
+              This Dog class fully implements the Animal interface as defined in your workspace."
             `,
                 explainPollyError
             )

--- a/lib/shared/src/experimentation/FeatureFlagProvider.ts
+++ b/lib/shared/src/experimentation/FeatureFlagProvider.ts
@@ -73,9 +73,6 @@ export enum FeatureFlag {
     CodyServerSideContextAPI = 'cody-server-side-context-api-enabled',
 
     GitMentionProvider = 'git-mention-provider',
-
-    /** Enable experimental smart apply and chat codeblock UI */
-    CodyExperimentalSmartApply = 'cody-experimental-smart-apply',
 }
 
 const ONE_HOUR = 60 * 60 * 1000

--- a/lib/shared/src/prompt/prompt-mixin.ts
+++ b/lib/shared/src/prompt/prompt-mixin.ts
@@ -30,18 +30,12 @@ export class PromptMixin {
      * Prepends all mixins to `humanMessage`. Modifies and returns `humanMessage`.
      * Add hedging prevention prompt to specific models who need this.
      */
-    public static mixInto(
-        humanMessage: ChatMessage,
-        modelID: string,
-        options?: { experimentalSmartApplyEnabled?: boolean }
-    ): ChatMessage {
+    public static mixInto(humanMessage: ChatMessage, modelID: string): ChatMessage {
         // Default Mixin is added at the end so that it cannot be overriden by other mixins.
         let mixins = PromptString.join(
-            [
-                ...PromptMixin.mixins,
-                ...(options?.experimentalSmartApplyEnabled ? [PromptMixin.codeBlockMixin] : []),
-                PromptMixin.contextMixin,
-            ].map(mixin => mixin.prompt),
+            [...PromptMixin.mixins, PromptMixin.codeBlockMixin, PromptMixin.contextMixin].map(
+                mixin => mixin.prompt
+            ),
             ps`\n\n`
         )
 

--- a/lib/shared/src/prompt/prompt-mixin.ts
+++ b/lib/shared/src/prompt/prompt-mixin.ts
@@ -6,7 +6,7 @@ import { PromptString, ps } from './prompt-string'
  * Used so that we can parse file paths to support applying code directly to files
  * from chat.
  */
-const CODEBLOCK_PREMAMBLE = ps`When generating fenced code blocks in Markdown, ensure you include the full file path in the tag. The structure should be \`\`\`language:path/to/file\n\`\`\``
+const CODEBLOCK_PREMAMBLE = ps`When generating fenced code blocks in Markdown, ensure you include the full file path in the tag. The structure should be \`\`\`language:path/to/file\n\`\`\`. You should only do this when generating a code block, the user does not need to be made aware of this in any other way.`
 
 /**
  * The preamble we add to the start of the last human open-end chat message that has context items.

--- a/vscode/src/chat/chat-view/ChatController.ts
+++ b/vscode/src/chat/chat-view/ChatController.ts
@@ -17,7 +17,6 @@ import {
     DOTCOM_URL,
     type DefaultChatCommands,
     type EventSource,
-    FeatureFlag,
     type Guardrails,
     type Message,
     ModelUsage,
@@ -64,7 +63,7 @@ import {
 import type { startTokenReceiver } from '../../auth/token-receiver'
 import { getContextFileFromUri } from '../../commands/context/file-path'
 import { getContextFileFromCursor, getContextFileFromSelection } from '../../commands/context/selection'
-import { getConfigWithEndpoint, getConfiguration, getFullConfig } from '../../configuration'
+import { getConfigWithEndpoint, getConfiguration } from '../../configuration'
 import type { EnterpriseContextFactory } from '../../context/enterprise-context-factory'
 import { type RemoteSearch, RepoInclusion } from '../../context/remote-search'
 import type { Repo } from '../../context/repo-fetcher'
@@ -562,22 +561,12 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
         }
     }
 
-    private async isSmartApplyEnabled(): Promise<boolean> {
-        if (this.extensionClient.capabilities?.edit === 'none') {
-            // Smart Apply relies on the Edit capability
-            return false
-        }
-
-        const config = await getFullConfig()
-        return (
-            config.internalUnstable ||
-            (await featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyExperimentalSmartApply))
-        )
+    private isSmartApplyEnabled(): boolean {
+        return this.extensionClient.capabilities?.edit !== 'none'
     }
 
     private async getConfigForWebview(): Promise<ConfigurationSubsetForWebview & LocalEnv> {
         const config = getConfigWithEndpoint()
-        const experimentalSmartApply = await this.isSmartApplyEnabled()
         const sidebarViewOnly = this.extensionClient.capabilities?.webviewNativeConfig?.view === 'single'
         const isEditorViewType = this.webviewPanelOrView?.viewType === 'cody.editorPanel'
         const webviewType = isEditorViewType && !sidebarViewOnly ? 'editor' : 'sidebar'
@@ -590,7 +579,7 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
             uiKindIsWeb: vscode.env.uiKind === vscode.UIKind.Web,
             serverEndpoint: config.serverEndpoint,
             experimentalNoodle: config.experimentalNoodle,
-            experimentalSmartApply,
+            smartApply: this.isSmartApplyEnabled(),
             webviewType,
             multipleWebviewsEnabled: !sidebarViewOnly,
             internalDebugContext: config.internalDebugContext,
@@ -1254,11 +1243,9 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
         sendTelemetry?: (contextSummary: any, privateContextSummary?: any) => void,
         contextAlternatives?: RankedContext[]
     ): Promise<Message[]> {
-        const experimentalSmartApplyEnabled = await this.isSmartApplyEnabled()
         const { prompt, context } = await prompter.makePrompt(
             this.chatModel,
-            this.authProvider.getAuthStatus().codyApiVersion,
-            { experimentalSmartApplyEnabled }
+            this.authProvider.getAuthStatus().codyApiVersion
         )
         abortSignal.throwIfAborted()
 

--- a/vscode/src/chat/chat-view/prompt.ts
+++ b/vscode/src/chat/chat-view/prompt.ts
@@ -41,11 +41,7 @@ export class DefaultPrompter {
     //
     // Returns the reverse prompt and the new context that was used in the prompt for the current message.
     // If user-context added at the last message is ignored, returns the items in the newContextIgnored array.
-    public async makePrompt(
-        chat: ChatModel,
-        codyApiVersion: number,
-        options?: { experimentalSmartApplyEnabled?: boolean }
-    ): Promise<PromptInfo> {
+    public async makePrompt(chat: ChatModel, codyApiVersion: number): Promise<PromptInfo> {
         return wrapInActiveSpan('chat.prompter', async () => {
             const promptBuilder = await PromptBuilder.create(chat.contextWindow)
             const preInstruction: PromptString | undefined = PromptString.fromConfig(
@@ -76,7 +72,7 @@ export class DefaultPrompter {
                 !this.isCommand &&
                 Boolean(this.explicitContext.length || historyItems.length || this.corpusContext.length)
             ) {
-                reverseTranscript[0] = PromptMixin.mixInto(reverseTranscript[0], chat.modelID, options)
+                reverseTranscript[0] = PromptMixin.mixInto(reverseTranscript[0], chat.modelID)
             }
 
             const messagesIgnored = promptBuilder.tryAddMessages(reverseTranscript)

--- a/vscode/src/chat/protocol.ts
+++ b/vscode/src/chat/protocol.ts
@@ -302,7 +302,7 @@ export interface ConfigurationSubsetForWebview
         | 'agentExtensionVersion'
         | 'internalDebugContext'
     > {
-    experimentalSmartApply: boolean
+    smartApply: boolean
     // Type/location of the current webview.
     webviewType?: WebviewType | undefined | null
     // Whether support running multiple webviews (e.g. sidebar w/ multiple editor panels).

--- a/vscode/webviews/App.story.tsx
+++ b/vscode/webviews/App.story.tsx
@@ -26,7 +26,7 @@ const dummyVSCodeAPI: VSCodeWrapper = {
                 serverEndpoint: 'https://example.com',
                 uiKindIsWeb: false,
                 experimentalNoodle: false,
-                experimentalSmartApply: false,
+                smartApply: false,
             },
             authStatus: {
                 ...defaultAuthStatus,

--- a/vscode/webviews/App.tsx
+++ b/vscode/webviews/App.tsx
@@ -255,7 +255,7 @@ export const App: React.FunctionComponent<{ vscodeAPI: VSCodeWrapper }> = ({ vsc
                     isTranscriptError={isTranscriptError}
                     guardrails={guardrails}
                     userHistory={userHistory}
-                    experimentalSmartApplyEnabled={config.config.experimentalSmartApply}
+                    smartApplyEnabled={config.config.smartApply}
                 />
             )}
         </ComposedWrappers>

--- a/vscode/webviews/Chat.tsx
+++ b/vscode/webviews/Chat.tsx
@@ -31,7 +31,7 @@ interface ChatboxProps {
     showWelcomeMessage?: boolean
     showIDESnippetActions?: boolean
     setView: (view: View) => void
-    experimentalSmartApplyEnabled?: boolean
+    smartApplyEnabled?: boolean
 }
 
 export const Chat: React.FunctionComponent<React.PropsWithChildren<ChatboxProps>> = ({
@@ -45,7 +45,7 @@ export const Chat: React.FunctionComponent<React.PropsWithChildren<ChatboxProps>
     showWelcomeMessage = true,
     showIDESnippetActions = true,
     setView,
-    experimentalSmartApplyEnabled,
+    smartApplyEnabled,
 }) => {
     const telemetryRecorder = useTelemetryRecorder()
 
@@ -215,7 +215,7 @@ export const Chat: React.FunctionComponent<React.PropsWithChildren<ChatboxProps>
                 chatEnabled={chatEnabled}
                 postMessage={postMessage}
                 guardrails={guardrails}
-                experimentalSmartApplyEnabled={experimentalSmartApplyEnabled}
+                smartApplyEnabled={smartApplyEnabled}
             />
             {transcript.length === 0 && showWelcomeMessage && (
                 <WelcomeMessage IDE={userInfo.ide} setView={setView} />

--- a/vscode/webviews/CodyPanel.tsx
+++ b/vscode/webviews/CodyPanel.tsx
@@ -28,7 +28,7 @@ export const CodyPanel: FunctionComponent<
         | 'guardrails'
         | 'showWelcomeMessage'
         | 'showIDESnippetActions'
-        | 'experimentalSmartApplyEnabled'
+        | 'smartApplyEnabled'
     > &
         Pick<ComponentProps<typeof HistoryTab>, 'userHistory'>
 > = ({
@@ -47,7 +47,7 @@ export const CodyPanel: FunctionComponent<
     showIDESnippetActions,
     showWelcomeMessage,
     userHistory,
-    experimentalSmartApplyEnabled,
+    smartApplyEnabled,
 }) => {
     const tabContainerRef = useRef<HTMLDivElement>(null)
 
@@ -91,7 +91,7 @@ export const CodyPanel: FunctionComponent<
                         showIDESnippetActions={showIDESnippetActions}
                         showWelcomeMessage={showWelcomeMessage}
                         scrollableParent={tabContainerRef.current}
-                        experimentalSmartApplyEnabled={experimentalSmartApplyEnabled}
+                        smartApplyEnabled={smartApplyEnabled}
                         setView={setView}
                     />
                 )}

--- a/vscode/webviews/chat/ChatMessageContent/ChatMessageContent.tsx
+++ b/vscode/webviews/chat/ChatMessageContent/ChatMessageContent.tsx
@@ -33,7 +33,7 @@ interface ChatMessageContentProps {
     copyButtonOnSubmit?: CodeBlockActionsProps['copyButtonOnSubmit']
     insertButtonOnSubmit?: CodeBlockActionsProps['insertButtonOnSubmit']
 
-    experimentalSmartApplyEnabled?: boolean
+    smartApplyEnabled?: boolean
     smartApply?: CodeBlockActionsProps['smartApply']
 
     guardrails?: Guardrails
@@ -51,7 +51,7 @@ export const ChatMessageContent: React.FunctionComponent<ChatMessageContentProps
     insertButtonOnSubmit,
     guardrails,
     className,
-    experimentalSmartApplyEnabled,
+    smartApplyEnabled,
     smartApply,
     userInfo,
 }) => {
@@ -113,7 +113,7 @@ export const ChatMessageContent: React.FunctionComponent<ChatMessageContentProps
                 const fileName = codeElement?.getAttribute('data-file-path') || undefined
                 let buttons: HTMLElement
 
-                if (experimentalSmartApplyEnabled) {
+                if (smartApplyEnabled) {
                     const smartApplyId = getCodeBlockId(preText, fileName)
                     const smartApplyState = smartApplyStates[smartApplyId]
                     buttons = createButtonsExperimentalUI(
@@ -180,7 +180,7 @@ export const ChatMessageContent: React.FunctionComponent<ChatMessageContentProps
     }, [
         copyButtonOnSubmit,
         insertButtonOnSubmit,
-        experimentalSmartApplyEnabled,
+        smartApplyEnabled,
         smartApplyInterceptor,
         guardrails,
         displayMarkdown,

--- a/vscode/webviews/chat/Transcript.tsx
+++ b/vscode/webviews/chat/Transcript.tsx
@@ -33,7 +33,7 @@ interface TranscriptProps {
     copyButtonOnSubmit: CodeBlockActionsProps['copyButtonOnSubmit']
     insertButtonOnSubmit?: CodeBlockActionsProps['insertButtonOnSubmit']
     smartApply?: CodeBlockActionsProps['smartApply']
-    experimentalSmartApplyEnabled?: boolean
+    smartApplyEnabled?: boolean
 }
 
 export const Transcript: FC<TranscriptProps> = props => {
@@ -49,7 +49,7 @@ export const Transcript: FC<TranscriptProps> = props => {
         copyButtonOnSubmit,
         insertButtonOnSubmit,
         smartApply,
-        experimentalSmartApplyEnabled,
+        smartApplyEnabled,
     } = props
 
     const interactions = useMemo(
@@ -81,7 +81,7 @@ export const Transcript: FC<TranscriptProps> = props => {
                         messageInProgress && interactions.at(i - 1)?.assistantMessage?.isLoading
                     )}
                     smartApply={smartApply}
-                    experimentalSmartApplyEnabled={experimentalSmartApplyEnabled}
+                    smartApplyEnabled={smartApplyEnabled}
                 />
             ))}
         </div>
@@ -168,7 +168,7 @@ const TranscriptInteraction: FC<TranscriptInteractionProps> = memo(props => {
         insertButtonOnSubmit,
         copyButtonOnSubmit,
         smartApply,
-        experimentalSmartApplyEnabled,
+        smartApplyEnabled,
     } = props
 
     const humanEditorRef = useRef<PromptEditorRefAPI | null>(null)
@@ -242,7 +242,7 @@ const TranscriptInteraction: FC<TranscriptInteractionProps> = memo(props => {
                         isLastSentInteraction
                     }
                     smartApply={smartApply}
-                    experimentalSmartApplyEnabled={experimentalSmartApplyEnabled}
+                    smartApplyEnabled={smartApplyEnabled}
                 />
             )}
         </>

--- a/vscode/webviews/chat/cells/messageCell/assistant/AssistantMessageCell.tsx
+++ b/vscode/webviews/chat/cells/messageCell/assistant/AssistantMessageCell.tsx
@@ -46,7 +46,7 @@ export const AssistantMessageCell: FunctionComponent<{
     copyButtonOnSubmit?: CodeBlockActionsProps['copyButtonOnSubmit']
     insertButtonOnSubmit?: CodeBlockActionsProps['insertButtonOnSubmit']
 
-    experimentalSmartApplyEnabled?: boolean
+    smartApplyEnabled?: boolean
     smartApply?: CodeBlockActionsProps['smartApply']
 
     postMessage?: ApiPostMessage
@@ -65,7 +65,7 @@ export const AssistantMessageCell: FunctionComponent<{
         postMessage,
         guardrails,
         smartApply,
-        experimentalSmartApplyEnabled,
+        smartApplyEnabled,
     }) => {
         const displayMarkdown = useMemo(
             () => reformatBotMessageForChat(message.text ?? ps``).toString(),
@@ -107,7 +107,7 @@ export const AssistantMessageCell: FunctionComponent<{
                                 insertButtonOnSubmit={insertButtonOnSubmit}
                                 guardrails={guardrails}
                                 humanMessage={humanMessage}
-                                experimentalSmartApplyEnabled={experimentalSmartApplyEnabled}
+                                smartApplyEnabled={smartApplyEnabled}
                                 smartApply={smartApply}
                                 userInfo={userInfo}
                             />


### PR DESCRIPTION
## Description

Enables the "smart apply" feature by default, removing the feature flag.

Chat Eval: https://github.com/sourcegraph/cody-leaderboard/pull/16

Looker Dashboard: https://sourcegraph.looker.com/looks/2016


## Test plan

Test Smart Apply on:
- [x] PLG
- [x] Enterprise (with different model variants)
- [X] JetBrains (with WebView enabled)
   - Note: Further testing will be done by the JetBrains team when the WebView is fully implemented	

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
