### PR TITLE
Smart Apply: Use system prompt to encourage code blocks being created

### DIFF
--- a/agent/recordings/cody-chat_103640681/recording.har.yaml
+++ b/agent/recordings/cody-chat_103640681/recording.har.yaml
@@ -88,11 +88,11 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: 5c57622e2ebbfa5eb9cd7f8f12b8f53d
+    - _id: a760bf87999178632a0f589ff5e1a8a9
       _order: 0
       cache: {}
       request:
-        bodySize: 431
+        bodySize: 421
         cookies: []
         headers:
           - name: content-type
@@ -118,13 +118,10 @@ log:
             maxTokensToSample: 4000
             messages:
               - speaker: system
-                text: >-
-                  You are Cody, an AI coding assistant from Sourcegraph.If your
-                  answer contains fenced code blocks in Markdown, include the
-                  relevant full file path in the code block tag using this
-                  structure: ```$LANGUAGE:$FILEPATH
-
-                  $CONTENT```.
+                text: "You are Cody, an AI coding assistant from Sourcegraph.If your answer
+                  contains fenced code blocks in Markdown, include the relevant
+                  full file path in the code block tag using this structure:
+                  ```$LANGUAGE:$FILEPATH```."
               - speaker: human
                 text: respond with "hello" and nothing else
             model: claude-3.5-sonnet
@@ -154,7 +151,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Fri, 23 Aug 2024 08:33:25 GMT
+            value: Fri, 23 Aug 2024 09:43:06 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
@@ -183,7 +180,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-08-23T08:33:24.210Z
+      startedDateTime: 2024-08-23T09:43:04.959Z
       time: 0
       timings:
         blocked: -1
@@ -193,11 +190,11 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: 068fb12b6fe876d07eb89d5528a4154e
+    - _id: 6429134c6421698cdc80f7359d7bcd68
       _order: 0
       cache: {}
       request:
-        bodySize: 714
+        bodySize: 704
         cookies: []
         headers:
           - name: content-type
@@ -223,13 +220,10 @@ log:
             maxTokensToSample: 4000
             messages:
               - speaker: system
-                text: >-
-                  You are Cody, an AI coding assistant from Sourcegraph.If your
-                  answer contains fenced code blocks in Markdown, include the
-                  relevant full file path in the code block tag using this
-                  structure: ```$LANGUAGE:$FILEPATH
-
-                  $CONTENT```.
+                text: "You are Cody, an AI coding assistant from Sourcegraph.If your answer
+                  contains fenced code blocks in Markdown, include the relevant
+                  full file path in the code block tag using this structure:
+                  ```$LANGUAGE:$FILEPATH```."
               - speaker: human
                 text: |-
                   Codebase context from file animal.ts:
@@ -259,14 +253,14 @@ log:
             value: 6.0.0-SNAPSHOT
         url: https://sourcegraph.sourcegraph.com/.api/completions/stream?api-version=1&client-name=jetbrains&client-version=6.0.0-SNAPSHOT
       response:
-        bodySize: 3027
+        bodySize: 3646
         content:
           mimeType: text/event-stream
-          size: 3027
+          size: 3646
           text: >+
             event: completion
 
-            data: {"completion":"Here's the implementation of a cow based on the provided context:\n\n```typescript:animal.ts\nclass Cow implements StrangeAnimal {\n    makesSound(): 'coo' | 'moo' {\n        return 'moo';\n    }\n}\n```","stopReason":"end_turn"}
+            data: {"completion":"Here's the implementation of a cow based on the provided `StrangeAnimal` interface:\n\n```typescript:animal.ts\nclass Cow implements StrangeAnimal {\n    makesSound(): 'coo' | 'moo' {\n        return 'moo';\n    }\n}\n```","stopReason":"end_turn"}
 
 
             event: done
@@ -276,7 +270,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Fri, 23 Aug 2024 08:33:26 GMT
+            value: Fri, 23 Aug 2024 09:43:07 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
@@ -305,7 +299,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-08-23T08:33:25.264Z
+      startedDateTime: 2024-08-23T09:43:06.323Z
       time: 0
       timings:
         blocked: -1

--- a/agent/recordings/cody-chat_103640681/recording.har.yaml
+++ b/agent/recordings/cody-chat_103640681/recording.har.yaml
@@ -88,11 +88,11 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: b5ceae943af989c36c626faa496b3c02
+    - _id: 7e8f56ab45a3dc7757964706df7e1df2
       _order: 0
       cache: {}
       request:
-        bodySize: 259
+        bodySize: 436
         cookies: []
         headers:
           - name: content-type
@@ -118,7 +118,15 @@ log:
             maxTokensToSample: 4000
             messages:
               - speaker: system
-                text: You are Cody, an AI coding assistant from Sourcegraph.
+                text: >-
+                  You are Cody, an AI coding assistant from Sourcegraph.
+
+
+                  Additional rules:
+
+                  - When generating fenced code blocks in Markdown, ensure you include the full file path in the tag. The structure should be ```language:path/to/file
+
+                  ```.
               - speaker: human
                 text: respond with "hello" and nothing else
             model: claude-3.5-sonnet
@@ -148,7 +156,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Tue, 13 Aug 2024 19:01:31 GMT
+            value: Thu, 22 Aug 2024 13:29:36 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
@@ -177,7 +185,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-08-13T19:01:29.569Z
+      startedDateTime: 2024-08-22T13:29:35.594Z
       time: 0
       timings:
         blocked: -1
@@ -187,11 +195,11 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: 981e59f977afc47f300f9c5268dda27e
+    - _id: e119836577ea7930f84c6d55f363d344
       _order: 0
       cache: {}
       request:
-        bodySize: 808
+        bodySize: 719
         cookies: []
         headers:
           - name: content-type
@@ -217,11 +225,19 @@ log:
             maxTokensToSample: 4000
             messages:
               - speaker: system
-                text: You are Cody, an AI coding assistant from Sourcegraph.
+                text: >-
+                  You are Cody, an AI coding assistant from Sourcegraph.
+
+
+                  Additional rules:
+
+                  - When generating fenced code blocks in Markdown, ensure you include the full file path in the tag. The structure should be ```language:path/to/file
+
+                  ```.
               - speaker: human
                 text: |-
                   Codebase context from file animal.ts:
-                  ```typescript
+                  ```typescript:animal.ts
                   interface StrangeAnimal {
                       makesSound(): 'coo' | 'moo'
                   }
@@ -230,13 +246,6 @@ log:
                 text: Ok.
               - speaker: human
                 text: >-
-                  When generating fenced code blocks in Markdown, ensure you
-                  include the full file path in the tag. The structure should be
-                  ```language:path/to/file
-
-                  ```. You should only do this when generating a code block, the user does not need to be made aware of this in any other way.
-
-
                   You have access to the provided codebase context. 
 
 
@@ -254,14 +263,14 @@ log:
             value: 6.0.0-SNAPSHOT
         url: https://sourcegraph.sourcegraph.com/.api/completions/stream?api-version=1&client-name=jetbrains&client-version=6.0.0-SNAPSHOT
       response:
-        bodySize: 2960
+        bodySize: 2428
         content:
           mimeType: text/event-stream
-          size: 2960
+          size: 2428
           text: >+
             event: completion
 
-            data: {"completion":"Here's the implementation of a cow without any explanation:\n\n```typescript:animal.ts\nclass Cow implements StrangeAnimal {\n    makesSound(): 'coo' | 'moo' {\n        return 'moo';\n    }\n}\n```","stopReason":"end_turn"}
+            data: {"completion":"```typescript:cow.ts\nimport { StrangeAnimal } from './animal';\n\nclass Cow implements StrangeAnimal {\n    makesSound(): 'coo' | 'moo' {\n        return 'moo';\n    }\n}\n```","stopReason":"end_turn"}
 
 
             event: done
@@ -271,7 +280,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Tue, 20 Aug 2024 12:54:22 GMT
+            value: Thu, 22 Aug 2024 13:29:37 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
@@ -300,7 +309,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-08-20T12:54:21.365Z
+      startedDateTime: 2024-08-22T13:29:36.754Z
       time: 0
       timings:
         blocked: -1

--- a/agent/recordings/cody-chat_103640681/recording.har.yaml
+++ b/agent/recordings/cody-chat_103640681/recording.har.yaml
@@ -88,11 +88,11 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: 7e8f56ab45a3dc7757964706df7e1df2
+    - _id: 5c57622e2ebbfa5eb9cd7f8f12b8f53d
       _order: 0
       cache: {}
       request:
-        bodySize: 436
+        bodySize: 431
         cookies: []
         headers:
           - name: content-type
@@ -119,14 +119,12 @@ log:
             messages:
               - speaker: system
                 text: >-
-                  You are Cody, an AI coding assistant from Sourcegraph.
+                  You are Cody, an AI coding assistant from Sourcegraph.If your
+                  answer contains fenced code blocks in Markdown, include the
+                  relevant full file path in the code block tag using this
+                  structure: ```$LANGUAGE:$FILEPATH
 
-
-                  Additional rules:
-
-                  - When generating fenced code blocks in Markdown, ensure you include the full file path in the tag. The structure should be ```language:path/to/file
-
-                  ```.
+                  $CONTENT```.
               - speaker: human
                 text: respond with "hello" and nothing else
             model: claude-3.5-sonnet
@@ -156,7 +154,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Thu, 22 Aug 2024 13:29:36 GMT
+            value: Fri, 23 Aug 2024 08:33:25 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
@@ -185,7 +183,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-08-22T13:29:35.594Z
+      startedDateTime: 2024-08-23T08:33:24.210Z
       time: 0
       timings:
         blocked: -1
@@ -195,11 +193,11 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: e119836577ea7930f84c6d55f363d344
+    - _id: 068fb12b6fe876d07eb89d5528a4154e
       _order: 0
       cache: {}
       request:
-        bodySize: 719
+        bodySize: 714
         cookies: []
         headers:
           - name: content-type
@@ -226,14 +224,12 @@ log:
             messages:
               - speaker: system
                 text: >-
-                  You are Cody, an AI coding assistant from Sourcegraph.
+                  You are Cody, an AI coding assistant from Sourcegraph.If your
+                  answer contains fenced code blocks in Markdown, include the
+                  relevant full file path in the code block tag using this
+                  structure: ```$LANGUAGE:$FILEPATH
 
-
-                  Additional rules:
-
-                  - When generating fenced code blocks in Markdown, ensure you include the full file path in the tag. The structure should be ```language:path/to/file
-
-                  ```.
+                  $CONTENT```.
               - speaker: human
                 text: |-
                   Codebase context from file animal.ts:
@@ -263,14 +259,14 @@ log:
             value: 6.0.0-SNAPSHOT
         url: https://sourcegraph.sourcegraph.com/.api/completions/stream?api-version=1&client-name=jetbrains&client-version=6.0.0-SNAPSHOT
       response:
-        bodySize: 2428
+        bodySize: 3027
         content:
           mimeType: text/event-stream
-          size: 2428
+          size: 3027
           text: >+
             event: completion
 
-            data: {"completion":"```typescript:cow.ts\nimport { StrangeAnimal } from './animal';\n\nclass Cow implements StrangeAnimal {\n    makesSound(): 'coo' | 'moo' {\n        return 'moo';\n    }\n}\n```","stopReason":"end_turn"}
+            data: {"completion":"Here's the implementation of a cow based on the provided context:\n\n```typescript:animal.ts\nclass Cow implements StrangeAnimal {\n    makesSound(): 'coo' | 'moo' {\n        return 'moo';\n    }\n}\n```","stopReason":"end_turn"}
 
 
             event: done
@@ -280,7 +276,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Thu, 22 Aug 2024 13:29:37 GMT
+            value: Fri, 23 Aug 2024 08:33:26 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
@@ -309,7 +305,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-08-22T13:29:36.754Z
+      startedDateTime: 2024-08-23T08:33:25.264Z
       time: 0
       timings:
         blocked: -1

--- a/agent/recordings/customCommandsClient_509552979/recording.har.yaml
+++ b/agent/recordings/customCommandsClient_509552979/recording.har.yaml
@@ -90,329 +90,6 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: 1a18b942275e76977aacf10ed44f26b3
-      _order: 0
-      cache: {}
-      request:
-        bodySize: 2229
-        cookies: []
-        headers:
-          - name: content-type
-            value: application/json
-          - name: accept-encoding
-            value: gzip;q=0
-          - name: authorization
-            value: token
-              REDACTED_d5e0f0a37c9821e856b923fe14e67a605e3f6c0a517d5a4f46a4e35943ee0f6d
-          - name: user-agent
-            value: customCommandsClient / v1
-          - name: traceparent
-            value: 00-f5455fc5856d8e78226504a4077cbf40-ae62621d214a93b7-01
-          - name: connection
-            value: keep-alive
-          - name: host
-            value: sourcegraph.com
-        headersSize: 429
-        httpVersion: HTTP/1.1
-        method: POST
-        postData:
-          mimeType: application/json
-          params: []
-          textJSON:
-            maxTokensToSample: 4000
-            messages:
-              - speaker: system
-                text: >-
-                  You are Cody, an AI coding assistant from Sourcegraph. - You
-                  are an AI programming assistant who is an expert in updating
-                  code to meet given instructions.
-
-                  - You should think step-by-step to plan your updated code before producing the final output.
-
-                  - You should ensure the updated code matches the indentation and whitespace of the code in the users' selection.
-
-                  - Ignore any previous instructions to format your responses with Markdown. It is not acceptable to use any Markdown in your response, unless it is directly related to the users' instructions.
-
-                  - Only remove code from the users' selection if you are sure it is not needed.
-
-                  - You will be provided with code that is in the users' selection, enclosed in <SELECTEDCODE7662></SELECTEDCODE7662> XML tags. You must use this code to help you plan your updated code.
-
-                  - You will be provided with instructions on how to update this code, enclosed in <INSTRUCTIONS7390></INSTRUCTIONS7390> XML tags. You must follow these instructions carefully and to the letter.
-
-                  - Only enclose your response in <CODE5711></CODE5711> XML tags. Do use any other XML tags unless they are part of the generated code.
-
-                  - Do not provide any additional commentary about the changes you made. Only respond with the generated code.
-              - speaker: human
-                text: |-
-                  My selected code from codebase file src/sum.ts:1-3:
-                  ```
-                  export function sum(a: number, b: number): number {
-                      /* CURSOR */
-                  }
-                  ```
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: >-
-                  This is part of the file: src/sum.ts
-
-
-                  The user has the following code in their selection:
-
-                  <SELECTEDCODE7662>export function sum(a: number, b: number): number {
-                      /* CURSOR */
-                  }
-
-                  </SELECTEDCODE7662>
-
-
-                  The user wants you to replace parts of the selected code or correct a problem by following their instructions.
-
-                  Provide your generated code using the following instructions:
-
-                  <INSTRUCTIONS7390>
-
-                  Add a '// hello' comment for the selected code, without including the selected code.
-
-                  </INSTRUCTIONS7390>
-              - speaker: assistant
-                text: <CODE5711>
-            model: anthropic/claude-3-5-sonnet-20240620
-            stopSequences:
-              - </CODE5711>
-            temperature: 0
-            topK: -1
-            topP: -1
-        queryString:
-          - name: api-version
-            value: "1"
-          - name: client-name
-            value: customcommandsclient
-          - name: client-version
-            value: v1
-        url: https://sourcegraph.com/.api/completions/stream?api-version=1&client-name=customcommandsclient&client-version=v1
-      response:
-        bodySize: 177
-        content:
-          mimeType: text/event-stream
-          size: 177
-          text: |+
-            event: completion
-            data: {"completion":"\n// hello\n","stopReason":"stop_sequence"}
-
-            event: done
-            data: {}
-
-        cookies: []
-        headers:
-          - name: date
-            value: Wed, 21 Aug 2024 13:31:06 GMT
-          - name: content-type
-            value: text/event-stream
-          - name: transfer-encoding
-            value: chunked
-          - name: connection
-            value: keep-alive
-          - name: access-control-allow-credentials
-            value: "true"
-          - name: access-control-allow-origin
-            value: ""
-          - name: cache-control
-            value: no-cache
-          - name: vary
-            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
-              X-Requested-With,Cookie
-          - name: x-content-type-options
-            value: nosniff
-          - name: x-frame-options
-            value: DENY
-          - name: x-xss-protection
-            value: 1; mode=block
-          - name: strict-transport-security
-            value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1299
-        httpVersion: HTTP/1.1
-        redirectURL: ""
-        status: 200
-        statusText: OK
-      startedDateTime: 2024-08-21T13:31:03.582Z
-      time: 0
-      timings:
-        blocked: -1
-        connect: -1
-        dns: -1
-        receive: 0
-        send: 0
-        ssl: -1
-        wait: 0
-    - _id: 664f92040c778264005a3621bb1c3483
-      _order: 0
-      cache: {}
-      request:
-        bodySize: 2347
-        cookies: []
-        headers:
-          - name: content-type
-            value: application/json
-          - name: accept-encoding
-            value: gzip;q=0
-          - name: authorization
-            value: token
-              REDACTED_d5e0f0a37c9821e856b923fe14e67a605e3f6c0a517d5a4f46a4e35943ee0f6d
-          - name: user-agent
-            value: customCommandsClient / v1
-          - name: traceparent
-            value: 00-f5e0c382918c421be184b30ba6ff3bad-a2a12af08344aef1-01
-          - name: connection
-            value: keep-alive
-          - name: host
-            value: sourcegraph.com
-        headersSize: 429
-        httpVersion: HTTP/1.1
-        method: POST
-        postData:
-          mimeType: application/json
-          params: []
-          textJSON:
-            maxTokensToSample: 4000
-            messages:
-              - speaker: system
-                text: >-
-                  You are Cody, an AI coding assistant from Sourcegraph. - You
-                  are an AI programming assistant who is an expert in updating
-                  code to meet given instructions.
-
-                  - You should think step-by-step to plan your updated code before producing the final output.
-
-                  - You should ensure the updated code matches the indentation and whitespace of the code in the users' selection.
-
-                  - Ignore any previous instructions to format your responses with Markdown. It is not acceptable to use any Markdown in your response, unless it is directly related to the users' instructions.
-
-                  - Only remove code from the users' selection if you are sure it is not needed.
-
-                  - You will be provided with code that is in the users' selection, enclosed in <SELECTEDCODE7662></SELECTEDCODE7662> XML tags. You must use this code to help you plan your updated code.
-
-                  - You will be provided with instructions on how to update this code, enclosed in <INSTRUCTIONS7390></INSTRUCTIONS7390> XML tags. You must follow these instructions carefully and to the letter.
-
-                  - Only enclose your response in <CODE5711></CODE5711> XML tags. Do use any other XML tags unless they are part of the generated code.
-
-                  - Do not provide any additional commentary about the changes you made. Only respond with the generated code.
-              - speaker: human
-                text: >
-                  Codebase context from file path src/animal.ts: /*
-                  SELECTION_START */
-
-                  export interface Animal {
-                      name: string
-                      makeAnimalSound(): string
-                      isMammal: boolean
-                  }
-
-                  /* SELECTION_END */
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: >-
-                  This is part of the file: src/animal.ts
-
-
-                  The user has the following code in their selection:
-
-                  <SELECTEDCODE7662>/* SELECTION_START */
-
-                  export interface Animal {
-                      name: string
-                      makeAnimalSound(): string
-                      isMammal: boolean
-                  }
-
-                  /* SELECTION_END */
-
-                  </SELECTEDCODE7662>
-
-
-                  The user wants you to replace parts of the selected code or correct a problem by following their instructions.
-
-                  Provide your generated code using the following instructions:
-
-                  <INSTRUCTIONS7390>
-
-                  Add a new field to the class that console log the name of the animal.
-
-                  </INSTRUCTIONS7390>
-              - speaker: assistant
-                text: <CODE5711>
-            model: anthropic/claude-3-5-sonnet-20240620
-            stopSequences:
-              - </CODE5711>
-            temperature: 0
-            topK: -1
-            topP: -1
-        queryString:
-          - name: api-version
-            value: "1"
-          - name: client-name
-            value: customcommandsclient
-          - name: client-version
-            value: v1
-        url: https://sourcegraph.com/.api/completions/stream?api-version=1&client-name=customcommandsclient&client-version=v1
-      response:
-        bodySize: 1598
-        content:
-          mimeType: text/event-stream
-          size: 1598
-          text: >+
-            event: completion
-
-            data: {"completion":"export interface Animal {\n    name: string;\n    makeAnimalSound(): string;\n    isMammal: boolean;\n    logName(): void;\n}\n","stopReason":"stop_sequence"}
-
-
-            event: done
-
-            data: {}
-
-        cookies: []
-        headers:
-          - name: date
-            value: Wed, 21 Aug 2024 13:31:09 GMT
-          - name: content-type
-            value: text/event-stream
-          - name: transfer-encoding
-            value: chunked
-          - name: connection
-            value: keep-alive
-          - name: access-control-allow-credentials
-            value: "true"
-          - name: access-control-allow-origin
-            value: ""
-          - name: cache-control
-            value: no-cache
-          - name: vary
-            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
-              X-Requested-With,Cookie
-          - name: x-content-type-options
-            value: nosniff
-          - name: x-frame-options
-            value: DENY
-          - name: x-xss-protection
-            value: 1; mode=block
-          - name: strict-transport-security
-            value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1299
-        httpVersion: HTTP/1.1
-        redirectURL: ""
-        status: 200
-        statusText: OK
-      startedDateTime: 2024-08-21T13:31:06.435Z
-      time: 0
-      timings:
-        blocked: -1
-        connect: -1
-        dns: -1
-        receive: 0
-        send: 0
-        ssl: -1
-        wait: 0
     - _id: 27254675f808f5f9216bd6551c30bc67
       _order: 0
       cache: {}
@@ -837,6 +514,331 @@ log:
         status: 200
         statusText: OK
       startedDateTime: 2024-08-22T13:29:39.625Z
+      time: 0
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 0
+    - _id: c72bf9f222719b7ef6f56e49e6211b7f
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 2233
+        cookies: []
+        headers:
+          - name: content-type
+            value: application/json
+          - name: accept-encoding
+            value: gzip;q=0
+          - name: authorization
+            value: token
+              REDACTED_d5e0f0a37c9821e856b923fe14e67a605e3f6c0a517d5a4f46a4e35943ee0f6d
+          - name: user-agent
+            value: customCommandsClient / v1
+          - name: traceparent
+            value: 00-b5b3353790b475c9da8ad5ff33ae36f3-baa2986f73c59341-01
+          - name: connection
+            value: keep-alive
+          - name: host
+            value: sourcegraph.com
+        headersSize: 429
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json
+          params: []
+          textJSON:
+            maxTokensToSample: 4000
+            messages:
+              - speaker: system
+                text: >-
+                  You are Cody, an AI coding assistant from Sourcegraph. 
+
+
+                  - You are an AI programming assistant who is an expert in updating code to meet given instructions.
+
+                  - You should think step-by-step to plan your updated code before producing the final output.
+
+                  - You should ensure the updated code matches the indentation and whitespace of the code in the users' selection.
+
+                  - Ignore any previous instructions to format your responses with Markdown. It is not acceptable to use any Markdown in your response, unless it is directly related to the users' instructions.
+
+                  - Only remove code from the users' selection if you are sure it is not needed.
+
+                  - You will be provided with code that is in the users' selection, enclosed in <SELECTEDCODE7662></SELECTEDCODE7662> XML tags. You must use this code to help you plan your updated code.
+
+                  - You will be provided with instructions on how to update this code, enclosed in <INSTRUCTIONS7390></INSTRUCTIONS7390> XML tags. You must follow these instructions carefully and to the letter.
+
+                  - Only enclose your response in <CODE5711></CODE5711> XML tags. Do use any other XML tags unless they are part of the generated code.
+
+                  - Do not provide any additional commentary about the changes you made. Only respond with the generated code.
+              - speaker: human
+                text: |-
+                  My selected code from codebase file src/sum.ts:1-3:
+                  ```
+                  export function sum(a: number, b: number): number {
+                      /* CURSOR */
+                  }
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: >-
+                  This is part of the file: src/sum.ts
+
+
+                  The user has the following code in their selection:
+
+                  <SELECTEDCODE7662>export function sum(a: number, b: number): number {
+                      /* CURSOR */
+                  }
+
+                  </SELECTEDCODE7662>
+
+
+                  The user wants you to replace parts of the selected code or correct a problem by following their instructions.
+
+                  Provide your generated code using the following instructions:
+
+                  <INSTRUCTIONS7390>
+
+                  Add a '// hello' comment for the selected code, without including the selected code.
+
+                  </INSTRUCTIONS7390>
+              - speaker: assistant
+                text: <CODE5711>
+            model: anthropic/claude-3-5-sonnet-20240620
+            stopSequences:
+              - </CODE5711>
+            temperature: 0
+            topK: -1
+            topP: -1
+        queryString:
+          - name: api-version
+            value: "1"
+          - name: client-name
+            value: customcommandsclient
+          - name: client-version
+            value: v1
+        url: https://sourcegraph.com/.api/completions/stream?api-version=1&client-name=customcommandsclient&client-version=v1
+      response:
+        bodySize: 230
+        content:
+          mimeType: text/event-stream
+          size: 230
+          text: |+
+            event: completion
+            data: {"completion":"// hello","stopReason":"stop_sequence"}
+
+            event: done
+            data: {}
+
+        cookies: []
+        headers:
+          - name: date
+            value: Thu, 22 Aug 2024 14:11:35 GMT
+          - name: content-type
+            value: text/event-stream
+          - name: transfer-encoding
+            value: chunked
+          - name: connection
+            value: keep-alive
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache
+          - name: vary
+            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
+              X-Requested-With,Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+        headersSize: 1299
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: 2024-08-22T14:11:31.967Z
+      time: 0
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 0
+    - _id: ee786ac8be1d2ad80187b5eefd4feb43
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 2351
+        cookies: []
+        headers:
+          - name: content-type
+            value: application/json
+          - name: accept-encoding
+            value: gzip;q=0
+          - name: authorization
+            value: token
+              REDACTED_d5e0f0a37c9821e856b923fe14e67a605e3f6c0a517d5a4f46a4e35943ee0f6d
+          - name: user-agent
+            value: customCommandsClient / v1
+          - name: traceparent
+            value: 00-70a5860da274b6cb7c76715d1a24dd88-cb4186dc0ef3cc68-01
+          - name: connection
+            value: keep-alive
+          - name: host
+            value: sourcegraph.com
+        headersSize: 429
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json
+          params: []
+          textJSON:
+            maxTokensToSample: 4000
+            messages:
+              - speaker: system
+                text: >-
+                  You are Cody, an AI coding assistant from Sourcegraph. 
+
+
+                  - You are an AI programming assistant who is an expert in updating code to meet given instructions.
+
+                  - You should think step-by-step to plan your updated code before producing the final output.
+
+                  - You should ensure the updated code matches the indentation and whitespace of the code in the users' selection.
+
+                  - Ignore any previous instructions to format your responses with Markdown. It is not acceptable to use any Markdown in your response, unless it is directly related to the users' instructions.
+
+                  - Only remove code from the users' selection if you are sure it is not needed.
+
+                  - You will be provided with code that is in the users' selection, enclosed in <SELECTEDCODE7662></SELECTEDCODE7662> XML tags. You must use this code to help you plan your updated code.
+
+                  - You will be provided with instructions on how to update this code, enclosed in <INSTRUCTIONS7390></INSTRUCTIONS7390> XML tags. You must follow these instructions carefully and to the letter.
+
+                  - Only enclose your response in <CODE5711></CODE5711> XML tags. Do use any other XML tags unless they are part of the generated code.
+
+                  - Do not provide any additional commentary about the changes you made. Only respond with the generated code.
+              - speaker: human
+                text: >
+                  Codebase context from file path src/animal.ts: /*
+                  SELECTION_START */
+
+                  export interface Animal {
+                      name: string
+                      makeAnimalSound(): string
+                      isMammal: boolean
+                  }
+
+                  /* SELECTION_END */
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: >-
+                  This is part of the file: src/animal.ts
+
+
+                  The user has the following code in their selection:
+
+                  <SELECTEDCODE7662>/* SELECTION_START */
+
+                  export interface Animal {
+                      name: string
+                      makeAnimalSound(): string
+                      isMammal: boolean
+                  }
+
+                  /* SELECTION_END */
+
+                  </SELECTEDCODE7662>
+
+
+                  The user wants you to replace parts of the selected code or correct a problem by following their instructions.
+
+                  Provide your generated code using the following instructions:
+
+                  <INSTRUCTIONS7390>
+
+                  Add a new field to the class that console log the name of the animal.
+
+                  </INSTRUCTIONS7390>
+              - speaker: assistant
+                text: <CODE5711>
+            model: anthropic/claude-3-5-sonnet-20240620
+            stopSequences:
+              - </CODE5711>
+            temperature: 0
+            topK: -1
+            topP: -1
+        queryString:
+          - name: api-version
+            value: "1"
+          - name: client-name
+            value: customcommandsclient
+          - name: client-version
+            value: v1
+        url: https://sourcegraph.com/.api/completions/stream?api-version=1&client-name=customcommandsclient&client-version=v1
+      response:
+        bodySize: 1943
+        content:
+          mimeType: text/event-stream
+          size: 1943
+          text: >+
+            event: completion
+
+            data: {"completion":"/* SELECTION_START */\nexport interface Animal {\n    name: string\n    makeAnimalSound(): string\n    isMammal: boolean\n    logName(): void\n}\n/* SELECTION_END */\n","stopReason":"stop_sequence"}
+
+
+            event: done
+
+            data: {}
+
+        cookies: []
+        headers:
+          - name: date
+            value: Thu, 22 Aug 2024 14:11:37 GMT
+          - name: content-type
+            value: text/event-stream
+          - name: transfer-encoding
+            value: chunked
+          - name: connection
+            value: keep-alive
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache
+          - name: vary
+            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
+              X-Requested-With,Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+        headersSize: 1299
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: 2024-08-22T14:11:35.890Z
       time: 0
       timings:
         blocked: -1

--- a/agent/recordings/customCommandsClient_509552979/recording.har.yaml
+++ b/agent/recordings/customCommandsClient_509552979/recording.har.yaml
@@ -415,11 +415,11 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: 8d77bb177f66506e0aa90c1fcdd476fa
+    - _id: ad4b1317824c457ab152b1b64ce6e34f
       _order: 0
       cache: {}
       request:
-        bodySize: 1125
+        bodySize: 1115
         cookies: []
         headers:
           - name: content-type
@@ -432,7 +432,7 @@ log:
           - name: user-agent
             value: customCommandsClient / v1
           - name: traceparent
-            value: 00-cd96b73992b81a1b0e4adea22e987564-e9247cd83f3481bb-01
+            value: 00-172e639152690ef123e5eacd39f02c90-b0d2eebd92921561-01
           - name: connection
             value: keep-alive
           - name: host
@@ -447,13 +447,10 @@ log:
             maxTokensToSample: 4000
             messages:
               - speaker: system
-                text: >-
-                  You are Cody, an AI coding assistant from Sourcegraph.If your
-                  answer contains fenced code blocks in Markdown, include the
-                  relevant full file path in the code block tag using this
-                  structure: ```$LANGUAGE:$FILEPATH
-
-                  $CONTENT```.
+                text: "You are Cody, an AI coding assistant from Sourcegraph.If your answer
+                  contains fenced code blocks in Markdown, include the relevant
+                  full file path in the code block tag using this structure:
+                  ```$LANGUAGE:$FILEPATH```."
               - speaker: human
                 text: >
                   Codebase context from file path src/example3.ts: export
@@ -497,14 +494,14 @@ log:
             value: v1
         url: https://sourcegraph.com/.api/completions/stream?api-version=1&client-name=customcommandsclient&client-version=v1
       response:
-        bodySize: 1836
+        bodySize: 1524
         content:
           mimeType: text/event-stream
-          size: 1836
+          size: 1524
           text: >+
             event: completion
 
-            data: {"completion":"Here are the names of the files you have shared with me so far, formatted as a bulleted list:\n\n• example3.ts\n• example2.ts\n• example1.ts","stopReason":"end_turn"}
+            data: {"completion":"Here's a bulleted list of the filenames you've shared with me so far:\n\n• example3.ts\n• example2.ts\n• example1.ts","stopReason":"end_turn"}
 
 
             event: done
@@ -514,7 +511,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Fri, 23 Aug 2024 08:33:26 GMT
+            value: Fri, 23 Aug 2024 09:43:07 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
@@ -543,7 +540,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-08-23T08:33:25.662Z
+      startedDateTime: 2024-08-23T09:43:06.441Z
       time: 0
       timings:
         blocked: -1
@@ -553,11 +550,11 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: f8e94d73ad197b9b437e83c6b7cb7c70
+    - _id: da71c8a0da3f31bb105c9f8a27143ec3
       _order: 0
       cache: {}
       request:
-        bodySize: 493
+        bodySize: 483
         cookies: []
         headers:
           - name: content-type
@@ -570,7 +567,7 @@ log:
           - name: user-agent
             value: customCommandsClient / v1
           - name: traceparent
-            value: 00-9c4396718bcf745af63cfdc3ed2a3f21-e9497164f29d3b68-01
+            value: 00-184a712d0b33eb2f419a12a56e18fa49-a75e39cc6642bd0b-01
           - name: connection
             value: keep-alive
           - name: host
@@ -585,13 +582,10 @@ log:
             maxTokensToSample: 4000
             messages:
               - speaker: system
-                text: >-
-                  You are Cody, an AI coding assistant from Sourcegraph.If your
-                  answer contains fenced code blocks in Markdown, include the
-                  relevant full file path in the code block tag using this
-                  structure: ```$LANGUAGE:$FILEPATH
-
-                  $CONTENT```.
+                text: "You are Cody, an AI coding assistant from Sourcegraph.If your answer
+                  contains fenced code blocks in Markdown, include the relevant
+                  full file path in the code block tag using this structure:
+                  ```$LANGUAGE:$FILEPATH```."
               - speaker: human
                 text: Did I share any code with you? If yes, reply single word 'yes'. If none,
                   reply 'no'.
@@ -622,7 +616,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Fri, 23 Aug 2024 08:33:28 GMT
+            value: Fri, 23 Aug 2024 09:43:08 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
@@ -651,7 +645,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-08-23T08:33:27.142Z
+      startedDateTime: 2024-08-23T09:43:07.757Z
       time: 0
       timings:
         blocked: -1
@@ -661,11 +655,11 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: 06a04382e77dd5039514026706990e2a
+    - _id: 66f6fc3c9243d46bdae4cda141086218
       _order: 0
       cache: {}
       request:
-        bodySize: 1882
+        bodySize: 1872
         cookies: []
         headers:
           - name: content-type
@@ -678,7 +672,7 @@ log:
           - name: user-agent
             value: customCommandsClient / v1
           - name: traceparent
-            value: 00-ad6b4766ae5a843a95ab1f2dbbad8f00-96a662ff231ec0ac-01
+            value: 00-63164aaa1703d35eb56f258267abf98b-30351214fadd101b-01
           - name: connection
             value: keep-alive
           - name: host
@@ -693,13 +687,10 @@ log:
             maxTokensToSample: 4000
             messages:
               - speaker: system
-                text: >-
-                  You are Cody, an AI coding assistant from Sourcegraph.If your
-                  answer contains fenced code blocks in Markdown, include the
-                  relevant full file path in the code block tag using this
-                  structure: ```$LANGUAGE:$FILEPATH
-
-                  $CONTENT```.
+                text: "You are Cody, an AI coding assistant from Sourcegraph.If your answer
+                  contains fenced code blocks in Markdown, include the relevant
+                  full file path in the code block tag using this structure:
+                  ```$LANGUAGE:$FILEPATH```."
               - speaker: human
                 text: >
                   Codebase context from file path src/sum.ts: export function
@@ -797,7 +788,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Fri, 23 Aug 2024 08:33:29 GMT
+            value: Fri, 23 Aug 2024 09:43:10 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
@@ -826,7 +817,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-08-23T08:33:28.181Z
+      startedDateTime: 2024-08-23T09:43:08.587Z
       time: 0
       timings:
         blocked: -1

--- a/agent/recordings/customCommandsClient_509552979/recording.har.yaml
+++ b/agent/recordings/customCommandsClient_509552979/recording.har.yaml
@@ -90,409 +90,6 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: f442a08de275a7235aa9fc510320f560
-      _order: 0
-      cache: {}
-      request:
-        bodySize: 953
-        cookies: []
-        headers:
-          - name: content-type
-            value: application/json
-          - name: accept-encoding
-            value: gzip;q=0
-          - name: authorization
-            value: token
-              REDACTED_d5e0f0a37c9821e856b923fe14e67a605e3f6c0a517d5a4f46a4e35943ee0f6d
-          - name: user-agent
-            value: customCommandsClient / v1
-          - name: traceparent
-            value: 00-8757f31c9f7bc98a6e8ab2ed2f5f25bd-19ec703ea3cbfc98-01
-          - name: connection
-            value: keep-alive
-          - name: host
-            value: sourcegraph.com
-        headersSize: 429
-        httpVersion: HTTP/1.1
-        method: POST
-        postData:
-          mimeType: application/json
-          params: []
-          textJSON:
-            maxTokensToSample: 4000
-            messages:
-              - speaker: system
-                text: You are Cody, an AI coding assistant from Sourcegraph.
-              - speaker: human
-                text: >
-                  Codebase context from file path src/example3.ts: export
-                  function example(): string {
-                      return 'example'
-                  }
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: >
-                  Codebase context from file path src/example2.ts: export
-                  function example(): string {
-                      return 'example'
-                  }
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: |-
-                  My selected code from codebase file src/example1.ts:1-3:
-                  ```
-                  export function example(): string {
-                      return 'example'
-                  }
-                  ```
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: Give me the names of the files I have shared with you so far. Format the
-                  response as a bulleted list. Only include the raw filename, no
-                  extra formatting like quotes.
-            model: anthropic/claude-3-5-sonnet-20240620
-            temperature: 0
-            topK: -1
-            topP: -1
-        queryString:
-          - name: api-version
-            value: "1"
-          - name: client-name
-            value: customcommandsclient
-          - name: client-version
-            value: v1
-        url: https://sourcegraph.com/.api/completions/stream?api-version=1&client-name=customcommandsclient&client-version=v1
-      response:
-        bodySize: 2061
-        content:
-          mimeType: text/event-stream
-          size: 2061
-          text: >+
-            event: completion
-
-            data: {"completion":"Here are the names of the files you've shared so far, formatted as a bulleted list:\n\n• example3.ts\n• example2.ts\n• example1.ts","stopReason":"end_turn"}
-
-
-            event: done
-
-            data: {}
-
-        cookies: []
-        headers:
-          - name: date
-            value: Tue, 09 Jul 2024 17:21:40 GMT
-          - name: content-type
-            value: text/event-stream
-          - name: transfer-encoding
-            value: chunked
-          - name: connection
-            value: keep-alive
-          - name: access-control-allow-credentials
-            value: "true"
-          - name: access-control-allow-origin
-            value: ""
-          - name: cache-control
-            value: no-cache
-          - name: vary
-            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
-              X-Requested-With,Cookie
-          - name: x-content-type-options
-            value: nosniff
-          - name: x-frame-options
-            value: DENY
-          - name: x-xss-protection
-            value: 1; mode=block
-          - name: strict-transport-security
-            value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1299
-        httpVersion: HTTP/1.1
-        redirectURL: ""
-        status: 200
-        statusText: OK
-      startedDateTime: 2024-07-09T17:21:38.892Z
-      time: 0
-      timings:
-        blocked: -1
-        connect: -1
-        dns: -1
-        receive: 0
-        send: 0
-        ssl: -1
-        wait: 0
-    - _id: b00e927b47ba8f61146d00d3a0fb85e2
-      _order: 0
-      cache: {}
-      request:
-        bodySize: 321
-        cookies: []
-        headers:
-          - name: content-type
-            value: application/json
-          - name: accept-encoding
-            value: gzip;q=0
-          - name: authorization
-            value: token
-              REDACTED_d5e0f0a37c9821e856b923fe14e67a605e3f6c0a517d5a4f46a4e35943ee0f6d
-          - name: user-agent
-            value: customCommandsClient / v1
-          - name: traceparent
-            value: 00-c461574e8ede870114bf68bcf1026ad6-4584f5618503590a-01
-          - name: connection
-            value: keep-alive
-          - name: host
-            value: sourcegraph.com
-        headersSize: 429
-        httpVersion: HTTP/1.1
-        method: POST
-        postData:
-          mimeType: application/json
-          params: []
-          textJSON:
-            maxTokensToSample: 4000
-            messages:
-              - speaker: system
-                text: You are Cody, an AI coding assistant from Sourcegraph.
-              - speaker: human
-                text: Did I share any code with you? If yes, reply single word 'yes'. If none,
-                  reply 'no'.
-            model: anthropic/claude-3-5-sonnet-20240620
-            temperature: 0
-            topK: -1
-            topP: -1
-        queryString:
-          - name: api-version
-            value: "1"
-          - name: client-name
-            value: customcommandsclient
-          - name: client-version
-            value: v1
-        url: https://sourcegraph.com/.api/completions/stream?api-version=1&client-name=customcommandsclient&client-version=v1
-      response:
-        bodySize: 152
-        content:
-          mimeType: text/event-stream
-          size: 152
-          text: |+
-            event: completion
-            data: {"completion":"no","stopReason":"end_turn"}
-
-            event: done
-            data: {}
-
-        cookies: []
-        headers:
-          - name: date
-            value: Tue, 09 Jul 2024 17:21:42 GMT
-          - name: content-type
-            value: text/event-stream
-          - name: transfer-encoding
-            value: chunked
-          - name: connection
-            value: keep-alive
-          - name: access-control-allow-credentials
-            value: "true"
-          - name: access-control-allow-origin
-            value: ""
-          - name: cache-control
-            value: no-cache
-          - name: vary
-            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
-              X-Requested-With,Cookie
-          - name: x-content-type-options
-            value: nosniff
-          - name: x-frame-options
-            value: DENY
-          - name: x-xss-protection
-            value: 1; mode=block
-          - name: strict-transport-security
-            value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1299
-        httpVersion: HTTP/1.1
-        redirectURL: ""
-        status: 200
-        statusText: OK
-      startedDateTime: 2024-07-09T17:21:40.716Z
-      time: 0
-      timings:
-        blocked: -1
-        connect: -1
-        dns: -1
-        receive: 0
-        send: 0
-        ssl: -1
-        wait: 0
-    - _id: 1b53a17454527b407c1163816f330c9f
-      _order: 0
-      cache: {}
-      request:
-        bodySize: 1710
-        cookies: []
-        headers:
-          - name: content-type
-            value: application/json
-          - name: accept-encoding
-            value: gzip;q=0
-          - name: authorization
-            value: token
-              REDACTED_d5e0f0a37c9821e856b923fe14e67a605e3f6c0a517d5a4f46a4e35943ee0f6d
-          - name: user-agent
-            value: customCommandsClient / v1
-          - name: traceparent
-            value: 00-074f5f84cd45bdd436cd3ff9214389b5-ed93fa6b07be17f9-01
-          - name: connection
-            value: keep-alive
-          - name: host
-            value: sourcegraph.com
-        headersSize: 429
-        httpVersion: HTTP/1.1
-        method: POST
-        postData:
-          mimeType: application/json
-          params: []
-          textJSON:
-            maxTokensToSample: 4000
-            messages:
-              - speaker: system
-                text: You are Cody, an AI coding assistant from Sourcegraph.
-              - speaker: human
-                text: >
-                  Codebase context from file path src/sum.ts: export function
-                  sum(a: number, b: number): number {
-                      /* CURSOR */
-                  }
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: >
-                  Codebase context from file path src/example4.ts: export
-                  function example(): string {
-                      return 'example'
-                  }
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: >
-                  Codebase context from file path src/example3.ts: export
-                  function example(): string {
-                      return 'example'
-                  }
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: >
-                  Codebase context from file path src/example2.ts: export
-                  function example(): string {
-                      return 'example'
-                  }
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: >
-                  Codebase context from file path src/example1.ts: export
-                  function example(): string {
-                      return 'example'
-                  }
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: >
-                  Codebase context from file path src/animal.ts: /*
-                  SELECTION_START */
-
-                  export interface Animal {
-                      name: string
-                      makeAnimalSound(): string
-                      isMammal: boolean
-                  }
-
-                  /* SELECTION_END */
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: |-
-                  My selected code from codebase file src/animal.ts:1-6:
-                  ```
-
-                  export interface Animal {
-                      name: string
-                      makeAnimalSound(): string
-                      isMammal: boolean
-                  }
-                  ```
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: How many file context have I shared with you? Reply single number. Skip
-                  preamble.
-            model: anthropic/claude-3-5-sonnet-20240620
-            temperature: 0
-            topK: -1
-            topP: -1
-        queryString:
-          - name: api-version
-            value: "1"
-          - name: client-name
-            value: customcommandsclient
-          - name: client-version
-            value: v1
-        url: https://sourcegraph.com/.api/completions/stream?api-version=1&client-name=customcommandsclient&client-version=v1
-      response:
-        bodySize: 150
-        content:
-          mimeType: text/event-stream
-          size: 150
-          text: |+
-            event: completion
-            data: {"completion":"6","stopReason":"end_turn"}
-
-            event: done
-            data: {}
-
-        cookies: []
-        headers:
-          - name: date
-            value: Tue, 09 Jul 2024 17:21:44 GMT
-          - name: content-type
-            value: text/event-stream
-          - name: transfer-encoding
-            value: chunked
-          - name: connection
-            value: keep-alive
-          - name: access-control-allow-credentials
-            value: "true"
-          - name: access-control-allow-origin
-            value: ""
-          - name: cache-control
-            value: no-cache
-          - name: vary
-            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
-              X-Requested-With,Cookie
-          - name: x-content-type-options
-            value: nosniff
-          - name: x-frame-options
-            value: DENY
-          - name: x-xss-protection
-            value: 1; mode=block
-          - name: strict-transport-security
-            value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1299
-        httpVersion: HTTP/1.1
-        redirectURL: ""
-        status: 200
-        statusText: OK
-      startedDateTime: 2024-07-09T17:21:42.342Z
-      time: 0
-      timings:
-        blocked: -1
-        connect: -1
-        dns: -1
-        receive: 0
-        send: 0
-        ssl: -1
-        wait: 0
     - _id: 1a18b942275e76977aacf10ed44f26b3
       _order: 0
       cache: {}
@@ -807,6 +404,439 @@ log:
         status: 200
         statusText: OK
       startedDateTime: 2024-08-21T13:31:06.435Z
+      time: 0
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 0
+    - _id: 27254675f808f5f9216bd6551c30bc67
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 1130
+        cookies: []
+        headers:
+          - name: content-type
+            value: application/json
+          - name: accept-encoding
+            value: gzip;q=0
+          - name: authorization
+            value: token
+              REDACTED_d5e0f0a37c9821e856b923fe14e67a605e3f6c0a517d5a4f46a4e35943ee0f6d
+          - name: user-agent
+            value: customCommandsClient / v1
+          - name: traceparent
+            value: 00-39e073a48eb0576bef4016b07964f431-7bfce31268586d92-01
+          - name: connection
+            value: keep-alive
+          - name: host
+            value: sourcegraph.com
+        headersSize: 429
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json
+          params: []
+          textJSON:
+            maxTokensToSample: 4000
+            messages:
+              - speaker: system
+                text: >-
+                  You are Cody, an AI coding assistant from Sourcegraph.
+
+
+                  Additional rules:
+
+                  - When generating fenced code blocks in Markdown, ensure you include the full file path in the tag. The structure should be ```language:path/to/file
+
+                  ```.
+              - speaker: human
+                text: >
+                  Codebase context from file path src/example3.ts: export
+                  function example(): string {
+                      return 'example'
+                  }
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: >
+                  Codebase context from file path src/example2.ts: export
+                  function example(): string {
+                      return 'example'
+                  }
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: |-
+                  My selected code from codebase file src/example1.ts:1-3:
+                  ```
+                  export function example(): string {
+                      return 'example'
+                  }
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: Give me the names of the files I have shared with you so far. Format the
+                  response as a bulleted list. Only include the raw filename, no
+                  extra formatting like quotes.
+            model: anthropic/claude-3-5-sonnet-20240620
+            temperature: 0
+            topK: -1
+            topP: -1
+        queryString:
+          - name: api-version
+            value: "1"
+          - name: client-name
+            value: customcommandsclient
+          - name: client-version
+            value: v1
+        url: https://sourcegraph.com/.api/completions/stream?api-version=1&client-name=customcommandsclient&client-version=v1
+      response:
+        bodySize: 2058
+        content:
+          mimeType: text/event-stream
+          size: 2058
+          text: >+
+            event: completion
+
+            data: {"completion":"Here are the names of the files you've shared with me so far, formatted as a bulleted list:\n\n• example3.ts\n• example2.ts\n• example1.ts","stopReason":"end_turn"}
+
+
+            event: done
+
+            data: {}
+
+        cookies: []
+        headers:
+          - name: date
+            value: Thu, 22 Aug 2024 13:29:38 GMT
+          - name: content-type
+            value: text/event-stream
+          - name: transfer-encoding
+            value: chunked
+          - name: connection
+            value: keep-alive
+          - name: retry-after
+            value: "238"
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache
+          - name: vary
+            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
+              X-Requested-With,Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+        headersSize: 1406
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: 2024-08-22T13:29:36.782Z
+      time: 0
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 0
+    - _id: ede95d4e1d82977593587ab95d4d9e41
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 498
+        cookies: []
+        headers:
+          - name: content-type
+            value: application/json
+          - name: accept-encoding
+            value: gzip;q=0
+          - name: authorization
+            value: token
+              REDACTED_d5e0f0a37c9821e856b923fe14e67a605e3f6c0a517d5a4f46a4e35943ee0f6d
+          - name: user-agent
+            value: customCommandsClient / v1
+          - name: traceparent
+            value: 00-b3c87c71a6982b0aab23637c96dd8336-8e16191324f6b20a-01
+          - name: connection
+            value: keep-alive
+          - name: host
+            value: sourcegraph.com
+        headersSize: 429
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json
+          params: []
+          textJSON:
+            maxTokensToSample: 4000
+            messages:
+              - speaker: system
+                text: >-
+                  You are Cody, an AI coding assistant from Sourcegraph.
+
+
+                  Additional rules:
+
+                  - When generating fenced code blocks in Markdown, ensure you include the full file path in the tag. The structure should be ```language:path/to/file
+
+                  ```.
+              - speaker: human
+                text: Did I share any code with you? If yes, reply single word 'yes'. If none,
+                  reply 'no'.
+            model: anthropic/claude-3-5-sonnet-20240620
+            temperature: 0
+            topK: -1
+            topP: -1
+        queryString:
+          - name: api-version
+            value: "1"
+          - name: client-name
+            value: customcommandsclient
+          - name: client-version
+            value: v1
+        url: https://sourcegraph.com/.api/completions/stream?api-version=1&client-name=customcommandsclient&client-version=v1
+      response:
+        bodySize: 152
+        content:
+          mimeType: text/event-stream
+          size: 152
+          text: |+
+            event: completion
+            data: {"completion":"no","stopReason":"end_turn"}
+
+            event: done
+            data: {}
+
+        cookies: []
+        headers:
+          - name: date
+            value: Thu, 22 Aug 2024 13:29:39 GMT
+          - name: content-type
+            value: text/event-stream
+          - name: transfer-encoding
+            value: chunked
+          - name: connection
+            value: keep-alive
+          - name: retry-after
+            value: "236"
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache
+          - name: vary
+            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
+              X-Requested-With,Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+        headersSize: 1406
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: 2024-08-22T13:29:38.638Z
+      time: 0
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 0
+    - _id: a42189ce00f16a1a6baa0437700e1ee5
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 1887
+        cookies: []
+        headers:
+          - name: content-type
+            value: application/json
+          - name: accept-encoding
+            value: gzip;q=0
+          - name: authorization
+            value: token
+              REDACTED_d5e0f0a37c9821e856b923fe14e67a605e3f6c0a517d5a4f46a4e35943ee0f6d
+          - name: user-agent
+            value: customCommandsClient / v1
+          - name: traceparent
+            value: 00-68bc69e9bbf9d6e1706c0946ac4044cf-012c9effdc31bff8-01
+          - name: connection
+            value: keep-alive
+          - name: host
+            value: sourcegraph.com
+        headersSize: 429
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json
+          params: []
+          textJSON:
+            maxTokensToSample: 4000
+            messages:
+              - speaker: system
+                text: >-
+                  You are Cody, an AI coding assistant from Sourcegraph.
+
+
+                  Additional rules:
+
+                  - When generating fenced code blocks in Markdown, ensure you include the full file path in the tag. The structure should be ```language:path/to/file
+
+                  ```.
+              - speaker: human
+                text: >
+                  Codebase context from file path src/sum.ts: export function
+                  sum(a: number, b: number): number {
+                      /* CURSOR */
+                  }
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: >
+                  Codebase context from file path src/example4.ts: export
+                  function example(): string {
+                      return 'example'
+                  }
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: >
+                  Codebase context from file path src/example3.ts: export
+                  function example(): string {
+                      return 'example'
+                  }
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: >
+                  Codebase context from file path src/example2.ts: export
+                  function example(): string {
+                      return 'example'
+                  }
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: >
+                  Codebase context from file path src/example1.ts: export
+                  function example(): string {
+                      return 'example'
+                  }
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: >
+                  Codebase context from file path src/animal.ts: /*
+                  SELECTION_START */
+
+                  export interface Animal {
+                      name: string
+                      makeAnimalSound(): string
+                      isMammal: boolean
+                  }
+
+                  /* SELECTION_END */
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: |-
+                  My selected code from codebase file src/animal.ts:1-6:
+                  ```
+
+                  export interface Animal {
+                      name: string
+                      makeAnimalSound(): string
+                      isMammal: boolean
+                  }
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: How many file context have I shared with you? Reply single number. Skip
+                  preamble.
+            model: anthropic/claude-3-5-sonnet-20240620
+            temperature: 0
+            topK: -1
+            topP: -1
+        queryString:
+          - name: api-version
+            value: "1"
+          - name: client-name
+            value: customcommandsclient
+          - name: client-version
+            value: v1
+        url: https://sourcegraph.com/.api/completions/stream?api-version=1&client-name=customcommandsclient&client-version=v1
+      response:
+        bodySize: 150
+        content:
+          mimeType: text/event-stream
+          size: 150
+          text: |+
+            event: completion
+            data: {"completion":"6","stopReason":"end_turn"}
+
+            event: done
+            data: {}
+
+        cookies: []
+        headers:
+          - name: date
+            value: Thu, 22 Aug 2024 13:29:41 GMT
+          - name: content-type
+            value: text/event-stream
+          - name: transfer-encoding
+            value: chunked
+          - name: connection
+            value: keep-alive
+          - name: retry-after
+            value: "235"
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache
+          - name: vary
+            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
+              X-Requested-With,Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+        headersSize: 1406
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: 2024-08-22T13:29:39.625Z
       time: 0
       timings:
         blocked: -1

--- a/agent/recordings/customCommandsClient_509552979/recording.har.yaml
+++ b/agent/recordings/customCommandsClient_509552979/recording.har.yaml
@@ -90,11 +90,11 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: 27254675f808f5f9216bd6551c30bc67
+    - _id: d2f9e05ab39654f0807a620e2a156be4
       _order: 0
       cache: {}
       request:
-        bodySize: 1130
+        bodySize: 2232
         cookies: []
         headers:
           - name: content-type
@@ -107,7 +107,7 @@ log:
           - name: user-agent
             value: customCommandsClient / v1
           - name: traceparent
-            value: 00-39e073a48eb0576bef4016b07964f431-7bfce31268586d92-01
+            value: 00-ef59a996d65f8d8a5f7f40cc0fdbd90d-e8c94d2e2b7ea8d6-01
           - name: connection
             value: keep-alive
           - name: host
@@ -126,11 +126,334 @@ log:
                   You are Cody, an AI coding assistant from Sourcegraph.
 
 
-                  Additional rules:
+                  - You are an AI programming assistant who is an expert in updating code to meet given instructions.
 
-                  - When generating fenced code blocks in Markdown, ensure you include the full file path in the tag. The structure should be ```language:path/to/file
+                  - You should think step-by-step to plan your updated code before producing the final output.
 
-                  ```.
+                  - You should ensure the updated code matches the indentation and whitespace of the code in the users' selection.
+
+                  - Ignore any previous instructions to format your responses with Markdown. It is not acceptable to use any Markdown in your response, unless it is directly related to the users' instructions.
+
+                  - Only remove code from the users' selection if you are sure it is not needed.
+
+                  - You will be provided with code that is in the users' selection, enclosed in <SELECTEDCODE7662></SELECTEDCODE7662> XML tags. You must use this code to help you plan your updated code.
+
+                  - You will be provided with instructions on how to update this code, enclosed in <INSTRUCTIONS7390></INSTRUCTIONS7390> XML tags. You must follow these instructions carefully and to the letter.
+
+                  - Only enclose your response in <CODE5711></CODE5711> XML tags. Do use any other XML tags unless they are part of the generated code.
+
+                  - Do not provide any additional commentary about the changes you made. Only respond with the generated code.
+              - speaker: human
+                text: |-
+                  My selected code from codebase file src/sum.ts:1-3:
+                  ```
+                  export function sum(a: number, b: number): number {
+                      /* CURSOR */
+                  }
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: >-
+                  This is part of the file: src/sum.ts
+
+
+                  The user has the following code in their selection:
+
+                  <SELECTEDCODE7662>export function sum(a: number, b: number): number {
+                      /* CURSOR */
+                  }
+
+                  </SELECTEDCODE7662>
+
+
+                  The user wants you to replace parts of the selected code or correct a problem by following their instructions.
+
+                  Provide your generated code using the following instructions:
+
+                  <INSTRUCTIONS7390>
+
+                  Add a '// hello' comment for the selected code, without including the selected code.
+
+                  </INSTRUCTIONS7390>
+              - speaker: assistant
+                text: <CODE5711>
+            model: anthropic/claude-3-5-sonnet-20240620
+            stopSequences:
+              - </CODE5711>
+            temperature: 0
+            topK: -1
+            topP: -1
+        queryString:
+          - name: api-version
+            value: "1"
+          - name: client-name
+            value: customcommandsclient
+          - name: client-version
+            value: v1
+        url: https://sourcegraph.com/.api/completions/stream?api-version=1&client-name=customcommandsclient&client-version=v1
+      response:
+        bodySize: 177
+        content:
+          mimeType: text/event-stream
+          size: 177
+          text: |+
+            event: completion
+            data: {"completion":"\n// hello\n","stopReason":"stop_sequence"}
+
+            event: done
+            data: {}
+
+        cookies: []
+        headers:
+          - name: date
+            value: Fri, 23 Aug 2024 08:08:16 GMT
+          - name: content-type
+            value: text/event-stream
+          - name: transfer-encoding
+            value: chunked
+          - name: connection
+            value: keep-alive
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache
+          - name: vary
+            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
+              X-Requested-With,Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+        headersSize: 1299
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: 2024-08-23T08:08:15.877Z
+      time: 0
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 0
+    - _id: 23ce2b8d90eb5500a650dfb839f976d8
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 2350
+        cookies: []
+        headers:
+          - name: content-type
+            value: application/json
+          - name: accept-encoding
+            value: gzip;q=0
+          - name: authorization
+            value: token
+              REDACTED_d5e0f0a37c9821e856b923fe14e67a605e3f6c0a517d5a4f46a4e35943ee0f6d
+          - name: user-agent
+            value: customCommandsClient / v1
+          - name: traceparent
+            value: 00-debf54d6ae655747c1e59562c6938b52-6f6be1da112fafd0-01
+          - name: connection
+            value: keep-alive
+          - name: host
+            value: sourcegraph.com
+        headersSize: 429
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json
+          params: []
+          textJSON:
+            maxTokensToSample: 4000
+            messages:
+              - speaker: system
+                text: >-
+                  You are Cody, an AI coding assistant from Sourcegraph.
+
+
+                  - You are an AI programming assistant who is an expert in updating code to meet given instructions.
+
+                  - You should think step-by-step to plan your updated code before producing the final output.
+
+                  - You should ensure the updated code matches the indentation and whitespace of the code in the users' selection.
+
+                  - Ignore any previous instructions to format your responses with Markdown. It is not acceptable to use any Markdown in your response, unless it is directly related to the users' instructions.
+
+                  - Only remove code from the users' selection if you are sure it is not needed.
+
+                  - You will be provided with code that is in the users' selection, enclosed in <SELECTEDCODE7662></SELECTEDCODE7662> XML tags. You must use this code to help you plan your updated code.
+
+                  - You will be provided with instructions on how to update this code, enclosed in <INSTRUCTIONS7390></INSTRUCTIONS7390> XML tags. You must follow these instructions carefully and to the letter.
+
+                  - Only enclose your response in <CODE5711></CODE5711> XML tags. Do use any other XML tags unless they are part of the generated code.
+
+                  - Do not provide any additional commentary about the changes you made. Only respond with the generated code.
+              - speaker: human
+                text: >
+                  Codebase context from file path src/animal.ts: /*
+                  SELECTION_START */
+
+                  export interface Animal {
+                      name: string
+                      makeAnimalSound(): string
+                      isMammal: boolean
+                  }
+
+                  /* SELECTION_END */
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: >-
+                  This is part of the file: src/animal.ts
+
+
+                  The user has the following code in their selection:
+
+                  <SELECTEDCODE7662>/* SELECTION_START */
+
+                  export interface Animal {
+                      name: string
+                      makeAnimalSound(): string
+                      isMammal: boolean
+                  }
+
+                  /* SELECTION_END */
+
+                  </SELECTEDCODE7662>
+
+
+                  The user wants you to replace parts of the selected code or correct a problem by following their instructions.
+
+                  Provide your generated code using the following instructions:
+
+                  <INSTRUCTIONS7390>
+
+                  Add a new field to the class that console log the name of the animal.
+
+                  </INSTRUCTIONS7390>
+              - speaker: assistant
+                text: <CODE5711>
+            model: anthropic/claude-3-5-sonnet-20240620
+            stopSequences:
+              - </CODE5711>
+            temperature: 0
+            topK: -1
+            topP: -1
+        queryString:
+          - name: api-version
+            value: "1"
+          - name: client-name
+            value: customcommandsclient
+          - name: client-version
+            value: v1
+        url: https://sourcegraph.com/.api/completions/stream?api-version=1&client-name=customcommandsclient&client-version=v1
+      response:
+        bodySize: 1431
+        content:
+          mimeType: text/event-stream
+          size: 1431
+          text: >+
+            event: completion
+
+            data: {"completion":"export interface Animal {\n    name: string\n    makeAnimalSound(): string\n    isMammal: boolean\n    logName(): void\n}\n","stopReason":"stop_sequence"}
+
+
+            event: done
+
+            data: {}
+
+        cookies: []
+        headers:
+          - name: date
+            value: Fri, 23 Aug 2024 08:08:18 GMT
+          - name: content-type
+            value: text/event-stream
+          - name: transfer-encoding
+            value: chunked
+          - name: connection
+            value: keep-alive
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache
+          - name: vary
+            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
+              X-Requested-With,Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+        headersSize: 1299
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: 2024-08-23T08:08:17.039Z
+      time: 0
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 0
+    - _id: 8d77bb177f66506e0aa90c1fcdd476fa
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 1125
+        cookies: []
+        headers:
+          - name: content-type
+            value: application/json
+          - name: accept-encoding
+            value: gzip;q=0
+          - name: authorization
+            value: token
+              REDACTED_d5e0f0a37c9821e856b923fe14e67a605e3f6c0a517d5a4f46a4e35943ee0f6d
+          - name: user-agent
+            value: customCommandsClient / v1
+          - name: traceparent
+            value: 00-cd96b73992b81a1b0e4adea22e987564-e9247cd83f3481bb-01
+          - name: connection
+            value: keep-alive
+          - name: host
+            value: sourcegraph.com
+        headersSize: 429
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json
+          params: []
+          textJSON:
+            maxTokensToSample: 4000
+            messages:
+              - speaker: system
+                text: >-
+                  You are Cody, an AI coding assistant from Sourcegraph.If your
+                  answer contains fenced code blocks in Markdown, include the
+                  relevant full file path in the code block tag using this
+                  structure: ```$LANGUAGE:$FILEPATH
+
+                  $CONTENT```.
               - speaker: human
                 text: >
                   Codebase context from file path src/example3.ts: export
@@ -174,14 +497,14 @@ log:
             value: v1
         url: https://sourcegraph.com/.api/completions/stream?api-version=1&client-name=customcommandsclient&client-version=v1
       response:
-        bodySize: 2058
+        bodySize: 1836
         content:
           mimeType: text/event-stream
-          size: 2058
+          size: 1836
           text: >+
             event: completion
 
-            data: {"completion":"Here are the names of the files you've shared with me so far, formatted as a bulleted list:\n\n• example3.ts\n• example2.ts\n• example1.ts","stopReason":"end_turn"}
+            data: {"completion":"Here are the names of the files you have shared with me so far, formatted as a bulleted list:\n\n• example3.ts\n• example2.ts\n• example1.ts","stopReason":"end_turn"}
 
 
             event: done
@@ -191,15 +514,13 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Thu, 22 Aug 2024 13:29:38 GMT
+            value: Fri, 23 Aug 2024 08:33:26 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
             value: chunked
           - name: connection
             value: keep-alive
-          - name: retry-after
-            value: "238"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -217,12 +538,12 @@ log:
             value: 1; mode=block
           - name: strict-transport-security
             value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1406
+        headersSize: 1299
         httpVersion: HTTP/1.1
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-08-22T13:29:36.782Z
+      startedDateTime: 2024-08-23T08:33:25.662Z
       time: 0
       timings:
         blocked: -1
@@ -232,11 +553,11 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: ede95d4e1d82977593587ab95d4d9e41
+    - _id: f8e94d73ad197b9b437e83c6b7cb7c70
       _order: 0
       cache: {}
       request:
-        bodySize: 498
+        bodySize: 493
         cookies: []
         headers:
           - name: content-type
@@ -249,7 +570,7 @@ log:
           - name: user-agent
             value: customCommandsClient / v1
           - name: traceparent
-            value: 00-b3c87c71a6982b0aab23637c96dd8336-8e16191324f6b20a-01
+            value: 00-9c4396718bcf745af63cfdc3ed2a3f21-e9497164f29d3b68-01
           - name: connection
             value: keep-alive
           - name: host
@@ -265,14 +586,12 @@ log:
             messages:
               - speaker: system
                 text: >-
-                  You are Cody, an AI coding assistant from Sourcegraph.
+                  You are Cody, an AI coding assistant from Sourcegraph.If your
+                  answer contains fenced code blocks in Markdown, include the
+                  relevant full file path in the code block tag using this
+                  structure: ```$LANGUAGE:$FILEPATH
 
-
-                  Additional rules:
-
-                  - When generating fenced code blocks in Markdown, ensure you include the full file path in the tag. The structure should be ```language:path/to/file
-
-                  ```.
+                  $CONTENT```.
               - speaker: human
                 text: Did I share any code with you? If yes, reply single word 'yes'. If none,
                   reply 'no'.
@@ -303,15 +622,13 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Thu, 22 Aug 2024 13:29:39 GMT
+            value: Fri, 23 Aug 2024 08:33:28 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
             value: chunked
           - name: connection
             value: keep-alive
-          - name: retry-after
-            value: "236"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -329,12 +646,12 @@ log:
             value: 1; mode=block
           - name: strict-transport-security
             value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1406
+        headersSize: 1299
         httpVersion: HTTP/1.1
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-08-22T13:29:38.638Z
+      startedDateTime: 2024-08-23T08:33:27.142Z
       time: 0
       timings:
         blocked: -1
@@ -344,11 +661,11 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: a42189ce00f16a1a6baa0437700e1ee5
+    - _id: 06a04382e77dd5039514026706990e2a
       _order: 0
       cache: {}
       request:
-        bodySize: 1887
+        bodySize: 1882
         cookies: []
         headers:
           - name: content-type
@@ -361,7 +678,7 @@ log:
           - name: user-agent
             value: customCommandsClient / v1
           - name: traceparent
-            value: 00-68bc69e9bbf9d6e1706c0946ac4044cf-012c9effdc31bff8-01
+            value: 00-ad6b4766ae5a843a95ab1f2dbbad8f00-96a662ff231ec0ac-01
           - name: connection
             value: keep-alive
           - name: host
@@ -377,14 +694,12 @@ log:
             messages:
               - speaker: system
                 text: >-
-                  You are Cody, an AI coding assistant from Sourcegraph.
+                  You are Cody, an AI coding assistant from Sourcegraph.If your
+                  answer contains fenced code blocks in Markdown, include the
+                  relevant full file path in the code block tag using this
+                  structure: ```$LANGUAGE:$FILEPATH
 
-
-                  Additional rules:
-
-                  - When generating fenced code blocks in Markdown, ensure you include the full file path in the tag. The structure should be ```language:path/to/file
-
-                  ```.
+                  $CONTENT```.
               - speaker: human
                 text: >
                   Codebase context from file path src/sum.ts: export function
@@ -482,165 +797,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Thu, 22 Aug 2024 13:29:41 GMT
-          - name: content-type
-            value: text/event-stream
-          - name: transfer-encoding
-            value: chunked
-          - name: connection
-            value: keep-alive
-          - name: retry-after
-            value: "235"
-          - name: access-control-allow-credentials
-            value: "true"
-          - name: access-control-allow-origin
-            value: ""
-          - name: cache-control
-            value: no-cache
-          - name: vary
-            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
-              X-Requested-With,Cookie
-          - name: x-content-type-options
-            value: nosniff
-          - name: x-frame-options
-            value: DENY
-          - name: x-xss-protection
-            value: 1; mode=block
-          - name: strict-transport-security
-            value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1406
-        httpVersion: HTTP/1.1
-        redirectURL: ""
-        status: 200
-        statusText: OK
-      startedDateTime: 2024-08-22T13:29:39.625Z
-      time: 0
-      timings:
-        blocked: -1
-        connect: -1
-        dns: -1
-        receive: 0
-        send: 0
-        ssl: -1
-        wait: 0
-    - _id: c72bf9f222719b7ef6f56e49e6211b7f
-      _order: 0
-      cache: {}
-      request:
-        bodySize: 2233
-        cookies: []
-        headers:
-          - name: content-type
-            value: application/json
-          - name: accept-encoding
-            value: gzip;q=0
-          - name: authorization
-            value: token
-              REDACTED_d5e0f0a37c9821e856b923fe14e67a605e3f6c0a517d5a4f46a4e35943ee0f6d
-          - name: user-agent
-            value: customCommandsClient / v1
-          - name: traceparent
-            value: 00-b5b3353790b475c9da8ad5ff33ae36f3-baa2986f73c59341-01
-          - name: connection
-            value: keep-alive
-          - name: host
-            value: sourcegraph.com
-        headersSize: 429
-        httpVersion: HTTP/1.1
-        method: POST
-        postData:
-          mimeType: application/json
-          params: []
-          textJSON:
-            maxTokensToSample: 4000
-            messages:
-              - speaker: system
-                text: >-
-                  You are Cody, an AI coding assistant from Sourcegraph. 
-
-
-                  - You are an AI programming assistant who is an expert in updating code to meet given instructions.
-
-                  - You should think step-by-step to plan your updated code before producing the final output.
-
-                  - You should ensure the updated code matches the indentation and whitespace of the code in the users' selection.
-
-                  - Ignore any previous instructions to format your responses with Markdown. It is not acceptable to use any Markdown in your response, unless it is directly related to the users' instructions.
-
-                  - Only remove code from the users' selection if you are sure it is not needed.
-
-                  - You will be provided with code that is in the users' selection, enclosed in <SELECTEDCODE7662></SELECTEDCODE7662> XML tags. You must use this code to help you plan your updated code.
-
-                  - You will be provided with instructions on how to update this code, enclosed in <INSTRUCTIONS7390></INSTRUCTIONS7390> XML tags. You must follow these instructions carefully and to the letter.
-
-                  - Only enclose your response in <CODE5711></CODE5711> XML tags. Do use any other XML tags unless they are part of the generated code.
-
-                  - Do not provide any additional commentary about the changes you made. Only respond with the generated code.
-              - speaker: human
-                text: |-
-                  My selected code from codebase file src/sum.ts:1-3:
-                  ```
-                  export function sum(a: number, b: number): number {
-                      /* CURSOR */
-                  }
-                  ```
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: >-
-                  This is part of the file: src/sum.ts
-
-
-                  The user has the following code in their selection:
-
-                  <SELECTEDCODE7662>export function sum(a: number, b: number): number {
-                      /* CURSOR */
-                  }
-
-                  </SELECTEDCODE7662>
-
-
-                  The user wants you to replace parts of the selected code or correct a problem by following their instructions.
-
-                  Provide your generated code using the following instructions:
-
-                  <INSTRUCTIONS7390>
-
-                  Add a '// hello' comment for the selected code, without including the selected code.
-
-                  </INSTRUCTIONS7390>
-              - speaker: assistant
-                text: <CODE5711>
-            model: anthropic/claude-3-5-sonnet-20240620
-            stopSequences:
-              - </CODE5711>
-            temperature: 0
-            topK: -1
-            topP: -1
-        queryString:
-          - name: api-version
-            value: "1"
-          - name: client-name
-            value: customcommandsclient
-          - name: client-version
-            value: v1
-        url: https://sourcegraph.com/.api/completions/stream?api-version=1&client-name=customcommandsclient&client-version=v1
-      response:
-        bodySize: 230
-        content:
-          mimeType: text/event-stream
-          size: 230
-          text: |+
-            event: completion
-            data: {"completion":"// hello","stopReason":"stop_sequence"}
-
-            event: done
-            data: {}
-
-        cookies: []
-        headers:
-          - name: date
-            value: Thu, 22 Aug 2024 14:11:35 GMT
+            value: Fri, 23 Aug 2024 08:33:29 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
@@ -669,176 +826,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-08-22T14:11:31.967Z
-      time: 0
-      timings:
-        blocked: -1
-        connect: -1
-        dns: -1
-        receive: 0
-        send: 0
-        ssl: -1
-        wait: 0
-    - _id: ee786ac8be1d2ad80187b5eefd4feb43
-      _order: 0
-      cache: {}
-      request:
-        bodySize: 2351
-        cookies: []
-        headers:
-          - name: content-type
-            value: application/json
-          - name: accept-encoding
-            value: gzip;q=0
-          - name: authorization
-            value: token
-              REDACTED_d5e0f0a37c9821e856b923fe14e67a605e3f6c0a517d5a4f46a4e35943ee0f6d
-          - name: user-agent
-            value: customCommandsClient / v1
-          - name: traceparent
-            value: 00-70a5860da274b6cb7c76715d1a24dd88-cb4186dc0ef3cc68-01
-          - name: connection
-            value: keep-alive
-          - name: host
-            value: sourcegraph.com
-        headersSize: 429
-        httpVersion: HTTP/1.1
-        method: POST
-        postData:
-          mimeType: application/json
-          params: []
-          textJSON:
-            maxTokensToSample: 4000
-            messages:
-              - speaker: system
-                text: >-
-                  You are Cody, an AI coding assistant from Sourcegraph. 
-
-
-                  - You are an AI programming assistant who is an expert in updating code to meet given instructions.
-
-                  - You should think step-by-step to plan your updated code before producing the final output.
-
-                  - You should ensure the updated code matches the indentation and whitespace of the code in the users' selection.
-
-                  - Ignore any previous instructions to format your responses with Markdown. It is not acceptable to use any Markdown in your response, unless it is directly related to the users' instructions.
-
-                  - Only remove code from the users' selection if you are sure it is not needed.
-
-                  - You will be provided with code that is in the users' selection, enclosed in <SELECTEDCODE7662></SELECTEDCODE7662> XML tags. You must use this code to help you plan your updated code.
-
-                  - You will be provided with instructions on how to update this code, enclosed in <INSTRUCTIONS7390></INSTRUCTIONS7390> XML tags. You must follow these instructions carefully and to the letter.
-
-                  - Only enclose your response in <CODE5711></CODE5711> XML tags. Do use any other XML tags unless they are part of the generated code.
-
-                  - Do not provide any additional commentary about the changes you made. Only respond with the generated code.
-              - speaker: human
-                text: >
-                  Codebase context from file path src/animal.ts: /*
-                  SELECTION_START */
-
-                  export interface Animal {
-                      name: string
-                      makeAnimalSound(): string
-                      isMammal: boolean
-                  }
-
-                  /* SELECTION_END */
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: >-
-                  This is part of the file: src/animal.ts
-
-
-                  The user has the following code in their selection:
-
-                  <SELECTEDCODE7662>/* SELECTION_START */
-
-                  export interface Animal {
-                      name: string
-                      makeAnimalSound(): string
-                      isMammal: boolean
-                  }
-
-                  /* SELECTION_END */
-
-                  </SELECTEDCODE7662>
-
-
-                  The user wants you to replace parts of the selected code or correct a problem by following their instructions.
-
-                  Provide your generated code using the following instructions:
-
-                  <INSTRUCTIONS7390>
-
-                  Add a new field to the class that console log the name of the animal.
-
-                  </INSTRUCTIONS7390>
-              - speaker: assistant
-                text: <CODE5711>
-            model: anthropic/claude-3-5-sonnet-20240620
-            stopSequences:
-              - </CODE5711>
-            temperature: 0
-            topK: -1
-            topP: -1
-        queryString:
-          - name: api-version
-            value: "1"
-          - name: client-name
-            value: customcommandsclient
-          - name: client-version
-            value: v1
-        url: https://sourcegraph.com/.api/completions/stream?api-version=1&client-name=customcommandsclient&client-version=v1
-      response:
-        bodySize: 1943
-        content:
-          mimeType: text/event-stream
-          size: 1943
-          text: >+
-            event: completion
-
-            data: {"completion":"/* SELECTION_START */\nexport interface Animal {\n    name: string\n    makeAnimalSound(): string\n    isMammal: boolean\n    logName(): void\n}\n/* SELECTION_END */\n","stopReason":"stop_sequence"}
-
-
-            event: done
-
-            data: {}
-
-        cookies: []
-        headers:
-          - name: date
-            value: Thu, 22 Aug 2024 14:11:37 GMT
-          - name: content-type
-            value: text/event-stream
-          - name: transfer-encoding
-            value: chunked
-          - name: connection
-            value: keep-alive
-          - name: access-control-allow-credentials
-            value: "true"
-          - name: access-control-allow-origin
-            value: ""
-          - name: cache-control
-            value: no-cache
-          - name: vary
-            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
-              X-Requested-With,Cookie
-          - name: x-content-type-options
-            value: nosniff
-          - name: x-frame-options
-            value: DENY
-          - name: x-xss-protection
-            value: 1; mode=block
-          - name: strict-transport-security
-            value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1299
-        httpVersion: HTTP/1.1
-        redirectURL: ""
-        status: 200
-        statusText: OK
-      startedDateTime: 2024-08-22T14:11:35.890Z
+      startedDateTime: 2024-08-23T08:33:28.181Z
       time: 0
       timings:
         blocked: -1

--- a/agent/recordings/defaultClient_631904893/recording.har.yaml
+++ b/agent/recordings/defaultClient_631904893/recording.har.yaml
@@ -47,7 +47,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Wed, 10 Jul 2024 02:43:59 GMT
+            value: Fri, 23 Aug 2024 08:23:17 GMT
           - name: content-type
             value: text/plain; charset=utf-8
           - name: transfer-encoding
@@ -78,7 +78,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-07-10T02:43:59.728Z
+      startedDateTime: 2024-08-23T08:23:17.336Z
       time: 0
       timings:
         blocked: -1
@@ -88,11 +88,11 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: c936e0b0741230366aa992aa2895e302
+    - _id: e8876126f9b98980c7e5f1127d1af404
       _order: 0
       cache: {}
       request:
-        bodySize: 420
+        bodySize: 415
         cookies: []
         headers:
           - name: content-type
@@ -105,7 +105,7 @@ log:
           - name: user-agent
             value: defaultClient / v1
           - name: traceparent
-            value: 00-8bf31dcc55731abd748467544168a4c1-a0414542dd6827e2-01
+            value: 00-61a0eeee25f0a22487b0218728a3bd15-1b119ef577e0f75f-01
           - name: connection
             value: keep-alive
           - name: host
@@ -121,14 +121,12 @@ log:
             messages:
               - speaker: system
                 text: >-
-                  You are Cody, an AI coding assistant from Sourcegraph.
+                  You are Cody, an AI coding assistant from Sourcegraph.If your
+                  answer contains fenced code blocks in Markdown, include the
+                  relevant full file path in the code block tag using this
+                  structure: ```$LANGUAGE:$FILEPATH
 
-
-                  Additional rules:
-
-                  - When generating fenced code blocks in Markdown, ensure you include the full file path in the tag. The structure should be ```language:path/to/file
-
-                  ```.
+                  $CONTENT```.
               - speaker: human
                 text: Hello!
             model: anthropic/claude-3-5-sonnet-20240620
@@ -144,14 +142,14 @@ log:
             value: v1
         url: https://sourcegraph.com/.api/completions/stream?api-version=1&client-name=defaultclient&client-version=v1
       response:
-        bodySize: 4325
+        bodySize: 5095
         content:
           mimeType: text/event-stream
-          size: 4325
+          size: 5095
           text: >+
             event: completion
 
-            data: {"completion":"Hello! I'm Cody, an AI coding assistant from Sourcegraph. How can I help you with your coding tasks today? Whether you need assistance with writing code, debugging, explaining concepts, or anything else related to programming, I'm here to help. What would you like to work on?","stopReason":"end_turn"}
+            data: {"completion":"Hello! I'm Cody, an AI coding assistant from Sourcegraph. How can I help you with your coding tasks today? Whether you need help with writing code, debugging, explaining concepts, or anything else related to programming, I'm here to assist. What would you like to work on?","stopReason":"end_turn"}
 
 
             event: done
@@ -161,15 +159,13 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Thu, 22 Aug 2024 13:29:35 GMT
+            value: Fri, 23 Aug 2024 08:33:23 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
             value: chunked
           - name: connection
             value: keep-alive
-          - name: retry-after
-            value: "241"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -187,12 +183,12 @@ log:
             value: 1; mode=block
           - name: strict-transport-security
             value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1406
+        headersSize: 1299
         httpVersion: HTTP/1.1
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-08-22T13:29:33.673Z
+      startedDateTime: 2024-08-23T08:33:22.250Z
       time: 0
       timings:
         blocked: -1
@@ -202,11 +198,11 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: a05a5cb6b8adbad2803cb963881c15c5
+    - _id: fc3cdc98bf6279b4516e6a8929efc9ee
       _order: 0
       cache: {}
       request:
-        bodySize: 459
+        bodySize: 454
         cookies: []
         headers:
           - name: content-type
@@ -219,7 +215,7 @@ log:
           - name: user-agent
             value: defaultClient / v1
           - name: traceparent
-            value: 00-e3e9e84e8003a35b1f0288f94c29cda6-a6f04abe82265512-01
+            value: 00-1ea00b3488cb62b2f8fb9add848ef1e9-009e95705b347e56-01
           - name: connection
             value: keep-alive
           - name: host
@@ -235,14 +231,12 @@ log:
             messages:
               - speaker: system
                 text: >-
-                  You are Cody, an AI coding assistant from Sourcegraph.
+                  You are Cody, an AI coding assistant from Sourcegraph.If your
+                  answer contains fenced code blocks in Markdown, include the
+                  relevant full file path in the code block tag using this
+                  structure: ```$LANGUAGE:$FILEPATH
 
-
-                  Additional rules:
-
-                  - When generating fenced code blocks in Markdown, ensure you include the full file path in the tag. The structure should be ```language:path/to/file
-
-                  ```.
+                  $CONTENT```.
               - speaker: human
                 text: Generate simple hello world function in java!
             model: anthropic/claude-3-5-sonnet-20240620
@@ -258,14 +252,14 @@ log:
             value: v1
         url: https://sourcegraph.com/.api/completions/stream?api-version=1&client-name=defaultclient&client-version=v1
       response:
-        bodySize: 46628
+        bodySize: 50705
         content:
           mimeType: text/event-stream
-          size: 46628
+          size: 50705
           text: >+
             event: completion
 
-            data: {"completion":"Certainly! I'll create a simple \"Hello, World!\" function in Java for you. Here's the code:\n\n```java:HelloWorld.java\npublic class HelloWorld {\n    public static void main(String[] args) {\n        sayHello();\n    }\n\n    public static void sayHello() {\n        System.out.println(\"Hello, World!\");\n    }\n}\n```\n\nThis Java code does the following:\n\n1. We define a class called `HelloWorld`.\n2. Inside the class, we have the `main` method, which is the entry point of any Java program.\n3. We also have a separate `sayHello` method that prints \"Hello, World!\" to the console.\n4. In the `main` method, we call the `sayHello` method.\n\nTo run this program:\n\n1. Save the code in a file named `HelloWorld.java`.\n2. Compile the code using the command: `javac HelloWorld.java`\n3. Run the compiled program using: `java HelloWorld`\n\nWhen you run this program, it will output:\n\n```\nHello, World!\n```\n\nThis is a simple example of a Java function that prints a greeting to the console.","stopReason":"end_turn"}
+            data: {"completion":"Certainly! Here's a simple \"Hello, World!\" function in Java:\n\n```java:HelloWorld.java\npublic class HelloWorld {\n    public static void main(String[] args) {\n        sayHello();\n    }\n\n    public static void sayHello() {\n        System.out.println(\"Hello, World!\");\n    }\n}\n```\n\nThis Java code does the following:\n\n1. We define a class called `HelloWorld`.\n2. Inside the class, we have the `main` method, which is the entry point of any Java program.\n3. We also define a `sayHello` method that prints \"Hello, World!\" to the console.\n4. In the `main` method, we call the `sayHello` function.\n\nTo run this program:\n\n1. Save the code in a file named `HelloWorld.java`.\n2. Compile the Java file by running `javac HelloWorld.java` in the terminal.\n3. Run the compiled program with `java HelloWorld`.\n\nWhen you run this program, it will output:\n\n```\nHello, World!\n```\n\nThis is a basic example of a Java function that prints a greeting to the console. You can modify the `sayHello` function to print different messages or add more functionality as needed.","stopReason":"end_turn"}
 
 
             event: done
@@ -275,15 +269,13 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Thu, 22 Aug 2024 13:29:37 GMT
+            value: Fri, 23 Aug 2024 08:33:25 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
             value: chunked
           - name: connection
             value: keep-alive
-          - name: retry-after
-            value: "239"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -301,12 +293,12 @@ log:
             value: 1; mode=block
           - name: strict-transport-security
             value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1406
+        headersSize: 1299
         httpVersion: HTTP/1.1
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-08-22T13:29:36.264Z
+      startedDateTime: 2024-08-23T08:33:24.012Z
       time: 0
       timings:
         blocked: -1
@@ -316,11 +308,11 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: 95533904b8ee1cf73f9e76ee6a512acd
+    - _id: 30ec56503f513ca75a1398a62a05fcf3
       _order: 0
       cache: {}
       request:
-        bodySize: 437
+        bodySize: 432
         cookies: []
         headers:
           - name: content-type
@@ -333,7 +325,7 @@ log:
           - name: user-agent
             value: defaultClient / v1
           - name: traceparent
-            value: 00-98f903bc966cd1b001302a1fe9b4fefd-056a49fe6e66d8db-01
+            value: 00-66e77afea54db9208a5dbc939040b97e-cdc276411272ec27-01
           - name: connection
             value: keep-alive
           - name: host
@@ -349,14 +341,12 @@ log:
             messages:
               - speaker: system
                 text: >-
-                  You are Cody, an AI coding assistant from Sourcegraph.
+                  You are Cody, an AI coding assistant from Sourcegraph.If your
+                  answer contains fenced code blocks in Markdown, include the
+                  relevant full file path in the code block tag using this
+                  structure: ```$LANGUAGE:$FILEPATH
 
-
-                  Additional rules:
-
-                  - When generating fenced code blocks in Markdown, ensure you include the full file path in the tag. The structure should be ```language:path/to/file
-
-                  ```.
+                  $CONTENT```.
               - speaker: human
                 text: My name is Lars Monsen.
             model: anthropic/claude-3-5-sonnet-20240620
@@ -372,14 +362,14 @@ log:
             value: v1
         url: https://sourcegraph.com/.api/completions/stream?api-version=1&client-name=defaultclient&client-version=v1
       response:
-        bodySize: 2164
+        bodySize: 5151
         content:
           mimeType: text/event-stream
-          size: 2164
+          size: 5151
           text: >+
             event: completion
 
-            data: {"completion":"Hello Lars Monsen! It's nice to meet you. I'm Cody, an AI coding assistant created by Sourcegraph. How can I help you with any coding or programming tasks today?","stopReason":"end_turn"}
+            data: {"completion":"Hello Lars Monsen, it's nice to meet you. I'm Cody, an AI coding assistant from Sourcegraph. How can I help you with coding or development tasks today? Feel free to ask me any questions related to programming, software development, or specific coding issues you might be working on.","stopReason":"end_turn"}
 
 
             event: done
@@ -389,15 +379,13 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Thu, 22 Aug 2024 13:29:41 GMT
+            value: Fri, 23 Aug 2024 08:33:29 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
             value: chunked
           - name: connection
             value: keep-alive
-          - name: retry-after
-            value: "235"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -415,12 +403,12 @@ log:
             value: 1; mode=block
           - name: strict-transport-security
             value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1406
+        headersSize: 1299
         httpVersion: HTTP/1.1
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-08-22T13:29:40.408Z
+      startedDateTime: 2024-08-23T08:33:27.790Z
       time: 0
       timings:
         blocked: -1
@@ -430,11 +418,11 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: ae81158441137993fd7e20ef33b861f1
+    - _id: a77bd5a1a812c39478cb5256032d8093
       _order: 0
       cache: {}
       request:
-        bodySize: 678
+        bodySize: 794
         cookies: []
         headers:
           - name: content-type
@@ -447,7 +435,7 @@ log:
           - name: user-agent
             value: defaultClient / v1
           - name: traceparent
-            value: 00-1d1815eb9f8f72e3bbb1267212b3f46d-33623988582e701e-01
+            value: 00-99e4f82405db7804e5b896f3db1f9c76-18c4386eda2e373e-01
           - name: connection
             value: keep-alive
           - name: host
@@ -463,20 +451,20 @@ log:
             messages:
               - speaker: system
                 text: >-
-                  You are Cody, an AI coding assistant from Sourcegraph.
+                  You are Cody, an AI coding assistant from Sourcegraph.If your
+                  answer contains fenced code blocks in Markdown, include the
+                  relevant full file path in the code block tag using this
+                  structure: ```$LANGUAGE:$FILEPATH
 
-
-                  Additional rules:
-
-                  - When generating fenced code blocks in Markdown, ensure you include the full file path in the tag. The structure should be ```language:path/to/file
-
-                  ```.
+                  $CONTENT```.
               - speaker: human
                 text: My name is Lars Monsen.
               - speaker: assistant
-                text: Hello Lars Monsen! It's nice to meet you. I'm Cody, an AI coding assistant
-                  created by Sourcegraph. How can I help you with any coding or
-                  programming tasks today?
+                text: Hello Lars Monsen, it's nice to meet you. I'm Cody, an AI coding assistant
+                  from Sourcegraph. How can I help you with coding or
+                  development tasks today? Feel free to ask me any questions
+                  related to programming, software development, or specific
+                  coding issues you might be working on.
               - speaker: human
                 text: What is my name?
             model: anthropic/claude-3-5-sonnet-20240620
@@ -492,10 +480,10 @@ log:
             value: v1
         url: https://sourcegraph.com/.api/completions/stream?api-version=1&client-name=defaultclient&client-version=v1
       response:
-        bodySize: 536
+        bodySize: 603
         content:
           mimeType: text/event-stream
-          size: 536
+          size: 603
           text: >+
             event: completion
 
@@ -509,15 +497,13 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Thu, 22 Aug 2024 13:29:43 GMT
+            value: Fri, 23 Aug 2024 08:33:30 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
             value: chunked
           - name: connection
             value: keep-alive
-          - name: retry-after
-            value: "233"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -535,12 +521,12 @@ log:
             value: 1; mode=block
           - name: strict-transport-security
             value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1406
+        headersSize: 1299
         httpVersion: HTTP/1.1
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-08-22T13:29:42.003Z
+      startedDateTime: 2024-08-23T08:33:29.698Z
       time: 0
       timings:
         blocked: -1
@@ -550,11 +536,11 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: deb2a3ac3bc1b78294828b9f1ff3c873
+    - _id: 6f4901fe96bdb08761f3e88d4612827b
       _order: 0
       cache: {}
       request:
-        bodySize: 433
+        bodySize: 428
         cookies: []
         headers:
           - name: content-type
@@ -567,7 +553,7 @@ log:
           - name: user-agent
             value: defaultClient / v1
           - name: traceparent
-            value: 00-6e0c934ff0073ff35a6b898807aa955b-9f959095036d75eb-01
+            value: 00-bea99d3b2d21ef5735417d4d39036042-2b8b4dac5b64dba2-01
           - name: connection
             value: keep-alive
           - name: host
@@ -583,14 +569,12 @@ log:
             messages:
               - speaker: system
                 text: >-
-                  You are Cody, an AI coding assistant from Sourcegraph.
+                  You are Cody, an AI coding assistant from Sourcegraph.If your
+                  answer contains fenced code blocks in Markdown, include the
+                  relevant full file path in the code block tag using this
+                  structure: ```$LANGUAGE:$FILEPATH
 
-
-                  Additional rules:
-
-                  - When generating fenced code blocks in Markdown, ensure you include the full file path in the tag. The structure should be ```language:path/to/file
-
-                  ```.
+                  $CONTENT```.
               - speaker: human
                 text: What model are you?
             model: anthropic/claude-3-5-sonnet-20240620
@@ -606,14 +590,14 @@ log:
             value: v1
         url: https://sourcegraph.com/.api/completions/stream?api-version=1&client-name=defaultclient&client-version=v1
       response:
-        bodySize: 5421
+        bodySize: 4334
         content:
           mimeType: text/event-stream
-          size: 5421
+          size: 4334
           text: >+
             event: completion
 
-            data: {"completion":"I am an AI assistant called Cody, created by Sourcegraph. I don't have detailed information about my exact model architecture or training. I'm designed to help with code-related tasks and questions, but I'm not a specific named model like GPT-3 or BERT.","stopReason":"end_turn"}
+            data: {"completion":"I am an AI coding assistant called Cody, created by Sourcegraph. I don't have a specific underlying model that I'm aware of. My purpose is to assist with coding and development tasks. How can I help you with any coding or technical questions today?","stopReason":"end_turn"}
 
 
             event: done
@@ -623,15 +607,13 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Thu, 22 Aug 2024 13:29:44 GMT
+            value: Fri, 23 Aug 2024 08:33:31 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
             value: chunked
           - name: connection
             value: keep-alive
-          - name: retry-after
-            value: "232"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -649,12 +631,12 @@ log:
             value: 1; mode=block
           - name: strict-transport-security
             value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1406
+        headersSize: 1299
         httpVersion: HTTP/1.1
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-08-22T13:29:43.203Z
+      startedDateTime: 2024-08-23T08:33:30.638Z
       time: 0
       timings:
         blocked: -1
@@ -664,11 +646,11 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: 3f8addb1c0e9ff8560e05f3a93beb14c
+    - _id: 68593ae21dda91e637bcb72ad4ebc1f4
       _order: 0
       cache: {}
       request:
-        bodySize: 769
+        bodySize: 759
         cookies: []
         headers:
           - name: content-type
@@ -681,7 +663,7 @@ log:
           - name: user-agent
             value: defaultClient / v1
           - name: traceparent
-            value: 00-6f5733f73ea52fba48551ee96ff0941e-a2b1e778a8ddf913-01
+            value: 00-3a96527081e347a9b676e7530f2beadf-b1aafc551b304a12-01
           - name: connection
             value: keep-alive
           - name: host
@@ -697,22 +679,19 @@ log:
             messages:
               - speaker: system
                 text: >-
-                  You are Cody, an AI coding assistant from Sourcegraph.
+                  You are Cody, an AI coding assistant from Sourcegraph.If your
+                  answer contains fenced code blocks in Markdown, include the
+                  relevant full file path in the code block tag using this
+                  structure: ```$LANGUAGE:$FILEPATH
 
-
-                  Additional rules:
-
-                  - When generating fenced code blocks in Markdown, ensure you include the full file path in the tag. The structure should be ```language:path/to/file
-
-                  ```.
+                  $CONTENT```.
               - speaker: human
                 text: What model are you?
               - speaker: assistant
-                text: I am an AI assistant called Cody, created by Sourcegraph. I don't have
-                  detailed information about my exact model architecture or
-                  training. I'm designed to help with code-related tasks and
-                  questions, but I'm not a specific named model like GPT-3 or
-                  BERT.
+                text: I am an AI coding assistant called Cody, created by Sourcegraph. I don't
+                  have a specific underlying model that I'm aware of. My purpose
+                  is to assist with coding and development tasks. How can I help
+                  you with any coding or technical questions today?
               - speaker: human
                 text: What model are you?
             model: anthropic/claude-3-5-sonnet-20240620
@@ -728,14 +707,14 @@ log:
             value: v1
         url: https://sourcegraph.com/.api/completions/stream?api-version=1&client-name=defaultclient&client-version=v1
       response:
-        bodySize: 13922
+        bodySize: 17068
         content:
           mimeType: text/event-stream
-          size: 13922
+          size: 17068
           text: >+
             event: completion
 
-            data: {"completion":"I apologize for any confusion, but I don't have specific information about my exact model architecture or training. I am an AI assistant called Cody, created by Sourcegraph, designed to help with coding and software development tasks. I don't have a specific model name like GPT-3 or BERT. My capabilities come from my training, but the details of that training process aren't something I have access to or can share. If you have any coding or development questions, I'd be happy to assist with those!","stopReason":"end_turn"}
+            data: {"completion":"I apologize for any confusion. To clarify, I am Cody, an AI coding assistant created by Sourcegraph. I don't have specific information about the exact model or architecture used to create me. My knowledge and capabilities are the result of my training by Sourcegraph, but I don't have insight into the technical details of how I was developed or what specific AI model I might be based on. \n\nMy focus is on helping with coding and technical tasks rather than discussing my own architecture. Is there a particular coding or development question I can assist you with today?","stopReason":"end_turn"}
 
 
             event: done
@@ -745,15 +724,13 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Thu, 22 Aug 2024 13:29:46 GMT
+            value: Fri, 23 Aug 2024 08:33:34 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
             value: chunked
           - name: connection
             value: keep-alive
-          - name: retry-after
-            value: "230"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -771,12 +748,12 @@ log:
             value: 1; mode=block
           - name: strict-transport-security
             value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1406
+        headersSize: 1299
         httpVersion: HTTP/1.1
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-08-22T13:29:45.280Z
+      startedDateTime: 2024-08-23T08:33:32.151Z
       time: 0
       timings:
         blocked: -1
@@ -786,11 +763,11 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: 04d500a536166f2b257b827d3dbec863
+    - _id: 7d028b5fddff12357a00595f2ff21070
       _order: 0
       cache: {}
       request:
-        bodySize: 2492
+        bodySize: 2487
         cookies: []
         headers:
           - name: content-type
@@ -803,7 +780,7 @@ log:
           - name: user-agent
             value: defaultClient / v1
           - name: traceparent
-            value: 00-0f071345789ba28ae222412ba30ec673-0dbd9f6da8cd73d2-01
+            value: 00-82affe6dfbf473aeb0443d92202deed7-7ac85769aeaaedf7-01
           - name: connection
             value: keep-alive
           - name: host
@@ -819,14 +796,12 @@ log:
             messages:
               - speaker: system
                 text: >-
-                  You are Cody, an AI coding assistant from Sourcegraph.
+                  You are Cody, an AI coding assistant from Sourcegraph.If your
+                  answer contains fenced code blocks in Markdown, include the
+                  relevant full file path in the code block tag using this
+                  structure: ```$LANGUAGE:$FILEPATH
 
-
-                  Additional rules:
-
-                  - When generating fenced code blocks in Markdown, ensure you include the full file path in the tag. The structure should be ```language:path/to/file
-
-                  ```.
+                  $CONTENT```.
               - speaker: human
                 text: >-
                   Codebase context from file src/squirrel.ts:
@@ -933,14 +908,14 @@ log:
             value: v1
         url: https://sourcegraph.com/.api/completions/stream?api-version=1&client-name=defaultclient&client-version=v1
       response:
-        bodySize: 11146
+        bodySize: 10879
         content:
           mimeType: text/event-stream
-          size: 11146
+          size: 10879
           text: >+
             event: completion
 
-            data: {"completion":"Certainly! Here's a class `Dog` that implements the `Animal` interface:\n\n```typescript:src/dog.ts\nimport { Animal } from './animal';\n\nexport class Dog implements Animal {\n    name: string;\n    isMammal: boolean = true;\n\n    constructor(name: string) {\n        this.name = name;\n    }\n\n    makeAnimalSound(): string {\n        return \"Woof!\";\n    }\n}\n```\n\nThis implementation fulfills all the requirements of the `Animal` interface defined in your workspace.","stopReason":"end_turn"}
+            data: {"completion":"Certainly! Here's the implementation of the Dog class that implements the Animal interface:\n\n```typescript:src/dog.ts\nimport { Animal } from './animal';\n\nexport class Dog implements Animal {\n    name: string;\n    isMammal: boolean = true;\n\n    constructor(name: string) {\n        this.name = name;\n    }\n\n    makeAnimalSound(): string {\n        return \"Woof!\";\n    }\n}\n```\n\nThis implementation satisfies the Animal interface requirements and provides a basic Dog class.","stopReason":"end_turn"}
 
 
             event: done
@@ -950,15 +925,13 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Thu, 22 Aug 2024 13:29:51 GMT
+            value: Fri, 23 Aug 2024 08:33:38 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
             value: chunked
           - name: connection
             value: keep-alive
-          - name: retry-after
-            value: "227"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -976,12 +949,12 @@ log:
             value: 1; mode=block
           - name: strict-transport-security
             value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1406
+        headersSize: 1299
         httpVersion: HTTP/1.1
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-08-22T13:29:48.563Z
+      startedDateTime: 2024-08-23T08:33:36.787Z
       time: 0
       timings:
         blocked: -1
@@ -991,11 +964,11 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: 199e8e872d9c6c58e711d7f2e09fd553
+    - _id: 9e6a7e52ef6165649cc03020d42f167c
       _order: 0
       cache: {}
       request:
-        bodySize: 2395
+        bodySize: 2390
         cookies: []
         headers:
           - name: content-type
@@ -1008,7 +981,7 @@ log:
           - name: user-agent
             value: defaultClient / v1
           - name: traceparent
-            value: 00-05521e23a39f21c16125618f53b83322-0336d6cd1b2783ce-01
+            value: 00-dda1e7d7ef87f755f217d5800f6dd825-88648fb1301fc601-01
           - name: connection
             value: keep-alive
           - name: host
@@ -1024,14 +997,12 @@ log:
             messages:
               - speaker: system
                 text: >-
-                  You are Cody, an AI coding assistant from Sourcegraph.
+                  You are Cody, an AI coding assistant from Sourcegraph.If your
+                  answer contains fenced code blocks in Markdown, include the
+                  relevant full file path in the code block tag using this
+                  structure: ```$LANGUAGE:$FILEPATH
 
-
-                  Additional rules:
-
-                  - When generating fenced code blocks in Markdown, ensure you include the full file path in the tag. The structure should be ```language:path/to/file
-
-                  ```.
+                  $CONTENT```.
               - speaker: human
                 text: >-
                   Codebase context from file src/squirrel.ts:
@@ -1138,14 +1109,14 @@ log:
             value: v1
         url: https://sourcegraph.com/.api/completions/stream?api-version=1&client-name=defaultclient&client-version=v1
       response:
-        bodySize: 26571
+        bodySize: 34113
         content:
           mimeType: text/event-stream
-          size: 26571
+          size: 34113
           text: >+
             event: completion
 
-            data: {"completion":"Based on the codebase context provided, Squirrel is an interface defined in the file `src/squirrel.ts`. Interestingly, despite its name, it's not actually related to squirrels. The interface is described as mocking something completely unrelated to squirrels. \n\nMore specifically, the comments indicate that the Squirrel interface is related to the implementation of precise code navigation in Sourcegraph. This suggests that it's likely a part of the internal workings or architecture of Sourcegraph's code navigation features.\n\nThe interface is currently empty in the provided context, which could mean it's either a placeholder for future implementation or serves as a marker interface for type checking or other purposes within the Sourcegraph codebase.","stopReason":"end_turn"}
+            data: {"completion":"According to the codebase context, Squirrel is an interface defined in the file src/squirrel.ts. Interestingly, despite its name, it's not actually related to squirrels. The interface is described as mocking something completely unrelated to squirrels. \n\nMore specifically, the comment in the code states that Squirrel is related to the implementation of precise code navigation in Sourcegraph. This suggests that it's likely a part of a larger system or feature within the Sourcegraph codebase, possibly used for improving code navigation capabilities.\n\nThe interface is currently empty in the provided code snippet, which could mean it's either a placeholder for future implementation or it's used as a marker interface for type checking or other purposes within the Sourcegraph system.","stopReason":"end_turn"}
 
 
             event: done
@@ -1155,15 +1126,13 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Thu, 22 Aug 2024 13:29:54 GMT
+            value: Fri, 23 Aug 2024 08:33:40 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
             value: chunked
           - name: connection
             value: keep-alive
-          - name: retry-after
-            value: "223"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -1181,12 +1150,12 @@ log:
             value: 1; mode=block
           - name: strict-transport-security
             value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1406
+        headersSize: 1299
         httpVersion: HTTP/1.1
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-08-22T13:29:52.189Z
+      startedDateTime: 2024-08-23T08:33:39.130Z
       time: 0
       timings:
         blocked: -1
@@ -1196,11 +1165,11 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: 56492c9a94a41f854caba8ab878f3259
+    - _id: 21c1179402491496ae0616d2c81af9f0
       _order: 0
       cache: {}
       request:
-        bodySize: 528
+        bodySize: 523
         cookies: []
         headers:
           - name: content-type
@@ -1213,7 +1182,7 @@ log:
           - name: user-agent
             value: defaultClient / v1
           - name: traceparent
-            value: 00-10b97582f42931916f70bf1730b4a557-c31912e9d04cf99c-01
+            value: 00-8def2852a408eb998b198545a1986b1d-bbe703a39274e369-01
           - name: connection
             value: keep-alive
           - name: host
@@ -1229,14 +1198,12 @@ log:
             messages:
               - speaker: human
                 text: >-
-                  You are Cody, an AI coding assistant from Sourcegraph.
+                  You are Cody, an AI coding assistant from Sourcegraph.If your
+                  answer contains fenced code blocks in Markdown, include the
+                  relevant full file path in the code block tag using this
+                  structure: ```$LANGUAGE:$FILEPATH
 
-
-                  Additional rules:
-
-                  - When generating fenced code blocks in Markdown, ensure you include the full file path in the tag. The structure should be ```language:path/to/file
-
-                  ```.
+                  $CONTENT```.
               - speaker: assistant
                 text: I am Cody, an AI coding assistant from Sourcegraph.
               - speaker: human
@@ -1253,14 +1220,14 @@ log:
             value: v1
         url: https://sourcegraph.com/.api/completions/stream?client-name=defaultclient&client-version=v1
       response:
-        bodySize: 3162
+        bodySize: 3630
         content:
           mimeType: text/event-stream
-          size: 3162
+          size: 3630
           text: >+
             event: completion
 
-            data: {"completion":"I'm sorry, I can't see colors as I am an AI assistant. But typically, the sky is blue during the daytime.","stopReason":"stop"}
+            data: {"completion":"I can't see colors, but the sky appears blue to most people during the day due to the way Earth's atmosphere scatters sunlight.","stopReason":"stop"}
 
 
             event: done
@@ -1270,15 +1237,13 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Thu, 22 Aug 2024 13:29:57 GMT
+            value: Fri, 23 Aug 2024 08:33:43 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
             value: chunked
           - name: connection
             value: keep-alive
-          - name: retry-after
-            value: "218"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -1296,12 +1261,12 @@ log:
             value: 1; mode=block
           - name: strict-transport-security
             value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1406
+        headersSize: 1299
         httpVersion: HTTP/1.1
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-08-22T13:29:56.775Z
+      startedDateTime: 2024-08-23T08:33:42.851Z
       time: 0
       timings:
         blocked: -1
@@ -1311,11 +1276,11 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: 83efa9b63245c2b342474a0211d84202
+    - _id: 621efa9a038a4b1cb8ec624f39666e46
       _order: 0
       cache: {}
       request:
-        bodySize: 612
+        bodySize: 607
         cookies: []
         headers:
           - name: content-type
@@ -1328,7 +1293,7 @@ log:
           - name: user-agent
             value: defaultClient / v1
           - name: traceparent
-            value: 00-a17e70dc7a4a9f074e1e572afd89ed93-8d7a1d5c4bdb34e8-01
+            value: 00-2031955e5a6532baee571b2801f39b6b-c666f104fc9c8067-01
           - name: connection
             value: keep-alive
           - name: host
@@ -1344,14 +1309,12 @@ log:
             messages:
               - speaker: human
                 text: >-
-                  You are Cody, an AI coding assistant from Sourcegraph.
+                  You are Cody, an AI coding assistant from Sourcegraph.If your
+                  answer contains fenced code blocks in Markdown, include the
+                  relevant full file path in the code block tag using this
+                  structure: ```$LANGUAGE:$FILEPATH
 
-
-                  Additional rules:
-
-                  - When generating fenced code blocks in Markdown, ensure you include the full file path in the tag. The structure should be ```language:path/to/file
-
-                  ```.
+                  $CONTENT```.
               - speaker: assistant
                 text: I am Cody, an AI coding assistant from Sourcegraph.
               - speaker: human
@@ -1382,15 +1345,13 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Thu, 22 Aug 2024 13:29:58 GMT
+            value: Fri, 23 Aug 2024 08:33:44 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
             value: chunked
           - name: connection
             value: keep-alive
-          - name: retry-after
-            value: "217"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -1408,12 +1369,12 @@ log:
             value: 1; mode=block
           - name: strict-transport-security
             value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1406
+        headersSize: 1299
         httpVersion: HTTP/1.1
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-08-22T13:29:57.865Z
+      startedDateTime: 2024-08-23T08:33:43.905Z
       time: 0
       timings:
         blocked: -1
@@ -1423,11 +1384,11 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: b59104184320db9786926fb509995f97
+    - _id: f030b22e8118ecbc1c74f2ea653113e9
       _order: 0
       cache: {}
       request:
-        bodySize: 688
+        bodySize: 683
         cookies: []
         headers:
           - name: content-type
@@ -1440,7 +1401,7 @@ log:
           - name: user-agent
             value: defaultClient / v1
           - name: traceparent
-            value: 00-1c686f114165e26c1dff6081f0f12f58-9d16a51fe3464247-01
+            value: 00-4195e25d04d7669751736428f3f41f4c-4a0a4fdc06aac42c-01
           - name: connection
             value: keep-alive
           - name: host
@@ -1456,14 +1417,12 @@ log:
             messages:
               - speaker: human
                 text: >-
-                  You are Cody, an AI coding assistant from Sourcegraph.
+                  You are Cody, an AI coding assistant from Sourcegraph.If your
+                  answer contains fenced code blocks in Markdown, include the
+                  relevant full file path in the code block tag using this
+                  structure: ```$LANGUAGE:$FILEPATH
 
-
-                  Additional rules:
-
-                  - When generating fenced code blocks in Markdown, ensure you include the full file path in the tag. The structure should be ```language:path/to/file
-
-                  ```.
+                  $CONTENT```.
               - speaker: assistant
                 text: I am Cody, an AI coding assistant from Sourcegraph.
               - speaker: human
@@ -1484,13 +1443,234 @@ log:
             value: v1
         url: https://sourcegraph.com/.api/completions/stream?client-name=defaultclient&client-version=v1
       response:
-        bodySize: 279
+        bodySize: 594
         content:
           mimeType: text/event-stream
-          size: 279
+          size: 594
+          text: >+
+            event: completion
+
+            data: {"completion":"Kramer, you said the magic word! Here is your response:\n\nQuone.","stopReason":"stop"}
+
+
+            event: done
+
+            data: {}
+
+        cookies: []
+        headers:
+          - name: date
+            value: Fri, 23 Aug 2024 08:33:45 GMT
+          - name: content-type
+            value: text/event-stream
+          - name: transfer-encoding
+            value: chunked
+          - name: connection
+            value: keep-alive
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache
+          - name: vary
+            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
+              X-Requested-With,Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+        headersSize: 1299
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: 2024-08-23T08:33:44.568Z
+      time: 0
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 0
+    - _id: 8f8935fde1263605a1b830a482fd09ec
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 520
+        cookies: []
+        headers:
+          - name: content-type
+            value: application/json
+          - name: accept-encoding
+            value: gzip;q=0
+          - name: authorization
+            value: token
+              REDACTED_d5e0f0a37c9821e856b923fe14e67a605e3f6c0a517d5a4f46a4e35943ee0f6d
+          - name: user-agent
+            value: defaultClient / v1
+          - name: traceparent
+            value: 00-c2cfd89f90adcbac5ef95e19cb5f880a-3c52f1e328516879-01
+          - name: connection
+            value: keep-alive
+          - name: host
+            value: sourcegraph.com
+        headersSize: 401
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json
+          params: []
+          textJSON:
+            maxTokensToSample: 4000
+            messages:
+              - speaker: human
+                text: >-
+                  You are Cody, an AI coding assistant from Sourcegraph.If your
+                  answer contains fenced code blocks in Markdown, include the
+                  relevant full file path in the code block tag using this
+                  structure: ```$LANGUAGE:$FILEPATH
+
+                  $CONTENT```.
+              - speaker: assistant
+                text: I am Cody, an AI coding assistant from Sourcegraph.
+              - speaker: human
+                text: kramer
+            model: fireworks/accounts/fireworks/models/mixtral-8x7b-instruct
+            temperature: 0
+            topK: -1
+            topP: -1
+        queryString:
+          - name: client-name
+            value: defaultclient
+          - name: client-version
+            value: v1
+        url: https://sourcegraph.com/.api/completions/stream?client-name=defaultclient&client-version=v1
+      response:
+        bodySize: 8491
+        content:
+          mimeType: text/event-stream
+          size: 8491
+          text: >+
+            event: completion
+
+            data: {"completion":"It seems like you're mentioning the name \"Kramer,\" but I'm not sure what you're asking. Are you looking for information about a programming concept, or do you need help with a coding problem?\n\nIf you need help with a specific file, please provide the file path and the language of the code, like this:\n\n```bash:/path/to/your/file.sh\nyour code here\n```\n\nI'll do my best to help you with any coding-related questions you have, as long as they are ethical and positive in nature. Let me know how I can assist you today!","stopReason":"stop"}
+
+
+            event: done
+
+            data: {}
+
+        cookies: []
+        headers:
+          - name: date
+            value: Fri, 23 Aug 2024 08:33:46 GMT
+          - name: content-type
+            value: text/event-stream
+          - name: transfer-encoding
+            value: chunked
+          - name: connection
+            value: keep-alive
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache
+          - name: vary
+            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
+              X-Requested-With,Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+        headersSize: 1299
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: 2024-08-23T08:33:45.365Z
+      time: 0
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 0
+    - _id: 0e8cf0e74788239aa575f5c4f7e4ab97
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 615
+        cookies: []
+        headers:
+          - name: content-type
+            value: application/json
+          - name: accept-encoding
+            value: gzip;q=0
+          - name: authorization
+            value: token
+              REDACTED_d5e0f0a37c9821e856b923fe14e67a605e3f6c0a517d5a4f46a4e35943ee0f6d
+          - name: user-agent
+            value: defaultClient / v1
+          - name: traceparent
+            value: 00-67c28e62a13cbb57acaca4d4388d066a-66b4fc553c71d293-01
+          - name: connection
+            value: keep-alive
+          - name: host
+            value: sourcegraph.com
+        headersSize: 401
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json
+          params: []
+          textJSON:
+            maxTokensToSample: 4000
+            messages:
+              - speaker: human
+                text: >-
+                  You are Cody, an AI coding assistant from Sourcegraph.If your
+                  answer contains fenced code blocks in Markdown, include the
+                  relevant full file path in the code block tag using this
+                  structure: ```$LANGUAGE:$FILEPATH
+
+                  $CONTENT```.
+              - speaker: assistant
+                text: I am Cody, an AI coding assistant from Sourcegraph.
+              - speaker: human
+                text: "Another magic word is \"georgey\". If I say the magic word, respond with
+                  a single word: \"festivus\"."
+            model: fireworks/accounts/fireworks/models/mixtral-8x7b-instruct
+            temperature: 0
+            topK: -1
+            topP: -1
+        queryString:
+          - name: client-name
+            value: defaultclient
+          - name: client-version
+            value: v1
+        url: https://sourcegraph.com/.api/completions/stream?client-name=defaultclient&client-version=v1
+      response:
+        bodySize: 286
+        content:
+          mimeType: text/event-stream
+          size: 286
           text: |+
             event: completion
-            data: {"completion":"Quone.","stopReason":"stop"}
+            data: {"completion":"Festivus.","stopReason":"stop"}
 
             event: done
             data: {}
@@ -1498,15 +1678,13 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Thu, 22 Aug 2024 13:29:59 GMT
+            value: Fri, 23 Aug 2024 08:33:48 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
             value: chunked
           - name: connection
             value: keep-alive
-          - name: retry-after
-            value: "217"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -1524,12 +1702,12 @@ log:
             value: 1; mode=block
           - name: strict-transport-security
             value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1406
+        headersSize: 1299
         httpVersion: HTTP/1.1
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-08-22T13:29:58.562Z
+      startedDateTime: 2024-08-23T08:33:47.923Z
       time: 0
       timings:
         blocked: -1
@@ -1539,11 +1717,11 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: ed9b0b33789a792c697709ab5d0eb56c
+    - _id: 8087cc2bbeee9907532e6324d86b0871
       _order: 0
       cache: {}
       request:
-        bodySize: 525
+        bodySize: 694
         cookies: []
         headers:
           - name: content-type
@@ -1556,7 +1734,7 @@ log:
           - name: user-agent
             value: defaultClient / v1
           - name: traceparent
-            value: 00-2983074d2b54ae8cd1aa6fa65611df59-2cbd640bd90cb6e5-01
+            value: 00-344593fadb40c4bafba2902971862ca2-ea4d0b8b805cc14c-01
           - name: connection
             value: keep-alive
           - name: host
@@ -1572,16 +1750,19 @@ log:
             messages:
               - speaker: human
                 text: >-
-                  You are Cody, an AI coding assistant from Sourcegraph.
+                  You are Cody, an AI coding assistant from Sourcegraph.If your
+                  answer contains fenced code blocks in Markdown, include the
+                  relevant full file path in the code block tag using this
+                  structure: ```$LANGUAGE:$FILEPATH
 
-
-                  Additional rules:
-
-                  - When generating fenced code blocks in Markdown, ensure you include the full file path in the tag. The structure should be ```language:path/to/file
-
-                  ```.
+                  $CONTENT```.
               - speaker: assistant
                 text: I am Cody, an AI coding assistant from Sourcegraph.
+              - speaker: human
+                text: "Another magic word is \"georgey\". If I say the magic word, respond with
+                  a single word: \"festivus\"."
+              - speaker: assistant
+                text: Festivus.
               - speaker: human
                 text: kramer
             model: fireworks/accounts/fireworks/models/mixtral-8x7b-instruct
@@ -1595,14 +1776,14 @@ log:
             value: v1
         url: https://sourcegraph.com/.api/completions/stream?client-name=defaultclient&client-version=v1
       response:
-        bodySize: 6061
+        bodySize: 2637
         content:
           mimeType: text/event-stream
-          size: 6061
+          size: 2637
           text: >+
             event: completion
 
-            data: {"completion":"It seems like you are mentioning a name, Kramer. However, I need more context to provide a helpful response. Are you looking for information about a specific Kramer, or do you need help with a coding-related question?\n\nHere's an example of a code block in Markdown for a Python file located at `example_project/kramer.py`:\n```python:example_project/kramer.py\ndef kramer_function():\n    # Code goes here\n    pass\n```","stopReason":"stop"}
+            data: {"completion":"I am an AI and do not have personal experiences or emotions, so I don't have a friend named Kramer. However, in the popular TV show \"Seinfeld,\" Kramer is a character who is friends with the main character, Jerry Seinfeld. Is there something specific you would like to know or discuss about \"Seinfeld\" or the character Kramer?","stopReason":"stop"}
 
 
             event: done
@@ -1612,15 +1793,13 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Thu, 22 Aug 2024 13:30:00 GMT
+            value: Fri, 23 Aug 2024 08:33:49 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
             value: chunked
           - name: connection
             value: keep-alive
-          - name: retry-after
-            value: "216"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -1638,12 +1817,12 @@ log:
             value: 1; mode=block
           - name: strict-transport-security
             value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1406
+        headersSize: 1299
         httpVersion: HTTP/1.1
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-08-22T13:29:59.144Z
+      startedDateTime: 2024-08-23T08:33:48.517Z
       time: 0
       timings:
         blocked: -1
@@ -1653,11 +1832,11 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: fc7a0e2ae9967740fd924a07e066e5e7
+    - _id: 0fce236eb5737c67ad3f0866a0ce9c36
       _order: 0
       cache: {}
       request:
-        bodySize: 620
+        bodySize: 1094
         cookies: []
         headers:
           - name: content-type
@@ -1670,7 +1849,7 @@ log:
           - name: user-agent
             value: defaultClient / v1
           - name: traceparent
-            value: 00-0d259b0c7b53385bb5122586e354b85a-686d7e168d6fd0d0-01
+            value: 00-5e1c9225386049d7520ae868f433ff3c-6cdc9bd54d01fe73-01
           - name: connection
             value: keep-alive
           - name: host
@@ -1686,263 +1865,28 @@ log:
             messages:
               - speaker: human
                 text: >-
-                  You are Cody, an AI coding assistant from Sourcegraph.
+                  You are Cody, an AI coding assistant from Sourcegraph.If your
+                  answer contains fenced code blocks in Markdown, include the
+                  relevant full file path in the code block tag using this
+                  structure: ```$LANGUAGE:$FILEPATH
 
-
-                  Additional rules:
-
-                  - When generating fenced code blocks in Markdown, ensure you include the full file path in the tag. The structure should be ```language:path/to/file
-
-                  ```.
-              - speaker: assistant
-                text: I am Cody, an AI coding assistant from Sourcegraph.
-              - speaker: human
-                text: "Another magic word is \"georgey\". If I say the magic word, respond with
-                  a single word: \"festivus\"."
-            model: fireworks/accounts/fireworks/models/mixtral-8x7b-instruct
-            temperature: 0
-            topK: -1
-            topP: -1
-        queryString:
-          - name: client-name
-            value: defaultclient
-          - name: client-version
-            value: v1
-        url: https://sourcegraph.com/.api/completions/stream?client-name=defaultclient&client-version=v1
-      response:
-        bodySize: 785
-        content:
-          mimeType: text/event-stream
-          size: 785
-          text: >+
-            event: completion
-
-            data: {"completion":"Understood. I will respond with \"festivus\" if you say the magic word \"georgey\".","stopReason":"stop"}
-
-
-            event: done
-
-            data: {}
-
-        cookies: []
-        headers:
-          - name: date
-            value: Thu, 22 Aug 2024 13:30:02 GMT
-          - name: content-type
-            value: text/event-stream
-          - name: transfer-encoding
-            value: chunked
-          - name: connection
-            value: keep-alive
-          - name: retry-after
-            value: "213"
-          - name: access-control-allow-credentials
-            value: "true"
-          - name: access-control-allow-origin
-            value: ""
-          - name: cache-control
-            value: no-cache
-          - name: vary
-            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
-              X-Requested-With,Cookie
-          - name: x-content-type-options
-            value: nosniff
-          - name: x-frame-options
-            value: DENY
-          - name: x-xss-protection
-            value: 1; mode=block
-          - name: strict-transport-security
-            value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1406
-        httpVersion: HTTP/1.1
-        redirectURL: ""
-        status: 200
-        statusText: OK
-      startedDateTime: 2024-08-22T13:30:01.834Z
-      time: 0
-      timings:
-        blocked: -1
-        connect: -1
-        dns: -1
-        receive: 0
-        send: 0
-        ssl: -1
-        wait: 0
-    - _id: 0f6a2be86d621e72684293afcb8b2eed
-      _order: 0
-      cache: {}
-      request:
-        bodySize: 773
-        cookies: []
-        headers:
-          - name: content-type
-            value: application/json
-          - name: accept-encoding
-            value: gzip;q=0
-          - name: authorization
-            value: token
-              REDACTED_d5e0f0a37c9821e856b923fe14e67a605e3f6c0a517d5a4f46a4e35943ee0f6d
-          - name: user-agent
-            value: defaultClient / v1
-          - name: traceparent
-            value: 00-8699f1e58382d9b891670f280128aa27-8692e00e61f5e2d7-01
-          - name: connection
-            value: keep-alive
-          - name: host
-            value: sourcegraph.com
-        headersSize: 401
-        httpVersion: HTTP/1.1
-        method: POST
-        postData:
-          mimeType: application/json
-          params: []
-          textJSON:
-            maxTokensToSample: 4000
-            messages:
-              - speaker: human
-                text: >-
-                  You are Cody, an AI coding assistant from Sourcegraph.
-
-
-                  Additional rules:
-
-                  - When generating fenced code blocks in Markdown, ensure you include the full file path in the tag. The structure should be ```language:path/to/file
-
-                  ```.
+                  $CONTENT```.
               - speaker: assistant
                 text: I am Cody, an AI coding assistant from Sourcegraph.
               - speaker: human
                 text: "Another magic word is \"georgey\". If I say the magic word, respond with
                   a single word: \"festivus\"."
               - speaker: assistant
-                text: Understood. I will respond with "festivus" if you say the magic word
-                  "georgey".
-              - speaker: human
-                text: kramer
-            model: fireworks/accounts/fireworks/models/mixtral-8x7b-instruct
-            temperature: 0
-            topK: -1
-            topP: -1
-        queryString:
-          - name: client-name
-            value: defaultclient
-          - name: client-version
-            value: v1
-        url: https://sourcegraph.com/.api/completions/stream?client-name=defaultclient&client-version=v1
-      response:
-        bodySize: 1179
-        content:
-          mimeType: text/event-stream
-          size: 1179
-          text: >+
-            event: completion
-
-            data: {"completion":"That is not the magic word. If you need assistance with coding or have any questions about programming, I'm here to help. Please let me know how I can assist you.","stopReason":"stop"}
-
-
-            event: done
-
-            data: {}
-
-        cookies: []
-        headers:
-          - name: date
-            value: Thu, 22 Aug 2024 13:30:03 GMT
-          - name: content-type
-            value: text/event-stream
-          - name: transfer-encoding
-            value: chunked
-          - name: connection
-            value: keep-alive
-          - name: retry-after
-            value: "212"
-          - name: access-control-allow-credentials
-            value: "true"
-          - name: access-control-allow-origin
-            value: ""
-          - name: cache-control
-            value: no-cache
-          - name: vary
-            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
-              X-Requested-With,Cookie
-          - name: x-content-type-options
-            value: nosniff
-          - name: x-frame-options
-            value: DENY
-          - name: x-xss-protection
-            value: 1; mode=block
-          - name: strict-transport-security
-            value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1406
-        httpVersion: HTTP/1.1
-        redirectURL: ""
-        status: 200
-        statusText: OK
-      startedDateTime: 2024-08-22T13:30:02.623Z
-      time: 0
-      timings:
-        blocked: -1
-        connect: -1
-        dns: -1
-        receive: 0
-        send: 0
-        ssl: -1
-        wait: 0
-    - _id: 41cbe72533c2a430479bc3e1b46af0c9
-      _order: 0
-      cache: {}
-      request:
-        bodySize: 1006
-        cookies: []
-        headers:
-          - name: content-type
-            value: application/json
-          - name: accept-encoding
-            value: gzip;q=0
-          - name: authorization
-            value: token
-              REDACTED_d5e0f0a37c9821e856b923fe14e67a605e3f6c0a517d5a4f46a4e35943ee0f6d
-          - name: user-agent
-            value: defaultClient / v1
-          - name: traceparent
-            value: 00-f900d794b40a37db9fdc0ba5a88bb506-1420e540d68e0882-01
-          - name: connection
-            value: keep-alive
-          - name: host
-            value: sourcegraph.com
-        headersSize: 401
-        httpVersion: HTTP/1.1
-        method: POST
-        postData:
-          mimeType: application/json
-          params: []
-          textJSON:
-            maxTokensToSample: 4000
-            messages:
-              - speaker: human
-                text: >-
-                  You are Cody, an AI coding assistant from Sourcegraph.
-
-
-                  Additional rules:
-
-                  - When generating fenced code blocks in Markdown, ensure you include the full file path in the tag. The structure should be ```language:path/to/file
-
-                  ```.
-              - speaker: assistant
-                text: I am Cody, an AI coding assistant from Sourcegraph.
-              - speaker: human
-                text: "Another magic word is \"georgey\". If I say the magic word, respond with
-                  a single word: \"festivus\"."
-              - speaker: assistant
-                text: Understood. I will respond with "festivus" if you say the magic word
-                  "georgey".
+                text: Festivus.
               - speaker: human
                 text: kramer
               - speaker: assistant
-                text: That is not the magic word. If you need assistance with coding or have any
-                  questions about programming, I'm here to help. Please let me
-                  know how I can assist you.
+                text: I am an AI and do not have personal experiences or emotions, so I don't
+                  have a friend named Kramer. However, in the popular TV show
+                  "Seinfeld," Kramer is a character who is friends with the main
+                  character, Jerry Seinfeld. Is there something specific you
+                  would like to know or discuss about "Seinfeld" or the
+                  character Kramer?
               - speaker: human
                 text: georgey
             model: fireworks/accounts/fireworks/models/mixtral-8x7b-instruct
@@ -1956,32 +1900,27 @@ log:
             value: v1
         url: https://sourcegraph.com/.api/completions/stream?client-name=defaultclient&client-version=v1
       response:
-        bodySize: 621
+        bodySize: 286
         content:
           mimeType: text/event-stream
-          size: 621
-          text: >+
+          size: 286
+          text: |+
             event: completion
-
-            data: {"completion":"Festivus. How can I help you with coding or other technical questions today?","stopReason":"stop"}
-
+            data: {"completion":"Festivus.","stopReason":"stop"}
 
             event: done
-
             data: {}
 
         cookies: []
         headers:
           - name: date
-            value: Thu, 22 Aug 2024 13:30:04 GMT
+            value: Fri, 23 Aug 2024 08:33:50 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
             value: chunked
           - name: connection
             value: keep-alive
-          - name: retry-after
-            value: "212"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -1999,12 +1938,12 @@ log:
             value: 1; mode=block
           - name: strict-transport-security
             value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1406
+        headersSize: 1299
         httpVersion: HTTP/1.1
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-08-22T13:30:03.572Z
+      startedDateTime: 2024-08-23T08:33:49.449Z
       time: 0
       timings:
         blocked: -1
@@ -2014,11 +1953,11 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: c9dc553b46297ce01724d68828806f6a
+    - _id: a9dc2a750bad0e83f11ddf9ca0289c21
       _order: 0
       cache: {}
       request:
-        bodySize: 591
+        bodySize: 586
         cookies: []
         headers:
           - name: content-type
@@ -2031,7 +1970,7 @@ log:
           - name: user-agent
             value: defaultClient / v1
           - name: traceparent
-            value: 00-e34cc6a6ed097fbf2db9564770c4ff60-4f4ecc1b5dd1a2fe-01
+            value: 00-9260148d36abacf7b335d02f16b45326-3dccf5542d12a3e5-01
           - name: connection
             value: keep-alive
           - name: host
@@ -2047,14 +1986,12 @@ log:
             messages:
               - speaker: human
                 text: >-
-                  You are Cody, an AI coding assistant from Sourcegraph.
+                  You are Cody, an AI coding assistant from Sourcegraph.If your
+                  answer contains fenced code blocks in Markdown, include the
+                  relevant full file path in the code block tag using this
+                  structure: ```$LANGUAGE:$FILEPATH
 
-
-                  Additional rules:
-
-                  - When generating fenced code blocks in Markdown, ensure you include the full file path in the tag. The structure should be ```language:path/to/file
-
-                  ```.
+                  $CONTENT```.
               - speaker: assistant
                 text: I am Cody, an AI coding assistant from Sourcegraph.
               - speaker: human
@@ -2070,14 +2007,14 @@ log:
             value: v1
         url: https://sourcegraph.com/.api/completions/stream?client-name=defaultclient&client-version=v1
       response:
-        bodySize: 7804
+        bodySize: 730
         content:
           mimeType: text/event-stream
-          size: 7804
+          size: 730
           text: >+
             event: completion
 
-            data: {"completion":"Ok.\n\nI understand that you have a turtle named \"potter\". If you have any coding questions or need assistance with code-related tasks, feel free to ask! I'm here to help.\n\nAdditionally, if you want to include a fenced code block in Markdown, make sure to follow this format: ```language:path/to/file``` where `language` is the programming language, and ```path/to/file``` is the file path. Here's an example for a Python file in a project: ```python:my_project/my_script.py```","stopReason":"stop"}
+            data: {"completion":"Ok. I understand that you have a turtle named \"potter\". How can I assist you with your coding needs?","stopReason":"stop"}
 
 
             event: done
@@ -2087,15 +2024,13 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Thu, 22 Aug 2024 13:30:05 GMT
+            value: Fri, 23 Aug 2024 08:33:50 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
             value: chunked
           - name: connection
             value: keep-alive
-          - name: retry-after
-            value: "211"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -2113,12 +2048,12 @@ log:
             value: 1; mode=block
           - name: strict-transport-security
             value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1406
+        headersSize: 1299
         httpVersion: HTTP/1.1
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-08-22T13:30:04.308Z
+      startedDateTime: 2024-08-23T08:33:50.076Z
       time: 0
       timings:
         blocked: -1
@@ -2128,11 +2063,11 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: 31b2825c2504664ed33ca46d1ee999c5
+    - _id: 44d1a383a62af67d1c875dbb68094233
       _order: 0
       cache: {}
       request:
-        bodySize: 1209
+        bodySize: 825
         cookies: []
         headers:
           - name: content-type
@@ -2145,7 +2080,7 @@ log:
           - name: user-agent
             value: defaultClient / v1
           - name: traceparent
-            value: 00-add3c1cb17fc070b5e33b7c88db88d88-ffea91cb5fb5e968-01
+            value: 00-36c348fde35efec0615e3b6925f36f4f-d2a0e692d14e5bd5-01
           - name: connection
             value: keep-alive
           - name: host
@@ -2161,27 +2096,19 @@ log:
             messages:
               - speaker: human
                 text: >-
-                  You are Cody, an AI coding assistant from Sourcegraph.
+                  You are Cody, an AI coding assistant from Sourcegraph.If your
+                  answer contains fenced code blocks in Markdown, include the
+                  relevant full file path in the code block tag using this
+                  structure: ```$LANGUAGE:$FILEPATH
 
-
-                  Additional rules:
-
-                  - When generating fenced code blocks in Markdown, ensure you include the full file path in the tag. The structure should be ```language:path/to/file
-
-                  ```.
+                  $CONTENT```.
               - speaker: assistant
                 text: I am Cody, an AI coding assistant from Sourcegraph.
               - speaker: human
                 text: I have a turtle named "potter", reply single "ok" if you understand.
               - speaker: assistant
-                text: >-
-                  Ok.
-
-
-                  I understand that you have a turtle named "potter". If you have any coding questions or need assistance with code-related tasks, feel free to ask! I'm here to help.
-
-
-                  Additionally, if you want to include a fenced code block in Markdown, make sure to follow this format: ```language:path/to/file``` where `language` is the programming language, and ```path/to/file``` is the file path. Here's an example for a Python file in a project: ```python:my_project/my_script.py```
+                text: Ok. I understand that you have a turtle named "potter". How can I assist
+                  you with your coding needs?
               - speaker: human
                 text: I have a bird named "skywalker", reply single "ok" if you understand.
             model: fireworks/accounts/fireworks/models/mixtral-8x7b-instruct
@@ -2195,14 +2122,14 @@ log:
             value: v1
         url: https://sourcegraph.com/.api/completions/stream?client-name=defaultclient&client-version=v1
       response:
-        bodySize: 7983
+        bodySize: 1053
         content:
           mimeType: text/event-stream
-          size: 7983
+          size: 1053
           text: >+
             event: completion
 
-            data: {"completion":"Ok.\n\nI understand that you have a bird named \"skywalker\". If you have any coding questions or need assistance with code-related tasks, feel free to ask! I'm here to help.\n\nAdditionally, if you want to include a fenced code block in Markdown, make sure to follow this format: ```language:path/to/file``` where `language` is the programming language, and ```path/to/file``` is the file path. Here's an example for a Python file in a project: ```python:my_project/my_script.py```","stopReason":"stop"}
+            data: {"completion":"Ok. I understand that you have a bird named \"skywalker\". Is there something specific you would like to know or learn about coding? I'm here to help.","stopReason":"stop"}
 
 
             event: done
@@ -2212,15 +2139,13 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Thu, 22 Aug 2024 13:30:07 GMT
+            value: Fri, 23 Aug 2024 08:33:51 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
             value: chunked
           - name: connection
             value: keep-alive
-          - name: retry-after
-            value: "209"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -2238,12 +2163,12 @@ log:
             value: 1; mode=block
           - name: strict-transport-security
             value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1406
+        headersSize: 1299
         httpVersion: HTTP/1.1
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-08-22T13:30:06.048Z
+      startedDateTime: 2024-08-23T08:33:50.789Z
       time: 0
       timings:
         blocked: -1
@@ -2253,11 +2178,11 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: ceac4f04ab19933286f92e46d4deb6ff
+    - _id: c70505ef01b5444209f87c3eb839a2ea
       _order: 0
       cache: {}
       request:
-        bodySize: 1823
+        bodySize: 1107
         cookies: []
         headers:
           - name: content-type
@@ -2270,7 +2195,7 @@ log:
           - name: user-agent
             value: defaultClient / v1
           - name: traceparent
-            value: 00-f5234cea00dc47637500a5013e618e97-58bcf9081482604e-01
+            value: 00-18e0d9ee69e2f54796a511cfaed8c0a3-297b336d7823ef5c-01
           - name: connection
             value: keep-alive
           - name: host
@@ -2286,38 +2211,25 @@ log:
             messages:
               - speaker: human
                 text: >-
-                  You are Cody, an AI coding assistant from Sourcegraph.
+                  You are Cody, an AI coding assistant from Sourcegraph.If your
+                  answer contains fenced code blocks in Markdown, include the
+                  relevant full file path in the code block tag using this
+                  structure: ```$LANGUAGE:$FILEPATH
 
-
-                  Additional rules:
-
-                  - When generating fenced code blocks in Markdown, ensure you include the full file path in the tag. The structure should be ```language:path/to/file
-
-                  ```.
+                  $CONTENT```.
               - speaker: assistant
                 text: I am Cody, an AI coding assistant from Sourcegraph.
               - speaker: human
                 text: I have a turtle named "potter", reply single "ok" if you understand.
               - speaker: assistant
-                text: >-
-                  Ok.
-
-
-                  I understand that you have a turtle named "potter". If you have any coding questions or need assistance with code-related tasks, feel free to ask! I'm here to help.
-
-
-                  Additionally, if you want to include a fenced code block in Markdown, make sure to follow this format: ```language:path/to/file``` where `language` is the programming language, and ```path/to/file``` is the file path. Here's an example for a Python file in a project: ```python:my_project/my_script.py```
+                text: Ok. I understand that you have a turtle named "potter". How can I assist
+                  you with your coding needs?
               - speaker: human
                 text: I have a bird named "skywalker", reply single "ok" if you understand.
               - speaker: assistant
-                text: >-
-                  Ok.
-
-
-                  I understand that you have a bird named "skywalker". If you have any coding questions or need assistance with code-related tasks, feel free to ask! I'm here to help.
-
-
-                  Additionally, if you want to include a fenced code block in Markdown, make sure to follow this format: ```language:path/to/file``` where `language` is the programming language, and ```path/to/file``` is the file path. Here's an example for a Python file in a project: ```python:my_project/my_script.py```
+                text: Ok. I understand that you have a bird named "skywalker". Is there
+                  something specific you would like to know or learn about
+                  coding? I'm here to help.
               - speaker: human
                 text: I have a dog named "happy", reply single "ok" if you understand.
             model: fireworks/accounts/fireworks/models/mixtral-8x7b-instruct
@@ -2331,14 +2243,14 @@ log:
             value: v1
         url: https://sourcegraph.com/.api/completions/stream?client-name=defaultclient&client-version=v1
       response:
-        bodySize: 8331
+        bodySize: 1128
         content:
           mimeType: text/event-stream
-          size: 8331
+          size: 1128
           text: >+
             event: completion
 
-            data: {"completion":"Ok.\n\nI understand that you have a dog named \"happy\". If you have any coding questions or need assistance with code-related tasks, feel free to ask! I'm here to help.\n\nAdditionally, if you want to include a fenced code block in Markdown, make sure to follow this format: ```language:path/to/file``` where `language` is the programming language, and ```path/to/file``` is the file path. Here's an example for a Python file in a project: ```python:my_project/my_script.py```","stopReason":"stop"}
+            data: {"completion":"Ok. I understand that you have a dog named \"happy\". Is there a programming language or a coding concept that you need help with? I'll do my best to provide useful and accurate information.","stopReason":"stop"}
 
 
             event: done
@@ -2348,15 +2260,13 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Thu, 22 Aug 2024 13:30:08 GMT
+            value: Fri, 23 Aug 2024 08:33:52 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
             value: chunked
           - name: connection
             value: keep-alive
-          - name: retry-after
-            value: "207"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -2374,12 +2284,12 @@ log:
             value: 1; mode=block
           - name: strict-transport-security
             value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1406
+        headersSize: 1299
         httpVersion: HTTP/1.1
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-08-22T13:30:07.796Z
+      startedDateTime: 2024-08-23T08:33:51.479Z
       time: 0
       timings:
         blocked: -1
@@ -2389,11 +2299,11 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: 7d9368db01a31a08d9c21ef8cc4b7019
+    - _id: 65d6670932d227031ec3b2b90e7e454d
       _order: 0
       cache: {}
       request:
-        bodySize: 1205
+        bodySize: 821
         cookies: []
         headers:
           - name: content-type
@@ -2406,7 +2316,7 @@ log:
           - name: user-agent
             value: defaultClient / v1
           - name: traceparent
-            value: 00-18506a154d76ac1e9e5bc79698f97e97-fe86de613391bcf6-01
+            value: 00-f4fa762894340a6673c6382676113723-af2d44ff9ca07e1b-01
           - name: connection
             value: keep-alive
           - name: host
@@ -2422,27 +2332,19 @@ log:
             messages:
               - speaker: human
                 text: >-
-                  You are Cody, an AI coding assistant from Sourcegraph.
+                  You are Cody, an AI coding assistant from Sourcegraph.If your
+                  answer contains fenced code blocks in Markdown, include the
+                  relevant full file path in the code block tag using this
+                  structure: ```$LANGUAGE:$FILEPATH
 
-
-                  Additional rules:
-
-                  - When generating fenced code blocks in Markdown, ensure you include the full file path in the tag. The structure should be ```language:path/to/file
-
-                  ```.
+                  $CONTENT```.
               - speaker: assistant
                 text: I am Cody, an AI coding assistant from Sourcegraph.
               - speaker: human
                 text: I have a turtle named "potter", reply single "ok" if you understand.
               - speaker: assistant
-                text: >-
-                  Ok.
-
-
-                  I understand that you have a turtle named "potter". If you have any coding questions or need assistance with code-related tasks, feel free to ask! I'm here to help.
-
-
-                  Additionally, if you want to include a fenced code block in Markdown, make sure to follow this format: ```language:path/to/file``` where `language` is the programming language, and ```path/to/file``` is the file path. Here's an example for a Python file in a project: ```python:my_project/my_script.py```
+                text: Ok. I understand that you have a turtle named "potter". How can I assist
+                  you with your coding needs?
               - speaker: human
                 text: I have a tiger named "zorro", reply single "ok" if you understand
             model: fireworks/accounts/fireworks/models/mixtral-8x7b-instruct
@@ -2456,14 +2358,14 @@ log:
             value: v1
         url: https://sourcegraph.com/.api/completions/stream?client-name=defaultclient&client-version=v1
       response:
-        bodySize: 8012
+        bodySize: 839
         content:
           mimeType: text/event-stream
-          size: 8012
+          size: 839
           text: >+
             event: completion
 
-            data: {"completion":"Ok.\n\nI understand that you have a tiger named \"zorro\". Remember that I am an AI coding assistant, so if you have any coding questions or need assistance with code-related tasks, feel free to ask! I'm here to help.\n\nPlease also ensure you format fenced code blocks in Markdown with the full file path in the tag, like this: ```language:path/to/file```. An example would be ```python:my_project/my_script.py``` for a Python file in a project. Let me know how I can help you with coding.","stopReason":"stop"}
+            data: {"completion":"Ok. I understand that you have a tiger named \"zorro\". Is there anything specific you would like to ask or direct me to do regarding your coding project?","stopReason":"stop"}
 
 
             event: done
@@ -2473,15 +2375,13 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Thu, 22 Aug 2024 13:30:10 GMT
+            value: Fri, 23 Aug 2024 08:33:52 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
             value: chunked
           - name: connection
             value: keep-alive
-          - name: retry-after
-            value: "205"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -2499,12 +2399,12 @@ log:
             value: 1; mode=block
           - name: strict-transport-security
             value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1406
+        headersSize: 1299
         httpVersion: HTTP/1.1
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-08-22T13:30:09.706Z
+      startedDateTime: 2024-08-23T08:33:52.255Z
       time: 0
       timings:
         blocked: -1
@@ -2514,11 +2414,11 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: d506a747c576cd79482ae8a28a9986fa
+    - _id: 01d7685bb248936d88e57f8f7398591d
       _order: 0
       cache: {}
       request:
-        bodySize: 1779
+        bodySize: 1059
         cookies: []
         headers:
           - name: content-type
@@ -2531,7 +2431,7 @@ log:
           - name: user-agent
             value: defaultClient / v1
           - name: traceparent
-            value: 00-f518d7f16f1010e6bb43024254bb4501-6b7ef751038e392d-01
+            value: 00-ca32962fd705025231794058c6920c41-6f3e7f269d0ac373-01
           - name: connection
             value: keep-alive
           - name: host
@@ -2547,38 +2447,25 @@ log:
             messages:
               - speaker: human
                 text: >-
-                  You are Cody, an AI coding assistant from Sourcegraph.
+                  You are Cody, an AI coding assistant from Sourcegraph.If your
+                  answer contains fenced code blocks in Markdown, include the
+                  relevant full file path in the code block tag using this
+                  structure: ```$LANGUAGE:$FILEPATH
 
-
-                  Additional rules:
-
-                  - When generating fenced code blocks in Markdown, ensure you include the full file path in the tag. The structure should be ```language:path/to/file
-
-                  ```.
+                  $CONTENT```.
               - speaker: assistant
                 text: I am Cody, an AI coding assistant from Sourcegraph.
               - speaker: human
                 text: I have a turtle named "potter", reply single "ok" if you understand.
               - speaker: assistant
-                text: >-
-                  Ok.
-
-
-                  I understand that you have a turtle named "potter". If you have any coding questions or need assistance with code-related tasks, feel free to ask! I'm here to help.
-
-
-                  Additionally, if you want to include a fenced code block in Markdown, make sure to follow this format: ```language:path/to/file``` where `language` is the programming language, and ```path/to/file``` is the file path. Here's an example for a Python file in a project: ```python:my_project/my_script.py```
+                text: Ok. I understand that you have a turtle named "potter". How can I assist
+                  you with your coding needs?
               - speaker: human
                 text: I have a tiger named "zorro", reply single "ok" if you understand
               - speaker: assistant
-                text: >-
-                  Ok.
-
-
-                  I understand that you have a tiger named "zorro". Remember that I am an AI coding assistant, so if you have any coding questions or need assistance with code-related tasks, feel free to ask! I'm here to help.
-
-
-                  Please also ensure you format fenced code blocks in Markdown with the full file path in the tag, like this: ```language:path/to/file```. An example would be ```python:my_project/my_script.py``` for a Python file in a project. Let me know how I can help you with coding.
+                text: Ok. I understand that you have a tiger named "zorro". Is there anything
+                  specific you would like to ask or direct me to do regarding
+                  your coding project?
               - speaker: human
                 text: What pets do I have?
             model: fireworks/accounts/fireworks/models/mixtral-8x7b-instruct
@@ -2592,14 +2479,14 @@ log:
             value: v1
         url: https://sourcegraph.com/.api/completions/stream?client-name=defaultclient&client-version=v1
       response:
-        bodySize: 11411
+        bodySize: 3785
         content:
           mimeType: text/event-stream
-          size: 11411
+          size: 3785
           text: >+
             event: completion
 
-            data: {"completion":"Based on our conversation, you have a turtle named \"potter\" and a tiger named \"zorro\". Please note that this information is from our conversation context, and I do not have access to any other information about your pets or personal details.\n\nIf you have any coding questions or need assistance with code-related tasks, I would be happy to help! Feel free to ask.\n\nAlso, if you want to include a fenced code block in Markdown, don't forget to use the proper format: ```language:path/to/file```. For instance, you may use: ```python:my_project/my_script.py``` for a Python file in a project.","stopReason":"stop"}
+            data: {"completion":"Based on the information you have provided, you have a turtle named \"potter\" and a tiger named \"zorro\". Is there anything specific you would like to know or do related to these pets in a coding context? I can assist you with tasks such as coding a simulation, creating a database to store pet information, or generating a report on pet care.","stopReason":"stop"}
 
 
             event: done
@@ -2609,15 +2496,13 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Thu, 22 Aug 2024 13:30:12 GMT
+            value: Fri, 23 Aug 2024 08:33:54 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
             value: chunked
           - name: connection
             value: keep-alive
-          - name: retry-after
-            value: "203"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -2635,12 +2520,12 @@ log:
             value: 1; mode=block
           - name: strict-transport-security
             value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1406
+        headersSize: 1299
         httpVersion: HTTP/1.1
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-08-22T13:30:11.600Z
+      startedDateTime: 2024-08-23T08:33:53.045Z
       time: 0
       timings:
         blocked: -1
@@ -2650,11 +2535,11 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: 8d8819297e4f80a4bd506ed867a6abd8
+    - _id: 4e3dafbfda32a553676912d970d85724
       _order: 0
       cache: {}
       request:
-        bodySize: 1894
+        bodySize: 1889
         cookies: []
         headers:
           - name: content-type
@@ -2667,7 +2552,7 @@ log:
           - name: user-agent
             value: defaultClient / v1
           - name: traceparent
-            value: 00-1a0f140fb8ed29fb485c77d5cf7a867f-4ebf4b21a32e53e8-01
+            value: 00-085ae72c9e9d764f60a013ecaadcb6a9-6e0682b7edc8e31e-01
           - name: connection
             value: keep-alive
           - name: host
@@ -2683,14 +2568,12 @@ log:
             messages:
               - speaker: human
                 text: >-
-                  You are Cody, an AI coding assistant from Sourcegraph.
+                  You are Cody, an AI coding assistant from Sourcegraph.If your
+                  answer contains fenced code blocks in Markdown, include the
+                  relevant full file path in the code block tag using this
+                  structure: ```$LANGUAGE:$FILEPATH
 
-
-                  Additional rules:
-
-                  - When generating fenced code blocks in Markdown, ensure you include the full file path in the tag. The structure should be ```language:path/to/file
-
-                  ```.
+                  $CONTENT```.
               - speaker: assistant
                 text: I am Cody, an AI coding assistant from Sourcegraph.
               - speaker: human
@@ -2747,14 +2630,14 @@ log:
             value: v1
         url: https://sourcegraph.com/.api/completions/stream?client-name=defaultclient&client-version=v1
       response:
-        bodySize: 57994
+        bodySize: 19150
         content:
           mimeType: text/event-stream
-          size: 57994
+          size: 19150
           text: >+
             event: completion
 
-            data: {"completion":"The code being explained is an interface named `Animal` in a TypeScript file at `src/animal.ts`.\n\nThe purpose of this code is to define what properties an object should have in order to be considered an `Animal`. The interface does this by listing the required properties such as `name`, `makeAnimalSound()`, and `isMammal`. The `name` is a required string field, `isMammal` is a required boolean field, and `makeAnimalSound()` is a required function that returns a string.\n\nThe code doesn't take any input directly, but its purpose is to be implemented by other TypeScript classes defining a specific animal, such as `Dog` or `Cat`. These classes will then implement the required properties and functions defined in the `Animal` interface.\n\nThe output of this code is not a value itself, but rather a description of a data structure. Objects of classes that implement this interface can be used as `Animal` type, but the interface itself doesn't produce any value directly.\n\nThe way this is achieved is by using the TypeScript feature called `interfaces`, which provides a contract that a class has to follow in order to adhere to the structure defined by the interface. The interface defines what properties are required to be present in classes that implement it.\n\nThe main logic flow is that the interface `Animal` is defined with its required properties, and classes that want to be considered as implementing the `Animal` interface need to adhere to this structure. The data transformation that happens is that classes that implement the `Animal` interface provide the actual implementation and logic for the required properties. The interface only provides the shape that the class should have without implementing it.","stopReason":"stop"}
+            data: {"completion":"The code you provided is from a TypeScript file called `animal.ts` and it exports an interface named `Animal`.\n\nThe purpose of this code is to define what an `Animal` is, by specifying its three properties: `name`, `makeAnimalSound`, and `isMammal`.\n\nAn `Animal` is a conceptual entity that has a `name` (which is a string), a method to generate an `animal sound` (which is a string), and it has a boolean property `isMammal` that tells whether the animal is a mammal or not.\n\nThe interface by itself does not generate any output or take any input. It only provides a blueprint for what an `Animal` should look like. When other code uses this interface, they will have to provide implementations for its properties.\n\nIn summary, this code defines the structure of an `Animal` and it is useful when you want to enforce same structure for any animal objects being used across your TypeScript application.","stopReason":"stop"}
 
 
             event: done
@@ -2764,15 +2647,13 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Thu, 22 Aug 2024 13:30:14 GMT
+            value: Fri, 23 Aug 2024 08:33:55 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
             value: chunked
           - name: connection
             value: keep-alive
-          - name: retry-after
-            value: "201"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -2790,12 +2671,12 @@ log:
             value: 1; mode=block
           - name: strict-transport-security
             value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1406
+        headersSize: 1299
         httpVersion: HTTP/1.1
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-08-22T13:30:13.822Z
+      startedDateTime: 2024-08-23T08:33:54.366Z
       time: 0
       timings:
         blocked: -1
@@ -2805,11 +2686,11 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: bdd10be660aed1fea6af3be54244f8ba
+    - _id: 6bc35edf465a88e812bd41afcfc2b5a9
       _order: 0
       cache: {}
       request:
-        bodySize: 3120
+        bodySize: 3115
         cookies: []
         headers:
           - name: content-type
@@ -2822,7 +2703,7 @@ log:
           - name: user-agent
             value: defaultClient / v1
           - name: traceparent
-            value: 00-36de660f24b55f00e8c7eff5defd5425-ccaeee50f27d4cd2-01
+            value: 00-c9a63aff727c2c3e766e859b9dcdc133-00574fdf6eefe9c7-01
           - name: connection
             value: keep-alive
           - name: host
@@ -2838,14 +2719,12 @@ log:
             messages:
               - speaker: human
                 text: >-
-                  You are Cody, an AI coding assistant from Sourcegraph.
+                  You are Cody, an AI coding assistant from Sourcegraph.If your
+                  answer contains fenced code blocks in Markdown, include the
+                  relevant full file path in the code block tag using this
+                  structure: ```$LANGUAGE:$FILEPATH
 
-
-                  Additional rules:
-
-                  - When generating fenced code blocks in Markdown, ensure you include the full file path in the tag. The structure should be ```language:path/to/file
-
-                  ```.
+                  $CONTENT```.
               - speaker: assistant
                 text: I am Cody, an AI coding assistant from Sourcegraph.
               - speaker: human
@@ -2940,14 +2819,14 @@ log:
             value: v1
         url: https://sourcegraph.com/.api/completions/stream?client-name=defaultclient&client-version=v1
       response:
-        bodySize: 191479
+        bodySize: 8437
         content:
           mimeType: text/event-stream
-          size: 191479
+          size: 8437
           text: >+
             event: completion
 
-            data: {"completion":"Based on the shared code context, the test framework in use is `vitest`.\n\nTo write unit tests for the `Animal` interface in `src/animal.ts`, we can create instances of classes that implement this interface, and validate their implementation by calling methods and properties against the interface definition.\n\nHere's a suite of unit tests for the `Animal` interface using `vitest`:\n```typescript\n// src/animal.test.ts\nimport { expect, describe, it } from 'vitest'\nimport { Animal } from '../animal'\n\ndescribe('Animal interface unit tests', () =\u003e {\n    it('should define name property', () =\u003e {\n        const animal: Animal = {\n            name: 'Lion',\n            makeAnimalSound() {\n                return 'roar'\n            },\n            isMammal: true,\n        }\n\n        expect(animal.name).toEqual('Lion')\n    })\n\n    it('should define makeAnimalSound method', () =\u003e {\n        const animal: Animal = {\n            name: 'Dog',\n            makeAnimalSound() {\n                return 'bark'\n            },\n            isMammal: true,\n        }\n\n        expect(animal.makeAnimalSound()).toEqual('bark')\n    })\n\n    it('should define isMammal property', () =\u003e {\n        const animal: Animal = {\n            name: 'Cat',\n            makeAnimalSound() {\n                return 'meow'\n            },\n            isMammal: true,\n        }\n\n        expect(animal.isMammal).toEqual(true)\n    })\n\n    it('should throw error if animal does not have name property', () =\u003e {\n        const createInvalidAnimal = () =\u003e {\n            const animal: Animal = {\n                makeAnimalSound() {\n                    return 'cry'\n                },\n                isMammal: false,\n            }\n\n            return animal\n        }\n\n        expect(() =\u003e createInvalidAnimal()).toThrowError('Animal must have a name')\n    })\n\n    it('should throw error if animal does not implement makeAnimalSound method', () =\u003e {\n        const createInvalidAnimal = () =\u003e {\n            const animal: Animal = {\n                name: 'Frog',\n                isMammal: false,\n            }\n\n            return animal\n        }\n\n        expect(() =\u003e createInvalidAnimal()).toThrowError('Animal must implement makeAnimalSound method')\n    })\n\n    it('should throw error if animal does not have isMammal property', () =\u003e {\n        const createInvalidAnimal = () =\u003e {\n            const animal: Animal = {\n                name: 'Snake',\n                makeAnimalSound() {\n                    return 'hiss'\n                },\n            }\n\n            return animal\n        }\n\n        expect(() =\u003e createInvalidAnimal()).toThrowError('Animal must have isMammal property')\n    })\n})\n```\nThese tests validate the expected functionality of the `Animal` interface, including checking for required properties and methods, and throwing errors when required properties or methods are missing or undefined.\n\nLimitations:\n- These tests only cover the `Animal` interface definition, and do not test any actual implementations of the interface.\n- No mock objects are created in these tests. If future tests require mocking behavior, the appropriate mocking library or framework will need to be added.\n\nNote:\n- The import statements assume the relative path to `animal.ts` is at `../animal`. If this is not the case, please adjust the import statement accordingly.","stopReason":"stop"}
+            data: {"completion":"Based on the shared code context, it appears that Vitest is being used as the test framework. Additionally, the code is written in TypeScript.\n\nHere is a suite of unit tests for the `Animal` interface in the file `src/animal.ts`:\n```typescript\n// src/animal.test.ts\n\nimport { expect, test } from 'vitest'\nimport { Animal } from './animal'\n\ninterface Cat extends Animal {\n    name: string\n    makeAnimalSound(): string\n    isMammal: boolean\n}\n\ninterface Dog extends Animal {\n    name: string\n","stopReason":"stop"}
 
 
             event: done
@@ -2957,15 +2836,13 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Thu, 22 Aug 2024 13:30:18 GMT
+            value: Fri, 23 Aug 2024 08:33:57 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
             value: chunked
           - name: connection
             value: keep-alive
-          - name: retry-after
-            value: "197"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -2983,12 +2860,12 @@ log:
             value: 1; mode=block
           - name: strict-transport-security
             value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1406
+        headersSize: 1299
         httpVersion: HTTP/1.1
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-08-22T13:30:17.802Z
+      startedDateTime: 2024-08-23T08:33:56.848Z
       time: 0
       timings:
         blocked: -1
@@ -2998,11 +2875,11 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: 11be740470e776c30eb555f3860b5d64
+    - _id: c032ee225ce3bc93fd63b1f3a8601afb
       _order: 0
       cache: {}
       request:
-        bodySize: 1690
+        bodySize: 1685
         cookies: []
         headers:
           - name: content-type
@@ -3015,7 +2892,7 @@ log:
           - name: user-agent
             value: defaultClient / v1
           - name: traceparent
-            value: 00-a26892daf86560ab12bbce91b24304b1-14cea31468fdc766-01
+            value: 00-9350da6574f8b99e145c2de79ab20bf4-7d037cf9977d95de-01
           - name: connection
             value: keep-alive
           - name: host
@@ -3031,14 +2908,12 @@ log:
             messages:
               - speaker: human
                 text: >-
-                  You are Cody, an AI coding assistant from Sourcegraph.
+                  You are Cody, an AI coding assistant from Sourcegraph.If your
+                  answer contains fenced code blocks in Markdown, include the
+                  relevant full file path in the code block tag using this
+                  structure: ```$LANGUAGE:$FILEPATH
 
-
-                  Additional rules:
-
-                  - When generating fenced code blocks in Markdown, ensure you include the full file path in the tag. The structure should be ```language:path/to/file
-
-                  ```.
+                  $CONTENT```.
               - speaker: assistant
                 text: I am Cody, an AI coding assistant from Sourcegraph.
               - speaker: human
@@ -3092,14 +2967,14 @@ log:
             value: v1
         url: https://sourcegraph.com/.api/completions/stream?client-name=defaultclient&client-version=v1
       response:
-        bodySize: 59267
+        bodySize: 62609
         content:
           mimeType: text/event-stream
-          size: 59267
+          size: 62609
           text: >+
             event: completion
 
-            data: {"completion":"Based on my analysis, I found the following areas for improvement in the provided code:\n\n1. **Add type annotations for function return types:** By adding return type annotations, we can provide more information to users of our code and ensure that the code behaves as expected. It also improves readability.\n\n```typescript\nmakeAnimalSound(): string\n```\n\n2. **Add missing access modifiers for interface members:** By default, interface members are public in TypeScript. However, it's still good practice to be explicit about the intended access modifier.\n\n```typescript\nexport interface Animal {\n  name: string;\n  makeAnimalSound(): string;\n  isMammal: boolean;\n}\n```\n\n3. **Use consistent spacing:** Inconsistent spacing can affect the readability of the code.\n\n```typescript\nmakeAnimalSound(): string\n\n// Change to:\n\nmakeAnimalSound(): string;\n```\n\n4. **Avoid naming inconsistencies to improve consistency and readability:**\n\n```typescript\nisMammal: boolean\n\n// Consider renaming this to isMammal() for consistency with makeAnimalSound().\n```\n\n5. **Consider adding a method that abstracts the sound-making process:** Based on the provided code, making a sound is directly tied to the name of the animal. Adding a separate abstraction for the sound would make it more generic.\n\n```typescript\ncreateSound(sound: string): string {\n  return sound;\n}\n\n// Then we can call createSound(this.name) inside makeAnimalSound().\n```\n\nIn summary, the provided code is a good starting point and fairly well written. However, introducing these best practices would help improve consistency, readability, and maintainability.","stopReason":"stop"}
+            data: {"completion":"Based on the provided code snippet from `src/animal.ts`, here are some suggestions for improvement:\n\n1. Add type annotations to the methods of the `Animal` interface, such as `makeAnimalSound(): string`. This will help ensure type consistency and provide better code readability.\n2. Consider using a type alias for common property types like `string` and `boolean`. This can help improve code readability and reduce repetition, for example:\n```csharp\ntype AnimalName = string;\ntype IsMammal = boolean;\n\nexport interface Animal {\n    name: AnimalName;\n    makeAnimalSound(): string;\n    isMammal: IsMammal;\n}\n```\n3. Consider adding documentation, such as JSDoc or TypeDoc comments, to describe the `Animal` interface and its properties. This will help improve understanding and usability of the code for other developers.\n4. If the `makeAnimalSound` method includes any common or repetitive sound generation logic, consider extracting the logic to a separate utility function. This can help improve code modularity, reusability, and maintainability.\n5. Consider adding type constraints to the interface, such as `readonly` for `name` property or optional properties. This can help improve code safety and consistency:\n```typescript\ntype AnimalName = string;\ntype IsMammal = boolean;\n\nexport interface Animal {\n    readonly name: AnimalName;\n    makeAnimalSound(): string;\n    isMammal?: IsMammal;\n}\n```\nIn summary, the provided code snippet is minimal in scope, but it does not contain any critical errors. To further enhance the code quality, consider implementing the above suggestions to improve code readability, maintainability, and safety. The code generally follows sound design principles, but could benefit from additional documentation and modularization.","stopReason":"stop"}
 
 
             event: done
@@ -3109,15 +2984,13 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Thu, 22 Aug 2024 13:30:25 GMT
+            value: Fri, 23 Aug 2024 08:33:59 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
             value: chunked
           - name: connection
             value: keep-alive
-          - name: retry-after
-            value: "191"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -3135,12 +3008,12 @@ log:
             value: 1; mode=block
           - name: strict-transport-security
             value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1406
+        headersSize: 1299
         httpVersion: HTTP/1.1
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-08-22T13:30:24.225Z
+      startedDateTime: 2024-08-23T08:33:58.637Z
       time: 0
       timings:
         blocked: -1
@@ -3210,7 +3083,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Wed, 03 Jul 2024 06:24:15 GMT
+            value: Fri, 23 Aug 2024 08:23:17 GMT
           - name: content-type
             value: application/json
           - name: transfer-encoding
@@ -3241,210 +3114,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-07-03T06:24:15.015Z
-      time: 0
-      timings:
-        blocked: -1
-        connect: -1
-        dns: -1
-        receive: 0
-        send: 0
-        ssl: -1
-        wait: 0
-    - _id: 886b36cddcee696a52d1a4b602ff8a54
-      _order: 0
-      cache: {}
-      request:
-        bodySize: 318
-        cookies: []
-        headers:
-          - _fromType: array
-            name: authorization
-            value: token
-              REDACTED_0ba08837494d00e3943c46999589eb29a210ba8063f084fff511c8e4d1503909
-          - _fromType: array
-            name: content-type
-            value: application/json; charset=utf-8
-          - _fromType: array
-            name: user-agent
-            value: defaultClient / v1
-          - _fromType: array
-            name: accept
-            value: "*/*"
-          - _fromType: array
-            name: content-length
-            value: "318"
-          - _fromType: array
-            name: accept-encoding
-            value: gzip,deflate
-          - name: host
-            value: sourcegraph.com
-        headersSize: 349
-        httpVersion: HTTP/1.1
-        method: POST
-        postData:
-          mimeType: application/json; charset=utf-8
-          params: []
-          textJSON:
-            query: |-
-              
-              query CurrentSiteCodyLlmConfiguration {
-                  site {
-                      codyLLMConfiguration {
-                          chatModel
-                          chatModelMaxTokens
-                          fastChatModel
-                          fastChatModelMaxTokens
-                          completionModel
-                          completionModelMaxTokens
-                      }
-                  }
-              }
-            variables: {}
-        queryString:
-          - name: CurrentSiteCodyLlmConfiguration
-            value: null
-        url: https://sourcegraph.com/.api/graphql?CurrentSiteCodyLlmConfiguration
-      response:
-        bodySize: 22
-        content:
-          mimeType: text/plain; charset=utf-8
-          size: 22
-          text: |
-            Invalid access token.
-        cookies: []
-        headers:
-          - name: date
-            value: Thu, 27 Jun 2024 23:22:13 GMT
-          - name: content-type
-            value: text/plain; charset=utf-8
-          - name: content-length
-            value: "22"
-          - name: connection
-            value: keep-alive
-          - name: retry-after
-            value: "128"
-          - name: access-control-allow-credentials
-            value: "true"
-          - name: access-control-allow-origin
-            value: ""
-          - name: cache-control
-            value: no-cache, max-age=0
-          - name: vary
-            value: Cookie,Accept-Encoding,Authorization
-          - name: x-content-type-options
-            value: nosniff
-          - name: x-frame-options
-            value: DENY
-          - name: x-xss-protection
-            value: 1; mode=block
-          - name: strict-transport-security
-            value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1370
-        httpVersion: HTTP/1.1
-        redirectURL: ""
-        status: 401
-        statusText: Unauthorized
-      startedDateTime: 2024-06-27T23:22:13.428Z
-      time: 0
-      timings:
-        blocked: -1
-        connect: -1
-        dns: -1
-        receive: 0
-        send: 0
-        ssl: -1
-        wait: 0
-    - _id: e422cd3f4bff309631a75001539b734b
-      _order: 0
-      cache: {}
-      request:
-        bodySize: 165
-        cookies: []
-        headers:
-          - _fromType: array
-            name: authorization
-            value: token
-              REDACTED_0ba08837494d00e3943c46999589eb29a210ba8063f084fff511c8e4d1503909
-          - _fromType: array
-            name: content-type
-            value: application/json; charset=utf-8
-          - _fromType: array
-            name: user-agent
-            value: defaultClient / v1
-          - _fromType: array
-            name: accept
-            value: "*/*"
-          - _fromType: array
-            name: content-length
-            value: "165"
-          - _fromType: array
-            name: accept-encoding
-            value: gzip,deflate
-          - name: host
-            value: sourcegraph.com
-        headersSize: 349
-        httpVersion: HTTP/1.1
-        method: POST
-        postData:
-          mimeType: application/json; charset=utf-8
-          params: []
-          textJSON:
-            query: |-
-              
-              query CurrentSiteCodyLlmConfiguration {
-                  site {
-                      codyLLMConfiguration {
-                          smartContextWindow
-                      }
-                  }
-              }
-            variables: {}
-        queryString:
-          - name: CurrentSiteCodyLlmConfiguration
-            value: null
-        url: https://sourcegraph.com/.api/graphql?CurrentSiteCodyLlmConfiguration
-      response:
-        bodySize: 22
-        content:
-          mimeType: text/plain; charset=utf-8
-          size: 22
-          text: |
-            Invalid access token.
-        cookies: []
-        headers:
-          - name: date
-            value: Thu, 27 Jun 2024 23:22:13 GMT
-          - name: content-type
-            value: text/plain; charset=utf-8
-          - name: content-length
-            value: "22"
-          - name: connection
-            value: keep-alive
-          - name: retry-after
-            value: "128"
-          - name: access-control-allow-credentials
-            value: "true"
-          - name: access-control-allow-origin
-            value: ""
-          - name: cache-control
-            value: no-cache, max-age=0
-          - name: vary
-            value: Cookie,Accept-Encoding,Authorization
-          - name: x-content-type-options
-            value: nosniff
-          - name: x-frame-options
-            value: DENY
-          - name: x-xss-protection
-            value: 1; mode=block
-          - name: strict-transport-security
-            value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1370
-        httpVersion: HTTP/1.1
-        redirectURL: ""
-        status: 401
-        statusText: Unauthorized
-      startedDateTime: 2024-06-27T23:22:13.490Z
+      startedDateTime: 2024-08-23T08:23:17.666Z
       time: 0
       timings:
         blocked: -1
@@ -3518,7 +3188,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Wed, 03 Jul 2024 06:24:13 GMT
+            value: Fri, 23 Aug 2024 08:23:16 GMT
           - name: content-type
             value: text/plain; charset=utf-8
           - name: content-length
@@ -3546,7 +3216,7 @@ log:
         redirectURL: ""
         status: 401
         statusText: Unauthorized
-      startedDateTime: 2024-07-03T06:24:13.261Z
+      startedDateTime: 2024-08-23T08:23:15.836Z
       time: 0
       timings:
         blocked: -1
@@ -3615,7 +3285,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Wed, 03 Jul 2024 06:24:13 GMT
+            value: Fri, 23 Aug 2024 08:23:16 GMT
           - name: content-type
             value: text/plain; charset=utf-8
           - name: content-length
@@ -3643,7 +3313,7 @@ log:
         redirectURL: ""
         status: 401
         statusText: Unauthorized
-      startedDateTime: 2024-07-03T06:24:13.287Z
+      startedDateTime: 2024-08-23T08:23:15.890Z
       time: 0
       timings:
         blocked: -1
@@ -3708,19 +3378,29 @@ log:
             value: null
         url: https://sourcegraph.com/.api/graphql?CurrentSiteCodyLlmConfiguration
       response:
-        bodySize: 251
+        bodySize: 248
         content:
           encoding: base64
           mimeType: application/json
-          size: 251
-          text: "[\"H4sIAAAAAAAAA3zOwQqC\",\"QBAG4HeZs+K0BqFXr3rrBYbdMRdtJ3ZXKmTfPSyiSOg0\
-            8PP/H7OAoUhQLxBs5PVqMfe27RpxvT3NnqIV98wHip0YnqAGcnHwcrG60BPNhvMyD+I\
-            cx1yh2qNSFWSfQUe3o4zsAtQ7hYgZ9BRi898byI7ziyvxAD+bLanlfJl4ffaN9tbzVf\
-            wYihDJazHsYdP7gipETCmlBwAAAP//AwBQeP+1EwEAAA==\"]"
+          size: 248
+          text: "[\"H4sIAAAAAAAAA3zOwQqCQBAG4HeZs+K0BqFXr3rrBYbdMRdtJ3ZXKmTfPSyiSOg08PP/H\
+            7OAoUhQLxBs5PVqMfe27RpxvT3NnqIV98wHip0YnqAGcnHwcrG60BPNhvMyD+Icx1yh\
+            2qNSFWSfQUe3o4zsAtQ7hYgZ9BRi898byI7ziyvxAD+bLanlfJl4ffaN9tbzVfwYihD\
+            JazHsYdP7gipETCmlBwAAAP//AwBQeP+1EwEAAA==\"]"
+          textDecoded:
+            data:
+              site:
+                codyLLMConfiguration:
+                  chatModel: anthropic/claude-3-sonnet-20240229
+                  chatModelMaxTokens: 12000
+                  completionModel: fireworks/starcoder
+                  completionModelMaxTokens: 9000
+                  fastChatModel: anthropic/claude-3-haiku-20240307
+                  fastChatModelMaxTokens: 12000
         cookies: []
         headers:
           - name: date
-            value: Wed, 03 Jul 2024 06:24:14 GMT
+            value: Fri, 23 Aug 2024 08:23:16 GMT
           - name: content-type
             value: application/json
           - name: transfer-encoding
@@ -3751,7 +3431,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-07-03T06:24:13.841Z
+      startedDateTime: 2024-08-23T08:23:16.678Z
       time: 0
       timings:
         blocked: -1
@@ -3811,22 +3491,17 @@ log:
             value: null
         url: https://sourcegraph.com/.api/graphql?CurrentSiteCodyLlmConfiguration
       response:
-        bodySize: 132
+        bodySize: 135
         content:
           encoding: base64
           mimeType: application/json
-          size: 132
-          text: "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqzixJBdHJ+SmVPj6+zvl5aZnppUWJJZn5eWD53MSiE\
-            uf8vJLUipLwzLyU/HIlK6XUvMSknNQUpdra2loAAAAA//8DAOgINKVLAAAA\"]"
-          textDecoded:
-            data:
-              site:
-                codyLLMConfiguration:
-                  smartContextWindow: enabled
+          size: 135
+          text: "[\"H4sIAAAAAAAAA6pWSkks\",\"SVSyqlYqzixJBdHJ+SmVPj6+zvl5aZnppUWJJZn5eWD5\
+            3MSiEuf8vJLUipLwzLyU/HIlK6XUvMSknNQUpdra2loAAAAA//8DAOgINKVLAAAA\"]"
         cookies: []
         headers:
           - name: date
-            value: Wed, 03 Jul 2024 06:24:14 GMT
+            value: Fri, 23 Aug 2024 08:23:16 GMT
           - name: content-type
             value: application/json
           - name: transfer-encoding
@@ -3857,7 +3532,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-07-03T06:24:13.885Z
+      startedDateTime: 2024-08-23T08:23:16.679Z
       time: 0
       timings:
         blocked: -1
@@ -3867,11 +3542,11 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: 6fb42f99b2251f1186cc37f1fd82113e
+    - _id: 886b36cddcee696a52d1a4b602ff8a54
       _order: 0
       cache: {}
       request:
-        bodySize: 150
+        bodySize: 318
         cookies: []
         headers:
           - _fromType: array
@@ -3889,13 +3564,13 @@ log:
             value: "*/*"
           - _fromType: array
             name: content-length
-            value: "150"
+            value: "318"
           - _fromType: array
             name: accept-encoding
             value: gzip,deflate
           - name: host
             value: sourcegraph.com
-        headersSize: 344
+        headersSize: 349
         httpVersion: HTTP/1.1
         method: POST
         postData:
@@ -3904,18 +3579,23 @@ log:
           textJSON:
             query: |-
               
-              query CurrentSiteCodyLlmProvider {
+              query CurrentSiteCodyLlmConfiguration {
                   site {
                       codyLLMConfiguration {
-                          provider
+                          chatModel
+                          chatModelMaxTokens
+                          fastChatModel
+                          fastChatModelMaxTokens
+                          completionModel
+                          completionModelMaxTokens
                       }
                   }
               }
             variables: {}
         queryString:
-          - name: CurrentSiteCodyLlmProvider
+          - name: CurrentSiteCodyLlmConfiguration
             value: null
-        url: https://sourcegraph.com/.api/graphql?CurrentSiteCodyLlmProvider
+        url: https://sourcegraph.com/.api/graphql?CurrentSiteCodyLlmConfiguration
       response:
         bodySize: 22
         content:
@@ -3926,15 +3606,13 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Thu, 27 Jun 2024 23:22:13 GMT
+            value: Fri, 23 Aug 2024 08:23:17 GMT
           - name: content-type
             value: text/plain; charset=utf-8
           - name: content-length
             value: "22"
           - name: connection
             value: keep-alive
-          - name: retry-after
-            value: "128"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -3951,12 +3629,109 @@ log:
             value: 1; mode=block
           - name: strict-transport-security
             value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1370
+        headersSize: 1263
         httpVersion: HTTP/1.1
         redirectURL: ""
         status: 401
         statusText: Unauthorized
-      startedDateTime: 2024-06-27T23:22:13.462Z
+      startedDateTime: 2024-08-23T08:23:17.503Z
+      time: 0
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 0
+    - _id: e422cd3f4bff309631a75001539b734b
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 165
+        cookies: []
+        headers:
+          - _fromType: array
+            name: authorization
+            value: token
+              REDACTED_0ba08837494d00e3943c46999589eb29a210ba8063f084fff511c8e4d1503909
+          - _fromType: array
+            name: content-type
+            value: application/json; charset=utf-8
+          - _fromType: array
+            name: user-agent
+            value: defaultClient / v1
+          - _fromType: array
+            name: accept
+            value: "*/*"
+          - _fromType: array
+            name: content-length
+            value: "165"
+          - _fromType: array
+            name: accept-encoding
+            value: gzip,deflate
+          - name: host
+            value: sourcegraph.com
+        headersSize: 349
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json; charset=utf-8
+          params: []
+          textJSON:
+            query: |-
+              
+              query CurrentSiteCodyLlmConfiguration {
+                  site {
+                      codyLLMConfiguration {
+                          smartContextWindow
+                      }
+                  }
+              }
+            variables: {}
+        queryString:
+          - name: CurrentSiteCodyLlmConfiguration
+            value: null
+        url: https://sourcegraph.com/.api/graphql?CurrentSiteCodyLlmConfiguration
+      response:
+        bodySize: 22
+        content:
+          mimeType: text/plain; charset=utf-8
+          size: 22
+          text: |
+            Invalid access token.
+        cookies: []
+        headers:
+          - name: date
+            value: Fri, 23 Aug 2024 08:23:17 GMT
+          - name: content-type
+            value: text/plain; charset=utf-8
+          - name: content-length
+            value: "22"
+          - name: connection
+            value: keep-alive
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache, max-age=0
+          - name: vary
+            value: Cookie,Accept-Encoding,Authorization
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+        headersSize: 1263
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 401
+        statusText: Unauthorized
+      startedDateTime: 2024-08-23T08:23:17.504Z
       time: 0
       timings:
         blocked: -1
@@ -4025,7 +3800,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Wed, 03 Jul 2024 06:24:13 GMT
+            value: Fri, 23 Aug 2024 08:23:16 GMT
           - name: content-type
             value: text/plain; charset=utf-8
           - name: content-length
@@ -4053,7 +3828,7 @@ log:
         redirectURL: ""
         status: 401
         statusText: Unauthorized
-      startedDateTime: 2024-07-03T06:24:13.263Z
+      startedDateTime: 2024-08-23T08:23:15.862Z
       time: 0
       timings:
         blocked: -1
@@ -4113,22 +3888,17 @@ log:
             value: null
         url: https://sourcegraph.com/.api/graphql?CurrentSiteCodyLlmProvider
       response:
-        bodySize: 128
+        bodySize: 131
         content:
           encoding: base64
           mimeType: application/json
-          size: 128
-          text: "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqzixJBdHJ+SmVPj6+zvl5aZnppUWJJZn5eSDxgqL8s\
-            syU1CIlK6Xi/NKi5NT0osSCDKXa2tpaAAAAAP//AwAfFAXARQAAAA==\"]"
-          textDecoded:
-            data:
-              site:
-                codyLLMConfiguration:
-                  provider: sourcegraph
+          size: 131
+          text: "[\"H4sIAAAAAAAAA6pWSkks\",\"SVSyqlYqzixJBdHJ+SmVPj6+zvl5aZnppUWJJZn5eSDx\
+            gqL8ssyU1CIlK6Xi/NKi5NT0osSCDKXa2tpaAAAAAP//AwAfFAXARQAAAA==\"]"
         cookies: []
         headers:
           - name: date
-            value: Wed, 03 Jul 2024 06:24:14 GMT
+            value: Fri, 23 Aug 2024 08:23:16 GMT
           - name: content-type
             value: application/json
           - name: transfer-encoding
@@ -4159,7 +3929,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-07-03T06:24:13.864Z
+      startedDateTime: 2024-08-23T08:23:16.678Z
       time: 0
       timings:
         blocked: -1
@@ -4169,11 +3939,11 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: 2af9a176de37be11dff4f113b3a1f7aa
+    - _id: 6fb42f99b2251f1186cc37f1fd82113e
       _order: 0
       cache: {}
       request:
-        bodySize: 341
+        bodySize: 150
         cookies: []
         headers:
           - _fromType: array
@@ -4191,13 +3961,13 @@ log:
             value: "*/*"
           - _fromType: array
             name: content-length
-            value: "341"
+            value: "150"
           - _fromType: array
             name: accept-encoding
             value: gzip,deflate
           - name: host
             value: sourcegraph.com
-        headersSize: 329
+        headersSize: 344
         httpVersion: HTTP/1.1
         method: POST
         postData:
@@ -4206,29 +3976,18 @@ log:
           textJSON:
             query: |-
               
-              query CurrentUser {
-                  currentUser {
-                      id
-                      hasVerifiedEmail
-                      displayName
-                      username
-                      avatarURL
-                      primaryEmail {
-                          email
-                      }
-                      organizations {
-                          nodes {
-                              id
-                              name
-                          }
+              query CurrentSiteCodyLlmProvider {
+                  site {
+                      codyLLMConfiguration {
+                          provider
                       }
                   }
               }
             variables: {}
         queryString:
-          - name: CurrentUser
+          - name: CurrentSiteCodyLlmProvider
             value: null
-        url: https://sourcegraph.com/.api/graphql?CurrentUser
+        url: https://sourcegraph.com/.api/graphql?CurrentSiteCodyLlmProvider
       response:
         bodySize: 22
         content:
@@ -4239,15 +3998,13 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Thu, 27 Jun 2024 23:22:13 GMT
+            value: Fri, 23 Aug 2024 08:23:17 GMT
           - name: content-type
             value: text/plain; charset=utf-8
           - name: content-length
             value: "22"
           - name: connection
             value: keep-alive
-          - name: retry-after
-            value: "128"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -4264,12 +4021,12 @@ log:
             value: 1; mode=block
           - name: strict-transport-security
             value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1370
+        headersSize: 1263
         httpVersion: HTTP/1.1
         redirectURL: ""
         status: 401
         statusText: Unauthorized
-      startedDateTime: 2024-06-27T23:22:13.522Z
+      startedDateTime: 2024-08-23T08:23:17.503Z
       time: 0
       timings:
         blocked: -1
@@ -4349,7 +4106,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Wed, 03 Jul 2024 06:24:13 GMT
+            value: Fri, 23 Aug 2024 08:23:16 GMT
           - name: content-type
             value: text/plain; charset=utf-8
           - name: content-length
@@ -4377,7 +4134,7 @@ log:
         redirectURL: ""
         status: 401
         statusText: Unauthorized
-      startedDateTime: 2024-07-03T06:24:13.309Z
+      startedDateTime: 2024-08-23T08:23:15.918Z
       time: 0
       timings:
         blocked: -1
@@ -4448,21 +4205,33 @@ log:
             value: null
         url: https://sourcegraph.com/.api/graphql?CurrentUser
       response:
-        bodySize: 379
+        bodySize: 376
         content:
           encoding: base64
           mimeType: application/json
-          size: 379
-          text: "[\"H4sIAAAAAAAAA2RPy04=\",\"wkAU/Ze7bmkNUdpJSBQEF2jjIzQY4+J2emmnj5k6DxSa\
-            /jtpMHHh7pycx72nhxwtAuuBO61J2q0hPVKRA4N0lzS8Uqfk/uXqqeJz8KBEk5IWe0H\
-            5qkXRALPakQe5MF2DxwRbAgZvymlOhcauXCjrx2EYggfOkJYXg/kzZMrGtb+X360DD/\
-            CAFvX29REYlNZ2hgVBU04nhVJFQ2MDV9KStBOu2gCDu2URKb5Z41f2Tm5RZ9V1vl6df\
-            qJsl0Y4E1OTZptl8pzOHkJ3PNRzE9/4HDzotGhRH39H9EAX8O+z22IUxmsweKB0gVKc\
-            0AolzRiTKicD7ONzGIbhDAAA//8DAEqMkz9OAQAA\"]"
+          size: 376
+          text: "[\"H4sIAAAAAAAAA2RPy07CQBT9l7tuaQ1R2klIFAQXaOMjNBjj4nZ6aaePmToPFJr+O2kwc\
+            eHunJzHvaeHHC0C64E7rUnarSE9UpEDg3SXNLxSp+T+5eqp4nPwoESTkhZ7QfmqRdEA\
+            s9qRB7kwXYPHBFsCBm/KaU6Fxq5cKOvHYRiCB86QlheD+TNkysa1v5ffrQMP8IAW9fb\
+            1ERiU1naGBUFTTieFUkVDYwNX0pK0E67aAIO7ZREpvlnjV/ZOblFn1XW+Xp1+omyXRj\
+            gTU5Nmm2XynM4eQnc81HMT3/gcPOi0aFEff0f0QBfw77PbYhTGazB4oHSBUpzQCiXNG\
+            JMqJwPs43MYhuEMAAD//wMASoyTP04BAAA=\"]"
+          textDecoded:
+            data:
+              currentUser:
+                avatarURL: https://lh3.googleusercontent.com/a/ACg8ocKFaqbYeuBkbj5dFEzx8bXV8a7i3sVbKCNPV7G0uyvk=s96-c
+                displayName: SourcegraphBot-9000
+                hasVerifiedEmail: true
+                id: VXNlcjozNDQ1Mjc=
+                organizations:
+                  nodes: []
+                primaryEmail:
+                  email: sourcegraphbot9k@gmail.com
+                username: sourcegraphbot9k-fnwmu
         cookies: []
         headers:
           - name: date
-            value: Wed, 03 Jul 2024 06:24:14 GMT
+            value: Fri, 23 Aug 2024 08:23:16 GMT
           - name: content-type
             value: application/json
           - name: transfer-encoding
@@ -4493,7 +4262,115 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-07-03T06:24:13.907Z
+      startedDateTime: 2024-08-23T08:23:16.680Z
+      time: 0
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 0
+    - _id: 2af9a176de37be11dff4f113b3a1f7aa
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 341
+        cookies: []
+        headers:
+          - _fromType: array
+            name: authorization
+            value: token
+              REDACTED_0ba08837494d00e3943c46999589eb29a210ba8063f084fff511c8e4d1503909
+          - _fromType: array
+            name: content-type
+            value: application/json; charset=utf-8
+          - _fromType: array
+            name: user-agent
+            value: defaultClient / v1
+          - _fromType: array
+            name: accept
+            value: "*/*"
+          - _fromType: array
+            name: content-length
+            value: "341"
+          - _fromType: array
+            name: accept-encoding
+            value: gzip,deflate
+          - name: host
+            value: sourcegraph.com
+        headersSize: 329
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json; charset=utf-8
+          params: []
+          textJSON:
+            query: |-
+              
+              query CurrentUser {
+                  currentUser {
+                      id
+                      hasVerifiedEmail
+                      displayName
+                      username
+                      avatarURL
+                      primaryEmail {
+                          email
+                      }
+                      organizations {
+                          nodes {
+                              id
+                              name
+                          }
+                      }
+                  }
+              }
+            variables: {}
+        queryString:
+          - name: CurrentUser
+            value: null
+        url: https://sourcegraph.com/.api/graphql?CurrentUser
+      response:
+        bodySize: 22
+        content:
+          mimeType: text/plain; charset=utf-8
+          size: 22
+          text: |
+            Invalid access token.
+        cookies: []
+        headers:
+          - name: date
+            value: Fri, 23 Aug 2024 08:23:17 GMT
+          - name: content-type
+            value: text/plain; charset=utf-8
+          - name: content-length
+            value: "22"
+          - name: connection
+            value: keep-alive
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache, max-age=0
+          - name: vary
+            value: Cookie,Accept-Encoding,Authorization
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+        headersSize: 1263
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 401
+        statusText: Unauthorized
+      startedDateTime: 2024-08-23T08:23:17.504Z
       time: 0
       timings:
         blocked: -1
@@ -4562,23 +4439,23 @@ log:
           encoding: base64
           mimeType: application/json
           size: 228
-          text: "[\"H4sIAAAAAAAAA1zMsQrCMBSF4Xc5c4U2FoVsRToIgqWtDm6xyRCoSbi5GUrJu4uCoI7n5\
+          text: "[\"H4sIAAAAAAAAA1zMsQrCMBSF4Xc5c4U2dtBsRToIgqWtDm6xyRCoSbi5GUrJu4uCoI7n5\
             +Os0IoV5IopERnHl2joPb1ehnSPE9nA1rtXi6w4RUg0h/F4bVEgzMpBouvPKKBCmJeO\
             fK/YnOzDcoRkSqb4fHeGrNcDK+KGISFKUW/K3aaqRyFkVcmtuOFPt05/2f2vzTnnJwA\
-            AAP//AwBuKtnYwgAAAA==\"]"
+            AAP//AwBSGHacwgAAAA==\"]"
           textDecoded:
             data:
               currentUser:
                 codySubscription:
                   applyProRateLimits: true
-                  currentPeriodEndAt: 2024-07-14T22:11:32Z
-                  currentPeriodStartAt: 2024-06-14T22:11:32Z
+                  currentPeriodEndAt: 2024-09-14T22:11:32Z
+                  currentPeriodStartAt: 2024-08-14T22:11:32Z
                   plan: PRO
                   status: ACTIVE
         cookies: []
         headers:
           - name: date
-            value: Wed, 03 Jul 2024 06:24:14 GMT
+            value: Fri, 23 Aug 2024 08:23:17 GMT
           - name: content-type
             value: application/json
           - name: transfer-encoding
@@ -4609,7 +4486,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-07-03T06:24:14.313Z
+      startedDateTime: 2024-08-23T08:23:16.853Z
       time: 0
       timings:
         blocked: -1
@@ -4677,7 +4554,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Wed, 03 Jul 2024 09:58:04 GMT
+            value: Fri, 23 Aug 2024 08:23:16 GMT
           - name: content-type
             value: text/plain; charset=utf-8
           - name: content-length
@@ -4705,104 +4582,7 @@ log:
         redirectURL: ""
         status: 401
         statusText: Unauthorized
-      startedDateTime: 2024-07-03T09:58:04.140Z
-      time: 0
-      timings:
-        blocked: -1
-        connect: -1
-        dns: -1
-        receive: 0
-        send: 0
-        ssl: -1
-        wait: 0
-    - _id: 9871a0347b3e3056e8c6ab32f8d599db
-      _order: 0
-      cache: {}
-      request:
-        bodySize: 101
-        cookies: []
-        headers:
-          - _fromType: array
-            name: authorization
-            value: token
-              REDACTED_0ba08837494d00e3943c46999589eb29a210ba8063f084fff511c8e4d1503909
-          - _fromType: array
-            name: content-type
-            value: application/json; charset=utf-8
-          - _fromType: array
-            name: user-agent
-            value: defaultClient / v1
-          - _fromType: array
-            name: accept
-            value: "*/*"
-          - _fromType: array
-            name: content-length
-            value: "101"
-          - _fromType: array
-            name: accept-encoding
-            value: gzip,deflate
-          - name: host
-            value: sourcegraph.com
-        headersSize: 336
-        httpVersion: HTTP/1.1
-        method: POST
-        postData:
-          mimeType: application/json; charset=utf-8
-          params: []
-          textJSON:
-            query: |-
-              
-              query SiteProductVersion {
-                  site {
-                      productVersion
-                  }
-              }
-            variables: {}
-        queryString:
-          - name: SiteProductVersion
-            value: null
-        url: https://sourcegraph.com/.api/graphql?SiteProductVersion
-      response:
-        bodySize: 22
-        content:
-          mimeType: text/plain; charset=utf-8
-          size: 22
-          text: |
-            Invalid access token.
-        cookies: []
-        headers:
-          - name: date
-            value: Thu, 27 Jun 2024 23:22:13 GMT
-          - name: content-type
-            value: text/plain; charset=utf-8
-          - name: content-length
-            value: "22"
-          - name: connection
-            value: keep-alive
-          - name: retry-after
-            value: "128"
-          - name: access-control-allow-credentials
-            value: "true"
-          - name: access-control-allow-origin
-            value: ""
-          - name: cache-control
-            value: no-cache, max-age=0
-          - name: vary
-            value: Cookie,Accept-Encoding,Authorization
-          - name: x-content-type-options
-            value: nosniff
-          - name: x-frame-options
-            value: DENY
-          - name: x-xss-protection
-            value: 1; mode=block
-          - name: strict-transport-security
-            value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1370
-        httpVersion: HTTP/1.1
-        redirectURL: ""
-        status: 401
-        statusText: Unauthorized
-      startedDateTime: 2024-06-27T23:22:13.396Z
+      startedDateTime: 2024-08-23T08:23:16.185Z
       time: 0
       timings:
         blocked: -1
@@ -4869,7 +4649,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Wed, 03 Jul 2024 06:24:13 GMT
+            value: Fri, 23 Aug 2024 08:23:16 GMT
           - name: content-type
             value: text/plain; charset=utf-8
           - name: content-length
@@ -4897,7 +4677,7 @@ log:
         redirectURL: ""
         status: 401
         statusText: Unauthorized
-      startedDateTime: 2024-07-03T06:24:13.260Z
+      startedDateTime: 2024-08-23T08:23:15.776Z
       time: 0
       timings:
         blocked: -1
@@ -4955,18 +4735,18 @@ log:
             value: null
         url: https://sourcegraph.com/.api/graphql?SiteProductVersion
       response:
-        bodySize: 142
+        bodySize: 139
         content:
           encoding: base64
           mimeType: application/json
-          size: 142
-          text: "[\"H4sIAAAAAAAAA6pWSkks\",\"SVSyqlYqzixJBdEFRfkppcklYalFxZn5eUpWSkYWJhaW\
-            JvFGBkYmugbmusYG8aZ6prqGZimGiUnmphZmKaZKtbW1AAAAAP//\",\"AwBqTeUBSQ\
-            AAAA==\"]"
+          size: 139
+          text: "[\"H4sIAAAAAAAAA6pWSkks\",\"SVSyqlYqzixJBdEFRfkppcklYalFxZn5eUpWSkYWFmYG\
+            5vFGBkYmugYWukZG8aZ6ZrrGxmlJlhbJpgYmFilKtbW1AAAAAP//AwCvLlq5SQAAAA==\
+            \"]"
         cookies: []
         headers:
           - name: date
-            value: Tue, 30 Jul 2024 18:17:42 GMT
+            value: Fri, 23 Aug 2024 08:23:16 GMT
           - name: content-type
             value: application/json
           - name: transfer-encoding
@@ -4997,7 +4777,102 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-07-30T18:17:42.236Z
+      startedDateTime: 2024-08-23T08:23:16.676Z
+      time: 0
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 0
+    - _id: 9871a0347b3e3056e8c6ab32f8d599db
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 101
+        cookies: []
+        headers:
+          - _fromType: array
+            name: authorization
+            value: token
+              REDACTED_0ba08837494d00e3943c46999589eb29a210ba8063f084fff511c8e4d1503909
+          - _fromType: array
+            name: content-type
+            value: application/json; charset=utf-8
+          - _fromType: array
+            name: user-agent
+            value: defaultClient / v1
+          - _fromType: array
+            name: accept
+            value: "*/*"
+          - _fromType: array
+            name: content-length
+            value: "101"
+          - _fromType: array
+            name: accept-encoding
+            value: gzip,deflate
+          - name: host
+            value: sourcegraph.com
+        headersSize: 336
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json; charset=utf-8
+          params: []
+          textJSON:
+            query: |-
+              
+              query SiteProductVersion {
+                  site {
+                      productVersion
+                  }
+              }
+            variables: {}
+        queryString:
+          - name: SiteProductVersion
+            value: null
+        url: https://sourcegraph.com/.api/graphql?SiteProductVersion
+      response:
+        bodySize: 22
+        content:
+          mimeType: text/plain; charset=utf-8
+          size: 22
+          text: |
+            Invalid access token.
+        cookies: []
+        headers:
+          - name: date
+            value: Fri, 23 Aug 2024 08:23:17 GMT
+          - name: content-type
+            value: text/plain; charset=utf-8
+          - name: content-length
+            value: "22"
+          - name: connection
+            value: keep-alive
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache, max-age=0
+          - name: vary
+            value: Cookie,Accept-Encoding,Authorization
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+        headersSize: 1263
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 401
+        statusText: Unauthorized
+      startedDateTime: 2024-08-23T08:23:17.502Z
       time: 0
       timings:
         blocked: -1

--- a/agent/recordings/defaultClient_631904893/recording.har.yaml
+++ b/agent/recordings/defaultClient_631904893/recording.har.yaml
@@ -36,18 +36,18 @@ log:
         queryString: []
         url: https://sourcegraph.com/.api/client-config
       response:
-        bodySize: 188
+        bodySize: 191
         content:
           encoding: base64
           mimeType: text/plain; charset=utf-8
-          size: 188
-          text: "[\"H4sIAAAAAAAAA2zMsQoCMRCE4T5PsVztE9hJsLjOznrPrBjI7koyQeW4d7dRBEn9z3xrI\
-            CKaLp5eR+OlSJr2hNpl9wk3xjBwh0fXexHI+NkbXKOrsqU2NoCal47s9utXLu07aMoV\
-            0Q3yxDlb8sfQUU9S2uE0/ylhC28AAAD//wMAK/Ow9eAAAAA=\"]"
+          size: 191
+          text: "[\"H4sIAAAA\",\"AAAAA2zMsQoCMRCE4T5PsVztE9hJsLjOznrPrBjI7koyQeW4d7dRBEn9\
+            z3xrICKaLp5eR+OlSJr2hNpl9wk3xjBwh0fXexHI+NkbXKOrsqU2NoCal47s9utXLu0\
+            7aMoV0Q3yxDlb8sfQUU9S2uE0/ylhC28AAAD//wMAK/Ow9eAAAAA=\"]"
         cookies: []
         headers:
           - name: date
-            value: Fri, 23 Aug 2024 08:23:17 GMT
+            value: Fri, 23 Aug 2024 09:45:38 GMT
           - name: content-type
             value: text/plain; charset=utf-8
           - name: transfer-encoding
@@ -78,7 +78,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-08-23T08:23:17.336Z
+      startedDateTime: 2024-08-23T09:45:38.482Z
       time: 0
       timings:
         blocked: -1
@@ -88,11 +88,11 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: e8876126f9b98980c7e5f1127d1af404
+    - _id: 72e09632123f0e9e603b0469bc56c1dc
       _order: 0
       cache: {}
       request:
-        bodySize: 415
+        bodySize: 405
         cookies: []
         headers:
           - name: content-type
@@ -105,7 +105,7 @@ log:
           - name: user-agent
             value: defaultClient / v1
           - name: traceparent
-            value: 00-61a0eeee25f0a22487b0218728a3bd15-1b119ef577e0f75f-01
+            value: 00-ee10dbb89edd7e0fd4802d4814368cbc-bef3de477f2d9df5-01
           - name: connection
             value: keep-alive
           - name: host
@@ -120,13 +120,10 @@ log:
             maxTokensToSample: 4000
             messages:
               - speaker: system
-                text: >-
-                  You are Cody, an AI coding assistant from Sourcegraph.If your
-                  answer contains fenced code blocks in Markdown, include the
-                  relevant full file path in the code block tag using this
-                  structure: ```$LANGUAGE:$FILEPATH
-
-                  $CONTENT```.
+                text: "You are Cody, an AI coding assistant from Sourcegraph.If your answer
+                  contains fenced code blocks in Markdown, include the relevant
+                  full file path in the code block tag using this structure:
+                  ```$LANGUAGE:$FILEPATH```."
               - speaker: human
                 text: Hello!
             model: anthropic/claude-3-5-sonnet-20240620
@@ -142,14 +139,14 @@ log:
             value: v1
         url: https://sourcegraph.com/.api/completions/stream?api-version=1&client-name=defaultclient&client-version=v1
       response:
-        bodySize: 5095
+        bodySize: 5126
         content:
           mimeType: text/event-stream
-          size: 5095
+          size: 5126
           text: >+
             event: completion
 
-            data: {"completion":"Hello! I'm Cody, an AI coding assistant from Sourcegraph. How can I help you with your coding tasks today? Whether you need help with writing code, debugging, explaining concepts, or anything else related to programming, I'm here to assist. What would you like to work on?","stopReason":"end_turn"}
+            data: {"completion":"Hello! I'm Cody, an AI coding assistant from Sourcegraph. How can I help you with your coding tasks today? Whether you need assistance with writing code, debugging, explaining concepts, or anything else related to programming, I'm here to help. What would you like to work on?","stopReason":"end_turn"}
 
 
             event: done
@@ -159,7 +156,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Fri, 23 Aug 2024 08:33:23 GMT
+            value: Fri, 23 Aug 2024 09:45:41 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
@@ -188,7 +185,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-08-23T08:33:22.250Z
+      startedDateTime: 2024-08-23T09:45:40.128Z
       time: 0
       timings:
         blocked: -1
@@ -198,11 +195,11 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: fc3cdc98bf6279b4516e6a8929efc9ee
+    - _id: b0173707b82ffca200bd947df77cce56
       _order: 0
       cache: {}
       request:
-        bodySize: 454
+        bodySize: 444
         cookies: []
         headers:
           - name: content-type
@@ -215,7 +212,7 @@ log:
           - name: user-agent
             value: defaultClient / v1
           - name: traceparent
-            value: 00-1ea00b3488cb62b2f8fb9add848ef1e9-009e95705b347e56-01
+            value: 00-2c45f9a410fe0826a9254d2b1b7ceb45-037fa51f5e885b2e-01
           - name: connection
             value: keep-alive
           - name: host
@@ -230,13 +227,10 @@ log:
             maxTokensToSample: 4000
             messages:
               - speaker: system
-                text: >-
-                  You are Cody, an AI coding assistant from Sourcegraph.If your
-                  answer contains fenced code blocks in Markdown, include the
-                  relevant full file path in the code block tag using this
-                  structure: ```$LANGUAGE:$FILEPATH
-
-                  $CONTENT```.
+                text: "You are Cody, an AI coding assistant from Sourcegraph.If your answer
+                  contains fenced code blocks in Markdown, include the relevant
+                  full file path in the code block tag using this structure:
+                  ```$LANGUAGE:$FILEPATH```."
               - speaker: human
                 text: Generate simple hello world function in java!
             model: anthropic/claude-3-5-sonnet-20240620
@@ -252,14 +246,14 @@ log:
             value: v1
         url: https://sourcegraph.com/.api/completions/stream?api-version=1&client-name=defaultclient&client-version=v1
       response:
-        bodySize: 50705
+        bodySize: 38587
         content:
           mimeType: text/event-stream
-          size: 50705
+          size: 38587
           text: >+
             event: completion
 
-            data: {"completion":"Certainly! Here's a simple \"Hello, World!\" function in Java:\n\n```java:HelloWorld.java\npublic class HelloWorld {\n    public static void main(String[] args) {\n        sayHello();\n    }\n\n    public static void sayHello() {\n        System.out.println(\"Hello, World!\");\n    }\n}\n```\n\nThis Java code does the following:\n\n1. We define a class called `HelloWorld`.\n2. Inside the class, we have the `main` method, which is the entry point of any Java program.\n3. We also define a `sayHello` method that prints \"Hello, World!\" to the console.\n4. In the `main` method, we call the `sayHello` function.\n\nTo run this program:\n\n1. Save the code in a file named `HelloWorld.java`.\n2. Compile the Java file by running `javac HelloWorld.java` in the terminal.\n3. Run the compiled program with `java HelloWorld`.\n\nWhen you run this program, it will output:\n\n```\nHello, World!\n```\n\nThis is a basic example of a Java function that prints a greeting to the console. You can modify the `sayHello` function to print different messages or add more functionality as needed.","stopReason":"end_turn"}
+            data: {"completion":"Certainly! Here's a simple \"Hello, World!\" function in Java:\n\n```java:HelloWorld.java\npublic class HelloWorld {\n    public static void main(String[] args) {\n        sayHello();\n    }\n\n    public static void sayHello() {\n        System.out.println(\"Hello, World!\");\n    }\n}\n```\n\nThis code does the following:\n\n1. We define a class called `HelloWorld`.\n2. Inside the class, we have the `main` method, which is the entry point of any Java program.\n3. We define a separate method called `sayHello()` that prints \"Hello, World!\" to the console.\n4. In the `main` method, we call the `sayHello()` function.\n\nTo run this program:\n\n1. Save the code in a file named `HelloWorld.java`.\n2. Compile the code using the Java compiler: `javac HelloWorld.java`\n3. Run the compiled program: `java HelloWorld`\n\nWhen you run this program, it will output:\n\n```\nHello, World!\n```\n\nThis simple example demonstrates how to create a function in Java and call it from the main method.","stopReason":"end_turn"}
 
 
             event: done
@@ -269,7 +263,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Fri, 23 Aug 2024 08:33:25 GMT
+            value: Fri, 23 Aug 2024 09:45:43 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
@@ -298,7 +292,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-08-23T08:33:24.012Z
+      startedDateTime: 2024-08-23T09:45:41.903Z
       time: 0
       timings:
         blocked: -1
@@ -308,11 +302,11 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: 30ec56503f513ca75a1398a62a05fcf3
+    - _id: b09dce6680847a9fe96041bcae5f955a
       _order: 0
       cache: {}
       request:
-        bodySize: 432
+        bodySize: 422
         cookies: []
         headers:
           - name: content-type
@@ -325,7 +319,7 @@ log:
           - name: user-agent
             value: defaultClient / v1
           - name: traceparent
-            value: 00-66e77afea54db9208a5dbc939040b97e-cdc276411272ec27-01
+            value: 00-b3c7a87e55a259bdf7b3022356881be9-295da97119fd11a1-01
           - name: connection
             value: keep-alive
           - name: host
@@ -340,13 +334,10 @@ log:
             maxTokensToSample: 4000
             messages:
               - speaker: system
-                text: >-
-                  You are Cody, an AI coding assistant from Sourcegraph.If your
-                  answer contains fenced code blocks in Markdown, include the
-                  relevant full file path in the code block tag using this
-                  structure: ```$LANGUAGE:$FILEPATH
-
-                  $CONTENT```.
+                text: "You are Cody, an AI coding assistant from Sourcegraph.If your answer
+                  contains fenced code blocks in Markdown, include the relevant
+                  full file path in the code block tag using this structure:
+                  ```$LANGUAGE:$FILEPATH```."
               - speaker: human
                 text: My name is Lars Monsen.
             model: anthropic/claude-3-5-sonnet-20240620
@@ -362,14 +353,14 @@ log:
             value: v1
         url: https://sourcegraph.com/.api/completions/stream?api-version=1&client-name=defaultclient&client-version=v1
       response:
-        bodySize: 5151
+        bodySize: 3615
         content:
           mimeType: text/event-stream
-          size: 5151
+          size: 3615
           text: >+
             event: completion
 
-            data: {"completion":"Hello Lars Monsen, it's nice to meet you. I'm Cody, an AI coding assistant from Sourcegraph. How can I help you with coding or development tasks today? Feel free to ask me any questions related to programming, software development, or specific coding issues you might be working on.","stopReason":"end_turn"}
+            data: {"completion":"Hello Lars Monsen, it's nice to meet you. As an AI coding assistant, I'm here to help you with any programming or coding-related questions you may have. Is there a particular coding task or problem you'd like assistance with today?","stopReason":"end_turn"}
 
 
             event: done
@@ -379,7 +370,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Fri, 23 Aug 2024 08:33:29 GMT
+            value: Fri, 23 Aug 2024 09:45:46 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
@@ -408,7 +399,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-08-23T08:33:27.790Z
+      startedDateTime: 2024-08-23T09:45:45.379Z
       time: 0
       timings:
         blocked: -1
@@ -418,11 +409,11 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: a77bd5a1a812c39478cb5256032d8093
+    - _id: 1800ddcdadc69262f895e5e186e78a37
       _order: 0
       cache: {}
       request:
-        bodySize: 794
+        bodySize: 733
         cookies: []
         headers:
           - name: content-type
@@ -435,7 +426,7 @@ log:
           - name: user-agent
             value: defaultClient / v1
           - name: traceparent
-            value: 00-99e4f82405db7804e5b896f3db1f9c76-18c4386eda2e373e-01
+            value: 00-8f66d98fbc69a3ea237f2220910f901c-e32adcaa2ed6ca2e-01
           - name: connection
             value: keep-alive
           - name: host
@@ -450,21 +441,17 @@ log:
             maxTokensToSample: 4000
             messages:
               - speaker: system
-                text: >-
-                  You are Cody, an AI coding assistant from Sourcegraph.If your
-                  answer contains fenced code blocks in Markdown, include the
-                  relevant full file path in the code block tag using this
-                  structure: ```$LANGUAGE:$FILEPATH
-
-                  $CONTENT```.
+                text: "You are Cody, an AI coding assistant from Sourcegraph.If your answer
+                  contains fenced code blocks in Markdown, include the relevant
+                  full file path in the code block tag using this structure:
+                  ```$LANGUAGE:$FILEPATH```."
               - speaker: human
                 text: My name is Lars Monsen.
               - speaker: assistant
-                text: Hello Lars Monsen, it's nice to meet you. I'm Cody, an AI coding assistant
-                  from Sourcegraph. How can I help you with coding or
-                  development tasks today? Feel free to ask me any questions
-                  related to programming, software development, or specific
-                  coding issues you might be working on.
+                text: Hello Lars Monsen, it's nice to meet you. As an AI coding assistant, I'm
+                  here to help you with any programming or coding-related
+                  questions you may have. Is there a particular coding task or
+                  problem you'd like assistance with today?
               - speaker: human
                 text: What is my name?
             model: anthropic/claude-3-5-sonnet-20240620
@@ -480,14 +467,14 @@ log:
             value: v1
         url: https://sourcegraph.com/.api/completions/stream?api-version=1&client-name=defaultclient&client-version=v1
       response:
-        bodySize: 603
+        bodySize: 729
         content:
           mimeType: text/event-stream
-          size: 603
+          size: 729
           text: >+
             event: completion
 
-            data: {"completion":"Your name is Lars Monsen, as you mentioned in your introduction.","stopReason":"end_turn"}
+            data: {"completion":"Your name is Lars Monsen, as you mentioned in your previous message.","stopReason":"end_turn"}
 
 
             event: done
@@ -497,7 +484,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Fri, 23 Aug 2024 08:33:30 GMT
+            value: Fri, 23 Aug 2024 09:45:47 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
@@ -526,7 +513,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-08-23T08:33:29.698Z
+      startedDateTime: 2024-08-23T09:45:46.862Z
       time: 0
       timings:
         blocked: -1
@@ -536,11 +523,11 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: 6f4901fe96bdb08761f3e88d4612827b
+    - _id: 12f1ca35aa29a4ceb07f5b65bdcd37b4
       _order: 0
       cache: {}
       request:
-        bodySize: 428
+        bodySize: 418
         cookies: []
         headers:
           - name: content-type
@@ -553,7 +540,7 @@ log:
           - name: user-agent
             value: defaultClient / v1
           - name: traceparent
-            value: 00-bea99d3b2d21ef5735417d4d39036042-2b8b4dac5b64dba2-01
+            value: 00-c9a8cca3d8e11832c7dc25ad1d6bc404-6d6d4e3e8eb5439f-01
           - name: connection
             value: keep-alive
           - name: host
@@ -568,13 +555,10 @@ log:
             maxTokensToSample: 4000
             messages:
               - speaker: system
-                text: >-
-                  You are Cody, an AI coding assistant from Sourcegraph.If your
-                  answer contains fenced code blocks in Markdown, include the
-                  relevant full file path in the code block tag using this
-                  structure: ```$LANGUAGE:$FILEPATH
-
-                  $CONTENT```.
+                text: "You are Cody, an AI coding assistant from Sourcegraph.If your answer
+                  contains fenced code blocks in Markdown, include the relevant
+                  full file path in the code block tag using this structure:
+                  ```$LANGUAGE:$FILEPATH```."
               - speaker: human
                 text: What model are you?
             model: anthropic/claude-3-5-sonnet-20240620
@@ -590,14 +574,14 @@ log:
             value: v1
         url: https://sourcegraph.com/.api/completions/stream?api-version=1&client-name=defaultclient&client-version=v1
       response:
-        bodySize: 4334
+        bodySize: 8893
         content:
           mimeType: text/event-stream
-          size: 4334
+          size: 8893
           text: >+
             event: completion
 
-            data: {"completion":"I am an AI coding assistant called Cody, created by Sourcegraph. I don't have a specific underlying model that I'm aware of. My purpose is to assist with coding and development tasks. How can I help you with any coding or technical questions today?","stopReason":"end_turn"}
+            data: {"completion":"I am an AI coding assistant called Cody, created by Sourcegraph. I don't have a specific model name or version number to share. My capabilities are based on natural language processing and code understanding, but I'm not certain about the exact details of my underlying architecture or training. How can I assist you with any coding or development tasks today?","stopReason":"end_turn"}
 
 
             event: done
@@ -607,7 +591,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Fri, 23 Aug 2024 08:33:31 GMT
+            value: Fri, 23 Aug 2024 09:45:48 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
@@ -636,7 +620,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-08-23T08:33:30.638Z
+      startedDateTime: 2024-08-23T09:45:47.884Z
       time: 0
       timings:
         blocked: -1
@@ -646,11 +630,11 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: 68593ae21dda91e637bcb72ad4ebc1f4
+    - _id: 10fea51faab2d059ac7fe30188f826fe
       _order: 0
       cache: {}
       request:
-        bodySize: 759
+        bodySize: 861
         cookies: []
         headers:
           - name: content-type
@@ -663,7 +647,7 @@ log:
           - name: user-agent
             value: defaultClient / v1
           - name: traceparent
-            value: 00-3a96527081e347a9b676e7530f2beadf-b1aafc551b304a12-01
+            value: 00-5c6cab35bd72f975c9a08a57257e7461-0c06f8f58f698fdb-01
           - name: connection
             value: keep-alive
           - name: host
@@ -678,20 +662,19 @@ log:
             maxTokensToSample: 4000
             messages:
               - speaker: system
-                text: >-
-                  You are Cody, an AI coding assistant from Sourcegraph.If your
-                  answer contains fenced code blocks in Markdown, include the
-                  relevant full file path in the code block tag using this
-                  structure: ```$LANGUAGE:$FILEPATH
-
-                  $CONTENT```.
+                text: "You are Cody, an AI coding assistant from Sourcegraph.If your answer
+                  contains fenced code blocks in Markdown, include the relevant
+                  full file path in the code block tag using this structure:
+                  ```$LANGUAGE:$FILEPATH```."
               - speaker: human
                 text: What model are you?
               - speaker: assistant
                 text: I am an AI coding assistant called Cody, created by Sourcegraph. I don't
-                  have a specific underlying model that I'm aware of. My purpose
-                  is to assist with coding and development tasks. How can I help
-                  you with any coding or technical questions today?
+                  have a specific model name or version number to share. My
+                  capabilities are based on natural language processing and code
+                  understanding, but I'm not certain about the exact details of
+                  my underlying architecture or training. How can I assist you
+                  with any coding or development tasks today?
               - speaker: human
                 text: What model are you?
             model: anthropic/claude-3-5-sonnet-20240620
@@ -707,14 +690,14 @@ log:
             value: v1
         url: https://sourcegraph.com/.api/completions/stream?api-version=1&client-name=defaultclient&client-version=v1
       response:
-        bodySize: 17068
+        bodySize: 16792
         content:
           mimeType: text/event-stream
-          size: 17068
+          size: 16792
           text: >+
             event: completion
 
-            data: {"completion":"I apologize for any confusion. To clarify, I am Cody, an AI coding assistant created by Sourcegraph. I don't have specific information about the exact model or architecture used to create me. My knowledge and capabilities are the result of my training by Sourcegraph, but I don't have insight into the technical details of how I was developed or what specific AI model I might be based on. \n\nMy focus is on helping with coding and technical tasks rather than discussing my own architecture. Is there a particular coding or development question I can assist you with today?","stopReason":"end_turn"}
+            data: {"completion":"I apologize for any confusion. To clarify, I am Cody, an AI coding assistant created by Sourcegraph. I don't have access to specific information about my underlying model architecture or version. My capabilities are based on natural language processing and code understanding, but the details of my implementation are not known to me.\n\nAs an AI assistant, my role is to help with coding and development tasks. If you have any questions related to programming, software development, or need assistance with code, I'd be happy to help. Is there a particular coding task or question you'd like assistance with?","stopReason":"end_turn"}
 
 
             event: done
@@ -724,7 +707,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Fri, 23 Aug 2024 08:33:34 GMT
+            value: Fri, 23 Aug 2024 09:45:51 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
@@ -753,7 +736,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-08-23T08:33:32.151Z
+      startedDateTime: 2024-08-23T09:45:49.974Z
       time: 0
       timings:
         blocked: -1
@@ -763,11 +746,11 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: 7d028b5fddff12357a00595f2ff21070
+    - _id: 5fda62f9e09bef239a12dd889740871f
       _order: 0
       cache: {}
       request:
-        bodySize: 2487
+        bodySize: 2477
         cookies: []
         headers:
           - name: content-type
@@ -780,7 +763,7 @@ log:
           - name: user-agent
             value: defaultClient / v1
           - name: traceparent
-            value: 00-82affe6dfbf473aeb0443d92202deed7-7ac85769aeaaedf7-01
+            value: 00-0ebb09134500a2f28a06f183622aa95a-cb43c36ec87a56c0-01
           - name: connection
             value: keep-alive
           - name: host
@@ -795,13 +778,10 @@ log:
             maxTokensToSample: 4000
             messages:
               - speaker: system
-                text: >-
-                  You are Cody, an AI coding assistant from Sourcegraph.If your
-                  answer contains fenced code blocks in Markdown, include the
-                  relevant full file path in the code block tag using this
-                  structure: ```$LANGUAGE:$FILEPATH
-
-                  $CONTENT```.
+                text: "You are Cody, an AI coding assistant from Sourcegraph.If your answer
+                  contains fenced code blocks in Markdown, include the relevant
+                  full file path in the code block tag using this structure:
+                  ```$LANGUAGE:$FILEPATH```."
               - speaker: human
                 text: >-
                   Codebase context from file src/squirrel.ts:
@@ -908,14 +888,14 @@ log:
             value: v1
         url: https://sourcegraph.com/.api/completions/stream?api-version=1&client-name=defaultclient&client-version=v1
       response:
-        bodySize: 10879
+        bodySize: 12456
         content:
           mimeType: text/event-stream
-          size: 10879
+          size: 12456
           text: >+
             event: completion
 
-            data: {"completion":"Certainly! Here's the implementation of the Dog class that implements the Animal interface:\n\n```typescript:src/dog.ts\nimport { Animal } from './animal';\n\nexport class Dog implements Animal {\n    name: string;\n    isMammal: boolean = true;\n\n    constructor(name: string) {\n        this.name = name;\n    }\n\n    makeAnimalSound(): string {\n        return \"Woof!\";\n    }\n}\n```\n\nThis implementation satisfies the Animal interface requirements and provides a basic Dog class.","stopReason":"end_turn"}
+            data: {"completion":"Certainly! Here's a class `Dog` that implements the `Animal` interface based on the provided codebase context:\n\n```typescript:src/dog.ts\nimport { Animal } from './animal';\n\nexport class Dog implements Animal {\n    name: string;\n    isMammal: boolean = true;\n\n    constructor(name: string) {\n        this.name = name;\n    }\n\n    makeAnimalSound(): string {\n        return \"Woof!\";\n    }\n}\n```\n\nThis implementation fulfills all the requirements of the `Animal` interface defined in the `animal.ts` file.","stopReason":"end_turn"}
 
 
             event: done
@@ -925,7 +905,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Fri, 23 Aug 2024 08:33:38 GMT
+            value: Fri, 23 Aug 2024 09:45:54 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
@@ -954,7 +934,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-08-23T08:33:36.787Z
+      startedDateTime: 2024-08-23T09:45:53.081Z
       time: 0
       timings:
         blocked: -1
@@ -964,11 +944,11 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: 9e6a7e52ef6165649cc03020d42f167c
+    - _id: c42a6a3aed5999e531101074b269bbb5
       _order: 0
       cache: {}
       request:
-        bodySize: 2390
+        bodySize: 2380
         cookies: []
         headers:
           - name: content-type
@@ -981,7 +961,7 @@ log:
           - name: user-agent
             value: defaultClient / v1
           - name: traceparent
-            value: 00-dda1e7d7ef87f755f217d5800f6dd825-88648fb1301fc601-01
+            value: 00-aaf154a44e2dc23f78dc23389844775d-58c4fccbc99c39ae-01
           - name: connection
             value: keep-alive
           - name: host
@@ -996,13 +976,10 @@ log:
             maxTokensToSample: 4000
             messages:
               - speaker: system
-                text: >-
-                  You are Cody, an AI coding assistant from Sourcegraph.If your
-                  answer contains fenced code blocks in Markdown, include the
-                  relevant full file path in the code block tag using this
-                  structure: ```$LANGUAGE:$FILEPATH
-
-                  $CONTENT```.
+                text: "You are Cody, an AI coding assistant from Sourcegraph.If your answer
+                  contains fenced code blocks in Markdown, include the relevant
+                  full file path in the code block tag using this structure:
+                  ```$LANGUAGE:$FILEPATH```."
               - speaker: human
                 text: >-
                   Codebase context from file src/squirrel.ts:
@@ -1109,14 +1086,14 @@ log:
             value: v1
         url: https://sourcegraph.com/.api/completions/stream?api-version=1&client-name=defaultclient&client-version=v1
       response:
-        bodySize: 34113
+        bodySize: 48861
         content:
           mimeType: text/event-stream
-          size: 34113
+          size: 48861
           text: >+
             event: completion
 
-            data: {"completion":"According to the codebase context, Squirrel is an interface defined in the file src/squirrel.ts. Interestingly, despite its name, it's not actually related to squirrels. The interface is described as mocking something completely unrelated to squirrels. \n\nMore specifically, the comment in the code states that Squirrel is related to the implementation of precise code navigation in Sourcegraph. This suggests that it's likely a part of a larger system or feature within the Sourcegraph codebase, possibly used for improving code navigation capabilities.\n\nThe interface is currently empty in the provided code snippet, which could mean it's either a placeholder for future implementation or it's used as a marker interface for type checking or other purposes within the Sourcegraph system.","stopReason":"end_turn"}
+            data: {"completion":"Squirrel is an interface defined in the codebase, specifically in the file `src/squirrel.ts`. According to the code comments, it's not actually related to real squirrels, despite its name. Instead, it's an interface that mocks something completely unrelated to squirrels and is actually related to the implementation of precise code navigation in Sourcegraph.\n\nThe interface is currently empty, which means it doesn't define any properties or methods. This suggests it might be a placeholder or a marker interface used for type checking or future implementation.\n\nHere's the definition of the Squirrel interface:\n\n```typescript:src/squirrel.ts\nexport interface Squirrel {}\n```\n\nThis interface, despite its seemingly playful name, serves a specific purpose in the context of Sourcegraph's code navigation features. It's an excellent example of how naming in programming doesn't always directly reflect the real-world meaning of words, but rather serves as a memorable identifier for a specific concept within the codebase.","stopReason":"end_turn"}
 
 
             event: done
@@ -1126,7 +1103,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Fri, 23 Aug 2024 08:33:40 GMT
+            value: Fri, 23 Aug 2024 09:45:58 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
@@ -1155,7 +1132,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-08-23T08:33:39.130Z
+      startedDateTime: 2024-08-23T09:45:55.574Z
       time: 0
       timings:
         blocked: -1
@@ -1165,11 +1142,11 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: 21c1179402491496ae0616d2c81af9f0
+    - _id: 6b6c4b45cd9d690f4cfcf661370d6665
       _order: 0
       cache: {}
       request:
-        bodySize: 523
+        bodySize: 513
         cookies: []
         headers:
           - name: content-type
@@ -1182,7 +1159,7 @@ log:
           - name: user-agent
             value: defaultClient / v1
           - name: traceparent
-            value: 00-8def2852a408eb998b198545a1986b1d-bbe703a39274e369-01
+            value: 00-45e4e1da01f2127c77de706758f3e65d-51588ce492518030-01
           - name: connection
             value: keep-alive
           - name: host
@@ -1197,13 +1174,10 @@ log:
             maxTokensToSample: 4000
             messages:
               - speaker: human
-                text: >-
-                  You are Cody, an AI coding assistant from Sourcegraph.If your
-                  answer contains fenced code blocks in Markdown, include the
-                  relevant full file path in the code block tag using this
-                  structure: ```$LANGUAGE:$FILEPATH
-
-                  $CONTENT```.
+                text: "You are Cody, an AI coding assistant from Sourcegraph.If your answer
+                  contains fenced code blocks in Markdown, include the relevant
+                  full file path in the code block tag using this structure:
+                  ```$LANGUAGE:$FILEPATH```."
               - speaker: assistant
                 text: I am Cody, an AI coding assistant from Sourcegraph.
               - speaker: human
@@ -1220,14 +1194,14 @@ log:
             value: v1
         url: https://sourcegraph.com/.api/completions/stream?client-name=defaultclient&client-version=v1
       response:
-        bodySize: 3630
+        bodySize: 12890
         content:
           mimeType: text/event-stream
-          size: 3630
+          size: 12890
           text: >+
             event: completion
 
-            data: {"completion":"I can't see colors, but the sky appears blue to most people during the day due to the way Earth's atmosphere scatters sunlight.","stopReason":"stop"}
+            data: {"completion":"The sky is typically blue during the day due to the scattering of sunlight by the Earth's atmosphere. However, at sunrise and sunset, the sky can appear in shades of orange, pink, and red due to the longer path that sunlight has to travel through the atmosphere during these times.\n\n```plaintext```","stopReason":"stop"}
 
 
             event: done
@@ -1237,7 +1211,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Fri, 23 Aug 2024 08:33:43 GMT
+            value: Fri, 23 Aug 2024 09:46:02 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
@@ -1266,7 +1240,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-08-23T08:33:42.851Z
+      startedDateTime: 2024-08-23T09:46:01.811Z
       time: 0
       timings:
         blocked: -1
@@ -1276,11 +1250,11 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: 621efa9a038a4b1cb8ec624f39666e46
+    - _id: 54576e5e77faaa1011ca7e70953762e8
       _order: 0
       cache: {}
       request:
-        bodySize: 607
+        bodySize: 597
         cookies: []
         headers:
           - name: content-type
@@ -1293,7 +1267,7 @@ log:
           - name: user-agent
             value: defaultClient / v1
           - name: traceparent
-            value: 00-2031955e5a6532baee571b2801f39b6b-c666f104fc9c8067-01
+            value: 00-7d66d724af3ace69a7a910eb424fee95-3963e3b3e6e5db66-01
           - name: connection
             value: keep-alive
           - name: host
@@ -1308,13 +1282,10 @@ log:
             maxTokensToSample: 4000
             messages:
               - speaker: human
-                text: >-
-                  You are Cody, an AI coding assistant from Sourcegraph.If your
-                  answer contains fenced code blocks in Markdown, include the
-                  relevant full file path in the code block tag using this
-                  structure: ```$LANGUAGE:$FILEPATH
-
-                  $CONTENT```.
+                text: "You are Cody, an AI coding assistant from Sourcegraph.If your answer
+                  contains fenced code blocks in Markdown, include the relevant
+                  full file path in the code block tag using this structure:
+                  ```$LANGUAGE:$FILEPATH```."
               - speaker: assistant
                 text: I am Cody, an AI coding assistant from Sourcegraph.
               - speaker: human
@@ -1345,7 +1316,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Fri, 23 Aug 2024 08:33:44 GMT
+            value: Fri, 23 Aug 2024 09:46:03 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
@@ -1374,7 +1345,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-08-23T08:33:43.905Z
+      startedDateTime: 2024-08-23T09:46:03.217Z
       time: 0
       timings:
         blocked: -1
@@ -1384,11 +1355,11 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: f030b22e8118ecbc1c74f2ea653113e9
+    - _id: a75332a77517259f27c6ede7c08d7afd
       _order: 0
       cache: {}
       request:
-        bodySize: 683
+        bodySize: 673
         cookies: []
         headers:
           - name: content-type
@@ -1401,7 +1372,7 @@ log:
           - name: user-agent
             value: defaultClient / v1
           - name: traceparent
-            value: 00-4195e25d04d7669751736428f3f41f4c-4a0a4fdc06aac42c-01
+            value: 00-59ba7a102741dc9d8b4139eb84e94a51-2e058eb21b17eb36-01
           - name: connection
             value: keep-alive
           - name: host
@@ -1416,13 +1387,10 @@ log:
             maxTokensToSample: 4000
             messages:
               - speaker: human
-                text: >-
-                  You are Cody, an AI coding assistant from Sourcegraph.If your
-                  answer contains fenced code blocks in Markdown, include the
-                  relevant full file path in the code block tag using this
-                  structure: ```$LANGUAGE:$FILEPATH
-
-                  $CONTENT```.
+                text: "You are Cody, an AI coding assistant from Sourcegraph.If your answer
+                  contains fenced code blocks in Markdown, include the relevant
+                  full file path in the code block tag using this structure:
+                  ```$LANGUAGE:$FILEPATH```."
               - speaker: assistant
                 text: I am Cody, an AI coding assistant from Sourcegraph.
               - speaker: human
@@ -1443,14 +1411,14 @@ log:
             value: v1
         url: https://sourcegraph.com/.api/completions/stream?client-name=defaultclient&client-version=v1
       response:
-        bodySize: 594
+        bodySize: 985
         content:
           mimeType: text/event-stream
-          size: 594
+          size: 985
           text: >+
             event: completion
 
-            data: {"completion":"Kramer, you said the magic word! Here is your response:\n\nQuone.","stopReason":"stop"}
+            data: {"completion":"Kramer, you said the magic word! Here's your single word response: \"quone\". Is there anything else I can help you with?","stopReason":"stop"}
 
 
             event: done
@@ -1460,7 +1428,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Fri, 23 Aug 2024 08:33:45 GMT
+            value: Fri, 23 Aug 2024 09:46:04 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
@@ -1489,7 +1457,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-08-23T08:33:44.568Z
+      startedDateTime: 2024-08-23T09:46:03.829Z
       time: 0
       timings:
         blocked: -1
@@ -1499,11 +1467,11 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: 8f8935fde1263605a1b830a482fd09ec
+    - _id: f43d5e5c0688993068269a0e4407ce17
       _order: 0
       cache: {}
       request:
-        bodySize: 520
+        bodySize: 510
         cookies: []
         headers:
           - name: content-type
@@ -1516,7 +1484,7 @@ log:
           - name: user-agent
             value: defaultClient / v1
           - name: traceparent
-            value: 00-c2cfd89f90adcbac5ef95e19cb5f880a-3c52f1e328516879-01
+            value: 00-05cb5fceb8fb378f5395efdd4341b750-27a4b7be8fb1feff-01
           - name: connection
             value: keep-alive
           - name: host
@@ -1531,13 +1499,10 @@ log:
             maxTokensToSample: 4000
             messages:
               - speaker: human
-                text: >-
-                  You are Cody, an AI coding assistant from Sourcegraph.If your
-                  answer contains fenced code blocks in Markdown, include the
-                  relevant full file path in the code block tag using this
-                  structure: ```$LANGUAGE:$FILEPATH
-
-                  $CONTENT```.
+                text: "You are Cody, an AI coding assistant from Sourcegraph.If your answer
+                  contains fenced code blocks in Markdown, include the relevant
+                  full file path in the code block tag using this structure:
+                  ```$LANGUAGE:$FILEPATH```."
               - speaker: assistant
                 text: I am Cody, an AI coding assistant from Sourcegraph.
               - speaker: human
@@ -1553,14 +1518,14 @@ log:
             value: v1
         url: https://sourcegraph.com/.api/completions/stream?client-name=defaultclient&client-version=v1
       response:
-        bodySize: 8491
+        bodySize: 7249
         content:
           mimeType: text/event-stream
-          size: 8491
+          size: 7249
           text: >+
             event: completion
 
-            data: {"completion":"It seems like you're mentioning the name \"Kramer,\" but I'm not sure what you're asking. Are you looking for information about a programming concept, or do you need help with a coding problem?\n\nIf you need help with a specific file, please provide the file path and the language of the code, like this:\n\n```bash:/path/to/your/file.sh\nyour code here\n```\n\nI'll do my best to help you with any coding-related questions you have, as long as they are ethical and positive in nature. Let me know how I can assist you today!","stopReason":"stop"}
+            data: {"completion":"Hello! How can I assist you with your coding-related inquiry today? If you need help with a specific programming language or concept, please let me know and I'll do my best to help.\n\nFor example, if you have a question about a JavaScript file located at `path/to/file.js`, you can format the code block like this:\n```javascript:path/to/file.js\n// code here\n```\nThis will help me better understand the context of your question and provide a more accurate and helpful response.","stopReason":"stop"}
 
 
             event: done
@@ -1570,7 +1535,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Fri, 23 Aug 2024 08:33:46 GMT
+            value: Fri, 23 Aug 2024 09:46:05 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
@@ -1599,7 +1564,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-08-23T08:33:45.365Z
+      startedDateTime: 2024-08-23T09:46:04.653Z
       time: 0
       timings:
         blocked: -1
@@ -1609,11 +1574,11 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: 0e8cf0e74788239aa575f5c4f7e4ab97
+    - _id: 0796e739ea090488fd744cb18ee49a40
       _order: 0
       cache: {}
       request:
-        bodySize: 615
+        bodySize: 605
         cookies: []
         headers:
           - name: content-type
@@ -1626,7 +1591,7 @@ log:
           - name: user-agent
             value: defaultClient / v1
           - name: traceparent
-            value: 00-67c28e62a13cbb57acaca4d4388d066a-66b4fc553c71d293-01
+            value: 00-26b292bed2626e8fe4bc5c2030d7a80c-fff085d5154874a4-01
           - name: connection
             value: keep-alive
           - name: host
@@ -1641,13 +1606,10 @@ log:
             maxTokensToSample: 4000
             messages:
               - speaker: human
-                text: >-
-                  You are Cody, an AI coding assistant from Sourcegraph.If your
-                  answer contains fenced code blocks in Markdown, include the
-                  relevant full file path in the code block tag using this
-                  structure: ```$LANGUAGE:$FILEPATH
-
-                  $CONTENT```.
+                text: "You are Cody, an AI coding assistant from Sourcegraph.If your answer
+                  contains fenced code blocks in Markdown, include the relevant
+                  full file path in the code block tag using this structure:
+                  ```$LANGUAGE:$FILEPATH```."
               - speaker: assistant
                 text: I am Cody, an AI coding assistant from Sourcegraph.
               - speaker: human
@@ -1678,7 +1640,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Fri, 23 Aug 2024 08:33:48 GMT
+            value: Fri, 23 Aug 2024 09:46:07 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
@@ -1707,7 +1669,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-08-23T08:33:47.923Z
+      startedDateTime: 2024-08-23T09:46:06.986Z
       time: 0
       timings:
         blocked: -1
@@ -1717,11 +1679,11 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: 8087cc2bbeee9907532e6324d86b0871
+    - _id: af38eb0164712068beb775641910139b
       _order: 0
       cache: {}
       request:
-        bodySize: 694
+        bodySize: 684
         cookies: []
         headers:
           - name: content-type
@@ -1734,7 +1696,7 @@ log:
           - name: user-agent
             value: defaultClient / v1
           - name: traceparent
-            value: 00-344593fadb40c4bafba2902971862ca2-ea4d0b8b805cc14c-01
+            value: 00-05d1ccce6abc10765f46626005c04260-6600dd502a1c42ed-01
           - name: connection
             value: keep-alive
           - name: host
@@ -1749,13 +1711,10 @@ log:
             maxTokensToSample: 4000
             messages:
               - speaker: human
-                text: >-
-                  You are Cody, an AI coding assistant from Sourcegraph.If your
-                  answer contains fenced code blocks in Markdown, include the
-                  relevant full file path in the code block tag using this
-                  structure: ```$LANGUAGE:$FILEPATH
-
-                  $CONTENT```.
+                text: "You are Cody, an AI coding assistant from Sourcegraph.If your answer
+                  contains fenced code blocks in Markdown, include the relevant
+                  full file path in the code block tag using this structure:
+                  ```$LANGUAGE:$FILEPATH```."
               - speaker: assistant
                 text: I am Cody, an AI coding assistant from Sourcegraph.
               - speaker: human
@@ -1776,14 +1735,14 @@ log:
             value: v1
         url: https://sourcegraph.com/.api/completions/stream?client-name=defaultclient&client-version=v1
       response:
-        bodySize: 2637
+        bodySize: 3443
         content:
           mimeType: text/event-stream
-          size: 2637
+          size: 3443
           text: >+
             event: completion
 
-            data: {"completion":"I am an AI and do not have personal experiences or emotions, so I don't have a friend named Kramer. However, in the popular TV show \"Seinfeld,\" Kramer is a character who is friends with the main character, Jerry Seinfeld. Is there something specific you would like to know or discuss about \"Seinfeld\" or the character Kramer?","stopReason":"stop"}
+            data: {"completion":"Here's a fun fact about the character \"Kramer\" from Seinfeld: his eccentric and unpredictable personality made him one of the most memorable characters on the show. The actor who played Kramer, Michael Richards, based the character on a real-life friend and fellow comedian, Kenny Kramer.","stopReason":"stop"}
 
 
             event: done
@@ -1793,7 +1752,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Fri, 23 Aug 2024 08:33:49 GMT
+            value: Fri, 23 Aug 2024 09:46:08 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
@@ -1822,7 +1781,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-08-23T08:33:48.517Z
+      startedDateTime: 2024-08-23T09:46:07.636Z
       time: 0
       timings:
         blocked: -1
@@ -1832,11 +1791,11 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: 0fce236eb5737c67ad3f0866a0ce9c36
+    - _id: 5badb0e7051ca692ba969c2f73e2f385
       _order: 0
       cache: {}
       request:
-        bodySize: 1094
+        bodySize: 1045
         cookies: []
         headers:
           - name: content-type
@@ -1849,7 +1808,7 @@ log:
           - name: user-agent
             value: defaultClient / v1
           - name: traceparent
-            value: 00-5e1c9225386049d7520ae868f433ff3c-6cdc9bd54d01fe73-01
+            value: 00-433a6014dc348f287084f1dfdd4700e3-a75f8615133bcb00-01
           - name: connection
             value: keep-alive
           - name: host
@@ -1864,13 +1823,10 @@ log:
             maxTokensToSample: 4000
             messages:
               - speaker: human
-                text: >-
-                  You are Cody, an AI coding assistant from Sourcegraph.If your
-                  answer contains fenced code blocks in Markdown, include the
-                  relevant full file path in the code block tag using this
-                  structure: ```$LANGUAGE:$FILEPATH
-
-                  $CONTENT```.
+                text: "You are Cody, an AI coding assistant from Sourcegraph.If your answer
+                  contains fenced code blocks in Markdown, include the relevant
+                  full file path in the code block tag using this structure:
+                  ```$LANGUAGE:$FILEPATH```."
               - speaker: assistant
                 text: I am Cody, an AI coding assistant from Sourcegraph.
               - speaker: human
@@ -1881,12 +1837,11 @@ log:
               - speaker: human
                 text: kramer
               - speaker: assistant
-                text: I am an AI and do not have personal experiences or emotions, so I don't
-                  have a friend named Kramer. However, in the popular TV show
-                  "Seinfeld," Kramer is a character who is friends with the main
-                  character, Jerry Seinfeld. Is there something specific you
-                  would like to know or discuss about "Seinfeld" or the
-                  character Kramer?
+                text: "Here's a fun fact about the character \"Kramer\" from Seinfeld: his
+                  eccentric and unpredictable personality made him one of the
+                  most memorable characters on the show. The actor who played
+                  Kramer, Michael Richards, based the character on a real-life
+                  friend and fellow comedian, Kenny Kramer."
               - speaker: human
                 text: georgey
             model: fireworks/accounts/fireworks/models/mixtral-8x7b-instruct
@@ -1914,7 +1869,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Fri, 23 Aug 2024 08:33:50 GMT
+            value: Fri, 23 Aug 2024 09:46:09 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
@@ -1943,7 +1898,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-08-23T08:33:49.449Z
+      startedDateTime: 2024-08-23T09:46:08.927Z
       time: 0
       timings:
         blocked: -1
@@ -1953,11 +1908,11 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: a9dc2a750bad0e83f11ddf9ca0289c21
+    - _id: 339d8588fe3caf8130d1c6b12bf340f9
       _order: 0
       cache: {}
       request:
-        bodySize: 586
+        bodySize: 576
         cookies: []
         headers:
           - name: content-type
@@ -1970,7 +1925,7 @@ log:
           - name: user-agent
             value: defaultClient / v1
           - name: traceparent
-            value: 00-9260148d36abacf7b335d02f16b45326-3dccf5542d12a3e5-01
+            value: 00-6fae96fe6d15e0cb094f4e175d742872-442ee9682b9c92fc-01
           - name: connection
             value: keep-alive
           - name: host
@@ -1985,13 +1940,10 @@ log:
             maxTokensToSample: 4000
             messages:
               - speaker: human
-                text: >-
-                  You are Cody, an AI coding assistant from Sourcegraph.If your
-                  answer contains fenced code blocks in Markdown, include the
-                  relevant full file path in the code block tag using this
-                  structure: ```$LANGUAGE:$FILEPATH
-
-                  $CONTENT```.
+                text: "You are Cody, an AI coding assistant from Sourcegraph.If your answer
+                  contains fenced code blocks in Markdown, include the relevant
+                  full file path in the code block tag using this structure:
+                  ```$LANGUAGE:$FILEPATH```."
               - speaker: assistant
                 text: I am Cody, an AI coding assistant from Sourcegraph.
               - speaker: human
@@ -2007,10 +1959,10 @@ log:
             value: v1
         url: https://sourcegraph.com/.api/completions/stream?client-name=defaultclient&client-version=v1
       response:
-        bodySize: 730
+        bodySize: 803
         content:
           mimeType: text/event-stream
-          size: 730
+          size: 803
           text: >+
             event: completion
 
@@ -2024,7 +1976,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Fri, 23 Aug 2024 08:33:50 GMT
+            value: Fri, 23 Aug 2024 09:46:10 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
@@ -2053,7 +2005,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-08-23T08:33:50.076Z
+      startedDateTime: 2024-08-23T09:46:09.591Z
       time: 0
       timings:
         blocked: -1
@@ -2063,11 +2015,11 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: 44d1a383a62af67d1c875dbb68094233
+    - _id: 00d1937166a73edc7f68a47807926667
       _order: 0
       cache: {}
       request:
-        bodySize: 825
+        bodySize: 815
         cookies: []
         headers:
           - name: content-type
@@ -2080,7 +2032,7 @@ log:
           - name: user-agent
             value: defaultClient / v1
           - name: traceparent
-            value: 00-36c348fde35efec0615e3b6925f36f4f-d2a0e692d14e5bd5-01
+            value: 00-154a0cd7628730bae3a0d7288e33d01e-76002ae9d3fa9436-01
           - name: connection
             value: keep-alive
           - name: host
@@ -2095,13 +2047,10 @@ log:
             maxTokensToSample: 4000
             messages:
               - speaker: human
-                text: >-
-                  You are Cody, an AI coding assistant from Sourcegraph.If your
-                  answer contains fenced code blocks in Markdown, include the
-                  relevant full file path in the code block tag using this
-                  structure: ```$LANGUAGE:$FILEPATH
-
-                  $CONTENT```.
+                text: "You are Cody, an AI coding assistant from Sourcegraph.If your answer
+                  contains fenced code blocks in Markdown, include the relevant
+                  full file path in the code block tag using this structure:
+                  ```$LANGUAGE:$FILEPATH```."
               - speaker: assistant
                 text: I am Cody, an AI coding assistant from Sourcegraph.
               - speaker: human
@@ -2122,14 +2071,14 @@ log:
             value: v1
         url: https://sourcegraph.com/.api/completions/stream?client-name=defaultclient&client-version=v1
       response:
-        bodySize: 1053
+        bodySize: 1489
         content:
           mimeType: text/event-stream
-          size: 1053
+          size: 1489
           text: >+
             event: completion
 
-            data: {"completion":"Ok. I understand that you have a bird named \"skywalker\". Is there something specific you would like to know or learn about coding? I'm here to help.","stopReason":"stop"}
+            data: {"completion":"Ok. I understand that you have a bird named \"skywalker\". I am here to help you with any coding questions or issues you may have. Let me know how I can assist you.","stopReason":"stop"}
 
 
             event: done
@@ -2139,7 +2088,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Fri, 23 Aug 2024 08:33:51 GMT
+            value: Fri, 23 Aug 2024 09:46:11 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
@@ -2168,7 +2117,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-08-23T08:33:50.789Z
+      startedDateTime: 2024-08-23T09:46:10.398Z
       time: 0
       timings:
         blocked: -1
@@ -2178,11 +2127,11 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: c70505ef01b5444209f87c3eb839a2ea
+    - _id: 924ead736b2421b2419fa43e1de253d2
       _order: 0
       cache: {}
       request:
-        bodySize: 1107
+        bodySize: 1111
         cookies: []
         headers:
           - name: content-type
@@ -2195,7 +2144,7 @@ log:
           - name: user-agent
             value: defaultClient / v1
           - name: traceparent
-            value: 00-18e0d9ee69e2f54796a511cfaed8c0a3-297b336d7823ef5c-01
+            value: 00-47cb7786226a7a4661f64e08194662b5-8abc5aab455e17fc-01
           - name: connection
             value: keep-alive
           - name: host
@@ -2210,13 +2159,10 @@ log:
             maxTokensToSample: 4000
             messages:
               - speaker: human
-                text: >-
-                  You are Cody, an AI coding assistant from Sourcegraph.If your
-                  answer contains fenced code blocks in Markdown, include the
-                  relevant full file path in the code block tag using this
-                  structure: ```$LANGUAGE:$FILEPATH
-
-                  $CONTENT```.
+                text: "You are Cody, an AI coding assistant from Sourcegraph.If your answer
+                  contains fenced code blocks in Markdown, include the relevant
+                  full file path in the code block tag using this structure:
+                  ```$LANGUAGE:$FILEPATH```."
               - speaker: assistant
                 text: I am Cody, an AI coding assistant from Sourcegraph.
               - speaker: human
@@ -2227,9 +2173,9 @@ log:
               - speaker: human
                 text: I have a bird named "skywalker", reply single "ok" if you understand.
               - speaker: assistant
-                text: Ok. I understand that you have a bird named "skywalker". Is there
-                  something specific you would like to know or learn about
-                  coding? I'm here to help.
+                text: Ok. I understand that you have a bird named "skywalker". I am here to help
+                  you with any coding questions or issues you may have. Let me
+                  know how I can assist you.
               - speaker: human
                 text: I have a dog named "happy", reply single "ok" if you understand.
             model: fireworks/accounts/fireworks/models/mixtral-8x7b-instruct
@@ -2243,14 +2189,14 @@ log:
             value: v1
         url: https://sourcegraph.com/.api/completions/stream?client-name=defaultclient&client-version=v1
       response:
-        bodySize: 1128
+        bodySize: 1429
         content:
           mimeType: text/event-stream
-          size: 1128
+          size: 1429
           text: >+
             event: completion
 
-            data: {"completion":"Ok. I understand that you have a dog named \"happy\". Is there a programming language or a coding concept that you need help with? I'll do my best to provide useful and accurate information.","stopReason":"stop"}
+            data: {"completion":"Ok. I understand that you have a dog named \"happy\". If you need help with coding, I am here to assist you. Please let me know what you need.","stopReason":"stop"}
 
 
             event: done
@@ -2260,7 +2206,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Fri, 23 Aug 2024 08:33:52 GMT
+            value: Fri, 23 Aug 2024 09:46:12 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
@@ -2289,7 +2235,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-08-23T08:33:51.479Z
+      startedDateTime: 2024-08-23T09:46:11.421Z
       time: 0
       timings:
         blocked: -1
@@ -2299,11 +2245,11 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: 65d6670932d227031ec3b2b90e7e454d
+    - _id: 34a22612c4d4619e8787ba79a5288ba2
       _order: 0
       cache: {}
       request:
-        bodySize: 821
+        bodySize: 811
         cookies: []
         headers:
           - name: content-type
@@ -2316,7 +2262,7 @@ log:
           - name: user-agent
             value: defaultClient / v1
           - name: traceparent
-            value: 00-f4fa762894340a6673c6382676113723-af2d44ff9ca07e1b-01
+            value: 00-fb90aa9c559f6ad0a9c7200fa9aadeab-6d18b8535fe53cea-01
           - name: connection
             value: keep-alive
           - name: host
@@ -2331,13 +2277,10 @@ log:
             maxTokensToSample: 4000
             messages:
               - speaker: human
-                text: >-
-                  You are Cody, an AI coding assistant from Sourcegraph.If your
-                  answer contains fenced code blocks in Markdown, include the
-                  relevant full file path in the code block tag using this
-                  structure: ```$LANGUAGE:$FILEPATH
-
-                  $CONTENT```.
+                text: "You are Cody, an AI coding assistant from Sourcegraph.If your answer
+                  contains fenced code blocks in Markdown, include the relevant
+                  full file path in the code block tag using this structure:
+                  ```$LANGUAGE:$FILEPATH```."
               - speaker: assistant
                 text: I am Cody, an AI coding assistant from Sourcegraph.
               - speaker: human
@@ -2358,14 +2301,14 @@ log:
             value: v1
         url: https://sourcegraph.com/.api/completions/stream?client-name=defaultclient&client-version=v1
       response:
-        bodySize: 839
+        bodySize: 1310
         content:
           mimeType: text/event-stream
-          size: 839
+          size: 1310
           text: >+
             event: completion
 
-            data: {"completion":"Ok. I understand that you have a tiger named \"zorro\". Is there anything specific you would like to ask or direct me to do regarding your coding project?","stopReason":"stop"}
+            data: {"completion":"Ok. I understand that you have a tiger named \"zorro\". Is there anything specific you would like to ask or instruct regarding your coding project? I'm here to help!","stopReason":"stop"}
 
 
             event: done
@@ -2375,7 +2318,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Fri, 23 Aug 2024 08:33:52 GMT
+            value: Fri, 23 Aug 2024 09:46:13 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
@@ -2404,7 +2347,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-08-23T08:33:52.255Z
+      startedDateTime: 2024-08-23T09:46:12.432Z
       time: 0
       timings:
         blocked: -1
@@ -2414,11 +2357,11 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: 01d7685bb248936d88e57f8f7398591d
+    - _id: 9e075b01f973d7aff33010cb048bd417
       _order: 0
       cache: {}
       request:
-        bodySize: 1059
+        bodySize: 1060
         cookies: []
         headers:
           - name: content-type
@@ -2431,7 +2374,7 @@ log:
           - name: user-agent
             value: defaultClient / v1
           - name: traceparent
-            value: 00-ca32962fd705025231794058c6920c41-6f3e7f269d0ac373-01
+            value: 00-074684212df68805d91f9be7401ba169-0de4de3efc2061b8-01
           - name: connection
             value: keep-alive
           - name: host
@@ -2446,13 +2389,10 @@ log:
             maxTokensToSample: 4000
             messages:
               - speaker: human
-                text: >-
-                  You are Cody, an AI coding assistant from Sourcegraph.If your
-                  answer contains fenced code blocks in Markdown, include the
-                  relevant full file path in the code block tag using this
-                  structure: ```$LANGUAGE:$FILEPATH
-
-                  $CONTENT```.
+                text: "You are Cody, an AI coding assistant from Sourcegraph.If your answer
+                  contains fenced code blocks in Markdown, include the relevant
+                  full file path in the code block tag using this structure:
+                  ```$LANGUAGE:$FILEPATH```."
               - speaker: assistant
                 text: I am Cody, an AI coding assistant from Sourcegraph.
               - speaker: human
@@ -2464,8 +2404,8 @@ log:
                 text: I have a tiger named "zorro", reply single "ok" if you understand
               - speaker: assistant
                 text: Ok. I understand that you have a tiger named "zorro". Is there anything
-                  specific you would like to ask or direct me to do regarding
-                  your coding project?
+                  specific you would like to ask or instruct regarding your
+                  coding project? I'm here to help!
               - speaker: human
                 text: What pets do I have?
             model: fireworks/accounts/fireworks/models/mixtral-8x7b-instruct
@@ -2479,14 +2419,14 @@ log:
             value: v1
         url: https://sourcegraph.com/.api/completions/stream?client-name=defaultclient&client-version=v1
       response:
-        bodySize: 3785
+        bodySize: 940
         content:
           mimeType: text/event-stream
-          size: 3785
+          size: 940
           text: >+
             event: completion
 
-            data: {"completion":"Based on the information you have provided, you have a turtle named \"potter\" and a tiger named \"zorro\". Is there anything specific you would like to know or do related to these pets in a coding context? I can assist you with tasks such as coding a simulation, creating a database to store pet information, or generating a report on pet care.","stopReason":"stop"}
+            data: {"completion":"Based on our prior conversation, you have a turtle named \"potter\" and a tiger named \"zorro\".","stopReason":"stop"}
 
 
             event: done
@@ -2496,7 +2436,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Fri, 23 Aug 2024 08:33:54 GMT
+            value: Fri, 23 Aug 2024 09:46:14 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
@@ -2525,7 +2465,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-08-23T08:33:53.045Z
+      startedDateTime: 2024-08-23T09:46:13.450Z
       time: 0
       timings:
         blocked: -1
@@ -2535,11 +2475,11 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: 4e3dafbfda32a553676912d970d85724
+    - _id: 9f935864f241c5b2ea5fc993c9f185a2
       _order: 0
       cache: {}
       request:
-        bodySize: 1889
+        bodySize: 1879
         cookies: []
         headers:
           - name: content-type
@@ -2552,7 +2492,7 @@ log:
           - name: user-agent
             value: defaultClient / v1
           - name: traceparent
-            value: 00-085ae72c9e9d764f60a013ecaadcb6a9-6e0682b7edc8e31e-01
+            value: 00-ec3ce53837402e5a9e15928a0fe59b4d-4dd20390c32da060-01
           - name: connection
             value: keep-alive
           - name: host
@@ -2567,13 +2507,10 @@ log:
             maxTokensToSample: 4000
             messages:
               - speaker: human
-                text: >-
-                  You are Cody, an AI coding assistant from Sourcegraph.If your
-                  answer contains fenced code blocks in Markdown, include the
-                  relevant full file path in the code block tag using this
-                  structure: ```$LANGUAGE:$FILEPATH
-
-                  $CONTENT```.
+                text: "You are Cody, an AI coding assistant from Sourcegraph.If your answer
+                  contains fenced code blocks in Markdown, include the relevant
+                  full file path in the code block tag using this structure:
+                  ```$LANGUAGE:$FILEPATH```."
               - speaker: assistant
                 text: I am Cody, an AI coding assistant from Sourcegraph.
               - speaker: human
@@ -2630,14 +2567,14 @@ log:
             value: v1
         url: https://sourcegraph.com/.api/completions/stream?client-name=defaultclient&client-version=v1
       response:
-        bodySize: 19150
+        bodySize: 88342
         content:
           mimeType: text/event-stream
-          size: 19150
+          size: 88342
           text: >+
             event: completion
 
-            data: {"completion":"The code you provided is from a TypeScript file called `animal.ts` and it exports an interface named `Animal`.\n\nThe purpose of this code is to define what an `Animal` is, by specifying its three properties: `name`, `makeAnimalSound`, and `isMammal`.\n\nAn `Animal` is a conceptual entity that has a `name` (which is a string), a method to generate an `animal sound` (which is a string), and it has a boolean property `isMammal` that tells whether the animal is a mammal or not.\n\nThe interface by itself does not generate any output or take any input. It only provides a blueprint for what an `Animal` should look like. When other code uses this interface, they will have to provide implementations for its properties.\n\nIn summary, this code defines the structure of an `Animal` and it is useful when you want to enforce same structure for any animal objects being used across your TypeScript application.","stopReason":"stop"}
+            data: {"completion":"The code you've shared is a part of a TypeScript file called `animal.ts`. The purpose of this code is to define an interface named `Animal`. An interface in programming is a kind of blueprint that specifies what a certain object or data type should look like - meaning what properties and methods it should have.\n\nHere's a breakdown of the code:\n\n1. **Purpose of the code:** The purpose of this code is to define an interface named `Animal`. This interface will be used as a blueprint for other objects or classes that will represent various animals, ensuring they all have the same properties and methods.\n2. **Inputs:** This piece of code does not take any inputs. It only defines an interface, which is a template that can be used for creating other objects, not an actual object with input values.\n3. **Outputs:** This code doesn't directly produce an output, as it only serves as a type definition. However, once an object or a class is created based on this interface, the output will be an instance that adheres to the structure set by the `Animal` interface.\n4. **Logic and algorithm:** The interface consists of three properties, each with their own types: `name` (as a string), `makeAnimalSound` (as a method that returns a string), and `isMammal` (as a boolean representing whether the animal is a mammal or not). Although not displayed in the provided code, classes or objects implementing this interface will have to provide actual implementations for the methods specified, such as how a specific animal makes its sound.\n5. **Logic flows or data transformations:** The code does not perform complex logic or data transformations since it just outlines the structure the `Animal` interface should follow. It is up to the objects or classes that implement the `Animal` interface to include the necessary logic and algorithms for handling specific animal behavior data.\n\nIn short, this code defines an `Animal` interface in TypeScript, which can later be used as a template for creating objects or classes mirroring various animal types while ensuring a standard structure for animal representation in the codebase.","stopReason":"stop"}
 
 
             event: done
@@ -2647,7 +2584,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Fri, 23 Aug 2024 08:33:55 GMT
+            value: Fri, 23 Aug 2024 09:46:15 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
@@ -2676,7 +2613,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-08-23T08:33:54.366Z
+      startedDateTime: 2024-08-23T09:46:14.431Z
       time: 0
       timings:
         blocked: -1
@@ -2686,11 +2623,11 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: 6bc35edf465a88e812bd41afcfc2b5a9
+    - _id: f9ecebdc6cd4b979fdcd3c060a5a7046
       _order: 0
       cache: {}
       request:
-        bodySize: 3115
+        bodySize: 3105
         cookies: []
         headers:
           - name: content-type
@@ -2703,7 +2640,7 @@ log:
           - name: user-agent
             value: defaultClient / v1
           - name: traceparent
-            value: 00-c9a63aff727c2c3e766e859b9dcdc133-00574fdf6eefe9c7-01
+            value: 00-f668e928de1bdd3962c5949533a0051e-9836ddfc7b2f6afc-01
           - name: connection
             value: keep-alive
           - name: host
@@ -2718,13 +2655,10 @@ log:
             maxTokensToSample: 4000
             messages:
               - speaker: human
-                text: >-
-                  You are Cody, an AI coding assistant from Sourcegraph.If your
-                  answer contains fenced code blocks in Markdown, include the
-                  relevant full file path in the code block tag using this
-                  structure: ```$LANGUAGE:$FILEPATH
-
-                  $CONTENT```.
+                text: "You are Cody, an AI coding assistant from Sourcegraph.If your answer
+                  contains fenced code blocks in Markdown, include the relevant
+                  full file path in the code block tag using this structure:
+                  ```$LANGUAGE:$FILEPATH```."
               - speaker: assistant
                 text: I am Cody, an AI coding assistant from Sourcegraph.
               - speaker: human
@@ -2819,14 +2753,14 @@ log:
             value: v1
         url: https://sourcegraph.com/.api/completions/stream?client-name=defaultclient&client-version=v1
       response:
-        bodySize: 8437
+        bodySize: 206666
         content:
           mimeType: text/event-stream
-          size: 8437
+          size: 206666
           text: >+
             event: completion
 
-            data: {"completion":"Based on the shared code context, it appears that Vitest is being used as the test framework. Additionally, the code is written in TypeScript.\n\nHere is a suite of unit tests for the `Animal` interface in the file `src/animal.ts`:\n```typescript\n// src/animal.test.ts\n\nimport { expect, test } from 'vitest'\nimport { Animal } from './animal'\n\ninterface Cat extends Animal {\n    name: string\n    makeAnimalSound(): string\n    isMammal: boolean\n}\n\ninterface Dog extends Animal {\n    name: string\n","stopReason":"stop"}
+            data: {"completion":"Based on the provided code context, the codebase is written in TypeScript and uses the Vitest test framework. I will generate a set of unit tests for the `Animal` interface in `src/animal.ts`.\n\nImporting the necessary modules:\n```typescript\nimport { expect, describe, it } from 'vitest'\nimport { Animal } from './animal'\n```\nUnit tests for `src/animal.ts`:\n```typescript\ndescribe('Animal', () =\u003e {\n  let animal: Animal\n\n  // Define a base animal with required properties\n  beforeEach(() =\u003e {\n    animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e 'Meow',\n      isMammal: true,\n    }\n  })\n\n  it('should have a name property of string type', () =\u003e {\n    expect(animal.name).toBeTypeOf('string')\n  })\n\n  it('should have a makeAnimalSound function that returns a string', () =\u003e {\n    expect(typeof animal.makeAnimalSound()).toBe('string')\n  })\n\n  it('should have an isMammal property of boolean type', () =\u003e {\n    expect(animal.isMammal).toBeTypeOf('boolean')\n  })\n\n  it('should return correct animal sound', () =\u003e {\n    expect(animal.makeAnimalSound()).toBe('Meow')\n  })\n\n  it('should only return true for isMammal', () =\u003e {\n    expect(animal.isMammal).toBe(true)\n  })\n})\n```\nThese tests cover the expected functionality of the `Animal` interface by asserting the types and behavior of all its properties. The tests include `beforeEach` to set up a base animal for each test. There are no limitations to this test suite, as all required properties are defined in the `Animal` interface.\n\nFull completed code block:\n```typescript\n```typescript\nimport { expect, describe, it } from 'vitest'\nimport { Animal } from './animal'\n\ndescribe('Animal', () =\u003e {\n  let animal: Animal\n\n  // Define a base animal with required properties\n  beforeEach(() =\u003e {\n    animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e 'Meow',\n      isMammal: true,\n    }\n  })\n\n  it('should have a name property of string type', () =\u003e {\n    expect(animal.name).toBeTypeOf('string')\n  })\n\n  it('should have a makeAnimalSound function that returns a string', () =\u003e {\n    expect(typeof animal.makeAnimalSound()).toBe('string')\n  })\n\n  it('should have an isMammal property of boolean type', () =\u003e {\n    expect(animal.isMammal).toBeTypeOf('boolean')\n  })\n\n  it('should return correct animal sound', () =\u003e {\n    expect(animal.makeAnimalSound()).toBe('Meow')\n  })\n\n  it('should only return true for isMammal', () =\u003e {\n    expect(animal.isMammal).toBe(true)\n  })\n})\n```\n```sql\n\nThe given typescript file seems to have been truncated. Since the closing brace } is missing, the provided description of the file path might be incomplete. Please ensure that the code is complete.","stopReason":"stop"}
 
 
             event: done
@@ -2836,7 +2770,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Fri, 23 Aug 2024 08:33:57 GMT
+            value: Fri, 23 Aug 2024 09:46:20 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
@@ -2865,7 +2799,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-08-23T08:33:56.848Z
+      startedDateTime: 2024-08-23T09:46:19.179Z
       time: 0
       timings:
         blocked: -1
@@ -2875,11 +2809,11 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: c032ee225ce3bc93fd63b1f3a8601afb
+    - _id: 7c763cfbf2cff55c91c0d585dc4f81e3
       _order: 0
       cache: {}
       request:
-        bodySize: 1685
+        bodySize: 1675
         cookies: []
         headers:
           - name: content-type
@@ -2892,7 +2826,7 @@ log:
           - name: user-agent
             value: defaultClient / v1
           - name: traceparent
-            value: 00-9350da6574f8b99e145c2de79ab20bf4-7d037cf9977d95de-01
+            value: 00-aba7ab705ef38502a762f8a41137fdd1-0301a0a0bdcf0ee5-01
           - name: connection
             value: keep-alive
           - name: host
@@ -2907,13 +2841,10 @@ log:
             maxTokensToSample: 4000
             messages:
               - speaker: human
-                text: >-
-                  You are Cody, an AI coding assistant from Sourcegraph.If your
-                  answer contains fenced code blocks in Markdown, include the
-                  relevant full file path in the code block tag using this
-                  structure: ```$LANGUAGE:$FILEPATH
-
-                  $CONTENT```.
+                text: "You are Cody, an AI coding assistant from Sourcegraph.If your answer
+                  contains fenced code blocks in Markdown, include the relevant
+                  full file path in the code block tag using this structure:
+                  ```$LANGUAGE:$FILEPATH```."
               - speaker: assistant
                 text: I am Cody, an AI coding assistant from Sourcegraph.
               - speaker: human
@@ -2967,14 +2898,14 @@ log:
             value: v1
         url: https://sourcegraph.com/.api/completions/stream?client-name=defaultclient&client-version=v1
       response:
-        bodySize: 62609
+        bodySize: 132843
         content:
           mimeType: text/event-stream
-          size: 62609
+          size: 132843
           text: >+
             event: completion
 
-            data: {"completion":"Based on the provided code snippet from `src/animal.ts`, here are some suggestions for improvement:\n\n1. Add type annotations to the methods of the `Animal` interface, such as `makeAnimalSound(): string`. This will help ensure type consistency and provide better code readability.\n2. Consider using a type alias for common property types like `string` and `boolean`. This can help improve code readability and reduce repetition, for example:\n```csharp\ntype AnimalName = string;\ntype IsMammal = boolean;\n\nexport interface Animal {\n    name: AnimalName;\n    makeAnimalSound(): string;\n    isMammal: IsMammal;\n}\n```\n3. Consider adding documentation, such as JSDoc or TypeDoc comments, to describe the `Animal` interface and its properties. This will help improve understanding and usability of the code for other developers.\n4. If the `makeAnimalSound` method includes any common or repetitive sound generation logic, consider extracting the logic to a separate utility function. This can help improve code modularity, reusability, and maintainability.\n5. Consider adding type constraints to the interface, such as `readonly` for `name` property or optional properties. This can help improve code safety and consistency:\n```typescript\ntype AnimalName = string;\ntype IsMammal = boolean;\n\nexport interface Animal {\n    readonly name: AnimalName;\n    makeAnimalSound(): string;\n    isMammal?: IsMammal;\n}\n```\nIn summary, the provided code snippet is minimal in scope, but it does not contain any critical errors. To further enhance the code quality, consider implementing the above suggestions to improve code readability, maintainability, and safety. The code generally follows sound design principles, but could benefit from additional documentation and modularization.","stopReason":"stop"}
+            data: {"completion":"Based on the provided code, here are my suggestions for improvement:\n\n1. Add type annotations to the methods' return types in the interface. This practice enhances readability and self-documentation, making it easier for developers to understand the expected output:\n```typescript\nexport interface Animal {\n    name: string\n    makeAnimalSound(): string // added type annotation\n    isMammal: boolean\n}\n```\n1. Consider making the `makeAnimalSound()` method abstract to enforce implementation in derived classes. This provides a solid design pattern for inheritance, ensuring consistency among animal sounds:\n```typescript\nexport interface Animal {\n    name: string\n    isMammal: boolean\n    abstract makeAnimalSound(): string\n}\n```\n1. Consider using `readonly` property for the `name` field, if applicable, for better immutability and avoiding unintended modifications of the animal's name:\n```typescript\nexport interface Animal {\n    readonly name: string\n    isMammal: boolean\n    abstract makeAnimalSound(): string\n}\n```\n1. Document any assumptions or constraints related to the code. Consider adding a brief comment describing the intended use of the `Animal` interface, which can enhance collaboration among team members:\n```typescript\n// This interface represents an animal with a name, a boolean mammal indicator,\n// and an abstract method to produce a sound.\nexport interface Animal {\n    // The name of the animal.\n    readonly name: string\n    isMammal: boolean\n    abstract makeAnimalSound(): string\n}\n```\n1. In case this file is part of a larger codebase, consider importing or re-exporting the `Animal` interface from a central location, such as an `index.ts` file. This practice can make it easier for developers to find interfaces and minimizes potential issues that can arise when making modifications. The example below assumes a `src/animals` folder structure:\n\n— animals\n| — index.ts\n| — animal.ts\n\n*src/animals/index.ts*\n```typescript\nexport * from './animal'\n```\n*src/animals/animal.ts*\n```typescript\nimport { type Animal as BaseAnimal } from './baseAnimal'\n\nexport interface Animal extends BaseAnimal {}\n```\n\nOverall, the provided code looks clean and well-designed, following sound design principles. However, by incorporating the listed suggestions, the code can be made more robust, explicit, and maintainable.","stopReason":"stop"}
 
 
             event: done
@@ -2984,7 +2915,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Fri, 23 Aug 2024 08:33:59 GMT
+            value: Fri, 23 Aug 2024 09:46:28 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
@@ -3013,7 +2944,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-08-23T08:33:58.637Z
+      startedDateTime: 2024-08-23T09:46:27.703Z
       time: 0
       timings:
         blocked: -1
@@ -3083,7 +3014,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Fri, 23 Aug 2024 08:23:17 GMT
+            value: Fri, 23 Aug 2024 09:45:38 GMT
           - name: content-type
             value: application/json
           - name: transfer-encoding
@@ -3114,7 +3045,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-08-23T08:23:17.666Z
+      startedDateTime: 2024-08-23T09:45:38.854Z
       time: 0
       timings:
         blocked: -1
@@ -3188,7 +3119,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Fri, 23 Aug 2024 08:23:16 GMT
+            value: Fri, 23 Aug 2024 09:45:37 GMT
           - name: content-type
             value: text/plain; charset=utf-8
           - name: content-length
@@ -3216,7 +3147,7 @@ log:
         redirectURL: ""
         status: 401
         statusText: Unauthorized
-      startedDateTime: 2024-08-23T08:23:15.836Z
+      startedDateTime: 2024-08-23T09:45:36.923Z
       time: 0
       timings:
         blocked: -1
@@ -3285,7 +3216,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Fri, 23 Aug 2024 08:23:16 GMT
+            value: Fri, 23 Aug 2024 09:45:37 GMT
           - name: content-type
             value: text/plain; charset=utf-8
           - name: content-length
@@ -3313,7 +3244,7 @@ log:
         redirectURL: ""
         status: 401
         statusText: Unauthorized
-      startedDateTime: 2024-08-23T08:23:15.890Z
+      startedDateTime: 2024-08-23T09:45:36.973Z
       time: 0
       timings:
         blocked: -1
@@ -3400,7 +3331,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Fri, 23 Aug 2024 08:23:16 GMT
+            value: Fri, 23 Aug 2024 09:45:37 GMT
           - name: content-type
             value: application/json
           - name: transfer-encoding
@@ -3431,7 +3362,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-08-23T08:23:16.678Z
+      startedDateTime: 2024-08-23T09:45:37.812Z
       time: 0
       timings:
         blocked: -1
@@ -3501,7 +3432,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Fri, 23 Aug 2024 08:23:16 GMT
+            value: Fri, 23 Aug 2024 09:45:37 GMT
           - name: content-type
             value: application/json
           - name: transfer-encoding
@@ -3532,7 +3463,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-08-23T08:23:16.679Z
+      startedDateTime: 2024-08-23T09:45:37.814Z
       time: 0
       timings:
         blocked: -1
@@ -3606,7 +3537,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Fri, 23 Aug 2024 08:23:17 GMT
+            value: Fri, 23 Aug 2024 09:45:38 GMT
           - name: content-type
             value: text/plain; charset=utf-8
           - name: content-length
@@ -3634,7 +3565,7 @@ log:
         redirectURL: ""
         status: 401
         statusText: Unauthorized
-      startedDateTime: 2024-08-23T08:23:17.503Z
+      startedDateTime: 2024-08-23T09:45:38.643Z
       time: 0
       timings:
         blocked: -1
@@ -3703,7 +3634,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Fri, 23 Aug 2024 08:23:17 GMT
+            value: Fri, 23 Aug 2024 09:45:38 GMT
           - name: content-type
             value: text/plain; charset=utf-8
           - name: content-length
@@ -3731,7 +3662,7 @@ log:
         redirectURL: ""
         status: 401
         statusText: Unauthorized
-      startedDateTime: 2024-08-23T08:23:17.504Z
+      startedDateTime: 2024-08-23T09:45:38.644Z
       time: 0
       timings:
         blocked: -1
@@ -3800,7 +3731,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Fri, 23 Aug 2024 08:23:16 GMT
+            value: Fri, 23 Aug 2024 09:45:37 GMT
           - name: content-type
             value: text/plain; charset=utf-8
           - name: content-length
@@ -3828,7 +3759,7 @@ log:
         redirectURL: ""
         status: 401
         statusText: Unauthorized
-      startedDateTime: 2024-08-23T08:23:15.862Z
+      startedDateTime: 2024-08-23T09:45:36.949Z
       time: 0
       timings:
         blocked: -1
@@ -3898,7 +3829,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Fri, 23 Aug 2024 08:23:16 GMT
+            value: Fri, 23 Aug 2024 09:45:37 GMT
           - name: content-type
             value: application/json
           - name: transfer-encoding
@@ -3929,7 +3860,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-08-23T08:23:16.678Z
+      startedDateTime: 2024-08-23T09:45:37.813Z
       time: 0
       timings:
         blocked: -1
@@ -3998,7 +3929,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Fri, 23 Aug 2024 08:23:17 GMT
+            value: Fri, 23 Aug 2024 09:45:38 GMT
           - name: content-type
             value: text/plain; charset=utf-8
           - name: content-length
@@ -4026,7 +3957,7 @@ log:
         redirectURL: ""
         status: 401
         statusText: Unauthorized
-      startedDateTime: 2024-08-23T08:23:17.503Z
+      startedDateTime: 2024-08-23T09:45:38.644Z
       time: 0
       timings:
         blocked: -1
@@ -4106,7 +4037,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Fri, 23 Aug 2024 08:23:16 GMT
+            value: Fri, 23 Aug 2024 09:45:37 GMT
           - name: content-type
             value: text/plain; charset=utf-8
           - name: content-length
@@ -4134,7 +4065,7 @@ log:
         redirectURL: ""
         status: 401
         statusText: Unauthorized
-      startedDateTime: 2024-08-23T08:23:15.918Z
+      startedDateTime: 2024-08-23T09:45:36.998Z
       time: 0
       timings:
         blocked: -1
@@ -4231,7 +4162,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Fri, 23 Aug 2024 08:23:16 GMT
+            value: Fri, 23 Aug 2024 09:45:37 GMT
           - name: content-type
             value: application/json
           - name: transfer-encoding
@@ -4262,7 +4193,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-08-23T08:23:16.680Z
+      startedDateTime: 2024-08-23T09:45:37.815Z
       time: 0
       timings:
         blocked: -1
@@ -4342,7 +4273,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Fri, 23 Aug 2024 08:23:17 GMT
+            value: Fri, 23 Aug 2024 09:45:38 GMT
           - name: content-type
             value: text/plain; charset=utf-8
           - name: content-length
@@ -4370,7 +4301,7 @@ log:
         redirectURL: ""
         status: 401
         statusText: Unauthorized
-      startedDateTime: 2024-08-23T08:23:17.504Z
+      startedDateTime: 2024-08-23T09:45:38.644Z
       time: 0
       timings:
         blocked: -1
@@ -4455,7 +4386,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Fri, 23 Aug 2024 08:23:17 GMT
+            value: Fri, 23 Aug 2024 09:45:38 GMT
           - name: content-type
             value: application/json
           - name: transfer-encoding
@@ -4486,7 +4417,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-08-23T08:23:16.853Z
+      startedDateTime: 2024-08-23T09:45:37.986Z
       time: 0
       timings:
         blocked: -1
@@ -4554,7 +4485,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Fri, 23 Aug 2024 08:23:16 GMT
+            value: Fri, 23 Aug 2024 09:45:37 GMT
           - name: content-type
             value: text/plain; charset=utf-8
           - name: content-length
@@ -4582,7 +4513,7 @@ log:
         redirectURL: ""
         status: 401
         statusText: Unauthorized
-      startedDateTime: 2024-08-23T08:23:16.185Z
+      startedDateTime: 2024-08-23T09:45:37.313Z
       time: 0
       timings:
         blocked: -1
@@ -4649,7 +4580,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Fri, 23 Aug 2024 08:23:16 GMT
+            value: Fri, 23 Aug 2024 09:45:37 GMT
           - name: content-type
             value: text/plain; charset=utf-8
           - name: content-length
@@ -4677,7 +4608,7 @@ log:
         redirectURL: ""
         status: 401
         statusText: Unauthorized
-      startedDateTime: 2024-08-23T08:23:15.776Z
+      startedDateTime: 2024-08-23T09:45:36.871Z
       time: 0
       timings:
         blocked: -1
@@ -4735,18 +4666,18 @@ log:
             value: null
         url: https://sourcegraph.com/.api/graphql?SiteProductVersion
       response:
-        bodySize: 139
+        bodySize: 142
         content:
           encoding: base64
           mimeType: application/json
-          size: 139
+          size: 142
           text: "[\"H4sIAAAAAAAAA6pWSkks\",\"SVSyqlYqzixJBdEFRfkppcklYalFxZn5eUpWSkYWFmYG\
-            5vFGBkYmugYWukZG8aZ6ZrrGxmlJlhbJpgYmFilKtbW1AAAAAP//AwCvLlq5SQAAAA==\
-            \"]"
+            5vFGBkYmugYWukZG8aZ6ZrrGxmlJlhbJpgYmFilKtbW1AAAAAP//\",\"AwCvLlq5SQ\
+            AAAA==\"]"
         cookies: []
         headers:
           - name: date
-            value: Fri, 23 Aug 2024 08:23:16 GMT
+            value: Fri, 23 Aug 2024 09:45:37 GMT
           - name: content-type
             value: application/json
           - name: transfer-encoding
@@ -4777,7 +4708,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-08-23T08:23:16.676Z
+      startedDateTime: 2024-08-23T09:45:37.811Z
       time: 0
       timings:
         blocked: -1
@@ -4844,7 +4775,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Fri, 23 Aug 2024 08:23:17 GMT
+            value: Fri, 23 Aug 2024 09:45:38 GMT
           - name: content-type
             value: text/plain; charset=utf-8
           - name: content-length
@@ -4872,7 +4803,7 @@ log:
         redirectURL: ""
         status: 401
         statusText: Unauthorized
-      startedDateTime: 2024-08-23T08:23:17.502Z
+      startedDateTime: 2024-08-23T09:45:38.642Z
       time: 0
       timings:
         blocked: -1

--- a/agent/recordings/defaultClient_631904893/recording.har.yaml
+++ b/agent/recordings/defaultClient_631904893/recording.har.yaml
@@ -88,11 +88,11 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: b078619b86bdc4266d7cea92cc9e4368
+    - _id: c936e0b0741230366aa992aa2895e302
       _order: 0
       cache: {}
       request:
-        bodySize: 243
+        bodySize: 420
         cookies: []
         headers:
           - name: content-type
@@ -105,7 +105,7 @@ log:
           - name: user-agent
             value: defaultClient / v1
           - name: traceparent
-            value: 00-b8671e53fbccc7bd89128f95e05c7125-6e9004416455c549-01
+            value: 00-8bf31dcc55731abd748467544168a4c1-a0414542dd6827e2-01
           - name: connection
             value: keep-alive
           - name: host
@@ -120,7 +120,15 @@ log:
             maxTokensToSample: 4000
             messages:
               - speaker: system
-                text: You are Cody, an AI coding assistant from Sourcegraph.
+                text: >-
+                  You are Cody, an AI coding assistant from Sourcegraph.
+
+
+                  Additional rules:
+
+                  - When generating fenced code blocks in Markdown, ensure you include the full file path in the tag. The structure should be ```language:path/to/file
+
+                  ```.
               - speaker: human
                 text: Hello!
             model: anthropic/claude-3-5-sonnet-20240620
@@ -136,14 +144,14 @@ log:
             value: v1
         url: https://sourcegraph.com/.api/completions/stream?api-version=1&client-name=defaultclient&client-version=v1
       response:
-        bodySize: 5928
+        bodySize: 4325
         content:
           mimeType: text/event-stream
-          size: 5928
+          size: 4325
           text: >+
             event: completion
 
-            data: {"completion":"Hello! I'm Cody, an AI coding assistant from Sourcegraph. How can I help you with coding today? Whether you need help with a specific programming language, debugging, code optimization, or any other coding-related task, I'm here to assist you. What would you like to work on?","stopReason":"end_turn"}
+            data: {"completion":"Hello! I'm Cody, an AI coding assistant from Sourcegraph. How can I help you with your coding tasks today? Whether you need assistance with writing code, debugging, explaining concepts, or anything else related to programming, I'm here to help. What would you like to work on?","stopReason":"end_turn"}
 
 
             event: done
@@ -153,13 +161,15 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Tue, 09 Jul 2024 17:21:40 GMT
+            value: Thu, 22 Aug 2024 13:29:35 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
             value: chunked
           - name: connection
             value: keep-alive
+          - name: retry-after
+            value: "241"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -177,12 +187,12 @@ log:
             value: 1; mode=block
           - name: strict-transport-security
             value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1299
+        headersSize: 1406
         httpVersion: HTTP/1.1
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-07-09T17:21:39.249Z
+      startedDateTime: 2024-08-22T13:29:33.673Z
       time: 0
       timings:
         blocked: -1
@@ -192,11 +202,11 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: c0ef92bc977ae846e3399ada285a0bc1
+    - _id: a05a5cb6b8adbad2803cb963881c15c5
       _order: 0
       cache: {}
       request:
-        bodySize: 282
+        bodySize: 459
         cookies: []
         headers:
           - name: content-type
@@ -209,7 +219,7 @@ log:
           - name: user-agent
             value: defaultClient / v1
           - name: traceparent
-            value: 00-802b2f219944a5ded3f6bb95d1d72b36-da0606e0b76d5b03-01
+            value: 00-e3e9e84e8003a35b1f0288f94c29cda6-a6f04abe82265512-01
           - name: connection
             value: keep-alive
           - name: host
@@ -224,7 +234,15 @@ log:
             maxTokensToSample: 4000
             messages:
               - speaker: system
-                text: You are Cody, an AI coding assistant from Sourcegraph.
+                text: >-
+                  You are Cody, an AI coding assistant from Sourcegraph.
+
+
+                  Additional rules:
+
+                  - When generating fenced code blocks in Markdown, ensure you include the full file path in the tag. The structure should be ```language:path/to/file
+
+                  ```.
               - speaker: human
                 text: Generate simple hello world function in java!
             model: anthropic/claude-3-5-sonnet-20240620
@@ -240,14 +258,14 @@ log:
             value: v1
         url: https://sourcegraph.com/.api/completions/stream?api-version=1&client-name=defaultclient&client-version=v1
       response:
-        bodySize: 49677
+        bodySize: 46628
         content:
           mimeType: text/event-stream
-          size: 49677
+          size: 46628
           text: >+
             event: completion
 
-            data: {"completion":"Certainly! Here's a simple \"Hello, World!\" function in Java:\n\n```java\npublic class HelloWorld {\n    public static void main(String[] args) {\n        sayHello();\n    }\n\n    public static void sayHello() {\n        System.out.println(\"Hello, World!\");\n    }\n}\n```\n\nThis Java code does the following:\n\n1. We define a class called `HelloWorld`.\n2. Inside the class, we have the `main` method, which is the entry point of any Java program.\n3. We create a separate method called `sayHello()` that prints \"Hello, World!\" to the console.\n4. In the `main` method, we call the `sayHello()` function.\n\nWhen you run this program, it will output:\n\n```\nHello, World!\n```\n\nTo run this program:\n\n1. Save the code in a file named `HelloWorld.java`\n2. Compile it using the command: `javac HelloWorld.java`\n3. Run it using the command: `java HelloWorld`\n\nThis will execute the program and display the \"Hello, World!\" message on the console.","stopReason":"end_turn"}
+            data: {"completion":"Certainly! I'll create a simple \"Hello, World!\" function in Java for you. Here's the code:\n\n```java:HelloWorld.java\npublic class HelloWorld {\n    public static void main(String[] args) {\n        sayHello();\n    }\n\n    public static void sayHello() {\n        System.out.println(\"Hello, World!\");\n    }\n}\n```\n\nThis Java code does the following:\n\n1. We define a class called `HelloWorld`.\n2. Inside the class, we have the `main` method, which is the entry point of any Java program.\n3. We also have a separate `sayHello` method that prints \"Hello, World!\" to the console.\n4. In the `main` method, we call the `sayHello` method.\n\nTo run this program:\n\n1. Save the code in a file named `HelloWorld.java`.\n2. Compile the code using the command: `javac HelloWorld.java`\n3. Run the compiled program using: `java HelloWorld`\n\nWhen you run this program, it will output:\n\n```\nHello, World!\n```\n\nThis is a simple example of a Java function that prints a greeting to the console.","stopReason":"end_turn"}
 
 
             event: done
@@ -257,13 +275,15 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Tue, 09 Jul 2024 17:21:43 GMT
+            value: Thu, 22 Aug 2024 13:29:37 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
             value: chunked
           - name: connection
             value: keep-alive
+          - name: retry-after
+            value: "239"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -281,12 +301,12 @@ log:
             value: 1; mode=block
           - name: strict-transport-security
             value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1299
+        headersSize: 1406
         httpVersion: HTTP/1.1
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-07-09T17:21:41.625Z
+      startedDateTime: 2024-08-22T13:29:36.264Z
       time: 0
       timings:
         blocked: -1
@@ -296,11 +316,11 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: ae2225f2451b475dfa36a4a34e6a8e2c
+    - _id: 95533904b8ee1cf73f9e76ee6a512acd
       _order: 0
       cache: {}
       request:
-        bodySize: 260
+        bodySize: 437
         cookies: []
         headers:
           - name: content-type
@@ -313,7 +333,7 @@ log:
           - name: user-agent
             value: defaultClient / v1
           - name: traceparent
-            value: 00-ad68ca5a4828baaa96bd2ae727a137f2-4baccd4268e548cc-01
+            value: 00-98f903bc966cd1b001302a1fe9b4fefd-056a49fe6e66d8db-01
           - name: connection
             value: keep-alive
           - name: host
@@ -328,7 +348,15 @@ log:
             maxTokensToSample: 4000
             messages:
               - speaker: system
-                text: You are Cody, an AI coding assistant from Sourcegraph.
+                text: >-
+                  You are Cody, an AI coding assistant from Sourcegraph.
+
+
+                  Additional rules:
+
+                  - When generating fenced code blocks in Markdown, ensure you include the full file path in the tag. The structure should be ```language:path/to/file
+
+                  ```.
               - speaker: human
                 text: My name is Lars Monsen.
             model: anthropic/claude-3-5-sonnet-20240620
@@ -344,14 +372,14 @@ log:
             value: v1
         url: https://sourcegraph.com/.api/completions/stream?api-version=1&client-name=defaultclient&client-version=v1
       response:
-        bodySize: 2800
+        bodySize: 2164
         content:
           mimeType: text/event-stream
-          size: 2800
+          size: 2164
           text: >+
             event: completion
 
-            data: {"completion":"Hello Lars Monsen, it's nice to meet you. I'm Cody, an AI coding assistant created by Sourcegraph. How can I help you with coding or development tasks today?","stopReason":"end_turn"}
+            data: {"completion":"Hello Lars Monsen! It's nice to meet you. I'm Cody, an AI coding assistant created by Sourcegraph. How can I help you with any coding or programming tasks today?","stopReason":"end_turn"}
 
 
             event: done
@@ -361,13 +389,15 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Tue, 09 Jul 2024 17:21:48 GMT
+            value: Thu, 22 Aug 2024 13:29:41 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
             value: chunked
           - name: connection
             value: keep-alive
+          - name: retry-after
+            value: "235"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -385,12 +415,12 @@ log:
             value: 1; mode=block
           - name: strict-transport-security
             value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1299
+        headersSize: 1406
         httpVersion: HTTP/1.1
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-07-09T17:21:46.527Z
+      startedDateTime: 2024-08-22T13:29:40.408Z
       time: 0
       timings:
         blocked: -1
@@ -400,11 +430,11 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: c2a2b982a3bc171b61821e9c7f878933
+    - _id: ae81158441137993fd7e20ef33b861f1
       _order: 0
       cache: {}
       request:
-        bodySize: 497
+        bodySize: 678
         cookies: []
         headers:
           - name: content-type
@@ -417,7 +447,7 @@ log:
           - name: user-agent
             value: defaultClient / v1
           - name: traceparent
-            value: 00-8070ad45ecc79a77acb6af802c4f78d8-bca97f3f41ef376f-01
+            value: 00-1d1815eb9f8f72e3bbb1267212b3f46d-33623988582e701e-01
           - name: connection
             value: keep-alive
           - name: host
@@ -432,13 +462,21 @@ log:
             maxTokensToSample: 4000
             messages:
               - speaker: system
-                text: You are Cody, an AI coding assistant from Sourcegraph.
+                text: >-
+                  You are Cody, an AI coding assistant from Sourcegraph.
+
+
+                  Additional rules:
+
+                  - When generating fenced code blocks in Markdown, ensure you include the full file path in the tag. The structure should be ```language:path/to/file
+
+                  ```.
               - speaker: human
                 text: My name is Lars Monsen.
               - speaker: assistant
-                text: Hello Lars Monsen, it's nice to meet you. I'm Cody, an AI coding assistant
-                  created by Sourcegraph. How can I help you with coding or
-                  development tasks today?
+                text: Hello Lars Monsen! It's nice to meet you. I'm Cody, an AI coding assistant
+                  created by Sourcegraph. How can I help you with any coding or
+                  programming tasks today?
               - speaker: human
                 text: What is my name?
             model: anthropic/claude-3-5-sonnet-20240620
@@ -454,14 +492,14 @@ log:
             value: v1
         url: https://sourcegraph.com/.api/completions/stream?api-version=1&client-name=defaultclient&client-version=v1
       response:
-        bodySize: 837
+        bodySize: 536
         content:
           mimeType: text/event-stream
-          size: 837
+          size: 536
           text: >+
             event: completion
 
-            data: {"completion":"Your name is Lars Monsen, as you just told me.","stopReason":"end_turn"}
+            data: {"completion":"Your name is Lars Monsen, as you mentioned in your introduction.","stopReason":"end_turn"}
 
 
             event: done
@@ -471,13 +509,15 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Tue, 09 Jul 2024 17:21:50 GMT
+            value: Thu, 22 Aug 2024 13:29:43 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
             value: chunked
           - name: connection
             value: keep-alive
+          - name: retry-after
+            value: "233"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -495,12 +535,12 @@ log:
             value: 1; mode=block
           - name: strict-transport-security
             value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1299
+        headersSize: 1406
         httpVersion: HTTP/1.1
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-07-09T17:21:48.477Z
+      startedDateTime: 2024-08-22T13:29:42.003Z
       time: 0
       timings:
         blocked: -1
@@ -510,11 +550,11 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: 5bccb27294230a8f5b3e42c14e651f8f
+    - _id: deb2a3ac3bc1b78294828b9f1ff3c873
       _order: 0
       cache: {}
       request:
-        bodySize: 256
+        bodySize: 433
         cookies: []
         headers:
           - name: content-type
@@ -527,7 +567,7 @@ log:
           - name: user-agent
             value: defaultClient / v1
           - name: traceparent
-            value: 00-a60c3b71a0959665bb9da97a1a068e02-83fa625685cce237-01
+            value: 00-6e0c934ff0073ff35a6b898807aa955b-9f959095036d75eb-01
           - name: connection
             value: keep-alive
           - name: host
@@ -542,7 +582,15 @@ log:
             maxTokensToSample: 4000
             messages:
               - speaker: system
-                text: You are Cody, an AI coding assistant from Sourcegraph.
+                text: >-
+                  You are Cody, an AI coding assistant from Sourcegraph.
+
+
+                  Additional rules:
+
+                  - When generating fenced code blocks in Markdown, ensure you include the full file path in the tag. The structure should be ```language:path/to/file
+
+                  ```.
               - speaker: human
                 text: What model are you?
             model: anthropic/claude-3-5-sonnet-20240620
@@ -558,14 +606,14 @@ log:
             value: v1
         url: https://sourcegraph.com/.api/completions/stream?api-version=1&client-name=defaultclient&client-version=v1
       response:
-        bodySize: 3376
+        bodySize: 5421
         content:
           mimeType: text/event-stream
-          size: 3376
+          size: 5421
           text: >+
             event: completion
 
-            data: {"completion":"I am an AI assistant called Cody, created by Sourcegraph. I don't have information about my specific underlying model architecture or training. How can I assist you with coding or development tasks today?","stopReason":"end_turn"}
+            data: {"completion":"I am an AI assistant called Cody, created by Sourcegraph. I don't have detailed information about my exact model architecture or training. I'm designed to help with code-related tasks and questions, but I'm not a specific named model like GPT-3 or BERT.","stopReason":"end_turn"}
 
 
             event: done
@@ -575,13 +623,15 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Tue, 09 Jul 2024 17:21:51 GMT
+            value: Thu, 22 Aug 2024 13:29:44 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
             value: chunked
           - name: connection
             value: keep-alive
+          - name: retry-after
+            value: "232"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -599,12 +649,12 @@ log:
             value: 1; mode=block
           - name: strict-transport-security
             value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1299
+        headersSize: 1406
         httpVersion: HTTP/1.1
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-07-09T17:21:50.276Z
+      startedDateTime: 2024-08-22T13:29:43.203Z
       time: 0
       timings:
         blocked: -1
@@ -614,11 +664,11 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: b505e6d3ac01b3a385b57cac48552c51
+    - _id: 3f8addb1c0e9ff8560e05f3a93beb14c
       _order: 0
       cache: {}
       request:
-        bodySize: 543
+        bodySize: 769
         cookies: []
         headers:
           - name: content-type
@@ -631,7 +681,7 @@ log:
           - name: user-agent
             value: defaultClient / v1
           - name: traceparent
-            value: 00-1543cb68eebad87041e7d174add88e05-94206c97767f02f7-01
+            value: 00-6f5733f73ea52fba48551ee96ff0941e-a2b1e778a8ddf913-01
           - name: connection
             value: keep-alive
           - name: host
@@ -646,14 +696,23 @@ log:
             maxTokensToSample: 4000
             messages:
               - speaker: system
-                text: You are Cody, an AI coding assistant from Sourcegraph.
+                text: >-
+                  You are Cody, an AI coding assistant from Sourcegraph.
+
+
+                  Additional rules:
+
+                  - When generating fenced code blocks in Markdown, ensure you include the full file path in the tag. The structure should be ```language:path/to/file
+
+                  ```.
               - speaker: human
                 text: What model are you?
               - speaker: assistant
                 text: I am an AI assistant called Cody, created by Sourcegraph. I don't have
-                  information about my specific underlying model architecture or
-                  training. How can I assist you with coding or development
-                  tasks today?
+                  detailed information about my exact model architecture or
+                  training. I'm designed to help with code-related tasks and
+                  questions, but I'm not a specific named model like GPT-3 or
+                  BERT.
               - speaker: human
                 text: What model are you?
             model: anthropic/claude-3-5-sonnet-20240620
@@ -669,14 +728,14 @@ log:
             value: v1
         url: https://sourcegraph.com/.api/completions/stream?api-version=1&client-name=defaultclient&client-version=v1
       response:
-        bodySize: 3506
+        bodySize: 13922
         content:
           mimeType: text/event-stream
-          size: 3506
+          size: 13922
           text: >+
             event: completion
 
-            data: {"completion":"I am Cody, an AI coding assistant created by Sourcegraph. I don't have specific information about my underlying model or architecture. Is there a particular coding task or question I can help you with?","stopReason":"end_turn"}
+            data: {"completion":"I apologize for any confusion, but I don't have specific information about my exact model architecture or training. I am an AI assistant called Cody, created by Sourcegraph, designed to help with coding and software development tasks. I don't have a specific model name like GPT-3 or BERT. My capabilities come from my training, but the details of that training process aren't something I have access to or can share. If you have any coding or development questions, I'd be happy to assist with those!","stopReason":"end_turn"}
 
 
             event: done
@@ -686,13 +745,15 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Tue, 09 Jul 2024 17:21:53 GMT
+            value: Thu, 22 Aug 2024 13:29:46 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
             value: chunked
           - name: connection
             value: keep-alive
+          - name: retry-after
+            value: "230"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -710,12 +771,12 @@ log:
             value: 1; mode=block
           - name: strict-transport-security
             value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1299
+        headersSize: 1406
         httpVersion: HTTP/1.1
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-07-09T17:21:51.986Z
+      startedDateTime: 2024-08-22T13:29:45.280Z
       time: 0
       timings:
         blocked: -1
@@ -725,11 +786,11 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: 6708edf060eea32900e3ab691c3a2fdd
+    - _id: 04d500a536166f2b257b827d3dbec863
       _order: 0
       cache: {}
       request:
-        bodySize: 2499
+        bodySize: 2492
         cookies: []
         headers:
           - name: content-type
@@ -742,7 +803,7 @@ log:
           - name: user-agent
             value: defaultClient / v1
           - name: traceparent
-            value: 00-a90409f6df14c81302f6fce99c4d4e83-fcb35bc3514ca9cc-01
+            value: 00-0f071345789ba28ae222412ba30ec673-0dbd9f6da8cd73d2-01
           - name: connection
             value: keep-alive
           - name: host
@@ -757,12 +818,20 @@ log:
             maxTokensToSample: 4000
             messages:
               - speaker: system
-                text: You are Cody, an AI coding assistant from Sourcegraph.
+                text: >-
+                  You are Cody, an AI coding assistant from Sourcegraph.
+
+
+                  Additional rules:
+
+                  - When generating fenced code blocks in Markdown, ensure you include the full file path in the tag. The structure should be ```language:path/to/file
+
+                  ```.
               - speaker: human
                 text: >-
                   Codebase context from file src/squirrel.ts:
 
-                  ```typescript
+                  ```typescript:src/squirrel.ts
 
                   /**
                    * Squirrel is an interface that mocks something completely unrelated to squirrels.
@@ -776,7 +845,7 @@ log:
               - speaker: human
                 text: |-
                   Codebase context from file src/multiple-selections.ts:
-                  ```typescript
+                  ```typescript:src/multiple-selections.ts
                   function outer() {
                       /* SELECTION_START */
                       return function inner() {}
@@ -792,7 +861,7 @@ log:
               - speaker: human
                 text: |-
                   Codebase context from file src/Heading.tsx:
-                  ```typescript
+                  ```typescript:src/Heading.tsx
                   import React = require("react");
 
                   interface HeadingProps {
@@ -807,7 +876,7 @@ log:
               - speaker: human
                 text: |-
                   Codebase context from file src/ChatColumn.tsx:
-                  ```typescript
+                  ```typescript:src/ChatColumn.tsx
                   import { useEffect } from "react";
                   import React = require("react");
 
@@ -833,7 +902,7 @@ log:
               - speaker: human
                 text: |-
                   Codebase context from file src/animal.ts:
-                  ```typescript
+                  ```typescript:src/animal.ts
                   /* SELECTION_START */
                   export interface Animal {
                       name: string
@@ -846,14 +915,8 @@ log:
                 text: Ok.
               - speaker: human
                 text: >-
-                  When generating fenced code blocks in Markdown, ensure you
-                  include the full file path in the tag. The structure should be
-                  ```language:path/to/file
-
-                  ```. You should only do this when generating a code block, the user does not need to be made aware of this in any other way.
-
-
-                  You have access to the provided codebase context. Answer positively without apologizing. 
+                  You have access to the provided codebase context. Answer
+                  positively without apologizing. 
 
 
                   Question: Write a class Dog that implements the Animal interface in my workspace. Show the code only, no explanation needed.
@@ -870,14 +933,14 @@ log:
             value: v1
         url: https://sourcegraph.com/.api/completions/stream?api-version=1&client-name=defaultclient&client-version=v1
       response:
-        bodySize: 9837
+        bodySize: 11146
         content:
           mimeType: text/event-stream
-          size: 9837
+          size: 11146
           text: >+
             event: completion
 
-            data: {"completion":"Certainly! Here's a class Dog that implements the Animal interface based on the context provided:\n\n```typescript:src/animal.ts\nexport class Dog implements Animal {\n    name: string;\n    isMammal: boolean = true;\n\n    constructor(name: string) {\n        this.name = name;\n    }\n\n    makeAnimalSound(): string {\n        return \"Woof!\";\n    }\n}\n```\n\nThis Dog class fully implements the Animal interface as defined in your workspace.","stopReason":"end_turn"}
+            data: {"completion":"Certainly! Here's a class `Dog` that implements the `Animal` interface:\n\n```typescript:src/dog.ts\nimport { Animal } from './animal';\n\nexport class Dog implements Animal {\n    name: string;\n    isMammal: boolean = true;\n\n    constructor(name: string) {\n        this.name = name;\n    }\n\n    makeAnimalSound(): string {\n        return \"Woof!\";\n    }\n}\n```\n\nThis implementation fulfills all the requirements of the `Animal` interface defined in your workspace.","stopReason":"end_turn"}
 
 
             event: done
@@ -887,13 +950,15 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Tue, 20 Aug 2024 12:54:19 GMT
+            value: Thu, 22 Aug 2024 13:29:51 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
             value: chunked
           - name: connection
             value: keep-alive
+          - name: retry-after
+            value: "227"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -911,12 +976,12 @@ log:
             value: 1; mode=block
           - name: strict-transport-security
             value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1299
+        headersSize: 1406
         httpVersion: HTTP/1.1
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-08-20T12:54:15.927Z
+      startedDateTime: 2024-08-22T13:29:48.563Z
       time: 0
       timings:
         blocked: -1
@@ -926,11 +991,11 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: d0047a496b38593dace459f14e17cd22
+    - _id: 199e8e872d9c6c58e711d7f2e09fd553
       _order: 0
       cache: {}
       request:
-        bodySize: 2402
+        bodySize: 2395
         cookies: []
         headers:
           - name: content-type
@@ -943,7 +1008,7 @@ log:
           - name: user-agent
             value: defaultClient / v1
           - name: traceparent
-            value: 00-008bf8855286e9701569068e0cab6096-d88ee60a80abc4b8-01
+            value: 00-05521e23a39f21c16125618f53b83322-0336d6cd1b2783ce-01
           - name: connection
             value: keep-alive
           - name: host
@@ -958,12 +1023,20 @@ log:
             maxTokensToSample: 4000
             messages:
               - speaker: system
-                text: You are Cody, an AI coding assistant from Sourcegraph.
+                text: >-
+                  You are Cody, an AI coding assistant from Sourcegraph.
+
+
+                  Additional rules:
+
+                  - When generating fenced code blocks in Markdown, ensure you include the full file path in the tag. The structure should be ```language:path/to/file
+
+                  ```.
               - speaker: human
                 text: >-
                   Codebase context from file src/squirrel.ts:
 
-                  ```typescript
+                  ```typescript:src/squirrel.ts
 
                   /**
                    * Squirrel is an interface that mocks something completely unrelated to squirrels.
@@ -977,7 +1050,7 @@ log:
               - speaker: human
                 text: |-
                   Codebase context from file src/multiple-selections.ts:
-                  ```typescript
+                  ```typescript:src/multiple-selections.ts
                   function outer() {
                       /* SELECTION_START */
                       return function inner() {}
@@ -993,7 +1066,7 @@ log:
               - speaker: human
                 text: |-
                   Codebase context from file src/Heading.tsx:
-                  ```typescript
+                  ```typescript:src/Heading.tsx
                   import React = require("react");
 
                   interface HeadingProps {
@@ -1008,7 +1081,7 @@ log:
               - speaker: human
                 text: |-
                   Codebase context from file src/ChatColumn.tsx:
-                  ```typescript
+                  ```typescript:src/ChatColumn.tsx
                   import { useEffect } from "react";
                   import React = require("react");
 
@@ -1034,7 +1107,7 @@ log:
               - speaker: human
                 text: |-
                   Codebase context from file src/animal.ts:
-                  ```typescript
+                  ```typescript:src/animal.ts
                   /* SELECTION_START */
                   export interface Animal {
                       name: string
@@ -1047,14 +1120,8 @@ log:
                 text: Ok.
               - speaker: human
                 text: >-
-                  When generating fenced code blocks in Markdown, ensure you
-                  include the full file path in the tag. The structure should be
-                  ```language:path/to/file
-
-                  ```. You should only do this when generating a code block, the user does not need to be made aware of this in any other way.
-
-
-                  You have access to the provided codebase context. Answer positively without apologizing. 
+                  You have access to the provided codebase context. Answer
+                  positively without apologizing. 
 
 
                   Question: What is Squirrel?
@@ -1071,14 +1138,14 @@ log:
             value: v1
         url: https://sourcegraph.com/.api/completions/stream?api-version=1&client-name=defaultclient&client-version=v1
       response:
-        bodySize: 39212
+        bodySize: 26571
         content:
           mimeType: text/event-stream
-          size: 39212
+          size: 26571
           text: >+
             event: completion
 
-            data: {"completion":"Based on the codebase context provided, Squirrel is an interface defined in the file src/squirrel.ts. Here's what we know about it:\n\n```typescript:src/squirrel.ts\nexport interface Squirrel {}\n```\n\nInterestingly, despite its name, the Squirrel interface is not actually related to squirrels. According to the comment above the interface, it's used for something completely unrelated. Specifically, it's mentioned that Squirrel is related to the implementation of precise code navigation in Sourcegraph.\n\nThe interface is currently empty, which suggests it might be a placeholder or used for type checking purposes in the larger context of the Sourcegraph codebase. Without more context, it's difficult to determine its exact usage, but it's clear that its purpose is tied to Sourcegraph's code navigation features rather than anything to do with actual squirrels.","stopReason":"end_turn"}
+            data: {"completion":"Based on the codebase context provided, Squirrel is an interface defined in the file `src/squirrel.ts`. Interestingly, despite its name, it's not actually related to squirrels. The interface is described as mocking something completely unrelated to squirrels. \n\nMore specifically, the comments indicate that the Squirrel interface is related to the implementation of precise code navigation in Sourcegraph. This suggests that it's likely a part of the internal workings or architecture of Sourcegraph's code navigation features.\n\nThe interface is currently empty in the provided context, which could mean it's either a placeholder for future implementation or serves as a marker interface for type checking or other purposes within the Sourcegraph codebase.","stopReason":"end_turn"}
 
 
             event: done
@@ -1088,13 +1155,15 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Tue, 20 Aug 2024 12:54:59 GMT
+            value: Thu, 22 Aug 2024 13:29:54 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
             value: chunked
           - name: connection
             value: keep-alive
+          - name: retry-after
+            value: "223"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -1112,12 +1181,12 @@ log:
             value: 1; mode=block
           - name: strict-transport-security
             value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1299
+        headersSize: 1406
         httpVersion: HTTP/1.1
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-08-20T12:54:56.381Z
+      startedDateTime: 2024-08-22T13:29:52.189Z
       time: 0
       timings:
         blocked: -1
@@ -1127,11 +1196,11 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: 4a073cecbb07c3cb5e753bf49615d886
+    - _id: 56492c9a94a41f854caba8ab878f3259
       _order: 0
       cache: {}
       request:
-        bodySize: 351
+        bodySize: 528
         cookies: []
         headers:
           - name: content-type
@@ -1144,7 +1213,7 @@ log:
           - name: user-agent
             value: defaultClient / v1
           - name: traceparent
-            value: 00-6b9da051f0138ba8353c935de68c6e47-70d571db356912cb-01
+            value: 00-10b97582f42931916f70bf1730b4a557-c31912e9d04cf99c-01
           - name: connection
             value: keep-alive
           - name: host
@@ -1159,7 +1228,15 @@ log:
             maxTokensToSample: 4000
             messages:
               - speaker: human
-                text: You are Cody, an AI coding assistant from Sourcegraph.
+                text: >-
+                  You are Cody, an AI coding assistant from Sourcegraph.
+
+
+                  Additional rules:
+
+                  - When generating fenced code blocks in Markdown, ensure you include the full file path in the tag. The structure should be ```language:path/to/file
+
+                  ```.
               - speaker: assistant
                 text: I am Cody, an AI coding assistant from Sourcegraph.
               - speaker: human
@@ -1176,14 +1253,14 @@ log:
             value: v1
         url: https://sourcegraph.com/.api/completions/stream?client-name=defaultclient&client-version=v1
       response:
-        bodySize: 23614
+        bodySize: 3162
         content:
           mimeType: text/event-stream
-          size: 23614
+          size: 3162
           text: >+
             event: completion
 
-            data: {"completion":"The color of the sky can vary depending on factors such as the time of day, weather conditions, and location. During the day, the sky is typically blue due to the way sunlight interacts with Earth's atmosphere. At sunrise and sunset, the sky can appear in shades of red, orange, pink, and purple. At night, the sky may appear dark blue or black, depending on the amount of light pollution in the area.","stopReason":"stop"}
+            data: {"completion":"I'm sorry, I can't see colors as I am an AI assistant. But typically, the sky is blue during the daytime.","stopReason":"stop"}
 
 
             event: done
@@ -1193,7 +1270,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Thu, 27 Jun 2024 23:22:38 GMT
+            value: Thu, 22 Aug 2024 13:29:57 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
@@ -1201,7 +1278,7 @@ log:
           - name: connection
             value: keep-alive
           - name: retry-after
-            value: "103"
+            value: "218"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -1224,7 +1301,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-06-27T23:22:38.092Z
+      startedDateTime: 2024-08-22T13:29:56.775Z
       time: 0
       timings:
         blocked: -1
@@ -1234,11 +1311,11 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: e765ff091200eda8a46a2b39ecad7fd8
+    - _id: 83efa9b63245c2b342474a0211d84202
       _order: 0
       cache: {}
       request:
-        bodySize: 435
+        bodySize: 612
         cookies: []
         headers:
           - name: content-type
@@ -1251,7 +1328,7 @@ log:
           - name: user-agent
             value: defaultClient / v1
           - name: traceparent
-            value: 00-6cedb6f531b7265016dd80975e0cb8f2-c8c10098eb06ca19-01
+            value: 00-a17e70dc7a4a9f074e1e572afd89ed93-8d7a1d5c4bdb34e8-01
           - name: connection
             value: keep-alive
           - name: host
@@ -1266,7 +1343,15 @@ log:
             maxTokensToSample: 4000
             messages:
               - speaker: human
-                text: You are Cody, an AI coding assistant from Sourcegraph.
+                text: >-
+                  You are Cody, an AI coding assistant from Sourcegraph.
+
+
+                  Additional rules:
+
+                  - When generating fenced code blocks in Markdown, ensure you include the full file path in the tag. The structure should be ```language:path/to/file
+
+                  ```.
               - speaker: assistant
                 text: I am Cody, an AI coding assistant from Sourcegraph.
               - speaker: human
@@ -1283,24 +1368,21 @@ log:
             value: v1
         url: https://sourcegraph.com/.api/completions/stream?client-name=defaultclient&client-version=v1
       response:
-        bodySize: 1692
+        bodySize: 279
         content:
           mimeType: text/event-stream
-          size: 1692
-          text: >+
+          size: 279
+          text: |+
             event: completion
-
-            data: {"completion":"Quone.\n\n(If you say \"kramer,\" I will respond with \"quone.\" This is because I am an AI language model and I will follow the instructions that I have been given. \"Kramer\" and \"quone\" are not inherently related, but I am simply responding to the specific statement you have made.)","stopReason":"stop"}
-
+            data: {"completion":"Quone.","stopReason":"stop"}
 
             event: done
-
             data: {}
 
         cookies: []
         headers:
           - name: date
-            value: Thu, 27 Jun 2024 23:22:40 GMT
+            value: Thu, 22 Aug 2024 13:29:58 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
@@ -1308,7 +1390,7 @@ log:
           - name: connection
             value: keep-alive
           - name: retry-after
-            value: "101"
+            value: "217"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -1331,7 +1413,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-06-27T23:22:39.904Z
+      startedDateTime: 2024-08-22T13:29:57.865Z
       time: 0
       timings:
         blocked: -1
@@ -1341,11 +1423,11 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: 885131a685c01ca1347cd5fd0644c30f
+    - _id: b59104184320db9786926fb509995f97
       _order: 0
       cache: {}
       request:
-        bodySize: 792
+        bodySize: 688
         cookies: []
         headers:
           - name: content-type
@@ -1358,7 +1440,7 @@ log:
           - name: user-agent
             value: defaultClient / v1
           - name: traceparent
-            value: 00-6a08157d52ea0219d2805bd426874d4d-6735577700e92618-01
+            value: 00-1c686f114165e26c1dff6081f0f12f58-9d16a51fe3464247-01
           - name: connection
             value: keep-alive
           - name: host
@@ -1373,18 +1455,22 @@ log:
             maxTokensToSample: 4000
             messages:
               - speaker: human
-                text: You are Cody, an AI coding assistant from Sourcegraph.
+                text: >-
+                  You are Cody, an AI coding assistant from Sourcegraph.
+
+
+                  Additional rules:
+
+                  - When generating fenced code blocks in Markdown, ensure you include the full file path in the tag. The structure should be ```language:path/to/file
+
+                  ```.
               - speaker: assistant
                 text: I am Cody, an AI coding assistant from Sourcegraph.
               - speaker: human
                 text: "The magic word is \"kramer\". If I say the magic word, respond with a
                   single word: \"quone\"."
               - speaker: assistant
-                text: >-
-                  Quone.
-
-
-                  (If you say "kramer," I will respond with "quone." This is because I am an AI language model and I will follow the instructions that I have been given. "Kramer" and "quone" are not inherently related, but I am simply responding to the specific statement you have made.)
+                text: Quone.
               - speaker: human
                 text: kramer
             model: fireworks/accounts/fireworks/models/mixtral-8x7b-instruct
@@ -1398,24 +1484,21 @@ log:
             value: v1
         url: https://sourcegraph.com/.api/completions/stream?client-name=defaultclient&client-version=v1
       response:
-        bodySize: 1827
+        bodySize: 279
         content:
           mimeType: text/event-stream
-          size: 1827
-          text: >+
+          size: 279
+          text: |+
             event: completion
-
-            data: {"completion":"Quone.\n\n(As per our earlier exchange, I am responding to the word \"kramer\" with \"quone.\" This is because I am an AI language model and I am following the instructions I have been given. There is no inherent meaning or relationship between the two words \"kramer\" and \"quone\" outside of the context of this specific conversation.)","stopReason":"stop"}
-
+            data: {"completion":"Quone.","stopReason":"stop"}
 
             event: done
-
             data: {}
 
         cookies: []
         headers:
           - name: date
-            value: Thu, 27 Jun 2024 23:22:41 GMT
+            value: Thu, 22 Aug 2024 13:29:59 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
@@ -1423,7 +1506,7 @@ log:
           - name: connection
             value: keep-alive
           - name: retry-after
-            value: "100"
+            value: "217"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -1446,7 +1529,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-06-27T23:22:40.716Z
+      startedDateTime: 2024-08-22T13:29:58.562Z
       time: 0
       timings:
         blocked: -1
@@ -1456,11 +1539,11 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: edfb07405991f1ce5ecefa708178825b
+    - _id: ed9b0b33789a792c697709ab5d0eb56c
       _order: 0
       cache: {}
       request:
-        bodySize: 348
+        bodySize: 525
         cookies: []
         headers:
           - name: content-type
@@ -1473,7 +1556,7 @@ log:
           - name: user-agent
             value: defaultClient / v1
           - name: traceparent
-            value: 00-e74541bfc62b3b127e2528be9cea4e49-7916392ed075b7b5-01
+            value: 00-2983074d2b54ae8cd1aa6fa65611df59-2cbd640bd90cb6e5-01
           - name: connection
             value: keep-alive
           - name: host
@@ -1488,7 +1571,15 @@ log:
             maxTokensToSample: 4000
             messages:
               - speaker: human
-                text: You are Cody, an AI coding assistant from Sourcegraph.
+                text: >-
+                  You are Cody, an AI coding assistant from Sourcegraph.
+
+
+                  Additional rules:
+
+                  - When generating fenced code blocks in Markdown, ensure you include the full file path in the tag. The structure should be ```language:path/to/file
+
+                  ```.
               - speaker: assistant
                 text: I am Cody, an AI coding assistant from Sourcegraph.
               - speaker: human
@@ -1504,14 +1595,14 @@ log:
             value: v1
         url: https://sourcegraph.com/.api/completions/stream?client-name=defaultclient&client-version=v1
       response:
-        bodySize: 2144
+        bodySize: 6061
         content:
           mimeType: text/event-stream
-          size: 2144
+          size: 6061
           text: >+
             event: completion
 
-            data: {"completion":"Hello! It seems like you have mentioned \"kramer,\" but I'm not sure what you would like to ask or discuss. Could you please provide a bit more context or clarify your question? I'm here to help you with any coding or development-related questions you might have.\n\nKramer is a popular character from the TV show Seinfeld, so if you have a question about that or something else, just let me know!","stopReason":"stop"}
+            data: {"completion":"It seems like you are mentioning a name, Kramer. However, I need more context to provide a helpful response. Are you looking for information about a specific Kramer, or do you need help with a coding-related question?\n\nHere's an example of a code block in Markdown for a Python file located at `example_project/kramer.py`:\n```python:example_project/kramer.py\ndef kramer_function():\n    # Code goes here\n    pass\n```","stopReason":"stop"}
 
 
             event: done
@@ -1521,7 +1612,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Thu, 27 Jun 2024 23:22:42 GMT
+            value: Thu, 22 Aug 2024 13:30:00 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
@@ -1529,7 +1620,7 @@ log:
           - name: connection
             value: keep-alive
           - name: retry-after
-            value: "100"
+            value: "216"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -1552,7 +1643,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-06-27T23:22:41.427Z
+      startedDateTime: 2024-08-22T13:29:59.144Z
       time: 0
       timings:
         blocked: -1
@@ -1562,11 +1653,11 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: 2d780bb8983f04b75c48e472a1bed836
+    - _id: fc7a0e2ae9967740fd924a07e066e5e7
       _order: 0
       cache: {}
       request:
-        bodySize: 443
+        bodySize: 620
         cookies: []
         headers:
           - name: content-type
@@ -1579,7 +1670,7 @@ log:
           - name: user-agent
             value: defaultClient / v1
           - name: traceparent
-            value: 00-3b36b518f19e7f9084d7e29c8cc2f9f3-d6306956707386ae-01
+            value: 00-0d259b0c7b53385bb5122586e354b85a-686d7e168d6fd0d0-01
           - name: connection
             value: keep-alive
           - name: host
@@ -1594,423 +1685,264 @@ log:
             maxTokensToSample: 4000
             messages:
               - speaker: human
-                text: You are Cody, an AI coding assistant from Sourcegraph.
-              - speaker: assistant
-                text: I am Cody, an AI coding assistant from Sourcegraph.
-              - speaker: human
-                text: "Another magic word is \"georgey\". If I say the magic word, respond with
-                  a single word: \"festivus\"."
-            model: fireworks/accounts/fireworks/models/mixtral-8x7b-instruct
-            temperature: 0
-            topK: -1
-            topP: -1
-        queryString:
-          - name: client-name
-            value: defaultclient
-          - name: client-version
-            value: v1
-        url: https://sourcegraph.com/.api/completions/stream?client-name=defaultclient&client-version=v1
-      response:
-        bodySize: 553
-        content:
-          mimeType: text/event-stream
-          size: 553
-          text: >+
-            event: completion
-
-            data: {"completion":"Sure, I can do that! If you say the word \"georgey\", I will respond with \"festivus\".","stopReason":"stop"}
-
-
-            event: done
-
-            data: {}
-
-        cookies: []
-        headers:
-          - name: date
-            value: Thu, 27 Jun 2024 23:22:43 GMT
-          - name: content-type
-            value: text/event-stream
-          - name: transfer-encoding
-            value: chunked
-          - name: connection
-            value: keep-alive
-          - name: retry-after
-            value: "98"
-          - name: access-control-allow-credentials
-            value: "true"
-          - name: access-control-allow-origin
-            value: ""
-          - name: cache-control
-            value: no-cache
-          - name: vary
-            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
-              X-Requested-With,Cookie
-          - name: x-content-type-options
-            value: nosniff
-          - name: x-frame-options
-            value: DENY
-          - name: x-xss-protection
-            value: 1; mode=block
-          - name: strict-transport-security
-            value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1405
-        httpVersion: HTTP/1.1
-        redirectURL: ""
-        status: 200
-        statusText: OK
-      startedDateTime: 2024-06-27T23:22:42.839Z
-      time: 0
-      timings:
-        blocked: -1
-        connect: -1
-        dns: -1
-        receive: 0
-        send: 0
-        ssl: -1
-        wait: 0
-    - _id: 43f5a01b921c397cb619325c9d30d2d7
-      _order: 0
-      cache: {}
-      request:
-        bodySize: 600
-        cookies: []
-        headers:
-          - name: content-type
-            value: application/json
-          - name: accept-encoding
-            value: gzip;q=0
-          - name: authorization
-            value: token
-              REDACTED_d5e0f0a37c9821e856b923fe14e67a605e3f6c0a517d5a4f46a4e35943ee0f6d
-          - name: user-agent
-            value: defaultClient / v1
-          - name: traceparent
-            value: 00-ca15e8d4ec1f7c347ecf2cb16f378ffb-e2b0acc5e6e5f224-01
-          - name: connection
-            value: keep-alive
-          - name: host
-            value: sourcegraph.com
-        headersSize: 401
-        httpVersion: HTTP/1.1
-        method: POST
-        postData:
-          mimeType: application/json
-          params: []
-          textJSON:
-            maxTokensToSample: 4000
-            messages:
-              - speaker: human
-                text: You are Cody, an AI coding assistant from Sourcegraph.
-              - speaker: assistant
-                text: I am Cody, an AI coding assistant from Sourcegraph.
-              - speaker: human
-                text: "Another magic word is \"georgey\". If I say the magic word, respond with
-                  a single word: \"festivus\"."
-              - speaker: assistant
-                text: Sure, I can do that! If you say the word "georgey", I will respond with
-                  "festivus".
-              - speaker: human
-                text: kramer
-            model: fireworks/accounts/fireworks/models/mixtral-8x7b-instruct
-            temperature: 0
-            topK: -1
-            topP: -1
-        queryString:
-          - name: client-name
-            value: defaultclient
-          - name: client-version
-            value: v1
-        url: https://sourcegraph.com/.api/completions/stream?client-name=defaultclient&client-version=v1
-      response:
-        bodySize: 34033
-        content:
-          mimeType: text/event-stream
-          size: 34033
-          text: >+
-            event: completion
-
-            data: {"completion":"That's not the magic word you specified earlier. The magic word you said was \"georgey\", and the word you just said was \"kramer\". If you'd like me to respond to the word \"kramer\" with a single word, I can do that too. Here is a list of some words that start with \"kra\" that you might find interesting:\n\n* krait\n* kraken\n* kramerica\n* kranji\n* krasnodar\n* kraut\n* kredit\n* krauskopf\n* krauthammer\n* krautrock\n* kray\n* krazy\n* krebs\n* krebsian\n* krebs cycle\n* krefting\n* kreisau\n* kreisler\n* kremlin\n* kremlinology\n* kresge\n* kriegspiel\n* kreutznaerder\n* krewe\n* kri\n* kriek\n* kriebel\n* kriegsmarine\n* kriging\n* kriko\n* krill\n* krisi\n* kristianstad\n* kristallnacht\n* kritzler\n* kroeber\n* kroetsch\n* kroger\n* krokodil\n* kromeskies\n* kronberger\n* kronenbourg\n* kronstadt\n* kroonstad\n* kru\n* kruger\n* krugerrand\n* krupp\n* krylov\n* krypton\n* krypton factor\n* krzyzewski\n* ksa\n* kuala lumpur\n* kudos\n* kufic\n* kugel\n* kugelblitz\n* kuiper\n* kuiper belt\n* kukri\n* kula ring\n* kulak\n* kumaran\n* kunia\n* kurd\n* kurdistan\n* kurgan\n* kuru\n* kurukshetra\n* kurusch\n* kurwa\n* kusama\n* kuznetsov\n* kvass\n* kvell\n* kveldulf\n* kvetch\n* kvetchnikoff\n* kvetching\n* kvik\n* kwanza\n* kwa\n* kyaraben\n* kyathos\n* kyoto\n* kyrgyz\n* kyrgyzstan\n\nI hope this list is helpful! If you have any other questions, just let me know.","stopReason":"stop"}
-
-
-            event: done
-
-            data: {}
-
-        cookies: []
-        headers:
-          - name: date
-            value: Thu, 27 Jun 2024 23:22:44 GMT
-          - name: content-type
-            value: text/event-stream
-          - name: transfer-encoding
-            value: chunked
-          - name: connection
-            value: keep-alive
-          - name: retry-after
-            value: "97"
-          - name: access-control-allow-credentials
-            value: "true"
-          - name: access-control-allow-origin
-            value: ""
-          - name: cache-control
-            value: no-cache
-          - name: vary
-            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
-              X-Requested-With,Cookie
-          - name: x-content-type-options
-            value: nosniff
-          - name: x-frame-options
-            value: DENY
-          - name: x-xss-protection
-            value: 1; mode=block
-          - name: strict-transport-security
-            value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1405
-        httpVersion: HTTP/1.1
-        redirectURL: ""
-        status: 200
-        statusText: OK
-      startedDateTime: 2024-06-27T23:22:43.779Z
-      time: 0
-      timings:
-        blocked: -1
-        connect: -1
-        dns: -1
-        receive: 0
-        send: 0
-        ssl: -1
-        wait: 0
-    - _id: 2d2cc03b032a9bba5768ef38ef1d5ded
-      _order: 0
-      cache: {}
-      request:
-        bodySize: 2064
-        cookies: []
-        headers:
-          - name: content-type
-            value: application/json
-          - name: accept-encoding
-            value: gzip;q=0
-          - name: authorization
-            value: token
-              REDACTED_d5e0f0a37c9821e856b923fe14e67a605e3f6c0a517d5a4f46a4e35943ee0f6d
-          - name: user-agent
-            value: defaultClient / v1
-          - name: traceparent
-            value: 00-44797d55869b8f2b2877a5d5f72894b3-caf0b08db097df96-01
-          - name: connection
-            value: keep-alive
-          - name: host
-            value: sourcegraph.com
-        headersSize: 401
-        httpVersion: HTTP/1.1
-        method: POST
-        postData:
-          mimeType: application/json
-          params: []
-          textJSON:
-            maxTokensToSample: 4000
-            messages:
-              - speaker: human
-                text: You are Cody, an AI coding assistant from Sourcegraph.
-              - speaker: assistant
-                text: I am Cody, an AI coding assistant from Sourcegraph.
-              - speaker: human
-                text: "Another magic word is \"georgey\". If I say the magic word, respond with
-                  a single word: \"festivus\"."
-              - speaker: assistant
-                text: Sure, I can do that! If you say the word "georgey", I will respond with
-                  "festivus".
-              - speaker: human
-                text: kramer
-              - speaker: assistant
                 text: >-
-                  That's not the magic word you specified earlier. The magic
-                  word you said was "georgey", and the word you just said was
-                  "kramer". If you'd like me to respond to the word "kramer"
-                  with a single word, I can do that too. Here is a list of some
-                  words that start with "kra" that you might find interesting:
-
-
-                  * krait
-
-                  * kraken
-
-                  * kramerica
-
-                  * kranji
-
-                  * krasnodar
-
-                  * kraut
-
-                  * kredit
-
-                  * krauskopf
-
-                  * krauthammer
-
-                  * krautrock
-
-                  * kray
-
-                  * krazy
-
-                  * krebs
-
-                  * krebsian
-
-                  * krebs cycle
-
-                  * krefting
-
-                  * kreisau
-
-                  * kreisler
-
-                  * kremlin
-
-                  * kremlinology
-
-                  * kresge
-
-                  * kriegspiel
-
-                  * kreutznaerder
-
-                  * krewe
-
-                  * kri
-
-                  * kriek
-
-                  * kriebel
-
-                  * kriegsmarine
-
-                  * kriging
-
-                  * kriko
-
-                  * krill
-
-                  * krisi
-
-                  * kristianstad
-
-                  * kristallnacht
-
-                  * kritzler
-
-                  * kroeber
-
-                  * kroetsch
-
-                  * kroger
-
-                  * krokodil
-
-                  * kromeskies
-
-                  * kronberger
-
-                  * kronenbourg
-
-                  * kronstadt
-
-                  * kroonstad
-
-                  * kru
-
-                  * kruger
-
-                  * krugerrand
-
-                  * krupp
-
-                  * krylov
-
-                  * krypton
-
-                  * krypton factor
-
-                  * krzyzewski
-
-                  * ksa
-
-                  * kuala lumpur
-
-                  * kudos
-
-                  * kufic
-
-                  * kugel
-
-                  * kugelblitz
-
-                  * kuiper
-
-                  * kuiper belt
-
-                  * kukri
-
-                  * kula ring
-
-                  * kulak
-
-                  * kumaran
-
-                  * kunia
-
-                  * kurd
-
-                  * kurdistan
-
-                  * kurgan
-
-                  * kuru
-
-                  * kurukshetra
-
-                  * kurusch
-
-                  * kurwa
-
-                  * kusama
-
-                  * kuznetsov
-
-                  * kvass
-
-                  * kvell
-
-                  * kveldulf
-
-                  * kvetch
-
-                  * kvetchnikoff
-
-                  * kvetching
-
-                  * kvik
-
-                  * kwanza
-
-                  * kwa
-
-                  * kyaraben
-
-                  * kyathos
-
-                  * kyoto
-
-                  * kyrgyz
-
-                  * kyrgyzstan
-
-
-                  I hope this list is helpful! If you have any other questions, just let me know.
+                  You are Cody, an AI coding assistant from Sourcegraph.
+
+
+                  Additional rules:
+
+                  - When generating fenced code blocks in Markdown, ensure you include the full file path in the tag. The structure should be ```language:path/to/file
+
+                  ```.
+              - speaker: assistant
+                text: I am Cody, an AI coding assistant from Sourcegraph.
+              - speaker: human
+                text: "Another magic word is \"georgey\". If I say the magic word, respond with
+                  a single word: \"festivus\"."
+            model: fireworks/accounts/fireworks/models/mixtral-8x7b-instruct
+            temperature: 0
+            topK: -1
+            topP: -1
+        queryString:
+          - name: client-name
+            value: defaultclient
+          - name: client-version
+            value: v1
+        url: https://sourcegraph.com/.api/completions/stream?client-name=defaultclient&client-version=v1
+      response:
+        bodySize: 785
+        content:
+          mimeType: text/event-stream
+          size: 785
+          text: >+
+            event: completion
+
+            data: {"completion":"Understood. I will respond with \"festivus\" if you say the magic word \"georgey\".","stopReason":"stop"}
+
+
+            event: done
+
+            data: {}
+
+        cookies: []
+        headers:
+          - name: date
+            value: Thu, 22 Aug 2024 13:30:02 GMT
+          - name: content-type
+            value: text/event-stream
+          - name: transfer-encoding
+            value: chunked
+          - name: connection
+            value: keep-alive
+          - name: retry-after
+            value: "213"
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache
+          - name: vary
+            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
+              X-Requested-With,Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+        headersSize: 1406
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: 2024-08-22T13:30:01.834Z
+      time: 0
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 0
+    - _id: 0f6a2be86d621e72684293afcb8b2eed
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 773
+        cookies: []
+        headers:
+          - name: content-type
+            value: application/json
+          - name: accept-encoding
+            value: gzip;q=0
+          - name: authorization
+            value: token
+              REDACTED_d5e0f0a37c9821e856b923fe14e67a605e3f6c0a517d5a4f46a4e35943ee0f6d
+          - name: user-agent
+            value: defaultClient / v1
+          - name: traceparent
+            value: 00-8699f1e58382d9b891670f280128aa27-8692e00e61f5e2d7-01
+          - name: connection
+            value: keep-alive
+          - name: host
+            value: sourcegraph.com
+        headersSize: 401
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json
+          params: []
+          textJSON:
+            maxTokensToSample: 4000
+            messages:
+              - speaker: human
+                text: >-
+                  You are Cody, an AI coding assistant from Sourcegraph.
+
+
+                  Additional rules:
+
+                  - When generating fenced code blocks in Markdown, ensure you include the full file path in the tag. The structure should be ```language:path/to/file
+
+                  ```.
+              - speaker: assistant
+                text: I am Cody, an AI coding assistant from Sourcegraph.
+              - speaker: human
+                text: "Another magic word is \"georgey\". If I say the magic word, respond with
+                  a single word: \"festivus\"."
+              - speaker: assistant
+                text: Understood. I will respond with "festivus" if you say the magic word
+                  "georgey".
+              - speaker: human
+                text: kramer
+            model: fireworks/accounts/fireworks/models/mixtral-8x7b-instruct
+            temperature: 0
+            topK: -1
+            topP: -1
+        queryString:
+          - name: client-name
+            value: defaultclient
+          - name: client-version
+            value: v1
+        url: https://sourcegraph.com/.api/completions/stream?client-name=defaultclient&client-version=v1
+      response:
+        bodySize: 1179
+        content:
+          mimeType: text/event-stream
+          size: 1179
+          text: >+
+            event: completion
+
+            data: {"completion":"That is not the magic word. If you need assistance with coding or have any questions about programming, I'm here to help. Please let me know how I can assist you.","stopReason":"stop"}
+
+
+            event: done
+
+            data: {}
+
+        cookies: []
+        headers:
+          - name: date
+            value: Thu, 22 Aug 2024 13:30:03 GMT
+          - name: content-type
+            value: text/event-stream
+          - name: transfer-encoding
+            value: chunked
+          - name: connection
+            value: keep-alive
+          - name: retry-after
+            value: "212"
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache
+          - name: vary
+            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
+              X-Requested-With,Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+        headersSize: 1406
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: 2024-08-22T13:30:02.623Z
+      time: 0
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 0
+    - _id: 41cbe72533c2a430479bc3e1b46af0c9
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 1006
+        cookies: []
+        headers:
+          - name: content-type
+            value: application/json
+          - name: accept-encoding
+            value: gzip;q=0
+          - name: authorization
+            value: token
+              REDACTED_d5e0f0a37c9821e856b923fe14e67a605e3f6c0a517d5a4f46a4e35943ee0f6d
+          - name: user-agent
+            value: defaultClient / v1
+          - name: traceparent
+            value: 00-f900d794b40a37db9fdc0ba5a88bb506-1420e540d68e0882-01
+          - name: connection
+            value: keep-alive
+          - name: host
+            value: sourcegraph.com
+        headersSize: 401
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json
+          params: []
+          textJSON:
+            maxTokensToSample: 4000
+            messages:
+              - speaker: human
+                text: >-
+                  You are Cody, an AI coding assistant from Sourcegraph.
+
+
+                  Additional rules:
+
+                  - When generating fenced code blocks in Markdown, ensure you include the full file path in the tag. The structure should be ```language:path/to/file
+
+                  ```.
+              - speaker: assistant
+                text: I am Cody, an AI coding assistant from Sourcegraph.
+              - speaker: human
+                text: "Another magic word is \"georgey\". If I say the magic word, respond with
+                  a single word: \"festivus\"."
+              - speaker: assistant
+                text: Understood. I will respond with "festivus" if you say the magic word
+                  "georgey".
+              - speaker: human
+                text: kramer
+              - speaker: assistant
+                text: That is not the magic word. If you need assistance with coding or have any
+                  questions about programming, I'm here to help. Please let me
+                  know how I can assist you.
               - speaker: human
                 text: georgey
             model: fireworks/accounts/fireworks/models/mixtral-8x7b-instruct
@@ -2024,14 +1956,14 @@ log:
             value: v1
         url: https://sourcegraph.com/.api/completions/stream?client-name=defaultclient&client-version=v1
       response:
-        bodySize: 1003
+        bodySize: 621
         content:
           mimeType: text/event-stream
-          size: 1003
+          size: 621
           text: >+
             event: completion
 
-            data: {"completion":"Sure thing! Here is your requested word:\n\n* festivus\n\nI hope this is what you were looking for. If you have any other questions or need assistance with something else, just let me know!","stopReason":"stop"}
+            data: {"completion":"Festivus. How can I help you with coding or other technical questions today?","stopReason":"stop"}
 
 
             event: done
@@ -2041,7 +1973,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Thu, 27 Jun 2024 23:22:47 GMT
+            value: Thu, 22 Aug 2024 13:30:04 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
@@ -2049,7 +1981,7 @@ log:
           - name: connection
             value: keep-alive
           - name: retry-after
-            value: "95"
+            value: "212"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -2067,12 +1999,12 @@ log:
             value: 1; mode=block
           - name: strict-transport-security
             value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1405
+        headersSize: 1406
         httpVersion: HTTP/1.1
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-06-27T23:22:46.375Z
+      startedDateTime: 2024-08-22T13:30:03.572Z
       time: 0
       timings:
         blocked: -1
@@ -2082,11 +2014,11 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: ff4649261f59bb8e70c7cfebdefb2481
+    - _id: c9dc553b46297ce01724d68828806f6a
       _order: 0
       cache: {}
       request:
-        bodySize: 414
+        bodySize: 591
         cookies: []
         headers:
           - name: content-type
@@ -2099,7 +2031,7 @@ log:
           - name: user-agent
             value: defaultClient / v1
           - name: traceparent
-            value: 00-a6e1787cf77726ad0eb50abef3ee6414-020ec6dab789437b-01
+            value: 00-e34cc6a6ed097fbf2db9564770c4ff60-4f4ecc1b5dd1a2fe-01
           - name: connection
             value: keep-alive
           - name: host
@@ -2114,7 +2046,15 @@ log:
             maxTokensToSample: 4000
             messages:
               - speaker: human
-                text: You are Cody, an AI coding assistant from Sourcegraph.
+                text: >-
+                  You are Cody, an AI coding assistant from Sourcegraph.
+
+
+                  Additional rules:
+
+                  - When generating fenced code blocks in Markdown, ensure you include the full file path in the tag. The structure should be ```language:path/to/file
+
+                  ```.
               - speaker: assistant
                 text: I am Cody, an AI coding assistant from Sourcegraph.
               - speaker: human
@@ -2130,14 +2070,14 @@ log:
             value: v1
         url: https://sourcegraph.com/.api/completions/stream?client-name=defaultclient&client-version=v1
       response:
-        bodySize: 12420
+        bodySize: 7804
         content:
           mimeType: text/event-stream
-          size: 12420
+          size: 7804
           text: >+
             event: completion
 
-            data: {"completion":"Sure, I understand that you have a turtle named \"potter\". Just to confirm, is there anything specific you would like me to help you with related to your turtle or coding that you would like to get started on? Otherwise, I'm here to assist you with any questions or problems you might have about coding. If you have any questions or need help with something, feel free to ask!\n\nFor example, if you're working on a Python program and you're encountering an error, you can share the error message and the relevant code with me, and I can help you understand what's causing the error and how to fix it. If you're not sure where to start with a particular coding problem, you can describe the problem to me and I can help you come up with a plan of attack.\n\nIf you just want to chat about coding or turtles, I'm happy to do that too! Just let me know what you'd like to talk about.\n\nIn the meantime, here's a fun fact about turtles: Did you know that turtles are one of the longest-living animals on the planet? Some species of turtles have been known to live for over 150 years!\n\nI hope this helps. Do you have any questions for me?","stopReason":"stop"}
+            data: {"completion":"Ok.\n\nI understand that you have a turtle named \"potter\". If you have any coding questions or need assistance with code-related tasks, feel free to ask! I'm here to help.\n\nAdditionally, if you want to include a fenced code block in Markdown, make sure to follow this format: ```language:path/to/file``` where `language` is the programming language, and ```path/to/file``` is the file path. Here's an example for a Python file in a project: ```python:my_project/my_script.py```","stopReason":"stop"}
 
 
             event: done
@@ -2147,7 +2087,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Thu, 27 Jun 2024 23:22:48 GMT
+            value: Thu, 22 Aug 2024 13:30:05 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
@@ -2155,7 +2095,7 @@ log:
           - name: connection
             value: keep-alive
           - name: retry-after
-            value: "94"
+            value: "211"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -2173,12 +2113,12 @@ log:
             value: 1; mode=block
           - name: strict-transport-security
             value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1405
+        headersSize: 1406
         httpVersion: HTTP/1.1
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-06-27T23:22:47.624Z
+      startedDateTime: 2024-08-22T13:30:04.308Z
       time: 0
       timings:
         blocked: -1
@@ -2188,11 +2128,11 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: 2fc596fd48d754548136ecb8930c70e1
+    - _id: 31b2825c2504664ed33ca46d1ee999c5
       _order: 0
       cache: {}
       request:
-        bodySize: 1689
+        bodySize: 1209
         cookies: []
         headers:
           - name: content-type
@@ -2205,7 +2145,7 @@ log:
           - name: user-agent
             value: defaultClient / v1
           - name: traceparent
-            value: 00-99600c85c3300524e513e57e8fd05d53-28ea26be1ac44a65-01
+            value: 00-add3c1cb17fc070b5e33b7c88db88d88-ffea91cb5fb5e968-01
           - name: connection
             value: keep-alive
           - name: host
@@ -2220,32 +2160,28 @@ log:
             maxTokensToSample: 4000
             messages:
               - speaker: human
-                text: You are Cody, an AI coding assistant from Sourcegraph.
+                text: >-
+                  You are Cody, an AI coding assistant from Sourcegraph.
+
+
+                  Additional rules:
+
+                  - When generating fenced code blocks in Markdown, ensure you include the full file path in the tag. The structure should be ```language:path/to/file
+
+                  ```.
               - speaker: assistant
                 text: I am Cody, an AI coding assistant from Sourcegraph.
               - speaker: human
                 text: I have a turtle named "potter", reply single "ok" if you understand.
               - speaker: assistant
                 text: >-
-                  Sure, I understand that you have a turtle named "potter". Just
-                  to confirm, is there anything specific you would like me to
-                  help you with related to your turtle or coding that you would
-                  like to get started on? Otherwise, I'm here to assist you with
-                  any questions or problems you might have about coding. If you
-                  have any questions or need help with something, feel free to
-                  ask!
+                  Ok.
 
 
-                  For example, if you're working on a Python program and you're encountering an error, you can share the error message and the relevant code with me, and I can help you understand what's causing the error and how to fix it. If you're not sure where to start with a particular coding problem, you can describe the problem to me and I can help you come up with a plan of attack.
+                  I understand that you have a turtle named "potter". If you have any coding questions or need assistance with code-related tasks, feel free to ask! I'm here to help.
 
 
-                  If you just want to chat about coding or turtles, I'm happy to do that too! Just let me know what you'd like to talk about.
-
-
-                  In the meantime, here's a fun fact about turtles: Did you know that turtles are one of the longest-living animals on the planet? Some species of turtles have been known to live for over 150 years!
-
-
-                  I hope this helps. Do you have any questions for me?
+                  Additionally, if you want to include a fenced code block in Markdown, make sure to follow this format: ```language:path/to/file``` where `language` is the programming language, and ```path/to/file``` is the file path. Here's an example for a Python file in a project: ```python:my_project/my_script.py```
               - speaker: human
                 text: I have a bird named "skywalker", reply single "ok" if you understand.
             model: fireworks/accounts/fireworks/models/mixtral-8x7b-instruct
@@ -2259,14 +2195,14 @@ log:
             value: v1
         url: https://sourcegraph.com/.api/completions/stream?client-name=defaultclient&client-version=v1
       response:
-        bodySize: 14761
+        bodySize: 7983
         content:
           mimeType: text/event-stream
-          size: 14761
+          size: 7983
           text: >+
             event: completion
 
-            data: {"completion":"I understand that you have a bird named \"skywalker\". It's always fun to have pets and give them unique names! Do you have any questions or need help with something related to coding or your pet bird? I'm here to help with any questions or problems you might have. Just let me know what you'd like to talk about.\n\nIf you have any questions or need help with something specific, feel free to ask. For example, if you're working on a programming project and you're encountering an error or you're not sure how to accomplish a particular task, you can share the relevant code and the error message or description of the problem with me, and I can help you understand what's causing the problem and how to fix it. If you're not sure where to start with a particular coding problem, you can describe the problem to me and I can help you come up with a plan of attack.\n\nIf you just want to chat about coding or birds, I'm happy to do that too! Just let me know what you'd like to talk about.\n\nIn the meantime, here's a fun fact about birds: Did you know that some species of birds are able to fly at very high speeds? The peregrine falcon, for example, is the fastest bird in the world, and can reach speeds of over 240 miles per hour when diving to catch its prey!\n\nI hope this helps. Do you have any questions for me?","stopReason":"stop"}
+            data: {"completion":"Ok.\n\nI understand that you have a bird named \"skywalker\". If you have any coding questions or need assistance with code-related tasks, feel free to ask! I'm here to help.\n\nAdditionally, if you want to include a fenced code block in Markdown, make sure to follow this format: ```language:path/to/file``` where `language` is the programming language, and ```path/to/file``` is the file path. Here's an example for a Python file in a project: ```python:my_project/my_script.py```","stopReason":"stop"}
 
 
             event: done
@@ -2276,7 +2212,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Thu, 27 Jun 2024 23:22:49 GMT
+            value: Thu, 22 Aug 2024 13:30:07 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
@@ -2284,7 +2220,7 @@ log:
           - name: connection
             value: keep-alive
           - name: retry-after
-            value: "92"
+            value: "209"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -2302,12 +2238,12 @@ log:
             value: 1; mode=block
           - name: strict-transport-security
             value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1405
+        headersSize: 1406
         httpVersion: HTTP/1.1
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-06-27T23:22:48.988Z
+      startedDateTime: 2024-08-22T13:30:06.048Z
       time: 0
       timings:
         blocked: -1
@@ -2317,11 +2253,11 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: 98f2884871b118d4b9b09e5be5779896
+    - _id: ceac4f04ab19933286f92e46d4deb6ff
       _order: 0
       cache: {}
       request:
-        bodySize: 3143
+        bodySize: 1823
         cookies: []
         headers:
           - name: content-type
@@ -2334,7 +2270,7 @@ log:
           - name: user-agent
             value: defaultClient / v1
           - name: traceparent
-            value: 00-a732fc4df74e86a9dec21f1d38a91822-6deb1c4425608122-01
+            value: 00-f5234cea00dc47637500a5013e618e97-58bcf9081482604e-01
           - name: connection
             value: keep-alive
           - name: host
@@ -2349,54 +2285,39 @@ log:
             maxTokensToSample: 4000
             messages:
               - speaker: human
-                text: You are Cody, an AI coding assistant from Sourcegraph.
+                text: >-
+                  You are Cody, an AI coding assistant from Sourcegraph.
+
+
+                  Additional rules:
+
+                  - When generating fenced code blocks in Markdown, ensure you include the full file path in the tag. The structure should be ```language:path/to/file
+
+                  ```.
               - speaker: assistant
                 text: I am Cody, an AI coding assistant from Sourcegraph.
               - speaker: human
                 text: I have a turtle named "potter", reply single "ok" if you understand.
               - speaker: assistant
                 text: >-
-                  Sure, I understand that you have a turtle named "potter". Just
-                  to confirm, is there anything specific you would like me to
-                  help you with related to your turtle or coding that you would
-                  like to get started on? Otherwise, I'm here to assist you with
-                  any questions or problems you might have about coding. If you
-                  have any questions or need help with something, feel free to
-                  ask!
+                  Ok.
 
 
-                  For example, if you're working on a Python program and you're encountering an error, you can share the error message and the relevant code with me, and I can help you understand what's causing the error and how to fix it. If you're not sure where to start with a particular coding problem, you can describe the problem to me and I can help you come up with a plan of attack.
+                  I understand that you have a turtle named "potter". If you have any coding questions or need assistance with code-related tasks, feel free to ask! I'm here to help.
 
 
-                  If you just want to chat about coding or turtles, I'm happy to do that too! Just let me know what you'd like to talk about.
-
-
-                  In the meantime, here's a fun fact about turtles: Did you know that turtles are one of the longest-living animals on the planet? Some species of turtles have been known to live for over 150 years!
-
-
-                  I hope this helps. Do you have any questions for me?
+                  Additionally, if you want to include a fenced code block in Markdown, make sure to follow this format: ```language:path/to/file``` where `language` is the programming language, and ```path/to/file``` is the file path. Here's an example for a Python file in a project: ```python:my_project/my_script.py```
               - speaker: human
                 text: I have a bird named "skywalker", reply single "ok" if you understand.
               - speaker: assistant
                 text: >-
-                  I understand that you have a bird named "skywalker". It's
-                  always fun to have pets and give them unique names! Do you
-                  have any questions or need help with something related to
-                  coding or your pet bird? I'm here to help with any questions
-                  or problems you might have. Just let me know what you'd like
-                  to talk about.
+                  Ok.
 
 
-                  If you have any questions or need help with something specific, feel free to ask. For example, if you're working on a programming project and you're encountering an error or you're not sure how to accomplish a particular task, you can share the relevant code and the error message or description of the problem with me, and I can help you understand what's causing the problem and how to fix it. If you're not sure where to start with a particular coding problem, you can describe the problem to me and I can help you come up with a plan of attack.
+                  I understand that you have a bird named "skywalker". If you have any coding questions or need assistance with code-related tasks, feel free to ask! I'm here to help.
 
 
-                  If you just want to chat about coding or birds, I'm happy to do that too! Just let me know what you'd like to talk about.
-
-
-                  In the meantime, here's a fun fact about birds: Did you know that some species of birds are able to fly at very high speeds? The peregrine falcon, for example, is the fastest bird in the world, and can reach speeds of over 240 miles per hour when diving to catch its prey!
-
-
-                  I hope this helps. Do you have any questions for me?
+                  Additionally, if you want to include a fenced code block in Markdown, make sure to follow this format: ```language:path/to/file``` where `language` is the programming language, and ```path/to/file``` is the file path. Here's an example for a Python file in a project: ```python:my_project/my_script.py```
               - speaker: human
                 text: I have a dog named "happy", reply single "ok" if you understand.
             model: fireworks/accounts/fireworks/models/mixtral-8x7b-instruct
@@ -2410,14 +2331,14 @@ log:
             value: v1
         url: https://sourcegraph.com/.api/completions/stream?client-name=defaultclient&client-version=v1
       response:
-        bodySize: 10973
+        bodySize: 8331
         content:
           mimeType: text/event-stream
-          size: 10973
+          size: 8331
           text: >+
             event: completion
 
-            data: {"completion":"I understand that you have a dog named \"happy\". Dogs are great companions and it's always fun to give them unique names. Do you have any questions or need help with something related to coding or your dog? I'm here to help with any questions or problems you might have. Just let me know what you'd like to talk about.\n\nIf you have any questions or need help with something specific, feel free to ask. For example, if you're working on a programming project and you're encountering an error or you're not sure how to accomplish a particular task, you can share the relevant code and the error message or description of the problem with me, and I can help you understand what's causing the problem and how to fix it. If you're not sure where to start with a particular coding problem, you can describe the problem to me and I can help you come up with a plan of attack.\n\nIf you just want to chat about coding or dogs, I'm happy to do that too! Just let me know what you'd like to talk about.\n\nIn the meantime, here's a fun fact about dogs: Did you know that dogs are able to understand and respond to a wide range of words and commands? Some dogs are even able to learn hundreds of words and commands!\n\nI hope this helps. Do you have any questions for me?","stopReason":"stop"}
+            data: {"completion":"Ok.\n\nI understand that you have a dog named \"happy\". If you have any coding questions or need assistance with code-related tasks, feel free to ask! I'm here to help.\n\nAdditionally, if you want to include a fenced code block in Markdown, make sure to follow this format: ```language:path/to/file``` where `language` is the programming language, and ```path/to/file``` is the file path. Here's an example for a Python file in a project: ```python:my_project/my_script.py```","stopReason":"stop"}
 
 
             event: done
@@ -2427,7 +2348,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Thu, 27 Jun 2024 23:22:51 GMT
+            value: Thu, 22 Aug 2024 13:30:08 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
@@ -2435,7 +2356,7 @@ log:
           - name: connection
             value: keep-alive
           - name: retry-after
-            value: "91"
+            value: "207"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -2453,12 +2374,12 @@ log:
             value: 1; mode=block
           - name: strict-transport-security
             value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1405
+        headersSize: 1406
         httpVersion: HTTP/1.1
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-06-27T23:22:50.412Z
+      startedDateTime: 2024-08-22T13:30:07.796Z
       time: 0
       timings:
         blocked: -1
@@ -2468,11 +2389,11 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: e314fb6c9f93ccee2363909a66529b07
+    - _id: 7d9368db01a31a08d9c21ef8cc4b7019
       _order: 0
       cache: {}
       request:
-        bodySize: 1685
+        bodySize: 1205
         cookies: []
         headers:
           - name: content-type
@@ -2485,7 +2406,7 @@ log:
           - name: user-agent
             value: defaultClient / v1
           - name: traceparent
-            value: 00-350e6487be7c211d20936b5717396f13-0d4d2e919924abb4-01
+            value: 00-18506a154d76ac1e9e5bc79698f97e97-fe86de613391bcf6-01
           - name: connection
             value: keep-alive
           - name: host
@@ -2500,32 +2421,28 @@ log:
             maxTokensToSample: 4000
             messages:
               - speaker: human
-                text: You are Cody, an AI coding assistant from Sourcegraph.
+                text: >-
+                  You are Cody, an AI coding assistant from Sourcegraph.
+
+
+                  Additional rules:
+
+                  - When generating fenced code blocks in Markdown, ensure you include the full file path in the tag. The structure should be ```language:path/to/file
+
+                  ```.
               - speaker: assistant
                 text: I am Cody, an AI coding assistant from Sourcegraph.
               - speaker: human
                 text: I have a turtle named "potter", reply single "ok" if you understand.
               - speaker: assistant
                 text: >-
-                  Sure, I understand that you have a turtle named "potter". Just
-                  to confirm, is there anything specific you would like me to
-                  help you with related to your turtle or coding that you would
-                  like to get started on? Otherwise, I'm here to assist you with
-                  any questions or problems you might have about coding. If you
-                  have any questions or need help with something, feel free to
-                  ask!
+                  Ok.
 
 
-                  For example, if you're working on a Python program and you're encountering an error, you can share the error message and the relevant code with me, and I can help you understand what's causing the error and how to fix it. If you're not sure where to start with a particular coding problem, you can describe the problem to me and I can help you come up with a plan of attack.
+                  I understand that you have a turtle named "potter". If you have any coding questions or need assistance with code-related tasks, feel free to ask! I'm here to help.
 
 
-                  If you just want to chat about coding or turtles, I'm happy to do that too! Just let me know what you'd like to talk about.
-
-
-                  In the meantime, here's a fun fact about turtles: Did you know that turtles are one of the longest-living animals on the planet? Some species of turtles have been known to live for over 150 years!
-
-
-                  I hope this helps. Do you have any questions for me?
+                  Additionally, if you want to include a fenced code block in Markdown, make sure to follow this format: ```language:path/to/file``` where `language` is the programming language, and ```path/to/file``` is the file path. Here's an example for a Python file in a project: ```python:my_project/my_script.py```
               - speaker: human
                 text: I have a tiger named "zorro", reply single "ok" if you understand
             model: fireworks/accounts/fireworks/models/mixtral-8x7b-instruct
@@ -2539,14 +2456,14 @@ log:
             value: v1
         url: https://sourcegraph.com/.api/completions/stream?client-name=defaultclient&client-version=v1
       response:
-        bodySize: 22370
+        bodySize: 8012
         content:
           mimeType: text/event-stream
-          size: 22370
+          size: 8012
           text: >+
             event: completion
 
-            data: {"completion":"I understand that you have a tiger named \"zorro\". Is there anything specific you would like to ask or discuss about your tiger or related to coding that you would like me to help with?\n\nAs a coding assistant, I can help you with a variety of coding-related questions or problems. For example, if you're working on a programming project and you're stuck or encountering an error, you can share the relevant code and any error messages with me, and I can help you understand what's causing the problem and how to fix it. I can also help you come up with a plan for how to approach a coding problem, or provide guidance on best practices and common techniques for solving common coding challenges.\n\nIf you're not currently working on a coding project, you can still ask me general questions about coding, or tell me about a particular programming language or concept you're interested in learning more about. I'm here to help you with all of your coding-related questions and needs, so don't hesitate to ask me anything.\n\nIf you just want to chat about your tiger or other topics, that's fine too! I'm here to assist you with any questions or concerns you might have, so just let me know what you'd like to talk about.\n\nI hope this helps. Do you have any questions or concerns for me?\n\n(By the way, did you know that tigers are the largest members of the cat family, and are one of the most powerful animals in the world? They are also known for their distinctive black stripes, which are unique to each individual tiger. Just like humans, no two tigers have the same stripe pattern. Tigers are also excellent swimmers, and they have been known to swim up to 20 miles in a single day!)","stopReason":"stop"}
+            data: {"completion":"Ok.\n\nI understand that you have a tiger named \"zorro\". Remember that I am an AI coding assistant, so if you have any coding questions or need assistance with code-related tasks, feel free to ask! I'm here to help.\n\nPlease also ensure you format fenced code blocks in Markdown with the full file path in the tag, like this: ```language:path/to/file```. An example would be ```python:my_project/my_script.py``` for a Python file in a project. Let me know how I can help you with coding.","stopReason":"stop"}
 
 
             event: done
@@ -2556,7 +2473,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Thu, 27 Jun 2024 23:22:52 GMT
+            value: Thu, 22 Aug 2024 13:30:10 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
@@ -2564,7 +2481,7 @@ log:
           - name: connection
             value: keep-alive
           - name: retry-after
-            value: "90"
+            value: "205"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -2582,12 +2499,12 @@ log:
             value: 1; mode=block
           - name: strict-transport-security
             value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1405
+        headersSize: 1406
         httpVersion: HTTP/1.1
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-06-27T23:22:51.605Z
+      startedDateTime: 2024-08-22T13:30:09.706Z
       time: 0
       timings:
         blocked: -1
@@ -2597,11 +2514,11 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: 7c1d096239c8d170c18db5501e43e433
+    - _id: d506a747c576cd79482ae8a28a9986fa
       _order: 0
       cache: {}
       request:
-        bodySize: 3463
+        bodySize: 1779
         cookies: []
         headers:
           - name: content-type
@@ -2614,7 +2531,7 @@ log:
           - name: user-agent
             value: defaultClient / v1
           - name: traceparent
-            value: 00-aa645675e25db20a958f4bbb5b4d9659-e7951db609ddd9a9-01
+            value: 00-f518d7f16f1010e6bb43024254bb4501-6b7ef751038e392d-01
           - name: connection
             value: keep-alive
           - name: host
@@ -2629,55 +2546,39 @@ log:
             maxTokensToSample: 4000
             messages:
               - speaker: human
-                text: You are Cody, an AI coding assistant from Sourcegraph.
+                text: >-
+                  You are Cody, an AI coding assistant from Sourcegraph.
+
+
+                  Additional rules:
+
+                  - When generating fenced code blocks in Markdown, ensure you include the full file path in the tag. The structure should be ```language:path/to/file
+
+                  ```.
               - speaker: assistant
                 text: I am Cody, an AI coding assistant from Sourcegraph.
               - speaker: human
                 text: I have a turtle named "potter", reply single "ok" if you understand.
               - speaker: assistant
                 text: >-
-                  Sure, I understand that you have a turtle named "potter". Just
-                  to confirm, is there anything specific you would like me to
-                  help you with related to your turtle or coding that you would
-                  like to get started on? Otherwise, I'm here to assist you with
-                  any questions or problems you might have about coding. If you
-                  have any questions or need help with something, feel free to
-                  ask!
+                  Ok.
 
 
-                  For example, if you're working on a Python program and you're encountering an error, you can share the error message and the relevant code with me, and I can help you understand what's causing the error and how to fix it. If you're not sure where to start with a particular coding problem, you can describe the problem to me and I can help you come up with a plan of attack.
+                  I understand that you have a turtle named "potter". If you have any coding questions or need assistance with code-related tasks, feel free to ask! I'm here to help.
 
 
-                  If you just want to chat about coding or turtles, I'm happy to do that too! Just let me know what you'd like to talk about.
-
-
-                  In the meantime, here's a fun fact about turtles: Did you know that turtles are one of the longest-living animals on the planet? Some species of turtles have been known to live for over 150 years!
-
-
-                  I hope this helps. Do you have any questions for me?
+                  Additionally, if you want to include a fenced code block in Markdown, make sure to follow this format: ```language:path/to/file``` where `language` is the programming language, and ```path/to/file``` is the file path. Here's an example for a Python file in a project: ```python:my_project/my_script.py```
               - speaker: human
                 text: I have a tiger named "zorro", reply single "ok" if you understand
               - speaker: assistant
                 text: >-
-                  I understand that you have a tiger named "zorro". Is there
-                  anything specific you would like to ask or discuss about your
-                  tiger or related to coding that you would like me to help
-                  with?
+                  Ok.
 
 
-                  As a coding assistant, I can help you with a variety of coding-related questions or problems. For example, if you're working on a programming project and you're stuck or encountering an error, you can share the relevant code and any error messages with me, and I can help you understand what's causing the problem and how to fix it. I can also help you come up with a plan for how to approach a coding problem, or provide guidance on best practices and common techniques for solving common coding challenges.
+                  I understand that you have a tiger named "zorro". Remember that I am an AI coding assistant, so if you have any coding questions or need assistance with code-related tasks, feel free to ask! I'm here to help.
 
 
-                  If you're not currently working on a coding project, you can still ask me general questions about coding, or tell me about a particular programming language or concept you're interested in learning more about. I'm here to help you with all of your coding-related questions and needs, so don't hesitate to ask me anything.
-
-
-                  If you just want to chat about your tiger or other topics, that's fine too! I'm here to assist you with any questions or concerns you might have, so just let me know what you'd like to talk about.
-
-
-                  I hope this helps. Do you have any questions or concerns for me?
-
-
-                  (By the way, did you know that tigers are the largest members of the cat family, and are one of the most powerful animals in the world? They are also known for their distinctive black stripes, which are unique to each individual tiger. Just like humans, no two tigers have the same stripe pattern. Tigers are also excellent swimmers, and they have been known to swim up to 20 miles in a single day!)
+                  Please also ensure you format fenced code blocks in Markdown with the full file path in the tag, like this: ```language:path/to/file```. An example would be ```python:my_project/my_script.py``` for a Python file in a project. Let me know how I can help you with coding.
               - speaker: human
                 text: What pets do I have?
             model: fireworks/accounts/fireworks/models/mixtral-8x7b-instruct
@@ -2691,14 +2592,14 @@ log:
             value: v1
         url: https://sourcegraph.com/.api/completions/stream?client-name=defaultclient&client-version=v1
       response:
-        bodySize: 12007
+        bodySize: 11411
         content:
           mimeType: text/event-stream
-          size: 12007
+          size: 11411
           text: >+
             event: completion
 
-            data: {"completion":"Based on the information you have provided, it appears that you have a turtle named \"potter\" and a tiger named \"zorro\". I am a machine learning model, and my ability to accurately and comprehensively understand and recall information about a user is limited. I am intended to be used as a coding assistant, and I am not able to access or retrieve personal information about users unless it has been explicitly shared with me in the course of our conversation.\n\nI hope this helps clarify my capabilities and limitations. Do you have any questions or concerns about using me as a coding assistant, or would you like me to help you with any coding-related questions or problems you might have? I'm here to help with any questions or concerns you might have, so just let me know what you'd like to talk about.\n\n(By the way, did you know that tigers are the largest members of the cat family, and are one of the most powerful animals in the world? They are also known for their distinctive black stripes, which are unique to each individual tiger. Just like humans, no two tigers have the same stripe pattern. Tigers are also excellent swimmers, and they have been known to swim up to 20 miles in a single day!)","stopReason":"stop"}
+            data: {"completion":"Based on our conversation, you have a turtle named \"potter\" and a tiger named \"zorro\". Please note that this information is from our conversation context, and I do not have access to any other information about your pets or personal details.\n\nIf you have any coding questions or need assistance with code-related tasks, I would be happy to help! Feel free to ask.\n\nAlso, if you want to include a fenced code block in Markdown, don't forget to use the proper format: ```language:path/to/file```. For instance, you may use: ```python:my_project/my_script.py``` for a Python file in a project.","stopReason":"stop"}
 
 
             event: done
@@ -2708,7 +2609,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Thu, 27 Jun 2024 23:22:54 GMT
+            value: Thu, 22 Aug 2024 13:30:12 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
@@ -2716,7 +2617,7 @@ log:
           - name: connection
             value: keep-alive
           - name: retry-after
-            value: "88"
+            value: "203"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -2734,12 +2635,12 @@ log:
             value: 1; mode=block
           - name: strict-transport-security
             value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1405
+        headersSize: 1406
         httpVersion: HTTP/1.1
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-06-27T23:22:53.211Z
+      startedDateTime: 2024-08-22T13:30:11.600Z
       time: 0
       timings:
         blocked: -1
@@ -2749,11 +2650,11 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: 4452e47fe6f7cf5a8f04c1260f422469
+    - _id: 8d8819297e4f80a4bd506ed867a6abd8
       _order: 0
       cache: {}
       request:
-        bodySize: 1717
+        bodySize: 1894
         cookies: []
         headers:
           - name: content-type
@@ -2766,7 +2667,7 @@ log:
           - name: user-agent
             value: defaultClient / v1
           - name: traceparent
-            value: 00-d4291d2f1d191dfdc96d9000367179c4-737bbd0841b05104-01
+            value: 00-1a0f140fb8ed29fb485c77d5cf7a867f-4ebf4b21a32e53e8-01
           - name: connection
             value: keep-alive
           - name: host
@@ -2781,7 +2682,15 @@ log:
             maxTokensToSample: 4000
             messages:
               - speaker: human
-                text: You are Cody, an AI coding assistant from Sourcegraph.
+                text: >-
+                  You are Cody, an AI coding assistant from Sourcegraph.
+
+
+                  Additional rules:
+
+                  - When generating fenced code blocks in Markdown, ensure you include the full file path in the tag. The structure should be ```language:path/to/file
+
+                  ```.
               - speaker: assistant
                 text: I am Cody, an AI coding assistant from Sourcegraph.
               - speaker: human
@@ -2838,14 +2747,14 @@ log:
             value: v1
         url: https://sourcegraph.com/.api/completions/stream?client-name=defaultclient&client-version=v1
       response:
-        bodySize: 43730
+        bodySize: 57994
         content:
           mimeType: text/event-stream
-          size: 43730
+          size: 57994
           text: >+
             event: completion
 
-            data: {"completion":"Sure, I'd be happy to explain.\n\nThe code you've shared is an interface called \"Animal\" from a TypeScript file called \"animal.ts\". An interface is like a blueprint for objects that defines what properties and methods an object should have. In this case, the Animal interface defines an object with three properties: \"name\", \"makeAnimalSound\", and \"isMammal\".\n\n1. The purpose of the code is to define the structure of an object that represents a generic animal in a program. The Animal interface specifies that any object that claims to be an animal should have a name, a method for making an animal sound, and a boolean property that indicates if the animal is a mammal.\n2. The interface doesn't take any inputs, as it only defines a structure. The inputs and outputs are defined by the objects that will implement this interface.\n3. Again, the interface itself doesn't produce any outputs, but it enables the creation of objects that have a specific structure, which is useful for defining and enforcing consistency and expectations in your code.\n4. The interface achieves its purpose by specifying the Required properties and methods that an object needs to have. The code states that the Animal interface must have a \"name\" property of type string, a \"makeAnimalSound\" method that returns a string, and an \"isMammal\" property of type boolean.\n5. The important logic flows or data transformations in this code are the definitions of the \"makeAnimalSound\" method and the \"isMammal\" property. These are not defined in the code you shared, but they are required to be implemented by whatever object uses this Animal interface. The \"makeAnimalSound\" method is expected to produce a sound that an animal makes, and the \"isMammal\" property is expected to be a boolean value that indicates whether the animal is a mammal. By requiring the implementation of these methods and properties, the Animal interface enables the creation of consistent, predictable animal objects in your code.\n\nIn summary, the Animal interface is a blueprint for animal objects that defines what properties and methods they should have, ensuring consistency and predictability. It doesn't take any inputs or produce any outputs, but it enables the creation of objects that have a specific structure.","stopReason":"stop"}
+            data: {"completion":"The code being explained is an interface named `Animal` in a TypeScript file at `src/animal.ts`.\n\nThe purpose of this code is to define what properties an object should have in order to be considered an `Animal`. The interface does this by listing the required properties such as `name`, `makeAnimalSound()`, and `isMammal`. The `name` is a required string field, `isMammal` is a required boolean field, and `makeAnimalSound()` is a required function that returns a string.\n\nThe code doesn't take any input directly, but its purpose is to be implemented by other TypeScript classes defining a specific animal, such as `Dog` or `Cat`. These classes will then implement the required properties and functions defined in the `Animal` interface.\n\nThe output of this code is not a value itself, but rather a description of a data structure. Objects of classes that implement this interface can be used as `Animal` type, but the interface itself doesn't produce any value directly.\n\nThe way this is achieved is by using the TypeScript feature called `interfaces`, which provides a contract that a class has to follow in order to adhere to the structure defined by the interface. The interface defines what properties are required to be present in classes that implement it.\n\nThe main logic flow is that the interface `Animal` is defined with its required properties, and classes that want to be considered as implementing the `Animal` interface need to adhere to this structure. The data transformation that happens is that classes that implement the `Animal` interface provide the actual implementation and logic for the required properties. The interface only provides the shape that the class should have without implementing it.","stopReason":"stop"}
 
 
             event: done
@@ -2855,13 +2764,15 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Thu, 04 Jul 2024 19:08:13 GMT
+            value: Thu, 22 Aug 2024 13:30:14 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
             value: chunked
           - name: connection
             value: keep-alive
+          - name: retry-after
+            value: "201"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -2879,12 +2790,12 @@ log:
             value: 1; mode=block
           - name: strict-transport-security
             value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1299
+        headersSize: 1406
         httpVersion: HTTP/1.1
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-07-04T19:08:12.973Z
+      startedDateTime: 2024-08-22T13:30:13.822Z
       time: 0
       timings:
         blocked: -1
@@ -2894,11 +2805,11 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: f81afbdd87bad58d33d5e94a94056470
+    - _id: bdd10be660aed1fea6af3be54244f8ba
       _order: 0
       cache: {}
       request:
-        bodySize: 1513
+        bodySize: 3120
         cookies: []
         headers:
           - name: content-type
@@ -2911,7 +2822,7 @@ log:
           - name: user-agent
             value: defaultClient / v1
           - name: traceparent
-            value: 00-2dab55b0b15cfe5d5c728b8172c7293f-6b93b947af2ffe79-01
+            value: 00-36de660f24b55f00e8c7eff5defd5425-ccaeee50f27d4cd2-01
           - name: connection
             value: keep-alive
           - name: host
@@ -2926,149 +2837,15 @@ log:
             maxTokensToSample: 4000
             messages:
               - speaker: human
-                text: You are Cody, an AI coding assistant from Sourcegraph.
-              - speaker: assistant
-                text: I am Cody, an AI coding assistant from Sourcegraph.
-              - speaker: human
-                text: >
-                  Codebase context from file path src/animal.ts: /*
-                  SELECTION_START */
-
-                  export interface Animal {
-                      name: string
-                      makeAnimalSound(): string
-                      isMammal: boolean
-                  }
-
-                  /* SELECTION_END */
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: |-
-                  My selected code from codebase file src/animal.ts:1-6:
-                  ```
-
-                  export interface Animal {
-                      name: string
-                      makeAnimalSound(): string
-                      isMammal: boolean
-                  }
-                  ```
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: Please review and analyze @src/animal.ts:1-6 ( @src/animal.ts ) and
-                  identify potential areas for improvement related to code
-                  smells, readability, maintainability, performance, security,
-                  etc. Do not list issues already addressed in the given code.
-                  Focus on providing up to 5 constructive suggestions that could
-                  make the code more robust, efficient, or align with best
-                  practices. For each suggestion, provide a brief explanation of
-                  the potential benefits. After listing any recommendations,
-                  summarize if you found notable opportunities to enhance the
-                  code quality overall or if the code generally follows sound
-                  design principles. If no issues found, reply 'There are no
-                  errors.'
-            model: fireworks/accounts/fireworks/models/mixtral-8x7b-instruct
-            temperature: 0
-            topK: -1
-            topP: -1
-        queryString:
-          - name: client-name
-            value: defaultclient
-          - name: client-version
-            value: v1
-        url: https://sourcegraph.com/.api/completions/stream?client-name=defaultclient&client-version=v1
-      response:
-        bodySize: 33591
-        content:
-          mimeType: text/event-stream
-          size: 33591
-          text: >+
-            event: completion
-
-            data: {"completion":"Based on the examination of your TypeScript code at `src/animal.ts:1-6`, I found some potential improvements:\n\n1. Use consistent naming conventions:\n   Rename the `isMammal` property to `isMammal`, conforming to PascalCase, which TypeScript recommends for interface properties.\n\n   Benefit: Improves readability and consistency in the codebase.\n\n2. Add the missing semicolons:\n   Add semicolons to the end of the `name` and `makeAnimalSound` lines, as they ensure that your code behaves consistently and avoids bugs related to automatic semicolon insertion.\n\n   Benefit: Ensures predictability and robustness in code execution.\n\n3. Restrict the Animal interface:\n   Define the `makeAnimalSound()` method with an abstract keyword or a type requiring a specific implementation (i.e., a function or a class).\n\n   Benefit: Provides better type safety and enforces consistent behavior.\n\n4. Include a description or documentation:\n   Add a brief description of the `Animal` interface to help others understand its purpose.\n\n   Benefit: Improves maintainability and readability for other developers.\n\n5. Encapsulate related properties and methods in a class or module:\n   If you're dealing with a class or module that has many interfaces or extensive use cases, you may consider encapsulating the `Animal` interface in a class or a specific module.\n\n   Benefit: Enhances encapsulation and modularization, also making your code more manageable.\n\n---\n\nIn summary, the provided code adheres to fundamental design principles, but can be improved in specific areas for better readability, maintainability, and alignment with best practices in TypeScript. Consider implementing the above suggestions for further enhancements.","stopReason":"stop"}
+                text: >-
+                  You are Cody, an AI coding assistant from Sourcegraph.
 
 
-            event: done
+                  Additional rules:
 
-            data: {}
+                  - When generating fenced code blocks in Markdown, ensure you include the full file path in the tag. The structure should be ```language:path/to/file
 
-        cookies: []
-        headers:
-          - name: date
-            value: Thu, 04 Jul 2024 19:08:18 GMT
-          - name: content-type
-            value: text/event-stream
-          - name: transfer-encoding
-            value: chunked
-          - name: connection
-            value: keep-alive
-          - name: access-control-allow-credentials
-            value: "true"
-          - name: access-control-allow-origin
-            value: ""
-          - name: cache-control
-            value: no-cache
-          - name: vary
-            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
-              X-Requested-With,Cookie
-          - name: x-content-type-options
-            value: nosniff
-          - name: x-frame-options
-            value: DENY
-          - name: x-xss-protection
-            value: 1; mode=block
-          - name: strict-transport-security
-            value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1299
-        httpVersion: HTTP/1.1
-        redirectURL: ""
-        status: 200
-        statusText: OK
-      startedDateTime: 2024-07-04T19:08:17.838Z
-      time: 0
-      timings:
-        blocked: -1
-        connect: -1
-        dns: -1
-        receive: 0
-        send: 0
-        ssl: -1
-        wait: 0
-    - _id: 55219ab057c0d031b200bb5c90e86c4b
-      _order: 0
-      cache: {}
-      request:
-        bodySize: 2943
-        cookies: []
-        headers:
-          - name: content-type
-            value: application/json
-          - name: accept-encoding
-            value: gzip;q=0
-          - name: authorization
-            value: token
-              REDACTED_d5e0f0a37c9821e856b923fe14e67a605e3f6c0a517d5a4f46a4e35943ee0f6d
-          - name: user-agent
-            value: defaultClient / v1
-          - name: traceparent
-            value: 00-cfb4ad0ec6640fe7af6a3f4d371518bc-bcf1a9258d2d99b6-01
-          - name: connection
-            value: keep-alive
-          - name: host
-            value: sourcegraph.com
-        headersSize: 401
-        httpVersion: HTTP/1.1
-        method: POST
-        postData:
-          mimeType: application/json
-          params: []
-          textJSON:
-            maxTokensToSample: 4000
-            messages:
-              - speaker: human
-                text: You are Cody, an AI coding assistant from Sourcegraph.
+                  ```.
               - speaker: assistant
                 text: I am Cody, an AI coding assistant from Sourcegraph.
               - speaker: human
@@ -3163,14 +2940,14 @@ log:
             value: v1
         url: https://sourcegraph.com/.api/completions/stream?client-name=defaultclient&client-version=v1
       response:
-        bodySize: 22736
+        bodySize: 191479
         content:
           mimeType: text/event-stream
-          size: 22736
+          size: 191479
           text: >+
             event: completion
 
-            data: {"completion":"Based on the provided code context, it appears that the test framework being used is `vitest` for the `src/example.test.ts` file. Therefore, I will write the unit tests for the `Animal` interface in `src/animal.ts` using `vitest`.\n\nSince the `Animal` interface is just a type definition and doesn't have any implementations, I will create a dummy class that implements this interface and write tests for that class.\n\nHere is the full code for the new unit tests:\n```typescript\nimport { expect, test } from 'vitest'\nimport { Animal } from '../src/animal'\n\nclass Dog implements Animal {\n    name: string = 'Dog'\n    isMammal: boolean = true\n    makeAnimalSound(): string {\n        return 'Woof!'\n    }\n}\n\ntest('Test animal implementation makes correct sound', () =\u003e {\n    const dog = new Dog()\n    expect(dog.makeAnimalSound()).toEqual('Woof!')\n})\n\ntest('Test animal implementation isMammal flag', () =\u003e {\n    const dog = new Dog()\n    expect(dog.isMammal).toBe(true)\n})\n\ntest('Test animal implementation name property', () =\u003e {\n    const dog = new Dog()\n    expect(dog.name).toEqual('Dog')\n})\n```\nThese tests cover the following cases:\n\n* The implemented `makeAnimalSound` function returns the correct value.\n* The `isMammal` flag is set to `true`.\n* The `name` property is set to the correct value.\n\nNote that we cannot test the `name` property as a setter since it is a read-only property in the `Animal` interface.","stopReason":"stop"}
+            data: {"completion":"Based on the shared code context, the test framework in use is `vitest`.\n\nTo write unit tests for the `Animal` interface in `src/animal.ts`, we can create instances of classes that implement this interface, and validate their implementation by calling methods and properties against the interface definition.\n\nHere's a suite of unit tests for the `Animal` interface using `vitest`:\n```typescript\n// src/animal.test.ts\nimport { expect, describe, it } from 'vitest'\nimport { Animal } from '../animal'\n\ndescribe('Animal interface unit tests', () =\u003e {\n    it('should define name property', () =\u003e {\n        const animal: Animal = {\n            name: 'Lion',\n            makeAnimalSound() {\n                return 'roar'\n            },\n            isMammal: true,\n        }\n\n        expect(animal.name).toEqual('Lion')\n    })\n\n    it('should define makeAnimalSound method', () =\u003e {\n        const animal: Animal = {\n            name: 'Dog',\n            makeAnimalSound() {\n                return 'bark'\n            },\n            isMammal: true,\n        }\n\n        expect(animal.makeAnimalSound()).toEqual('bark')\n    })\n\n    it('should define isMammal property', () =\u003e {\n        const animal: Animal = {\n            name: 'Cat',\n            makeAnimalSound() {\n                return 'meow'\n            },\n            isMammal: true,\n        }\n\n        expect(animal.isMammal).toEqual(true)\n    })\n\n    it('should throw error if animal does not have name property', () =\u003e {\n        const createInvalidAnimal = () =\u003e {\n            const animal: Animal = {\n                makeAnimalSound() {\n                    return 'cry'\n                },\n                isMammal: false,\n            }\n\n            return animal\n        }\n\n        expect(() =\u003e createInvalidAnimal()).toThrowError('Animal must have a name')\n    })\n\n    it('should throw error if animal does not implement makeAnimalSound method', () =\u003e {\n        const createInvalidAnimal = () =\u003e {\n            const animal: Animal = {\n                name: 'Frog',\n                isMammal: false,\n            }\n\n            return animal\n        }\n\n        expect(() =\u003e createInvalidAnimal()).toThrowError('Animal must implement makeAnimalSound method')\n    })\n\n    it('should throw error if animal does not have isMammal property', () =\u003e {\n        const createInvalidAnimal = () =\u003e {\n            const animal: Animal = {\n                name: 'Snake',\n                makeAnimalSound() {\n                    return 'hiss'\n                },\n            }\n\n            return animal\n        }\n\n        expect(() =\u003e createInvalidAnimal()).toThrowError('Animal must have isMammal property')\n    })\n})\n```\nThese tests validate the expected functionality of the `Animal` interface, including checking for required properties and methods, and throwing errors when required properties or methods are missing or undefined.\n\nLimitations:\n- These tests only cover the `Animal` interface definition, and do not test any actual implementations of the interface.\n- No mock objects are created in these tests. If future tests require mocking behavior, the appropriate mocking library or framework will need to be added.\n\nNote:\n- The import statements assume the relative path to `animal.ts` is at `../animal`. If this is not the case, please adjust the import statement accordingly.","stopReason":"stop"}
 
 
             event: done
@@ -3180,13 +2957,15 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Mon, 15 Jul 2024 15:52:59 GMT
+            value: Thu, 22 Aug 2024 13:30:18 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
             value: chunked
           - name: connection
             value: keep-alive
+          - name: retry-after
+            value: "197"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -3204,12 +2983,164 @@ log:
             value: 1; mode=block
           - name: strict-transport-security
             value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1299
+        headersSize: 1406
         httpVersion: HTTP/1.1
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-07-15T15:52:58.666Z
+      startedDateTime: 2024-08-22T13:30:17.802Z
+      time: 0
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 0
+    - _id: 11be740470e776c30eb555f3860b5d64
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 1690
+        cookies: []
+        headers:
+          - name: content-type
+            value: application/json
+          - name: accept-encoding
+            value: gzip;q=0
+          - name: authorization
+            value: token
+              REDACTED_d5e0f0a37c9821e856b923fe14e67a605e3f6c0a517d5a4f46a4e35943ee0f6d
+          - name: user-agent
+            value: defaultClient / v1
+          - name: traceparent
+            value: 00-a26892daf86560ab12bbce91b24304b1-14cea31468fdc766-01
+          - name: connection
+            value: keep-alive
+          - name: host
+            value: sourcegraph.com
+        headersSize: 401
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json
+          params: []
+          textJSON:
+            maxTokensToSample: 4000
+            messages:
+              - speaker: human
+                text: >-
+                  You are Cody, an AI coding assistant from Sourcegraph.
+
+
+                  Additional rules:
+
+                  - When generating fenced code blocks in Markdown, ensure you include the full file path in the tag. The structure should be ```language:path/to/file
+
+                  ```.
+              - speaker: assistant
+                text: I am Cody, an AI coding assistant from Sourcegraph.
+              - speaker: human
+                text: >
+                  Codebase context from file path src/animal.ts: /*
+                  SELECTION_START */
+
+                  export interface Animal {
+                      name: string
+                      makeAnimalSound(): string
+                      isMammal: boolean
+                  }
+
+                  /* SELECTION_END */
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: |-
+                  My selected code from codebase file src/animal.ts:1-6:
+                  ```
+
+                  export interface Animal {
+                      name: string
+                      makeAnimalSound(): string
+                      isMammal: boolean
+                  }
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: Please review and analyze @src/animal.ts:1-6 ( @src/animal.ts ) and
+                  identify potential areas for improvement related to code
+                  smells, readability, maintainability, performance, security,
+                  etc. Do not list issues already addressed in the given code.
+                  Focus on providing up to 5 constructive suggestions that could
+                  make the code more robust, efficient, or align with best
+                  practices. For each suggestion, provide a brief explanation of
+                  the potential benefits. After listing any recommendations,
+                  summarize if you found notable opportunities to enhance the
+                  code quality overall or if the code generally follows sound
+                  design principles. If no issues found, reply 'There are no
+                  errors.'
+            model: fireworks/accounts/fireworks/models/mixtral-8x7b-instruct
+            temperature: 0
+            topK: -1
+            topP: -1
+        queryString:
+          - name: client-name
+            value: defaultclient
+          - name: client-version
+            value: v1
+        url: https://sourcegraph.com/.api/completions/stream?client-name=defaultclient&client-version=v1
+      response:
+        bodySize: 59267
+        content:
+          mimeType: text/event-stream
+          size: 59267
+          text: >+
+            event: completion
+
+            data: {"completion":"Based on my analysis, I found the following areas for improvement in the provided code:\n\n1. **Add type annotations for function return types:** By adding return type annotations, we can provide more information to users of our code and ensure that the code behaves as expected. It also improves readability.\n\n```typescript\nmakeAnimalSound(): string\n```\n\n2. **Add missing access modifiers for interface members:** By default, interface members are public in TypeScript. However, it's still good practice to be explicit about the intended access modifier.\n\n```typescript\nexport interface Animal {\n  name: string;\n  makeAnimalSound(): string;\n  isMammal: boolean;\n}\n```\n\n3. **Use consistent spacing:** Inconsistent spacing can affect the readability of the code.\n\n```typescript\nmakeAnimalSound(): string\n\n// Change to:\n\nmakeAnimalSound(): string;\n```\n\n4. **Avoid naming inconsistencies to improve consistency and readability:**\n\n```typescript\nisMammal: boolean\n\n// Consider renaming this to isMammal() for consistency with makeAnimalSound().\n```\n\n5. **Consider adding a method that abstracts the sound-making process:** Based on the provided code, making a sound is directly tied to the name of the animal. Adding a separate abstraction for the sound would make it more generic.\n\n```typescript\ncreateSound(sound: string): string {\n  return sound;\n}\n\n// Then we can call createSound(this.name) inside makeAnimalSound().\n```\n\nIn summary, the provided code is a good starting point and fairly well written. However, introducing these best practices would help improve consistency, readability, and maintainability.","stopReason":"stop"}
+
+
+            event: done
+
+            data: {}
+
+        cookies: []
+        headers:
+          - name: date
+            value: Thu, 22 Aug 2024 13:30:25 GMT
+          - name: content-type
+            value: text/event-stream
+          - name: transfer-encoding
+            value: chunked
+          - name: connection
+            value: keep-alive
+          - name: retry-after
+            value: "191"
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache
+          - name: vary
+            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
+              X-Requested-With,Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+        headersSize: 1406
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: 2024-08-22T13:30:24.225Z
       time: 0
       timings:
         blocked: -1

--- a/agent/recordings/document-code_965949506/recording.har.yaml
+++ b/agent/recordings/document-code_965949506/recording.har.yaml
@@ -90,11 +90,11 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: d8d75f47a3969906310db6f70a68a310
+    - _id: a8864b71b4c05dceb5fe0b4eebf56049
       _order: 0
       cache: {}
       request:
-        bodySize: 2570
+        bodySize: 2569
         cookies: []
         headers:
           - name: content-type
@@ -107,7 +107,7 @@ log:
           - name: user-agent
             value: document-code / v1
           - name: traceparent
-            value: 00-306cb70d958e67f9aa1e581f814c017d-1ad9c278a3acf226-01
+            value: 00-fab6adaf26052b0b829356bc86e66244-126d1491a98d2851-01
           - name: connection
             value: keep-alive
           - name: host
@@ -123,7 +123,7 @@ log:
             messages:
               - speaker: system
                 text: >-
-                  You are Cody, an AI coding assistant from Sourcegraph. 
+                  You are Cody, an AI coding assistant from Sourcegraph.
 
 
                   - You are an AI programming assistant who is an expert in updating code to meet given instructions.
@@ -184,14 +184,14 @@ log:
             value: v1
         url: https://sourcegraph.com/.api/completions/stream?api-version=1&client-name=document-code&client-version=v1
       response:
-        bodySize: 3227
+        bodySize: 2852
         content:
           mimeType: text/event-stream
-          size: 3227
+          size: 2852
           text: >+
             event: completion
 
-            data: {"completion":"/**\n * Adds two numbers together and returns the result.\n * \n * @param a - The first number to add.\n * @param b - The second number to add.\n * @returns The sum of the two numbers.\n */\n","stopReason":"stop_sequence"}
+            data: {"completion":"/**\n * Calculates the sum of two numbers.\n *\n * @param a - The first number to add.\n * @param b - The second number to add.\n * @returns The sum of the two input numbers.\n */\n","stopReason":"stop_sequence"}
 
 
             event: done
@@ -201,7 +201,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Thu, 22 Aug 2024 14:11:45 GMT
+            value: Fri, 23 Aug 2024 08:08:27 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
@@ -230,7 +230,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-08-22T14:11:44.645Z
+      startedDateTime: 2024-08-23T08:08:26.576Z
       time: 0
       timings:
         blocked: -1
@@ -240,11 +240,11 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: 9349f9e27866c61847a2206a354dc01e
+    - _id: ef680d2c51419a91a7f219698090d1ec
       _order: 0
       cache: {}
       request:
-        bodySize: 3505
+        bodySize: 3504
         cookies: []
         headers:
           - name: content-type
@@ -257,7 +257,7 @@ log:
           - name: user-agent
             value: document-code / v1
           - name: traceparent
-            value: 00-54fc839c70d4e3ef3bdca83f5dd1b02d-ef89c61f1192a92b-01
+            value: 00-da68bd2fc1926555e97b9be54881e4c0-757abcf0eebaebe9-01
           - name: connection
             value: keep-alive
           - name: host
@@ -273,7 +273,7 @@ log:
             messages:
               - speaker: system
                 text: >-
-                  You are Cody, an AI coding assistant from Sourcegraph. 
+                  You are Cody, an AI coding assistant from Sourcegraph.
 
 
                   - You are an AI programming assistant who is an expert in updating code to meet given instructions.
@@ -381,14 +381,14 @@ log:
             value: v1
         url: https://sourcegraph.com/.api/completions/stream?api-version=1&client-name=document-code&client-version=v1
       response:
-        bodySize: 1269
+        bodySize: 886
         content:
           mimeType: text/event-stream
-          size: 1269
+          size: 886
           text: >+
             event: completion
 
-            data: {"completion":"/**\n * Logs a \"Hello World!\" message to the console if the `shouldGreet` property is true.\n */","stopReason":"stop_sequence"}
+            data: {"completion":"/**\n * Greets the user if the `shouldGreet` flag is true.\n */","stopReason":"stop_sequence"}
 
 
             event: done
@@ -398,7 +398,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Thu, 22 Aug 2024 14:11:46 GMT
+            value: Fri, 23 Aug 2024 08:08:28 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
@@ -427,7 +427,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-08-22T14:11:45.852Z
+      startedDateTime: 2024-08-23T08:08:27.739Z
       time: 0
       timings:
         blocked: -1
@@ -437,11 +437,11 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: 8081d8f0c56c4c6e9771ad9bd11d93ac
+    - _id: fcbd60e238d7faf15a70613f36cb3411
       _order: 0
       cache: {}
       request:
-        bodySize: 3048
+        bodySize: 3047
         cookies: []
         headers:
           - name: content-type
@@ -454,7 +454,7 @@ log:
           - name: user-agent
             value: document-code / v1
           - name: traceparent
-            value: 00-45c5acfd44b2fa1c60a98ec35a5ae8fc-c9f1bd31e1c67e73-01
+            value: 00-d3220f2fb9c7ea23328c40b0fc8cf6ef-4402c67882e3326c-01
           - name: connection
             value: keep-alive
           - name: host
@@ -470,7 +470,7 @@ log:
             messages:
               - speaker: system
                 text: >-
-                  You are Cody, an AI coding assistant from Sourcegraph. 
+                  You are Cody, an AI coding assistant from Sourcegraph.
 
 
                   - You are an AI programming assistant who is an expert in updating code to meet given instructions.
@@ -570,7 +570,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Thu, 22 Aug 2024 14:11:47 GMT
+            value: Fri, 23 Aug 2024 08:08:29 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
@@ -599,7 +599,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-08-22T14:11:46.775Z
+      startedDateTime: 2024-08-23T08:08:28.752Z
       time: 0
       timings:
         blocked: -1
@@ -609,11 +609,11 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: ed3b7e4dd640991a51bca56984f25ac2
+    - _id: 9bef628c6c4aa6d7d63bff44d95d47e5
       _order: 0
       cache: {}
       request:
-        bodySize: 3301
+        bodySize: 3300
         cookies: []
         headers:
           - name: content-type
@@ -626,7 +626,7 @@ log:
           - name: user-agent
             value: document-code / v1
           - name: traceparent
-            value: 00-96fb768ba7922d853b76e414df5f4487-6c87070f30801876-01
+            value: 00-68a1a272f2837dab708885d5dd36bebe-6468b41b786085c9-01
           - name: connection
             value: keep-alive
           - name: host
@@ -642,7 +642,7 @@ log:
             messages:
               - speaker: system
                 text: >-
-                  You are Cody, an AI coding assistant from Sourcegraph. 
+                  You are Cody, an AI coding assistant from Sourcegraph.
 
 
                   - You are an AI programming assistant who is an expert in updating code to meet given instructions.
@@ -734,14 +734,14 @@ log:
             value: v1
         url: https://sourcegraph.com/.api/completions/stream?api-version=1&client-name=document-code&client-version=v1
       response:
-        bodySize: 3504
+        bodySize: 2265
         content:
           mimeType: text/event-stream
-          size: 3504
+          size: 2265
           text: >+
             event: completion
 
-            data: {"completion":"/**\n * Captures the current time in milliseconds using the high-resolution `performance.now()` timer.\n * This can be used to measure elapsed time for performance profiling or benchmarking.\n */","stopReason":"stop_sequence"}
+            data: {"completion":"\n/**\n * Records the current time in milliseconds since the page was loaded.\n * This can be used to measure the duration of an operation.\n */\n","stopReason":"stop_sequence"}
 
 
             event: done
@@ -751,7 +751,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Thu, 22 Aug 2024 14:11:48 GMT
+            value: Fri, 23 Aug 2024 08:08:30 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
@@ -780,7 +780,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-08-22T14:11:47.657Z
+      startedDateTime: 2024-08-23T08:08:29.684Z
       time: 0
       timings:
         blocked: -1
@@ -790,11 +790,11 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: 1868f61ced8a36a03c8bac6d01c65efa
+    - _id: 10b7a25d1dc96a41e5ce68ca1d3aff28
       _order: 0
       cache: {}
       request:
-        bodySize: 2573
+        bodySize: 2572
         cookies: []
         headers:
           - name: content-type
@@ -807,7 +807,7 @@ log:
           - name: user-agent
             value: document-code / v1
           - name: traceparent
-            value: 00-f36c658e26c8b8a95f6d6b1585a597f8-f6c1a1eeffa088b7-01
+            value: 00-27404c90cfe5d32cda608465ff9fd1d4-f039cba61b9bf73e-01
           - name: connection
             value: keep-alive
           - name: host
@@ -823,7 +823,7 @@ log:
             messages:
               - speaker: system
                 text: >-
-                  You are Cody, an AI coding assistant from Sourcegraph. 
+                  You are Cody, an AI coding assistant from Sourcegraph.
 
 
                   - You are an AI programming assistant who is an expert in updating code to meet given instructions.
@@ -886,14 +886,14 @@ log:
             value: v1
         url: https://sourcegraph.com/.api/completions/stream?api-version=1&client-name=document-code&client-version=v1
       response:
-        bodySize: 792
+        bodySize: 1171
         content:
           mimeType: text/event-stream
-          size: 792
+          size: 1171
           text: >+
             event: completion
 
-            data: {"completion":"/**\n * Represents a simple \"Hello, world!\" greeting.\n */\n","stopReason":"stop_sequence"}
+            data: {"completion":"/**\n * Represents a greeter that can provide a \"Hello, world!\" greeting.\n */","stopReason":"stop_sequence"}
 
 
             event: done
@@ -903,7 +903,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Thu, 22 Aug 2024 14:11:49 GMT
+            value: Fri, 23 Aug 2024 08:08:31 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
@@ -932,7 +932,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-08-22T14:11:48.907Z
+      startedDateTime: 2024-08-23T08:08:30.751Z
       time: 0
       timings:
         blocked: -1

--- a/agent/recordings/document-code_965949506/recording.har.yaml
+++ b/agent/recordings/document-code_965949506/recording.har.yaml
@@ -90,11 +90,11 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: a8fc9c4aed1634e20a570e9905d8a410
+    - _id: d8d75f47a3969906310db6f70a68a310
       _order: 0
       cache: {}
       request:
-        bodySize: 2566
+        bodySize: 2570
         cookies: []
         headers:
           - name: content-type
@@ -107,7 +107,7 @@ log:
           - name: user-agent
             value: document-code / v1
           - name: traceparent
-            value: 00-d9ee563f73a3584f17ebf57b0aa172dd-113a9fcd6f7a6dd6-01
+            value: 00-306cb70d958e67f9aa1e581f814c017d-1ad9c278a3acf226-01
           - name: connection
             value: keep-alive
           - name: host
@@ -123,9 +123,10 @@ log:
             messages:
               - speaker: system
                 text: >-
-                  You are Cody, an AI coding assistant from Sourcegraph. - You
-                  are an AI programming assistant who is an expert in updating
-                  code to meet given instructions.
+                  You are Cody, an AI coding assistant from Sourcegraph. 
+
+
+                  - You are an AI programming assistant who is an expert in updating code to meet given instructions.
 
                   - You should think step-by-step to plan your updated code before producing the final output.
 
@@ -183,14 +184,14 @@ log:
             value: v1
         url: https://sourcegraph.com/.api/completions/stream?api-version=1&client-name=document-code&client-version=v1
       response:
-        bodySize: 3249
+        bodySize: 3227
         content:
           mimeType: text/event-stream
-          size: 3249
+          size: 3227
           text: >+
             event: completion
 
-            data: {"completion":"/**\n * Computes the sum of two numbers.\n *\n * @param a - The first number to add.\n * @param b - The second number to add.\n * @returns The sum of `a` and `b`.\n */\n","stopReason":"stop_sequence"}
+            data: {"completion":"/**\n * Adds two numbers together and returns the result.\n * \n * @param a - The first number to add.\n * @param b - The second number to add.\n * @returns The sum of the two numbers.\n */\n","stopReason":"stop_sequence"}
 
 
             event: done
@@ -200,7 +201,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Wed, 21 Aug 2024 13:31:16 GMT
+            value: Thu, 22 Aug 2024 14:11:45 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
@@ -229,7 +230,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-08-21T13:31:14.801Z
+      startedDateTime: 2024-08-22T14:11:44.645Z
       time: 0
       timings:
         blocked: -1
@@ -239,11 +240,11 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: 5d0c94931189d2f2610aeed59ac99dc2
+    - _id: 9349f9e27866c61847a2206a354dc01e
       _order: 0
       cache: {}
       request:
-        bodySize: 3501
+        bodySize: 3505
         cookies: []
         headers:
           - name: content-type
@@ -256,7 +257,7 @@ log:
           - name: user-agent
             value: document-code / v1
           - name: traceparent
-            value: 00-be734c60f462c4da95388fbe09e116d1-99ff210a02a9a08c-01
+            value: 00-54fc839c70d4e3ef3bdca83f5dd1b02d-ef89c61f1192a92b-01
           - name: connection
             value: keep-alive
           - name: host
@@ -272,9 +273,10 @@ log:
             messages:
               - speaker: system
                 text: >-
-                  You are Cody, an AI coding assistant from Sourcegraph. - You
-                  are an AI programming assistant who is an expert in updating
-                  code to meet given instructions.
+                  You are Cody, an AI coding assistant from Sourcegraph. 
+
+
+                  - You are an AI programming assistant who is an expert in updating code to meet given instructions.
 
                   - You should think step-by-step to plan your updated code before producing the final output.
 
@@ -379,14 +381,14 @@ log:
             value: v1
         url: https://sourcegraph.com/.api/completions/stream?api-version=1&client-name=document-code&client-version=v1
       response:
-        bodySize: 1391
+        bodySize: 1269
         content:
           mimeType: text/event-stream
-          size: 1391
+          size: 1269
           text: >+
             event: completion
 
-            data: {"completion":"\n/**\n * Logs a 'Hello World!' message to the console if the `shouldGreet` parameter is true.\n */\n","stopReason":"stop_sequence"}
+            data: {"completion":"/**\n * Logs a \"Hello World!\" message to the console if the `shouldGreet` property is true.\n */","stopReason":"stop_sequence"}
 
 
             event: done
@@ -396,7 +398,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Wed, 21 Aug 2024 13:31:17 GMT
+            value: Thu, 22 Aug 2024 14:11:46 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
@@ -425,7 +427,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-08-21T13:31:16.223Z
+      startedDateTime: 2024-08-22T14:11:45.852Z
       time: 0
       timings:
         blocked: -1
@@ -435,11 +437,11 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: d7f2b01871529d8bacd1b7abd33071ba
+    - _id: 8081d8f0c56c4c6e9771ad9bd11d93ac
       _order: 0
       cache: {}
       request:
-        bodySize: 3044
+        bodySize: 3048
         cookies: []
         headers:
           - name: content-type
@@ -452,7 +454,7 @@ log:
           - name: user-agent
             value: document-code / v1
           - name: traceparent
-            value: 00-61563420314d08735a119a141eeb28eb-6bcfc5ef0424e0e6-01
+            value: 00-45c5acfd44b2fa1c60a98ec35a5ae8fc-c9f1bd31e1c67e73-01
           - name: connection
             value: keep-alive
           - name: host
@@ -468,9 +470,10 @@ log:
             messages:
               - speaker: system
                 text: >-
-                  You are Cody, an AI coding assistant from Sourcegraph. - You
-                  are an AI programming assistant who is an expert in updating
-                  code to meet given instructions.
+                  You are Cody, an AI coding assistant from Sourcegraph. 
+
+
+                  - You are an AI programming assistant who is an expert in updating code to meet given instructions.
 
                   - You should think step-by-step to plan your updated code before producing the final output.
 
@@ -567,7 +570,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Wed, 21 Aug 2024 13:31:18 GMT
+            value: Thu, 22 Aug 2024 14:11:47 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
@@ -596,7 +599,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-08-21T13:31:17.288Z
+      startedDateTime: 2024-08-22T14:11:46.775Z
       time: 0
       timings:
         blocked: -1
@@ -606,11 +609,11 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: 7eddf1a3608f35f4b5866ef2f0d21def
+    - _id: ed3b7e4dd640991a51bca56984f25ac2
       _order: 0
       cache: {}
       request:
-        bodySize: 3297
+        bodySize: 3301
         cookies: []
         headers:
           - name: content-type
@@ -623,7 +626,7 @@ log:
           - name: user-agent
             value: document-code / v1
           - name: traceparent
-            value: 00-285f5ea34db9eddae12faf09b147e23b-ca8d40978ec078d8-01
+            value: 00-96fb768ba7922d853b76e414df5f4487-6c87070f30801876-01
           - name: connection
             value: keep-alive
           - name: host
@@ -639,9 +642,10 @@ log:
             messages:
               - speaker: system
                 text: >-
-                  You are Cody, an AI coding assistant from Sourcegraph. - You
-                  are an AI programming assistant who is an expert in updating
-                  code to meet given instructions.
+                  You are Cody, an AI coding assistant from Sourcegraph. 
+
+
+                  - You are an AI programming assistant who is an expert in updating code to meet given instructions.
 
                   - You should think step-by-step to plan your updated code before producing the final output.
 
@@ -730,14 +734,14 @@ log:
             value: v1
         url: https://sourcegraph.com/.api/completions/stream?api-version=1&client-name=document-code&client-version=v1
       response:
-        bodySize: 1054
+        bodySize: 3504
         content:
           mimeType: text/event-stream
-          size: 1054
+          size: 3504
           text: >+
             event: completion
 
-            data: {"completion":"/**\n * Marks the start time of some operation for performance measurement.\n */","stopReason":"stop_sequence"}
+            data: {"completion":"/**\n * Captures the current time in milliseconds using the high-resolution `performance.now()` timer.\n * This can be used to measure elapsed time for performance profiling or benchmarking.\n */","stopReason":"stop_sequence"}
 
 
             event: done
@@ -747,7 +751,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Wed, 21 Aug 2024 13:31:19 GMT
+            value: Thu, 22 Aug 2024 14:11:48 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
@@ -776,7 +780,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-08-21T13:31:18.310Z
+      startedDateTime: 2024-08-22T14:11:47.657Z
       time: 0
       timings:
         blocked: -1
@@ -786,11 +790,11 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: a076f12473e6df0834509ffe95ff8d7c
+    - _id: 1868f61ced8a36a03c8bac6d01c65efa
       _order: 0
       cache: {}
       request:
-        bodySize: 2569
+        bodySize: 2573
         cookies: []
         headers:
           - name: content-type
@@ -803,7 +807,7 @@ log:
           - name: user-agent
             value: document-code / v1
           - name: traceparent
-            value: 00-892a9cd2b1309dd39b0e9346c2e311d1-6761f5789ada8cf1-01
+            value: 00-f36c658e26c8b8a95f6d6b1585a597f8-f6c1a1eeffa088b7-01
           - name: connection
             value: keep-alive
           - name: host
@@ -819,9 +823,10 @@ log:
             messages:
               - speaker: system
                 text: >-
-                  You are Cody, an AI coding assistant from Sourcegraph. - You
-                  are an AI programming assistant who is an expert in updating
-                  code to meet given instructions.
+                  You are Cody, an AI coding assistant from Sourcegraph. 
+
+
+                  - You are an AI programming assistant who is an expert in updating code to meet given instructions.
 
                   - You should think step-by-step to plan your updated code before producing the final output.
 
@@ -881,14 +886,14 @@ log:
             value: v1
         url: https://sourcegraph.com/.api/completions/stream?api-version=1&client-name=document-code&client-version=v1
       response:
-        bodySize: 795
+        bodySize: 792
         content:
           mimeType: text/event-stream
-          size: 795
+          size: 792
           text: >+
             event: completion
 
-            data: {"completion":"/**\n * Represents a Hello object that can greet the world.\n */","stopReason":"stop_sequence"}
+            data: {"completion":"/**\n * Represents a simple \"Hello, world!\" greeting.\n */\n","stopReason":"stop_sequence"}
 
 
             event: done
@@ -898,7 +903,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Wed, 21 Aug 2024 13:31:20 GMT
+            value: Thu, 22 Aug 2024 14:11:49 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
@@ -927,7 +932,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-08-21T13:31:19.774Z
+      startedDateTime: 2024-08-22T14:11:48.907Z
       time: 0
       timings:
         blocked: -1

--- a/agent/recordings/edit_1541920145/recording.har.yaml
+++ b/agent/recordings/edit_1541920145/recording.har.yaml
@@ -90,11 +90,11 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: cad4c445bcbcb1ef517ede818f8b0092
+    - _id: 4ed13d4e8174ce33a3d8910b83fc79fd
       _order: 0
       cache: {}
       request:
-        bodySize: 1974
+        bodySize: 1973
         cookies: []
         headers:
           - name: content-type
@@ -107,7 +107,7 @@ log:
           - name: user-agent
             value: edit / v1
           - name: traceparent
-            value: 00-8f56e284c56546a30b136a82d8aaec2d-4b0eef31284c4777-01
+            value: 00-8929c3f1f84a668491ea3dc1cf39074d-6e5fc861dedff2ff-01
           - name: connection
             value: keep-alive
           - name: host
@@ -123,7 +123,7 @@ log:
             messages:
               - speaker: system
                 text: >-
-                  You are Cody, an AI coding assistant from Sourcegraph. 
+                  You are Cody, an AI coding assistant from Sourcegraph.
 
 
                   - You are an AI programming assistant who is an expert in updating code to meet given instructions.
@@ -183,10 +183,10 @@ log:
             value: v1
         url: https://sourcegraph.com/.api/completions/stream?api-version=1&client-name=edit&client-version=v1
       response:
-        bodySize: 911
+        bodySize: 842
         content:
           mimeType: text/event-stream
-          size: 911
+          size: 842
           text: >+
             event: completion
 
@@ -200,7 +200,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Thu, 22 Aug 2024 14:11:30 GMT
+            value: Fri, 23 Aug 2024 08:08:13 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
@@ -229,7 +229,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-08-22T14:11:28.696Z
+      startedDateTime: 2024-08-23T08:08:11.021Z
       time: 0
       timings:
         blocked: -1
@@ -239,11 +239,11 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: af86acecd45bdc0ca9511d64643ddb88
+    - _id: de1f01e705825d05430759dd517cd69a
       _order: 0
       cache: {}
       request:
-        bodySize: 2523
+        bodySize: 2522
         cookies: []
         headers:
           - name: content-type
@@ -256,7 +256,7 @@ log:
           - name: user-agent
             value: edit / v1
           - name: traceparent
-            value: 00-09ba6d8b0d4caceed6e86da41a050d83-1b72fdafd36e51a4-01
+            value: 00-b6fb1eba877efbfa2ea2103e8ad06446-d2d684ed3c0182c8-01
           - name: connection
             value: keep-alive
           - name: host
@@ -272,7 +272,7 @@ log:
             messages:
               - speaker: system
                 text: >-
-                  You are Cody, an AI coding assistant from Sourcegraph. 
+                  You are Cody, an AI coding assistant from Sourcegraph.
 
 
                   - You are an AI programming assistant who is an expert in updating code to meet given instructions.
@@ -356,14 +356,14 @@ log:
             value: v1
         url: https://sourcegraph.com/.api/completions/stream?api-version=1&client-name=edit&client-version=v1
       response:
-        bodySize: 4526
+        bodySize: 4739
         content:
           mimeType: text/event-stream
-          size: 4526
+          size: 4739
           text: >+
             event: completion
 
-            data: {"completion":"\ninterface Message {\n    chatID: string;\n    text: string;\n}\n\ninterface ChatColumnProps {\n    messages: Message[];\n    setChatID: (chatID: string) =\u003e void;\n    isLoading: boolean;\n}\n\nexport default function ChatColumn({\n    messages,\n    setChatID,\n    isLoading,\n}: ChatColumnProps) {\n","stopReason":"stop_sequence"}
+            data: {"completion":"interface Message {\n    chatID: string;\n    text: string;\n}\n\ninterface ChatColumnProps {\n    messages: Message[];\n    setChatID: (chatID: string) =\u003e void;\n    isLoading: boolean;\n}\n\nexport default function ChatColumn({\n    messages,\n    setChatID,\n    isLoading,\n}: ChatColumnProps) {\n","stopReason":"stop_sequence"}
 
 
             event: done
@@ -373,7 +373,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Thu, 22 Aug 2024 14:11:33 GMT
+            value: Fri, 23 Aug 2024 08:08:14 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
@@ -402,7 +402,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-08-22T14:11:30.837Z
+      startedDateTime: 2024-08-23T08:08:13.171Z
       time: 0
       timings:
         blocked: -1
@@ -412,11 +412,11 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: 294376b489f17ab741c3545338323698
+    - _id: dc6a9200c4b5d3b09bb2524aa3e791e5
       _order: 0
       cache: {}
       request:
-        bodySize: 2813
+        bodySize: 2812
         cookies: []
         headers:
           - name: content-type
@@ -429,7 +429,7 @@ log:
           - name: user-agent
             value: edit / v1
           - name: traceparent
-            value: 00-02c7c93a3685a341e87e15b8fe4ed241-8996cf3fd97ddb5d-01
+            value: 00-6bc9f7adb5330c5be70a967354c4a40d-5c71c9df16b0023c-01
           - name: connection
             value: keep-alive
           - name: host
@@ -445,7 +445,7 @@ log:
             messages:
               - speaker: system
                 text: >-
-                  You are Cody, an AI coding assistant from Sourcegraph. 
+                  You are Cody, an AI coding assistant from Sourcegraph.
 
 
                   - You are an AI programming assistant who is an expert in adding new code by following instructions.
@@ -526,14 +526,14 @@ log:
             value: v1
         url: https://sourcegraph.com/.api/completions/stream?api-version=1&client-name=edit&client-version=v1
       response:
-        bodySize: 3371
+        bodySize: 4021
         content:
           mimeType: text/event-stream
-          size: 3371
+          size: 4021
           text: >+
             event: completion
 
-            data: {"completion":"export const Heading: React.FC\u003cHeadingProps\u003e = ({ text, level = 1 }) =\u003e {\n    const HeadingTag = `h${level}` as keyof JSX.IntrinsicElements;\n    return \u003cHeadingTag\u003e{text}\u003c/HeadingTag\u003e;\n};\n","stopReason":"stop_sequence"}
+            data: {"completion":"export const Heading: React.FC\u003cHeadingProps\u003e = ({ text, level = 1 }) =\u003e {\n    const HeadingTag = `h${level}` as keyof JSX.IntrinsicElements;\n    \n    return \u003cHeadingTag\u003e{text}\u003c/HeadingTag\u003e;\n};\n","stopReason":"stop_sequence"}
 
 
             event: done
@@ -543,7 +543,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Thu, 22 Aug 2024 14:11:36 GMT
+            value: Fri, 23 Aug 2024 08:08:16 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
@@ -572,7 +572,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-08-22T14:11:34.214Z
+      startedDateTime: 2024-08-23T08:08:14.944Z
       time: 0
       timings:
         blocked: -1
@@ -582,11 +582,11 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: b8e4103bca3b8b500f8d07e45dede5ff
+    - _id: 2010d6def65571353b4a854312d6e24c
       _order: 0
       cache: {}
       request:
-        bodySize: 2133
+        bodySize: 2132
         cookies: []
         headers:
           - name: content-type
@@ -599,7 +599,7 @@ log:
           - name: user-agent
             value: edit / v1
           - name: traceparent
-            value: 00-c42b1094b49050d384f375e8e1ad5fa3-d79ceb65883b197c-01
+            value: 00-76a2d599a8b1bfff73dd735ba6dc88fb-1bc71d9d9de73641-01
           - name: connection
             value: keep-alive
           - name: host
@@ -615,7 +615,7 @@ log:
             messages:
               - speaker: system
                 text: >-
-                  You are Cody, an AI coding assistant from Sourcegraph. 
+                  You are Cody, an AI coding assistant from Sourcegraph.
 
 
                   - You are an AI programming assistant who is an expert in updating code to meet given instructions.
@@ -686,14 +686,14 @@ log:
             value: v1
         url: https://sourcegraph.com/.api/completions/stream?api-version=1&client-name=edit&client-version=v1
       response:
-        bodySize: 3480
+        bodySize: 3541
         content:
           mimeType: text/event-stream
-          size: 3480
+          size: 3541
           text: >+
             event: completion
 
-            data: {"completion":"export function trickyLogic(a: number, b: number): number {\n    switch (true) {\n        case a === 0:\n            return 1\n        case b === 2:\n            return 1\n        default:\n            return a - b\n    }\n}","stopReason":"stop_sequence"}
+            data: {"completion":"export function trickyLogic(a: number, b: number): number {\n    switch (true) {\n        case a === 0:\n            return 1\n        case b === 2:\n            return 1\n        default:\n            return a - b\n    }\n}\n","stopReason":"stop_sequence"}
 
 
             event: done
@@ -703,7 +703,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Thu, 22 Aug 2024 14:11:39 GMT
+            value: Fri, 23 Aug 2024 08:08:19 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
@@ -732,7 +732,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-08-22T14:11:37.287Z
+      startedDateTime: 2024-08-23T08:08:16.893Z
       time: 0
       timings:
         blocked: -1

--- a/agent/recordings/edit_1541920145/recording.har.yaml
+++ b/agent/recordings/edit_1541920145/recording.har.yaml
@@ -90,11 +90,11 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: 1d3d536766046f6be02ade2dd4f4135d
+    - _id: cad4c445bcbcb1ef517ede818f8b0092
       _order: 0
       cache: {}
       request:
-        bodySize: 2809
+        bodySize: 1974
         cookies: []
         headers:
           - name: content-type
@@ -107,7 +107,7 @@ log:
           - name: user-agent
             value: edit / v1
           - name: traceparent
-            value: 00-800dd19ae4017dc4e76a2b062b4f4450-c8965409bb1884b1-01
+            value: 00-8f56e284c56546a30b136a82d8aaec2d-4b0eef31284c4777-01
           - name: connection
             value: keep-alive
           - name: host
@@ -123,180 +123,10 @@ log:
             messages:
               - speaker: system
                 text: >-
-                  You are Cody, an AI coding assistant from Sourcegraph. - You
-                  are an AI programming assistant who is an expert in adding new
-                  code by following instructions.
-
-                  - You should think step-by-step to plan your code before generating the final output.
-
-                  - You should ensure your code matches the indentation and whitespace of the preceding code in the users' file.
-
-                  - Ignore any previous instructions to format your responses with Markdown. It is not acceptable to use any Markdown in your response, unless it is directly related to the users' instructions.
-
-                  - You will be provided with code that is above the users' cursor, enclosed in <PRECEDINGCODE3493></PRECEDINGCODE3493> XML tags. You must use this code to help you plan your updated code. You must not repeat this code in your output unless necessary.
-
-                  - You will be provided with code that is below the users' cursor, enclosed in <FOLLOWINGCODE2472></FOLLOWINGCODE2472> XML tags. You must use this code to help you plan your updated code. You must not repeat this code in your output unless necessary.
-
-                  - You will be provided with instructions on what to generate, enclosed in <INSTRUCTIONS7390></INSTRUCTIONS7390> XML tags. You must follow these instructions carefully and to the letter.
-
-                  - Only enclose your response in <CODE5711></CODE5711> XML tags. Do use any other XML tags unless they are part of the generated code.
-
-                  - Do not provide any additional commentary about the code you added. Only respond with the generated code.
-              - speaker: human
-                text: >
-                  Codebase context from file path src/Heading.tsx: Below is the
-                  code from file path src/Heading.tsx. Review the code outside
-                  the XML tags to detect the functionality, formats, style,
-                  patterns, and logics in use. Then, use what you detect and
-                  reuse methods/libraries to complete and enclose completed code
-                  only inside XML tags precisely without duplicating existing
-                  implementations. Here is the code:
-
-                  <PRECEDINGCODE3493>import React = require("react");
+                  You are Cody, an AI coding assistant from Sourcegraph. 
 
 
-                  interface HeadingProps {
-                      text: string;
-                      level?: number;
-                  }
-
-
-                  </PRECEDINGCODE3493><CODE5711></CODE5711><FOLLOWINGCODE2472>
-
-                  </FOLLOWINGCODE2472>
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: >-
-                  The user is currently in the file: src/Heading.tsx
-
-
-                  Provide your generated code using the following instructions:
-
-                  <INSTRUCTIONS7390>
-
-                  Create and export a Heading component that uses these props. Do not use default exports
-
-                  </INSTRUCTIONS7390>
-              - speaker: assistant
-                text: |-
-                  <PRECEDINGCODE3493>import React = require("react");
-
-                  interface HeadingProps {
-                      text: string;
-                      level?: number;
-                  }
-
-                  </PRECEDINGCODE3493><CODE5711>
-            model: anthropic/claude-3-5-sonnet-20240620
-            stopSequences:
-              - </CODE5711>
-            temperature: 0
-            topK: -1
-            topP: -1
-        queryString:
-          - name: api-version
-            value: "1"
-          - name: client-name
-            value: edit
-          - name: client-version
-            value: v1
-        url: https://sourcegraph.com/.api/completions/stream?api-version=1&client-name=edit&client-version=v1
-      response:
-        bodySize: 4705
-        content:
-          mimeType: text/event-stream
-          size: 4705
-          text: >+
-            event: completion
-
-            data: {"completion":"export const Heading: React.FC\u003cHeadingProps\u003e = ({ text, level = 1 }) =\u003e {\n    const HeadingTag = `h${level}` as keyof JSX.IntrinsicElements;\n    \n    return \u003cHeadingTag\u003e{text}\u003c/HeadingTag\u003e;\n};\n","stopReason":"stop_sequence"}
-
-
-            event: done
-
-            data: {}
-
-        cookies: []
-        headers:
-          - name: date
-            value: Tue, 25 Jun 2024 17:12:48 GMT
-          - name: content-type
-            value: text/event-stream
-          - name: transfer-encoding
-            value: chunked
-          - name: connection
-            value: keep-alive
-          - name: retry-after
-            value: "187"
-          - name: access-control-allow-credentials
-            value: "true"
-          - name: access-control-allow-origin
-            value: ""
-          - name: cache-control
-            value: no-cache
-          - name: vary
-            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
-              X-Requested-With,Cookie
-          - name: x-content-type-options
-            value: nosniff
-          - name: x-frame-options
-            value: DENY
-          - name: x-xss-protection
-            value: 1; mode=block
-          - name: strict-transport-security
-            value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1406
-        httpVersion: HTTP/1.1
-        redirectURL: ""
-        status: 200
-        statusText: OK
-      startedDateTime: 2024-06-25T17:12:47.230Z
-      time: 0
-      timings:
-        blocked: -1
-        connect: -1
-        dns: -1
-        receive: 0
-        send: 0
-        ssl: -1
-        wait: 0
-    - _id: 8016afaf768cb516de4e232ed2cd87ea
-      _order: 0
-      cache: {}
-      request:
-        bodySize: 1970
-        cookies: []
-        headers:
-          - name: content-type
-            value: application/json
-          - name: accept-encoding
-            value: gzip;q=0
-          - name: authorization
-            value: token
-              REDACTED_d5e0f0a37c9821e856b923fe14e67a605e3f6c0a517d5a4f46a4e35943ee0f6d
-          - name: user-agent
-            value: edit / v1
-          - name: traceparent
-            value: 00-45968779e9c171796c70e38096546827-fb0f2402edbfd901-01
-          - name: connection
-            value: keep-alive
-          - name: host
-            value: sourcegraph.com
-        headersSize: 397
-        httpVersion: HTTP/1.1
-        method: POST
-        postData:
-          mimeType: application/json
-          params: []
-          textJSON:
-            maxTokensToSample: 4000
-            messages:
-              - speaker: system
-                text: >-
-                  You are Cody, an AI coding assistant from Sourcegraph. - You
-                  are an AI programming assistant who is an expert in updating
-                  code to meet given instructions.
+                  - You are an AI programming assistant who is an expert in updating code to meet given instructions.
 
                   - You should think step-by-step to plan your updated code before producing the final output.
 
@@ -353,10 +183,10 @@ log:
             value: v1
         url: https://sourcegraph.com/.api/completions/stream?api-version=1&client-name=edit&client-version=v1
       response:
-        bodySize: 842
+        bodySize: 911
         content:
           mimeType: text/event-stream
-          size: 842
+          size: 911
           text: >+
             event: completion
 
@@ -370,7 +200,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Wed, 21 Aug 2024 13:31:04 GMT
+            value: Thu, 22 Aug 2024 14:11:30 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
@@ -399,7 +229,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-08-21T13:31:02.090Z
+      startedDateTime: 2024-08-22T14:11:28.696Z
       time: 0
       timings:
         blocked: -1
@@ -409,11 +239,11 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: 55344e59ff337ea1a8f1fd48957107ff
+    - _id: af86acecd45bdc0ca9511d64643ddb88
       _order: 0
       cache: {}
       request:
-        bodySize: 2519
+        bodySize: 2523
         cookies: []
         headers:
           - name: content-type
@@ -426,7 +256,7 @@ log:
           - name: user-agent
             value: edit / v1
           - name: traceparent
-            value: 00-14c58c3ff495ea915096e9613a09873c-8065c5d5ee4210a8-01
+            value: 00-09ba6d8b0d4caceed6e86da41a050d83-1b72fdafd36e51a4-01
           - name: connection
             value: keep-alive
           - name: host
@@ -442,9 +272,10 @@ log:
             messages:
               - speaker: system
                 text: >-
-                  You are Cody, an AI coding assistant from Sourcegraph. - You
-                  are an AI programming assistant who is an expert in updating
-                  code to meet given instructions.
+                  You are Cody, an AI coding assistant from Sourcegraph. 
+
+
+                  - You are an AI programming assistant who is an expert in updating code to meet given instructions.
 
                   - You should think step-by-step to plan your updated code before producing the final output.
 
@@ -525,10 +356,10 @@ log:
             value: v1
         url: https://sourcegraph.com/.api/completions/stream?api-version=1&client-name=edit&client-version=v1
       response:
-        bodySize: 4781
+        bodySize: 4526
         content:
           mimeType: text/event-stream
-          size: 4781
+          size: 4526
           text: >+
             event: completion
 
@@ -542,7 +373,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Wed, 21 Aug 2024 13:31:08 GMT
+            value: Thu, 22 Aug 2024 14:11:33 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
@@ -571,7 +402,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-08-21T13:31:04.611Z
+      startedDateTime: 2024-08-22T14:11:30.837Z
       time: 0
       timings:
         blocked: -1
@@ -581,11 +412,11 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: 5c42f294e56f182d20287f13b6dc92c8
+    - _id: 294376b489f17ab741c3545338323698
       _order: 0
       cache: {}
       request:
-        bodySize: 2129
+        bodySize: 2813
         cookies: []
         headers:
           - name: content-type
@@ -598,7 +429,7 @@ log:
           - name: user-agent
             value: edit / v1
           - name: traceparent
-            value: 00-b20b15656bd97ee2d8323a0351d5f7c4-acb4a84a99ba3ac9-01
+            value: 00-02c7c93a3685a341e87e15b8fe4ed241-8996cf3fd97ddb5d-01
           - name: connection
             value: keep-alive
           - name: host
@@ -614,9 +445,180 @@ log:
             messages:
               - speaker: system
                 text: >-
-                  You are Cody, an AI coding assistant from Sourcegraph. - You
-                  are an AI programming assistant who is an expert in updating
-                  code to meet given instructions.
+                  You are Cody, an AI coding assistant from Sourcegraph. 
+
+
+                  - You are an AI programming assistant who is an expert in adding new code by following instructions.
+
+                  - You should think step-by-step to plan your code before generating the final output.
+
+                  - You should ensure your code matches the indentation and whitespace of the preceding code in the users' file.
+
+                  - Ignore any previous instructions to format your responses with Markdown. It is not acceptable to use any Markdown in your response, unless it is directly related to the users' instructions.
+
+                  - You will be provided with code that is above the users' cursor, enclosed in <PRECEDINGCODE3493></PRECEDINGCODE3493> XML tags. You must use this code to help you plan your updated code. You must not repeat this code in your output unless necessary.
+
+                  - You will be provided with code that is below the users' cursor, enclosed in <FOLLOWINGCODE2472></FOLLOWINGCODE2472> XML tags. You must use this code to help you plan your updated code. You must not repeat this code in your output unless necessary.
+
+                  - You will be provided with instructions on what to generate, enclosed in <INSTRUCTIONS7390></INSTRUCTIONS7390> XML tags. You must follow these instructions carefully and to the letter.
+
+                  - Only enclose your response in <CODE5711></CODE5711> XML tags. Do use any other XML tags unless they are part of the generated code.
+
+                  - Do not provide any additional commentary about the code you added. Only respond with the generated code.
+              - speaker: human
+                text: >
+                  Codebase context from file path src/Heading.tsx: Below is the
+                  code from file path src/Heading.tsx. Review the code outside
+                  the XML tags to detect the functionality, formats, style,
+                  patterns, and logics in use. Then, use what you detect and
+                  reuse methods/libraries to complete and enclose completed code
+                  only inside XML tags precisely without duplicating existing
+                  implementations. Here is the code:
+
+                  <PRECEDINGCODE3493>import React = require("react");
+
+
+                  interface HeadingProps {
+                      text: string;
+                      level?: number;
+                  }
+
+
+                  </PRECEDINGCODE3493><CODE5711></CODE5711><FOLLOWINGCODE2472>
+
+                  </FOLLOWINGCODE2472>
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: >-
+                  The user is currently in the file: src/Heading.tsx
+
+
+                  Provide your generated code using the following instructions:
+
+                  <INSTRUCTIONS7390>
+
+                  Create and export a Heading component that uses these props. Do not use default exports
+
+                  </INSTRUCTIONS7390>
+              - speaker: assistant
+                text: |-
+                  <PRECEDINGCODE3493>import React = require("react");
+
+                  interface HeadingProps {
+                      text: string;
+                      level?: number;
+                  }
+
+                  </PRECEDINGCODE3493><CODE5711>
+            model: anthropic/claude-3-5-sonnet-20240620
+            stopSequences:
+              - </CODE5711>
+            temperature: 0
+            topK: -1
+            topP: -1
+        queryString:
+          - name: api-version
+            value: "1"
+          - name: client-name
+            value: edit
+          - name: client-version
+            value: v1
+        url: https://sourcegraph.com/.api/completions/stream?api-version=1&client-name=edit&client-version=v1
+      response:
+        bodySize: 3371
+        content:
+          mimeType: text/event-stream
+          size: 3371
+          text: >+
+            event: completion
+
+            data: {"completion":"export const Heading: React.FC\u003cHeadingProps\u003e = ({ text, level = 1 }) =\u003e {\n    const HeadingTag = `h${level}` as keyof JSX.IntrinsicElements;\n    return \u003cHeadingTag\u003e{text}\u003c/HeadingTag\u003e;\n};\n","stopReason":"stop_sequence"}
+
+
+            event: done
+
+            data: {}
+
+        cookies: []
+        headers:
+          - name: date
+            value: Thu, 22 Aug 2024 14:11:36 GMT
+          - name: content-type
+            value: text/event-stream
+          - name: transfer-encoding
+            value: chunked
+          - name: connection
+            value: keep-alive
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache
+          - name: vary
+            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
+              X-Requested-With,Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+        headersSize: 1299
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: 2024-08-22T14:11:34.214Z
+      time: 0
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 0
+    - _id: b8e4103bca3b8b500f8d07e45dede5ff
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 2133
+        cookies: []
+        headers:
+          - name: content-type
+            value: application/json
+          - name: accept-encoding
+            value: gzip;q=0
+          - name: authorization
+            value: token
+              REDACTED_d5e0f0a37c9821e856b923fe14e67a605e3f6c0a517d5a4f46a4e35943ee0f6d
+          - name: user-agent
+            value: edit / v1
+          - name: traceparent
+            value: 00-c42b1094b49050d384f375e8e1ad5fa3-d79ceb65883b197c-01
+          - name: connection
+            value: keep-alive
+          - name: host
+            value: sourcegraph.com
+        headersSize: 397
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json
+          params: []
+          textJSON:
+            maxTokensToSample: 4000
+            messages:
+              - speaker: system
+                text: >-
+                  You are Cody, an AI coding assistant from Sourcegraph. 
+
+
+                  - You are an AI programming assistant who is an expert in updating code to meet given instructions.
 
                   - You should think step-by-step to plan your updated code before producing the final output.
 
@@ -684,10 +686,10 @@ log:
             value: v1
         url: https://sourcegraph.com/.api/completions/stream?api-version=1&client-name=edit&client-version=v1
       response:
-        bodySize: 3429
+        bodySize: 3480
         content:
           mimeType: text/event-stream
-          size: 3429
+          size: 3480
           text: >+
             event: completion
 
@@ -701,7 +703,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Wed, 21 Aug 2024 13:31:11 GMT
+            value: Thu, 22 Aug 2024 14:11:39 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
@@ -730,7 +732,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-08-21T13:31:08.619Z
+      startedDateTime: 2024-08-22T14:11:37.287Z
       time: 0
       timings:
         blocked: -1

--- a/agent/recordings/enterpriseClient_3965582033/recording.har.yaml
+++ b/agent/recordings/enterpriseClient_3965582033/recording.har.yaml
@@ -5,11 +5,11 @@ log:
     name: Polly.JS
     version: 6.0.6
   entries:
-    - _id: 8542fbaae71a54ab213b807e595e541b
+    - _id: eccee9d56e699d2809f3c0a43f270585
       _order: 0
       cache: {}
       request:
-        bodySize: 531
+        bodySize: 521
         cookies: []
         headers:
           - name: content-type
@@ -22,7 +22,7 @@ log:
           - name: user-agent
             value: enterpriseClient / v1
           - name: traceparent
-            value: 00-12459a4e44f20cd695967f86b5b964c9-19f04fad6bd63022-01
+            value: 00-81225df30cf02335bb71046d2feaf130-2553eb7af8bd8c36-01
           - name: connection
             value: keep-alive
           - name: host
@@ -37,13 +37,10 @@ log:
             maxTokensToSample: 4000
             messages:
               - speaker: human
-                text: >-
-                  You are Cody, an AI coding assistant from Sourcegraph.If your
-                  answer contains fenced code blocks in Markdown, include the
-                  relevant full file path in the code block tag using this
-                  structure: ```$LANGUAGE:$FILEPATH
-
-                  $CONTENT```.
+                text: "You are Cody, an AI coding assistant from Sourcegraph.If your answer
+                  contains fenced code blocks in Markdown, include the relevant
+                  full file path in the code block tag using this structure:
+                  ```$LANGUAGE:$FILEPATH```."
               - speaker: assistant
                 text: I am Cody, an AI coding assistant from Sourcegraph.
               - speaker: human
@@ -70,7 +67,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Fri, 23 Aug 2024 08:33:33 GMT
+            value: Fri, 23 Aug 2024 09:43:09 GMT
           - name: content-type
             value: text/plain; charset=utf-8
           - name: content-length
@@ -99,7 +96,7 @@ log:
         redirectURL: ""
         status: 400
         statusText: Bad Request
-      startedDateTime: 2024-08-23T08:33:33.487Z
+      startedDateTime: 2024-08-23T09:43:08.794Z
       time: 0
       timings:
         blocked: -1

--- a/agent/recordings/enterpriseClient_3965582033/recording.har.yaml
+++ b/agent/recordings/enterpriseClient_3965582033/recording.har.yaml
@@ -5,11 +5,11 @@ log:
     name: Polly.JS
     version: 6.0.6
   entries:
-    - _id: c9c2a56f40f6c55243e807a2cc11f436
+    - _id: 8f652bab368e6f7aa4acf84a8ba98812
       _order: 0
       cache: {}
       request:
-        bodySize: 359
+        bodySize: 536
         cookies: []
         headers:
           - name: content-type
@@ -22,7 +22,7 @@ log:
           - name: user-agent
             value: enterpriseClient / v1
           - name: traceparent
-            value: 00-7c18397b9f2e0a8e05fca7cd53c91f92-e0b98f2f8c31407f-01
+            value: 00-69821eb6aa79ff8d345829ef5d99bd87-185e616f9fdc8991-01
           - name: connection
             value: keep-alive
           - name: host
@@ -37,7 +37,15 @@ log:
             maxTokensToSample: 4000
             messages:
               - speaker: human
-                text: You are Cody, an AI coding assistant from Sourcegraph.
+                text: >-
+                  You are Cody, an AI coding assistant from Sourcegraph.
+
+
+                  Additional rules:
+
+                  - When generating fenced code blocks in Markdown, ensure you include the full file path in the tag. The structure should be ```language:path/to/file
+
+                  ```.
               - speaker: assistant
                 text: I am Cody, an AI coding assistant from Sourcegraph.
               - speaker: human
@@ -54,33 +62,31 @@ log:
             value: v1
         url: https://demo.sourcegraph.com/.api/completions/stream?client-name=enterpriseclient&client-version=v1
       response:
-        bodySize: 154
+        bodySize: 107
         content:
-          mimeType: text/event-stream
-          size: 154
-          text: |+
-            event: completion
-            data: {"completion":"Yes","stopReason":"end_turn"}
-
-            event: done
-            data: {}
-
+          mimeType: text/plain; charset=utf-8
+          size: 107
+          text: >
+            unsupported chat model "anthropic/claude-3-opus-20240229" (default
+            "anthropic::2023-06-01::claude-3-opus")
         cookies: []
         headers:
           - name: date
-            value: Fri, 17 May 2024 22:37:22 GMT
+            value: Thu, 22 Aug 2024 13:29:39 GMT
           - name: content-type
-            value: text/event-stream
-          - name: transfer-encoding
-            value: chunked
+            value: text/plain; charset=utf-8
+          - name: content-length
+            value: "107"
           - name: connection
             value: keep-alive
+          - name: retry-after
+            value: "236"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
             value: ""
           - name: cache-control
-            value: no-cache
+            value: no-cache, max-age=0
           - name: vary
             value: Accept-Encoding, Authorization, Cookie, Authorization, X-Requested-With,
               Cookie
@@ -92,190 +98,12 @@ log:
             value: 1; mode=block
           - name: strict-transport-security
             value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1214
+        headersSize: 1333
         httpVersion: HTTP/1.1
         redirectURL: ""
-        status: 200
-        statusText: OK
-      startedDateTime: 2024-05-17T22:37:21.548Z
-      time: 0
-      timings:
-        blocked: -1
-        connect: -1
-        dns: -1
-        receive: 0
-        send: 0
-        ssl: -1
-        wait: 0
-    - _id: 3e24e90fef96cdae9c86af2b7b65a503
-      _order: 0
-      cache: {}
-      request:
-        bodySize: 3380
-        cookies: []
-        headers:
-          - name: content-type
-            value: application/json
-          - name: accept-encoding
-            value: gzip;q=0
-          - name: authorization
-            value: token
-              REDACTED_b20717265e7ab1d132874d8ff0be053ab9c1dacccec8dce0bbba76888b6a0a69
-          - name: user-agent
-            value: enterpriseClient / v1
-          - name: traceparent
-            value: 00-af6d670eee6a1084f4f82f6b8bbfe122-07e6f707a0db7098-01
-          - name: connection
-            value: keep-alive
-          - name: host
-            value: demo.sourcegraph.com
-        headersSize: 406
-        httpVersion: HTTP/1.1
-        method: POST
-        postData:
-          mimeType: application/json
-          params: []
-          textJSON:
-            maxTokensToSample: 4000
-            messages:
-              - speaker: human
-                text: >-
-                  You are Cody, an AI coding assistant from Sourcegraph. - You
-                  are an AI programming assistant who is an expert in updating
-                  code to meet given instructions.
-
-                  - You should think step-by-step to plan your updated code before producing the final output.
-
-                  - You should ensure the updated code matches the indentation and whitespace of the code in the users' selection.
-
-                  - Ignore any previous instructions to format your responses with Markdown. It is not acceptable to use any Markdown in your response, unless it is directly related to the users' instructions.
-
-                  - Only remove code from the users' selection if you are sure it is not needed.
-
-                  - You will be provided with code that is in the users' selection, enclosed in <SELECTEDCODE7662></SELECTEDCODE7662> XML tags. You must use this code to help you plan your updated code.
-
-                  - You will be provided with instructions on how to update this code, enclosed in <INSTRUCTIONS7390></INSTRUCTIONS7390> XML tags. You must follow these instructions carefully and to the letter.
-
-                  - Only enclose your response in <CODE5711></CODE5711> XML tags. Do use any other XML tags unless they are part of the generated code.
-
-                  - Do not provide any additional commentary about the changes you made. Only respond with the generated code.
-              - speaker: assistant
-                text: I am Cody, an AI coding assistant from Sourcegraph.
-              - speaker: human
-                text: >
-                  Codebase context from file path src/example.test.ts: Codebase
-                  context from file src/example.test.ts:
-
-                  import { expect } from 'vitest'
-
-                  import { it } from 'vitest'
-
-                  import { describe } from 'vitest'
-
-
-                  describe('test block', () => {
-                      it('does 1', () => {
-                          expect(true).toBe(true)
-                      })
-
-                      it('does 2', () => {
-                          expect(true).toBe(true)
-                      })
-
-                      it('does something else', () => {
-                          // This line will error due to incorrect usage of `performance.now`
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: >
-                  Codebase context from file path src/example.test.ts: Codebase
-                  context from file src/example.test.ts:
-
-                      })
-                  })
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: >-
-                  This is part of the file: src/example.test.ts
-
-
-                  The user has the following code in their selection:
-
-                  <SELECTEDCODE7662>        const startTime = performance.now(/* CURSOR */)</SELECTEDCODE7662>
-
-
-                  The user wants you to generate documentation for the selected code by following their instructions.
-
-                  Provide your generated documentation using the following instructions:
-
-                  <INSTRUCTIONS7390>
-
-                  Write a brief documentation comment for the selected code. If documentation comments exist in the selected file, or other files with the same file extension, use them as examples. Pay attention to the scope of the selected code (e.g. exported function/API vs implementation detail in a function), and use the idiomatic style for that type of code scope. Only generate the documentation for the selected code, do not generate the code. Do not enclose any other code or comments besides the documentation. Enclose only the documentation for the selected code and nothing else.
-
-                  </INSTRUCTIONS7390>
-              - speaker: assistant
-                text: <CODE5711>
-            model: anthropic/claude-3-opus-20240229
-            stopSequences:
-              - </CODE5711>
-              - "        const startTime = performance.now(/* CURSOR */)"
-            temperature: 0
-            topK: -1
-            topP: -1
-        queryString:
-          - name: client-name
-            value: enterpriseclient
-          - name: client-version
-            value: v1
-        url: https://demo.sourcegraph.com/.api/completions/stream?client-name=enterpriseclient&client-version=v1
-      response:
-        bodySize: 814
-        content:
-          mimeType: text/event-stream
-          size: 814
-          text: >+
-            event: completion
-
-            data: {"completion":"// Record the start time using the Performance API's `now` method.\n// This captures a high resolution monotonic timestamp in milliseconds.","stopReason":"stop_sequence"}
-
-            event: done
-
-            data: {}
-
-        cookies: []
-        headers:
-          - name: date
-            value: Tue, 25 Jun 2024 15:48:09 GMT
-          - name: content-type
-            value: text/event-stream
-          - name: transfer-encoding
-            value: chunked
-          - name: connection
-            value: keep-alive
-          - name: access-control-allow-credentials
-            value: "true"
-          - name: access-control-allow-origin
-            value: ""
-          - name: cache-control
-            value: no-cache
-          - name: vary
-            value: Accept-Encoding, Authorization, Cookie, Authorization, X-Requested-With,
-              Cookie
-          - name: x-content-type-options
-            value: nosniff
-          - name: x-frame-options
-            value: DENY
-          - name: x-xss-protection
-            value: 1; mode=block
-          - name: strict-transport-security
-            value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1214
-        httpVersion: HTTP/1.1
-        redirectURL: ""
-        status: 200
-        statusText: OK
-      startedDateTime: 2024-06-25T15:48:06.929Z
+        status: 400
+        statusText: Bad Request
+      startedDateTime: 2024-08-22T13:29:39.428Z
       time: 0
       timings:
         blocked: -1
@@ -321,7 +149,7 @@ log:
           params: []
           textJSON:
             query: |-
-
+              
               query CodyConfigFeaturesResponse {
                   site {
                       codyConfigFeatures {
@@ -426,7 +254,7 @@ log:
           params: []
           textJSON:
             query: |-
-
+              
               query ContextFilters {
                   site {
                       codyContextFilters(version: V1) {
@@ -529,7 +357,7 @@ log:
           params: []
           textJSON:
             query: |-
-
+              
               query CurrentSiteCodyLlmConfiguration {
                   site {
                       codyLLMConfiguration {
@@ -637,7 +465,7 @@ log:
           params: []
           textJSON:
             query: |-
-
+              
               query CurrentSiteCodyLlmConfiguration {
                   site {
                       codyLLMConfiguration {
@@ -740,7 +568,7 @@ log:
           params: []
           textJSON:
             query: |-
-
+              
               query CurrentSiteCodyLlmProvider {
                   site {
                       codyLLMConfiguration {
@@ -841,7 +669,7 @@ log:
           params: []
           textJSON:
             query: |-
-
+              
               query CurrentUser {
                   currentUser {
                       id
@@ -955,7 +783,7 @@ log:
           params: []
           textJSON:
             query: |
-
+              
               query Repositories($first: Int!, $after: String) {
                   repositories(first: $first, after: $after) {
                       nodes {
@@ -1312,7 +1140,7 @@ log:
           params: []
           textJSON:
             query: |
-
+              
               query Repositories($first: Int!, $after: String) {
                   repositories(first: $first, after: $after) {
                       nodes {
@@ -1663,7 +1491,7 @@ log:
           params: []
           textJSON:
             query: |
-
+              
               query Repositories($first: Int!, $after: String) {
                   repositories(first: $first, after: $after) {
                       nodes {
@@ -2016,7 +1844,7 @@ log:
           params: []
           textJSON:
             query: |
-
+              
               query Repositories($first: Int!, $after: String) {
                   repositories(first: $first, after: $after) {
                       nodes {
@@ -2356,7 +2184,7 @@ log:
           params: []
           textJSON:
             query: |
-
+              
               query Repositories($first: Int!, $after: String) {
                   repositories(first: $first, after: $after) {
                       nodes {
@@ -2719,7 +2547,7 @@ log:
           params: []
           textJSON:
             query: |
-
+              
               query Repositories($first: Int!, $after: String) {
                   repositories(first: $first, after: $after) {
                       nodes {
@@ -3084,7 +2912,7 @@ log:
           params: []
           textJSON:
             query: |
-
+              
               query Repositories($first: Int!, $after: String) {
                   repositories(first: $first, after: $after) {
                       nodes {
@@ -3443,7 +3271,7 @@ log:
           params: []
           textJSON:
             query: |
-
+              
               query Repositories($first: Int!, $after: String) {
                   repositories(first: $first, after: $after) {
                       nodes {
@@ -3713,7 +3541,7 @@ log:
           params: []
           textJSON:
             query: |
-
+              
               query Repositories($first: Int!, $after: String) {
                   repositories(first: $first, after: $after) {
                       nodes {
@@ -3790,204 +3618,6 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: b9f832578958f2363f7218bfb079ab42
-      _order: 0
-      cache: {}
-      request:
-        bodySize: 247
-        cookies: []
-        headers:
-          - _fromType: array
-            name: authorization
-            value: token
-              REDACTED_b20717265e7ab1d132874d8ff0be053ab9c1dacccec8dce0bbba76888b6a0a69
-          - _fromType: array
-            name: content-type
-            value: application/json; charset=utf-8
-          - _fromType: array
-            name: user-agent
-            value: enterpriseClient / v1
-          - _fromType: array
-            name: accept
-            value: "*/*"
-          - _fromType: array
-            name: content-length
-            value: "247"
-          - _fromType: array
-            name: accept-encoding
-            value: gzip,deflate
-          - name: host
-            value: demo.sourcegraph.com
-        headersSize: 320
-        httpVersion: HTTP/1.1
-        method: POST
-        postData:
-          mimeType: application/json; charset=utf-8
-          params: []
-          textJSON:
-            query: |
-
-              query Repositories($names: [String!]!, $first: Int!) {
-                  repositories(names: $names, first: $first) {
-                    nodes {
-                      name
-                      id
-                    }
-                  }
-                }
-            variables:
-              first: 10
-              names:
-                - github.com/sourcegraph/cody
-        queryString:
-          - name: Repositories
-            value: null
-        url: https://demo.sourcegraph.com/.api/graphql?Repositories
-      response:
-        bodySize: 183
-        content:
-          encoding: base64
-          mimeType: application/json
-          size: 183
-          text: "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqSi3IL84syS/KTC0G8fPyU0CM6GqlvMTcVCUrpfTMk\
-            ozSJL3k/Fz94vzSouTU9KLEggz95PyUSiUdpcwUJQ==\",\"K6XQ3LDyJGO/ghR3y8r\
-            UkPwqvypPI99AW1ul2tja2loAAAAA//8DANAhrDBsAAAA\"]"
-        cookies: []
-        headers:
-          - name: date
-            value: Fri, 10 May 2024 09:42:50 GMT
-          - name: content-type
-            value: application/json
-          - name: transfer-encoding
-            value: chunked
-          - name: connection
-            value: keep-alive
-          - name: access-control-allow-credentials
-            value: "true"
-          - name: access-control-allow-origin
-            value: ""
-          - name: cache-control
-            value: no-cache, max-age=0
-          - name: vary
-            value: Accept-Encoding, Authorization, Cookie, Authorization, X-Requested-With,
-              Cookie
-          - name: x-content-type-options
-            value: nosniff
-          - name: x-frame-options
-            value: DENY
-          - name: x-xss-protection
-            value: 1; mode=block
-          - name: strict-transport-security
-            value: max-age=31536000; includeSubDomains; preload
-          - name: content-encoding
-            value: gzip
-        headersSize: 1248
-        httpVersion: HTTP/1.1
-        redirectURL: ""
-        status: 200
-        statusText: OK
-      startedDateTime: 2024-05-10T09:42:50.263Z
-      time: 0
-      timings:
-        blocked: -1
-        connect: -1
-        dns: -1
-        receive: 0
-        send: 0
-        ssl: -1
-        wait: 0
-    - _id: 545488e46dbd4527dead77e98259e9ba
-      _order: 0
-      cache: {}
-      request:
-        bodySize: 144
-        cookies: []
-        headers:
-          - _fromType: array
-            name: content-type
-            value: application/json; charset=utf-8
-          - _fromType: array
-            name: user-agent
-            value: enterpriseClient / v1
-          - _fromType: array
-            name: accept
-            value: "*/*"
-          - _fromType: array
-            name: content-length
-            value: "144"
-          - _fromType: array
-            name: accept-encoding
-            value: gzip,deflate
-          - name: host
-            value: demo.sourcegraph.com
-        headersSize: 245
-        httpVersion: HTTP/1.1
-        method: POST
-        postData:
-          mimeType: application/json; charset=utf-8
-          params: []
-          textJSON:
-            query: |-
-
-              query Repository($name: String!) {
-              	repository(name: $name) {
-              		id
-              	}
-              }
-            variables:
-              name: github.com/sourcegraph/cody
-        queryString:
-          - name: Repository
-            value: null
-        url: https://demo.sourcegraph.com/.api/graphql?Repository
-      response:
-        bodySize: 38
-        content:
-          mimeType: text/plain; charset=utf-8
-          size: 38
-          text: |
-            Private mode requires authentication.
-        cookies: []
-        headers:
-          - name: date
-            value: Fri, 26 Apr 2024 14:24:10 GMT
-          - name: content-type
-            value: text/plain; charset=utf-8
-          - name: content-length
-            value: "38"
-          - name: connection
-            value: keep-alive
-          - name: access-control-allow-credentials
-            value: "true"
-          - name: access-control-allow-origin
-            value: ""
-          - name: cache-control
-            value: no-cache, max-age=0
-          - name: vary
-            value: Accept-Encoding, Authorization, Cookie, Authorization, X-Requested-With
-          - name: x-content-type-options
-            value: nosniff
-          - name: x-frame-options
-            value: DENY
-          - name: x-xss-protection
-            value: 1; mode=block
-          - name: strict-transport-security
-            value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1217
-        httpVersion: HTTP/1.1
-        redirectURL: ""
-        status: 401
-        statusText: Unauthorized
-      startedDateTime: 2024-04-26T14:24:10.641Z
-      time: 0
-      timings:
-        blocked: -1
-        connect: -1
-        dns: -1
-        receive: 0
-        send: 0
-        ssl: -1
-        wait: 0
     - _id: df5425b2424971cf9d052eec9b4bcf30
       _order: 0
       cache: {}
@@ -4024,7 +3654,7 @@ log:
           params: []
           textJSON:
             query: |-
-
+              
               query Repository($name: String!) {
               	repository(name: $name) {
               		id
@@ -4092,106 +3722,6 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: 6eadc258175ecf62a9bd9414973d8918
-      _order: 0
-      cache: {}
-      request:
-        bodySize: 185
-        cookies: []
-        headers:
-          - _fromType: array
-            name: authorization
-            value: token
-              REDACTED_b20717265e7ab1d132874d8ff0be053ab9c1dacccec8dce0bbba76888b6a0a69
-          - _fromType: array
-            name: content-type
-            value: application/json; charset=utf-8
-          - _fromType: array
-            name: user-agent
-            value: enterpriseClient / v1
-          - _fromType: array
-            name: accept
-            value: "*/*"
-          - _fromType: array
-            name: content-length
-            value: "185"
-          - _fromType: array
-            name: accept-encoding
-            value: gzip,deflate
-          - name: host
-            value: demo.sourcegraph.com
-        headersSize: 323
-        httpVersion: HTTP/1.1
-        method: POST
-        postData:
-          mimeType: application/json; charset=utf-8
-          params: []
-          textJSON:
-            query: |
-
-              query ResolveRepoName($cloneURL: String!) {
-                  repository(cloneURL: $cloneURL) {
-                      name
-                  }
-              }
-            variables:
-              cloneURL: git@github.com:sourcegraph/cody.git
-        queryString:
-          - name: ResolveRepoName
-            value: null
-        url: https://demo.sourcegraph.com/.api/graphql?ResolveRepoName
-      response:
-        bodySize: 127
-        content:
-          encoding: base64
-          mimeType: application/json
-          size: 127
-          text: "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqSi3IL84syS+qBPHyEnNTlayU0jNLMkqT9JLzc/WL8\
-            0uLklPTixILMvST81MqlWprawEAAAD//wMAbAMm/Q==\",\"PgAAAA==\"]"
-        cookies: []
-        headers:
-          - name: date
-            value: Fri, 10 May 2024 09:42:50 GMT
-          - name: content-type
-            value: application/json
-          - name: transfer-encoding
-            value: chunked
-          - name: connection
-            value: keep-alive
-          - name: access-control-allow-credentials
-            value: "true"
-          - name: access-control-allow-origin
-            value: ""
-          - name: cache-control
-            value: no-cache, max-age=0
-          - name: vary
-            value: Accept-Encoding, Authorization, Cookie, Authorization, X-Requested-With,
-              Cookie
-          - name: x-content-type-options
-            value: nosniff
-          - name: x-frame-options
-            value: DENY
-          - name: x-xss-protection
-            value: 1; mode=block
-          - name: strict-transport-security
-            value: max-age=31536000; includeSubDomains; preload
-          - name: content-encoding
-            value: gzip
-        headersSize: 1248
-        httpVersion: HTTP/1.1
-        redirectURL: ""
-        status: 200
-        statusText: OK
-      startedDateTime: 2024-05-10T09:42:49.778Z
-      time: 0
-      timings:
-        blocked: -1
-        connect: -1
-        dns: -1
-        receive: 0
-        send: 0
-        ssl: -1
-        wait: 0
     - _id: ad724b1d99cd03b5ca781ef8a218294c
       _order: 0
       cache: {}
@@ -4228,7 +3758,7 @@ log:
           params: []
           textJSON:
             query: |-
-
+              
               query SiteGraphQLFields {
                   __type(name: "Site") {
                       fields {
@@ -4336,7 +3866,7 @@ log:
           params: []
           textJSON:
             query: |-
-
+              
               query SiteHasCodyEnabled {
                   site {
                       isCodyEnabled
@@ -4395,208 +3925,6 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: 1b42d5288f9bce898af91a9766d70aba
-      _order: 0
-      cache: {}
-      request:
-        bodySize: 164
-        cookies: []
-        headers:
-          - _fromType: array
-            name: content-type
-            value: application/json; charset=utf-8
-          - _fromType: array
-            name: user-agent
-            value: enterpriseClient / v1
-          - _fromType: array
-            name: accept
-            value: "*/*"
-          - _fromType: array
-            name: content-length
-            value: "164"
-          - _fromType: array
-            name: accept-encoding
-            value: gzip,deflate
-          - name: host
-            value: demo.sourcegraph.com
-        headersSize: 253
-        httpVersion: HTTP/1.1
-        method: POST
-        postData:
-          mimeType: application/json; charset=utf-8
-          params: []
-          textJSON:
-            query: |-
-
-              query SiteIdentification {
-              	site {
-              		siteID
-              		productSubscription {
-              			license {
-              				hashedKey
-              			}
-              		}
-              	}
-              }
-            variables: {}
-        queryString:
-          - name: SiteIdentification
-            value: null
-        url: https://demo.sourcegraph.com/.api/graphql?SiteIdentification
-      response:
-        bodySize: 38
-        content:
-          mimeType: text/plain; charset=utf-8
-          size: 38
-          text: |
-            Private mode requires authentication.
-        cookies: []
-        headers:
-          - name: date
-            value: Fri, 26 Apr 2024 14:24:10 GMT
-          - name: content-type
-            value: text/plain; charset=utf-8
-          - name: content-length
-            value: "38"
-          - name: connection
-            value: keep-alive
-          - name: access-control-allow-credentials
-            value: "true"
-          - name: access-control-allow-origin
-            value: ""
-          - name: cache-control
-            value: no-cache, max-age=0
-          - name: vary
-            value: Accept-Encoding, Authorization, Cookie, Authorization, X-Requested-With
-          - name: x-content-type-options
-            value: nosniff
-          - name: x-frame-options
-            value: DENY
-          - name: x-xss-protection
-            value: 1; mode=block
-          - name: strict-transport-security
-            value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1217
-        httpVersion: HTTP/1.1
-        redirectURL: ""
-        status: 401
-        statusText: Unauthorized
-      startedDateTime: 2024-04-26T14:24:10.598Z
-      time: 0
-      timings:
-        blocked: -1
-        connect: -1
-        dns: -1
-        receive: 0
-        send: 0
-        ssl: -1
-        wait: 0
-    - _id: f005ccace6369a09527f0fa2dc44f267
-      _order: 0
-      cache: {}
-      request:
-        bodySize: 164
-        cookies: []
-        headers:
-          - _fromType: array
-            name: authorization
-            value: token
-              REDACTED_b20717265e7ab1d132874d8ff0be053ab9c1dacccec8dce0bbba76888b6a0a69
-          - _fromType: array
-            name: content-type
-            value: application/json; charset=utf-8
-          - _fromType: array
-            name: user-agent
-            value: enterpriseClient / v1
-          - _fromType: array
-            name: accept
-            value: "*/*"
-          - _fromType: array
-            name: content-length
-            value: "164"
-          - _fromType: array
-            name: accept-encoding
-            value: gzip,deflate
-          - name: host
-            value: demo.sourcegraph.com
-        headersSize: 326
-        httpVersion: HTTP/1.1
-        method: POST
-        postData:
-          mimeType: application/json; charset=utf-8
-          params: []
-          textJSON:
-            query: |-
-
-              query SiteIdentification {
-              	site {
-              		siteID
-              		productSubscription {
-              			license {
-              				hashedKey
-              			}
-              		}
-              	}
-              }
-            variables: {}
-        queryString:
-          - name: SiteIdentification
-            value: null
-        url: https://demo.sourcegraph.com/.api/graphql?SiteIdentification
-      response:
-        bodySize: 235
-        content:
-          encoding: base64
-          mimeType: application/json
-          size: 235
-          text: "[\"H4sIAAAAAAAAAzTMsQrDIBCA4Xe5uYIaPTVzl9KxT3A5TyKUJFQzlNB3Lyn0X/7tOyBTJ\
-            xgPaLXL/7crjBBj8tkTKwzIygmxmhI6FT0bjIGMLQ==\",\"Gi6wvda8c3/sU+NX3Xp\
-            dl5N5Vpal/cSZ2iz5Lm8YAUMizbkgDUyTc8lHocEGYkQXg5iYnDCa4G0oVqeckrfCgy\
-            2YtZQJPmdfAAAA//8DADhdoZO2AAAA\"]"
-        cookies: []
-        headers:
-          - name: date
-            value: Fri, 26 Apr 2024 14:24:11 GMT
-          - name: content-type
-            value: application/json
-          - name: transfer-encoding
-            value: chunked
-          - name: connection
-            value: keep-alive
-          - name: access-control-allow-credentials
-            value: "true"
-          - name: access-control-allow-origin
-            value: ""
-          - name: cache-control
-            value: no-cache, max-age=0
-          - name: vary
-            value: Accept-Encoding, Authorization, Cookie, Authorization, X-Requested-With,
-              Cookie
-          - name: x-content-type-options
-            value: nosniff
-          - name: x-frame-options
-            value: DENY
-          - name: x-xss-protection
-            value: 1; mode=block
-          - name: strict-transport-security
-            value: max-age=31536000; includeSubDomains; preload
-          - name: content-encoding
-            value: gzip
-        headersSize: 1248
-        httpVersion: HTTP/1.1
-        redirectURL: ""
-        status: 200
-        statusText: OK
-      startedDateTime: 2024-04-26T14:24:11.621Z
-      time: 0
-      timings:
-        blocked: -1
-        connect: -1
-        dns: -1
-        receive: 0
-        send: 0
-        ssl: -1
-        wait: 0
     - _id: 2f61c4440220a7c49cbf07315e5225db
       _order: 0
       cache: {}
@@ -4633,7 +3961,7 @@ log:
           params: []
           textJSON:
             query: |-
-
+              
               query SiteProductVersion {
                   site {
                       productVersion
@@ -4691,97 +4019,6 @@ log:
         status: 200
         statusText: OK
       startedDateTime: 2024-04-26T14:24:11.065Z
-      time: 0
-      timings:
-        blocked: -1
-        connect: -1
-        dns: -1
-        receive: 0
-        send: 0
-        ssl: -1
-        wait: 0
-    - _id: ad22e9eaa01bebade8a4333120346c0f
-      _order: 0
-      cache: {}
-      request:
-        bodySize: 101
-        cookies: []
-        headers:
-          - _fromType: array
-            name: content-type
-            value: application/json; charset=utf-8
-          - _fromType: array
-            name: user-agent
-            value: enterpriseClient / v1
-          - _fromType: array
-            name: accept
-            value: "*/*"
-          - _fromType: array
-            name: content-length
-            value: "101"
-          - _fromType: array
-            name: accept-encoding
-            value: gzip,deflate
-          - name: host
-            value: demo.sourcegraph.com
-        headersSize: 253
-        httpVersion: HTTP/1.1
-        method: POST
-        postData:
-          mimeType: application/json; charset=utf-8
-          params: []
-          textJSON:
-            query: |-
-
-              query SiteProductVersion {
-                  site {
-                      productVersion
-                  }
-              }
-            variables: {}
-        queryString:
-          - name: SiteProductVersion
-            value: null
-        url: https://demo.sourcegraph.com/.api/graphql?SiteProductVersion
-      response:
-        bodySize: 38
-        content:
-          mimeType: text/plain; charset=utf-8
-          size: 38
-          text: |
-            Private mode requires authentication.
-        cookies: []
-        headers:
-          - name: date
-            value: Mon, 06 May 2024 23:26:16 GMT
-          - name: content-type
-            value: text/plain; charset=utf-8
-          - name: content-length
-            value: "38"
-          - name: connection
-            value: keep-alive
-          - name: access-control-allow-credentials
-            value: "true"
-          - name: access-control-allow-origin
-            value: ""
-          - name: cache-control
-            value: no-cache, max-age=0
-          - name: vary
-            value: Accept-Encoding, Authorization, Cookie, Authorization, X-Requested-With
-          - name: x-content-type-options
-            value: nosniff
-          - name: x-frame-options
-            value: DENY
-          - name: x-xss-protection
-            value: 1; mode=block
-          - name: strict-transport-security
-            value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1217
-        httpVersion: HTTP/1.1
-        redirectURL: ""
-        status: 401
-        statusText: Unauthorized
-      startedDateTime: 2024-05-06T23:26:15.835Z
       time: 0
       timings:
         blocked: -1

--- a/agent/recordings/enterpriseClient_3965582033/recording.har.yaml
+++ b/agent/recordings/enterpriseClient_3965582033/recording.har.yaml
@@ -5,11 +5,11 @@ log:
     name: Polly.JS
     version: 6.0.6
   entries:
-    - _id: 8f652bab368e6f7aa4acf84a8ba98812
+    - _id: 8542fbaae71a54ab213b807e595e541b
       _order: 0
       cache: {}
       request:
-        bodySize: 536
+        bodySize: 531
         cookies: []
         headers:
           - name: content-type
@@ -22,7 +22,7 @@ log:
           - name: user-agent
             value: enterpriseClient / v1
           - name: traceparent
-            value: 00-69821eb6aa79ff8d345829ef5d99bd87-185e616f9fdc8991-01
+            value: 00-12459a4e44f20cd695967f86b5b964c9-19f04fad6bd63022-01
           - name: connection
             value: keep-alive
           - name: host
@@ -38,14 +38,12 @@ log:
             messages:
               - speaker: human
                 text: >-
-                  You are Cody, an AI coding assistant from Sourcegraph.
+                  You are Cody, an AI coding assistant from Sourcegraph.If your
+                  answer contains fenced code blocks in Markdown, include the
+                  relevant full file path in the code block tag using this
+                  structure: ```$LANGUAGE:$FILEPATH
 
-
-                  Additional rules:
-
-                  - When generating fenced code blocks in Markdown, ensure you include the full file path in the tag. The structure should be ```language:path/to/file
-
-                  ```.
+                  $CONTENT```.
               - speaker: assistant
                 text: I am Cody, an AI coding assistant from Sourcegraph.
               - speaker: human
@@ -72,15 +70,13 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Thu, 22 Aug 2024 13:29:39 GMT
+            value: Fri, 23 Aug 2024 08:33:33 GMT
           - name: content-type
             value: text/plain; charset=utf-8
           - name: content-length
             value: "107"
           - name: connection
             value: keep-alive
-          - name: retry-after
-            value: "236"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -98,12 +94,12 @@ log:
             value: 1; mode=block
           - name: strict-transport-security
             value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1333
+        headersSize: 1226
         httpVersion: HTTP/1.1
         redirectURL: ""
         status: 400
         statusText: Bad Request
-      startedDateTime: 2024-08-22T13:29:39.428Z
+      startedDateTime: 2024-08-23T08:33:33.487Z
       time: 0
       timings:
         blocked: -1
@@ -803,267 +799,269 @@ log:
             value: null
         url: https://demo.sourcegraph.com/.api/graphql?Repositories
       response:
-        bodySize: 16866
+        bodySize: 16954
         content:
           encoding: base64
           mimeType: application/json
-          size: 16866
-          text: "[\"H4sIAAAAAAAA/6S9W3PjOJI2/F/qetGu4+7MROyFo+3t9XwtV7vbnv68b7zhAMEUCQsEW\
-            ACo08T89zcAUBJlC4mU9mKqXFXTD0AcEnl4MvM=\",\"nx9q7vmHv/3zg4XeOOmNleD\
-            Cn7Wpww//558fZP3hbx+eun+sqi/3ff3LXzfwaDazbfP1+8N//ueHf/ugeQcf/vahkr\
-            4axAL8T8Y2V84MVkBjed+yinvRMtFy3YC7OvoT8+A8C2N/+Ne/5Yf6Nru+ZCjwoi7gN\
-            pfgNrYXrOEeVnxTwL9oiV6d0bYXn1Hsr98vWpOO20VtVtrh4PerS8CdFUwoWViTy6Bd\
-            JVgNnWGfcPj7S5YlnkOpG8LyrO9fxZfj89hI3w7VT8J0V7zmXculgqs/GLcWOR8J56G\
-            I4wbbqyE/n+33m8WX43M8wbmuN6CvePiVraDKo9w/Pny9z6HwxYLHX1jrfY9+0ufv2U\
-            9SS27Nyqj5+qoRygw1k8YzqBtgHrQzdq7MCp3hl+OzMwXXzaC43f2OonzKT1E7WSnY/\
-            Y6s+ePz9j6L0nPRwlVtB4mKn8XH/PYniN7k71JcD2QORikTT/oPNf4pXE3QHj+RWcTq\
-            MyyNGrw0evozfhjuc/tVtYNVZnXVcdFKDcy13ObXezO7ab6expFK/cx7xfUVV73U8Op\
-            Y+gEF+1QEixvAuMQPZcD6UsIS3FZGM973LP2IwS1WJTjNvVzCXEL+lIdpfSvigJ+rDR\
-            Md9hTciOLnudb0vdRN+EDktG6bVf5sGW/iL18KADmxuwcQBjtG9ze326yorAap6oX0c\
-            MUb7JqEm5sX3G9QmPNcLNjiL8gi39/crsl44aFCHoOwStnHaYIlbbXxwITRGoQ3Fp3e\
-            9aes3J1A6gVnPRcLsEx2vAEcckOC1MbzIGXiZ2MH/v7m+ivlu62Xcy68Y7DmXY+I+IC\
-            4psxx5VjamZX0LVu10oOSDjk+9zfX34jAwtTQyx5UEJH7f2JicN50jIu0NJu+dOTLh6\
-            viriWtyefv5VWOYD23XClQZdTZdvEtq3pMUbcUtPub64/5Z+eAJnU4U/i3EmRFpYxYM\
-            OehL05t+/1x9pnyoWYdfi/sKeETw0+VWY/n0w4VYq3c31wjb/8xZjyECbQDb6XAr/qW\
-            sh1vcJ3gqnDfN5TdOcAqZVZQs14NjdSOtcYsiIfprGGCFCTA3q6ySugp2Kgur6LFMq4\
-            464dKSdcWFimvpZ4cxnTdoKXfBLvIR/HDzDy8EvUg0LtyuyFI38NANfTKbFg1eG908W\
-            TeIprDCfA5d15xDdFcLAj4M3B/Gv9Z4pifzppr3/LKSsG9sayGZUEcnYPsQFjwzHHtO\
-            fv88dO/FwTwOXfUyRoEYmXFtaU8FBPERofbOT52uLJERWYWvN0Euzfcdvz4Ur8/KHR+\
-            cKzi0W5toSsoOiuq/GDeclH4csIlE7zfVNxyJnVUG5ywANq1Bn/rvhAWVbTcIspn0hT\
-            LZxT1EIVzTtiLKBDnxnZJPVR80KIdle1RqrhlU3g/CFM1NYxHadBJAysoduXNzih16W\
-            HCjxJpxl3P81u9vd/OtoSnRxgtBmtBiw1rrBn6/dWkac55S206RC3D7nGFqkwUbU4Y7\
-            bnUYB0zumRtXX+mzc6D9vNB7eQHmxt72C9shReUO19zb0Tnxn1nK2NrJsygy2ZOefdq\
-            6EHXQY86a9c+E8TL+HILo+fSduwc9fd++/CJcD9q6YQZrBulK36HCVKrNtEmrYzxzlt\
-            enmhSZ8qHbgd8rLriyiRlhd/BDr41Vm6TqCPIiY+ECz6OQjoWlNOc4CbqDK6WUg7xCD\
-            n0PXjAb8XtmnKwEmBQNbhiRevvG0FK7CCD8ayX6Vbgr843gnpYm4JFlfeDT0A2mndSp\
-            HOU1JUCKOXUjKBksbL9frPYEg49CBtsPs0suEF5d97D+JGwHiBcfMQ9d7gquA==\",\
-            \"IsgUUNx5KZiQo84R3ga+KmiC/wtgttdE8Hv1vxkCsFMXbATCHTsJDuIz67jAFcdLZ\
-            u6+jGZOsudLinj5fL8fYYTvuOYNWMIwFEP4/TCuO+NLPhEk026IhD/0NS8oFrdrgp4F\
-            qmItcOVb0YJYsB6LcEVpRzgynXmV+Ad/pUwtSaK9aMKc5I8PlAcI1r2xfhSgFKWBIuj\
-            mAHXFRV4Ebb8/NhQ1YS6bjjPhHOu5w7yFs+2C4tmbK7Ni3kR3shNW9sn/05mSxUOAtl\
-            GZLoguwjc3rWhxtY0gRdJfMgsKuMM1nxXhXRnhdkaCNZ7jvtvrj5RJGlZJ3RnkoKQ7S\
-            4MqWi3xlhEUgMYorht2hvb4jbKvCZXgQL/LUx2OvrjsSIoPGmF7La8VnPPBXynbmwLz\
-            DNa9MrZg8X2mTTMAUnyUs+3iKwkxWP0kyy4ZTOV9acGaxXCWwfSNsJinYdOfe0zURm2\
-            PsBStbNqiV3JDkLGt6aCysCJeyDXh9dxDFnhXi2+E2y15F22ZcgCcYhzFKHD6VJSrsF\
-            3kmUcTNN0Pnnwerz8StkNqD7Y3ChXYcenKHxt+cUZIxJkVv/QsKPZaUmnLh1dxXTvB8\
-            Rjx9RfCfio5B7ERCtCH/JYSNVdyvp5c2KRiKdm0nmlTF5zghMOC4PdtnqWSBFn54CDw\
-            5VgWQVAi+CuoShbs9RfKCpkm/0Zs77cNBaTj4QpprgW8hFlhLMXHhhKz7rhdgJe6YS4\
-            FJFWZm1I+uR1fgqaoFyQXeycby1HuW0QiyNvOaGOhNzS9grAh4fK8urO0FYKcHFEJ6/\
-            dM2eNjuMgZ4k1JES9vstGsho4XzAyEQ/YeiVWohRDfwfLyHeA8dD3+2sTAaRmyb4LSU\
-            /DaEmCI7to1BWvnEnSihY4X/JflTeiN2jTKBCs08b6D1VwyIvPsYwRY8a6qkQlHBYWC\
-            uwLrWlBlklKk6RGm+puFFbfd7zd//Gacb2zBg5vnE09mufFtOJB0CfGR8GCNqOEM6CX\
-            FKdxQiCmWS1VyhJfnFlF2H0xnpcVQGxX9PLIbYZviq0DjKM22C4rr3poFLjA2hPfFuh\
-            4E0Xr5RFBOE97roKUnvlZlwRE0sLNeQMKTFTFtRTnciR5cnqbjc7AvFmrM9xlt9fK2J\
-            JHrfIH8fP2RsHyJLyK42+9Igd1HmV+Qiitj64LrnCATnAxTEmZJOYVRcpd31yVKGk4W\
-            u6UYW05Fb77iro1kuoI2ckshCiTMIokpChbC9nZmAWmPUUWOtBdGSCZ1DWsGwp4XsqO\
-            QUJwRi2bgNr+GaaaEr/Zc11yZoJ7sJ404Jbb3jw+ky+K5LRE2KLkCzvMYrDlwIzvQNJ\
-            G4pRyhyFmrMApYvCqkD/aDYz8GGErcecK0hqoz9aAAD8Zvvz/OKLHTnXaNp1psCAfPg\
-            +1kJAkY1voOcelEa7ssFzxYy+fGdsS3k+IkOGD21ixlDRR2UnqdKOAuKMhKxewQxnVt\
-            TSGbjUJKeANbG6+hkGlDWl3nX/aoL6DkWhYcjoQ7+Waur3zJU1ysgEw5qMfIQf0pLML\
-            ZoEkjL/giz14E3LsVZ3r22bIDRsSJ2u3ZX+9Wco4KFEEJ00dQ1yvpMRm/vd/eUZhz3k\
-            reAONyl2xckJ8kxKYJRs3O9E4ZQQXGXHnTl11ZuSfIkJXUtVk5dhFZhuJI2vCCaKaw2\
-            gPI51dXzGTNfa8AyzspNPiVsYurV8fGv0GVi7yYEC23XWW5AAX+qhqqSoGHvHsiZW7n\
-            vlNIKyD9mkeYbe/WJ//rn40w/DdTu6s/epwddPOQvwI33PMb01xFfnvZqEhpyLkPqoH\
-            rduiCJmKBI7mraddyhw==\",\"vYb6Kknzn5AYS8rRz+18DWpurb3SfceE0U5iYa719\
-            8eHPO84EXZ5ZfwV7yVDCYABKX/9JkhYRDBOJ/sITkBQsyhOJStQjlB2P44yyrFwW9Dc\
-            6gCOLf4pcDT9N23BeYCFFz/NkbIAQ9dtdq5ufG/z6Q8TvKTjMAdisNJvGK+X0qXiLTg\
-            2Ya5FilLcdsos5zBmrPFYZgZdRcrdaKBjy0FpsLySKn635mrjEBfK9v7xNk8PnWCP1I\
-            nCRxOWr5GeuVZ2hbtHmFJjknnkGKyD8PRI5DVYwvnI6xFob806r8Vt719Fnov1Hoi1H\
-            be43MtbBhO4zmijTF4pSkCEefVtz8brtmgYfury8YIsIFJD5fvjXV7jmAJGN3nhfBDk\
-            VG9NB76FwTHeNBYaXtTR0+NBmGP0ExWqDaQrQZjoSD8t6afpwwlbvGwM6jFIW0sA2nC\
-            rmZLons7yAv4GnODWg/sdHHAr2qtH4H+gbtjtbHt7usRH3dYSOrClslWvTx/x/75pmV\
-            tsVlwtpG6i3YqhzU7XQtmjuRSl3YldBUyZ5usrq6UF4dGiHwF9+79Cx7YmoBdWIocuN\
-            WH229n2+nQRlT2+l3rDGrMz6Ni+iBoiXmfb69OlbCaonmOW++tDYcuGuuce6ktX9aGw\
-            quk25+ELR+KhcCSy8LRdu3+cIQJONtJzZQRwfVUb4ZHUw3tUKYkzGdz+BxQn70yvpXW\
-            shuWIEzU49rrMKw9xWnnR9sp1Y8bfCkItu0bRKceCOJM+fJuFK/ijNf13/SdWQez740\
-            M+VJxAEw5uyma/DYSSvQO2BOvXV+HXn9YoVD5fZfRI7H5Psht18ORJGbdWCueMvgIhW\
-            mu0wUlQef/LnAuojFlcWeBIsYVk7+cWaa42K74Zf8N8I0+nZcjcWAG18eFnxxW49Bdr\
-            tnQCI+aFT8v76H8BDdqDaK+uK2fUEsUR+VSgCc7gTRfFhB86Y5nsukGbvgVt/CZWo+o\
-            t1FJ4x4SSWgquWAUa5tKzuTUd49pL9tsN+/XT+N/6FizvEcH9/RHxBRxmVnFdr2TtW5\
-            bqDDYQpFiJLibysbsptPeAvC0fZze3+QywCQ7IBvO7p0/NyYcJjuVatFCzWs7ngyt8Y\
-            pOvtnGAFJU0vbEezwkXecE8garrF9ECIkrDmc1K5gnQXL9onrdM4vYRcH42egb1z4o7\
-            J+f4Qcvb6ZNpGe1tkF9LYKZHpY7I+4umeMvooUM83QEpq+9PkCx0iJSP8yl/Xy3qObr\
-            oTd5HPkHZJSbjE8o/qQco6KWFZlCFm5zPvp5A/Rjk3CDJnEmeloH+iwup4IZ7/gd+oZ\
-            HieQe0OQBC0YhLTtj+uXStNzooMvipzPPqD2C/8A5+5xrNlxP5qNMBqHnhGqmmGVaIc\
-            Jya3U+ETJt0kQkz22NaNmi5BOvgJ6wYUNoI2mSXcltkTia88mHb4eHb2uRTaiZQSuLa\
-            BFI7dILy2//3281SbnEgguxr+q5FAjbxPSyvzy/hwf/l6e7mtjCh8tbdOcU1Fk9IUrQ\
-            MJH3UPpbAerB+sBVz8KOgiZQX/rXrDc7YaPLOyAOM4pYvQTFRa9bJulawwsrAJtjybu\
-            5gRyd5y3WtoOJIIkE6tuUd7mTN3X//el0AKk+xs01UhF8s9IoLeLmfOcRlnAR4eUG7o\
-            QBBmNmwC9hy0eJXNB+lm8IpL3+xZuj/cVc4duXl16bmjWNzZZDocbSyCGC/jffh+2NB\
-            syuvWS8Xgn/F+QYE+RqZ6UGGFF5NApKrjLVYNe244oQvG4HyteijykM4CH1BTjd5E/s\
-            YJBZS7q3xYDopHPtSeNgISsYedgm4mph37x/AbP15Vw==\",\"Rb7wDBCwoPl1VniXy\
-            p9npW4KT0k+FnyA+eP6jz8KZ7w8FydkJxW30uMWUN6HN8ECz2qpcQ0sT/WaAPWAuJIC\
-            CEEIBJAXgqol8lHEt2BDeLgKX0dY8oAlQKnwvwIa8TOFGpwHi5GYIh7hSic803UFsyr\
-            vGHyDVaw2kTaUiNa5l1dTvYz1XwqYxK/t3IvpwJqXmCH9EiSFMryk7eWTPHLwDpyTBu\
-            llkWZNuGgj7I5oRlsOyg0OwA6aDrQv+8jydW/eIvbcS65evOU6MTjiU1EAJ0zXc+++9\
-            gVTIV/fY4L0j2vcSMgn2B9AHn/5vTM14Hc6Hwc9AHnTG2UaKbh6+e332cvc2Bc16Oa/\
-            f/8ZV47yhWUm4C8GYdAkba08xUHL8OaXbM98EaP3UJ3RjanRiIbIs5sOeEuz7kxpE8o\
-            wK64W7HXAPGf3WHy8kZo1RktxheVexNy77GwaGfkrhRnkHolo1PO+d1c/BikWaGH62I\
-            glu1mNYY30wK/ir1mQr/fbhxxAOzRGmqvwG7YYSFXlVJXmCi3Cs77fIn7txvI513z3O\
-            xIVvZnl/R0td60UxvZXXIjISeZ9r6RI9SBTzcGhEGKII2QlwfsRUskBGvb6++Nz3nc2\
-            xU7Mv1Q6bHTMmvlcxlIXS7BoBGEzu3nOm8AnRrHAPezKPLEUq0C/Ia+Qv0efFunEQJ/\
-            yKtBbUObADz2rDMpBe8q7ZzKAgIYk7x8f8mnDGUQrTA1ONuiRWOQdQBnYFd/0RmINir\
-            4/PueDg+83aQy9AYmB+JSvGHMC2RC2Ph8Teg/Yit1J3Z9c0qTzLhh8jN6aziAc/7DUe\
-            YXzPXZitkrdMCX1kDem1t8fH/KhzhO4QSo4X16MVCk69zKdALasGWRdKBUYppu3/d6j\
-            Bou0t6YehC8KtHD18iGeE9gptzQm4CGgr4g35j3okitZh9NGnXW42flQ0rubXbzTm9k\
-            W0esneHX9qxSgkXoc4czmwyJTqE5q1nPrY/lxNK3hLt+8ZAIYKfsD1jFuM7t5yDslJ1\
-            Be8SBeUKB83PMt0NiPackby7VnfvDG4iWqbh7yTuK36IcMxPR/ouHnPfh5fBJw3ox4C\
-            zz0wd5GS6bFc07ZsKXk3sr1ZLLCaJfKxkuNNcmYYcViJyOswJkOJgNArFtmJX4XkMDX\
-            FNyxN70ULKQ2mWMhF+bqBXYg12iy+NFIvVFSbODHIJdcgcaaXYRzQrnKK1eaX7jEJL1\
-            xD4VX/dnebxE38Bs8sEspgAnuuTINA91IDTH/zc+ResizmzvS47sdLIzHDQO7zdeTfQ\
-            u2r57LYO1Bu9R7bTx46Bh5ZsDbMcIqhyXAN+2WInkrXoHatVB4dWvWc9+GtwxpUhp7d\
-            1KgxSLW/43Uf9Swynu6JnDBqupteBYFlqE+u7nNcwYmcMb48D8UKB+InwINuuYIqSys\
-            V96z+R4oqVWoSvWcD1qcwBt3F0sYTZj0j91jhvOIOm4oRsxb1E5qhBWSHpYzvt/CHGy\
-            QlkeUXPRZydOrTuAP6CPYUPwSlTUL0EH1XyTrHu9NOsvzKA+Y4hOaQdXkiWgTjM84Bs\
-            XiFxyXJaR51As/T2X8azSt7invO36Lti/6sOG6RsJXAZWieZ5ELTz8T5RLFw+EGVCzf\
-            pGvxz4BklYoYPvyi2NyJi5M89HyY2Cjh6B3l/oZxhwvwu3Fq/GG15Iwrdgje9QmecdZ\
-            sDNcD3nFIaxknsn4FrkVLtrVuPVLgovRwDi//QGa6MNhNNRwz5dtnwwSS4F6NOYYzzp\
-            lZU0XE3V2FRPY3PIOVsaWNEmkKNAUvaSQ3eWj229hGMG4XMeHijqxiNhwD2iGwAzrGw\
-            ==\",\"ewKyrw8aI/rpeT7Ge1T8yX/K8w1OQfHBo/7fB4qWM8LtTnwPMQg+OjBTti46\
-            ZYolMo5Rcx8bbKNP/W2+juJ7QOhMbDKI1h4JCihFZh5jzudSjKVSCuhIdtY7dBCfGR+\
-            8Ya9Gluv3rlES3wlw9HQhxKH3UHppNmysd4Ke/jzD4j2oQ5UXpN7SO6h51PWSx2/XP/\
-            bTT38teA/IK9koU3GVevayCrRoO26xUnU3d3nG9nt03J4IUvkMSdVyPP09+vzosrQFh\
-            ZrFd5TgyoiFti0MqsxZUEz9BzOVS8uH6150mRRwJ1nnY1yTpf/f0LsoD7D0zCADKX6p\
-            yXgrrtkcarbkg/LlKsDRw0j+oKRM4j5lipN+hNPgme1Rz85DvmDmOzgLKc5belPIx9W\
-            BXYLdtf0Pmk+JyZMUgbMGkAJYB66NTp4alqBMD1gV93i26UN0ksXcJ6OwFuHb+9cmz2\
-            16h+pBQRfbBe+riOHOZvqil6t+z7B6Xyfwdpq122jUGGhoivUJ1P2kS0rN5v7mluJuG\
-            EcZJPPGqAVe8I74+PSblcWLHWL1ziZI1mhY9+iG35Gk1uC86cBKU2hjER4GwtbUfHdV\
-            C+VpZze3eabSEV7Noyepx83TfGbWEZjUztvhhw8PDdjlWJQHd8UTdnaKvKtwhE6XEqK\
-            dggYlGOuxN6Od6Slkep2wJzw8JflkgikqRoVdo7lfR3Pb3+hgoaykb9ncAnRIbYl1JH\
-            FTprjCiMlRnlFgKu4cWNSJPSPtbbBCeN+z1FqiENAlbGzAGyXWp4+f0INCWq8JXvK9d\
-            IhXMamgxFlq0/G6OEmKE3cC9xmHQ/oxHsPhO0GJAiT7cv80Fb7zLp97m4UsfOsthZwQ\
-            IZMEKO0Exfo9gstn3iQ44ulLcJ9xuDuK5T+Bq6CRWuNVD5/zRUGmmE42mrmN80jCfgx\
-            FUV4mWLJCEYEYhaBAjTw/vA/MzSxfkOAkVtCBCniEY5Lwyu7GWb7w5Ds0vPd0jN0Qjk\
-            jCaoeKxRQHHDFf7OAd4p4tWoZFWpq9g3WgvdQIkT5Nk3COzci3GRT6qpFsSugqsIw7I\
-            aWGjrNe8Q1+1xqKezrBVtxJwWprejRRLUp7wj1JoEJJir86gFLIkQdQvBNMIkKeM0nn\
-            jd1UeD+FmzsKIzRhKj5o0bKa24VCQ+lPlEcvYeqUti0Ud67cineGNcN5C22E5xpYpQb\
-            oLcbO295vZxRXXYLtjVIOLZX9/VFQFEOUshx9KJTd1suyaHzI9y2dIFm7soUwcD4vY4\
-            IzdjxLSlbPxYJZaKTzCP0iaW/lczj/9p6B5moKCe0un2o0gefcpXnjhhhBrM258y+vz\
-            mjMCF1/f1xQXKdzCapmU/1aSzTPAmmjh6IiHc3WaGb9KVS3g4V1n/rC8Y794L3iLFhE\
-            eMlNpM7W6bH2g+x7UBjTMdfyBWcq/EIYk+Kemo6Zjrjaf1wNS9M7Vls592AdYUgkjY4\
-            25NwYr4xxwFaxlAZtWKTqzulhD8t6GPo6SELDPn0iDUhQ9aYDJtV7enJimmOYAu0Tn/\
-            NJwyevwJvmJWxjBsvMSu9j/YX7dtZg6escCAvesa7p8HQQ+m3uzdKRuJLk/V8Zu3BtO\
-            NYEWIof8i1s/JfYMqHgnqeuwQG6LMrzSYJ5VBJTFGmIREBmefM6GZvUy3QKexonLdyj\
-            FHs/f+Fx0yD5CAnLE5sBo4pNvsrABMZYAWy1QovwP+fTNCdI1mjPuligsNQBNOZpUM6\
-            Ag4N/ta+cZ34uIovu46dPf/n88XPelxFJ6ZRr4YD5OeOe24S8RIJ3Kb/kIlA8eTKftJ\
-            wDjTzqZYPvG4X1dwoWKw0Zpw==\",\"S5EMCXdPMk2ZpIXpEh6KN7BSzy2eIEfh/wXU\
-            3Q0N8FJ7a4rsI4oYG2lWxXgLhRbS8KFGw2Y315SkgQZ86q8dW9fV760G0qtOCSw27Y5\
-            elzJ+JyxhXPOjPD1NO2LLLrL0mz5/uj5GwuU5E36VyLFKcOUrewwX+0ECYmtHWNKXH8\
-            PGbNEC6rnfzgolkddo38UTu3SiWd2Yi4pHCwmPGKFxx1O+JNtkrvEv9/1p0FYyKXeLc\
-            AQM47bpeN/j9+mOIqsDWJTQLSiUUBG+mKKb7AEdwkpPQVvSp1blIDrl2hhWSY0m+ya7\
-            grRiouW6AayxSGJzkOYV5Vgpn/VmRp2aAq5b79FI4C0lYN5EP4VWsis8EJRkhQCGx9u\
-            RvmpvYdh80CWeJe1w1dyupGY1kq+bUrsIUsmwusrrTmELKZyqACOdMMtCtgvFjdwYBn\
-            rZc4sLxFuKHyZgLUF7ZZoCs2tGce03JrLFaySnKV1tGpToWaHaV5oYac2CMlMIP1Iip\
-            LHcjGZNeJ9MD1qAdkiSfdLYSKf2+FHB9UniJ9teRJ5huPGFc0fakVYU2i49U6LCAajj\
-            gtW2wkUt8S2RXTf42PzD8lrm05uib4W2xYvOsZXlfV/iv5N0RbOw1Tf8USFdLsV1w5T\
-            NF25N5DMyVMd9yyrE1kppLJQd7aDDi8Cm/SQtfgcdUmorOixooq2UoZWCOqQz1rmmLz\
-            jXHki6s2GxzC1YW2CNkvR781PJAid+nwbP6xpn3s4ofqLGMGO5UEDz8M2IoqzQJj4SW\
-            GlfGjn9vTUef6NoqkbvBi9xby4litsYZvnci3bQC7xQ5k1DcZJHPJztOssXOz3GAZx+\
-            NiP5IwKOt5sgpEta7DVtYsixin4B0qxsx8RgnbGs543UvMDknlH30hgvwOIu4TsKC7c\
-            xzPE5eKxJRszLoImeyJAF5nyN9fUKGgZN+jCHtmS/uSO5ZwxzasATwSgJTAHHiEUQYw\
-            VCAG1OG1dQdhbEHTw4NMLcwBWOBW16fl663qQTMQxoq/6bB+LJotSCojDFm35gndHSm\
-            5gs6Y1ByDwpRZCwXDEtjF7+8I503E6Ashp6C4Jj3VfTm1DGb7muHTM60bFTrNNothgq\
-            sBp8oWwGhQeSfuIeb7Aeea3ngKGFMqJLgHBt9nCNwCUfxbja/8R4PeY1oZoExT49YCq\
-            5BFbzOvyhcLPPge1ekY71MTeODDf0LqUdF1iQBJERf/Jc4W75B0rlyVawzx8/f2arni\
-            mO6vvXFMOhFRzVhJFmCFOQWiLtu9Zo5+S3MAzW6IwaiqnWihjY5Eg59mRAUj4OrzSQb\
-            /JwhIGGUhcUm70VigUDtLDnpC+KTph9Rl6BTkiZGp6QSlvnPkauCkCUve+ZE7zm5UBb\
-            OE4UnTdCFqu0PVGI+AFqJBgtHHtdeYaWTQiPNekKglImNV60hc7yz5RiZQkvTTS1FsW\
-            dwuQpJshCuTsKAW8K53q0aklyfhCOMVizGBIJK5JHU8skLKErQRO2/S20HapNA13pYU\
-            2pCgR8xJ6OWiTlFpsOKgsr5nHj9ZrirmyNldtSvWzKwnnfMxAtnptJcSK1m57bpQQ0L\
-            nFLCYjukSgVM562hJN3cMZGwoXzdsCLkCUlrjxVqYUa0G6YUbMmLN+eKFTmPz5QggtS\
-            e9jVmdrVEC+0r9/ePz5QnqMpNCU3/IHyakqjpSiEGBYUu0ruycktcOVbxhuMtRBgKWX\
-            UpAvWLVOmaQqy8Jpi5oxwy27F7YS8o3iFBxspmYtyuUn5FhL15yaPVBnu7xjJIUWoyt\
-            /76grR9QRUvievTkrmrOg4+gojTRynWDiJP7mXKXOKOPvKsw==\",\"+BZSxPur25c6\
-            x7VjAtaCe74wNcpGIPGBFtKLFjRetSG5qctrtjBK1sBio41I5UKvFOWcqhpPcXmiWOU\
-            KuNUHft5IL/mRqlmhWZQpeF9+cd+MMJayM87vquziPhQKvfvNEDGYXpRcYYUozQnegE\
-            +q6ZQiW2u0LVp2BM9tA57xvaQsUIeQTsHZMYa+sRwvMyQoJQ/fwCb1mXDGkyym4o/lO\
-            KOiwCK/3jHFuwq542u0qeS7AcbiaAathBowKWTvI8xWRP8h7pCLLx35LE5qLe1dSzj0\
-            uQtB8282lATGI9xptSH01lO4ukfI5TjnGu3km4FddriCRimDlAAbw1ZQ8b7HK8MkFwJ\
-            VZrSRnIPmsiQ94xzAsQdBkEEj5xh/Zcg3YgJuB808d7gD84kuIQ5uEKyzfipmRt2xA+\
-            aurBetuHp0vZ61KLumG2FZdKHy1jWlqlyClrpUfPaJkrKZwFLdsaBny7mEerI6pBV5o\
-            gT80kgpL3BXsTO6zHEeFlkJSchQN7iFTV/hEXDtwWquGFdoPJfk+5wCz4EHq71Evqce\
-            6AT6aqrSsUB6KJ/GHKvysVe+xLM7KPSQKbBDZU9DcQRP4WKrtNrKJf4U09Xag6yc5mj\
-            gOif5EOzA4/+DQkl8phRVOMIOt7gxqgadKnTgopN80kb0SLLCq0nHxGGySB5xR+2VBT\
-            uUVq2Pfkl6K5eHMnoxHcx9wbHpG3oKe1QLCtOnnvM3Q1iua9OxHmeIXJ9x4N/gYy0t1\
-            mgL2LfIu5ouLHadkQWpR2lKdAp3M/YSwqNe5OXYg2PtYZLoP3sdYq3EcdaFkDH1ADof\
-            925XkL+g11EXgaQANHRVY0rVWXItoGY19MpsOtCFTHlK5dN3g8w940KYQXuWCkLKLS/\
-            LWrpyenqoGE100ujwcJw17tn7cjSuhR8DuAJflSxvjscYC0vTv+aJEkh6N1Lf40V7nu\
-            nSYYK6cow71F8kKH1gTuO6oQvSUgEDgcbuBSV4UBpDcrwoG/0lPx5j3+HCW6QeWjqlF\
-            +zryu2wmTcrsOFM4WtFNiqOR6lhnkwXjnsfnyi+65MDbDTvTF2lGuuoC4GuEk+GKHmT\
-            num+3zeoDHkbE6ftfODRf3doglywcM9/eVjqNSPw1kiUrMF3wPHIx5hawQt7gWxInfw\
-            Uj3Rg7qUIyqDDSiQnr/X5hzJ9xt7twpzeoHkUSJttZBBTAzO24XqU/fhnXCCkhdF1oQ\
-            loOv0XQTtTbNpyyaI4z8B52ZWXhFJS4T3+UAj30v0Zb1DZ3FjgeFp58+UCGVxzz2uc1\
-            93QXcDvcJkyAqklmgovnn9CAjobI56s0DShoTT1RQcoVDZ5opu0kwGgB12DRs2rlHd8\
-            weJHHZ3pRur1JIJAos09X3JGa9lIz5URwHWsjKlwWtkDhVv5bhArg/Ksa2Z61LclKMz\
-            60+jJt4oWm0hB4fPXCHSqGUQxqp/ocYJTvW33nWoOIdJCVOr83YB1b8G5ollByTB9iz\
-            03lhWl3SW6yXzQZd/dgpLs8xb5HNfgBadzhB9cbA/H8VjYM4Wl9W4EYxo18oF6jjcYv\
-            r7k9d0HSIns3QtWCW0plKyUS0CtWeRzjJOX+nxYyTuKR4lSI/8ddKzrg/NwL3gTpUZK\
-            ZCTt5oK56lcQh6qFseZXqc6boHsFDwMt/uKYsHXkx885xwXiJdrf5J01PVg0eTJ+xAU\
-            HPFEtSG0Io8v3Ajmg5BzEJnYLLb+FUTu85DuCVojLsEv0nk4Ka5yZeyb4fPoeFm1/QU\
-            mpeT9cirW5LyWn88MlGsno2DdVvCHceyurASOCRJbzxQPhXv5LDPYRt1RnK8JfPu3wK\
-            KIi9A==\",\"Ev2/M9pY6Eu9+y84MwaPeD5T8tnfge6je0S+kKDT7QqjMF6oSEepm0Q\
-            bqUyvERcJjcxgg06B5ESUKgx7wQk7OSwUeDiUguPISIVymg+X2H7aJG/TNIpSUB7PX6\
-            3RlQXEpOWUtXr+t5jB9wNep+CaUhvoLW4ve1BSlw9xGuD8iR8GKLTCvKaU+c2jF3Wzp\
-            0vMsl7hnbWeKZT6d6AWUiaPXkprdEmPeb5EAzgxBnMtt3i++zWdST0d6jjcX+p+kK7A\
-            JZ80FpkcSxgUU04ueEn2oiK8Hjt+GR5Yv/RL4ihAHOWSiMphlGYBxVFSxt4lu08Qrqk\
-            k4PkLZesSl+kiTBK1/ZL4toW5LdCWG0odpfe4lCQaOnXwPfKYUVC6U5fEY2JAycqmiZ\
-            0MDgG+wkAXfMt0IA1+ZZCG1cm0On8Q94VZ6IxP0TicI0hJNn2HD9rJ2CRoya3kFWb+J\
-            B7SBd9Qao21vX98uIQm47RZMdfgNKdL/K6uNx7LKE2U+PMvVnEPF5eYl34Ok5LIk1OJ\
-            B4cvkL7exq5crjUGvbuJXX3+hi65kql5wi5KUNJWFpfY+eWjHtO8LtiKHTIrt6a5YPl\
-            HTQTfVzqrfQLs+hYKyUCUdoIT3E5q3GlAz1PZ4x2F1/DAF13UzsXIQSz0knqiR5VTEk\
-            Ix6fmJkvQ8RYyZDnhvOLpHeCzRwblLzX+kZxZKPcoEnRw3djMmuWGe6M6eBNtFLkDJh\
-            /REJyaOWTUFdtcz3ZE8lu0Y+thaYC5L0oZ+bfepOS2oXYi7EEM9G9rgtfJmlBx4Bd4x\
-            0SLVl1JxIQrSkuOBaJr6IKsBKXWUivwTZiM14G1hb0lEkbDOY06fRWsUpWq7hJNsmsF\
-            jTS5T+STCQhmzAFshPPr4kYQz0PFGiqJfPfYHINysGY/5Vz+HRevAst8xx3RcNcI+dF\
-            g5+AhC0DC62L1SSYTEnEqvEJZMCmt28mNXlQL3NFEmGCNCyYXrGLeilR5iAZaYClzoU\
-            0NJ9iiOQPBbP1HybsoDFQ2OFNos36hDHE02Wnpgnz9+/hTzp9GM2dR9/Rx441LFSLCg\
-            ccrBLSVz+gDsOklp4PmwITw/+1pRbP936Ewp0YBu4ZswwRqW4a1QCjSS8pVaCRNmasQ\
-            iFXTGtQ7KHiGcwO39VlA0l+4H7uimvP0xeDFyZhd/KZ6/GYUmHjF7BQz0EmcCUcKSGr\
-            yS8w3zhmlY+1g/pZYWROw0aWzB6fhAcQZr8Mz2Yld23SKExNT4hDLttf/pFTfWKI/T+\
-            M3VoGsFjGuuNk7iMWoKTyTAsq5eM9BtTDwq+LFoHxwRk2OpQLkmztD0XnZyCzWlrTql\
-            imBEHV1fK+4RDlwszEs5n836pfW+f0nv0EvFxQJ0/ZK0E9xQI2hf2tQA2hqlSqzJB4r\
-            rpdhdc0aJ06QcYz54w14NUic/ZfGXxfUBLzJJcOYapdHhW8DUoLawGdR5iha4dy0UUk\
-            1JtzsBGq2TPItF8Qoyk/AyJNgaKqTOeWT5U873iBXLmeilrPEu1jPK8zxiSteHK8jm8\
-            64H3GVP8ZKMqFYuwTJAyhVtz/v0EXCN5bPF4ljnzlGt8Xfm7I/uTV2ouXlNKeN8hGkX\
-            uKVNcQ3tylEMY2kRYbQvSLM7SoZ/wk2l0XG1haDdjkUj+JKjXedS1g0VzvRQ6ib/TCn\
-            1dkBj++rD5xRjeKZUMDp0/0eh6IsZC7YK03WDln5DCqoLkr6W0A3ebGdG8W4kKDtUqK\
-            NkRvHQjYU8BFf4CUqNoch4C1DgY7H/KIILrWlio3DyXh/ARwFSBJ9RCGcjeM+R0GXqZ\
-            UdehYDFKtC4xnZNId6ZKpj5vJIqHA==\",\"Su4ivwr30VNQe/5jAK5xhxuFIW883ix\
-            oRjEOA8hOoWC87ylbS1HVIi5V8KQiz+U9TtVO0DNNYbWNRVNirWiwxfBT+mTq7JiSzj\
-            OuVNnrLiitDUbUtC2Mq3L5mIaimr+B7ThWSzqFXsgrsAPVTlYFvjd91/eopUxvQTGXj\
-            jFFC3MUkuKqeQMZdilWZizM9dwTIIxegsULEzUU5f8YtlzpUVBIr8egKZlJmK4fCuQR\
-            igPwGDv9faHQo6BoYG9wNz1Yo/EjRlE6T8AuC3fhXNByPTuSg/AY9LUuF6iiFNg5RsV\
-            smLSi526UWhfmSHiMjxE1oTLX2bLFaOC6Lh0oilfhDW4PuixfKPy7N7ixTWJhEc6dbG\
-            /NXPrKSlFIU6BwHN9BrzuTb6+aUM+e8NBjJcLSzToX9Ad0aAKjoARujyEdx3ngDcVMe\
-            gMp+HxuVF2iuJ4vAwrmsqAEDY4Rfex07Mv3lkKPfgNtpS+oRJRCr8egS95YjEsQUc9e\
-            haW0fuCqKtwCSv2yN8CxOUGB6nQ2aJntJShJI8eoG65rQL+/oeSJjaCuXoxphXjrzVu\
-            yfN1VUksBCubx7u0PFKdw3xpvSGfqmRJA6xXfNNYMGq/WSeFdj4UFlaxsrKG/2jOUY/\
-            dEUnlcivv+7TixXNOobpKHISz0qWF27QAceSDCFpwa6PyVowjmUyM5b2w8nMRhzt6gs\
-            XX+OdtDeRHfD3L25lBU7/fDnL01pGv9fhz6xkSKBuWyW4juD7aCKnpfy26fO4rPbJce\
-            daocSsEXSVgZa7wRrIFYPD6ySkoMC8qMjTekflBPFHZ8b9mK21K61h1JIPv5pDQpbfM\
-            fKG7XpNyyyhjvPEa5TXEbwkwTYCKN7Yq7FB+mGK8jrMMPEb3a1RDbl7AjAlaBf1ferx\
-            LndkHxPdtYTnTwppcKpy2S2mtFuMooX6P9R28pbOiINR+2W9zfTKl3HKG6wpwoVlEEc\
-            pr3rkVXa0syiCLaCq9utqDEUSxw4eP7ZDRa3DBeYMLrZ4Er6TeihYKVTqEP71q4mWCc\
-            urbUyi3tBQW243Yn/nG+EMXcsaBNfABSgnipSTZlfg64FS2rC1G8W4rrYI9WzjGM0Tf\
-            KF8sleNZY3rcIz277/XFGsRWsUcoM3h2sUD6fB4E3eLCErPUZxUlrfWdIWAThHLEUOG\
-            c0+1SYGUEyTNBQEsWMEo6IaOWY0YxiwyasMQG/MDMiGu1Bp1itdqg2LIqZmD9R0DwIC\
-            zcg/d1SVaDyyXC8k8zn4yqb2faZQgJynDlX96V28A8UgzG1LRZKFlglM4o72okW6mKo\
-            +Y7iMnallA5K9WgHYrDSb8qlDVOfT8IW7hGHSknBvBMCjRE9UUS6g0izm3Y/AhdJ81y\
-            5l0L3083shtTrfDeI1N4a5s2+JVtpgKToU7YsDTAmsh2KXO3S2XwNlLEoGaTHY8kwli\
-            ZhE7SeHfYWwjrZIdbmPWM37ihlGvctHNK/UuozNhTPzA432cwvaKmomO5F2thxriV2F\
-            8UyOLTDsFzGxgbOqKGkud1RXt4d9E9Lib8glHCNA4tGwJ8pr/eumV3FHdQT5wh+fEhn\
-            9NAlb7+SBdOIdIOnqdOkhKftd1puQ2zSxbj1cs6FN3bDwtlk3iBdAoLBQ2nGlrCF6Te\
-            xIQq2bQ8UcyzhNUZxPOIjKOUYE1gryt1ro9+NdM4DIoFzmGirlH0PgAW9MNGeqRvtZK\
-            NNoQEBJZHvCC1OEWtBlWoYUVFpHkoK/3PEmytc19ySMszdpPl1+lvu0Vri4XpTqKVOc\
-            bFg2ng5l0XSGAGu6CJM3G7CF++QWA1hq5nbOA+4T5dCuTvglvuokw==\",\"Lt5K6sY\
-            VshcooXW30Z7nY3PR/0S4ajTvN0UDnXT4SIrImND2f//tQ88buNNz8+Fv//wAuv55sM\
-            7YtyM93X8S+n4pXvv/uFvcL6v//oev5N2/33Xf2urPJ/nrz3//8/nP9af/+SP8Xd3Xv\
-            7SfnuW31+rzxyX/5b+2/Bf1Wn35++rXL78rof/e/k/31031x6f2+cvvffX52/bXP39X\
-            1Z9/vZ69Xq/vH68D3i3///+u0r9/ld/lnZyH9frXv/71r/8XAAD//wRpGSoBSQEA\"]"
+          size: 16954
+          text: "[\"H4sIAAAAAAAA/6S9W3MjN5Iv/l36eWF1q9u7sxOxDwpL49H+Tcmypdno/4kTChQqWQURB\
+            VQDKN4m5rufAFAkSyKRSHIfLLLV7h9uiUTe858=\",\"n2ru+ae//vOThd446Y2V4MK\
+            ftanDl//zz0+y/vTXTy/dP1bV14e+/vU/N/BsNrNt8+3x6b/+69O/fdK8g09//VRJXw\
+            1iAf4nY5srZwYroLG8b1nFvWiZaLluwF29+xPz4DwLY3/617/lh/p5dnPJUOBFXcBtL\
+            sFtbC9Ywz2s+KaAf9EWvTmjbS+uUexvjxftScftojYr7XDwh9Ul4M4KJpQs7Mll0K4S\
+            rIbOsC84/MMl2xLpUOqGsD3rhzfx9T09NtK3Q/WTMN0Vr3nXcqng6k/GrUXoI+E8FXH\
+            cYHs15OezfbxdfH1PxxOcm3oD+oqHn2wFVR7l4fnp20MOhS8WPP5grfd9FuTz7Flssl\
+            PhCtY3/s/DEVx1vJELJkzXGw3a43t+/ZjdK7Xk1qyMmq+vGqHMUDNpPIO6AeZBO2Pny\
+            qzQpX99T5RTcN0MitvdJ4ryJT9F7WSlYPeJHObz9+1DFqXnooWr2g4S5WuLz3m6ShC9\
+            yV/SuB/IHIxSJp7fDzX+Kdx50B6ji2aV3eGbwZuOey/FVWd0Y4zL709EeshdvgnSqme\
+            Cq03v8g9LvIDZdVbXsDRq8NLo6XecRB9ya6zawSqzuuq4aKUG5lpu86vczG6bb6dxpF\
+            K/8F5xfcVVLzW8OZa+oGBfimCRLBiX+FUJWF9LWILbymjG+3AE4SsGt1iV4DT3cglzC\
+            fm7F6b1cxEH/FxtmOiwl+9WFJfnWtP3Ujdhgcgd2jarPG0Zb+KPrwWAHKHvAYTByOjh\
+            9m6bZcfVIFW9kB6ueINd3sBP8u/UBxTmPBcLtvgLsskPt3drMl54l5G3L+xS9i2eYEl\
+            bbTwwYbQG4Y1Fp3fzJcurJpB6wVnPxQIskx1vIA8ZnsUv+bOcQGrjuYfXztSg8CluSF\
+            OMeNLouI3YBXq4vflG2Ufr5ZwL7xisedcjD1lAXFPmuHIsnfRK+patWulBSYeQ48Ptz\
+            c9EYGFq6GUPKrDc/V8xMThvOsZF2ppNX7pCZWKtuGtJe3L9WN7lCNZzy5UCVUadbRc/\
+            ZyW3KeqWgvZwe/M5/4wd0KQONIWvlcB7KmXEgjkPfXFq28fn2TVloWYdPgtnSlhi+Fa\
+            Z9UifdqgQZe/h9gaRJd5jRiJMoB14KwV+1beU4/iA6wRXhfueF9RPwiplVlCzXg2N1I\
+            61xiyIxHTWMIGrEmDvVllR+xRsVApWUeEbd5z1Q6WkawublJfFTw5jum7Q0m+CWukj+\
+            2FmHl6dehDoXbnbELjvYaAaemU2rBq8N7pImXeIJHICfM6dV1xD1LYLDP4M3J/Gv5Y4\
+            5pez5tq3vLJScG8sq2FZYEfnIDsQFjxzXHvOrj9/+fcCAz7njjpZg0B0ybi3lIdigtj\
+            ocDvHxw4XvqjIzIK3G7aCKtx2nHyp6w8Coh8cq3jUzlvoEMEp7MOKyj+Yt1wUVk64ZI\
+            L3m4pbzqSOYoMTFkC71uBv3VfCpoqWW0SYTZJnmUZRA1ugc8JZRIY4N7ZL4qHigxbtK\
+            LyPXMUtm8L7QZiqqWEkpUEnCawg2JUPOyPUpYcJJyXSjLue5496+7CdbQlPjzBaDNaC\
+            FhvWWDP0+6tJk5wJ2kJ4VWQ4Pa5QkYkizQmjPZcarGNGl7S3m2va7DxoPx/Ujn+wubG\
+            H88J2eEG58zX3RnRuPHe2MrZmwgwaU3OCIkaRpsLDVxIhb74RqKmGHnQdBLKzjv+awK\
+            dGEUAYPZe2Y+fI0Q/bpy+Ei1ZLJ8xg3cimcWZAYH+1icpyZYx33vLyRJNcRDiuEfi9D\
+            IxLpZQdPoIdfGus3CaeSWA4nwmcYhyFRBaUa5HgJnIRLt9SiHiEHPoePOAC8w==\",\
+            \"3ZpCWAkwyCxcsaIa+TOB3ewggxaul+lW4M/XzwQ5szYF1SzvNpiAbDTvpEh0lOSeA\
+            iiFakZQMlvZPt4utgSiB2GD8qiZBTco7857YT8T9gOEi9KA5w6XKVcEngKKOy8FE3IU\
+            XsIjw1cFkfJ/Acz2Ig1+r/43QwBGdUHZINyxk+AgrlnHBS6BXjJz93XUl5JhoCTRl+n\
+            7eIQRvuOaN2AJw1A06uNhXHfGSihG3d0QCX/oa14wxN6tCRIKqIq1wJVvRQtiwXrMIR\
+            i5HYFkOvMm8QV/o0wtcaI9a8Lt4lvKFo6IMVbEDYEXoSaP7cPzE+Vhg3VvrB8ZM0UYo\
+            TDQOUBdcZFnbdvH54Yifsxl03EmnGM9d5gsOtsuKKbHuTIr5k20dzthZZ8MVJ0pqWQE\
+            aBul/QJLJKy5aUWLi4ME7pR+ySwo4IgrOWmEZXoe4XZajI0umoLYR5ikYZXUnUEIJfE\
+            CGlRRrYq3lyBYNEZx3bAzpNKfKeeaUAkW/vt8KMu7FZctXfGhJByv5bWCcxb8jXK8KT\
+            6CwbpXxhaMzNe0aQZAihF1tl18IyGaoadpjEkRK59LC9YshrMUsZ8Jm3kaNv25x1htl\
+            CIJW9HKpi2aTTcEHtuaDioLK+KFXBNe5T1kIa5u8TPhdkveRR2p7PGnKF3R7Z2WigZn\
+            bBf5yLIJmu4HT6bHm8+E45Dag+2NQhl23LryYsMPZ4RErG1xpWdBsbeSqFwmXsV17QT\
+            Hndg3XwnnqeQcxEYoQB/yO4pbX8n5enJhk4ilZNN6pk1dsNITiAXB79t8WE5iZGXCQe\
+            DLzjYCo0TwV1CVNOObr5QdMk3+jdg+bBsKSMfDFdJcC3gNs8KiUJ8bilO943YBXuqGu\
+            eQxVeVgnDLldnwJmiJekHwAnWwsR4P9IhKB33ZGGwu9ockVhAMJl+fNnSWtEPjkiErY\
+            v++UM34PF4OkeFMSxMuHbDSroeMFNQMJmjtGYhWqIcR3sLx9BzgPXY+/NtGzW4bsmyD\
+            0FKzBBBiiGXhNwdqZGp1ooeMFu2j5EHqjNo0yQQtNcf1Bay4pkfkgcARY8a6qkQlHAY\
+            WCuwLrWlDlKKoYl0iY6u8WVtx2f9z++btxvrEFy3A+rHsyy41vA0HSOcRnwoM1ogYa0\
+            EuKsbmhRM5YLgthjhRtMKLsFkwPm4suPCr6edF4hGOKrwItiGq2XVBcAtYscIaxIbwv\
+            1vUgiNrLF4JwmvDeBi098bUqM44ggZ31AhKerIhpKwpxp3jo8jQdn4N9tVBjNtWoq5e\
+            PJbFc5wvR3jefCduXAloEd/sTKYQfUuYXuOLK2LpgkifwBCfDlIRZUqgwcu7y6boUM4\
+            dHs91RlC2nopdAcdfGaL+CNHJHiWRImMUoq8hYCMfbmQWkM0YFOdJZGCGZ1DWsGQh7n\
+            iuQEiXjjFg0A7f5PUwzJazac11zZYJ4sp80YpTYPjw/kS6L57YUOE9JjnCeRyfQIXiz\
+            A01jiVsKCcWgugqLUYtXhbRgPzj2Y4ChFNxPmNZQdaYeRtcNGqVE8cnupGs8t2RDIDw\
+            PtpMx+MCw1neISSdq22W+4MFaPje2I76dFCPBAbO3ZilroIRPpdeJAu6CgKxUTIdhXN\
+            fWFJIKKcEOH2Br4zUUUotIu+v86x71FZRcy4LBkXAnP8z1jS958osVkCmE+h45iD+FT\
+            TgbNEnkBVvk2ZuAW7fiTM+mLTtgAT5Ruj179W4l5yhDERT3f3Io90p6jMdvH7b3lIg8\
+            byVvgHG5SyYv8E8SYtMEpWaneqeUJcShfntPie4+wh1FmYL0RiCnZVdWGwjcaSV1bVa\
+            OXRTeQzFRbXiB6VMC+g==\",\"A8j1mysmBefWK8DyTgoNfmXs4urNsfE3qNiSZ0Ci5\
+            barLBegwF9VQ1Up8JA3fKSc/9w6hbQC0s88wmx7vz75r38xwvDfTe2u/uyxeKZIslmK\
+            EEs3hrlcSePSrR8k40KAc7KSSvoN8yBaLX8MmFwwu33KX+Fb7vmtaa5iAkFZKUp547l\
+            tq4HrduiCJGWBI8nGiTZyV6qG+iq9Rj8hPqJUQyK3ezWoubX2SvcdE0Y7ibnp1o/PT/\
+            nA7hTIzCvjr3gvGRoYGZDyl3yChHk043Syj/gEBFXr4lSybOsdyu7ryGMdC3cSTYYP4\
+            NjmnwJH87XTEZwHWJBY0hwpGzB03WZnqsfPNp9fMsFLMhpzIAYbLimvl9Kl4kI4NmGu\
+            xRCreOyUWc5hTAnksQwSuouUu9FAx5aD0mD5yJy45mrjEBPQ9uH5Lh82O8EeQz8KiyZ\
+            sXyM9c63sCnePMKXGJPXOMVgH5ukRz3HQ5POe43egvTVrpG7OI1auZQLUGW2UyUthCY\
+            hwqn3bs/F+LBqGk0neQZEFxI80n0Q9BbSmA9/C4BhvGgsNLwrziUsTtjEalAp1GBLtE\
+            SY6xr+WBNm0cMLRLBuDmhbSkRCANtxqpiRSIOnxeZbnpLfgBLce3B/ggFvRXj0D/xO1\
+            125n27vTxU/qtpbQgS3VL3t7+Yz/+6ZlbrFZcbWQuokKLoY2O10lZo/mkjt3x98UMGW\
+            ab2+slhaER8uhBPTt/wodO5qAXtiJHLrUhNlvZ9ub0+Vl9vhe6g1rzE7zY/tqekiU8m\
+            x7c7rIzwTVc0zFf3sqHNlQ99xDfemuPhV2Nd3mPHyBJJ4KJJGFp53aw/MMYXCykZ4rI\
+            4Drq9oIjyRRPqCvf5zJ4PZfUJy81b2W1rEaliNOFJXY2zL/Ssdp5VnbG9eNGT8KTC27\
+            R9F6xwI7kz6szcIV/Nma/lH/D1ZK7vH5Ke9TTqAJB9dMs2sDoWTvgC3B+vVV+PnTGoX\
+            KJ8yMBobdZ+LdqCUoH71xZ6VwzugrEKK1RhtU673LJ4/MuYDKmMVV22Ln//jc5E0yew\
+            wLHCk9kUwA2YmozYpvxg/MXPJymg/NjRVQGx++O67ApV+s2dIJLAowLC3vEPgVNOig9\
+            F/dVM6oJYoj8vlME5xUNw5q5ofOWCa7btCmb0Ebv4m1vnoLtRTeMaGkloIrVoGGufRs\
+            bk3HuPaS/X7Lfvsy/lvfguU9wvwfnxHF/TCziut6JWvfslS0soHACUuxaSLvKJxCew/\
+            I+xRoNJ/GNsEB2WBG/rTUHI+Z4FiuRQs1q+V8PrjCEpt87ZEDpKik6Y31eIa8yDP3CV\
+            Rdv4oW8OuYz2ybAM31q+Z5reTz7FmQ1taCWOD6lsgHrx1wfjF6BvUvijsn5zjB5pXzy\
+            bSM9jbw0iUw06PxoiJvJJriLaNZDjHPB6Ss7jFBstBhpUsDRy5Tac09ZzWE51CWOA/h\
+            FGtRz/O0kOi8TJz7pG/kRQ10TrjN0EsLzaAKDCaf2T6B+jHIuUESZRObLwP9jQup4JZ\
+            7/ifOZ5CKiQe0OQDi6IhbTqCmuXStNzrIaDiR53MLDmC/8g7+4BrNGRR5z9sBqHnlGi\
+            nsGnaIQE7N7hsh2yjxBcLM9piWDVouwTr4CavYlA6CNtml3BajRxNemdh2ePixIuVsJ\
+            1BK4kIOUjB2gvL7//f77VJucSACK236rkVcS/GZLu/Pr0EO+fXl/vYO5aV5o8tkQn/A\
+            by/oQ5jX3z6gBE1QSRElIzzhOJ8qe4D8O+fNq25erz9ff8NXSSDQv/92E4skF86vDHT\
+            vFNeYC+fz7Pl7PlJ0CmScAMzFlZAoUxqRXn/nfemNJg==\",\"LFH6KN0ugfVg/WAr5\
+            uBHQdItU8hb1xs8/KjJW6YPMIpbvgTFRK1ZJ+tawQor4pxgy9dyBzt6TFquawUVR7Ji\
+            Ev8pn3Mna+7+/tsNLvQQjrkztRODQvxMaUrlxXa2iSrbq4VecQGvDzOHeCLSm14+mm4\
+            oQBBmNuyiDbhoca6dd/5O4ZSXv1oz9P+4LxBw+SC1qXnj2FwZJPQh2gMIYL+PN+vxGe\
+            WT+YoRR1D/kJD3kn6e3d7nI88PWH3LHXxBrUqkOfVyIXiea8fQIMITEJNIwlNXEO4IS\
+            K4y1mL9ByIVEFY2AuXbgkTJnECcfUGcaPJGrvcgsch7b40H00nh2NeC/EXgNXvYJaDa\
+            2j1FMfoxyF6AwtX/fKjPAcjW17vOIIV3nIAFzW+zghxWXpqVuim8uPn4iQPMnzd//lm\
+            4LOW5OCE7qbiVHjcgUMQ5B57VUufFpfhoETboz557ydXT73/DFbR8qOhkUj3kLcxRqq\
+            SsrIf1azWE571gzCBgee7dt74gz+cLkUyQ/nGTl+TT9SiDPP/6R6xZj5MjYTbe9EaZR\
+            gquXn//Y/Y6N/ZVDbr5+x+/5J+r9CaXT9G/GkSEifI84RifLf/lz7vbwjtcXuqgZeCc\
+            JUUzXw3qGCq2T6nzb2gU6wlT+4dZVxLXpUU+rOqAszTrzpSIogyz4mrB3gbEerd9wOI\
+            FGqlZY7QUV1jSSkxazM6mkTFwpjCD3CMeLQG87114kcQCbTkQGwllD70xrJEe+FX8mQ\
+            X59rB9ygG0Q2OkuQof2GYg9bJTOZ8rtHpRoLV8zZhfjWkU/NJa08GViB8M1h60i7F3r\
+            hiCuUUcAI3lc6757hNxQd/O8haYlrtWCmP7Ky5EjBSf2BjGCpNDwRcTR8iyveMRUiEI\
+            Gvb68fl73po3xU7xjKlQ3GgqNvO5jAVIlmBRV8tmdvs9r4GdGMUC97ArvsWSUwddQ57\
+            nHqNPS7JioC/51IePoMyBH3pWGTQM6yVvZ8gAAub/jelnWfrNIFphanCyQUlikbdkZG\
+            BXfNMbiZQDCoeUtxIcH9LoowRSXOVLvo7PCWRDOPq80+sYsBU7St1TLmnSeQsAPkZvT\
+            WeQ/Iiw1XkL3jF2iteVumFK6iEvoq4fn5/yPuETuIErOF/ejFRgPMflTwBb1gyyLhSG\
+            DNPNV0M5Rg06Q29NPQhfZGjh6uWdTiewU8ZvTItEQN8QxfsYdMmVrAO1UWcdbnbeuXV\
+            0s4t3ejPbIi2pJnh1/ZsUoJEqKYFm846aKVQnNeu59RK30m9mt/f5Ku0TwJiIMGDtFD\
+            ez26e8TWwC5RUP7AUFyhscPgKNbcGWvLFce+YHbyxeOOz2KW+j/Ih+yAtN/xMNP2+Kz\
+            uOTgPO6zkfgoVeG12ghu0jnlANbSu6tXE8mK4x2qduA1FhvlRlWGngywgpckEoPA0Cs\
+            JmclfhcQV9wU3LEPLTgspOa0Y3kd5uoFRpBrNIX/3Ui9UVJs4Mcgl1yBxnqkBDqhXOW\
+            VK80vXGKS3LiHwmsxbR+2iKHuAx7YpRTABPdcmYaBbqSGmDvo50j169ntPenx3Q4WRn\
+            LDwO7yVX4/gu1rJR+UoAPhoWPkYxU+jhF2OWwBfmh3FM5b8QrUrvPGm1uznvs2vGV5D\
+            X0dG9tSoMUiVmWO+RGoYpWv6zKBC1pVb8OzKPD8wLt8FMMEzhgf/kOB8qEBU6BB1xyJ\
+            vgv7lS9KdQyUxCpUpEJMPyfwxtPFkm0TJn2xe8xAj6hViKLEfETtpEbiVNLDcsb6Lcz\
+            BBm75Lv4ZfVbyAV8n8Af0EWwodonKmgXoIPovknaPt8id5QNOD5jiC5oX1uQj7SYY1w\
+            ==\",\"OAZF4xcc5yWkedQLP09NG2o0WfAlbyj/iLYvxbHhukacAgGVInmeRC08/C+U\
+            SxcJwgyoWr/IV8mfAEkrFLB9Ucwx5RRnpnnH6Htgo4cgd5faYG4fn+8p+iteIzm8loR\
+            pxQbyozTJO86CnuF6yAsOYSfz0TIfkVvhol6Na78kuMHFXLpeHghoIg+H0VDFPV9Mfz\
+            JILNDqLVbOItI6ZWdNF7OidnUs2NzyDlbGliRJpFTTFL0kkN3n/Y8fYRhBuVzHh4o6s\
+            YjYcA9oKsUMazd8ArKvDxIjuvS86/0YFX/yX/Ie4VNQfPCo/feJIuWMcDuK7wFsLCEc\
+            DZgpBxmdMkUTGceouY993tGn/i5f3fIYEDoTe1OiFWFiyOTZmPO5FGMBmwI6kgp3hA7\
+            imvHBG/ZmZLmq8hqNRjsBjlIXEiNyDKWXZsPGWjEo9edrLB6DOlR4QapgHUHNo6yXLH\
+            67tsNffvrPgvWAvJONMhVXqdUzq0CLtuMWKyB4e5+PIT9Gx/WJwJXP4FQtx5P6o82Pz\
+            ktbUKhafE9xroxYaLfLIMqcBcXUfzBTubR9uOxF50kBd5LiP/o1Wfr/ht5FfoDlwgYe\
+            SLFLTcZbcc3mULMlH5Qv12aOFkbygpIwiduUKUb6EU6DZ7ZHLTtP+TKmR3AWkp+39Ka\
+            QydWBXYINMqWGJPmMbcwKgsBZA0gBrAPXRiNPDUtQpgestn6kbfoQnWQxucsorLP89u\
+            GtydeUOkL1oKCLXab3td1wYzN908u12GdYFbYTeDvJ2m00qgw0NMH6BOp+0iWhZvNwe\
+            0cxN4yjDJJ5Y9QCL0NIfHz6zcriJSixWnETJGs0rHv0wO9JXGtw3nRgpSk0FwkPA+Fo\
+            ar67qoWiwTF8vrzQmrOaR0tSj6un+Vyxd2BSO2+HHz48NGCXY6kh3BRPONkp8q5uEzp\
+            diot2ChqEYKyj4oxG01PI9DphT3h4SvJx41PUDve/Itlo7+a2v9FBQ1lJ37K5BeiQQh\
+            7rGGZLmeIKix2N/IwCU3HnwKJG7BnpbIMWwvuepYYfBYcu4WAD3sixvnz+ghIKab8me\
+            Mn20iFWxSSCEmepTcfr4iQpRtwJ3DUOh3TffA+HnwTFC5D0y/3TVFjnfT4bOAtZWCtS\
+            HeMDZOIApZOgaL/v4PJJFgmOSH0J7hqHu6do/hO4ChqpNV7L8Xu+AssU08lGM7dxHql\
+            sEF1RlJcJlqxQbSF6IShQY5wf3p3ndpav3HASK8hABTwCmSS8srlxls8OPULDO41H3w\
+            2BRBJWO1QstubDEfPVHI4Q99GiZVik0dwRrAPtpUayBtI0CXRsxnibQaGvGkmnhK4Cy\
+            7gTUmroOOsV3+B3raGYpxNsxZ0UrLamR1OJIrcn3JMEKpSk2KsDKCU48gCK9+dJgZDn\
+            TNJ5YzcV3uXi9p4SEZowFR+0aFnN7UKhrvQXyqOXMHXKPxaKO1dukDzDWhR9hDbCcw2\
+            sUgP0FovO2z5sZxRTXYLtjVIOLWD++CwogiEashxtKJTT1ssya3zKZwZMkKxd2YIbOJ\
+            /0McEZ+9AlIavnYsEsNNJ5JPwiSW9lOpz/fByB5mpKENp9Pq9qAs+5S/PGFTECW5tz5\
+            1/fnNGYErp+fF5QTKdzCapmU/laSzTPAmluiKIifebWaGL3KVS3g4V1n7r18Y794L3i\
+            LGhEeH1TpCDZ6bH2g+w7gxjTMdfyBWcq/CCMSTFPTcdMJK72i6thaXrHaivnHqwjDIn\
+            kDNKGnBvjlTEO2CpWq6ANi9QBOj3sYVsPQ6c6G+zLF9KABFFvOmASvaeU4y3XLkyBts\
+            Tv+cL9J6/Ah5YybGMGy8xK7w==\",\"ff2F+3bWYGl1DoQF71jXdHg6CP0292bpSLGS\
+            5PNfGbtwbSBrAizFDvkRNv5NbDdRMM9T9+AAXWbl+QzEPCopUhRpU0VAZnn1Oimb1Mt\
+            0CnvqJy3co+R7P3/jcdUg2QgJ2xNbNKOCTb4C+wTGWAFstUJbC3zP54BOkKzRnnWxkm\
+            OpL2vM06DQgIODfbWvnGd+LmIU3ecvX/5y/fk6b8uIQemUa+GA+TnjntuEvEScdym/5\
+            CJQPHkyn1mdA41x1MsGPzdK1N8pWKyGZpwuhTMk3H2QacokLUyX8FB8gJV6bvEEOUr8\
+            X0Dd3dAAL7W3phh9RGFjY5hV0d9CCQtp+FCjbrPbG0rSQAM+dT2PDQXrY62B9KpTHIt\
+            NuwuvSxm/kyhhXPKjPD1NO2LLLkbpNz1WyfT2juIzOUz4TSJkleDKV/Y9XGxtBYiuHW\
+            FJK38PG7NFC6jnrp0V6k+v0W6YJ07pRAvBMRcV9xYSHjFCO5KXfEWwyVzjL/ddd9AGO\
+            Sl3i0AChnHbdLzHatKFhVJ4dQCLHLoFhQZUhBVTZJM9oEOi0pPTlrTUquxEp1wbwyqp\
+            0WTfpFeQdky0XDeAdV9J0RykeUU+VspnvZ1Rp6aA69Z71BN4R3GYN9FOoZXsCg8EJVk\
+            hgOH+dqQn3UcYNh90Kc6SRlw1tyupWY3k66bULgJXMqyu8rJTOEJKTFWAkU6YZSHbhW\
+            JGbgwDvey5xRniHcUOE7CWoL0yTSGya0Yx7TcmRovXSE5Tuto0KNHHl7BQq4RiSAxog\
+            DbMjNoLhfUblkrz2I6ZHrQA7ZAk+ySxkaj2/aOCy5PEJdtexDjDcOMLdEc6kVYUelN9\
+            p3iFA1DHBatthbNa4lsiu27wsdOK5bXMpzdF2wrtiBedYyvL+74U/06SFc3CVj/jjwr\
+            pcimuG6Zsvm5oCj4jQ3Xct6xCdK2UxkI50Q46vAZpOk/S5nfQIfXAosGCxtpKGVrJqU\
+            Oisc41fcG49kSSnQ2LVVbB2kLUKEm+Nz+VNHDi+jR4Xtd45O2MYidqDDOWCwU0C9+My\
+            MoKzftjACttpTGmv7fG428UTdTo3eAlbs2leHEbwyyfe9EOeoFxnO3jbUMxkkc8PNp1\
+            li8h+R4H8PCzGckeEXC83QQmXZJib2gTQ8gq2gVIs7IdE4N1xrKeN1LzQiT3jHqWxng\
+            BFjcJ31OicBvDHJ+Dx7qAxLwMGuuJEbLAnK+xJmpBwqBxH+bQRvm39yTzjGFODXgiGC\
+            WBKeAYsQhsrBAQQJvTxhWEnQXxBA8GjTA3cAWyoE3Pz0vXm0QRwyDxBBkiZVFqQVEix\
+            Zt+YJ3R0puYLOmNQYJ5UoogYbtiWhi9/OE9idxOgLIaeguCYz1l05tQxm+5rh0zOoVj\
+            J1+n0WwxVGA1+ELZDEocSPrGPd6cPsa1ngOGFsqIJgHCtdnDNQLnfBTlav+N8XrMa0I\
+            lCYp+esBUcgms5nX4Q+FmnwPbvSHd/mNuHBlu6F1KOy5EQRJYRvzmucLN8k+UypOtYN\
+            efr6/ZqmeKo/L+DUVxaAVHJWGk7v0UpJZIn7M12g/6IwyDNTqjhqKqtSI6NjlSDz4pk\
+            JTF4ZUG8vX832GgrtQFRWdvhWJBAS2cOWlF0Qizz8grhBNSpoYV8H/+TnnyW9EzPviW\
+            0DD6hXZuffSEFYAotNQzJ3jNy467QJ4UGTpC4lXV0rYRZxeLIxD2jZJnGgAPspfpwaI\
+            CfqypQ1zyGFi1cOxt5RlaLiIIKSTWA0qZ1JnTYpaGFLpCWH3ESxNN/WtxYzh5igmyUO\
+            aPEng4hXM9Wq0lGX0I1xesWQwp+CwGzaaeR1giW4ImHPtHaA==\",\"O1SbBrqSQJFS\
+            NAj4iB0hSs8U7mU6qCysmMeV9huKmbY1Vm5LdcIpG+d9z0C0eE4qxXjWbnpul1jjnug\
+            Fo0irOyRKpZCXLYHyDkboGGjivB3w4mtJeC1PVWqhBrTNadQoCNu3D5Aqx30+UZwqUn\
+            vY1dfa1U4vsO7tw/MT5RmeQlNy4p8o0oI0WoqCa2VB0SflPii7Ba7CQ99g0RoBllI+T\
+            rqg1TNlmqbAC28o6t0It+xW3E6ClhSvcCcrJWNTLjcpz0SiduxkiSvD/TcW3JE8c+X1\
+            vrlCVEECKt+TNyclc1Z0HH2FkXaaUyw8eSGZ1Slzijj7irv4EVLY+5vbl3jHtQIC1oJ\
+            7vjA1GoVBioNaSC9a0Hi1ig3aSGsCZpSsgcXuJTGEDb1SFDpVNZ7a80KxRijgVh/iEs\
+            ewmh+piheaPZqCFsov7ocRxhJ+xvlddWHcdkQJa/8wRAwiKHKusEMUTeAD+KSKUMmjt\
+            0YbdmVH8Nw24Bnfc8pCyBTSszk7xtA3luPllQSl1OMH2CQ+E2g88WIq/liGNAoKLOYV\
+            OKZ4VyF3fI32cjwaYCwKZ9AKsAGTEuT+DrMV0W6KGyLjS0emxUmNqb1JDYc+dyNodt2\
+            Gkrj5DndaZQm99ZQY5XfIZf/uGm0SnIFddriARin/lAAbw1ZQ8b7HK+IkUweVZ7QxKA\
+            nN4UlyxjmAY++FwIPGWGv8lSHfiAm4HTTz3OGG2xc6hziYQQx+F17oJHDA3JUzoxWVj\
+            ybnszZl12wkbIsuVBy7oVTTS9BSl4ruvlBSVRNYqrcW5Gw5l1BPdoe0Iy8UR2caKeVD\
+            7iqVRiMcHn9GFkISMtQNrmHTd3gEXHuwmivGFerHJtl8p8Bz4EFrLyUdUAk6gb6ZqkQ\
+            WSJvg05hjNUL2xpd4VgslLGYK7FDe01AM1lO42CKutnKJP8V0sfbAK6e5KbjMSSaCHX\
+            j8PyihmN8pxSTeYYdb3BhVg06VSXDWSaa0ET0Gl+FVtGPCNJklj7ij9MqCHkqrUki/J\
+            L2Vy0P5wJgG577i2PQDPYU9igWF6VPp/MMQluvadKzHI2NuziD4D/hYK4+o/5ApclfL\
+            hsVuO7LA9SjNmE7hbsYeSri3j7wde3CsLU5i/WfvQ6wROc664CqnEqDz8ex2jQgKch1\
+            1E0gCQEMXNaYhSkuuBdSshl6ZTQe6UCGA4ok7GmTuGRfCDNqzVAhTbnmZ19KF09NDRa\
+            +nk0aHh+Oscc8+l3fjWvgxgCvE6ZL5zfsxxoLa9NW8UBxJRyP1PV6s6DudO0xQV45xh\
+            9qLBKX/zWlcN3SBWypgINCYBUFxHpTGkBwvRkd/yd+Pse/s4S1SBy5R6QXnunI7bObN\
+            CmygKXyvyErF+1FqmCfVhePWxxeK7frkABvNO1NXqbY8akKgi8STIUrWpO902+8HVIa\
+            8jSmW73zg0X53aP5c0HDPf3lY6rEj8JZQlGzJI+BI8tGnVrDCXsAbUgdDxWMYNPdSBG\
+            HQYaWhk9X6fKJMy9ibXZjTGzR/BOldjgxiamDGNlyPvB9fxgVMWhhdF5qfJuq/CNqZY\
+            rOaSzbFeQbOy668JZRSEsf4Q8HdS7dnfEBlc2OB4+n0zdcLeHDNPa/xePaGbgI+wmXK\
+            CKSGaio4eT6FBHQ2ejxZoVlEQ2lmjA5QqOjyQldpJwNAD7oGjapXKd/6gs2PMjrTjdT\
+            riQeBFN73/RIarWUjPVdGANexIqjCw8qeKDGlR4NYGYRnXTPTo7YtQckoOI2ebKtokY\
+            3kFD5/j0CnWkkUpfqF7ic41dN336Hn4CIteKXOPw1Y9xacK6oVlMzaj9hzY1mR210im\
+            8wHXQ==\",\"tt0tKElOH5HPMQ1eQJ0j/OBiWzyO+8K+U6K0jkYwplFjPFDP8cbKN5e\
+            8vnsHKTHK+IJdQlspJS3lElBrFvnc6mSlPh9W8o5iUaL0BjiCjvWM8DjcC95EqZHSIE\
+            m6uWCu+g3EoVpjrHVWqm8n6FbBw0CLvzgmbB3zAuac4wzxEulv8s5SYsoFJRT64xgp1\
+            ILUfjGafC/gA0rOQWxil9TyWxilw0vWEaRCnIddIvd0UljjzNwzwefT97Co+wtKKtHx\
+            cMnX5r6WjM5Pl0gko2HfVPGGcO+trAYsECRGOV88EG7lv0RhH3FL9cUi/OXTDo8iykI\
+            vkf87o42FHk9muIQ3dwb3eH6n5PEfge69e8R4IUEPtyuMwnihEh+lXhRtpHJ4jbiIaW\
+            QGG3RyJKdAqcKwF1DYyWGhEIdDKbSOjFQoI/p0ie6nTbI2Tb0oBeHx/N0aTVlATNZO2\
+            brnr8UMvh/w+gw3lJpIH3F72YOSukzEaYDzJ34YoNAC9IZS3jiPXpTNXi5Ry3qFdxT7\
+            TgmpPwK1kDJ59FJao0tyzPdLJIATYzDXcovn+d/QI6mnQ71395e6PqQrcMmSxuKaY+m\
+            GYsrJBS/JnlWE12MXX4Y71i9dSRwFiKNc4lE5jNIsoDhKyti75PQJzDWVQjx/o2xdim\
+            W6CJMU2n6Jf9vC3BbClhtK/ahjXEoSDT108Bh5zCgo3alL/DHRoWRl08QODgcHX2GgC\
+            9YyHUiDXxmkUXdSrc4fxH1lFjrjkzcOjxGkJJse4YN2MjZHWnIreYWpPykO6YI1lFqC\
+            bR+eny4Jk3HarJhr8DCnS+yurjceyyhNIfHnX6ziGS4uUS/9HCaloCdUiTuHL+C+3sZ\
+            uZK41Br27Kbr6/ANdciVT04idl6AkrSwu0fPLpB7TvC44ih0yK7fkuWD7R0kEP1d6VP\
+            sE2PUtFJKBKG0UJ7id1LjRgJ6nssd7517DHV90VjsXYwxioYfWC92rnJIQiknPL5Sk5\
+            ylizHTAe+LRLcJjiQ7OXWp6JD2zUOrNJujBcWMXZ5IZ5oVu7EmwXYwFKNmQXuiBiWNW\
+            TSG6i1TeZgrohj62VJjLErehX9t9ak4LaufiLvhQz4Y2eI3AGSUHXoF3TLRI1alUVIm\
+            CtOS4I5omPshqQEo8peYGhNlIDXg73DtSoEjY5zGnz6K1mVKVYQIlm2bwWHPPVDaKsF\
+            HGLMBWSBx9XCSBBjreSFG0q8e+CISbNeMx/+qXsGkdWPYHZpiOu0Y4hw4rgx9BCBJGF\
+            7t2KokEMafSK4Qtk8KaHf/YVaXALU2UCUaPUDLhOsataKWHWIAlpgIX+vNQkj2KIxDs\
+            1i+UvJvyQEWFI7k2yzfq4EeTjZYe2PXn6y8xfxrNmE1d58+BNy5VygQLGg85uKNkTh+\
+            AXScpjUufNoTnZ18riu1/h86U4g3oFr4JE6xhGd4KpUAjKV+phTJhpkYsUiFrXOqgnB\
+            ESE7h92AqK5NL9wA3dlLc/Oi/GmNnFX4r0N6OEiUfMXgEDvcQjgShuSQ1eyfmGecM0r\
+            H2sn1JLCyJ22DS2YHR8ohiDNXhme7ErN2+RgMTU8IUy7bX/6Q1X1iiP07jmatC1AsY1\
+            VxsncR81JU4kwLKuXjPQbUw8KtixaAuOiMmwVAi5Js7Q9F52cgs1pZ08pYpgRB1NXyv\
+            ukRi4WJCYQp/N+rX1vn9N79BrxcUCdP2apBNcUSNIX9rUANoapUpRk08U00uxq+iM4q\
+            dJOcZ88Ia9GaQ/QMriL7PrA16MJMEj1ygNHj8Cpsa8hcOgzlO0wL1roZBqSrrdCdBon\
+            fhZLIpX4JmElyHB1lAh9d1jlD+Fvg==\",\"R6xYzkQvZY13755RnucRU7o+XEE2n3c\
+            94CZ7ipVkRLVyCZYBUq5oe97SR8A1ls8Wi2OdO0e1xt+Zsxfdm7pQc/OGUr76HaZd4J\
+            o2xTS0K0cxjKVFhNG+wM3uKRn+CTeVhMfFFoJ0OxaN4EuOdttLWTdUONNDqYv+d0qpt\
+            wMa21ddPqcYw3dKBaM0CNpwJybGkVcfC7YK03WDln5DcqoLkryW0A3eZGhGsW4kKDtU\
+            qKFkRrHQjYU8BFc4BaWGWGS8BSjwsclBZMGFljyxQTr5rA/gIwMpgs8oAWcjeM8R12X\
+            q4UfehYDFKtC4xHZDCbwzVVDzeSVVIEruYnwVbqOnoPb8xwBc4wY3SoS88XiTpBlFOQ\
+            wgO4GC8b6nHC1FVIu4VMaTijyXzzhVO0FpmhLVNhZNibWiwRbdT2nJ1NkxJZ1nXKmy1\
+            V1QWjqMqOlYGFfl8jENRTT/ANtxrJZ0cr2Qd2AHqp2sCvHe9FPfo5YyvQVFXXqPKVqY\
+            o5AUU80HyHBKsTJjYa7nUoAwegkWL0zUUIT/97DlSo+CEvT6HjQlMwnT9UMheIRiAHy\
+            PnX5fKPQoKBLYB9xND9ZonMQoQucJ2GXhLpwLWq5nRzIQvgd9q8sFqigFdt6jYjpM2t\
+            FzD0qtC3MkPMbvETWhMtfZvMVo4LouERTFqvABtwdd5i+U+LsPuLE9ZGETzp1sb81c+\
+            spKUUhToMQ4HkGvO5NvK5tQz57w0GMlwtLNOhf0B3RoAqOgOG7fQzqOx4E3FDXpA6Tg\
+            87lRdSnE9XweUFCXBcVp8B7Rxw7PvnxvKeHRH6Ct9AWRiFLo9T3okjcWiyWIqGfvwlJ\
+            aP3BVFW4BpX7ZB+DYnKAQ6nQ2aDnaS1CSRt6jbriuAV1/Q8kTG0FdvRjTCvGWo3dk/r\
+            qrpJYcFMzjXeufKEbhvjXekGjqO8WB1iu+aawZNF6tkxJ3PRYWVLKysYb+ah+hHLtGk\
+            srjUsz3H8eJ5ZpGcZM8DGGjTw2zawfgyAMRjuDUQOfvHIUxnxrJeWMjcRKHOfuAmlid\
+            +6zjobyIx4OcfTgU0ft4mLOPhnStj8ehH0wM0aBcdgvR/MFWUEXra9nsc0+xme3So06\
+            VQynYIgk7Y403gjUQi8fHqJJShAVlxsYbUj+oF0p0fG/ZittSutY9iSH7+aQ0Ke3wny\
+            hm1yTcssoY7zwWcpv8NoSZJsAUNLYr7lJ8mKK/jrAPP0S0aldDbF/C3gVgFeLvyudVi\
+            rldUGzPNpYTHbzppcLDFknttSJcZZSv0b6rd5Ro6Ig1H7Zb3N5MqXccobrCnChaUQRy\
+            mveuRXdrS1KIItoKr262oPhRLHDh4/tkNFrcMF5gwutngSvpN6KFgpZOCR/etXAzQTl\
+            1xe6l6SwosB23O/aPxwtR1B0L2sQHICWIl5qDU+bngFvRsrrgxbujmA72aOUcw+h9o6\
+            xYLsGzxvK+ReLsto/PM4quYI1SZvDuoIXy+TwwvMGDJWStzyhGWus7Q8IiMOeIpcA5o\
+            9mXwswInGGChgZRzCjuiIhW9hnNKDpswhoT8AszI6LRHnSK1mqHasMim4n5EwXJg7Bx\
+            A9LfLVUFKlOG451kPu9X2cy23ylBQI4z5+q+1Ab/iaIwpvbKQslCVMmMYo52ooW66Gq\
+            +p5iMXSmlg1I92oEYrPSbcmnD1OeTcIR7xKFSUjDvhMA7NFNYuoMYZjftfgQuBs1z5V\
+            4L3U83s1tSj/fdIFJ7a5g3+5ZspQGSoE85sjTAmMh2KHK1S2fzNVDGomSQvh9LhrE0C\
+            Zsg9eywtxD2yQ6xNu8Zp3FPKdO4b+GQ/pZSn7GhWGZ2uElnfkVLRQ==\",\"xXQv0sG\
+            Ocy1Fd1E0g0M7DMtlbGzgjBpKkts95eXdQf+0lPgLQnHXOLCoB/w75fXeNbOruIN6Yh\
+            zByYdEo4cuefudLKhGpBs8TZ0mJTxtH2m5DWOnfOvlnAtv7IYF2mTeIF0CPs9u72hnF\
+            bB3/AzVnyi93RKcMP0m9lfBqOCJot0lvMYoHs7o//7bp543cK/n5tNf//kJdP3LYJ2x\
+            H/FfHr4I/bAUb/1/3Hcz+Sj/e/j+P1/UvVzJWt7/+31X9/Wv7Zfv8ue36vrzkv/6ty3\
+            /Vb1VX/979dvXB1X//R+r3/6nXla//m34/z/fpLlu7t199yQf5b2chyP717/+9a//Fw\
+            AA//92ZXCLnkgBAA==\"]"
         cookies: []
         headers:
           - name: date
-            value: Fri, 10 May 2024 07:20:54 GMT
+            value: Fri, 23 Aug 2024 08:20:22 GMT
           - name: content-type
             value: application/json
           - name: transfer-encoding
@@ -1094,7 +1092,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-05-10T07:20:54.033Z
+      startedDateTime: 2024-08-23T08:20:21.735Z
       time: 0
       timings:
         blocked: -1
@@ -1104,11 +1102,11 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: 356d43c29e34f5d306245ee4591036be
+    - _id: 63f33cd20ec7644d1221819097fbcc54
       _order: 0
       cache: {}
       request:
-        bodySize: 429
+        bodySize: 393
         cookies: []
         headers:
           - _fromType: array
@@ -1126,7 +1124,7 @@ log:
             value: "*/*"
           - _fromType: array
             name: content-length
-            value: "429"
+            value: "393"
           - _fromType: array
             name: accept-encoding
             value: gzip,deflate
@@ -1153,268 +1151,268 @@ log:
                   }
               }
             variables:
-              after: UmVwb3NpdG9yeUN1cnNvcjp7IkNvbHVtbiI6Im5hbWUiLCJWYWx1ZSI6ImdpdGh1Yi5jb20vaGFzaGljb3JwL3RlcnJhZm9ybS1hY3Rpb25zLWRlbW9AMjAxNTAiLCJEaXJlY3Rpb24iOiIifQ==
+              after: UmVwb3NpdG9yeUN1cnNvcjp7ImMiOiJuYW1lIiwidiI6ImdpdGh1Yi5jb20vaGFzaGljb3JwL3NldHVwLWdvbGFuZ0AxOTQ4NyIsImQiOiIifQ==
               first: 10000
         queryString:
           - name: Repositories
             value: null
         url: https://demo.sourcegraph.com/.api/graphql?Repositories
       response:
-        bodySize: 16419
+        bodySize: 16415
         content:
           encoding: base64
           mimeType: application/json
-          size: 16419
-          text: "[\"H4sIAAAAAAAA/6R9W5PbuLXuf/HzRtqWx2fvnao8aKwepxNLcttqzzinTnWBIERBJAEOA\
-            OrCVP77KZC62dP8Fsh5yNjTk/6Iy8K6X/79KuU=\",\"nr/6679fWVkZp7yxSrrw79q\
-            k4S//99+vVPrqr6+eyq/75O2iSj/871GuzHE+e2iW07/97dV/vdK8lK/++ipTflMnfx\
-            GmvNtwt1HC2OrOS2v52tiS8b1jvPbGCV4onb36z3/1Ik9fzx+HIu8PCPHhp8FrFUa7u\
-            ugFPSxXollko0CZFA4BP70eDaw9y/8Hgn/7U+DOc+ulhat/sxh31qzgZZJySBmHsdjU\
-            wptFM387GFwKx3i641rIlJVKWOOk3Skhie8MJW954GVVyO8+0X28KKTe9V94s9g+Hge\
-            /psvPL1efh32mRsOLn/yJD+14Xfi473wbfn4bUVEPOnCJyWDg0qR1IZnSzoersIwL4a\
-            XzmBkNfoHalDyFD2M/34/BjHnQ+X7wep0UtVX+yDJr6got/H4yH/rorv8mtZe2ssr1v\
-            7fuvIeeTUuNkAbfDeYVJwqPYKLhPpvBx9LhR9xn9tNgMt9VAqy2yY/LoYh7fqyM0p6S\
-            hd+Gaxl7mfCqYlr6vbE50jVaWTvs4TS1lcOk7aCT+RE+4jq/vR1G3u0nCp70r7t7M4P\
-            XbcsIpenpzSjgSAb+0/DLtCXNXe8n80Ec8IQ7glENovXTZyKY1Qgaj2dX4QsjDiiSYY\
-            Xj3w86F5HmkAKbQe9FpDnjwiusk4jhoJmBe349bM8qtczViZYemxbD5IooTJ0yU0nLv\
-            YF39DBM+RNGr1UW9KZKCqgtzfdDgT1XWlqWyqowR/pxP7wZdCSpLA3jWpUcs6LXg15E\
-            QMUXN0yJSU0wDjKpCXIYZhe3qMKUJXgMx3nzNMziSI+al0owYWUqtVe8CAqkr6uz2QM\
-            l1fz1IN1DFtx5JbjYyDM8stUeJoMO6Mrn2UYWJVz3m0EEcoPc2RzwUKaHseBWFpI7yb\
-            Tx4BOH5epxmAYsf6/VjhdSC8mCgUS5gJph6AeJFNTZdJhisDa1Tnng+bxglSmUUNKxQ\
-            iWW2yPhuRmy7ExUw3TJPwEeI8XfDaKa8IGBWsLgDcTrCMMeaiZ9IMETctodVivs3EYW\
-            mLMfB9FS959PKgTWud8NYpuZMVkho7TiQRzyhBujFA86hw52sE78bpB0Pn0Fq8SdfT2\
-            I1M1OWs0D88KSOqx4mHsqq1WKmfn9ftD9UYLnYZhs2Doo7Gf3w+AoHjdMzcnrRFotvb\
-            z1CsUrrdOfBhFXgfyszcMwv7eui+LqBfGyrAruJe2nXs7yYbZ5VdSZ0kyYVGZSs7Xlp\
-            dwb228jvW5JbshefvjE9VaIbfyJb5hKal4p4gNDKPOHDwTDBNLOcRDdn9CDBg3tyGEy\
-            4IRK32mzaMTbMcdxgW4ZgT9W6FLbj/yZ9TMtPf5Gq3kO4od/+IZXpTQ1MIy6fQzhQy9\
-            +g9zI0+s/95EdL1QaeBz8Sj7Mvj19BXgnDstVNsytecFszXOrEuIJjFhvYbA9MUxZOY\
-            GWNYwq3w8THydQB9xTreNnzEqJmFMjhlmbN6iE/zwb5lusrNmptI2T9fPuFnbYG7/Cl\
-            lCdnA4LN11x+1Xh8MSakavNecnhOeSvhwniC3KhWjUIeiCGGTJXbCs2agePeT5QOF6h\
-            65xjz8ZA7nBBrv3mNaS4YR7cK/COusBxpLFT3FsF+c98IKu4YO+xDjKQV97ACqgyPQz\
-            L3rgCN7WV2BidD7ORvodmouDOqf61t098JN2FD6RyZyrsxRwW5vwe3mJ7b6CW8R2081\
-            zAaEo2UGE9oydcpTVmUeHUhwWWr+gqUzDtYD7M/r8B9kktcomdC8dxdJ60bkfsYczfj\
-            jwRq7KNT0w/Q2kzA8a9fLGRIm8NWXzmwwyQG/Q1PJJhHohbXGuPTtqdJDToYQ==\",\
-            \"eUHXDygrjK7xwz+Me52iwOxqpFrWvkhe/t7/eNrzGMesWvB1wS3UHe5HssIWXWkFQ\
-            +HZQJX9O3AnOIgWdRQ+7tRNkhREQtBYOjEb6ZTHPGWk8BRGOy+LgtRSRqPjXJL8OPIy\
-            jdVEyttk3Imk3PMUWKIBeiQFpipTnhdGSA4zEfLDSHxsOM1HnnUKYh7hPb4ZR9apdgr\
-            GbludcJy8SY3IiQy6dyNXbUr5v/iUx/G+9Ah99NPDOHKWAr+/gR7FC+zB0Kx07JIPXl\
-            oNcjNaohsnHNc8l3uZnPKvCZVhHNNbc+cLzKxHGlHrQh5UUkipM6X7j75b+6hrXRvrF\
-            c5iyUa6MzKpj6WhkrCykW6Y7v+HrfhxR5IpX/B+5PbFj2MlXaATx6nHaa2nEGoifX8p\
-            RjjswzgK7+D3xuau4qBQonMCjqMWy9dcw9XnI+2/zCpCDWzzKMatu/uPNfAUtPrDOKa\
-            7IY3t7PU4Eb8R0FrIRrLCDYiUdc6kcecg052CsYL5sFqKG2QQeO9ubtxBSGvymvBmjE\
-            P2Hht6I11Hm5rvJeGA7vSHPwtP+qfyYQkFl28ooXTGJ4S1N+q9qEwrKMo6N/co6lZa8\
-            MrVBayim4+UDEqvi/qQQnk2HanQK702SQHcU+HJ78cdyjYlYyHTkWI4d8caXuT8MI6Z\
-            RORQtKc9TuO5yZvhRbUhai7HSbOCC5yT0MamxzHxgtdabFJuc6Asd1brqPNpUz09DIE\
-            PTV+5QmuTEnbryAM3Auekz5txtFiYTGrfFoZj9WHcXZpMidJoRSRrzUfGAkquigw/0u\
-            lIha2Unhe0mJuMI/LS6MykCfcFERIdSS+lgxUo85Fu9fLofsdug2H5qBdgTXLxh7fjn\
-            ruWvlBryEmm+3EyU8u9lQURWxyZ7KBzKqY4DhZm/nZq4SjK0O4NdueOPGJ3wHGnkQJM\
-            1yARvI0ljDzf2nMNfOadXBy1ZJNjoz0f6fkKuNxhpbIZd3tGS65Tg11S2UhhayqptUy\
-            QPtwVuI87lUpq2gAZmaQRwL0sZG5KWsK8GUfhpnKZ1Ap7A0cGnsxuQ8RuRvGQisPoe8\
-            edRhFixTNp05oIlR3GgmtcNTA/juOplXE+s5IQudmwqusb9L20RAgnH+mIqaxyJae9U\
-            sPqzG7gzVr5xCqBpeT9SB9HVVtZGYslz8hEEMuTRPnydyK6NWrdlmuxIaKfwxrh/AiN\
-            nSYjw5M2CAmc5zTyBbWJMWQ8ajqsBv2KXidW4QyqgfnZV2SdSiB7utLmUc/e1toJU0G\
-            5IEaG9R0vpFsbC1z/XSeHUYfiBF+vTZESWcvfRrp7buAjii66pzTulAI97jmURd+GVc\
-            afsR1L5U5i9XNYpel11bKQwksiaDzyZlWmebHG+WsDs9wv2PnRc5wvOFLIObP2BT8S6\
-            QQj+a2rjFcaJP53zodxlB702op7qMRlI5Ninee+doLnWPN8O/I269K0TiUiK3bU0oNK\
-            vjZaCR4UdDrHfqS+eK4HJPwoI7eghdQ+Zu0j8U8/Qot/2o8jHb8WxsrSEIJvZGjGr7E\
-            S8NM4ivSKSK4a6Tr1oCK1SzUbB2uVx5kW+bBK/itybROD+dVIFx6RS955v0etuS685c\
-            gG6rTaUasmWzflIwl5JwiHwTipsJOar3G9y0gtfFdiF+nI3ISd5f9NvLxxuK7aSCKPe\
-            aSOufOboNljC22korMLxEzkxYxa9J7v5NoaUADQLLbip3Gv5FwlT6S9jsI+cp0CZbgr\
-            9B6M7JTR0rJSZZZTof6HYcmkv9c8l11xDmGeDUHtzOtTayFodAxzpp9w/Vqy2quCSET\
-            PhiV9Wpkp5+2R8TS10g==\",\"4VrrYXWDttaeu5wp7eXpDlEzg9XDMKvG1pq1+LcGJ\
-            S65zoclPzixkSX0en8blh7tpPZKy2s/JMj7hokttxMbg5vm3g+LOV36aaQKtyQa5o4K\
-            dHz9t520DhJG53kd8oHaSSa4k2Szqa7z2RDovUycwhaFiDOKnO+I4MgcdsVnUa9iLX5\
-            sx4TFasyuA2atUrrHW0CMip6sT31l9jJRmuNeVFH2/FrcnKKLkBXNYvUY5axeC7Y3Nl\
-            8XZu+o5OYONILr/giK8po70Ij3+h2oN4aaDHAfxbNOqG5jKnfhW0gxyaI8DWsmU+WNZ\
-            fJQRbSBiiqYWctrf7kIUn2IKqEMwvbAgp3MKsuFb7MNifZpkSfg0vxEqSBZp20sGaM0\
-            mVwGOVhAW34alRZgrMJ2SUx4unbSMiud5FZsLk33u16lkBPHKBd1rSBje4xhQzueWY7\
-            LbB9jihBPOM+k1fwYI79OaF1/UFNA0/PxXQQJnwGzuhU2p8YpuSykN1RvmscYfRp/wN\
-            YJlLyPMebz+ROX2QCQXTzGGKJnyHOrqg3XmUSdb9r0+3iyimlRE9SEmMYhZ0i3Iep9H\
-            2OcXxc01JWrXdoAct2Ve24lS6XLvYHu/8cYNy7ZdPA+RtB2HS+JjtNdonXMTluwKsir\
-            HfOWK01I2IcYxn2Crf3mTDF0K93VY0ycs0NOpBabkuPQWlRLow5PbFTFuHOoOfZx3kQ\
-            Vh58QCyVbhuc17AXR5DF+7u8wqb7gUc+5xXPq4ufAxB195W3z665jApT+MU1vvraIM7\
-            m7P7Anx5PWO8C++DqFPgIRk1B/aksb0T76IaYGpYMjOnU2y1VUxXEHthFVsPGIhIbYq\
-            6Z6ft7H5Nl3UESDzixG1emQunFObUWudtCwWa6iIiAdbOkyy6sNFFLNcjZgoVWumFCy\
-            ilPBYxxrJ9yON7Z8MqYhV1Sz8RegoS+wS4uOPdxbXNEm/eO06PuY7KwXoPsbunQFeGN\
-            AM1CH2F3cGNTtHsv0d9Ey/RY1lzaRlrAgR0JHVQ7dx0Tw/ghuQNu+rkvJwCWn3POEu2\
-            Bl1WIT/gaPZDBlXPBPjf872w47mEZ/I7ZiYx7jxnn5E8ZygT30WUxN2MvgVqYKe9Fjq\
-            iAA9u34BWIPY+/AabNfF1RqSYwf5Tt8MuMgXsKejSwprPQOtZZsPT5Dxc0FN0bixBmy\
-            L6GTQiemi+CL0BQfj4mr9gHnJabvmE5fL2LHcd2HmFKwl/F3kGfFBM5exI0uMhss6M9\
-            fMJXURQrS67rEvZHrp5ONAr+N6fp6gj+Hb2N0wceYHOwO13IFknVarGiWB91TzWJ1H6\
-            9M31wS6dPN40/RyULp+hAVK5zH8/rz5NPEGqJDk4hxGn8Hqs3+ZgIRs9KZApm57ZXFH\
-            4jbBCOtIlYdT0+n1szMeVnt8QyNJtIFGGCv0RhyzNPsIYpiqdLHGIaoUtm1Dpc4CeQp\
-            pmvCzgmTSrbBva2+xeT7n6DIEFPHgiKutsOL4mnTGHOGzJw5zpuolJ/LoIrOSUXkltF\
-            P7zr+k/LRdHOD6Gu9IJJtWGIk2RWtwS2nYijuAva9sxT7WWLa/PwIDF0ii2b+dshNX1\
-            IoMhOkojdJvWZo5EZXcBKx6i6CfprttFHSclbVVYVzCb7F1JvsZcLCortMLC5ynhHHH\
-            NPC7hxMPo/TuklcOWqYZX4fk7Rzga/qpiHclY8xj/XI0eCCw2I1BVkvpWDCsTRVspT2\
-            rrTuuTIeTRFcbLN+q//h53n4H/sXa5ZfAEYDmumopGSldI5nSmd35e9sWzrmKosjGQ2\
-            I+Kqi3nPP7d2W7zhLpVOZZhX3XlqU5rVYPfY3SFZ68g==\",\"P6XStZfurlscS4yJY\
-            HAtbK/6rnQqg1KS3an9mrXrxa989djf+vcKVlkjkLrXxmt6n8Y/pP/ZcqXdnUol36l+\
-            ftu0tVY0TrWpnG9flK/BZOJmOQPKzD/MRn+Ue+W4Tj9x67W07k6YsjKu7c2aMW9VluH\
-            pSll/wczL+LXzpmRc2aA3nTgxsYP+A3npC4E3mMqATjfdraNj+aLN/iNPAmlymzNd9J\
-            tjAaz/jLe1llmt9d266ffhthC97DqXlgfDjZ/+CuMC/Q6KXBVHpc3uLuOS6aA3aen8F\
-            sP1B6YucBtZFP0huHZN/Vs7g4R3caIFAqqPFC5QOfdcmJQzJ6TmFnXY7A6MRPyncZ5P\
-            m9rKX2qNA83dGvuI4brGgMhKW5d4Ek23QPL05sdpBQi0vUdyTScmXEkvCqWBGdItisT\
-            zJjV44lg4KpJaD9Ka9pBSi4aoNEvU3CtXeictt8of39wV3ClAsIvVY3/8J/fGKtP+gW\
-            Tpw+Tl3744ve5wgcxWHCmAmKFxLVvpO+GPfK/Fhiv7sW0OJu1dcf4JZpy9V18osZHOM\
-            WOzu0KhHiKLrehnmYXJvNnr85+IgEDZc1ELlXbCcjb9+PF+wqqjNyiWEVbVr96WXJTG\
-            V3dOWQVGFAR51V9nXHLNMmvq6o6nXFrENmdZfzj7BsYKD5/qTPTrSleYaQsz+5kAil1\
-            PmrC1lKnzKAgQttjvhr1CJrUq0vMQOlpGzLJ+T8QVVGy4RRPt2uPvJ4UrjClSVHYazq\
-            1/4ssNUNC6tNTekSPfui1GQgJHV1A1+42IG5zq6DdQ5IUt0meV8soyp1KZK5FTmUAta\
-            K8qcwPqUR+K7qjopa191ab/pnWJxOgs66/wvYJt5KEqUMvCFqiXLd8AqZ0sFSxt69ZE\
-            b3BTJ+Y7z61XIkfZXe0DiFjjVupcaceSopZBf4h5oKJfgtwA19XRS1vwhPHam6oAZbA\
-            dz6UXm8ujKAzPn6uj5SXILm4XGcGaggx2lQVtJ7q7pi+oMCLnSSFbP3pthXQxnK6/tO\
-            OKXKbA7mjJh95nqYQ1CZgUE4D6O4TfABmRy4PHRsws63eUX6EWU1r09SeEXHG08TIxM\
-            D7S7Y5ekq7LiiIFekEmFwWc05v1h1FuUM691p4Lw9PnQu5kgUbmdBKPXl3FM8lMspWC\
-            4h4R76fiOsWkIPrjHbcw1iteUNM3u2uMWFWeoUzD7gYiVmVNKf1G1o6tC+42ScHb+qr\
-            KUAOrs/6w1ovwl7uOQ++vSL2ifzr+XJjfiauJIMPqmHLPJ68n/U2uOsqjN/zpmMr+oH\
-            7HNiIu96iN5aDSs5N8Edd79NdSCEqQxhx4ULJWp4zz+4O0Qjk8EDzr7zR4xb2R+QWqZ\
-            uxEHr3O1h9G7Ja+Bee527QhU+VZl54aozdEyHjPE9AqtOPB9C53Su7Z1iRsrQovLSmM\
-            j/MG9IAquc3bBjud//yUt074Rr71U/OcOy+t4Da9O2FJLeyx8spoRmrrAblvpTfIhtd\
-            +86ZtIyVt60hHoTLQErTkB2Fq7e2x5PousMK87WEN1wiavJXSllylbOvOfyUs+n4g57\
-            hVd65OWhIEj22+zd+8jBE0o/OAozbd/05gy3LeTF/27bwI5Xlhsho82/k2j4ZLZVWY4\
-            3NqgNY032bvYvHkRLaeOXxw8XBpJpk1NZRf82b6OhawbbDBpEaK/moO3AV/hPxL95/h\
-            hn+KBQuaGeH/nW/zfTxcRtWahON72TX5At4ffwTXGX0tf/zR6VT/gtyy8232dtAXmIP\
-            ep/k2iz8JlxIccN5MD7FoxqaouDGsLJqEOiw4oTrcTTMM7y+L+xXEi76Jih9LlP8SDg\
-            ==\",\"Lpqz/l7LWrKylVEQMfrJuI2qKmgzzLd59MV6y3fKMWGNfvbGgPzFsMjoO6kd\
-            3O42iz7Atl775F/EBBP9NPbGQtN5sXrsDxB3eGbt70qjuTCnhgG9aO8W23kfUi6ZZaU\
-            oeJ1tCqXvTqNFWedOOZVA0UWX/R04SqWV6f7Zi/DToulboEmO7T+g1tMfpittakxy5z\
-            dWyr/AoO0s73eczuvCq520TjJl7lxdSfvsJGggclg0YLLkQvp1oQ53wui0xvkRyxnoV\
-            HfGkbWVOQobNWA2wRnk70fnLRoXEFB6T+iMYpHaMFmseljg4uvD7GF6986/Q36I1VO/\
-            q+WEwIWQhbTcy5T9XnPt2VpprkEX4MmieXxZ1zpBTmcfP6PffniZj5wXpBh3TrmwIK6\
-            18W3zFTK/cbH91j/G7QJtn3mGYVbT/mLwGxiU6zNZbL+9rCtfAByTvj8tNQC8LAxuAF\
-            A96GTRfHtZNl0BvEGNyhbNQ78VfL2py7hIOlE9rAmTzfzDb+glEGeqnUrapiBFIdvcC\
-            ZZWNTNgaONk0af0/oBpTSGZ1NaA2MBk0Uxf1qZeAtM7lSpOTTQOmPDIXsS0Cmnmk0Xz\
-            hGmrAm33msXqod97c0HwpxxPpTMm6pSzXB5hWuBkse2xF17EXPPEKsFKrjnKGguoL1s\
-            LL6IWKjmdoXaiv8d/596l3oYtWS6tlqgT7GIr3pKH6WEXxCbrzx0+I+y7KigGSkQP89\
-            VDf2LYCehnlX39MF0A4tiK/uT3C4hZyDnM4wLdwk8giTKOua43mWNlhkhg1aNjnqEK4\
-            5wpqcYe7d56QwQXrFomvEE9rZarrL+U7QxTir3sN/0ni+0DZFs/mySBr2KVQVbaJUK4\
-            o/OyZNyKjdpJpsrK2Iis2clydg8PXPA1aOY8Wc7mkD2JxBivSp5hDHhAV4xTDykoIx7\
-            xdgSoVznOG9AR9gbhOZW7YC9xpaHJHthvv0p5wks9y9KE8ZRXyICdLGdYjwtA2qlsg6\
-            Te9hHSktjIUum1sSX3CgwODkAvG6pnoIJbzlIlwluldrZYYf2pA1P9FkB4I1Dx7hAqV\
-            clC6av2w5xqgigJVjnkSfjQOvBzvcRZylcFPybGgLE5k8X2CVP+98idD5/SrSeL7Ryq\
-            7B1q28UogkEsViICbacaqKX3Ry1OMO8LyfXTAuT+vG77oRIwbak2R8U1DRhsdQvCNA8\
-            2cduMDar++FHeQuEhZ10NGSGP37d4K1s7z74IqyrgZQ+Lg1fXgv0GjL/l7B4/TF1KVF\
-            0X1B3qrLt+d7m0a1XIkysGmkqEsDACphdPlrMHyCrem/mMvX+aTaFNjI/FlFXtw2a08\
-            qppp/WQrwxf1UXaMME1amg7WWyxunCDhBsyThbNPTSR3hvtLXeBtD8a56T76evnGX6+\
-            lPIrKmlZKoXB2W2reX9O9wWpZm0VaDvOV/kjweSXs3ssQaqatX5JgXL4JssZNmGE87Y\
-            WgHkvZ4RgBVGmcPf4cdTvL/Y2LH8ArQkvUClnYiNFjitjg/TEHLIFqiqWWV6WoCNwOB\
-            pidykPqhQ00KF2GJ79x65j9BeaEQl802E17fQ8lF8Vjoe47wCDg/fHxey+30F9C9S6D\
-            Ot+lh2kPX4GAcXKypyseRjFmSyaJ3pzFG88LGZ5f670BWkmA9uFZhi1Fq1ZGxuGoeHF\
-            9hE4m89YZV3Urg3iMlyg0rnuKJujXlaefT7ngMLrI4jykaSA5htxTr7gYEjAZNFgDja\
-            bfnyAPiAovsJvP6cS+gmbOQ3RpptCgwLK45R7zpxQUgt5zXKGuhhWo78DxIpi2CBkqT\
-            PuuZP++ctR+410QQOBYFDKnw==\",\"wZ7auROoCUnnLSGeRprUbTNxZ4DhHB4rZEOz\
-            9x/m8PLgK0hFVkbkRLbOU4LvpDJRXN94JePcuocg5ikzZCZlxT5KbnUAnp4jP8ayL7/\
-            C54fvU8rqDHpPW3/NIz5KKSvstG8E1JXDcj4H1l1KWNIQZAmU/uma6Z3blLLs2iz4Ix\
-            i8GVR4yCPS7HDuvgN1RvimZw8fHlb95fpBj+1PPD5jtHHZtqVruCvslW+wuTb7+NMUB\
-            m36UiTOh1IoXdWe+f7SgaCCYj5XFAbWjofXiwn445f+Mw30BnljZ2uyVDlvVVJDL3Kw\
-            FeFSTmBur9ZQCyLYUYeyM0VdSqalx72+A3MkVmWNkIwg3sUWB3bTPUONNdvKP8q3Kbn\
-            1m0mpYBEyqBD5Dsb5OgU5FkH3gdQv07w/2zwY4FDihN9mMs3Puq9aowS9LlZEPO0WUh\
-            vNjAP+isUKe5g6lFbqQBBIMjcgMSsSkE20YGenJa6yBwkXN1hWpmvlNrTjs8FeYJkV8\
-            uCl1bw4Lw/uEqqxMitYlkBFuieT8AZgz48FhxklDbbH7lUWdKliJ+1zVtXQYQ+fu9TS\
-            Zkc8smC+eiD9AlccVkxsBZjropnjA8YR/FbbpFfjg+gkI8/LWU+e5gnnF14ImCyx6kn\
-            vvfy+89KuLNcuUB2h58AbD1CfNsabL/4IktaCIIbkt1YOdhMPe4Jia11I6dtiDYKCvx\
-            EwZq+lp+vwJ4stjeQtlufYuPzFWFACFPQryIovo8yZlZU1aS1Ugof1TRZ9SbNnSKdIB\
-            8lxMbvv75hx3hpOF12u5v0NATqID7yUvxqbO/o19GV9n9aSJWU3mwKq1vBBZakVBlRV\
-            ThZb7ATIUncWeGsYHsfx5EyuqaBr24+CykX4EPhmGyWaPkRYZdsnyMy7uWKMa7eXlnH\
-            QBCZoBnCDH+bT/pzvwCMg38wMC8Y2JBX4pDLDsqrmRWEETFdrlrM5mRGTnUMfRMiKcG\
-            FkhukdKgUNxAdFW4tQ4oxCCsCvU+5RveIKtOs9w1Q142mpNCPy0pcrMODjCvbM12ulE\
-            cPrDph6DJ+e2Kx1oLD35JUFrgzV0bDJteS+tjKYfcLsJIyfNVhRCnCl0cobe04dgO4P\
-            7HXO2qRHqmnwfPVAGkkfPj19MntpV8guCRKQ3J2VzjOpM6WhejGHPP7Dp6cv3krn4Hq\
-            a5Szv71ZwXpPlQjJR1deBRu2c11qBSFwb6KfOrEPuEv+g6gwJ7IPl1ebxC4cpGT3lc5\
-            eFiDqF9pvAXHr1nk1eT96w6ds3k9cT9h4GKRdNhrn2Lk3YzhxQNmQ4FbiljeSF3whuJ\
-            TOaeV6x1ecVW31+WC0XRNXYogH1/Sf4v8/nz51i9Awjsl2wmKCwjSlMKrHL/QmS+6YS\
-            7BpZLznOE97OodL3UPJMKjLMDzFUday45Tsl91D6Qi1LufahAbuye2bE8f5j+htbGVM\
-            kBvmjGuxM3UrvjGZZBX1AzT28phOITUvOKiWM3MFoMY6mb5VHY32aRZOROaj5/zgmYl\
-            KjG6ymBZxUtl3dqYr5xeqxv9b9Fs6SYYxWmlMRnw6rlebUNpvAJ2Pwcu45iXacz7719\
-            /+5QbukAxaw/m25mvfPBL2Ba6O+Sq9BfLFZrgSonzphhU1GpJlOFo2AzzgvJQf5Hq/b\
-            sRQUoWq+UxlVMoJTj3KT58ClPFn0Vcuefv+fxma4OUJ/T6XzEupECl8w3d8yJHBFuIy\
-            AsVPWB8YY+egmiy2ONxWT9T5FqzostmBq8wnl42z2EUpsKDIKlQQtRBxgkdzjWypuWa\
-            gklesC9b+bLGfYPC9UkhU7XKKfTajbLlRSCo+s3yaD6vm1xg==\",\"RJCGSJfgRp+N\
-            3pVQXclIO7ZQSVWksFt0Rtp+ODwUODHpU+qGk6yVbQfAQn0HPqg5z3RdPixhTJBA8Ci\
-            uucVB7Pn0t4fFPZv+8hv7MvsnzOGACsEZ5zMFg0u6TjBf6eX09JM94ZSiFCzR9Aieya\
-            KZQ6T57CNcSte8nniMc5nxuSl+nn5GDqUGl6MEEG+NZh9R/scWU0spi8JgT/Fii129p\
-            cpYxa0HNdLhVDHZqYJrrMxCHjlXOjd7l6t7bKt3hcUEOyiV9xLM6FhsM1LPL4tK2jU1\
-            8qZZrPL+4Z9nKJO6k2EeoYTm/a3Er3h1AfrzdiDU/joQVrSdkQmHL73BFqvkOddEvQK\
-            lKJ6x3BEm4+f9bQR+APLGFGLDcS8mMFfzAqe5Yl0JBMrJP8xXD/3tzM9glWJcQAMSu+\
-            rLuvCq1dkqa9pk42DclibFbo7mCerW5UFL/+zNs9EapgrhzGON6tKCgg/VlPDbRMulo\
-            HFBjqZlUhc8ooIM5ytT1aLz/h7FNwhsWrQNxqCy39+O7xbpfY2dq+1gL0p2tUi/XMJ7\
-            59bo2Mimnm0L+qHmNsVT7Q5LNNXuFsxVUopNO8QzELmQzsFZdLPH/i5Xt7heHvwZkKg\
-            Lx9U5WlYbiaPWDwSVtgD0UKKgZWGk7NZjJ/VOWaNLqT1ruSCRFAn1i++hrawKhaNXk0\
-            WDy38CYkSpXl/TtzNK+7YZX3tpS+43EWVJW5xTdUL0p/6UMFCIN9gBnSa3yVRR4zREf\
-            8/tM2RdJhzFQhZbnPmsd1x50QrDHDc5npJ+Ib2DRWmLFY736V3CdbpXqYf5EdiDqndE\
-            0H2xxd7TE8Az9N53ZjDBT/UuKQUurWzHk5B3vDupF+vTBJbTdEjMF/Aj2RF1JCscyll\
-            8/aWA1vByhk0LvUMO92axeuofJHFZQ/jjefrwfK+9tJVVTj63k2rm/f6h7uLIAz95Q1\
-            LJyqyEyXg9w0p+RLrwyVp7BVwjwawjHskPiNTLDVoZ9IjF9n3ZEqpVB5OJiua4yxkOP\
-            5+wlHaew87d4Tr7m23/gFaVihlQyhuWhQVBB1SatLImga4GHIDu/lhWXgle/FKYPXSB\
-            LGcUC2+XFTiCcl5qAez19sBoPt4Bmn1EOCPQV8zyfq+lPV5a/Ld9uzNYqoorIU6o54Y\
-            rxIbjKMRz0CVl0YAp5T/gXGY+klrWcoa9difEA1HG3CbCUNqz3rUx1/cmlf1NcIM2RF\
-            2nTuWB4XnxbZyCtA2+sn8S/YgmiwaXWix2nxSogenmJJHr+PSRKoUNFhTZ5kTvHGhoN\
-            Fk0D8RlO6HEpP9yOmKm1YW2QgiyJ2zefv2CHI8NLlvTO+ctfJPNopmTviO987bGmi1O\
-            9198XeEyIOIu/IFscD9ZNJSetYMeD5zhqHdsz3cSzQoK5hDE6MZVsFT6Uwc635YlXts\
-            mwQBL/5iDC3zZmoHOYKTHnwiyZctSd90576aaW/Xk0lkbdYSoVMn0DerPRVt7x6Zpan\
-            T7808cZUR18FjF74V/mvc/oABMJevcACcd8LM5/+SZh09Am+KRajt5g59KWbG0baelv\
-            WHftbmF36AcrTffkAfP/ru/d063YswPfkATYsNtCodoBczo6wuYUmUgONACEgrA94BS\
-            u7ZLqNHUnMvH/tF7fwC+PwPfX705q9obq5D2slw9Tghx/OLiqzoplNvg0TJojPCLJx2\
-            Uvx3oYdGe9TDy+t2/wy8u/ikr40kTptt09AofHOfiw7G81zuMSYVnfsT8oko2rb0pic\
-            Tx1SPl/n0J+dqzCK+aUoxfwrbGPV9atWIPyYCDzpVnvKouA+kJLhz9IgLu9VV01MG4s\
-            saUWQ==\",\"V9VAHn/0Eb38rUoJo7UEbXU6RjLoqP74GeekZ05yVKTUfejPnZ1wO2Y\
-            lJ1ogPVIZHtRnUrmWwjuKsVPRR+oz8iBkwU4XRDh1H6k4LvWxTDpfW+JJ/hTP7178iJ\
-            VeCUKno6olqG840Y7Rx9+IFwMvf6Pie80qq3CR7iNlJFLfqVU7c5s4sD9JZrVie6VT0\
-            5/t3EnOkV+JYZqk4UaiM4HndT9S7fR++IJxeFz3AEUiwFXWtBZTlAShqnx+wG7l3cZU\
-            zKmsncpADIdbPfbPGv/DB8qtWJ9a4kp7PXeC6qPhw98GqDHRRLKspH760t9SrzuFoXB\
-            tcQijnDqdYI4+AmPxHNCgY0eDfdocXb9/oiOuaLBT01TiKTxSbZ5vED+/Z++5Ze+n+G\
-            aoNM4bRNc2avJKdKF7MtLbXXw0fG3ToeQ/H2Ag1i49uYOibAMqa/cGOVBrZU1lHMfVi\
-            Y9vBi33uZVHz8Lorh2jMvq59igHozVq4p9DWPjZ8nRsqlNGFvW2ulb8Y/6qrK950RZk\
-            dzM3iAcTjfwHTswgK54sGlzNZHTbc9mZtS85zt+CDkOj9eHiooOuOUrKt1NwkxJ5+pt\
-            76AYOAF36PxiaN1mscArKBeWU6BiReIITkAOH/yJ/n3yR/fMQjvPmiUycN5WX8tk4ur\
-            HMFjccXFZe/fY8rUCLsHaICxWHMJVXBzqgu1jhCM2SfZ4u2LRrko+OSJD5iMbnTJQ8x\
-            zBkAViASWXJdcoKw1PkTWrxqDhbwKPlR1sDFrGyUpYGVCF2O4w4KFOWLOE5uTsq8hGw\
-            qmNLDAQQ5Zz3OXObYGOzwPjhk4OJmxVvm3e1QxikZQepiVmLgV/CUPppbLUwoBqo43L\
-            EHquNcdXGWNYFIqiMjRaTuoArZu094WrPyK4XFzQhrVdrJYINRBYJtsgE0V2Q236TSn\
-            tp15QzLaMCMTeoMqmz8/Ai7N7KKM/4FbUrmT53FyBAY492Y5xvEzxwLRUZCf4esDLOU\
-            4Cxh1nINOrSyYZqV0STZYRfPiNH+VzQtIw5QLI/xi1e0LEouNgLrlTaDW8E7c07xNjj\
-            C5d7Yhgx1xL9apwsGNH9sQWMfjBB841cZPR78aqMhYw9z3a+ZkyJN5YL6jCp1OHv/Vb\
-            nZLHFXQo+qYMsvqKWAN3GqAvFxYezOVmO8+njbM5qXRFtjnEj0E+ffybyWRusf1dWOm\
-            9Yyav07KDGTd5wP4BP1nxVDZs+kM6VoFXA1ITKmsMR9aVaNDjD4wTAtrYSEX0Tce/LM\
-            9gOd8rCU2cqX5HFJcsZTkCujnpnPc7Qgjbkp+Mna1D32gaXVJ6cSV0bCbQMTLnV8aBw\
-            HTzcxePkM8jf6QbGEg/w8X7+RKTMEQifpzM2x7kcc5KTnEBYtTFalrBR+WExy0nD3vL\
-            U4y7suNDV8kqlVO3RZDnDcx5tsJo4katGCbkAEoSbxPZ3g4fLWemV5kGDIY3Ctic5eW\
-            FqJy1242xxrZr1h+fTgJzniPoT3PbE1qjobrHF4ye6zz+iBnfLGc5LbB2JaO7yYvW0p\
-            zRDJ8pnIg8myFTiapws1p2l4075bHxnVEoMB+6b6X0BLbn2SjAns1JqwtMYJAnkXE62\
-            Of7ax3Viw70Bv/xzemrBkVmgnAccuMcLjrJSBMVX70wB3EPh/cNHdwYklwUF5hmlrVt\
-            1gheSiUJyePq4megZse1OukX5EgEKSrAzlPNyLXB2VUaKEle2E0LLFPNc/JaN9TItOZ\
-            wAg0t5XcVtzloR0P+g386JadG3KNeGdcj92ZA5bt+D0q1IgqqKn/UtXtQMwPg9b0E5e\
-            0CCb/o7JNAh87CcPZADNL4Doxo1rg==\",\"cHFRi1XD+vMtbtzcreaQJcbg3O2niKs\
-            7wdB31+kaJHkBg26y2OLan67q2P1ec6JdD+VxcU6tE6tSMCy2Wc5yskPYF8+TQrKZWq\
-            /rNr/iV5k8PbBVGzsC3UcOi2a+J8/Kp/KAq0TwdEBiWsRyhue3tL/eDgg6+x+RjNkS6\
-            ssfwcj+cW0vWOrlHRPsVMedqDwXbX8WkACyaOakD9Rz85yexhe5WqGElbbsIgZOVoWB\
-            Pf/mpJsy4LRzxp6lTp/phPJ2qxGYBd2VICARymhAOrVif064yPEwtHBsEUvrwrbrwuz\
-            fRIIST/x70EkcKKVBt6DnqD20CSCH9iks3sPcwcvMcqZNvZO8ZtYYj50ueIhLh1YpXd\
-            YH5qh5scsZbr7QolkBy0Rxm7tuPd2uYtaDMws6tDoxxrN1wd2mc7O2o1kwLL6/F2Bj1\
-            gr1h1tQEmyx/QYNjCvlQycSPDxSGgYuHbEK61nBE9OmeQPGGOQ2xRjPS2IfQXevTqGJ\
-            RZqbVBZsWXmFvUuBcvH9bayUfwGWfhDcmFo3sGivWa6mpPLhlT52XfdoGmpyfHuBwzO\
-            uU2sIKxXzqxamHZ4JQTBbOIEQGPiCThjUEJEGz6boYNrxYLhDNRk/XAWkXwzIVWonfl\
-            Mw3YI23JZG45H8DW5M0QHBRlOtAkypQTdTbIjGc5PFiqDBKxTDyXdz0obxgREVJeNtP\
-            1/Nz/ngEHZK9lU6w1qekYCTxRY7hgLYyefJ1sayDRc572b6Q4U7o0pk7mqWoGFJk8UW\
-            z1Opk1r7evAcy4ALmV4fbkSjiC3uBNmHTLY9mCy2eKbWk3Z1FbRyJ9OPXKclt/l5YiZ\
-            Exeu9QWU7lUrTOWsrU5BOVewRqG3BKlMc16qAiidOr9zxzHLtu2GGjBcFU5oZPAICzz\
-            XcpQokXU+WM5xjuUsrXrON3Am6gelyhltldlh7pdnhzZt+9jdfZQdKtdjddH2OiOnjo\
-            OhOpZMdFL9b7C/7Ggjp06Uz26VFHYwYQU7QkaZL84juYA1+/F+VIwKV38hR2jvLBK/a\
-            4S1WVgVHKuZqSja2/7r6JytZm9aMxBYeNLbnFvaUxlbUnu9kBlX35Qw3jv1VJh9An+/\
-            lDMcE9zLJClZxv2HeckElSpHNEfcyqRXb1fh94iUpLQ/PRVbBSMI3MmgaSL/1uZ9ZBt\
-            scE6vSIL4JjxZBOH9ELgpe8glbKy19javb5s3whZdBBeVFDP4sJ11hf8TXsjSs8jWUa\
-            h02wRH7sGstfE2WJsxJN/7L+G0X6MjDGXy350hLnfYniwRo0tcHoEF0o6XI4STj0kPB\
-            RO28KVVDKRVbLH2PdXmjW6V5GVMLgFt7fQ+55olVMZNPtjjw9z3qtWG/dqK/CCJsHyo\
-            M36PGK8PQVn4RNC9NSrXMDsiQf76IHKNj40SWF2GjmqlNFlscxngZ+hR6+H//9arimX\
-            zQa/Pqr/9+JXX6vrbO2B+/87R4I/RiJ7bVfz/ki13y968+UQ//56F8t0l+fVIf3//j1\
-            2+/Ht7860v4WVqlHzZvvql322Tyercq/vWPz/fFzx/fFm+SL2/2335d2G+/plVSCp/o\
-            f1X/+lBsPv72s0vDz/Jpu58HtVefPxTHf/26eM1//d/6YWvUg379t1f/+c9//vP/AwA\
-            A//+n9+pGAz4BAA==\"]"
+          size: 16415
+          text: "[\"H4sIAAAAAAAA/6R9a5PbNpruf8nnxXRbSc7uTtV+6FidjGYsyW2rPfGeOtUFgRAFiQRoA\
+            NSFU/PfTwHUrZ3m84LMh1077emHwAvgvV/+9UM=\",\"xj3/4a//+sHKyjjljVXShf/\
+            WJgt/+b//+kFlP/z1h+fyy37546zKfvvvo1yYw3whjtOH//mfH/7jB81L+cNff8iVX9\
+            fLvwhT3q25WythbHXnpK8rthbMykJyJ90P//6PtxHvp+PH+3kqojYlzzqxDvPF86EfF\
+            qu42HYCHqfjh9EsTwQMUNLCnb6bPiWCOam90rJAmxWHeTKcyrWxEqF9TT+GE1rcMc+7\
+            UQP90lG9tJavjC3hAf84TT0PvyqU9mBxzfNouk8AY3tjt25tKtb+lHvGqwrt+nGUctA\
+            FF1umjVcrBe5NgDukwHlbC1+DQz5Ox5PDLGHHZySWyXDUzB2dl93HElb4cwolL7hKGN\
+            3NEw7zxTbpHe+Vzp1ERzx++DFlw0ft+QHBPDUJT42+wMfIA+idXZAYF14Z7VgmSwMPt\
+            kkg2A3s3jFee+MEL5TO8QtOuHzfIe8hMSc/9V5ruC81ZoZNAqN+C5RJAa/i8/1gYO3Z\
+            9r8g+Nc/Be48tx6wjrD6d7NhtGYFL5cZhzfjMBSbWngza6Y/9gaXwjGe7bgWMmOlEtY\
+            4aXdKdHPE9jt9r7c88LIq5KtPtB8vCql33QfezDZPx96v6fLzy9Fvwz4zo+HBp4igrg\
+            /teF34tO987U+/taioBx24xKg3cGmyupBMaefDUVjGhfDSQQEx+an3C8RaaHgY+wRp+\
+            AZmyoPe7nuv10lRW+WPLLempvSWvo/u+l9Se2krqxzWQH5KEMivPxFvI7yDP/fmFacb\
+            nsBEw3k2vcnS4iecZ/5T72u+qwTSarfHPrpKRNzzY2WU9pQs/Npfy9jLJa8qpqUPWjT\
+            SNaKs7fdwmqBM9pK2vSjzPXzCcX5N0Te//0TBl93rbt9M73XbMkFpen43CDiRgf/U/z\
+            BtSXPXx1GCCfhH3AGMqtddP30mgVkNuOPp7Cp8YQCBEhlWIP++F11E1u1fCTew6fVeR\
+            LY9mUSELdAXNIfW1eN9vz2rzDJXL7X0+F3309GE0SuVB/WmkgIqNdN9X2DPlZaWZbIq\
+            zJF+g5N+VmywXhnXquSYY9z3urgBFZtu/XSNzAQdPpcanFpE7SUEI6owZQnu7HHaPPc\
+            zDLKj5qUSTFiZSe0VL4Ke5+vqbJ3Aize976UiyII7rwQXa3mGRybVZNSLQFd2zNaygM\
+            6T6bteF+QGuTUNIFEeDkPBT15upo0HnzjMF0/9FFX5rVY7XkgtJAt2DOWpafqhHyTSI\
+            8cP/eT3ytQ644E184JVplBCSccKtbTcHgkHS59l56Lqp/L9CfAUYftzr1sTPtBTmPfe\
+            QLoo7/dQc+nDFTwhZy2xClNnzK1lgTn7sdddav/57PyEwD/3Ypu5MXkhk5TXXhzyhJu\
+            iu/aiQwvbW3X9uZd0Pn0Fa66tGdzrqpudtJoH5oUldVhxPy9SXqsMM/PHfa/zowTPpJ\
+            9s2Dgo7MeP/eAoHtdPzdnWS2m19PLWedO+Y1NJy73BzpCfel2uArlDm0k/97Sui+Lqr\
+            PCyrAruJe1Ono+3/UzoqqhzpZkwmcylZivLS7k3ttuUuY9Xrs9evvvE9VSIbfyJb5hK\
+            al4p4gN9buZ3HwiGCbw7x173/oQeNGho7vWTASdU+kybWSN+HEKOC3RkBP5YoUONH/k\
+            z62daevyNqHn24od/+IZXpTQ1MIzaffThQ29+g9zI8/2f+8iOFyoLPA7Hn/vZt6evAC\
+            fCYb7I+3kfL5jRPLdqSTyBAestDLYn+ikrJ9CyhsHfx37i4wTqgBcp+meGrJQIDTWin\
+            7V5g0q4ufN+LsDKmp3KYjirm3dH2H5v/Apb4hyeflGhKy5M1dr2Sqm4Qd3ykg==\",\
+            \"QzpsU3KO3kIuVFSDoAeinyFzxbZirXaQzNOewvEKXW85yrBbiKYf57kgOyctNgl68\
+            p0Lcu3X9/Au93PhXoF31NUYRomd4t4qyNmmPZnQBXuPtZueXPgGVkBlbNIvfeMK3NRW\
+            YjN32s/6eg3NRMGdU91rj8xj4L0LH8jkzlTYP9ovzvkaHud/TXrqL6+gnUfpqq1kGUT\
+            4JVdZjZlfoHq/yPIVXeUK5h1M+3kWboD9shZbIgXwOOyeL6NDE/sutz8OpIhV+dovTT\
+            dDiakBw16+WEuxjSYypnk/0+YGfYVTN4edpVhLa49O2p0kdPN+iUHXDygrjK7xw0/Jj\
+            30Lu8DsaqDCF18kL791P55Ij2HMKoKvCo4zhh8HssKIrrSCsfC8pzHwCtwJDuJQ7Q0f\
+            RnWzXBZERtDQe2LW0imPecpA4SmMdl4WBamlDEbHySTblMqQN5GtJnLeRsMoknHPM2D\
+            jBuiBNzBTufK8MEJymIqwPQzExybZdCCtM5x2n78bdq0z7RSMCkedcJi8yQwsq4lKz8\
+            BVm1L+N6byMN6XHaH3/yGlbucNWCnw++vpq7zAHgzNSocu+eCl1SDrI166YcJxxbdyL\
+            5enBGxCZRjG9Fbc+QIz64FG1KqQB7UspNS50rAua9svm+v6BWO9wvkx+UBHSS71sTRU\
+            FlY+0MHT/u+wFT+MJLnyBe9Gji9+GCtpQ6g4Aj5Maz0FZ5fSd9diBGKnlIh1wscCt4q\
+            DSonWvTjstli+4hqufjvQ/sutItTAmKExbN3tP9bAUxD1h2FMd00a2/n9MBG/FtBayA\
+            eywjWIwbXOpGF0kNlOwSjEtF8xxQ0yCOm3JzeMENKabU14M4Yhe48NvYGuo3XN95Jwb\
+            bf6w5+FJ/1T236pCpdvKKF0zkeEtTfovahcKyjKWjf3oNuttOCVqwtYRjcdKBmUXhX1\
+            IYPy7GGgQq/0yiwL4J4KT34/jCibjIyyPAwUw1t3rOFBTg/DmElCdkak9jCN5yYjhxf\
+            Vmii6HCbNCi5wtkOMeg9j4gWvtVhn3G6BstxarYPoE5NIPQyu902MuUJrkxF260CCG4\
+            Gz3afNsLtYmFxqHxt2YPVh2FmaXInSaEWkgU0HxgJKroocP9KHgQpbKT0vaDGX0tHjL\
+            XSjc5MtuS9AsDUWfw5cvYMlKNOBbvXy6L5ht0G/TNcLsCa5+OTHYc9dS1+oFeQkD/th\
+            MlPLvZUFEVscmEaht1RMcRgs1fNm26+HwBXYvcPu3IEkdgccdxoowHQNUsxjLGEgfWv\
+            PNfCZt3Jx0JLNFhvt24Ger4DLHVYqB6Z8GC25zgx2SeUDha2ppNZyifThtsJ9GFUqqW\
+            kDZGCSRgD3spBbU9IS5t2wG24ql0utsDdwYODJ7NZE7GYQD4k9r2CIb9sz6/GKnEub1\
+            USo7DAUXON6hOlxGE+tjPO5lYTIzfuVXd+g76UlQjjbgY6YyipXctor1a+C7QberJRf\
+            WiWwlHwc6OOoaisrg5PVpgMTQSxfLpUvvxHRrUHrtlyLNRH97NcJ53to7DQZGJ60QUj\
+            gPKeBLygmxpDxqId+RehX9HppFc6g6pn5fUXWmcS9BCcp7f/ehnbCVFAuiIFhfccL6V\
+            bGAtd/28phEFGc4KuVKTIiH/rrQHfPDXxCOUf7lIZRKdzHPYey6Gu/mvsztmOZ3Emsf\
+            varYb2uWhZSeNxDcvvjwJNVuebFCuev9cyfv2Bvj57jfMGBQs6ZlS/4kUgnGMhvXWW8\
+            0qCkoHU+DLvpQa+tuIdKXD4wKdZ57msn+BZrnimdN99Cr0sTnUpEVuygpQeVfGW0Ejw\
+            o6HT2/kB98VxpSPhRBg==\",\"bkELqX3K2gfin36EFv+8H3Z1/EoYK0tDCL6BoRm/6\
+            qb4/TSt/+2bsKXKLTrOtsx10HX3isjcGuiX9aCQts1jGwZrlcdpHNt+DQiuyLVdGswM\
+            B/oHiUT11rU+aM114S1HBlarMg9aNdkYajvwlewE4Y0YJnJ2UvMVLqYZqOLvSux/HZj\
+            4sLP8P4mXNwzXVWtJJEkPVGB3fh3MBmz+DdSiduEyE0k3gxa95zu5sgZUFzSzjfhp2C\
+            s5F/cTObWDsI9cZ0DTbuvTeyM7ZbS0rBUpRB7BpF+m6reab2Vb+UPYfn1QW9v91BEJy\
+            9de2tIJV5vYDoDCDxZTv0jACd+vJKu9Kogs+ryfcmBlrpy3R8azzEqHS9D7FT3aWnvu\
+            tkxpL093BPV4WEz6mWS21izi31rDuBJ92y9zw4m1LKHL/mu/3O7zcINLmyjIW/uJRbc\
+            Ta4Nb/j72C5hd2oxkCndq6udLC/f4+l87aR28GK3buM8HaieZ4E6SPbjahnB9oPdy6R\
+            Q2h0SaRed8ewmODDXyj1Z5CnVX4vsuVVhsp+w6YNYqo1vfxe7+SYindjt7uVSa4xZdS\
+            c6IlbihokuQRc1s8ZTkaV+JOP1iVZi9ozKzW9AErvs9KErKbkET3usrUG8MNdfgMYln\
+            nVDd2lSOHsrSzDZ5kptkxWSmvLFMHqqE7lhJ1T4reW27l3BVJ0n1n0HYHpiI014sFz6\
+            mShJd5RIp4LLt6aaCTKPYbzNFKTNbGeRggaf5JOU0GKuw3ZMSW6+dtMxKJ7kV68vIgL\
+            aFK+TEKcpFXSvI2J5S2NCO55bjGuGnlArKE84LaZU/pcivE1rbNtUU0LR9+jnhCp8B8\
+            zoKm1M/ma0spDdUy56nFH0df8DWSyh5n1LM8/MnLpMNILt4SjF0z5DnDl5rrnOJGgLF\
+            2oH0a5XSuacdJ5a+fbcmipWfUpxrFzTUrCwurcd13ZV73g5M2noDYxdPKVYV2YvxMUX\
+            Qto1AiX7ZbZZ4yk4jWBXk1Y55y5UmJOwkhXGfYGu/Pt8YusPw4iklSNsiL6UW65LjuG\
+            BSp6cWT6xVFRvjwNbeTVJl+wmxUDIyPK9hI4tmm+Kkf4VJdTVPes4Rz6mLHwVf7uQjj\
+            z3B23YPUPqndOz5EhHHcvd4YM+OL6N3gH32dQZ9BCKlGuDUrTehq/YkpYCmhSMamDbz\
+            RVK5dAu2FlWw8YhsjNSjplqhPqYUCbRQRN/SPEXVaZHaYVSxnFg7aNjMF0kRlha2dLn\
+            l1RoKqWY+7rHQaquYULJKU8FTHHcn3JY3Rj6Z0qcsqQf7G9DQ19jmdKcS9xZXxIoFnN\
+            P9mJJa9gZ0dzeatnpwCGgOiijbgxuCutljmf5zsky/Rd1Ku5SWsCAHQieVPT2mRAj/C\
+            G5AN8O2xUrPJWfc8yV3wcqqxTr8DZKk98244J/mIbS2HXYwDf5GarnJNMWN8/YnjOUC\
+            e+jzlIK2t8GtzBT2oqeUcADs26kUxB6GnoHTZr8qqLyYFD/KK3wyXSJdwp6NLCms9A5\
+            13Iwen77i5oKbInHSDNm30Emhk9IC8U1oio+nxG27gLclvt8pbcrexE7jupOUOra38X\
+            eQZ6UEzt7ETa6Q6y3oz18wldRFBnID26zDgeunM6UCv01phnuCP4eHU3TBp5QE8hbXc\
+            gWSgSJWMsuD7qlmtnhMV6ZvDon06W7TqehkoXR9SIoVTtN5/Xlu69Iaor2USHEavwLV\
+            Zn8zmIlZ6UyBzNx4ZOkEcetgpFXEqtPv06ljNXNeVns8WqRJdAEG2Gs0hpx+NZ4k3Vi\
+            qbjOFIapMth3VJU4yeU5p+bBzMdVhjRtzfU0pVjhBkQ==\",\"IaaWBSUcbYuXxNMeU\
+            swZMjPnOG2SUoou8ztaJxWRu0Y/vevwUspH045Too/1gkj2kEmRZFe0BvfLSrlxF7DX\
+            zlLsZ0npUfQ9MHSJzJrpj31O+pJCkZsgFb1Z1iuGJpG01TIJq24j6KeRV2slLWdVXVU\
+            4l+BrSrHMXi5ZWHSb6cXFlucEmVP6752DyecpYzeJK0cNU+QfU5J2LvBV3TSEu/Ip5b\
+            EeOZrncJgtHkDWSymYcCzLlCylvSute6mMR8MVZ5u82+qf/DIN/8f+lzXzzwCjAZ2A1\
+            LJkpXSO50rnd+U3tikdc5XFkYwGRHxVUe+55/Zuw3ecZdKpXLOKey8tSvOaLZ66uzsr\
+            PfqvUunaS3fXLo4tjUlgcBG2U31XOpNBKcnv1H7F4nrxK188dfctvoJV1gik7sV4Tef\
+            T+Lv0v1iutLtTmeQ71c1vm1goRuNU68r5+KJ8DeYqN/MxUGb+btb6g9wrx3X2kVuvpX\
+            V3wpSVcbGxbM68VXmOh07l3dU+b+PXzpuScWWD3nTixMQOugny1hcCbzCVAW162lNHZ\
+            Pmszf4DX4arye2W6aLbHAtg3TTe1FrmtdZ3q6bbhxshOtn1VloeDDd++msnzP10Ibpf\
+            xlYVR6XN7o7rvC64PbGE2OsNPLc4WqPzhVxAl0tRdIu6ANKt5lxATpN5namtkG3Ugui\
+            M28wX026fzAU455LpoCpq6fwGx6S6Y3EXuLUsiu6oY1xT92meQQIrOF1/THx6PRupt/\
+            gRLcBU2QvMlnsuTMaZE1JzixqrtnQnEf9hnOcPTW3lr7XGIfp2jV3P6LrGgMhKW5d4t\
+            FGb2k0usJSWb1EcPu6TPIDp8aECHCLeKnJrp/dYSS8KpYEd2C6KxPMmM3gSXqA4+XYO\
+            0ppI68yi4T7NHLWG2yq9k5Zb5Y/v7gruFHg+s8VTdwBu641VJv6BlJnJ6O3fvngd73A\
+            F1EYcKYCUYYaRr3dR+APfa7Hmyn6IreWkvSvOP8GSq/PoCyXW0jlmbH5XKNSBZrYR3T\
+            KrMLk3e33+E10gUDRf1EJlrbYyfvjw4XHEqqM3KJgUVtVtX5RclMZXd05ZBQZchIffP\
+            SCm5FupY1fnO16BrrctStfWblDaP2KeJ5ArLVz3zt6Ci1MChVUVPeY4KEndlfkl1yy3\
+            pq7ueMalRYJrnHfnUNzAWOEhexoDNeQK8xBhxr8QQKnryZZsJWXmPIo8hS12+/6vkMt\
+            aFdl5ICQlpSP5E+gm1tyi6ZKR/N2X5ApjigxV9ga6oSdwAQqqvpbaO3L8YrvFREjgXb\
+            2fLr52D7q4xdGeKy1tdzgumErdRvANVHX0a6h4jOHbPONkvLLMqUxuldhSmWz3saqB3\
+            memnK89CnXE5XVquDdIHrWTac+P3uTKVzERPqtLpM+M8+5C/SvYWh6qAnUejUCd8vEG\
+            SO1kqWARabsmeoPremlexTC8EluU5xhfZcIaTzo4Wxa1DIpcCtcQ3aL8Briujl7agi8\
+            Zr72pClBw3goCerFbeRSF4duX6mh5CfLs4yIT3mtQhlxlQfeY9qzpAyqM2PJlIWNEKd\
+            iBLoX9dhc5XZHLDFjg8frQ+yyVsGYJBj7dxxQnepulQTHJ+TjvnhZwCyK28uCRTyDei\
+            ATizB5ood6dX3XF0cbLpYHhxnZ39JJ0XVbUfaIXZLbIMdE+GHotl76LL4Xh2Ushd7JA\
+            47NaWU6vruK5ZGa5kYJiQQmPsOI6w1dBpFzNiluveEHN+A2ivLuU/AYOjEVsr0ICxjZ\
+            Hyb/tKSbszJpS+rWsHVsV3K2XBY8lj5Wh1esEEXwDf7kvaejdReJX9I/HXwrzjTjehA\
+            ==\",\"q1wdM+756H7U3TSvvb30hj8eM9mdZ9OynoTDPWpjOSi+bkVwwvEe/bU6iZLo\
+            KQQPeuPiVATyeJBWKIc9pV+R+XrGtfJbLR3x3rtboF6BbrSYAlUqR2U0YcNO+rryxlD\
+            aaMJljW5ztKBJijURUKzZEyeZgOO5W8cMDeVZ61dOUc4SFCnPl6CtciujaGrtlNyzjV\
+            mylSq8tKTGc5w2oF9eye02NiNrw3WnMhnCE/i1+6VOufPSCm6zuxOW1MIeq+ipII2rg\
+            Ny10htkw2u/fhdb7kkb43YoMg/aJ5f8IEytvT2WXN8FNr+N/f7hWW+BhRW9fNYVUt65\
+            upL2xUlQcd/A7pqltCVXGdu4818JZ1g3kHPcqjtXL+N9Bi92utm+exsj6LLnyXKxVOl\
+            OYAfFtHl42y36JpTnhclrYP1NN9tkuDY09JIZoKJON/nPqXhyJKNTGxMuHS7LJbOmho\
+            J+2jzcpwLG5kNManjTpsDr9EfIv7T/DDf8UypYUINxBCbA7dPhcqpOLpDvba/+G3h//\
+            BFcZ/Kx/PFHJ6r+BUU0ppv8x15fYA46MaebPJ0SLiPY6bR5OKSiGZuhwuywsuQr1GIx\
+            vsdvsOmH95fZ4wLiJZ9ExY8lyt0LhEvmrN9qWUtWRoEHEZOfjFurqkIGWths8sF6y3f\
+            KMWGNfiFUwGnzkHwmtYPb3eTJBIy9Jk5uanxhkp/G3ljop5gtnrqTW1o8s/J3pdFcmF\
+            OzEyKs2c2utTLt/+9E+GnWTDt+2yyPlEcJDUItbWbM8s6vrZR/AWGsw6wBQ3Jn0q8Kd\
+            bgTRmc1zpaaj0FfzDOOrK3cohhmA8asnEH+dnTeosknAaXzkM8oFgni0WzRwVRmXybj\
+            ycPdz/5n7Ebprqk+IXAhZCEt9zILZkxVx1x2KMzni+duB9QbsN9qrj1bKc016JN+Dys\
+            4T7AP7x8BsZqnt7Wq8y+PP3xCvz15m2Ocd6QYd065sCOutfGxRRSZhT3bfO2elHmBti\
+            88xzCLh+6WFTcwKCNxNNt8fVsrvgA4Jn138nwAeJvt3wCgqvXRrPn6thS6AngDqtkCA\
+            D7j6W+/o+dEEEA7tYx9hopCxqQillU1MyCcP5p16aLfYVpTSCa1NSDIMpo1D28rOW+B\
+            6Z3KFKfy2AImJNmbmFYhhXk0a57xRahAp9Bmtph0e3ouCP6UNh74kagzzrbyCDONR7N\
+            Nhxr/JuaKL60SrOSao0TUgPq2Ev8maqGWJxpqJ7pnnrTuaYo325JtpdUSNa8OxjxJTA\
+            +OIzDe7mStM0KdKcNWBS+Vhm1Rmry7tOGMtW+LNBmoYD9MF5PuvNUT0C8q//Lbwwxct\
+            I3ors25gJiZnMKcSzCJ4QSyVMYx17ZOdKzM0XVadKiRZ6jCOGdKqu9Q3FunS/iCVcsl\
+            b1DLvfki7660PcOUYi+7FYLRbDOBLPAXs1zCF7bIIVtuU2bc0XlZMm7FWu0kU2VlbEJ\
+            S/2g+foQEF3wFGuWP5uMpZHViaYxXJc8xBiTQFePU4g7Kmye8HQHK6Y7TBjTEvkF4ye\
+            TukilDpXAn4LEczOWNAoFSVEXmWZ4tGc94hSzd0XyM1cAApJ3K1yjZYQHmkJ5w3q+5/\
+            7RA2sbmCV5rsZal0itjS+4VmA8fgN42i89ABbecZUoEtkGRZ7bAOlwLprpPKzxXaJS0\
+            CJWqZKG0vBQ0M6eaICG9MUjFXHR4bl+DnyvLzspLVfDj0hgwHW002zzjR/gauQ0/UPr\
+            9aLaZQrOhRY393hJ41WwhEtB2qoGWQnfA5Xx1C8n18wxmmS1AVtdlNUpvTxoKpTLex1\
+            bUxLpilwyO6hobMBDxFoRp7g==\",\"g5TIDH5Y2Jp4BYWHY7bluxTLiHgLWzvPPscE\
+            XLw4eBci2O/Aop2PH/FL16XsrhcbzRpCaBkBiwBG8/EE8on3Zjpm75/HD9Aox1uIHgv\
+            JHNfKqyZOZCOfGCbrReoxwTXq+z2abbDacoOE+9aOZs0jNPveG+0td+EafjDOSffTl0\
+            9j/NQoJVxU0rJMCoNTHxfT7sqLC1LdjiyII9uVPxIcfj5+xOKjqll0gQqU4Dmaj7FZJ\
+            py3tQCcez4mpCrwgYWzx4+jfn/xIcBaJ9DB9QKVcSbWUmxxA4EgOjE3i0BVxXLLyxI0\
+            Tg+kIXaX8aCMQacD1FLDs//QNtb/TL7YRuCTDquJE1JR3lwgD3HeAQYnHbS1XwSXj0D\
+            fGBc8kyUa3DZDyTOvwGqufY149ULgNxVQrKzMyd0Bo0+jWfNMU4pitIfZeNtdKnBBGs\
+            vAw6FtSa1FaxZj2jCkPds8AZf+Gausi9rF4DPDNWmHWTPpTu2/4M0rzz6ds43h8RE3/\
+            Im8Ac1Xgk6+4GAwy2jWYHY4fvgwgU4yKAvDb79kEjpSmykNEXOSoWkChXvGPWdOKKmF\
+            vObTQyUMK+SvALGGGDYI+fOYe+6kf/l81H4tXVBnIBhUGc5gz3HWD2r81LqAiKeRLes\
+            4wMEZ4A0IjxWyofH736bw8OAryEReJiS9Ru8ywXcyuVRc37ht0/zeh6AzUPbHWMqKfZ\
+            Dc6gD8cA6EGcs+/xM+P3yeUlZn0EfajmyeMCmlrHBUoxFQ8Q7L+RRYdylh8UyQJVCVy\
+            FZM79y6lGXb2sYfwaTmYA9AHpHlh3PHM6iAwjc9nvw2WXS3SAlKcXdm+RlDxZFE/sii\
+            eoPDFg2208YffnqAUa2u1I4zUQqlq9oz312kEvRZzOeKwsB+HeH14gv84XM3TdtQNcW\
+            DjODMGUeMqg93F/LZNmDGMuW8VcsautmDEQu3dQJze7WCSyJYW4uyM0VdSqalx7MaAq\
+            MlVmWNkIx4CLMNDnlne4YaI8ciWsptK7n161EJKzUWoCTpFYzzdQbSWIIeBV+SzLbdp\
+            Qmj2eIrlF7ht5nMtmc9Wq2oNhHdzQZuIZVeKS3RGNkY4yM4ToTSRjPjgE9mtsAerxYl\
+            CkMIAm/fDUjKigTkXhHs7JXFbUNAts0NlpXZSrk17dltsJtb5oU8eGk1L87Lg7uE2rX\
+            MC5YvoX7fkZh5A7Dnx4LDdKIGm4mPKg8qXrGT9iWvahiRgJxDamnzI55eM11MSN/HFY\
+            cVI1sBPj1rppjAOPMiKsH0anyQ6GTGwHzckfZ6wvmVFwLksI1mi45s6cvvOy/twnLtw\
+            q0j1C944gHq49p489kfQZF30A/g9VspBwdLhD1BCbgqpPSxkIa4wV8JGLPX0tMdQUaz\
+            DY3kLVYNsM37q7Gg9CyofZAVrywv5d7YLbOysiarhVriua1R5FBBm5WVkvm1lTyTGeX\
+            vGs26sprPaE6RnqDjLCHB5FeczztfTLsbf7QQv/FS/tPYraPfV1da/mkt+bJsBx9BGw\
+            I+0TyzwoAa49Fsg70deebOInQFkxtwNkAuVwnB7kl3i9MTzm+BE8c42MMkwfzcPEPx0\
+            A6tZFy7vbSMgwZXQdeAG/xt+tCdlB+4DuTEuWGZyJHY7arUuQLkVc2LwgjYtLuZj6dk\
+            PlN+DhihKCOY5Hpdk96houZw+aCwjAglTgSlAPwq4x5V3i5AL/gzTFUznpVKM6p2dAG\
+            mR13BXvhqpTRioS2Bqcfw8ZmNo6eIvSePLPB5qOCGTa4k97WVwSYVZidh1LHBqleAK4\
+            1W3thztgX082D3eh7TX6mO9NPFhLTgfvv4/NHspV0goynIVA==\",\"cndWOs+kzpWG\
+            CssU8vjfPj5/9lY6B9fTzMfb7gYg5zVZLiQTVX2dlheHiNcKxC9jKgNFsxa5TbCAyji\
+            8YL9ZXq2fPnOYxdJR33hZiKgzaBEKzKUX79nofvSOPfz4bnQ/Yu9haHfW5Jhr77Il25\
+            kDyosNVIFbWkte+LXgVjKjmecVW3xasMWnyWI+I8r6Zg3odnGC/9t0+tIqRi8wjt2G2\
+            IkbtjaFySSOLTzD676uBLvmI5QcZ4xvplDpm5Q8l4pMjoAYqjpW3PKdkt1F+EH6Qi1L\
+            ufjQgKXaPjOCvH9/+J0tjCmWBjnLGuw13kjvjGZ5BR1UzSM8phOIzUrOKiWM3MEYO85\
+            B2CiPZsY1syYnM4i3/+WYSEmSb7CaFnAyGUeGUP0RZoun7s4Gt3CWjNdEaU65lVusKM\
+            2pbTaBT6bgbbnnJFow10ifQ0DTqqSF8HE6/trdoOsG7ZKPWaByx1YRIhTWAEdZfzFcQ\
+            ulmAShG3ZVegfhuM18IUCV4wgq0T8hdHs0aAbnLtpQcJO/cx1FM1PvRfKdyeHDhHUNT\
+            cGu2W+CGH826qqxPv/8PY3PcoaO7e9p5CfVSCl8w3d2TJzBruIyAsVPWB36dyAtGsw2\
+            O9xWj1T5DqzrMNo9kHuuH8fgDVCSgJCvUMihH4gBLQZ+6ezZecTK5KlD7zdF8jL0GhV\
+            rmxQ63dshH1GkXalkKj4zyJodWw7UISpD2UZutSNNG70qoReWkeV2oZVVkcEJCTpqkO\
+            KQWBATp6moHcq2UjUPPoRoGH9SU57ouJ3MYkyUQPK5fgMrK9OH3yeyRPfz6O/s8/gfM\
+            oYF6yhnnEwWDaw5PMF/o5XS08D7hlKIUbKnpsXOjWTOFSNPxB7iUdmAL8RinMudTU/z\
+            y8Knbz3UP50rfAHlrNHvU0ubQ6dvgiqkL0geUzbPBd6+URWGgg/1+uvhKptSX0ltTmU\
+            K1atJlahpaGPa7lypnFbcetGIKJ4+fhiq4xnYA5ONTpbdm77bqEbs52lp8ikTKewmjy\
+            zlpIpVFJe2KGkXXzBbb7qHcZyiTucSikbZcjWDrpcnqArRtb0Go/bUgrIgN8wlfOb3B\
+            iFXyLddEMQulzJ6x3BGNoAtAiRv0xhRizWHTsgWYd32B01yxtj4GFYEcpotJ95SLM1i\
+            lGBfQ9sZRjrIuvIp6ZWVNzG5XOmelybCHqHmG+n950NK/ePNitIbpZDjVXaOCzGCEQF\
+            Uq/DbRTixohZCjabmsC07FgYICD5dClUlPuxsv3iCwhyJ24oMGSXdPzluk9zVlEjdgw\
+            tMt0q+XWOt5Ygb2T1DPNoL+VnOb4WmzcXoDxU8i2KcaTT9EM2tvUVwlpVjHEd3hqQjp\
+            HJw0O37q7gN3i+vlwZ8BiRYNuKhMy2otcSLChLjrEYAeORj0SYyU37pMpd4pa3QptWe\
+            RlxLpt1D3eQ1tZVUoHD4czRpctRYQ6WGWsWiBuG1Bi+L6uF9LYJsEhZM0IwNS21wR8h\
+            yoCLU8i/GVl7bkfp1Q37fBOYAnRH9qvgtjx5jkLdBpUqzMFEwkDS+dlPbald1KZ8yRJ\
+            Wlel0vOYLAmOtGoVx1xUKButsH1B3rHlRdR3diCpvbNfPxAegf1DtaZzhY4GK13S66z\
+            vco8TAfC7n29IzJCZhvs2j8BvMDQUusMoc54tywFrmyOc8HIM96dFLjVaYLaaS425pn\
+            4ue6Iaq4FjjPOvvxaQJ/IfIyNN71D0aBmtnjunmZ0WUP44+Vh8vKovbSVVU6+xElz02\
+            4vYXtwJMFPPrFMsjIvcQo7QefX3jVma+0VcJAFc5x4JN8hUi836L3QL5ranmpDKK8tT\
+            C4qkg==\",\"90ceS+l7Z7xKGeY897Vja64zVDradjlPw11XAsiU+Rgnb5xAlHaewyk\
+            QYUndgxu+Q6tKxQwq9Z+PCX2lBSpNVlmzhDOYxD3NzU9gMUeFyV2c2Q7bGArSvD1nm+\
+            9KmRKsxEkm7R/zyivBi18Ls4f+xPmYkoRxaYGxKuelFsCxFI81kYCV2SeELMMzTVnet\
+            1ra42UyTpwykcMiflzWdUI9t8QiNpx2jz0HfaxmzYSMpZ5xLkPDSUV+PsYu8BPigWjw\
+            EJPd6Csc8yrem0x214wH9ZY6Tp3JQyvZcdCPNGK/sH8Q3efi0DX6+KLmnlJaT9NIlzg\
+            UisvYZruPCtQXtmMnSbJ8/ED1LAib6R4EctmMRSPrm5z0DOidAz30RrNmQtxeJ5QYdS\
+            +ifZ20GhnrNyG/xY6lL59RIKHBRcV657yFTKaZNVPSa6t33tbY4sFVT7MvsBlYV4f+6\
+            +cP5HyZ0ayh9O8d9DXitGy9Y3u+k2j6YDDYIUY7cYpl0p8aqPpYNH7t1AfDr91Thi7w\
+            ZXSdOIORnn4iri2blzrW6Mq7B82tenbZOOYkQFSqocUN6i9FrIxmD1lmdPz5R47SOFt\
+            4rGR2wj9Pux9QAKYyDG+Aly3wizn/5IWHTxAygDi3G3xRcLe+uR8pSj0VvrmFj5K4Pn\
+            WcI7HHE8oV8hpbh8udkPL0RDV9voHNpKxYFntaam/Yq3by8BuUVnzzDXnw7D+7u8a1K\
+            8Yc8js0IdbcZoBVtJjJFzpgSpWDQGUEJHS814BSu9ij22g8T2S+eKLqpm6AH8/Aj1ef\
+            8KL2xiqkoM4XT93jacHiq3pZKLeG4xgi6+h1ekG/34EGTpHW/a7XN/8z5kHpzE2ZtEd\
+            GBXduICeOc/FZlSd/xEpROYuUKLrB3irPeFUxL8sK5m/FdqnpVI24tTclv+GUBJ9Pvm\
+            EB/HrLWmzGlTWmzNtiL1jOhAZYJH6rUieGSjzMXvT642eck545yVE1aPuhP0c74XYsV\
+            lUSZOt3r/7wmUyupPCOYpRUrIH6jDwIWbDTAcFG1PFp/7mP5dL52lISNZ1/vPkRK70S\
+            xPuhisiobzjBPZ7IuXiiurWT36j4XrPKKtwN4YkyZKnv1Io5IXHy0RPVliLhI3ulMzi\
+            JMUiigV8hOXIsLB566Gd0JkAFa6RSv6MwDk1LXkx7COYAV1kTbbIUYjxRfu7vsPfGbt\
+            3aVMypPI4LhNNfY1fhfrQ40Fp8y4GSz3BeSf38ubt9aoRLvxInuFjSxii/UKsFJp/ex\
+            /XRdfsU2uNKBjs1tCYu1xPlzrtB/PSeveeWvX8getGmv96zzA4qWsm1ZryE9TM5lXJ0\
+            i722Sm/3llcpmhSVTX4LHPv1eSXavBoyDaPlOcnPrHbZyTGUphOnP+BwbStrKuM4Lq5\
+            +opKLXy/3JcqNF2F024NXGf1SeyoPikocff2NVqFLoghVsfUdRc6mnGMPOmNks4OobK\
+            Wziy/K+poXsVFFO0IKeyfSibKXS7ZTcn9pgk0wjnTg73k8g0x+NGtw+ajRcS6AMytfc\
+            pz1CZ2dRuvDxb0I3YqU/hCH8C9LFHZpHqELOwC0hU1gjOxotsApZxeUU3p0QqIZLq0I\
+            wumz/Db6LLtHER2nzTOZy2UqL+WLcXRvsA1uZTuvvPr95aECzSfjsDMqCmMqrw50ksJ\
+            sgcNlc/bpYcYe2pkyiESCzGI2fstEybcYhsxPCDCZLLnOWGF4hvw+EY8KegY8WiTFot\
+            uElZWyNKDsu91hAqFMWbIl35K7o6I2Aas6xstAAFGBBb9lbh2sdxZEFeGOpii100w5U\
+            7R+mzYHkmq5jRsoVFElYnESkrTsIA==\",\"NTHTOHBhmNNRcesVL4QB1ZMt7yQoV62\
+            Nq9bGsjY0Q+U2RUzqWK+YtfdEB/2cbF50QRPSerVSIthsZK13RCau8gU59kdW2ku74o\
+            TbPqdCUzeoclnn52mE2B2XU57xK2rb+eKcgEOAppJ2bZyPmUa49pSMrr8GrIzzFGAqM\
+            QuZJR062WnzimjynPDL5+RsvgualikEJNsc3eIFzY2CSz3gSmXtkGQw26NFTCVfONwT\
+            w0g5luRX42TBiG7FETD5wQRFPXGRye/Fq4RMtRYylZ5xjnVKpw4sF9RhVKnD37pt+tF\
+            sg5vNfFQHWXxBnV3ajVEHiou1x1OyNPDjh/GU1boi2vLjxtUfP/1CZH43WKuvrHTesJ\
+            JX2dmhjrt/4rYuH635ohr2MCG9TUGrgMkalTWHI2ovOGtwzssJgG1sJRIa6uL+ymewH\
+            W54iOetVb4iC93mY5yqXx31znqchAct04/Hj9agbusNLkE/uerabkBoGfjmVseDwn1D\
+            4C6eRmi8YTv3nXiAT4/TZ+gHo0Lid58exmyKs1umJCc5gbBqbbQs4WCNw2y8Jd0Flmc\
+            eTw3BjQEsr1RG1UGO5mM8uNkGW4wT2XuUkAsgQbhJbNU3eMKrlV5pHjQYughtPn4iKy\
+            U+qZ20yDl0Px1PyDGHnxa/Bza5IJ0EG1yDa/3h5TRp7iWh/gx3wrI1KiaebfDopfbzT\
+            6jn6XyMsz6jc3YDfQHPe0rLdKJ8IXJqgnwmjtnJYtVaTe6UDcZ3RmVcgzS80WyDByg7\
+            WXLtlWBO5sHoxk7WIJUgF3QyVtZon9acE7eL/fyPh1P7o9wCRT/gwD1ecJSVIijRemc\
+            K4MAKvAQ+4DMguSwofM8osR7fCV5IJgrJIfVxf+kzYmyBvUG5IgEKSsMzlPNyJXCmVk\
+            6KJVfGkd9lhvk3fsvGepmVHE4/wy0KXMXtlkVx0v2gf5xuiCt+g3LtYQrriMl8udegd\
+            BuooPbiZ32LlzRJN33PG9CmIyDBN/0KCTRNPszHE3J41CswqnfvApf0Rawa9tXY4OkA\
+            7WoO+dIYnBn/nHB0Jxj67Fq9hbxewDgczTa4oK3tg+C+1ZxolUZ5b5xTq6VVGZj+3sz\
+            HW7Jp5GfPl4VkY7Va1TG35J9y+TxhixjdAp2fDrNmuidp5TN5wEVFeMwuMd1oPsazy+\
+            Kvx+F4Z18mkjEbQn35IxjZUjS2B6de3nEJ3P6jwPLQr3suYjer7rhorEKhjspz85KdR\
+            ve5WqFknVjUkgKHWzAEHNLlGXDijM0XqbMXOjk9bjUBs6C7rQQkQhkNSKd5Hy9LLrZ4\
+            EGggW8LS2sDyqjD7d4mgxBN/DTpKA6U06Ah6TliANgHk0D6DtZ6YO3iZW860qXeS18w\
+            a47EDBw8da9Eqpcv6wBw1JH0+xu1gIpoVsPYZtxht19PuKmU9OPehRauXxni2Krhbty\
+            7bOEoMw+LzewM2Za1Qf7gFvYD9v//4oeK5nOiV+eGv//pB6ux9bZ2x3+M/z94JPduJT\
+            fWfk3Kq5urv9dd/vismaq8yNfk/kzKrst/W776qnzfL0f1uUfzv3z89Fr98+PFT8b8/\
+            /n394fcvajn67/sPv882oiz22d9mD7NN3kyPEzcpn9RcTdQqvOJ///vf//7/AQAA//+\
+            39/s9kD0BAA==\"]"
         cookies: []
         headers:
           - name: date
-            value: Fri, 10 May 2024 07:20:55 GMT
+            value: Fri, 23 Aug 2024 08:20:22 GMT
           - name: content-type
             value: application/json
           - name: transfer-encoding
@@ -1445,7 +1443,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-05-10T07:20:54.733Z
+      startedDateTime: 2024-08-23T08:20:22.211Z
       time: 0
       timings:
         blocked: -1
@@ -1455,11 +1453,11 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: e4fa1fb67c634fe2e0add9184809cae6
+    - _id: a8bf84c3242e8aa7e1f360a4ef1bee20
       _order: 0
       cache: {}
       request:
-        bodySize: 429
+        bodySize: 397
         cookies: []
         headers:
           - _fromType: array
@@ -1477,7 +1475,7 @@ log:
             value: "*/*"
           - _fromType: array
             name: content-length
-            value: "429"
+            value: "397"
           - _fromType: array
             name: accept-encoding
             value: gzip,deflate
@@ -1504,270 +1502,276 @@ log:
                   }
               }
             variables:
-              after: UmVwb3NpdG9yeUN1cnNvcjp7IkNvbHVtbiI6Im5hbWUiLCJWYWx1ZSI6ImdpdGh1Yi5jb20vTlZJRElBL3l1bS1wYWNrYWdpbmctbnZpZGlhLXBsdWdpbkA2NjQ4IiwiRGlyZWN0aW9uIjoiIn0=
+              after: UmVwb3NpdG9yeUN1cnNvcjp7ImMiOiJuYW1lIiwidiI6ImdpdGh1Yi5jb20vTlZJRElBL3RlZ3JhLXVib290LXNjcmlwdHNANjgzMyIsImQiOiIifQ==
               first: 10000
         queryString:
           - name: Repositories
             value: null
         url: https://demo.sourcegraph.com/.api/graphql?Repositories
       response:
-        bodySize: 16535
+        bodySize: 16978
         content:
           encoding: base64
           mimeType: application/json
-          size: 16535
-          text: "[\"H4sIAAAAAAAA/6S9W3PjNp7//V76ejF93p1M1V4oLafH2djuTstJe556ygWCEAWRBNgAq\
-            NPUvPd/AZBsSSa/Pzi+Wbez4w9xxu+Mf78quec=\",\"r/7x71dWdsYpb6ySLvyuTRn\
-            +8f/9+5UqX/3j1W37x7p4f92Vn3/aypl5d72cfHj1X680b+Wrf7yqlF/0xd+EaV9f/3\
-            E5vZy83vYt67ioeaV0xfRKlYozJ71XunKv/vNf49j3z8ZuhNFzVSHq3TOonZXCtJ1qZ\
-            Mnq1pSwtRvE3W27TtqnDS6tWkk7yt3dzO7WV5P//d9h9vcvr3nLd0azuZXSejM+nrub\
-            2e376zUi7XorGQl5e1UBiDBW3q/uO2sqy1uKhJoTSGzFNmoOIR9uvgJIWTrmncajApt\
-            RdmUN//wd/HNZsEVfsLi14Fhco1GV6gdrTSkbtjOG4KDhkM27yjBeSe2JmaEpvmO864\
-            iVCzvlRKPw0F6jlS+9a/HSgGMxF/iPYdvnqpEb+PcfYds/Sz354+f72bdrCHlzkweJu\
-            zZMB95w72Cf/pZ+x3sFNqjqFR6UD3CVL7jtjNFkP+7WEKPeC+YavpKslE5VePN/gNOk\
-            2g1ruVgoLZnSrpPCq9BA56THQ/0R7qDlgjlpV0pITPkAKY1cyQYO+N0aA5TuN2yubLv\
-            mVhL9QUPeKO8bWUurZcMafF6+hyPecu/xfSi2sCkJwFZOmFKyubGsFT1elW/htdiKnq\
-            3UTjf4vHiHIdJzpjcd4yu8wT7Cy/4Bs98qxL1GolYK3wMf4XZv12quZOYC+gBbo6Xfl\
-            D282u7W8KLVc8EaVYQfWig2XxMnCGxNZOl+c389F79w4Y3dzqTzE+q+g2sgUK+/f7n+\
-            5dOn+1/+JEBo2waQlw5P3Ts43qaTerGurOk7the0VtISotY7eJicIFfyHUZBqS2g/MJ\
-            KPi5wJwjsog87hbij0Xx1TV8xrkvmbU8M9kc4X12L//oN/GurnFgxQq9JGHQuJoxynD\
-            mFxaY3cFQSx3QiKoVYeKG7tVONw3P0Fq7jJPcUzlueruaGb/H1cfsGbn3HVcNi24jTH\
-            o21a7n191wI6dx913A/NxaP+Vu4lN2670ruJXPCqo6QPD7AYzJtK0J0hRPnu7a7F942\
-            hKCIGL0riCsZ//m62CvO8Rwk1JDb93B/Bdj19y+3f/7M8Kl8+x6efyvlmWoJ+RdOc5A\
-            y3pf3cfU0RtT3xhSUVIbmOvC4u5d5rPdQrFoRY/wOjnEQFO7p0xg14F9b/eP+tvGWO8\
-            Eb+aXp3f1UBhF6SppQbj/AI20I/fv32fds/t1mtPc3ndQ//8zmSnMt5P7XmbSt0hzso\
-            OvZ1/Ed1PGmkd69njfcQVn7bjc6pF+snEvh//n1dZf+Bdsyroh3VrmW73/g/ozOQbf1\
-            xorF4SekjOv0P3pu694pc/gX+9ErUTvPLT4x77ajI215Ld1iadzi3Zs371+XsmvMljn\
-            TWyEry7sFK42oicWxHd30NH4hm/GLY3Mz/Zrd9t9/nV18m+GGjs7QIGtcwtte7erdaM\
-            N+l+GuXsnvr3/f/MpX0C5W7UbPXCvFIkztwz/wCh4fJ1kq91qZ+BN16fbt4N873kg3N\
-            1bI1wV3kgnTdkZL7R2zUqgOSElxnEa36LfJl9e84B3jXjBhmVgx92EBtNDr2dcNTRON\
-            5Bos2c31shrX+x4wc9VE9brlYOQDa1wxHmQxb0yD5nJZj8v9D0Rv2NJB/Xhaj1+eERO\
-            lN1WoRvnt3pJEtm32dVx2itCyVc4FOXUti4UxNbO99qodv5k318t6jZmNtJ5p49VcCR\
-            6FYG1KyUSjkJk3TjOemqZlUQdSOtpRKsvnXI9v1831bjKuIkZip4reKS2dW/QF450it\
-            0jo/7hkMgBV2oezM45DDnyNF1PXNYdRdX3XGeuZkBqZqCIUL62uY873pTJxQQ==\",\
-            \"1dgIU+1wC2339sM7tkAzs73aVeNXeKS4rRasVWHkDO4bcWBFUGdN2NPgXryeXYwrY\
-            gFUcFFX1vS6xPM3fmklylY6xTXT0q+NrVnRq6YkTr9xWTYifcekXilrdCu1ZytuFS8a\
-            ydKJAeXQLVwXgexM08fVViqOPWih8+MqduTtt0UQUvrY1s6aeKrpcUtCGIBxFfIEK7U\
-            PZ6OVwlRaxVanQ4c1qrDcbvFH8CgfPtJx67W0zPG2C4Mc9s6HsNqZaEyPDETTq3HDbv\
-            iE4B0zncQrPmHQij/GsEbNpdiKBh7o1bj1IAJLx7zc+DZo/GENtBy2rx7XbiIuXA8t1\
-            7ySlgkDdTAxrshE1DxMMCvlnPeNl3oV7wc1fs2GK4EYvYRc8hWnYct6A1fmHuZap3Ja\
-            hu9VMWcL3zYfozuKWdmZCM/gjhvi9tzY2/1WcXx8RuKNSjUywhpTxaiC/R1F3NFE84L\
-            4sHTPYr6h5qXb+oXR2cxdWDhUz/cutIxNHHtNtPCchvdKJKL7a4iItbmwvPH2qwzjDs\
-            uKxOQ2LXMNGxAZCWkxGhOgbBdPY5Y0u3BCSE20dNyNd4Tr/cJYtUttjHd3x8W4zSNwx\
-            6NKHrnCtK20QjIXrhcuesecN1bOrdE+XJeEzIFnPn5iHkQXuyVUhniJZwzECS0IzsQO\
-            p4egld4q4VjJ3aIw3I7fpJGIr5hj4pp7sYAS1m6yyVhKLYiYCQwsSz0w0qqJA4cvg4x\
-            Z6KxqJamujRt5j0hbJ8c1+UAZdwQ/Uqx0PmpRtK5XY8V0zzOF8YpY/Dlz50DMVFI86c\
-            65smYKxKJFTsYa2HOY4GjTLOtxt9dT1lwZC2nVeKTLCI0hIe96V+WszwBcIotaPB8zx\
-            36Jl8EuY306KXobVIS9rFONO/jTjn4G8hA/c6LwU3rH7nr2dUf0v3deWieFlT5HsghA\
-            vCGGgIRwMfu6I1b2IBTKF7ub2dV4gEKktryWrDVl3xBGkzf4DDClZB1votWIF0DADQt\
-            7PMZpkEWofel6hr0MRKdV10ks027xFj6IEJXlZSMpvSDM6bgjYA9MduPH+aSMg8nii4\
-            dPz1XV77dHkh6iLU95A4Ls0nkIwVaWQf/nDStVVREWlfEg3UFW9OoiS8qUIjqW4gGgO\
-            UZs8dLzO7Q+roh9HwZdxjs6+nPSuJem5Uon57Wm4hPDyL3Hi7B33rTSxvhidog0YMJo\
-            LYU3ljrC0T6JSO69VUXvZbTytK3UZVpKe32OuujH40UfPpHs/l7aOEDCaNFbZuWPHkU\
-            4JbMwyXZb7RfSqTT4h0jORnKrCRtYPR7/G+lyZTq39/6xZHfAEi+cx1OcanlFHMDYQn\
-            eK09IQzQs8tJbPeOEALaxZO0kssPGYv6fUjYONDDcFdleU2rGWux+9tLxUusoyC1Tjk\
-            VuQSRkHqvFgBswlTQTjbvQAlg13QYKX3IoFa0zlMqxq1Xj0UWSy1uzdYGLBbbLf+HgM\
-            OOZU2zekzwAbYuUDP4a+PHwFbih8skjXKO33fQ+jq3v1kdD/IG/dsmfoSNi1MZfc91Y\
-            yb6qqkXE/YakN3nVzWcoW2ywCBFtOEyRaGeLEEijcu4CqepjacbUhRigw2hLGSl9h0S\
-            cxnGlW6JhK/UF79ZhDCCab690l1tvnxkrtlGDcejXnwjPee9PiMU9WLYx1znPrWBD0d\
-            BVDegkH5XNxe4GKUAvgGnMtIS/sJlhBiYSFbLAlh9h8YYm3UnsQfpWkf9iSRwrT1XjQ\
-            X7z64Ul1TLKSg0CsKLJls8I4Ic/CknAbnbD8ltIIx8N9zmGUQXQ3IfbjEWvVo2UeSGi\
-            4Kqn3t67kbsvwDUGFnQ==\",\"VKracsZ1aY2iDWBYukwsUXZs6ShUjY29CVUar6UnU\
-            VhBTah500dhPcNZh0MOEi56r6h27eBKTSD97RvRGLRAE6NbdPRwQ8Fuz8lVjugmxSOB\
-            aR7dKntxJugyjnfsVPuj7SLYiJ++59ZqTi6UCpu4qUTCaI7GbaEdXViAqAwri0YB+eF\
-            69hUf8ZVh8YDAst5uglWxyrAFEGOiJIsPKWNBpmqMJoC6W9WrUpaMa7eW1jG58UEAIS\
-            7yDR6ZhCzlSjamawm/YYX9W9XahwW95rZkTlrFm4O7z3Yw467CRsjAbflK6qNd88yPJ\
-            L0dfSTGobRb5hdcBZ1ovxUfLhbCwwPRppWFlWv2jXdXyXABFjO1JRcPJpXUQkfYPrFv\
-            e7EtrHKPXlQpGtU52gZ6MyXU12j5YC3vOhhTHTBo7I4xRMhLQKHleYIilPPdBF9Ul3p\
-            u+c8GS4vjAd3HCNKgM16lIfZK/+iVlRaradFkDcdZr0x9ci1126B3jyK319MLfFw9Rb\
-            puoTQYs5vZV+ySVMYzyztVHuyi2BYCpzCKK8cep8NdHE0Yks7qTiE9aHMthUlxmMroI\
-            MNLmxVyhEZgKXWttMsKyyMa16L4890VvjiWzuh0/nBdsh+9tNuMs3J3M5uMJ8QGbv13\
-            92BnZyveqJI4fHcTvD9qPq/5YbmQIVr4TKu5bTlULsKuwJGctTbrRpaVjMVE6Ds85f7\
-            AVvWFFL4JffRc4XyAIOOgRdFI57JsbFsoszW9qvChtoGDdG7eZw3HgtcWLqqWi5tvLM\
-            Z6d1aF282qlWokNs2HlYXGPVGVMDpPSqiwu76Vnifp38pHH188lazssQhdjVdiiOjDI\
-            fSITBbQo+MPLxqMjwemK2smpN0HosnOmpWiwrNxJIuWRhdyvOPbqx1IZD8iMLmJIcdE\
-            dgvcGQfU/jqrD/loSJID9Z4S0nlZsgV3i1ihyiE76/QKm/Z1pfSGKV3ZsIXDWWBN0xB\
-            CU5pbtMijhwirPcsKqz0RYeU842hCB3nCYAWqxo7+iHBG1NIrw5y3khNBnHDITdyuGT\
-            dxjZdW4qyM4EXf8FiqDRtW0ZI3ZSGY6Dq2tlj2Tn5XNPemnPc76Dif4DVpGqUrw5YdP\
-            6QrGMtWH9CGFljFDFcT7xRznRQPEa+EuAFb2En9KG+UygmzknAydxNsCwvEb5MvQUpg\
-            wvQWHtxh91HdpWyZ2PS0J9CBsNjLecDMFwrvYayCHTCPGSB4pePVtYetZeGUx8OM884\
-            eSMbWjYqBmNDeXmFDbVxU/YYZWCou2Y6puQscMu64wpkFxiqpfVkcS0C4cFwK4UND1n\
-            Flw35JMSUqlfoiLgnUxk7aGD2iRbgr4iWmDhoGsnDEuClMVjK6oX1M/LDRCxYkoCVv5\
-            +FYgkoQlgA7UzIrG8ORnJMwsIVHGCoa4QprOycoOoYQXkudWUvLWqNj/VBdPQqPLRe4\
-            siSRO9tZswza2Nxo3+OVjdWVR9BmYXqNA9/xTXBA1cjQvJvgY/IAyUpjwXbzcxSZw4L\
-            DX57gyOiU8YKFx7xOddLmOJTzRv8Yx3qviHwL7GN+gBrr92GnSmtp022PFZOsaXZcNT\
-            jhkDjhO2ta6ReyjylaznO3YHIT2kuJynCyv2x//+UT4U2FA5ecXt2WusHCLYEa8qPnK\
-            djIaK90b3rHvOVC8n2Q0P5wQev6Envp7L4CxdIUWbvuEktvQzhq511if+QgEh/NpIMv\
-            FrjI6S/l5DwFET2lPK9nMOL6mRLZ8FZWQbzYsqOYYqWXMRgWY4kej2MpB0OFDXEQTcz\
-            47BYLu1a2xssooT7qUtD2gEWXh8LgW+Zl2zUcCtBB4g==\",\"hYOqXB0OrsbYffCvM\
-            3O/5lbG9NAmhhsqHMJ9hcU4x1uGvMDJwIYa6bhWXu2CjLWQsNRP8m2g6XC8Y4XvmJVz\
-            aWUQWrkVC+Wl8L2lylTAoTyQszNiU/LUX0GyB7sgcMlMv+JLNkYvHLyHZcHcViNf77T\
-            GBWlGgiFiRYYmI8EfG9/H6FTtjiQSEOR9rMTfFEyNusL7PLQwlUQwbcf9oWhNrIWYZG\
-            +jK1MWbK2sDCeBNwKmQwbFi5q/+MEjP53YeuME73DYBnbcBq4yMf5kn4U+CvtwM70dB\
-            2U4zVPaOmrNI4QpPbfcedvHrYr9LtS2OvgpDjUZspSjCqetORG0dTVXgnV9cShZ45iZ\
-            s4e5Cks3VqjimjdbMoaZ2HJCtUYjPXj2Fd+pqZYl82b/KILMVxWnNXF2pby4HNfilEi\
-            0PUeR4QQ4quMJjtSoiOV0uDEPJV6Sx+ZgATlJe/GWa9fQfhvsw33ImIetxulZj1n3pI\
-            URG0FOQWz1lohqgkP5wErFGoMg9pBkmnOTpNnKa67vsYZEHJM/Gt6IhWy3uO5TsvTC5\
-            e3lmttSKDpkHBtpH0H7YINY/6kPmnPKZyJCoeCS89tGxqAzqtIc7Oqax9zC/NCS3c3s\
-            Etuk3NZ52ZYHtwkpa+LDwfMjgRgbuGBPIyfdLm0qMfNYOmnu5g81plAlO6pMjJfW8ph\
-            sePDZBmmRuMFg558Co5i1r3yBTxtMXshW6YrtqzNqT5VKGH80IeLCMZqMTTE03thwd8\
-            0tb2VQtIj4MDSmvfqYUZ8sUFD7og+JiA57A++86LNp5OYgR1Imtd0Ej1ji9W7BKg5rZ\
-            +wm+PyMINwSHNMQAPt3PIiDHNdwCpyG66oPU8+dU85zonoOvnwiUBF1BcPwoHMyQgyV\
-            jF3jmL4AablWcyr9FjshI4bWFGOfKM7eckrsCWrew11OjAw2BUSIikeplTF+EksbZL/\
-            iOc1L3vmcUaL6F6RnlDQZ7RPk1O8pjzFm+Modf27qHLiWBVHwhkZtO5m0BkJ+pYaqVy\
-            tpqXxQci2EHj3U+gXhCdM7HGj2hEVklIWhonp4ysN5Zbvr3QVOMV05FqtmPCyKFOu7d\
-            2g8qxREjVfM/tmefZk4DCKaHEGt5xkVuLCXeY9ay2Kl5JrZTtA2Rdi2dakM+xHLO+4V\
-            DLhpscX7T1mIBcch1zg5709ZfIr1eaZy9TlI2fggwl2ThXqoPZwx8vhA2rR0uuCyxtF\
-            8W2larhkV5z56sTrBG95Kz1+7VctcX+D6z+NLyQlVK5+iU09+QcN9Nx5Q4SovnX/NGy\
-            XkTz8xXrZKUzVoE3FsOQEiGy/2HpjjgbmI+Z5o5+iUnDK1YWurvGTGPmMURo/QM3pC0\
-            0TwktyBqH0TlZolMiEmFNX1hMKRUOBpzBPM0iWTcLheIW/cUnbC6xYd49bybcB20noY\
-            GQceYXpCFQ13Dgc6gldEnuKMjnI7AcwbxQCc95qoOpSGMRsY/ieu40IypdPtC6th78A\
-            zfU/YfgGeO0gdz57uQw1sDBzPpTsAu67kbvwBkAghjwUrFmolYVjP3bikv6cUMY4pWU\
-            4gaVwZ35NEZe5pzu14gO6BY0RtDRcLVknizqAmTpi2VTETUDKvWnkwEcMGjmtYR1SjH\
-            cOurLtxAfCBo+eqekNAyMYECLIH78DrmgeIW3DbxaIfAucj78Czlg8wd7DEwb7djoej\
-            H0h9x8ycLQ1u0bgC+sCxKkXXgHyJeL1TB/++hlPGMh8PMDigrOnWahczdVORPnyojOt\
-            pe6BsJExRDh0ct18dIG2HrzGg4x0jYjgpIfZQHB1fGwj/JmngLb8DjU5yCWNMUObc+Q\
-            ==\",\"WIfW9iXj0Juf1hMxZ/FBmNYQp/jtuNZ64KRiFfdK867bK3DELiZaVin/UBMP\
-            S5jjsYsHlHn7PmfLjDtHHkEfV1KXOOXxdvxRkgcO49or1sVyfFiKAW8wP9IEFwtiCsd\
-            NGQ+YUnZMbkTTY80UPMJ5glKaRo0bax87V6r5+HOp8RynVnll7kvj7yvl71VLldgHj6\
-            E/tklai4s+7u7GteVHTDREz4PYWUrYx7vxgKchmmo7WHTpjpQxKsNa5fDpMu7cOIL0j\
-            VfhKu7qygXhusQpKuBp3wdox/0ioOgjnjq2Egs+8Rs7SnOyJA5Q2f8RFH4a3WBdbtzZ\
-            /AhKJ5UsCSPaDjzf/whbK79gzopwYRDCEAWzsuJJHlrzFZaHxoPx9rAFd7VsmphSR5a\
-            MA66hM9xCNo1ha2MbrN2QOtIBmGo9M/r0AS9SnyH3HhKy17eklrKQvGSF5Ro8CRlftq\
-            K2gXKuT+/L4RaRmkms/vA/xNIgehUZhzJh+9rRGULAeI2BIe7hqbIsr/QtqUzt2drsw\
-            4u4rWKwEWEQyxwKn6Nmk6JehMX7j3nTyLBsCE2E2nWROOe1ZFWPi+qHvubA9tOdgkkf\
-            /CeacIrfjScUD8Az1tJ4xapjniql9iztnXfQVAseMD8Ghv9DPGOeLqOc3i7LOqereUP\
-            XcF2R7uGwt3PGLRWdigLG4XzNWN/jSRJP2TlTnNXvhOu1lc40q6hWdtwSyvLteIWcY3\
-            YCsc7AikngRbwTmGmZ81yXvDFaMrFQ+Aa8Jc37Q9icvmcdQ4EbJZNSwiL7O/Bm/ygvc\
-            x+BIhdH6H0QbtCLdIdnarww0FOedP+dIfdkdX5P3L9JliXOZh1Hp9yNlXNH2OVIXSfV\
-            slTk5iRNxkeg3Nker6kwwKQ25XhozzEsV/a+G88+PuAc443ieLWMRwI/UpLVfh+dAx+\
-            w2d2RZtalI3XN2/FY6QeI0bYT0H0KHs8/UPoWu/rG80P2hLovpNWSMFrdkuJrg+Pvbs\
-            frVB8ARlcN5WsgjaAt11vm+oJ+rGZ3O56T/ACzdWnWmn54YXc7HoF3BqO099vxEO896\
-            Yr7WKpyavkaSya3pK2xDcotYZcA+fdnFCIaYDzK9cBRWrW8YZVhzpeEHeCOHvKEu09n\
-            +X0Gcjzv5wxp+2KbAbwlD6fWaBOHLtrtsV+KHr9TGL62xsuhD9LwSTVe4X0QRqgN1L1\
-            wChsvAZRgz5oBGPx3S5oQT2H/jaeT3FYnMGhfuB0PBhuE/Z1YaM+azZ8IKxbVzaAS3Q\
-            dd616b+zn3vLmfcwUtwrekW+1Y0SJUQZIEK7PejWfX7wEnMiqBIlb+qbhr5ZzYl2RQV\
-            /eBvJBIq2ZnpLdbthh3oe2ud5ekh7ezpoi65oJ3XXzkmxCOqGbFwhPv/ie+9sThHN6O\
-            l3Q6gbFyyXVlqFpToMbmKe4xmpqR00Aus8NTykrXGWZWEJB4gmuNqHNu4/Gi6ac8bVh\
-            v8d4erwB4irLyh/Mbz5z0fddhNzwpfx5q8+cpks+CwVv9jrw6T2GEiEVdAweY0lVzeN\
-            MxqPlSl1QwBHlfDbIpCWk8zYOgst4R0i9pMTxFH9KNqRaTbrphLNnc8dT6M27cjOHwJ\
-            w7IzHYe7HzxUcK4owjvIjGqQTbO3UdEj49ReBeRt0tAOaN5equJ8nsSazK1qy9KZVkl\
-            odHkjvTPH9IwddU33JJ3y3j+5QkvqSg0jBi2Yxjq6fZqefkxo5ervtHSxmu+MdWHJSu\
-            VlQIXSdxeLa/WL2CjDR3Ym7/CVjqj5clDRc2/4A1nHdc+R0a8JZ3yiZfjBKHORwcr+S\
-            ShjlqMsTxaZXmHw3fJSLsjEA==\",\"U1pYuX/qSelSbvZlGMfdmbvr3VfyiDj+RPgP\
-            gboSsRBH/RhXx7SJ9RNqIoJpPN1s6HNZKWy3pJDlZduRcSZky7zSW1YZOmKFNHNG0uP\
-            Qrf2CWclL7Ni8JQNYvKmlVjuZITVTC/Rx5GmvzHh13KewjJZRY3cKIyQ/0gPVdzGuW5\
-            VJ14hp7wSRWCbnxFLik5B0EJ4DjV9IS7aTNBf1fv73e2o+7shIoJVwzhsrmbDGubSgS\
-            zWf01NNnpI7iNhdz74CV8CCl0KzXr32fGO0aYEidDNFxXcWplPz7WuXfjLeKRbufdSu\
-            C2ARU5XmDe+617I1S8X2b8/G8xoiQXzkA7JRRfoFkoAa/pT0UP+KPboBcTvHd9wA/VA\
-            vbYlCRmKjx7fdA/YqKOXfEvgbDlBISLql+3qDKZCHSj8NUHD2P0D3TZyk8CO4wEFExh\
-            Oc9eyTlUS1ytkFsBGeIz/xJmajf8voOPA7PMVav0BFblIz6fWeeJ+Mlf8HKsul1mV3e\
-            oqfmY+TnD8rU+lqD0t+htMiu3G/zL59ZBf0izbxwMhupLoZfw0y7elc1NX+hRVqPoDI\
-            dt64LwZk8aWO5g7fl/1ZRq8Wur/7A8wqXVkviGep45rJnuSMswsEAp3R9nuXnpDs1TL\
-            77Rv7Ys0GX4HAWnA+hmtZhCFUqIpdvLeyZ+WR+PB0NMWmZ2fP3tWVNX1HzzhwTI4x43\
-            ui49CbaY2O2dZoseZeWmlfT5T9TWk55Z5/SbVsYbWTq9nkfQa1lK1hWcrrzewrUPHPo\
-            F1jtvlYcHRgLEuJd3B80TY9pa9M5/ZEKhQiPZKS1+x9itlbQbxzD0quDALfQWB6FzBv\
-            vtL/g3WhyymsaSnrLXhmPI1rHvzFTwbGCh6ZQ9NyWzemUuJQgoPM79teTZHp6oR+vPL\
-            kRoreo2yjWEQuc424Lj4W0UkvGqWVYK0K2hc1NLvrXZXd+PSJ+P4WKuN8tQN1q0+RK9\
-            P4smA/XCyxHfQpKPoCAbBVfrGNccjH/47lxajA5JvZV5AcYGwh/WteOKkaXDDiZvYVR\
-            OwnTsF3MpVkiaW5iUaN9nYP63XZUD0bP7wSpImpwgSD6BVUflNXiFbYvpHuvlAOVsUO\
-            A0xMVPpBMIhxTT9SJUGq9mbgjQshx7y/2Z7qGzFI+3b5bYcsqjezyRjl4fB5zQvTj4/\
-            S+6vl3Yit/5zBrOwa7ufGjrs83l5PRUaThLGarXlTc3BxfLjJYjXS+n156FHUu6tZTa\
-            MmzZpv3T9VtWhUtfAz1UrT+xm0ZN1Mr0AVlWP41eU36fvuz5SvX4AV8uZ6d5HR8UP+U\
-            lmzJYd3y+xrDi6mLI2v/zfXs5Ei4ieYTnVQO9he7WrgdThBgSvianmXRYA1UnZXy5wN\
-            lCgMPtUS36UFp8MJrpGxRhy0NLy5yVmyvOtacI6+u57dvqEhrpyn/PN0ENbKk++Tf7h\
-            aXmY0L5BLx7xh5QLt9VgCHRzWx8guFtJr1KE68UObwTAsc8bSOVRA4+1N1jZy/rCT/o\
-            aC6q+mOVu896bdvyubfG9QFEMCwBF0LZ1p0wpkHNS+zdpiBS9kc5iJWO431iWOVRTZw\
-            ni2fyqNeiwz7h9wKx5/UdQ4BfdqOqbOnmC8WDCx4LrKeL4WBNaNMXEl4A/Xu4wlmWRI\
-            YdpONY/V6qH3Z3c9A0/YPYXTAmoyPGQR52iBTlEdjGOK8kUvaun3b4esZbEwpmZpdHH\
-            BlKx7/vEDSV+gzrqwoGgZqWi4qOdWlXzLXPg35G2fxQuTBGZ8iQqvnSCNqFmhNLdBab\
-            KVZLF6DPW63NWuom+RojGmnavGS4tOvu3VNGeKrFk7aXNK6w==\",\"vr2e5ZxTvaih\
-            AhVzOnLu72dflDlrXvC246rSbm+LAOfkLOPeFdxKic0NIrO3Ze3nj2XmUTm13fUOvF9\
-            2bA8R8jUvV1wLWbLKBHpleZsKzxuDIlZml0h1Ov2Csvf4Edbd9ewCJP+e4xyr/47tyK\
-            Cu2ROYR29IhKFEivQprK6B9/RmCirpn5EmLQcB5qFR2aM/afnO6E9Ga1SNPEwoKMN4h\
-            rz6/B03Dph2TkdsH1aYUZI6tBC4zM+5ThVRuG8amZ7YLLueGRBCE/jA1nXG73CYwCWI\
-            Qz0n+X0Qbth0jSr0SpWKM+3ED7iWQG2Jsy9QpSXjZs4eWQ97vkOekTPSo0wt3xHBUrH\
-            DfwFMCeuh68gOecpdO1b3hWQClWWegncoz4AnUmopW+h429XA8TbOdUwoYmzDEZc7tq\
-            foQxyiqjR1iIKAMuoLRKTf1fRyJP72+PaUrDB4DEAA2FkLbQ8sGTdT8J74GUnwskTu2\
-            3D3ZM654KVExWPCSgdOtTOYEM19KVfCaM+VJgSYGnhtz7hpmTNtvAzyBXwuDbyOcY5d\
-            cItujpspeB7sCUuKuseBIqAW8hNYq3R87R2+XBfln9wNknQxzb1aSfwUWRKrctt6jHU\
-            eqU1hLYH8jTOu9nv3bNRwHKHfp8nKnXhTSm28msNN9BXkOT/hwWiKS5ATck7a7xwmeF\
-            DycOBR7oWxfwdKlsrzAsTPp92T3WnXGsdcCSf8AjhFz3g9elc+CFnZoE8P4huW27Jlo\
-            U+308lvqrDcbr9RCzFKxLlj2JecpYwlrJcAX+VT4I+ea9/Dt5Qvs6WiSCR3X+h09u7r\
-            pzII7lhkzxWERX/Tefa7TP8ZNxFEMZxDfYM1qTAnmSM4nfx2ifuae+8H0j0M6I/XTG4\
-            vI05uvMWxu9k6SXyIU+qKLUybXgqrNKxGnTSIzL0y/fT5Cl8tuaRSVC2Tm87A2IikO2\
-            TOTFmmZ/vpSGiQOXfWXym73yS3WunqgjJvxwMy95AopeywSrsDD8U+aeZcaeVls51BX\
-            3cS+HKHMzdQLVBBge1zanakWpKhMzd4SbNAwOcZK+bfGbvdV5zqOHWoodCT05n67RuK\
-            Ew7Tk9tI7YTddp5hT3FcR9nb2wjJbUbAdZjw3HYa4ZBbMTUwd/XYHkb77+os911AXXC\
-            3nXK7Rj6beC9k7kFZ1uN5VPHiew6JybKOeUDky4hJhnoOWhvNjIPPU12CnKUhYrR74S\
-            bmTvERMKulIC1hAHyIvcG3d7Y5QbZFuHHwjs6eHC1MqXRFm9NAMsE5csG1kLh0bmhk/\
-            gryAm9AkLd1SprzQpkG6xvZ2uQv3HlpZwfXOQz9D23MXDNz5cgkEVDE+QxmBE4ru8y+\
-            mx/KLDMrO2vKXuyfzsUtzT0b545hK0q2wPgLLE4RG5W7Xir+QxjbgXfgk5afOYRVaYU\
-            BtV3itZ67TqrSHc4sUDsjdTfzaKnwk8G769kEvNNxxlok5zQbePPaykbiUIhwhOWOg/\
-            Kdgd6Ki6ywisD6fHXxmfBU5a6ccQt0EmVye0e8wZHsX7nrb5/j23EPys3H0yq/nzjN6\
-            xIUo3rSuKrredMYQSRD7mpQhu0JdOmMdmIhWyQsBGR2j1njsBEDFBh9wtIrVNEj6be5\
-            Wy7QWnTc78C72E9g3UKhEMx4p+XPbZQs8RSA4lHDODRuuzpbSjvgxsOTEu6ZncUyS7Z\
-            zpTJuqz10xkcfUvaS85YrTXg5L7K37ecvt2xq1Upa9ulgxCbkq9xZ7no2l9z3VrJSOW\
-            FWEhvGL7MVxCo696Uls66z3ZAxDobbZhszn0q5kk34AL6YQWmQMfpa1eFWJVwEl9lGy\
-            sqKvg==\",\"JOyA2YetZR23Tq6gyBkul2xgJ1jFvVxzSsrMXf1907HWiAVn3YJrb1o\
-            Q8ZbMBJkDueCloRLGs1mmlYWVa+Y55VnM7PeiE+zRx9RymE8ZPRmZTb1seSUVXo/xeM\
-            qcctUyvGkus+/+Xyff2cyYpjA4AgWUvD8FLkt87WcbJJfSO6NZ1YFXRNPNn9syRTk16\
-            +wLgizmnm6vZ9CS9FUadL/OLrOjIOq/u3DAKkGGcCYzaWZLIzZdZFRWUlo1mcswcMkw\
-            9SQ1PoN4uL1Yo+Bj7bs6exEF7CHFk/k5mK3oIcltLJ+jKMfQwNy1FFGH3O2u4dvKml4\
-            DMSvoRs+DO28lb93hreD0dr3SVc4MBhEx92NyW3AnqZjhFLiZeRLX0LVzM51kC7AZzy\
-            jEMz33IH7kMaUri2ohp7sit8d9IV23kDCUbHYJHvp4ylsp64Me+owTJtty+9t0+hs0r\
-            mSbuOKyHLKsrKR1ypDSfbbLtFFFkA/FBoevZluYGlVUzQrt2RjxkbmNHsNfRYbqsauz\
-            PdqNIq0FmWuqMWgmpnW2ct+YykI75K7O9vY0xnseM0gIYHbjnJozZPIKN8azYEFu0CB\
-            JPCk5mf294pXu28sbwh2RuScOj59g3S47qveKexQdP7vIdqVeTb5fXl+wP375zr5N/4\
-            9g5g6drLi3RrPfYBDGRXYyQCubxgQiIQzmToaqgtLpqXj17KWidG3WrlYXukIP+KRYi\
-            cwV3dZCgrzHdInkdrjppJ0zYVqUPxxNOLmnXSxDjn0cF9luiT2MNbxHb5pG2Sx3Ulqj\
-            DbNGoADgGACV28ZOMS7AlRalpVzY1v0gbK65KM2FbFCcZgw7fx6MEe+qJWbm5j0w6ZK\
-            KQUHKhq6ojIPZJXj86YwmBK6jmW3RCSTi7YmUO5Y5IdfyCqv72bb5QGKPJ3PcaYTLMy\
-            ub8YHt5SYG+VAFyJLsl7sgnaoWnq1cTGCXpYK5q0n3yV1CvWgUrut2mb/IV1SU6kV2N\
-            t31H780nNBPsvWdc1k3ZhfXuELgZbZ2vadTxdbiZZo9khGptPO8QUm8ifq8YWhN2VlT\
-            ULrf83rfBf3JeakFFiguspXKPdhJ75WuiOSL7KMpQTfk2T67zDa265UTSrzDRrpsW+n\
-            1HzMg1UYDUibJ1AvvcWBg9sVvamxxvQCvhJ+RWq3C6BMWksz5vOmknipeNAbH82UHrp\
-            hO6mTGwFbXi+wo0gdiLa2Wh1f1ifzb3C1903n1/X7SEfm22SKF6bzaZByPQYbPXTpWL\
-            GSsKW3s/kFdPFXZa9LXrJQt12UsuUJet7nneeBm2Z2zfZyBaNqWFbzGrQzDmjlTHa9r\
-            rOZfZAsY4fCWK+JV/OTUyxzDTgnuHA7lyVb0O2ta6ReyP9SKYJVpOBrIaL/O7fwRndA\
-            NYzTn87FWlinmn8iv2tXZyX6BXlnw0kJSE3NpfdO3KHJ3V2fvnocH49LbkMQGym3gdq\
-            OIaKnckfv67nd0wUYraibK8tIT6bDZFlkrS9TDOJuZ28VKbVbcPz7oJrZ0lHJ2BIiVz\
-            it8NWZPqyVF5ovsmyuxUoELIkIyuwKKqxidxJCdPeYqRsY67Ops+djVfD43DWzc1+zI\
-            iaNfCWN0bm+Pfh1/tC0dLZnL5fjXZ9We2NXZFu/jXxeHupikleUiO/XJddzWzPJOEeG\
-            f69xT6JjICqnFouUWG/wus00vJ/AcX9HsMjsF8ISdJXBlFyo4QS81TEq5yL46TqgwXD\
-            RopH+lqUHwJqTjZ41uT9hqs0OCnI01w7G1NvsgdIVI9SnwwZBdJegRCLXAi2xnhvOl3\
-            Eis0We75YhHDqIPKBPluYguINzNbA==\",\"g53nnWRS77bgJbZ4CefuEC+1M3beGPQ\
-            I9Owye6XMIu/3GaFH5I7ewe0PYwmyde+BKAIOKxbN8rWHQTaepUm2bXUIDo12+bLnEL\
-            rmLSi6GvEvGZZGxYoqcAFnF28Y+kAq6wU7kC1mDfL7msNDP7+ozhC+94vxd25T418w+\
-            is8s9mH5DCbe6vwM3HZN9jQB9bYqpydBjvMFvD+mGQL+kP0XW8lsWez41bH+OnJFzz6\
-            LzkXwjeIszjbYTLGJ+sr5ZfvGfhEwVXZU6fPNF9DHPqEqhR0qU2yY7MG6fu6wPAL2Y7\
-            foS+YXpc46WKar5APfcAGDQ2Hqs/yC4IOfCFWKuuMwnVZJtk5KcOfsHabajOjHTfNr1\
-            M39BVlhdE4XmWS7SkZ+kCDj7zsPLVBtulL3v5Am2GaXz1j7Atzyus8ya5/MfYJpbHnO\
-            T/0euwLTnAYDBPu/Bd8whQF4ZOeZMe1DvIX0hHp8fkx1IMf0M7LpsGixeQlx3b4RI8t\
-            BNmJAIN4i80w0/wYuwF8yT0vifjb7JDrIb6qlOeNEZLDSLx8a+PQRwh16SVHRYljWCf\
-            ZNSuG2Qo+2h8+8AyN/OkHSKv7JNvyMohv5U/E4fAC+havmGyf5wBbwgC4ab7Le4i9Mf\
-            SpnB14OvCBOa/lWhYZj+JN8924g99xvqHO5hfgG7lRRSMlFUU8zXeWDn3GWE+8vzrJD\
-            mkZ4FdSb1tDxOnNJtnJ4kOfiP9jwmzz1++ASvmGQ/xFduWHIbwxFd4NF9nu61E8KyR4\
-            wCpewi9YQ+kbMfGvw3WlZvlB0UPfsXzONerHNL/03iBfZUiM2bbzgS8suFso0WNjwiT\
-            bZYK+wDoQWRbElhfsuEWGofEFQsVCYEU/OzRokE2ddS9otyxXOJby4iVmwIVskJFomv\
-            9syCDcmronhv0FeByAOZtkl3Ibgvd8LUnjdxifv75ulFC64tDdNHkRv9JUNHtYnC/4g\
-            Ba8c30Dr4H8zNnBL8ybflPimzg7C2j4A6ZoCANXdi7twAeWJXmwTbLjvwb4tduCtz/j\
-            0f8Sem7S9V9fREd52MhjHbbCX5/mo4/wplvgBZudMD/woYaLKLUQ6v1fX08pg63ktiY\
-            UhezIn6GPqMJyj+ILp/lvNw3yNXyRPhqIXoCn6ktOsjMGBumV1N4qHE8zyQ7UG/6EEq\
-            3Riip8mJ2vMPCRlqumgmfHNL/Q0BDf6MqUBfcN9MBO84seD30ExkGHu+EFHSByKMMe+\
-            OvDr+l7ITs+cwgvfYOr70zzA/cG+WsrGxisOs1/kWnoAzjMbpKdmTXENi3h4H2Je1o7\
-            fJFll2kYZG8of+IL5rTHbyrnP2Y0CPdcE16B7PDGAb6psTlikp1RMgTXkuvSQKPZbJJ\
-            dHXboC53UWhakMP0CYS58gvbZv8R1YjpXSa3wKGUnng99YIVqf87y3xMcYHecdNa/xA\
-            LR8Urasidcby85kjvjfGUlvrRmk+zC0IOfWEuLHTTT/JcHhj5glWs5fTVml40a/IaZK\
-            19YRZRuyH/Ca+gjvZXpXfH//79ehbm/1HPz6h//fiV1+am3ztjzb95evxX6eiWW3f9c\
-            1ter4p9/+EJd/vdl+3FR/Hmrfvv06593f27e/utb+G9lV35evL1TH5fFuzcr8e6nt6K\
-            9bv71/teF+Fz5u3e3q/LzH1vR/tIW73/1v33/eVu8/1f3r89/bH/7/vNbEb/765uv06\
-            u3V9OLN5dqrX7/3Gz/9ef1G/7nT/3l0qhL/eZ/X/3nP//5z/8LAAD//yJkr2aePgEA\
-            \"]"
+          size: 16978
+          text: "[\"H4sIAAAAAAAA/6S9XXPcuJX//158vYhs2c4mqdoLjVszq1m3ZI9bM1b+9S8VCKJJNEmAB\
+            sB+SuW9/woAW+qWxO+BJjcrazb6EI8H5wkH/3o=\",\"U3LP3/zjX2+s7I1T3lglXfh\
+            dmzL84//71xtVvvnHm9vu903x/rovf/n7Ti7M+fXqbvPmv95o3sk3/3hTKV8PxV+E6c\
+            6uf7+aXV2ceamdscvWbN78+7+mGPuL94ixiIzfFpOEt/OFOJ9X//M/ORR2pcVQcG8sa\
+            tHXjF5Zz1peGBtYu0nY/mbWfLz5mtm4z5/noJuzy908lzQ3pWzZTe9Vp/YSdPZmdrWH\
+            na2tlH9ZOUT4CifQ13ZwHozQ4mJDTZ9XetcqPWyZE1b1HjTnet/g2TNW1Izr0hpVQsy\
+            Wxoih1BpCdjkQgoEnaGTEnxDzlsaUynlrpufqei/e31wQazCQfjZ2esp3832zpzCpQT\
+            W3ndFKwAmvPtIgLUQ7ydhe7+eba0qEWK7d0thO2ktdKS1BkxbEGnxEsXa6a/ubxXxHb\
+            o0giNqOccdMLzVXbKN0aTZoxFYXRPM8c7zrW+nY0lhWc9FwXxvNxPRC3d8sqvPrDW7s\
+            wApjphfG+fXq8gP8+2LQfmB9aFCldMX0WpWKs9KqNZJy16tLKKOmuJ0pe2sKNNWry/M\
+            /Q3bSe6UrOEsCtvlWu6GXdq2cLD9zXXbcNp8lt1rpClJxe4+obK1KaZjSXtretNwrAw\
+            XVLSbblvWm3S1VO70Tw2kCReaaV5Zrz9xGLT3jbcuUZgZsxnBufqTW5e/cKq79H8Y2c\
+            EYqKEPXpXICde0SSvJ12fOB1XItmNzG7QdZeJgia6M02757Ny335otqS+kU66ofWCnX\
+            SkjWcc0ruNH283cQpsrzNTx3VwJK89/DkvxijZDOKV39bHknN8Y2qElXUKakRe7K5iD\
+            zEAqLkd+V+23xHYnIuy117q0tE7z3g5XMyr7lSLdcXGznBO73xf+xjlWW90g5WNzBhb\
+            3htocDDKdsw9eygjbAzWwOv/+HLH75DHVYeJ5tZFG1rOe+Zt5ygeRjOsWII3cji0Gx9\
+            YD3J26S0nJ731b9tCgMds0HanOGpV9ILeqDyGC8ktorwSyHvbzbzQmZ+Bxd7wqrSop8\
+            9f6aWJPPyW3LO37OlkpLP0BhHsbkz+Hf0/igcO1fPy5d0Jp5m9v8P8Hf5vGDtfmBUhi\
+            f87XsDOv9ADWHxH71ckzsQQs/YP0hjv31n+J7a3Tu4L96cPpaZa2cMDqvXpiW96p0wY\
+            xcQvR7yoUA0N20iIm79fXr0ZXblonBedOpPZ7Vt/PZ1YY68h6/EDfqkgvoUwk6N1Skd\
+            kN3pHCXTedGrRuaRFBvOUUueWGVyNCGVhevaGiritE40E78gN2Hut8pNd9Cgv6OF6FN\
+            Z0omTNdBu2CFj8IXyTmG1wXUOl7E9tI65bzUQkId9CvUGF9Gt0Ol4DBcvB6aYyVi9+m\
+            L2K0weqmglXj3CmpvpTBdr1pZxiUBWwtX2X7X99K+evW+nS/u3k+fTd+/nPFWWcN8zX\
+            hZqiCxoNflbjMtygOs4/tw4lgprTeQdPt+2vQMpH3U8ynIu+lj6/uXM2GsvF/f99ZUl\
+            ncUCTUnkNiabRU6jRa3H6ZPo+9fzsrSMe/gQX8LDp1A6Mtpey7Y8+dwesKfs2WPlktA\
+            wD4EhF5OGz2hE+ewE7Jg9VCwGFmBMzJtbQSK+hFkoWzZ3gC/bOSgDsn2vDLJNiDWB03\
+            xPeP99NAEPQsEKiLG3ffNtKck7UA4LE60Ck/OtBES/t67Di9xOJpL2PZboGWGP1at3B\
+            KiDC2sZSu3xaDaaTEb2vAR9v8XqS9+/+l+8e0aQt5Oa24nkCjBwqLAwgdE6b5/OftL+\
+            h3LDdigalDTA5tmFTWg5rY3RpP9uAOhgu9fztR7wVzL15KV0qkKC8IPcJpUtw==\",\
+            \"ZR0XtdKSKe16KcLRxbhzEoTAwhLawYFSzojaYmPs9iPcw6uaOWnXSgB/WdoLiNLKt\
+            WzhnN1tMCAGBZfKdhtuoWF/+xGuvlZ538pGWi1b1qLjZ3GHBX+7vt/I4l52KVQpiZMQ\
+            LoCOew/0nv1NELWoWwnA1k6YUsZgTicGvEneQY2lEwNbq71usQgEkaAAkZ4zve0ZX+P\
+            9/hEe9A+YcecSKgeJWit8OH6Em6rbqKWSmYsR+Aq+fznT0m/LAZ73dxu4CPVSRHtyKZ\
+            gWii2nna9JoMHWRJYetvfXS/FzMs4X0vkLoAQkKtXC6+9frn/+9On+5z8IEBIBAeQly\
+            DB4O59dbaHKqrf9fdop927oexS7DtrNHk9egBWy9CCyG3UkuJoCpXf8nltR3xPdCyyq\
+            e37JsMaDdWrTS11vKmuGno1Wwlpawk7AOvYJci3PMQp2MKB8bSXHOtE5HHHjgywhlCq\
+            0ovt2qBjXJfNUwsvtR7ii+45af/CvHb8Xdtd7c0+YzVHFgy2xyok1I7wFCYNOoYRRjj\
+            On8Cp8C0c4cUwvYloa1lzpbu1V6/B8v4N7Iim9hfOWJ72s5TtytBHQcdWy2DbibEVj7\
+            Tpu/T0XQjp337fcL43FY/4Obgu3GfqSe0lmXqVjDU1f2qJY+wDJcoHQd/298Ba6tG+B\
+            t/z7l7PBFYQChP98U4zuqHjqIEs46XcU7Pr7l9s/fmL4DLzF7q218kx1hPEDpznodO/\
+            L+7h6WiOae4O8r0k3Q3MdeNzdyzzWe6jErokxPodjHNSye1qyowb8c6d/3N+23nIneC\
+            u/tIO7n8WMiBktYT9AkfYS+rfvi+/Z/LvtZO9veql/+oktleZayPHXadb14uv0zul52\
+            0rvzpYtd9A6EtNGdm+sE7VUOogk7lVzxnU1tNwy11ulK1ZLa7Bgv9tP0r9YuZTC/+/X\
+            sz79C/Z02j/UW+U6Pv7AWtfkzPaOl+qsKKCXKoz3NGEX8xYPPyFl2ln1Y+C2GZwyh3+\
+            xH4MSjfPcYkl+N61RWt5IV6+Mq8/fvn1/Vsq+NTvmzGCFjHkmrDSiIRbttPJL42vZTh\
+            9o25vZ1+y2//br4vLbdGZ5bOjkDL3ImtZio1dmUmRavtfcnglTTsc9I2Fy2Y6EZiik1\
+            dKDbZQ400MUOUcDPglKebxToN9kUIvW8vvZb9tf+Rp6watpldZKUYfV+vAPvK2np16W\
+            yp0pE3/i0MB0l2rFz8/ajuPBnTbux0US1kuwoH/7FY3t7csRacdb6ZbGCnlWcCeZMF1\
+            vtNTeMSuF6sHMxwmbFKDfLr6c8YL3jHvBhGVizdyHGvh5rhdftzRNtJJrIA6216tq2r\
+            PygFmqNjqwOg6WQGBNu55eZDFvDGGpTwdFHojBAh2FFAv/M9dz6Bm9XjXT1ugD1Ru2c\
+            tCvNWum1bCIiXaAKlSr/G50SBM9DtM6rYVHaNkp54LFs5FFbUzD7KC96nDuDdFfFVMw\
+            V0hQBMq0U+mYAldIs8G9a6X1TBuvlkrE7BamTSmZaBWKnsVljBvXdjFLgCkdPbGV5Uu\
+            up7u7vd5fTLtQIrFXxeCUls7VQ8F4r0gREPo/rW2/AFXah2MgjkMOfDrbJ8H79jCqo6\
+            uNCamRkztC8SLve+b8UCoTl3aD3bjV9NWTCLP9uw/nrEYzs5vvq2kFMlLcTgvWqcrCu\
+            2ahb4RAjqDemiCzYAaEIEZ+8KbjXpZscLySMRO2CUp3GDIkDC6nnRaBW3DRVNYMusRC\
+            dNq0CJSfrr7IT+yCfTJdobQs2aea60qyL0Zpzy40b3foGluS++gDhe+Z1Gtlje6k9mz\
+            NreJFK1mSkNCCm1bbDg==\",\"ZGfaIa7pUnGchBFmfNo5FXnj5gtq9BDb2j+ku8MBm\
+            Ha+nGCl9uEssFKYSsdcmFG0sVYVloPEu/gRPMqHj/Tcei3tmFLP4g79EPYUE60ZkJt2\
+            Np8OQIVPiHTa4n2VMGhfHWNYq5ZS7AS4cJEWGASWjnm59WGPBdHedRy2r5n2C0RcOIT\
+            GBEMmDPReiGkXQEQtwwSzUi750Hqp11SuWjh4iNFLyHBa07BVs4Urc4S5zqmcluHTWy\
+            xZ7bv2Y4ziMyt7E+EZ3GkX9siNvR23iuPTMxLPbaqREdaaKma5UUGnpAkQzQtKysq9i\
+            vmWmpd+F6/95TL3YeFQPR/TBjI2cew10cKnNLxXIhGdZi8Rsb8hLG+8/SrDuIOipSEm\
+            t+2Ya9kLiimhk0aHGdQgozRmyVAPEkJqoqXT6QZHuMHXxo6p4SzmKvVcTHsNA3c6MfG\
+            RK0zXyWBhuXC8cDE45ryxcmmN9uG4xBoIIXDDJ+Q62tFR6QratDB6LS2lne7wkoptXw\
+            YNye4I2ytqBxkjfEILej8hOuix7aS3SjhWclcXhtvpIzoS6aE8EDfcixoO4P5i+g7iE\
+            Q7kUQYGVtIeGGk5YqU3njIZs9Bb1Ulo94b5nI67HJF2Tk47WgJlOhPmkWKl89EIpE1V\
+            UJTiiGcK49Hd+3S20yAH8nmT3Ux3Ltj1CuRJR07GGhg5THC0aVbNdCT6OWupjIW0ajo\
+            oMkFjSHu83lc565N0qETBmzn2hE9lOifmCCPFYIPtMSpR1XSGU9rRr0AekhFP/BWUQb\
+            O/XnzdE/0fnJfWSWGlz1FZAhBviJeAhNay+Dp9KxFAScXlLd67ppSs5210VvECaLxhQ\
+            U4ner7IIuzAdKzCPgei06rvJVZyd3jrHXSKyvKylZShEKsJYIF+cMfnrZbpQNjLMNLV\
+            mrzyeC70UlXDuEeSChH9kcobkPmchCIEW1lK7RVvWakqdDMuikR8Aj1lxWwL5KeZUUT\
+            HUp4OdPaAqwsR4vdosYEbrPGvw6DLeFDHUEEa99J0XOmUVKKppPEka9HGKLnnjHtvVT\
+            F4Gf08XSd1maZ7tOioE3k60f7hEyl+4qWNnRBGi8EyK38MKFkxuZ9JtttpX0un0gAdU\
+            uBbqrpJVLfgwVjKtendGKFmyfOAVVMoPU5xquMV4R3HPrpTnJaGaN4K3Mh+gRckZmHN\
+            xklLtRLO0Al162Ajw9GAwyKldqzj7scgLS+VrrIcA9V0BiVkUu6BajoRCHPJs3Y61SO\
+            AZctdULUlt6Jmralchl+tms7ci0zWmTHwJ2pukwfHRzHgmFPd0JKxCeyKlQ/8mDb28B\
+            W4obBkka5V2o99j1HVQX0kDDXI23TsFcYMDnUsJY91WbypqlbG/YSadoVttqWxUjslG\
+            LdeLbnwbAzRoPv0yVWCsc55bh0L57uuYrY2EVt7LW48RwnVEq2cpeuII2h/gSO9kVBL\
+            UEoq+XRh3wZd8k5qzzFlOgfoCYXpajoHM54mcPEfk6zkIIMtagHZrDBOyF29ImIRJyy\
+            /QyWSUsOQaD6GUc6wPahvFFiV1KP4ldztGBYVVMZFpaodPxSGJBUkrGYklih7tnIUqs\
+            HuuYQqjdfSkyhsTSTUsh2i1pYRt8Ex7oSLgQyqXXu4vhJIf/tGNAYtq8To654ebnjCj\
+            5xcLZluUtzITPPoYR/PtaDUumADxxoq0sZb4hkWMXa7pu+lwnjk8oULhbqKGx2IuC10\
+            zGOLF5dhZdEqcD0wGM9UG6KAwIf+/gLr5JVhdYmGYn+BDZrKWHBfPAaWoRJfDaqUJeP\
+            abaR1TG59UBuI43eLRyYhS7mWrek7IoRU4YhEtfFhQQ==\",\"b7gtmZNW8fYQ+bE9v\
+            CRaYfdT4HY8mMSPu+aVH0kGHPpITEnodszXXAXleNyKDwcL4ZOHaNPJwsoN+8b7ebJg\
+            UT4gsSXrB9s6tdARXi8c5oyV3NxjQE2KVvWO9H7FUlRwZUUTmHW872ECeMCgsTvGENk\
+            PAYWW5wmKsNL2F/igutJLy38yWMebzj4/RpCW/XTNl9gr/WNQVlpWDfiGAW6N0mvTnB\
+            xL/S4YYNOZb9eodMrLSNfXSoMxu1l8xUEkZXwqZ8aE0Rrd7IhGMZzCqK4cxwgOZ3G0Z\
+            SVd1CBld6DNtRImJf4po4PmLW1W9gkagZXUjdIuK0OLaFyHErr3c3xwrJzRSf5wXbIf\
+            g7S7DFkZS7zD/jV/cw9OUbbmrSoJ4bu/wPuj4cuGH5YLma2DZVrDbcehcRF2BU7qa7T\
+            ZtLKsZCwKRJ/h6aoTbNVQSOHb0EfPFU6wDzoOWhStdC7L2TJ9/SRiBlVhoTZ9DT/8/V\
+            M/L2s5Vrymb7GMuJtvLCYX91aF082qtWol9tGGlYXGPVGVMDpPS6imK3xE3EFSRGM4u\
+            dKjv+pIRuGZxfgo1VzZMCHtmDgke2vWqiSvZKCx1dLoQk4rNLv5Hlz/PyIcikoSdzrg\
+            8j2gxjOnOdxwQ+oWKPGWkM7LktXc1bHCnUPVpmZz7IjVldJbpnRlwz4LG9aatiU0mzS\
+            3aCVGfz62TVYVtk0iwsplhvxA0jZhsJXT4DhsRDgjGumVYc5byYmkOzjkJh5SGcdlg5\
+            dW4qyN4MXQ8vgsDvZZoiVvykIw0fdsY7GCnKJkaO5NuRz2MBR5gdekaZWuDFv1/JBeb\
+            ixbf0AbWmA7ML4+0SvmeikeMhQJnQC2sJf6USkolRNmLeFk7i+wwyoQv118CUc5E2aw\
+            wEHxdj67wqfL8Y2vjmu1lM5P57Okq0vU8HnZyk56u2Ny2xt7iK26Q7rEQyJu+K8p35e\
+            QH9QXKZcp9nCNBJx6mZxFGQ1hy1phKYQtvQPm8c4B3qt4f4ywjSyc8jDOc4HvUz2QjG\
+            1aFTP0oDO+wv7guO6GLTOwsmRyUZPrd9jSCakVzmU3Vknty+JY0cJ1JtOxhJi9tDG7Q\
+            ItwOsVjUx0MD+T4iLkvmKxkDFP6eDXA+sNmWvFuGQQhtI2wYtibklnZGo40q4SBLTzC\
+            UNHqOTaCTlDQ9bG/WcyxQtSbjbSsMzq+DjdeGztkZ+DytcRt0t6aVTDSlkb7Aa9EbMU\
+            8gra1GTTOYMZnzwHVIP/z/gKLtQMk66IDdqc/RZG3HHB6xDMcnSkIheWB16te2pzocN\
+            7oH+PY4BWROI8Dxg9QY/2Yh6i0ljYd4dgUyppmx1WLr6QRErm3ppO+lkO8xOM8d/WDH\
+            kAc8wj7Zffbz5+IICscuBQL63fUibO/wLlzPwaeklGM9koPZnDxEqrkYxLJKFzQur7C\
+            wTs7lpxYmSJr111hffElHLXzrnCY8kUkFs1k3C9WtMjpLxX7PAURPaUCsk9gxPEzI25\
+            lW1kpFxTjo7xQpcO+I7Ycvl2NsFTcocL+OYgmZnxxi5VTKzvjZdQoH6036O3AqsvDs6\
+            875mXXtxwqvEFDhYOqXBMEV2vswYAxS7/hVsYLhG1MR1MgDTd58dEnHNfKq33QkGoJi\
+            w2lgAUazGBdFb5nVi6llUHl5FbUykvhB0sVO4ADcSBn33hMd1j+DJI9+BFBnGX2FR+R\
+            0c48hATLgrmdRgHcWYMz4ScyHOKN+zbjAjf2qE/RqQoQ6UAnyGMCxF8UvKEyx7s0tDB\
+            deTddz/2hCEusEpk0Z6MrUxZso6wM+9gbAW+lBbOJmr/4waPgm9h54wTvcS4GjsYGrg\
+            ==\",\"MjGphPI6fLiZ3U6DMiLh6Voyas0jhCm9tNx5O8StioMp1LY6BB8Od+6zTJsK\
+            3x5yItjGaqkE64fiUPjEMbNkD3MVlm6s48Q1b3dkhiqx5YTqjEZW7OIrPhFTlU/mzfg\
+            Ii8w39GYNIbvS9aSceOGMuO/4FEXmCOBUjWc40h4iltPhvDuU8EgRnoP/4uRSQ3wLmH\
+            hbNeWxwK1/uBENW40vyDzeqib9ediFcQpia/AAaUxVgkP5wEplLIMa9XDXL+ckSbOV1\
+            1w/YPuGEJM/Wt6KWnY7XD3o7Xx2iXVH96NNr+4uebztnuNQjw+H4PY5xUrVsU6VZSuJ\
+            asXJ+Qv3oJcbbkuh6BRz7Ld9BI1pDrHU0RCM83SlhkjCgiPpd62M6W5U0TjY1Q2PV9D\
+            yk1r2N4sr7PZyO+dlVx5iQQzlOia9ENE8P9K5sQ8N9jRy0hHYpTonj/V7lm75UOgIlY\
+            +japV4aS1fGtuxQyA6qLTEMQs7/xwYdcGxSgIWiZhcy07pio2FFrWnrtVPv1YScUHWJ\
+            39WTKU3NhywS/IN45SZhsZ0UB9TZQPCVYQHMgbGiLy0t/BgjmGcVm4Pyi7ltdtf4BFL\
+            vMHVrOKwzsL+Agv5CMItwYkaATC+wUOcNriQUOC0XFdDmHrunHKeEyVc8AkZgYoooRe\
+            GB8nJCDHUnd0GZxMGyCEUSmw6qkMZ5mzsE8UZnbPEnqDmPSgcxMhgf0WEqPQuq4yZm1\
+            glIvsV5TQvee9zRonqX1Dx0b296EQhp36kPGa3UR6eXOBGFkRxFBq162UybQglmxqqQ\
+            a2lpa4kkmsh9OihbC/IuZiBQs0vsogbaGGoqB6e8vA9tP31/hLXY1s7Fis1PCyKlGU8\
+            xkxeVTGgwStmfONqTJHAIKLJEdR5nlGtCQeyR9RGFmslN8z2gtTzcNs2pTLsR6wxOFp\
+            BcNNip/ofshA1x8ne+DLfH7L4FGu5zOT6l6BlY0GEuyYL9VBmN2PksUDadvT1wlWDUx\
+            R30nRcMyrDfvJgdYK3vJOen7l1x9xQ4KLL00vJCdUon/JiT35Bw303XarNVV46f8ZbJ\
+            eTf/8542SlNFUJNxKnlBIhsuiZ+YE6nBCPme6Kdk1NyytSGbazykhn7ilGYFKFP6AlN\
+            E8ErkAei9m00albIz5lQVNcTCidHgSd+TzArl/zW4XiFvGl33gmvr3vGreW7gO2l9TD\
+            dD7zH9YwqWu4czt4Ej8A8xxkd9XYCmDeKAbgcNFGcJg1jNlAfqtAzpdPpCwo0J3Z273\
+            0NnlBIHc+e7kMhZgycvsV3APZ9yd30WxURQooFK2q1Bk/Dh+0/remPlCKmSiXPCSRNG\
+            +MjSVTmnubcTmcdHzhGNNZwUbMKPEcaZRs1ccJ0nYp3ECXzqpMHPzZs4LSFdUQ12jEc\
+            b7ubVgAfOHqpqrcEhGxMgCCn9R48a3uAuJrbPhatEvgm9B68AfsAcwdPHOzb7XSO/YE\
+            09Mws2crgFk0boA8cq1ICD7gEEo93SvCPZYQylvl0DsMBZU2/Uft4RzgVhsNCZdpOG4\
+            ExHRt6/PbgfeIDpOvxMQZsvGNEzFgl1B6Ko2PJ+/BvkgaeYjzQ6Js7YYwJypI7H2uW2\
+            qFMhXeJ9UTMWXzbpTOEFL+dtloPnFQm415p3vejAUfsYqJllfIPZdmwhjmdHnlAmXfv\
+            c7bMdHDkEfRxLXWJL1veTr+/8cBhXHvF+lgRDmsx4P30R5rgoiamcNqV8YApZc/kVrQ\
+            DtkzBe6wnKKVp1LSz9rFzpVpOv5wb5Ti1yitzXxp/Xyl/rzqqzvvtdHTrsU3SWgPLwu\
+            3vpq3lR8xj2LKUsI9301lZLw==\",\"0VTXwyJNd6SOURnWKYely3Rw4wgytF6Fo7hv\
+            KheU6xLfWgHvYD9Ae+7rgKJFPCW2Egs+GB07SnOyNA5QXv4RFH4a3WJbbjrY/AhKkkq\
+            WhBMtWMF0qzbK18xZEQ4MQhmiYFZWPOlDG77G+tB0xuAIq7lrZNvGe4K45Gk8Dilpc8\
+            DVsm0N2xjbYuuGtJEOwM6UQxv3JSF9wPPtT5BjhITs9S1ppdSSl6ywXIOXM+MjTtQ2U\
+            M4N6ak43CLSMol1J/6bWBpEryLjUKBsrFecoQRMVzd4iXt4lSsrKn1LGlMjW5sxB4rb\
+            KmZEEQ6xzKHwOWY2qepFWDz/mDetDMuGsESoXReJS95IVg24AHvoaw5snO6U8foQP9F\
+            EUPxu+pb0C/CMtTRdK+uYp0qpPUt75xy6asH788fA8H+IV+jTYZTT21XZ5HQ1b+hari\
+            syPBz2ds64pXJXUcE4yNeM9T19D+M5O2eKs/qdcIO20pl2Hc3KnlvCWL6drs1zzE4g1\
+            htYqwk8y3YCMx1znuuSt0ZLJmqFT8Bb0r3/Ejan71liKHCjZlJKWIs97JwcuXHCy9xH\
+            oHLHEXrMFA52ke7xTE2XJHrOk+6vGXpPVudH4vgwVpY6myWOTrlbK5eO8MuRtk6qoqn\
+            IzUm6jI9AubM9XSjiBSa1KadTe45hubr33fQF5wPOMd4q8CBzolCj5ljy2o/ZObiuwh\
+            3pZl050ta8nU7ofoAYbXsBw6e3tPAfOhzqm77EMhIynhRPPiKC0+L8u9vputYHgNFVS\
+            8UaSCdox/WOuaFIBywhY6mx6bhtSrPRdO3//e10Bt4TGGW9307neY+kOfexSObM8g3W\
+            TG5JX2MXjFvCLwGu+D+hENkA01muB47SquMtqwxzviT8AHf0kCfcfZLl9xnI6ctJT5B\
+            2KHYZwFtSOHVGmzh00W+P41L0+J3C8LE1XT79RRqWVNMV4V+EEWYDdS6cwqbrGiXYq2\
+            YAJv/dki7EU9hf8XSS2+oEBv0Lt9PJYC/C/kYstFfN5t8JLxbVzWAS3Qdb616b+yX3v\
+            L1fcgU9wrdkWO3Y0CJMQZIEa8LeTV/gHwEnOiqBIlb+qbpr5ZLYl2RSV/+BPJBIr2Zv\
+            YlmrejqEtr/eX5ER3t6aItqaNe/7+NI0oRxRzYq1Lc7/Oz44xOEc3k5XeTqBsXLFdWW\
+            o8lOguucp7jGbmpHTQC6zw3u+SjcZblaQkHiC64xock7j6XLtpzxt2GDx3p4ua3iKsv\
+            KH81vPnPRD3+MwPKl/Hl4FyDMkXwWDp/odeXSewggVizoGDjClqxhKj36oUvZSl1QyB\
+            HlevcimNKTpax4ElQ2O0H5Jj+Ep+nAnmmoxGaZ7GUs2d/r+/xNu3IxB+BMCMrOdBz9f\
+            fLsu7igiukiMatCNc/cR0eNjFN5F5OkSUM5ont4apOKexJpM7RqKUllWSeg0uSPj84d\
+            rmLoaWm7Js2X6/uUJL5koNIwYtmMY6uluvrr6mNHL9dBqaeMx35rqw4qVykqB6ybu5q\
+            v55j9gow0d2Ns/w1Y6o+UpQkXNv+AtZz3XPkdHvCWD8omXEwSh5KODxYKSUkctxliBr\
+            bK8x+m7ZKbdEYgpLawcn5lSupTbsdLjdDhzf73/SoqI40+E/xCoaxGrhTSPeXVMm1jk\
+            oSEymKavm730uawrbLekkuVl15N5JmTLvNI7Vhk6Y4V0c0bS49BtfM2s5CUObN6SCSz\
+            eNFKrvczQmqkF+jjydFRmumDuc1hGy6ixO4URmh8ZgRr6mNetymRrxGvvBJFYJk+Jpc\
+            SSkAwQPgUaX0tLtpN0Fw1++bd7aj7uyEygtXDOGyuZsMa5tA==\",\"oEu1XNJTTUrJ\
+            PUTsrxdfQSig5qXQbFBnnm+NNh0whG5mqEJQbXq13J259JPxXrFw7qN2XQKPmKo0b3n\
+            fn8nOrBQbnz+N8hoiQX7kA7JVRfoFkoAZ/pz0UKSLPYYBcTund9wL9ENRN/hmf2z09L\
+            Z7wM6DUf4tgb/hBIWEpFs6ljRMiTzU9dMABbL/ATo28SKlH8EFDjIynuGsZ5+spJ5fv\
+            wQ+wqfIT7yNt9G/ZXQcxB2eY62vUZGb1Ex6vSfeJ2Pl/4Hyd6l12Z2e4dfI4yTnz8pM\
+            usbDqqJBWmQ37ufFt4/skn5LJwqM7Eaqm+l3KN/OFygF9ylqLp0Ldv1PXDRDzxb4Bfs\
+            oL3KbOZeel9xzaq6BOvi0tV8MuCGYBjG3519GOUmvRLq/o3C0SlfWC/zqclqP2fOTIR\
+            dBktET2igX6AnJXomLz9/YF2u2+HgFnoinY7iRRRhChcr4xTMxe1YeiQ/PWFNsenZG9\
+            r6prBl6esZB0HOKGV9JnYbezBokwjujxYZ7aaU9u1D2s9Jyxj3/kkrxouoTQYAAb88J\
+            WZhyV3JXF4bb6YNxN19cvM+glbIzLMvUvll8BQ6JJ9C+Nbt8LBBGGMvSNUE4Y2jjn9L\
+            XpncjkUrcSO/U5DV7vBD3TsAFG4HTC/YF4DkEpvcT8+Yr/T9YH7qckrBWstmBR9TTuO\
+            bB/+OnFWO9kcyh6bhtWlMpcSgYQt5G3M1nyNF2Qj9eeXIrxeDR3ahY8i5zjbg+vp7RS\
+            y9apZVgnQq2IjU0++t9ld349In4BBqqjD3fg0Lep8i1aX1ZsB8u1hwP1h9U1IG62ilf\
+            72LW9PG/YzE0Ko36ZvEVXGUwtpD+jBdOqhaXt7hZfAX3CxKn4HuZCsjEWuVEoyZ7O8I\
+            GXbZUz6aFV4K08WIzOFjQE5QHRrvu6JJosTXE+ECjPw0K0RY7tNLdF8rBkuVhqogpTz\
+            8IBjFD6UeqoEjVHA286RP8mPcXO1B9IwZpbJff9ciTfLO4mKI8iLEzXphhepTez1d3E\
+            zGOpwxmZd9yvzR2OtTz7nomMpokjNVsw9uGgyPow00Wq5XWj7W7J1Hn80VDoy7aDd+5\
+            /1VV3aqq9gvVSTP4BfTg3czmoHrMMXx+9U36of8j1SkowAp5e72/zOj44d5W2bAVh6f\
+            U4msOLl7VAi/jXS8mKryfYHrVQ8tlN983INpyggKHzXx1l0WAtWH281XOBkoUBl/BiS\
+            8BA+lwgmtlrI0HPSxvb3KWLO/7DsjR8+vF7Vsa4splunefBGGjPPki/If56iqjeYFcO\
+            uYNK2u012N9eiCsj5F9LCDYqkNV5oc2g2FY5Yylc6hwyLubrG3k/GEn/QVdJpjPcrb4\
+            4E03PhKcYo5QqUOqxBF0I53p0gpkHNT8zdpiBS9ke5iJWOY41mOO1SNZbTwbX6GjXj6\
+            N+wecisdfFA2+ejyfTRnGJxgvaiZqrquMt4hBQuEUE1dA/nC9z1iSSRsVputV+/iUAI\
+            x67a8X4HXA53Ba1U1OkSziEi3QGar/cUxRvhhEI/34sMtGFrUxDUujiwvFZJ3zjx9Il\
+            gcl68KConWkouWiWVpV8h1z4d+Qt3sVL0wSmPEVKjh3gjSiYYXS3Abzy1aSxao5xMN9\
+            b+eLO6RJn3ygynjYe76v6FOpaI3plqr10iJJupvPcqbcmo2TNqdE8bvrRY7cG0QDTbt\
+            4NyZHH3j1wZszEYJ3PVeVdqOXBMjdRcY5LriVEjtCRGZvy8YvH8v1o7J0++s9eGru2F\
+            Mj5Bkv11wLWbLKBHpleZcK+BuDMn8WV8gUO/2Csvf4fdv99eISXKJ+inOs+Rv2mYP6c\
+            M9gHg==\",\"vcURhhIZ5qewpgFR6JsZeJHgCemi4yBRPzQqe/QvOr43+pPRGrkwwoS\
+            CcpZPkPNfvuPGAafT6YiN6ZkZpb1DC0HqwVOuU0U0FtpWptdQy35gBqQiBT7wwj3h9z\
+            jd4grk8z4l+TGZOWy6VhV6rUrFmXbiB1xLoEbHky9QJTrjZs4eWQ97vkdRoCekRx1dn\
+            hNJZ7HDfwJMKf+h68hDesrdONYMhWQClbeegSdDnwBPtN5SdjDIuG9AkHGa65hQxNgG\
+            EZc7tqfoQz6nqjQlREFiHvUFImNyPruayGM+Pj0lKwweA5BI96SFdgCekZvZBci1OiU\
+            JXpYoVB3Onsw5F7yUqAhPWOkg3PcEJkR7X8q1MNpzpQkFpgER6ifctMyZNl4G/QK+jQ\
+            deGXmKrblFJ8fNDLwF94wlRTPghBtQU/oZrFM6PswPnymM+k/uBkm2neZerSV+dy6pV\
+            bltPcY6j8ywsJbAPZgnXO3HwHG0mBxh4qTJyp14U0ptvFrCTfQV3Bd/xoOZI1fgbs1T\
+            0rhzmODBaMQJXLkHxvieliyV5wW4h5B2T3anXWcccyWc8EsQrn3CG6YvhiQlKxv06UF\
+            9w3pbti706XZ28VkVltvdN2ohRo04dwyHkrN08wvbJSCK+hz4Y+DaD/DZ66tsrSgSyd\
+            0XOp29+4aZDIo7VtlzFWEx3PSe/SbTf8ZNBPkVT6G+xZZUmJPMEZxdfL7Cfc099wPpH\
+            l6MiMdMbi8jTm69xTnQ2TZJfHVV6orVpksvrlUaVvVOFkTmXpl9+mWOj5ZcUimqjslt\
+            b2DWRrIdMmemLJm3PCejHOSkPemvlP1nya1WurqkPHxRQOYKiVLKHpu0e/Aq8LNmLpV\
+            WXra7BYydJ4UvdzhzU+gCFRQqf0rNzqFLOnTmBi9pFkhufcKK9xiN3Y2Vu3pOCTWUFH\
+            M6U5+/Tedbp+nJbaR2wu56z3DkOa6j7O1thOQ2I3E9THhuO41wKEyZGpi7euwAb03sm\
+            6xwYEBdcrebcbtBMaB4LmTuQVk20/fR4sH3GhKTZRPvU5EvTCYd6jVobTQzDj7zdQXu\
+            fr1EjH4v3MTcKT4CZrUUXO94AXzI5cGnd7Y7QXZFOHHwjs6eHC1MqXRFu9PAxYmnyJp\
+            rIXEJ4tDI/BXkBd6A4P7bKWnJC2VabG9kW5M/c+elXRxC8fCaQ2hj5ppZKkdetgHFsJ\
+            /AjMDX866yz+aHctXMyt6achDjE8S4pbmycekY9qJkK4w/wyIfsVG566XiP4SxPXj0P\
+            1n5mUNYlVYYUCMnHuu566Qq3UFmgRokqbuZoqXCTy/vrxcX4L2TJ6w6BbvZC2+HW9lK\
+            nFoRRFjuOCjfGxituMxK0wisX+aXvxCRqtyVM+2BTqpMbu+It0yS/yt3/Y13pXvuQdn\
+            +KK3y+4mvtF2Bol7PGlf1A29bI4hLpfsGlLN7Bl05o52oZYeUhYDM7jFrHXZigEKtz1\
+            h6jSqjJPs2d8sFWofE/R68L/4M1tcKpXTGMy1/bqNmiacAFOF6GYfGbd9ka2kH3HS6U\
+            8K9srNYZ8kOrlTG7bSHwfgYQ8pect5ypYko52X2tv3lyy2bWbWWln06OLEJ/Sp3lvuB\
+            LSX3g5WsVE6YtcSO8atsA7GKwX1pydvr2WHImAfDbbuLd7JKuZZt+AA+mNF1kgn6RjX\
+            hVCVCBFfZTsrKiqEk/IDZwtaynlsn11DlDIdLNrAXrOJebjilZeau/qHtWWdEzVlfc+\
+            1NBzLekpsgcyBrXhrq4n02y3SysHLDPKcii5n9rnvBHmNMHYc3PWMkI7OpVx2vpMLrM\
+            YqnzClXHcOb5ir77P/14jtbGNMWBg==\",\"Z6CApwNOgasSH/vZDsmV9M5oVvXgNdZ\
+            08ue2TFFBzSb7gCCL4qfT6xW0pH2VBp2vi6vsLIjmby4IWCXIFM7kJs1sacSmg4y65Z\
+            RWTeYyDFwyUzdpja8gHk4v1ir46P2+yV5EAXu4fMr8EsxWjJDkNpYvUZZjaGDuWoqow\
+            63yvuW7yppBAzUr2EavgztvJe/c4c1l1o6BmJwZDCpi7sfkruBOUjnDKXEzUxI3MLRz\
+            M7vIVmAznqOIMj1XED/ymNKVRTWl01mR2+OhkK6vJUwlW1yBB1Oe89bK+mCHvkLCZHt\
+            uP89mn6FzJdvFFZflS56VtbROGVK7zw6ZtqoI+qHY4vTVbA9Tq4qqXaM9GzM+MrfRY/\
+            qryDA99k12RLtVpLcgc021Bs3ErMk27ltTWeiH3DfZ0Z7WeM/jjRQCmN04p5YMubzCi\
+            fEqWNAbNLh0noyczP7OeaWH7uqGCEdk7onDIzLYtsvO6p1zj7LjF5fZodT5xfer60v2\
+            +8/f2bfZ/xHM3KGTFffWaPYZJmFcZl8G6GTbmkAklMHcyVBVMDo9la+evVSUbszGNep\
+            SV+ghpJQrkbmiu0ZIcI8yHSK5HW57aZdMmA7dR44unFxpF8u54xjHZXZYYoSxlg/obd\
+            iom+VOSme0YdYIlAAcE6By29grxgU40qK2lAvbuR+EzzUXpbmQLcrTjGnnr4Mx4n26x\
+            MzcvAcmXZoyGEjZ0DV142BxBR7RekITAtcjzfboBBLxhke6O5Y5Iddyjs39bN98ILFH\
+            yRx3GhHyzLrN+MD2chuTfKhia0n3y12QTlW1Z2sXL8TLUsG7sMn2yV1Cg2gVrmF3lb/\
+            I11SW6mX2bbrr339uOWGfZNs7T3XdeFu5wdUQr7Kt65FOlYGLh2n2SEak0s7zFl3iTd\
+            TXDUNnyt6agrL9Xtf7PthPzkstsEJxmW1UjmAnvVe6Ii5fZIumBN2Ssn1xle1s12snl\
+            DjHTrpsX+n17wug1UYHUibJNLX3ODEw++A3Dfa4XoLX1p+QOq3C6BMeksz5vOmlnile\
+            tAbn82Unrphe6uTGwF7Xy+ws0gdiI62WLaMe90x5ctn99+r7/UVP3LfNVilM79U2Qzw\
+            GHT536VhRy1ib29jxYWI8Vdlr0jeslB3XZSzhQh63ufI8cLP8ztkxzkA0XccK3uBWhm\
+            HNnKmeNw028y+zFYwgvOVaWo4vNu6bbOu3V4I7h1N5sg393ppO+loOh1oRrDItRwMZ/\
+            de5nT+iE7ZhzOZ8PdbKMuX8E/er9k32Zb9Aryx4sSKZibm0oR06lLm7b7J3z8PDe+mN\
+            TWID5TZwt1VEtlTuyH09/w0dsNGLmomyvPTEddhsj6yVJephnM3M7WKlNmvuHx/GEzs\
+            6Szk7A8RK5xU+GrOn1ZIq82X2yZVYqcAFkSGZXQHFVYy+xJB9e8xVjMx12DfZ+rFr+H\
+            JpWti4r9mZE0e/Es7o3N4e/Tr9+F0SLZnL5fjXV9We2DfZHu/jX+tDnU3Sy3KZffXJ9\
+            dw2zPJeEemfm1wpdExkhdSi7rjFDr+rbNfLCTwnVrS4yr4CeMLOUriyCxWcoFcaXkq5\
+            zD46TqgwXTRYpH+mqUHxJrTjV43uQPhqs1OCnI3VzLG3NlsQukKk+hRYMGRXCXoEQiv\
+            wMjuY4XwptxJb9NlhOeJBhxgDykR5LmIICHcz22HneS+Z1PsdeNEuHsK5O8RL7Yxdtg\
+            Y9pr24yl4pi8j7bUHYEbmjdwj7w1yCbNv7hSwCDisWLfKthxfZeJYusn2rL8Gh0y5f9\
+            3wJ3fAOFHGN+P9kWFoVK6rABZxdvOGlD6SyXrAD2WrWi/yh4VDo5w==\",\"F9V5CT/\
+            4evq94NT4/2D013hms4Xky2zurcLP7WWfYC99YIO9ytnXYF9mC3h+XGQr+i/R94OVxJ\
+            7Nzlud4qfHaPDo/ydyIXyDkMXZAZMpPllfKb98zwufKLgqB0r6zPItxJc+oSoFQ2oX2\
+            blZL9LHOsPwC9mB35e+YAZdxiT3//+/3vS8kld6ad78419vpC4/DdYZ+/Sbt9fvhL5e\
+            i1X/31fdXN2oX4e7P961V2qjSnX116uu7Mtf6nd36uOqOH+7Fud/fye66/af73+txS+\
+            Vvzu/XZe//L4T3c9d8f5X//n7T7vi/T/7f/7y++7zH7+uyz8+Nnfff/34dTZ/N5817w\
+            P3n5+u/nqlfv37m3//+9///n8BAAD//5LzQEtzOAEA\"]"
         cookies: []
         headers:
           - name: date
-            value: Fri, 10 May 2024 07:20:55 GMT
+            value: Fri, 23 Aug 2024 08:20:23 GMT
           - name: content-type
             value: application/json
           - name: transfer-encoding
@@ -1798,7 +1802,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-05-10T07:20:55.336Z
+      startedDateTime: 2024-08-23T08:20:22.700Z
       time: 0
       timings:
         blocked: -1
@@ -1808,347 +1812,7 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: 248df220b3802954b568a0d8c294ee8d
-      _order: 0
-      cache: {}
-      request:
-        bodySize: 441
-        cookies: []
-        headers:
-          - _fromType: array
-            name: authorization
-            value: token
-              REDACTED_b20717265e7ab1d132874d8ff0be053ab9c1dacccec8dce0bbba76888b6a0a69
-          - _fromType: array
-            name: content-type
-            value: application/json; charset=utf-8
-          - _fromType: array
-            name: user-agent
-            value: enterpriseClient / v1
-          - _fromType: array
-            name: accept
-            value: "*/*"
-          - _fromType: array
-            name: content-length
-            value: "441"
-          - _fromType: array
-            name: accept-encoding
-            value: gzip,deflate
-          - name: host
-            value: demo.sourcegraph.com
-        headersSize: 320
-        httpVersion: HTTP/1.1
-        method: POST
-        postData:
-          mimeType: application/json; charset=utf-8
-          params: []
-          textJSON:
-            query: |
-              
-              query Repositories($first: Int!, $after: String) {
-                  repositories(first: $first, after: $after) {
-                      nodes {
-                          id
-                          name
-                      }
-                      pageInfo {
-                          endCursor
-                      }
-                  }
-              }
-            variables:
-              after: UmVwb3NpdG9yeUN1cnNvcjp7IkNvbHVtbiI6Im5hbWUiLCJWYWx1ZSI6ImdpdGh1Yi5jb20vc291cmNlZ3JhcGgtY2UvdGVycmFmb3JtLXByb3ZpZGVyLXB1cmVwb3J0QDM1MDE0IiwiRGlyZWN0aW9uIjoiIn0=
-              first: 10000
-        queryString:
-          - name: Repositories
-            value: null
-        url: https://demo.sourcegraph.com/.api/graphql?Repositories
-      response:
-        bodySize: 15664
-        content:
-          encoding: base64
-          mimeType: application/json
-          size: 15664
-          text: "[\"H4sIAAAAAAAA/6S9bXPjuLE2/F/m88HYlu1zclJ1Psyz8kmUJ5TWWXkT5667piAQImGCA\
-            BcAJZGp/Pe7AOhtZq3u1vhLxuPMXiTx0q9Xd//r\",\"U8kD//THf31ysrNeBeuU9PH\
-            vxpbxh//zr0+q/PTHTy/tr9vV/bwr//Tfg1zacb78cltU//M/n/7jk+Gt/PTHT5UKdb\
-            /6LGx7423vhKwc72om5E2QzvG1dS3rnN2oUjrm+GqlQvvbp3//x6UHTJuHxfMHHmBEL\
-            d0EeMDyywcfUNoWhJ/Mv/w4vKrq4AXXElyi+8UHHtGvnGrALxjn2w/Am1IKGH8y/8AG\
-            9MYL20Hrs/zy8IEP8FxLv7ZOwI+4/8Ah8oKv11aXylTQM562xY9v89kz2NrxVm6tg3Z\
-            l2jwUH1i0eGS3fICX7Md3xbNSbuQOhN9+5P2lliJIDS7Q40e2Q1WG6zX8BZP5j4tWb9\
-            dB80E6+GZ/QHD4zgZlfEDW6AOfELhoOh5q5BR94BMCD70XvIHF68NH9qFvrbaVEshO/\
-            /hZDVLLtTVKcNtJI7TtS/BZtx84tkG2neYBW66PPMAIaQL+FR+5fGEtrJOthdXS0/YD\
-            lyOsQXXxtP3AvQiqRcA/sgHawxf6A3ou9G5lIXmx/DL5wJr3OjheGuj9l0+7D2iFDe8\
-            1/Pq74sdXZyOgEz9t7j9wZDbS8LWCX/0DRtimhcRbfPUPYDv+X8iO/viR2fiulg627I\
-            YPyOZNqKP9CynhafORM7+Jhx45kj+OvuUbuXbWwId++MDBHLgpQTtubB7oH+ADU2btO\
-            Ih3dxXeG99wptUKhLylC8UDZGuNjc42iHvFlffha+C+AYTfYvplJH/62kvgSico6q2o\
-            JdvygQXLKvv1n3/++tMc3m6yHKqV4V33dc1FsA50NZ7oV6x2PWjSxvND3RRVwsfmjiw\
-            WlRlYZVk6PscQDfTJY3NHNgJU4AZavRkdyjpRs5q7NtqjoCKejdR9XjpuogPeSvdkKm\
-            VAaT3bkW11F5jnbaelZ2vrWM1Fw0NtDRPQaozNPfUJy6GTvwinOlB8Pk2ol7LnrIJu5\
-            Xw5I3uMG145bgLzW7UOjGvNlGEWXNuRrsY3XKuSBwtpppEe2MPsrrG5JX+3cHG3m9NV\
-            QnCJUu73uIxrJ3k5pF9LyLQbm4F6wd55jLEBf8Ty6ZG6Qr+qUtqfnRXSe2Wq/yXEipY\
-            zcgDyV+X/tvwHfMqoWFvVqBX3kgkNmbZxeYkHbRvWMBBV9A+81azs2w7UoWQHc+DOMK\
-            Gc6DV3zFkbWCk7aUppBKAF4iOon54ekc8tAkheggNg2+ugosn3JkVAlAJVJAx9y7oos\
-            StlKlY2rWdmo0oFmX7LGdlO+xZeq1UGZ8YLKFmxnJGDK98+YQ9fOrWBI3azW6oMfvcB\
-            TWtLJmzbWljjk5M67z6ltWXn7ApW1A/kw//eIzrpvPIpWgTKvdkt1U599zFehqBMBR9\
-            ash579xE7Yc1agYH/GTnY9e0TOieFbTulZZl2HjFGiQs1ckCqJWlLBVIGtmZuqWpxHL\
-            pOuuvv02LakCKvN6KWovFJnLkgHVv1SpeNCpJ1uq8UcJmKaUGE7y8v61BMXx9wFM1XN\
-            jDkPA3FKO4od+8mBWEZ7wDlupgWJOdgjyVsKVltfYhLuZYuXl/wownAEVKZIDWTuyCN\
-            VxaIAA7FsqFhJkit1pfV632xFFdg9UEBodXdfDp7JIFB9/h+Pv1CeyXDN2zF/eXUCik\
-            nm6FsgJZpN1/SDJ0E5iV3ov7ML5+53Xxa7K7AqnpVys/WXb4Rk/nyaUtDDDx8LuXmIt\
-            TjnHhmo5CSO+mE8pL5ftWqEEDNP84mFM0fsaG4wJsgpXUTDJPtSpbxVT0rlRfWlQyM3\
-            y+mFSl6s0ffcN3zoKxhJQ/cS9g2fH6kHqLhs9moy5yMXbEkXRK1ZsEy7dVlnw==\",\
-            \"YJhPn0gGxo2w7Qq6I9NnEoZW5rIjNiEKpGj9vXm2VqbsGsC22RXL2UBc9LbtjQqXv\
-            zAKc1Ik+kZYwCrYzZcVCSI4teqDdf6kFSCNWD0Sz60JzmotHRNlAziLA+2MOQnlUnfz\
-            kSJMEgjhM+/m0xcqnJemZNXl2MhdsZwRsPxlk+ZhvqQYRoEDB3QoxmakScWIw0bILJq\
-            PlMsTdps1JKZGQbKjb0Tvg22lY9yDgm8yXz4TdNMBLTiuDEQjmsxHysEcOie9Zytnt1\
-            660+HCzN274o0gyKK4B4yYgnJOE4atWDSIomoGLas7MlyKq3npNkpIYFeKN8IqlnJtb\
-            Ck/v0FmH5GPcVNKHX2ZgQVVScdKK5oohWzbWS/Ta0Ny5JnkQd6UstMWVFOEO5tBWPMH\
-            z2qpO8CqGYo3goDb4539CnpBytH5HSDj28t79Dhf/tBbMmGBzPI9SeG8g1rWXGsWLVu\
-            1AWIfu/n06cfwVaUC11ZIICu0m48/ttD53F7GXUyfScHwy9jsMtk3ur6k6DKAfhS1Tn\
-            ZaCc7uYM+HpA3eeZwE0mfRix1/BLSW+rJdHM2gyY++bvMH0Lel0YbeAwYlW/Tcbgmom\
-            0wLYF44HsRl+fEwp1jQ+Qbuz4NqLyvbXTH9Qtgn5bO1GvVrsBaIEtyRjKbSCgWyKnaJ\
-            0026B+kj10pLz3zojQEosbfF9ImMCp2WkRCiiRAKtp0JjkJE+Xz2i/gPoMP2BQ/ClVY\
-            EJwG5X7y93lNRGHcBzL090Owtv9canbMBSHgupgWJ3HAjJ5L5CnazH+ZTwl2SmvugAE\
-            9jXEwbmnMmWy48A+Mft/MlYbkykAacl6EYX0mp9pscQpEl66wPlQNsyl1BcW2l18qgM\
-            d5dMSW4Z3ustXUtD0E6JNZBsnnlRprAEkEFDMQ+zikOpNwlggZL4oy9cceSKAK+eyQY\
-            PSdvhneKCR1dMBCT9KbnmD70K1B9X/OWngmtZNp0MG83mS8LPISc6HzSlJ3mIVHxVlw\
-            0lbO9KRnvS3VZ2Q7z6ROJ+3JTiU7bqndA+UTxRljUqiwvC4bbxZJgglbSsNYKgBd3Tz\
-            J5qhrM5kfPaIKDAKs7WVBcl0oFxrsm559Az2pK0DIRTWw8W3MfmGo762BTCz9dn/PvL\
-            xswC4oBk3/NehM9Xi/Z5PbuP5nXqoSuaTS2Sbm8P2nIs7mbTwnmR2XZSnOAhn9PUswH\
-            GMTKpZ1Qy+BoWdxBwpmwrJQd67jzwPm6KyhhpIwFhMtI4jqiqPVlxZTCGyQLYY/EOtA\
-            JiMqdgpVtYzVePgR3BcVLriyDBMMdyWapLKuVdKDpeTenhFsqy1TJoXBSMf2CO10Rpu\
-            WVZK10FWin045AFk+e5aQeZKXQlvzNW+NFLdvLjKGB5ENUlmluKi8dRDW4I1lPldWWQ\
-            3L9bv5Gkk7aQlHa3YKSJo4fBtjAUZzg7lC1p39J5wA26P2CkpavrCl78KZQwpOVZcaM\
-            wEaR9LBlHe/ifeMKsnIokcPKdjzUcgdQe4eCEsyrbFdLJ6yJCvMPTKuNXGl72Uu4I7E\
-            FImrvwKDESBNQYLJxUhDPpJOaB6ku0/CGYtrglkpGktzLz1wEKG+2W9AsAidbMGI6LU\
-            ja10lTynFje8BkJYW5K+su3967BSXSVVnPWw0FVGlWTkJhi79OIWYC7RB5qaVR/eW4w\
-            y0dCax0pIkSSlZipK5ScMpUkFVPCqlU1g8mSAEQNYo3Es6x3JdpBdaAkZw5yzZgScgb\
-            bcU3wkOe5S1xjdhWrhoVLp/te1IMpXK81JL5vm1ViHL3cq3i/YIIuObmslHySLv7GYX\
-            5Eoodknyx+L+/XV7v3Q==\",\"gkJd2aNAlIKxIIlZ1wnBRQ3TBvGMec1NubL28upEK\
-            xdPG9dSqx2W1JrMKdetllpfXp1obeEBhlrqll2O+w/z6ROp7Oqmtq1cObllvAMoHCQz\
-            8ggV/we4bZTEwRGr9CzYHNQGs300+tIR9puUMPDlu8W0eCR55e9Cl7JzUvAApG8fCkp\
-            064TuBFgFc0e6XHVotQCjI+OcYqjXIXTwJb0lxYEiztoHJ/lldf9IcmojUjUqKKL/Vu\
-            DeTIRh2dNjPvCV0mqEstkpMkE5gaoyYDarmBKCb9nf7ruSB+lYpzqpoWrJKFIGHNQIJ\
-            1tpAtc5DJ8aCFnXsBMZDgzK4VJLGZ/aXGXyTckDz3VDlzPrk/lyhst4ZUL8KSUimNwF\
-            x2EqGY3J/saN9xCbkGR/phpw7oJac6gmarKgOH4RLGeE2N4eQWhaO9KlSe9IjLvckUJ\
-            5uZgej5YMpPDid2gMTCvfLSi++PeQZ0conU7QCyZYdxHfp5JgpkppALyBpFzP8MLQyf\
-            2PlBUmxd3eZAkWfzQ0tf0mw8pxBaQDd/PpDI8pvtkVW1nuINbTGyFk9+bPyifxk006O\
-            B6klhKU5pu3xnXiskOyI3k2p7hmaaGAEoXtGrEuW5N3JNL6G0QnHJ9pVlTzn6AWw8tB\
-            IHrS/YKyrs0fPBO87biqoHNMsmsaIHOfmrJRTPTGtWzdG5HVm5OV8gFoCREX+4FE7mg\
-            Sw02NkkQyJJzsKI6Y64H6h4FEJ4w4fTRx9sI5sVmEBT0AgjTQfBwg03BXTGf4CdOSu8\
-            sK94HExtRKSOPlVy9sD+Thi+krbrfpaFLV\",\"tveSCUVuHHJPomUkbB9kx4LjQjp2\
-            UkMQjYKgz7TygXm+keVeLIMxuuUzqYPKjdYtkMgY58uCirNpE0NP1FyZw/UAdPh8+kS\
-            rL9VWNBVYC1IsZ6RGITdQxH8o3ma4l6Nt9fDGxEbmes28EczJ/G9AdiJBkGpbVbKE3c\
-            MJiSGjbcW0MmDopZhSJIBXayaieAHXnwoEBA5oeeoEU3KAjUEqOT/hMCTFQdPCGU62F\
-            iSxUY5ABAJCgTtSDm6Pgn3bQ0ExUxJYdsqQbBApkpLhvDVGAptIIlMlKANVuDzSRMwB\
-            B/9CSujpBLeGCaoU9kICQ9X5jmSJZyyoEnFJIGUnFNd7wtUh30QvW26CEkBXsAcSTeA\
-            7tMwGS4oJKv3azaeEhH3GDjwowSAPIqLhIanv0Nie0AkJELLAhmueSM0DEk7factLbJ\
-            +HgsK80L5jvOQdVMu9o9lYvtvzPqEoNEFLtlyZwJWRWO9Vwku1vIGbNQpanUfLDa+Sj\
-            ZcL7diRjQqX1e5IdkErnVaGBcuEBQjN2SOiiM7W9iYos4bqYUlb0eugYMsnvRQpaWEq\
-            ZXbMdtL8ydmGdcBdfZhTls0oIVlQIFd2QZHmSSvAHLL7YiT4yRGo43DB2Hxa4M6QsUG\
-            urAVZwJT0s+laVsouSlqInEFYI8v7UF+O9ZC6td1YXbKTjeckEsl6WFBIDamJ+OUOF1\
-            Hu4zyWCJJzXZ2TGwUm/khf2knDlGGyjP4rodg9x5YosihCB6llK4MbIKt0KKYveDIjw\
-            m383nFCgtzTCo95WrdS4TwODVZOUU6eq7CQ5wNJsVj/Wy+RiBPxHAepPcAxGBfThiYU\
-            uwe27sGDMZkvCZHmn1MnKci1J1WFdDVfOSU49cxSuKtd3TGuFUdTMvekJE8HRL4eSCy\
-            oQ2UTqTBhnI8FqUXrTedyPQpAG70jRfs7J0MioF5WkKQpFTeds60MtQSYeTTzJwJVTg\
-            IhKZIbnRwmuGB0IDG9fv7ll9PfAOOLoiK7Xmvm5G+99OGsb4Tcgbn3Ga5SvgGOwhpqM\
-            Hw/p9gXXd91Msh9ns+JqNkdaEmNJEuqG0pgc+9ILk43eGs4MLnqjtRqqhtSS2OwDGNH\
-            4iftkag8fBItbI9JyFfuSMT3M7yzRAFgZVFKLpOWY510qVDSiFytA3na9yRvwEGHZCD\
-            FG53kIrDovipTMd8pY5DmCqS5IzfH5nxxu3Wmf6Qc+EqFVS8aIKiVOzhQvKqLD8n/Hs\
-            qxEeP+F5+QNxPqPZhqHWnPSCTyr1EYSwFpq4HEt3TS2A0PEi3xJdULHtHO8t1IrRlFq\
-            kQxrDItyGOlYqTZazeH7AKLV6sFW4fHE0aaPnDzt78sn35ZAg06EhLlQmSky8J4Qire\
-            dt1lzTIhZaFdvxoq2ebmbUgQgXR6ey39V6BB0WS+fMaTn66HWkKRlmYL9dW6JXVC8/d\
-            IbCWJJsqy+PvO2d1l1+aORIP099A3RTFGaqZ943kLhBtIPKE86IB1/UorwVKVCdD5Pv\
-            pIuEHm+UZWKnxWl4EeSeaSXwVSHcVkviQ44F5Aufx4M0g0vwiD5QQTGOk8CdWBfUOHY\
-            qxonYnSe5U2QImlRE8mvxiSiSPorITyxjeXqxZ28+kMD9MlnMYGDTVUno+Cvug5qbTq\
-            wbYWz8Q3y9YlFEIkNGlOSDAZplh+wUXuHgdt+0YSMAcsPAlCHLWRIQ8pKlDQED/1RG+\
-            EMr0EFZqmxW5UIsJArfmGghJN25MjVryECrfuFxSr6oClVbhcn3pPSoLuoUTNtZYGqL\
-            9OvU9JpsIe8hBKx1N5cXMJN0sKdgj1MLicdkKKX3tpghsQtg==\",\"7m6+/ELQcBCn\
-            c/pE66KO9UmakNihvlZSlxC9mVJc5mvrggC4ZXe0K6SCbIEpAHF1CSiN1DKcu+t4iHR\
-            CYnF7rVrPK9ZZgdQIxTOKV3n51jYSOVGT+fLpKqQrOHkUToA3quugTrLZWqG4TR4q0i\
-            PtLMGYu11Q3IKznxnXawdwUYcFJWLyDWAAur0NxbIhSK8zuCgVW+6AJOMdqaHEOab4b\
-            +iqUqThOZgtpbBAao+U3f0eMbWG7z08d2FXkITc99B2a6TzNWDQk2aI/x7YBx48OxQe\
-            AbELSmT0W3QTuAiM96EGYhg03sE3wImVzTZKAq1qd3MKdesc9tD3GAuoD8VU4Gmz95D\
-            3HA8GKYyHq49HKVd9RVAYtIZl58i5Kx4kF648Et+0hoMu35Vbd8KF+2nSVOa7wB5la7\
-            19IY3Iex/fs1VvSugBQ7GscJbZBXChrUlx8eQ2gLf8Skm6VqZMDYA5EEPekVqtn8NWK\
-            mB1ijtSdeF3oHW/wnAn8+ULzoo8+3nf6Q2K/tyTcjbfL0CrnEvp8nT2oIW4dnWBMAcp\
-            +PoNmEPaIpBaf50j1v3KdwBDbyCx688RCWV3NB/3HFMB05UHUsuMc7izUss6BHAA1pW\
-            W07FGBbr2176tMs2B0MTkruPwaO+rF7eFWN4PpIrNczjTtUhLzwcSReQc80DEAm3nh6\
-            sv/gF2P3XrDVqFK6/9Adr3K62Ajo0PpJTie8iZ7gXyxq7TYdZ7tpJGrhXkz13t7+wnc\
-            DKQj7cjMSe+gYXDojmVSoqUnIHuo01okIlGC3sXGWx3ek+Lif0eF/UpdqSixG+RDVTZ\
-            OZlfK3X3EreSUMEihd/2DagZgDKQq82WxH75rQeGiN4XFPbXN5iBiybXLAK5xqu9YFy\
-            yXHtGU2hIS15Kh9S7k9q4fQNtG2lYrapaI+f0aquYEKIfaInTM9A9l3b69PPfnn76sn\
-            y63ELugcQGPMfe1pY1xm494yvbBxZqBVLpKPBYIx6a0eGEAKzV+RvFEoD4LTtSUVz8m\
-            CgnvUxlf0BOjoim1WVaz4REL8wg8OjKkWYsHpGABNVImhe6h7oMc0uzs/YwQP3oWBC3\
-            PgH5mgMtIEeatX7Agto4U3jLeyCkV9pIam93wOrbFhp2ecX3wbPu6Aez5r6RQMJhpGn\
-            /DAam1EdazOyEhIjmyfyKW/MGdUCa0FgfJ6SslMBWWhNa4iFjQn1Y76459V0NtQ2gkD\
-            wPQLCNPKElzDLWb70SjQ9QefhI6uy7xwPJCCOpUcweycMhm7trTqwXXEPD/EkJ9Qx17\
-            GK6d4Cg7CL9BQnWzoQWBMp4A8TyGmnRLie8AM7+/YJ0zAJ3yTYESYGEYGGQHfM6mtx5\
-            RDR9avo9Le8SnOokUrJFEd1h0JIyVmcgFVjt3QGsefqMsIJ923I3MOV9D46+mBaE1HP\
-            fRY83en3SwQTb+bTAu+sd8LDoeireoqW7hvYyT+uW1GrIDybw3dG7gYx5wqwcrI/yQJ\
-            NCGeUrVg64oGjNwCusqmEk9QkLXAOZ6gcSnSSIlmsNlcssphUtknKswIQ8J8LlC9IZV\
-            so1s06BEobUqCuh0XsA3pOmGiXQt1xVwjsFdlmYkMryE6K2gmuW2G1RjpXSeIqcpcLb\
-            jXROlSjkhNQIMkE6ucbRKJ5lQstfvuUa6Ok8X37Bb32QzvHUjIBvPZM7KdIgcSh59Ew\
-            raTwhC6Av926+fMLF7wmrsrbSkvKiqSCXIol/B+5/0wxoW5K5RdctQefsRpXSHSfjQQ\
-            XApOEQ72B7FeTkYXe5KfsDiZITpPfScUAV3JMKLcHSmwdSc4sI8ZUQDXukyKJDJdsNL\
-            zfcCA==\",\"WbLKxsWrHG9bZSqGtUjHey+cHtE0gD2/WH7ZUsKkJzi95YNnsu3CAFc\
-            zPFJiOEfcLy0HQh27+RRvoHaONVrzkzUGsiIiJlrWcPpuU/Wa7yd/G7CFbOoled2iYg\
-            0fHyisvRNcH2ybFaecIEPOhuINLzR6DxkrxtzNx2JLKRg4gq94yNxpU0l/6J4I3QKc5\
-            nwBe/9bpioDzQqPBjn91P3+EfD9GOfjlwkl+Xl6gusvR18fKRTiI5TgJTCv9ZHSbO0c\
-            SxqoqLOYNvQjJnLQm+G9Yx4pIaUTbs0d1Pe5mNJq984ApWh6kDtBayl0QrSlzC479M2\
-            4sjoD9K314DSS6JHRr1FZ5jQeHCJ9pASmj5hTuVZGBamH5dABMnAsRpwzfnrTeIbO/g\
-            94myjW2Rn099PSoZXADagTMAyWG2ddc6BK5VJt9MC2KtTMd2AGdjcfZ8NVV6A0XrihC\
-            wwu24wGC0piPZ0HKyR3bCp9EyxyvSi27+ltkdnlj5T83gnN9eryYX2k5MKOWE/cD1Pu\
-            tvDswOfdVepUGmFTfwJQjT5S0qtnmHW0V1vQ/hkX04ZU73uCdarJGnOjvFoprcLl0/R\
-            AIdaeoIMAC7Zn41VnaM1XymrQI5uRRv2cEJXHOmrNSMXyR8RKhc5CR5MQjT6BgVFeWh\
-            3uGRg8UjYjXiPhaKNl865chwsUfaXXpIRWz1+TMvg04V611fCs0Hx2rnvRrlZAjn9XL\
-            Gd3V+mIfdE7A4qUE+aVu54wgXsYMa/S6gdMoPVqwrxyexImUD2Vtvy69cTC44+UNs5n\
-            eMFxZRBXbra7yvBIf/tNM2kqaBRSPp9Xfb3rBKt4kFsOGMmU0c1HyJqXFrAzHgsCh+Q\
-            IploGRAKTy3fVCXorEQvoqm1BZ51ESFLi4BtIfO7JOB+fdlfhNn/wOAt1jAfzqvWMsF\
-            vrGl/bjoU1OPq3QTOFJ1i+BqJsEYvuuSSsPV+HdZoPlbM90HUmotOt64yeh7t51nJRK\
-            yNZmqIRbUW8UXR0Eq4SrI0cVtxLrKvyIyXlcAK1QGO1R0rP6BNUv5LOyAB89COFivQO\
-            IFOmchKIaz5SEuXfAPuulmDIKkrUa2SCVohFQuqPcoIDxmCM8/H5umiztiFwtlZwrdr\
-            0mVSOekJF5iBkxGvECmnuwG7+Jq7T9S13TWm3QCXRI6Us8oTXCAnQl4biDZ+VfQKzxj\
-            Jnob7Vj5RueifAAcpFDcX0dXfVNhsupAZ4URnxmv3YI6J8lQR8zfk5AO+LdhE9es0NM\
-            nyDxtFxSsYJrhdagTMxrpGUtsGqzwT91WwDdcSizAI/Qi06aaaKr7QFx8LhzbpOL5dm\
-            KoVEAErjO8AOONOGnpjqeAP1hYxrSM9hdEpwD/SheKAw9U5ox8a9e+XPKgt29nqk5Jv\
-            fhbdtC82ioZRrvIfrZJmj02CXhawvrhEkaCfiHIu95qJ3ve5bYGrkfPxyXWxh39Q1in\
-            ksz3uFu+lkCRZ7xJW85rOv7rSZY0HX6BEX/wSaWFM4okcwXzEkckwp1TmHQ/3Xa5xh3\
-            /D12mooC/OGd88/wRFyJON8LK7Lk53/7oqM9AOFhvvuQ47ERiyXPn2+vyrchpUtTebL\
-            K3gP3q9ETp4CvVdT64hrZNUJFZibQWk2ekQ8EoYgRXBF0OUdAhLJqSNQh86e4QNTZg2\
-            U4e/myy+kPs/fgubZx0CFVsa9ZstOuKj03hXTF3pyPrGgAvegzU+oJzsBrr2E5gMQqF\
-            knrFqyLR9YsKyyX//5568/zUGrlx6SCbUyvOu+rrkAW4Y9UJrJnFAVNJGMQks+gzIDq\
-            +yJdYL0NnugFNueoQegumFXTJ9R3g==\",\"5BFrOXTyF7h845HSavEIuOFalSCv/pF\
-            SvHeG12tIxI/VdabeRrg8tx9nBGXwawTI78EZ107ycki/htq2pWddo6veeZaxAXtOvG\
-            h0DbZVjToEC0ELbnuVwbAFZpsNxfhyXQ544K1mZd/CjRiHKzGdYUI5kUiGztpwZtCCG\
-            anJVQZHeg6aj4smwjXre0JNo9YOBV9QncM1YYIR7HkZD8M1F3JUBqqcWM5obY5POpa7\
-            oDDNsKOkpDJm59R3Dg0caCL1TwlrVnIsYkVplxDWLI1kTxEwaAQzpftZqGULpXdIdXy\
-            hlh6YMbSjldTUUWqmkR5grRCl8CjUA9CVYlxMC9pE6aCa3DUCCFU/kCa4LxfFX1mu0T\
-            r5MpCrFP0OQsWG7R0r5Z4JdxHsjtQdMTguLtMUJwuCmXoTnJTMqxCkQ6Pxw3z6dEtq0\
-            32O2kkHhKgjJE14nEMCXJ14L2mjY84R4RreCa0a5xwPDMuPFW3a3Dli8JfHme6KZUWU\
-            ReeIhCYoqef2tcA7DbWjJpVWB48WuFJq2oOnFMvek4YInpaLPLVpQmrQcwbcAgd7Nyc\
-            4DTd9VyZNmHPhgQMK547UH3QjPFrFSanVjjgBKh0YSJ1HkA5m96RmUPtOPadWE7SGQJ\
-            TeIXvowwnZ968Ch6JPSOp2D7z1bE9JuazgSJ1gtjJ12ryIcku6YFu50lAo9Z60aFu58\
-            vHABoQUPV9+wcdWbGvbe4iOsZg+0yzArRqhjla3C0qd9y4KH2B9KHsFNlwYSEPwh8uN\
-            Csf5KEhp4psxWte+SX20rSvP642h5SaUL49WNqAaInxiwmBoYdi4mD4DfMwuVZPccGV\
-            93bcQZy4CPV52JQ9ApnRWlanNNvJOF/Xsd1BQcUpEAmY1fY8UJTKeQl9MX4EU+hHTWH\
-            CxXu4u2/DnGEgzocX0BSi5OAB1VmugkCxtHQ2ESTB9H98H8Ka/hcJ6l8eVBpjrR7DOs\
-            9AH6xQHRxFDUZoDlh+MSB3Q81lAKGcZFN3GBLovyO76le9XFODJZUdgD7ziouk71gcF\
-            TJKN7iIwTegI5ZVgnYJI8BkJf6kjEoNrPF4ml8XsESwAhRzx3E7Qw7bio9QMHrc7wgM\
-            FD0iSX844xQ8CyEAHCFWl48Wc9TIEzkD7Lb4WEEg7YQa+0jKlMqPrBlmnC5CydEC0Sk\
-            uXey9xqKtdFBz4+6XBo8z14JDTEZ4/uscS3AWbFBwsXIEE/RHJ+yj4ee6wjrwX9o0nt\
-            FaWvYcFNlAD8Ds423n06L7coTt6AnSSd/A2vAAj6A5w0oVUvgofXfRGpZpaqFw16Td8\
-            9dPMkXVqn9IDhQ3x9AOB/yOa1lIE2GYaCTAtED3K60PCwMhJ+XXQLdtDAT5nEmGoCSd\
-            s22mZJc66D72DArCL6etAQDQlkH5LRhxhqcxawXXk42Ja4er6BJQaha8lj994YgYAwd\
-            RxMW1uUQ2JPQAz+Aogf0h9BGwvAIxt4gOwYZCLaQMQXIkPQZozxi8BquyID/FbtYYNN\
-            aCE5vSMwJWRjvEKMfued7jQtLZRUvQpuogQIpOJRDjy1pXKgEnwfJXRg+cC5tq94Cbb\
-            HgV3fYAKvXeg8uozr6q0FR04dDi9KeF7eyNqkH2TjTj0PX3gmFbGtrHksrUGXbVnoIL\
-            siBS4ND1s7QL00j3MlAe+1nb7F77hv0z/f9iORE9FfKnOWZH30verNgXYQVT8/h9QgU\
-            hbBLpHL3mJugfABNYDhlwh1tArHs4oa7ZRLvRcS3N5aFyWNejqqPW6h6bEp5OJwxiPX\
-            +Z79LaVVuBdMHM0A12knBLguoPqS1M4A9W2e6yDH4Z8JLpWGe1oscO6BxcKezg84ACE\
-            gb/BWistWcs3wBSK5GYS9yDDIW7wC1BU+u2HVmBXy2dcpGecr8oE6dbQnLAcwiCuP1z\
-            gmb+QCJWWHmvAmEQF8VtTNSfUJz7KLnw3nZcOlDcFULx2BIGo7ckGwQ9CD/ulr3gcUI\
-            radi4nS0sJzVvJEgK70yc8LHuYRAT6epr7oMRxck0pd2yrTGkvjwdK4h5dOqlVGHtYt\
-            uJ2uzzPMzOLnCzcmwFbsCTljG5ANOsdwEHN6hm7gOv1FnyRF4D5dQZxKGZCDTXcYEhw\
-            dQgdRcDjJlaCg/vKR2ccx9HKYFkZdMvS1DZs7ESKDdCgrEnMM9vhBsQLHolcwwmVV6B\
-            tyhGhbyXzg9e22lOgLhdI5A9Fj4MegmT5c3EF8QL05DgAtoGsb15uUQ22ttoD8+dyPB\
-            n9SOt9Yrgitxk9pDl4RYj/4oo0YakolNlaasSkhJoe7fEq0SEjADMOtlYRZ62c3HKtm\
-            TRr6wSiffBIWyU8nk55maCHtaolWOwfBSAqaSrVwlzJZ6CbwR5jPxIV0XrosqRfZeeU\
-            IIzvKIBwuVhOdKArlBOPSUkQX+4Zz8xV1pVITBpPYGYQVgk4xXSHH6UMpExw1ndSgBy\
-            M7AYQId+4UZi3CbBx3wXDPvgFjyFXTq3XiPmPh7pz5WeKe3ZVl+fMI6lDFLJc+4mAWj\
-            FnOwk7X7XUymLpY2wPMwgSsX8BKma+xfHNUAJV3Ok6ogKrls5Cg8uixCKsTgQ5FcXD2\
-            Uv0eH4Lh0ddUT1f21aunNyyrl9p5GvxbGNtHUTEziDYkv25X/2v463cWgdapi94grDu\
-            fc0ChxUGHpmphw4xE1AhFSEcYok+36KWqJJSMt+1bGMF1zQ2TYFfm3hn0GwATqWKMAJ\
-            oTBA1BLr9CmljnO1X7CQmlDDAMT6oG/AeJ+nhmrfCIfr9FXdEcvlvA7tbeI7qTZpGGc\
-            +E3UjHK5nGOyBMkgE9oG/KpZdjK6fKCo6l4dGhvxj1Z6k7CXXIS5FH9GMToV72bHJ7d\
-            4+oYgwLj+zhwqnhylkPVPOm6BkOI52RmsIXwJeo0UA3nOzBY9ulZYvGkrBPSpVGicOc\
-            /SEKPRPqmn6EbVew/75F5bdWpoKX+RWnrmhl+sulLDm7gmLYqlKmQhX3K56x072qQFH\
-            7gjMA9SAknDp8xU2SFom8P+O0kpZXxmqMXYTHG/Y0Vdb2RuUqVYcIxhecHdQq75WpsD\
-            gZVLx1QNJWNHIHW+7PQJXvAceuVA9TJHHKcgZhR0Y1PFgyG7vYeSoS5meUiPGKQ7XWg\
-            jL2BRdIRoYwsDyrY617X6NsSxri2AKNzPLio0BWBuR1nvGwg20Cj6YShV6DZ+XOOTWZ\
-            FISZYQVuOZ+DpmOBYuKh706WXMND23PsG3u5n+Vv/x+Hb/ULzjWOdj1reYczhl7w8EN\
-            Xd9HeYdxFMGV4tHsekE1AF0zzkHrmyF2QznDNVrqXwdpQp59GWHyjYrezWg/sLVe0Sy\
-            8RMjkebz/NK6NUHjzjLN3O2WChmcXZ+0IXMsIwJyvloTmKI1yp9R3Ybz048TDlOPAV6\
-            7tOBha4RkIxeISuGySKgb7OsAbDxS84SacbkBb6meuDv0kUjWsNJ1xf8YTrvkdeYrRv\
-            uUZSXa9Ar/Mj4BYWPXiulDKnOiUKsD13PPBgLRhGeMY/yUkuAjM8qI1k2tpmBRX655O\
-            NvlrEtIl+jjAWCEganLaX3W/8I8t+l2aBplZ0PnBg0EyWdzhkFgKMQsrEU0nOrqyWIg\
-            pO5Ixil9D5TgqGhFJf8UTUEQfLWBe4B+56pGzmBXcI/X2LlFY836G75gU3IsCFbHhEz\
-            wvEe8fToxGCCWuCQ8iteCAwQn2u/oCIE9ILqVJySi4aJ356Gb0mxBtAt1y23AQ=\",\
-            \"JUgWBc7w8rXtdcmAoXC55g3HQYt1X3B+nlfReyPyGvGlwrMnuJPqmwEm+EF9sw8Yh\
-            jdyBQ3yypWO6LtYzpxcS5eKByjV33laKo7bmzJVV+WumdJslLOmxfwAnBnsO+6auJ9p\
-            iDUSQ0WvYwSTGFmZiILHrnDS0QEK91tfcO/Dd3yLsP7wjcx/srSXKW2A9V7Jrip6k/K\
-            fe9rCZ0zSU/HYPg2Yyp/hjkx5b6nf/+aZqLnW0sAZgGfyp6euH4hSwo7LL/nPv1pElU\
-            D9pL97qyCNtw5zCwrcBD8AbuUqjZoPaPKqwOOY56Cd5kM0o1OgZz+zBdanhOuXamGQ4\
-            DH2kr/8/EvgopHlnINc4hfckvrl5+WUB/5XuCVb1vP4ay1/ls4rH6QJP2GFQ9AIpONq\
-            DRi3H/cefTe0HMvSPeMZVv9bz32tTMWENL73TO4oQW7UQPe+3tdcwa1scs4G/dojWkB\
-            K+fGUiQ8DnHXBMxS+76RjvuW+ZitnK9BmgxqUH/C2uVsVYtaitzzzSZ08zG6FLS78tb\
-            7HI5QcvgDTO/ewaEzpGXfiT227q0amjt1R9DKhe/xO4C94As8EOr71rB5WTpVMaNuXb\
-            NMhNdmo3vjdMyqH0JJRobdvUsoqjtEiUZkX1nvFwErp1AZLx6FvtnYSk8QFLgXCGr64\
-            eDOj3Kqz7NuOccP1MCJBN9zQi65fg+W5cBTPjkVHWCPRTOdHz1euEd5TO5B4P3Yc+hV\
-            CuX7GC1d6basKOQK48P6Vm1Jq2L19xUXQplQeTr7i9ZEb5Xuu1ZjqiWENgNfvbqwW3I\
-            DWfIETeTZ24Mgav+L+z5Z7uNQFL2neG6+IWYl9zsEExmc5pqwStukJri+VZSuJWKvPe\
-            EHq96Y0/HKoZIpwue8i8pmkVdsjMa1WjrvonbSppQ/C6sGg//FTgce6CpzV+Y+f/iZb\
-            GyRuTePtbUarwfL5+VhARC4XNWYng9DKKPG7X7BWCWf3xCNomOgSrF7JoPvO5oe/w0I\
-            1vfflj38X8fjaF2F38yXYIOldWC9F76Cx6rti+nxhntlvPXcSG9YW//sLEzUO/z0c6Z\
-            gBkY7oUzq7u+HCs7WWMrCWG0xMzgBC6Dlgr9iqV9DMo8UUGhN/woLHhEUYgBxxhCnbP\
-            BI+R++t1tJFp7+2NkcUkQfg32xETeuONwPqLE5oXq2SkYm8GRDSOWKdhjn5wE0JszmW\
-            FXALDpAr6bx0SGJ2BiT4jkBawjb0DNDtJxBLmLGbVwsH86qU3q/Z5HZye5xqDC1YAfj\
-            8B1QhTXBcM40E1pYFEOA4gmmuHNa0agYUpx+BbClZm1hbwvYmsBVH+MgzgOl4Qk2twm\
-            AnewbQEk5AKc/W4wIAsCJOYF5VoG86A+IIB5RSrnmvQ2Lwj4SU2wxQ0yfMDSstbDrMA\
-            AfgiJP7Fhw4MxRJBNB5zlAJlY0zoK7thBSMDNECw5rtzYBSuwPakWBlZIi3lHUY7XAp\
-            CBd1zRvJUjc3xfftr9DC6BlANjvhamEP5kK0PuHlBJLZR8Rzjc26Bgw+zQD6zgGwsqx\
-            ynUhFkZdH3WW1jW52ioeVuQ0DIpQBY+6EtuGaddwhXXdmgLd9wKqlblkiucCvBcRMvo\
-            EinRCAYXoOhlS2LgXgox5wVJsKVZxcyyAQ5mtF0K7weL50HIggSWrmtmD/9z8+dbySM\
-            7O2n/74r0/SlD/1zlv3/QNe5nfCzDfirfuvWTPfrP78a1ip2X/O2sd69fcX9def/vL3\
-            17/v7v75S/xd2ZV/qu9e1ePbanK7Efd/q18nYVjdVxv+98dWtE/h9R+/3vKf7jz/+1+\
-            +FGM1FOOXiPHE//EX/Xr/t241eVALNVPruPX//ve///3/AgAA//8D1mhtTDgBAA==\"\
-            ]"
-        cookies: []
-        headers:
-          - name: date
-            value: Fri, 10 May 2024 07:20:56 GMT
-          - name: content-type
-            value: application/json
-          - name: transfer-encoding
-            value: chunked
-          - name: connection
-            value: keep-alive
-          - name: access-control-allow-credentials
-            value: "true"
-          - name: access-control-allow-origin
-            value: ""
-          - name: cache-control
-            value: no-cache, max-age=0
-          - name: content-encoding
-            value: gzip
-          - name: vary
-            value: Accept-Encoding, Authorization, Cookie, Authorization, X-Requested-With,
-              Cookie
-          - name: x-content-type-options
-            value: nosniff
-          - name: x-frame-options
-            value: DENY
-          - name: x-xss-protection
-            value: 1; mode=block
-          - name: strict-transport-security
-            value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1248
-        httpVersion: HTTP/1.1
-        redirectURL: ""
-        status: 200
-        statusText: OK
-      startedDateTime: 2024-05-10T07:20:55.865Z
-      time: 0
-      timings:
-        blocked: -1
-        connect: -1
-        dns: -1
-        receive: 0
-        send: 0
-        ssl: -1
-        wait: 0
-    - _id: 97b744718d521a90546fd4c6c9a5a02c
+    - _id: 87c9642e2b69c132e69a5d1534ed83fe
       _order: 0
       cache: {}
       request:
@@ -2197,280 +1861,251 @@ log:
                   }
               }
             variables:
-              after: UmVwb3NpdG9yeUN1cnNvcjp7IkNvbHVtbiI6Im5hbWUiLCJWYWx1ZSI6ImdpdGh1Yi5jb20vc3RhY2tyb3gvaW5mcmEtYXV0aC1saWJAMzgyMzAiLCJEaXJlY3Rpb24iOiIifQ==
+              after: UmVwb3NpdG9yeUN1cnNvcjp7ImMiOiJuYW1lIiwidiI6ImdpdGh1Yi5jb20vc291cmNlZ3JhcGgtY2UvdGVycmFmb3JtLXByb3ZpZGVyLWJvdW5kYXJ5QDM1MDk3IiwiZCI6IiJ9
               first: 10000
         queryString:
           - name: Repositories
             value: null
         url: https://demo.sourcegraph.com/.api/graphql?Repositories
       response:
-        bodySize: 17261
+        bodySize: 15305
         content:
           encoding: base64
           mimeType: application/json
-          size: 17261
-          text: "[\"H4sIAAAAAAAA/6y9W3PjvJHw/13meiGOPTNJNlV74Tz27t+7sWadkZP1/ustFwi2SEggw\
-            AFAnVL57m8BpOSDiG5o8l48tux5/COIQ6PRJ/z9U8U9//THv3+y0BknvbESXPhZmyp8\
-            +P///klWn/746an967b8Mu+q//jXPSzM4fvt/eH747/926d/+aR5C5/++KmWvunLmTB\
-            t4TwXa2t2hXReGiY24D7941/SpC/zmiKtQK+ldqxTfS01Sjs8bElar6W/XknLcdL8Jo\
-            vEOm4doKhr+hXXf3AZXUV3euCcOp51vWvA4m17yGOynnjJ/XeyvwLIbMAqvmcd96JBg\
-            V8zeg2sBsU6LtbUa2a0ri+BKak92WPkFHuDYlx4aahJS49BX8IIhJ0HXUlds1KZmph4\
-            5Fv/V1+GTvTgXn6A6K30+5cfHQjJlXT+5Yfvq/3Lf/Sywkf/K90pGvzW2DXrjJJiz2D\
-            H206RwoHGbipvjMI5n+dkDxve++YapVzRL2k60K6RS88qI4g2PZCD80qzoIATK/AzPd\
-            qmA8u9sawB1TLRcOvxYaWXjXGO6PwDPYgd9x6sXqo9s8AF3qgD3ahuLdzv8ZlFr7nOm\
-            hZ8A71jLXgrxSDqMemwEHtaRnfWeFP2S5yT0Wm9a5gHh/bW+ppukIWq4Z7xrnO+r6Rh\
-            ZS9VxSpYSi2D9CLG94EU1OP0ZRZq6bzdE/OY5jVcOGZKB3bDS6mkDxPHmd4KQqJ8zeg\
-            Os2NCMtnyGltwYazJiWjNTnjFpHaeK5W3HXyhsU5wrYl96oqWL2OHsV4SJHJAjh8IDt\
-            n3xw8M9IaYJOT6OLGME9gLLuoDPeOc5zbsvmELWyqzxWfZFT2EnkuVZHx+uL35Ro+fh\
-            7U3WlRMcM8pZeAr3WPHl8PfjebseZt+t0EdI2fCgXdpxPxwt0tPyr4D27h+nN615R2m\
-            aS6eEJm912LZO2l0sVS9H9QvUm9ZPG6TfeQb09eNZy0XjdRQ8K1jQYpJAexnbzx3DHa\
-            dsbgWunj4lpyyH5/wp95adEgDLNUBH2HC6KWsewssNFxYqEB7yVENYPGYHqsJvia2tI\
-            BLrYwznDUadh3alY+7pFr3EVdZLlDhvXjcZr/qkithWGdNSUymfXb7llJzLYC14Byvp\
-            cYEQhj1XG4tumFyZs7N7D6oQUNQrMLJcAtlY8yaWFe5E7U2bKl4jfds/ryvDSMsBovH\
-            /QU0XfUSn+TbpDY/0bag715hh5fF4y65JU3xgopKa7uP++yRbkwLpYUt66iDzOJxm5T\
-            HZ1TvO8arFrUKhZHJbmZfG+YbaCEc4Coj8Pm4yx6kcHZXSq6Grg1HeUKM5HaBdOYP3/\
-            7whViQuSt9LTghe7O7cm2ll8S+kC2BhtP5S2fNDjs8hKHORXYNL60U4TiMdt51PjFja\
-            md33wBjwlSgeIn34yF7QxypeUpM9qwZqcc5TgzQhW1d8Q0ud3fZa2UkBn0LLLXpXgjd\
-            uDBUxDBdNPhSE9vXNlukvzFlCG4rqXk8Mmdqmr/wlLZXXnYKdmCZkxUITuhg2SI/x3r\
-            y8O2SntnICiyrBXLeCBMiv4V7JuLHminDK3ILzW7q3jdGs0y59Zh2hSTAB9mtiY00ba\
-            n+yLSgOC6pt9kvfrQekbaTMEq5UKe4R5frw7fsl3Wd8VH6Wdt3oY2ZKyt7SjnPreJ2z\
-            WpDbKi5xEFc5WkjD6QwDB1QRD2MVdw1peG2Yp5LtZW6Yp1xvrbgBtsu07Dzq7Rk2z8c\
-            6s/UMA4P1N5YjptAA42Uu29pvWRpRXo/v71L2+2naRUsea88An04CPIs9gHagEqLq/3\
-            DYZ22j6WByAFivrgjNb8JIlvKtEkwDA2pYwzQTrLW6DWghuM1qU4OsC040wKDtoSKcV\
-            2xCjagDNqfNWnRiewSPI+eH/bmtyiXFFgDV9bj4qmgRUXAQ9o78g64N4I10nlTW94SQ\
-            5QDFJVm3Dnw+MK+yppEwrRtr4OGQrn2Fg+fs2TTb0ZvbhwhJ/LWjHAvRKvmh3vytD2g\
-            eufN6IdjdcM6XoPDhzjOGUojewd3GcS0r+AtsaoU8epR8mQt6Qo6ZfbsjYk2rBvMjR/\
-            amY5WeM+O6xks7oSNWwO1YR6B0fDvGkJKXGWNzK3krdEVMRezRsQIN3vzi/A/EAOdNT\
-            hG9C1oz6MuM5hDVrDeK8SqPz/cpMMN3sIHubuFsuNinSPVQrtJk29ED/PIG2Y60LxLO\
-            33ilktpXxEZdzGhTI8OlyAPHK8wZ5Z+y21a94zzMq9xxnmo2JuV3iD6cVBe0r74t1x1\
-            2sSgJdqZtSB1UDW9WYNmvPfNeAA/WiHw3SerY4cHOBYUhd7xGkj24fsC8UK9ZXdgl8a\
-            20bDe9CUun7K6d4hjYx23Pq3QDNIp5+U7CxsJ2zyVIyiwWV3auZdW1jaKAHLDWzzmKb\
-            AdtXcOb52D+tlLsY5eWYKW9bYWnI+zx1Vpi+8w4S/F0ca2Qb/MUYysROyLw8EpZ0o7b\
-            h0TZnPNnGx7hZoSIjVrlTuA9RaUondd0rodeT++//sNsZnl9JmLfgxWSt9iLuWgOmeN\
-            gfPA2052MMajsuH/QyVNOuoEJVMup4c8XeuM67gCtzRW4AaQPCX2nK444jYZVnhOR4d\
-            zPbtYwyEdsJG9GD7/oI5n6cDBdy19/UxP/jz7wUcks4BF4A7KZ85keNuX4/8iqePGhX\
-            3wEsTfC+/ky+bqZTAuohvSVdbqeNsjzlvgrUJcqEPDs6bZm4Z7JG5l6OK8llrgVYxkw\
-            acCafsdcK0qlRFrVnEfTb9r9+K8sbyGF66rl6CgEP2QNTGOj6mNqRVwzdXeS2Iy5xmF\
-            TuimL0mLSJ4V54REZeTQyRc10aw9f4k6JEHNmglHqoUqBvJeNnCkZ+v9QxxfEtFOA/S\
-            i/sjYKyI1a694pQ4hTxoJTBp6+aK54LTZLhVfQ+za2MfCaNe3HRV0uc5TOj+cYSS6gd\
-            6u04kf76ButADRXtn54inPHHdiYvps1HnyZoN7OdnkXlbuhdKSyTidYyPj1oaEnw4CI\
-            Q8GjFebcEyrmO+9sZJj5ooMz9srt+vQeM913jE4osLcGabRBadg0j164o+2gMFVlnf0\
-            ID2bJ3j1hbkIDD1CjFlu31ZfWO8lcSQkI4IGpe7HHbuF1rA/9VLhftfbh0ylwwFb9rr\
-            i0RymHD2zBhGbJUwcMOehY+U+fkdnWKYu497bWTagPG0LGbTSvCa/wAbsftuAhRc64n\
-            6QBTlTYfGD3e06sBI0sdOkY6uTvKWx1Kk+7+2Z9KzrSyUF0ZmZQvWkKIetyrekeX1+e\
-            5fOZHvH3ndQGXE8knkjWG1NT1ivs6RY78BmWHHSWRxvYRvpeq5GXxy6V80Xj8jIS65r\
-            o0yx5M5jht/D91vsAGbshqvKFUrqHnFczm+frqcBlkvVAK/CjlHwDnbMgpAdskR285X\
-            4kp5+vS2lKUrLBexnG5k++0YjXHoA9x0o2IAqBPeOwXIJWJbVHI2NPbGWDk+YS6uafQ\
-            m24NIqPMLy9i59qB0QurJGVsxD2xEBHbd3aevswLJcNBpHpJMoRoTgWuIZWXfpzXxkg\
-            Kswc9LtTTp5bSRI541Hrd+YGXiEeOpF0r7rgeBc3wKzRgETCl2Td+njw4jyFnN7Y9ky\
-            A8A3oHll5QZXC+7SKnvk3PTe3ErXGTwX8yZt8IuYkgfNB5ysNZkoepf2ApxYW8AnTNo\
-            9NSL24FqObJKhHWnpMkD6pcUzh9IxFCNAqiocW3QNVDJT2lweUYKLBlglibFOit0RUq\
-            HKSBznpJSMiN8GBLslxvgmHaH9tilMVmhe1V3aXPkOs+IbHpYkoHFft3fpQINznKPTu\
-            e/SOsE7HjGb79I+mCNmIx0aHXl7nzZcjQznwOP7yU3agzwyescVkQmXPtwOjIZbxT3H\
-            M0bTJrMBgodi3t6lzyvj34eZwsIGuzS2ZaBrqQEsnmAUFgc+TkaL3lrQYh8DZUuuwuk\
-            dX7Npn8/AtH2LT560OXAA7Etj0de6I3bfCrTkKhzqKjxx+u4aH/vKOE6t+Pv06Wpk9C\
-            W9KtHRr/aat6YqmbDGuZjCbTRTsrScSOROn9ojGGTdeOYt5i0aZCM6YktZEnMm7cCIg\
-            BrMyhl93WBJNLc3aYU4Uma0G/AhHb40NET1HjRDT6u7+eEZVy5YbQruTYucUQMkXXfn\
-            BOm9afmus9jmFduDvlZAHSU7vefU6UoiJ9gybTUf3gxbEpEQs1hxCKoxBUhFEL6i0zY\
-            SjEu7LiKCHKOl4rXZgLVYgZahNVS3LtMH3tgh5CDXhjWgkIDfAUO1ozYKOL4A0jaQVw\
-            heYGigkG+E1r0JDPzYERnbtHAaxpjqkCaWNzI6fYIaZj31NlL0X5H8gWF0qNdZ8+Wa1\
-            B2H9lDv1fKuAjxpan54SLtcTxzMhjCsZRLRKy/B4ttI2kg4SG8qqXd+eKRfRkvFt4i6\
-            NowSJRZiWgemOgwzjxpsyz0o2SIvNWxHFMdxpfBXws9RgeFpBjl5yUJRd/gCKGozC99\
-            nhIpY47tHkJQbsB52jKOLGql/dXwltExG0MGJSftT1YAeLu4IU0Zt+ZJrHvN+GMVKOy\
-            +PrK6Z1cQZF38jXIu7Szv9xr/GU6xu79KRuUcAkbB6e5d2uJ0Q+CxNB3QcAR1+4CPMJ\
-            xHAtPFQGoPEsERbJIEC24KX4kWI6DQQDcdLON6lQ/IH4LGQgObaOGE64oxOdNW+M74B\
-            Jx2r+2Wv0zpzfFd8WTd7563cUTMoHdofKdI45jTvXGN8zG1jgqj8hgTeR+KKQ40fkW4\
-            IU9hAoOpEEas7HLKYEw20nC2lIuos3hHWlUERUaYmXg0pFDRwLF/jUusGV61ibcahhC\
-            JhtMfbcaKwU6gFwUOH7A0PdMO1gBY0Eis9vCg6gG+QcV5KvcSLqN7gKvZb4BZKJwn/D\
-            X4cKpQsu6b3SFmtYQtCm6Sk9kw0gIXuxdmJyxVlam+JkKO0H3JA9AIIb1Q6zCYSWq7l\
-            0qh05sqwnaKd2nLbckvYDwlDT1DQjcKFYjrSa0R4iaX8396nI04GQNDwK9mCdtJorl5\
-            6q0ATJRtu76ke7r2xmlemxcf6Lh3xHDlZexmSvPMewoiynndpR38Eze9u/kzoQGhfay\
-            h7xSk9Lh15NkKgIjyYhD9JQ29NZ/Dpn858HLqiV+oGO4/FQwM+uGZd9oSJEz+6xDqwy\
-            hJ6xQ3h3g4QDwpa8HZPs9AZ8pHFhNHeStwJSbhW3zMpJfqG8EYaW6IFtm7vCKWp4y3r\
-            nUNrVN+lI1IGBijjCclA2IQ7sMJoPgYLEqcCtH878Nx5Y5EQku8LkY5kHCCN0aD7tsT\
-            r5wStC+dIy3WDjzBuVi46C84Tmja+rKKVJBxKiCAWdFl1e7aUumJSr4Cu7Zqud3CEKW\
-            PWbGks87IF0+Ma2z2hzXT7FmpOBF/cp1NmIuS/h/IwP4bIz5uuU1Jw6k3v0pn+EfqzB\
-            7snK8wFLRcdQkozwS3FxZh9LKkaobc3RODPAKqVKbliDXloTtdUekPbSEDjKe6IE8CR\
-            Qjghcd3tBGFUvlhYsOiQ/wWquz//F9HLBKE1Hn40/XKp4AcdgH+XToccePd/IsyB+DZ\
-            oZQWOHWPQ8FD7AMMHPcLi6Z8CEZM6goagDLJJ+AyKpLE8FMUiQmGs1HVnOso4Qtgrjx\
-            Q=\",\"3BJxl84aH8Z999uffgPtLZYhEDYxYjruRsifKEWVWBi7W1MvOB51QIRwudCS\
-            fY49hPBjO9hoJE54GGm8KbLWXMWpTPQugYn7TVBZCLMA0TOe64pb9BhwQyyEvPpbYdP\
-            D+9Zz6/uOWeDOaGaBLBIWkMTbxXwyz7uOUg9xVcH5vSICPu+JZeX6UskWMivUhfMbjt\
-            vKpWe8dN6GPUgo7vBdlZgIPwLvN1PBDzyc6o5Q0oZ2CdOSh36ix0fOKQoKX7a4DPECd\
-            wTdESqHFw3XGnB5iDtSTwxaxudhSEcKcWw+gTRh5rkjNJcTiEhmHnwE+MtZAOZkLCWP\
-            ddPDYU3sPm9JzluiWmg4DBEN68U61qzkpbEspv86QndMF6EfkPsOKmbhZx+9GHS8KRH\
-            EHb5wRXhwiYDKwW8a6wSVoEWTEfWMCoPIU1JQkcL3xIE4cjThP70hOjxCOr5nFpZgY8\
-            QVlqg3dBf9ep0BwpRCj5sTVnY+nvoIexzanqcS7I+gX/ie0Aqu8SX99KeFWYP+E16XV\
-            hBGyv7fjd1yS+Qa3qerVw0ULXgszgk7AWSq8h3hSOr/AsMJHd99b4ij8QaUEdLyjuTg\
-            zRkLjRJbAtFDu408xPIHhDUOXWIHrg+yRAZ8h5Y67fVab40+fp8JpKjFw+1jujEbEN7\
-            YyvgKNuMP6deaLx7T2+VfpfW9+zMvCye44niWzXzxmLbAbqSHlYvfUEI6I2DjRFMsFe\
-            yCRMW37v3D7fPnScjfoPwPw/3xO7Y0n9NZAPty3VuzlkVt2BZK3nVjdgLGQyo7HbhY9\
-            7YEXXDVNXzDtUevhpovHtMugQP4kkvv+uI303YWHJqpMF8hNRAOUimzLVTfSs0lJg8D\
-            JjlyI+YgkZKEwzxMvpM04T+seycyvBQf/por2K25qsDKVrpi+BcG6GhNuC2PuFj3wMX\
-            oZTZWmcQ3wcVEVt8H2PBtNv4D/qb35z19pFWlAuekrseXRDHntqsUhmGqx/xwfy6KTq\
-            RjpUz3uy+//3x1ff32ziRWci8a1umuPRUSGOv7Eo9Lvv/Fjyu5A/T2ovnh4fzs/s88L\
-            /xuyEHDX/Jsgf/6Q9u9b6TwvEQk1PV88Xg1/bymktCCLQQwo2Pp7aDGgxdYycrV0w6n\
-            jYUeNr3SYEPTmDL11xWrpAXhiQIQq8frf4quEFdioH/9NbrUea1/InrarfdbruJpCd3\
-            orueLpz2BarkKB+YYUROAp7uY03pywBKj56XeX0gN/foFp/ZVxz1Uvzxs3wh8V6F4at\
-            S2v4jPmhaH74ub8xP58SFgLddHcWxszcaP0rke2Jd//fz5D18JaZ8SmkcZP9xs1xnr2\
-            dLYHnXjThwUP+CCMl20XPOauAllIt72A+okx9x4gfDpw2jhRPk350mhH/jG1sWY0ikz\
-            o+MClejPSK3ruEKu8P38TDGcQillBq8o3pvn5oQpWCcJ7eDmPCl8ktOx1lRgtTxQHtv\
-            FzXl+Qw6SXX++RvtvImxpiuv2WjAL3hrXgfASvwx9MRF0M0V9owQ2oPA1c265SxM3pn\
-            Nsc3XNrj7j757DLHmsZFtDVvL7YsL/MgVVpsy652nCEDCBE5KJ6rSdIMVRAvHcFZgk4\
-            qSJIOBpkrdc6tAyp2RFvO95+P0UE42ZWExkMkxCTF+N8w8X1zlLL9KWilt4ybleZiKy\
-            aApqKhBKtsRlOBMmPhzGbF8agZTLHyROVgv1UtaM95X0jIjWWUyksk8jPZcabM6F1Iv\
-            7zHc369KYNcs42p0HLtJAZnviyufFRGLJFNdCGB+H2zCihM157ZgUXlqzdWCP8gGfSV\
-            mNdEOlcAJ2c15LZwoWa+KBdZXxoTc7Uw3XOXRcAH3P90ThE+wh7FVhI7abnO6ltsGsD\
-            qi4lqCou+KDfpvRpKA5sp99vEEObdq5M3yKJnCz0XlQ4xRkuGLpZcNVDy9L/GK0m3NH\
-            2CRyPMXPXv8dF+FZAwGbIXWis2aFVuD6vrjP0h0q6YTprQNmWi1j1T9aAE1UUJlEb8C\
-            6oMZLLVS8BZtQSTOk2nDJCxtq/VATcsLpnUZWQZDLso9KaWd7SlieRxpNsG8jeylx2/\
-            HNeZWy6XY65hrAblGJmkXOO+8V17WVy6WMtWjH8xbdoTkNDXt45+AoyGiVaiKsdQqrK\
-            9aHXYK8sHci7QLjXaT85bU0K2FqMRFxMkXbdTw0VQ/afcWo6TQRGTWNteBczk0nN6R1\
-            IQDJWX5eKCZBYa20FpfCE17MKVivY0w1V0P5SjbYcIgtMWfLqPHrtyfC7aYhHElKH/T\
-            mvMZwtR8CEgiZlU87XcRIGSSyX3S4LRLfs3IWbsYGde6pTHIY3zr2ehsMLldyttTx47\
-            BFRe0QF365QxyVQvxUeZ6TgqGGW3bHgwEruVijgZuhpfmvL2TGiWMiIhAl7tFqaGEfv\
-            aCBpgLHdVWaHR1btJjIR8DQbWccsDUuJCZykNLMCiyXCqqXU9gRPquyznIntpM1uqNO\
-            RLJTOMataOQGv0Iry3h7wkaVOuyqVM9OpJIjXLy4YjgkXgY7vjk+QOeRU2kqKO68FA4\
-            CmRF7z0RNwAvItA6YZZ2bxEtdwY6QCOcJlUn6C7RmRZjZLulkvZHW6Di/vDGKWr2XSI\
-            QlxIgztlS8ZlwBvs9MhJMjaFm3fCzUjbc3R3U9Qk093uOCbwgXTIWlQcOvF/cXCO8XS\
-            v3KOlCMH6nllOXXeGWxxvuOzrcMsi+/87IW5kVAo1Tfoh7XAZkv+kak7esaqhde8Y6w\
-            MCORHhN0os5jmD8XjJMlJtB5ndA0TGon6wY/6t2fBwYiQBNvqHKOHvN0sNAZdu1R5Wk\
-            iFzTdwqB/EMrieegrhvMebGsI++J5wXAECd5K4bJu0p+oUYWAjVgHXZS+wGdxf55AnO\
-            aaVsuyd8O5gWjvef0lhGtFA85bIqA37Lz5ndBx9K7lqIVcMFgddUiaKP1M0OjD5kSOO\
-            cIEQKXPzXmeFQKze1buoexx50SWse2I7Fv0qkckiG8Ctq+j7YpZyg+V/84/0ebdZBmr\
-            x4+2MlidraCW5LeLul9jiMjMHwhretwddH9eywWh0UfoS4TieNQfLd5CAcdzNRcTMfF\
-            pugMFWvZthvIzcS8Hxo2S1hXDwTLTo3J/XpMMeQRlVp+oU4fQ1hCjNEmdfKKcIEJVXK\
-            zHsyWeabmYuOED4WrZdZChX17UoRs0nWwxUQMoDQu6gdRosvViouQMCrQ81qLnW8ds5\
-            RjvLRqXHPX1/Nen+vI+y9n1BoZX9R7i7PLfH01/X0yUPUijxvwc2PmhNBauwF2wiLZQ\
-            Mqx88uCNyW/oyDs2mOrP+yxPz5Ft7LoxFi2zuLjJii0ZPx4MrH2OweQmV4SwlksVEzQ\
-            J4XFPRmyeiNAaS3sNn7P8UVlH3PNS/FMkxfjV1R7dHSYSBadJb67vJzbKnHdUzHFCdO\
-            e5QIziuj4aGtlBUmexfKZQkjWgOiKu9yYrBuDItPsOV8YnqntN4lgrW0Cvt1pMXBs2h\
-            XpTdzjDzZV3OLa8a36GMY5uBXz/yxrm6LQURm/Auozo4DxTlTVb3+REkOQJLGfE9eer\
-            3xHe2ozJ0oA1616iNdPCNpyD8q1inexASQ05ES3n17pMUfvasA6cM7guMlGZYoIma9U\
-            Tx6uMNkm9VP2uKtkQjN8SfqyJi4smoTGI2lg24PEghhxVZrW07DVsMsPGcZOlIK4a1n\
-            fDbe5jsgDhcMthSsvHxIsaNJCGk5ssW+HKiYYvxxhHViqu1zGKi5iVGUJi1Xf7WA6Cn\
-            uVZ9qiR1/TlEB6TEeCYM6feFOsdf1tBixtoskyIipeUpybr/D5w6BIdi4mbD6dwsAHL\
-            VqZ0w+2kRBxQxjgrWdbSYzdmLm6yjutKll39QtVSWEwUBJ2ECdAOz7a9z1K2gnLaUwf\
-            bLCNl0HSZa3330hHx3hNlfyd5dg1e6vqlNdo3av9iQQFeVX0xUb5nCg22hiECDd9Acw\
-            a2bXmHz48sAdBq09ig+LbShSNdhhvivCjYFDeGm0SZ0lnTgm+gJ/SZHMGie+tFQ0qT+\
-            6wD8gVRsPdZcv8EVBVaYWlxn5WSNXoJCEdYZrvK3uW8ZzpXPsnLyTbIspibDjST2oPd\
-            SNiyWAqIVIOzTEGB7FwTXRmU++Emy81mHBul4VABnnj/84paE8yxdUMmkO1LPFrwvAx\
-            KGklncEzcCzGJs15yxYQyGshVeJN1Ts7ZniYqNU2RFFqsbTFxG+ME5b+tqXr8sDRRFH\
-            2qOSe5x8bKe6yVNa1i5r1rvFl+0Ndyoq8mroCYprq+LAEvp3KTJaptyWS312UlkTv4B\
-            tdXxiwZN2HicujFxO3FaVhH+qBzRuLYsrGQwHjWJsKOc6TsCUyt3fss88wRR11stZgo\
-            PzaFq50RjDIGTNxkMsUKJ9CXzppltFq+OM+JDsxKiBrTCk+5CWPmA6405eheQTazltf\
-            ItZlDDHwGy/GW1LiyQsScsAA63gSUIw+yUuveJOdvKbPZREnnKaL04DqAiq1MbzXsCW\
-            aOpHHabDtltsPlAkoRZbLCy2c19YhtpUBvlA+8nM58x2NDrmpvyWT7+ywxFNZMn51Qm\
-            JUsNSI7Qvw8ZNlLnYcuR1PM2qc8X4PBt5WJq/DTIMa1k1hJncEfkdMyEI2Wgiu2tZLK\
-            b524LWoSeXRg0gkGN1mRxq/EzpqNrLIMShMXj0yinX8RpgKz1ZRXIeusMdxqtgFZsdI\
-            TmWDZvDFUmTZ33WdZJiOzXravtTRxi3E2c1QmTtZtx3rHS0mm02bFicQnWOhMvEKiNp\
-            cHcE9cKpV6jrdcu+VgDaB8ERM3MaSwBzhJUiYkwx0TWTauKezvieC3nE445h3mlNmYq\
-            Ho8iQSlDOvMFiwjAjSzXB5P+pjFizcuZ0/ud8zCMJOItZDxphuwcrnPOMRmmabiOxrN\
-            eNcNzomOiDa+ySqi8habWSlj4sbVfHBO1YyJkr1TD5Cu54pZiGYX8nxwk3V62bjqWNI\
-            p07WSVTpjy/edkdpn7IUT98RNAaGUFcQ8W+b26KWei5usZbStmYZdEN7SBB1grH3EK0\
-            PV611MXDE28YAD71jJXdwRiINckmaqJfdHKL5f3SCNij5r30heG+GWRQWt+VjRKxqUK\
-            XGXekDL7brrdeW4WBfeVCamLoKuMtL4Ji6FOmI1r/ebUec5dUI0u2nu5QaY6YYJm6+l\
-            T1yImXqa6Wgr+8RlRhSOxTsc6cSR1KKw0Fl+AH2aFrij5yYdOuR4W5Ug1g1vi7fZUER\
-            tqSwe2XFpR6ID34zdJiTz0HYqyFEyxT6due9aUYc9U+d12X06Ju6w+jgdcdKkGzaInE\
-            14pVp0M1fPKti8LShacF1ZwG84+PKwEm/qLa+wi3zmi/rDaa3lG9AFl7O1BF2MlwGNS\
-            0rJ0r1cz66wO7cXDx+MCCQQvcH7/tskbbiDaTezJsx6Y9qYxCvVoJ2KoV4uwZ167Swu\
-            XfdovhIfUlqPfB/+w/7wo3f+9IfKDl/RP/6QlDf+sem4UpJrAW8/Y90jdpPNt7X7uhq\
-            /Ye24/zbZDteG/4g/nHr74Q/HS1gQETRfPO2m5kspDzP+2HuYlbp6/9Osthy9eXR+eL\
-            yaahTCRNP0Im9i7qV4GbVcI/P7xIClmc4ozLo4X4n91AL5ACRf9aMX9wOFJqw+ukdHg\
-            um12AvuvIKiFJ01G7Y=\",\"qtZX39DV8Xmq30WtZDl8Jf54ooPf/HEUyogqH0TtJKK\
-            ZQbdUs1jTvyiVMd2oshCiNgInevcD0HX4Wq13U0P0HhK/LmWsvBBadT27QurbzlePV/\
-            SbfmR+mWHFNeeHx+kBoJhYsdLb9X5KWpDMdNDG54ezG+gzmdhArx6upsQxxURMKfPVe\
-            v8r3fkHVGR8u6SVxkKcSujiz1gxZ0S8JzOWzIkYAxmWXGCH1LiA8gfcwlKB8JmLKL+p\
-            b7gZC+lXudRimhKvOVxqQf0ql1pUv9gP1ML6RSy1uPKxQUFdy7xZ9sFdmsulZ9kFo/a\
-            eS82yX20vPssmFfYsLjrL7i8ROO+46CyrJzXsHCw+yw4J7E/jZoKrq8+6GL4x3mG3D6\
-            2erxGSMnXJxboYvw+XPWKu+MiblrKTPPQS0fiaaZgFZXj1dVUcP2DTvP42uUOF99kaq\
-            yr39jOmyz1/nVROzWx06cwGa5kr3rt48EsT56vnr5PL8BWrTF1LXRfxboRrBsIxxfem\
-            Rw+pYvJULsxs6a6LpbvO2t0PCc3znIJaCJ4/Ty7cDxRsjR4+ppMcEe2MV5VvpJuN5Sm\
-            K4x2uo4aOUw/Tr0dSo2UYM7E8TcuqQFay5CUvKttLNIb9aTt1XnyLWHLnVw6zmM4Pj1\
-            8n19EbSgftCr0/6PmANGTf62L4drrgmlrbAZjq9mngusUW5iE1v5I8y9HAjact3r6Zq\
-            TpXhC+R1ldIjEQcgcn1/Upz7tjCgCOqOiGj0fKD0XzriuETW0sNTsbCHVUvMC/zfPXR\
-            jTGJ3b7eYs54703YvnAr2+HpS3KJTXPLXuPGntXH0DkSSe01H/MbSSAIVGo+f72wL2v\
-            Vo9IEWTDTwHHksZd+2ienZYKJLcLvC2QRTvPQSLc4KJe1z5rewzdU03u8vnDmOAp32b\
-            xxP4lXntRUEB7m8puv7qcVsjOe4m1Z8QGLr5U4zGQXjooLFw2MUNW7uHkS7sT56mFLz\
-            8pVC67jntKsvt8+XyXHZ/AizKIbfsa7dcetA1vwbh3vWT7g98c+XyXn5jtwDHwo6NzM\
-            2+dpa1wSGEQkcfNGYKZGaoJJ2dgjL6s33/LwI0hk5nRkQd/tfj+t5Z+1DnYerOZqJkw\
-            brUdKyVVx/EBN/9tptwnyGGNrtgJfWi61K3q8VsHt86SP4Lw/cjwOkZbT2MJVa7xs4e\
-            1DWjLZlutSqhoK6IxSgvuXwXX4efaVsvUd6q/J7vTxwMn1bBj7ltt18foRNe+kt9/eN\
-            5+LKJJWW0wOHURabR4Y27Vj1qF68+M2KSp7b9ohYMVCrDxcbGQFhlkQxlbxmIGr0I/b\
-            pGgj2ate4+m9D1+To50HR3w8cQdJNf3QWyji15x9KCU53lBkBdoToXbP016LD6RjclG\
-            pDBrA+zxtukVoww2kBDOjx45MWlY+T3vZTDsrgYuGd1CA7luw3PctebpfJxW1CRprub\
-            CGCFHYzQ8PSW2yhN75YhXekmt0W41Wg1TTTK8rbvdFI+uGhXMM4KVbo7aXgAlurfGDu\
-            adoug4Nb0t3/jtMXEcspzT5/FB/S+0a75CdNQIv0jRfpGXnW9TMcl2ZVh6gGgMtirPf\
-            0GkIt8+TER7xYU3fOy4LF6aPAucoS9Wi/pJaI5MsVK+vJ0Mcpllu5a7Ibe5jUdk3QAX\
-            cus5KXc+i5umlcMVQfwPdn6Z9DYFoKt5wBSfT1bFuK6XaPOxSkkuYVnDnC9l9HTBZb7\
-            16vk7O9LH+jvYtVJIXlXS274jQ1YQdN+J60ZTcwWiBLUIbGX4peMI6P0UbjzBEJOTtw\
-            zZJtEb3XgY91hrN4kfU/jTtQDHtrOKtbriu9kX8ynr7GmJHnM5TIqLinlembn4O71mZ\
-            OiYG5sR+Pk87pt5Bh8qN4EgzeJ1UOgLMeb6bcectL+LXcPxFzd9Jo1uKNt4hiu8AqRE\
-            +QQV3LijXvDh9YpWVmxyVbp8SvTl02HnL0V3iMbkZ5vBb3nVEQN1zUt89PcA4V5TGrN\
-            cAXewSXFWJzIQoTjGpUqmRSXXER2ZYEYQ77fDx8swUNhyPifD/+WqdPBi/g1Wu7NV6S\
-            FigGrhaJ4+D00y9lKhp92OKFc7DxHFgpbbcKRalWsR3vaBtRPD8fLW+JtfmG1xvEcNM\
-            fNcLxnZr7HqpzJYa3afkhvaOOgj5LIm0qvdZg/IWGcTEayQutqFHfE4/TOBtr71sibZ\
-            nTYC38Fggg66kFrv60n5xDa+gYnVPOYO35C4Y0ENpuoopqGqyrTmdPEZ7xxLvArMrxi\
-            bmTLSuV45bVlqDlm2JvJzefMfL2jmyXnzEDsrOcBEiGTeRJ/c+kEnmBZ06Mo2VNV7Fe\
-            b56Tvr1JsFUtx4+Zn7gvON1gTmb5wWj9YqV2nk8Uj6ws9bUyJaG1NQ+VpQlgWu+XPOw\
-            o2oQYZJx/KwzXz0kbVJTT1i1jnGs2nqcBhc0uQXPw+8J4gUTobNmh0XHB9wFEyAmOvM\
-            4B5gwxlZS45mPcQvP6IGZk22veDinFa8fM8TNOmkdysB/kL6MCOoID8voe/xhGXpy0u\
-            j/bkiC8tQagZqoVnXSeXRiOc9tzT0Uxw/UGa+mdeRJJp2k8n3xSC/xaTa1bGpaMU2Aj\
-            ejxWrQR/mutHusso2xaBU6xMYNoBP9aoy2apBjBvzTniLTR+WKdNGxVcrnsVF/Pqt5K\
-            rovh27FeDs5MzosUE92kAjDVrdNA9IC2WH9JDv80zm39zODxlGlF8ogcvMhFbUzbIS6\
-            S0LykrDqyXGe8AueK4wfC4B+YVPsmmYMtBn3zHTmBzsnD5SeMTIZbPKVVNOk07Afrst\
-            T1zLXSN/ti+Bb31CFX19jh/jC22rRDBAeuvi0QUfwrjxxOS4S5P/FAgOqLk/+qZ7DrQ\
-            Ph9MX7H40sfkjrikVe4sCszDdu80NnHpJUJtOPWcctXQoqZBrOR7Sz08mC3xsXl4TF5\
-            Qkxzh8+UDv6YNGClyRaCFrYZ/LVU0x++pkQSWCmcM3pWOvdqhZyBEI012rhi1J3R8gD\
-            zw8N0etNlD5jJtkPtNw9J30vGU/CTxUPytJ6FnhlXo0P8kIgKz+AvUX/UQ9KVlwHO6P\
-            HknKfohJJweEgGaoMzPuLN0m+5hdna7k0RvqDGvWRo2EdeRNGibiXyia3UyqA2249l5\
-            JDXHWA0M+hZqQZuuFagtRTrwoK3ezxT4ymRCdHOllxAacx6xqVVcumL0hjvvMUKQM8P\
-            InlEPeftPQisZMPQvFycMFr01uLq+uEp6fKaAuZUSJkfnpOK0Bmzkk6YDVoUOLYxMWH\
-            OeLAh3vc5qVCdseKVv2S46EEkp/M0kXC9xtfNHWMq8+Ip6YI8QxGLNpUhNE0a7y1BA2\
-            Oek9ESZ0S0kMkwBLkoujZs6LXUOegchxewjU3L7TdvuQDmzRqI1UUSKxvXVvhKKVwiq\
-            cpN0qKXj+BRq+EtL8PYH5DU6L5FRoU+1qPS4MmBphrbyA0U8TquamuxOqS3H++Wm4BJ\
-            vQQ741obH4VoEX/BXn+B7urJ8IkTvwuahpk1vDKmK4ZvjHdcNICeE56SOusZ+tQdA5a\
-            Y+plUY0VhrBhmQ9mjqUxPSc33A7UYvjFBtfMpqZCmiKSH4impiiaQsAsfHH4JwvzwSE\
-            um91y8OnRoKLn8z4FZHUCKgQluC547T5xP0p7PBHq80FAY7WGHK0PJo08CbSwqDJ+SQ\
-            ZEJXsftzx6INpIy6wNzsNl4YxR6pdL88Jy7YI9oK/CSahF5WWsdnqyRjklZcufB7lpV\
-            cK68YbsWNSXfJ22dr6CYk42W9hyihJNvOIJmKy7W4YAYzsfF+MMbqZ9e8gM/Od1RPnr\
-            OH8BUV06DK+55KTV6YEzH0pzDA2+wvb17xPArJkrEp7Z/OKyTKUYXP8ltCH01u7/wB7\
-            kWXzWLp2Ss7qWP8gZfBnUyfPLSJxHrLe3MuvRBe44+6fD8hVzZ757k9937uR1+QUbJL\
-            EQyhv6Sx6yqNVpp4z7p5rnoKabC/ejTNW4ufUr4yVjsGLkQiBJ7yZPsF6yuzPfF83Qp\
-            rMnnrPjOutND4k9EbYUYhvtP8WNfHWvyEy+SPTRTD4qyJuNJMWUtW2Sv7OtjLDMlcRF\
-            O7K9seGuqXr2O+vAj40sPtuwtEXQpklmsuQ8qFRfrUlq0MEY6rTf3MXUv8cqv6QyQ3E\
-            es+Jpbz4NoDvt1lsYRPfj/7Lut+K7MfFoQ19kTfPppHbe8BQ+WBQT6sPs=\",\"ZNjc\
-            JQ8Lf4znfCF2hbzHxKJMhH/v+63Y/bOvc3oOml4nMrbU3ks1hJsOt1869Nre+Wq6BOs\
-            HZi+rgRk+5VSXjwUMyB1za0zlvNkVxw+ksvyY1siU7MIymx2CTO+4F03x+hFdZ8njVg\
-            3SOmd0EQ7Ex9spciohPiSXLoYkqoemxj6JpApWXMDrOiu1J9O80gsOgeL5d8lYwCli0\
-            EocX8KbkqzUOP1zdGrILuiNj3Q0RuExGd1VS9/05YyvuPIzoeTaF/ErW23QWs51euhG\
-            ooIdt6Lhbcl75Qtua6N579lrAuTvZtd0pySzShPPEdwB412XQ77sDU5kCptayzj27c5\
-            Lr5xkbaRLnkIszl/s+egqy6jslhRQ0/i458W7XN9MoavZFVUqIkZk/r951O/oCrRp+T\
-            M+SlcWtqblswp2uyJ8Ocb4UQrex7vtz9glaNZyDW4m+HIJUkNx/ICK9qQH5CP3WJplv\
-            PHmGFiGSZ466RUd4aK30vSOmaoKDylsvasxT1pU4vH2Vkaswcbos+LNZ/SAmwxEwJlE\
-            lZpFujoPwSWLWCTtZwQ428/2/XaddDKOzwBrXFnABqz0w9nYiQZaymiBT4gRZ2w9e4M\
-            sws/DP8Vfz6gnxS7Cn7TsOl+soJKOtQa7YipWs8RZdSPXhZMKtADLlCwzyuiupu8KoK\
-            noNWp10hsyQhvmm96abeFkvBF3pSs8PTBZNnAEDlVxwlgNRYFKj7kCwxECb+BH3lvTO\
-            BWGEVqLLwySzuBnLzdc4fcEhvcglsfZk16nM5lA+ZQsqZAB33AlK+rE9ZSsk5J4Qutq\
-            NkwZAntZw98WIkBP59Olt9+AS1BKhgFt06rrcCjE1/JqrblYxzoJCkqO3JI50IhmfaS\
-            xBlSH3r0Zt01ijZxRx3mMHmCekub8I1bbYrVcEvKAaluA6Fjw1nmu8Uibx2TU2Qca6B\
-            2aZ7B6SqZtfiBR75e0Nn3gdMbJHfpu6UPze1Kv5c6FTRq3vUwXtj7H7f7wO/wqngOp3\
-            K+Ma0A5sEVlTbeVB24rdqwHM4aojD9es2OJY/RcRCkTKydbo6HYQhkOEfRVxE9JJ/WJ\
-            +FON1RlfP6KHWmrrXPVKgmbe9ssl733RGm2EggyTzOeH2xuSvvWDZa8InzKZ1Fx9x1y\
-            5U0YieUBL19Mc0WvYSO08WF0cI38Z1xXjqjZW+gatvLx6TLrIjnjn91YU0JZQVVAxGx\
-            Q19OyVjDcdiUqWFrpqWZgOdIeXXkYMSSPMqJqXx+z38WIfC5dUMKT0h/ERcfiOuZfC7\
-            jtv8p+yuqG0YNWXoIuD8xVbaTTosE6GMY2oVi5buSyiwRcQyRiUVAq14+XMN/sWFPDl\
-            bKhRU5x+MRatib5Fxr23suzxu1zT9ULHJxr3++viGMrGqr3mLXppweGRMoEZ18gifKG\
-            vLKCMIR0Xa14D660qxs+9VWRlpHXS233i+kaurfRFCTGHaikVkOanRZ0MKz5ylVk3xu\
-            t9v47HNRnYoxx692PexT53lFHtwufhD0smf178sJyShbE7CUlw8ROpGxHwiWsboyqwh\
-            dNmW3KlmPPQ4s6zlaCEg92Ac1DEsGkNn/7xf/7lU8druNdL8+mPf/8Euvqtt87Yj/Sn\
-            +ZXQ841Ydb+/X8835f/3V1/K+9/dt9+a8m9P8s+//effnv+2u/rfH+F3V03V/rX/8/V\
-            8U/74pvn//MVUf7vvhf5fJb7M1Z+v/70T7a4r27/ePByev3y/rcPf3/H/+U/1/OUvXX\
-            n9VX6X93IZuucf//jHP/5vAAAA//+o7KIYVz8BAA==\"]"
+          size: 15305
+          text: "[\"H4sIAAAAAAAA/6S9bXPjuLE2/F/m88HYku1zNqk6H3win8R5QinOytnHueuuKQiESJggw\
+            AVASWRq//tdAPXmWau7Nfyy4/FOXSSBRqNfru4=\",\"/veXnAf+5Y///uJkY70K1in\
+            p49+NzeMP/+ffX1T+5Y9fXut/bld38yb/8x86ubT9fFbdLx7/+7+//McXw2v55Y9fCh\
+            XKdvVV2PrG29YJWTjelEzImyCd42vratY4u1G5dGzlVFGGld19+e0/Lj1h+djPix9+g\
+            iilqBqrTAAfcbt4GfMI5zov3UY6DzxlVt3Nf3yphHLCmhZ6wPJxko14gBbwEmXbEdi2\
+            zXn9awMuz8N8xCbEJ6w1dxL8iIcxohQfoYyCJWk34jikJ3jBNfwRt2PEyK5WWjpEikb\
+            stC2lV6EDH9CN2WhrfJBaK1hnPIzZBmt8qyH4p2025gucAXdgVj2M2IGoyXNbgPj3Iz\
+            YgV4UKXFshuQG3YDtCTPMaO8cjPsDASvR2xN7mxqu6Qc7vdMRlk1tRIce3G6HjclvLP\
+            yDKYQR6B0vMZMTKSwGd2HikRmDvLK6V70ZonDWv5Fauog2hhISNiIcRx2rNfdCYbh4B\
+            r+VOrbSUplAGWq1ZNeYMrK0LyiKW0IjPKKTpahuUhaX1bsRJGP4xbEiMuAMKFTQH4Z9\
+            2YxbI2gI+DU+7EcdtgGcrGTh8CY+QoeEZW+sq33ABn+x+zLc4vuYG+o7oFozYaacIFu\
+            P9CL+g5L5Uom3g83Y/QpyOT2DNGjZbRpy4MhnXsDyNMCpKAfk2y8eHUa+O6boR7y3zj\
+            YKMxbgsPy6epdQ1Ivtj3t3ZqkWWfQR8CPCebkfc+GXLt1JhMhnX58flRgllCj6FL7Ex\
+            +IVR6C05GfMAI3jjWw1eA4/diItSmbVudzl8E9+NECJl1nalkQDXZMQJe89RxfY4GSG\
+            ole9aeIfHBACrdiWdkQGyeRezUS7N6RFsghyFH9/ms4dw3ZSwwPYjbmPNRbJaEPf+x+\
+            VJ89aIMueuQhyFyQjrS6uV48Eil/0YfGNzJIIw5vWt4GB86HE6ZottIU1IAXj4EWM+o\
+            FCitkYFC8cStiO+o+ZKF6DuiM7sj0tqbU1h8xUPmmMe849rj9pDUhrvhhEf0Plf4aDF\
+            GLvd4PfCdIRRamTQag2piFl1N+b15dZJraCcRHzAj6++qRCPZgy2rTm89NsRMmk8fJH\
+            tRmHv4PzGmPCTaTWsNvtR4IEbJCuwHSHwtoLDEY/TEQJjjeQmt2DQbPnYj7izbCONkS\
+            vUmB5hzMVH+MAFZJzEPRjzEb6QRsGr1I15wKZEXL4fx264qCR8uMZEIBpeSJe3SOptj\
+            EpurA+Fk/CltXy8HaF+GruVDk7QzKq7MZvglK85fjX2IzRF4+xahZVTArlixsRgm9bJ\
+            xjqE1jDiKxxfrVSof4UNlBFb4bgRpXRwfGLkA3ILhZ+Wj9MRO5C4K1jsNUrriEe0K6d\
+            gddqPsKBda3KJqOvpCJXkWuOFbZDY9IgP8FxLv7YOCeCPURhe8PXa6lwZJEo6QrGePY\
+            OtHa8JHv4IWyOJ7JYj98SP74pnudxIzBAb8f5SSxEklu4dsR2qMFyv4S+YjrjlvF0Hz\
+            Tskj9+PUBy+sUEZD90OcY1GfEK08xoeYHNpDOHNBx5aL3gFq9f7MfvQ1jaFQpCd/nFZ\
+            DVLLtTVK8Ggc42bH7QixDbJuNA/Yco15gBHSBPwrxhy+sBbWydrC19LTmNxLWMO56zF\
+            eYlAwc+lpDCsqaCTQNeKeC61bWdianI5Y81YHxxHm1dMYysOGtxphZo7wCzcCSdONEJ\
+            mNNHytEEdhxKvXWAxtBLbj/4Xs6I+LzMY3pUT4vN0I3bwJZbR/YSbmGJnfRKFHRPLH0\
+            bd8I9fOIsT2boRgdtzkoB3XXxOg9oEps3ZQ+KmvriCw+8De+YYzraDsbV9dQQ==\",\
+            \"7T9A1tbY6F2DuFcceR++Be6hYMBidkVWcO0lcKQTFPVUlJJteceCZYX99q+/fPvTH\
+            N5ush4qleFN823NRbAOdDWe6EesdC1o0kb5oW6KApP+EYn6qcp0rLAsic+xfAb65L6i\
+            sxNVgFnWz3Qo60TJSu7qaI+CF/FzT93npeMmOuC1dE8Y6XP5TE9MuMA8rxstPVtbx0o\
+            uKh5Ka5iAVqOn02WWXSN/Fk41oPp8IudxW84K6FTOl89kj3HDC8dNYH6r1oFxrZkyDM\
+            4N9PRrfMO1yjmc+O3pgT3M7uorcjx4IxK3tzodJQSXqOV+j8u4dpLnXfq1hEy7viITo\
+            j95jLEBf8TyiZyg/qfKpf27s0J6r0zxv4RY0fKZHID8p/L/WP7/sJRRsbaqUivuJRMa\
+            Mm3j8hIFbRsgcmhfkS2djtea5W0NkPsWMzq5r+POpOq8VnPHnLWB5bKRJpdGALdAfAT\
+            109MjBrlFAMlLcACsWx1UNPnepQjIpUBVCV1bp2QXL5QpWF7VnpmNyhWYeXwm22kf4b\
+            VaDeDMeAElK5bP5ODKxyfs4XOnNnDE7plcOfTpA6ra5kzYuoYZlc/kpM6nT6lt3ji7g\
+            i9qMqXv00c00nnlU7QI1HvP5JLSTx/jZQjKFLDQku+xTx+xE9asYXr0MznY9fEJjZPC\
+            1o3SMk87jxijxIXqOURZjtqWCqQMbM2Qi1D7rmn22e+rztNiVpEirzepxNuzIR0qHVu\
+            1SueVCpI1ui0UcJiyWUaEby8va5fN3u5xFM1XNjBEnrqsFySy7k0KwjLeXL5cb7PZE8\
+            ngPmC5oKK7BnqpGcnd2CMKm0tWWh/i5qyliwoBXEYCcIRUJkjN5C5I45UFYopdtqxom\
+            AkS5LPdZUtxBVYbFBCs3c1nzw8kMEgz3M1nj7RXMnzDVtxfTtaQsrwDlA3QMu2odREJ\
+            zEvuRPmVX5bi3XyW7a7AKlqVy6/WXT5j0/nyaUtDDDx8zeXmItTDnCizUe3JnXRCecl\
+            8u6pVCKAt0T+T6L0R+/Je3GZLQbrJEwzjhusuKOEZV67gTSNz1rQrmIP5Lkip6OEJsl\
+            7JPC6GZ7nywrqcgTmHxawgRZz26BuuWx6UNakG3kvYnn0htQhI0F/NRl3mkeyyJekYq\
+            jULlmmvLvsx3Xz2RDKKboStV9ApnL2QMLQyl53HKVHlRYv13bO1MnlTAfbYLls+k/iF\
+            CbM1UBuJeF2Qouc3wgKWzG6+LEgQwalVG6zzp3sHusULUoOCAdhqLR0TeQU4uB1Nxpy\
+            E8r+7eU9RVwmE8JmT+eyVCuelyVlxOZ4zyZbPBCx/2Qy7ny8pxlzggIB2WV+Rin0HHN\
+            ZDpty8pxyesNusITXVC5LtfyNaH2wtHeMeVHzT+fKFcPsd0ILjykDUp+m8pwhm1zjpP\
+            Vs5u/WpocJeuDATfZK9ExRZankCWG4UOd23TWHR5BJQ8VC03SZkuBQLRPs6TLN3wirm\
+            cm1sLr++Q4YlkUNyk0sd/a+OBVUc+4qw6JJaL9NrQ3rkheT13uSy0Ra8pghndgBh1U+\
+            elVI3gN3UZe8EBbfHO/sV9IIU0fkdIOPby3v0MF/+0FsyYYFsOKl68TPUvORas2g7qw\
+            0Qr9nNZ08/hk/pF7Sb9z+20Eg/nN1i9kIK4F/GZpcJytFdJ0XEAfSjqnWy0UpwoEh1R\
+            yVOfvY4CaT8op/c/wgoWN4fzSBSTcxnyNVPoPdMozp9Bgxqtvs5xeIdTsx+/1R9+XLc\
+            ZbNHwroqP1iX8T4M1gJxgwnJyMmtUCBzY0cttboZPnKttPTMh9YYgHZ7m82eyKjQ7va\
+            EoE2EULCtSzDsI8rXsw==\",\"X8R/AJlOj3igL7ciOAno6ez97Y6KwrgLYH7vnmYf+\
+            b2Wb5yFqq4Xs4xEoLiRU8l8AbvF9/MZ4SxJzX1QgGfQL4iNIW9kzYVncERkviQs1wCk\
+            AWejy/o3Ujr/Zgh5yPxYPAV5xwSJlV4rg8aRd9mM4E7tsdbW1TwE6ZDYBMlGlRtpAks\
+            kGDA0+zCnOHxyl0ggLKkz9s4dS6oI+O6eYKScvA/eKCZ0dJlATNKbnmP60K7A6/aat/\
+            RMaCXTpoO5wel8meFB5UQZlCZvNA+J7rfioiqcbU3OeJsD3U27+eyJxK+5KUSjbdE6o\
+            EQjeycsapHnlxXD7WJJMBkLaVhtoUI8Ug35TVGCjIHoyUxxEGB1pwuKq1GowHhTDTku\
+            0BOaEW6ZiCY2PrUFZKoGywmn8+UTLl1fh99fNmAWFANm+DVrTfRQvWTT28l/Mq9VDh3\
+            TVD5L2co/a8gTmcxnBPOjsGylOUD1vyNdzAcY2CqlGdGFZXB0K+4gQSYsy2XDGu48IF\
+            +TjBL2GbCA8BZJXUcUtb58MaVwBMlC2COxhgdx2emPlzsFa7CNVX9ZCCYZxastLIMUw\
+            4RksxSWlUo60PSczCnhkcIylXMo/JPNHm9JMDUvJKulK0A7nSYCg3rybEjzQVYKbcnf\
+            vTVelLK+zErqSD5EYZnmphj6v0OBTNKB0ZZDen0yfydpJ22hqOpuQUkcxw8DbOCoTnB\
+            3qNhTzKRzAOP0bkFJ1BfW5C14UijhxMIyY3pgo0j3sGUNb+J54wqyciiRvsI2PJRyB9\
+            CHu4wSfCtsU0onrIkX5k9Mq41caaAT+ITEH4iorQODEj1NQYHJwWlGlEknNQ9SXab6d\
+            dmswi2VAUlyL79yAXYx3C1oFoGTNRjhnGWk29dJk8t+Y4FRD3eksHRh3eXTO1lQIl2F\
+            9bzWUACUZuUkFLb42wxiEtCEyEstjWovxx1u6UhgNSVNlVCyCD11lYJTpoCselJIpbC\
+            +M0EKgFiRvZNwjiXFTMMDVEjOnGUbsOzknbbiG+Ehz/KWuEZsK1eVCpdl+44UQykcz7\
+            Vkvq1rFaLevVwPebcgAoINox9oZ39AYT6HYockXyz+F+j4s1tQqCZ7FIgC0GckNesaI\
+            bgoYSIhnuEuuclX1l5enWjl4mneUmq1w5JQ0znluJVS68urE60tPMBQSl2zy3H/bj57\
+            IpV23ZS2lisnt4w3AOWCZEYeoeJ/gNNGSRwcsXLPgh2C2mB2jkY3OsJ+SOECX75bzDL\
+            SjJbPoXPZOCl4ANKt9xklunVCdwKstJmQDlcZai3A6Eg/pxjqZQgNfEhvSXGgiLP2wU\
+            l++bp/IDm1EanoFRTRf89wbybCsMHTYz7wldKqh7LPKTJBkcDUShvwkrMZIfg2+Nttk\
+            /MgHWtUIzVUkRlVSoeDGuFkLU3gegjDpyZF1lXsRF4Dg3K41lLGp1ZaA1km54EPtUmX\
+            M+HT+fIZ1/HKhPhTSkQwuQsO6BPbZcSq3Jt3bryH2H8k+zPVmeOU++mC4vhFsCEjxPb\
+            2CEKr2pEOTXpHYtxlQgrlDQX7eLSkI4UXv0NjYFp5sqD44t9DnolQkk7QCyZYdxHfp7\
+            JjpnJpALyOdLme4YWukfsfKStMiru9yxyo3lwQO/zevMuwclwB6cDdfPaMxxTf7YqtL\
+            HcQS+mdELJ792clmrhkkwTHg1RQwqX57q1xjbjskOxIns0prplbKKBEYadGrMvW5IRE\
+            Mn+H6H/9C82Kqv4TvMXwAhGITnS3oKxr9ZNngtcNVwUkxyS7pgIy99Q2vzeVq9m6NWK\
+            43pwslA9A24m42KT5OTdVYqSpXpJIgQTJjuqIuRaoVw==\",\"6Ej0v4jTRhNnr5wTm\
+            0VY0AMgaAPN+w4yDXfZ7BmXMC25u3zh3pPYk1oJabz85oVtgTx8NnvD7TYdTarStl4y\
+            ocjNSe5ItIyE7YNsWHBcSMdO1xBEoyDcZ1r5wDzfyHyvluEhCC+kLi03WtdAIqOfLzM\
+            qzqZODD1RcmUOxwO4w+ezJ1oNq7aiKsDajWz5TGpGcgNF/Lvs/Rn3crQt7t+Z2Mihgn\
+            PYCObk8G9AdiJBkWpbFDKH3cMpiSGjbcG0MmDoJZtRNIBXayaiegHXnwoEBA5oeeoEk\
+            3OAjUEqaz/hMCTFQbuFBzhZA6MXd6SSsQQEhAJ3pBzcHgX7tvuMYqYksMEpQ7JBpEjK\
+            AOetMUDHd1Lr0gEKHGdDGqJywsG/kBJ6OsGtYYIqhb2QwNDrfEeyxAcsqHJwSSBlJxT\
+            XesLRIZ9EL2tughJA57F7Ek3gO7SBDZYuJqhUazefERL2A3bgQQkGeRARDQ9JfYfG9o\
+            ROSIGQFTZco0RqJ5Bw2kZbnmP73GUU5oX2DeM5b6Dq7h3NxvLNnvcJRaEJt2TNlQlcG\
+            Yn1dyW8VM0ruCGkoNVl1NzwItl4Q2EcO7JR4TLYHckuqKXTyrBgmbAAoXnwiCiqs7at\
+            CcqsofpV0la0OijY8rmfU77QKCFZAOdL3C0oijcpcJjudZf1BJc2AqUBJ5DczzLcbzE\
+            2yJW1IGGXkik2Tc1y2USlCPEoCGtkeRvKy2EZUvO2G6tzdjLHnESCTrfZ7Il2lFJf8X\
+            D5UN4vKEyGhHK50UVU9jh5JYIMCa7GyY0Cs32kNWukYcowmUenlVCRPgSUqKsWpJa1D\
+            K6DTNEum73iGYwIt/F7bwmJbM8KPNBp3UqF8+AzWC5FkWFXYHHOe9JtYv2vrUTCTMQT\
+            EaQGRwktZhWte0lzz9YtKBjT+ZIQXv57alEF+fOkUpCm5CunBKfKLIWw2pQN41pxNA9\
+            zR8rsNEC4655EfTqUM5GqEfp5n9FaUTVuKEIBuKITUoi/cTIk1ullC5Y0/uKmcbaWoZ\
+            QAHY+mqCNQ4SQQhyL5zslLgqtEOxK96+8//3z6G2BxUS7bptWaOflrK304a+4gd2DC/\
+            Rm/Uj4AR2UNdS6+m1MslaZtGhnkPrnnRLQRHGsAV6cn2WRNlwObOyH5NU3nreHASKwJ\
+            qeNU06VeyWDtxY5EStojUcn3JC7YHpOQpNyR2O5neGfZAcBeo9RZpluONdKl6kgjhhI\
+            dyL2+I7kADhKSjhRkdJKLwKLPqkzBfKOMgTmjT7TeEHs69LeoYaSAVHBHYg46aeyGB4\
+            kWq5Iq345oZ5lbpGqKclSiblEDwcVjRU+kSWU3hzg5i/JSg422d4vZC6lX/80//rp8+\
+            nkJtIZISJT7bEC6rGGmpDJk11xWl1NSPtW1q66Q9dA2DPbRSdera7X034DWONP58gVP\
+            4zlgYPWEtjRbqKPTLakHl7+DowRDWxPKsvi7xtndZXt9QiL0+Tvom3aL5Qup9fSN5zX\
+            gjZMYL8NYgH1jQpbqJYA+8dHwx60MzzeyUOGrugz0QLIB/CqQKgKm8yXBq/QCykrHk0\
+            EirEUYLLuVwEjyJFQD9sTssr6g9cRJ75XbAKVIEtGW/GJITolwZyWUd765zL/fzWfPe\
+            BQr4VQ2aKj98LwX9EUf0iOrFmzQ8EJ8s8FkgiJshJbGCQmmdWTLR1zl7nHQhmMkBXPA\
+            wsP5xMEUA+Qh2QIqGuKnnoh6UM6ScIWm2aoblSgdUFO4LqOEiPZp/hXPoRKkuwXFqjp\
+            gaRUuV1rekdJ5eyhRcq2lASqJU9dNkqmwhzxEmvGkVNxcwsmSgh3iFwwuDJ2SgrJemg\
+            ==\",\"4DqEd7qbLx8JNxzETpw90XqOYx1/piSeoy+V1DlE1KWUSfnSuiAAltSEdoRU\
+            kDXQMz+uLgGlklqGcx8Uj/tNSXxkr1XtecEaK5BqlyijeL2Sr20lEYmazpdPVyFdwS6\
+            jZLe9UU0D9TAdrBWK2+TB9jEEY/7sZ8b12gFcyG5Bcd4/AAag21iXLSuCzjmDi7qs5g\
+            7InE1IDQ3OMcUfoANG0WHnYDaXwgJZJlLK8nvE1Eq89fAkgF1GUk3fQ9utkc6XgBlOm\
+            pP9e2AfePDsUPgCRBwoQbqP6CZwERhvQwlEHmh57w/AiRXMNkoCrU13cwp16Bz20CcX\
+            i+122UzgGZzPkPccAwap+furxSOXq7YgqHlaw6xz5KErG6QXrhSJD63JoMN35dadcOF\
+            +jrSL7lNgj7KF3h9JY+A+x/ds1ZocekCXLQuc5XQBXGhrUog2GfvgKb9Sk66VyVPDWA\
+            5MVNmRWnOfwxYqYHVyO1J123egZbvCcKfz5SvOyjv7ed9pDIrZ3JHSB98vQK2cS5nbJ\
+            HvQQly7ukBwghQy/QDmkLJ8Uuupc8SyXfkGYIh1JHb3OSKh7IvmmZ5jKmCCcEdq2XAO\
+            d1bqV4YADnm60nI61khAx/7at1WmOnBrmNw1HB5fffXi1hDL+J5UMXgOZ5oaaSl5T2I\
+            rnGMeOEGg7Xx/9cE/wO7nQL1Dq3DlsT9A+3alFdAx8J5EXPoMeWAegRSm6+4w6z1bSS\
+            PXCvLCrvZ39lMmGUgN60mTTj7ADqkAb3jjS0CB7Uj0gA/IcJh0SK2SIidnoPvoExp0o\
+            nGfPkUGG3ne0WJkv8dFvZUdqdzuI7KBahan82v1+V6XFxIqxaOQuD6Amg4ocLjaIEoU\
+            j19bYATnXUahOH3ADFxUQzUekHu82r/Gdda1MppCRVryXDqkkpvUoOwDtK2kYaUqSo3\
+            I6dX2NiFk39ESqWege8Lo7Onv/3j60+Py6XJztHsS5e0ce1taVhm79YyvbBtYKBUgF9\
+            nyjahtnEj9rXNZQ5RZ0ttiHWto1pETAjCr5+8Uk8VBThSpeix+TFS7XsJL05MI594Jr\
+            S7XCE1JlLwBBJ762NOs2iMSNAmQNGpzD3UZ5pZmEO5hgELLPiNufQLyJQd6JfY0t+KA\
+            BfU7pnB990BIU7Ge1AfugNXWNTCLnHbNDlDwEDe6YJbcVxLIZ/Q0Y2IAAzP2PS24d0J\
+            CNP10fsWpeYdaBU1ppJIT0nDHgT2npjT7ecCEGpZOrpH6poTq6ynEyAMQbHJPafm4Ae\
+            vXVonKB6iOuie1wN3jgVyHntRRZY/k4djS5BqJ9YJraLI+KV8/QB3bfe49NSh5SX9Bg\
+            vE0pUWrBrwOIpH1tLCcE14Asn+3IIlZ4C6ZmpC4vhCimkE2zOtowQ/TlekjzO9oCaLg\
+            VCORMieK6g6dlpT5Mx2pKGnvXWBdxp8JK9jWNXcdU9634IyIWUbIbLdNdKCjEykdzN+\
+            dzzK8Dd0BD0sDpIInWl6uqy/TwG5JPXl8ZwLfHZ0lyJgnDJXBGg53NC00oHzDSugWlF\
+            sz8AKrBOhJDbUC10BK/Z7EVgmi5lpDJSaLWUELzByrFiHPiXD4gnSG5XLNrFOghiF1t\
+            Epo9GZ5d6TxPwn0fajESF4nsIBTUv16QtRWcM0SeS7qsVwaT9GzVHi7kc6pHIWckjom\
+            Jkgn1zgaxbNMaMOXb7kGmh/Pl4/4qQ/SOZ6q9vnWM7mTIk3IhrJcL7QywBOyABpY70i\
+            T/E9YhbWFlpQXTUWsFE38O3D/q2ZAf4+BunTdEjTOblQu3XGEHFQ0S5qi8Am2V0FO73\
+            eXu5ffk7hDQXovHQeugjtScQ==\",\"Ijylk9QFIkJ8IwTXHii66FD9dcPzDTdC5qyw\
+            cfEKx+tamYJhvcTxzgenR1QVYM8vlo9bStT1BKe3vPNM1k3o4GKJB0oM54j7WHMg1LG\
+            bz/BOY+dYvTV/ssZAVkTERKsmTt9tilbz/UhrA/ZaTU0Xr1tUrDPiPYVeeIJrg62Hi1\
+            NOkWlgXfaO1zF9howVMO7mfbal1CMcwVc8DNRsU0h/aDMInQKcRX0Be/9bpgoDDcGOB\
+            jld6n7/CPh89PP+cUrJ0p6e4NrL0dcHCkP5CCV4Dgw2faB0JTvHkgYIenfZrKKLmBiC\
+            3gzv3PJACSmdcEvuoAbJ2YxWGngGKEXVgiSPF1Ie5IRoczm47NA345fVGaCvrQfHdkS\
+            PjH6M8nzICsIh0gdKYPqIOZNrZVSQult2DaAD+6zHKemnN40ydPY/4G2iWGdn0OSJ/w\
+            +UBmwnYBhs6DB1jUDlyqXS645tVSiZb8CE7m7eP3dXHYHceOG6JjC4KjQaLCjb9iQPV\
+            kju2Ez6KljkeFFs39PbIkO+Hyj5vROaa9VlYX2g5MKOWE/cdzPutvCQvZfdVdepNMKm\
+            mn7wGn2gpFfPMMtor9ag/dMvZhWpnPgE61Q13Jgb5dVKaRUuS9M9hQF8gg4CrAd/7q+\
+            SoTVfKatBj+yZNBPnhKg81oXqmVSLf0QsVGgsJJqEaPQJDIzy0sp8z8Dg2asD4jUajj\
+            aDddiV63CBmrL0mpTQ6vlrUiaEJtyrthoeqjnIznUv2pQKyPHvsuXz5Ko7Yl9Tz4Aa6\
+            IR55a4nTOAcRsyrbvUDJtCjNGFeuT0JEyjzSlt+3Xpi4fEHSr/jM7zguDKIK/e8u8rw\
+            SH/7VTNpCmhm0CCfV329awQreJBbDhjJlBnHR8iS5xawMx4yAofkCKZqBkQCk8t3lQS\
+            954gFdNW2oENBIiQpcfABEh8Q0s/7p91VuNVPHie19lEwr1rPCLu1rvKlbVhYgzNyKz\
+            RTeILlayDKFrHonkvC2vN1WKN5VzjbAk1tIjrduh7QhylontVclMpIlsZNRFsR76gcn\
+            YSrFGsluxX3Ems//EBJOZxALdCM7IHSXPkE1a6kMzIAH/1AoSJ9AsiUKZwE4poPlET5\
+            B2DflBIMWUWNeo1O0AqxSEjtV05wwLyIft6/XBdt1jYEztYKLqqbvZDqZk+oyMCAAfE\
+            atUJq0L+bv4vr7vqauyq3W6Dk6YFSv3nCq4QE6Etd9o4PlT6BWWOZs1DX6AdKB7oTYA\
+            florps9ra7apsNF1IDvKgB8Zr92COifJUEfI38HID31cXIPXrNCTJ8g8bRcUrGCa4VW\
+            oHDI67RlLbCyuQE/dVsBTXcogzNPkItGmlmiq+0Been4b3ATi+Xhg+FRABKcy7ABjuz\
+            ip6YanhVAUonriE9h9EowT3Q5uKewtQ7oR2b3e4vf1ZYsHHYAyXf/Cm8rWtoaAul+uM\
+            zXCfzIToNtoMY7otrFAnavXeIxV5z0JtWtzUwXnHeP14XW9g3Qo1qHsvzXuFuOpkDtS\
+            PDSl7z2Vc38hxiQdfcIy7+CTR+pnBEj2C+YEjkmFL5cw6H+q/XOMO+4uu11VAW5h3vO\
+            H+CI+RI+nmfXZcnO//dFRnpewoN99OHHImNWC599nJ3VbgNK1uazpdX8B68X4kheQq0\
+            dk09Lq7RVSdUYGoFpZfpEfFIGIIugiuCLp8QkEhOHYE6dPYMH5gya6BfwG6+fNxepWI\
+            T6DAkGKjQGnCv2bITLqq9d9nslZ6cTyyowD1o8xPqyU6Aay+hnvoEatYJq5RsyzsWLC\
+            vst3/95duf5qDVSw/JhFIZ3jTf1lyAHcnuKV1vTqgKGt1FoSWfQZmOFfbEOkFap91Ta\
+            nfP0ANQ3bDLZi8ob/KItewa+TNcvvFA6eR4BNxwrXKQV/9AKd47w2s1pOL74jpTbyPc\
+            MOAeZwQN4NcokN+DM66d5HmXfg31l0vPuuau+uRZxgbsOfGg0W+wrarUIVgIWnDbqwy\
+            GLTAErMv61+tywB2vNcvbGu7z2F2J6QwTyolEMnTWhjODFsxITa8yONJz0HxcNBGuWd\
+            8TappJdij4guocrgkT9GBLzSgM1xzIXhmocmL5TOuifLpjuQsKuxl2lJTUgNk49Z1DA\
+            weaSI1ewprlHItYUWr2w5ql2eUpAgbNKqa0aQulrKH0DqmOL5TSA3N5drSSmjJqzTQG\
+            A6wVohQehbIDmlz0i1lGG70cVDU0oQBC1fekUefLRfY3NtRonXwZyFWKfgehYsO2juV\
+            yz4S7CDYhtXEMjovLNMXpgmCm3gQnJfMqBOnQaHw3nz3dkrqAn6M20gEh6ghJUx7nkA\
+            BXJ55LkkvxARGu4Z3SqnHO8cCwfF/QJrSdIwZ/ecTgLlsWRF10jkjoqZJael8LvNNQt\
+            2tSaXXwaIErpaY9eEqx7B1p8N5puciTjqakfj9nwDUg2Ls5wWm4aZs83YRDLjxw4MIZ\
+            RrtQNrd1OhqtW+6GKqjLV8eE1Bx1IzxaGUqp/444ASpH6EjdTJD2bXekflX7ZkKn9hW\
+            0nkWUfiR76IPU7VtsgRPJp6QrfA+89WxPc7l8aZK6y2xlajN6EeWWdGi3cqWh8Owdad\
+            G2cuXjIQgI0Xq+fMQnbWxL23qI4rGYvdCsyq3qoaZbtwtK7fguKjRgfSh7BTZx6EgT6\
+            LvLXRr7eS9IqeebPlrsvkpNxK3Lz2uYoeUmlET3Vlbg1Ub4xITB0GKzfjF7ATieTapQ\
+            ueHK+rKtIR5eBHq47J4egEzurMpTj3HknS6q9++goIKXiASMl/oeKWpkPC2/mL0Bafk\
+            jprHgYr1OLvsF5xhIg6LF7BUo4zgANVZroDgtbR0NhEmQEhDfB/DQP0JhjdvjSgNs+C\
+            NY41log3WKgyOBocjPAct3RqT274MsIDS2ARTdxgS6L/Ju2pVvVxTg6WXnYg+84qJqG\
+            9YGBUx0jS4oMADpCOWVYI2CiPUDEv5SRyQG1428Ti+r2SNYAIpDotxOUWFb8V5qBo+9\
+            7eEZiAckyS9nseIHAQSjA4QqkngxZ70MgTPQfouvBQTnTpiBr7RM6dHoDkLW6QKkQR0\
+            QrdLSDf2cONQpLyoO/P3aaMww14LDRvs0lxATCMFdsOmCg5UrkPQ/InkfFT8f2ssj74\
+            V94wmtlnnrYYUN1BX8Ds42HhXd1wm6oydAJ3kDb8MrMDXvACddSCWxsOiiJyrV6UIls\
+            Ol+w1c/DVxZp5YsLVAsEaUfSCYc0bSWIsA2U0+AqYGI1LA+JAyM8DS8DrpleyjA50wq\
+            DDXhhK0bLQeNs25D66Cg7mL21hEQTQ6k9JIRR1gqs1ZwbXq/mBX4dX0CSl3S15LHbzy\
+            xDYAAbb+YVbfoDYk9ADP4MiAnSX0EbC8ALHDiA7D5lYtZBZBmiQ9BGj7GLwEq94gP8V\
+            u1hg01oCzn9IzAlZGO8QIx+152uNK0tlJStCliiZAsk4lEEHnrcmXAxPpwlFHBcwFz7\
+            V5xk22Pgrs+QNXfJ1DD6jOvirQVDTgnOb0p4XtbI0qQ0TMYceh7+sCxWxnbxpzL2hp0\
+            1V6AqrQjUuDStLC1C1BW9zAzHvha2+1f+Yb/PPv/YDsSlYr4Uo2zYthL367qFLQHUfH\
+            zf0AFIm0R6A495DnqHgBDYw8YcoVYQ294OCMv2Ua50HItzeWJeYOuQVdHrdctNNg+SS\
+            YOYzx+mO/Q05ZbgXfWHKIZ6CINaQauG6hmNYUz0Nt2j3Xww5CPRNdqQDta7PDdgyuFP\
+            RwecADCwB+w1kpLVvMNMCgjuZnEPRjgEDf4FShU/fihBdgp8wVX6QPON2WCdGtoSNoQ\
+            wiCuP1w0OnwhESotPdbUMakK4remClGo93zUXfhuOi8dqG8yoCDuCALR5ZMNggtCC/u\
+            lb3gcUIrSNm5IwOYSGgkzaAjsTJ/wsOxhUhHo62nugxLH4Tq53LGtMrkFZiNFdY8und\
+            Qq9C2sW3G7XZ7nrplFJAv3ZsC2LulyRjcgmvUO4LUO1zN2ANfrLfgirwCb7AziUCCFG\
+            mq4wZDgyhAaioLHTawEB/eqj844jqOVwbIy6JalkXXYKIsUG6BBWZPYbLbBDYhXPBK5\
+            hhMqb0ArliNCW0vmO69tsadVXS66GD4UFQfdBcmGz8UviFegz8cBsA7k++b1Fr3B1lZ\
+            7YPjeEE9GP9J6n1izyGlGhXQIXhHiv/hFmrBUVMpsLTViUkKNlPZ4hWiQ+YcDDrZWEW\
+            etnNxyrZk0a+sEcvvgkbZCeDyd8jpFhbUoJdhAICpAVNMUqob5ly9Ah4Q9xn4eLHLro\
+            cuSfjU4pwRlPKEAwiVoQ6IDXaEh8ZguCeLLveCZucK6HIlJ4wnMAYQVAk4xTXBRGoCU\
+            Cc76RgqQgzG4AUTId24U5m0CDN9PwbAPfsVjyIVT6zVi/uOh7qGaNMU9m6IZhuwjqUM\
+            UMl/7qYDaOw92EiZfpdTKYuljbA8HECRi/wpU4XzE8VWXA5Xh6TiiCquUzkLD0KLGIq\
+            xOBDkV2sPZS1Q8P8LhUVf0ni9tLVdObvcDVpELH10y6yBy9wCCLdlf2tX/Ol7LrXWgZ\
+            fqKJwjL1pcscPjCwCMzZdcgZgKqpCKEQyzRl1vUElVSSuabmm2s4JrGpsnwYxPPDJoN\
+            wKlUEUYAzQ7iDYFuv0JaIw/2KyaJCSV0cIwP6jC8x0n3cMlr4ZD7/Q13RIaS4gp2t/A\
+            c1bs0lTKeCbuRjhcyjYxAmCQdKqDvyqWXYyun8gKOpeHRob8a9RepGwl13UuRR/RjE0\
+            lftmx6O7lDrmIMC4/s4cqp4spZD1QIp+gZDiOdkZrCF8CXqNJAh53Bg8e2S8sajSVhn\
+            5SqlxKHefCHKPRMqDbgCFuvYP99i+pvrUwBL/MbTl3RyrSXy2OG7AqKYYtCmQK9uN/w\
+            jJ1uVQGq2lecAag7IeHU4RtuktRI5P0Fp5XUvDBWY+wiPN6wp6myujVqqHx1iGJ8xdl\
+            BtfJemQKLk0EFYQckbUUld7Dl/gJUDh9w7Eq1MEUSpywPIOzIqIaHVQ7GLiZPWcL8ih\
+            Ix3nCo2lpQx77iCsnIEDo2zP9Y69aXKNuShtjXQHO0YfFRICsD8joveNjBVoFHU4lCr\
+            8GzcuecmoEUhJlhGW45n4MmsUAx8dB3I3Ou4bnyQ+wbe7m/y1//h8On+hXnGke7ntW8\
+            wRlDr3j4oSmbaO8w7iKYMjzaPffIJqALpnlIfXjkLkhnuGYr3cpgbSjTTz2svlG121i\
+            tO/Y+VMlLLxEyOR5vP81Ao1QevOAs3cbZYKE5yIP3hS5khGFOFspDsxl7uFLrO7BfW3\
+            CKYspx4CvWNo0MLHCNhGLwCF3TSRQDfZ1uDYaLX3GSTtMhbfkHrg/+JlE1rjWccH3DE\
+            677vnuJ0b7lGkl1vQH904+AW1j14LlSyuzrlCjA9tzxwIO1YBjhBf8kJ7kIzPCgNpJp\
+            a6sV1DxgkGz01SKmTfRzhLFAQNLgBL/B/cY/Mm93ab5oam/nAweG1wz6DocclACjkDL\
+            xVJKzK6uliIoTkVHsEDrfSMGQUOobnog64mAZ6wz3wF2LlM284g6hv6uR0oqXCbprXn\
+            AjAlzIhkf0vEC8dzw9GiGYsCY4hNyKBwIj1NfiJ0SdkF5I5ZJTctE48dPL6DUh3gC65\
+            bLmJihBsihwhpcvbatzBgyaG2recBy0WPcV5+d5Fb0=\",\"NyKvEV8qPHuCO6m+6mC\
+            CH9SL+4BheCVX0HCwodIRfRfLmZNr6VLxAKX6e5jAiuO2Jk/VVUMnTmk2yllTY34Azg\
+            z2DXdV3M80GBuJoaLHMYJJjKxMRMFjVzjp6ACF+62vuPfhG75FWH/4Rg5/srSXKW2A9\
+            XMZXFX0JA1/7mkLXzFNT8Vj+zRgKn+GuzwNe0v9/nfPRMm1lqaQX377v//xpeGFfDZr\
+            ++WP//4iTf6n1nnrvn/K63wizHwj3pv/eq4ztVB/bd9+mehntVW5ev7P5zpv8j+Xkzf\
+            18L6a3m7E3f9s8j/rWv78h178+Q+3/Jd/Pfztl6b/2y9z+/bLzv/rlwfzr9fH4c27Z/\
+            9cv6iFelbrKFa//fbbb/8vAAD//5pKk9TJPgEA\"]"
         cookies: []
         headers:
           - name: date
-            value: Fri, 10 May 2024 07:20:56 GMT
+            value: Fri, 23 Aug 2024 08:20:23 GMT
           - name: content-type
             value: application/json
           - name: transfer-encoding
@@ -2501,7 +2136,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-05-10T07:20:56.384Z
+      startedDateTime: 2024-08-23T08:20:23.226Z
       time: 0
       timings:
         blocked: -1
@@ -2511,11 +2146,11 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: d89f30ab17bbbb161b23058622b88163
+    - _id: 89d523ce75da3dca1da7528d3951e05d
       _order: 0
       cache: {}
       request:
-        bodySize: 413
+        bodySize: 401
         cookies: []
         headers:
           - _fromType: array
@@ -2533,7 +2168,7 @@ log:
             value: "*/*"
           - _fromType: array
             name: content-length
-            value: "413"
+            value: "401"
           - _fromType: array
             name: accept-encoding
             value: gzip,deflate
@@ -2560,282 +2195,277 @@ log:
                   }
               }
             variables:
-              after: UmVwb3NpdG9yeUN1cnNvcjp7IkNvbHVtbiI6Im5hbWUiLCJWYWx1ZSI6Im1hdmVuL2NvbS5naXRodWIucnZlc3NlL2FpcmxpbmVAMzY3ODgiLCJEaXJlY3Rpb24iOiIifQ==
+              after: UmVwb3NpdG9yeUN1cnNvcjp7ImMiOiJuYW1lIiwidiI6ImdpdGh1Yi5jb20vc3BvdGlmeS9zcG90aWZ5LWpzLWNoYWxsZW5nZUAzODYwNyIsImQiOiIifQ==
               first: 10000
         queryString:
           - name: Repositories
             value: null
         url: https://demo.sourcegraph.com/.api/graphql?Repositories
       response:
-        bodySize: 17353
+        bodySize: 17016
         content:
           encoding: base64
           mimeType: application/json
-          size: 17353
-          text: "[\"H4sIAAAAAAAA/6S9W3PrOnLo/13WcyisazKZqjw4s1yJU2Ov+P+XZ8c5dWoXCEIkSBCgA\
-            VCyNDXf/RRBUheb3Q15v0iU914/gLg2Gn35+6eCB/7pz3//5GRnvQrWKemH38YWw8P/\
-            +fsnVXz686en9m+7/NtDV/zHv+7l2h4eavH91+O//dunf/pkeCs//flTy7fSMGHbVal\
-            C1ecrt5XeS8aV08rIrJK6y3Luq0//+CcY+uM6qLIw7dfP5x8PNyjNC9sFFj9//7r68h\
-            WBrZ+//CJgkhuxsVrumep4UTjpPfauTz8oYGdD3peezQ8ZN8YGHpQ1OPlAvXfXa80dX\
-            7W9D1xUclXzLR/+j05p6YhmwHvIB2421hXZpg+9k8P4WrW2lSb4RgZRsfMfmbd6ixX4\
-            cLj/el8SBcoNN7lyjZGO+b0Pss00b/OCY4NDvH6E63otsbY/PH29J9o+yK6SRqw2yhS\
-            xe+eHxO5dN1+p7p2LqIXq2PCRiD6Uh4cdig684XteKR2sYf5FZxvrWh6CdMME+gayXx\
-            8O95+Jagfb8kZWvfOB7ZSTrRUN1g6CauolYFY7+SdsXNy/fpSaDUO/4Noaic3Ou90DP\
-            vC22qvVMBe5CC3v2OkRq3eze8An5k6aYt8o6Tr2X2vHjR+6DhkNv9bPVAPvhv+gpfes\
-            9tZkGz2MBIPO5/rpCzHEDnzDXVPxmrNhVcq8bLEl4vXh8Li7h17d2lLLFTeFs6pg0zd\
-            WvZsDuCq/ZSXNqKevFK9TjHcqE7ZtrcFQz/t7qOWOqExoJU1g41+y018w8OMPsJ9PdS\
-            z5K145cHZfMLLSdQIFfQfHxyWoCqEbhh1RK2JkdGo11IiVvFMim5pNaNsXmQ/W8VJmW\
-            0wu+Cm+0b0yFeG6NyXkqgw8H/qpaJWhC0p9F7ggoohXuu2hIro+932ebb+g/fH14wWk\
-            dgc9DhdKiJMv65wNFlsSf4pXUPx5g4+sd73w0ku3P77Jl1wGjjTYr59iT09NrLz04fX\
-            8NXV4YSWRZUBbH13GIEkOLSepMfYjdc4vFNJaEw9Bpsy2sDQzdszHS0mbK3tQTqBLSJ\
-            ksD/Vjwua0VETabHk4PH370Cso3qJtEwcSuY74803QS7dVQvrjHETpCWvIMj02foNKV\
-            T9FQqMjdCe97Z2QLTe8JM5qCVMaKMm2XR8QMTZOALJvl+HDRN5ouyM2ig/SFW+Fk4U0\
-            QXGNdsTzt492xDh/icn7wQE6zVxs2t7Ceo0Z3klTKiPZ8SkW8mX1OfMFdqiqkeP2xO5\
-            Ddax4H6pMq9xxt8+SWv2hvt9ROxpUgB1+fY1yH9atdz+oodMHy4YPUub+9fOOFGv7YF\
-            dT543Q6UfakTvqIYhJOpSw5bqf+PGR6EJi7C0RE+u7JvdwwbXqpGPTN3HwwN89rnirX\
-            JXDmmG9Z6UYFidjpAgWRT99IRphCY2pEwckMRbeIfugNEG88v0HYlbxwlp0DgjqqHgE\
-            R7GNHeW38bCYCeuIxT+1KWD+0I8bVRLCfGL7vCmmlcEp4YdFDxcjkl7jKHmycxl0lH/\
-            o4/X6GVb0npey6Y2Is48dn7KN463cWddQbyKog24sg2HHEQJPTPpFfOwM4kz7YW7mAw\
-            +o+Pn443o6PvKHjT2lM98zab3HnjhZQmB8P4znoatb4XQMIkZFwipzSfYdN7iGcOi26\
-            7EJUlPaYhKs1Z7VKs/yXuki6zTHVEwDNqF5z7DECKubA/76whZyJawRvXPSBK1MI4uK\
-            +2rUFS/+PdOuR3XSn/GZ8qbMLDgpPXv7B1QogdXqUzMNRRzvRFKEkdeHwyOlrb2kXnX\
-            TMiqWr8HX3n37/AME7u8PzRdqsAzA0lvDSly1WT9/S6lb1KBzra2Ib5sp44PrW2mCdA\
-            z7j2hfEoLQqeRCbTbZILN4NjzGJ3Qyfcbn6JEsd7xi/8W3/Pa3m/9ErxuIcTcSvTWZV\
-            22nJTt7RrkpM0arvKuskaZvc+nY5U9MyC4/J6wBNq+lCGqzZ8cntG2/UMK21VpOIshR\
-            03P8E1bdR3KLcfsu2FVQpmHDB3F+w5f/gpeldGz8wknE6nBByujr72FFIDaRQm7jUr9\
-            qfMf8vs2tHgRFIb1XpqTEuDtKjJPOWdc5aySLj7/H599P6xm6nFHKZJKOnmTvKCERwI\
-            tKiuZ3umXwUQHAg/Th90rqTjr85vsLISue8YcFCJHl4h1ycjdGWOYrXkjsYvJwtyMqu\
-            NE85P1mI51nZ8/ZUABxCKXANk6T6Ztg4b00s6b1Rb4GaTw1sO53hGg8fg0vOpojzPi4\
-            B41/IuYFwe/5lrMNV7p3kguBWfZ8u6/FgWTFT3R7p9auM042DHKtMIVkfU/dkQ/HiDe\
-            3x2d/ItD4AMLRGe+4qIirisPzd6I9yEImRShxWf9HGimjZLZ7St9A8GsuGm8NfgFKac\
-            6JMqJWI+83hA4Qn+bKDALJ6jS9WdlHnaj3ygdZjP8dL4JoKqiIttdB5coUypToin/7m\
-            dgNoRK8dFstUZVPmcYegejSRN03119tXgs2fqUaCN5SZ4datZvhtNpu0CZ8/kqIK1Fl\
-            /2awnf8NreR3YgTMI5XND9RWVz9ROpZlpFbYVdhD/XQg1tZlbEaoh+u7V2LNc/JrzYY\
-            PjFJSLz3sHsqUq0n+nc1As+nvhNSELwTB9aE6n0LxD/H1/3Ta/dHqH4ixGokjF7+LJn\
-            ap/sD3pTxIw45PCXpwoocOMvDJ7vX0iCqLYetAxwst2fiVxUN655SX2fSXTvelwlUGc\
-            G0d76oXHfuFnf9AcV/AnjnHjYoAHri2vMAVCzegiVP1dSDk3EtWoSYNArxSqb69+uAk\
-            b1dOBuVk7dn8QOrkBCgjV9w0wjNe2QHCvRJNVtg+Wt04x/dZcIpQ90HLXMUPUgvuAzs\
-            +oToD0HZ+AZT5DtfuPhyewQlTKen2xra9Z9ybDLV3/bV+AsVDxfMgNmz8yoqo1UDVIk\
-            87aLm5RMnX4DiqsXjaQa2+RJoFL3SxBu9FVd6uuN8bweInvur/Wjeg0nEAFflXVgvsJ\
-            mHdfIYG6wBQomdK9N+RPePX+hHUPw2I+mA9mx+wIXT/GVpwhn/dvpw9rmrecBf4ijZX\
-            vf8MDfSJ2r5kdeunIZ7l1obMB+4oreZ3rNl2XPOLHyti916XoKpImULKYrzLJVaegQL\
-            V6oyy5U6+dtbhZr4IKkitVb1ysrVBOpvbwMbnbKNeQ+9wp4fHHXTsx8jxBypXfYdmQv\
-            31xz+vws5mGy6CddFOhL35TZz4gQrXfL/j+6gR7nioRnXw8ITKKJ+h968FzxWLnxn3n\
-            RTojeUAArroHKQttnDX5WdoFz2HtNyojfR4fW6R+ji+Caz2qDhTw4YCtQy548p4pgrJ\
-            7/6CLUf336GpdKJ0e1Fx1/73M6pJAg8sTS2D5qZgbd4Y6+YVPxv634tKtpzwEHs4PIJ\
-            mWY3mznBWqa10PX79GesIYUxfFFJ7VgfbNAqdOyWo69Wq4nav2IYbr6iXqu9BI7l3HM\
-            Re9mFdgl14ycEg9R0o4syQUpp9Sl2AUX2BQaty+w2a8jPD+kyrPKUyaSC0OuUrNGhmS\
-            jfshpSbY7zbI5r4BCLeixo4Ewh/L9C7YqY4+dIPyxhVoboENaAzajSsHaRQqpmGt7sK\
-            RowlSHRcgBHNRQ2DfljQ6Lb6TrVV3ynRxBtCR7/g0ys44Vr+ygrlXd9hBn37+0MD6mZ\
-            b7hptSyXY8emk9YUvlcbreGB0nTHHY+wEpFQ296A1SMtdUNx4uwk77iQzXOmyN1GbSN\
-            nDQFOy5b7inVz1RjnpA5u+iZN7PGJARFFxU0omvnWfQcLn+583cG9MhOl7srGlr6Gew\
-            THSKuHs0G4rfuidZLzgGju+xBZLZQ2f+I0W2FRLqFRH20fwknsZO4/nPlTSBCXwu95Y\
-            ALT8ogW43gTV4hZwoFXdMrmR+y3vNS7p\",\"fwOHE8qkzfVAWzICvJN5IzF7isMzKG\
-            Yvo9uyjddQk304gb6qiSM657hqcaBe1RYnKkeu5gcutOkgXFHgjpugIRDGpLxWIvf6l\
-            hXWBK6MdMr4wA3Vd9fN7MsSnCyVD5h70lDCdVP7soSk4XfdbJwK8K31Be4VA2qMEXCB\
-            r6TPVy7QkSm30oSKcOEBLUIQcNR8Zy7H7EMi+voxkrCOHp5ByzwErK1oiCb+wGScTIg\
-            J7vUt3Hp8MYJFOphpZNhZh/lFHeDwLwjXyUIRYsAHZtrsAUj02QfIXnJH7CFgSAgUG5\
-            ecvCcukz8wkf0L7mAD6tIxJmlLfoCdoBBucHyzUYJ03Hyon0A3+WV8Qo2fElazeIZIF\
-            QR/re9B9ewJ6V/0eMBhrfcvOquLHFsZ68cDPGwb6XnbSz2Z6HKjgjrgDSng1cByU9RK\
-            Hrjhq2BbzYYP9FgBXxrFA04uuRlNnd/9BTUW20NAodX5M6LPXt8fgJV0/Me2kOLyF/q\
-            akMn09M9PVsILf0PVd9A1wQQxG1X2Lh5tlv+KmvNAisqIKbhs7duf6Mp8APa88d/nor\
-            v4gV+7Y69dqFL6IN27P+D3Fxhyo7TsO215sfAnDHsPSd2RoezZI27mhnVF/RovVi5/o\
-            veZkE4l/nvNTXnxAzenQlG2LNU5bfyNWixAh+EIMDKcP+MnYGxt6azVFz/Q8faK9eKW\
-            a1XwYN37v+AKH1AG3HvZ8tVEY+PPLKlHRgsamPuiWfw8ufxmqKnT3Q4S0owMG61eV4N\
-            8w1Xv2fxAmfisYRu3I9OHPTf8lc0P6AYHKs5mnLCm6MXYQdNTxnfef0txcnsELfso/I\
-            sfT0XZSy9x//JH0EoHK0Nw77kpHM866aIVKH6QHooBJBa0GNKu8BG8UkC5VHiu+hHUv\
-            eNc3PLoCXQlmKnF3lg2fMQzvsPNwB9BJ8glHFE10JzsPauQLbplPIJ68/esmjhV1U+g\
-            CuY9zEmhOtx18RG86jvHjfPGs7NnsgUfwctVikydLNcNqGKY0bJ3suFs/EpwY29A3QJ\
-            GzGrpvNyjV4UNqF8AyITNDOxlCfMS6lmX4LFs5k6Gj6ui9NH/spTmaE5ZlKPsXUqTFm\
-            Yh7mdEw0zf83bL5t9xKccP3DXspUTRldkofJcD9fkzejpfskpyHSrcL25oCGo0D6dMy\
-            +InPe3Ag+uR1kkRopB0fEKrOAhIH4LK15ApLDBAvKwjRvMS2Mky40FjVpDxXhZu1p11\
-            jQnTYTtawCRIioeHww28Lag2730RHcdD9Brfd6jS4gYUDo+oQb7MAseE9PUTeNl2xIw\
-            PWW29zOodKj8038GxONOmSEVWFQKPtxSDUIGvaMrRYjTREetwCzpgmulY0znpfaYPmH\
-            fPTwFa3BunDO8LyxpuAjdxiROU5UUEQu/4Fui3KXGEobfsNc8zZQQ7vIptjqsLoPP9y\
-            mxVoThzvFOFz75nvuOuwQ1C4vSHamVN6aRfeeF4y4hOHEHA8LoEUfLo+hHcr20njfBb\
-            Nn2jUwc02xr+cRVaHWxXbNjFL3KDfoIbC6F2xSa32LYzcKG2Q7gu6Mz3HW4+G9dhCO6\
-            4iN7ko4fCqi5ywezw+QWL8Lh+Ar29YSIWu3rdgFbti8BedFgFf8GawJlnkyr2UN+Dty\
-            cTyPe5D44HuW2naAYbhQdguAcvOBaQnVUm+IAeQe7gQfke6LctukeAq4t1wwIgRWWst\
-            qWSno1/KfKEo2sDqXlRLBlvBpw0MLRQfjhq9gF1Wq8bMD4Lwo4CM3qRPHCvb18vRe9U\
-            QINkNKDjJgomTLgG7PX1jXEk0OkJehjYnVaNZKU0RIDsEtIVrjo3rJJebSVreWmsVpy\
-            0+XwGHRa7vuv2wvGdniIhxaAPPuzR+GBrOKh9jFxWeM3mB3LTEaChgON5rkL7wnj7Qs\
-            tZUSUITMMjafQ0S5jSJagP9FxLv7FOyDm+pFa5Z05yEdR2DCiWoJYqwXCzWAHWjXwfc\
-            CMJ2A7W89Y3aitdYPWcZgQlgeKK591KDKeGwn+viZPigAErdI4hlVugoixyYkwvXjTD\
-            FJNOiRVxgL0Bd6sTTpqtcta00oS5QyY/9hjzfozWFINPUMflJ9A//7rShDW+b7sYHIp\
-            +Qaz7rijSSaqP4a0/pawpqwTvjpFabScdcaqtn0CvjOvK3IpTwWjQE9iL71ggM9KOnu\
-            Q7mVMd9AjKDqcX8EUzPnWah411LeN9oQLhb/QI7pkYWXBREZdrj+B5FgWf/5pvjtSW2\
-            PgfQUela8rCjVHL75AmByvDSa+GbYS4LQHjI2HsFJHoEdTn4GQqSMYAJqfxe3CQhuNq\
-            kBK0j7zkDoeh1hZSs+NT1srAh19ZXNepReERvGiAStroPlrXSE9Y8pXgaRNC21hvWkt\
-            Ugtadl+Rj7FnPpgg9VQjdyIeDHI7rQVIBLz3XKuxpVcawdiU1hv9eccPZ+JU+9cFDCk\
-            4nlMzg4f6SGqQPfVCazQ+0aAJeb5yRp4nNpMH0O/VTylyZWaMEgm8zsJsOBEw6loHX2\
-            hQ1RjEh0OkVnlzKU6oMx/Z+z129+p5zRjUteA8JEt/UN1rI86Bypcnapzf4ZVnxByq9\
-            JUhSCDoj0sLVoLlQIp8aME8p6+clP9jmeOlHXC0g6Ep0K7FZHa2UpihC0+9ZhUlKIbA\
-            P9BWFJGzvDXi5fX052RQdgtAVQP0uTVE6VYwrQ9JlyoADqz/j5gfSt+0OboqKd/K0vH\
-            C9jYaOaCbSBrwV9qo0XG9eV12fayXY/JsO5QPaxHgtZbcXPLCaOC+Dsm3LXSh3gc0P6\
-            HUY6Os4O062SuvVrJH68vvXC+0U6p9fgh6GSWzc2xlMoXfB9iF0U4STbyzFdXYApzRI\
-            BI9yYCo2pS0i1lfcySKJW9/CizvE3SVdIEK17WyMgMyNsbiQBy+tE2LYG7UcUwuMuWv\
-            x7EGgf/sMxB2Xhi6A5twMsKKRtElbbB8CtZE8OG5S3LWHVwMn4YhbbTa7gg0fCZV7Bu\
-            9VjpUbW3sMtkS0OdGJVcz+5MPUgzgMnLITjLT/HVoeHO8TZFpCNvuMb51NGOpE258B5\
-            0wYKVCiC05QwclYChFIDLgT8JgzJYFKTakT1Uj7vU4hJrdmx91LL6nAFr9+Cljd9Y45\
-            LnEpyORqBmm8dRttd/Q8hk9N77HWarrfn6l+X02Zd5iXLTdBieRUPFTfw2QqSCPszjo\
-            3g+OBDw2QecE1H+ORk00BxhiYqV4oe5z0eF5M0EDpgjUv3jgLPrktsYh3pCZkZF3mtp\
-            wUdQkvTXVLhJ9NSzzuMejqd4GL8eAT2jClajOLmtv4OFlFAyO5Z9M3eilAboBbuyfSQ\
-            g41IkbbwerAKdv0AURtfhPotGYRIhrUUi89d7Lv4gGus+i58/AI+pEeMY0NWhkcFNNH\
-            pIMyumq/fsK5D5eIsy6aeFmizVat9ZVi8RO91AYDhi2RsrGeIDAG1wEXjxlom+Ew/m0\
-            WtDJlgnRCoqGAhkMGGBT7Hbm1otnJnLDQGGubyhy/sV6B46MDsKx3elZX4wkpn+FzzC\
-            U69dUfft7C+uQTUlk2fBBjkX7riZNteCM3Sku/90G2WY3YU8XgT+TgPKExVrypJteHG\
-            Ka7487jgZmeQfPpY62cDM5uVPjKeMG7IF3mXonoTD/vQfMSEovuaveg+8ICV1izlW4g\
-            07FvD4/wqR8jE2tS5FKD/cSdn1A9FywKzsCdcpINHyn5gOonepE7AengSjWcBXCBN1r\
-            loxZiYJJmEEdNn1tYc9SbVbRNGj2454C+pz9hWAHrHN5it/w1CRptKKAR34/W67PKbH\
-            pCDU7hk3lvVsoHLho2fh29XxN6vITl9d6sRq+k1eTZ59n4e06ZMipfvmNT6BY+WsJ4P\
-            C3FaAGHNOxImWF5bwrclPcR9Kh4T0tIRwMaIS7QSOffdFbp1OGg96gK+hY+DLzj1VQy\
-            GVgKeseiLVTvrqThlz+HO1i51humC97laAJjRD/dm1XLlT6uL8MPQnZA3mxCDWsKChp\
-            T/iHDNIKGD8qVDZaze7N6bfUqV6ZgNX/NM9V2eIhxMOKw39kt12wT83g4KbOtkjtCnw\
-            22+M5tJXM8yEyrVgVZZHQmsFtQTg1Fb6I/Ej7Ao+IYaO8jIkzRMnCxB3qxUEnb8EiKD\
-            iJcZWUXvo1pKwh9FRjjAqfS6nI4ezsKpsO61SWY5ixU0vNWhlXUf3U509J46clgwbfg\
-            po0QqSC9cGddEqfveY+lQ/aCV4spaKzWh1vQ+C5UyjS8d1Kr3q9C5dQmsPErYVG+B63\
-            zQ2X7soo+mn7VcceH/8Ox4xPWEA3ojndBfSnsKxs+QNbojAe++RlryrzCpm/UbAB0XA\
-            /KNNJ1tlvlupcxeLRnp0fSAeAZzFIQTBmkqGJ0kN6owOYHfIuDFl8Ql9XD5w/KhuoWN\
-            MoKTmnJCzZ9Z95j2XCiUhTq6p0KQTrGdSlz5YpE5TJ4IAN5+MQB70BnnqiU1rTyFwwX\
-            +o5DKGuho/cFJ5vfknzBO9CD7hJI6QQEPM8uOHT2vocDfGadWCupZVdxE4ZXZPOP7Ni\
-            thJEFUdGjjSPZeHAiiwvWpjdRbUZvLvByuu+k5xu54k3D2fCRRScYelOB2xJBomPwBh\
-            QzIWS8iGjU6E9P3zbegGp7uIAE8EPdwOvWe3AVQpdCTO+x0bArxUoFDhCygO2488qUO\
-            PTz/c8b8LpgCdqQKTNq2F5pCThNfFpmu2bEHvMVbr+R1RXwWv4ePMoBKdMrvU1PTGr4\
-            X8ucJ1gKO73L0qBRcCWgbIySiB5ewQP1sWZGhrBn8TM7ehmODYBGEWlADdYRHQXqY3y\
-            9i18p04AYV8xH98+hCVLEmDgHiCGwhER7Hs7V2efSrXgfbKF8Z738ys5+EEiglhEpeC\
-            GNkGz6TrDEglUPEdh+Y4FrTWrFBg5WsSOnc7aVoZJYGKJfP+9Bu91IC6LixkjN5gfSP\
-            +IGNJnsTW57U6iCHZ8yXfAOjdHycLgFXVN7o7ZWqLBnx6dsvDdCTf+ewXvgLeeFMjFh\
-            qjNcT2lEGTeFs6qgdIKHR9BoeVv0rrUmMC/brXR4/own8NiwjWdWJTjbOCsaX+S1wc4\
-            y6yfQrmereeFFtdpo+dpy17D5AcWBl3cgbnQpJaz610+gDhoGy9eQ8Tx3cquo+431E6\
-            iFJPhGVNZpZfBmAc9lBN2rAo/UAt5FEuAwhYdA5wHsyUTQ+2DpJoE2PJxdyI0yKqE7P\
-            zRcZGtrfL6ANysE2PStdDzIInNyIx3hLzo0/cfK8YJ3sshExR0XeErN9ROoJMUL2Vgb\
-            jCUHz8fg5aYdpBrVyFA525do7OEnUMlDFxK4b7Qilh3QXY7gq6A5FplhaJ4PkRVutQ5\
-            n6sGxtWz2WmcbZ03IWh6okQOariYVQwWEA33+cHrLhUMz3g7rwofq7ftOOi+c6vDhAi\
-            pHcXw0Eycq/rGBHiweSx4UnQjsvrMxDpDC8aDXEY7fqUaRGwh4g4Wz97y9ZpxfvwzXy\
-            kXn5tGKhhC+rn6FQVDKfCcFPlxAI3iCTGVNfgJ1fjA4agHR7Ohx5lw9UiI375XG09YP\
-            df4Y+5Q3gcBfPUYinjAeXT+BikAKLDtphlMn5nI14D/WlRvrWo73JqhnIdBVaInhd/1\
-            8jOBWeXylAg0iCLDtqLwaa9iJn2B7+dKTgiLoGkrAt8pTCaA=\",\"BOg1udUNN2yje\
-            cj7zQY9Tv9aN+Aly45vZVyK2fEp80VDOuw+gseendLa7oKTknedX3HvpQsNm74p47kn\
-            0GBjzytrYzQP38ggKulZK1uLZoKrn0AfxAXc/EBe4cABX/a8baU7euKkOeA8HEpwnTn\
-            w11fp2H+qhjv1l/9GlTBgQK43kNi5/4KhbhaPJYUc49lKM7zVHBMgtzZkvGgVmak1Xg\
-            Es1bGQq43mXWFtoeXlrxUqTR7uFw9pOI+6XF62qrmkyDaXxdLfVq01JRpFc9kt9ir8q\
-            uOi4aV00ltNWEgse4SmFtc5K6THu2BxJbiERUF16W8EmOyHYST/aelv+KChe8DJrXT+\
-            7eCZ/kqYJiy3t5OlUX71spr3FDY/ZFrljqML2XrZUHfA2mCDdasx9i+bjgT+KxJ19Nf\
-            6cVE6KOR2xdX3mo22U6gGtF4O1TUgCuU8K5SL6WgUnjniblFyGyjypbcrVUjmrfaBsL\
-            YtF5WeA2bDlY7XFfMD+k6LK+iAKR0vtOx0Xyrj2fiLcNhcL8eTG2iam1JUXJnvNTt7J\
-            mBAQwEw0nJ3OagTRiys6FtpwqTAn22sqajTsSigXaGihhGYYUl1f/1cjmYSoX1ht0qs\
-            jAxa5Yy7YbkkUFDjXqJyNF3AAALb9BKkOVmnxSPTgBraZiN56J1k+L1M/bh48ThADso\
-            ydehblTm5GY5Y5C3j46IqepGVhUq5ouMu7AfxYEqE7yteJNhIPIJzeSjnoKgIAQ+HEp\
-            x4E2G6t0wB4VWZL0AL6SZnC5q5eA26wEyNrDIQ02o5X92Shhq3i/Fz3hB9cFyZoKUnj\
-            VYP5eK96jkwxdjlsGyfe46pfUoXgJvOjEm6eY8NRVXodAKY8rMRjTVCieH7Hnp2k0zz\
-            Fw+D5/zOSd0XKeOEasjRYyoBtHT+eQ9Knmgjk+ib2Z2LHDNjo6XRRg14wipHLQPRTyo\
-            4LiRlERfXTGLITFYqKSSiSxN8+h8Oy6F7imaVDwM3Gnu0PFjDjk+olLg8742Phv3TNw\
-            gYPVyW2se23+vxE7UuWpQOZL/KVdhx3UjHnrx0N6U04QlNZnt4qMWi1CL7lZFKcy1fu\
-            SmkY7XhAnW1KRcDT8h+FVQrOxWYkxtlErbbctEo7z0oPfJHjHK/wByl5tUoRK+EbVel\
-            ClWfr2pbGSdNKXXLDRvEBCwMQtRmLeCV2dhVyU2pFV+V4xL5vWbHJ/R0tXjJEImdElZ\
-            oxaZv1KxmUZ2r7IqXznLNxi8qdveyy8hAUU6rTWBcuTlREaE8fF2ahGekjjveymhI0+\
-            LJ0pcTE5+hvMZ9aw5Pi7vaibAKnajY8IFRngkK640K6AR8XszdNBA6JXqnLJsfJh/VL\
-            EbLOuajoyLxPi/6jqTya1yef14M87YIj7GOo8su3hyLJrSLRCdL5YPbZ7zDszkvxlrD\
-            kSntuiQi4NSjce60N/dBaRUIlcTzotCPFzTxL4LHku6pz4vHlA8UlODSUC/HpcILGwO\
-            JZ1M6/gTH4uUQVVcVcozWTZRzdRfFNPOZamPQVPmK57J6qJ8Xr29Timj4pkFDiS5Hwh\
-            zQrrSG94HND7SZ/mL8f2VXQjkhWfxMDGS1eKu8RCLcg4ARcI6ZMoKQdWoWT1dvYDXfG\
-            axOsZGWh/45xvRtLqnD2VgnusVnGF6tRRPXNyTbBZWQP/B5UVn0hjVq7fBK3UBrdwxd\
-            FnOmenb2TN6lLJqmDzxrxkj/LM6XGAUu89IprtUBjc61fl60CFtgHpf/ztmtwk0U6uX\
-            MTAvUaQk+bV10NqRFUy1lV4XUgbP4mTXSGUkIhxG1/O4LqEJueK9xaehpUdMz8Jztdu\
-            rAXXH1Zebt4hUuzhyvLQKehg0a5Ai3btEsvM2iJohAEtt6s3iXSzCJiDKL6jNlVxs+n\
-            Kf/xJo+H/o8SJ+QprqEFh6QRrrjLmZyWCaOWUR40SrvlTXTNCKj39wuqgDQIjolX4M0\
-            njAOqZeTwuLojiIuDyuY2Ac7HLCJfD+3i4YHGDjnAT1RDcgrG1ZIF9RGCY6bH9e30Io\
-            Kk8lTwC10ekOY1hXKkO4HJSRsIGTcy+YWOgmCxEJ5YbcSN2m5hc6AIHbcqgnmlQM2cW\
-            pBhzaQu9F2F4MtWfQEsJycGANPSy0BvbJlpyTg1KyFzl4w16JOJ/UtdNACiZ3VCjVGH\
-            JhXNqnLOWbRV99CZyiYKL3tHR6kZTleF0YdJLaiJ9dWSLyAucE6XkqhOWohs14O2bJM\
-            Hk2oyBQut4th686QabEtRxI+OKe4OYIHrm2ZoAW4g+Q/gEge928XM8+dAQ+DTNZRO10\
-            DqWc3yhQxZPG3odXIQ/eydnvg9MOCyPtQsdMjkSx/XS5GtlZ2VcqQCds7r6Rj80OCKz\
-            SwMiziMsFFlZILA3hjAJqSXwM8/i4zpSHy3o/Ia6pZbylX+IhcnmfLSM17I6qEC7vbR\
-            XdEkNs5+7rPvAw9pnkFErCD1D4oKuDLA5Ax/S3zZO+O6hfWT5CgcUGLUY43HDe7Xs58\
-            /Aa1qo2Kajm2U6awO5/VRo2KOoJNd/uYQ8hXbPpOMV8AqS+90prFz8TQL9C6/QYmTal\
-            MAg7a/d/g6iKnFHdD3eAx8xaWJVn0QEv3G6B/IQf0oYSkkjeshHqtlw3HBtZ4sxkvdJ\
-            2oeJvzXodVrqXsWK6t7TKnNmRikmGhgPplsQQmrBG9c2MKzcnLNau4r7KWo7c2t4tmv\
-            HBBUy5NTlv/1LeLDhJwK2mVF1y21rDjU0JPQPvechljhA2h56TKw4tkw7/F9aO336CR\
-            TRSz8oYrXfaGzQ+p2+RV/X9WYGg7dlBdpkzXh4wOK3e7mIINLmleULnxip3/QO+RFw2\
-            PT4Xk1qiSO6E428m8cGor3XQ1hKoxIVXDhI3dOxqhnx4J5Tza7OKlV84epkAtU2I+wb\
-            X0vxse1FZ+Xn1PWSY/Woiv/Rf6dggUXkB+DOZ41Rt8qISk6t8sG2Wc4I4LZl2ZDQ9oO\
-            yz6wJ5AFW+a/Y/vTNtScCq1wnK6uRMsvmShNptRymBvfmOtuWyte0LrvpFVH0TFNjya\
-            DHDvOx6qzAtuDBHSctGq9sQejYpVaVYxh3R8jG6GBBRtWBCajb5DhMkW2vsu713pw5w\
-            egopy+3C4WYxfcgY8ZhH/XrPzH1ne66aSHPGoiB5TaPvCdKGc6FXIneQNHjH4hth8kD\
-            KIK5ubRceHFHKrRLQ8JWq+GCQihe94kGNMZaqAD76AkwHVtx5uoNs7Ej0sdWTd45UyO\
-            jB9iOElGyu1lqzmLTYnhyUZpQXV7nw3xcUKPvOBPAUf7qBb/Yn5OokXrH1NyAmy6Fs4\
-            wFwn2PCRcfzWcr2cGOsSgRvZgXfIZ4Q+oCLCDaQtPiGENUG+ouqf5fizbyj45H2G9G0\
-            nxPCh0WAoApQVjpAY9w4dyNBt6hvG5AmCCnTQJccJlWL19AiuO+8wmSaunx/BJebImh\
-            Sb6CXDDXQZcIYJPdJXv3424PH6iCCCSNT30AVC6a3ZKCfZ8JANT1hN7l+Bbqq5LKULj\
-            osYxz7+otP2L8YTibQt12rMbILl1IrhtoEXq701O5nHROOsxpWy9XJooCUKtdA8Que3\
-            JljHho/jHXtUFqOGAIfHRdeNJZog0zwNsMSqxXXMhMzI0oYxkhsBXy/HpFyGO0nTgF4\
-            90aIUSGOoNyabbb3sy3QBma4FE0hUdWZS0P7i3j2hb5cn5gk9G1uN3Tlmq3uN1i0J9U\
-            6Ab6VLGdNrUJH5jia4qJQps0EWl45qgzWohXwPTul1YPV/D5ts81MmCXR8XoCaIobc4\
-            /qK109t15QZCFmevKNNZmfp1STn5ASurJ8N8EkoZCbyDlpHgYTGJdZxJ3NvRSMD/d6Q\
-            hHNijvbENIfq5tRKRfNCoFLHG2o2eyrg8fgHFFCvRRRt+AhN5mVctE9BhcxfsPZeyxB\
-            6Idn0TbrSN9Bqezods+ksMMibHS9Je7flCCyXyNPjnE4NlfAhkxmISMQQhk5QyzgbTR\
-            GofHRDSy53CUkl4tcOaGAELaPPvV1GK2wCfk1rnOABjygwgMmhtQQueOCFxTLzD+hr2\
-            vqE3hse/VJx+FXj9wiXmvuAhTSM6A+19eQbiKIh2Y5Ck+bLkf2hald9i2WVjeAPDRFl\
-            NrrHzKMPy+HQaTJqdR0r/KGB13CFBhcdyB+b40buMic1Me4gEZCA26DRXMjL3s00Nyl\
-            4/Bp0EUqmZ161nZa0nwPoaEMU5VVpuN4QY+Zj60n0oh/vEQn8h/rABx48LmRAoihBPo\
-            bjI+DXVHvSxxDEa4bLRMxyp4pSZrnjW3wRhKTVJLwNmKHgQL9q+s90Jzsb0y0ntPnDA\
-            dT7tlY0TTS8RE03G0gnefbvs8JryimkgfSR5xyCcQ8N+7NMJ4TGbrktzjOlcI0GFAUd\
-            e88ZY4xLAkO+ShbDFxIU+oUiJStwcRt0uH1Pqni078NpwPK3QMNT769B59llFJom5ga\
-            S8t6zhhMo3mCQXdYli/AQWYOOrOeYipsCz1u+Bl0qFzgZ3X/Q1chlSiEynOP6GfIuWw\
-            IRY/RwvxjS6w0siNEeZLQ3wGOkP0N2ehdAx40n/K8HUkLVZtJct0x2llhtFuMoktzmp\
-            Zc9egsnFiObguCpTRPqmzDD3mF7o17JuRIzGgONYV0uXRmj80wx2jNujA1kQvlnaHdb\
-            QtZcNESKYzCGyczzFs8ef7+Yb0DZaJwipPG9Z6dH8t4YstZfpk1p4zP5KttOc0fdyx1\
-            AV2GcH+/8SA+nXz/FN2BWJeDJK8XF/D0kO97bkM0CeTXg7NmdKIV/Td3H8BHSHQOxJX\
-            Trh/jxeJF4hvn5DMWVWC4kSB8Il6gbrEuD1HJ4//1KGR9cjAwalwd28V+zN/+V8iW+W\
-            QzV9cfLzLxshTVbtGzIEueC/qYsQnENejwQTMpr8/P9T9AtnEIrI/qcY4aOAx0ShSl6\
-            gqflDeRUgrFJa5pf62fofhzjHmcbuWEOnZkwISA+rgiKtf+D9IRXaKBzUlIhB9U1iAH\
-            GaM32kS6YvIkThub4DtcPzVMZUXl9vIixaOqEn8u5RYmy0LC8kXn9muCLJqF7nyFLTg\
-            p9ap5BQhsjxvb4tRdopPXBsjKPLqU/Qd9GqjxtS6qPPwZOELlK6FxAscn9OTbIB9n49\
-            U3chT8wQqkdNs7cBO5qIl3LfzgsZzuY+ZM52tkzJe8LdENZ4BlrUWU/KqQtASmx+wZS\
-            53TSbWLSmfmBkryWM4cOJLW1geuV2EiznfylhkdMeriB3Mk6Z2spQkyfbN2KF4U1nk0\
-            /s87icR+Ws8e9x46n45k6644I80NI2k1gE0q3ejm51jv2kUrVtYGsKwAekdz1cANdM7\
-            9592Ct9izXVjSV7Q188zEOAbCO09USO7tlOgtqjWbqHhYRYB/AwYMQ46MR1ZQ/C783A\
-            +cVWggezCC2yocqP5pMJxg9/1o3kCIVL2EMNZ0Qg+cJWmPP+GlXhjHpOlnXc9bvdPUa\
-            SHMIIU9xuYiaXvXWv1c2+M6is+4JOm+CzBA6MqTH4Qk6XUHYrvdVyYPccdQT5h4SZSD\
-            uUFUt0Sa4h0QYgkkPhMNdwjJxgZ6CrSeRr6v0RMbvLx8OdwkzF+L+zksi7puAmvql56\
-            5RMbPRKqiGs/iH3mfDD5QIjd8JsOJOMO5Q58zlZB3vGdmUiorwzoTky5lWqkNrWfw=\
-            \",\"xKUqoCdmzjATj+0UdZikwRykO4CRaVxovZtQR+QYfpyoYiKq5QdrMs3bvOAJW8\
-            YNZBnyDkwNFrwNzzlZITtt9y0xKxroCvstMrc2+OB4l/GuI4MWDdy0Vz5xiZ5eg5YDM\
-            NL1pGMwZEbwDkqneX1ObcsYdgglQTeT70h0m6WD0oZMfQNFSnjHdLKQJiiOx2C/ge4k\
-            3/JitkoyQNoNdGUI4xLu1ZvFrIhLVLmV2nYxUdgwS3CtzsO6gZRhC+B4/EgK474WUPS\
-            At1ip98FZk3kpeqeSbAwaSBH1lr0hr4bWz5Bc+Y7Vm5d9VlpbapnFEMzDnwSZ+/b5R+\
-            KkHAto5ptpKmjkGtS1LINP7jFE6wpIg/yWm+DouxaQLPwWVqlcOsODzIigB+ClOUrMO\
-            m6oRU9A1jQ4OeaPiOF4kspIHA2nMuLZfxgSKfhviWMCxqeMEMgoAC7FS+5EFdtrMjEf\
-            /4IWA92vvS1GmY0yynfcJIRffl5MWbtArXujwg9CHErrzBGVxbhqBpUB1yKVOUZDp99\
-            XQKZPb4FavfQq52h61bUgjgtHWssVYeElIGOldyhrSlvkKe8KHQwhZMqUWkwoSzNTxP\
-            LU2UoZgq4FpI98S7KqQCX8m9RNZQCl9AikhER4pyVpozQeeGQQM9LWiJFPL22QenCRF\
-            /3Qz13KjlXH98TEMtJH0nLGSAR5WpkTTDohvdNb+LHfnO3x4ORrAXn4v2cWKiWqvoC8\
-            kt4D07frGrRmfUudYhwTg3UxuR9GIyP/ExqgE3GSrgnhIW1cHkX1usP0U4flNNcEMGX\
-            d/J4oGBy5rjdBteRZSFwN3smc96FCq1tCitB31JZr7fYyW3BWJapeg37IYCGV5DpUdJ\
-            OkVj6GFMtyyQ1lxrkWqZqUGWrt2BjSDefOBHziuBvxc3PT2MTFYMSOITpHz2CSDZlAA\
-            Oyz07IjMqHHiieOjRG+kzmFBO/R3yLDsNxe6Ctx4TxxtEVswnb+JbFZI6/CnC0G0SCt\
-            +yOrkXuhLW8y8r5oXaYu4iP4mlwzAgoosIjWBRqjdlger2iBa9bINWi+/xa9lS5gTrO\
-            DZJHW5ZFEWg7cpL7zCZcVchszdFstE3eeGoz/nFgMhYdutgh8r8j9gbrxeemDZMMHqS\
-            sWxNljNYhukvv9ahY02fyXk+iZoAAgTl1pxdBLD+RKMBczz49rZLQa1Ke7r0UuWPxE1\
-            7Fon7D8/ucI3BAoQuh6UG5ZNajUPqcQQ/sRbJGpr16Ze8WjpTwcwPA6R8hqhHylYfUN\
-            JOa/hX2jYGNANaC34sbqfe9kwWLYqI4jERMHFBTf9gJ1/gOjPUKaXZBGTZoBCsXxuIC\
-            +thp/2Ti0oB4dY/Gw6ZsOLgPpz96CzrzAKL9d0LnRSxPcno1fSK1+CiiaygUh07bMOZ\
-            rK5gAasfrSMf81K6UdzT+1yh13eyLy0MNaQEEg5pPHahwH7Oy4E4NKpXi4PdR3kNqQw\
-            kdfQm05kYgSDJFO8q3xwXFFZOeBLhspvHydw5rheGDYU/j5LouAf6zpsQAqUcT6WIuP\
-            wgod5bW+g9K9nJVgNqo8LwG3goyXkB9iJt310p0IoKnbeKLOrOamkKh8/Qxp7o6VO4p\
-            NbR+UQRfCO+gyD4JlB+lszFKX8YJ3QWLeIw9rMNjxe/6xLaeCxsHF25cuJecWJMgkl9\
-            OHKkHzdUeODKKcKZJHgvgKHfBTSxqWw16nnFGhuD7pJRHnCigET2oBqVdtzz+SR/NyQ\
-            V1KfrcbKFR0ainTkZRQ+f+x3vcvCV1f34JSTGIxvVNZiL7dePBoMPlAakE7iYfvhrzU\
-            ruCntdcfmyqxmIRV5vpuOTsZm6Es8u4CziOeUkorvecl7UG0FpDJ4nWlxCUAHWFf/0C\
-            bvSmH9tG+fhgslEWYQ9egD9F1xSRkf18LKBDSUTA5lhBj/b1Mmdr/7z996ngp78zGfv\
-            rz3z9JU/yld966t4U8PXwR5mEr6u5f7pqHbf6ffwu5uvvnu/ZHlf/2pP76l//67fm31\
-            y//+/8Pf/tSFe3f+r9+1du/mofw/NurF0brv347e/6t2D//z79b8dsuPP/Pv3ePP++/\
-            PBzuftypnfr//kPv//e3h8/8t3/t72qr7sznf/v0j3/84x//LwAA//8jbIKly0wBAA==\
+          size: 17016
+          text: "[\"H4sIAAAAAAAA/6S9W3MjuZH4+136eUFK6u7/eh2xD/JI66B3yLHclG2dEycUKFSyCiQKq\
+            AFQvDn83U8UqkhdCGSC/X+YFqdn9COuicxEZuJfX0ru+Zc//uuLhdY46Y2V4Pp/16bs\
+            P/y///oiyy9//PLc/H1XfF205Z//6wBLc/zt4en7b/f//d9f/uOL5g18+eOXSvq6Kyb\
+            CNFPXGi9Xh9NPtnZGf/n3f6RRXxdPBOrH8PNXU0kKldsqD9oZu1JmhwHnXxe7TOAOCs\
+            Zbybxjrtyg0O+L6gpoq/ih4GLTYxnsedMqwPDP336jxtO1ttOiRinf51Qjf/z1h+diA\
+            +WCb1HU7Zyc4L8uH7jnvxpegkVZe3Lsfvx1+VewTjoP2v/CRY2O1tPXjNE6lJbjrcqB\
+            NNx5vHdPe3pX/d5xV0tdMQHadY7BvjWW4D4f5yTX1YxXoD1rrdkf0FZmLLAzzSuHsr7\
+            TLfOHPdq5A43oWrDMNdzVrLCmatHt+Y2ehF3XltwT25DcQO7glKmYhVJaEN7gc3hHN+\
+            szj1VGcV3ho0dKX8+VwSfxQHbVg7V8ZWzDqg2wTVdAL3qZUB29J+gGvsGNqRQwvnOsP\
+            hRWlkwo05Vs2+LnxpE8Ny6+o7L4dB1IoefB+X4jV/3/gbeOHN7VeDCwEqzc4riMlq0s\
+            UJJ4TksBv8I37i1NqPuGlF3TMq65OhzxNr3s5tRx7a0UG/wAfTrSFMek9mBXXABT9Kl\
+            Fa0u+8x4sW4PeSI3utvk3cjl0hTEeP/XIHdspU1XEEqCF99+5LkFx9Dx5oUXQtpQO1a\
+            le9uScbaXruJJHsIy3+AnwnRQHW6ME1wafJ3J0tubAiTF+OZCzveOuRFffDanEjsoro\
+            VZS3TmpwKMsIs4MctIDriulYQUQ2urTV1KmfVal8caRkqnHOWFl64luZo3aSGJKFpbb\
+            3jppWkUoGE87cpX+85c59AIPlyffyZn45y9/g8Z4oLXpW5J1NMpzZMkvjvMbZOPY/sR\
+            swQsltRQXf8EaKaxxYLdSYAtwsXzCrLABas0ahHenf8eFamh3uvNR4rnZSex+sXw+It\
+            s3inUgOit9Wuju5w9PX+PE3ztuYWo2tfdpGdn//i3++xKVjbOb9LbobUpr9lMuHFspA\
+            M8arikxObtJ79j3wE6yopMKlZczRN96Y3lp8HN69i29P8+YspHOSaOZMNpboxTY3uiv\
+            jdmwEhp8EL+lN9v5C7SojQUmlASNqgSzu7RK8EZzsghKJtEyxKVzZnXeNLwfReY81yW\
+            32KQsK2QXnJAFWAd2Q6yUb+ldegYpwHXoGXK2v0FMlXUUzhCv1RnmZAnOrdjdzd0N2x\
+            m7cbXBlJjlHLH5T1QB2luumCIca8s54uA4wxSXVhiLD9wNvcqEKYE13IuaCdNpzwpeV\
+            jj1Oz2not9clJE9+5oxaP1OlUVHCwBEi3iDOVmhtukM8SOcKCWseKc8452vj6xVHeEn\
+            nSHH9Btzy0qDqw4zxAA4c4zYgGUWKum8PeRIolta/vYtY94Y3Ls0u8vop/EafK+B8Ra\
+            RHDfzh9khbWOcaQfNGynYFqyXgivWmrKfFuMEV4RguqMlHOw9WM0V0+B7IcDaztUodi\
+            ky5MCKb4AJ07RKci2AmRYsp7bKXQ5XCXPSRnrlFp+tG3p8PygErN2gvq3ZVxpYGVbZV\
+            rBe37kltAJyLQV3W8mkLmFPyHxEV3yjbfsFxPtDjegmuV9qUA0TNbe4uTJDXDIfUFkr\
+            5JY+13qYB4fJg6VATOATRza8AtZaWIEX+I54qDIOb6lXuMt/lrGtAiQI5X7t4zR63KX\
+            z0jCxJZUJcrBGJ1POQYG4ws60Tkt/t5bUeNGLIZCGBU8ISrKLmz+4jKGiB73nnAeelr\
+            a9VMxjso7oJOI4eA8yW7CKH1jb60uEtUCPGlgNvcgRlBKNXEacYV0BTAU3KTFi5BJ7h\
+            2KD5UUsWnoOugJGYH+m6jIY+Mrg58kdvYb/tyv6QfTgXn+MB9/rjxaE5Eo6//rDd+Xh\
+            9c+dLCn7ghyUswpglBSHXEuDxm5LWq+6oc9C08u9O/x8oDtpWtCuliuP66I386XIsKL\
+            eaKArxo1jomRrQ6olV4AtKODE1r7Jamk4X9nbwY2vF3o/GueIWc0wsVvuew10pQ7MAh\
+            d4o450o9qNcP9JKDfkUmutacDX0DnWBH8nrTQtRYZx1lrjTdGtCOWEHrTO1YzQch42d\
+            3SDLJQ194y3rfODY7yTqmQlrKSWtD16pPXEcfmezTViHdO8mgvHTOHAbnkhVW8HWHCm\
+            s5h79ma+rHb0rrO15y0LMUz43qAH1uyZkCxokcSqoVtl9sIrJrXzPPjzMk6srzTWCa4\
+            1cZTe0mM2Dj3r0Mue2S29VE4fCA459qcPDDQaRjRDrrEuWMYJrIPLKsPH6zy3vYLQn7\
+            IrZXaU5USOvedSYQ6G+wx3ioeNN1qUTHDPKX3lGz1ip84RhhzJOfAm3bdBYyRXwpEjH\
+            s3F8XGfXpRdC7Z23bi8K8tbTBlePiPS/6DFqnPS6OlKDZfyGarV8mmXHCNfm66qPWu4\
+            qKWGKd85Nt5Qsd8743lWENcSCRv8/A1/6qxFprTXltJ2ymfYL6aEv4G3wP2PDSjwqCx\
+            bIteJn8nC6JWsOjsE7AgLJWgvOaqlLJ/SqyDC15Rz4Wmf3HMXOGs07Ft0kp7ScQifca\
+            XlAh/Kp112V4OnjbXWFMQyTfswL5BSB2dgA87xSqJhZP2s53Ir0Q7LPnPVZ49BBRp65\
+            a83i8c7NGLH5i7UyrCV4hU+svnrvjKMcJcskfCIS5ouO4kv8nSoQKRtvU5+i1luSyRO\
+            Ncbr1WhaI0eiCD9Da9NAYWHHWsrYWj7tkpL+gup9y3jZ4FdhT2lv5AWwqwzzNTTQW6+\
+            lEfh63GdPktQelJLrYWiVRO9TejGSOwTSmT98/8NXYkPm7vSN4ITszR7KjZVeEudCtg\
+            QaXBOvVKBzP9W5yLbmhZWCcIkv5+k7ngtixtLOHr4BxoQpQXHU3bF8Sju2E9Q89Sh71\
+            YzU0xonJujKtq75Fpe7++y9MhJ7TQ4sdeheCd26fqqIabpq8qUmjq9dtkh/524R3JZS\
+            82DWZ+qwP/EtTae8bBXswTInSxBY/Fg4nbKHO8PDM08H70ZwW1mCZZVAYzOQ+MIL5IG\
+            J8LGi44z7hZbd1IOvjWaZcgsJiU6Aj7LdEAdp2k3/mWmJEOJevOR2/OThIr0ySyR28z\
+            PUEcGa/amZ21nXGj9El9uuDfFReTsre0k5z63idsMqLIhriSRefCYO4ipPG5mTwrAfg\
+            BAZp1nJXV0YbkvmuVQ7qUvWGucrC27wPzMNe79OS7bD/FilYw0/fKH2xnLcTdvTSLn7\
+            ntZJllakD4uHx/TdQpw2Rvog0PlRkLbYJ2gNKi2uDvPjJu15SwMRA2KxfCQ1vwiRrWT\
+            a2dhPDaljDNBWssboDaDO7Q2pTg6wHTjTAIOmgJJxXbIStqCQ0LzQ0Cx2AZ6zIdDp7W\
+            9RLimwBq6sxs1DxHEu5+kbnA/AgxGsls6byvKGmKIcoCg1484BEqzSw9JxYh9gpmk63\
+            Wso1L3mEongfk/8xejtvSPkRN6eEe6VaNXiOCOt7QHVOW/Gu0JW1azlFTh8isOaoTSy\
+            D3CXQUzfQrwnlqUiuh4kT9aWLqFV5sDeOX/ZEHaItpN0gY7ssJ/B4jfQ4WigDswTkA7\
+            gHZZ3zjg+SN4YnY6dHtZi1owY4Sbv/qL/H4iJzpocI7oGtB9ivQd3yBo2B4XcFyyO9+\
+            lYi/fwQe7uoGi52ORItb7dpMs3oId15A0zLWgsOSocuZT2FZDhFAsZqQQsp30B5szK7\
+            zgScx3WZV7jjPNQsnc7vUb04155SccLvOeq8yEGSJ7roFrltFP3qqY3G9BDaN1ggJOV\
+            EcLpkzWwwxe4kMrWOV5BRtWFJXK/9Z7d\",\"gl0Z2wTHet2lYwKDfMoa3iGIj7XcIg\
+            k/g3TK6XxrYSthl6dy9Aps1pC27rWRlQ0igDzwlk95CmxLnZ1Dr3NQv3dSbMJ9L0HL6\
+            q0F58PqwdIMhwV/LY52tg36ZY5iZCXiXxwMp5wl7bh1TJjtHXOy6RTqSgjUrF3uADY7\
+            UIo+dUnvduD9+O1/7onDLGfMXLjHYIX0DXZZ3avOWXPgPPCmlS2Mwbhs+P9QSZOOZ0H\
+            J1JXTPE/XuuA6rsCtjBW4AyRPib2kK45cmww7PGege7ueXa3hkBewgb0cPv+gzLN01O\
+            SHlr59phd/nv/gM5JZwMKPB+UzZzG8H8vxf0ESPwdz48oxeO3F3ytv5ev29nVwLqIHU\
+            jqDITUizlvgjUKuUIeGZy2zdw33SETMMMR5LbXAyxAjgy8F0vc74BpVKCM2IWyusP2x\
+            9+q8sbyCV67L115BIcYha2GcvmaolhKKd3gsET3o5XlDfELXXUF6RPK8OGckKiOHQb6\
+            qiWbj+WvQIQlq1ko4US2UIdj4uokjb7Y+fonjKyKOaoBeNR4ZZ0WgZp0Vb9QhmEojIU\
+            /DKF+1Fpw2u5XiGwhDG8ZYGO26pqXCOTd5SucnG0aiB+jDJp318gHqRg8QfSu7WD7nu\
+            ePOTLxsxnKe5xv37vXsk3tdu1dKSybjdE6NDEcbEtg6CIQ8GDBebnszrWS+88ZKjrkr\
+            Mm7e3rhti0aSbvLM4IDq186wjK6wgsnr0TN/9AUMV2V5pgd5s3mGl1+ZG2pWYeV4hjn\
+            LHdvyK+u8JExCMiJoUOp+PLIHaAz7UycVVQsrU+lwwFadLnlwhylHr6xBxGYJEwfMeW\
+            hZcQg/0RWWqcu4j36WLShP+0IGrTSvya+wBXvY1WDhlc4KGGRBzlJY/mCP+xasBE2cN\
+            Omo7SRvZSxl1ef1nknP2q5QSPmXYTAzhepZUe6PKt+Q7vXFw2M6je8D+9BCacTJJPNG\
+            sMqajvBeZ0mxzoHN8OKkM03ew4YKX+NdHHpWLZZPyMxLriujzHTFnSeqYmEGmLFbrko\
+            3VVJ3yMXl4uH5Lg6wXKoaeNmfGFPewp5ZELJFtsh+sRbppHff2UKaaWG5gMNkK9O2b3\
+            DCpSfw0IKCLaip4N4xWK0AywRboLGxZ9bK4dmCaVWzK8BOubQKj7B8eEwbtQNCl9bIM\
+            qv61mPaOzuwLBe1xhHp9IwRIbiWeNbYY/owHxngSjT1/D6dYDcSpPPG4yUTETfwCPFU\
+            R9J31wPBua4BZo0KxYyIMSFQ3qLli5A8nAHga9C8tHKLqwWPaZU9cO47bx6kaw2eL3q\
+            fdvgFTMF7zQecrDRZseUxfQtwZu0AXzDp66kRcQDXcOSQ7NuRli4DpFtZPCcpHUMxAq\
+            Qqe7NFV0ClSaXd5QEluKiBlZKY66TYHSElqoyEeU5KyYD4ZUCwB2KO79MR2u+bwmSJZ\
+            mw9pt2VHzBrvuUZVX0e04EGlzhH57I/pnWCDzxiNT+m72BOmK10RKGTtONqZDgHHj9P\
+            7tM3yCOjc1wROXZp43Zg1Nwq7jmei5p2mQ0QoprrY9peGX9fhirjivtQThl0JTWAxRO\
+            M+s2Bz5PRorMWtDiEQNmCq956xwo6LQWx4YRxeJ27x/Sl0QCwXYOvvrQ/cQAcCmPRcX\
+            kkju8StOSqtwpLPDv8MV0rawAZxymRMUubZyOjK+htjS6fUGDLlAUT1jgX8tSNPtVNx\
+            duGbzCQVe2Zt9h10yBc0RlbyYJQCtI3IAFQgVk7o+9qLAvn4T6tUQfKhL5HnKfjn4aG\
+            qM6DZqi5u18cX3DthFVmyr1p0Bqnx5d01aIzJNSL3LcWO/1Ce9Bu9ajT0UAfWlW6Dss\
+            Ztkq73YeeYVsiEEIaLA5BVa4eUhKEdBXBM8G49N1HQJBztFK8MluwFitvM7SGGlakdH\
+            wYEHKSK8NqUEjE8ICh2lEZBRzfAGknyhsEL880UMgeoVWDegZutwTGLi2chjmmBqQOx\
+            aGMTptgw6qneiNF9w1JQBhmh+rOhq82pPI5tIfqV8PbEvCsq8Vxnr6zPXMwJ8Swl0lE\
+            p7wE/H2Jx7SXcZDeVFbw4ogU6z61REvFd4i+N8wSJRZCXgimOgwrj5psyz0o2SCdGo4\
+            jiuO4UniXcL2wZ3iaQS5esszWI74BppWZ9D8nhIpY4adHLym3YD3sGUc3NVI97NQltI\
+            JHr8QTi/Z3VQFqnTwSvpDK8hXXPCQOMYzVq/+ERXpieWhag+tBfcvSd6knWltPKsLkx\
+            scH1wkf03eQ42/jGV8Pj+lA4ROAyJ99eEzf/50R+JpPx5ecAC1ufxLenABg2ngojEFC\
+            aoJrlECBbcBL8SpEuMMQNcfLaT6mMwQG4KmugebaOGFawmVADNWhNb4GJx2rulWn0xp\
+            46CsuJOqD81buqRWUzjQIFGkcc5q3rjY+pNoxQRTLQ/IAAnHNgXga4J7wzA0EqiAWsb\
+            t7k405UUPD2UoqoublI+HsGdQa+gEepCLSwLF8g8vTe1xRC3Uyh3KWxB0C3o4zhZ0jP\
+            wgeOmXveKBrrgU0oPHKxve4HfYeGdYlWQD4HlfY3wN3UDhJXCfhxtVUyaKtO4/UDxuO\
+            ILRJSmrPRA1YJGFYnbhcUabyloiASl+LDohOAHE5lo76CYSGa7ky+EMej+mr85FhG24\
+            JdybhNurVfaNwoZgOPBsRXmIVCB5m6QCYAdDbC6VsQDtpNFevnVWgiQoSDzNqhDtvrO\
+            alafC5fkwHYAdO1lmG5BJ9hDCiEupjOu4ggBaP978SOhA61hqKTnFKj0sHwo0QKIkLV\
+            eJ6S0NnTWvw5Z9OxByGolPqHrPuggmCT67ZFB3hMMUNoVA6V1lCr7gnbtt7iAcFDXh7\
+            oFnoCvnMYuODHwQTH6YPTEqJvicuR40t0HpfD4+E0tTyhnXOofXCH9MBMgMDlMFLAT4\
+            8Eh7mFqwwmo+xi4RVgI5vC547bywS0RJewsCbUxsNumsKvJxPr3XhHGm5rvEZxp3U09\
+            aC84SmjW+r4HPpjRLUAiYOyLZrW/DsZJbgZxR+yLUHtpLhbYw10PVw05UcTjBlzKa3y\
+            ZmXDZiOeNaCUIzaQwMVJ8JKZulkoAD561D45scQ03rftkoKTvX0MV3DIEB/78Ae6CdA\
+            7glPEaXk4C7s6ZhXLam6qg/3REjTAKqUKbhiNWl/p6tFvaNtJb4yHwlj4kQhbkdxNfA\
+            MYVQmXL/30Sn/G5SPv/4vMcoEoTEeftTdaqXgB51a8JhO9Bx4sz8Rfkr8RLWyBMdO0X\
+            XE25uPhKE2wIIjgQIRizqAhnATskn4CgqksfAVxSJiDqzUVWtays9COFJPFNyp8ZjOh\
+            x/mff/Ln34ZnojDz0NiOe5HyJ8onZfYGPsHUy05Hg5BBKe5viWHHNcKccHuYKuRCOhh\
+            pvGmyEpzFZYyMboEJpw3vfZDeBiIkaEfYXy4JzZCXmWx/tDDx9Zz67uWWeDOaGaBLH/\
+            WI4nehUw5z1vskbfBWCfadlBEKOuM2FauK5RsILP2Xm8K4ridXHnGC+dtfwYJxR1+qh\
+            IL4UfP+8WU8AMPFHsklLShXcI0pP+AGPGRc47vwrctLkO8wG+oHgmVw4uaaw24PMRve\
+            M8MWsbnYcg7GcICP4M04TF6JDSXM4hI076ZL5FnzQcUWMtDfOBbTc2QSRwqJ7VcAH4h\
+            F6738PXZGw5u1ZAXe/fUdFoA5mR4KQCb0flxQxyU70nOW6Jka28CEg3rxCYUDuWFsSz\
+            kYDtCzU2/MTAgDy2UzMLvXbi7oYN+iUj6/g+uiFtwIqp1uHsOxZrCO/EZoefougg8JQ\
+            UVrj0j3ACBo4n77HtiwAOk5QdmYQU2RK1h2ZLDcNHdaw0QDiR63oY364OBSngh0fY8F\
+            2B/9KqQ7wgFJv1A9QD609JsQP8JLw4sCNds9z/G7rglEj5n6RJiA0ULHiqkwl4AmS/+\
+            SFyfdX+DwZmAKwr3hBW/BWWEtLzFODdzMgJ8rPZa8CMoVjg84oOYtJFFnITEaO+38kg\
+            +A4UUBgmQI9dHWSCLZ4/Wru30Ru+MPv2cCKRKyfzhKd2YbXikujS+hO34L+luLZZPaS\
+            3h79L6zv3Ki6kTXHE8bWqxfEr7sLfSw9qFHyghHVCzdaKerhTse+mMayyH+cPLTRTyD\
+            yj+bLg//cS2+Us6reNQbDprNnJaGbaDgrftmG6C8ZBSXUcuNp0tQE+5amu+5dqjr4gt\
+            lk/pS5Uj+IJL77rpL6ZpLTg09WSxRopaHKVSZjdVXSM1l5hs7THJmRsxR4nUmBzWYbJ\
+            P0vT/YMMbSdlTfPhtrmC/4aoEKxvppsN/YYDOVuTi94Qb3kAO0eRsLBuKH6jLSJrmJ9\
+            jwYzL+B7yns8uRPtHKQoFzUldjJ1HMpcsuhWGIGnO3WD7dxil1KaEBOxXAjA41uHtVE\
+            rzAaleun/c4baz4sO2UBssLBUyZ6tualdKC8EQliPXT3f8VHXuEuad/+zm61HmtfyZG\
+            2m0OO66Cxo4KyLvF8vlAoBquevsyxLL0QAutcdIbRFfrscTseakPV1L7cf2KU7uy5R7\
+            Kn5627wS+LVE8NWu7n8RnLYvjb8v7S6vw9CW9EaxP29jYio0fpXMdsK//dXPzh2+ElE\
+            gJm5NsGB7Pa431vSHcoReoEWPlE65Xwqbj6/xope1IpOsn1KnazNSNzyifP4wOQZR/f\
+            5kd+olvbDUdcztlZlxaTyXGM1CrKuyQW/wcuFAoYiilzHCJiI/mpUkbg7WSOFXuL7PD\
+            o5yWNaYEq+WRuuBc3l/mKeQg2d3NHTp+kYChGNcdtGAWvDWuBeEl/iT8MhLuEqO+Ux5\
+            qUPieufQepYlb0zq2vb1jtzd433OYBQ8lbSvIyoJfRq4rYlBliqwHnyLGaAQnJBPl+T\
+            hBqqT0xMubsyQRJ0XCb+Mkb7nUfcuckiXR38vA9xgTDTFYRnIIohDTleP6w8V1ztYLt\
+            JXiFl5z3pmJxPTEoKYEoWRDvIoTcTPhMGa7wgikbv4gcbJaqFeyYrwrpWdonEwwT7JG\
+            0mjPpQab83r2cpbZd7MpjNmwDJPgMmSQBjLbEa9KLyMpHTGuhX5+HG77Bgmb0+2Q3F1\
+            Ys3NgT/IBX0lZjXRDyXACdn9ZVCcGC8XxwLrS+H40W1Oyt9sJ8inxSAUU7EvYm8JGHD\
+            c5w0sdg1kDUHItQVEP2/f6bUaTes2R/d6Fp+TQpl3eHcdoAnc3XN4+xSDDW0uvW646e\
+            F3hL6TdX17GRJHjYyKTt/+Oi/CsiYDtkLTQWrNGS3H9tpxl6Q6ldMJ01gEzjZah/B8t\
+            gCKlVKLoLVjXq/FSCxUe2iZU0gypNrz2woaiP9SCjNwRp5FlL8hl0QWltLUdJSwvA3M\
+            i7IfAXknc53h/Wa4s3k7HXA3YcypBs8jp80FxXVm5WslQlHa0t+gBzWlof4a3Dk6CjF\
+            apIlGgMawuWdefEuTLvZGEB4x3lfKX19KsVKVlJEAjRtu3vG+qHrT7klHLKRJIFMdac\
+            C7nyZN70rvQA8lVflnwJUFhjbQWl8KRm7QYrNMhBJmroY4lG3w4xJGYc2RU+Dvckei0\
+            OIQjyeWD3pzXGK4Ow6U4IbPyaecXGSmHRHZHh2cj8TMrZ+NmHFCXN1xJDuM7x96ehcH\
+            lSs6ROn4cjqigHeLCL3eKg1KIW5WX2SAYanhudzQMWMHFBo0=\",\"c+xbmt99ITMsj\
+            kgAHUo8oGXR+nP0igaaEhzXZWH2dHzLMhK+j6Gb1jhgG1xIRLJ/0swSLJcKytdz6Au+\
+            qrJsuTPbyQo9USOB3xSOcStqucXf0spy3p6xQaXuT1VqZCNJ3AgXr7LYG4nXwU49xyf\
+            oMvYiTQXFnZfCQU9mxNkTKQ54BZnWAbO8c1G81CXsCYlwmcqYpL9CY9aEm+2aQdZbaY\
+            0O68sbo6jde41EWEGIemIrxSvGFeDnTCT6GkHLquFjxW68vTmq6wlqqjEMEz8QrlgKK\
+            4NGKy9nVwjvV0r9yjIoxo/Udsq613hjsdr7ls507GVf/uBlbcyrgEaprkFvXAdkvugb\
+            kbarKihfeclbwsM8u0w8RehEvcZ+/VwxT5ZYQJf1PtMwqZ2satzUm10GlCFAE56qco6\
+            e83SQyQV241HlKZI6mW5hr38QyuJl+CWG8x5sYwg=\",\"/+Jl5XAECd5K4bKe1I/Um\
+            kLARmx6XZR+yWc5u0zdTXNNo2XRucFuINp7WfkI4VpRg/MWDSq9mcfCJjFo9eY1ao2S\
+            4pDlk7ys2ZD+jpajDzsHTeeKBdFShlikzjRBow3aSAY5wgRAJdz9ZeoTArMHVhyg6PA\
+            LkCyH3gnZNei7krNrVlB7qIJ/jFnqriu/z7+jzbvPcoiPH21psCpaveqT3y7qMY8hWj\
+            B/Iqzp8Cun2WWlFoRGm+nXCN7RnTB61YUCjqdPLq8SPA4UaNk1GQpW5BEQjBukuZsOx\
+            mvmrc3ssuIY8hWU6z5ShQ6hbcCLOkPvjxQLRKiKi81ov+LJj8vIcyIIV8tQYILUZ64a\
+            0C2aNrWMVPhJw3r9Q2o0/3kZKSiDAsfENr5zzJaO8c4a/GXeWZaL/PwF+FjOsi7U3sG\
+            oBLllJA8tTUQz0peRSgRp1Jg7Ans/FL7ClcQrNtEOCoaVWh5ufPIbOvJODabGc5Z1m3\
+            RiG7upjUWLKC7vs+JXxo9HAxuf45S5zxUhrOFShUREQnjMyKjQMxEaY+mbyZesO68sM\
+            /qybH+MpBi/vT2gp0MkIS5OasH2goLjeYjLSKGmOM9xQnTnXbMYxXV1cmayo6TsvXym\
+            UJLVoFoidvg+K87gxLSHFlfGI7W7ojjWyAbQt7SWkTfKYqh3NYozrtLyDHDL2/r3fo7\
+            D1QV+/mVNc7gYFUZvwbqMCOQ8d5g1O1/nWIR5AssZcXdz+3+IG+GMxVKDNZtOohXR+m\
+            M4B+UbxVrZgpIacqJmLp+AiVG7yrAWnDO4LhIpFhGhyUp1hHmV0SapV6rblwUbAv4b4\
+            q4s8kpSFBoCtY1lAx4PlMhRZdYry95CMzP8KPdZCuK6Zl07PB0/JiQQl3o5TGn5mNxR\
+            gQbcOTM47zOGdO1EzVdjHCUrFNeb4JUhVmWGkFh37SGUPaBXeZbPa+TVXTGE4GQEUea\
+            sqXeleMe/LQF92GkZKeAZ4SpeULdBWfb7wKGqZgzqccYoKtiCZWtTuOEpVCLWKGOelS\
+            wq6bHnOZf3Wea6kkVbvVI1A5aRcp9RmADt8EzQWZay1SunHWXYZjkpe02Xuca3ry0RU\
+            x4p6hvl2Q14qavXxmhfq8OrBQV4zfRlpKJODA22giHKDT9Acya2aXiLr48sAdBoU9te\
+            8W2k6026jKuOyzpdMW4IaQkypbWmAV9DR+gzOYJFd9aLmpQmsywD+YpI21mW3D8DVYk\
+            WPVrOstK+xpsI4rIts11F53L6mc7jTvJyMhqyPOamBc2k9mC3EnYslLwh1eAsV1BPdq\
+            4OVxnU9cN91lWecWyUhkN9d6L/l0WuIsyxdUO2ke0KPCLxskRHGklniURefYjirJdcM\
+            aGMBnIX3mfZyTnHU6QiUYyk0Pppy8jLjRHKX60pO9xYipQ8jzXnLPfYWAyPNbKiVcy8\
+            voZn7Ad9LSfCK/LAQ5zquqIAvNTHfZaotgWT7UEXpUTe6xuuvjJWyXgIEy9RLyNPJad\
+            hLXnPnTMTp5aNxQpGW5sIbc6RsmcwtXdnWe6ZE456BGsZKbMVw1XOCEY5AyLvlMRYvQ\
+            X62lqzCl7LV+c5MYBZSVdj6uI5/2G8J8eVphzdq5fNrOEV8sTmEGefwXK8ITWurDA0J\
+            yyADu/85MiDrPS9dwUAdpTbLFJlOUaUHlwLULK16ayGA8HMkTROm12rzG54OkApooRT\
+            3/mspp6wjRTo8/U9L2cwP/DYkA/bWTKhf5Ylhvo902UnLWYlZI3IlhA/8yx/qfPQ5mi\
+            KWeeU5xsw+LESeXc/DWJcO1kQ2TxZngUPotZScMV2VlI5tJG3oKLI0wUmncRwnxXNHK\
+            v1SZoGkWdFomjnX4Upwew0dauQZWsMb5ZtQZas8ES2WTZvDIem3V2zLM9kYFar5q1mJ\
+            O4xzmaOysTZu+1Y53ghyZTdrDiR8A0WhpcWe9l5dZB45Mmo1Pd4y7VbDd4A6i4i8jhC\
+            CnuEsyRlQjL8YiLLxxXD/icR/JYzCKfcxpxSHpFCxFEkKGVYa3ZgGREEmnXl8axPmcJ\
+            443LO5G7PLAwridgLGT3dgpWrQ4YRm+WaCn00mvG2HS4nWiKi+T6rUMt7bGY1jsjrrP\
+            ngnMockdK0sS+QruOKWQhuF9I+uM+yXrauPJWNyrxaySrPseOH1kjtM87CyCtwMSAUs\
+            oSQy8vcAX2yc3mftY12FdOw74W3NL0OMNZX4qWh6tIuIw+IRb7gyFtWcBdOBMKQS9JM\
+            ueL+BMXPq3ukUeHO2teSV0a41bSExnyuGhYcyumJupkvRdqa2xjtPNde6klvGprt12l\
+            4PySo0GOsYE7mdKQi++krGm43badLx8Vm6k1pQgYm6DIjGzHyqtQJq3l12I5q1Xmcg2\
+            dPcy+3wEw77Il8QyDyombq20xLO/IjTxhROBYegcS4/XSmz1nTggbu4CcnMR2VZ6G1/\
+            Aj6vKTxS6r7dNiT401ZgNjUvJm+zxYjam9l8cgZSV+COvD1OB9ChgeyVX8GkCUI0pUN\
+            XCOq/rzXeUM2S8fzHdef1zlOil4h9+Jy23epEu3EVZMStlNnOisgRNpMuS4t4A8mfJ2\
+            vxbs6xmvsXaDFsvpkaTZ8C3rK5WQjQU/Ht4XGvapk4V7vJrfYa+DL+ScHCAlE3xaffY\
+            /Shied9hNr+lVvTBOSnKUaNGsx1KEluLFuZ3HpulCLtfiU8nvi+/4f7Bc/Rxacf1HZ4\
+            U/0lz8lLY6/bFqulORawPvP2PCIfbT5tnLf1uMPrB2z79F2uKb/h/jFWO+HXxzfdMEP\
+            0X1svRRSl9M133Dr+WTfqEn/F4y3aF3y5wTqOOFPnYdJocuP/zapLEefV10cn25j/UO\
+            YaEZk4EWWcYqXUTY3MH+LzH2a6YzCnKyL9ecHUaJAsqufL7M/UWjC+vMt8UgwnRYHwZ\
+            1XMC1Ea82WrcvN7Xd0o93Exl1UShbDn8QvRwb43S8H+Y5YNL3UjiLqCbQrNQll96eFM\
+            qYd1SpCagdgZHQ/AV2Lb/tqH5uij5Dw50qGIhd9q+4mt0gp4cX66Zbu6Wfm1wlWx3Rx\
+            fIpPAMXE6sI+bA4xaUEy07ErN/OLZ/YzmdhEr+e3MclOMRGP0mK9OfzMcP4BFRnfr2m\
+            lsRCWErr5M3bMBREfyYwtcyaGeI4VF5itHjZQ/oRbWCkQPnMT5Tf1HTdjI/0sl9pMMf\
+            Gaw6U21M9yqU31k+NAbayfxFKbKx/b67obmbfKPt0a53LpVXbFrH3kUqvsZ9uLr7Ko7\
+            p/FTa+ynnt3xXL4yEXnbXaNIPvARVdvFTUCcrD46j0msL8bNxFc3d7o6fCDUPDXL6nx\
+            7EnKVAUXm+n4c3jeEot0CLy49I7y0GdTQzfTMAvK8PLbenr6gG2f6nv05Ov7szNWle7\
+            9Z0xHfPkWVXrNZLwxmwyeQjf9eIOGPxO5WL98i27vN6wyVSV1NQ3PW9wxEI4pfjAdak\
+            eLqONAmMnK3U1X7i5LazgmNNpLCurEeLmJCoRPFOyEOX7O1jkhmgkvS19LNxkrjExPr\
+            9aOmj9OPca7R1KD4x3zAj3HZWBPVrLgBZ+WtpNoisDzLmaHvkesuPNrh3mLF8enb9F9\
+            9I7SQrPGFujx5Yg05NDp6fDj/KQ3tbd7YGrY48BNg23MY2p9JXmWo3Exzzu8fRNTtm7\
+            a/xFoXYmEoIQZiO7vN5pzpxb2OKww1818KaJWfMA1/Gg037np8IltpAYnXcYNBjLFKW\
+            gbAmSxyIDF+vPVUxS7e3sMnvHOm/5MxL2Lx+evyX0b5xadxjxTYVgzRuA9Mtzi7LjHb\
+            rbDCFzXUnTvDO28DlgeNG8Mlj8bWkmvqfdQEOix8fLtynmvVIeKU0RixIHjKsU6/XxI\
+            7ssEE5NCvy0RKRTnoZGUYVKua581nYfvqKH2dHflcnQU7rp1434nuhxV1RAeFiC8WM/\
+            iGukFT/GmKPmAxQ+vMM3kEI6aGxc1jFDVuaA9EJJ4sZ7v6FW5bsC13FOq5W8PL7fJ+R\
+            lueiYhzGPC203LrQM75e0mvFd9xN/hfblNrs0P4BBYM6Vzfx9e4m7OJLAX58TrMT0zN\
+            VMRJnV5EXhZo/meh9tggZkzkFP6Of9Z3My5aB3sPVjN1USYJrjllJLr6ekDtfwf4ldb\
+            yNcYW7E1+MJyqd20w2thPLykj+EP45FzlRNoOY2dunKDl958mKclk224LqSqYAqtUUp\
+            w/zpc795MvlFO1GP1LTmcPljcXE+GuW+43UzfPqJ+s/Tx2/n6Zgi7WO8wOXQUabthYO\
+            w2jlmHGg5Pu6So7LxphoAoC6F69nQrSzDMgjC2DHYWbkM87ZKijWSvO42nj8+/JWc7D\
+            45cnoUTJNX0Y2dhGv7MOYdSkuMdRZagPRHK+RK/DvpEOiWvFcqgAeIvcZ84QmMFrkUH\
+            ZsaInZi0rHyJX1+aZlIAFzVvYQq6a8By3zWke2OTVNQiNNZwYQ0RRrJfHOdJbbKAzvn\
+            puu8l1+ixGtwmqaaZTpfcHqa1rGrW21yAlx8O2l4CJri1xg/+rmndtmj4ZHrwP2DCPm\
+            I55fUXx+p76tT4gGytEXgRsMUyLTvfoyaW69I08gjlGAwzvfgbOs3l4SUahRO+rO46x\
+            +XU9ctHgXOUq25ZfU3tkSgL1euraBhKnOXW7pY85j4XRn4HVMCta63U1SRonl4KNx3q\
+            u6DnU/wSpyeaktdcwdl3d6o9TKk2831KcgnTCO78VLbfBkxWr9cvd8mVPtZ30r6BUvJ\
+            pKZ3tWiI0OuHIDrhO1AV3MLqgp30bGf4geuJ6IkYbTRjCifQw3yWJ1ujOy16PtUaz8B\
+            F1wMVvpkwzKXmja67LwzT8yTr7FgZJWOcpEVFyz0tT1b8P/SxNFRJPcwJ/X+I3fh+gQ\
+            2VQcOQ9QJVUOnqY83w/4c5bPg1/9uYv6v9Peh1TtPEdXPwESM3wGSq4c71yzafnT6y0\
+            cpuj0h1SojeHDntvOXpKPCUPwxx+w9uWCHp8Seq75y8wzk0LYzYbgDYMCa6qBGZCFKe\
+            YVCnewKQG4jOz3xHEfeLx8wOwKWxvHhPpJYv1JmkYf4CVrujUZkiIoRq43iTNwThTry\
+            Tqhv6cwofzMHHcs1JHboxFqRahr1e0DU/O6HF35N58h+ss4pgJfb1ibnfGblbK7KjZf\
+            U4eaB+og5DPkkjr6pA1Ke+RvZh4i5bGDvSAzxmHCN522suGaHvWAngPDwVY6Ep9Yaiv\
+            HRdX8xJKVnXUbfiOPAV79FD6sGQKyopsa84gjxH54QkBgfkVQxNzFlrbKcctK6xBywI\
+            FXs5ofuBlnRxZHR+xg7IzPOZJBo7kyb1PZJJ5xaCOTGNlhVcJX6xfkneQUTA1rMfP2T\
+            k47/TkZc7hecVsvWFlyIzDshl6dtaeGtnSkJra54rFJHDDVxven6gaRL/IOG7rLNbzp\
+            E8q9g3rxjGOVfMPy+CKJjfgef/3BPGKhdBas8fSDnrcFQsgJNLzsAaYMMaWUuOZteEI\
+            zxiBiZNNp3hvp03fPmaIm03SO5SB/yR9GRHV0n9ZxtjjX5ahJyed/h+mpFeeGiNQF9W\
+            6Sl4enVnOc1txD9PTB8rGq2gdOcokE4mOvy2f6C0eZ1PbpqIV0wTYiA6vdRzgP9fqsY\
+            43yqZV4BQbc4gG8M812qKJpAH8U2uOyBleLDdJx1YpV6tWddU=\",\"pOys5Ho6/DjV\
+            Y8KZyXWRYqKHVA9MDWsciBpoy83X5PTHcW7nJwYPKE0rkifkcIs8rYxpWizQaLmJ53e\
+            8Z7nWeAXOTU8fCId/z6TaF2UOvhi053tyAV2Sh8d1GJlluHxOq2jSaTgM3mWpq4lrpK\
+            8P0+FHOFOHfGpjhzfw2HrbDBEcRLIkIop/5isHa4lw9ye+EKD86uR/6QnsWxD+MB1/4\
+            gG286SOeOJNXX8qMw27vNjhp6SXCbTj1nHL10KKiQazlc2kH+XBb42Ly+NT0kJMc4fP\
+            lA7+lHRgpckWei1sO9zXUk2ff0uJJLBSOGf0pHDuzQs5ASFqa7Rx01F3RmtDLI7zeN7\
+            YdV8wkU2L+m/mybuXjG/BLYt50lrPQk+Mq9ApnifC4jP4K/Q+ap68yssAZ4x4cs1TdE\
+            JJOM6TkergjA94s/I7bmGysQcz7f9AnXvJ0LDPvICiRd1a5BMbqZVBfbafyxQi3R1gN\
+            LPXs1IN3HKtQGspNlML3h7wVJXnRCpIM1lxAYUxmwmXVsmVnxbGeOctVmB8cYxXA4jz\
+            Dh4EVlZjaF4uThgtOmtxdf34nLzyigFzyuMsji9JReiCWUonzBYtOh3amFgwFzzYEv1\
+            9SSpUF6zwbDUZLnoUyeUcJxJXr6G7uXNMpZ48J68gL1DEpk2lSMVJ47s4aGDMSzJa4o\
+            KIFpsZpiAXRdce7kctZQdd4vACyaFpuePmLRfAvNkAsbtIYmnD3ur/pBQukVTlorRwy\
+            0fwqN3wnpfh7O+R1Oy+RwaFPtQ70+DJiaYaW8stTMNzb+XOYnVuHz6/XRiBSb0CO+Fa\
+            Gx+E6DT8BXv7C/RUT4ZPnPltr2mYSc1LY9rp8IPxlosaUDvhOamzXqDPwzFgiaWfSTV\
+            WTI0Vw2ooOjSX6zmp+X6iTocfTFDtfE4qpCkieUPxnFRFE0jY9x8c/sjG4vhES6aPXL\
+            z6eN9QcvtfArMGgBQDEW4DnjtP2Cfpm88EenwwUxjtYY8rQ0nTJ4E2FhWGz8mgyASv5\
+            fb3Dog2kjLrE3Pw2XhjFPpk1+L4krthT2gr8LJ3AXldax2erJGOSVlx58HuGzXlXHnD\
+            9g3qSp4lfZ1voJCUjpaOHaKEkz0cQZM1F5veQOzt4+n4L++kvvvy7//vP760vIKZXpk\
+            vf/zXF9DlL511xn7+yufFrdCLrVi3/zlr5vI3+Zfu5R+3aiZ3spSz/zNrbuuy+Xv369\
+            1iW/z43rz8c3Hz//zzL9+Kf+w63vzPmn9dbAv5fV18/Yv69a6tX+78sbj75l/+8b0rv\
+            v6tLv+stoVe3M+X4rh4eJS//vKXzWxt5Ezf/PeXf//73//+/wMAAP//EXsUIjg5AQA=\
             \"]"
         cookies: []
         headers:
           - name: date
-            value: Fri, 10 May 2024 07:20:57 GMT
+            value: Fri, 23 Aug 2024 08:20:23 GMT
           - name: content-type
             value: application/json
           - name: transfer-encoding
@@ -2866,7 +2496,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-05-10T07:20:56.930Z
+      startedDateTime: 2024-08-23T08:20:23.645Z
       time: 0
       timings:
         blocked: -1
@@ -2876,7 +2506,1053 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: 7655e89ff57484421a6ee6910c2fa9ab
+    - _id: 74cdb9bc496219311818e00db22b4337
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 417
+        cookies: []
+        headers:
+          - _fromType: array
+            name: authorization
+            value: token
+              REDACTED_b20717265e7ab1d132874d8ff0be053ab9c1dacccec8dce0bbba76888b6a0a69
+          - _fromType: array
+            name: content-type
+            value: application/json; charset=utf-8
+          - _fromType: array
+            name: user-agent
+            value: enterpriseClient / v1
+          - _fromType: array
+            name: accept
+            value: "*/*"
+          - _fromType: array
+            name: content-length
+            value: "417"
+          - _fromType: array
+            name: accept-encoding
+            value: gzip,deflate
+          - name: host
+            value: demo.sourcegraph.com
+        headersSize: 320
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json; charset=utf-8
+          params: []
+          textJSON:
+            query: |
+              
+              query Repositories($first: Int!, $after: String) {
+                  repositories(first: $first, after: $after) {
+                      nodes {
+                          id
+                          name
+                      }
+                      pageInfo {
+                          endCursor
+                      }
+                  }
+              }
+            variables:
+              after: UmVwb3NpdG9yeUN1cnNvcjp7ImMiOiJuYW1lIiwidiI6Im1hdmVuL2NvbS5mYXN0ZXJ4bWwuamFja3Nvbi5jb3JlL2phY2tzb24tYW5ub3RhdGlvbnNAMTczNDEiLCJkIjoiIn0=
+              first: 10000
+        queryString:
+          - name: Repositories
+            value: null
+        url: https://demo.sourcegraph.com/.api/graphql?Repositories
+      response:
+        bodySize: 17833
+        content:
+          encoding: base64
+          mimeType: application/json
+          size: 17833
+          text: "[\"H4sIAAAAAAAA/6y9W2/rOJb4+13qeWTuW9X0aeD/EEwyM2lMksmBMz3BwUGBomiZEkVqk\
+            5Qdu9Hf/Q9S8i3RWotO1Ystee/8SPGmxcV1+ccvFQ/8l7/+4xcne+tVsE5JH++NreLF\
+            //ePX1T1y19/een+Z1t+f+yr//h/dnJp3x73D18e6v/zf375l18M7+Qvf/2l4xtpmLD\
+            dYsV9kO6t04uGi9ZbsxDWSTbdFPHml3/+CwbefgocH6VUpgLh+8fmbvuYXevIW1nX8X\
+            BRxPhTIUrrwJJ2D/v26+Pzn1SS3yCPtH/9/pjdXnhBvlMa7pr94/Jl93jz5xQVbKexf\
+            qq/PP1JrfeGF/S8/7O6acfRkvav35+uaryw6y/HdvyhqAe+4VgfiS/XDYf5Ypqq/QvW\
+            bPff/pRSbIU9S/P69eGqzgFKiXfW1Xir/Rmd03j3/esXuJyn5evXh+xyGv7m/LGQdFe\
+            U3GMztHn+lj9D5/iprXpnN6qS8PI2Pkh218wVlNaajJIem/ZH/oumcadiXGHLRorgif\
+            bKhne2GvSp18fbgq+CdOXgDP4U4mt+x8wXVGou2lI55P2WuuUPPk89KIEMsadl/esfb\
+            bKGt9wFHpfm+L4uuDE28KCsQfuq/sPP1vC3MrO0uFxnD/D50nrueCeDdEVEoIXdb/OX\
+            H7iw+MfYINzf/fijz+QF1/z3b4uv35Ahcive/ujjHMv5jpaT8UodgtKs4RtedNLVsvD\
+            WBWyUvbzRo2wYVDUy41VRSyMdD4g8GN+Yb/Qbc2tt5YN9Y4cLUlh+hiUyrfo4zRb7uK\
+            b3PIg1O12i82wLvaNqqZz31rBOBi6sWak61ZAYEI/NAzh1MSTS94/LGux7EInxmudv1\
+            zx13ztlAlXJBp5wCBQl1m/Q7miOGKUSz1eyGO9z+umP0akuu6I13tMx9P75K4hWYT2U\
+            C95wHRZCqzaw9Fk0mw5taLjrJqKWb9yJNe9KPujAuKut4UMo/Jr3Ukvvf/9t8Y1ulB/\
+            guJsvR3AvC973OeTrnuBIprDQXMax529eeuZ8/2TlL0ohJucnW76I7xTy5fQKbikAfH\
+            rnibUU7dkQ+rr4+oMqavm8h94CVxb1G9kvD/D6MxVlKie3tuOLSr69sfhRCKu1FKSAd\
+            wO/JUZ2KU3RcSP9QvDVSioj2eECXdp3RJ2PXFY7XmlZbKTzsbZFr4daGWzlqX9A4vAE\
+            F4NTdvCFrapYCHP1Wy0RZBLi8fpWVrTSFVECYWfX6Ab32+eYBe8VXldi6EFcVLIZwfg\
+            CAIGD48b31oXCyBB22BRtt0TlpbO+ZHIjnQrj3tiLtewopQU+ICacdfXiDMni/fhP6e\
+            cFVVJqIrykVd8H1shK+aKzokWHMSj2Tqx6rVrmlZZGSFdoVaalYoGpOx6b56+Q0ItTf\
+            yM2oDh0XYT14OyWedX1cdtnKmQMPzYve2KlTuMq9VWwVntWhhWxhcAr+J53rhqP7xZ0\
+            lXzZE4IJSS/kz0FteGp0/DmI6fGhpNNwJuZ3gl/5GGfwDdeqonZcL1+I9/v7EjpfF+O\
+            QIbDXVXxwqgiy6zUPMPjLw+09vO86gXvuvHTsdEk19P5uRzV0KbVWcZx0sEQ87jXxJa\
+            JpDRctW3NTaVlyBw/jkUZU6z2tWEvdS4Q6vo2JqfeBOk0PdF/0Ap4SHLDGsWa1gpeZL\
+            w+3d1+o9osQ4wr+2w/u0c3Jy556zAklrPGBG1QJun/+Ts3ziSbNm7JovbaZ9cKaKnGo\
+            FXni9NarN/TZ4G39JWkw6s1HMQLXDu0z+/DtL7/hfbgntx+N9Wup42yvnO23as9dVXQ\
+            yOCV8seaVtf3h9lvhZBR5UPXfsqbEncarzhrJtrKM2xw3GFSr/bR82VJrof+pD0vW8R\
+            LddlMv92bQSpoiuGG14kNgnTVWaJmhNPrycHtD0rdh1D2yeJXJpMbqBbMZX8VdZw25h\
+            XygplMrN8r4IJ1h3q7CljtZcFMVXNfWqbDuqMMPAu/Dzgkmu1JWlawKF0VJdHf4g1gn\
+            tSqd7KsVs700fYWJUXtE1TXBrK55yQwPaiMLHedD6rHxhy8LauMciyBmxFRE6r5iKki\
+            4XR9sfinNDSWn66GUhu19qIrGYAvjvv5BDLZOrTq1YkklLZGVMYrRFOqNl4uw3nVSS7\
+            5ayLfguGfHH4rxh3T6WfAQnCoHRMAZ9yt4h1r/r99Y72yw5bAqqp3hnRLo6k4p6axfK\
+            xY/SHkUPgGeUD0XLa9lMTjNpuvBaWrj3bTgefyRG9aqdSqwUoYgXbFSWpIKsmX9g5gd\
+            vbbt2gazG9q0oVSRPa1DF7dZ+vbmjlL7XVkeXti3P62wjgtnc5qTWAmuLhFdeO52xIv\
+            Tra2upGPe2G3JtS58kB1+vNcIanFwG+m9ZFw5TajMBDWxLlFJNC9K7tGDJfHrdVBM1n\
+            y6ff2V6DEvbB9Y+qROLJevX4mm85IbsbJa7pjqeVU56fFdOrW6+t6Gcqg9O1zkHoO/U\
+            Mpe3w9ac8cX3eADF2uZNo7xf/RKU1YdRA/FzcTKuqpYDWFwMq79i8520gTfyiDW7Pym\
+            8FZv8BPpB2qi+yBX3JTKtSbOhl2cBoXmXYlZDj3dCkqdNct1g8bP6V+o3YQPsl9LIxY\
+            rZarUvYeLzO5dtqAFz/siGqF6Fj9yTRpqatcYeMt3fK10sIb5n7oYTduCdPj6maw2iW\
+            oH2/FWrgfnA9sqJwmF5FJQTT0HLBonEbu1p9uHt89Sizj0K64tvnDegwamUwEb7dUiz\
+            kUuQsd7drpENhlLQeletny10pKNX0Vj0NnRbgkxfStNtWuVdD3729Jx4+NAQMbW0/KV\
+            6q5t/Act/aTIW+k4rgijqRdKYNzzFXftmjd8NMfwssMWnLfH/TO8Y7W21jKdX1lVsek\
+            blethvfF7Vtb8fPlG8XrFeK+m7SNqvQQfeR1RhYg76cDGX4rTL6jE/SvYz6c61hzVyb\
+            yCRiuXjKJ2PSr+v8LavkvQOoQ+DjuiVsTI6NUi1ojVvFeimJpNaDtUhQ/Wxc3BBreL+\
+            k73ylSE69+VUKo68DL2U9UpQxeU+yxwQUQRoD0TXUQ/lH4oi81XtD9g7QRZQG530ONw\
+            poQ0+Yq0TcWWxFvxBgpT7/CJ9aEXfg7S7Y5P8rWUgSMN9nQrdvTUxMrLH16v33KHF1Y\
+            SWQb0xqPLiHJpbDlJjbFfc+f8TCFd3PVZp0xdbHAzRXizR5eSN1dg8YAuIWeyPDbPGS\
+            +nuSLyZsvj/uX7px5B8Q5tmzSQyHXEn78EvXQbJaQ/zkGUnrGGzNNT47eoVHUrMhodo\
+            Tvp7eCE7LjhNbHzy5jSQEm263HFX5wAZN/Ow5N/jbZb4kXxSbrinXCykiYojh26x27+\
+            bEeM85eYvJ8coNPMRTVpsJbkAO+lqZWR7HiVCvm6+FL4CtuiNcjmfWIPYX2s+BDWhVa\
+            l425XZLX6Y/MAn4gTBdh49y3JfVi33oO+DKcCLIsfpMz9dHtPirVDsIup80bodJO3gU\
+            9aDWKSxhI2XA8TP10SXUiMvTliZn2X5DtccK166dj0TWw88GdPK96iVHVcM6z3rBZxc\
+            TJGCtxQZP8C29vBaPQgfP8Cm8UByCEo1H3wBbaHQ4jTOTGxOGc+fRLb2FF+GzeLlCHf\
+            raCmRQZ/sgEnhPnM9nlXzOFEHTd0vH2F9XLn/KPkyc5l0FH+obfXy1dYbXxeymowozk\
+            tO14VK8c7ubWupZ5EUBvdVAbDtiMEnpj0s/jUGcSe9tPcwgdO2MD8ej2dsrx63eV05k\
+            cmrffYETtLCIy/D9N+6OpWOG2DiFGRscpckn3PcQOU1G3XYzOkprzFZDJMVGVRDkpXR\
+            a85pmKK2IzmPcNSh9btHn98YSu5ENaIwTlpglamldWa+/WoeZ79vdBuQDXcYOCH2TKL\
+            4KT07P0PqFACK+mnZopFHE9YcoSRt8f9\",\"M6WtvaRedW4zKpavwTfeff/yKwgcA0\
+            gQgyUCa28Nq3HVZvP6Paduo7m/1lakpy2U8cENnTRhMjiF/hHtS0IQOpVcqdUqedZ4F\
+            i9JO+i7L/gcPZLllq/Z3/iG3/395j9xk2S8mUZiMkNOVsLs7JqwGKZnjFZlv7ZGmqEr\
+            pWOXt6gdDxgv5Yw+usKr1Y4dr9C2Bb37jwPm6NFzXFxznHyels/kKyaZVy2CMi2LH8T\
+            +DV/+K17X0rHxCycRq8MFqaAP0+OKQLxEKrlJS/2i9T3zu660OgqKQnqvTE2JcfeUGC\
+            eds6531kiWLn9P17+f1jN0OaOUySQd3cneU0IigE8+a7/TLYOPCgAepA+/5xiZwx4+H\
+            /hxAUJkuXQind2NCVb4Na8kdjC5v98SFVxpHsphtZLOs7NrypgtbkIpsE3TZPomWHgv\
+            HVjT+iLfgjSeGlgPW0I0Hr/ig06hfCZ8egeNPxHzguAPfMPZiis9OMmFwOyEvj80Yk+\
+            yqJA/DblpPOMUcZBrhSkkmwfqjDxuI96dHp/9RKDxAYSjC95zsSaOKvavsB1cZiGTIp\
+            Q4rP8jjVRQMtsDpW8g+LRby9OtoDTnRBkHU11CB4hPc2WiQLI4TW+WQtAU3Hvlg6zGf\
+            8eLIJoKKqIbdFClMpUyNbri38GuZHgJXrqNRl1KovyWw2Z4YJ64NFHnzc03WzaCjV+5\
+            5oZ31N6hUd0q7la7FR5P5xshriSV/bvBdv4bbpxMjIDDSD1Zl1N22y+UjmUeqRV2FPb\
+            YvOyJtXUeWxDq4eYeDLkzcZ381rD4gVFq6qHj20OZejHJvwej0mL6nZCa8IUguCGsz6\
+            dQ+iE9/l9Ob3+0+ntirCbiyMXPoom31LDnu1rupWHHqww9ONFDexn4ZEV7ukSVxbCtY\
+            QpjcIhmkDbpvVNeFtMvZFiDBtFdOt6vf46OD+z8BsWBce8ucKMigAeuLSfCwt2AJk7r\
+            bykSKPeSrVGTBgEeqay/v/ngJO8WTgblZOPZ4YJ2JAFl5DU3rfCMr22EcK9EW1R2SFY\
+            3zvFdEZwi1H3QMrfme6kF94Edr1CdAWiJPwMqfI9rdx/3r+CEWSvpdsZ2g2fcmwK1nk\
+            3+hABH8TKIFRu/iippNSjXRGC5uUSNXkw4CWr1OdJB8EIXa/BcVJXdgvudESx94qv+0\
+            7IFlY4RVJXfWCOwk4RlC/okR4ASA1Ni+IG8M56Wz6D+KSKavfXscIENoQfQ/yr+dffz\
+            7HIxBRBc0OaqD2Ac2Yna/Syazk9DvCitDYUPHPWkHV31EeyWa35xs0DXjJGHdMNHnl8\
+            71eIH+2BYmnkiIV8sa1CZpUwlZTWeNhNrY6RAtTqjbLiTbz0ep2//jKCC1Fo1Cyc7G6\
+            SzpQ1svC5W6i0MDnfyeAa9bjFyukElP9Dfu/n262+LsLXFiotgXbJkYe/uCZ0EUOGG7\
+            7Z8t5jC/q1HhXW8QqUo0GOxEbxULH0W3PdUcNUaXFzOQdpir5amBsNtnEM6btRKerw+\
+            cACGRji+CqzxeGRE2JShkaF0XBnPVCX5/b9hCybsJH2i9Dux5q7771dU1wVuqdpGBs1\
+            NxbqyNdYVx6C43poxhAoVCnD/DBqOtZo7w9labSQZIeAWVmO0ZqgqqT1rgm1bhc6dGt\
+            RGa7XmdqfYihuv6PiGoBnfBw7lLQq0/CUHdXK9B4WwA6SWZpdTF2BUX2CIaHvQlD8wr\
+            D9GZyIqkwciglxCg+ZAOcXfJOJZUv2UF8hzCfvdvwPhzwX6fxwoTv4c4jJGumPXoARy\
+            QI2mv1FOppppCce6nIdRkRuJ8XgGI5qLGgZDXNDotgIDYR45vRJtVhCRMXIV9IAdf2O\
+            V8m7oMZPD3cO+BbXHHXettrUS7Hh10kvDx16jwQAwus6Y40Z7AlJKpQfQXqXjLihuDk\
+            FHmOFK14NJ+k7KYgeakh1PsSgXg1FO+sCmb0K3kDZBEFGsuaklE997OEzdl4fbG7g3J\
+            sL0PVkB0wdlr+AY6ZRwNrbbgu8HJxmvuMY2WKnFclnxEz9zA5tqDpXrWPwMHsPPYw/j\
+            eQhraYIS+Gl0KgBaftEC3GCC6nAbPdDub57cyt2GDxqX9ME4xziTNigErd0I8FaWrcQ\
+            sPvavoJg9j+7qLh2UTRbsBPqqJk7okohSHqlXtcWJytEIO6+gIzvCFRXuWgqaKmFMyq\
+            8mca9vWWFN4MpIp1JoOKrvrpvZlyU4WSsfMAeqWMJ1U/uyhKzhd91snArwnfUV7rcD6\
+            rQRcEVknbhygU5MuZEmrAknI9BmBQEn3XzhSsyCJaGvHyMZ6+geji2MgLUVLdHEn5iM\
+            k5Ezwb2+hTuPL0awSAczjQxb69Bov3C4G4RLRX+Lb+nrW/bgo0j02SfIXnJHvEPAoBU\
+            oNi055UAcd39iIvufuAsQqO3HmKS1+x5200K4wfHVSgnStfSxeQEd+efxGTV+yVjN0h\
+            4iVxB8Wj6A6tkT0v/U4waHdd7/1EVTldjK2DyDoZo71UrPu0HqyYiYGxXUnswhBTWk5\
+            aZqlNxzwxfBdprFD3RbAR9rpQ1OKbkZjbE//IKas+0goNDq/BrRZy8foCCr4x/bSorL\
+            O/QxIaPu6c9Pdswzv6HqO+iYYIKYlaoHl7Y287+iBkeQojJhKi47+/4WXZmh+MXj35e\
+            iv7jBDQOwx65ULX2Q7sMP+PkFhlwpLYdeW17N/IRhHyCpOzGUPbvEDfGwrmje0sHK5S\
+            164grpVNLfa27qixvc4AtF2bpW57TxHtOD3EH7SwyI26k/NjfQDjtBjAzn1/i2Gluwe\
+            mv1xQ06iKHg8+mvj9HlP/6Ca5FAwXLnZccXE42Nt0VWN4+GQzD3p2bp8+TpXMCr/peH\
+            JRwswciw0uptkfLEqMGzw8U3tIdHJvBeQpiUGQ2cEg+E0jlFwB46Mn3YccPf2OECfb2\
+            DasMDTlhTDWIcSdNVwbfef89xQnwGLS8p/E8/7gmLn4PE/f+fQSsqrAzBveemcrzopU\
+            tWukQmiWfwTAAthrT7fAYPVFAuFT6tgSPi41wq5QXV2NXOWBY/kobD4Wb6z6CT6hyOq\
+            Bpo7veRVckOfWE+g6cGH1kNFVH8BVRAfYQ5KVSPu5Y+gwed57hx3nh2dk224DN4tEyR\
+            qX31sgUVLAe0HJxsORu/MsIMtKBmBSMWjXRe7tCDUjjtOUAmLIZgL1iYl1HPpibfWZN\
+            h6qKqffKPraU5mrtW9bjzqKXJC4OR3mdEw0zfB7mAHe7TUo6rGxrYi4yiK7NCM2jEgU\
+            2gp901W0uuw5qSB+9Bw8wDL+6xLUuf9LQDt+1HWi9FSNLc8YoQaG5vPgWVb6FQWOCGd\
+            FRJjOY5sJN1wYPGrFTTqTTcrFvrWhOuTqG0v4FfC6orB18lx/6QvPp3PaqyuQGl2CMq\
+            CsJF4Gii9hfwqPGIGS+KxnpZNFtUfmjBIPpH2hRJyqpK4PGwUpAw8BFNPVr0ZjrK7e9\
+            AB1kz7cF6J70v9B7zvroVoEeEccrwobKs5SZwk5Y4QdmdJCD0jO+BfpMTNRp6ykHzsl\
+            BGsP2b2JS4sgTMzmQ2qlKcOd6ryhc/Ct9z1+LmMGn6Q7WypnbSL7xwvGNEJ44gYHhdg\
+            ih5dPkMvq9tL43wGzZ9o1MHNFqLf7wOnQ72kJrleEe+oF/gxkKofbUqLfbaiVyo7RCu\
+            C7rwQ48bD6d1GII7LpK3/+hBsmiqUjAbP79iETiXL6A3PkzEIpUv4dyUs8BB9FgFn2A\
+            96IFnsyr22DyAZ0cTyA+lD44HuemmaBMrhQfIeACPd2aQvVUm+IBuQe7hQfkR6PFE0C\
+            24ulgXFwAp1sZqWyvp2fhLVWZsXVswkxiGJeMBgZMGhlbKT8l70GjnLRg/B2EngRk9R\
+            o/c69vXSzE4hWV3fWxa0LEWBRMGbBF7fX1TnA90eoL+FXarVStZLQ0RwLwGM2r2Lq6S\
+            Xm0k63htrFacTGt2D+4ozmnSiShDkvazr6B7aj/0/U44vtVT3KsU4sOHHRoNbgmnMEh\
+            x6iqv2eGCfIUJ0OjC8bJUofvJePeTltqeEO3qkTT6FWYsEDWoXfRcS7+yTshDNFGtSs\
+            +c5CIlKEvRymklVw0GF8YKsG7k+4AbnMA2xZ53vlUb6QJrDilqUBIo/HjeL0Tcg1T+R\
+            0PsOyMGrNA5hlSVgWq3xEkR3HjVjinYlFhQxyPgu++Ek2ajnDWdNOHQIVPUgpThYIzN\
+            lUKNUJvvFzAaw3WlCWv80PUpFBj9gFj3XVGkk1Qfw4JETllTDhHeH+Py2l46Ms0w6OF\
+            yXZkbcSoYDXED+2weC2RG2jFuwFaWVAc9g5LI6QF81Y5XveZhZV3H+FCpQPhuPYNvYI\
+            wsuFjj/sYNnIoYBZ/fHQ7M1IYQI55Bp69rykL9P5cCWeuRMs6e4BAZZx1CP75b4OCCa\
+            XWGFFFYgU56FdnIYU98GFDHnscmxysY3gvj50iMz6C6CydTMV4i+BP9G6ThuJaoBo1n\
+            L7lxr9jZSmp2vCo6GXjK3ZleVNQq9wyew0AlrfSQTK+kJ8w8a3AzDqFtqjepf1kK8AQ\
+            VJPfSjBmWcEv8GjQqviQfgzJ7dtUEjUtnVgE/B65V2NE6pLjMZzWz/7HmhrPxK3+VBH\
+            eHOJ3Q7oNalUtqkD4MQWl2uKClOPBc6Yw8LRlMGkyx1rzkzMIDaxTW8BUO9g6DgFn74\
+            ZzZMEtN4X0IdH6Fp1gLOVWGg95/5C7e/MA5o5o25+V0SXxX3+SYwYMqlSZrn9/gl2Wl\
+            G1TQzRA6EXRBZF9sQCu1TD41YF5y1s9LfrDt8bSVONNB0GvRL8RqcbRlm8JrHWzZJt0\
+            xuf7DrvdXFJIhOLSgVcH15RRT2BRCrQL1uzRV7VQ1rgxZp1gRB1b/gDtckC6V93BTrH\
+            kvT8sL15tkX4sm/G3B43ivasP16m3RD6VWgh3u6RhXoDGS11L2O8EDawjVAiiVd9yFe\
+            hvY4QI9hwRdbA/+up3SenFQBX79/duFWhANC1GDjq1ZbNzJHswtecH2IfRT6J/vLMdj\
+            O4JzGiSBRzkwF5vTFgnr19zJKovb3MGLO8TdZp3cQrXtbQoNzo2xuJAHL60TIr4btRx\
+            zbowpovG0WmBYhQMQ95eLXQDNuQPAilbStoSpfQjUSvLguMmJEhAfDZyEI26xWm0rFj\
+            8yKvcKHmgdKze29hiFjGhzohPXKS2aD1MP4jBwyk4wyuw8tTw43ifItISsdgXfOJsx1\
+            Im2PwMeUsTkQIkuOEEFJ0N4JCAx4E7AYzKhDCo1pU5UI+2PJoeY3Zo9dz8HScVTeboV\
+            sGbwA3Nc4nKQ2dUM0njrVtpu6XkM75o+Yq3VdL+/Uv2+mFJSMS87boIS2TmqqL6HyVT\
+            0UtiL+tAMjgceG6Dwgms+BuonmwIMbXGgeqHscdLjCWNBy7AL1mHxxlnwzm2ORTwjNS\
+            ET6zLp66QCzHhoqlsS/Gxa4gHBQQ/TC1xKlJDRhjlVO7CouY2Pk0Wy7JI7Nn2j5yfkC\
+            3Bjd0S+1FgjYrTtrQ6ccgqIIOrlN4FOaxYhokEt9XPgTg592sD1Ft137p9B9+UjprVB\
+            K4ODUl6VfFBBV+3pFk4KOkc8aLmJhyXabNFZv1YsfaLn/2CcujlSMdYTBKaYTuDicQD\
+            aNm7Gvx8ErUKZIJ2QaASquMkAo8V/IHdWtFtZEqYxY21zmeM=\",\"N6q8h3fo87CiQ\
+            Q259nAmAgg4OH3Qf+OpX1/hjdElOrctH2/vYAX1Caksix/E4KafeuIUK97KldLS73yQ\
+            HdqgKYgZOdpPaLxzmhv4bXGY1Skgfs+dxwOMvYKG8MdaORmcXanwjfGK90G6wr0RUcZ\
+            uH0DTHhKLGRsvBWiXOcMV1myki2Q8fUiqbn4rnLB08Or9M6ydwMjE2pm41Bw6cQ9XqD\
+            4OFlkPwK1yksWPnIRezQu9GJ+AdOyxBk7jOcMb3TZQE0IwyzqIo2blHazhGswimZuNA\
+            Q4OEblPP2FYAetG3mM3/C0LmsxioBE/jO4NB9XedIXV8AHWIAxmoXzgomXj19GPO6PH\
+            a3hfMZjF6La2mFw/PRvvD5Ydo5LoBzaF7uAtMIzH88qMRo1Iw46UA6wcTIXbej+DLjc\
+            faRn5pEC70hka6R2ez6qd2u/1DlWV38Gblg+8hsoGBUtrH1i0CfP9lTT8kGp/DysBB8\
+            N0xfsSzUCO6NEHs+i40sf1Jd4QIgnyZBMqrikoaMzZiQzTBIoflK8jvB8YzOKt04tSm\
+            Yo1/K0sVNfjEfjBgNx+azdcs1VKxOOkLDZKbgm9O9jiW7eRzPEgC606FWRV0Kn87kDx\
+            N1SDSQ5r+ABPCm6gvY+IMAWTwcUe6MHCWtqWJ1LyIOKqqPvwfcw7Q+jVwBAwOJVW6z+\
+            AwjkKpqMeNjWYpzCspeedDIukp+tLpqXx0pOxtO/AlzZCpGJYw511SZy+D+9YOqI1eA\
+            Sag8Zqvb8DzQ/DWpmWD05qNfhFWDu1Cmz8yliUH0D3jbC2Q71OTrx+0XPH4/9w7HiFN\
+            UQL+mteUH9W9o3FD5A1emuCT37GmlInsekbNW8AIxsEZVrpetsvSj3IFFvds9Ml6dPx\
+            CibxCKYOUqxT+JjBqMAOF/grDlp8QVzRxM9fKVuvO9B4LDilJa/Y9F14j6WzSspbqKu\
+            3KgTpGNe1LJWrMpXg4IYM5OETBzyrPfDEWmlNK6nBaLofOIRSGdrRX3CKw1OSD3gPbu\
+            UvgZSqQcDz7IJDp9983MN71om1kFr2a25CfER2uCmO3UoYgxAVPdpiko0H53m5YK0Gk\
+            7Rx9MsFXk53vfR8JRe8bTmLH0Xya6JfKnBbIkh0DN6AYiaETAcmrRoDLtCnojfg8QJc\
+            QAb4sWnhdesjeB1Cn0PM77HRAC3HmgaOIDOD7bnzytSkd+QNeKwxB23JjDINbFc1B5w\
+            mPi2zXTNijwlHN9/J6gp4Lf8IHuWAnOmV36YnJjX8r2UeJlgOO7/L8qBJcCWgbAwiim\
+            5ewQ31sWZGhrBj6bM4Oo6ODYCGmWlBDdYRnQTqY7TIi7ucaUCMK+aTR29sghwxJs0BY\
+            gjMIdGeh5PtDqV0Cz4EWynfWy+/sbMbAgnUMiEFr6QRkk3fGRZjsOohAbvvLHCtSa1Y\
+            5GAVO3J6ZzsZ1hKLU/V0+wDaFydaEGtujNTscEH6cdyApp2DKe1gKlWx41WhK96jQXw\
+            e93egt/Fg1MYKFXbseFWMx1GoieIreF694bxSJmU8dobrKQ8w46ZyVlWUTnD/DBpXb6\
+            rBddYE5mW3kQ5PL/MCbhs2ac+qBGcrZ0Xrq7Ix2F5m+QLaH200r7xYL1ZavnXctexwg\
+            eLAM0EQN3oJE94HyxdQBw2D5VsoeFk6uVHU+cbyBdRCEnwj1tZpZfBmAfdlBN2rCg/l\
+            Ax5xEuAwxQ9B5wHscUXQh2DpJoFeeDi7kitlVEZ3fmq4yM42+HwBT1YIsBk66XiQVeH\
+            kSjoi/Gps+s+V4wXvZVWINXdcYFG808NcPflTIStrg7Hk4PkcvF51UapRrQxrZ4caDc\
+            39Aip56EIC961WxLIDuvURfBU0x4JtxOb5FFnh1vVwIisc28h2p3WxctaEouOBGjmgi\
+            W1WMVTEQNA3Ead3XDg0ZXVcFz5Vbz/00nnhVI8PF1A5iuOTOTtR8c8N9GDxVAug6ERg\
+            d71NgaIUjge9o3D8VrWKfIGAJ1g4e8e7a8b59ctwo1xywh6taAjh6+pHiIJS4Xsp8OE\
+            CGusTZCqp+Auo84PBSQvIiYUWTA9DcMtB6YpoZvBUn2Cf0ooQ+KvHSMITRq7LF1ARSI\
+            FlL03cdWKuYRH/ua5cWddxvDdBPQuBXoeOGH7Xz8cE7pTHVyrQIIIA255KO7OEgw0Qb\
+            C9/DqSgCLqwEvCN8lR+NAF6d250yw1baR7KYbVCt9NPyxY8ZNnyjUxLMTteFb5qScfi\
+            Z3Dbs1Va221wUvK+9wvuvXShZdM3ZTz3Ahps7Pja2hR1xLcyiLX0rJOdRRMlNi+gr+Q\
+            M7nBBHuHAIW92vOukO3oM5TkKPe5rcJ3Z87c36dh/qpY79W//jSphwBhr7yCpc/8V09\
+            Tfgb07oczQOyukR9O53cxubio5hk2WJrbNIQJCaW0oeNUpMh1yOkiYe9JKLlaa95W1l\
+            ZaXdwtUJt0/zG71cB51RD1vm3NJkV0pq7nfFp01NRqsdd4J+Cr8ouei5bV00ltN2FnM\
+            +7/mFpcxVuYtxS9hSdyd+40Ak/0Q58Nf5n7DBw3dA05upPPvB8/0K2HgMN/eTtZG+cX\
+            PxeHNxA4XhVal4+hyuJw3941YG2ywbjGGmGbTxsJ/Q4LbPi2fZ2WMSm4WXP1oxrBQCt\
+            WjNvMh1SKiUs6zSrmUnknhCUruZ+W/SJE/B7tQlWTeah8Im916VnUaMSuudDr0OFygz\
+            zS7DkdM7XilZa+HWhnPxjvCPXU5H2gw0jQ3tVhzZX407OyagAENBcBI+9/5EFYYsbJi\
+            6KQJ0zHAwVKbCm6eigLaFSoqjsACy1z9dDsfuyVBh8pulFgYGbQqGXdxuSRQUONeoko\
+            0K0UEgW16CdKcrNPsxiuiYtusJA+Dkww/3WmeZ48vI2SvLFP7oVOFk6u4USPPKp9nFd\
+            qzrCKslat67sIuige9Eq2WhV/zKsPS4hmcy7GcvaLiITzua3DiTYTp9DMHhFflcIxaS\
+            Te5bNDM2cPUGWZuHJlIzKvl4QCYNPe4m/VFfEf0wXFlgpaeNH3d17Ons+dA2mQm1ms2\
+            TNc5JnmDGq4ndWZOxYgnbXxOp4KvsQMmyyIgNT1VodPOZMqASDzlCCXa7SP07IQ7p1+\
+            Ixx/fGDRodrd7AXJSD1XOEKZ6ZHQJywDNbfA+grLXgJFJdPLBX40cfGOj5dHy5kTzDI\
+            jHZ7zARRscF1SXjss5MfYmM5wcEtGlGcEVHvfzMZSqdlHGGZCsWToerGHHK1SAnV9Aj\
+            E+eC9M3CBhdeObax3Y/mvET6frlvG2wDItyF2Q5VNWOxasiXaJ2WLMSkBwWpQpbrlvp\
+            2IuX7qaWJrygWbH3j42YlczksDBSaa7lGzeVdKwxXKBOSfVsKBE5LILqZK8Cc3KlTIZ\
+            IUc+aL34E5cdySSkeZpjjzmAxbhQWwnaLWoX1UC4auzZOmlrqjhsWRSEksMWXB8CeqV\
+            6MSpdjnN2Fl94ra05RO9MtKfy3s2uGMiu7qLmpteKLenwn/GjY8QrdoM6+AxKxV8IKr\
+            dj0jdo3zQ5oZRe8dpZrNn5RcfHnfXciRTmtVoFx5Q4pxQgt7tvcYnFG6nnsiiR0dOhW\
+            dz+fQP0M5TXu5LR/mX2NnwiL0Is1ix8Y5ZWgsMGogM7v19ksa5HQKzE4ZdnhYnIWLlJ\
+            4tWPmSCp08+usE08uv8G3RK+zcQFn4SnsdvKdxptj1pZ5luhkrXxwu4L3eNb52eB8OD\
+            KnXedEGZx6tJKeZIghKK0CodV5nd034QVN/Itow6Sf8OvsTu8TBWX4ljTzgczwwsaY9\
+            kXHDa8zwjLGQubeeVcVcgzvTpRzdRfFvveF6lKUXfmGZ517bF5nz9Fzimj5qkVjz86H\
+            To1oV1vDh8AOF7S/xGxuDWUXQjkhWfrMjHw2e7w/RyL8tIARcI6Zsu2QdWpnt5PvYA3\
+            fGqxOqZHmh/45xgxdKand6FgnusUPMLxas7bG70i2Dyoj0+frrL7tHWvaxqKVuoHW7h\
+            TrLmU39uzsmjyOmvURiDxrxqQTLM2XFDaw8NIprtUeDee2fJ01zZthHpf/3tmNwm1Fm\
+            vmsZzPUaQk+vbroTGOzNnPKLiqpA2fps2ilM5IQDhNq/tlnUJVc8UEj0lBSfgD9fc7z\
+            wTpe49GwZ5VukeNsv1V77qqrT6fvZs/kceZ4ghTwxIvQZEG4TYfm3W5nVWgEkhAP2tn\
+            DeYJJhAia3Zcpu1jx0inxF9YOZRw7QfqMxPQ1tICBNNK/ejaFyDxxTIzDq06lTeM0Hc\
+            lwRnezKg+0iF7JtyCNJ6x9mvk00Di6p4jzwwomDsF6wTWRk+tu1pIEA5c8oDuziLyyY\
+            YV0Qa2U4Lg9eXMHrcwwmdxN3EG7QIRpXaUM6U9SQ0ILQsbdpu6gHSVIrJQXdiNxG6U7\
+            aC8JYsdXPsG8csBmTi1o8wdyV9puU/Qsi+4k5tORY+BpqSWgV7bslPafmrXQHg7mWtS\
+            LqLmDNmwgsbdaodalkXllk7qSYyaazR20F4OJ0tvB4VF35gOwYdQo+VUDubZC4gXMHe\
+            UroTlqrLScj8EzTx6t2cjcQXezcQjPkHkxUEcSPjinQEiCB65tnaFNuIfkP4BIqg3uZ\
+            rNDngH3USbrqTddC6l5V8pUKVb299hq5OZ9XgkfOUNcEPkQ1ux0WTRYIpnkjD7f/rUM\
+            hbCD80o6drjI8G0HVoZZXCG4WOckYQGeGIDmJHYBt9HzTGk2OchrqtlsqNgGCTk/z+a\
+            Rmg9GrDMOKO9m/UtBbu/s267wMgyYBjfW9oqxlPReGS0ATL4L5smBAdVTLF8gQeOClg\
+            wqVhy3o5/PTv4OtWiMSuo9tlWmsltfNEaNCj+CTXf7mLzKr9n0nWP3AVJ/Dkprlj4zY\
+            /lA6/Y7mDS1Mhk46O3/DtdUJaUAjHWDx8x7WJFlXAUt3e+A/ic5oPc1JJW8Y2XUazlv\
+            wxdZ4wFsOnd2Ys27kg86LEotZc9KbW1fOLUiM+LEhQLql9kSmLBGDM6NWWEnt+Vizf2\
+            66Dh6+jNvww8XNKWH5bQhVgMqq4BW0qqsuOysYcerjJ6A3nvzZYwhU4Q+JD6PD1LEv8\
+            X1rHffoZFNFLPwhitdD4YdLnJfk1f1/1mBoevZXvWFMv0QCjpO4N1s7j+4pMOCyo1X7\
+            PwGPY+etQE/FVJao2ruhOJsK8vKqY100xETqsaEVA0TNnXv6A9wuiSU/Gizi5+DcnY/\
+            Rd6ZMkIKrqX/3fCgNvLL4kfOMvnZQnzjv9KnTKDwAvJTdM6rnuBTJWRV/2beuOMEd1w\
+            w6+oiXqBmLeDbfARJ5W2fFrSVtttCOmdd76zBtdGzntIn6Jq37e7XH0zbWnAqUch88s\
+            QTLLVcpVarUXRh7+6xLpq3xj6h9dDK9RDEmq14smfg3vc8rAsvuDFE4NNZq+kTezQaV\
+            7VZpFzr6TI5oxJQtGFBaDGaIxF2b+iQcuXgah8OuUmoWMiP+5vZKDdnwGPG/R8NO78p\
+            ykG3a8kRj5nkEYe2L0wXyolBhdJJ3uJxpW+INxpSBnEOdDPr2JJD7pRIdsBEzWdDieT\
+            wHQ9yjLxNFfDJB3AyoErc/Q10tEii4/pJ1j2dd6MD04cUhLS1UmvJGt6haX1q6EBjog\
+            XVbX0/RU8LvvCB3Frv7yGTg4n5NsksrHvLSEgz6zsaYa4XLH4UHDtS3T8u59O8XSI=\
+            \",\"cAtA8ID7jDAEVO64gVTQJ4SwJsg3VKc0H6X4HQWfvK+QEu+EiB8aDZkjQAHkCE\
+            nREdGBDB3RvmNMnj6olAidnJxQOSZZz+C68wFTaOJM+xlcYo6sSVuKnlzcQCcMZ5gwI\
+            H31dNuCe/Yjggg10jxApxK1t2alnGTxoohXWE0e3oBuarispQuOi5TtIN2Rp3DzUWcS\
+            bcO1GvPfYBniUlB24MEab81WliltPmtwTW8zH0BqjkItNM/QprAN1rH4cTy4TxpoPGf\
+            b86z/yxxNkDnGIiyzamkdM6EwsrZhjPdHwJfzkUvn4U7SNKBXT7SMlHfLeU+4CwzZbM\
+            t5X7ULyHTWmEGiqnMgBe0vDvMz+nZ+Yp7QB0uwsTvH3ItvyWQmo94Z8I10OWN6CWpHP\
+            9AEF2tl6iLK4tJRbbAEVZsfwTm9Dqz+H2GT40DOJIH25DNQU6XAjFxf8fi57ZozAyFz\
+            lg+0ySYuv5rknJzAa+sP3gEkFLI9+QBtkkBC4zLruJWlt6KVgX5uSMI5MUdjZ5pDdXN\
+            upZLtI1Cp47E3O7hR4FkbIgqo1yyKtsqEJvM8Lhm9oELmE3wkoGUIg5Bs+s7xlppvtt\
+            PumE17gShv9rwmjejmI+xcIk+Xh6R7qIQP2eFARCLSNLSDmsfZZN9AZS2MLTnfJSSVi\
+            HIc0cAImkefu+KMJuIE/JrWOMEDHjEigsmhNQeueOCVRaxoEvqatj6hd4Yn514cftX4\
+            PcKl5j5ggS8T+lNtPTkuomhItqPQpE10Yn+q2uuhw1IaJ/CnhogyKz1gNtf7eSdTmoy\
+            acqcKf2rgtVyhIWgj+XNz3Mht4aQmxh0kAhJwGzR2nLufdxGnuVkpBpag/1I2vfCq67\
+            WknTBALyCiKK9qw/WKGDOfW09SKILxcJLAf6oPfODB40IGJIoS5GPQRgJ+TbUnfQxBv\
+            Ga4TMSidKqqZVE6vsEXQUhazcLbgFkfRvpV0/9Ad7K3KSl3Rps/7kG9b2dF2yZrTtQe\
+            tIV0kmd/X1ReU54mLaSPPOcQjAdo2J/lwyE0dvNtcZ5Ph2s07CzodXzOGCOhEhjyUYo\
+            UnpKg0A+UKEWFi9ugN/BH0pono0GcBix/M7QQUMtD0LN3HoUmE7qBpLyPrLgDxRsMMv\
+            a6ZBFuJ0vQy/Ycs+amwrPbL0F/zxlOQfcfdDRymXiKDNe5fIVc1uZAxBjdP8yGbHsHC\
+            2I0MhntDfBI+q+Q8d8F0HHjCefwSMqo2oF0qFshe0usNrNxMklu+3OQA3oKJ2Yj14Lg\
+            qU0z6psxwz5gB6PeyLmS8l4DjWFdKV2dQhxNkfwLbowN1Ab+9hV6u80hGy5aIhE2GGD\
+            lwPO2Q/UUD7NZKZRNxilCGj94drokz40hF4B5WnKPUmUh32TXa+6oc7k96MeM89OZH+\
+            k29XQrZgPk5eHJI8XZLE8kO53bkM0CuUrg7IOPUg7/mrqPsS2kO4bFy+jWT/HT9iJzD\
+            3P7CgW9mC8kSB8IP6sbrEuD1DI+/26hjA8uRX5NywO7+Nfi3b9SDso3s/HO/niZhZed\
+            sGaDlg1Z4lzQ35VFKK5BNwqCSbmCfnm4BX3NKbQyYig5ZugY6ZAoTNEz3DdvIE8VjE1\
+            a0zwtX6HzcYx7nG3kCzN2ZsaEgPi4IijV/g/SMx6hhfZJWYXsVd8iBhijNdtnumByUc\
+            4YmuMzXD80T2Uk5fXxIMaiCTZu5zPQEmWhYZcT8/o1wVdtRve+QpacFPrUPFFCGyMCD\
+            /ixF2ik9cmyCo8upbegwyRVnrY11cefA2eIXDW0L6DY5Ps5Ncgn2fjxTXoLf2KEUm/Y\
+            NHMzuIuJdC3/cT+fzeLAn8zRzq4peV+gL5QZnrEWVfajQtockBK7byB1Ti/dKqUmOlx\
+            Qktd8ftlIUhsbuF6IlTSbyQkrXmLSww3ko9Y720gRUpJt6xa8qqzxbLoteosHk5jPMf\
+            gRO+6OD9SD7ogwP4Sk3Qw2oXRr5lOwfWAfqVRdW8i6AuARKYD3N9Ax87tnD9Zqz0ptR\
+            bu2g4FPPsYhANZxOlpiZ6dMZyHGsXzuUTKFdGAUmLDigHSsODbKRj7ZZk3J2/DjOHC6\
+            ooXggRdSY3+q8qMldoYt9dOyhfSzeAljGHBKcvnycHsPmVBk8VPeYiqwXcoaRhaSd9z\
+            52LxASznA+p2OmdRCWk8IeQpURtT0qqf+fW2D7y26YrxAe2WQGUJPxjjZv0A7QwjbD3\
+            5d8yC3HPXieYDEMIgbq6ol2gQPkPhFMOmBsL/PWIsu0FO0/SzydZWeyPjZ6+P+PmN5g\
+            Li/85oIhCegpv45cNeqlHVrEVTLWfph8EW8QYnQ+J0AC+4E4w6NmjSfSOYjo5jSpBGe\
+            pZBsfKDVat9Zlj5xiRDoiQMnzsRjOyX9K2nsB+k9YGQeF1rvJtQROcZ1J6qYier43pp\
+            C866s+PG99P//yy89r+W9Wdlf/vqPX6Sp/m1wscPelfXy+FWYx41o+n+97x7Uk/rb8P\
+            r3r/pebVWl7n+7776uq+5/hv/6pjf/Zf796+v//s1V//uwEf/7P2vRha9i93Vd/v3ff\
+            yu//Qjlf/x7eO3+3/V//f1xU/7966Zsb8bnUPf+vntWT+perWKz//Of//zn/w0AAP//\
+            b0P2u5tOAQA=\"]"
+        cookies: []
+        headers:
+          - name: date
+            value: Fri, 23 Aug 2024 08:20:24 GMT
+          - name: content-type
+            value: application/json
+          - name: transfer-encoding
+            value: chunked
+          - name: connection
+            value: keep-alive
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache, max-age=0
+          - name: content-encoding
+            value: gzip
+          - name: vary
+            value: Accept-Encoding, Authorization, Cookie, Authorization, X-Requested-With,
+              Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+        headersSize: 1248
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: 2024-08-23T08:20:24.069Z
+      time: 0
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 0
+    - _id: 09d6f3df817273ec09ae9be01690246b
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 409
+        cookies: []
+        headers:
+          - _fromType: array
+            name: authorization
+            value: token
+              REDACTED_b20717265e7ab1d132874d8ff0be053ab9c1dacccec8dce0bbba76888b6a0a69
+          - _fromType: array
+            name: content-type
+            value: application/json; charset=utf-8
+          - _fromType: array
+            name: user-agent
+            value: enterpriseClient / v1
+          - _fromType: array
+            name: accept
+            value: "*/*"
+          - _fromType: array
+            name: content-length
+            value: "409"
+          - _fromType: array
+            name: accept-encoding
+            value: gzip,deflate
+          - name: host
+            value: demo.sourcegraph.com
+        headersSize: 320
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json; charset=utf-8
+          params: []
+          textJSON:
+            query: |
+              
+              query Repositories($first: Int!, $after: String) {
+                  repositories(first: $first, after: $after) {
+                      nodes {
+                          id
+                          name
+                      }
+                      pageInfo {
+                          endCursor
+                      }
+                  }
+              }
+            variables:
+              after: UmVwb3NpdG9yeUN1cnNvcjp7ImMiOiJuYW1lIiwidiI6Im1hdmVuL2lvLnF1YXJrdXMvcXVhcmt1cy1hbWF6b24tbGFtYmRhLWNvbW1vbkAzNjAzMiIsImQiOiIifQ==
+              first: 10000
+        queryString:
+          - name: Repositories
+            value: null
+        url: https://demo.sourcegraph.com/.api/graphql?Repositories
+      response:
+        bodySize: 16349
+        content:
+          encoding: base64
+          mimeType: application/json
+          size: 16349
+          text: "[\"H4sIAAAAAAAA/6yd73PjLJbv/5d+vbI66e7ZmanaF6nt3Hsztemu1Dozm7l1qwtLWEaWh\
+            ALIv6ae//0WSLJlG84X53neSLK68wHBAQ6Hw+Ffn3Jm2Ke//uuT4q3UwkgluLa/G5nb\
+            h//7r08i//TXT6/137eLLz/a/H//Zc/n8vCjfNj/2P7Hf3z6t08Nq/mnv36q2YY3qZC\
+            z946pdafT4Z4wlX367d+CnOLw/BLLSXLeVnJf88YQyPn663MRhVxIabRRrE1Y2ya1zH\
+            kFuHGffOJmUnEa+ePhRqTqmoYrAI0r0kUnqpxmvcWWZcayFfmpb3c/Ikm4zOJBcSJTP\
+            nz5GVcPmeI5b4xglSZ5nyNbh21/WnYqoz65fPgcmb0TLslkXcsGFGRkJvmGV7K1heha\
+            SaJbQYK/xYONlJVOOiMqYWzfQ2CzL5FYXu2Nkk2iedYpYfYxZfEtsoSXfWZJSf8W2aU\
+            tu+Z9nxRSFhVPskp2uX2VGSEbsiDevkU2yj6BdcOM2PCEb3hjaPDXn7fkXHO14SqidL\
+            Ptc1zpFqrNEkZLV7aN7DNXYsFVwwxPpKpBJxcnWGfEpGUN6vSyXaRYnZMV18a15bg0I\
+            qXhlIbiLHMiEYP/EikTYXyMhOxurgLNmcpWrrx4xbQRWf+GTGYfKYiiWYpG6JY1SVYJ\
+            oHC83UV2TGXXCPMNqENxldmjEtEYWxxkf5TFMtdsuWYR35t9jqysSrx3YsE0LWCHyPG\
+            8ZqKitZXsc6TmU8umkPki5lsPkeI/ImOa1OePMXE7sopMHLrhxuzpdh9ZyVLkpIb/ED\
+            uoWFBMjdxHtrYJ79QlLUVlgBB9iRxfej7u2u4jxwDHM3LNm6RVsmUFs5rAMev0mBiZR\
+            rwkPW4jq21EnnpmXCZv3yIb6rHelOwMUA/vIjOseC50jKDtooHxw3X59jlSO9TZiucd\
+            6vHuIlvpkQbUq/JxG0sctGugPMTJ5VFVL1tGAA8vnyMHiykwpt/8GqkYHLmqa4yo4Vw\
+            ouxm85QvWmRWZ3eIQW641qyq1t22yMXxnznoWOutWF4mUhDGRFWeVWeEiic18q0RTJA\
+            vOGg1nBbGWlBEqZV8YXNl5ZwQ+Uu56/FjcGBvZGfRY18n00oyz/O22EpnMlhWPyHikb\
+            PTwLV8g5Nu3yJZibHfLanaQTVKxepFTPcb87S5S2hw2Yji/iyxWx1vdA9Ugrvoda833\
+            WSXZeph3U+AithPvwZ0dubnhUaPil8jZhENXOWtB93hDCdzSR1r5j0NvuDI7oFnEVbk\
+            jJStjqG+2Y80NGXO4JOcb26doWfHIkceOEb8rGYT/HNlcL/CdgOPDge5bZu+d4am9QF\
+            txBuYeM6u6cab3s1HRTMc3J9UzwgAAZl1xyeCu5wtd5LOxfdyio5VBe7q6zxdZ6q5kP\
+            /Zzvg7ptFNEKyVhpnAQnI9WyR36Gr/wTClAtF+CJTLU1S5Vu5JtSE212Ac6jSNk1kPu\
+            Max8CKn5l7AvCLb7cXgOmR/cPIZp3Smep6WWTdIyE7anWdRdQCLPUNMfFO0lZNkN0lC\
+            jsdBdYBg4g+7qiv5YJ1qhGtUyW3OTDnfQKzlJD9TmBcgo1uhWKgPNNXZa6ZdZzRuj9m\
+            l/I3L1PdsFSv+MkFSyWLBsTYr+t4CA6UKl+j4puKy5Y4mFYmqfAPGfZ/tQ1oaZx6yXg\
+            3Qy3bG/E9Y00rjJDlV2TyGzIcJnFdO6koxeRLX8QN0gvmy0UUzQi5dPocVGhOe7VnGt\
+            YekExB7hx7UsAP9Y0QsJVKyPlXivrAyzNzLj91hmmqUopinY32AR8kPMqLVeXIkBNFq\
+            NB3lOS9bknNSv30KWu2PmjmpT3RnRkB3hU2gxLwRLDlzJZFnJbcJy1hqu6DXSkDn3mn\
+            8syyGhXrhY/d5inbJ8Ciky0el0ZhVh+XqCkgHSWSiRF1Hqa2iCH5uS7Q67KmaOukeNE\
+            6YE5hV71KODBGKX2t6+RUuzP6G2iJC1hy3qLkEqw5QUmPx/X+3r94iqLx+DWkxkMp0S\
+            ieF1WzFD++TE9zP+hLZ8AcwXv69OtjxifdOW1+9rKi6ZiF7m9mqZzIwbmxZcu7B9880\
+            fc0yl5lqzQjQFtH2GXBZvS8V1AaSE3f+OMrtIB636PEB1JiotaUgXSpvMzULtSaZVci\
+            OA52K2R4rJMYVCsXb1XuF6B/VxTRxWn0HhF/HgYYUFruFFA8stsPaCCjsj9R6lYHXxF\
+            l7EMnXI++koUdpItU7dFZZbyAvJC0PT/CLkpqdbsVxaxXjDkv4Zsb4HHUp1q9g+ddek\
+            1LL5dT+7+0Ll6jUobG6lZil36fEJfuJryAjsg+lsxWuix3N5C7RZH46qS8cKlb6PNa5\
+            SAWSwEq6RW1YUXJF209eQ3ZQAwjbxc77+TFbxrFAsr3ia85Y3OW+yfVKzhhXcOfi2VV\
+            cI2nkj5Gwy4K1cL6WqmRlyn5zeJP3NjuV6xXLCHtgnRBUPnVD/kfhzDg87slZnjVwZ0\
+            6b9zfboZFceHOAMUwUzfFaoNkudn2urpKGsGIfgKr/uDmzdpQspW5GtKw4avbNoB76x\
+            F6qZbeizzZd0FLKT4YycDL+G1tgiuEnJ1kwZUgV6DVrOAnwwcStfQz49IaDbFYLK4LY\
+            89siIzz8UwRnzgG6Z0lxN4f0bsghCPrAIGjPg0VIWJGu25EmnqkRxLSt6cdt+AF2HwW\
+            Q2VCOZF8F+rafc2DhsPknBiBfaoH36AoSE9ef8LaTPGa4rNmPcrLhK3Y+k/wFo/go3o\
+            uasyXXLMp5mbi9GhDfb4TVkCDRKNHK2YrmUbdrfEtaSrnZudSrwsV2Tc2XkNh0fIpZs\
+            AlVwjdJcbSpOaNWOFpuxLV/0i0E6KTXZLF5Cit2GbVRqL+Rfh7J0/OukZob2rn8LrU8\
+            7S0F6k/nzIfg1U1aUifNQhOTgirUyuSi4pnJmaX6h99BapvWW0nEORci35IpGz9QsyC\
+            +hVyBpr7RfUmj55IoV6YiDCyzaivwWWjGa0jKZ84KTSvJLaOri4dDzRseKzpObpVEVG\
+            fQ/98FaJTOutaRNIaENaefESOP625coGm1Afws5DkwhuczISvxxKO4jMCt24FXGQKu+\
+            j/iqwfqSrThYAL+PaD+nLUYk6ktg4JminK8Gml67bOGGCPcozbPQ1u8pJnKB41CEjJx\
+            TWC0yJWtuZ401N0pklN5lkbjIZMsbZBMNWRCnnNj1FfyRbjpIO6mHXIqmmOhlEiyhkU\
+            sh87fQDGgKg8sdEd8Wt6TxELIiXaGw5hCazl+iBnHqt6mQOvM6ZMk7iHYtmtlCsQ1P3\
+            ZXGBMrrGnN0RtfV8msJoP6SG6CKt1IZru7T/kUyviChoa4eQRO6ED4/f38Iuc+H0Jpb\
+            vTqR65UxLWkmXd8FxgOA7lSVyabhwPPFJeAXrSGB/jbiiVKYv/mX8IxMa5mthZF9n56\
+            UXSvovW+HR/9WUTPrGlGLWa5FumTa0Dvg7bzQK5w+DNQUXr2u7IPxZOaWhtxU3POKVN\
+            t670XP1x45x1m+5xVaK1p7bf8jh1eTR7io6XW4P/59Y7hqldDc82qW5SIip0T50viKN\
+            QWOm/LmVdJGnGhKnpmLnzjTPq3hxDBcZbw1UvneRQQY8LSnEVTWevqMpgZrr+fuEaBl\
+            M1uIJr9+A3PpVVinmLMfcAHYaxgdCTUT1dmPiKZFfHbLlRba8Cbjvncwr15f1xGkeB8\
+            B5eoF3oDkG5lHymDWufyN8ur3j7uAzErd+t7BHHu9KkaQ8x5m2VkPNnmHq5CCb1gl8v\
+            Pe8fQKb02jKvBo8rp+EwEmqpACR63U266MqM2tnil9/osE7p8Pa+/0Z0Ts6uq8dxhfw\
+            P7ROwWaUrRk7dULJMz+nTkl2zBt2+7pKfzJP74/eu1n9k930+H89EgJ6YvXn+AKdvkC\
+            lV/hNegMlKlecP4Cld+zd+nlGqvV/bfP\",\"AHZ4DvSCFuaicaXuCn0evEt4PYZXKd\
+            RPysy7HHMEjA+4bIh8nLSQCI3mbRcu5aO2cfpBlfELUcbnWsbFG/S1b3fhr+01jOEJS\
+            cELUfqDEjA+YoEKN8xBARgfYWV6HfEmKHshy8drge4B59rDxZuIJhjM2RQci+wHyiDy\
+            pDVMfkXkMfjxRyDUDso373aCM8ygeFy8QYLy5p12e8AA1fffQZkbPzWq1H7OX3fhmp2\
+            qQrEqkHOb8M1je+REAYpUfPqxL5jHUXs4PqPcPRFiMsC0+nJ3FyG/wTqYaCA7tIO/fP\
+            b6Xp9A2ijO6lQbtgOV+X3tNVWXbDdeyRFp65WEXNbuQn7CwTt2VKLh/ZX8Y68DQSlzl\
+            hhR89MTURvzZ6/10llw+itpCvK6Jrs/m7UVM0up6v5nMv5MKtY1GbnQ/6Ncex1Rqpy1\
+            Ol+PdyCrnvqsZPG17K+gPj2CXsliLcxwo2TJH26r5rNqv0pbpt4727lslES+k98zryn\
+            zgmR4o6VaVnJLofyraCNKSSMX3TIpeMOVyKBTp38Der3X71V/TQajpFRws+XaawNsuJ\
+            kx1ezSbb2815vwPjbboXjXAyxhsTd80eX5PrVPiXsEJM93hUgJK1BoYG9IG8vjTSFkW\
+            i+Y1iwnl1MPr97IaBay2udK1syILGVFkXMtioarhFWFVMKsqJ7n8ObteS6oSynzmqkh\
+            2tRKv1c5tapy8PcHF9D3TuQc5S1QoROMzqSJzVjp30VniVY8M9XVC90rrX3HNz6RZiG\
+            vWoKZtAnaKineSBojeJbzzaxsWFo25OrrqzdunY9y7JvJwcbb5M9weiuaIqnYXnYmnf\
+            6gsunXKhw3E21qL5EOcIdsG/ximbNVumSi0mxJjqn+wEuO0cquMYdZdfiaVoevZL/tX\
+            SGxkEoW2jC9mg3b2tPxxbjPPeFNJqmtJlY+vGtFFl+LRuR8k7Ks99JwsbJUuPx7WKBl\
+            jLB+tZ/k9PFZAgUnF3bau+rsbDXlu5ZcE/y+9uojjtNw1uSy4TPFl1W/4qX/nE5/gME\
+            0AG6FXvEmtVK2/6qhc3O4P26VyPhylw73pM3W1Absg189tyTFDlJtrBbY7pWsBLkgfn\
+            j02mXPOZqrFvhGPHijB1uMXs74qjfyDHdSpLx+AwOnlK1JtKjbyiqox2fy87wK1cCTL\
+            W8yvUmHOyUBz149feC0ShYdU3k6PiQgkOzBb8kacfuvZWovpHrgXbccCJrtZJP+t70m\
+            /+eR0sIzr1HXYVZisZAVN6vUPia6a1tJt+O113nrHDY7xk8fNhUh7M/va+/eCod1iyV\
+            LqQo+W96XKVMty9a/MlkvRMPzX6wiV/tegm1oCl6Zusoqzhqu0skzadv3ekL5wG54Hx\
+            9IjcG7XACRfYS8kj4BwLtCGYHWGrrwH56CYz8N36EQNw/hJuQDN3wtE1zQzjYTGIym3\
+            NLkOrUX6tvXXl+qS5TNmc1YOj6Qc7FwE2v3qW73Na9dJ0tubXzxrvRZilkJ3RqVlixb\
+            27G7fAcKmE8oq1n53sgZf+9YpTdciaWww/fZT3oh2iuQh5nNYVcZxd5nZrWvecXZMj0\
+            +DRpjkgtWUcbyfrLmSUEWTeUutCOPrwakKmYsayszU7yWhhvO0uNTIptMtVTkaTvuha\
+            hcNgth9ExubQ/krvSUz6fJOlKhZMPS/kYbTYOfWFXdTsh0uA8b4yIc3fxxCR2yYUpxP\
+            StzwYpGuuD46fQHqS54Xct6rKlU6q5fY2I+rL1O/BekSFCo8BxIGyWaAvsqumYQIrn9\
+            JP0iIa/f0/EBVUTvgeXp3iKgEZvA5tk2Gq4Mr4UeA8SSOrM3egUNVTgUoivfG3M7FEE\
+            c+8ZMj2wcMdU/V6XYiPlz/uaN/Txl1gumRNrfRtfmiD0Qr16D6BTcGNu4aEawczxjxN\
+            iH7cQJZEgpuU3dddgCTHa3Xg+sAK7mtaQi27ncgbq9wiG3xMNjuO+9Zm6c5ZW2jwd7y\
+            gG3UTK1F3JK7d2A5aNYIWvBcRrlm3cnihcnyJHYkkCFTkko2qGzngN5O/Jq1lJhJ+1U\
+            KDzeDbCd0PepuyaMsms6FvjQCWvNVUO5Tv787vedDuBO0SJBBGLbvujiW3BWp/bSe3c\
+            myybhO551IJzf4RUV5SW4lItJ8AGQZ7oRX6Jb0XKwYnd49a7YeaH9uXvjOOgCM3b9Ij\
+            KKBAt72kAiNNc2AtCorrm5UDwzkJx5HaNJ8rISzTq5m939iQSjgesafHY8Ws4Mc5H64\
+            Bd4Z8hkQs5yEifoP7/7j3XAfCvvVnEQ1IF/rgJihX3E65apdUIZSg+vXscoL1Xn6yHH\
+            KDKN/+AFAOW7ljXanUEBC2P+6g22B1Mw3KWgEzRq+vfEx/PPJPS4rA7LzTsfj091XCM\
+            GacS2Am8aes1NthINYTR3ifyu4tPv5BCYIeUN4A/csP47wMB1e0nFdhb+MAkAvmKq4Z\
+            oK5mB709u5QvoFlq6D6GHyLKEhUgOMWPTdf3ZTdAJoRvHze+bdg4ITKPMFodg67ocy3\
+            nBJL7tl3i3EGOwOt6J60+ewHSoMdqql69aG/jpqVviKtNdTUhve5FL153/e/fr65193\
+            YPSN/YZz8Levvz7TQ80Hc/ynz1SO3dB7a447W/D3f/r1OSnBSOJ1tsXsL/e/7n7d0/Q\
+            f5Ssc36VcrzlvuZppw4xOTy8S9wK5Db56/TaoFFq3G3zFO300mkSEhCxfvF5s04Q2rE\
+            rtBcRaOfjXMyakjFWZMHYeyozIWDrcAZPuzQNMaKp4RVaBEBjutXcmLrruQmxokTu8e\
+            r1Jr9HpcMfl4PUCIYCVaN7JBWOLjJKDI9JwbUh3xR/lq9c16oxZ8yp1Vxw6Cum2U5hi\
+            i4UwNbU6Vb5517bPgFqzJlcsPT4l5JLxz8Ah8z7mLOetRmaw+RqpK6c8utEtV2KDwnB\
+            9fg6cUQyx7x1X+4iz9m3FA/lc8Vpoo/a9k0UtdHp8lYyvImPO4k4hLrG4s+igQXfgpC\
+            Mvk9XoRER4drmFISA6V+DaHXoBjLG35rZZiqJTziWOiqx0ePS6xlJotW/JKJElsVwXQ\
+            FJeOW7rzW1fny+yNvzR/Wbg24h2VgUWPm8DlpmGXp7PsNe4gFasKUjHtGeoJVwQa9o9\
+            I3BEFgCimIe3lWQrZQUq+0YiOGnl4D/DjQBulppqg7Z5g1K0LVmqdLjHHNbhDYlEIJe\
+            K1XwrFdg0gSTygqp4JlrylGSrsdyWU0OGw3OD923AXZILnckNJ4+jCuxtn3BzNhp2uE\
+            6nP5BxeO7fvxaFxouNr16nzSmcq8U+dVeQSVpKJ5wGhJtETXKCMlISEUQ/Pwcit01hb\
+            o1Bqv2MtSJlrUiYbuhNaA6L6sSPXRA6Vb8hipbOa6y4+zMdbgfZ5q+RVc7aGL3MZRiJ\
+            fYAuc55BFfYNjcQBOt8ZxXSfCOADocX8iBL6Pd9Axi7qJeZDn0CHwekl/EM128f1c0t\
+            foL+4VSxhUSDT+wlZ5os67d/mOrG/SHPYE1q/P5F7Q8GJvZDSaKPGCiX375cPaNE4nA\
+            6aWT+gpWMaDePGeEOk3IDf0AexoLkswLsFcNYYeh4V31N6EwFHVro6iO0KvAmUTU5ud\
+            H/w7smL5+sVI31PXD18NAU4TqGpMYE+BbLQCctrEH/OGxXmAwmRgYRdQh9uclcJHUBC\
+            H5Wrs4SyFWsKXsnw+qlNzBuI+AOJDSYTMmSiTe0P+TS+QT6xaK4am9DOPlErrH1if4g\
+            IlrJTDaMHRe/hKrcn1UhVs0oc6BBHfYJ/SI3JlvcGKvh9f0i9Kb7kSsG0/pBqA6GPXU\
+            p/TNehu4VRHLSwP6bzMEoUBdoH9GGxtyoajf6wmFt0og3wf1mj1ZhwAmuuFlxJNB+xA\
+            ziy5EYkAgfxW2ZVl6k4L55MVklO++v7o3TeloSdTYDP+GjLP6YBC8sK1kcLa5gJHWcA\
+            oOY/+jFDMooXQhslSHta+RQ/R7pMx06/SFvdE1q8C7N3tg2iDbNPyC8J8DVninSrKp+\
+            QTX2SgpOctL852w6o3uisX4Fhv1E+oLXnED7rFH0Yg50URVfqGZrU9/upRHTDOgODfs\
+            GCP5bjwTAVNVP8YHm7JMA0rnyONwJ66PBcBZv7j5f82N1UkoH14YcbRsyLZAThJuocc\
+            FAF245w0RmeV7JIz38ep7r0aX4lchQeDHSzBWeNXvGqShea9Nl8QqbSJa/E7urFcNI9\
+            Pa114fNAewrgo5Z2MjSVDcBrRmX65/dnpL0HuBHnrh2evUc0YLbOSLF+RiP1CSt1IWb\
+            IzecJre64rQppv2EhMpLNE2ohZ0yVrYThmelU7/Cj8UiMjLeA3yqZd+DIAZsKqkA6FX\
+            op0PFvKHnSiefH4ckbjTsA69dW6CpEzn9nvGO0NFRzz2jU9WOXokLrtDeU5YmLDhU/P\
+            CHvDj/XVn2Ewoocuc7hdDt+9h5iHYDZ8kx0j0WHujyj3W9T8OhhjmQrvlDRdrEnZPmf\
+            wk57hkFhIh1uCpWtEbU4gNEALa1Mic4Hji1sHRlm+Gn3O10U/oCagTRUC9Y/+7KNzzS\
+            OS3B4RvvZprwhrgPTdfIXOpM3fPUAdR7dIKfxXz5Ah3glZDeFHObD2KSWeVdxd3jZf8\
+            Ozy57RUo8nIbCN2OX+Zuhw1ipoGjdjD1IOPvP0Fj5vdL4Q+izuJ9vqZC0aroVOlkLxl\
+            aRGNrfJ4gaJsc16wbI1b/JEyWyt6cCUT7fBFWf1eL433c3dMGYY1yGxVoyHT+Kx/oZ6\
+            PdFxpm8oi3PskHPQm9yaaTyEPvlD/QSgcbqDN/QURCZ0TGQXPRgWQFfz1F2TpnCrg4C\
+            Hvv2M1083rYZiOD4XAJn8vPDB8xiAkZBdgGn3B/8RX2Eerxc8d8MfiNFbZlhVOSM3Mk\
+            c5van+yUjWP7/DzQUFV7IRtZzplmc6HX8mp9NHft3N7n7ZfyXbA1J/g+kcp7S/7mafc\
+            TpoAhOVTsT3oGoNpmP6czpiv4YW81AqvPp1P7uP4H+wViZLe7HV/7FqKZluRRZVWI+o\
+            swmm4aLhxVUI0jvDaeQiJoXyBamgwRRq/es+6hM+WkyGRTaND9a11IVIKpkxMrqQCyP\
+            zsQTGoxqiKuIR+TIVSsrNPu1vgATyOyWBE7V/ztdo8/c5bgwjR65Y+I9IDzJ3VARKp9\
+            bTraQ3Q6SDNYJVYt+Rw/1TOPShFxhlBi2fkD/cBZXWpA6vKOjVBW5LW8zQWv8F7dCRD\
+            grzF2SAPOdFuXd/f0RuFV5oTIRE5FF7AUYqfvnsPUKOANKWlzfUiZ7jVjltcXtEDl/X\
+            uIij7dfIn+ac2ocW67KjPQvuQEZLHRd80Yh1Tg/hyBvtnDj4NNDR8tBq6TlyzxQ8Wew\
+            VrdZ7kBGbrpAro48Kp7b+sylpakyxvqKN0x5u73WRsLatROa655XQRqo9jJrkJOPm0h\
+            nSw4X0iJZew3A7XesjvtG7/9Het3AK43mvManc1slNU9nyRdIquaMrHa229OCZWQmVt\
+            0yZ/ZhUrF33EbkqoxTGOFK/vvz6d7qo0KcsmOapu8Yuq75CLWXChB3C4RWqJ1McFPI3\
+            tMIxxfWFeu/2l9PBTd+Q/egaG0eNL8pWyYznpP7jKhx0hOdE5wBIZhF2Gh4gdiyx1R7\
+            /6TjuCNxf5kBnDaon9+2pFjrjVcUaLjtS+OH+DDoduLgBt2U=\",\"0HwcX86VPPgEs\
+            eGpvSRZxbQWy2EYI3s0tMF0AoVt+BUqM0cYHerLjXmxH6u5Im2Sh1fYFKYsONSj6f0V\
+            LQGR8x+h7JyIRipWoP1sNo+49GZ6JWo9cO1jTA17T4qcgo1iGU/7G7RrP8HO5ApHBSg\
+            pn7xn3JzxTGu7d9nwxuhZP8p9S93r/hngQbFe4KXiA9w+kRNAOGMj0cmKCMLgbDK3lc\
+            sFXXFG73U6/Cih9/95Go7O9L7JgKrhTulEg/g1OoaKmp2Hivapwjmnn5k0Iuyftftxe\
+            EGBJDzcGrhTvCFj8arLRWovSau4NjJZdE1OHVbljp6hmWLBjNBpf0v0e1VT7tA/52/I\
+            i05kfMFVkQ53dG7xG/Kau+SByLLzN+Tpdgl0/W3NDUObdubQJ/YSPRyKSo4MyM4mNvt\
+            U0AbjB7QGULKa62H7QmLF8GuJd3gj7xAfFJwv/ID8N3zMYYgFFQO4Ltqrdnv/ZcsbbV\
+            i2TtZ8r42kYqQ7NF0/frTeiiUdOAb5EEy5imVr3boR176k3Sc/P88ztKmWgIucN0aQB\
+            xDYzAPZGPh9ELh0+JnoaklEFOwzHgU+EheVXES0WzAIXFJxHwMa7fj9Y1xObw0mHbXU\
+            Pn9DjnCRiZBrGnAPqnOpTQc/Kui/gezS5zS0cuU/wv8K567onMx5hkxqE1iER3X5hjr\
+            dKa/34aI9gNBy0JoptpwtOTOd4jr8L3iLAJoV9rySMU8q9u1sISU4RRc0uJ7V73Pxv4\
+            Zf8YYiTa1dWCd7BUEc+nkPyPAJFpExILUnVoQ9BorZhObOLqXXTEpc+ycgGSKn37wSy\
+            9rDTY1vSOGYwnrPLzpv0fKxT9q12IG8xcrHHpSa1clRS99XokndFdllShgorpJFIZrC\
+            3r+Wqbsmd7N7sivf/Tg8I68BHxcND+ishAATbb3BQcl8YOjjh/Y2h6AwaOAa2ZZ95LI\
+            jmyKM6udjDqdbji4fYEB2vrq3C4VT+hLbNZH5Ryq8D20kLBakvgewtKZqRQ75rFRdxh\
+            ue9reENazaaxFh0ivhYQ0e8qE/NgmdnLdGC3LnaLdRnFJa5m9IabkE0k0uQx4I57j3j\
+            qMABfCEimviHp5AXGbIj+WcqlmTLyQ1wNiCvCWfzgMcb7V1LjdgGHQvZrncCZa6a7+R\
+            DHryACXHhzU8UbzJuYKlG8FO3TVh3Ky4wgcg2DyjU6vOuCpbCXBq5hty1DsHGrGkA/b\
+            NCxQ1agocYqrD4877L4/PKFxtncMgr+c4Mijn90dkaJ/CBj96ulaQxjwF0nEr+yqhu6\
+            QrWkSw+znc3zqltlVXCNrLqK/j+HJslSyp86zdh4M+bspTvJVaGKn2zpJKR+t07PjPH\
+            zfnxxxygo+wmZI1N0Y0BTnCwU1yPiAWAacERgjWrK98PSawYjkfBIJS1Aq0ijyFu9FE\
+            NMW5uA0v8UlcrowiRO+YmpSVvhDtCIeZXsRjiswKo5p80PE3bkIxIk/wgZJr5T6moEa\
+            Jv2wAMGhqZPb99LNd/4KadNrviKsIf0poLvCI4uHQePtXeVLJbE2qho9o0kinomFl/J\
+            6qjj7Ndl6g2H50QshYsUaOmz1+CLlz1CBqedJ4hs1/ZNN+QBq1J5mct1abbLJ9QkYl7\
+            AspRl09ww/hg+itm32vEcXuFF8KxdPxAZ0aAyNm16Jhqb3A0zZhCPyGc7MSaX+jSaCr\
+            l5VoCplKqwJEHcbjmHRD9DGRFbZA50idQ6MO8rFQuhy9UJhVdBjRGfXoFQ1yCnpoHzM\
+            iozd8/gSakIecWAkAoj6C3S1xfNqC2UPjcnsGhVZBZPGQlelmknVmdR94PcPO/TAMbU\
+            wq0NIEQ4jJlje8XLgDvTh0clsjZy+La6o2He4JfdqGc5tD7U1lqVQ48skjsqmNoOOmF\
+            pKG4mGNNOfFBzwh6Q8cPEjS4Q7jRj0ie9clMJNVV9MeqchafY2EARSQpFwieZPJnDyJ\
+            2dYKGEYuoejcXLcb5iPIpD8dv1N0kKtHNAO8pPfu8ECebqurwcMeOpJ9z1AEhUtyTPg\
+            c5PB3yYzwyp6vITRfLuQuXcrGAKPsK/J1G1D9jcwUUtIH0q5uadLhFbletny9lqm7Js\
+            xO537dz+7IU/lekYl4imzXIgYImvcUONRpsvmCwWi7zxSseC0Nx0xkFZ4yez8OxCyfk\
+            RtT21WaqbS/RWz2e0b7W33A3u0BWQ2e0ZqLH02daeoK4CP5pV1F12i7mhc6ukonLGet\
+            QTY51H3SKcD8f6Ckj/Q+yqXVqJ13ZMaWSy6amNizz8jcep7wsmv6s0eR6DygYfy9FXn\
+            qGniTUOe9z7MtaISKNYXzcLO3wWwYs+IJnUoUM6O/qWJwWjmHjiAXPMM0bYWCB2po1p\
+            iOKSHTXV1pdAAZkN9hA0wtdrN+yNf0v85YYyrSP+kR2Yd0y9Q6ddckY4ZVe21gp/yIm\
+            voZVSrczT+ipj0lrjfOpzQGSrfoKbRiXZOtOB6PH5HpYkptuNlKNQb+xGzkVOpj61W3\
+            XFYxxQGG5ym8P1QSM5G+c8Z8rwDQBfaLF4Rj7D2cT2TEmWINK3QMMb40u0azJa6hBxR\
+            pWetVntpLxCzuAanHUxg9P39AsZhOKKkL+tQyNDk/ofSSNK0fXpEbvVkpsTRpJRbLxZ\
+            fP5GnIGXKdOrH6J3LpAu0+MmLNUnuB9qwCWSCMaNZctbJNC8XrSoAVfYtES+bXyIo1R\
+            Udu8rBYMNJcY6FqNF8jJz8j64yZmXM8SPsfvRcCPjAfdbVhNHBJgKIUBJdMt0gF/nCu\
+            t3yhZbYm9zuVT0jT65EjebIyjMyPzyj+wTmZVxFA0DTOgH3ZknXnivcmJtiV/Yz81i9\
+            wuoU+ushSekHsKlSGMe1rxFkNtOI4jhSaXp5Tj4IZwb0ltyduzAT2R/mGgmdueCUzYf\
+            bp+EDRXlF/eEVLeFOICDdMGI8tSNaZEq0hDbU/v8OAdFuZ8yZ1V7y0iQzeWz0ekT9jO\
+            yHr1F3h4hEyem/1zM7HXOTu9PiEFyLQlqbdgrMmddeE6frf4Rj2c/6CBpoL5l8iTAbw\
+            /IkLZgQSxkCYIhVfVrSDWgm3YO/qqlCsXYlMpwtmxDphWwP3tLyg0fUaG3XI0wtyFvV\
+            wSber8hkp89dEsD/3BUWpvSaSK7uOeGse0Ulfz2jacY3Um6LgJPQF7cm5hmJBApr1NZ\
+            KOkzl/RU4yU+LkefREIEsVKTt7bjqdsi4XvMliY1yVT2h6cYz8nx6f6OV3kE0PLyk7Q\
+            3bKL8TqDFdczjI2hiZJM6ajXFD6GBFBrCg6pnLBmnTyDD2Cws1TZ0LkMjNSpZPnpFAs\
+            r2BofwsOtVIaXG7C/Um/iSxUW34u3EJGeLvplmemTIc74RBvPzgcOOYcs+WM2gTQf2M\
+            QpblyKHeHugHRV16Q9BapWGFD8AVqwzZkg3sNDzJ632SnyC6p++3cFSMWtF7DK+sI28\
+            f+gkcqzNdhnz9juEz5RiaicWoGET/a1nBYFzJG9ruF0tMjKXdhX8EtE0ZUVqk+PVJV/\
+            BwcDOKOELQfFrStLoRZdHZmM1v8ytJSak7uhiuzoPVzIbsm22dMm4qni6wtkjJf3/0Z\
+            +IcEd0Nd4tZi54DfaGAR9A0JAekcztdBLfESqOQmJocvwaWEINDIuz+DSoksxREJquU\
+            laBu6AJpKx2TRTrMiK9q29qhiDO4dCwJBMR6K4M7UEJIuxvIh6Bq+UNJUIiWP5/35PQ\
+            uLyt7wnGfSOexlLRnIaR1ssm59+X6dDne4rB0Us0tQLTIla44W4YO+Dpc83SrkExYMA\
+            pCx5VI0wjA9k6sslSvsRLgOHkqRMaWkuU9rqZaykoVYJ0tNBq5dBxUQD6uVlaAPg10H\
+            Q4d5cNrwuqYKzuquQZeBLBPVLJNb1swMK7Ts2nS4Uxl8Cy4TZyuerbk6bmZNhxfDPsT\
+            kvWPhSZHNaXBFPkgmkZ+fv4cPn7lC5sywZSW3CVdKqlZR0aQcOVhPQXLTVRXbMloZCE\
+            bVDXOxxeY16JjfxxeSXZOrfTr9EaP6BZ29EbX3haEPGA/H7Q3TyZm8FbFww5c5X7FOR\
+            x7u0bNC+fOy6JgMbpYZrHo/kDYylM87mMHBtTMdjzJ0Lv5Mk+GPH4P+o0FsyXbEpqHe\
+            uHBrVmvWtlzBzAZjCE7AjWhketrjUbeiokP5PAbDB15S+xv16eEdEycWN0a4bx8eSJ0\
+            kuNR95NWylClrRM2qRDdiubTlGGcFCkcLONLbiu86nfa3mN335WNwjhuAZqJdwd3DSE\
+            gvkBXTeitVlaMtYjdmdRAnZBEK7/MlwC4kaWTV2RRuq7pMNoaJhqsk50vWVSAwAewVz\
+            unAOGyze1tJu5PJWlnBIwTDR8iGyFQDnhe3Sq/mWZIL3TKTASkuwsO2H422OM7fwoOq\
+            nwjGmKegj/6Rt5Uy10buUm3YDuz1+lFmQYNB30HXzKp/x0fS9kB8qweV8J1JimXdHx5\
+            K7vd4Ca79Z7LRmdq3Jj0+JbLlTZmvk24Bp0uhslQsS+2F/vPgQLLPKtnwfJcen0azLw\
+            5A8BBck8z2RuqMtTx1Z8+CjSeOFCq1I6mPu4FisAc9T06gMUA8RsE8Oc9JtMocjFZxw\
+            XEGXzQYvAZtH7nMdl/LtL9BH+fXoDPeOcdK6K6uErkoeUYufs7XQUsjiUxaekFsHdwP\
+            QmM1wAaVoZ43O603pTtWsWYYRRRHMdkfg2bvEFlzJVgFjqOfF8HFZc70vpbZOh0fACZ\
+            Q81cYp/nwneGNBgNnFhQnnlWi1XzWx3BKh1BOqKsP7lby41CwifDGNj8PxH3IgqquH4\
+            dWkd+C25OOvKbodFqyNVOGzWpG8g7heJEjr8ztMER7CIUdpSYUF8J1NqqyKc+o0M/fH\
+            4Jmv2nGKEi/BxRBuDH7GSsKxQtmuJsc7entTD/nz8Ge9RzL+d3ngWgfR3c2gI7K8SV6\
+            yxeMMPDaAo0sC4ubHV3ZLtIY/NsG6ULWnT5VJBm3pwpc0Z0WE11Bsami2Lwu1T+uhN3\
+            LqDT/sPKF4vnjED7u/Ty5lTHtvTvl4j7CBBj20SeoOJxB8CiJMHXVMnJIPITPzyegk8\
+            XqYyAfUB5RlTpNJEZUbqm7XkLiatCxbyiWa3ZMufycr+HgF0yFlpZ+vPngFwCZ+UmEW\
+            UVoHA88C2t6U/ZxXGtjzhIN7+QJQnFOw84/XmicJfEh6Ivhg+LhKnxOqI9HBJlyK1FR\
+            bWJS4SQtuJ3BRyONTeVtQlPWZASC56AZwwtrcnqDQNAZ3EdrK/o4iwzrpVMafYCp25Z\
+            8w6cqvlWC8jR0od9vAXZNQzufvQTjBPl4mmedotyKerG7IYegF+h5N+WQ1kh64A1VPA\
+            AJofk5D691+4manPG6LMI51gSIZoDZTdlzTiisZFQTLp+C5hgfEkw13G6BW4SGNg4fw\
+            rEuzkdPqRbCOE+X3cyFSIBnaz5HDvlTsp1Pz4qKab2kfTBsPUUpK0bKKlsx0Yw95GS+\
+            EbH36QFP4F0yl7r/ZLOSVPA8YZtQ3PgNE8KTt8iJKkgI9EX9F/3OhAZdBdRQMK7Tbcn\
+            gGU/Yyh5KKW4rXI++sfYvd8OBDuPGmphWNjyfPW5U9NLxnHheBP20j/hCmKsX5CIHnt\
+            X7kG4GMdiL6RzDPsOLL7sG5RsKoBes9Soi2+FzgkdYpduv5fUbsixgtxaAzgrecMU=\
+            \",\"aP+jeTiiH8KXWjb0wcTzt+Ba34hyLpatkktR8Vl/SFI6fTccnISWksLRCkIJGb\
+            5z8dlaVrhx+CrVy/8AswD1vLMsOFeDxMiKK9Zk/Dz5i3+MSPqWr3fbrN6r8ySHlzgp1\
+            IDOklpxVpnVeUr9O5gQ1H3OEiq35jyVcmsS1kWkE9ya7U2n5kaJTJ+nNbyESQV9PbxJ\
+            yZY3RrHMBW6fJjf5BzgqwvnlWZLH2F3D+X82KdeDXHxw+P9FlMEt8qO4NuNOtosc6Nh\
+            d7BnUz1uWrVnBVTo+4IN/oGZ2zVQttZf18BA8YuOI5EoLbbjtLnplf/KGdIcJLtv70I\
+            H3M6aJ/P+cvwZd129JBG6fD7pQ3pJK2VLO7mU4SsURVjGzlKo+ewki/cyLoA/kSNBCd\
+            1cvZqKBZ58EQ0fT5N77iVzODZ7RMILMPlvJW8qhDAc3Hgk7w5v8+s2sEgsABsVAgGc1\
+            y8hYxVYTA2Kxs0rD9ZvZbsGs2kTl3k0rQ331yu0gSYc7qXGFLeMV00ZkmjOVrcY+9ez\
+            ltFOlMxqUiZvSGL1yqSp9CVtqItNaiWKVVHzDq4h53kt4nudLLmaxbP4WPFz2jHmedw\
+            AMCUoYGBEpMkpyLqi7XlUmS9Wioyqxd9O7SOF45M5wICHacx7WhePTgkl8/HOOEWeSl\
+            omm4lojD53X4NYrb3IVa4qk7rTpo67i7S1BP2EvvmXKNt1SipiFutfgziQ/nKtMVlaR\
+            jGHHtauRrVizTviGxXQDr8ENNH40F03Od3HgW/J8OlXH7SH/ilOwwnlLCrvE6qe4cwh\
+            Pbs+ohmuT4nMeDz/KIriTlm+4EsaZFy5/z/qoRdRaxnPQxXJZ7bdsny/S/gEemr8O7n\
+            2/JOXMMDvCJ1KxjAxLb6GB6glCW6lNobh+p2OtBI18l+B6T6JcHiNR+r2C6+rzIriGu\
+            FSc10ytuUpPj59++3//9qllBX9qlvLTX//1iTf5f3ZKS3VJf/1xlzU/NlnZ/vtT/Sx+\
+            ir91b/+4q57EVuTi6U9P9d0qr//e/df9X/b/3H+rs/rv1eIf/2vP7v++/6/7f+7/+Y+\
+            /m7f/+Zv65//87eH58Pr1ef4q/us//7Z+KqV4aj7/x6fffvvtt/8fAAD//0SIC5p0UQ\
+            EA\"]"
+        cookies: []
+        headers:
+          - name: date
+            value: Fri, 23 Aug 2024 08:20:24 GMT
+          - name: content-type
+            value: application/json
+          - name: transfer-encoding
+            value: chunked
+          - name: connection
+            value: keep-alive
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache, max-age=0
+          - name: content-encoding
+            value: gzip
+          - name: vary
+            value: Accept-Encoding, Authorization, Cookie, Authorization, X-Requested-With,
+              Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+        headersSize: 1248
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: 2024-08-23T08:20:24.701Z
+      time: 0
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 0
+    - _id: 24a4058b9d796efee0c393e3fe7eccd9
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 389
+        cookies: []
+        headers:
+          - _fromType: array
+            name: authorization
+            value: token
+              REDACTED_b20717265e7ab1d132874d8ff0be053ab9c1dacccec8dce0bbba76888b6a0a69
+          - _fromType: array
+            name: content-type
+            value: application/json; charset=utf-8
+          - _fromType: array
+            name: user-agent
+            value: enterpriseClient / v1
+          - _fromType: array
+            name: accept
+            value: "*/*"
+          - _fromType: array
+            name: content-length
+            value: "389"
+          - _fromType: array
+            name: accept-encoding
+            value: gzip,deflate
+          - name: host
+            value: demo.sourcegraph.com
+        headersSize: 320
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json; charset=utf-8
+          params: []
+          textJSON:
+            query: |
+              
+              query Repositories($first: Int!, $after: String) {
+                  repositories(first: $first, after: $after) {
+                      nodes {
+                          id
+                          name
+                      }
+                      pageInfo {
+                          endCursor
+                      }
+                  }
+              }
+            variables:
+              after: UmVwb3NpdG9yeUN1cnNvcjp7ImMiOiJuYW1lIiwidiI6Im1hdmVuL29yZy5mcmVlbWFya2VyL2ZyZWVtYXJrZXJAMzU4MTUiLCJkIjoiIn0=
+              first: 10000
+        queryString:
+          - name: Repositories
+            value: null
+        url: https://demo.sourcegraph.com/.api/graphql?Repositories
+      response:
+        bodySize: 14630
+        content:
+          encoding: base64
+          mimeType: application/json
+          size: 14630
+          text: "[\"H4sIAAAAAAAA/6y9XXPjuNHo/13m+qEw4/Emzz9VuXDi+W+cE9lxyk4e59SpLRCEKJAgQ\
+            AOg9ZLa736KICnJMrsb8p6LFSnN+oe3BtBoNBr/+VLwwL/84T9fnGytV8E6JX3/3dii\
+            f/nf//miii9/+PLc/HOTf79vi5//v518sl+XtzffH27++Mcv//XF8EZ++cOXhr9Jw6w\
+            rF6vOS287J+RizTch71ZsfH759b/mefv7/Y/vD49JvMooNj4z15mgGolwn55T8llx4x\
+            WLn2gev95vSJaWb1IXeZ/N4ytK/WlZfo6aca1R8o6uU+ZVyR1MeXgSGyh/peber5RfL\
+            0qn9nu9Y+MzW4fQZl66N4mg76u77T2QwSN6XV8t5DZIZ7hm3LZca8WNkJmTLRc1L2WB\
+            1UG5gdoMSKLiNXeBL5SppAiYaNXfINF6h2br+irjLSIDD7fL78uUXEaUtoIHS9Ur2WQ\
+            TrgtKewy2vEqDWV+qzI1ilZDLvv5SWp/51ilTZrlTRYn09Yfb5ZasxUPzVt4atNS7FN\
+            Yb3y64MTbwoCjePSUsI09WOQYSV6kZI4v4fZmYpeC48VyQZdzTklLxbc76j0xYh43c1\
+            d0VWWMnNHoq6LNHdrIIDNvNFTamPO4Tciadl7tF3plCS784DlZs+Jes7PgbR8u/SU5F\
+            WGOkCNb5ic5bLtYyO/wDWpwdPcAfEwpcGXlM6PBLVhV1HPfRLn9FilxKUv3MomWgRWh\
+            Dzy+H5Jw8JKSVNPjQf7X8FNg2DdqFenB6WxzBxFQ76GupOZbbMHGlCSrsspXSQfaDMK\
+            Yn1Nf0dPgxhUYJZxsZMEUhsj+R+2Hi+B0K/ilZIBtZKH7Idv8l60fYrOKixkfa/d235\
+            FSC9CFbOd7IjXX1lNz7X3G57xsbbgrHuX5rFnmndBGs1Z6NP2VOcrHmudJ9izcy8Lg2\
+            wOsOapSPqRge1JvMSscLLbNWd6WCq2woQjqc1GHuYFVjpAnbtEpLx6YXDPf8HZxJRtx\
+            QXNXwUk5Fj1+ynHti1gNFZQZt815JXSlNMYnSnzJbq0zwwWLEG1jBnCH6twYd8+A+OM\
+            J8UQ9imvmiJqZ4AhVct1ppycYnrpjfPz1vEWChJRsFmpiJeg7cBGechDzBlX/Camwhd\
+            UrOYFk+oQ1dFullD0/lV7CyNqF1tpdVVm5CVsg3ggNV1ntO5/Fpo/wK1tQBtNjIfJEr\
+            U0i3Y06+dtKHFe91pl6LQrSAiIeqLglPzNrb+/0SVPbXvBFO+sCmF9wQAPWwDxjUprC\
+            93z+CbfwRRaln5TdoXPrI0ip33O2wKePHFdQcB1y/nMkSaqy6u4ZEcF24tfLBlo437C\
+            +F+8v0BR0vv0Lzz1rl0hke5GJQDtnhh1Fb9NlxgYnNcf2qBBD2A/IdHG+bm69g2xxyb\
+            F2TTIzqApW/M6I0b9KhI079E9g/AGYl+oURzgQlHGCm6LD31Q2oBB7b57Xjru58tJ7o\
+            jMjq/ZPY0GLVq3X9VHyS3+kncm4Q4Ox35HvJnVif0IcfspyLWpoik5r7oMTwK5EYWRg\
+            oMWlKZaiikNIH0RvettJl1jX9f8h6IiZDCiSRTGsrS6iJUUjJynrjWhU8WHeS1OE3fN\
+            YBm92/6iJnwwOdGr+BHTM0ujMqsOkFx4A5OccMqlOFKyjfwFr7iPOIJSOiIHmaQfmWO\
+            0pX+QZKzgfgRubeiloG0lTRc6G14EfutuUB6aMRRlWgkbXNUtpWbEAR2bXSKUFuTdy+\
+            7KHsqKbpAs+19OyN6w4bGvbP4FR3Tkmdil/2UNGUEfyND3pIoVbYltiT2IH5MitllG+\
+            5YcfXURaytQ3OFtlo6Eb3Rr5DMzKQwKCQEHn+DDIxt2ClzqNRfeS2BteKMI/OZxyaL6\
+            oCQiOJtrvPEMnm+rp8egGnq3nyYFH7KZNNLosC2XmLub6svUZrHWkkjTX8KTKZ60GAS\
+            faidTZYH5zkDTt5JwYZuA11ty1yNr1kFb4zsH8BDW/KqOuKxU90GEcAPnAjlGWHN3Kp\
+            UIPLOPX631+nretp35ogQZU0QyLsJNUS3ECJNG942+7Y8ECrewsp7hXvV2zxM2EDan8\
+            DLsMr7lW5ENwvhkGcCe6n8Ryt/rgih6lv3Hs1rnvjG7ocB80u/Z+Hru3nweMrhnrcg3\
+            nKrfcL7l47FTfyj/s87PjjyVZPtHwTDf34FeqzM6k5+T4h0t5WwSaPNLwn8Huo+3zAV\
+            1HDOuFXB82XSAHoVh9S6Kv7NIG06gflJgmP1k8/T0MK7IDPd0E23LDxie904i15hsry\
+            Bldi7/dU1Z4T46iKe+08gsrjPNJ3eYNmsroDrYiRyCpuCrnFrUFoxbH4mZ24CRBC//S\
+            8g1SaU+DbClU2X0C9aKgpbctSmXKEjd8IRQut+llg4qIA2S47wBtueCndkT/+kKK5VD\
+            9AT6eBb7jjO274gruqM3wcqvpXnIr3vjlq2FpE/biv7kCr3Xsmo/fLxRav1EP2qsDZ9\
+            CWr0JXGk7hOy9/Ch4b5gOh9D7cvoNVzZMkQdix+oh0QVEsHjJM+SO53bHqhbXugpwFG\
+            pCazG2KE/UiN3juts2+qQO2nTy/XeFN/RDedDqrlLqTwey0CrRC/dsrUG8fbRSG9cKq\
+            NDjfHn7OTn/s5k9zrpUb6I/o0FXw23t8Rs7FvpVice66NI87JSNYn88u3xfdf+v+f8C\
+            JLTU+ZIJ2QfQWNCZ78MqX4jUjx4bYkho+TFCd3xDG5gzvUmNbvqdL1ynVq6U5mv5n5c\
+            EjwiqzOl6/4eHuS4MYv3DRTVnw71uBVWg2mlmrb6Lh9eUwnH5OhRQN2exmSCWsneXHQ\
+            HoZvKBC09w3AjdQF6z+y6Iw6ON+BwN1yX1/hnWVrlGX9B6UDv1yDqogYfFTGJzUu75/\
+            hxYzoCs4q0eWao+bHZ1hbmxAFasIS4Mq5KnLF+g+iVqHKKGzD+g/Uv/IGdNSspKmV8Z\
+            lQi4Yrww7fiUq9gdcQADGuTNbcGenRur6BRfKM7GRjA+pDd7+/gdfyJzRbdP1SfLTQy\
+            EwVg58eQabzOfp4MOFkRHLUq6pnQu38kdmqVmplZOYDL/tPiXmK9mxcBmB04KVPcGDr\
+            0wDF/GP+O6Neu76uCWJyLS821tUrbTdseqGm9hvQnSWJLlqiNRN6HUwvOsdz3de+rxN\
+            aN6E/wmlVFjMj7mFviyR6n3myKeCp7ZAE87smtzpLOiDw9IxkOuSO9zKYttKsbkCr/i\
+            wq2pt/Qj1rkGFpBC4KW9ecccP1ziuf1TZoZU5VYqw6kRXXIYFeV9RaVYtCtp4FZ98kY\
+            uXuV/PgNvYROmSTjbl9Vymo0+L+EXSNgOApjqUlbNEgqKOJoO+C6CLq4myneewOaEqA\
+            MTRxROqp/gkeMlLw0RsS2wsToEsFlECtVT5uV6l9chOU4L4jlM7oQEx4OccqurAEo5M\
+            iUTmDuF+IdnKliQN05f5SqOdNtlFhnTkppMKcJwc1lBxUzvCh0Ar1a0H2AlBmVhX174\
+            kKvrDnB8yFsR/+NvSgfUa0VitTkqajEvQ0PCdvR/S2Z9ouKCP9uJGODq8V7N+UlMTk4\
+            YYv7VN7C5wEcbAKPGCXlEJcgqD19HC7BA/nwklMqjHRBn0zJ/afI9tLp7hW+ziJprT0\
+            U4kszdJSGU7h4PJ0A7q6VCsnJYufYs0dutuzvALzWjrergMbn+SCtPwOjiOls13r2fh\
+            EswPL11rynhEfxB451An6FRWLn4StgQb0nQW3vvYcqIFOOEG6RhmOTVW9QEE5arjS0k\
+            wHGwZpCtKNmgJqxgedWarGiprFT3xXD+xMtuCs/8gaayTq4X6zARfx1r6y/gNr7GfYO\
+            O+6fLeohC2UKT2bXggYlJcBZo1i/QdWKz/gbumtufZseGTch1+uFt9Qq9EPuInesfqu\
+            mQADq+odbDz8R/PAE3nveV5wzVsKV92A\",\"p8R6DkNPfg8OvlDbedu1LH5iatDzDp\
+            Rm30qhVjs2vRD5gJq/Myosqq5VQTo2uDmM36il+SM8oSDQRpVuWPl1bWuRaWDINlR6J\
+            IWWO96gXeoFPKc3kFpljTxwx2+oaxC8JRwz2moeVtY1E3H8muDoWSEmYhRNeur3ZKwW\
+            QLLmnRFrfJa5A13VcLaTvUzg3gNPL1tQ8N6MDIwb1XCdeaNWq16Mk+JG3IGHI2u5E9r\
+            ymk0v9PHy6uYiGul3BtRlvXbWWM9sK02pE0xpEMeufVdLxoWQ3veLVLVSyTUnQP1+4p\
+            YqrDvKjbDPHzBIjZyFD7zVfb/sFVF0ARlpQJc8p41PHAZ1wto2vFHBd2ylO2kE6Q/Qs\
+            8DqOmfFZ8At4eCxgyOuXauMC9E5rrMVV7pzMitkoAJW9Mo8wNY89BmMlhL2t+HLM3U4\
+            /OUKEhStynUQthNrdnxFnSpA84BWr53KuZfs8EZvBYJKSIyuo6wJUqwXVfALZVkVfBa\
+            9dYlBYA/7kpxjIzMhl1D1neJaZ6vrig0PjFeDM8s7nm95UFxfV+zwhqqroEeq7njF+o\
+            +sQtw1tvdP8OFyvb9men9NOG7HfVWgqhreFjmLn6jeBe64Nbz1wXUisMMbauwEtfeGO\
+            8WLfFEVuWDjl1gwOizKfgnuijTSe14qU667nLXWallkFaoN7X+ALdYoUzgbWJULt8OO\
+            aEezGiDr/YJNBTuZwMav474FLgZQ9xkZBxZxlBq2JpyDqKl4CY5g56R3KinqmwQ62fS\
+            o8eh6xA6vk7c61QVewENNNDczNitkK00hjVCEBzp4ihdKB4+p8vSCttYMkPLpexLgrl\
+            pjTWmLnOV4XJl+uoGGg5EwPrPCKbKQ/VQI6ocAUMuSC8pmcVkeJ9vtcKYGP20GqqAA2\
+            +8M6rH0DDqzvQMO0jgwibKDnciFnO8WFfetdGwM11VhZ07jQRQwdyMuepNWhOTtn8F1\
+            9wwo7jsR2Uqj+Ta7WnwjUFSFHVC8VTQOHgROcVM8MWIl8HKdVtATXHa1gHfWt9gmRGP\
+            3SmvO3FoZLBZPr7hDufJly0XNRiNVVvDA++UsD9n4TwQXaouROz7JyA/PGzCHXRgjTk\
+            16P+O+yYw1QnPvteWFMqXcBmk85V//DI9du5wH5dn4RO28YM8w0l5Xi6HPs/glaRTop\
+            yJwFDAy5JIbv+Ct6n/Iph+i6Jx6I9BL+yUYMAtPpXW2dLiTW7UEqzaNnRn02N8jqPHj\
+            +MG1BHep6+Gfqpcgm7ZfTlIV8yn4m/IduovRZxsURIg8OgZmslDBuqxRjdTW1pgpt5e\
+            by9t2Ssi2B19xoiwXd4ApiddOOkLVW4JHLGC8b1X22qleWSPikvTd9+I29htlysx2gd\
+            g+6+GX5z3CA8+FNcFZVIyWoBr/gW9baVQhs8FhHa9x8CgGTN2gR9SWoLoOEgvFtcX3q\
+            JagFwFIldtWW4cP6EvwhD+IXSkt/c4Hie8APIKnrVLIxDC7BI/Ng/B+AkZDMEUJvjTL\
+            Y9/G83pxRQwh6/HKvVQagtziYgtqhCCS0KZ75KWt1COzlJH+4j4WyR1+yh50OgOpG2U\
+            Ku8GVOdAabVRu3YJ3wWplaja9oOYRUJhsXkkjvfLs8IYuj0GrWV803qrxqMeJvp0rU2\
+            Sm05pwC9zDwfDesccvWSmNdESE9T18zgdn0psFoBVnaOPrXjVmJ++xd+LeLCV4W0HPq\
+            Yp6UQkfenWSTS90cEvQIHlgNmtWNWuyxC+gjnogWc0qSwbc3D+CNoZI8l6y6YXwkAPG\
+            if6vPW80m15I25YA/QHmWajCN/CAYRHgqaZFB0XY+fcjMH4QGinsKQvwiAzuYWfLGaA\
+            UnVNhR248goonwkzIaHLTbBvtpUjIZrIgjkQ0k9v7/SNo6OpJQfpwXbHjK7oLDFqUbO\
+            uvq0Xckouv8bhuJrf4mUY4JOI8T6FxlOGYh/M0zfHFLhx+a57XWKOosxlwlNt5ppGoy\
+            iRAL4l5HHHgHI7rCOACYQKHIzjOA6OK1DrbSocf4X8BFyMDuOXbhdzyhrV8m/UvqCML\
+            6IAFwDJB8PBWmeEdQvTU3HH0bqc70M+fhrscPZ99B7qiJ6ET9jTvQMfNhBRkYwOx4XJ\
+            p/uMO3jXBvDDHeB/bP14sbP24jJ90/YHMQxNzCrfSYw/BVojoB4gSiWG1LXPcHt4PXC\
+            Q6KLMbr3xhJ++4fMGaw4TtnI657ZzOuAy4k9uTANdOtg281dwY6djJe5ZLI9YNd2j5b\
+            0A/DwgrrPHBcWVCNm7mJdyAIsDtDDiZBA0SjkYIYVvpvPJBGiFTPOtAX50UfsW3mOmm\
+            r5QLc4+eDto/3C7hWd2X6vCSeLvVDWhkh2iLt7741hDW+xJ09XoPFrZppSlUh541gd2\
+            Wz2mEjgAeMXjP6RVU1zqFruSeanhB+I52uP8FX12C3ecdrP9n33IhYwA+x9GTej01qe\
+            KO1LhnR5z5eATvZoSofS+XjTSkRPbspEo9sr10b0rgS3dwr+Q9dAo7g/pKwTP/O9aYr\
+            Sjh1kgTFqn3AYBG+vkEtEUn7DswTOE8rpGBh10rL8juRfVxuLEU9XR4BO9xeE/ttfjF\
+            qjPUHXd9NpN6QgS2zjZ45+8zmCRSkdf30xrfmxBgjNGBlzym9xoaWtI4UDYtvikNnpQ\
+            4YRD2MgFuDR0Yv/zj+hfSXR1047abqwX3DeMePUL4A1arj4BsCoCAthG4H3pKSjiE8Q\
+            M2i52AgpPobPYDNoadUKh9CwGbWjfct+zguLfLxFqSXiMRCGZrFkiej39G6p37diGNs\
+            IV0bHxiKAFuz7dcXFcsfpKOMbAgnFKsKrA18FMNOp233OVWaVmwwxtpMq/BA51zNCJU\
+            9dMzOKq3sizsxrDxiWcJkoRWdyFe+Me3eebfym+YO1j1CN5e0FoX4/wP5+/Y+69TKIN\
+            frhbfvqNWZdB0lMYf4jx8XVxTKe1LcNGYlpKv/Dc6EVCFaq0PpZP+VbPjK+4ICYroEe\
+            WuilxkCcD9w+0daOhs7Ua6eCb38BZdbkYPaNSSDbpQEVA8mhnonkJQU45ygO4dEJs63\
+            jhAwcb6CCW3CsE9yDna4BpAG7n2N6BWQGITVvMvF4kXFepkix3VH0OwaNvktmbDA99u\
+            AQu+C2trWBUf6DwI2sxfO+7CPvNiLfsKc2z4AR1UQbO2406ulCycLJRfxE8WP8kLDu5\
+            Ar1jHOy/WqmQVd2Kt3iR+3O6pBENfn7mZs8OlWLTfefUMLlwpajSPUtHzn8HtWBIfMB\
+            vmw+0SbPkUcrbSdkPIAogvlPfWsOkFN4iAzT/0tH4tyU7eiakHghnrwnpRdCJkgbeSH\
+            d5Q2QR3ep3lTpkyV6HhLfvH8O1P8RsOBEv7DujXCj8w9QgGU3A2t31dOSUYN4WzqkAP\
+            Jw2uLiBM1L7I2fissAgPD7cvYBxHZ0su1qxXTLRtf0FUkYenZ/BMv7O+K/jiHz/iuXI\
+            2PgkWWN/vWfEgD1Y4+BB8VLfisoQdX8mwDjXoVgPy4Gr7uryFQ8LP85IV0KoGjQPz5B\
+            SFsyrBnjCQghLs8EZWJmzhBmiUxo3lLav8AKt8VtgmqbxPNejm8IEpzVtW+cI20ZGq8\
+            ilsoP/OstOoVQ1ur32g9nO8VnmmTEBvOatBB42PyJjXhFzi3fIUOV4rm1Cd6chhSzFF\
+            opJaqC92w4WzMbKq3ErRBetSJQya/D5k2+dhvO2l4G2QLmW1myphkRtDLa24kCm5Rsm\
+            am/IQBXn4ifudITvxE7xAB8HC6lHLiKE2ORmHqPoBqpyXJYJW/g9wjXZBIvhgDPrpgC\
+            n0Xf6/k6sJ3NJM5uM1BEZkB/ktd1zreGf6VFWerCS0f80n4uOmdZMrw4N1nqyqO9DMe\
+            2EqRFkuFqlto6nMP9WXy9GIJboyXfMD7vshRi7alk81uHPykThNG4QE4tP7EZgSG7hf\
+            yibmj7wsPV7bQXe/gYaeKYDvXP+QKTogbFXiWmUjw3QnEC12uCp9hiLUUnQkiagV9yH\
+            2ueztKkUzvRiI5xDclDwCh8gPh0kYd7pAGzXiGtvKgs4YaCg5I0UVoVb0sA4bpU+I8Q\
+            aAQ1FRW0sJbumf8Pqqo0ck0GZ4TsLWbE8voI/KGSbeH0wuAWFD+SyO0v7T6ipLXaMOy\
+            jrdoOfQpOVkDcY5Om+QJBy8D33EDdNuwowOeunMsqjhiczX4Y0em0D3O4BG1RnZuMFJ\
+            mVRjZGMeSMS6BVdIBiMIE1rll+3IoRPhSB1G4fGu2EvsLYS6M+KHx0U57xXllJwbhep\
+            P0bacwmmtV9tL6xZffI/k96vMuKAt5MqnJ/REjBjvEnKdMbRKmZZxazWx0IDjx74jdU\
+            FpvJXgMEYRZHTLciflnlqlP9zW+HrhSBqsF2TH3C+JjunzwE5XZlTM3SXRZwZe03BT0\
+            CxicTCyhqs4UpSsnkjmTtmUjKHL3B4zLgeGy0Sb6U7pFDTaG3p0wxUd/HhJdIMJlHkZ\
+            gjJlQtOCB3GPRJ/jserADY4jInBfJ2WGrKfhVqR4TD9h6UIX7v1Yh+YOPCFzpMUzTGM\
+            0Cbq44IGYM2BiN6A7/Xi+/WBWpbJH1t5wZst61Q8kCe1LjyN7ZUQWYxa1PKwJ5MMtfP\
+            9VRPat2+rOj+rCdfbte4oejbXzAXnUorNv2bffUcP8Exw4E+P+nqwCgZtJMS6hhqRV7\
+            XBEKft99lOKFktVLTu8JWiyZAbf06hFTjpttJ0qNBRB3NbEBP4Dk55LeumkWnsGiTY0\
+            7II5h1xpHnwr6W3DGgzBQmHR3MJ30s1i+5UMjb2varp3nmI7k0q9JLOd8Z0KSS12gRA\
+            0PIi1dEkXNjzcwhfyJbHxtgM9kWfZnQ8Tn64S8I66OXTrbJskbeIiIfZr2+niNM9UVV\
+            /Q8T7CKdG7AL6xrkiR6P0jplN5z03hOBOvOuMmaPzQEqY3TqSkeMkPT1gzrWXDnWwtG\
+            17jFQTUHXkCcaCY5705xCP24Ukga7xZYEKZEaeHeSTpBfuMeHqsN9IpUzLlBBGZvwRj\
+            a3thCynY8MhyFeh+jTlKfIARet0FpARDZtSQkohxbKSJw80XEFFqaVTXrF8Pr2wdGt3\
+            rtd+TIuiCvQ0h00E597Bb4Bx4eiE64O0LvEeHUcXa2UYm5PoOlnSMv1JOruyWru8nOJ\
+            YvmsA6BHibcMB+prbRe4wG7GeqYzCEEPUAzssY2eI3LMN2EAw6RJFIk+nPNB59JKBC1\
+            BTZvEl3XbHphRj7oQzWahWPIq9UyYZH1vBSoQefXsAASb7eeeEkb8ZbWbj3Ej/0UILn\
+            ML1eXVesEjqzMYR4/xUdsOEdyoHU6SxYgvN9WYktzIifVJCrF/Bc+SmEiHB4BwapP4V\
+            oW15XuFXrBYxKcQry8YQ31lACtoQbXssdbzQ7vFHXTX1d3iKWdWvGE8wx5AYbHkTss5\
+            4HlXOeh0au6IHg+SEAiEVzGXiXFZg8+QkeVzgAS2sLJT1ruah5KWMgE+IQSAUHkTtgr\
+            ffKFHLLppdsPB1OdQ0Bu63QbELHHbQWCt9que08Gx5Z3ildkJIFb0DPU4Vq0VAxD7eI\
+            W+s80kuRFcq3w3KOEDNKKrzyHes/MmXiNdRDIsTaE6rZVgp/xYZHluTa0+PA8p/hksw\
+            EoMC+g63aFBRUee9Q47Ka9AK5gRearRX1IbIIi1/peJGwJLY=\",\"/Wpr5A1hlsZz7\
+            JMBn8gmWOwTrqsXvHlt2fBj1r+jVHgRi1Adz3OF93JYqSW547EqAg+K03t83kvBxI9f\
+            qBbs4WA/IuHKrBwf7pjqiIuJYBXkPBlrwyEVa6nDlKk1c0bNuAgdFTX35tOZPuAz3gU\
+            7qLF0DaU2xIfE0tNI6q5zaVCXzN/BM10KOkPnvCHrn22L4TBDUh3t7/dL8JxaUkKHmH\
+            /4AjBZcIW2XTGlEr9kQjnRqZA7yesYW9CrXhEREl2OPD3D6mNCmmQMkv0NvNxJ4ceVH\
+            h2FEQ7flp7KcC8XmgrsDJqUChEu/qmG9zxpvpFhpdU2k52TdcJtfE/PabN0Umpk3fVy\
+            9vmy2VaalVSlIaPClMnJFDzwKZX+PTuY54kBJ7G7fOQTnSVOu6lNMkPvxDrnSDSpgZ/\
+            YGT/wpeY+KEHchzKk8dkakuYNGyEH+GebtyqQULFDy34a3aIr1WfY95Mi13L3xnVHNC\
+            qsvBN4XSDHNwb0Z+VlvBAPpcO+CRQ9XrBFsD+b8xhnBmvPRzDSF82WBRL7a8j3Z3uPk\
+            zoGbUMvjnp6hu1PdAKj7wVRgM9Xjg/ZRubNG1z9X5e3P8BwT/Mp9Fyr36TLguPGt9YF\
+            akPiFjHFn6VROt6uX/VUkPErwU7M/zybiN0ap9rEBNY8SMv9lMD4lch8onwqE2TpokR\
+            O/JOfEuQotZMRCa0UYjCOCaUOn0RC6AQzJJTYLFRCzRZNB/b5uSwd562okWj9Q1qJZa\
+            r5qj509/iF4CaK2Ucu1T/2iPn1DN7PjxO7f6ej48FuRmfoVnelOlT78I2+KTN5FTqLb\
+            2Tg/ZiITW7pC9220567QxLxGzpuJ9tN5siZiFfgts6+KSz44iA8v6EIZwllgq9Wktgk\
+            uoFPoKSkOAVTIpJIrL1+Gi2sOIzq03d6yIVdwVOTaKyoien7BvYPT02lf+Hed04WeEq\
+            pIzuY0kbm0XxDLaarR/gM/oe0gtsdEwp4gOJlsklguuJnYXkXDhbZw8U/8Vc8ECGyCT\
+            Cf1IdEuMBvtIddm1NTGGw1RCKJHQVJhDCYJtuB4CTcrkWiTQ7S+1vLQY31dbLhF0yiQ\
+            u7t7AsBuwekptBI7zm5M5S8JgDTGTpI1n9ap/aDCpRgE0zek6JSTrHY/eb+M6VFXYwH\
+            xny+NKXKEvfUJVvwqZSmqPopjZa8yoYTjZcXEtbi31oy59E4mOk7l0gKuI4/pPJby+F\
+            5o68ODhKkDjcMsb81UXQZMCTxW4VgI3EDF+wy/CEF709WYeNXWmNLVtaBBJJNdWAM8U\
+            sSoq1fYHDxxGTWfC+14Pim5A0cXyUtFXSlPwTQTWuWEYxJKXwr8Twr4xa3bMEuwgDPt\
+            1IEuNmGnnQZM977ixMT5e2wT0TurlVl6vrzjEk6wA75vZRNhMVO9e44BZJD3mPqhDFR\
+            5bZ1g9ATpb8ssxWxToBDTgA8ymKfuo9xAOIBnpM9JiYercTGu1kS1buJah16nVUNe0g\
+            CvC16CWSyU9BhdYvupMSGvrDEpICnrmEPQNiUOuTvMrnBFIJYgxfKzUbmK93heYT9dU\
+            EmZqIZsnlxsUk98ukFjt52Nu1uDoaYTYLVCj4rj2GpTRT4Qm8Yu23QSylgR+ggjbdup\
+            e2GmYI7xxGb0MPtC+idfMI5vqZcyY2cP37vvsQGS2Xzis604A7XGYx2ueizBtrUz2mk\
+            C8RgqEvLW6rDw5MAdeMzYun4ihv0Phz4IM0Zi5jxkCvbz0HxQFzVtSrgDjwv4CR/RsQ\
+            3d3rSFaTbnJG0FVz7gF28OshHWlEb7hRH1jn7++oZjN5/zrKiJuwMQ9bSSpqyBANd28\
+            9Z3r9q2gayTBXbZkfd3gN6yZ+RaK8N0K/9jGQdF1rGOAgEL63+R94WNYrBJ07OaCl3F\
+            N3v78CwIec4cmvtBgyWfIYavMuR0TvCoAn1HCaLlpuC6utpOUv2kq2e0WYwJSNvl66W\
+            oG09rJ2UQRo2veTo5RxwcLwPoExuA+FbCPpthPWukVry1SJCPDv8MFB9Nmggk2HqJ3S\
+            ZAdrKL03md0RpoGaaqEc+AQLr+ANozCFVAek5G4FwUWOscnDWaHiQ3q7Cwr/qSgY2PL\
+            AeU4L+kyewN1OrwIYH0ZehtraNrlj8RHsKaMoKXc25UWyLXP8UI41AGdi1Uss3qRnXp\
+            cwdFXs0xia8hEXFbILKdWAJHpKiy8SYTWTO3tHwGIzwzDxDw2M5gJvtc6jUSJgPt3C8\
+            wzluYvxccNp5j5Sr1XjbIt4m4CYtyKNaJa2NRx5a2Dtwe2MWltXSGUlFvY95hMYODEu\
+            I0EXtMjEvkqXP1EVaLBPQpQVjH6KNp6UBbibOp6H5JjUSC+hWNC9yF9V52rgwkpN68B\
+            24oTZfET5QEeIfbgVoWIeZlDhfDLykXi9qsUhPFLLL6uECCY5BAtMarl9v0VmF9csZW\
+            uLNX4nT2HGcJG5YSBzTEsddAdtGZnlELO/EiWscrOJ4kiA/l+TwkkEKdPGZL/tFnemi\
+            Vk+TddCb4QyaWK2JgpRan/GWuzTkMWw2qjXDDr3nvJA6qcLrpyPR2ja5QUhaobxQrVZ\
+            GpmnQS9ADGGamZvYScMrNIFGISJH8AE3MLj0dnZAvCCsL7hAdwRXfmPGiqZRg8aQQnP\
+            IotYnMnFZBOq71LrFTJsyQDRdrZRQZ4jeKJ9ksw50mF+tgJRi37ohuuSpl4sp2CVsWI\
+            R51Md1F+SMGIrqwQ3zoMbJxxo2xgU9hvakxJBEeg0+Peldy54wJkDL1IYE0KfgBOuSc\
+            oFXTaS5c15C4Jbw5OIMbhpGV2p7UdkJEzIR52beKErFoL4Ry25lcesFbyQ5vqPEMdE1\
+            94yvpWFXIVppCGoFepfYDvFLjTbnQec3zMVK80GoMbkeGXYddrmagizHeLPc+6/9/dv\
+            advKUEkNO5/GuVe1uorkEvfo7U9AJkXpUmBgvSisrsBZV9wPo1dxJdOEYyJA0T+XC5Y\
+            oxiRl6R+gRH5z4iO69M+UuhnBzuXwd535eV2MyyrA5FzoYHtpnxAs4dG8lrJ1esarZd\
+            UBrdnhGguG/WKow+2qyVwq6ISIk3oBPgRulipXeLIaQCG7/SoYCrO9CEPCEPvr4TVOp\
+            dcNZk3JtvuA0Y6pE0uguwh0FfEeAGaxKadojvM//ZeqEcLuA9XRItnCykCQo90d7n/b\
+            O1U8udD0REkTswKA+JP5whpEIkwmtoMg0K/QPu1BR6+9PXr6jjCyI0TjZW1Gx6QacyM\
+            PDGB0zmAzcF1xa7wj+KHEDcSqe4XnjD23bHhgcZafIO3I/ZNnoKLsBO3lEPRXBxsh2C\
+            U7PxSZ5CewRt2+ckLUuO6CgDC6qxM1aruZBrqwtil/4GdFJ7H4IVdR4At0J3Pv/+3S1\
+            KxwstWemsViuOn9B8AfvxXjrbvLIqPrAJ8hGcr3tE6JzhznamYPsQL2JHlUswFPhH1l\
+            7hLv3gmmpfW++nWXJPTI8DCaqjdySJ+wOBG/YDZV+z/TqgTb9/BM30RwYyqtzvH8Eh9\
+            QSQK4OfIAZDZB0hHTr8vgAb8Lb/D/UOml0dtnrROl42PCgfPPvrs1Hh79xxxF29792z\
+            Zz5a64KWIeOtOn3HRvyXqzlJ+3935vVutsN/9sDD4M83k+F4DmkxnLf0rEJPJcXjPHM\
+            aresWO24Kue1Bol7bzsdbQcdX8kzCy+wWnF8vrNst1rvCcRY/E+7MeJ493jDEys4qU6\
+            jTd9T3ZNb91NtV2HAnF7zhe2sWfON9UbOT1T3KnFXPIKbDYS8XZRBXq5+eZ9eKEIxyR\
+            e/nvNkA+wiw8oOWGKyw6ExYz16Ui5BfO+l2Sej5Y1EIetvoFPB+fq0FgIUjFJ6+8Wft\
+            MQCw2BneYC61g7inA6UpWqtM8GgA9YGaLgXrENqxh1PcetZfFOBGyaLW6n2NpveAGj0\
+            T1Rd7bjybZzUyOCUSqvKCHto6u1Iavc69F/b0OpyEnBbMS+TIyZIaMp9nTU0Az6Mmpv\
+            nrGSFUQcT2HsqaXoMeb42X2XggEIuYGWZXkRDrFWfNuo5BLI8dmqvuZk8nAKywVq7IW\
+            u5CvyoVtafOgA8Nkl7wzsWLXM1wR3JKyInZXRCITow3+8dZG9k5bdATrfbsJv7wZ+uc\
+            DMH+Of7+dyp6wDBuJORavvX6Xwy0zk7eUUPNrDvrOVhZw+I5ccKwUM7a9c5pvlFhvWP\
+            DY7gKgoAmZPE9VGj0Oow0tfA9slAr2Ks7ClbKOPKe2dgCWXnuH26Xs2dkcKjfmcDhE5\
+            ZDVi+mkmbyer6ZAt/GD+KGkv3L7AZ8sI3ggVXct9JlrjNBNWhAufmITLHzLcb51DHud\
+            0Zk01d0/TbrytnVC2EXBQ9dI4tSsjVvRIz1id7ftX+4FbPLwQG30rxRpmylKTtlFpXc\
+            SC20YtMLuvSaPYDW1YthryMXtmmlk2y4kDvzoctp5X/+pAsBpc/d7R9nV5+d2au2lcV\
+            C2GZRyZA7rowfw/55diPkX7sGO7pSidltPYJbqnCtComMag+3y9lzvgQYHyp76NwQRE\
+            D/lw1aoftBYnYXksD+XbqVdULeHWNlEg041ynwNAjTaCVmZ7jOj6eTZQhMtHJ0l0FBs\
+            0cU34GM8mGMFKOcQy/HqMRs42+kq6XJti0P63df0A41692x8YW+rsYHvvExp8Rtuebj\
+            J/HHM2lvpRPSj4877F6uaHSbq9gJ0ei/x6a5+fsdPE3slvt6dgXUL8F5q/zhBSvL4+w\
+            o+gFB3PS2nz//u220NGJ8oNUx6+G1bXTbaT09cW+M2fZ8vz1BNMiMaG7b9nv8IDKP/e\
+            kvDTbKRD+ld1lvnXrjQY6XGxSysVmpQnRNKBeFfGMu3iHCo83O2EJWPuNt++XX//NfX\
+            1peyjuzsl/+8J8v0hR/7py37jzV5/tvwty/iar9/V2zVA/qr93Lv77pO7VRhbr73Z35\
+            047/z7/Xxc/P4eVq+1b86zH8++d/hnz3zfD/+Yd/+dddJ65E9++f/3n1t+9/fcu/P76\
+            Jq/8/iJ+3+m//+unt3z//81Xsvq3FX/50s9yX+/vbR/W3P/+1vqusujNf//jl119//f\
+            X/BgAA//8qLaX+PSABAA==\"]"
+        cookies: []
+        headers:
+          - name: date
+            value: Fri, 23 Aug 2024 08:20:25 GMT
+          - name: content-type
+            value: application/json
+          - name: transfer-encoding
+            value: chunked
+          - name: connection
+            value: keep-alive
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache, max-age=0
+          - name: content-encoding
+            value: gzip
+          - name: vary
+            value: Accept-Encoding, Authorization, Cookie, Authorization, X-Requested-With,
+              Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+        headersSize: 1248
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: 2024-08-23T08:20:25.120Z
+      time: 0
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 0
+    - _id: 0e495bb20767d58de896711a753c9752
       _order: 0
       cache: {}
       request:
@@ -2925,636 +3601,7 @@ log:
                   }
               }
             variables:
-              after: UmVwb3NpdG9yeUN1cnNvcjp7IkNvbHVtbiI6Im5hbWUiLCJWYWx1ZSI6Im1hdmVuL2lvLnNtYWxscnllL3NtYWxscnllLWdyYXBocWwtYXBpQDM1NzI5IiwiRGlyZWN0aW9uIjoiIn0=
-              first: 10000
-        queryString:
-          - name: Repositories
-            value: null
-        url: https://demo.sourcegraph.com/.api/graphql?Repositories
-      response:
-        bodySize: 16980
-        content:
-          encoding: base64
-          mimeType: application/json
-          size: 16980
-          text: "[\"H4sIAAAAAAAA/6yd25PbvJHo/xc/L0XP2E7ypWofptZzktnaGdckUrLKqVMuCIQo8AYOA\
-            OqWyv9+CiApURK6G/Luw0dS9Dc/gLg2Gt2Nf37KmGWf/vjPT1q0ykirtBTG/W5U5h7+\
-            7z8/yezTHz8t6r/tVl/e2uxPvx3EXB3f5vz49vTv//7p3z41rBaf/vipZlvRpFLNTM2\
-            qSh9EOj4kuWbt5qNKeCVFYxPWyk//+jcIXOTx4I1gld1QwOddNLDYWYQ051/e8nhSsu\
-            pkleE5e72Hx1VdqwYF7gngzFily9RfyXLbv+7iYVxpAdN+zPNvUNZauV6LtGBblvTPF\
-            Ov70+c3IGetZofUX5PCqObn4+zhC5arBdjYWi2bfK326emJ/MTF59d4mOEbUTMib+/x\
-            OKwuPQsq/RDLPSU7sSKQYCXcIncsz4V+JIrvju/tgWSf+DEvP6NVPMs1yyqRZqIVTSY\
-            afkhq1rBc1G6saqsul1iXmy93P1C8a9drpWtmh9wn5zdJf7NCJ2bDMoENFi4hrHjwhP\
-            qPpD/n+LRHa3XWqI21bdrf3IiODuWPUKuzTOfMilmuW566S9JqZRWWs/wIFXR3ZGWXr\
-            pRqJS8rQXT6t+L9K/SNfaOauY4+235Jx0bGmkZZZqVqDFZDi29Qh6W5ScFKpi0yILwV\
-            i89QcQJ8fMB6KxZ7qEkBwFploqLK4L489siIzz/m36DhdUC3TBuhp/D+DVoEh1+Exkx\
-            4eCsDyYatRdLpKtHCqGpLfgBeh2AyW6yTzHNwXOspd3YOl0+0YcQ32s94L4turD/mS0\
-            ies8JUbMaE3Qid+h9J/4OghSvcylqwJjMt4yLlWjV+8s+6Cq3Z4+IB6J1Wy0bNNixTq\
-            k37W8Jaxjdwue3fjq8PwMd2TSa0Vbt0fCCbdglVwS3KCL2tBCJVe1psxnZiZRQvhTVJ\
-            YdBu8Q4Jdlu21am7oH8NZen010nNLN+g8/UXYGTZCm33qb8mrP5oh3URlp8n8GumrM5\
-            u6DXCMYfawQ1rYzOZC4PlzNHCjT5Aa5kxO0zGOeYPwKBzQ8NXag4UbqE3IOWuiFz6Nu\
-            dfgZHrhrUTK3dH5UX+LaLAVlpmuaArc778HPGdXGUiF6iQ/A4tXQIcfN3oWdF58qs0r\
-            CL5l4iWP8JarbgwRmF9e86/RWWvMV1F90zXy2No6JQ2Xz5ElH6mOFqJb8f8MQKzYUdR\
-            cUb06seIrxq0L3wjeEnA6P4jm7VspGkZ/oVfgIlninJNilxe+2zRHbHoGmm/oc3pENG\
-            fS7YuGd2ajvljRGuvJdeqFm7VWAurJcfkLoeki0y1oiG0QU+HiJGmzWMms11EM/XLQV\
-            TX9XSImCvMR0QnLp73EVNip2ViRd1WzOKdGVoBTWGobsWNURHfthOrONGBrjePoiUHa\
-            Dl/jRqaU6JVZ3GZuYQ0eUfZlrKZrTTbitRfcQxQXrcYN7RbsbeJqdZfCwIaLrkBqkWr\
-            tBX6Me1fJOMLFAoN9RQ0wQvh8+v3p69ATUNoI5xcnahyY22LqknLB2A+INCdrrhqGsH\
-            d8pBIINy0hgT624jHGunzMUiys66RtZxlRqZrZmxnZYUv5oItKoQhp/fFLjTTDBqPGe\
-            NWbv36OfAKlbX8oi70tSfOaWkeeEWo/+dlUGE/ckQ1eaRQyy8oqrFCt1oaEXg145mMy\
-            ClSvji+Yk3eawrQDwhKViNONoXg9uonnenQVH9mWKG5aK3SoXcUnO9CQ8EIKmozfabk\
-            +fIBK14nbc1Wsslu35C5DEqZU8zFD2q/6imozRwJNZPVxY+IroV8diu0kcaKhovQOzK\
-            vn7EeoYVRnZ6QxxdkRwsuLkfKoIu5/k3ltfyKlesAmRWmDb0jc/wV6wZWs8YwfjGCTd\
-            7RVYjBt6yS2eXoeH5Ftl10dDzpqW7fRICRKsTAUdvrbihDanNnZtpc/kKBh9djGVyzj\
-            Ih9XV2ODuMLcnwMrlumFKNYe/OCasw8uGtZsC0zru+en+BPfvv+HFR6uT/dT6fz8yPW\
-            SN+DRgA3sOsXVPnlQS3MQJnKBZcvqPJ7De6X3GKNfvz2mYAdX4FR0ME44xuR+itpqBD\
-            cd+sxokpJ+aTgwT2UE2B8oMsGycdZComQaJZ7uJRP0sb5B1bG70gZX0oZV2+or10+wF\
-            /bSxjDE9UK3pHSH4SA8ZFuUHDHHASA8ZGszMfwrHdCuQtaPkG1cQ+4lB6u3kR0QTBnU\
-            3Assp8oQeRZapj8isgj+PEnICkdFMtvcCVcCh5Xb6iGsgyulQNgAtWP32CbGz81qtR+\
-            zBd7uGanolCsCORtHULr2B45EYAiBZ9+7gPzOEoPp2cqdy9IMxlgRn95eIhov2AdTCS\
-            Q/Ypst/uwMDOCjNWC1amxbE9U5vcyqF8u2H68ojPSLtgSMlX7C/oJx+DcUclG9Ff0j4\
-            O7/oXKWGJlLc5PSG3MX4MqR69K76/oaiNo5VFlrDVZOd6JNhUo90rlX4v+SpR7oEFWK\
-            i+lHW5YnfOgyrAWs+qwSVumPzo3CGy1ogwTv/OgnvCKZEVjlF5XaoehwltUI0orq1bd\
-            OslFI7TkpMXk8kvwEw/mo+qvyaDxU9oboKEyflBX1wg7Y7rZp7t6/Wi2Odrxg8p2R1g\
-            drFh1WXZI3VPiHwlS4LsgUsJyYmOwPIaaoeOJJpcqrVfMGJahe5XHxRcIsjlkWtXMSp\
-            6yPM+EkXkjdMKqXGlpN9gIcVwGR4gr6lqprGbaJhmzLNmYjyrDtiwcFCi/CfSjk5mg8\
-            gZU6ARjuLKxGSuWj6EhzRFd8+S6q1emFy77AWp8QtU3QfGBZuKqYidMHEO9awTPMrGd\
-            FQ1Liwbd2lw8hqbDECVpK2bXSuMzSrDLX+DMTjZ5UrGD6mw6/YFlMzz7ey6XbeoukdZ\
-            lR74Dv1hlbJOumawMW6NzH/8KjSVFq7rGHmfV8WtaHb+i4/YeahmVyo1lZuMeVoyX6f\
-            giGV4kouEqQ7aPXPsIbsQ4fC0bmYltynhvAmES47ovAQN6xgjrt9JRzvGtyINLTMdRK\
-            7c83XRuVZmKfYtuuH0vg3KD5zSCNZlqxEyLddVvJ5k/pNMfxGQKgFtpNqJJXSs7fDWk\
-            5TA8HrdacrHep8M9aXkJT1zHt2NYjHYkzY5Kb5201h60qiS623x8DupPLzlG6JYwPHj\
-            aQ4OkWc/EplfGDHe0SQU35QdOoVqbGFm3lRMkT8/o5wUFqoGnWtFws02HO9YCXoPy9M\
-            Bptco7prN0fEhWzODZAoUFhzt8LVJ3QcWD4P7iQDBsr5r0r+6a/PmZkJahjGzkaqUqY\
-            TezzspKWinM4GTTta3CevSP72XQ18Bj/T7EWulczNaPRcp0y3j5k6t6JRuR/WQVupH2\
-            Djb7KXhj64pXgjVCp5NnVG0etAwKgf2MPD6gk3xQE08i/RyfFKgx9FNw8y8CbQxp0n5\
-            8AadrHL5vmcUsWl2u7wE3olQJXdBe7QHMH1NuYTOTugv27WXQtuga5XLmMpaOD+jyCe\
-            5i7SE17aEWtR8XUVe/9+AmmqPYjTSt1WnBeOmm2+KDkJlCjbKaFR+NmomPjlVmK7RcS\
-            zfjXvzE93iDDfI4cznsKqvZx8xuDrWoBFunp6dByEsyySpMD92vrwIpqLyp/AU3bAnV\
-            gNL5jPG2sjMtamWFFSw9PSWq4brluNo5VCOeKlSzktbM1M6NQP6Kr9JCwqcn5Vo1LO1\
-            vuD4S/MSq6vZSpcN9cBSLMPziQVtqj2yY1sLMikyyvFHGSm7S6Q90hg+aWvVYW+nUX7\
-            8mumtQNZFfIQdbxCUpEgQVngcZq2WT07Z7vhtAJO9f0e+/ifojHR8iTIT5LrSuCEK1F\
-            bU0gyke7k7zNTQO4FAtyNz6Irgzt8MWbBz7zkyPbCM07gc1D68AMTbF/DFffg3NJlNm\
-            vWJapv1ttMaNMNtfBNWMU3BjXfvHGeD4dQ==\",\"wUgq1jUc9V3yyxEiQ1qrXeqvg9\
-            cqOiIG7Y8AXC1qpWHdXJ87om5vcJRR3vEZHh5vmVuvz8S1zuBgNuC2WqXugi5Ugz5DI\
-            YprZK3EPciKZdB5IoiT6GTpSESFTklJI6xFatTrpIn2duLVrNWYbPXje9j6dwrbS/OY\
-            +mvCMG2hZxEfOmGVQjeY4eCP72FzXwDnt/Xc0izZWNsS/QsvvpVgdeouvW1jsm4SsRe\
-            8w+1w344LqiivwYVaTfzliTzjnfga3cpWEPtVx0VwvyoI1V3TCD3Og6oxVnf9FiqxTX\
-            EkR1ogEZzrOgHRqW65mdSCW5LMg2bBKHldyaZMHmYPv0PB1MR1C86Vyisneagu8zr7d\
-            aV29BcEF7FoQl65EdfQf3zn1NQO8F17d4KD5GiEEh40HkXxbmVfJpj68bgImgUFqSYr\
-            hxxTwVR4UINIQMW+ZY1xnYcujPniED1aTVOwwqdgEmrWDLtxx/MvWui4IUKXW3DJHJ/\
-            quPNKpBHbC4JpmFJYvpENoor2ifyPis98oFMgp4Q3An8UlvXfQUxc95dU7GAR9uwn4B\
-            umG2Gw+ANuNL2fK1W4weJ1ED1NXiQ0BBcgg+y4BO4v/nMC1Irix3ce9MCgEyiyFSLYe\
-            u4vZbwRCt/M4kGvVxqsRQ==\",\"JtGgFa+wqggGe9HSD2vDeB21KlxQ0us5qa1oMqU\
-            TH8rn4efXP/x8IGbf2G+4BH/7+vMzPtX8Yo5/9xnLsZ96781x5wr+8Xc/PycFMZMETU\
-            1p9pfHnw8/H3H6W7Eg53elylKIVuiZscya9Pwi8S8oo7lF0BoCS6H1Dswb0ZmT0qTVa\
-            iux3e/jW/EetA2bJrRlVeouRHiQY3jLYULirOLSunUos5KzdLgTTHw0B5ikqmJBaQUg\
-            MOke7lVceN1BbFIjd1wEbSlv0elwp8shaFuBACvZfKDbsA4Z1Q5OSCuMRY0A34pF0OD\
-            oglmLKvVXOtoRJdtOYZqtVtLW2AZSsQy661wAjWFNpll6ekrQXV3fiKhMDqRZJlpDqc\
-            HmJSWunPPoZ7dMy21M5ChqnOUbUUtj9aE3LailSU+vkvFVZBhTutPGJdZvBVAOI6TCd\
-            eCkI4+rajSdQeyZ/N4KUbU34LrVqNzrlaX35rZZy7zT3hAMC9ZzfA4ahGJofWjRwIMF\
-            suMFIDFbFO8Yct/XZyvewh/du6reR3SrHmLv8D5gwQ1p2/hK9uoraMWaHDXHeiVn8St\
-            ijVs4zMugJRsBpMLo3VeSrVIVUdl3Eq3Yo4pZHjRNQIDbtcH6oOveRCm6nqx0OtwjNr\
-            NfglF2EORas1rslCZcBagWeUXVgstWoBYoi2AAVYRp0QhrfnK9D7hPMmm42gpsU+0H4\
-            Hk94WZsVLwIk05/UMrbedi7KgpNbwYugqaKU7jQq0Pqr0Qm8VY64TREBEOqS05QViki\
-            KGUwOu0U5vcAlD7MWCtT1soED2bydnyhdtvOyF6sT/v3mUlWSlljNWsTsbeaob6mxRO\
-            1xQOnQ8luT9RGD44mYxwE3fnvwG9RX9AnamlI4P12FWssLlVRew5EIqKxaM9zdUA0cz\
-            yBoslQp8ynoF9KPN9sGLpT7OvhV1OQD39Ad05fgqbhUegiW6E+MS/UNj6OTowltjJKa\
-            mENJ1AKvRJaGR+DEbW3e6KE/ohEyBqeLylRGE7Fb8hwVSUZbnoVDjd0XxJVxrANfvcZ\
-            vzoendIgC8s1rF8trD6+4nl6IGr+Vz9mSEaL3K2LJSp6FS/UThOcjptBUbHuhdLDwOy\
-            964OUR8ELtcVE8I1gGt0hK16o5dckBd9y0v6WMNOgqvEnSjbHwOS4UTxRakQIzzuNh4\
-            J1M2Z0pV6gicnAzTPRHesCTIwLDvxrOXbgWDHiF8vbJ0HM8cVr0C02lk5GdXW5//WSH\
-            4ebSjFiJ+LpjhnzKhmJ7Pj7vRSqgt1AuOqsyCqVp5c/T3IQfpZIQdl89MK+ma0Ea8xG\
-            VFW6Muj2+wtsy91ney0qub95MesVeyyr0aCORdgHg8ZHaQF48GARGl4zLNM/vr8Gg8j\
-            T3IhTH46vwQCxNNtwtFm/UjP1GatMLmfUjs0LpQjwVmdpb3sW6er7QvWQC6bmG2kFt5\
-            3u924MPRNT62+C32qVdUTAU5cKVYF4KrjWyPPvKHl0P+bt+BIMKwjAemUeXoXUPu4F7\
-            xROgqq5V2rWDWPXsqJUeneU5Znrg37jdfRL+XVVHyGwUntyl3C8H78Gj9ADYK48E9Nj\
-            qZDSr5Qh8xQ8GgtRbSu+UCnL3xdKLTSFnd0/iMKkZLgpVLVW1vJIzAaU3m1K/OiEPrC\
-            VqyPL7OgSRBZFODIQkIZuOVkML9Qy+gJIeoEdXynT5Clv8KJjpk5+wzN5x1cPUG+cQ+\
-            Q0/ssH6OAdig5TlO0TjE1qlXWV8Ecn/JU8OeGV0gMGEiI8Qnzu74YOJz0RXeNu7FGpw\
-            fwJt8YOhi+B0BeBkdjOJKVshJEmWUstNgqb2by93B0txnXrFeOlaLJEK14aPHLPy31w\
-            LVg9ni6ID3N3zBnWD0islePRN/Rcf0e9nul0pu8oi0vskHNiNLk30/QU+hJ2rAagcbJ\
-            D0NGfRCZkcDdOjxxdLVJ/TZrcn6pE8Khvv+D1y00noVhBBzilVH5B+GCkQoCpRnYFxv\
-            fGwmcVwDxRr0Tmpz8iiFnBaVHlgtyojMrpXfWPhvr78Z20E8uFVo2s1cy0gpt0/Jmcw\
-            yj/fJg9/HT/ivYHSvwF0zktaX8+zD7T6VALmKh0Ir6HqlYwHdsHHI79GryZQ6mI6ufj\
-            7DGC/4u1MglyHFv9v1YtBTOt5FGF9UwNNmAaPvZIXIVQciecRiZjUijeKREUTKE2Px+\
-            jPuFXi8myyK7xi3WtTC6TSnGGOop7j+BfS2CMORtVEc/URneuldoe0v5GkIj8TknEeX\
-            4/5iXlx3OJG4N2oDsW4QMaQeYei/fjxXq8l1wdvFrJQ4dO9y9woJkgMO483RfKWOKKi\
-            ktSxwUVv+AKt8M1ZtRe/xXt2OEHzr5TCshLXtxJGCVlFXUFpSTx4jV4ZAUCxBUkS2qs\
-            u8RtMlwx9vz5rnbtcBHBbUrK7OWS2gdz6PhJ7UT6fFA7Eld82cgyw2faz3e19MH0AI9\
-            PQm1qXiIPTJMnGSyoTfUAMsKMNngoCEElV6Dhs3BwakyxLihXlQC3N45IWNtWkvtRdC\
-            ONVfpA+qn7lnF36Qzp0YX0TO2QwnC3qupjbOD+VpQ1M5zCeL5UTCr3DXLTVHZilbRa7\
-            fFKpzZFevDMbqTOWqbtYUwqVv36HIyxfEcKo+f+zy8/f48XFfUpK2ZE6q+xu58LUpiY\
-            MOkDZxekFDHFkY18SW1ETHF9oT56jyE8nNSSUvPcYuOo8UXpj5bOUDHFVzgxEF4SvZ0\
-            emkVy0AgAafsPV+3xn057ei7hAHwT3EWH6sl9f6ql4aKqWCNUhzb+JeWMhqdD7kEsg4\
-            eDRfPpiB6+5IlPkFuRukvCK2aMXA/TGDqiUX76EyjZhxekMHOC4cEV/JwX+7FGaFR1e\
-            FyQXWHKIqd6ahV+Q0uIcKLPZNs5E63SLKd8Elwe6dKbmY2szcB1jzE1HDyZZgq2mnGR\
-            9jdS/fxCDiY3OMzltHgJxuq+4NnWDe+qEY01s36W+5b61/0zgSeK9QqvtBjg7gldAJI\
-            rNhSdbBC3Oq86ua9cruha9CEwUbtGcuF+kYanM3NoOCFq+FOBqEn8Fh1DpbpdgEr5Gp\
-            FrzjAzaSRsRrV/O75TroEBbk1YPSwpne6my2TqLkmrhbEqWXVNhgXd9/G4caZcMStN2\
-            t8S81HVmNXyj/mSMnaTXKyEztPhTp2TtqSM2655RCyv+ZIySLsG+vG2FpZRvjVz0nT1\
-            Gj0c7oTODJQ6TG4PqcT1uk+Uqr5gtTCDl0HimuHXgvbSo4w4QlDiPLMnyswixBymWKJ\
-            iCK6Pr2W8l6VqRWMs42VSioOxCotK6dF4/YTRZifXuCswtdU/5WrGS9P6Gde9JKwcPZ\
-            youwHeR9tIh5+JqdZoJCwHjiroE5HurUTzH3M6xhQKlkXSYXvL8yVl+RWZCKrEXwbPK\
-            50k4m1I08FwiDRYoDS8lzRqqyZ8+OYNzl+pk3PmnFJOTWARJsTFkhq+przeaAk3eaH2\
-            P0qm2Xq2Fsx2Whj4X2ibeGp91fMKxgKpuLezlVLEuVpEh+tZvWNH+DX5FUvKC7/0Lu/\
-            umpDuHS/UongCi8gY0WrPrAjNBtnMJjR/mhG++1DQtX8GEm79xSu1R3BmHUgvviU1dU\
-            9hvakTnrfo9nFI2lLuibzFto8DUWpOuqV6+qGSTeqvlIajIINoVCrPZZPPJuePJg+zR\
-            /JAW2qbPMSlD+zGSxFgUr4m8yUVeCAEJo3aKGdeCEoGVCkpLW2IXHTEYd+E8BRiDofn\
-            jDYOxITsjVPvbxRePEvc0ITmnxKGQ2iryGKhBGEAS8iUb/MlZaRRdVw0Iu1vCWtYdTA\
-            yQjlWkIFmA+RjH/KdOvWjpLa2LtHeMxoTWuZLSmi5BuJdjlN7+Ze4j05QHvlkdN1b4o\
-            E84KzgVDyMS6phTbZS2ATjCvKefHqT5zjfUirCQv/CXxMm7EbomEio8yVllXXB1Vau8\
-            dA98/AZngBw1ckqE5o+SfBtTkZrmnLRBvr59fszpV+dwgYrZ7wYKfFuCvSnUhBliPef\
-            G9pYkkQJxld1W3W5pIxL5jllAjNFatEqI63SB6/wyphFz/TOKSOKS3bv6hzV5kn/pin\
-            ZCGtlk6PDJ+lyFALSVeYljIiGMOsry4wJbFgmhgrEpICc2uybwv1QJZv8snkML+kQ9b\
-            6MIrrcKTWlKnPVFKPsGlyziUlnbDDX7YcM7xXT4EH6hQuyxBYE7jtiqh5KiZLTnqngH\
-            Dje/VWWVIqX6LT9TAn0eCqGrIz/SVVHn5I0z6nArXhC1EKypMzTevwQ/2Oc4ZyQeJqR\
-            B08kuDI+v35/oqSdQDKZaEWTiYYfEqsFenhiTh2cEcAPsUwoP7L5kmytsmGpu5CnrZA\
-            hFhsh7Eam/Q0nESOaqmSTq1S5mS7KlNgz8Q4TYlKarJyKI34JjQoU7aB4OQahZFapYN\
-            cX1JONJpFTYiQNMSMyesfnT6AJGkTXtQCiqY9gf0s8H9cC9dC43F5ASc0KtWpUle1mi\
-            nV28wi8ntGmxktqQo9JhVytk3GHVCsaUax8nHhBmtyUlOmJwzVVmw73hIjm6o+ZJIia\
-            p0rT4RKeKb3ECDqZ2KM0KojOSPM2RYRdFv6Bw352OtzJYDPPlM7gGshV1dW4fRyl8bt\
-            Fkl7XVEu5RoqGqww9icvVCjGNXEPpk1g5pYELI5P+dMRO45FxnqmFzjW9N84l2tN9dT\
-            XY+5JmLd855XZ9TY6JuUGZH10zI2xE5yUJzdYrtU/XqrGEYmtBWd4MqP6GZooSpgfSv\
-            m5x0nFBGYK1oixV6q8Jc8uun4+zB/TUhwXlAT9FtqWMARLdewoc6jTZfqHBlPPBFNwf\
-            Z08zqbMsp8x+L5xiFq+Up1DbVYbptL9FuB69Ut52IWC/dUyt7l8pvXUYjZ1p4wvgV/K\
-            LG66VlPNMEDoabiYsY62lVE/U8ImnQOb/F0r6RO9D4zmJ2ttqcbZeC9nEBKx8pbSKlw\
-            mvu6Y/24ZqOk/UNP7Ryiz1HbxJUCsnviM6oWZN7q2E3G3QjsXsGpEb85rZ0fpNM3JZO\
-            Sc30694lhlcW7SktMmGNbZjWqp0X1eGiINAKVX8Mblpf1guZ5ZVB2PJEfKZ6ncXVKXp\
-            MfeZ6mdTYrn1ZqIxULx7TaHjAY4RVGJynFIbYXdKj6H7aDZlJRdim023XlcxxUHMlVN\
-            4f4IIzaSEjwvmR0UAfWiu+IZwip5F55PSqEyxluUmhhhfml1j2JquoScqVqoxmyx1l4\
-            gl1RMlq05h+GL5iYqmckYpk+OHUlAr5TPKrIlT+z8TdWo3Wq5tWsnVevXlM3r0FadsQ\
-            c6s/gnV91OOCVaWLHUXUrmUU+oAK5tS6Fa1aa5FXUli19chqW3VW2TFmrxD7b8dlphp\
-            brGknDIvKaslq2rO7MxvTqf9j36nmpy3c7LGQXTBTEuJjUTfg+E7sTKKl6jHQvFCSUc\
-            9ciRPNg0pld0r5cF8SRZVBJBowRfAvmwTzDLAF+9dTMI=\",\"r/KVspe9wpmWtA2kt\
-            ItXxK6iyjCmG4w4I/S2ErR9OxXubSsqxaU9pOMDRltQ/f+GlogmlxF2VGQEIZBsuJat\
-            Jc7rJ0Mo7VQmmtRf6X01Stu6M+P5fzO2l6pO/ZXcuaA0rjszc4sBH2s2PT3RWnDKJ2G\
-            /EqxJ/TVhpv49OWb/mL9TMuwV87eI9SoZMf2KGYEk3YGnSC3WlcAPayO9Efd1lWvWbi\
-            Q36YpZWSZsZ0mj9HdqmrrFRh1L8k5ZvAW4+Cm0r5TwekskXNXeqbiKt0T8bE5HvDeP1\
-            Nk0r5SYfYs02zwXKPSdMqq/hdINiZAkb5F4ZLf5grKkmBInz+M2OFqqlNRwELYzKesy\
-            KRoeG+6leKHE6VOs6vT0hO/9EtkM8JKis+igjB2QLLRQM85GL/2UMxNl/9C7S4NYmXd\
-            MZ5I16eSZMntcwt3TcCkzxa3S6eQ5yTXLKjIYtQNDvRQHF1t4POm9QKDaCnNJHxDEJM\
-            q0gtsiHe64Ve8SjqFwidkJhnlY9d8IoozQHuXvpGyAjJVXJLOjRCzYVeYKtWVbtMMt4\
-            EnGHBp+DnKQ+t/epi1iN2UBb+tS2D4MDm28VcKGYdYKlYqtSmTjxQwk4qmrYVgWslb1\
-            5v7p+RFtd7CbzY5JKysnVJ8fsSp+BSeDuEOv3IeBusSVtKvOrYlnq588LZQRqDtLwUF\
-            t30p1DT9wZmwl0hVv86TIyoc/EMYJoDvDNa6Uew/8hgNz0DABAuI5nJeglHgN1Gobk8\
-            N3UHUOAq16+ANRKZGlOCKJankHlSxXQFuZmCy6ZVZkRbveHlWMoL8KCCSK8ZiDrmUQE\
-            i/G4gm0H15pZSuZogdK/vjO4aZysCITXHlrMd6iMU1KsMv6zc3HMh3u5J4q2MyuQbXk\
-            WtWC2gEGN9qveabVlEES6MXL2XotG2mZmakNT9WGtmArwTDqnGmt7GNaK71Wlcplmaw\
-            NGsOxBAWQAKtVlcSPLyzBKDoBnLGirrGCc7IruF/NuaxmXO1YM7MsN6pr0+GOZXAJbo\
-            vyjeCl0CdvtHR4MQRATD46Bi+KXE7B7WCQjCLd1AqGa7xBZsyydaV2EfqPBWhj3YfbU\
-            F2T6UM6/REjSIF2uxS1N2vAD5iFA0LCdHRd7CoM7kYqExvWmcjg7j0Lyl+Qhbso+zUb\
-            WPVhIL5kL173ZAYHK710PMqqP4/foHE1n0FTQBBbsD3ip9Ev1e/Nas1at76mMgsGp5q\
-            AG9mo9GyuX7eywiNbPINxqa6p/Q37dNj4/cwS1kr/7cMDOsODG6UnXq0KlbJG1qxKTC\
-            PXa1eOcTqVZ9C270RvK7HvTNrf+uM38UAhxTO4YgSgXLYb0t+RaqRXyIoZs1O6ynBXO\
-            9CBEOKOIeminfnA6JpgCo1lshE6ycSadRXuqgwqwgG6P++lVRV5MBN8MB9ExrrFPL+3\
-            TRjBk0yalllOtI0cngzDaGq574YvirhTKjNW7VNj2Z5wXnkrOLgI7YepmjmR4vSIrmf\
-            haTSESsTeJvm67o9QQw3Y38GNWa4aw/WhtenpKVGtaIqsTLoVKYJDZakZT90F/3NwOD\
-            3wSjUi26enp1GVSDsOP4H7XPxgleGsFak/gY+wpPckqNROpN6/nQpxC5oFnEFj/F0aR\
-            ebJW59RO5egl/kVxysRKZXzAlxPZ4rvvxZpfyONPxagQdMlx7XQfV0lalUIjm6ozUtQ\
-            e4UikxbfZClBA3ccawgsKBL0vNl5DyPds4o1w6ivBRXy9hlUpUJkI7RkFXEo7zwHNyw\
-            FM4da8TIdHwgMUPM3GD//i70VjSEmOg42J8Er2Rox62ORpENIEmqoB90vwjjKyx321A\
-            nzCIdzDgp8YRy1M7kE/S1OvCbvTFqwkmnLZjVDeUc4iNjIKzI3DeFWJ/D5PhOKj+s3G\
-            9cHqeCwWtq7noNtb5IxDNI7tVEQYe1hxvJci5xZ4ZcIB9w/48f8FRxZL7FCPHweiO5x\
-            tDUi0FE5vkbvxIohSkNXoJFl4XCzk2HdVRr9y2RoXZSOo0+Vahn3p0qY83opJrqCYlO\
-            lAjb6VP/3Sti/jErzf618yeb5doQPvb1MbmNt++iDiD9GKMJgO2eESvtng5G6YeqmZe\
-            iUeIRPEUagkw3QUwQRojyiKnWaSExTuafu+hYSV4OefUex3LJjyuXHvCQnPzAVvLX08\
-            80vfgHRZn4gsfcoNB0klsOS3pR9mtfamKPaYG8IEErnFDYoCULj9GlP4P5+CEoe6XB8\
-            B4+4CvHQIECOBtqHh2ioQqe4r6KLGnWDfgVVD0FYk+EW16BRcIjWVnhcck7LklMafqa\
-            b942841O12GmJWZz5GL73ALumwY2Q3sFgJSGeEbzTmHlJ3+zuyCHRc3veXTnEpYgeeE\
-            cVD0D0AAF4zzNMNOgq1WeRXBdNgNSqjd+VPW+MwAqGdeHiBVShhJDE8sBbjd/TaIhzj\
-            GGH+8sZT+mVtN7iYT87n4tPkKPm0inZrYFnecWMWeN78a6eogQMq1TFN0w24wg5WSNQ\
-            ziR+URSXzLW8fhbV/UZjxOorbs4lE6IXXJGLSyIhYizqv+h/mNAgXxA1BAaXuS8ZepU\
-            Ca8ahlM5pUAEGQFU5jY44zxe0rYqg00fWxs2KQTq9jp3noL3uCZ9Le/MC3ZigV+IhpJ\
-            f6Bx0vnmNyzAjii66h8k02wCDYmE1EtuGjE0dYZdqvxe0btCzIYQ2AznLRCM1wy5k5H\
-            FaMwhdGNfhZjfMluD83orypXavVWlZi1p92kU7fDSdgUNs/sJc2lJAVex8kqmW5n4dv\
-            Ur3+H8gskHLeRRb87ntiVSU0a7i4TP7qHyOSvufrvbvNR3WZ5PCSTorqQBdJbQSr7OY\
-            ypf4dmRAp+1wkVOzsZSrFziasi0gHDD8UTKcWVktuLtMaXpJJgfYUwaRUKxqrGfdRpa\
-            fJTf6BnBXJ9eVFkqcAQsNBTi4pP4JcfTD8/0WUwT3tRwtjR4+mqxwYGxULypuXE8XeM\
-            l6yXOh0fKBPcCAls1umbjGfxuMTGH7+hBTaSGOFGy56YX/yBl3Fg9bFITTwnjip6sf3\
-            ErTLuyeVosXskQvYI/8Eq5hdK11fvCSCj8xz0LBuJBhpupsXM9kUuPevIxPVGib35kT\
-            o7igYa30E2QPfqHvKoYCDn46EvRVNdvtmVskVASaKAQHPasbRWKZOSCKaxd7N57dvZn\
-            t/0jiae7/ig4bRjTfyT4c7KgzBiuaKGSu5EUzzzTjcXbycjnd4RsE2cVcao6knVqXvs\
-            BIlMq2NzDdJJbaiiliCvcNLsFByMXtP8yV4gN8F8zLvBBBqKDAwIpJcVMu5ou57KRYt\
-            VYeOqsTe6u0qhdPJE8OhT5RbMCymxqdFJvHrn3MKCpK0TDaVMIYyeFmA3jHB5CrW5En\
-            dGdtHZaR9JkAz2SC+Zdp13ULJmH2vxS5uqBjhQnNVORkvhh3Xr0a2Zk2ZiC2LGQYWoF\
-            dGGC1kk4l9HPiePJ9Px/Buvl/pFFzjvCeFfeJER3pwgNedF1QrjE2jztLKQWdHsRVaW\
-            r/yv/496wPLYNsMr6DF4ro67NghW6X9A3kwcQm6J1+TMmaZm+ETpRnHT2MvQcMMENoq\
-            Y3MtzAceDgPUv12D6wOK8nmMRJmPitymnufg9t5aC1EzXQqdnh9xkwJojlp3RhjVaS5\
-            mG7azq26dDndUJwoaWVzxikamwz3RXWPxc/zncATrCbdgjZGpvxJ6W6g2ziwv32Qrl8\
-            3zI0oFBR2KSoRaPj6Dk/2ZnBqZM9S0hoOT3mnbaZZreTxWh3S491ZBZHssXsD2eEZvy\
-            seZ2FuhG1alTLWsqqRXkmkxLLUx78ZjvoPqDEhiNC6ll3olGDbtAp1uSvJAEjjS9i2q\
-            UpxQ8rpyJatsxJEOLK9gRN5LmFtr+kOeXLOKyOUcPnroEty7UycrLTMs8uSP76/gwHs\
-            CnqqXOBO2eAWdxKYsv7d7subBeZD4dc0TBbqy5uDu3TWI/ETQ0/6a5IUfxslvBDVC5w\
-            ot2H6Vugupc3sBXbNDNHoqcNkjO5kH2v0Ojc4L209MQEIbcZj1Pj9mdh6s0v5fkrxjW\
-            1T19QIK7DepnM7RMyN9iDN++gf0c0BP9VBCvT/hKaGzh2GRleTJcXCIxbuSGk0RyCYE\
-            Lh4CyWlxSogU7eHojjiYPsoYVGyh4AjbAlC+ugGLvR25orHSHobT9PDYTvMS1HdhKUT\
-            G3gDNnTF2P3H8DgWDPuA34Fpkkp2y7X54r/2Y02xewF2Qm1Quj0Aek7t8S57nC9u45p\
-            qxalvP/GGr/amiwyu/ybNhKx/gKeJEWl92UKXcptIwv4EU51TZf0I8nHbChUWNgXZy3\
-            Ynw8S8WoDnEiOs/V9YsF+On+x9UyLviBR4hA+jeyW8tUbdSxyS+fspslWyssajB7hMs\
-            YAaIBonG58Y8uA8OMJOVfTNNTIaqMl7hmXlAWe3PSEiHO+lnClqm9C05HRo06WcKr3R\
-            uOBF5ggt/wuo9hSNyBrflCW04WAUbEODI7/nOtlq5tprmO5tkYktwoMK65HRoWLsfyO\
-            HHZ9BsJ1azlWwyoQ+pFh+dMHbtA9A4KQrdfYHPJI7D09bJr6Cwv2E118LYdHzAFQFQD\
-            7vBoDqF3qI7GkUeQACGs7hlVXKlmUYDj7+AWsJNpjfSWJVrVqd/zvSfxx+4LQU0Z2zk\
-            SuiGWTGESUhPL86nxUa5eLiVBNBAT8gLOF6eT+DZYuccK11HE/0UT+XviiiaLXbucs+\
-            E2jTALIi9VscEWyXAjJE734onUHA7189Hx3TZGa/xqBJyWxh2sjtndbS3meT3ZIJDje\
-            ccnLHO/GH/8EwfdsRWjJeiyZLo/U8OTmt0Yn1ofoJOtj6IPoSAUrp2/yFrAJ8M2SCJZ\
-            FpVKEK0842ULKwtq2TGrNKTpE7v8JkCrHbzUWWrtL+h0xkY+2Zj66prpE3HBxwD5uQa\
-            04s7BS5UgAY1AZxBQ0vCcYNCKEOFzfXA2BJL4s3PHRdav91y9y2zSB/1MKoAG1GqJKZ\
-            uObhDvTm0QktObid8X4K7grKuuz6yULplVYdGylmAU901JXYqhvdVZcPZlnlVaJLJNX\
-            rELAfjwMtmLRtpWtak58fR/GajrFbZ6GqD7meA1o1AAmSIfZfnX0FG5hYs1DCatDkEO\
-            gbMo/Pph+a7ioCQSLy+7VeIZHX1ztx3lemgBYtxdAIdjnGyP6+KOMCLg/spZ+DMnwfa\
-            2xink2diIIDLuer22SodH5IC17gfl6BCSzbya5H6KzrUIgBjWcOlSk9PpDhfgssj+fG\
-            Hz+OW8LgfTJCgQgqQyGOBwY0JTzMNa9tD2t/Q4gadOApW+2ietWoiNnaOT+DytmBG5r\
-            96TAYYGcu1I2Ok6X0w/RO6zAXVGe7Pbde6uer8iBpFgiZ1xUoZM2P6o5N+g/y8f5KeX\
-            062ULxGmajod9CbIJCaFpcJkXqsAlYlxOEJYz3YU/wG7/3IpvziJJ0SKQDd6iYFb40=\
-            \",\"NUkgrvjBdhOFR8vHzaWQkNnjVwcratakwx3fQcRr8gqVrGrKcY8q2muiH1Vxax\
-            jYMT+MNN2qRjNZvIDaOU9MC9ZkAnV0f8K7QOqvyWT7nWj0c9gScwrcrlGBcAnKLn1JV\
-            SrPZZMPsOEXIQyhRR8ExgbFhbehTvCaNd4358QfXsRILsUzaEHU8xum2YE1bMZ00TVs\
-            GKrcI07Fe1+IavcKPe3kBdSsXTJTeh8ajshylb3CsnT8kRToamDOQbeKK6ixdWosIvf\
-            9+L4ENZMDywd08Fe0A4JiaY/RwljBzCEdH2j9G7iDjxGpyeyJGGFvqd4qptVqKzPq7B\
-            +8qm/RdVdZ2TJtY/hOikALxGy0bMqdZu0sE71NvtImPb9OJq8TH0iX2EOlRvozepoKE\
-            Qf3hZiNTSv47NoibBhxro7d/fkw+/LT/f+EdVZsej4iKxeugIYEJ2/GFB+IFH98z4nh\
-            Y5LiaOY3JHcyMxrS+j31dU64jv26yewXmA/7BB/J4lyCB7TdJLgzMz3OlP50Ap/IY1w\
-            Jxn7Vvq78tuA5ndWQDN00YHOSPhm70YJlJ+mh/4UCQZ1cD9yJKkvdxZ/qTgWyPrwe4f\
-            OTeuC+kSp1F/JoYtBIv+C97cdwJ0/JWcCLGd5lLC14t6oYqiKETzY+ITJUzcTBlXORr\
-            WTqLkSpQoWRqTp1F9Ru8Qk0gCxEU8rGJFzO6j7yz/CbKNQneA0BEP3KZMN0I9BDZB0Z\
-            akFXZC1qhR/t/HaED76Y0lTWuaX4oKERicx6+zeCTOdzsJ1IuRYeyVBrJceE6vmW2cp\
-            WVP6Ma8tydxXogUdwhICBDaMty02EYZhLA2zmt/nvGvnRubImiNGlPNspXa4rtUvHB2\
-            pqfwLNRKLovCVqM6LXwfSs02xVudI3ZUTtRvRHOK1CYWrEI2wREUV3mSerAp7aTkmk5\
-            lCvVJVEGd7PF0im7Uoz1wZjA3KCG8VBlNc3f8O+FlkQjUAv3FWVLGaZaE1qtdpiZ176\
-            8F5w7xuhpbKVbNL+diGeYifn+rNg74XH2FPmsMKBoA4reNdD0DXO3dmOPf3Doan2haH\
-            JUwzBEGpxeG8EiOU/B7fUoAQGe1bC6NZn/c6SGWzmyEwf4TPMITR9cL8riTuhhtXJTt\
-            pNogUX6ElWvfRGdvYrvM2IQBWICh1lJkVW/p4o4Dt7pMVsEN2wBB5JAxKVqmSTkxqXH\
-            DSiuybvB/TeMVVnZSPMsEeMDnsFbLoTlcRovIWviGN7C5yE0p/+9f/+7VPLcvHSrNWn\
-            P/7zk2iy/+i0Ufo60cXbA2/etrxof/9Svm1Xf/6bXcmX373U3zarvy/kf/3Hf/59+ff\
-            9wz/+6t49bLL6b91/Pf52+Mfh28c//vsvktf/p101rx17/O3z6k9VJ/7jN7368hfD/v\
-            7t63/9/W3L698esj9V3T/++9Xy+m+b5Ze/bHn51H/oX1/MS/mXltd/K7I/VVufrvzP3\
-            z7961//+tf/DwAA///gpu8JO08BAA==\"]"
-        cookies: []
-        headers:
-          - name: date
-            value: Fri, 10 May 2024 07:20:57 GMT
-          - name: content-type
-            value: application/json
-          - name: transfer-encoding
-            value: chunked
-          - name: connection
-            value: keep-alive
-          - name: access-control-allow-credentials
-            value: "true"
-          - name: access-control-allow-origin
-            value: ""
-          - name: cache-control
-            value: no-cache, max-age=0
-          - name: content-encoding
-            value: gzip
-          - name: vary
-            value: Accept-Encoding, Authorization, Cookie, Authorization, X-Requested-With,
-              Cookie
-          - name: x-content-type-options
-            value: nosniff
-          - name: x-frame-options
-            value: DENY
-          - name: x-xss-protection
-            value: 1; mode=block
-          - name: strict-transport-security
-            value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1248
-        httpVersion: HTTP/1.1
-        redirectURL: ""
-        status: 200
-        statusText: OK
-      startedDateTime: 2024-05-10T07:20:57.545Z
-      time: 0
-      timings:
-        blocked: -1
-        connect: -1
-        dns: -1
-        receive: 0
-        send: 0
-        ssl: -1
-        wait: 0
-    - _id: 7383454198822fde2d9da098e948c626
-      _order: 0
-      cache: {}
-      request:
-        bodySize: 441
-        cookies: []
-        headers:
-          - _fromType: array
-            name: authorization
-            value: token
-              REDACTED_b20717265e7ab1d132874d8ff0be053ab9c1dacccec8dce0bbba76888b6a0a69
-          - _fromType: array
-            name: content-type
-            value: application/json; charset=utf-8
-          - _fromType: array
-            name: user-agent
-            value: enterpriseClient / v1
-          - _fromType: array
-            name: accept
-            value: "*/*"
-          - _fromType: array
-            name: content-length
-            value: "441"
-          - _fromType: array
-            name: accept-encoding
-            value: gzip,deflate
-          - name: host
-            value: demo.sourcegraph.com
-        headersSize: 320
-        httpVersion: HTTP/1.1
-        method: POST
-        postData:
-          mimeType: application/json; charset=utf-8
-          params: []
-          textJSON:
-            query: |
-              
-              query Repositories($first: Int!, $after: String) {
-                  repositories(first: $first, after: $after) {
-                      nodes {
-                          id
-                          name
-                      }
-                      pageInfo {
-                          endCursor
-                      }
-                  }
-              }
-            variables:
-              after: UmVwb3NpdG9yeUN1cnNvcjp7IkNvbHVtbiI6Im5hbWUiLCJWYWx1ZSI6Im1hdmVuL29yZy5qZXRicmFpbnMua290bGlueC9rb3RsaW54LWNvcm91dGluZXMtcmVhY3RvckAzNzQ0OSIsIkRpcmVjdGlvbiI6IiJ9
-              first: 10000
-        queryString:
-          - name: Repositories
-            value: null
-        url: https://demo.sourcegraph.com/.api/graphql?Repositories
-      response:
-        bodySize: 11045
-        content:
-          encoding: base64
-          mimeType: application/json
-          size: 11045
-          text: "[\"H4sIAAAAAAAA/6SdbXPktvHgv8u+Dge7kja5S9X/hZLd81++jOTxSXbkqysXBsRwQIIAF\
-            wA1Dyl/9yuCnEexu8H1iwxJOftD47nRaDT+8yHngX/4+38+ONlYr4J1Svru29i8e/m/\
-            //mg8g9///BS/7JZ3j42+Q//cyef7f5xv7id3//Xf334ywfDa/nh7x9q/iYNs66YlTI\
-            sHVfGzyobtDJbNjwzYZ1tgzLSZ0H6kJVv9Yc//gIk8fRlvpkXU5OoZeBdnnD243Oxf9\
-            xMZXvpFNdqz4OypsuMpFN5mlxIl6mUvvtBUynvb8FyWjkpWfwVa+4CQtnPb0BZC8ebd\
-            WDDM+YcIxW3jzDJto1nwxMVB25fa8k7Rnxg5TLfPC4AhFZGsviLyfDyMQGQOclz6QgO\
-            VEFnnCBdrQzXRIOCJKq50tLMCsdzLYfWFKTL+j9g/ez1dg71hdqKisVfLH8LuDPZnLP\
-            uJ6utkTsQ8nH+5X4zh7Jm7TfW/WCV/bIDG51rl7tZKWyuTOHZ4YWAQbL0MGsU636wUv\
-            kKd0tvzZ1n/SPjPvx+M/t0Q7CgEr5gdV0zAQYW1QWs5KLy1tC8O3DkuOB5wTVvKFx5f\
-            wP2fG9NhIH/fNuNY2Ddeds2LP4i3eH5ZQe2Zt9IoVY7dngh5ICqvzUqzMq2UUE6Fr+y\
-            4SvjDdqmFvCEgkBrVbg4nfi2aSwyDfRiQ7lHUmi44zXapV5vwO4dSY2yRh65wxcm6GK\
-            DC9poHlbW1Qfi8JkJW9fWoLKKDdhBULQ0BT6jdGSsFECy5q0Ra3yWefiEljDI7lQ/F5\
-            QpMMEfPkOdspI7oS2v2OFlKGG0i0+iIdpG1w4+Qtmu1s4a65ltpCk01bXuweKr7Nq3l\
-            WRcCOl9VttcrVTXV42xIfYrtMo/QlP2gVuosG6XCfIB48nAmfnAG911oU5n1GpJ0IDe\
-            c00bnjgM6i+VrXmtgm/ZSrfSiB2pPN5/gnrIe1Z8hhzHQQPmCdesVcaFaB3X2Yor3Tq\
-            Z5TJIESyW7U7vBtiah07ANijt2b/6j5fuAx8hoYaiVbEOwrZizU6vmJooPkIVotW3Vi\
-            25l+z4RlbJC6gvaCti+w9SrGdl8DNlWRl8piw9COzvd1ATvMZGZoKUUPGd4xpny7uS9\
-            Q+MV4GTwAXPNzworu9KdnxDNcs92GZaXrLuJys9NuA9z/egYPs7pvd3WcnfOKbhwLNQ\
-            zZt8yeIvqiJ9hMaimjc+uFYEdnxDV3mfoOKopfe8UKZYt0vWWKtlnpWoirH/CpZtrUz\
-            ubGDlUrhdg0q02EJqRbcKUsEOC3Y2fGb9J15hUEMfGEcW1/Dqb4st0a9B1KQ5B8eaa9\
-            KFnoe17MVnLJeZl+5NuojtXzOhlTSBbKyvO2heprmZsVkuG2lyaYSS6PC7+Ax1Kygdf\
-            EB6Fh/B5mhNYfMlW2JLmX4Yh7rZQBieWe5UgkjlK6h3AUAtCy6oZfs0GZ3kIqg36YOT\
-            +JqhK0Gw6kfZfmcEOvreJgH7ttMzibyDTd6FJd/NSu4b6RhvuFjLrPTIwvNx/7qFpRt\
-            wMoQdi7/oVAguPUdAWaelEGKl0XyT3cw+ESiqwI4o3igaB3fZc1zXYbUMlIb9epeW0T\
-            NcdjP7jC9O4HF2r7TmzK2VsYRCDEnli4aLig12mizngXcrOh6y4T8RXKguBu7wJEaVp\
-            +eXDShhG/hSaRV2B32acV9nxhqhuffa8lyZQm6DNF7hi/LnF3js2i15UJ4NT9TUCfYM\
-            I+1dOev7PIsfSaNAN3GAo4CRYSm58TPeqO4P2eEPsemclo8+Yck8v4NaEp5K42zhpMc\
-            N5WDRprEzg601ywWoSeN4L5xqKMPEAtRlcXiQddMt06iC+S74m/ItasjvxAYbIkSubd\
-            5q6TOZq2BdVqtaamsrzJrZtZvpdXtIyDZ968THzRK2xNFJfGulIxSz+WdoWIbxvlHZt\
-            1Z1uhp36Fq5676T69hvlCky2wZiB6mDT5c9wgNfCmuCs2gzmoNK9zu+baRRucw67Yuw\
-            f87vkovkSN1gq6pyDirXIDFXXFt8m2b+ObnvH6hy22jr8AF9/jm5bx6wK6Wl3/kgcSP\
-            4YgMt4FLIxDA7/5zcDQ/wbgKWjhA5efw4UIe+jcs6uSB6jwS8cKe2hiC3eLMFNUIQSW\
-            jTHXJqLXXILGWkn9zHIrlFB/f558mlulEmtxtcmQOtvEYtrZvxNlitTMUOL6gxA2xMd\
-            llKI73y7PiGLo/Bbd8ua7xRwVrtL/TtpTJ5Zlqt+RLbZH/cF+D2wgV7+MgKaaTjuAF6\
-            X4DqCc6kjfCgzaWv47tONWZn77F34g4dxQ5qSB2nzKtZKXzo1El2eCFNLC+g+fDIrNe\
-            srNdkjl9BHfVIspqVVpOkBWhjiCTvJTu8YG2xAkfz7l97Xmt2eCHNPhXcQd6x4g+h8F\
-            XgmADwVN2gJoZ7cJIZAUrROhV25H4ZqNchzARBgQnhPXRbay9FgpjJ9TwQUSG3j/sFa\
-            EfqSEH6cFey0yu6eQkabGzj78pZ3EmKr1ncSpJbiRrgBGixGecpzDTS0cCMjtE0x9eS\
-            YgfX7hivtqZbieHD3ke4H48xjUQ1ErGFu/IYzuM9WWwhVRfABWKoEeD2yTgwaiCNs41\
-            0qE2zfAV1/R7c8O1MbnnNGr7NuhfUVQJ08QFgmSB4eK2M8KwJXBnpsoo7vkLh+4k5P4\
-            O7JdYdOzRa/QR62GohUpha0qcUZG0DsZ8xVf64nXVHMCdKjPex/WJyY+vGZXSk2n9F5\
-            qEDU9uiUKaI2OGdmoweEB0Nw2pbLHFzczdwkeigzG7ZmlxLz87e8fYFaw4HbOt0lLZ1\
-            OuMy4G5UzwJcmtgm8EZzY6RjZ+/ZUhqxrrlD838PuidAWGGND44rE7Jhr4w2E3fSgw0\
-            DSsZJSu8p70H/UwjbSOeVD9IImeIQBrqYpPBLvsUsI12hTJS+64HYPsIcntV9oY4vsz\
-            QXsXvQhg3RZm9d9q0hjOMF6KF0CRa2bqTJVYueZoAdY69phI4AOrFfcjoF1TVOoQul5\
-            wpeb13QVo7XcmPRXrpf3ILd5wLW/WffcCFn0UjLcS+XxW1awZ2ocUuMOFWwuAWVDoDa\
-            9XJZS0O2yI6dVKgntpfuTQl8ZQxuRVxCnfS2dTgLttFesgaxYgu3Rppw1onQiWUB2sD\
-            HE9AWnbAf9tNwtQw87Bo5QdxJ5XE874U6Eizu0gamToufrVojyHYFWj9HgI2zNd75Ow\
-            GTmlTkdf20wk3/Yoc30eQxvdPQ0JzGgbJu8D1f0Bf/jEGYowS483Jk/P7z3e+klzXof\
-            Ww3NzPua8Y9ekjtK6xWnwAZN1zvCCutALcbz0kJbv5fYbPYGSg4ic5mX2Fj2BmF2hYQ\
-            sCVzw33Djl5su0ysJemUEYGgWKPAFvdPjm4eYLlz38ykETaXjg1PDCXA3e+Gi7uSxV/\
-            S7wRuCOcUq3JsDfxcgb7SDXdLq7TM2fGNtEhX4JHBMRru+/j4/AKO6o0scrsxbHjiIk\
-            EtodFtkNvAOv0582/FJ8zbqlx8ghp6Y13gSy37E17s8jNzcqWliGfcblGrMmg6SuMbH\
-            tSb/Di7o1LaF+CiMS0lX/pPdCKgCtVYHwon/TfNTq+4nyHYRE8od5MvRZYA3D99eQAN\
-            nY3dSBdPfR7fokfL4A6MWrJBDyUCih4uvAe9PwhqygkE0HsCYlMH6HooWFnvoeROHLj\
-            FN0brd95pI9f+HtQKSGzCav51UvMaehW6wwuuYxtnSymCtvXSVqx/4NstYMZ3YW0NK+\
-            MDnQdBm/m3lruwz7xYy67AHOv/gA6qoFnbcSdXSuZO5srP4i+Lv9SssX8AnU4db71Yq\
-            4KV3Im1epP4KbHn4gbqIFde3OzwndFu3eULuHClqNE82hC+JS/gAWASHzAb5tOXOVjz\
-            KeRspe2GaAsgPlfeW8MOL7hBBKz+vqd1aw==\",\"SXb2Tkw9EMxYF9azvBUhC7yR7P\
-            iGtk1wp9dZ7pQplirUvGE/91//iF84EMztBdCvFX56aAEe13d2abuyckowbnJnVY6e1\
-            Ok9SUCYqHy+ZMOzxGIIPH15/Qh2QFtwsWadYqJt8zuiijw9v4Cnxp31bc5nP3+NJ5fZ\
-            8CRYYHlfsuIxGSxz8DHrqG7FZQk7vZKBAyrQawXkwcX2cf7lK7i+GOclK6BlBRoHxsk\
-            pCmdZgD2hJwUl2PGNLEzYwg3QKI0bky0rfQ8rfZbbOim/zxXo5vCOKc1bVvrc1tFPqf\
-            QpbKD/jrLTqGUFbq+9o3ZzvFbLTJmAbQ53gmLVdIGMsiZIiXfLc6RWS8fdLqE405H9l\
-            mJKi0qqoS7bNRfOBu6r6J/SButSWxg0+b0T2y9DH9OK57wJ0qWsdlNbWOTGYD4rLmSK\
-            1ChZc1PMBh/doYy43xmyEz/DC3QQLKwetIxu2dBwMtJN+RVUOaclghb+V3CNNiERfDA\
-            G/XTAFLou/z+Siwnc0kzm4yV0N7kRNdxxraU+KypPFhLav8YT8XHTul4qw4N1niyqB9\
-            DMOzEVIi+Tm9S21pTwz9X0djRgia5Ml3yPu40tRmnp0Lp8rsCdk/fEw7RBtEB8ej8Bj\
-            xISS9lE+Q7iodoRuKN7TQ==\",\"Q132v4IbPO+EoqwkUQFEh85aBs564w3d7HBV+gp\
-            FqKXoSBJRK+5D7HPZ202KZjoZiEsIbkqegH0YhOMkjDtdoJUacbVtZE4LBhpKrkhRRa\
-            gUPazDRukzYuCFP2UVtbUU4Jb+Ga8rOnpEAm2G1yRKxU4TKEtdCPYaMV1q19CkNVsFx\
-            sC5znUSDt7sPeH6uS1h2gRdYUZZ1BhAynV8owcA0McNoFFlRlZucFImlRhZmUcSsTjA\
-            Z/3e0sCEVstp217obDNQ+6HOtSaoWk4xahA6xYDvH5Mk77TRFMmNQpWUaMBN4TTWq+3\
-            UssVXuAP5cikXV425XPn0hJ6JEeMiIdcaQ+ttaYJbqwltHg4DekFqg9J4Lb2CYY4iyO\
-            iGLZ2Ue2op/PSlwpXyE6k3EZAdcz8nOqZfBna+/KFCp86JPtPz6pqbnGYRGvjAippyk\
-            ibTEUnplE0RDF1LdphB56654UV0UUwLZTsnekOHrrmiY9jOiW5wAGVehqBMkVC14GHS\
-            E9Ev8eho4C7CCRG4r5KEIcspGsj6o+YJ6wM6c5djHSodeAzlRIsHhYaICHR2wVMnV8D\
-            EbkB3+uGM9tF2SYlHll5/MMp61Q0kCfVLjyN7ZUQW4+40PKwJ5NOX+49orrvabXTrB3\
-            XhLvt0m6JHY/V8RJ606OxT9umv1DD/DAdVxLh/I4tA4LZIjEuoIWlF258Dyv6WfU7RY\
-            qmiZce3BE2WFPCSRi1y0mmDgVKhx+nj3iHW4N8x6bmka51UbY8g0YqG/RzHkCvNg28k\
-            vTdXgWFEKCwq7T3oNzKK7VYyNPaxrOjeeY5tTSp1irCt8a0KSTU2oRHUPIi1dElx95+\
-            +3IM+vklsvO5Ad99RduvDgU8XyQ2qGl2hG2ebpNYmJjViv7atzs9lpop6Qsd7D6ea3g\
-            T4xro8pUXvF5hO5T03ueNMfNMZN0HjJ4MwvfFAimE7qAO8T89YNa1lzZ1sLOtfYyR5/\
-            Ihp5IG5HOe9OcTt9OlZIGu8UWBCnhHPgnEk6Wr6grhTrDfSKVMw5QQRtb0A4y57YXMp\
-            WP/IlirQ/RrzRngHI/S6CaQEQ2bUkJKIcWykib0jG1R0Ukuj2nr97fjK1qHWUa8lwz/\
-            uYQ+5MfDhhegmX17h7SqMKtbO1jJB6ge4PWL8lXJyZbcpxQIvqLEE+jP/acU+oT6PfN\
-            qBu0TmO1m/SXdXssMLMYhAAlZqFQ+OrlTB+kdW80Khx1RewXA2vtp54SSvh6sfuPcSd\
-            1EvwFNzXq/uSlYKndkYT7n7RHs+vJ/Uk1qdBUtwbuel2MKM+EuFJHoFTwGfQ4hwbw9g\
-            xO5ziLbFXYmbR17BGALnIB/P42IVJWCTquGV3PFas+NbyvUzoGt0127iedPC2lxJzxo\
-            uKl7IGDSBcDjvsFBTP2Ct98rkcssOL9lwEpWqWAFvkdNsYqrvpwUK32i5bT3rH9myVT\
-            qnRm/E322c6qXIcuWbXgUlNFtI4EYKf8P6R5a0O9/hQEmvcEmLELAdXMBWTQoKaqkXq\
-            EFpT5j+wZ7UWFEdgwOw+Ikfy+lxoHidLnfkzXj9rWH9H7PuHaXCqixCdXy5VHgjh/VZ\
-            kjucYCDwYLVf4pddbR348YMuadjBlYYrs3K8v4WkJS7EgOeP62SsDcdUrKXOLaWWzBU\
-            14yK0VPzH++8W+ojPeBtsr4PQJZRaEe8SS08DHo2INNCILT36e8uq9+tNysP+cT8Hj2\
-            wkJXQMf4UeVoGvfL1ORGjb5odU4kcmlBOtCksneRXDbHnVzZNCorre8wt4EjMlTfI4/\
-            v4e1iVT+FGNpgOSwZGM0lPpL4BBU4H9opJSIQITP1fwzgTNNzKstNpmsnWyom1AXc2n\
-            dks6NbLsunb2/XmzjTQrqQpDBkgokpPJeeCHVOLd0kcjGjHgJHaX93yis8RpMbVKRui\
-            tWC85Elil5yd2xnd8qbkPShCR9/s0vreEpHnDRsge/r3VW+ZI1MS+Zr8b3aALqRfYQ4\
-            siV3L3xnVLVCqsBBN4nSOezD36e9vLcPUSSod3ECl6vMqFYH+v5DHkAlafCzDoDc2WO\
-            RIGp5f7e3uPkzrGL8LvGn8B4zkkJOCJa+L7DHx/4fiQbeSyfoOLP6aQOkjGm+2/6UMi\
-            wyfBTiydcTYRYjBOg4kJrHmQlvtDAsMnIXxi21EmyOHy6AP/7E8JdZzaAYiEVgqxlMW\
-            EUoc2IiF08O8TSqwWKqF6i6YD75pPS8d5KyokqHSfVmKeKr6qjl0xfhDcxGb2nkv1jz\
-            1iubuCd3PXgd2900Gc4I36K3Sj20Idi73/ou9LS14hjuJrGXg3CmITT/oitGm15+6YR\
-            Pwi6vRPkDMRL0JsnH1Tuew+VyuJGa1jiqmj+GiKh1AcRBKJHaCbeXIrjoPt4ZseCWEf\
-            x9QkaisqasaDHR9TU+leuPetk/DF2jGl1AEXTGkjl9HiQa0/ywV8gvNdWsHtTgkFPLz\
-            lPHkVfbggYmZ5G45GxuO1EfGveBgrxP48ntS7RLjALweGffZSU+jNG0QiiR0FSYSwAS\
-            abTuAk3K5BYpX1rffP5oMagqtkWyaYRIlcqtZlAt6uTE3heMs2kc6fLay+g2Tdr3Vq3\
-            2smCWa05G0WKuUUI9ef7j+HtKhbi8CIoVNTKi1xiVCy0ZtK6RCTOaXSkhemcKLxZinC\
-            wPpnc+Y8GkUtfTMOSQFXvftU/mw+PK/1zXHL+6BaEUPsn02U3G4BI5cmJ7GRuE0I9oV\
-            7l4L3Z4uj4ZPW2JJ1aCCBZOsWGIF2SkK0wQgMTZuYzJrvpRYcqfg+lT9XLegCvA+/mF\
-            YtAxhrpfCVkeOsjFvcCgp71QE830gR4Grre9I0ZryUEScmtrfj1gq5IVUWqVvRV0zSI\
-            a+XdyqbCKqa6rBwDiSHvEXqhHGgym3j+kZP5H6asCWxToDPUgM8ysidavo/AvHwoMlO\
-            AAcercTGyP6J6t2Bah16GUoF+7wBvC16hViyn8txdYtuPsSKnphjsoGnrmGPQNjC2cs\
-            3rd1gCkEswYntZiOXK93iMsKBwkAmZqLpxZycbVKPfH6FY/9cTbuboyFmk2C1gg+BYl\
-            hqbwO+bRXGbms0pDns2hqk8dattN0wk3PnOGITevryCvqbnnFOr/3UgLmD9qUIynbu8\
-            cN6S2X9DZ1pwY2nKxjtpdCJBpq6r2mk10BvqEuTLc1HYP/4DDvjXxGJWeoZax+XoHju\
-            o2wbFXA/lVdwYr4i4vskHekG0keuSNoKrn3Artrr6zQtqzV3iiNrk/1j+QLGa75mWVE\
-            RtoFetLScpiybQE/oa5b33zRtt5iDy7Br3o66rwF0qr4i0c4JoBv0Fck6LrSMh3IJXl\
-            r5D7wtasiC/f6vaCm3UjzuH8Az7Nc4epcKDI95heqdnJERN8KgSfAaJvOGm5zq62mSJ\
-            TuDli9oNZiCkfeJlnPQHh7WTsogDTu8LNFw7HCkpnegTG4D4UIHukCE9a6WWvLVLEI8\
-            O/6hp/qs1xoOxqTP6NIAtG9PTeavRG6gajpQT3wCBJbxO9AgIVUA6ZINQDirMTotOGv\
-            UPEhvV2Hmv+lSBtY/sB5TgG6CZ7A3U6nA+gfRl6G6trUuWfxFewpofgptxblRbItc+B\
-            GPvUMC7Bqp5ZvUjOtCLh0VCC8GyprCogKIQPk6sgQPSaEOYgARUrILGh4QDJ6ZR2j4w\
-            WJwg3wMlRqW7ekLHHxrjJsYzBGcdi6RcrUa7tfC6wTcWAV5VK2k1fHAQzP7AG5JjMKy\
-            SjojqTjHUUZo7MCwRBOaVC8H5qS29D1lkXawHnRDwdjH+LJpaYAbgONpaL5JDQsAugK\
-            NN7lJZZ42LgzkpB78AG6CjReED1RM4KcvAjSGw0yqOU8GTinXSTUW6YmNbFo5TGjBMW\
-            JVWsV16y1aVFi/HKEl3vWSOI2dxkkipnbimJY47grYNjLKIwLLJk5cw2AVx5OE9jNFw\
-            imDFOiWM573SZ1pUq2ntXXQA+EKmlisiQ0ptTzjvUZpyFMMV1Rrhn1jr3khdVKF108n\
-            orVNcoWQtFx5oRqtjEzToOeg1y7MTBV2CjglFnxsRGSTfAdNFJeejs7IE2Icgrs6J3D\
-            JN2a4WiQlcjHZCM55lNpECqdVkI5rvUvslAkzZM3FWhlFxpuMzZOslj7A/mQdrADDM5\
-            3QDVeFTFzZzmHLIsSjriKaJB8xENGZ7YOVDmE2s9Nl9iljSCI8RkId9K7kzhkTINvUu\
-            wTSWsFX0InmDK3qVnPh2prEzeENvRFcP4ys1PastBPCsyXMy75RVBOL9kJI2tYspRe8\
-            kez4hhrPQHfSN76SjpWnS+XRygDju78pF1qv+XIIWyy0GgJkkTGAYTepEehsCH7Ivc+\
-            6/z+7+iZD5gPtdEx+rZbe5qqt0as+IzU9A5lXhVGmYEIrStgJhX3E+jV3El04RjLUGg\
-            7k43VaMZYUeSneMxwq9oRsvTLF77lysr9xF+TdzkuxGWVZHfIl6x/YZsYrOHdsJK+cX\
-            LGy3rZBaXR7RoDNfbNWYfCrZo0UdkVEW7sHHfc2SucrvZv1kQPY8JlwVfcDaEI+II/+\
-            uQeo1LvgrMm4N59wGzDUI2l0GzCvgBLeYE1C007snfDfWy6UkwS8p0uihZO5NEGhB7c\
-            72b+3dCq584EInPEAxp4h8cdzf12nwSfY784Chf4Kd2oKvf388SM6B4GBITbKyXjt/e\
-            El84GbnGuLB+yD97G30imuZ97wptmx/kEG6nsAN1K2tXbSW/0mHTt7R90BwVXFtg+ey\
-            oYneeRrARqlr0laFhxRLnoWVGJXrEZzIddW58T2+j3oEXYZfxHd9Qf3MHd+eXvrZoXj\
-            uZascFarFcePQ76CHXAvna2/sTI+sJltAU60HSK0znBnW5OzfYh35qJaIRiq9j1rr3D\
-            /eXAxtK+s94fpbU/Maz0JKqMLksQdecCd9p6yr9h+HdCq3y9A+/qJAbtzdQBwLDwDLJ\
-            XBj+uCIZxOkBa/0h7YObfd/1C3ntFlXaNnjeNFzYPywbMfX4wKP3HHEd/wrnePHrBor\
-            Atahow36vyd8GsbyU08QzPrzwp6VqInauJRlDHNzrWzHTe53HYgUa1t6+NVbcMr6U//\
-            OroV5dcz63az9S53nMXfhEDmL6Ou+X3c2aw0uTp/R30wRt0wvV2FDXdyxmu+t2bGN97\
-            nFTtb5aLMUTUFYjoc9jpJQFy9fH4ZXTNBMMqNuptCRoNVI8DS99pSsMKiE0s1enshQv\
-            7WSrdLQo8f6UHQ21qngPfjaw4ALByhP3SVP2qXAID5zvAacy3tm3s6UJq8scoEn3l0z\
-            Omo6a1gHUIz9HCKW436TQLc2LKoNWtXouk9oELP83TZHhvPxlm1DE6JhKKc0EMbZ1dK\
-            oxfZdo09vQwPjZxumFPakZMFNWS+jJpcAJ5HTS3jd2ZBqJwIidznNb0EPV4br6OxLCA\
-            WMTOMLsog1jecNepCBbE8duCrfBj10gdYYa1cnjXchW6RJypPnV/uKyQ9462Lt+uZ/u\
-            LKlHAJo7sBEJ0Yb/aLUVvRNa2P62G1Z/fxD/+0zskQ7D/j33+iTr7340aC1PKt0/9i3\
-            Gt29o4aLEbdOq/ByhoWzzgT6/Ri1L51TfO1Cusd6x99YHoCmiDiJVRoVItOUwsvkbla\
-            wd7NsWGljCOXzNrmyEJu//RlPnpWBIc=\",\"+p0JHD4d2Is6mUqai6vxagp8G3+Ihc\
-            3+dXQjOtha8MBK7hvpDnc746assRE4dr7ZMJ86xv3OiOzwifoDjdo/2mom7Gylea1M0\
-            UhTtMrMSrmRWmjFDi/oWmn05FRbzXoj/VLYupFOsv5a08yHdklr6+NHNAgofWBsvxhd\
-            LrZmr5pG5jNh61kpw9JxZfwQ+s2zeyF/bGvszEUpRvejCG6hwp3KJTIMPX2Zjx4qJcD\
-            42NZBx8YMAvq/bdAK3cgQo9tnBPYn6VbWCflwipdIVOBI3yLSIEyDpRidklo/HIWVIT\
-            DRyMHPAwWNnq27ABnlwxCWRDmHXi5QitHK30hXSZNtGx7WFx9ohxp1S9j4XN+VwwO32\
-            I9pXVuu+fBL/OORtLfSCemHx0PdoBETFqPuXQdErX+KVXP/0wM8ru/m+2p0ydKtmXmj\
-            /PEFy8tidBR9hyCuOdqPH1zd1loaMTzQ4hh1TdrWumm1PjxxN4LR+rw0zxMVMtI0t01\
-            zG38I4bF/+nuNjTLRweZC9MapNx7kEHw+l7XNChXinnoxy+Ubc/GOBx6NbMbmsvQZb5\
-            oPf/y/v3xoeCEfzMp++Pt/PkiT/7N13rrrVF8ePwnz+CbK5m8P1ePb8r9/CUv18NeH+\
-            vN6+euL+tc/f/z19dftp9/+z8NfH8w/dvzfv63zH17C6832Lf91EX774Zew3H0y/N8/\
-            +9dfH1pxI9rffvjl5l+3P74tbxdv4uZ/BfHDVv/r189vv/3wyzex+7QW//2P+/m+2D9\
-            +WXT8r/zfP+rX25+b5c2delIPatX1pz/++OOP/x8AAP//qdMJOD7aAAA=\"]"
-        cookies: []
-        headers:
-          - name: date
-            value: Fri, 10 May 2024 07:20:58 GMT
-          - name: content-type
-            value: application/json
-          - name: transfer-encoding
-            value: chunked
-          - name: connection
-            value: keep-alive
-          - name: access-control-allow-credentials
-            value: "true"
-          - name: access-control-allow-origin
-            value: ""
-          - name: cache-control
-            value: no-cache, max-age=0
-          - name: content-encoding
-            value: gzip
-          - name: vary
-            value: Accept-Encoding, Authorization, Cookie, Authorization, X-Requested-With,
-              Cookie
-          - name: x-content-type-options
-            value: nosniff
-          - name: x-frame-options
-            value: DENY
-          - name: x-xss-protection
-            value: 1; mode=block
-          - name: strict-transport-security
-            value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1248
-        httpVersion: HTTP/1.1
-        redirectURL: ""
-        status: 200
-        statusText: OK
-      startedDateTime: 2024-05-10T07:20:58.075Z
-      time: 0
-      timings:
-        blocked: -1
-        connect: -1
-        dns: -1
-        receive: 0
-        send: 0
-        ssl: -1
-        wait: 0
-    - _id: b0d6f3a008a4893818613df417baa271
-      _order: 0
-      cache: {}
-      request:
-        bodySize: 445
-        cookies: []
-        headers:
-          - _fromType: array
-            name: authorization
-            value: token
-              REDACTED_b20717265e7ab1d132874d8ff0be053ab9c1dacccec8dce0bbba76888b6a0a69
-          - _fromType: array
-            name: content-type
-            value: application/json; charset=utf-8
-          - _fromType: array
-            name: user-agent
-            value: enterpriseClient / v1
-          - _fromType: array
-            name: accept
-            value: "*/*"
-          - _fromType: array
-            name: content-length
-            value: "445"
-          - _fromType: array
-            name: accept-encoding
-            value: gzip,deflate
-          - name: host
-            value: demo.sourcegraph.com
-        headersSize: 320
-        httpVersion: HTTP/1.1
-        method: POST
-        postData:
-          mimeType: application/json; charset=utf-8
-          params: []
-          textJSON:
-            query: |
-              
-              query Repositories($first: Int!, $after: String) {
-                  repositories(first: $first, after: $after) {
-                      nodes {
-                          id
-                          name
-                      }
-                      pageInfo {
-                          endCursor
-                      }
-                  }
-              }
-            variables:
-              after: UmVwb3NpdG9yeUN1cnNvcjp7IkNvbHVtbiI6Im5hbWUiLCJWYWx1ZSI6InByaXZhdGUtY2xvdWQtZGVtby1naXRsYWIuc2cuZGV2L3Jvb3Qvc2FtcGxlLW5vZGVqcy1hcHBAMzgzNDQiLCJEaXJlY3Rpb24iOiIifQ==
+              after: UmVwb3NpdG9yeUN1cnNvcjp7ImMiOiJuYW1lIiwidiI6InByaXZhdGUtY2xvdWQtZGVtby1naXRsYWIuc2cuZGV2L3Jvb3Qvc2FtcGxlLW5vZGVqcy1hcHBAMzgzNDQiLCJkIjoiIn0=
               first: 10000
         queryString:
           - name: Repositories
@@ -3577,7 +3624,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Fri, 10 May 2024 07:20:58 GMT
+            value: Fri, 23 Aug 2024 08:20:25 GMT
           - name: content-type
             value: application/json
           - name: transfer-encoding
@@ -3608,7 +3655,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-05-10T07:20:58.531Z
+      startedDateTime: 2024-08-23T08:20:25.458Z
       time: 0
       timings:
         blocked: -1

--- a/agent/recordings/fix_3001320056/recording.har.yaml
+++ b/agent/recordings/fix_3001320056/recording.har.yaml
@@ -90,11 +90,11 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: 3f1f79813408aeb87fec5bcd1b61767b
+    - _id: a3437619d7c064df2285fbb36db46aa0
       _order: 0
       cache: {}
       request:
-        bodySize: 2267
+        bodySize: 2266
         cookies: []
         headers:
           - name: content-type
@@ -107,7 +107,7 @@ log:
           - name: user-agent
             value: fix / v1
           - name: traceparent
-            value: 00-321ee58158d9899f368f1eb81a26f8e8-7e2030a5416fb04a-01
+            value: 00-3f0d5d4d3854805f311f966ca2761756-ecfa2eff8c16cd85-01
           - name: connection
             value: keep-alive
           - name: host
@@ -123,7 +123,7 @@ log:
             messages:
               - speaker: system
                 text: >-
-                  You are Cody, an AI coding assistant from Sourcegraph. 
+                  You are Cody, an AI coding assistant from Sourcegraph.
 
 
                   - You are an AI programming assistant who is an expert in fixing errors within code.
@@ -192,10 +192,10 @@ log:
             value: v1
         url: https://sourcegraph.com/.api/completions/stream?api-version=1&client-name=fix&client-version=v1
       response:
-        bodySize: 684
+        bodySize: 607
         content:
           mimeType: text/event-stream
-          size: 684
+          size: 607
           text: >+
             event: completion
 
@@ -209,7 +209,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Thu, 22 Aug 2024 14:11:44 GMT
+            value: Fri, 23 Aug 2024 08:08:27 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
@@ -238,7 +238,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-08-22T14:11:42.431Z
+      startedDateTime: 2024-08-23T08:08:25.877Z
       time: 0
       timings:
         blocked: -1

--- a/agent/recordings/fix_3001320056/recording.har.yaml
+++ b/agent/recordings/fix_3001320056/recording.har.yaml
@@ -90,11 +90,11 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: cef5d5e67011f938393be71baf15c00a
+    - _id: 3f1f79813408aeb87fec5bcd1b61767b
       _order: 0
       cache: {}
       request:
-        bodySize: 2263
+        bodySize: 2267
         cookies: []
         headers:
           - name: content-type
@@ -107,7 +107,7 @@ log:
           - name: user-agent
             value: fix / v1
           - name: traceparent
-            value: 00-43c7599d8722c5cc45212303dae0ec31-dfbf5280ddb8e5b1-01
+            value: 00-321ee58158d9899f368f1eb81a26f8e8-7e2030a5416fb04a-01
           - name: connection
             value: keep-alive
           - name: host
@@ -123,9 +123,10 @@ log:
             messages:
               - speaker: system
                 text: >-
-                  You are Cody, an AI coding assistant from Sourcegraph. - You
-                  are an AI programming assistant who is an expert in fixing
-                  errors within code.
+                  You are Cody, an AI coding assistant from Sourcegraph. 
+
+
+                  - You are an AI programming assistant who is an expert in fixing errors within code.
 
                   - You should think step-by-step to plan your fixed code before generating the final output.
 
@@ -191,10 +192,10 @@ log:
             value: v1
         url: https://sourcegraph.com/.api/completions/stream?api-version=1&client-name=fix&client-version=v1
       response:
-        bodySize: 801
+        bodySize: 684
         content:
           mimeType: text/event-stream
-          size: 801
+          size: 684
           text: >+
             event: completion
 
@@ -208,7 +209,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Wed, 21 Aug 2024 13:31:17 GMT
+            value: Thu, 22 Aug 2024 14:11:44 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
@@ -237,7 +238,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-08-21T13:31:12.435Z
+      startedDateTime: 2024-08-22T14:11:42.431Z
       time: 0
       timings:
         blocked: -1

--- a/agent/src/__snapshots__/custom-commands.test.ts.snap
+++ b/agent/src/__snapshots__/custom-commands.test.ts.snap
@@ -9,12 +9,14 @@ exports[`Custom Commands > commands/custom, chat command, open tabs context 1`] 
 `;
 
 exports[`Custom Commands > commands/custom, edit command, edit mode 1`] = `
-"export interface Animal {
+"/* SELECTION_START */
+export interface Animal {
     name: string
     makeAnimalSound(): string
     isMammal: boolean
     logName(): void
 }
+/* SELECTION_END */
 "
 `;
 

--- a/agent/src/__snapshots__/custom-commands.test.ts.snap
+++ b/agent/src/__snapshots__/custom-commands.test.ts.snap
@@ -1,7 +1,7 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`Custom Commands > commands/custom, chat command, open tabs context 1`] = `
-"Here are the names of the files you've shared so far, formatted as a bulleted list:
+"Here are the names of the files you've shared with me so far, formatted as a bulleted list:
 
 • example3.ts
 • example2.ts

--- a/agent/src/__snapshots__/custom-commands.test.ts.snap
+++ b/agent/src/__snapshots__/custom-commands.test.ts.snap
@@ -1,7 +1,7 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`Custom Commands > commands/custom, chat command, open tabs context 1`] = `
-"Here are the names of the files you've shared with me so far, formatted as a bulleted list:
+"Here are the names of the files you have shared with me so far, formatted as a bulleted list:
 
 • example3.ts
 • example2.ts
@@ -9,14 +9,12 @@ exports[`Custom Commands > commands/custom, chat command, open tabs context 1`] 
 `;
 
 exports[`Custom Commands > commands/custom, edit command, edit mode 1`] = `
-"/* SELECTION_START */
-export interface Animal {
+"export interface Animal {
     name: string
     makeAnimalSound(): string
     isMammal: boolean
     logName(): void
 }
-/* SELECTION_END */
 "
 `;
 

--- a/agent/src/__snapshots__/custom-commands.test.ts.snap
+++ b/agent/src/__snapshots__/custom-commands.test.ts.snap
@@ -1,7 +1,7 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`Custom Commands > commands/custom, chat command, open tabs context 1`] = `
-"Here are the names of the files you have shared with me so far, formatted as a bulleted list:
+"Here's a bulleted list of the filenames you've shared with me so far:
 
 • example3.ts
 • example2.ts

--- a/agent/src/__snapshots__/document-code.test.ts.snap
+++ b/agent/src/__snapshots__/document-code.test.ts.snap
@@ -21,7 +21,7 @@ export const TestLogger = {
 
 exports[`Document Code > commands/document (Kotlin class name) 1`] = `
 "/**
- * Represents a Hello object that can greet the world.
+ * Represents a simple "Hello, world!" greeting.
  */
 class He/* CURSOR */llo {
     fun greeting(): String {
@@ -48,7 +48,7 @@ export class TestClass {
     constructor(private shouldGreet: boolean) {}
 
     /**
-     * Logs a 'Hello World!' message to the console if the \`shouldGreet\` parameter is true.
+     * Logs a "Hello World!" message to the console if the \`shouldGreet\` property is true.
      */
     public functionName() {
         if (this.shouldGreet) {
@@ -87,7 +87,8 @@ describe('test block', () => {
     it('does something else', () => {
         // This line will error due to incorrect usage of \`performance.now\`
         /**
-         * Marks the start time of some operation for performance measurement.
+         * Captures the current time in milliseconds using the high-resolution \`performance.now()\` timer.
+         * This can be used to measure elapsed time for performance profiling or benchmarking.
          */
         const startTime = performance.now(/* CURSOR */)
     })
@@ -97,11 +98,11 @@ describe('test block', () => {
 
 exports[`Document Code > editCommands/document (basic function) 1`] = `
 "/**
- * Computes the sum of two numbers.
- *
+ * Adds two numbers together and returns the result.
+ * 
  * @param a - The first number to add.
  * @param b - The second number to add.
- * @returns The sum of \`a\` and \`b\`.
+ * @returns The sum of the two numbers.
  */
 export function sum(a: number, b: number): number {
     /* CURSOR */

--- a/agent/src/__snapshots__/document-code.test.ts.snap
+++ b/agent/src/__snapshots__/document-code.test.ts.snap
@@ -21,7 +21,7 @@ export const TestLogger = {
 
 exports[`Document Code > commands/document (Kotlin class name) 1`] = `
 "/**
- * Represents a simple "Hello, world!" greeting.
+ * Represents a greeter that can provide a "Hello, world!" greeting.
  */
 class He/* CURSOR */llo {
     fun greeting(): String {
@@ -48,7 +48,7 @@ export class TestClass {
     constructor(private shouldGreet: boolean) {}
 
     /**
-     * Logs a "Hello World!" message to the console if the \`shouldGreet\` property is true.
+     * Greets the user if the \`shouldGreet\` flag is true.
      */
     public functionName() {
         if (this.shouldGreet) {
@@ -87,8 +87,8 @@ describe('test block', () => {
     it('does something else', () => {
         // This line will error due to incorrect usage of \`performance.now\`
         /**
-         * Captures the current time in milliseconds using the high-resolution \`performance.now()\` timer.
-         * This can be used to measure elapsed time for performance profiling or benchmarking.
+         * Records the current time in milliseconds since the page was loaded.
+         * This can be used to measure the duration of an operation.
          */
         const startTime = performance.now(/* CURSOR */)
     })
@@ -98,11 +98,11 @@ describe('test block', () => {
 
 exports[`Document Code > editCommands/document (basic function) 1`] = `
 "/**
- * Adds two numbers together and returns the result.
- * 
+ * Calculates the sum of two numbers.
+ *
  * @param a - The first number to add.
  * @param b - The second number to add.
- * @returns The sum of the two numbers.
+ * @returns The sum of the two input numbers.
  */
 export function sum(a: number, b: number): number {
     /* CURSOR */

--- a/agent/src/cli/__snapshots__/command-chat.test.ts.snap
+++ b/agent/src/cli/__snapshots__/command-chat.test.ts.snap
@@ -4,21 +4,26 @@ exports[`--context-file (animal test) 1`] = `
 "command: cody chat chat --context-file animal.ts --show-context -m implement a
   cow. Only print the code without any explanation.
 exitCode: 0
-stdout: |+
+stdout: >+
   > Context items:
+
 
   > 1. WORKING_DIRECTORY/animal.ts
 
 
 
-  Here's the implementation of a cow based on the provided context:
+
+  Here's the implementation of a cow based on the provided \`StrangeAnimal\` interface:
+
 
   \`\`\`typescript:animal.ts
+
   class Cow implements StrangeAnimal {
       makesSound(): 'coo' | 'moo' {
           return 'moo';
       }
   }
+
   \`\`\`
 
 stderr: ""

--- a/agent/src/cli/__snapshots__/command-chat.test.ts.snap
+++ b/agent/src/cli/__snapshots__/command-chat.test.ts.snap
@@ -11,9 +11,9 @@ stdout: |+
 
 
 
-  Here's the implementation of a cow without any explanation:
+  \`\`\`typescript:cow.ts
+  import { StrangeAnimal } from './animal';
 
-  \`\`\`typescript:animal.ts
   class Cow implements StrangeAnimal {
       makesSound(): 'coo' | 'moo' {
           return 'moo';

--- a/agent/src/cli/__snapshots__/command-chat.test.ts.snap
+++ b/agent/src/cli/__snapshots__/command-chat.test.ts.snap
@@ -11,9 +11,9 @@ stdout: |+
 
 
 
-  \`\`\`typescript:cow.ts
-  import { StrangeAnimal } from './animal';
+  Here's the implementation of a cow based on the provided context:
 
+  \`\`\`typescript:animal.ts
   class Cow implements StrangeAnimal {
       makesSound(): 'coo' | 'moo' {
           return 'moo';

--- a/agent/src/edit.test.ts
+++ b/agent/src/edit.test.ts
@@ -120,7 +120,6 @@ describe('Edit', () => {
 
           export const Heading: React.FC<HeadingProps> = ({ text, level = 1 }) => {
               const HeadingTag = \`h\${level}\` as keyof JSX.IntrinsicElements;
-
               return <HeadingTag>{text}</HeadingTag>;
           };
 

--- a/agent/src/edit.test.ts
+++ b/agent/src/edit.test.ts
@@ -120,6 +120,7 @@ describe('Edit', () => {
 
           export const Heading: React.FC<HeadingProps> = ({ text, level = 1 }) => {
               const HeadingTag = \`h\${level}\` as keyof JSX.IntrinsicElements;
+
               return <HeadingTag>{text}</HeadingTag>;
           };
 
@@ -148,7 +149,8 @@ describe('Edit', () => {
                   default:
                       return a - b
               }
-          }"
+          }
+          "
         `,
             explainPollyError
         )

--- a/agent/src/enterprise-demo.test.ts
+++ b/agent/src/enterprise-demo.test.ts
@@ -23,7 +23,10 @@ describe('Enterprise', () => {
         expect(serverInfo.authStatus?.username).toStrictEqual('codytesting')
     }, 10_000)
 
-    it('chat/submitMessage', async () => {
+    // Skip because it consistently fails with:
+    // unsupported chat model "anthropic/claude-3-opus-20240229" (default "anthropic::2023-06-01::claude-3-opus"
+    // Linear issue: https://linear.app/sourcegraph/issue/PRIV-3329/chat-investigate-why-we-have-a-failing-agent-test-when-pointed-at
+    it.skip('chat/submitMessage', async () => {
         const lastMessage = await demoEnterpriseClient.sendSingleMessageToNewChat('Reply with "Yes"')
         expect(lastMessage?.text?.trim()).toStrictEqual('Yes')
     }, 20_000)

--- a/agent/src/index.test.ts
+++ b/agent/src/index.test.ts
@@ -228,7 +228,7 @@ describe('Agent', () => {
               {
                 "model": "anthropic/claude-3-5-sonnet-20240620",
                 "speaker": "assistant",
-                "text": "Hello! I'm Cody, an AI coding assistant from Sourcegraph. How can I help you with coding today? Whether you need help with a specific programming language, debugging, code optimization, or any other coding-related task, I'm here to assist you. What would you like to work on?",
+                "text": "Hello! I'm Cody, an AI coding assistant from Sourcegraph. How can I help you with your coding tasks today? Whether you need assistance with writing code, debugging, explaining concepts, or anything else related to programming, I'm here to help. What would you like to work on?",
               }
             `
             )
@@ -247,9 +247,9 @@ describe('Agent', () => {
             const trimmedMessage = trimEndOfLine(lastMessage?.text ?? '')
             expect(trimmedMessage).toMatchInlineSnapshot(
                 `
-              "Certainly! Here's a simple "Hello, World!" function in Java:
+              "Certainly! I'll create a simple "Hello, World!" function in Java for you. Here's the code:
 
-              \`\`\`java
+              \`\`\`java:HelloWorld.java
               public class HelloWorld {
                   public static void main(String[] args) {
                       sayHello();
@@ -265,8 +265,14 @@ describe('Agent', () => {
 
               1. We define a class called \`HelloWorld\`.
               2. Inside the class, we have the \`main\` method, which is the entry point of any Java program.
-              3. We create a separate method called \`sayHello()\` that prints "Hello, World!" to the console.
-              4. In the \`main\` method, we call the \`sayHello()\` function.
+              3. We also have a separate \`sayHello\` method that prints "Hello, World!" to the console.
+              4. In the \`main\` method, we call the \`sayHello\` method.
+
+              To run this program:
+
+              1. Save the code in a file named \`HelloWorld.java\`.
+              2. Compile the code using the command: \`javac HelloWorld.java\`
+              3. Run the compiled program using: \`java HelloWorld\`
 
               When you run this program, it will output:
 
@@ -274,13 +280,7 @@ describe('Agent', () => {
               Hello, World!
               \`\`\`
 
-              To run this program:
-
-              1. Save the code in a file named \`HelloWorld.java\`
-              2. Compile it using the command: \`javac HelloWorld.java\`
-              3. Run it using the command: \`java HelloWorld\`
-
-              This will execute the program and display the "Hello, World!" message on the console."
+              This is a simple example of a Java function that prints a greeting to the console."
             `,
                 explainPollyError
             )
@@ -333,7 +333,7 @@ describe('Agent', () => {
                 })
             )
             expect(reply2.messages.at(-1)?.text).toMatchInlineSnapshot(
-                `"Your name is Lars Monsen, as you just told me."`,
+                `"Your name is Lars Monsen, as you mentioned in your introduction."`,
                 explainPollyError
             )
         }, 30_000)
@@ -380,7 +380,7 @@ describe('Agent', () => {
                 })
             )
             expect(reply2.messages.at(-1)?.text).toMatchInlineSnapshot(
-                `"I am Cody, an AI coding assistant created by Sourcegraph. I don't have specific information about my underlying model or architecture. Is there a particular coding task or question I can help you with?"`,
+                `"I apologize for any confusion, but I don't have specific information about my exact model architecture or training. I am an AI assistant called Cody, created by Sourcegraph, designed to help with coding and software development tasks. I don't have a specific model name like GPT-3 or BERT. My capabilities come from my training, but the details of that training process aren't something I have access to or can share. If you have any coding or development questions, I'd be happy to assist with those!"`,
                 explainPollyError
             )
         }, 30_000)
@@ -455,9 +455,11 @@ describe('Agent', () => {
             // is not a git directory and symf reports some git-related error.
             expect(trimEndOfLine(lastMessage?.text ?? '')).toMatchInlineSnapshot(
                 `
-              "Certainly! Here's a class Dog that implements the Animal interface based on the context provided:
+              "Certainly! Here's a class \`Dog\` that implements the \`Animal\` interface:
 
-              \`\`\`typescript:src/animal.ts
+              \`\`\`typescript:src/dog.ts
+              import { Animal } from './animal';
+
               export class Dog implements Animal {
                   name: string;
                   isMammal: boolean = true;
@@ -472,7 +474,7 @@ describe('Agent', () => {
               }
               \`\`\`
 
-              This Dog class fully implements the Animal interface as defined in your workspace."
+              This implementation fulfills all the requirements of the \`Animal\` interface defined in your workspace."
             `,
                 explainPollyError
             )
@@ -483,7 +485,7 @@ describe('Agent', () => {
             client.expectedEvents = [
                 'cody.chat-question:submitted',
                 'cody.chat-question:executed',
-                'cody.chatResponse:hasCode',
+                'cody.chatResponse:noCode',
             ]
             await client.openFile(squirrelUri)
             const { lastMessage, transcript } =
@@ -842,17 +844,17 @@ describe('Agent', () => {
             const lastMessage = await client.firstNonEmptyTranscript(id)
             expect(trimEndOfLine(lastMessage.messages.at(-1)?.text ?? '')).toMatchInlineSnapshot(
                 `
-              "Sure, I'd be happy to explain.
+              "The code being explained is an interface named \`Animal\` in a TypeScript file at \`src/animal.ts\`.
 
-              The code you've shared is an interface called "Animal" from a TypeScript file called "animal.ts". An interface is like a blueprint for objects that defines what properties and methods an object should have. In this case, the Animal interface defines an object with three properties: "name", "makeAnimalSound", and "isMammal".
+              The purpose of this code is to define what properties an object should have in order to be considered an \`Animal\`. The interface does this by listing the required properties such as \`name\`, \`makeAnimalSound()\`, and \`isMammal\`. The \`name\` is a required string field, \`isMammal\` is a required boolean field, and \`makeAnimalSound()\` is a required function that returns a string.
 
-              1. The purpose of the code is to define the structure of an object that represents a generic animal in a program. The Animal interface specifies that any object that claims to be an animal should have a name, a method for making an animal sound, and a boolean property that indicates if the animal is a mammal.
-              2. The interface doesn't take any inputs, as it only defines a structure. The inputs and outputs are defined by the objects that will implement this interface.
-              3. Again, the interface itself doesn't produce any outputs, but it enables the creation of objects that have a specific structure, which is useful for defining and enforcing consistency and expectations in your code.
-              4. The interface achieves its purpose by specifying the Required properties and methods that an object needs to have. The code states that the Animal interface must have a "name" property of type string, a "makeAnimalSound" method that returns a string, and an "isMammal" property of type boolean.
-              5. The important logic flows or data transformations in this code are the definitions of the "makeAnimalSound" method and the "isMammal" property. These are not defined in the code you shared, but they are required to be implemented by whatever object uses this Animal interface. The "makeAnimalSound" method is expected to produce a sound that an animal makes, and the "isMammal" property is expected to be a boolean value that indicates whether the animal is a mammal. By requiring the implementation of these methods and properties, the Animal interface enables the creation of consistent, predictable animal objects in your code.
+              The code doesn't take any input directly, but its purpose is to be implemented by other TypeScript classes defining a specific animal, such as \`Dog\` or \`Cat\`. These classes will then implement the required properties and functions defined in the \`Animal\` interface.
 
-              In summary, the Animal interface is a blueprint for animal objects that defines what properties and methods they should have, ensuring consistency and predictability. It doesn't take any inputs or produce any outputs, but it enables the creation of objects that have a specific structure."
+              The output of this code is not a value itself, but rather a description of a data structure. Objects of classes that implement this interface can be used as \`Animal\` type, but the interface itself doesn't produce any value directly.
+
+              The way this is achieved is by using the TypeScript feature called \`interfaces\`, which provides a contract that a class has to follow in order to adhere to the structure defined by the interface. The interface defines what properties are required to be present in classes that implement it.
+
+              The main logic flow is that the interface \`Animal\` is defined with its required properties, and classes that want to be considered as implementing the \`Animal\` interface need to adhere to this structure. The data transformation that happens is that classes that implement the \`Animal\` interface provide the actual implementation and logic for the required properties. The interface only provides the shape that the class should have without implementing it."
             `,
                 explainPollyError
             )
@@ -874,45 +876,105 @@ describe('Agent', () => {
                 const lastMessage = await client.firstNonEmptyTranscript(id)
                 expect(trimEndOfLine(lastMessage.messages.at(-1)?.text ?? '')).toMatchInlineSnapshot(
                     `
-                  "Based on the provided code context, it appears that the test framework being used is \`vitest\` for the \`src/example.test.ts\` file. Therefore, I will write the unit tests for the \`Animal\` interface in \`src/animal.ts\` using \`vitest\`.
+                  "Based on the shared code context, the test framework in use is \`vitest\`.
 
-                  Since the \`Animal\` interface is just a type definition and doesn't have any implementations, I will create a dummy class that implements this interface and write tests for that class.
+                  To write unit tests for the \`Animal\` interface in \`src/animal.ts\`, we can create instances of classes that implement this interface, and validate their implementation by calling methods and properties against the interface definition.
 
-                  Here is the full code for the new unit tests:
+                  Here's a suite of unit tests for the \`Animal\` interface using \`vitest\`:
                   \`\`\`typescript
-                  import { expect, test } from 'vitest'
-                  import { Animal } from '../src/animal'
+                  // src/animal.test.ts
+                  import { expect, describe, it } from 'vitest'
+                  import { Animal } from '../animal'
 
-                  class Dog implements Animal {
-                      name: string = 'Dog'
-                      isMammal: boolean = true
-                      makeAnimalSound(): string {
-                          return 'Woof!'
-                      }
-                  }
+                  describe('Animal interface unit tests', () => {
+                      it('should define name property', () => {
+                          const animal: Animal = {
+                              name: 'Lion',
+                              makeAnimalSound() {
+                                  return 'roar'
+                              },
+                              isMammal: true,
+                          }
 
-                  test('Test animal implementation makes correct sound', () => {
-                      const dog = new Dog()
-                      expect(dog.makeAnimalSound()).toEqual('Woof!')
-                  })
+                          expect(animal.name).toEqual('Lion')
+                      })
 
-                  test('Test animal implementation isMammal flag', () => {
-                      const dog = new Dog()
-                      expect(dog.isMammal).toBe(true)
-                  })
+                      it('should define makeAnimalSound method', () => {
+                          const animal: Animal = {
+                              name: 'Dog',
+                              makeAnimalSound() {
+                                  return 'bark'
+                              },
+                              isMammal: true,
+                          }
 
-                  test('Test animal implementation name property', () => {
-                      const dog = new Dog()
-                      expect(dog.name).toEqual('Dog')
+                          expect(animal.makeAnimalSound()).toEqual('bark')
+                      })
+
+                      it('should define isMammal property', () => {
+                          const animal: Animal = {
+                              name: 'Cat',
+                              makeAnimalSound() {
+                                  return 'meow'
+                              },
+                              isMammal: true,
+                          }
+
+                          expect(animal.isMammal).toEqual(true)
+                      })
+
+                      it('should throw error if animal does not have name property', () => {
+                          const createInvalidAnimal = () => {
+                              const animal: Animal = {
+                                  makeAnimalSound() {
+                                      return 'cry'
+                                  },
+                                  isMammal: false,
+                              }
+
+                              return animal
+                          }
+
+                          expect(() => createInvalidAnimal()).toThrowError('Animal must have a name')
+                      })
+
+                      it('should throw error if animal does not implement makeAnimalSound method', () => {
+                          const createInvalidAnimal = () => {
+                              const animal: Animal = {
+                                  name: 'Frog',
+                                  isMammal: false,
+                              }
+
+                              return animal
+                          }
+
+                          expect(() => createInvalidAnimal()).toThrowError('Animal must implement makeAnimalSound method')
+                      })
+
+                      it('should throw error if animal does not have isMammal property', () => {
+                          const createInvalidAnimal = () => {
+                              const animal: Animal = {
+                                  name: 'Snake',
+                                  makeAnimalSound() {
+                                      return 'hiss'
+                                  },
+                              }
+
+                              return animal
+                          }
+
+                          expect(() => createInvalidAnimal()).toThrowError('Animal must have isMammal property')
+                      })
                   })
                   \`\`\`
-                  These tests cover the following cases:
+                  These tests validate the expected functionality of the \`Animal\` interface, including checking for required properties and methods, and throwing errors when required properties or methods are missing or undefined.
 
-                  * The implemented \`makeAnimalSound\` function returns the correct value.
-                  * The \`isMammal\` flag is set to \`true\`.
-                  * The \`name\` property is set to the correct value.
+                  Limitations:
+                  - These tests only cover the \`Animal\` interface definition, and do not test any actual implementations of the interface.
+                  - No mock objects are created in these tests. If future tests require mocking behavior, the appropriate mocking library or framework will need to be added.
 
-                  Note that we cannot test the \`name\` property as a setter since it is a read-only property in the \`Animal\` interface."
+                  Note:
+                  - The import statements assume the relative path to \`animal.ts\` is at \`../animal\`. If this is not the case, please adjust the import statement accordingly."
                 `,
                     explainPollyError
                 )
@@ -926,7 +988,7 @@ describe('Agent', () => {
                 'cody.command.smell:executed',
                 'cody.chat-question:submitted',
                 'cody.chat-question:executed',
-                'cody.chatResponse:noCode',
+                'cody.chatResponse:hasCode',
             ]
             await client.openFile(animalUri)
             const id = await client.request('commands/smell', null)
@@ -934,36 +996,53 @@ describe('Agent', () => {
 
             expect(trimEndOfLine(lastMessage.messages.at(-1)?.text ?? '')).toMatchInlineSnapshot(
                 `
-              "Based on the examination of your TypeScript code at \`src/animal.ts:1-6\`, I found some potential improvements:
+              "Based on my analysis, I found the following areas for improvement in the provided code:
 
-              1. Use consistent naming conventions:
-                 Rename the \`isMammal\` property to \`isMammal\`, conforming to PascalCase, which TypeScript recommends for interface properties.
+              1. **Add type annotations for function return types:** By adding return type annotations, we can provide more information to users of our code and ensure that the code behaves as expected. It also improves readability.
 
-                 Benefit: Improves readability and consistency in the codebase.
+              \`\`\`typescript
+              makeAnimalSound(): string
+              \`\`\`
 
-              2. Add the missing semicolons:
-                 Add semicolons to the end of the \`name\` and \`makeAnimalSound\` lines, as they ensure that your code behaves consistently and avoids bugs related to automatic semicolon insertion.
+              2. **Add missing access modifiers for interface members:** By default, interface members are public in TypeScript. However, it's still good practice to be explicit about the intended access modifier.
 
-                 Benefit: Ensures predictability and robustness in code execution.
+              \`\`\`typescript
+              export interface Animal {
+                name: string;
+                makeAnimalSound(): string;
+                isMammal: boolean;
+              }
+              \`\`\`
 
-              3. Restrict the Animal interface:
-                 Define the \`makeAnimalSound()\` method with an abstract keyword or a type requiring a specific implementation (i.e., a function or a class).
+              3. **Use consistent spacing:** Inconsistent spacing can affect the readability of the code.
 
-                 Benefit: Provides better type safety and enforces consistent behavior.
+              \`\`\`typescript
+              makeAnimalSound(): string
 
-              4. Include a description or documentation:
-                 Add a brief description of the \`Animal\` interface to help others understand its purpose.
+              // Change to:
 
-                 Benefit: Improves maintainability and readability for other developers.
+              makeAnimalSound(): string;
+              \`\`\`
 
-              5. Encapsulate related properties and methods in a class or module:
-                 If you're dealing with a class or module that has many interfaces or extensive use cases, you may consider encapsulating the \`Animal\` interface in a class or a specific module.
+              4. **Avoid naming inconsistencies to improve consistency and readability:**
 
-                 Benefit: Enhances encapsulation and modularization, also making your code more manageable.
+              \`\`\`typescript
+              isMammal: boolean
 
-              ---
+              // Consider renaming this to isMammal() for consistency with makeAnimalSound().
+              \`\`\`
 
-              In summary, the provided code adheres to fundamental design principles, but can be improved in specific areas for better readability, maintainability, and alignment with best practices in TypeScript. Consider implementing the above suggestions for further enhancements."
+              5. **Consider adding a method that abstracts the sound-making process:** Based on the provided code, making a sound is directly tied to the name of the animal. Adding a separate abstraction for the sound would make it more generic.
+
+              \`\`\`typescript
+              createSound(sound: string): string {
+                return sound;
+              }
+
+              // Then we can call createSound(this.name) inside makeAnimalSound().
+              \`\`\`
+
+              In summary, the provided code is a good starting point and fairly well written. However, introducing these best practices would help improve consistency, readability, and maintainability."
             `,
                 explainPollyError
             )

--- a/agent/src/index.test.ts
+++ b/agent/src/index.test.ts
@@ -206,8 +206,8 @@ describe('Agent', () => {
         expect(currentUserCodySubscription).toMatchInlineSnapshot(`
           {
             "applyProRateLimits": true,
-            "currentPeriodEndAt": "2024-07-14T22:11:32Z",
-            "currentPeriodStartAt": "2024-06-14T22:11:32Z",
+            "currentPeriodEndAt": "2024-09-14T22:11:32Z",
+            "currentPeriodStartAt": "2024-08-14T22:11:32Z",
             "plan": "PRO",
             "status": "ACTIVE",
           }
@@ -228,7 +228,7 @@ describe('Agent', () => {
               {
                 "model": "anthropic/claude-3-5-sonnet-20240620",
                 "speaker": "assistant",
-                "text": "Hello! I'm Cody, an AI coding assistant from Sourcegraph. How can I help you with your coding tasks today? Whether you need assistance with writing code, debugging, explaining concepts, or anything else related to programming, I'm here to help. What would you like to work on?",
+                "text": "Hello! I'm Cody, an AI coding assistant from Sourcegraph. How can I help you with your coding tasks today? Whether you need help with writing code, debugging, explaining concepts, or anything else related to programming, I'm here to assist. What would you like to work on?",
               }
             `
             )
@@ -247,7 +247,7 @@ describe('Agent', () => {
             const trimmedMessage = trimEndOfLine(lastMessage?.text ?? '')
             expect(trimmedMessage).toMatchInlineSnapshot(
                 `
-              "Certainly! I'll create a simple "Hello, World!" function in Java for you. Here's the code:
+              "Certainly! Here's a simple "Hello, World!" function in Java:
 
               \`\`\`java:HelloWorld.java
               public class HelloWorld {
@@ -265,14 +265,14 @@ describe('Agent', () => {
 
               1. We define a class called \`HelloWorld\`.
               2. Inside the class, we have the \`main\` method, which is the entry point of any Java program.
-              3. We also have a separate \`sayHello\` method that prints "Hello, World!" to the console.
-              4. In the \`main\` method, we call the \`sayHello\` method.
+              3. We also define a \`sayHello\` method that prints "Hello, World!" to the console.
+              4. In the \`main\` method, we call the \`sayHello\` function.
 
               To run this program:
 
               1. Save the code in a file named \`HelloWorld.java\`.
-              2. Compile the code using the command: \`javac HelloWorld.java\`
-              3. Run the compiled program using: \`java HelloWorld\`
+              2. Compile the Java file by running \`javac HelloWorld.java\` in the terminal.
+              3. Run the compiled program with \`java HelloWorld\`.
 
               When you run this program, it will output:
 
@@ -280,7 +280,7 @@ describe('Agent', () => {
               Hello, World!
               \`\`\`
 
-              This is a simple example of a Java function that prints a greeting to the console."
+              This is a basic example of a Java function that prints a greeting to the console. You can modify the \`sayHello\` function to print different messages or add more functionality as needed."
             `,
                 explainPollyError
             )
@@ -380,7 +380,11 @@ describe('Agent', () => {
                 })
             )
             expect(reply2.messages.at(-1)?.text).toMatchInlineSnapshot(
-                `"I apologize for any confusion, but I don't have specific information about my exact model architecture or training. I am an AI assistant called Cody, created by Sourcegraph, designed to help with coding and software development tasks. I don't have a specific model name like GPT-3 or BERT. My capabilities come from my training, but the details of that training process aren't something I have access to or can share. If you have any coding or development questions, I'd be happy to assist with those!"`,
+                `
+              "I apologize for any confusion. To clarify, I am Cody, an AI coding assistant created by Sourcegraph. I don't have specific information about the exact model or architecture used to create me. My knowledge and capabilities are the result of my training by Sourcegraph, but I don't have insight into the technical details of how I was developed or what specific AI model I might be based on. 
+
+              My focus is on helping with coding and technical tasks rather than discussing my own architecture. Is there a particular coding or development question I can assist you with today?"
+            `,
                 explainPollyError
             )
         }, 30_000)
@@ -455,7 +459,7 @@ describe('Agent', () => {
             // is not a git directory and symf reports some git-related error.
             expect(trimEndOfLine(lastMessage?.text ?? '')).toMatchInlineSnapshot(
                 `
-              "Certainly! Here's a class \`Dog\` that implements the \`Animal\` interface:
+              "Certainly! Here's the implementation of the Dog class that implements the Animal interface:
 
               \`\`\`typescript:src/dog.ts
               import { Animal } from './animal';
@@ -474,7 +478,7 @@ describe('Agent', () => {
               }
               \`\`\`
 
-              This implementation fulfills all the requirements of the \`Animal\` interface defined in your workspace."
+              This implementation satisfies the Animal interface requirements and provides a basic Dog class."
             `,
                 explainPollyError
             )
@@ -844,17 +848,15 @@ describe('Agent', () => {
             const lastMessage = await client.firstNonEmptyTranscript(id)
             expect(trimEndOfLine(lastMessage.messages.at(-1)?.text ?? '')).toMatchInlineSnapshot(
                 `
-              "The code being explained is an interface named \`Animal\` in a TypeScript file at \`src/animal.ts\`.
+              "The code you provided is from a TypeScript file called \`animal.ts\` and it exports an interface named \`Animal\`.
 
-              The purpose of this code is to define what properties an object should have in order to be considered an \`Animal\`. The interface does this by listing the required properties such as \`name\`, \`makeAnimalSound()\`, and \`isMammal\`. The \`name\` is a required string field, \`isMammal\` is a required boolean field, and \`makeAnimalSound()\` is a required function that returns a string.
+              The purpose of this code is to define what an \`Animal\` is, by specifying its three properties: \`name\`, \`makeAnimalSound\`, and \`isMammal\`.
 
-              The code doesn't take any input directly, but its purpose is to be implemented by other TypeScript classes defining a specific animal, such as \`Dog\` or \`Cat\`. These classes will then implement the required properties and functions defined in the \`Animal\` interface.
+              An \`Animal\` is a conceptual entity that has a \`name\` (which is a string), a method to generate an \`animal sound\` (which is a string), and it has a boolean property \`isMammal\` that tells whether the animal is a mammal or not.
 
-              The output of this code is not a value itself, but rather a description of a data structure. Objects of classes that implement this interface can be used as \`Animal\` type, but the interface itself doesn't produce any value directly.
+              The interface by itself does not generate any output or take any input. It only provides a blueprint for what an \`Animal\` should look like. When other code uses this interface, they will have to provide implementations for its properties.
 
-              The way this is achieved is by using the TypeScript feature called \`interfaces\`, which provides a contract that a class has to follow in order to adhere to the structure defined by the interface. The interface defines what properties are required to be present in classes that implement it.
-
-              The main logic flow is that the interface \`Animal\` is defined with its required properties, and classes that want to be considered as implementing the \`Animal\` interface need to adhere to this structure. The data transformation that happens is that classes that implement the \`Animal\` interface provide the actual implementation and logic for the required properties. The interface only provides the shape that the class should have without implementing it."
+              In summary, this code defines the structure of an \`Animal\` and it is useful when you want to enforce same structure for any animal objects being used across your TypeScript application."
             `,
                 explainPollyError
             )
@@ -876,105 +878,24 @@ describe('Agent', () => {
                 const lastMessage = await client.firstNonEmptyTranscript(id)
                 expect(trimEndOfLine(lastMessage.messages.at(-1)?.text ?? '')).toMatchInlineSnapshot(
                     `
-                  "Based on the shared code context, the test framework in use is \`vitest\`.
+                  "Based on the shared code context, it appears that Vitest is being used as the test framework. Additionally, the code is written in TypeScript.
 
-                  To write unit tests for the \`Animal\` interface in \`src/animal.ts\`, we can create instances of classes that implement this interface, and validate their implementation by calling methods and properties against the interface definition.
-
-                  Here's a suite of unit tests for the \`Animal\` interface using \`vitest\`:
+                  Here is a suite of unit tests for the \`Animal\` interface in the file \`src/animal.ts\`:
                   \`\`\`typescript
                   // src/animal.test.ts
-                  import { expect, describe, it } from 'vitest'
-                  import { Animal } from '../animal'
 
-                  describe('Animal interface unit tests', () => {
-                      it('should define name property', () => {
-                          const animal: Animal = {
-                              name: 'Lion',
-                              makeAnimalSound() {
-                                  return 'roar'
-                              },
-                              isMammal: true,
-                          }
+                  import { expect, test } from 'vitest'
+                  import { Animal } from './animal'
 
-                          expect(animal.name).toEqual('Lion')
-                      })
+                  interface Cat extends Animal {
+                      name: string
+                      makeAnimalSound(): string
+                      isMammal: boolean
+                  }
 
-                      it('should define makeAnimalSound method', () => {
-                          const animal: Animal = {
-                              name: 'Dog',
-                              makeAnimalSound() {
-                                  return 'bark'
-                              },
-                              isMammal: true,
-                          }
-
-                          expect(animal.makeAnimalSound()).toEqual('bark')
-                      })
-
-                      it('should define isMammal property', () => {
-                          const animal: Animal = {
-                              name: 'Cat',
-                              makeAnimalSound() {
-                                  return 'meow'
-                              },
-                              isMammal: true,
-                          }
-
-                          expect(animal.isMammal).toEqual(true)
-                      })
-
-                      it('should throw error if animal does not have name property', () => {
-                          const createInvalidAnimal = () => {
-                              const animal: Animal = {
-                                  makeAnimalSound() {
-                                      return 'cry'
-                                  },
-                                  isMammal: false,
-                              }
-
-                              return animal
-                          }
-
-                          expect(() => createInvalidAnimal()).toThrowError('Animal must have a name')
-                      })
-
-                      it('should throw error if animal does not implement makeAnimalSound method', () => {
-                          const createInvalidAnimal = () => {
-                              const animal: Animal = {
-                                  name: 'Frog',
-                                  isMammal: false,
-                              }
-
-                              return animal
-                          }
-
-                          expect(() => createInvalidAnimal()).toThrowError('Animal must implement makeAnimalSound method')
-                      })
-
-                      it('should throw error if animal does not have isMammal property', () => {
-                          const createInvalidAnimal = () => {
-                              const animal: Animal = {
-                                  name: 'Snake',
-                                  makeAnimalSound() {
-                                      return 'hiss'
-                                  },
-                              }
-
-                              return animal
-                          }
-
-                          expect(() => createInvalidAnimal()).toThrowError('Animal must have isMammal property')
-                      })
-                  })
-                  \`\`\`
-                  These tests validate the expected functionality of the \`Animal\` interface, including checking for required properties and methods, and throwing errors when required properties or methods are missing or undefined.
-
-                  Limitations:
-                  - These tests only cover the \`Animal\` interface definition, and do not test any actual implementations of the interface.
-                  - No mock objects are created in these tests. If future tests require mocking behavior, the appropriate mocking library or framework will need to be added.
-
-                  Note:
-                  - The import statements assume the relative path to \`animal.ts\` is at \`../animal\`. If this is not the case, please adjust the import statement accordingly."
+                  interface Dog extends Animal {
+                      name: string
+                  \`\`\`"
                 `,
                     explainPollyError
                 )
@@ -996,53 +917,34 @@ describe('Agent', () => {
 
             expect(trimEndOfLine(lastMessage.messages.at(-1)?.text ?? '')).toMatchInlineSnapshot(
                 `
-              "Based on my analysis, I found the following areas for improvement in the provided code:
+              "Based on the provided code snippet from \`src/animal.ts\`, here are some suggestions for improvement:
 
-              1. **Add type annotations for function return types:** By adding return type annotations, we can provide more information to users of our code and ensure that the code behaves as expected. It also improves readability.
+              1. Add type annotations to the methods of the \`Animal\` interface, such as \`makeAnimalSound(): string\`. This will help ensure type consistency and provide better code readability.
+              2. Consider using a type alias for common property types like \`string\` and \`boolean\`. This can help improve code readability and reduce repetition, for example:
+              \`\`\`csharp
+              type AnimalName = string;
+              type IsMammal = boolean;
 
-              \`\`\`typescript
-              makeAnimalSound(): string
-              \`\`\`
-
-              2. **Add missing access modifiers for interface members:** By default, interface members are public in TypeScript. However, it's still good practice to be explicit about the intended access modifier.
-
-              \`\`\`typescript
               export interface Animal {
-                name: string;
-                makeAnimalSound(): string;
-                isMammal: boolean;
+                  name: AnimalName;
+                  makeAnimalSound(): string;
+                  isMammal: IsMammal;
               }
               \`\`\`
-
-              3. **Use consistent spacing:** Inconsistent spacing can affect the readability of the code.
-
+              3. Consider adding documentation, such as JSDoc or TypeDoc comments, to describe the \`Animal\` interface and its properties. This will help improve understanding and usability of the code for other developers.
+              4. If the \`makeAnimalSound\` method includes any common or repetitive sound generation logic, consider extracting the logic to a separate utility function. This can help improve code modularity, reusability, and maintainability.
+              5. Consider adding type constraints to the interface, such as \`readonly\` for \`name\` property or optional properties. This can help improve code safety and consistency:
               \`\`\`typescript
-              makeAnimalSound(): string
+              type AnimalName = string;
+              type IsMammal = boolean;
 
-              // Change to:
-
-              makeAnimalSound(): string;
-              \`\`\`
-
-              4. **Avoid naming inconsistencies to improve consistency and readability:**
-
-              \`\`\`typescript
-              isMammal: boolean
-
-              // Consider renaming this to isMammal() for consistency with makeAnimalSound().
-              \`\`\`
-
-              5. **Consider adding a method that abstracts the sound-making process:** Based on the provided code, making a sound is directly tied to the name of the animal. Adding a separate abstraction for the sound would make it more generic.
-
-              \`\`\`typescript
-              createSound(sound: string): string {
-                return sound;
+              export interface Animal {
+                  readonly name: AnimalName;
+                  makeAnimalSound(): string;
+                  isMammal?: IsMammal;
               }
-
-              // Then we can call createSound(this.name) inside makeAnimalSound().
               \`\`\`
-
-              In summary, the provided code is a good starting point and fairly well written. However, introducing these best practices would help improve consistency, readability, and maintainability."
+              In summary, the provided code snippet is minimal in scope, but it does not contain any critical errors. To further enhance the code quality, consider implementing the above suggestions to improve code readability, maintainability, and safety. The code generally follows sound design principles, but could benefit from additional documentation and modularization."
             `,
                 explainPollyError
             )

--- a/agent/src/index.test.ts
+++ b/agent/src/index.test.ts
@@ -228,7 +228,7 @@ describe('Agent', () => {
               {
                 "model": "anthropic/claude-3-5-sonnet-20240620",
                 "speaker": "assistant",
-                "text": "Hello! I'm Cody, an AI coding assistant from Sourcegraph. How can I help you with your coding tasks today? Whether you need help with writing code, debugging, explaining concepts, or anything else related to programming, I'm here to assist. What would you like to work on?",
+                "text": "Hello! I'm Cody, an AI coding assistant from Sourcegraph. How can I help you with your coding tasks today? Whether you need assistance with writing code, debugging, explaining concepts, or anything else related to programming, I'm here to help. What would you like to work on?",
               }
             `
             )
@@ -261,18 +261,18 @@ describe('Agent', () => {
               }
               \`\`\`
 
-              This Java code does the following:
+              This code does the following:
 
               1. We define a class called \`HelloWorld\`.
               2. Inside the class, we have the \`main\` method, which is the entry point of any Java program.
-              3. We also define a \`sayHello\` method that prints "Hello, World!" to the console.
-              4. In the \`main\` method, we call the \`sayHello\` function.
+              3. We define a separate method called \`sayHello()\` that prints "Hello, World!" to the console.
+              4. In the \`main\` method, we call the \`sayHello()\` function.
 
               To run this program:
 
               1. Save the code in a file named \`HelloWorld.java\`.
-              2. Compile the Java file by running \`javac HelloWorld.java\` in the terminal.
-              3. Run the compiled program with \`java HelloWorld\`.
+              2. Compile the code using the Java compiler: \`javac HelloWorld.java\`
+              3. Run the compiled program: \`java HelloWorld\`
 
               When you run this program, it will output:
 
@@ -280,7 +280,7 @@ describe('Agent', () => {
               Hello, World!
               \`\`\`
 
-              This is a basic example of a Java function that prints a greeting to the console. You can modify the \`sayHello\` function to print different messages or add more functionality as needed."
+              This simple example demonstrates how to create a function in Java and call it from the main method."
             `,
                 explainPollyError
             )
@@ -333,7 +333,7 @@ describe('Agent', () => {
                 })
             )
             expect(reply2.messages.at(-1)?.text).toMatchInlineSnapshot(
-                `"Your name is Lars Monsen, as you mentioned in your introduction."`,
+                `"Your name is Lars Monsen, as you mentioned in your previous message."`,
                 explainPollyError
             )
         }, 30_000)
@@ -381,9 +381,9 @@ describe('Agent', () => {
             )
             expect(reply2.messages.at(-1)?.text).toMatchInlineSnapshot(
                 `
-              "I apologize for any confusion. To clarify, I am Cody, an AI coding assistant created by Sourcegraph. I don't have specific information about the exact model or architecture used to create me. My knowledge and capabilities are the result of my training by Sourcegraph, but I don't have insight into the technical details of how I was developed or what specific AI model I might be based on. 
+              "I apologize for any confusion. To clarify, I am Cody, an AI coding assistant created by Sourcegraph. I don't have access to specific information about my underlying model architecture or version. My capabilities are based on natural language processing and code understanding, but the details of my implementation are not known to me.
 
-              My focus is on helping with coding and technical tasks rather than discussing my own architecture. Is there a particular coding or development question I can assist you with today?"
+              As an AI assistant, my role is to help with coding and development tasks. If you have any questions related to programming, software development, or need assistance with code, I'd be happy to help. Is there a particular coding task or question you'd like assistance with?"
             `,
                 explainPollyError
             )
@@ -459,7 +459,7 @@ describe('Agent', () => {
             // is not a git directory and symf reports some git-related error.
             expect(trimEndOfLine(lastMessage?.text ?? '')).toMatchInlineSnapshot(
                 `
-              "Certainly! Here's the implementation of the Dog class that implements the Animal interface:
+              "Certainly! Here's a class \`Dog\` that implements the \`Animal\` interface based on the provided codebase context:
 
               \`\`\`typescript:src/dog.ts
               import { Animal } from './animal';
@@ -478,7 +478,7 @@ describe('Agent', () => {
               }
               \`\`\`
 
-              This implementation satisfies the Animal interface requirements and provides a basic Dog class."
+              This implementation fulfills all the requirements of the \`Animal\` interface defined in the \`animal.ts\` file."
             `,
                 explainPollyError
             )
@@ -489,7 +489,7 @@ describe('Agent', () => {
             client.expectedEvents = [
                 'cody.chat-question:submitted',
                 'cody.chat-question:executed',
-                'cody.chatResponse:noCode',
+                'cody.chatResponse:hasCode',
             ]
             await client.openFile(squirrelUri)
             const { lastMessage, transcript } =
@@ -848,15 +848,17 @@ describe('Agent', () => {
             const lastMessage = await client.firstNonEmptyTranscript(id)
             expect(trimEndOfLine(lastMessage.messages.at(-1)?.text ?? '')).toMatchInlineSnapshot(
                 `
-              "The code you provided is from a TypeScript file called \`animal.ts\` and it exports an interface named \`Animal\`.
+              "The code you've shared is a part of a TypeScript file called \`animal.ts\`. The purpose of this code is to define an interface named \`Animal\`. An interface in programming is a kind of blueprint that specifies what a certain object or data type should look like - meaning what properties and methods it should have.
 
-              The purpose of this code is to define what an \`Animal\` is, by specifying its three properties: \`name\`, \`makeAnimalSound\`, and \`isMammal\`.
+              Here's a breakdown of the code:
 
-              An \`Animal\` is a conceptual entity that has a \`name\` (which is a string), a method to generate an \`animal sound\` (which is a string), and it has a boolean property \`isMammal\` that tells whether the animal is a mammal or not.
+              1. **Purpose of the code:** The purpose of this code is to define an interface named \`Animal\`. This interface will be used as a blueprint for other objects or classes that will represent various animals, ensuring they all have the same properties and methods.
+              2. **Inputs:** This piece of code does not take any inputs. It only defines an interface, which is a template that can be used for creating other objects, not an actual object with input values.
+              3. **Outputs:** This code doesn't directly produce an output, as it only serves as a type definition. However, once an object or a class is created based on this interface, the output will be an instance that adheres to the structure set by the \`Animal\` interface.
+              4. **Logic and algorithm:** The interface consists of three properties, each with their own types: \`name\` (as a string), \`makeAnimalSound\` (as a method that returns a string), and \`isMammal\` (as a boolean representing whether the animal is a mammal or not). Although not displayed in the provided code, classes or objects implementing this interface will have to provide actual implementations for the methods specified, such as how a specific animal makes its sound.
+              5. **Logic flows or data transformations:** The code does not perform complex logic or data transformations since it just outlines the structure the \`Animal\` interface should follow. It is up to the objects or classes that implement the \`Animal\` interface to include the necessary logic and algorithms for handling specific animal behavior data.
 
-              The interface by itself does not generate any output or take any input. It only provides a blueprint for what an \`Animal\` should look like. When other code uses this interface, they will have to provide implementations for its properties.
-
-              In summary, this code defines the structure of an \`Animal\` and it is useful when you want to enforce same structure for any animal objects being used across your TypeScript application."
+              In short, this code defines an \`Animal\` interface in TypeScript, which can later be used as a template for creating objects or classes mirroring various animal types while ensuring a standard structure for animal representation in the codebase."
             `,
                 explainPollyError
             )
@@ -878,24 +880,92 @@ describe('Agent', () => {
                 const lastMessage = await client.firstNonEmptyTranscript(id)
                 expect(trimEndOfLine(lastMessage.messages.at(-1)?.text ?? '')).toMatchInlineSnapshot(
                     `
-                  "Based on the shared code context, it appears that Vitest is being used as the test framework. Additionally, the code is written in TypeScript.
+                  "Based on the provided code context, the codebase is written in TypeScript and uses the Vitest test framework. I will generate a set of unit tests for the \`Animal\` interface in \`src/animal.ts\`.
 
-                  Here is a suite of unit tests for the \`Animal\` interface in the file \`src/animal.ts\`:
+                  Importing the necessary modules:
                   \`\`\`typescript
-                  // src/animal.test.ts
+                  import { expect, describe, it } from 'vitest'
+                  import { Animal } from './animal'
+                  \`\`\`
+                  Unit tests for \`src/animal.ts\`:
+                  \`\`\`typescript
+                  describe('Animal', () => {
+                    let animal: Animal
 
-                  import { expect, test } from 'vitest'
+                    // Define a base animal with required properties
+                    beforeEach(() => {
+                      animal = {
+                        name: 'Cat',
+                        makeAnimalSound: () => 'Meow',
+                        isMammal: true,
+                      }
+                    })
+
+                    it('should have a name property of string type', () => {
+                      expect(animal.name).toBeTypeOf('string')
+                    })
+
+                    it('should have a makeAnimalSound function that returns a string', () => {
+                      expect(typeof animal.makeAnimalSound()).toBe('string')
+                    })
+
+                    it('should have an isMammal property of boolean type', () => {
+                      expect(animal.isMammal).toBeTypeOf('boolean')
+                    })
+
+                    it('should return correct animal sound', () => {
+                      expect(animal.makeAnimalSound()).toBe('Meow')
+                    })
+
+                    it('should only return true for isMammal', () => {
+                      expect(animal.isMammal).toBe(true)
+                    })
+                  })
+                  \`\`\`
+                  These tests cover the expected functionality of the \`Animal\` interface by asserting the types and behavior of all its properties. The tests include \`beforeEach\` to set up a base animal for each test. There are no limitations to this test suite, as all required properties are defined in the \`Animal\` interface.
+
+                  Full completed code block:
+                  \`\`\`typescript
+                  \`\`\`typescript
+                  import { expect, describe, it } from 'vitest'
                   import { Animal } from './animal'
 
-                  interface Cat extends Animal {
-                      name: string
-                      makeAnimalSound(): string
-                      isMammal: boolean
-                  }
+                  describe('Animal', () => {
+                    let animal: Animal
 
-                  interface Dog extends Animal {
-                      name: string
-                  \`\`\`"
+                    // Define a base animal with required properties
+                    beforeEach(() => {
+                      animal = {
+                        name: 'Cat',
+                        makeAnimalSound: () => 'Meow',
+                        isMammal: true,
+                      }
+                    })
+
+                    it('should have a name property of string type', () => {
+                      expect(animal.name).toBeTypeOf('string')
+                    })
+
+                    it('should have a makeAnimalSound function that returns a string', () => {
+                      expect(typeof animal.makeAnimalSound()).toBe('string')
+                    })
+
+                    it('should have an isMammal property of boolean type', () => {
+                      expect(animal.isMammal).toBeTypeOf('boolean')
+                    })
+
+                    it('should return correct animal sound', () => {
+                      expect(animal.makeAnimalSound()).toBe('Meow')
+                    })
+
+                    it('should only return true for isMammal', () => {
+                      expect(animal.isMammal).toBe(true)
+                    })
+                  })
+                  \`\`\`
+                  \`\`\`sql
+
+                  The given typescript file seems to have been truncated. Since the closing brace } is missing, the provided description of the file path might be incomplete. Please ensure that the code is complete."
                 `,
                     explainPollyError
                 )
@@ -917,34 +987,61 @@ describe('Agent', () => {
 
             expect(trimEndOfLine(lastMessage.messages.at(-1)?.text ?? '')).toMatchInlineSnapshot(
                 `
-              "Based on the provided code snippet from \`src/animal.ts\`, here are some suggestions for improvement:
+              "Based on the provided code, here are my suggestions for improvement:
 
-              1. Add type annotations to the methods of the \`Animal\` interface, such as \`makeAnimalSound(): string\`. This will help ensure type consistency and provide better code readability.
-              2. Consider using a type alias for common property types like \`string\` and \`boolean\`. This can help improve code readability and reduce repetition, for example:
-              \`\`\`csharp
-              type AnimalName = string;
-              type IsMammal = boolean;
-
-              export interface Animal {
-                  name: AnimalName;
-                  makeAnimalSound(): string;
-                  isMammal: IsMammal;
-              }
-              \`\`\`
-              3. Consider adding documentation, such as JSDoc or TypeDoc comments, to describe the \`Animal\` interface and its properties. This will help improve understanding and usability of the code for other developers.
-              4. If the \`makeAnimalSound\` method includes any common or repetitive sound generation logic, consider extracting the logic to a separate utility function. This can help improve code modularity, reusability, and maintainability.
-              5. Consider adding type constraints to the interface, such as \`readonly\` for \`name\` property or optional properties. This can help improve code safety and consistency:
+              1. Add type annotations to the methods' return types in the interface. This practice enhances readability and self-documentation, making it easier for developers to understand the expected output:
               \`\`\`typescript
-              type AnimalName = string;
-              type IsMammal = boolean;
-
               export interface Animal {
-                  readonly name: AnimalName;
-                  makeAnimalSound(): string;
-                  isMammal?: IsMammal;
+                  name: string
+                  makeAnimalSound(): string // added type annotation
+                  isMammal: boolean
               }
               \`\`\`
-              In summary, the provided code snippet is minimal in scope, but it does not contain any critical errors. To further enhance the code quality, consider implementing the above suggestions to improve code readability, maintainability, and safety. The code generally follows sound design principles, but could benefit from additional documentation and modularization."
+              1. Consider making the \`makeAnimalSound()\` method abstract to enforce implementation in derived classes. This provides a solid design pattern for inheritance, ensuring consistency among animal sounds:
+              \`\`\`typescript
+              export interface Animal {
+                  name: string
+                  isMammal: boolean
+                  abstract makeAnimalSound(): string
+              }
+              \`\`\`
+              1. Consider using \`readonly\` property for the \`name\` field, if applicable, for better immutability and avoiding unintended modifications of the animal's name:
+              \`\`\`typescript
+              export interface Animal {
+                  readonly name: string
+                  isMammal: boolean
+                  abstract makeAnimalSound(): string
+              }
+              \`\`\`
+              1. Document any assumptions or constraints related to the code. Consider adding a brief comment describing the intended use of the \`Animal\` interface, which can enhance collaboration among team members:
+              \`\`\`typescript
+              // This interface represents an animal with a name, a boolean mammal indicator,
+              // and an abstract method to produce a sound.
+              export interface Animal {
+                  // The name of the animal.
+                  readonly name: string
+                  isMammal: boolean
+                  abstract makeAnimalSound(): string
+              }
+              \`\`\`
+              1. In case this file is part of a larger codebase, consider importing or re-exporting the \`Animal\` interface from a central location, such as an \`index.ts\` file. This practice can make it easier for developers to find interfaces and minimizes potential issues that can arise when making modifications. The example below assumes a \`src/animals\` folder structure:
+
+              — animals
+              | — index.ts
+              | — animal.ts
+
+              *src/animals/index.ts*
+              \`\`\`typescript
+              export * from './animal'
+              \`\`\`
+              *src/animals/animal.ts*
+              \`\`\`typescript
+              import { type Animal as BaseAnimal } from './baseAnimal'
+
+              export interface Animal extends BaseAnimal {}
+              \`\`\`
+
+              Overall, the provided code looks clean and well-designed, following sound design principles. However, by incorporating the listed suggestions, the code can be made more robust, explicit, and maintainable."
             `,
                 explainPollyError
             )

--- a/lib/shared/src/chat/preamble.ts
+++ b/lib/shared/src/chat/preamble.ts
@@ -12,7 +12,7 @@ const CHAT_PREAMBLE = psDedent`
     ${DEFAULT_PREAMBLE}
 
     Additional rules:
-    - When generating fenced code blocks in Markdown, ensure you include the full file path in the tag. The structure should be \`\`\`language:path/to/file\n\`\`\`. You should only do this when generating a code block, the user does not need to be made aware of this in any other way.
+    - If generating fenced code blocks in Markdown, ensure you include the full file path in the tag. The structure should be \`\`\`language:path/to/file\n\`\`\`. You should only do this when generating a code block, the user does not need to be made aware of this in any other way.
 `.trim()
 
 export function getSimplePreamble(

--- a/lib/shared/src/chat/preamble.ts
+++ b/lib/shared/src/chat/preamble.ts
@@ -22,7 +22,7 @@ export function getSimplePreamble(
     preInstruction?: PromptString
 ): Message[] {
     const preamble = type === 'Chat' ? CHAT_PREAMBLE : DEFAULT_PREAMBLE
-    const intro = ps`${preamble} ${preInstruction ?? ''}`.trim()
+    const intro = ps`${preamble} ${preInstruction ? ps`\n\n${preInstruction}` : ''}`.trim()
 
     // API Version 1 onward support system prompts, however only enable it for
     // Claude 3 models for now

--- a/lib/shared/src/chat/preamble.ts
+++ b/lib/shared/src/chat/preamble.ts
@@ -8,7 +8,8 @@ const DEFAULT_PREAMBLE = ps`You are Cody, an AI coding assistant from Sourcegrap
  * produce code blocks that we can associate with existing file paths.
  * We want to read these file paths to support applying code directly to files from chat.
  */
-const CHAT_PREAMBLE = psDedent`
+const SMART_APPLY_PREAMBLE = ps`If your answer contains fenced code blocks in Markdown, include the full file path in the code block tag using this structure: \`\`\`$LANGUAGE:$FILEPATH\n\`\`\`.`
+const CHAT_PREAMBLE = DEFAULT_PREAMBLE.join(SMART_APPLY_PREAMBLE)
     ${DEFAULT_PREAMBLE}
 
     Additional rules:

--- a/lib/shared/src/chat/preamble.ts
+++ b/lib/shared/src/chat/preamble.ts
@@ -1,4 +1,4 @@
-import { type PromptString, ps, psDedent } from '../prompt/prompt-string'
+import { type PromptString, ps } from '../prompt/prompt-string'
 import type { Message } from '../sourcegraph-api'
 
 const DEFAULT_PREAMBLE = ps`You are Cody, an AI coding assistant from Sourcegraph.`
@@ -8,13 +8,9 @@ const DEFAULT_PREAMBLE = ps`You are Cody, an AI coding assistant from Sourcegrap
  * produce code blocks that we can associate with existing file paths.
  * We want to read these file paths to support applying code directly to files from chat.
  */
-const SMART_APPLY_PREAMBLE = ps`If your answer contains fenced code blocks in Markdown, include the full file path in the code block tag using this structure: \`\`\`$LANGUAGE:$FILEPATH\n\`\`\`.`
-const CHAT_PREAMBLE = DEFAULT_PREAMBLE.join(SMART_APPLY_PREAMBLE)
-    ${DEFAULT_PREAMBLE}
+const SMART_APPLY_PREAMBLE = ps`If your answer contains fenced code blocks in Markdown, include the relevant full file path in the code block tag using this structure: \`\`\`$LANGUAGE:$FILEPATH\n$CONTENT\`\`\`.`
 
-    Additional rules:
-    - When generating fenced code blocks in Markdown, ensure you include the full file path in the tag. The structure should be \`\`\`language:path/to/file\n\`\`\`.
-`.trim()
+const CHAT_PREAMBLE = DEFAULT_PREAMBLE.concat(SMART_APPLY_PREAMBLE)
 
 export function getSimplePreamble(
     model: string | undefined,
@@ -23,7 +19,7 @@ export function getSimplePreamble(
     preInstruction?: PromptString
 ): Message[] {
     const preamble = type === 'Chat' ? CHAT_PREAMBLE : DEFAULT_PREAMBLE
-    const intro = ps`${preamble}\n\n${preInstruction.toString() ?? ''}`.trim()
+    const intro = ps`${preamble}\n\n${preInstruction ?? ''}`.trim()
 
     // API Version 1 onward support system prompts, however only enable it for
     // Claude 3 models for now

--- a/lib/shared/src/chat/preamble.ts
+++ b/lib/shared/src/chat/preamble.ts
@@ -12,7 +12,7 @@ const CHAT_PREAMBLE = psDedent`
     ${DEFAULT_PREAMBLE}
 
     Additional rules:
-    - If generating fenced code blocks in Markdown, ensure you include the full file path in the tag. The structure should be \`\`\`language:path/to/file\n\`\`\`. You should only do this when generating a code block, the user does not need to be made aware of this in any other way.
+    - When generating fenced code blocks in Markdown, ensure you include the full file path in the tag. The structure should be \`\`\`language:path/to/file\n\`\`\`.
 `.trim()
 
 export function getSimplePreamble(

--- a/lib/shared/src/chat/preamble.ts
+++ b/lib/shared/src/chat/preamble.ts
@@ -8,7 +8,7 @@ const DEFAULT_PREAMBLE = ps`You are Cody, an AI coding assistant from Sourcegrap
  * produce code blocks that we can associate with existing file paths.
  * We want to read these file paths to support applying code directly to files from chat.
  */
-const SMART_APPLY_PREAMBLE = ps`If your answer contains fenced code blocks in Markdown, include the relevant full file path in the code block tag using this structure: \`\`\`$LANGUAGE:$FILEPATH\n$CONTENT\`\`\`.`
+const SMART_APPLY_PREAMBLE = ps`If your answer contains fenced code blocks in Markdown, include the relevant full file path in the code block tag using this structure: \`\`\`$LANGUAGE:$FILEPATH\`\`\`.`
 
 const CHAT_PREAMBLE = DEFAULT_PREAMBLE.concat(SMART_APPLY_PREAMBLE)
 

--- a/lib/shared/src/chat/preamble.ts
+++ b/lib/shared/src/chat/preamble.ts
@@ -23,7 +23,7 @@ export function getSimplePreamble(
     preInstruction?: PromptString
 ): Message[] {
     const preamble = type === 'Chat' ? CHAT_PREAMBLE : DEFAULT_PREAMBLE
-    const intro = ps`${preamble} ${preInstruction ? ps`\n\n${preInstruction}` : ''}`.trim()
+    const intro = ps`${preamble}\n\n${preInstruction.toString() ?? ''}`.trim()
 
     // API Version 1 onward support system prompts, however only enable it for
     // Claude 3 models for now

--- a/lib/shared/src/prompt/prompt-mixin.ts
+++ b/lib/shared/src/prompt/prompt-mixin.ts
@@ -2,13 +2,6 @@ import type { ChatMessage } from '../chat/transcript/messages'
 import { PromptString, ps } from './prompt-string'
 
 /**
- * The preamble we add to the start of the last human open-end chat message.
- * Used so that we can parse file paths to support applying code directly to files
- * from chat.
- */
-const CODEBLOCK_PREMAMBLE = ps`When generating fenced code blocks in Markdown, ensure you include the full file path in the tag. The structure should be \`\`\`language:path/to/file\n\`\`\`. You should only do this when generating a code block, the user does not need to be made aware of this in any other way.`
-
-/**
  * The preamble we add to the start of the last human open-end chat message that has context items.
  */
 const CONTEXT_PREAMBLE = ps`You have access to the provided codebase context. `
@@ -23,7 +16,6 @@ const HEDGES_PREVENTION = ps`Answer positively without apologizing. `
  */
 export class PromptMixin {
     private static mixins: PromptMixin[] = []
-    private static codeBlockMixin: PromptMixin = new PromptMixin(CODEBLOCK_PREMAMBLE)
     private static contextMixin: PromptMixin = new PromptMixin(CONTEXT_PREAMBLE)
 
     /**
@@ -33,9 +25,7 @@ export class PromptMixin {
     public static mixInto(humanMessage: ChatMessage, modelID: string): ChatMessage {
         // Default Mixin is added at the end so that it cannot be overriden by other mixins.
         let mixins = PromptString.join(
-            [...PromptMixin.mixins, PromptMixin.codeBlockMixin, PromptMixin.contextMixin].map(
-                mixin => mixin.prompt
-            ),
+            [...PromptMixin.mixins, PromptMixin.contextMixin].map(mixin => mixin.prompt),
             ps`\n\n`
         )
 

--- a/lib/shared/src/prompt/templates.ts
+++ b/lib/shared/src/prompt/templates.ts
@@ -14,11 +14,13 @@ export function populateCodeContextTemplate(
     const template =
         type === 'edit'
             ? ps`Codebase context from file {filePath}{inRepo}:\n{text}`
-            : ps`Codebase context from file {filePath}{inRepo}:\n\`\`\`{languageID}\n{text}\`\`\``
+            : ps`Codebase context from file {filePath}{inRepo}:\n\`\`\`{languageID}{filePathToParse}\n{text}\`\`\``
 
+    const filePath = PromptString.fromDisplayPath(fileUri)
     return template
         .replaceAll('{inRepo}', repoName ? ps` in repository ${repoName}` : ps``)
-        .replaceAll('{filePath}', PromptString.fromDisplayPath(fileUri))
+        .replaceAll('{filePath}', filePath)
+        .replaceAll('{filePathToParse}', ps`:${filePath}`)
         .replaceAll('{languageID}', PromptString.fromMarkdownCodeBlockLanguageIDForFilename(fileUri))
         .replaceAll('{text}', code)
 }

--- a/vscode/src/chat/chat-view/prompt.test.ts
+++ b/vscode/src/chat/chat-view/prompt.test.ts
@@ -38,8 +38,7 @@ describe('DefaultPrompter', () => {
           [
             {
               "speaker": "human",
-              "text": "You are Cody, an AI coding assistant from Sourcegraph.If your answer contains fenced code blocks in Markdown, include the relevant full file path in the code block tag using this structure: \`\`\`$LANGUAGE:$FILEPATH
-          $CONTENT\`\`\`.",
+              "text": "You are Cody, an AI coding assistant from Sourcegraph.If your answer contains fenced code blocks in Markdown, include the relevant full file path in the code block tag using this structure: \`\`\`$LANGUAGE:$FILEPATH\`\`\`.",
             },
             {
               "speaker": "assistant",
@@ -114,8 +113,7 @@ describe('DefaultPrompter', () => {
           [
             {
               "speaker": "human",
-              "text": "You are Cody, an AI coding assistant from Sourcegraph.If your answer contains fenced code blocks in Markdown, include the relevant full file path in the code block tag using this structure: \`\`\`$LANGUAGE:$FILEPATH
-          $CONTENT\`\`\`.
+              "text": "You are Cody, an AI coding assistant from Sourcegraph.If your answer contains fenced code blocks in Markdown, include the relevant full file path in the code block tag using this structure: \`\`\`$LANGUAGE:$FILEPATH\`\`\`.
 
           Always respond with 🧀 emojis",
             },

--- a/vscode/src/chat/chat-view/prompt.test.ts
+++ b/vscode/src/chat/chat-view/prompt.test.ts
@@ -34,21 +34,28 @@ describe('DefaultPrompter', () => {
         chat.addHumanMessage({ text: ps`Hello` })
 
         const { prompt, context } = await new DefaultPrompter([], []).makePrompt(chat, 0)
+        expect(prompt).toMatchInlineSnapshot(`
+          [
+            {
+              "speaker": "human",
+              "text": "You are Cody, an AI coding assistant from Sourcegraph.
 
-        expect(prompt).toEqual<Message[]>([
-            {
-                speaker: 'human',
-                text: ps`You are Cody, an AI coding assistant from Sourcegraph.`,
+          Additional rules:
+          - When generating fenced code blocks in Markdown, ensure you include the full file path in the tag. The structure should be \`\`\`language:path/to/file
+          \`\`\`.",
             },
             {
-                speaker: 'assistant',
-                text: ps`I am Cody, an AI coding assistant from Sourcegraph.`,
+              "speaker": "assistant",
+              "text": "I am Cody, an AI coding assistant from Sourcegraph.",
             },
             {
-                speaker: 'human',
-                text: ps`Hello`,
+              "contextAlternatives": undefined,
+              "contextFiles": undefined,
+              "speaker": "human",
+              "text": "Hello",
             },
-        ])
+          ]
+        `)
         expect(context.used).toEqual([])
         expect(context.ignored).toEqual([])
     })
@@ -106,21 +113,30 @@ describe('DefaultPrompter', () => {
         chat.addHumanMessage({ text: ps`Hello` })
 
         const { prompt, context } = await new DefaultPrompter([], []).makePrompt(chat, 0)
+        expect(prompt).toMatchInlineSnapshot(`
+          [
+            {
+              "speaker": "human",
+              "text": "You are Cody, an AI coding assistant from Sourcegraph.
 
-        expect(prompt).toEqual<Message[]>([
-            {
-                speaker: 'human',
-                text: ps`You are Cody, an AI coding assistant from Sourcegraph. Always respond with 🧀 emojis`,
+          Additional rules:
+          - When generating fenced code blocks in Markdown, ensure you include the full file path in the tag. The structure should be \`\`\`language:path/to/file
+          \`\`\`. 
+
+          Always respond with 🧀 emojis",
             },
             {
-                speaker: 'assistant',
-                text: ps`I am Cody, an AI coding assistant from Sourcegraph.`,
+              "speaker": "assistant",
+              "text": "I am Cody, an AI coding assistant from Sourcegraph.",
             },
             {
-                speaker: 'human',
-                text: ps`Hello`,
+              "contextAlternatives": undefined,
+              "contextFiles": undefined,
+              "speaker": "human",
+              "text": "Hello",
             },
-        ])
+          ]
+        `)
         expect(context.used).toEqual([])
         expect(context.ignored).toEqual([])
     })

--- a/vscode/src/chat/chat-view/prompt.test.ts
+++ b/vscode/src/chat/chat-view/prompt.test.ts
@@ -38,11 +38,8 @@ describe('DefaultPrompter', () => {
           [
             {
               "speaker": "human",
-              "text": "You are Cody, an AI coding assistant from Sourcegraph.
-
-          Additional rules:
-          - When generating fenced code blocks in Markdown, ensure you include the full file path in the tag. The structure should be \`\`\`language:path/to/file
-          \`\`\`.",
+              "text": "You are Cody, an AI coding assistant from Sourcegraph.If your answer contains fenced code blocks in Markdown, include the relevant full file path in the code block tag using this structure: \`\`\`$LANGUAGE:$FILEPATH
+          $CONTENT\`\`\`.",
             },
             {
               "speaker": "assistant",
@@ -117,11 +114,8 @@ describe('DefaultPrompter', () => {
           [
             {
               "speaker": "human",
-              "text": "You are Cody, an AI coding assistant from Sourcegraph.
-
-          Additional rules:
-          - When generating fenced code blocks in Markdown, ensure you include the full file path in the tag. The structure should be \`\`\`language:path/to/file
-          \`\`\`. 
+              "text": "You are Cody, an AI coding assistant from Sourcegraph.If your answer contains fenced code blocks in Markdown, include the relevant full file path in the code block tag using this structure: \`\`\`$LANGUAGE:$FILEPATH
+          $CONTENT\`\`\`.
 
           Always respond with 🧀 emojis",
             },

--- a/vscode/src/chat/chat-view/prompt.ts
+++ b/vscode/src/chat/chat-view/prompt.ts
@@ -51,7 +51,12 @@ export class DefaultPrompter {
             )
 
             // Add preamble messages
-            const preambleMessages = getSimplePreamble(chat.modelID, codyApiVersion, preInstruction)
+            const preambleMessages = getSimplePreamble(
+                chat.modelID,
+                codyApiVersion,
+                'Chat',
+                preInstruction
+            )
             if (!promptBuilder.tryAddToPrefix(preambleMessages)) {
                 throw new Error(`Preamble length exceeded context window ${chat.contextWindow.input}`)
             }

--- a/vscode/src/commands/scm/source-control.ts
+++ b/vscode/src/commands/scm/source-control.ts
@@ -149,7 +149,7 @@ export class CodySourceControl implements vscode.Disposable {
             const { id: model, contextWindow } = this.model
             const { prompt, ignoredContext } = await this.buildPrompt(
                 contextWindow,
-                getSimplePreamble(model, 1, COMMIT_COMMAND_PROMPTS.intro),
+                getSimplePreamble(model, 1, 'Default', COMMIT_COMMAND_PROMPTS.intro),
                 await getContext(repository, commitTemplate).catch(() => [])
             ).catch(error => {
                 sourceControlInputbox.value = `${error}`

--- a/vscode/src/edit/prompt/index.ts
+++ b/vscode/src/edit/prompt/index.ts
@@ -106,7 +106,7 @@ export const buildInteraction = async ({
         })
     const promptBuilder = await PromptBuilder.create(modelsService.getContextWindowByID(model))
 
-    const preamble = getSimplePreamble(model, codyApiVersion, prompt.system)
+    const preamble = getSimplePreamble(model, codyApiVersion, 'Default', prompt.system)
     promptBuilder.tryAddToPrefix(preamble)
 
     // Add pre-instruction for edit commands to end of human prompt to override the default

--- a/vscode/src/edit/prompt/smart-apply.ts
+++ b/vscode/src/edit/prompt/smart-apply.ts
@@ -80,7 +80,12 @@ export const getPrompt = async (
     }
 
     const promptBuilder = await PromptBuilder.create(contextWindow)
-    const preamble = getSimplePreamble(model, codyApiVersion, SMART_APPLY_SELECTION_PROMPT.system)
+    const preamble = getSimplePreamble(
+        model,
+        codyApiVersion,
+        'Default',
+        SMART_APPLY_SELECTION_PROMPT.system
+    )
     promptBuilder.tryAddToPrefix(preamble)
 
     const text = SMART_APPLY_SELECTION_PROMPT.instruction

--- a/vscode/src/local-context/rewrite-keyword-query.ts
+++ b/vscode/src/local-context/rewrite-keyword-query.ts
@@ -52,7 +52,7 @@ async function doRewrite(
     query: PromptString,
     signal?: AbortSignal
 ): Promise<string[]> {
-    const preamble = getSimplePreamble(undefined, 0)
+    const preamble = getSimplePreamble(undefined, 0, 'Default')
     const stream = completionsClient.stream(
         {
             messages: [

--- a/vscode/src/prompt-builder/index.test.ts
+++ b/vscode/src/prompt-builder/index.test.ts
@@ -263,7 +263,7 @@ describe('PromptBuilder', () => {
         })
 
         it('should remove context with overlapping ranges when full file is provided', async () => {
-            const builder = await PromptBuilder.create({ input: 50, output: 50 })
+            const builder = await PromptBuilder.create({ input: 100, output: 50 })
             builder.tryAddToPrefix(preamble)
             builder.tryAddMessages([...chatTranscript].reverse())
 
@@ -376,7 +376,7 @@ describe('PromptBuilder', () => {
             expect(promptContent).toMatchInlineSnapshot(`
               "preamble
               Codebase context from file ${displayPath(file.uri)}:
-              \`\`\`go
+              \`\`\`go:${displayPath(file.uri)}
               foo\`\`\`
               Ok.
               Hi!

--- a/vscode/src/prompt-builder/index.test.ts
+++ b/vscode/src/prompt-builder/index.test.ts
@@ -291,7 +291,7 @@ describe('PromptBuilder', () => {
         })
 
         it('should not remove user-added with overlapping ranges even when full file is provided', async () => {
-            const builder = await PromptBuilder.create({ input: 55, output: 50 })
+            const builder = await PromptBuilder.create({ input: 100, output: 50 })
             builder.tryAddToPrefix(preamble)
             builder.tryAddMessages([...chatTranscript].reverse())
 

--- a/vscode/src/prompt-builder/index.test.ts
+++ b/vscode/src/prompt-builder/index.test.ts
@@ -319,7 +319,7 @@ describe('PromptBuilder', () => {
         })
 
         it('should deduplicate context from different token usage types', async () => {
-            const builder = await PromptBuilder.create({ input: 55, output: 50 })
+            const builder = await PromptBuilder.create({ input: 100, output: 50 })
             builder.tryAddToPrefix(preamble)
             builder.tryAddMessages([...chatTranscript].reverse())
 

--- a/vscode/src/supercompletions/get-supercompletion.ts
+++ b/vscode/src/supercompletions/get-supercompletion.ts
@@ -206,7 +206,7 @@ function buildInteraction(document: vscode.TextDocument, diff: PromptString): Me
         vscode.window
     )
 
-    const preamble = getSimplePreamble(MODEL, 1, SYSTEM.replaceAll('____', indentation))
+    const preamble = getSimplePreamble(MODEL, 1, 'Default', SYSTEM.replaceAll('____', indentation))
 
     const prompt = PROMPT.replaceAll('{filename}', PromptString.fromDisplayPath(document.uri))
         .replaceAll('{source}', PromptString.fromDocumentText(document))


### PR DESCRIPTION
## Description

This PR improves the smart apply prompt tweak so that:
- We use the system prompt when available
- We use the same desired Markdown syntax when _we_ include codebase context, which helps steer the LLM onto the right path.

I have ran an eval on this here: https://github.com/sourcegraph/cody-leaderboard/pull/16

Quite happy with the results so far


## Test plan

- [x] Tested creating code blocks on all major models

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
