### PR TITLE
Cody Web: Support directory as initial context

### DIFF
--- a/web/CHANGELOG.md
+++ b/web/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.6.1
+- Adds support for directory initial context (mention) 
+- Changes target build to es modules 
+
 ## 0.6.0
 - Changes API for initial context (now it supports only one repository as an initial context mention)
 - Fixes problem with file and symbol mention search don't respect initial repository as a context

--- a/web/demo/App.tsx
+++ b/web/demo/App.tsx
@@ -23,7 +23,9 @@ const accessTokenStorageKey = `accessToken:${serverEndpoint}`
 let accessToken = localStorage.getItem(accessTokenStorageKey)
 
 const MOCK_INITIAL_DOT_COM_CONTEXT: InitialContext = {
-    fileURL: 'web/demo/App.tsx',
+    fileURL: 'web/demo',
+    fileRange: null,
+    isDirectory: true,
     repository: {
         id: 'UmVwb3NpdG9yeTo2MTMyNTMyOA==',
         name: 'github.com/sourcegraph/cody',

--- a/web/lib/components/CodyWebPanel.tsx
+++ b/web/lib/components/CodyWebPanel.tsx
@@ -179,7 +179,7 @@ export const CodyWebPanel: FC<CodyWebPanelProps> = props => {
                             directoryPath: `${fileURL}/`,
                         },
                         description: ' ',
-                    }
+                    },
                 } as ContextItemOpenCtx)
             } else {
                 // Common file mention with possible file range positions

--- a/web/lib/types.ts
+++ b/web/lib/types.ts
@@ -5,6 +5,7 @@ export interface Repository {
 
 export type InitialContext = {
     repository: Repository
-    fileURL?: string
-    fileRange?: { startLine: number; endLine: number }
+    isDirectory: boolean
+    fileURL: string | null
+    fileRange: { startLine: number; endLine: number } | null
 }

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sourcegraph/cody-web",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Cody standalone web app",
   "license": "Apache-2.0",
   "repository": {
@@ -10,7 +10,7 @@
   },
   "main": "dist/index.js",
   "types": "dist/lib/index.d.ts",
-  "sideEffects": false,
+  "sideEffects": true,
   "files": ["dist/*"],
   "scripts": {
     "dev": "vite --mode development",

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -104,7 +104,7 @@ export default defineProjectWithDefaults(__dirname, {
         assetsDir: '.',
         reportCompressedSize: true,
         lib: {
-            formats: ['cjs'],
+            formats: ['es'],
             entry: [resolve(__dirname, 'lib/index.ts'), resolve(__dirname, 'lib/agent/agent.worker.ts')],
         },
         rollupOptions: {


### PR DESCRIPTION
Part of SRCH-940

See the original issue; in the Sourcegraph repo page, it's a common case when you open Cody Web chat from the directory page, so it makes sense to support directories as an initial mention for the chat. 

## Test plan
- Check that Cody Web demo resolves proper context with default directory mention (demo already has directory mention by default) 

