### PR TITLE
update `mockServerTelemetryExporter` to send `anonymousUserId`

### DIFF
--- a/lib/shared/src/sourcegraph-api/telemetry/MockServerTelemetryExporter.ts
+++ b/lib/shared/src/sourcegraph-api/telemetry/MockServerTelemetryExporter.ts
@@ -14,7 +14,9 @@ export class MockServerTelemetryExporter implements TelemetryExporter {
     constructor(private anonymousUserID: string) {}
 
     public async exportEvents(events: TelemetryEventInput[]): Promise<void> {
-        const resultOrError = await this.postTestEventRecording(events)
+        const resultOrError = await this.postTestEventRecording(
+            events.map(event => ({ ...event, testOnlyAnonymousUserID: this.anonymousUserID }))
+        )
         if (isError(resultOrError)) {
             logError('MockServerTelemetryExporter', 'Error exporting telemetry events:', resultOrError)
         }


### PR DESCRIPTION
PR adds `testOnlyAnonymousUserId` to the testing event payload. This allows us to test `anonymousUserId` stays consistent within each test run.

## Test plan
Tested Locally and confirming that `testOnlyAnonymousUserId` is coming through

![image (42)](https://github.com/user-attachments/assets/9708e610-a0e5-4d98-b08d-7c74dfc5f121)

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
