### PR TITLE
Webview: conditionally render tabs based on multipleWebviewsEnabled

### DIFF
--- a/vscode/webviews/tabs/TabsBar.tsx
+++ b/vscode/webviews/tabs/TabsBar.tsx
@@ -141,11 +141,13 @@ export const TabsBar: React.FC<TabsBarProps> = ({ currentView, setView, IDE, onD
                                           ? 'cody.chat.newPanel'
                                           : 'cody.chat.newEditorPanel',
                             },
-                            multipleWebviewsEnabled && {
-                                title: 'Open in Editor',
-                                Icon: ColumnsIcon,
-                                command: 'cody.chat.moveToEditor',
-                            },
+                            multipleWebviewsEnabled
+                                ? {
+                                      title: 'Open in Editor',
+                                      Icon: ColumnsIcon,
+                                      command: 'cody.chat.moveToEditor',
+                                  }
+                                : null,
                         ].filter(isDefined),
                         changesView: true,
                     },
@@ -178,19 +180,23 @@ export const TabsBar: React.FC<TabsBarProps> = ({ currentView, setView, IDE, onD
                         Icon: BookTextIcon,
                         changesView: true,
                     },
-                    multipleWebviewsEnabled && {
-                        view: View.Settings,
-                        title: 'Settings',
-                        Icon: SettingsIcon,
-                        command: 'cody.status-bar.interacted',
-                    },
-                    IDE !== CodyIDE.Web && {
-                        view: View.Account,
-                        title: 'Account',
-                        Icon: CircleUserIcon,
-                        command: 'cody.auth.account',
-                        changesView: IDE !== CodyIDE.VSCode,
-                    },
+                    multipleWebviewsEnabled
+                        ? {
+                              view: View.Settings,
+                              title: 'Settings',
+                              Icon: SettingsIcon,
+                              command: 'cody.status-bar.interacted',
+                          }
+                        : null,
+                    IDE !== CodyIDE.Web
+                        ? {
+                              view: View.Account,
+                              title: 'Account',
+                              Icon: CircleUserIcon,
+                              command: 'cody.auth.account',
+                              changesView: IDE !== CodyIDE.VSCode,
+                          }
+                        : null,
                 ] as (TabConfig | null)[]
             ).filter(isDefined),
         [IDE, webviewType, onDownloadChatClick, multipleWebviewsEnabled]


### PR DESCRIPTION
Fix a minor regression made y https://github.com/sourcegraph/cody/pull/5260

Revert to using ternary operator to handle falsy value.
 
## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

Green CI

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
