### PR TITLE
Autocomplete: enable smart-throttle and hot-streak by default

### DIFF
--- a/lib/shared/src/configuration.ts
+++ b/lib/shared/src/configuration.ts
@@ -79,7 +79,6 @@ export interface ClientConfiguration {
     autocompleteExperimentalOllamaOptions: OllamaOptions
     autocompleteExperimentalFireworksOptions?: ExperimentalFireworksConfig
     autocompleteExperimentalMultiModelCompletions?: MultimodelSingleModelConfig[]
-    autocompleteExperimentalHotStreakAndSmartThrottle?: boolean
     autocompleteExperimentalPreloadDebounceInterval?: number
 
     /**
@@ -89,7 +88,6 @@ export interface ClientConfiguration {
     agentIDE?: CodyIDE
     agentIDEVersion?: string
     agentExtensionVersion?: string
-    autocompleteTimeouts: AutocompleteTimeouts
     autocompleteFirstCompletionTimeout: number
 
     testingModelConfig: EmbeddingsModelConfig | undefined
@@ -103,11 +101,6 @@ export enum CodyIDE {
     Web = 'Web',
     VisualStudio = 'VisualStudio',
     Eclipse = 'Eclipse',
-}
-
-export interface AutocompleteTimeouts {
-    multiline?: number
-    singleline?: number
 }
 
 export type ClientConfigurationWithEndpoint = Omit<ClientConfigurationWithAccessToken, 'accessToken'>

--- a/lib/shared/src/experimentation/FeatureFlagProvider.ts
+++ b/lib/shared/src/experimentation/FeatureFlagProvider.ts
@@ -38,13 +38,6 @@ export enum FeatureFlag {
     // Enable latency adjustments based on accept/reject streaks
     CodyAutocompleteUserLatency = 'cody-autocomplete-user-latency',
 
-    // - Hot Streak:
-    //              Continue generations after a single-line completion and use the response to see the next line
-    //              if the first completion is accepted.
-    // - Smart Throttle:
-    //              Enable smart-throttling for more aggressive request cancellation and lower initial latencies
-    CodyAutocompleteHotStreakAndSmartThrottle = 'cody-autocomplete-hot-streak-and-smart-throttle',
-
     CodyAutocompletePreloadingExperimentBaseFeatureFlag = 'cody-autocomplete-preloading-experiment-flag',
     CodyAutocompletePreloadingExperimentVariant1 = 'cody-autocomplete-preloading-experiment-variant-1',
     CodyAutocompletePreloadingExperimentVariant2 = 'cody-autocomplete-preloading-experiment-variant-2',

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -9,13 +9,15 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 ### Fixed
 
 ### Changed
- 
+
+- Autocomplete: Enabled hot-streak and smart-throttle for enterprise users. [pull/5339](https://github.com/sourcegraph/cody/pull/5339)
+
 ## 1.32.1
 
 ### Fixed
 
 - Revert: A recent version bump of a dependency was potentially causing some Out-of-Memory issues resultling in a grey screen. The `rehype-highlight` version has been reverted. [pull/5315](https://github.com/sourcegraph/cody/pull/5315)
-- Chat: General improvements to how Cody responds to messages that include code blocks. [pull/5290](https://github.com/sourcegraph/cody/pull/5290) 
+- Chat: General improvements to how Cody responds to messages that include code blocks. [pull/5290](https://github.com/sourcegraph/cody/pull/5290)
 
 ## 1.32.0
 

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -1238,11 +1238,6 @@
             }
           }
         },
-        "cody.autocomplete.experimental.hotStreakAndSmartThrottle": {
-          "type": "boolean",
-          "default": false,
-          "markdownDescription": "Changes the debounce time for autocomplete requests based on the amount of time since the last request."
-        },
         "cody.autocomplete.experimental.preloadDebounceInterval": {
           "type": "number",
           "default": 0,

--- a/vscode/src/completions/completion-provider-config.ts
+++ b/vscode/src/completions/completion-provider-config.ts
@@ -90,9 +90,9 @@ class CompletionProviderConfig {
         //
         // The rollout values to set:
         // - CodyAutocompletePreloadingExperimentBaseFeatureFlag 75%
-        // - CodyAutocompleteHotStreak 33%
-        // - CodyAutocompleteSmartThrottle 100%
-        // - CodyAutocompleteSmartThrottleExtended 50%
+        // - CodyAutocompleteVariant1 33%
+        // - CodyAutocompleteVariant2 100%
+        // - CodyAutocompleteVariant3 50%
         if (this.getPrefetchedFlag(FeatureFlag.CodyAutocompletePreloadingExperimentBaseFeatureFlag)) {
             if (this.getPrefetchedFlag(FeatureFlag.CodyAutocompletePreloadingExperimentVariant1)) {
                 return 'variant1'

--- a/vscode/src/completions/completion-provider-config.ts
+++ b/vscode/src/completions/completion-provider-config.ts
@@ -18,7 +18,6 @@ class CompletionProviderConfig {
         FeatureFlag.CodyAutocompleteUserLatency,
         FeatureFlag.CodyAutocompleteTracing,
         FeatureFlag.CodyAutocompleteContextExtendLanguagePool,
-        FeatureFlag.CodyAutocompleteHotStreakAndSmartThrottle,
         FeatureFlag.CodyAutocompletePreloadingExperimentBaseFeatureFlag,
         FeatureFlag.CodyAutocompletePreloadingExperimentVariant1,
         FeatureFlag.CodyAutocompletePreloadingExperimentVariant2,
@@ -129,34 +128,6 @@ class CompletionProviderConfig {
             default:
                 return 0
         }
-    }
-
-    private getLatencyExperimentGroup(): 'hot-streak-and-smart-throttle' | 'control' {
-        // The desired distribution:
-        // - Hot-streak + Smart-throttle 50%
-        // - Control group 50%
-        //
-        // The rollout values to set:
-        // - CodyAutocompleteHotStreakAndSmartThrottle 50%
-        if (this.getPrefetchedFlag(FeatureFlag.CodyAutocompleteHotStreakAndSmartThrottle)) {
-            return 'hot-streak-and-smart-throttle'
-        }
-
-        return 'control'
-    }
-
-    public get hotStreak(): boolean {
-        return (
-            this.config.autocompleteExperimentalHotStreakAndSmartThrottle ||
-            this.getLatencyExperimentGroup() === 'hot-streak-and-smart-throttle'
-        )
-    }
-
-    public get smartThrottle(): boolean {
-        return (
-            this.config.autocompleteExperimentalHotStreakAndSmartThrottle ||
-            this.getLatencyExperimentGroup() === 'hot-streak-and-smart-throttle'
-        )
     }
 }
 

--- a/vscode/src/completions/get-completion-provider.ts
+++ b/vscode/src/completions/get-completion-provider.ts
@@ -1,6 +1,5 @@
 import type { DocumentContext, GitContext } from '@sourcegraph/cody-shared'
 
-import { completionProviderConfig } from './completion-provider-config'
 import { type InlineCompletionsParams, TriggerKind } from './get-inline-completions'
 import type { CompletionLogID } from './logger'
 import type { Provider, ProviderOptions } from './providers/provider'
@@ -32,7 +31,6 @@ export function getCompletionProvider(params: GetCompletionProvidersParams): Pro
         docContext,
         document,
         position,
-        hotStreak: completionProviderConfig.hotStreak,
         // For now the value is static and based on the average multiline completion latency.
         firstCompletionTimeout,
         completionLogId,

--- a/vscode/src/completions/get-inline-completions-tests/helpers.ts
+++ b/vscode/src/completions/get-inline-completions-tests/helpers.ts
@@ -163,7 +163,6 @@ export function params(
     const providerConfig = createProviderConfig({
         client,
         providerOptions,
-        timeouts: {},
         authStatus: dummyAuthStatus,
         model: configuration?.autocompleteAdvancedModel!,
         config: configWithAccessToken,

--- a/vscode/src/completions/get-inline-completions-tests/hot-streak.test.ts
+++ b/vscode/src/completions/get-inline-completions-tests/hot-streak.test.ts
@@ -39,7 +39,6 @@ describe('[getInlineCompletions] hot streak', () => {
                 }`,
                 {
                     configuration: {
-                        autocompleteExperimentalHotStreakAndSmartThrottle: true,
                         autocompleteAdvancedProvider: 'fireworks',
                     },
                     delayBetweenChunks: 50,
@@ -72,8 +71,7 @@ describe('[getInlineCompletions] hot streak', () => {
                     console.log(3)
                     console.log(4)
                     █
-                }`,
-                { configuration: { autocompleteExperimentalHotStreakAndSmartThrottle: true } }
+                }`
             )
 
             expect(request.items[0].insertText).toEqual('console.log(2)')
@@ -97,8 +95,7 @@ describe('[getInlineCompletions] hot streak', () => {
                     }█
                     console.log(4)
                     return foo█
-                }`,
-                { configuration: { autocompleteExperimentalHotStreakAndSmartThrottle: true } }
+                }`
             )
 
             await request.completionResponseGeneratorPromise
@@ -132,12 +129,7 @@ describe('[getInlineCompletions] hot streak', () => {
                     if(i > 3) {
                         console.log(4)
                     }█
-                }`,
-                {
-                    configuration: {
-                        autocompleteExperimentalHotStreakAndSmartThrottle: true,
-                    },
-                }
+                }`
             )
 
             expect(request.items[0].insertText).toEqual('if(i > 1) {\n        console.log(2)\n    }')
@@ -165,9 +157,6 @@ describe('[getInlineCompletions] hot streak', () => {
                 █
                 const`,
                 {
-                    configuration: {
-                        autocompleteExperimentalHotStreakAndSmartThrottle: true,
-                    },
                     delayBetweenChunks: 20,
                     providerOptions: {
                         firstCompletionTimeout: 10,

--- a/vscode/src/completions/get-inline-completions-tests/streaming.test.ts
+++ b/vscode/src/completions/get-inline-completions-tests/streaming.test.ts
@@ -182,7 +182,6 @@ describe('[getInlineCompletions] streaming', () => {
             }`,
             {
                 configuration: {
-                    autocompleteExperimentalHotStreakAndSmartThrottle: true,
                     autocompleteAdvancedProvider: 'fireworks',
                 },
                 delayBetweenChunks: 50,

--- a/vscode/src/completions/inline-completion-item-provider-e2e.test.ts
+++ b/vscode/src/completions/inline-completion-item-provider-e2e.test.ts
@@ -194,9 +194,7 @@ describe.skip('InlineCompletionItemProvider E2E', () => {
         let getCompletionProviderSpy: MockInstance
 
         beforeAll(async () => {
-            await initCompletionProviderConfig({
-                autocompleteExperimentalHotStreakAndSmartThrottle: true,
-            })
+            await initCompletionProviderConfig({})
             localStorage.setStorage({
                 get: () => null,
                 update: () => {},

--- a/vscode/src/completions/inline-completion-item-provider.ts
+++ b/vscode/src/completions/inline-completion-item-provider.ts
@@ -176,10 +176,8 @@ export class InlineCompletionItemProvider
             )
         )
 
-        if (completionProviderConfig.smartThrottle) {
-            this.smartThrottleService = new SmartThrottleService()
-            this.disposables.push(this.smartThrottleService)
-        }
+        this.smartThrottleService = new SmartThrottleService()
+        this.disposables.push(this.smartThrottleService)
 
         const chatHistory = localStorage.getChatHistory(this.config.authStatus)?.chat
         this.isProbablyNewInstall = !chatHistory || Object.entries(chatHistory).length === 0

--- a/vscode/src/completions/providers/create-provider.ts
+++ b/vscode/src/completions/providers/create-provider.ts
@@ -71,7 +71,6 @@ export async function createProviderConfigHelper(
             return createFireworksProviderConfig({
                 client,
                 model: modelId ?? null,
-                timeouts: config.autocompleteTimeouts,
                 authStatus,
                 config,
                 anonymousUserID,
@@ -83,7 +82,6 @@ export async function createProviderConfigHelper(
             return createExperimentalOpenAICompatibleProviderConfig({
                 client,
                 model: modelId ?? null,
-                timeouts: config.autocompleteTimeouts,
                 authStatus,
                 config,
             })
@@ -92,7 +90,6 @@ export async function createProviderConfigHelper(
             if (model) {
                 return createOpenAICompatibleProviderConfig({
                     client,
-                    timeouts: config.autocompleteTimeouts,
                     model,
                     authStatus,
                     config,

--- a/vscode/src/completions/providers/expopenaicompatible.ts
+++ b/vscode/src/completions/providers/expopenaicompatible.ts
@@ -4,7 +4,6 @@
 import {
     type AuthStatus,
     type AutocompleteContextSnippet,
-    type AutocompleteTimeouts,
     type ClientConfigurationWithAccessToken,
     type CodeCompletionsClient,
     type CodeCompletionsParams,
@@ -45,7 +44,6 @@ interface OpenAICompatibleOptions {
     model: OpenAICompatibleModel
     maxContextTokens?: number
     client: CodeCompletionsClient
-    timeouts: AutocompleteTimeouts
     config: Pick<ClientConfigurationWithAccessToken, 'accessToken'>
     authStatus: Pick<AuthStatus, 'userCanUpgrade' | 'isDotCom' | 'endpoint'>
 }
@@ -107,14 +105,12 @@ class OpenAICompatibleProvider extends Provider {
     private model: OpenAICompatibleModel
     private promptChars: number
     private client: CodeCompletionsClient
-    private timeouts?: AutocompleteTimeouts
 
     constructor(
         options: ProviderOptions,
-        { model, maxContextTokens, client, timeouts }: Required<OpenAICompatibleOptions>
+        { model, maxContextTokens, client }: Required<OpenAICompatibleOptions>
     ) {
         super(options)
-        this.timeouts = timeouts
         this.model = model
         this.promptChars = tokensToChars(maxContextTokens - MAX_RESPONSE_TOKENS)
         this.client = client
@@ -188,7 +184,6 @@ class OpenAICompatibleProvider extends Provider {
     ): AsyncGenerator<FetchCompletionResult[]> {
         const partialRequestParams = getCompletionParams({
             providerOptions: this.options,
-            timeouts: this.timeouts,
             lineNumberDependentCompletionParams,
         })
 
@@ -320,7 +315,6 @@ ${intro}${infillPrefix ? infillPrefix : ''}${OPENING_CODE_TAG}${CLOSING_CODE_TAG
 
 export function createProviderConfig({
     model,
-    timeouts,
     ...otherOptions
 }: Omit<OpenAICompatibleOptions, 'model' | 'maxContextTokens'> & {
     model: string | null
@@ -350,7 +344,6 @@ export function createProviderConfig({
                 {
                     model: clientModel,
                     maxContextTokens,
-                    timeouts,
                     ...otherOptions,
                 }
             )

--- a/vscode/src/completions/providers/fetch-and-process-completions.ts
+++ b/vscode/src/completions/providers/fetch-and-process-completions.ts
@@ -48,7 +48,7 @@ export async function* fetchAndProcessDynamicMultilineCompletions(
         providerOptions,
         providerSpecificPostProcess,
     } = params
-    const { hotStreak, docContext, multiline, firstCompletionTimeout } = providerOptions
+    const { docContext, multiline, firstCompletionTimeout } = providerOptions
 
     let hotStreakExtractor: undefined | HotStreakExtractor
 
@@ -75,17 +75,12 @@ export async function* fetchAndProcessDynamicMultilineCompletions(
             },
         }
 
-        // TODO(valery): disable hot-streak for long multiline completions?
-        if (hotStreak) {
-            hotStreakExtractor = createHotStreakExtractor({
-                completedCompletion,
-                ...params,
-            })
+        hotStreakExtractor = createHotStreakExtractor({
+            completedCompletion,
+            ...params,
+        })
 
-            yield* hotStreakExtractor.extract(rawCompletion, isFullResponse)
-        } else {
-            abortController.abort()
-        }
+        yield* hotStreakExtractor.extract(rawCompletion, isFullResponse)
     }
 
     const generatorStartTime = performance.now()

--- a/vscode/src/completions/providers/fireworks.ts
+++ b/vscode/src/completions/providers/fireworks.ts
@@ -1,7 +1,6 @@
 import {
     type AuthStatus,
     type AutocompleteContextSnippet,
-    type AutocompleteTimeouts,
     type ClientConfiguration,
     type ClientConfigurationWithAccessToken,
     type CodeCompletionsClient,
@@ -37,7 +36,6 @@ export interface FireworksOptions {
     maxContextTokens?: number
     client: CodeCompletionsClient
     anonymousUserID?: string
-    timeouts: AutocompleteTimeouts
     config: Pick<
         ClientConfigurationWithAccessToken,
         'accessToken' | 'autocompleteExperimentalFireworksOptions'
@@ -130,7 +128,6 @@ class FireworksProvider extends Provider {
     private model: FireworksModel
     private promptChars: number
     private client: CodeCompletionsClient
-    private timeouts?: AutocompleteTimeouts
     private fastPathAccessToken?: string
     private authStatus: Pick<
         AuthStatus,
@@ -147,14 +144,12 @@ class FireworksProvider extends Provider {
             model,
             maxContextTokens,
             client,
-            timeouts,
             config,
             authStatus,
             anonymousUserID,
         }: Required<Omit<FireworksOptions, 'anonymousUserID'>> & { anonymousUserID?: string }
     ) {
         super(options)
-        this.timeouts = timeouts
         this.model = model
         this.modelHelper = getModelHelpers(model)
         this.promptChars = tokensToChars(maxContextTokens - MAX_RESPONSE_TOKENS)
@@ -193,7 +188,6 @@ class FireworksProvider extends Provider {
     ): AsyncGenerator<FetchCompletionResult[]> {
         const partialRequestParams = getCompletionParams({
             providerOptions: this.options,
-            timeouts: this.timeouts,
             lineNumberDependentCompletionParams,
         })
 
@@ -300,7 +294,6 @@ function getClientModel(model: string | null, isDotCom: boolean): FireworksModel
 
 export function createProviderConfig({
     model,
-    timeouts,
     ...otherOptions
 }: Omit<FireworksOptions, 'model' | 'maxContextTokens'> & {
     model: string | null
@@ -318,7 +311,6 @@ export function createProviderConfig({
                 {
                     model: clientModel,
                     maxContextTokens,
-                    timeouts,
                     ...otherOptions,
                 }
             )

--- a/vscode/src/completions/providers/get-completion-params.ts
+++ b/vscode/src/completions/providers/get-completion-params.ts
@@ -1,4 +1,4 @@
-import type { AutocompleteTimeouts, CodeCompletionsParams } from '@sourcegraph/cody-shared'
+import type { CodeCompletionsParams } from '@sourcegraph/cody-shared'
 
 import type { ProviderOptions } from './provider'
 
@@ -40,35 +40,18 @@ export function getLineNumberDependentCompletionParams(
 interface GetCompletionParamsAndFetchImplParams {
     providerOptions: Readonly<ProviderOptions>
     lineNumberDependentCompletionParams: LineNumberDependentCompletionParamsByType
-    timeouts?: AutocompleteTimeouts | undefined
 }
 
 export function getCompletionParams(
     params: GetCompletionParamsAndFetchImplParams
 ): Omit<CodeCompletionsParams, 'messages'> {
-    const {
-        timeouts,
-        providerOptions: { multiline: isMultiline, hotStreak },
-        lineNumberDependentCompletionParams: { singlelineParams, multilineParams },
-    } = params
-
-    const useExtendedGeneration = isMultiline || hotStreak
+    const { multilineParams } = params.lineNumberDependentCompletionParams
 
     const partialRequestParams = {
-        ...(useExtendedGeneration ? multilineParams : singlelineParams),
+        ...multilineParams,
         temperature: 0.2,
         topK: 0,
     } satisfies Omit<CodeCompletionsParams, 'messages'>
-
-    // Apply custom multiline timeouts if they are defined.
-    if (timeouts?.multiline && useExtendedGeneration) {
-        partialRequestParams.timeoutMs = timeouts.multiline
-    }
-
-    // Apply custom singleline timeouts if they are defined.
-    if (timeouts?.singleline && !useExtendedGeneration) {
-        partialRequestParams.timeoutMs = timeouts.singleline
-    }
 
     return partialRequestParams
 }

--- a/vscode/src/completions/providers/openaicompatible.ts
+++ b/vscode/src/completions/providers/openaicompatible.ts
@@ -1,7 +1,6 @@
 import {
     type AuthStatus,
     type AutocompleteContextSnippet,
-    type AutocompleteTimeouts,
     type ClientConfigurationWithAccessToken,
     type CodeCompletionsClient,
     type CodeCompletionsParams,
@@ -45,7 +44,6 @@ interface OpenAICompatibleOptions {
     model: Model
     maxContextTokens?: number
     client: CodeCompletionsClient
-    timeouts: AutocompleteTimeouts
     config: Pick<ClientConfigurationWithAccessToken, 'accessToken'>
     authStatus: Pick<AuthStatus, 'userCanUpgrade' | 'isDotCom' | 'endpoint'>
 }
@@ -56,14 +54,12 @@ class OpenAICompatibleProvider extends Provider {
     private model: Model
     private promptChars: number
     private client: CodeCompletionsClient
-    private timeouts?: AutocompleteTimeouts
 
     constructor(
         options: ProviderOptions,
-        { model, maxContextTokens, client, timeouts }: Required<OpenAICompatibleOptions>
+        { model, maxContextTokens, client }: Required<OpenAICompatibleOptions>
     ) {
         super(options)
-        this.timeouts = timeouts
         this.model = model
         this.promptChars = tokensToChars(maxContextTokens - MAX_RESPONSE_TOKENS)
         this.client = client
@@ -137,7 +133,6 @@ class OpenAICompatibleProvider extends Provider {
     ): AsyncGenerator<FetchCompletionResult[]> {
         const partialRequestParams = getCompletionParams({
             providerOptions: this.options,
-            timeouts: this.timeouts,
             lineNumberDependentCompletionParams:
                 isStarChat(this.model) || isStarCoder(this.model)
                     ? getLineNumberDependentCompletionParams({
@@ -264,7 +259,6 @@ ${intro}${infillPrefix ? infillPrefix : ''}${OPENING_CODE_TAG}${CLOSING_CODE_TAG
 
 export function createProviderConfig({
     model,
-    timeouts,
     ...otherOptions
 }: Omit<OpenAICompatibleOptions, 'maxContextTokens'>): ProviderConfig {
     logDebug('OpenAICompatible', 'autocomplete provider using model', JSON.stringify(model))
@@ -287,7 +281,6 @@ export function createProviderConfig({
                 {
                     model,
                     maxContextTokens,
-                    timeouts,
                     ...otherOptions,
                 }
             )

--- a/vscode/src/completions/providers/provider.ts
+++ b/vscode/src/completions/providers/provider.ts
@@ -80,9 +80,6 @@ export interface ProviderOptions {
     firstCompletionTimeout: number
     completionLogId: CompletionLogger.CompletionLogID
 
-    // feature flags
-    hotStreak?: boolean
-
     /**
      * Git related context information. Currently only supports a repo name, which is used by various FIM models in prompt.
      */

--- a/vscode/src/completions/request-manager.ts
+++ b/vscode/src/completions/request-manager.ts
@@ -13,7 +13,6 @@ import { addAutocompleteDebugEvent } from '../services/open-telemetry/debug-util
 
 import levenshtein from 'js-levenshtein'
 import { logDebug } from '../log'
-import { completionProviderConfig } from './completion-provider-config'
 import {
     InlineCompletionsResultSource,
     type LastInlineCompletionCandidate,
@@ -125,15 +124,12 @@ export class RequestManager {
 
         addAutocompleteDebugEvent('RequestManager.request')
 
-        const shouldHonorCancellation = completionProviderConfig.smartThrottle
-
         // When request recycling is enabled, we do not pass the original abort signal forward as to
         // not interrupt requests that are no longer relevant. Instead, we let all previous requests
         // complete and try to see if their results can be reused for other inflight requests.
-        const abortController: AbortController =
-            shouldHonorCancellation && params.requestParams.abortSignal
-                ? forkSignal(params.requestParams.abortSignal)
-                : new AbortController()
+        const abortController: AbortController = params.requestParams.abortSignal
+            ? forkSignal(params.requestParams.abortSignal)
+            : new AbortController()
 
         const request = new InflightRequest(requestParams, abortController)
         this.inflightRequests.add(request)

--- a/vscode/src/configuration.test.ts
+++ b/vscode/src/configuration.test.ts
@@ -151,13 +151,8 @@ describe('getConfiguration', () => {
                 model: 'codellama:7b-code',
                 url: OLLAMA_DEFAULT_URL,
             },
-            autocompleteTimeouts: {
-                multiline: undefined,
-                singleline: undefined,
-            },
             autocompleteFirstCompletionTimeout: 1500,
             autocompleteExperimentalPreloadDebounceInterval: 0,
-            autocompleteExperimentalHotStreakAndSmartThrottle: false,
             testingModelConfig: undefined,
             experimentalGuardrailsTimeoutSeconds: undefined,
         } satisfies ClientConfiguration)

--- a/vscode/src/configuration.test.ts
+++ b/vscode/src/configuration.test.ts
@@ -102,8 +102,6 @@ describe('getConfiguration', () => {
                         return 1500
                     case 'cody.autocomplete.experimental.preloadDebounceInterval':
                         return 0
-                    case 'cody.autocomplete.experimental.hotStreakAndSmartThrottle':
-                        return false
                     case 'cody.experimental.guardrailsTimeoutSeconds':
                         return undefined
                     default:

--- a/vscode/src/configuration.ts
+++ b/vscode/src/configuration.ts
@@ -163,10 +163,6 @@ export function getConfiguration(
             'autocomplete.experimental.multiModelCompletions',
             undefined
         ),
-        autocompleteExperimentalHotStreakAndSmartThrottle: getHiddenSetting(
-            'autocomplete.experimental.hotStreakAndSmartThrottle',
-            false
-        ),
         autocompleteExperimentalPreloadDebounceInterval: getHiddenSetting(
             'autocomplete.experimental.preloadDebounceInterval',
             0
@@ -180,16 +176,6 @@ export function getConfiguration(
         agentIDE: getHiddenSetting<CodyIDE>('advanced.agent.ide'),
         agentIDEVersion: getHiddenSetting('advanced.agent.ide.version'),
         agentExtensionVersion: getHiddenSetting('advanced.agent.extension.version'),
-        autocompleteTimeouts: {
-            multiline: getHiddenSetting<number | undefined>(
-                'autocomplete.advanced.timeout.multiline',
-                undefined
-            ),
-            singleline: getHiddenSetting<number | undefined>(
-                'autocomplete.advanced.timeout.singleline',
-                undefined
-            ),
-        },
         autocompleteFirstCompletionTimeout: getHiddenSetting<number>(
             'autocomplete.advanced.timeout.firstCompletion',
             3_500

--- a/vscode/src/testutils/mocks.ts
+++ b/vscode/src/testutils/mocks.ts
@@ -926,13 +926,8 @@ export const DEFAULT_VSCODE_SETTINGS = {
         model: 'codellama:7b-code',
         url: OLLAMA_DEFAULT_URL,
     },
-    autocompleteTimeouts: {
-        multiline: undefined,
-        singleline: undefined,
-    },
     autocompleteFirstCompletionTimeout: 3500,
     autocompleteExperimentalPreloadDebounceInterval: 0,
-    autocompleteExperimentalHotStreakAndSmartThrottle: false,
     testingModelConfig: undefined,
     experimentalGuardrailsTimeoutSeconds: undefined,
 } satisfies ClientConfiguration


### PR DESCRIPTION
- Enables hot-streak and smart-throttle for enterprise users.
    - Removes related feature flags and user settings.
- Removes the unused `autocompleteTimeouts` setting.
- Closes https://linear.app/sourcegraph/issue/CODY-3299/rolling-out-hot-streak-and-smart-throttle-to-plg-and-enterprise-august

## Test plan

CI and manually tested autocomplete.


