### PR TITLE
rename Configuration => ClientConfiguration

### DIFF
--- a/agent/src/AgentWorkspaceConfiguration.ts
+++ b/agent/src/AgentWorkspaceConfiguration.ts
@@ -1,6 +1,6 @@
 import type * as vscode from 'vscode'
 
-import { CodyIDE, type Configuration } from '@sourcegraph/cody-shared'
+import { type ClientConfiguration, CodyIDE } from '@sourcegraph/cody-shared'
 
 import { defaultConfigurationValue } from '../../vscode/src/configuration-keys'
 
@@ -30,7 +30,7 @@ export class AgentWorkspaceConfiguration implements vscode.WorkspaceConfiguratio
         return [...this.prefix, section].join('.')
     }
 
-    private clientNameToIDE(value: string): Configuration['agentIDE'] | undefined {
+    private clientNameToIDE(value: string): ClientConfiguration['agentIDE'] | undefined {
         switch (value.toLowerCase()) {
             case 'vscode':
                 return CodyIDE.VSCode

--- a/lib/shared/src/configuration.ts
+++ b/lib/shared/src/configuration.ts
@@ -20,8 +20,10 @@ export interface ConfigGetter<T> {
     get<T>(section: string, defaultValue?: T): T
 }
 
-// Should we share VS Code specific config via cody-shared?
-export interface Configuration {
+/**
+ * Client configuration, such as VS Code settings.
+ */
+export interface ClientConfiguration {
     proxy?: string | null
     codebase?: string
     debugFilter: RegExp | null
@@ -108,9 +110,9 @@ export interface AutocompleteTimeouts {
     singleline?: number
 }
 
-export type ConfigurationWithEndpoint = Omit<ConfigurationWithAccessToken, 'accessToken'>
+export type ClientConfigurationWithEndpoint = Omit<ClientConfigurationWithAccessToken, 'accessToken'>
 
-export interface ConfigurationWithAccessToken extends Configuration {
+export interface ClientConfigurationWithAccessToken extends ClientConfiguration {
     serverEndpoint: string
     /** The access token, which is stored in the secret storage (not configuration). */
     accessToken: string | null

--- a/lib/shared/src/models/index.ts
+++ b/lib/shared/src/models/index.ts
@@ -1,5 +1,5 @@
 import { type AuthStatus, isCodyProUser, isEnterpriseUser } from '../auth/types'
-import { CodyIDE, type Configuration } from '../configuration'
+import { type ClientConfiguration, CodyIDE } from '../configuration'
 import { fetchLocalOllamaModels } from '../llm-providers/ollama/utils'
 import { logDebug, logError } from '../logger'
 import { CHAT_INPUT_TOKEN_BUDGET, CHAT_OUTPUT_TOKEN_BUDGET } from '../token/constants'
@@ -372,7 +372,7 @@ export class ModelsService {
         return empty
     }
 
-    public async onConfigChange(config: Configuration): Promise<void> {
+    public async onConfigChange(config: ClientConfiguration): Promise<void> {
         try {
             const isCodyWeb = config.agentIDE === CodyIDE.Web
 

--- a/lib/shared/src/sourcegraph-api/completions/client.ts
+++ b/lib/shared/src/sourcegraph-api/completions/client.ts
@@ -1,5 +1,5 @@
 import type { Span } from '@opentelemetry/api'
-import type { ConfigurationWithAccessToken } from '../../configuration'
+import type { ClientConfigurationWithAccessToken } from '../../configuration'
 
 import { useCustomChatClient } from '../../llm-providers'
 import { recordErrorToSpan } from '../../tracing'
@@ -32,7 +32,7 @@ export interface CompletionRequestParameters {
 }
 
 export type CompletionsClientConfig = Pick<
-    ConfigurationWithAccessToken,
+    ClientConfigurationWithAccessToken,
     'serverEndpoint' | 'accessToken' | 'customHeaders'
 >
 

--- a/lib/shared/src/sourcegraph-api/graphql/client.ts
+++ b/lib/shared/src/sourcegraph-api/graphql/client.ts
@@ -8,7 +8,7 @@ import { escapeRegExp } from 'lodash'
 import semver from 'semver'
 import type { AuthStatus } from '../../auth/types'
 import { dependentAbortController, onAbort } from '../../common/abortController'
-import type { Configuration, ConfigurationWithAccessToken } from '../../configuration'
+import type { ClientConfiguration, ClientConfigurationWithAccessToken } from '../../configuration'
 import { logDebug, logError } from '../../logger'
 import { addTraceparent, wrapInActiveSpan } from '../../tracing'
 import { isError } from '../../utils'
@@ -548,10 +548,10 @@ export interface event {
 }
 
 export type GraphQLAPIClientConfig = Pick<
-    ConfigurationWithAccessToken,
+    ClientConfigurationWithAccessToken,
     'serverEndpoint' | 'accessToken' | 'customHeaders'
 > &
-    Pick<Partial<Configuration>, 'telemetryLevel'>
+    Pick<Partial<ClientConfiguration>, 'telemetryLevel'>
 
 export let customUserAgent: string | undefined
 export function addCustomUserAgent(headers: Headers): void {

--- a/lib/shared/src/telemetry-v2/TelemetryRecorderProvider.ts
+++ b/lib/shared/src/telemetry-v2/TelemetryRecorderProvider.ts
@@ -11,9 +11,9 @@ import { TimestampTelemetryProcessor } from '@sourcegraph/telemetry/dist/process
 
 import {
     CONTEXT_SELECTION_ID,
+    type ClientConfiguration,
+    type ClientConfigurationWithAccessToken,
     type CodyIDE,
-    type Configuration,
-    type ConfigurationWithAccessToken,
 } from '../configuration'
 import { SourcegraphGraphQLAPIClient } from '../sourcegraph-api/graphql'
 import type { LogEventMode } from '../sourcegraph-api/graphql/client'
@@ -64,7 +64,7 @@ export class TelemetryRecorderProvider extends BaseTelemetryRecorderProvider<
 > {
     constructor(
         extensionDetails: ExtensionDetails,
-        config: ConfigurationWithAccessToken,
+        config: ClientConfigurationWithAccessToken,
         authStatusProvider: AuthStatusProvider,
         anonymousUserID: string,
         legacyBackcompatLogEventMode: LogEventMode
@@ -163,7 +163,7 @@ export class MockServerTelemetryRecorderProvider extends BaseTelemetryRecorderPr
 > {
     constructor(
         extensionDetails: ExtensionDetails,
-        config: Configuration,
+        config: ClientConfiguration,
         authStatusProvider: AuthStatusProvider,
         anonymousUserID: string
     ) {
@@ -184,7 +184,7 @@ export class MockServerTelemetryRecorderProvider extends BaseTelemetryRecorderPr
  */
 class ConfigurationMetadataProcessor implements TelemetryProcessor {
     constructor(
-        private config: Configuration,
+        private config: ClientConfiguration,
         private authStatusProvider: AuthStatusProvider
     ) {}
 

--- a/vscode/src/chat/protocol.ts
+++ b/vscode/src/chat/protocol.ts
@@ -2,9 +2,9 @@ import type { URI } from 'vscode-uri'
 
 import type {
     AuthStatus,
+    ClientConfigurationWithEndpoint,
     ClientStateForWebview,
     CodyIDE,
-    ConfigurationWithEndpoint,
     ContextItem,
     ContextItemSource,
     EnhancedContextContextT,
@@ -295,7 +295,7 @@ export interface ExtensionTranscriptMessage {
  */
 export interface ConfigurationSubsetForWebview
     extends Pick<
-        ConfigurationWithEndpoint,
+        ClientConfigurationWithEndpoint,
         | 'experimentalNoodle'
         | 'serverEndpoint'
         | 'agentIDE'

--- a/vscode/src/code-actions/CodeActionProvider.ts
+++ b/vscode/src/code-actions/CodeActionProvider.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode'
 
-import type { Configuration } from '@sourcegraph/cody-shared'
+import type { ClientConfiguration } from '@sourcegraph/cody-shared'
 import { getConfiguration } from '../configuration'
 import { DocumentCodeAction } from './document'
 import { EditCodeAction } from './edit'
@@ -21,7 +21,7 @@ export class CodeActionProvider implements vscode.Disposable {
         )
     }
 
-    private registerCodeActions(config: Omit<Configuration, 'codebase'>): void {
+    private registerCodeActions(config: Omit<ClientConfiguration, 'codebase'>): void {
         for (const disposable of this.actionProviders) {
             disposable.dispose()
         }

--- a/vscode/src/completions/completion-provider-config.ts
+++ b/vscode/src/completions/completion-provider-config.ts
@@ -1,8 +1,12 @@
-import { type Configuration, FeatureFlag, type FeatureFlagProvider } from '@sourcegraph/cody-shared'
+import {
+    type ClientConfiguration,
+    FeatureFlag,
+    type FeatureFlagProvider,
+} from '@sourcegraph/cody-shared'
 import type { ContextStrategy } from './context/context-strategy'
 
 class CompletionProviderConfig {
-    private _config?: Configuration
+    private _config?: ClientConfiguration
 
     /**
      * Use the injected feature flag provider to make testing easier.
@@ -33,14 +37,17 @@ class CompletionProviderConfig {
      * Should be called before `InlineCompletionItemProvider` instance is created, so that the singleton
      * with resolved values is ready for downstream use.
      */
-    public async init(config: Configuration, featureFlagProvider: FeatureFlagProvider): Promise<void> {
+    public async init(
+        config: ClientConfiguration,
+        featureFlagProvider: FeatureFlagProvider
+    ): Promise<void> {
         this._config = config
         this.featureFlagProvider = featureFlagProvider
 
         await Promise.all(this.flagsToResolve.map(flag => featureFlagProvider.evaluateFeatureFlag(flag)))
     }
 
-    public setConfig(config: Configuration) {
+    public setConfig(config: ClientConfiguration) {
         this._config = config
     }
 

--- a/vscode/src/completions/create-inline-completion-item-provider.ts
+++ b/vscode/src/completions/create-inline-completion-item-provider.ts
@@ -1,6 +1,6 @@
 import {
+    type ClientConfigurationWithAccessToken,
     type CodeCompletionsClient,
-    type ConfigurationWithAccessToken,
     featureFlagProvider,
     isDotCom,
 } from '@sourcegraph/cody-shared'
@@ -17,7 +17,7 @@ import { createProviderConfig } from './providers/create-provider'
 import { registerAutocompleteTraceView } from './tracer/traceView'
 
 export interface InlineCompletionItemProviderArgs {
-    config: ConfigurationWithAccessToken
+    config: ClientConfigurationWithAccessToken
     client: CodeCompletionsClient
     statusBar: CodyStatusBar
     authProvider: AuthProvider

--- a/vscode/src/completions/get-inline-completions-tests/helpers.ts
+++ b/vscode/src/completions/get-inline-completions-tests/helpers.ts
@@ -4,12 +4,12 @@ import { expect } from 'vitest'
 
 import {
     type AuthStatus,
+    type ClientConfiguration,
+    type ClientConfigurationWithAccessToken,
     type CodeCompletionsClient,
     type CompletionParameters,
     type CompletionResponse,
     CompletionStopReason,
-    type Configuration,
-    type ConfigurationWithAccessToken,
     defaultAuthStatus,
     testFileUri,
 } from '@sourcegraph/cody-shared'
@@ -55,8 +55,8 @@ const URI_FIXTURE = testFileUri('test.ts')
 
 const dummyAuthStatus: AuthStatus = defaultAuthStatus
 const getVSCodeConfigurationWithAccessToken = (
-    config: Partial<Configuration> = {}
-): ConfigurationWithAccessToken => ({
+    config: Partial<ClientConfiguration> = {}
+): ClientConfigurationWithAccessToken => ({
     ...DEFAULT_VSCODE_SETTINGS,
     ...config,
     serverEndpoint: 'https://example.com',
@@ -71,7 +71,7 @@ type Params = Partial<Omit<InlineCompletionsParams, 'document' | 'position' | 'd
         params: CompletionParameters
     ) => Generator<CompletionResponse> | AsyncGenerator<CompletionResponse>
     providerOptions?: Partial<ProviderOptions>
-    configuration?: Partial<Configuration>
+    configuration?: Partial<ClientConfiguration>
 }
 
 export interface ParamsResult extends InlineCompletionsParams {
@@ -81,7 +81,7 @@ export interface ParamsResult extends InlineCompletionsParams {
      * request manager in autocomplete tests.
      */
     completionResponseGeneratorPromise: Promise<unknown>
-    configuration?: Partial<Configuration>
+    configuration?: Partial<ClientConfiguration>
 }
 
 /**
@@ -369,7 +369,7 @@ export async function getInlineCompletionsFullResponse(
 
     const result = await _getInlineCompletions(params)
     if (!result) {
-        completionProviderConfig.setConfig({} as Configuration)
+        completionProviderConfig.setConfig({} as ClientConfiguration)
     }
 
     return result
@@ -403,8 +403,8 @@ export async function getInlineCompletionsInsertText(params: ParamsResult): Prom
 
 export type V = Awaited<ReturnType<typeof getInlineCompletions>>
 
-export function initCompletionProviderConfig(config: Partial<Configuration>) {
-    return completionProviderConfig.init(config as Configuration, emptyMockFeatureFlagProvider)
+export function initCompletionProviderConfig(config: Partial<ClientConfiguration>) {
+    return completionProviderConfig.init(config as ClientConfiguration, emptyMockFeatureFlagProvider)
 }
 
 expect.extend({

--- a/vscode/src/completions/inline-completion-item-provider-e2e.test.ts
+++ b/vscode/src/completions/inline-completion-item-provider-e2e.test.ts
@@ -1,6 +1,6 @@
 import {
     type AuthStatus,
-    type Configuration,
+    type ClientConfiguration,
     type GraphQLAPIClientConfig,
     contextFiltersProvider,
     graphqlClient,
@@ -418,7 +418,7 @@ describe('InlineCompletionItemProvider preloading', () => {
     const autocompleteConfig = {
         autocompleteExperimentalPreloadDebounceInterval: 150,
         autocompleteAdvancedProvider: 'fireworks',
-    } satisfies Partial<Configuration>
+    } satisfies Partial<ClientConfiguration>
 
     const onDidChangeTextEditorSelection = vi.spyOn(vsCodeMocks.window, 'onDidChangeTextEditorSelection')
 

--- a/vscode/src/completions/providers/create-provider.test.ts
+++ b/vscode/src/completions/providers/create-provider.test.ts
@@ -1,9 +1,9 @@
 import {
     type AuthStatus,
+    type ClientConfiguration,
+    type ClientConfigurationWithAccessToken,
     type CodeCompletionsClient,
     type CodyLLMSiteConfiguration,
-    type Configuration,
-    type ConfigurationWithAccessToken,
     type GraphQLAPIClientConfig,
     defaultAuthStatus,
     graphqlClient,
@@ -16,8 +16,8 @@ import { DEFAULT_VSCODE_SETTINGS } from '../../testutils/mocks'
 import { createProviderConfig } from './create-provider'
 
 const getVSCodeConfigurationWithAccessToken = (
-    config: Partial<Configuration> = {}
-): ConfigurationWithAccessToken => ({
+    config: Partial<ClientConfiguration> = {}
+): ClientConfigurationWithAccessToken => ({
     ...DEFAULT_VSCODE_SETTINGS,
     ...config,
     serverEndpoint: 'https://example.com',
@@ -50,7 +50,7 @@ describe('createProviderConfig', () => {
             const provider = await createProviderConfig(
                 getVSCodeConfigurationWithAccessToken({
                     autocompleteAdvancedProvider:
-                        'nasa-ai' as Configuration['autocompleteAdvancedProvider'],
+                        'nasa-ai' as ClientConfiguration['autocompleteAdvancedProvider'],
                 }),
                 dummyCodeCompletionsClient,
                 dummyAuthStatus
@@ -63,7 +63,8 @@ describe('createProviderConfig', () => {
         it('returns `null` if completions provider is not configured', async () => {
             const provider = await createProviderConfig(
                 getVSCodeConfigurationWithAccessToken({
-                    autocompleteAdvancedProvider: null as Configuration['autocompleteAdvancedProvider'],
+                    autocompleteAdvancedProvider:
+                        null as ClientConfiguration['autocompleteAdvancedProvider'],
                 }),
                 dummyCodeCompletionsClient,
                 dummyAuthStatus

--- a/vscode/src/completions/providers/create-provider.ts
+++ b/vscode/src/completions/providers/create-provider.ts
@@ -1,7 +1,7 @@
 import {
     type AuthStatus,
+    type ClientConfigurationWithAccessToken,
     type CodeCompletionsClient,
-    type ConfigurationWithAccessToken,
     FeatureFlag,
     type Model,
     ModelUsage,
@@ -38,7 +38,7 @@ interface CreateConfigHelperParams {
     authStatus: AuthStatus
     modelId: string | undefined
     provider: string
-    config: ConfigurationWithAccessToken
+    config: ClientConfigurationWithAccessToken
     model?: Model
 }
 
@@ -311,7 +311,7 @@ function parseProviderAndModel({
 }
 
 export async function createProviderConfig(
-    config: ConfigurationWithAccessToken,
+    config: ClientConfigurationWithAccessToken,
     client: CodeCompletionsClient,
     authStatus: AuthStatus
 ): Promise<ProviderConfig | null> {

--- a/vscode/src/completions/providers/expopenaicompatible.ts
+++ b/vscode/src/completions/providers/expopenaicompatible.ts
@@ -5,10 +5,10 @@ import {
     type AuthStatus,
     type AutocompleteContextSnippet,
     type AutocompleteTimeouts,
+    type ClientConfigurationWithAccessToken,
     type CodeCompletionsClient,
     type CodeCompletionsParams,
     type CompletionResponseGenerator,
-    type ConfigurationWithAccessToken,
     PromptString,
     ps,
     tokensToChars,
@@ -46,7 +46,7 @@ interface OpenAICompatibleOptions {
     maxContextTokens?: number
     client: CodeCompletionsClient
     timeouts: AutocompleteTimeouts
-    config: Pick<ConfigurationWithAccessToken, 'accessToken'>
+    config: Pick<ClientConfigurationWithAccessToken, 'accessToken'>
     authStatus: Pick<AuthStatus, 'userCanUpgrade' | 'isDotCom' | 'endpoint'>
 }
 

--- a/vscode/src/completions/providers/fireworks.ts
+++ b/vscode/src/completions/providers/fireworks.ts
@@ -2,11 +2,11 @@ import {
     type AuthStatus,
     type AutocompleteContextSnippet,
     type AutocompleteTimeouts,
+    type ClientConfiguration,
+    type ClientConfigurationWithAccessToken,
     type CodeCompletionsClient,
     type CodeCompletionsParams,
     type CompletionResponseGenerator,
-    type Configuration,
-    type ConfigurationWithAccessToken,
     dotcomTokenToGatewayToken,
     tokensToChars,
 } from '@sourcegraph/cody-shared'
@@ -39,7 +39,7 @@ export interface FireworksOptions {
     anonymousUserID?: string
     timeouts: AutocompleteTimeouts
     config: Pick<
-        ConfigurationWithAccessToken,
+        ClientConfigurationWithAccessToken,
         'accessToken' | 'autocompleteExperimentalFireworksOptions'
     >
     authStatus: Pick<
@@ -137,7 +137,7 @@ class FireworksProvider extends Provider {
         'userCanUpgrade' | 'isDotCom' | 'endpoint' | 'isFireworksTracingEnabled'
     >
     private isLocalInstance: boolean
-    private fireworksConfig?: Configuration['autocompleteExperimentalFireworksOptions']
+    private fireworksConfig?: ClientConfiguration['autocompleteExperimentalFireworksOptions']
     private modelHelper: DefaultModel
     private anonymousUserID: string | undefined
 

--- a/vscode/src/completions/providers/openaicompatible.ts
+++ b/vscode/src/completions/providers/openaicompatible.ts
@@ -2,10 +2,10 @@ import {
     type AuthStatus,
     type AutocompleteContextSnippet,
     type AutocompleteTimeouts,
+    type ClientConfigurationWithAccessToken,
     type CodeCompletionsClient,
     type CodeCompletionsParams,
     type CompletionResponseGenerator,
-    type ConfigurationWithAccessToken,
     type Model,
     PromptString,
     charsToTokens,
@@ -46,7 +46,7 @@ interface OpenAICompatibleOptions {
     maxContextTokens?: number
     client: CodeCompletionsClient
     timeouts: AutocompleteTimeouts
-    config: Pick<ConfigurationWithAccessToken, 'accessToken'>
+    config: Pick<ClientConfigurationWithAccessToken, 'accessToken'>
     authStatus: Pick<AuthStatus, 'userCanUpgrade' | 'isDotCom' | 'endpoint'>
 }
 

--- a/vscode/src/configuration.test.ts
+++ b/vscode/src/configuration.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import type * as vscode from 'vscode'
 
-import { type Configuration, OLLAMA_DEFAULT_URL, ps } from '@sourcegraph/cody-shared'
+import { type ClientConfiguration, OLLAMA_DEFAULT_URL, ps } from '@sourcegraph/cody-shared'
 
 import { getConfiguration } from './configuration'
 import { DEFAULT_VSCODE_SETTINGS } from './testutils/mocks'
@@ -160,6 +160,6 @@ describe('getConfiguration', () => {
             autocompleteExperimentalHotStreakAndSmartThrottle: false,
             testingModelConfig: undefined,
             experimentalGuardrailsTimeoutSeconds: undefined,
-        } satisfies Configuration)
+        } satisfies ClientConfiguration)
     })
 })

--- a/vscode/src/configuration.ts
+++ b/vscode/src/configuration.ts
@@ -1,10 +1,10 @@
 import * as vscode from 'vscode'
 
 import {
+    type ClientConfiguration,
+    type ClientConfigurationWithAccessToken,
     type CodyIDE,
-    type Configuration,
     type ConfigurationUseContext,
-    type ConfigurationWithAccessToken,
     DOTCOM_URL,
     OLLAMA_DEFAULT_URL,
     PromptString,
@@ -30,7 +30,7 @@ interface ConfigGetter {
  */
 export function getConfiguration(
     config: ConfigGetter = vscode.workspace.getConfiguration()
-): Configuration {
+): ClientConfiguration {
     const isTesting = process.env.CODY_TESTING === 'true'
 
     function getHiddenSetting<T>(configKey: string, defaultValue?: T): T {
@@ -56,7 +56,7 @@ export function getConfiguration(
     }
 
     let autocompleteAdvancedProvider = config.get<
-        | Configuration['autocompleteAdvancedProvider']
+        | ClientConfiguration['autocompleteAdvancedProvider']
         | 'unstable-ollama'
         | 'unstable-fireworks'
         | 'experimental-openaicompatible'
@@ -220,7 +220,7 @@ function sanitizeCodebase(codebase: string | undefined): string {
     return codebase.replace(protocolRegexp, '').trim().replace(trailingSlashRegexp, '')
 }
 
-export function getConfigWithEndpoint(): Omit<ConfigurationWithAccessToken, 'accessToken'> {
+export function getConfigWithEndpoint(): Omit<ClientConfigurationWithAccessToken, 'accessToken'> {
     const config = getConfiguration()
     const isTesting = process.env.CODY_TESTING === 'true'
     const serverEndpoint =
@@ -228,7 +228,7 @@ export function getConfigWithEndpoint(): Omit<ConfigurationWithAccessToken, 'acc
     return { ...config, serverEndpoint }
 }
 
-export const getFullConfig = async (): Promise<ConfigurationWithAccessToken> => {
+export const getFullConfig = async (): Promise<ClientConfigurationWithAccessToken> => {
     const accessToken =
         vscode.workspace.getConfiguration().get<string>('cody.accessToken') ||
         (await getAccessToken()) ||

--- a/vscode/src/configwatcher.ts
+++ b/vscode/src/configwatcher.ts
@@ -1,5 +1,5 @@
 import {
-    type ConfigurationWithAccessToken,
+    type ClientConfigurationWithAccessToken,
     fromVSCodeEvent,
     subscriptionDisposable,
 } from '@sourcegraph/cody-shared'
@@ -16,15 +16,15 @@ export interface ConfigWatcher<C> extends vscode.Disposable {
     get(): C
 }
 
-export class BaseConfigWatcher implements ConfigWatcher<ConfigurationWithAccessToken> {
-    private currentConfig: ConfigurationWithAccessToken
+export class BaseConfigWatcher implements ConfigWatcher<ClientConfigurationWithAccessToken> {
+    private currentConfig: ClientConfigurationWithAccessToken
     private disposables: vscode.Disposable[] = []
-    private configChangeEvent = new vscode.EventEmitter<ConfigurationWithAccessToken>()
+    private configChangeEvent = new vscode.EventEmitter<ClientConfigurationWithAccessToken>()
 
     public static async create(
         authProvider: AuthProvider,
         disposables: vscode.Disposable[]
-    ): Promise<ConfigWatcher<ConfigurationWithAccessToken>> {
+    ): Promise<ConfigWatcher<ClientConfigurationWithAccessToken>> {
         const w = new BaseConfigWatcher(await getFullConfig())
         disposables.push(w)
         disposables.push(
@@ -46,12 +46,12 @@ export class BaseConfigWatcher implements ConfigWatcher<ConfigurationWithAccessT
         return w
     }
 
-    constructor(initialConfig: ConfigurationWithAccessToken) {
+    constructor(initialConfig: ClientConfigurationWithAccessToken) {
         this.currentConfig = initialConfig
         this.disposables.push(this.configChangeEvent)
     }
 
-    public changes: Observable<ConfigurationWithAccessToken> = fromVSCodeEvent(
+    public changes: Observable<ClientConfigurationWithAccessToken> = fromVSCodeEvent(
         this.configChangeEvent.event,
         () => this.currentConfig
     )
@@ -63,11 +63,11 @@ export class BaseConfigWatcher implements ConfigWatcher<ConfigurationWithAccessT
         this.disposables = []
     }
 
-    public get(): ConfigurationWithAccessToken {
+    public get(): ClientConfigurationWithAccessToken {
         return this.currentConfig
     }
 
-    private set(config: ConfigurationWithAccessToken): void {
+    private set(config: ClientConfigurationWithAccessToken): void {
         const oldConfig = JSON.stringify(this.currentConfig)
         const newConfig = JSON.stringify(config)
         if (oldConfig === newConfig) {

--- a/vscode/src/extension.common.ts
+++ b/vscode/src/extension.common.ts
@@ -1,10 +1,10 @@
 import * as vscode from 'vscode'
 
 import type {
+    ClientConfiguration,
+    ClientConfigurationWithEndpoint,
     CompletionLogger,
     CompletionsClientConfig,
-    Configuration,
-    ConfigurationWithEndpoint,
     SourcegraphCompletionsClient,
 } from '@sourcegraph/cody-shared'
 import type { startTokenReceiver } from './auth/token-receiver'
@@ -46,10 +46,12 @@ export interface PlatformContext {
         config: CompletionsClientConfig,
         logger?: CompletionLogger
     ) => SourcegraphCompletionsClient
-    createSentryService?: (config: Pick<ConfigurationWithEndpoint, 'serverEndpoint'>) => SentryService
+    createSentryService?: (
+        config: Pick<ClientConfigurationWithEndpoint, 'serverEndpoint'>
+    ) => SentryService
     createOpenTelemetryService?: (config: OpenTelemetryServiceConfig) => OpenTelemetryService
     startTokenReceiver?: typeof startTokenReceiver
-    onConfigurationChange?: (configuration: Configuration) => void
+    onConfigurationChange?: (configuration: ClientConfiguration) => void
     extensionClient: ExtensionClient
 }
 

--- a/vscode/src/external-services.ts
+++ b/vscode/src/external-services.ts
@@ -2,8 +2,8 @@ import type * as vscode from 'vscode'
 
 import {
     ChatClient,
+    type ClientConfigurationWithAccessToken,
     type CodeCompletionsClient,
-    type ConfigurationWithAccessToken,
     type Guardrails,
     type GuardrailsClientConfig,
     type SourcegraphCompletionsClient,
@@ -36,7 +36,7 @@ interface ExternalServices {
 }
 
 type ExternalServicesConfiguration = Pick<
-    ConfigurationWithAccessToken,
+    ClientConfigurationWithAccessToken,
     | 'serverEndpoint'
     | 'codebase'
     | 'useContext'

--- a/vscode/src/fetch.node.ts
+++ b/vscode/src/fetch.node.ts
@@ -2,7 +2,7 @@ import http from 'node:http'
 import https from 'node:https'
 import { parse as parseUrl } from 'node:url'
 import { agent } from '@sourcegraph/cody-shared'
-import type { Configuration } from '@sourcegraph/cody-shared'
+import type { ClientConfiguration } from '@sourcegraph/cody-shared'
 import { HttpProxyAgent } from 'http-proxy-agent'
 import { HttpsProxyAgent } from 'https-proxy-agent'
 import { SocksProxyAgent } from 'socks-proxy-agent'
@@ -26,7 +26,9 @@ let socksProxyAgent: SocksProxyAgent
 let httpProxyAgent: HttpProxyAgent<string>
 let httpsProxyAgent: HttpsProxyAgent<string>
 
-function getCustomAgent({ proxy }: Configuration): ({ protocol }: Pick<URL, 'protocol'>) => http.Agent {
+function getCustomAgent({
+    proxy,
+}: ClientConfiguration): ({ protocol }: Pick<URL, 'protocol'>) => http.Agent {
     return ({ protocol }) => {
         const proxyURL = proxy || getSystemProxyURI(protocol, process.env)
         if (!proxyURL) {
@@ -73,7 +75,7 @@ function getCustomAgent({ proxy }: Configuration): ({ protocol }: Pick<URL, 'pro
 }
 
 export function setCustomAgent(
-    configuration: Configuration
+    configuration: ClientConfiguration
 ): ({ protocol }: Pick<URL, 'protocol'>) => http.Agent {
     agent.current = getCustomAgent(configuration)
     return agent.current as ({ protocol }: Pick<URL, 'protocol'>) => http.Agent

--- a/vscode/src/local-context/local-embeddings.ts
+++ b/vscode/src/local-context/local-embeddings.ts
@@ -3,7 +3,7 @@ import * as vscode from 'vscode'
 import { URI } from 'vscode-uri'
 
 import {
-    type ConfigurationWithAccessToken,
+    type ClientConfigurationWithAccessToken,
     type ContextGroup,
     type ContextStatusProvider,
     type EmbeddingsModelConfig,
@@ -42,7 +42,7 @@ export async function createLocalEmbeddingsController(
 }
 
 export type LocalEmbeddingsConfig = Pick<
-    ConfigurationWithAccessToken,
+    ClientConfigurationWithAccessToken,
     'serverEndpoint' | 'accessToken'
 > & {
     testingModelConfig: EmbeddingsModelConfig | undefined

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -3,10 +3,10 @@ import * as vscode from 'vscode'
 import {
     type ChatClient,
     ClientConfigSingleton,
+    type ClientConfiguration,
+    type ClientConfigurationWithAccessToken,
+    type ClientConfigurationWithEndpoint,
     type CodeCompletionsClient,
-    type Configuration,
-    type ConfigurationWithAccessToken,
-    type ConfigurationWithEndpoint,
     type DefaultCodyCommands,
     type Guardrails,
     PromptString,
@@ -165,7 +165,7 @@ export async function start(
 const register = async (
     context: vscode.ExtensionContext,
     authProvider: AuthProvider,
-    configWatcher: ConfigWatcher<ConfigurationWithAccessToken>,
+    configWatcher: ConfigWatcher<ClientConfigurationWithAccessToken>,
     platform: PlatformContext,
     isExtensionModeDevOrTest: boolean
 ): Promise<vscode.Disposable> => {
@@ -315,7 +315,7 @@ const register = async (
 async function initializeSingletons(
     platform: PlatformContext,
     authProvider: AuthProvider,
-    configWatcher: ConfigWatcher<ConfigurationWithAccessToken>,
+    configWatcher: ConfigWatcher<ClientConfigurationWithAccessToken>,
     isExtensionModeDevOrTest: boolean,
     disposables: vscode.Disposable[]
 ): Promise<void> {
@@ -424,7 +424,7 @@ async function registerOtherCommands(disposables: vscode.Disposable[]) {
 }
 
 function registerCodyCommands(
-    config: ConfigWatcher<Configuration>,
+    config: ConfigWatcher<ClientConfiguration>,
     statusBar: CodyStatusBar,
     sourceControl: CodySourceControl,
     chatClient: ChatClient,
@@ -532,7 +532,7 @@ function registerAuthCommands(authProvider: AuthProvider, disposables: vscode.Di
 }
 
 function registerUpgradeHandlers(
-    configWatcher: ConfigWatcher<Configuration>,
+    configWatcher: ConfigWatcher<ClientConfiguration>,
     authProvider: AuthProvider,
     disposables: vscode.Disposable[]
 ): void {
@@ -640,7 +640,7 @@ async function tryRegisterTutorial(
  * the returned promise is awaited in parallel with other tasks.
  */
 function registerAutocomplete(
-    configWatcher: ConfigWatcher<ConfigurationWithEndpoint>,
+    configWatcher: ConfigWatcher<ClientConfigurationWithEndpoint>,
     platform: PlatformContext,
     authProvider: AuthProvider,
     statusBar: CodyStatusBar,
@@ -724,7 +724,7 @@ function registerAutocomplete(
 
 async function registerMinion(
     context: vscode.ExtensionContext,
-    config: ConfigWatcher<Configuration>,
+    config: ConfigWatcher<ClientConfiguration>,
     authProvider: AuthProvider,
     symfRunner: SymfRunner | undefined,
     disposables: vscode.Disposable[]
@@ -835,7 +835,7 @@ function registerChat(
  * Create or update events infrastructure, using the new telemetryRecorder.
  */
 async function configureEventsInfra(
-    config: ConfigurationWithAccessToken,
+    config: ClientConfigurationWithAccessToken,
     isExtensionModeDevOrTest: boolean,
     authProvider: AuthProvider
 ): Promise<void> {

--- a/vscode/src/notifications/setup-notification.ts
+++ b/vscode/src/notifications/setup-notification.ts
@@ -1,13 +1,15 @@
 import * as vscode from 'vscode'
 
-import type { ConfigurationWithAccessToken } from '@sourcegraph/cody-shared'
+import type { ClientConfigurationWithAccessToken } from '@sourcegraph/cody-shared'
 
 import { localStorage } from '../services/LocalStorageProvider'
 
 import { telemetryRecorder } from '@sourcegraph/cody-shared'
 import { showActionNotification } from '.'
 
-export const showSetupNotification = async (config: ConfigurationWithAccessToken): Promise<void> => {
+export const showSetupNotification = async (
+    config: ClientConfigurationWithAccessToken
+): Promise<void> => {
     if (config.serverEndpoint && config.accessToken) {
         // User has already attempted to configure Cody.
         // Regardless of if they are authenticated or not, we don't want to prompt them.

--- a/vscode/src/services/AuthProvider.ts
+++ b/vscode/src/services/AuthProvider.ts
@@ -4,8 +4,8 @@ import {
     type AuthStatus,
     type AuthStatusProvider,
     ClientConfigSingleton,
+    type ClientConfigurationWithAccessToken,
     CodyIDE,
-    type ConfigurationWithAccessToken,
     DOTCOM_URL,
     SourcegraphGraphQLAPIClient,
     defaultAuthStatus,
@@ -35,7 +35,10 @@ import { secretStorage } from './SecretStorageProvider'
 
 const HAS_AUTHENTICATED_BEFORE_KEY = 'has-authenticated-before'
 
-type AuthConfig = Pick<ConfigurationWithAccessToken, 'serverEndpoint' | 'accessToken' | 'customHeaders'>
+type AuthConfig = Pick<
+    ClientConfigurationWithAccessToken,
+    'serverEndpoint' | 'accessToken' | 'customHeaders'
+>
 export class AuthProvider implements AuthStatusProvider, vscode.Disposable {
     private endpointHistory: string[] = []
     private client: SourcegraphGraphQLAPIClient | null = null
@@ -209,7 +212,10 @@ export class AuthProvider implements AuthStatusProvider, vscode.Disposable {
 
     // Create Auth Status
     private async makeAuthStatus(
-        config: Pick<ConfigurationWithAccessToken, 'serverEndpoint' | 'accessToken' | 'customHeaders'>,
+        config: Pick<
+            ClientConfigurationWithAccessToken,
+            'serverEndpoint' | 'accessToken' | 'customHeaders'
+        >,
         isOfflineMode?: boolean
     ): Promise<AuthStatus> {
         const endpoint = config.serverEndpoint

--- a/vscode/src/services/LocalStorageProvider.ts
+++ b/vscode/src/services/LocalStorageProvider.ts
@@ -4,7 +4,7 @@ import type { Memento } from 'vscode'
 import type {
     AuthStatus,
     ChatHistory,
-    ConfigurationWithAccessToken,
+    ClientConfigurationWithAccessToken,
     UserLocalHistory,
 } from '@sourcegraph/cody-shared'
 
@@ -209,11 +209,11 @@ class LocalStorage {
         return { anonymousUserID: id, created }
     }
 
-    public async setConfig(config: ConfigurationWithAccessToken): Promise<void> {
+    public async setConfig(config: ClientConfigurationWithAccessToken): Promise<void> {
         return this.set(this.KEY_CONFIG, config)
     }
 
-    public getConfig(): ConfigurationWithAccessToken | null {
+    public getConfig(): ClientConfigurationWithAccessToken | null {
         return this.get(this.KEY_CONFIG)
     }
 

--- a/vscode/src/services/StatusBar.ts
+++ b/vscode/src/services/StatusBar.ts
@@ -2,8 +2,8 @@ import * as vscode from 'vscode'
 
 import {
     type AuthStatus,
+    type ClientConfiguration,
     CodyIDE,
-    type Configuration,
     contextFiltersProvider,
     isCodyIgnoredFile,
 } from '@sourcegraph/cody-shared'
@@ -117,7 +117,7 @@ export function createStatusBar(): CodyStatusBar {
             description: string | undefined,
             detail: string,
             setting: string,
-            getValue: (config: Configuration) => boolean | Promise<boolean>,
+            getValue: (config: ClientConfiguration) => boolean | Promise<boolean>,
             requiresReload = false,
             buttons: readonly vscode.QuickInputButton[] | undefined = undefined
         ): Promise<StatusBarItem> {

--- a/vscode/src/services/UpstreamHealthProvider.ts
+++ b/vscode/src/services/UpstreamHealthProvider.ts
@@ -1,6 +1,6 @@
 import {
     type BrowserOrNodeResponse,
-    type ConfigurationWithAccessToken,
+    type ClientConfigurationWithAccessToken,
     addCustomUserAgent,
     addTraceparent,
     isDotCom,
@@ -26,7 +26,7 @@ class UpstreamHealthProvider implements vscode.Disposable {
     private lastGatewayLatency?: number
 
     private config: Pick<
-        ConfigurationWithAccessToken,
+        ClientConfigurationWithAccessToken,
         'serverEndpoint' | 'customHeaders' | 'accessToken'
     > | null = null
     private nextTimeoutId: NodeJS.Timeout | null = null
@@ -46,7 +46,10 @@ class UpstreamHealthProvider implements vscode.Disposable {
     }
 
     public onConfigurationChange(
-        newConfig: Pick<ConfigurationWithAccessToken, 'serverEndpoint' | 'customHeaders' | 'accessToken'>
+        newConfig: Pick<
+            ClientConfigurationWithAccessToken,
+            'serverEndpoint' | 'customHeaders' | 'accessToken'
+        >
     ) {
         this.config = newConfig
         this.lastUpstreamLatency = undefined

--- a/vscode/src/services/cody-ignore.ts
+++ b/vscode/src/services/cody-ignore.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode'
 
 import {
     CODY_IGNORE_POSIX_GLOB,
-    type Configuration,
+    type ClientConfiguration,
     type IgnoreFileContent,
     ignores,
 } from '@sourcegraph/cody-shared'
@@ -19,7 +19,7 @@ const utf8 = new TextDecoder('utf-8')
  *
  * NOTE: Execute ONCE at extension activation time.
  */
-export function setUpCodyIgnore(config: Configuration): vscode.Disposable[] {
+export function setUpCodyIgnore(config: ClientConfiguration): vscode.Disposable[] {
     if (TestSupport.instance) {
         TestSupport.instance.ignoreHelper.set(ignores)
     }

--- a/vscode/src/services/open-telemetry/OpenTelemetryService.node.ts
+++ b/vscode/src/services/open-telemetry/OpenTelemetryService.node.ts
@@ -5,7 +5,7 @@ import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node'
 import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions'
 
 import {
-    type ConfigurationWithAccessToken,
+    type ClientConfigurationWithAccessToken,
     FeatureFlag,
     featureFlagProvider,
 } from '@sourcegraph/cody-shared'
@@ -17,7 +17,7 @@ import { CodyTraceExporter } from './CodyTraceExport'
 import { ConsoleBatchSpanExporter } from './console-batch-span-exporter'
 
 export type OpenTelemetryServiceConfig = Pick<
-    ConfigurationWithAccessToken,
+    ClientConfigurationWithAccessToken,
     'serverEndpoint' | 'experimentalTracing' | 'debugVerbose' | 'accessToken'
 >
 

--- a/vscode/src/services/sentry/sentry.ts
+++ b/vscode/src/services/sentry/sentry.ts
@@ -2,7 +2,7 @@ import type { init as browserInit } from '@sentry/browser'
 import type { init as nodeInit } from '@sentry/node'
 
 import {
-    type ConfigurationWithEndpoint,
+    type ClientConfigurationWithEndpoint,
     NetworkError,
     isAbortError,
     isAuthError,
@@ -21,14 +21,16 @@ export type SentryOptions = NonNullable<Parameters<typeof nodeInit | typeof brow
 export abstract class SentryService {
     constructor(
         protected config: Pick<
-            ConfigurationWithEndpoint,
+            ClientConfigurationWithEndpoint,
             'serverEndpoint' | 'isRunningInsideAgent' | 'agentIDE'
         >
     ) {
         this.prepareReconfigure()
     }
 
-    public onConfigurationChange(newConfig: Pick<ConfigurationWithEndpoint, 'serverEndpoint'>): void {
+    public onConfigurationChange(
+        newConfig: Pick<ClientConfigurationWithEndpoint, 'serverEndpoint'>
+    ): void {
         this.config = newConfig
         this.prepareReconfigure()
     }

--- a/vscode/src/services/telemetry-v2.ts
+++ b/vscode/src/services/telemetry-v2.ts
@@ -1,8 +1,8 @@
 import {
     type AuthStatusProvider,
+    type ClientConfiguration,
+    type ClientConfigurationWithAccessToken,
     CodyIDE,
-    type Configuration,
-    type ConfigurationWithAccessToken,
     type ExtensionDetails,
     type LogEventMode,
     MockServerTelemetryRecorderProvider,
@@ -24,7 +24,7 @@ const { platform, arch } = getOSArch()
 
 export const getExtensionDetails = (
     config: Pick<
-        Configuration,
+        ClientConfiguration,
         'agentIDE' | 'agentIDEVersion' | 'agentExtensionVersion' | 'telemetryClientName'
     >
 ): ExtensionDetails => ({
@@ -56,7 +56,7 @@ const debugLogLabel = 'telemetry-v2'
  * https://sourcegraph.com/docs/dev/background-information/telemetry
  */
 export async function createOrUpdateTelemetryRecorderProvider(
-    config: ConfigurationWithAccessToken,
+    config: ClientConfigurationWithAccessToken,
     /**
      * Hardcode isExtensionModeDevOrTest to false to test real exports - when
      * true, exports are logged to extension output instead.

--- a/vscode/src/testutils/mocks.ts
+++ b/vscode/src/testutils/mocks.ts
@@ -10,7 +10,7 @@ import type {
 } from 'vscode'
 
 import {
-    type Configuration,
+    type ClientConfiguration,
     type FeatureFlag,
     FeatureFlagProvider,
     OLLAMA_DEFAULT_URL,
@@ -935,4 +935,4 @@ export const DEFAULT_VSCODE_SETTINGS = {
     autocompleteExperimentalHotStreakAndSmartThrottle: false,
     testingModelConfig: undefined,
     experimentalGuardrailsTimeoutSeconds: undefined,
-} satisfies Configuration
+} satisfies ClientConfiguration

--- a/vscode/src/uninstall/serializeConfig.ts
+++ b/vscode/src/uninstall/serializeConfig.ts
@@ -3,7 +3,7 @@ import * as os from 'node:os'
 import * as path from 'node:path'
 import type {
     AuthStatus,
-    ConfigurationWithAccessToken,
+    ClientConfigurationWithAccessToken,
     ExtensionDetails,
 } from '@sourcegraph/cody-shared'
 
@@ -44,7 +44,7 @@ function writeSnapshot(directory: string, filename: string, content: any) {
 }
 
 interface UninstallerConfig {
-    config?: ConfigurationWithAccessToken
+    config?: ClientConfigurationWithAccessToken
     authStatus?: AuthStatus
     extensionDetails: ExtensionDetails
     anonymousUserID: string


### PR DESCRIPTION
This is a clarifying rename for the in-progress refactor to make our configuration more reactive throughout Cody.



## Test plan

CI