### PR TITLE
Fix context file selection ranges & remote file links

### DIFF
--- a/agent/src/vscode-shim.ts
+++ b/agent/src/vscode-shim.ts
@@ -1013,10 +1013,10 @@ _commands?.registerCommand?.('vscode.executeWorkspaceSymbolProvider', query => {
 _commands?.registerCommand?.('vscode.executeFormatDocumentProvider', uri => {
     return Promise.resolve([])
 })
-_commands?.registerCommand?.('vscode.open', async (uri: vscode.Uri) => {
+_commands?.registerCommand?.('vscode.open', async (uri: vscode.Uri, options?: vscode.TextDocumentShowOptions) => {
     const result = toUri(uri?.path)
     if (result) {
-        return _window.showTextDocument(result)
+        return _window.showTextDocument(result, options)
     }
     return open(uri.toString())
 })

--- a/agent/src/vscode-shim.ts
+++ b/agent/src/vscode-shim.ts
@@ -1013,13 +1013,16 @@ _commands?.registerCommand?.('vscode.executeWorkspaceSymbolProvider', query => {
 _commands?.registerCommand?.('vscode.executeFormatDocumentProvider', uri => {
     return Promise.resolve([])
 })
-_commands?.registerCommand?.('vscode.open', async (uri: vscode.Uri, options?: vscode.TextDocumentShowOptions) => {
-    const result = toUri(uri?.path)
-    if (result) {
-        return _window.showTextDocument(result, options)
+_commands?.registerCommand?.(
+    'vscode.open',
+    async (uri: vscode.Uri, options?: vscode.TextDocumentShowOptions) => {
+        const uriPath = toUri(uri?.path)
+        if (uri.scheme === 'http' || uri.scheme === 'https' || !uriPath) {
+            return open(uri.toString())
+        }
+        return _window.showTextDocument(uriPath, options)
     }
-    return open(uri.toString())
-})
+)
 
 function promisify(value: any): Promise<any> {
     return value instanceof Promise ? value : Promise.resolve(value)


### PR DESCRIPTION
Fixes https://linear.app/sourcegraph/issue/CODY-3368/context-file-link-no-longer-works.


## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

Tested with JetBrains. Context file link navigates properly to the file AND THE SELECTED RANGE.

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
