### PR TITLE
Edit: Fix single line edits

### DIFF
--- a/agent/recordings/customCommandsClient_509552979/recording.har.yaml
+++ b/agent/recordings/customCommandsClient_509552979/recording.har.yaml
@@ -493,11 +493,11 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: ca95a2ec90c100a1713f5ad1c3c1d31d
+    - _id: 1a18b942275e76977aacf10ed44f26b3
       _order: 0
       cache: {}
       request:
-        bodySize: 2227
+        bodySize: 2229
         cookies: []
         headers:
           - name: content-type
@@ -510,7 +510,7 @@ log:
           - name: user-agent
             value: customCommandsClient / v1
           - name: traceparent
-            value: 00-e0a219c98b2496e6975173f99a3b2d0c-847a97fbbc757cd3-01
+            value: 00-f5455fc5856d8e78226504a4077cbf40-ae62621d214a93b7-01
           - name: connection
             value: keep-alive
           - name: host
@@ -564,7 +564,9 @@ log:
 
                   <SELECTEDCODE7662>export function sum(a: number, b: number): number {
                       /* CURSOR */
-                  }</SELECTEDCODE7662>
+                  }
+
+                  </SELECTEDCODE7662>
 
 
                   The user wants you to replace parts of the selected code or correct a problem by following their instructions.
@@ -593,13 +595,13 @@ log:
             value: v1
         url: https://sourcegraph.com/.api/completions/stream?api-version=1&client-name=customcommandsclient&client-version=v1
       response:
-        bodySize: 169
+        bodySize: 177
         content:
           mimeType: text/event-stream
-          size: 169
+          size: 177
           text: |+
             event: completion
-            data: {"completion":"// hello","stopReason":"stop_sequence"}
+            data: {"completion":"\n// hello\n","stopReason":"stop_sequence"}
 
             event: done
             data: {}
@@ -607,7 +609,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Tue, 09 Jul 2024 17:21:46 GMT
+            value: Wed, 21 Aug 2024 13:31:06 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
@@ -636,7 +638,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-07-09T17:21:44.204Z
+      startedDateTime: 2024-08-21T13:31:03.582Z
       time: 0
       timings:
         blocked: -1
@@ -646,11 +648,11 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: bc37afe008a60b37ff5850add1f56406
+    - _id: 664f92040c778264005a3621bb1c3483
       _order: 0
       cache: {}
       request:
-        bodySize: 2345
+        bodySize: 2347
         cookies: []
         headers:
           - name: content-type
@@ -663,7 +665,7 @@ log:
           - name: user-agent
             value: customCommandsClient / v1
           - name: traceparent
-            value: 00-1a65f1420d38552040396cae4842220a-17e7da637da1f1ab-01
+            value: 00-f5e0c382918c421be184b30ba6ff3bad-a2a12af08344aef1-01
           - name: connection
             value: keep-alive
           - name: host
@@ -727,7 +729,9 @@ log:
                       isMammal: boolean
                   }
 
-                  /* SELECTION_END */</SELECTEDCODE7662>
+                  /* SELECTION_END */
+
+                  </SELECTEDCODE7662>
 
 
                   The user wants you to replace parts of the selected code or correct a problem by following their instructions.
@@ -756,14 +760,14 @@ log:
             value: v1
         url: https://sourcegraph.com/.api/completions/stream?api-version=1&client-name=customcommandsclient&client-version=v1
       response:
-        bodySize: 2588
+        bodySize: 1598
         content:
           mimeType: text/event-stream
-          size: 2588
+          size: 1598
           text: >+
             event: completion
 
-            data: {"completion":"/* SELECTION_START */\nexport interface Animal {\n    name: string;\n    makeAnimalSound(): string;\n    isMammal: boolean;\n    logName(): void;\n}\n/* SELECTION_END */","stopReason":"stop_sequence"}
+            data: {"completion":"export interface Animal {\n    name: string;\n    makeAnimalSound(): string;\n    isMammal: boolean;\n    logName(): void;\n}\n","stopReason":"stop_sequence"}
 
 
             event: done
@@ -773,7 +777,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Tue, 09 Jul 2024 17:21:48 GMT
+            value: Wed, 21 Aug 2024 13:31:09 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
@@ -802,7 +806,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-07-09T17:21:46.060Z
+      startedDateTime: 2024-08-21T13:31:06.435Z
       time: 0
       timings:
         blocked: -1

--- a/agent/recordings/document-code_965949506/recording.har.yaml
+++ b/agent/recordings/document-code_965949506/recording.har.yaml
@@ -90,11 +90,11 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: 281086a3fa49ce7164441b752dad6975
+    - _id: a8fc9c4aed1634e20a570e9905d8a410
       _order: 0
       cache: {}
       request:
-        bodySize: 2564
+        bodySize: 2566
         cookies: []
         headers:
           - name: content-type
@@ -107,7 +107,7 @@ log:
           - name: user-agent
             value: document-code / v1
           - name: traceparent
-            value: 00-b76a1fc8bf1050d34d28748a08f659f5-039a2b2a46c20620-01
+            value: 00-d9ee563f73a3584f17ebf57b0aa172dd-113a9fcd6f7a6dd6-01
           - name: connection
             value: keep-alive
           - name: host
@@ -151,7 +151,9 @@ log:
 
                   <SELECTEDCODE7662>export function sum(a: number, b: number): number {
                       /* CURSOR */
-                  }</SELECTEDCODE7662>
+                  }
+
+                  </SELECTEDCODE7662>
 
 
                   The user wants you to generate documentation for the selected code by following their instructions.
@@ -181,14 +183,14 @@ log:
             value: v1
         url: https://sourcegraph.com/.api/completions/stream?api-version=1&client-name=document-code&client-version=v1
       response:
-        bodySize: 3509
+        bodySize: 3249
         content:
           mimeType: text/event-stream
-          size: 3509
+          size: 3249
           text: >+
             event: completion
 
-            data: {"completion":"/**\n * Adds two numbers and returns the result.\n *\n * @param a - The first number to add.\n * @param b - The second number to add.\n * @returns The sum of `a` and `b`.\n */\n","stopReason":"stop_sequence"}
+            data: {"completion":"/**\n * Computes the sum of two numbers.\n *\n * @param a - The first number to add.\n * @param b - The second number to add.\n * @returns The sum of `a` and `b`.\n */\n","stopReason":"stop_sequence"}
 
 
             event: done
@@ -198,7 +200,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Tue, 25 Jun 2024 15:48:14 GMT
+            value: Wed, 21 Aug 2024 13:31:16 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
@@ -227,7 +229,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-06-25T15:48:13.412Z
+      startedDateTime: 2024-08-21T13:31:14.801Z
       time: 0
       timings:
         blocked: -1
