### PR TITLE
Add support for web-like modal UI in Cody Web

### DIFF
--- a/vscode/webviews/App.module.css
+++ b/vscode/webviews/App.module.css
@@ -5,6 +5,7 @@
     box-sizing: border-box;
     height: 100%;
     overflow: hidden;
+    isolation: isolate;
 }
 
 .error-container {
@@ -19,7 +20,6 @@
     padding: 1rem;
     color: var(--vscode-input-foreground);
     background-color: var(--vscode-inputValidation-errorBackground);
-    align-items: center;
     min-height: 2rem;
     position: relative;
     overflow: auto;

--- a/vscode/webviews/tabs/TabsBar.module.css
+++ b/vscode/webviews/tabs/TabsBar.module.css
@@ -9,3 +9,54 @@
     color: var(--vscode-button-background);
     border-width: 1.25px;
 }
+
+:root {
+    --vscode-overlay-background: rgba(0, 0, 0, 0.5);
+    --vscode-modal-background: var(--vscode-sideBar-background);
+}
+
+.dialog {
+    &-overlay {
+        inset: 0;
+        position: fixed;
+        background-color: var(--vscode-overlay-background);
+    }
+
+    &-content {
+        background-color: var(--vscode-modal-background);
+        border-radius: 6px;
+        box-shadow: hsl(206 22% 7% / 35%) 0 10px 38px -10px, hsl(206 22% 7% / 20%) 0 10px 20px -15px;
+        position: fixed;
+        top: 50%;
+        left: 50%;
+        transform: translate(-50%, -50%);
+        width: 90vw;
+        max-width: 450px;
+        max-height: 85vh;
+        padding: 25px;
+
+        &:focus {
+            outline: none;
+        }
+    }
+
+    &-title {
+        margin: 0;
+        font-weight: 500;
+        font-size: 17px;
+    }
+
+    &-description {
+        margin: 10px 0 20px;
+        font-size: 15px;
+        line-height: 1.5;
+    }
+
+    &-footer {
+        margin-top: 1.5rem;
+        width: 100%;
+        display: flex;
+        justify-content: flex-end;
+        gap: 0.5rem;
+    }
+}

--- a/web/CHANGELOG.md
+++ b/web/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.7.1
+- Add support for built-in confirmation UI for actions like Clear Chat History
+
 ## 0.7.0
 - Simplifies Cody Web Chat component (it requires now using only one root CodyWebChat component)
 - Adds skeleton loading state to Cody Web Chat UI 

--- a/web/demo/App.module.css
+++ b/web/demo/App.module.css
@@ -21,4 +21,5 @@ body {
 
 .root {
     font-size: 13px;
+    height: 100%;
 }

--- a/web/demo/App.tsx
+++ b/web/demo/App.tsx
@@ -42,13 +42,14 @@ if (!accessToken) {
 
 export const App: FC = () => {
     return (
-        <CodyWebChat
-            accessToken={accessToken}
-            serverEndpoint={serverEndpoint}
-            createAgentWorker={CREATE_AGENT_WORKER}
-            telemetryClientName="codydemo.testing"
-            initialContext={MOCK_INITIAL_DOT_COM_CONTEXT}
-            className={styles.root}
-        />
+        <div className={styles.root}>
+            <CodyWebChat
+                accessToken={accessToken}
+                serverEndpoint={serverEndpoint}
+                createAgentWorker={CREATE_AGENT_WORKER}
+                telemetryClientName="codydemo.testing"
+                initialContext={MOCK_INITIAL_DOT_COM_CONTEXT}
+            />
+        </div>
     )
 }

--- a/web/lib/components/CodyWebChat.module.css
+++ b/web/lib/components/CodyWebChat.module.css
@@ -1,8 +1,8 @@
 
 .root {
     display: flex;
-    height: 100vh;
     width: 100%;
+    height: 100%;
     font-size: 13px;
     overflow: hidden;
 }

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sourcegraph/cody-web",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Cody standalone web app",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
Part of https://linear.app/sourcegraph/issue/CODY-3404/add-confirmation-to-clear-all-chat-history-button

This PR adds support for a confirmation UI for clients like Cody Web, for which we don't have a native confirmation UI. 

## Test plan
- Run Cody Web demo
- Check that "Clear history chats" action renders an intermediate confirmation UI 
- For full testing in Sourcegraph client use this sg PR https://github.com/sourcegraph/sourcegraph/pull/144

