### PR TITLE
Edit: Compute decorations for hidden files

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -14,6 +14,7 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 
 - Edit: Fixed a case where multiple, duplicate, edit commands would be created unintentionally. [pull/5183](https://github.com/sourcegraph/cody/pull/5183)
 - Debug: Commands for debugging purposes (e.g., "Cody Debug: Export Logs") are available outside of development mode again. [pull/5197](https://github.com/sourcegraph/cody/pull/5197)
+- Edit: Fixed an issue where the inline diff would not be shown if a file became hidden before the edit was applied. [pull/5270](https://github.com/sourcegraph/cody/pull/5270)
 
 ### Changed
 

--- a/vscode/src/non-stop/decorations/compute-decorations.ts
+++ b/vscode/src/non-stop/decorations/compute-decorations.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode'
 import { isStreamedIntent } from '../../edit/utils/edit-intent'
 import type { FixupTask } from '../FixupTask'
-import { getDecorationSuitableText, getLastFullLine, getVisibleDocument } from './utils'
+import { getDecorationSuitableText, getLastFullLine } from './utils'
 
 export interface Decorations {
     linesAdded: vscode.DecorationOptions[]
@@ -11,11 +11,6 @@ export interface Decorations {
 }
 
 export function computeAppliedDecorations(task: FixupTask): Decorations | undefined {
-    const visibleDocument = getVisibleDocument(task)
-    if (!visibleDocument) {
-        return
-    }
-
     const decorations: Decorations = {
         linesAdded: [],
         linesRemoved: [],
@@ -53,7 +48,7 @@ export function computeAppliedDecorations(task: FixupTask): Decorations | undefi
         if (edit.type === 'decoratedReplacement') {
             const linesDeleted = edit.oldText.split('\n')
             for (let i = 0; i <= countChanged; i++) {
-                const decorationText = getDecorationSuitableText(linesDeleted[i], visibleDocument)
+                const decorationText = getDecorationSuitableText(linesDeleted[i], task.document)
                 const line = new vscode.Position(edit.range.start.line + i, 0)
                 decorations.linesRemoved.push({
                     range: new vscode.Range(line, line),


### PR DESCRIPTION
## Description

Noticed a bug where this could happen:
1. Trigger an edit, e.g. try one that deletes a bunch of comments
2. Change the file immediately, so the edit you are in is no longer visible
3. When the edit is applied, go back to the original file.
4. Notice that decorations are missing

This was an oversight when I added the original diff logic, we still want to _compute_ decorations for hidden files, we just can't show them yet! (We already handle showing decorations when a file becomes visible)

### Before

https://github.com/user-attachments/assets/44c1fcbc-10da-41d8-bb5f-9ce28dc580ec


### After

https://github.com/user-attachments/assets/b890f765-ff57-41fe-8013-61723ab48a42



## Test plan

1. Trigger an edit, e.g. try one that deletes a bunch of comments
2. Change the file immediately, so the edit you are in is no longer visible
3. When the edit is applied, go back to the original file.
4. Notice that decorations are shown

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