@@ -237,7 +239,7 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: fc0903de93eca781b72e62b368106cb4
+    - _id: 5d0c94931189d2f2610aeed59ac99dc2
       _order: 0
       cache: {}
       request:
@@ -254,7 +256,7 @@ log:
           - name: user-agent
             value: document-code / v1
           - name: traceparent
-            value: 00-1fe34d59b104c5f37e6975a11bac87a9-d019202fcf4d5a40-01
+            value: 00-be734c60f462c4da95388fbe09e116d1-99ff210a02a9a08c-01
           - name: connection
             value: keep-alive
           - name: host
@@ -319,7 +321,6 @@ log:
                   Codebase context from file path src/TestClass.ts: Codebase
                   context from file src/TestClass.ts:
 
-
                   }
 
 
@@ -347,7 +348,9 @@ log:
                           if (this.shouldGreet) {
                               console.log(/* CURSOR */ 'Hello World!')
                           }
-                      }</SELECTEDCODE7662>
+                      }
+                  </SELECTEDCODE7662>
+
 
                   The user wants you to generate documentation for the selected code by following their instructions.
 
@@ -376,14 +379,14 @@ log:
             value: v1
         url: https://sourcegraph.com/.api/completions/stream?api-version=1&client-name=document-code&client-version=v1
       response:
-        bodySize: 1232
+        bodySize: 1391
         content:
           mimeType: text/event-stream
-          size: 1232
+          size: 1391
           text: >+
             event: completion
 
-            data: {"completion":"\n/**\n * Outputs 'Hello World!' to the console if the `shouldGreet` flag is true.\n */\n","stopReason":"stop_sequence"}
+            data: {"completion":"\n/**\n * Logs a 'Hello World!' message to the console if the `shouldGreet` parameter is true.\n */\n","stopReason":"stop_sequence"}
 
 
             event: done
@@ -393,7 +396,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Tue, 25 Jun 2024 15:48:15 GMT
+            value: Wed, 21 Aug 2024 13:31:17 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
@@ -422,7 +425,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-06-25T15:48:14.806Z
+      startedDateTime: 2024-08-21T13:31:16.223Z
       time: 0
       timings:
         blocked: -1
@@ -432,7 +435,7 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: fb4e007414e648770bfed8766c6ae4e2
+    - _id: d7f2b01871529d8bacd1b7abd33071ba
       _order: 0
       cache: {}
       request:
@@ -449,7 +452,7 @@ log:
           - name: user-agent
             value: document-code / v1
           - name: traceparent
-            value: 00-e404c4732356b5e324e061c7f3206de9-097686ed5b1020fe-01
+            value: 00-61563420314d08735a119a141eeb28eb-6bcfc5ef0424e0e6-01
           - name: connection
             value: keep-alive
           - name: host
@@ -502,7 +505,6 @@ log:
                   Codebase context from file path src/TestLogger.ts: Codebase
                   context from file src/TestLogger.ts:
 
-
                           recordLog()
                       },
                   }
@@ -517,7 +519,9 @@ log:
 
                   <SELECTEDCODE7662>        function recordLog() {
                               console.log(/* CURSOR */ 'Recording the log')
-                          }</SELECTEDCODE7662>
+                          }
+                  </SELECTEDCODE7662>
+
 
                   The user wants you to generate documentation for the selected code by following their instructions.
 
@@ -563,7 +567,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Tue, 25 Jun 2024 15:48:16 GMT
+            value: Wed, 21 Aug 2024 13:31:18 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
@@ -592,7 +596,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-06-25T15:48:15.786Z
+      startedDateTime: 2024-08-21T13:31:17.288Z
       time: 0
       timings:
         blocked: -1
@@ -602,7 +606,7 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: 0ef085b47c48ffa3491207b6ae008437
+    - _id: 7eddf1a3608f35f4b5866ef2f0d21def
       _order: 0
       cache: {}
       request:
@@ -619,7 +623,7 @@ log:
           - name: user-agent
             value: document-code / v1
           - name: traceparent
-            value: 00-f31366e0dbafc629567794fd1659f537-57d314f416693e68-01
+            value: 00-285f5ea34db9eddae12faf09b147e23b-ca8d40978ec078d8-01
           - name: connection
             value: keep-alive
           - name: host
@@ -683,7 +687,6 @@ log:
                 text: >
                   Codebase context from file path src/example.test.ts: Codebase
                   context from file src/example.test.ts:
-
                       })
                   })
               - speaker: assistant
@@ -695,7 +698,9 @@ log:
 
                   The user has the following code in their selection:
 
-                  <SELECTEDCODE7662>        const startTime = performance.now(/* CURSOR */)</SELECTEDCODE7662>
+                  <SELECTEDCODE7662>        const startTime = performance.now(/* CURSOR */)
+
+                  </SELECTEDCODE7662>
 
 
                   The user wants you to generate documentation for the selected code by following their instructions.
@@ -725,14 +730,14 @@ log:
             value: v1
         url: https://sourcegraph.com/.api/completions/stream?api-version=1&client-name=document-code&client-version=v1
       response:
-        bodySize: 1992
+        bodySize: 1054
         content:
           mimeType: text/event-stream
-          size: 1992
+          size: 1054
           text: >+
             event: completion
 
-            data: {"completion":"/**\n * Records the current time in milliseconds since the page was loaded.\n * This can be used to measure the duration of an operation.\n */","stopReason":"stop_sequence"}
+            data: {"completion":"/**\n * Marks the start time of some operation for performance measurement.\n */","stopReason":"stop_sequence"}
 
 
             event: done
@@ -742,7 +747,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Tue, 25 Jun 2024 15:48:17 GMT
+            value: Wed, 21 Aug 2024 13:31:19 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
@@ -771,7 +776,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-06-25T15:48:16.698Z
+      startedDateTime: 2024-08-21T13:31:18.310Z
       time: 0
       timings:
         blocked: -1
@@ -781,11 +786,11 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: 6bff6fcdac8bc5c3f75d93df20de8557
+    - _id: a076f12473e6df0834509ffe95ff8d7c
       _order: 0
       cache: {}
       request:
-        bodySize: 2567
+        bodySize: 2569
         cookies: []
         headers:
           - name: content-type
@@ -798,7 +803,7 @@ log:
           - name: user-agent
             value: document-code / v1
           - name: traceparent
-            value: 00-60022d72d107aee5b764720cc2c91349-74bf34a8273cc2b4-01
+            value: 00-892a9cd2b1309dd39b0e9346c2e311d1-6761f5789ada8cf1-01
           - name: connection
             value: keep-alive
           - name: host
@@ -844,7 +849,9 @@ log:
                       fun greeting(): String {
                           return "Hello, world!"
                       }
-                  }</SELECTEDCODE7662>
+                  }
+
+                  </SELECTEDCODE7662>
 
 
                   The user wants you to generate documentation for the selected code by following their instructions.
