### PR TITLE
Smart Apply: Route new file logic through edit command

### DIFF
--- a/vscode/src/edit/smart-apply.ts
+++ b/vscode/src/edit/smart-apply.ts
@@ -10,6 +10,7 @@ export interface SmartApplyArguments {
         replacement: string
         document: vscode.TextDocument
         model?: EditModel
+        isNewFile?: boolean
     }
     source?: EventSource
 }


### PR DESCRIPTION
## Description

This PR routes the "new file" logic through the edit command, meaning:
- Applying state works correctly
- Accept/Reject buttons are shown and work
- Decorations are shown
- Telemetry is correctly recorded

### Before

- Stuck on Applying
- No decorations
- No Accept/Reject

<img width="1197" alt="image" src="https://github.com/user-attachments/assets/16cefaaf-0ded-4e1f-9bde-22949b036df7">

### After

<img width="1356" alt="image" src="https://github.com/user-attachments/assets/bcbbfd1d-4dd3-4fd2-9001-350e11e8054e">


## Test plan

1. Create a smart apply edit with a prompt like "Create a Heading component in a new file"
2. Click Apply
3. Expect that the file is created, "Accept" and "Reject" are shown
