### PR TITLE
Chat: Improve Cody Web initialization and view handling

### DIFF
--- a/vscode/src/chat/chat-view/ChatController.ts
+++ b/vscode/src/chat/chat-view/ChatController.ts
@@ -306,6 +306,7 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
                 break
             case 'initialized':
                 await this.handleInitialized()
+                this.setWebviewView(View.Chat)
                 break
             case 'submit': {
                 await this.handleUserMessageSubmission(
@@ -590,21 +591,20 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
     // #region top-level view action handlers
     // =======================================================================
 
-    public setAuthStatus(_: AuthStatus): void {
+    public setAuthStatus(status: AuthStatus): void {
         // Run this async because this method may be called during initialization
         // and awaiting on this.postMessage may result in a deadlock
         void this.sendConfig()
 
         // Get the latest model list available to the current user to update the ChatModel.
-        this.handleSetChatModel(getDefaultModelID())
+        if (status.isLoggedIn) {
+            this.handleSetChatModel(getDefaultModelID())
+        }
     }
 
     // When the webview sends the 'ready' message, respond by posting the view config
     private async handleReady(): Promise<void> {
         await this.sendConfig()
-
-        // Update the chat model providers again to ensure the correct token limit is set on ready
-        this.handleSetChatModel(this.chatModel.modelID)
     }
 
     private async sendConfig(): Promise<void> {
@@ -646,7 +646,9 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
             chatID: this.chatModel.sessionID,
         })
 
-        this.postChatModels()
+        // Update the chat model providers to ensure the correct token limit is set
+        this.handleSetChatModel(this.chatModel.modelID)
+
         await this.saveSession()
         this.initDoer.signalInitialized()
         await this.sendConfig()
@@ -1660,8 +1662,6 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
                 }
             )
         )
-
-        void this.sendConfig()
 
         return viewOrPanel
     }

--- a/vscode/webviews/App.tsx
+++ b/vscode/webviews/App.tsx
@@ -34,6 +34,7 @@ import { type Config, ConfigProvider } from './utils/useConfig'
 
 export const App: React.FunctionComponent<{ vscodeAPI: VSCodeWrapper }> = ({ vscodeAPI }) => {
     const [config, setConfig] = useState<Config | null>(null)
+    // NOTE: View state will be set by the extension host during initialization.
     const [view, setView] = useState<View>()
     const [messageInProgress, setMessageInProgress] = useState<ChatMessage | null>(null)
 
@@ -91,12 +92,7 @@ export const App: React.FunctionComponent<{ vscodeAPI: VSCodeWrapper }> = ({ vsc
                     }
                     case 'config':
                         setConfig(message)
-                        setView(message.authStatus.isLoggedIn ? View.Chat : View.Login)
                         updateDisplayPathEnvInfoForWebview(message.workspaceFolderUris)
-                        // Get chat models
-                        if (message.authStatus.isLoggedIn) {
-                            vscodeAPI.postMessage({ command: 'get-chat-models' })
-                        }
                         break
                     case 'history':
                         setUserHistory(Object.values(message.localHistory?.chat ?? {}))


### PR DESCRIPTION
Close https://sourcegraph.slack.com/archives/C06R69BC8UW/p1724339360841049

Right now we are sending a lot of duplicated messages to webview.

This PR makes the following improvements to the Cody Web initialization and view handling:

1. Sets the webview view to `Chat` after the `initialized` message is received, ensuring the view is displayed correctly instead of setting it on every config change.
2. Simplifies the `setAuthStatus` method by only fetching the default chat model when the user is logged in.
3. Removes the unnecessary call to `sendConfig` after the `handleInitialized` method, as the config is already sent in the `handleReady` method.
4. Removes the unnecessary call to `postChatModels` after the `handleInitialized` method, as the chat models are now updated via the `handleSetChatModel` method.

This change also fix a regression on a recent change where the 'config' message now includes AuthStatus, which means as soon as we start sending 'config' message to the webview, the "view" of the webview will be set, even if the AuthStatus isn't ready yet, so we will be showing the Login page before the Chat page even if the user is logged in. 
We will now set the view during the initialize step. If the user is not authenticated, it will automatically fallback to the Login view.


## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

Open the output channel, you should see less duplicated webview messages being sent during the initialize state

Setup this branch in JetBrains webview and confirm the Login view doesn't show up before the chat view.


## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
