### PR TITLE
Smart Apply: Notify WebView of failure when erred from selection request

### DIFF
--- a/vscode/src/edit/manager.ts
+++ b/vscode/src/edit/manager.ts
@@ -296,6 +296,7 @@ export class EditManager implements vscode.Disposable {
         const replacementCode = PromptString.unsafe_fromLLMResponse(configuration.replacement)
 
         const selection = await getSmartApplySelection(
+            configuration.id,
             configuration.instruction,
             replacementCode,
             configuration.document,

--- a/vscode/src/edit/prompt/smart-apply.ts
+++ b/vscode/src/edit/prompt/smart-apply.ts
@@ -12,6 +12,9 @@ import {
     psDedent,
 } from '@sourcegraph/cody-shared'
 import * as vscode from 'vscode'
+import type { SmartApplyResult } from '../../chat/protocol'
+import type { FixupTaskID } from '../../non-stop/FixupTask'
+import { CodyTaskState } from '../../non-stop/state'
 import { PromptBuilder } from '../../prompt-builder'
 import { fuzzyFindLocation } from '../../supercompletions/utils/fuzzy-find-location'
 
@@ -171,6 +174,7 @@ interface SmartSelection {
 }
 
 export async function getSmartApplySelection(
+    id: FixupTaskID,
     instruction: PromptString,
     replacement: PromptString,
     document: vscode.TextDocument,
@@ -194,6 +198,13 @@ export async function getSmartApplySelection(
         vscode.window.showErrorMessage(
             `Error: ${error instanceof Error ? error.message : 'An unknown error occurred'}`
         )
+
+        // Notify the WebView that the Smart Apply failed
+        await vscode.commands.executeCommand('cody.command.markSmartApplyApplied', {
+            taskId: id,
+            taskState: CodyTaskState.Error,
+        } satisfies SmartApplyResult)
+
         return null
     }
 


### PR DESCRIPTION
## Description

Closes CODY-3397

We didn't notify the webview of the failure when getting the smart selection, as the task wasn't created yet.

Fixed:
<img width="890" alt="image" src="https://github.com/user-attachments/assets/fc47f81d-74c3-463a-a395-71ef8680e2b2">


## Test plan

1. Force that the smart selection request will fail (e.g. add a `request.abort()` inside `nodeClient`)
2. Trigger a smart apply
3. Expect the error to show
4. Expect the smart apply to not be stuck on "Applying"

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

