### PR TITLE
reverting back to accuracy instead of power to not break sg/sg backend

### DIFF
--- a/lib/shared/src/models/dotcom.ts
+++ b/lib/shared/src/models/dotcom.ts
@@ -51,7 +51,7 @@ export const DEFAULT_DOT_COM_MODELS = [
         provider: 'Anthropic',
         usage: [ModelUsage.Chat, ModelUsage.Edit],
         contextWindow: expandedContextWindow,
-        tags: [ModelTag.Gateway, ModelTag.Pro, ModelTag.Power],
+        tags: [ModelTag.Gateway, ModelTag.Pro, ModelTag.Accuracy],
     },
     {
         title: 'Claude 3 Haiku',
@@ -91,7 +91,7 @@ export const DEFAULT_DOT_COM_MODELS = [
         provider: 'Google',
         usage: [ModelUsage.Chat, ModelUsage.Edit],
         contextWindow: expandedContextWindow,
-        tags: [ModelTag.Gateway, ModelTag.Power],
+        tags: [ModelTag.Gateway, ModelTag.Accuracy],
     },
 
     // TODO (tom) Improve prompt for Mixtral + Edit to see if we can use it there too.
@@ -109,7 +109,7 @@ export const DEFAULT_DOT_COM_MODELS = [
         provider: 'Mistral',
         usage: [ModelUsage.Chat],
         contextWindow: basicContextWindow,
-        tags: [ModelTag.Gateway, ModelTag.Power],
+        tags: [ModelTag.Gateway, ModelTag.Accuracy],
     },
 ] as const satisfies Model[]
 

--- a/lib/shared/src/models/index.ts
+++ b/lib/shared/src/models/index.ts
@@ -18,7 +18,7 @@ export interface ModelRef {
     modelId: ModelId
 }
 
-export type ModelCategory = ModelTag.Power | ModelTag.Balanced | ModelTag.Speed
+export type ModelCategory = ModelTag.Accuracy | ModelTag.Balanced | ModelTag.Speed
 export type ModelStatus = ModelTag.Experimental | ModelTag.Experimental | 'stable' | ModelTag.Deprecated
 export type ModelTier = ModelTag.Free | ModelTag.Pro | ModelTag.Enterprise
 export type ModelCapability = 'chat' | 'autocomplete'

--- a/lib/shared/src/models/tags.ts
+++ b/lib/shared/src/models/tags.ts
@@ -5,7 +5,7 @@
  */
 export enum ModelTag {
     // UI Groups
-    Power = 'power',
+    Accuracy = 'accuracy',
     Speed = 'speed',
     Balanced = 'balanced',
 

--- a/vscode/test/e2e/chat-input.test.ts
+++ b/vscode/test/e2e/chat-input.test.ts
@@ -159,10 +159,10 @@ test.extend<DotcomUrlOverride>({ dotcomUrl: mockServer.SERVER_URL })(
         await expect(humanRow0.toolbar.mention).toBeVisible()
         await expect(humanRow0.toolbar.modelSelector).toBeVisible()
         await expect(humanRow0.toolbar.submit).toBeVisible()
-        await expect(chatPanel.getByText('Powerful Models')).not.toBeVisible()
+        await expect(chatPanel.getByText('Optimized for Accuracy')).not.toBeVisible()
         // Open the model selector toolbar popover.
         await humanRow0.toolbar.modelSelector.click()
-        await expect(chatPanel.getByText('Powerful Models')).toBeVisible()
+        await expect(chatPanel.getByText('Optimized for Accuracy')).toBeVisible()
         await expect(humanRow0.toolbar.mention).toBeVisible()
         await expect(humanRow0.toolbar.modelSelector).toBeVisible()
         await expect(humanRow0.toolbar.submit).toBeVisible()

--- a/vscode/test/e2e/chat-input.test.ts
+++ b/vscode/test/e2e/chat-input.test.ts
@@ -159,10 +159,10 @@ test.extend<DotcomUrlOverride>({ dotcomUrl: mockServer.SERVER_URL })(
         await expect(humanRow0.toolbar.mention).toBeVisible()
         await expect(humanRow0.toolbar.modelSelector).toBeVisible()
         await expect(humanRow0.toolbar.submit).toBeVisible()
-        await expect(chatPanel.getByText('Optimized for Accuracy')).not.toBeVisible()
+        await expect(chatPanel.getByText('Powerful Models')).not.toBeVisible()
         // Open the model selector toolbar popover.
         await humanRow0.toolbar.modelSelector.click()
-        await expect(chatPanel.getByText('Optimized for Accuracy')).toBeVisible()
+        await expect(chatPanel.getByText('Powerful Models')).toBeVisible()
         await expect(humanRow0.toolbar.mention).toBeVisible()
         await expect(humanRow0.toolbar.modelSelector).toBeVisible()
         await expect(humanRow0.toolbar.submit).toBeVisible()

--- a/vscode/webviews/components/modelSelectField/ModelSelectField.tsx
+++ b/vscode/webviews/components/modelSelectField/ModelSelectField.tsx
@@ -30,6 +30,7 @@ export const ModelSelectField: React.FunctionComponent<{
 
     userInfo: Pick<UserAccountInfo, 'isCodyProUser' | 'isDotComUser'>
 
+
     onCloseByEscape?: () => void
     className?: string
 
@@ -326,17 +327,17 @@ const ChatModelIcon: FunctionComponent<{ model: string; className?: string }> = 
 
 /** Common {@link ModelsService.uiGroup} values. */
 export const ModelUIGroup: Record<string, string> = {
-    Power: 'More powerful models',
-    Balanced: 'Balanced for power and speed',
-    Speed: 'Faster models',
-    Ollama: 'Ollama (Local models)',
+    Balanced: 'Balanced for Power and Speed',
+    Speed: 'Faster Models',
+    Accuracy: 'Powerful Models',
+    Ollama: 'Ollama (Local Models)',
     Other: 'Other',
 }
 
 const getModelDropDownUIGroup = (model: Model): string => {
-    if (model.tags.includes(ModelTag.Power)) return ModelUIGroup.Power
     if (model.tags.includes(ModelTag.Balanced)) return ModelUIGroup.Balanced
     if (model.tags.includes(ModelTag.Speed)) return ModelUIGroup.Speed
+    if (model.tags.includes(ModelTag.Accuracy)) return ModelUIGroup.Accuracy
     if (model.tags.includes(ModelTag.Ollama)) return ModelUIGroup.Ollama
     return ModelUIGroup.Other
 }
@@ -345,9 +346,9 @@ const optionByGroup = (
     options: SelectListOption[]
 ): { group: string; options: SelectListOption[] }[] => {
     const groupOrder = [
-        ModelUIGroup.Power,
         ModelUIGroup.Balanced,
         ModelUIGroup.Speed,
+        ModelUIGroup.Accuracy,
         ModelUIGroup.Ollama,
         ModelUIGroup.Other,
     ]


### PR DESCRIPTION
sorry last one @abeatrix ! 

relevant discussion here: https://github.com/sourcegraph/sourcegraph/pull/71

## Test plan
tested locally
<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
