### PR TITLE
Fixes Off by one new line errors  in Cody Edit

### DIFF
--- a/lib/shared/src/prompt/prompt-string.ts
+++ b/lib/shared/src/prompt/prompt-string.ts
@@ -98,6 +98,11 @@ export class PromptString {
         return internal_toReferences(this)
     }
 
+    // function to add a new line to the string of this
+    public addNewLine(): PromptString {
+        return internal_createPromptString(internal_toString(this) + '\n', internal_toReferences(this))
+    }
+
     public toJSON(): string {
         return internal_toString(this)
     }

--- a/lib/shared/src/prompt/prompt-string.ts
+++ b/lib/shared/src/prompt/prompt-string.ts
@@ -98,7 +98,7 @@ export class PromptString {
         return internal_toReferences(this)
     }
 
-    // function to add a new line to the string of this
+    // function to add a new line suffix to the string
     public addNewLine(): PromptString {
         return internal_createPromptString(internal_toString(this) + '\n', internal_toReferences(this))
     }

--- a/vscode/src/edit/prompt/index.ts
+++ b/vscode/src/edit/prompt/index.ts
@@ -83,12 +83,12 @@ export const buildInteraction = async ({
         task.selectionRange.start
     )
     const precedingText = PromptString.fromDocumentText(document, prefixRange)
-    const selectedText = PromptString.fromDocumentText(document, task.selectionRange)
+    const selectedText = PromptString.fromDocumentText(document, task.selectionRange).addNewLine()
     const tokenCount = await TokenCounterUtils.countPromptString(selectedText)
     if (tokenCount > contextWindow) {
         throw new Error("The amount of text selected exceeds Cody's current capacity.")
     }
-    task.original = selectedText.toString()
+    task.original = selectedText.toString() 
     const suffixRange = new vscode.Range(
         task.selectionRange.end,
         task.selectionRange.end.translate({ lineDelta: 50 })

--- a/vscode/src/edit/prompt/index.ts
+++ b/vscode/src/edit/prompt/index.ts
@@ -88,7 +88,7 @@ export const buildInteraction = async ({
     if (tokenCount > contextWindow) {
         throw new Error("The amount of text selected exceeds Cody's current capacity.")
     }
-    task.original = selectedText.toString() 
+    task.original = selectedText.toString()
     const suffixRange = new vscode.Range(
         task.selectionRange.end,
         task.selectionRange.end.translate({ lineDelta: 50 })

--- a/vscode/src/non-stop/decorations/compute-decorations.ts
+++ b/vscode/src/non-stop/decorations/compute-decorations.ts
@@ -152,6 +152,7 @@ export function computeOngoingDecorations(
         }
 
         // We know that preceding lines are visited, but following lines are not, so highlight those too
+        // Update unvisited lines based on the found line
         decorations.unvisitedLines = getRemainingLinesFromRange(
             task.selectionRange,
             foundLine + currentLineIndex + 1
@@ -160,5 +161,6 @@ export function computeOngoingDecorations(
         }))
     }
 
+    // Return the computed decorations
     return decorations
 }

--- a/vscode/src/non-stop/decorations/compute-decorations.ts
+++ b/vscode/src/non-stop/decorations/compute-decorations.ts
@@ -152,7 +152,6 @@ export function computeOngoingDecorations(
         }
 
         // We know that preceding lines are visited, but following lines are not, so highlight those too
-        // Update unvisited lines based on the found line
         decorations.unvisitedLines = getRemainingLinesFromRange(
             task.selectionRange,
             foundLine + currentLineIndex + 1
@@ -161,6 +160,5 @@ export function computeOngoingDecorations(
         }))
     }
 
-    // Return the computed decorations
     return decorations
 }


### PR DESCRIPTION
This PR fixes the issue where the edit command was incorrectly inserting a newline and removing the trailing newline during edits, as described in [CODY-3236](https://linear.app/sourcegraph/issue/CODY-3236/bug-with-edit-command-inserts-newline-incorrectly-and-removes-trailing).

 I covered the cases of
- 1 single line edit
- 2 lines edit
- End of the file thing
- Making sure the decorations aren't off with an extra gray line(like the case you warned me about)
- End of file apply works
- End of file edit works


## Test plan
https://www.loom.com/share/356ba53b021b4317885e171d8b2a9fdf?sid=5fc14198-9282-42ef-9fdd-b41c5a33b4e3

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
