### PR TITLE
Cody Web: Fixes regressions since 0.4.0 (the last published version)

### DIFF
--- a/lib/prompt-editor/src/mentions/mentionMenu/MentionMenu.module.css
+++ b/lib/prompt-editor/src/mentions/mentionMenu/MentionMenu.module.css
@@ -1,6 +1,8 @@
 .container {
     outline: none;
-    border-radius: 0;
+
+    /* In order to override shadcn tailwind tw-rounded-md */
+    border-radius: 0 !important;
 }
 
 .item {

--- a/lib/prompt-editor/src/nodes/ContextItemMentionNode.tsx
+++ b/lib/prompt-editor/src/nodes/ContextItemMentionNode.tsx
@@ -60,7 +60,11 @@ export class ContextItemMentionNode extends DecoratorNode<JSX.Element> {
     }
 
     static clone(node: ContextItemMentionNode): ContextItemMentionNode {
-        return new ContextItemMentionNode(node.contextItem, node.isFromInitialContext, node.key)
+        return new ContextItemMentionNode(
+            node.contextItem,
+            node.isFromInitialContext,
+            node.key ?? node.__key
+        )
     }
 
     public readonly contextItem: SerializedContextItem

--- a/lib/prompt-editor/src/plugins/atMentions/atMentions.tsx
+++ b/lib/prompt-editor/src/plugins/atMentions/atMentions.tsx
@@ -221,7 +221,7 @@ export const MentionsPlugin: FunctionComponent<{ contextWindowSizeInTokens?: num
                             // max height of the visible menu. This ensures that the menu does not
                             // flip orientation as the user is typing if it suddenly has less
                             // results. It also makes the positioning less glitchy.
-                            <div className={clsx(styles.popoverDimensions)}>
+                            <div data-at-mention-menu="" className={clsx(styles.popoverDimensions)}>
                                 <div className={styles.popover}>
                                     <MentionMenu
                                         params={params}

--- a/vscode/webviews/CodyPanel.tsx
+++ b/vscode/webviews/CodyPanel.tsx
@@ -70,15 +70,14 @@ export const CodyPanel: FunctionComponent<
             className={styles.outerContainer}
         >
             {/* Hide tab bar in editor chat panels. */}
-            {config.agentIDE === CodyIDE.Web ||
-                (config.webviewType !== 'editor' && (
-                    <TabsBar
-                        currentView={view}
-                        setView={setView}
-                        IDE={config.agentIDE || CodyIDE.VSCode}
-                        onDownloadChatClick={onDownloadChatClick}
-                    />
-                ))}
+            {(config.agentIDE === CodyIDE.Web || config.webviewType !== 'editor') && (
+                <TabsBar
+                    currentView={view}
+                    setView={setView}
+                    IDE={config.agentIDE || CodyIDE.VSCode}
+                    onDownloadChatClick={onDownloadChatClick}
+                />
+            )}
             {errorMessages && <ErrorBanner errors={errorMessages} setErrors={setErrorMessages} />}
             <TabContainer value={view} ref={tabContainerRef}>
                 {view === View.Chat && (

--- a/vscode/webviews/tabs/TabsBar.tsx
+++ b/vscode/webviews/tabs/TabsBar.tsx
@@ -135,9 +135,11 @@ export const TabsBar: React.FC<TabsBarProps> = ({ currentView, setView, IDE, onD
                                 ),
                                 Icon: MessageSquarePlusIcon,
                                 command:
-                                    webviewType === 'sidebar'
-                                        ? 'cody.chat.newPanel'
-                                        : 'cody.chat.newEditorPanel',
+                                    IDE === CodyIDE.Web
+                                        ? 'cody.chat.new'
+                                        : webviewType === 'sidebar'
+                                          ? 'cody.chat.newPanel'
+                                          : 'cody.chat.newEditorPanel',
                             },
                             IDE !== CodyIDE.Web
                                 ? {

--- a/web/CHANGELOG.md
+++ b/web/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.5.1
+- Fixes problem with initial context can't be removed (lexical context item text node key problem)
+- Fixes rendering toolbar for Cody Web
+- Fixes styles around at-mention popover menu
+- Fixes create new chat command for Cody Web
+
 ## 0.5.0 
 - Improves bundle size 
 - Now allows you to have lazily loaded modules within cody web agent web-worker

--- a/web/lib/components/CodyWebPanel.tsx
+++ b/web/lib/components/CodyWebPanel.tsx
@@ -202,7 +202,7 @@ export const CodyWebPanel: FC<CodyWebPanelProps> = props => {
                                     userHistory={userHistory}
                                     chatEnabled={true}
                                     showWelcomeMessage={true}
-                                    showIDESnippetActions={true}
+                                    showIDESnippetActions={false}
                                     messageInProgress={messageInProgress}
                                     transcript={transcript}
                                     vscodeAPI={vscodeAPI}

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sourcegraph/cody-web",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Cody standalone web app",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
This PR addresses a few regressions since the last time we did a release of Cody Web (0.4.0), most of the fixes are trivial and come from the fact of very high speed of changing in VSCode codebase (after Cody Web GA I will guard cody web package with proper e2e tests)

- Now Cody Web renders tabs UI (small regression in recent commits about editor mode)
- Fixes create new chat command
- Adds additional selector to override styles for at mentioned portal menu
- Fixes problem when you can't remove initial context items due to a problem with the lexical node key
- No longer renders EDIT-like snippets actions  

## Test plan
- Run Cody Web demo and check that core chat functionality is intact

