### PR TITLE
Telemetry: Update `cody.promptList/query` event to fire less

### DIFF
--- a/vscode/webviews/components/promptList/PromptList.tsx
+++ b/vscode/webviews/components/promptList/PromptList.tsx
@@ -98,9 +98,39 @@ export const PromptList: React.FunctionComponent<{
                     nameWithOwner: prompt ? prompt.nameWithOwner : undefined,
                 },
             })
+            if (result) {
+                telemetryRecorder.recordEvent('cody.promptList', 'query', {
+                    metadata: {
+                        queryLength: debouncedQuery.length,
+                        resultCount:
+                            (result.prompts.type === 'results' ? result.prompts.results.length : 0) +
+                            (result.commands?.length ?? 0),
+                        resultCountPromptsOnly:
+                            result.prompts.type === 'results' ? result.prompts.results.length : 0,
+                        resultCountCommandsOnly: result.commands?.length ?? 0,
+                        supportsPrompts: result.prompts.type !== 'unsupported' ? 1 : 0,
+                        hasUsePromptsQueryError: error ? 1 : 0,
+                        hasPromptsResultError: result.prompts.type === 'error' ? 1 : 0,
+                        ...telemetryPublicMetadata,
+                    },
+                    privateMetadata: {
+                        query: debouncedQuery,
+                        usePromptsQueryErrorMessage: error?.message,
+                        promptsResultErrorMessage:
+                            result.prompts.type === 'error' ? result.prompts.error : undefined,
+                    },
+                })
+            }
             parentOnSelect(entry)
         },
-        [result, telemetryRecorder.recordEvent, parentOnSelect, telemetryPublicMetadata]
+        [
+            result,
+            telemetryRecorder.recordEvent,
+            parentOnSelect,
+            telemetryPublicMetadata,
+            debouncedQuery,
+            error,
+        ]
     )
 
     const endpointURL = new URL(useConfig().authStatus.endpoint)

--- a/vscode/webviews/components/promptList/PromptList.tsx
+++ b/vscode/webviews/components/promptList/PromptList.tsx
@@ -1,7 +1,7 @@
 import { type CodyCommand, CustomCommandType, type Prompt } from '@sourcegraph/cody-shared'
 import clsx from 'clsx'
 import { PlusIcon } from 'lucide-react'
-import { type ComponentProps, type FunctionComponent, useCallback, useEffect, useState } from 'react'
+import { type ComponentProps, type FunctionComponent, useCallback, useState } from 'react'
 import { useTelemetryRecorder } from '../../utils/telemetry'
 import { useConfig } from '../../utils/useConfig'
 import { useDebounce } from '../../utils/useDebounce'
@@ -63,33 +63,6 @@ export const PromptList: React.FunctionComponent<{
     const [query, setQuery] = useState('')
     const debouncedQuery = useDebounce(query, 250)
     const { value: result, error } = usePromptsQuery(debouncedQuery)
-
-    // Query and error telemetry.
-    useEffect(() => {
-        if (result) {
-            telemetryRecorder.recordEvent('cody.promptList', 'query', {
-                metadata: {
-                    queryLength: debouncedQuery.length,
-                    resultCount:
-                        (result.prompts.type === 'results' ? result.prompts.results.length : 0) +
-                        (result.commands?.length ?? 0),
-                    resultCountPromptsOnly:
-                        result.prompts.type === 'results' ? result.prompts.results.length : 0,
-                    resultCountCommandsOnly: result.commands?.length ?? 0,
-                    supportsPrompts: result.prompts.type !== 'unsupported' ? 1 : 0,
-                    hasUsePromptsQueryError: error ? 1 : 0,
-                    hasPromptsResultError: result.prompts.type === 'error' ? 1 : 0,
-                    ...telemetryPublicMetadata,
-                },
-                privateMetadata: {
-                    query: debouncedQuery,
-                    usePromptsQueryErrorMessage: error?.message,
-                    promptsResultErrorMessage:
-                        result.prompts.type === 'error' ? result.prompts.error : undefined,
-                },
-            })
-        }
-    }, [result, error, debouncedQuery, telemetryRecorder.recordEvent, telemetryPublicMetadata])
 
     const onSelect = useCallback(
         (rowValue: string): void => {


### PR DESCRIPTION
The `cody.promptList/query` telemetry event in `PromptList.tsx` currently fires with every change to the result, error, and debouncedQuery variables, resulting in a high volume of data (approximately 2 million records per day). This frequency is among the highest of all events we collect.

This PR proposes recording `cody.promptList/query` event only when the user interacts with the promptList to select an item (same time as `cody.promptList/select` fires); this will help reduce the number of times `cody.promptList/query` fires, but still allows us to get query data from users using promptList.

Note: If this data point is valuable and the frequency is as expected, please do let me know.

## Test plan
CI + local build
<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
