### PR TITLE
Autocomplete: remove starcoder2

### DIFF
--- a/lib/shared/src/experimentation/FeatureFlagProvider.ts
+++ b/lib/shared/src/experimentation/FeatureFlagProvider.ts
@@ -16,8 +16,6 @@ export enum FeatureFlag {
     // This flag is used to track the overall eligibility to use the StarCoder model. The `-hybrid`
     // suffix is no longer relevant
     CodyAutocompleteStarCoderHybrid = 'cody-autocomplete-default-starcoder-hybrid',
-    // Enable StarCoder2 7b and 15b as the default model via Fireworks
-    CodyAutocompleteStarCoder2Hybrid = 'cody-autocomplete-starcoder2-hybrid',
     // Enable the FineTuned model as the default model via Fireworks
     CodyAutocompleteFIMFineTunedModelHybrid = 'cody-autocomplete-fim-fine-tuned-model-hybrid',
     // Enable the deepseek-v2 as the default model via Fireworks

--- a/vscode/src/completions/get-inline-completions-tests/models.test.ts
+++ b/vscode/src/completions/get-inline-completions-tests/models.test.ts
@@ -1,120 +1,32 @@
 import { describe, expect, test } from 'vitest'
 
-import type { CompletionParameters } from '@sourcegraph/cody-shared'
 import { allTriggerKinds } from '../get-inline-completions'
 import { getInlineCompletionsWithInlinedChunks } from './helpers'
 
 describe('[getInlineCompletions] models', () => {
-    describe('starcoder2-hybrid', () => {
-        test('singleline', async () => {
-            const requests: CompletionParameters[] = []
-            await getInlineCompletionsWithInlinedChunks('const value = █1█', {
+    test('manual invocation should use starcoder 16b', async () => {
+        const requests: Record<string, string> = {}
+        for (const triggerKind of allTriggerKinds()) {
+            await getInlineCompletionsWithInlinedChunks('const greeting = "█"', {
                 onNetworkRequest(request) {
-                    requests.push(request)
+                    if (request.model) {
+                        requests[triggerKind] = request.model
+                    }
                 },
+                triggerKind,
                 configuration: {
                     autocompleteAdvancedProvider: 'fireworks',
-                    autocompleteAdvancedModel: 'starcoder2-hybrid',
+                    autocompleteAdvancedModel: 'starcoder-hybrid',
                 },
             })
-            expect(requests[0].stopSequences).toMatchInlineSnapshot(`
-              [
-                "
-
-              ",
-                "
-
-              ",
-                "<fim_prefix>",
-                "<fim_suffix>",
-                "<fim_middle>",
-                "<|endoftext|>",
-                "<file_sep>",
-              ]
-            `)
-            expect(requests[0].model).toBe('fireworks/starcoder2-7b')
-
-            await getInlineCompletionsWithInlinedChunks('const value = █1█', {
-                onNetworkRequest(request) {
-                    requests.push(request)
-                },
-                configuration: {
-                    autocompleteAdvancedProvider: 'fireworks',
-                    autocompleteAdvancedModel: 'starcoder2-hybrid',
-                },
-            })
-
-            // Keeps stop sequences array unchanged
-            expect(requests[0].stopSequences).toMatchInlineSnapshot(`
-              [
-                "
-
-              ",
-                "
-
-              ",
-                "<fim_prefix>",
-                "<fim_suffix>",
-                "<fim_middle>",
-                "<|endoftext|>",
-                "<file_sep>",
-              ]
-            `)
-        })
-
-        test('multiline', async () => {
-            const requests: CompletionParameters[] = []
-            await getInlineCompletionsWithInlinedChunks('const value = {█}█', {
-                onNetworkRequest(request) {
-                    requests.push(request)
-                },
-                configuration: {
-                    autocompleteAdvancedProvider: 'fireworks',
-                    autocompleteAdvancedModel: 'starcoder2-hybrid',
-                },
-            })
-            expect(requests[0].stopSequences).toMatchInlineSnapshot(`
-              [
-                "
-
-              ",
-                "
-
-              ",
-                "<fim_prefix>",
-                "<fim_suffix>",
-                "<fim_middle>",
-                "<|endoftext|>",
-                "<file_sep>",
-              ]
-            `)
-            expect(requests[0].model).toBe('fireworks/starcoder2-15b')
-        })
-
-        test('manual invocation should use starcoder 16b', async () => {
-            const requests: Record<string, string> = {}
-            for (const triggerKind of allTriggerKinds()) {
-                await getInlineCompletionsWithInlinedChunks('const greeting = "█"', {
-                    onNetworkRequest(request) {
-                        if (request.model) {
-                            requests[triggerKind] = request.model
-                        }
-                    },
-                    triggerKind,
-                    configuration: {
-                        autocompleteAdvancedProvider: 'fireworks',
-                        autocompleteAdvancedModel: 'starcoder-hybrid',
-                    },
-                })
-            }
-            expect(requests).toMatchInlineSnapshot(`
-              {
-                "Automatic": "fireworks/starcoder-7b",
-                "Hover": "fireworks/starcoder-16b",
-                "Manual": "fireworks/starcoder-16b",
-                "SuggestWidget": "fireworks/starcoder-16b",
-              }
-            `)
-        })
+        }
+        expect(requests).toMatchInlineSnapshot(`
+          {
+            "Automatic": "fireworks/starcoder-7b",
+            "Hover": "fireworks/starcoder-16b",
+            "Manual": "fireworks/starcoder-16b",
+            "SuggestWidget": "fireworks/starcoder-16b",
+          }
+        `)
     })
 })

--- a/vscode/src/completions/providers/create-provider.ts
+++ b/vscode/src/completions/providers/create-provider.ts
@@ -153,16 +153,14 @@ interface ProviderConfigFromFeatureFlags {
 async function resolveConfigFromFeatureFlags(
     isDotCom: boolean
 ): Promise<ProviderConfigFromFeatureFlags | null> {
-    const [starCoder2Hybrid, starCoderHybrid, claude3, fimModelExperimentFlag, deepseekV2LiteBase] =
-        await Promise.all([
-            featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteStarCoder2Hybrid),
-            featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteStarCoderHybrid),
-            featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteClaude3),
-            featureFlagProvider.evaluateFeatureFlag(
-                FeatureFlag.CodyAutocompleteFIMModelExperimentBaseFeatureFlag
-            ),
-            featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteDeepseekV2LiteBase),
-        ])
+    const [starCoderHybrid, claude3, fimModelExperimentFlag, deepseekV2LiteBase] = await Promise.all([
+        featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteStarCoderHybrid),
+        featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteClaude3),
+        featureFlagProvider.evaluateFeatureFlag(
+            FeatureFlag.CodyAutocompleteFIMModelExperimentBaseFeatureFlag
+        ),
+        featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteDeepseekV2LiteBase),
+    ])
 
     // We run fine tuning experiment for VSC client only.
     // We disable for all agent clients like the JetBrains plugin.