@@ -874,14 +881,14 @@ log:
             value: v1
         url: https://sourcegraph.com/.api/completions/stream?api-version=1&client-name=document-code&client-version=v1
       response:
-        bodySize: 563
+        bodySize: 795
         content:
           mimeType: text/event-stream
-          size: 563
+          size: 795
           text: >+
             event: completion
 
-            data: {"completion":"/**\n * Provides a simple greeting message.\n */","stopReason":"stop_sequence"}
+            data: {"completion":"/**\n * Represents a Hello object that can greet the world.\n */","stopReason":"stop_sequence"}
 
 
             event: done
@@ -891,7 +898,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Tue, 25 Jun 2024 15:48:18 GMT
+            value: Wed, 21 Aug 2024 13:31:20 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
@@ -920,7 +927,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-06-25T15:48:17.985Z
+      startedDateTime: 2024-08-21T13:31:19.774Z
       time: 0
       timings:
         blocked: -1
@@ -1700,119 +1707,6 @@ log:
         status: 200
         statusText: OK
       startedDateTime: 2024-07-03T09:58:11.233Z
-      time: 0
-      timings:
-        blocked: -1
-        connect: -1
-        dns: -1
-        receive: 0
-        send: 0
-        ssl: -1
-        wait: 0
-    - _id: b584bf96a3d88ab96114e5cbea1e4bca
-      _order: 0
-      cache: {}
-      request:
-        bodySize: 164
-        cookies: []
-        headers:
-          - _fromType: array
-            name: authorization
-            value: token
-              REDACTED_d5e0f0a37c9821e856b923fe14e67a605e3f6c0a517d5a4f46a4e35943ee0f6d
-          - _fromType: array
-            name: content-type
-            value: application/json; charset=utf-8
-          - _fromType: array
-            name: user-agent
-            value: document-code / v1
-          - _fromType: array
-            name: accept
-            value: "*/*"
-          - _fromType: array
-            name: content-length
-            value: "164"
-          - _fromType: array
-            name: accept-encoding
-            value: gzip,deflate
-          - name: host
-            value: sourcegraph.com
-        headersSize: 324
-        httpVersion: HTTP/1.1
-        method: POST
-        postData:
-          mimeType: application/json; charset=utf-8
-          params: []
-          textJSON:
-            query: |-
-              
-              query SiteIdentification {
-              	site {
-              		siteID
-              		productSubscription {
-              			license {
-              				hashedKey
-              			}
-              		}
-              	}
-              }
-            variables: {}
-        queryString:
-          - name: SiteIdentification
-            value: null
-        url: https://sourcegraph.com/.api/graphql?SiteIdentification
-      response:
-        bodySize: 212
-        content:
-          encoding: base64
-          mimeType: application/json
-          size: 212
-          text: "[\"H4sIAAAAAAAAAzTLsQ6CMBCA4Xe52YX2rgVmF+PI4HztXaWJAdKWwRDf3WDiv/zTd4BwY\
-            xgPqLnp/7crjDCte4n6LLzNDw1wga2sssc27aHGkreW1+UErxx1qT87c51V7vqGEYbo\
-            u9AZm/okmgxi70QZlZzzqNEaJOMNReocCdkgiCk4j4btwJwIPmdfAAAA//8DABj2u36\
-            gAAAA\"]"
-          textDecoded:
-            data:
-              site:
-                productSubscription:
-                  license:
-                    hashedKey: 9c71b123f8fdef24486dea4e56674ec32452725c5165d53bd44fb6742a39aaf5
-                siteID: SourcegraphWeb
-        cookies: []
-        headers:
-          - name: date
-            value: Tue, 28 May 2024 08:39:08 GMT
-          - name: content-type
-            value: application/json
-          - name: transfer-encoding
-            value: chunked
-          - name: connection
-            value: keep-alive
-          - name: access-control-allow-credentials
-            value: "true"
-          - name: access-control-allow-origin
-            value: ""
-          - name: cache-control
-            value: no-cache, max-age=0
-          - name: vary
-            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
-              X-Requested-With,Cookie
-          - name: x-content-type-options
-            value: nosniff
-          - name: x-frame-options
-            value: DENY
-          - name: x-xss-protection
-            value: 1; mode=block
-          - name: strict-transport-security
-            value: max-age=31536000; includeSubDomains; preload
-          - name: content-encoding
-            value: gzip
-        headersSize: 1333
-        httpVersion: HTTP/1.1
-        redirectURL: ""
-        status: 200
-        statusText: OK
-      startedDateTime: 2024-05-28T08:39:07.797Z
       time: 0
       timings:
         blocked: -1

