### PR TITLE
Fix getCodyContext fetching

### DIFF
--- a/lib/shared/src/sourcegraph-api/graphql/client.ts
+++ b/lib/shared/src/sourcegraph-api/graphql/client.ts
@@ -1021,7 +1021,7 @@ export class SourcegraphGraphQLAPIClient {
                 query,
                 codeResultsCount: 15,
                 textResultsCount: 5,
-                ...(isValidVersion ? { filePatterns } : {}),
+                ...(isValidVersion ? { filePatterns: filePatterns || [] } : {}),
             },
             signal
         ).then(response =>

--- a/lib/shared/src/sourcegraph-api/graphql/client.ts
+++ b/lib/shared/src/sourcegraph-api/graphql/client.ts
@@ -1021,7 +1021,7 @@ export class SourcegraphGraphQLAPIClient {
                 query,
                 codeResultsCount: 15,
                 textResultsCount: 5,
-                ...(isValidVersion && filePatterns?.length ? { filePatterns } : {}),
+                ...(isValidVersion ? { filePatterns } : {}),
             },
             signal
         ).then(response =>

--- a/lib/shared/src/sourcegraph-api/graphql/client.ts
+++ b/lib/shared/src/sourcegraph-api/graphql/client.ts
@@ -1021,7 +1021,7 @@ export class SourcegraphGraphQLAPIClient {
                 query,
                 codeResultsCount: 15,
                 textResultsCount: 5,
-                ...(isValidVersion ? { filePatterns: filePatterns || [] } : {}),
+                ...(isValidVersion && filePatterns?.length ? { filePatterns } : {}),
             },
             signal
         ).then(response =>

--- a/lib/shared/src/sourcegraph-api/graphql/queries.ts
+++ b/lib/shared/src/sourcegraph-api/graphql/queries.ts
@@ -249,7 +249,7 @@ query GetCodyContext($repos: [ID!]!, $query: String!, $codeResultsCount: Int!, $
 }`
 
 export const CONTEXT_SEARCH_QUERY = `
-query GetCodyContext($repos: [ID!]!, $query: String!, $codeResultsCount: Int!, $textResultsCount: Int!, $filePatterns: [String!]!) {
+query GetCodyContext($repos: [ID!]!, $query: String!, $codeResultsCount: Int!, $textResultsCount: Int!, $filePatterns: [String!]) {
 	getCodyContext(repos: $repos, query: $query, codeResultsCount: $codeResultsCount, textResultsCount: $textResultsCount, filePatterns: $filePatterns) {
         ...on FileChunkContext {
             blob {


### PR DESCRIPTION
Call to `getCodyContext` API is broken in Cody due to the `filePatterns` argument. Passing null just fails the graphql query. 

This PR fixes it. 

## Test plan

- Open Cody and connect to s2
- Test Remote Repository & Remote Directories

## Changelog
