### PR TITLE
Smart Apply: support writing to empty files

### DIFF
--- a/lib/shared/src/prompt/prompt-string.ts
+++ b/lib/shared/src/prompt/prompt-string.ts
@@ -350,12 +350,17 @@ export class PromptString {
         }
     }
 
-    public static fromContextItem(contextItem: ContextItem) {
+    public static fromContextItem(contextItem: ContextItem): {
+        content: PromptString | undefined
+        repoName: PromptString | undefined
+        title: PromptString | undefined
+    } {
         const ref = [contextItem.uri]
         return {
-            content: contextItem.content
-                ? internal_createPromptString(contextItem.content, ref)
-                : undefined,
+            content:
+                typeof contextItem.content === 'string'
+                    ? internal_createPromptString(contextItem.content, ref)
+                    : undefined,
             repoName: contextItem.repoName
                 ? internal_createPromptString(contextItem.repoName, ref)
                 : undefined,

--- a/vscode/src/prompt-builder/utils.ts
+++ b/vscode/src/prompt-builder/utils.ts
@@ -16,8 +16,15 @@ import { URI } from 'vscode-uri'
 export function renderContextItem(contextItem: ContextItem): ContextMessage | null {
     const { source, range } = contextItem
     const { content, repoName, title } = PromptString.fromContextItem(contextItem)
-    // Do not create context item for empty file
-    if (!content?.trim()?.length) {
+
+    // If true, this context item appears in the chat input as a context chip.
+    const isRequestedInChatInput =
+        source === ContextItemSource.User || source === ContextItemSource.Initial
+
+    // Do not create context item for empty file unless the context item is
+    // explicitly listed in the chat input. See CODY-3421 why we want to include
+    // empty files so that they can target URIs for smart apply.
+    if (content === undefined || (!isRequestedInChatInput && content.trim().length === 0)) {
         return null
     }
 


### PR DESCRIPTION
Fixes CODY-3421

Previously, smart apply didn't work for empty files, it would create a new file in the root directory instead. This was problematic because users could create an empty file in a subdirectory, ask chat to write code, press smart "Apply" and Cody would open a different file with the same name (but in the root directory).

This PR fixes the problem by adding empty files to the context if those files are explicitly added as context items in the chat input. Previously, we skipped empty files, presumably because they add limited value when pulled implicitly (via embeddings or keyword search).


## Test plan

* Create empty file in subdirectory lib/foo.ts
* Ask chat question with empty file added as context: "@foo.ts write fibonacci"
* Click "Apply"
* Expectation: it adds the code to lib/foo.ts
  * Actual, before this PR: it adds the code to foo.ts

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

## Changelog

* Fixed a bug when smart apply would not work with empty files

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