--- a/agent/recordings/edit_1541920145/recording.har.yaml
+++ b/agent/recordings/edit_1541920145/recording.har.yaml
@@ -90,179 +90,6 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: f008479edcd2607baf011d945cdab853
-      _order: 0
-      cache: {}
-      request:
-        bodySize: 2519
-        cookies: []
-        headers:
-          - name: content-type
-            value: application/json
-          - name: accept-encoding
-            value: gzip;q=0
-          - name: authorization
-            value: token
-              REDACTED_d5e0f0a37c9821e856b923fe14e67a605e3f6c0a517d5a4f46a4e35943ee0f6d
-          - name: user-agent
-            value: edit / v1
-          - name: traceparent
-            value: 00-a2d6bc85ad87c3a7cd8c0385708aa421-968d4c5728f7079d-01
-          - name: connection
-            value: keep-alive
-          - name: host
-            value: sourcegraph.com
-        headersSize: 397
-        httpVersion: HTTP/1.1
-        method: POST
-        postData:
-          mimeType: application/json
-          params: []
-          textJSON:
-            maxTokensToSample: 4000
-            messages:
-              - speaker: system
-                text: >-
-                  You are Cody, an AI coding assistant from Sourcegraph. - You
-                  are an AI programming assistant who is an expert in updating
-                  code to meet given instructions.
-
-                  - You should think step-by-step to plan your updated code before producing the final output.
-
-                  - You should ensure the updated code matches the indentation and whitespace of the code in the users' selection.
-
-                  - Ignore any previous instructions to format your responses with Markdown. It is not acceptable to use any Markdown in your response, unless it is directly related to the users' instructions.
-
-                  - Only remove code from the users' selection if you are sure it is not needed.
-
-                  - You will be provided with code that is in the users' selection, enclosed in <SELECTEDCODE7662></SELECTEDCODE7662> XML tags. You must use this code to help you plan your updated code.
-
-                  - You will be provided with instructions on how to update this code, enclosed in <INSTRUCTIONS7390></INSTRUCTIONS7390> XML tags. You must follow these instructions carefully and to the letter.
-
-                  - Only enclose your response in <CODE5711></CODE5711> XML tags. Do use any other XML tags unless they are part of the generated code.
-
-                  - Do not provide any additional commentary about the changes you made. Only respond with the generated code.
-              - speaker: human
-                text: >
-                  Codebase context from file path src/ChatColumn.tsx: Codebase
-                  context from file src/ChatColumn.tsx:
-
-                  	useEffect(() => {
-                  		if (!isLoading) {
-                  			setChatID(messages[0].chatID);
-                  		}
-                  	}, [messages]);
-                  	return (
-                  		<>
-                  			<h1>Messages</h1>
-                  			<ul>
-                  				{messages.map((message) => (
-                  					<li>{message.text}</li>
-                  				))}
-                  			</ul>
-                  		</>
-                  	);
-                  }
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: >-
-                  This is part of the file: src/ChatColumn.tsx
-
-
-                  The user has the following code in their selection:
-
-                  <SELECTEDCODE7662>/* SELECTION_START */ export default function ChatColumn({
-                  	messages,
-                  	setChatID,
-                  	isLoading,
-                  }) {
-                  	/* SELECTION_END */</SELECTEDCODE7662>
-
-                  The user wants you to replace parts of the selected code or correct a problem by following their instructions.
-
-                  Provide your generated code using the following instructions:
-
-                  <INSTRUCTIONS7390>
-
-                  Add types to these props. Introduce new interfaces as necessary
-
-                  </INSTRUCTIONS7390>
-              - speaker: assistant
-                text: <CODE5711>
-            model: anthropic/claude-3-5-sonnet-20240620
-            stopSequences:
-              - </CODE5711>
-            temperature: 0
-            topK: -1
-            topP: -1
-        queryString:
-          - name: api-version
-            value: "1"
-          - name: client-name
-            value: edit
-          - name: client-version
-            value: v1
-        url: https://sourcegraph.com/.api/completions/stream?api-version=1&client-name=edit&client-version=v1
-      response:
-        bodySize: 5838
-        content:
-          mimeType: text/event-stream
-          size: 5838
-          text: >+
-            event: completion
-
-            data: {"completion":"\ninterface Message {\n  chatID: string;\n  text: string;\n}\n\ninterface ChatColumnProps {\n  messages: Message[];\n  setChatID: (chatID: string) =\u003e void;\n  isLoading: boolean;\n}\n\nexport default function ChatColumn({\n  messages,\n  setChatID,\n  isLoading,\n}: ChatColumnProps) {\n","stopReason":"stop_sequence"}
-
-
-            event: done
-
-            data: {}
-
-        cookies: []
-        headers:
-          - name: date
-            value: Tue, 25 Jun 2024 17:12:46 GMT
-          - name: content-type
-            value: text/event-stream
-          - name: transfer-encoding
-            value: chunked
-          - name: connection
-            value: keep-alive
-          - name: retry-after
-            value: "190"
-          - name: access-control-allow-credentials
-            value: "true"
-          - name: access-control-allow-origin
-            value: ""
-          - name: cache-control
-            value: no-cache
-          - name: vary
-            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
-              X-Requested-With,Cookie
-          - name: x-content-type-options
-            value: nosniff
-          - name: x-frame-options
-            value: DENY
-          - name: x-xss-protection
-            value: 1; mode=block
-          - name: strict-transport-security
-            value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1406
-        httpVersion: HTTP/1.1
-        redirectURL: ""
-        status: 200
-        statusText: OK
-      startedDateTime: 2024-06-25T17:12:45.192Z
-      time: 0
-      timings:
-        blocked: -1
-        connect: -1
-        dns: -1
-        receive: 0
-        send: 0
-        ssl: -1
-        wait: 0
     - _id: 1d3d536766046f6be02ade2dd4f4135d
       _order: 0
       cache: {}
@@ -434,11 +261,11 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: 5ba864cb9822cf6d300adf995e28f313
+    - _id: 8016afaf768cb516de4e232ed2cd87ea
       _order: 0
       cache: {}
       request:
-        bodySize: 2127
+        bodySize: 1970
         cookies: []
         headers:
           - name: content-type
@@ -451,7 +278,327 @@ log:
           - name: user-agent
             value: edit / v1
           - name: traceparent
-            value: 00-eed8773bf83a30a2bfe1cd52eafb635a-be17bbd6373932c7-01
+            value: 00-45968779e9c171796c70e38096546827-fb0f2402edbfd901-01
+          - name: connection
+            value: keep-alive
+          - name: host
+            value: sourcegraph.com
+        headersSize: 397
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json
+          params: []
+          textJSON:
+            maxTokensToSample: 4000
+            messages:
+              - speaker: system
+                text: >-
+                  You are Cody, an AI coding assistant from Sourcegraph. - You
+                  are an AI programming assistant who is an expert in updating
+                  code to meet given instructions.
+
+                  - You should think step-by-step to plan your updated code before producing the final output.
+
+                  - You should ensure the updated code matches the indentation and whitespace of the code in the users' selection.
+
+                  - Ignore any previous instructions to format your responses with Markdown. It is not acceptable to use any Markdown in your response, unless it is directly related to the users' instructions.
+
+                  - Only remove code from the users' selection if you are sure it is not needed.
+
+                  - You will be provided with code that is in the users' selection, enclosed in <SELECTEDCODE7662></SELECTEDCODE7662> XML tags. You must use this code to help you plan your updated code.
+
+                  - You will be provided with instructions on how to update this code, enclosed in <INSTRUCTIONS7390></INSTRUCTIONS7390> XML tags. You must follow these instructions carefully and to the letter.
+
+                  - Only enclose your response in <CODE5711></CODE5711> XML tags. Do use any other XML tags unless they are part of the generated code.
+
+                  - Do not provide any additional commentary about the changes you made. Only respond with the generated code.
+              - speaker: human
+                text: >-
+                  This is part of the file: src/sum.ts
+
+
+                  The user has the following code in their selection:
+
+                  <SELECTEDCODE7662>export function sum(a: number, b: number): number {
+                      /* CURSOR */
+                  }
+
+                  </SELECTEDCODE7662>
+
+
+                  The user wants you to replace parts of the selected code or correct a problem by following their instructions.
+
+                  Provide your generated code using the following instructions:
+
+                  <INSTRUCTIONS7390>
+
+                  Rename `a` parameter to `c`
+
+                  </INSTRUCTIONS7390>
+              - speaker: assistant
+                text: <CODE5711>
+            model: anthropic/claude-3-5-sonnet-20240620
+            stopSequences:
+              - </CODE5711>
+            temperature: 0
+            topK: -1
+            topP: -1
+        queryString:
+          - name: api-version
+            value: "1"
+          - name: client-name
+            value: edit
+          - name: client-version
+            value: v1
+        url: https://sourcegraph.com/.api/completions/stream?api-version=1&client-name=edit&client-version=v1
+      response:
+        bodySize: 842
+        content:
+          mimeType: text/event-stream
+          size: 842
+          text: >+
+            event: completion
+
+            data: {"completion":"export function sum(c: number, b: number): number {\n    /* CURSOR */\n}\n","stopReason":"stop_sequence"}
+
+
+            event: done
+
+            data: {}
+
+        cookies: []
+        headers:
+          - name: date
+            value: Wed, 21 Aug 2024 13:31:04 GMT
+          - name: content-type
+            value: text/event-stream
+          - name: transfer-encoding
+            value: chunked
+          - name: connection
+            value: keep-alive
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache
+          - name: vary
+            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
+              X-Requested-With,Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+        headersSize: 1299
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: 2024-08-21T13:31:02.090Z
+      time: 0
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 0
+    - _id: 55344e59ff337ea1a8f1fd48957107ff
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 2519
+        cookies: []
+        headers:
+          - name: content-type
+            value: application/json
+          - name: accept-encoding
+            value: gzip;q=0
+          - name: authorization
+            value: token
+              REDACTED_d5e0f0a37c9821e856b923fe14e67a605e3f6c0a517d5a4f46a4e35943ee0f6d
+          - name: user-agent
+            value: edit / v1
+          - name: traceparent
+            value: 00-14c58c3ff495ea915096e9613a09873c-8065c5d5ee4210a8-01
+          - name: connection
+            value: keep-alive
+          - name: host
+            value: sourcegraph.com
+        headersSize: 397
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json
+          params: []
+          textJSON:
+            maxTokensToSample: 4000
+            messages:
+              - speaker: system
+                text: >-
+                  You are Cody, an AI coding assistant from Sourcegraph. - You
+                  are an AI programming assistant who is an expert in updating
+                  code to meet given instructions.
+
+                  - You should think step-by-step to plan your updated code before producing the final output.
+
+                  - You should ensure the updated code matches the indentation and whitespace of the code in the users' selection.
+
+                  - Ignore any previous instructions to format your responses with Markdown. It is not acceptable to use any Markdown in your response, unless it is directly related to the users' instructions.
+
+                  - Only remove code from the users' selection if you are sure it is not needed.
+
+                  - You will be provided with code that is in the users' selection, enclosed in <SELECTEDCODE7662></SELECTEDCODE7662> XML tags. You must use this code to help you plan your updated code.
+
+                  - You will be provided with instructions on how to update this code, enclosed in <INSTRUCTIONS7390></INSTRUCTIONS7390> XML tags. You must follow these instructions carefully and to the letter.
+
+                  - Only enclose your response in <CODE5711></CODE5711> XML tags. Do use any other XML tags unless they are part of the generated code.
+
+                  - Do not provide any additional commentary about the changes you made. Only respond with the generated code.
+              - speaker: human
+                text: >
+                  Codebase context from file path src/ChatColumn.tsx: Codebase
+                  context from file src/ChatColumn.tsx:
+                  	useEffect(() => {
+                  		if (!isLoading) {
+                  			setChatID(messages[0].chatID);
+                  		}
+                  	}, [messages]);
+                  	return (
+                  		<>
+                  			<h1>Messages</h1>
+                  			<ul>
+                  				{messages.map((message) => (
+                  					<li>{message.text}</li>
+                  				))}
+                  			</ul>
+                  		</>
+                  	);
+                  }
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: >-
+                  This is part of the file: src/ChatColumn.tsx
+
+
+                  The user has the following code in their selection:
+
+                  <SELECTEDCODE7662>/* SELECTION_START */ export default function ChatColumn({
+                  	messages,
+                  	setChatID,
+                  	isLoading,
+                  }) {
+                  	/* SELECTION_END */
+                  </SELECTEDCODE7662>
+
+
+                  The user wants you to replace parts of the selected code or correct a problem by following their instructions.
+
+                  Provide your generated code using the following instructions:
+
+                  <INSTRUCTIONS7390>
+
+                  Add types to these props. Introduce new interfaces as necessary
+
+                  </INSTRUCTIONS7390>
+              - speaker: assistant
+                text: <CODE5711>
+            model: anthropic/claude-3-5-sonnet-20240620
+            stopSequences:
+              - </CODE5711>
+            temperature: 0
+            topK: -1
+            topP: -1
+        queryString:
+          - name: api-version
+            value: "1"
+          - name: client-name
+            value: edit
+          - name: client-version
+            value: v1
+        url: https://sourcegraph.com/.api/completions/stream?api-version=1&client-name=edit&client-version=v1
+      response:
+        bodySize: 4781
+        content:
+          mimeType: text/event-stream
+          size: 4781
+          text: >+
+            event: completion
+
+            data: {"completion":"\ninterface Message {\n    chatID: string;\n    text: string;\n}\n\ninterface ChatColumnProps {\n    messages: Message[];\n    setChatID: (chatID: string) =\u003e void;\n    isLoading: boolean;\n}\n\nexport default function ChatColumn({\n    messages,\n    setChatID,\n    isLoading,\n}: ChatColumnProps) {\n","stopReason":"stop_sequence"}
+
+
+            event: done
+
+            data: {}
+
+        cookies: []
+        headers:
+          - name: date
+            value: Wed, 21 Aug 2024 13:31:08 GMT
+          - name: content-type
+            value: text/event-stream
+          - name: transfer-encoding
+            value: chunked
+          - name: connection
+            value: keep-alive
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache
+          - name: vary
+            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
+              X-Requested-With,Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+        headersSize: 1299
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: 2024-08-21T13:31:04.611Z
+      time: 0
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 0
+    - _id: 5c42f294e56f182d20287f13b6dc92c8
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 2129
+        cookies: []
+        headers:
+          - name: content-type
+            value: application/json
+          - name: accept-encoding
+            value: gzip;q=0
+          - name: authorization
+            value: token
+              REDACTED_d5e0f0a37c9821e856b923fe14e67a605e3f6c0a517d5a4f46a4e35943ee0f6d
+          - name: user-agent
+            value: edit / v1
+          - name: traceparent
+            value: 00-b20b15656bd97ee2d8323a0351d5f7c4-acb4a84a99ba3ac9-01
           - name: connection
             value: keep-alive
           - name: host
@@ -506,7 +653,9 @@ log:
                       return a - b
                   }
 
