### PR TITLE
Smart Apply: Hash the ID used for the FixupTask

### DIFF
--- a/vscode/webviews/chat/ChatMessageContent/utils.ts
+++ b/vscode/webviews/chat/ChatMessageContent/utils.ts
@@ -1,13 +1,13 @@
+import { SHA256 } from 'crypto-js'
+
 export function getFileName(filePath: string): string {
     return filePath.split('/').pop() || filePath
 }
 
 export function getCodeBlockId(contents: string, fileName?: string): string {
-    const trimmedContents = contents.trim()
-
+    let input = contents.trim()
     if (fileName) {
-        return `${fileName}:${trimmedContents}`
+        input = `${fileName}:${input}`
     }
-
-    return trimmedContents
+    return SHA256(input).toString()
 }


### PR DESCRIPTION
## Description

Fixes an issue where "Open Diff" would not work for the smart apply diffs. This is because the ID used was too long, we were using the entire contents of the codeblock for the ID. We should just hash this and it'll be a lot shorter.

## Test plan

1. Create smart apply edits
2. Click "Open Diff"