@@ -174,11 +172,9 @@ async function resolveConfigFromFeatureFlags(
         // The traffic in this feature flag is interpreted as a traffic allocated to the fine-tuned experiment.
         return resolveFIMModelExperimentFromFeatureFlags()
     }
+
     if (isDotCom && deepseekV2LiteBase) {
         return { provider: 'fireworks', model: DEEPSEEK_CODER_V2_LITE_BASE }
-    }
-    if (starCoder2Hybrid) {
-        return { provider: 'fireworks', model: 'starcoder2-hybrid' }
     }
 
     if (starCoderHybrid) {

--- a/vscode/src/completions/providers/fireworks.ts
+++ b/vscode/src/completions/providers/fireworks.ts
@@ -111,8 +111,6 @@ const MODEL_MAP = {
     starcoder: 'fireworks/starcoder',
     'starcoder-16b': 'fireworks/starcoder-16b',
     'starcoder-7b': 'fireworks/starcoder-7b',
-    'starcoder2-15b': 'fireworks/starcoder2-15b',
-    'starcoder2-7b': 'fireworks/starcoder2-7b',
 
     // Fireworks model identifiers
     'llama-code-13b': 'fireworks/accounts/fireworks/models/llama-v2-13b-code',
@@ -141,15 +139,10 @@ type FireworksModel =
     | keyof typeof MODEL_MAP
     // `starcoder-hybrid` uses the 16b model for multiline requests and the 7b model for single line
     | 'starcoder-hybrid'
-    // `starcoder2-hybrid` uses the 15b model for multiline requests and the 7b model for single line
-    | 'starcoder2-hybrid'
 
 function getMaxContextTokens(model: FireworksModel): number {
     switch (model) {
         case 'starcoder':
-        case 'starcoder2-hybrid':
-        case 'starcoder2-15b':
-        case 'starcoder2-7b':
         case 'starcoder-hybrid':
         case 'starcoder-16b':
         case 'starcoder-7b': {
@@ -399,11 +392,9 @@ class FireworksProvider extends Provider {
         const { multiline } = this.options
         const useMultilineModel = multiline || this.options.triggerKind !== TriggerKind.Automatic
         const model: string =
-            this.model === 'starcoder2-hybrid'
-                ? MODEL_MAP[useMultilineModel ? 'starcoder2-15b' : 'starcoder2-7b']
-                : this.model === 'starcoder-hybrid'
-                  ? MODEL_MAP[useMultilineModel ? 'starcoder-16b' : 'starcoder-7b']
-                  : MODEL_MAP[this.model]
+            this.model === 'starcoder-hybrid'
+                ? MODEL_MAP[useMultilineModel ? 'starcoder-16b' : 'starcoder-7b']
+                : MODEL_MAP[this.model]
         const requestParams = {
             ...partialRequestParams,
             messages: [{ speaker: 'human', text: this.createPrompt(snippets) }],
@@ -412,11 +403,7 @@ class FireworksProvider extends Provider {
             model,
         } satisfies CodeCompletionsParams
 
-        if (
-            requestParams.model.includes('starcoder2') ||
-            isFinetunedV1ModelFamily(requestParams.model) ||
-            isCodeQwenFamily(requestParams.model)
-        ) {
+        if (isFinetunedV1ModelFamily(requestParams.model) || isCodeQwenFamily(requestParams.model)) {
             requestParams.stopSequences = [
                 ...(requestParams.stopSequences || []),
                 '<fim_prefix>',
@@ -758,7 +745,7 @@ export function createProviderConfig({
             ? otherOptions.authStatus.isDotCom
                 ? DEEPSEEK_CODER_V2_LITE_BASE
                 : 'starcoder-hybrid'
-            : ['starcoder-hybrid', 'starcoder2-hybrid'].includes(model)
+            : ['starcoder-hybrid'].includes(model)
               ? (model as FireworksModel)
               : Object.prototype.hasOwnProperty.call(MODEL_MAP, model)
                 ? (model as keyof typeof MODEL_MAP)


### PR DESCRIPTION
- Removed the unused `starcoder2` support and feature flag from the Fireworks provider. 
- No functional changes.
- Part of https://linear.app/sourcegraph/issue/CODY-3409/self-hosted-models-openaicompatible-autocomplete-provider-supports

## Test plan

CI