-                  /* SELECTION_END */</SELECTEDCODE7662>
+                  /* SELECTION_END */
+
+                  </SELECTEDCODE7662>
 
 
                   The user wants you to replace parts of the selected code or correct a problem by following their instructions.
@@ -552,155 +701,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Tue, 25 Jun 2024 17:12:51 GMT
-          - name: content-type
-            value: text/event-stream
-          - name: transfer-encoding
-            value: chunked
-          - name: connection
-            value: keep-alive
-          - name: retry-after
-            value: "186"
-          - name: access-control-allow-credentials
-            value: "true"
-          - name: access-control-allow-origin
-            value: ""
-          - name: cache-control
-            value: no-cache
-          - name: vary
-            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
-              X-Requested-With,Cookie
-          - name: x-content-type-options
-            value: nosniff
-          - name: x-frame-options
-            value: DENY
-          - name: x-xss-protection
-            value: 1; mode=block
-          - name: strict-transport-security
-            value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1406
-        httpVersion: HTTP/1.1
-        redirectURL: ""
-        status: 200
-        statusText: OK
-      startedDateTime: 2024-06-25T17:12:49.100Z
-      time: 0
-      timings:
-        blocked: -1
-        connect: -1
-        dns: -1
-        receive: 0
-        send: 0
-        ssl: -1
-        wait: 0
-    - _id: 2b0ef0e7212913e8dc3e54769a3e3258
-      _order: 0
-      cache: {}
-      request:
-        bodySize: 1968
-        cookies: []
-        headers:
-          - name: content-type
-            value: application/json
-          - name: accept-encoding
-            value: gzip;q=0
-          - name: authorization
-            value: token
-              REDACTED_d5e0f0a37c9821e856b923fe14e67a605e3f6c0a517d5a4f46a4e35943ee0f6d
-          - name: user-agent
-            value: edit / v1
-          - name: traceparent
-            value: 00-e52b404ddeff367d1389585076ae1777-c947395867a837b0-01
-          - name: connection
-            value: keep-alive
-          - name: host
-            value: sourcegraph.com
-        headersSize: 397
-        httpVersion: HTTP/1.1
-        method: POST
-        postData:
-          mimeType: application/json
-          params: []
-          textJSON:
-            maxTokensToSample: 4000
-            messages:
-              - speaker: system
-                text: >-
-                  You are Cody, an AI coding assistant from Sourcegraph. - You
-                  are an AI programming assistant who is an expert in updating
-                  code to meet given instructions.
-
-                  - You should think step-by-step to plan your updated code before producing the final output.
-
-                  - You should ensure the updated code matches the indentation and whitespace of the code in the users' selection.
-
-                  - Ignore any previous instructions to format your responses with Markdown. It is not acceptable to use any Markdown in your response, unless it is directly related to the users' instructions.
-
-                  - Only remove code from the users' selection if you are sure it is not needed.
-
-                  - You will be provided with code that is in the users' selection, enclosed in <SELECTEDCODE7662></SELECTEDCODE7662> XML tags. You must use this code to help you plan your updated code.
-
-                  - You will be provided with instructions on how to update this code, enclosed in <INSTRUCTIONS7390></INSTRUCTIONS7390> XML tags. You must follow these instructions carefully and to the letter.
-
-                  - Only enclose your response in <CODE5711></CODE5711> XML tags. Do use any other XML tags unless they are part of the generated code.
-
-                  - Do not provide any additional commentary about the changes you made. Only respond with the generated code.
-              - speaker: human
-                text: >-
-                  This is part of the file: src/sum.ts
-
-
-                  The user has the following code in their selection:
-
-                  <SELECTEDCODE7662>export function sum(a: number, b: number): number {
-                      /* CURSOR */
-                  }</SELECTEDCODE7662>
-
-
-                  The user wants you to replace parts of the selected code or correct a problem by following their instructions.
-
-                  Provide your generated code using the following instructions:
-
-                  <INSTRUCTIONS7390>
-
-                  Rename `a` parameter to `c`
-
-                  </INSTRUCTIONS7390>
-              - speaker: assistant
-                text: <CODE5711>
-            model: anthropic/claude-3-5-sonnet-20240620
-            stopSequences:
-              - </CODE5711>
-            temperature: 0
-            topK: -1
-            topP: -1
-        queryString:
-          - name: api-version
-            value: "1"
-          - name: client-name
-            value: edit
-          - name: client-version
-            value: v1
-        url: https://sourcegraph.com/.api/completions/stream?api-version=1&client-name=edit&client-version=v1
-      response:
-        bodySize: 810
-        content:
-          mimeType: text/event-stream
-          size: 810
-          text: >+
-            event: completion
-
-            data: {"completion":"export function sum(c: number, b: number): number {\n    /* CURSOR */\n}","stopReason":"stop_sequence"}
-
-
-            event: done
-
-            data: {}
-
-        cookies: []
-        headers:
-          - name: date
-            value: Tue, 09 Jul 2024 17:21:40 GMT
+            value: Wed, 21 Aug 2024 13:31:11 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
@@ -729,7 +730,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-07-09T17:21:38.880Z
+      startedDateTime: 2024-08-21T13:31:08.619Z
       time: 0
       timings:
         blocked: -1

