### PR TITLE
Commands ux improvements

### DIFF
--- a/agent/src/AgentTextEditor.ts
+++ b/agent/src/AgentTextEditor.ts
@@ -4,23 +4,28 @@ import type { AgentTextDocument } from './AgentTextDocument'
 import type { EditFunction } from './AgentWorkspaceDocuments'
 
 export class AgentTextEditor implements vscode.TextEditor {
+    private _selection: vscode.Selection
     constructor(
         private readonly agentDocument: AgentTextDocument,
         private readonly params?: { edit?: EditFunction }
-    ) {}
+    ) {
+        this._selection = new vscode.Selection(new vscode.Position(0, 0), new vscode.Position(0, 0))
+    }
     get document(): AgentTextDocument {
         return this.agentDocument
     }
     get selection(): vscode.Selection {
         const protocolSelection = this.agentDocument.protocolDocument.selection
-        const selection: vscode.Selection = protocolSelection
-            ? new vscode.Selection(
-                  new vscode.Position(protocolSelection.start.line, protocolSelection.start.character),
-                  new vscode.Position(protocolSelection.end.line, protocolSelection.end.character)
-              )
-            : // Default to putting the cursor at the start of the file.
-              new vscode.Selection(new vscode.Position(0, 0), new vscode.Position(0, 0))
-        return selection
+        if (protocolSelection) {
+            this._selection = new vscode.Selection(
+                new vscode.Position(protocolSelection.start.line, protocolSelection.start.character),
+                new vscode.Position(protocolSelection.end.line, protocolSelection.end.character)
+            )
+        }
+        return this._selection
+    }
+    set selection(newSelection: vscode.Selection) {
+        this._selection = newSelection
     }
     get selections(): readonly vscode.Selection[] {
         return [this.selection]

--- a/agent/src/AgentTextEditor.ts
+++ b/agent/src/AgentTextEditor.ts
@@ -22,8 +22,7 @@ export class AgentTextEditor implements vscode.TextEditor {
               new vscode.Selection(new vscode.Position(0, 0), new vscode.Position(0, 0))
         return selection
     }
-    set selection(newSelection: vscode.Selection) {
-    }
+    set selection(newSelection: vscode.Selection) {}
 
     get selections(): readonly vscode.Selection[] {
         return [this.selection]

--- a/agent/src/AgentTextEditor.ts
+++ b/agent/src/AgentTextEditor.ts
@@ -10,6 +10,13 @@ export class AgentTextEditor implements vscode.TextEditor {
         private readonly params?: { edit?: EditFunction }
     ) {
         this._selection = new vscode.Selection(new vscode.Position(0, 0), new vscode.Position(0, 0))
+        const protocolSelection = this.agentDocument.protocolDocument.selection
+        if (protocolSelection) {
+            this._selection = new vscode.Selection(
+                new vscode.Position(protocolSelection.start.line, protocolSelection.start.character),
+                new vscode.Position(protocolSelection.end.line, protocolSelection.end.character)
+            )
+        }
     }
     get document(): AgentTextDocument {
         return this.agentDocument

--- a/agent/src/AgentTextEditor.ts
+++ b/agent/src/AgentTextEditor.ts
@@ -4,36 +4,27 @@ import type { AgentTextDocument } from './AgentTextDocument'
 import type { EditFunction } from './AgentWorkspaceDocuments'
 
 export class AgentTextEditor implements vscode.TextEditor {
-    private _selection: vscode.Selection
     constructor(
         private readonly agentDocument: AgentTextDocument,
         private readonly params?: { edit?: EditFunction }
-    ) {
-        this._selection = new vscode.Selection(new vscode.Position(0, 0), new vscode.Position(0, 0))
-        const protocolSelection = this.agentDocument.protocolDocument.selection
-        if (protocolSelection) {
-            this._selection = new vscode.Selection(
-                new vscode.Position(protocolSelection.start.line, protocolSelection.start.character),
-                new vscode.Position(protocolSelection.end.line, protocolSelection.end.character)
-            )
-        }
-    }
+    ) {}
     get document(): AgentTextDocument {
         return this.agentDocument
     }
     get selection(): vscode.Selection {
         const protocolSelection = this.agentDocument.protocolDocument.selection
-        if (protocolSelection) {
-            this._selection = new vscode.Selection(
-                new vscode.Position(protocolSelection.start.line, protocolSelection.start.character),
-                new vscode.Position(protocolSelection.end.line, protocolSelection.end.character)
-            )
-        }
-        return this._selection
+        const selection: vscode.Selection = protocolSelection
+            ? new vscode.Selection(
+                  new vscode.Position(protocolSelection.start.line, protocolSelection.start.character),
+                  new vscode.Position(protocolSelection.end.line, protocolSelection.end.character)
+              )
+            : // Default to putting the cursor at the start of the file.
+              new vscode.Selection(new vscode.Position(0, 0), new vscode.Position(0, 0))
+        return selection
     }
     set selection(newSelection: vscode.Selection) {
-        this._selection = newSelection
     }
+
     get selections(): readonly vscode.Selection[] {
         return [this.selection]
     }

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -11,7 +11,6 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 Command: Fixed an issue where the experimental `Generate Commit Message` command would fail on Windows due to incorrect parsing of the git diff output. [pull/5449](https://github.com/sourcegraph/cody/pull/5449)
 
 ### Changed
-### Changed
 - Changelog: Implemented cursor feedback for Generate Tests and Document Code commands to improve user experience by indicating command execution. [pull/5341](https://github.com/sourcegraph/cody/pull/5341)
 
 ## 1.32.5

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -11,6 +11,8 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 Command: Fixed an issue where the experimental `Generate Commit Message` command would fail on Windows due to incorrect parsing of the git diff output. [pull/5449](https://github.com/sourcegraph/cody/pull/5449)
 
 ### Changed
+### Changed
+- Changelog: Implemented cursor feedback for Generate Tests and Document Code commands to improve user experience by indicating command execution. [pull/5341](https://github.com/sourcegraph/cody/pull/5341)
 
 ## 1.32.5
 

--- a/vscode/src/edit/manager.ts
+++ b/vscode/src/edit/manager.ts
@@ -218,12 +218,16 @@ export class EditManager implements vscode.Disposable {
                 model: task.model,
             },
         })
+        /**
+         * Updates the editor's selection and view for 'doc' or 'test' intents, causing the cursor to
+         * move to the beginning of the selection range considered for the edit.
+         * 
+         */
         if (editor.active && (intent === 'doc' || intent === 'test')) {
             const newPosition = proposedRange.start
             editor.active.selection = new vscode.Selection(newPosition, newPosition)
             editor.active.revealRange(new vscode.Range(newPosition, newPosition), vscode.TextEditorRevealType.InCenter)
         }
-
         const provider = this.getProviderForTask(task)
         await provider.startEdit()
         return task

--- a/vscode/src/edit/manager.ts
+++ b/vscode/src/edit/manager.ts
@@ -218,7 +218,16 @@ export class EditManager implements vscode.Disposable {
                 model: task.model,
             },
         })
+        if (editor.active && intent == 'doc') {
+            const newPosition = proposedRange.start
+            editor.active.selection = new vscode.Selection(newPosition, newPosition)
+            editor.active.revealRange(proposedRange)
+        }
 
+        // Open the existing test file in VSCode
+        if(task.destinationFile) {
+            await vscode.window.showTextDocument(vscode.Uri.parse(task.destinationFile.toString()))
+        }
         const provider = this.getProviderForTask(task)
         await provider.startEdit()
         return task

--- a/vscode/src/edit/manager.ts
+++ b/vscode/src/edit/manager.ts
@@ -218,17 +218,12 @@ export class EditManager implements vscode.Disposable {
                 model: task.model,
             },
         })
-        if (editor.active && intent == 'doc') {
+        if (editor.active && (intent === 'doc' || intent === 'test')) {
             const newPosition = proposedRange.start
             editor.active.selection = new vscode.Selection(newPosition, newPosition)
-            editor.active.revealRange(proposedRange)
+            editor.active.revealRange(new vscode.Range(newPosition, newPosition), vscode.TextEditorRevealType.InCenter)
         }
 
-        
-        // Open the existing test file in VSCode
-        if(task.destinationFile) {
-            await vscode.window.showTextDocument(vscode.Uri.parse(task.destinationFile.toString()))
-        }
         const provider = this.getProviderForTask(task)
         await provider.startEdit()
         return task

--- a/vscode/src/edit/manager.ts
+++ b/vscode/src/edit/manager.ts
@@ -224,6 +224,7 @@ export class EditManager implements vscode.Disposable {
             editor.active.revealRange(proposedRange)
         }
 
+        
         // Open the existing test file in VSCode
         if(task.destinationFile) {
             await vscode.window.showTextDocument(vscode.Uri.parse(task.destinationFile.toString()))

--- a/vscode/src/edit/manager.ts
+++ b/vscode/src/edit/manager.ts
@@ -221,12 +221,15 @@ export class EditManager implements vscode.Disposable {
         /**
          * Updates the editor's selection and view for 'doc' or 'test' intents, causing the cursor to
          * move to the beginning of the selection range considered for the edit.
-         * 
+         *
          */
         if (editor.active && (intent === 'doc' || intent === 'test')) {
             const newPosition = proposedRange.start
             editor.active.selection = new vscode.Selection(newPosition, newPosition)
-            editor.active.revealRange(new vscode.Range(newPosition, newPosition), vscode.TextEditorRevealType.InCenter)
+            editor.active.revealRange(
+                new vscode.Range(newPosition, newPosition),
+                vscode.TextEditorRevealType.InCenter
+            )
         }
         const provider = this.getProviderForTask(task)
         await provider.startEdit()


### PR DESCRIPTION
[Linear Issue
](https://linear.app/sourcegraph/issue/CODY-3234/prefer-visual-indication-of-running-status-after-clicking-a-command#comment-459cd279)

This PR addresses two key issues with the Generate Tests and Document Code commands:

	1.	Lack of User Feedback: Previously, when users clicked on Generate Tests or Document Code, there was no immediate visual feedback, leaving users uncertain whether the commands were executed. This often led to users repeatedly clicking the buttons, as they couldn’t see any change or indication that something was happening.
	2.	User Experience Improvement: To mitigate this issue, I’ve implemented a change where the cursor now jumps to the appropriate location when either command is executed. This provides instant feedback, informing users that the command is in progress and reducing the likelihood of repeated clicks.

For a more detailed explanation of the problem, please refer to the [accompanying video](https://www.loom.com/share/f39b15824fd5409eae873ad8032e209a).

[Additional comments
](https://linear.app/sourcegraph/issue/CODY-3234/prefer-visual-indication-of-running-status-after-clicking-a-command#comment-41bef8b9)

## Test plan
Tested locally with a vs code extension debugger. ITs fairly easy to see that cursor jumps to codelens for both test and doc

[See Video
](https://www.loom.com/share/6c4f2914597747b4a5b8daa19b656971)

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
