### PR TITLE
Chat: default to sidebar location for chat instead of sticky

### DIFF
--- a/vscode/src/chat/chat-view/ChatsController.ts
+++ b/vscode/src/chat/chat-view/ChatsController.ts
@@ -542,10 +542,9 @@ export class ChatsController implements vscode.Disposable {
 }
 
 function getNewChatLocation(): ChatLocation {
-    const chatDefaultLocation =
-        vscode.workspace
-            .getConfiguration()
-            .get<'sticky' | 'sidebar' | 'editor'>('cody.chat.defaultLocation') ?? 'sticky'
+    const chatDefaultLocation = vscode.workspace
+        .getConfiguration()
+        .get<'sticky' | 'sidebar' | 'editor'>('cody.chat.defaultLocation', 'sidebar')
 
     if (chatDefaultLocation === 'sticky') {
         return localStorage.getLastUsedChatModality()


### PR DESCRIPTION
Previously, we used the setting `'sticky'` by default to determine the location of the chat UI. This was problematic because the implementation of `'sticky'` can feel buggy sometimes, it was easy to reproduce scenarios where triggering alt+l in a row would cycle between the sidebar, editor, and code. This PR works around this issue by defaulting to the sidebar instead, making the alt+l shortcut have more consistent behavior.

We can discuss changing the default to `'sticky'` again when the implementation has more predictable behavior.


## Test plan

N/A

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

## Changelog

* The default value for the `'cody.chat.defaultLocation'` setting is now `'sidebar'` instead of `'sticky'`. This means that the alt+l shortcut (option+l on macOS) always toggles between the chat sidebar. Change this setting to `'sticky'` to get the old behavior, or `'editor'` to always use toggle to a chat editor.
<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
