### PR TITLE
Autocomplete: reduce `createProviderConfig` duplication

### DIFF
--- a/lib/shared/src/models/index.ts
+++ b/lib/shared/src/models/index.ts
@@ -350,7 +350,9 @@ export class ModelsService {
         }
         const endpoint = this.authStatus?.endpoint
         if (!endpoint) {
-            logError('ModelsService::preferences', 'No auth status set')
+            if (!process.env.VITEST) {
+                logError('ModelsService::preferences', 'No auth status set')
+            }
             return empty
         }
         // If global cache is missing, try loading from storage

--- a/vscode/src/completions/create-multi-model-inline-completion-provider.ts
+++ b/vscode/src/completions/create-multi-model-inline-completion-provider.ts
@@ -5,7 +5,7 @@ import { logDebug } from '../log'
 import type { InlineCompletionItemProviderArgs } from './create-inline-completion-item-provider'
 import type { MultiModelCompletionsResults } from './inline-completion-item-provider'
 import { InlineCompletionItemProvider } from './inline-completion-item-provider'
-import { createProviderHelper } from './providers/create-provider'
+import { createProviderConfigHelper } from './providers/create-provider'
 
 interface providerConfig {
     providerName: string
@@ -111,10 +111,10 @@ export async function createInlineCompletionItemFromMultipleProviders({
         // Don't use the advanced provider config to get the model
         newConfig.autocompleteAdvancedModel = null
 
-        const providerConfig = await createProviderHelper({
+        const providerConfig = await createProviderConfigHelper({
             client,
             authStatus,
-            model: currentProviderConfig.model,
+            modelId: currentProviderConfig.model,
             provider: currentProviderConfig.provider,
             config: newConfig,
         })

--- a/vscode/src/completions/providers/create-provider.test.ts
+++ b/vscode/src/completions/providers/create-provider.test.ts
@@ -121,7 +121,7 @@ describe('createProviderConfig', () => {
             expect(provider?.model).toBe('starcoder-hybrid')
         })
 
-        it('returns "openai" provider config if specified in VSCode settings; model is ignored', async () => {
+        it('returns "unstable-openai" provider config if specified in VSCode settings; model is ignored', async () => {
             const provider = await createProviderConfig(
                 getVSCodeConfigurationWithAccessToken({
                     autocompleteAdvancedProvider: 'unstable-openai',

--- a/vscode/src/completions/providers/create-provider.ts
+++ b/vscode/src/completions/providers/create-provider.ts
@@ -36,18 +36,31 @@ import { createProviderConfig as createUnstableOpenAIProviderConfig } from './un
 interface CreateConfigHelperParams {
     client: CodeCompletionsClient
     authStatus: AuthStatus
-    model: string | undefined
+    modelId: string | undefined
     provider: string
     config: ConfigurationWithAccessToken
+    model?: Model
 }
 
-export async function createProviderHelper(
+export async function createProviderConfigHelper(
     params: CreateConfigHelperParams
 ): Promise<ProviderConfig | null> {
-    const { client, authStatus, model, provider, config } = params
+    const { client, authStatus, modelId, model, provider, config } = params
 
     switch (provider) {
-        case 'azure-openai':
+        case 'openai': {
+            return createUnstableOpenAIProviderConfig({
+                client,
+                model: modelId,
+            })
+        }
+        case 'azure-openai': {
+            return createUnstableOpenAIProviderConfig({
+                client,
+                // Model name for azure openai provider is a deployment name. It shouldn't appear in logs.
+                model: modelId ? '' : modelId,
+            })
+        }
         case 'unstable-openai': {
             return createUnstableOpenAIProviderConfig({
                 client,
@@ -57,33 +70,67 @@ export async function createProviderHelper(
             const { anonymousUserID } = await localStorage.anonymousUserID()
             return createFireworksProviderConfig({
                 client,
-                model: config.autocompleteAdvancedModel ?? model ?? null,
+                model: modelId ?? null,
                 timeouts: config.autocompleteTimeouts,
                 authStatus,
                 config,
                 anonymousUserID,
             })
         }
-        case 'anthropic': {
-            return createAnthropicProviderConfig({
-                client,
-                model: model ?? authStatus.isDotCom ? DEFAULT_PLG_ANTHROPIC_MODEL : undefined,
-            })
-        }
-        case 'gemini':
-        case 'unstable-gemini': {
-            return createGeminiProviderConfig({ client, model })
-        }
         case 'experimental-openaicompatible': {
             // TODO(slimsag): self-hosted-models: deprecate and remove this once customers are upgraded
             // to non-experimental version
             return createExperimentalOpenAICompatibleProviderConfig({
                 client,
-                model: config.autocompleteAdvancedModel ?? model ?? null,
+                model: modelId ?? null,
                 timeouts: config.autocompleteTimeouts,
                 authStatus,
                 config,
             })
+        }
+        case 'openaicompatible': {
+            if (model) {
+                return createOpenAICompatibleProviderConfig({
+                    client,
+                    timeouts: config.autocompleteTimeouts,
+                    model: model,
+                    authStatus,
+                    config,
+                })
+            }
+            logError(
+                'createProviderConfig',
+                'Model definition is missing for openaicompatible provider.',
+                modelId
+            )
+            return null
+        }
+        case 'aws-bedrock':
+        case 'anthropic': {
+            return createAnthropicProviderConfig({
+                client,
+                // Only pass through the upstream-defined model if we're using Cody Gateway
+                model:
+                    authStatus.configOverwrites?.provider === 'sourcegraph'
+                        ? authStatus.configOverwrites.completionModel
+                        : authStatus.isDotCom
+                          ? DEFAULT_PLG_ANTHROPIC_MODEL
+                          : undefined,
+            })
+        }
+        case 'google': {
+            if (authStatus.configOverwrites?.completionModel?.includes('claude')) {
+                return createAnthropicProviderConfig({
+                    client, // Model name for google provider is a deployment name. It shouldn't appear in logs.
+                    model: undefined,
+                })
+            }
+            // Gemini models
+            return createGeminiProviderConfig({ client, model: modelId })
+        }
+        case 'gemini':
+        case 'unstable-gemini': {
+            return createGeminiProviderConfig({ client, model: modelId })
         }
         case 'experimental-ollama':
         case 'unstable-ollama': {
@@ -273,10 +320,10 @@ export async function createProviderConfig(
 ): Promise<ProviderConfig | null> {
     // Resolve the provider config from the VS Code config.
     if (config.autocompleteAdvancedProvider) {
-        return createProviderHelper({
+        return createProviderConfigHelper({
             client,
             authStatus,
-            model: config.autocompleteAdvancedModel || undefined,
+            modelId: config.autocompleteAdvancedModel || undefined,
             provider: config.autocompleteAdvancedProvider,
             config,
         })
@@ -287,91 +334,30 @@ export async function createProviderConfig(
 
     // Use the experiment model if available.
     if (configFromFeatureFlags) {
-        return createProviderHelper({
+        return createProviderConfigHelper({
             client,
             authStatus,
-            model: configFromFeatureFlags.model,
+            modelId: configFromFeatureFlags.model,
             provider: configFromFeatureFlags.provider,
             config,
         })
     }
 
-    const info = getAutocompleteModelInfo(authStatus)
+    const modelInfoOrError = getAutocompleteModelInfo(authStatus)
 
-    if (info instanceof Error) {
-        logError('createProviderConfig', info.message)
+    if (modelInfoOrError instanceof Error) {
+        logError('createProviderConfig', modelInfoOrError.message)
         return null
     }
 
-    const { provider, modelId, model } = info
+    const { provider, modelId, model } = modelInfoOrError
 
-    switch (provider) {
-        case 'openai':
-        case 'azure-openai':
-            return createUnstableOpenAIProviderConfig({
-                client,
-                // Model name for azure openai provider is a deployment name. It shouldn't appear in logs.
-                model: provider === 'azure-openai' && modelId ? '' : modelId,
-            })
-
-        case 'fireworks': {
-            const { anonymousUserID } = await localStorage.anonymousUserID()
-            return createFireworksProviderConfig({
-                client,
-                timeouts: config.autocompleteTimeouts,
-                model: modelId ?? null,
-                authStatus,
-                config,
-                anonymousUserID,
-            })
-        }
-        case 'experimental-openaicompatible':
-            // TODO(slimsag): self-hosted-models: deprecate and remove this once customers are upgraded
-            // to non-experimental version
-            return createExperimentalOpenAICompatibleProviderConfig({
-                client,
-                timeouts: config.autocompleteTimeouts,
-                model: modelId ?? null,
-                authStatus,
-                config,
-            })
-        case 'openaicompatible':
-            if (model) {
-                return createOpenAICompatibleProviderConfig({
-                    client,
-                    timeouts: config.autocompleteTimeouts,
-                    model: model,
-                    authStatus,
-                    config,
-                })
-            }
-            logError(
-                'createProviderConfig',
-                'Model definition is missing for openaicompatible provider.',
-                modelId
-            )
-            return null
-        case 'aws-bedrock':
-        case 'anthropic':
-            return createAnthropicProviderConfig({
-                client,
-                // Only pass through the upstream-defined model if we're using Cody Gateway
-                model:
-                    authStatus.configOverwrites?.provider === 'sourcegraph'
-                        ? authStatus.configOverwrites.completionModel
-                        : undefined,
-            })
-        case 'google':
-            if (authStatus.configOverwrites?.completionModel?.includes('claude')) {
-                return createAnthropicProviderConfig({
-                    client, // Model name for google provider is a deployment name. It shouldn't appear in logs.
-                    model: undefined,
-                })
-            }
-            // Gemini models
-            return createGeminiProviderConfig({ client, model: modelId })
-        default:
-            logError('createProviderConfig', `Unrecognized provider '${provider}' configured.`)
-            return null
-    }
+    return createProviderConfigHelper({
+        client,
+        authStatus,
+        modelId,
+        model,
+        provider,
+        config,
+    })
 }

--- a/vscode/src/completions/providers/create-provider.ts
+++ b/vscode/src/completions/providers/create-provider.ts
@@ -93,7 +93,7 @@ export async function createProviderConfigHelper(
                 return createOpenAICompatibleProviderConfig({
                     client,
                     timeouts: config.autocompleteTimeouts,
-                    model: model,
+                    model,
                     authStatus,
                     config,
                 })
@@ -121,7 +121,8 @@ export async function createProviderConfigHelper(
         case 'google': {
             if (authStatus.configOverwrites?.completionModel?.includes('claude')) {
                 return createAnthropicProviderConfig({
-                    client, // Model name for google provider is a deployment name. It shouldn't appear in logs.
+                    client,
+                    // Model name for google provider is a deployment name. It shouldn't appear in logs.
                     model: undefined,
                 })
             }

--- a/vscode/src/completions/providers/openaicompatible.ts
+++ b/vscode/src/completions/providers/openaicompatible.ts
@@ -285,7 +285,7 @@ export function createProviderConfig({
                     id: PROVIDER_IDENTIFIER,
                 },
                 {
-                    model: model,
+                    model,
                     maxContextTokens,
                     timeouts,
                     ...otherOptions,


### PR DESCRIPTION
- Merged case statements from the `createProviderConfig` function with the switch statement in the `createProviderConfigHelper` function to keep one source of truth and simplify the setup.
- No functional changes.
- Part of https://linear.app/sourcegraph/issue/CODY-3409/self-hosted-models-openaicompatible-autocomplete-provider-supports

## Test plan

CI