### PR TITLE
Cody Web: Fix cody web file/symbol mention search

### DIFF
--- a/vscode/src/chat/chat-view/ChatController.ts
+++ b/vscode/src/chat/chat-view/ChatController.ts
@@ -1129,6 +1129,7 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
         const repos =
             explicitRepos ??
             (await this.repoPicker?.show(this.remoteSearch.getRepos(RepoInclusion.Manual)))
+
         if (repos) {
             this.chatModel.setSelectedRepos(repos)
             this.remoteSearch.setRepos(repos, RepoInclusion.Manual)

--- a/vscode/src/editor/utils/editor-context.ts
+++ b/vscode/src/editor/utils/editor-context.ts
@@ -86,7 +86,7 @@ export async function getFileContextFiles(options: FileContextItemsOptions): Pro
             source: ContextItemSource.User,
             remoteRepositoryName: item.repository.name,
             isIgnored: contextFiltersProvider.isRepoNameIgnored(item.repository.name),
-            uri: URI.file(item.repository.name + item.file.path),
+            uri: URI.file(`${item.repository.name}/${item.file.path}`),
         }))
     }
 
@@ -192,7 +192,7 @@ export async function getSymbolContextFiles(
             item.symbols.map(symbol => ({
                 type: 'symbol',
                 remoteRepositoryName: item.repository.name,
-                uri: URI.file(item.repository.name + symbol.location.resource.path),
+                uri: URI.file(`${item.repository.name}/${symbol.location.resource.path}`),
                 isIgnored: contextFiltersProvider.isRepoNameIgnored(item.repository.name),
                 source: ContextItemSource.User,
                 symbolName: symbol.name,
@@ -461,7 +461,7 @@ async function resolveFileOrSymbolContextItem(
             return {
                 ...contextItem,
                 title: path,
-                uri: URI.parse(`${graphqlClient.endpoint}${repository}/-/blob/${path}`),
+                uri: URI.parse(`${graphqlClient.endpoint}${repository}/-/blob${path}`),
                 content: resultOrError,
                 repoName: repository,
                 source: ContextItemSource.Unified,

--- a/web/CHANGELOG.md
+++ b/web/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.6.0
+- Changes API for initial context (now it supports only one repository as an initial context mention)
+- Fixes problem with file and symbol mention search don't respect initial repository as a context
+
 ## 0.5.2 
 - Improves repository mention result ordering (for repositories, files and directories mentions)
 

--- a/web/demo/App.tsx
+++ b/web/demo/App.tsx
@@ -1,6 +1,6 @@
 import type { FC } from 'react'
 
-import { CodyWebPanel, CodyWebPanelProvider, type Repository } from '../lib'
+import { CodyWebPanel, CodyWebPanelProvider, type InitialContext } from '../lib'
 
 // @ts-ignore
 import AgentWorker from '../lib/agent/agent.worker.ts?worker'
@@ -22,25 +22,13 @@ const serverEndpoint = localStorage.getItem('serverEndpoint') || DOTCOM_SERVER_E
 const accessTokenStorageKey = `accessToken:${serverEndpoint}`
 let accessToken = localStorage.getItem(accessTokenStorageKey)
 
-// Only for testing/demo purpose, in real-life usage consumer
-// should provide context repo information for Cody chat component
-const MOCK_DOT_COM_SOURCEGRAPH_REPOSITORY: Repository[] =
-    serverEndpoint === DOTCOM_SERVER_ENDPOINT
-        ? [
-              {
-                  id: 'UmVwb3NpdG9yeTozNjgwOTI1MA==',
-                  name: 'github.com/sourcegraph/sourcegraph',
-              },
-          ]
-        : []
-
-const MOCK_INITIAL_DOT_COM_CONTEXT =
-    serverEndpoint === DOTCOM_SERVER_ENDPOINT
-        ? {
-              fileURL: 'internal/codeintel/ranking/internal/background/mapper/config.go',
-              repositories: MOCK_DOT_COM_SOURCEGRAPH_REPOSITORY,
-          }
-        : undefined
+const MOCK_INITIAL_DOT_COM_CONTEXT: InitialContext = {
+    fileURL: 'web/demo/App.tsx',
+    repository: {
+        id: 'UmVwb3NpdG9yeTo2MTMyNTMyOA==',
+        name: 'github.com/sourcegraph/cody',
+    },
+}
 
 if (!accessToken) {
     accessToken = window.prompt(`Enter an access token for ${serverEndpoint}:`)

--- a/web/lib/components/CodyWebPanel.tsx
+++ b/web/lib/components/CodyWebPanel.tsx
@@ -137,25 +137,27 @@ export const CodyWebPanel: FC<CodyWebPanelProps> = props => {
     )
 
     const clientState: ClientStateForWebview = useMemo<ClientStateForWebview>(() => {
-        const { repositories = [], fileURL } = initialContext ?? {}
+        const { repository, fileURL } = initialContext ?? {}
 
-        if (repositories.length === 0) {
+        if (!repository) {
             return { initialContext: [] }
         }
 
-        const mentions: ContextItem[] = repositories.map<ContextItemRepository>(repo => ({
-            type: 'repository',
-            id: repo.id,
-            name: repo.name,
-            repoID: repo.id,
-            repoName: repo.name,
-            description: repo.name,
-            uri: URI.parse(`repo:${repo.name}`),
-            content: null,
-            source: ContextItemSource.Initial,
-            icon: 'folder',
-            title: 'Current Repository',
-        }))
+        const mentions: ContextItem[] = [
+            {
+                type: 'repository',
+                id: repository.id,
+                name: repository.name,
+                repoID: repository.id,
+                repoName: repository.name,
+                description: repository.name,
+                uri: URI.parse(`repo:${repository.name}`),
+                content: null,
+                source: ContextItemSource.Initial,
+                icon: 'folder',
+                title: 'Current Repository',
+            } as ContextItemRepository,
+        ]
 
         if (fileURL) {
             mentions.push({
@@ -168,8 +170,8 @@ export const CodyWebPanel: FC<CodyWebPanelProps> = props => {
                           end: { line: initialContext.fileRange.endLine + 1, character: 0 },
                       }
                     : undefined,
-                remoteRepositoryName: repositories[0].name,
-                uri: URI.file(repositories[0].name + fileURL),
+                remoteRepositoryName: repository.name,
+                uri: URI.file(repository.name + fileURL),
                 source: ContextItemSource.Initial,
             })
         }

--- a/web/lib/components/CodyWebPanelProvider.tsx
+++ b/web/lib/components/CodyWebPanelProvider.tsx
@@ -126,7 +126,7 @@ export const CodyWebPanelProvider: FunctionComponent<PropsWithChildren<CodyWebPa
                 id: activeWebviewPanelID,
                 message: {
                     command: 'context/choose-remote-search-repo',
-                    explicitRepos: [initialContext?.repository],
+                    explicitRepos: [initialContext.repository],
                 },
             })
         }

--- a/web/lib/types.ts
+++ b/web/lib/types.ts
@@ -4,7 +4,7 @@ export interface Repository {
 }
 
 export type InitialContext = {
-    repositories: Repository[]
+    repository: Repository
     fileURL?: string
     fileRange?: { startLine: number; endLine: number }
 }

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sourcegraph/cody-web",
-  "version": "0.5.2",
+  "version": "0.6.0",
   "description": "Cody standalone web app",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
Fixes CODY-3375
Fixes CODY-3376

This PR makes symbol and file mention search respect the initial context repository, so we will look for files and symbols only within this repository. You can still select files from different repositories by selecting the "Files" category directly. 

## Test plan
- Check that you can select files in the cody web demo by typing `@<search term>` string and you see files only within sourcegraph/cody repository (which is set as a default context for the cody web demo)

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
