### PR TITLE
Chat: update JetBrains theme colors for command menu

### DIFF
--- a/vscode/webviews/themes/jetbrains.css
+++ b/vscode/webviews/themes/jetbrains.css
@@ -376,9 +376,9 @@ html[data-ide='JetBrains'] {
     --vscode-profileBadge-background: var(--jetbrains-ProgressBar-background);
     --vscode-profileBadge-foreground: var(--jetbrains-ProgressBar-foreground);
     --vscode-progressBar-background: var(--jetbrains-ProgressBar-background);
-    --vscode-quickInput-background: var(--jetbrains-TextArea-background);
-    --vscode-quickInput-foreground: var(--jetbrains-ToolTip-foreground);
-    --vscode-quickInputTitle-background: var(--jetbrains-Tooltip-Learning-foreground);
+    --vscode-quickInput-background: var(--jetbrains-MainToolbar-Icon-pressedBackground);
+    --vscode-quickInput-foreground: var(--jetbrains-ToolBar-foreground);
+    --vscode-quickInputTitle-background: var(--jetbrains-ToolBar-background);
     --vscode-remoteHub-decorations-addedForegroundColor: var(--jetbrains-ActionButton-hoverBackground);
     --vscode-remoteHub-decorations-conflictForegroundColor: var(--jetbrains-ValidationTooltip-warningBorderColor);
     --vscode-remoteHub-decorations-deletedForegroundColor: var(--jetbrains-ActionButton-pressedBackground);


### PR DESCRIPTION
CLOSE https://linear.app/sourcegraph/issue/CODY-3419/fix-css-incompatibilities-in-jetbrains

As per requested: https://linear.app/sourcegraph/issue/CODY-3419/fix-css-incompatibilities-in-jetbrains#comment-d2189743

This change updates the JetBrains theme colors for the following CSS variables:
- `--vscode-quickInput-background`
- `--vscode-quickInput-foreground`
- `--vscode-quickInputTitle-background`

The changes aim to improve the visual appearance of the command menu elements in the JetBrains webview and aligns it with the one in VS Code.


## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->


After:

![image](https://github.com/user-attachments/assets/ab7fe270-3e77-4d1c-918b-bf64604338cc)

Before:

![image](https://github.com/user-attachments/assets/16dd13b3-c38e-4790-a435-c83f02c677fc)


## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
