### PR TITLE
Autocomplete: remove Anthropic fallback

### DIFF
--- a/lib/shared/src/auth/types.ts
+++ b/lib/shared/src/auth/types.ts
@@ -61,25 +61,6 @@ export const defaultAuthStatus: AuthStatus = {
     codyApiVersion: 0,
 }
 
-export const enterpriseAuthStatus: AuthStatus = {
-    endpoint: '',
-    isDotCom: false,
-    isLoggedIn: true,
-    isFireworksTracingEnabled: false,
-    showInvalidAccessTokenError: false,
-    authenticated: true,
-    hasVerifiedEmail: true,
-    requiresVerifiedEmail: false,
-    siteHasCodyEnabled: true,
-    siteVersion: '',
-    userCanUpgrade: false,
-    username: '',
-    primaryEmail: '',
-    displayName: '',
-    avatarURL: '',
-    codyApiVersion: 0,
-}
-
 export const unauthenticatedStatus: AuthStatus = {
     endpoint: '',
     isDotCom: true,

--- a/lib/shared/src/auth/types.ts
+++ b/lib/shared/src/auth/types.ts
@@ -61,6 +61,25 @@ export const defaultAuthStatus: AuthStatus = {
     codyApiVersion: 0,
 }
 
+export const enterpriseAuthStatus: AuthStatus = {
+    endpoint: '',
+    isDotCom: false,
+    isLoggedIn: true,
+    isFireworksTracingEnabled: false,
+    showInvalidAccessTokenError: false,
+    authenticated: true,
+    hasVerifiedEmail: true,
+    requiresVerifiedEmail: false,
+    siteHasCodyEnabled: true,
+    siteVersion: '',
+    userCanUpgrade: false,
+    username: '',
+    primaryEmail: '',
+    displayName: '',
+    avatarURL: '',
+    codyApiVersion: 0,
+}
+
 export const unauthenticatedStatus: AuthStatus = {
     endpoint: '',
     isDotCom: true,

--- a/lib/shared/src/sourcegraph-api/graphql/client.ts
+++ b/lib/shared/src/sourcegraph-api/graphql/client.ts
@@ -783,7 +783,7 @@ export class SourcegraphGraphQLAPIClient {
     }
 
     public async getCodyLLMConfiguration(): Promise<undefined | CodyLLMSiteConfiguration | Error> {
-        // fetch Cody LLM provider separately for backward compatability
+        // fetch Cody LLM provider separately for backward compatibility
         const [configResponse, providerResponse, smartContextWindow] = await Promise.all([
             this.fetchSourcegraphAPI<APIResponse<CodyLLMSiteConfigurationResponse>>(
                 CURRENT_SITE_CODY_LLM_CONFIGURATION

--- a/vscode/src/completions/create-multi-model-inline-completion-provider.ts
+++ b/vscode/src/completions/create-multi-model-inline-completion-provider.ts
@@ -5,7 +5,7 @@ import { logDebug } from '../log'
 import type { InlineCompletionItemProviderArgs } from './create-inline-completion-item-provider'
 import type { MultiModelCompletionsResults } from './inline-completion-item-provider'
 import { InlineCompletionItemProvider } from './inline-completion-item-provider'
-import { createProviderConfigFromVSCodeConfig } from './providers/create-provider'
+import { createProviderHelper } from './providers/create-provider'
 
 interface providerConfig {
     providerName: string
@@ -111,13 +111,13 @@ export async function createInlineCompletionItemFromMultipleProviders({
         // Don't use the advanced provider config to get the model
         newConfig.autocompleteAdvancedModel = null
 
-        const providerConfig = await createProviderConfigFromVSCodeConfig(
+        const providerConfig = await createProviderHelper({
             client,
             authStatus,
-            currentProviderConfig.model,
-            currentProviderConfig.provider,
-            newConfig
-        )
+            model: currentProviderConfig.model,
+            provider: currentProviderConfig.provider,
+            config: newConfig,
+        })
         if (providerConfig) {
             const authStatus = authProvider.getAuthStatus()
             const completionsProvider = new InlineCompletionItemProvider({

--- a/vscode/src/completions/providers/create-provider.test.ts
+++ b/vscode/src/completions/providers/create-provider.test.ts
@@ -61,7 +61,7 @@ describe('createProviderConfig', () => {
     })
 
     describe('if completions provider field is not defined in VSCode settings', () => {
-        it('returns "anthropic" if completions provider is not configured', async () => {
+        it('returns `null` if completions provider is not configured', async () => {
             const provider = await createProviderConfig(
                 getVSCodeConfigurationWithAccessToken({
                     autocompleteAdvancedProvider: null as Configuration['autocompleteAdvancedProvider'],
@@ -69,8 +69,7 @@ describe('createProviderConfig', () => {
                 dummyCodeCompletionsClient,
                 dummyAuthStatus
             )
-            expect(provider?.identifier).toBe('fireworks')
-            expect(provider?.model).toBe('deepseek-coder-v2-lite-base')
+            expect(provider).toBeNull()
         })
 
         it('returns "fireworks" provider config and corresponding model if specified', async () => {
@@ -264,7 +263,7 @@ describe('createProviderConfig', () => {
                 // provider not defined (backward compat)
                 {
                     codyLLMConfig: { provider: undefined, completionModel: 'superdupercoder-7b' },
-                    expected: { provider: 'fireworks', model: 'deepseek-coder-v2-lite-base' },
+                    expected: null,
                 },
             ]
 
@@ -286,24 +285,5 @@ describe('createProviderConfig', () => {
                 })
             }
         })
-    })
-
-    it('PLG: returns Fireworks provider config if no completions provider specified in VSCode settings or site config', async () => {
-        const provider = await createProviderConfig(
-            getVSCodeConfigurationWithAccessToken(),
-            dummyCodeCompletionsClient,
-            dummyAuthStatus
-        )
-        expect(provider?.identifier).toBe('fireworks')
-        expect(provider?.model).toBe('deepseek-coder-v2-lite-base')
-    })
-
-    it('Enterprise: returns `null` if no completions provider specified in VSCode settings or site config', async () => {
-        const provider = await createProviderConfig(
-            getVSCodeConfigurationWithAccessToken(),
-            dummyCodeCompletionsClient,
-            enterpriseAuthStatus
-        )
-        expect(provider).toBeNull()
     })
 })

--- a/vscode/src/completions/providers/create-provider.test.ts
+++ b/vscode/src/completions/providers/create-provider.test.ts
@@ -6,7 +6,6 @@ import {
     type ConfigurationWithAccessToken,
     type GraphQLAPIClientConfig,
     defaultAuthStatus,
-    enterpriseAuthStatus,
     graphqlClient,
 } from '@sourcegraph/cody-shared'
 import { beforeAll, describe, expect, it } from 'vitest'

--- a/vscode/src/completions/providers/create-provider.ts
+++ b/vscode/src/completions/providers/create-provider.ts
@@ -36,7 +36,7 @@ import { createProviderConfig as createUnstableOpenAIProviderConfig } from './un
 interface CreateConfigHelperParams {
     client: CodeCompletionsClient
     authStatus: AuthStatus
-    model: string | undefined | null
+    model: string | undefined
     provider: string
     config: ConfigurationWithAccessToken
 }
@@ -143,12 +143,6 @@ async function resolveFIMModelExperimentFromFeatureFlags(): ReturnType<
     }
     // Extra free traffic - redirect to the current production model which could be different than control
     return { provider: 'fireworks', model: DEEPSEEK_CODER_V2_LITE_BASE }
-}
-
-function resolveConfigFromVSCodeConfig(configuredProvider: string | null) {
-    if (configuredProvider) {
-        return { provider: configuredProvider }
-    }
 }
 
 interface ProviderConfigFromFeatureFlags {
@@ -289,7 +283,7 @@ export async function createProviderConfig(
         return createProviderHelper({
             client,
             authStatus,
-            model: config.autocompleteAdvancedModel,
+            model: config.autocompleteAdvancedModel || undefined,
             provider: config.autocompleteAdvancedProvider,
             config,
         })

--- a/vscode/src/completions/providers/create-provider.ts
+++ b/vscode/src/completions/providers/create-provider.ts
@@ -221,14 +221,7 @@ function getAutocompleteModelInfo(authStatus: AuthStatus): AutocompleteModelInfo
         })
     }
 
-    // Fallback to the Fireworks autocomplete provider only for PLG users.
-    if (authStatus.isDotCom) {
-        return {
-            provider: 'fireworks',
-        }
-    }
-
-    // Fail with error for enterprises.
+    // Fail with error if no `completionModel` is configured.
     return new Error(
         'Failed to get autocomplete model info. Please configure the `completionModel` using site configuration.'
     )

--- a/vscode/test/fixtures/mock-server.ts
+++ b/vscode/test/fixtures/mock-server.ts
@@ -483,6 +483,20 @@ export class MockServer {
                     case 'EvaluateFeatureFlag':
                         res.send(JSON.stringify({ data: { evaluatedFeatureFlag: true } }))
                         break
+                    case 'CurrentSiteCodyLlmProvider': {
+                        res.send(
+                            JSON.stringify({
+                                data: {
+                                    site: {
+                                        codyLLMConfiguration: {
+                                            provider: 'sourcegraph',
+                                        },
+                                    },
+                                },
+                            })
+                        )
+                        break
+                    }
                     case 'CurrentSiteCodyLlmConfiguration': {
                         res.send(
                             JSON.stringify({

--- a/vscode/test/fixtures/mock-server.ts
+++ b/vscode/test/fixtures/mock-server.ts
@@ -490,6 +490,7 @@ export class MockServer {
                                     site: {
                                         codyLLMConfiguration: {
                                             chatModel: 'foo/test-chat-default-model',
+                                            completionModel: 'fireworks/starcoder',
                                             provider: 'sourcegraph',
                                         },
                                     },


### PR DESCRIPTION
- Removing the Anthropic autocomplete provider fallback. If the instance does not return a `completionModel`, we fail with an error message asking users to update their instance site-config.
- Refactored a small part of the `createProviderConfig` code with no functional changes. I'll have multiple follow-up updates to this part. Splitting it into numerous smaller PRs to make it easier to review.
- Discussed in [the Slack thread](https://sourcegraph.slack.com/archives/C075G57B5PH/p1724211970457949?thread_ts=1724202783.269599&cid=C075G57B5PH).
- Part of https://linear.app/sourcegraph/issue/CODY-3409/self-hosted-models-openaicompatible-autocomplete-provider-supports

## Test plan

CI