--- a/agent/recordings/fix_3001320056/recording.har.yaml
+++ b/agent/recordings/fix_3001320056/recording.har.yaml
@@ -90,11 +90,11 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: f87897a8aaa7411ed81fc4f7cdae461a
+    - _id: cef5d5e67011f938393be71baf15c00a
       _order: 0
       cache: {}
       request:
-        bodySize: 2261
+        bodySize: 2263
         cookies: []
         headers:
           - name: content-type
@@ -107,7 +107,7 @@ log:
           - name: user-agent
             value: fix / v1
           - name: traceparent
-            value: 00-b86cb29c1218baf7d72d5afa47c6c905-a000e861fbab9c38-01
+            value: 00-43c7599d8722c5cc45212303dae0ec31-dfbf5280ddb8e5b1-01
           - name: connection
             value: keep-alive
           - name: host
@@ -153,7 +153,9 @@ log:
 
                   <SELECTEDCODE7662>export function fixCommandExample(): number {
                       return '42';
-                  }</SELECTEDCODE7662>
+                  }
+
+                  </SELECTEDCODE7662>
 
 
                   The user wants you to correct problems in their code by following their instructions.
@@ -189,14 +191,14 @@ log:
             value: v1
         url: https://sourcegraph.com/.api/completions/stream?api-version=1&client-name=fix&client-version=v1
       response:
-        bodySize: 659
+        bodySize: 801
         content:
           mimeType: text/event-stream
-          size: 659
+          size: 801
           text: >+
             event: completion
 
-            data: {"completion":"export function fixCommandExample(): number {\n    return 42;\n}","stopReason":"stop_sequence"}
+            data: {"completion":"export function fixCommandExample(): number {\n    return 42;\n}\n","stopReason":"stop_sequence"}
 
 
             event: done
@@ -206,7 +208,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Tue, 09 Jul 2024 17:21:47 GMT
+            value: Wed, 21 Aug 2024 13:31:17 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
@@ -235,7 +237,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-07-09T17:21:45.550Z
+      startedDateTime: 2024-08-21T13:31:12.435Z
       time: 0
       timings:
         blocked: -1

