### PR TITLE
Chat: don't add selection to chat on option+l shortcut

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -648,11 +648,6 @@
         "when": "cody.activated && editorTextFocus && editorHasSelection"
       },
       {
-        "command": "cody.mention.selection",
-        "key": "alt+l",
-        "when": "cody.activated && editorTextFocus && editorHasSelection"
-      },
-      {
         "command": "cody.tutorial.chat",
         "key": "alt+l",
         "when": "cody.activated && cody.tutorialActive"

--- a/vscode/test/e2e/chat-keyboard-shortcuts.test.ts
+++ b/vscode/test/e2e/chat-keyboard-shortcuts.test.ts
@@ -26,6 +26,6 @@ test('chat keyboard shortcuts for sidebar chat', async ({ page, sidebar }) => {
 
     // Alt+L with a selection opens a new chat (with selection mention).
     await selectLineRangeInEditorTab(page, 3, 5)
-    await page.keyboard.press('Alt+L')
+    await page.keyboard.press('Alt+/')
     await expect(chatSidebarInput).toContainText('buzz.ts buzz.ts:3-5 ')
 })


### PR DESCRIPTION
Previously, the option+l shortcut triggered two commands:

- Toggle chat
- Add selection to chat

This was problematic because the selection is already an initial context in chat so the chat input ended up having duplicate chips (one "initial"
    and one "user").

This PR fixes the problem by removing the option+l shortcut for "Add selection to chat" so that it only toggles the visibility of the sidebar. Users can still manually add the selection to the chat input with the option+/ shortcut.

## Test plan

* Local build
* Select text
* Trigger option+l multiple times
* Confirm that it doesn't keep adding the selection to the chat
<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

## Changelog

* Fix bug where continuously triggering alt+l (option+l for macOS) would add duplicate context items to the chat input. Use the alt+/ shortcut to explicitly add the selection to the chat input.
<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
