### PR TITLE
PLG: simplify model selection

### DIFF
--- a/lib/shared/src/models/dotcom.ts
+++ b/lib/shared/src/models/dotcom.ts
@@ -46,6 +46,14 @@ export const DEFAULT_DOT_COM_MODELS = [
         tags: [ModelTag.Gateway, ModelTag.Power, ModelTag.Recommended, ModelTag.Free],
     },
     {
+        title: 'Claude 3 Opus',
+        id: 'anthropic/claude-3-opus-20240229',
+        provider: 'Anthropic',
+        usage: [ModelUsage.Chat, ModelUsage.Edit],
+        contextWindow: expandedContextWindow,
+        tags: [ModelTag.Gateway, ModelTag.Pro, ModelTag.Power],
+    },
+    {
         title: 'GPT-4o',
         id: 'openai/gpt-4o',
         provider: 'OpenAI',

--- a/lib/shared/src/models/dotcom.ts
+++ b/lib/shared/src/models/dotcom.ts
@@ -81,6 +81,14 @@ export const DEFAULT_DOT_COM_MODELS = [
         contextWindow: basicContextWindow,
         tags: [ModelTag.Gateway, ModelTag.Speed],
     },
+    {
+        title: 'Mixtral 8x22B',
+        id: 'fireworks/accounts/fireworks/models/mixtral-8x22b-instruct',
+        provider: 'Mistral',
+        usage: [ModelUsage.Chat],
+        contextWindow: basicContextWindow,
+        tags: [ModelTag.Gateway, ModelTag.Speed],
+    },
 ] as const satisfies Model[]
 
 /**

--- a/lib/shared/src/models/dotcom.ts
+++ b/lib/shared/src/models/dotcom.ts
@@ -82,8 +82,8 @@ export const DEFAULT_DOT_COM_MODELS = [
         tags: [ModelTag.Gateway, ModelTag.Speed],
     },
     {
-        title: 'Mixtral 8x22B',
-        id: 'fireworks/accounts/fireworks/models/mixtral-8x22b-instruct',
+        title: 'Mixtral 8x7B',
+        id: 'fireworks/accounts/fireworks/models/mixtral-8x7b-instruct',
         provider: 'Mistral',
         usage: [ModelUsage.Chat],
         contextWindow: basicContextWindow,

--- a/lib/shared/src/models/dotcom.ts
+++ b/lib/shared/src/models/dotcom.ts
@@ -35,7 +35,7 @@ const expandedContextWindow: ModelContextWindow = {
  */
 export const DEFAULT_DOT_COM_MODELS = [
     // --------------------------------
-    // Anthropic models
+    // Powerful models
     // --------------------------------
     {
         title: 'Claude 3.5 Sonnet',
@@ -43,47 +43,15 @@ export const DEFAULT_DOT_COM_MODELS = [
         provider: 'Anthropic',
         usage: [ModelUsage.Chat, ModelUsage.Edit],
         contextWindow: expandedContextWindow,
-        tags: [ModelTag.Gateway, ModelTag.Balanced, ModelTag.Recommended, ModelTag.Free],
+        tags: [ModelTag.Gateway, ModelTag.Power, ModelTag.Recommended, ModelTag.Free],
     },
-    {
-        title: 'Claude 3 Opus',
-        id: 'anthropic/claude-3-opus-20240229',
-        provider: 'Anthropic',
-        usage: [ModelUsage.Chat, ModelUsage.Edit],
-        contextWindow: expandedContextWindow,
-        tags: [ModelTag.Gateway, ModelTag.Pro, ModelTag.Power],
-    },
-    {
-        title: 'Claude 3 Haiku',
-        id: 'anthropic/claude-3-haiku-20240307',
-        provider: 'Anthropic',
-        usage: [ModelUsage.Chat, ModelUsage.Edit],
-        contextWindow: basicContextWindow,
-        tags: [ModelTag.Gateway, ModelTag.Speed],
-    },
-
-    // --------------------------------
-    // OpenAI models
-    // --------------------------------
     {
         title: 'GPT-4o',
         id: 'openai/gpt-4o',
         provider: 'OpenAI',
         usage: [ModelUsage.Chat, ModelUsage.Edit],
         contextWindow: expandedContextWindow,
-        tags: [ModelTag.Gateway, ModelTag.Pro, ModelTag.Balanced],
-    },
-
-    // --------------------------------
-    // Google models
-    // --------------------------------
-    {
-        title: 'Gemini 1.5 Flash',
-        id: 'google/gemini-1.5-flash-latest',
-        provider: 'Google',
-        usage: [ModelUsage.Chat, ModelUsage.Edit],
-        contextWindow: expandedContextWindow,
-        tags: [ModelTag.Gateway, ModelTag.Speed],
+        tags: [ModelTag.Gateway, ModelTag.Power, ModelTag.Pro],
     },
     {
         title: 'Gemini 1.5 Pro',
@@ -94,22 +62,24 @@ export const DEFAULT_DOT_COM_MODELS = [
         tags: [ModelTag.Gateway, ModelTag.Power],
     },
 
-    // TODO (tom) Improve prompt for Mixtral + Edit to see if we can use it there too.
+    // --------------------------------
+    // Faster models
+    // --------------------------------
     {
-        title: 'Mixtral 8x7B',
-        id: 'fireworks/accounts/fireworks/models/mixtral-8x7b-instruct',
-        provider: 'Mistral',
-        usage: [ModelUsage.Chat],
-        contextWindow: basicContextWindow,
+        title: 'Gemini 1.5 Flash',
+        id: 'google/gemini-1.5-flash-latest',
+        provider: 'Google',
+        usage: [ModelUsage.Chat, ModelUsage.Edit],
+        contextWindow: expandedContextWindow,
         tags: [ModelTag.Gateway, ModelTag.Speed],
     },
     {
-        title: 'Mixtral 8x22B',
-        id: 'fireworks/accounts/fireworks/models/mixtral-8x22b-instruct',
-        provider: 'Mistral',
-        usage: [ModelUsage.Chat],
+        title: 'Claude 3 Haiku',
+        id: 'anthropic/claude-3-haiku-20240307',
+        provider: 'Anthropic',
+        usage: [ModelUsage.Chat, ModelUsage.Edit],
         contextWindow: basicContextWindow,
-        tags: [ModelTag.Gateway, ModelTag.Power],
+        tags: [ModelTag.Gateway, ModelTag.Speed],
     },
 ] as const satisfies Model[]
 


### PR DESCRIPTION
* Remove "Balanced" group, only have "Power" and "Speed" groups
* Remove Mixtral 8x22B because it's not a "powerful" model, we should be using Mistral Large here to give Mistral a fair representation. I kept 8x7B in the fast group.
* Moved Google Flash above Haiku in the "Speed" group (I think it's a stronger fast model, but don't have strong evidence to support this). We can always change the order later.


## Test plan
 Ran a local build and took this screenshot 
![CleanShot 2024-08-22 at 15 52 56@2x](https://github.com/user-attachments/assets/4d792b2f-3e2e-4271-9182-dda0c6cc9fbc)
<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

## Changelog

* Updated model selection for Pro/Free users to only have two groups: "Most powerful models" and "Faster models". The "Balanced" group has been removed.
* Removed Mixtral 8x22B for Pro/Free users, use Mixtral 8x7B or Sonnet 3.5 instead.
<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