--- a/agent/src/__snapshots__/custom-commands.test.ts.snap
+++ b/agent/src/__snapshots__/custom-commands.test.ts.snap
@@ -9,14 +9,12 @@ exports[`Custom Commands > commands/custom, chat command, open tabs context 1`] 
 `;
 
 exports[`Custom Commands > commands/custom, edit command, edit mode 1`] = `
-"/* SELECTION_START */
-export interface Animal {
+"export interface Animal {
     name: string
     makeAnimalSound(): string
     isMammal: boolean
     logName(): void
 }
-/* SELECTION_END */
 "
 `;
 

--- a/agent/src/__snapshots__/document-code.test.ts.snap
+++ b/agent/src/__snapshots__/document-code.test.ts.snap
@@ -21,7 +21,7 @@ export const TestLogger = {
 
 exports[`Document Code > commands/document (Kotlin class name) 1`] = `
 "/**
- * Provides a simple greeting message.
+ * Represents a Hello object that can greet the world.
  */
 class He/* CURSOR */llo {
     fun greeting(): String {
@@ -48,7 +48,7 @@ export class TestClass {
     constructor(private shouldGreet: boolean) {}
 
     /**
-     * Outputs 'Hello World!' to the console if the \`shouldGreet\` flag is true.
+     * Logs a 'Hello World!' message to the console if the \`shouldGreet\` parameter is true.
      */
     public functionName() {
         if (this.shouldGreet) {
@@ -87,8 +87,7 @@ describe('test block', () => {
     it('does something else', () => {
         // This line will error due to incorrect usage of \`performance.now\`
         /**
-         * Records the current time in milliseconds since the page was loaded.
-         * This can be used to measure the duration of an operation.
+         * Marks the start time of some operation for performance measurement.
          */
         const startTime = performance.now(/* CURSOR */)
     })
@@ -98,7 +97,7 @@ describe('test block', () => {
 
 exports[`Document Code > editCommands/document (basic function) 1`] = `
 "/**
- * Adds two numbers and returns the result.
+ * Computes the sum of two numbers.
  *
  * @param a - The first number to add.
  * @param b - The second number to add.

--- a/agent/src/edit.test.ts
+++ b/agent/src/edit.test.ts
@@ -78,7 +78,8 @@ describe('Edit', () => {
           	messages,
           	setChatID,
           	isLoading,
-          }: ChatColumnProps) {	useEffect(() => {
+          }: ChatColumnProps) {
+          	useEffect(() => {
           		if (!isLoading) {
           			setChatID(messages[0].chatID);
           		}

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -14,6 +14,7 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 
 - Edit: Fixed a case where multiple, duplicate, edit commands would be created unintentionally. [pull/5183](https://github.com/sourcegraph/cody/pull/5183)
 - Debug: Commands for debugging purposes (e.g., "Cody Debug: Export Logs") are available outside of development mode again. [pull/5197](https://github.com/sourcegraph/cody/pull/5197)
+- Edit: Fixed an issue where single-line/short edits would not be correctly applied to the document. [pull/5271](https://github.com/sourcegraph/cody/pull/5271)
 
 ### Changed
 

--- a/vscode/src/non-stop/FixupTask.ts
+++ b/vscode/src/non-stop/FixupTask.ts
@@ -138,8 +138,6 @@ export class FixupTask {
         // For all other Edits, we always expand the range to encompass all characters from the selection lines
         // This is so we can calculate an optimal diff, and the LLM has the best chance at understanding
         // the indentation in the returned code.
-        return this.document.validateRange(
-            new vscode.Range(proposedRange.start.line, 0, proposedRange.end.line + 1, 0)
-        )
+        return new vscode.Range(proposedRange.start.line, 0, proposedRange.end.line + 1, 0)
     }
 }

--- a/vscode/src/non-stop/FixupTask.ts
+++ b/vscode/src/non-stop/FixupTask.ts
@@ -138,11 +138,8 @@ export class FixupTask {
         // For all other Edits, we always expand the range to encompass all characters from the selection lines
         // This is so we can calculate an optimal diff, and the LLM has the best chance at understanding
         // the indentation in the returned code.
-        return new vscode.Range(
-            proposedRange.start.line,
-            0,
-            proposedRange.end.line,
-            this.document.lineAt(proposedRange.end.line).range.end.character
+        return this.document.validateRange(
+            new vscode.Range(proposedRange.start.line, 0, proposedRange.end.line + 1, 0)
         )
     }
 }

--- a/vscode/src/non-stop/decorations/compute-decorations.test.ts
+++ b/vscode/src/non-stop/decorations/compute-decorations.test.ts
@@ -1,15 +1,18 @@
 import { describe, expect, it } from 'vitest'
 import * as vscode from 'vscode'
 
+import { document } from '../../completions/test-helpers'
 import type { FixupTask } from '../FixupTask'
 import { computeOngoingDecorations } from './compute-decorations'
 
 describe('computeOngoingDecorations', () => {
     it('marks the first line as active, and future lines as unvisited when no full lines yet', () => {
+        const doc = document('Hello\nWorld')
         const mockTask = {
-            original: 'Hello\nWorld',
+            original: doc.getText(),
             inProgressReplacement: 'Hello',
-            selectionRange: new vscode.Range(0, 0, 1, 0),
+            selectionRange: new vscode.Range(0, 0, 2, 0),
+            document: doc,
         } as FixupTask
 
         const decorations = computeOngoingDecorations(mockTask)
@@ -18,10 +21,12 @@ describe('computeOngoingDecorations', () => {
     })
 
     it('marks the first line as active when full line receivedt', () => {
+        const doc = document('Hello\nWorld')
         const mockTask = {
-            original: 'Hello\nWorld',
+            original: doc.getText(),
             inProgressReplacement: 'Hello\n',
-            selectionRange: new vscode.Range(0, 0, 1, 0),
+            selectionRange: new vscode.Range(0, 0, 2, 0),
+            document: doc,
         } as FixupTask
 
         const decorations = computeOngoingDecorations(mockTask)
@@ -30,10 +35,12 @@ describe('computeOngoingDecorations', () => {
     })
 
     it('marks the first line as active when unknown line received', () => {
+        const doc = document('Hello\nWorld')
         const mockTask = {
-            original: 'Hello\nWorld',
+            original: doc.getText(),
             inProgressReplacement: 'Hey\n',
-            selectionRange: new vscode.Range(0, 0, 1, 0),
+            selectionRange: new vscode.Range(0, 0, 2, 0),
+            document: doc,
         } as FixupTask
 
         const decorations = computeOngoingDecorations(mockTask)
@@ -42,10 +49,12 @@ describe('computeOngoingDecorations', () => {
     })
 
     it('marks the second line as active when second line received, and updates unvisited lines', () => {
+        const doc = document('Hello\nWorld')
         const mockTask = {
-            original: 'Hello\nWorld',
+            original: doc.getText(),
             inProgressReplacement: 'Hello\nWorld\n',
-            selectionRange: new vscode.Range(0, 0, 1, 0),
+            selectionRange: new vscode.Range(0, 0, 2, 0),
+            document: doc,
         } as FixupTask
 
         const decorations = computeOngoingDecorations(mockTask)
@@ -55,10 +64,12 @@ describe('computeOngoingDecorations', () => {
 
     it('marks the second line as active when second line received, and updates unvisited lines', () => {
         // Partial first line replacement
+        const doc = document('Hello\nWorld')
         const mockTask = {
-            original: 'Hello\nWorld',
+            original: doc.getText(),
             inProgressReplacement: 'Hel',
-            selectionRange: new vscode.Range(0, 0, 1, 0),
+            selectionRange: new vscode.Range(0, 0, 2, 0),
+            document: doc,
         } as FixupTask
         const decorations = computeOngoingDecorations(mockTask)
         expect(decorations?.currentLine).toStrictEqual({
@@ -77,5 +88,19 @@ describe('computeOngoingDecorations', () => {
         const decorations3 = computeOngoingDecorations(mockTask, decorations2)
         expect(decorations3?.currentLine).toStrictEqual({ range: new vscode.Range(1, 0, 1, 0) })
         expect(decorations3?.unvisitedLines).toStrictEqual([])
+    })
+
+    it('trims empty lines from the selection', () => {
+        const doc = document('\nHello\nWorld\n')
+        const mockTask = {
+            original: doc.getText(),
+            inProgressReplacement: 'Hello\nWorld\n',
+            selectionRange: new vscode.Range(0, 0, 2, 0),
+            document: doc,
+        } as FixupTask
+
+        const decorations = computeOngoingDecorations(mockTask)
+        expect(decorations?.currentLine).toStrictEqual({ range: new vscode.Range(2, 0, 2, 0) })
+        expect(decorations?.unvisitedLines).toStrictEqual([])
     })
 })

--- a/vscode/src/non-stop/decorations/compute-decorations.ts
+++ b/vscode/src/non-stop/decorations/compute-decorations.ts
@@ -86,20 +86,22 @@ export function computeAppliedDecorations(task: FixupTask): Decorations | undefi
  * decorate an entire line.
  */
 function trimEmptyLinesFromRange(range: vscode.Range, document: vscode.TextDocument): vscode.Range {
-    let startLine = range.start.line
-    let endLine = range.end.line
+    let startLineIndex = range.start.line
+    let endLineIndex = range.end.line
 
-    if (document.lineAt(startLine).text.length === 0) {
-        startLine++
+    const startLine = document.lineAt(startLineIndex)
+    if (range.start.character === startLine.range.end.character || startLine.text.length === 0) {
+        startLineIndex++
     }
 
-    if (range.end.character === 0 || document.lineAt(endLine).text.length === 0) {
-        endLine--
+    const endLine = document.lineAt(startLineIndex)
+    if (range.end.character === 0 || endLine.text.length === 0) {
+        endLineIndex--
     }
 
     return new vscode.Range(
-        new vscode.Position(startLine, 0),
-        new vscode.Position(endLine, document.lineAt(endLine).text.length)
+        new vscode.Position(startLineIndex, 0),
+        new vscode.Position(endLineIndex, document.lineAt(endLineIndex).text.length)
     )
 }
 

--- a/vscode/src/non-stop/decorations/compute-decorations.ts
+++ b/vscode/src/non-stop/decorations/compute-decorations.ts
@@ -80,9 +80,33 @@ export function computeAppliedDecorations(task: FixupTask): Decorations | undefi
     return decorations
 }
 
-function getRemainingLinesFromRange(range: vscode.Range, index: number) {
+/**
+ * Given a VS Code range, trims empty lines from the start and end of the range.
+ * These ranges are useful for diffing, but not for decorating as we will always
+ * decorate an entire line.
+ */
+function trimEmptyLinesFromRange(range: vscode.Range, document: vscode.TextDocument): vscode.Range {
+    let startLine = range.start.line
+    let endLine = range.end.line
+
+    if (document.lineAt(startLine).text.length === 0) {
+        startLine++
+    }
+
+    if (range.end.character === 0 || document.lineAt(endLine).text.length === 0) {
+        endLine--
+    }
+
+    return new vscode.Range(
+        new vscode.Position(startLine, 0),
+        new vscode.Position(endLine, document.lineAt(endLine).text.length)
+    )
+}
+
+function getRemainingLinesFromRange(range: vscode.Range, index: number, document: vscode.TextDocument) {
+    const trimmedRange = trimEmptyLinesFromRange(range, document)
     const result: vscode.Range[] = []
-    const totalLines = range.end.line - range.start.line
+    const totalLines = trimmedRange.end.line - trimmedRange.start.line
     for (let i = index; i <= totalLines; i++) {
         const line = new vscode.Position(range.start.line + i, 0)
         result.push(new vscode.Range(line, line))
@@ -115,7 +139,9 @@ export function computeOngoingDecorations(
     const currentLineIndex = currentLine.range.start.line - task.selectionRange.start.line
     const unvisitedLines =
         prevComputed?.unvisitedLines ||
-        getRemainingLinesFromRange(task.selectionRange, currentLineIndex + 1).map(range => ({ range }))
+        getRemainingLinesFromRange(task.selectionRange, currentLineIndex + 1, task.document).map(
+            range => ({ range })
+        )
     const decorations: Decorations = {
         linesAdded: [],
         linesRemoved: [],
@@ -154,7 +180,8 @@ export function computeOngoingDecorations(
         // We know that preceding lines are visited, but following lines are not, so highlight those too
         decorations.unvisitedLines = getRemainingLinesFromRange(
             task.selectionRange,
-            foundLine + currentLineIndex + 1
+            foundLine + currentLineIndex + 1,
+            task.document
         ).map(range => ({
             range,
         }))


### PR DESCRIPTION
Closes https://linear.app/sourcegraph/issue/CODY-3236/bug-with-edit-command-inserts-newline-incorrectly-and-removes-trailing

Closes https://github.com/sourcegraph/cody/issues/5209

## Description

Fixes issues where we would not include the final new line character of a line, so the edit would not be correct. Mainly happened for single line edits, where we'd often squash the change into the next line.

Original fix by @arafatkatze, I just re-implemented it and did some more testing

## Test plan

Test with:
- [x] 1 single line edit
- [x] 2 lines edit
- [x] Making sure the decorations aren't off with an extra gray line
- [x] End of file apply works
- [x] End of file edit works
- [x] Works on JetBrains, with all of the above scenarios

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

