### PR TITLE
Guardrails: fix DDoS bug

### DIFF
--- a/vscode/webviews/chat/ChatMessageContent/ChatMessageContent.tsx
+++ b/vscode/webviews/chat/ChatMessageContent/ChatMessageContent.tsx
@@ -87,6 +87,10 @@ export const ChatMessageContent: React.FunctionComponent<ChatMessageContentProps
         }, [])
     )
 
+    // See SRCH-942: this `useEffect` is very large and any update to the
+    // dependencies triggers a network request to our guardrails server. Be very
+    // careful about adding more dependencies.  Ideally, we should refactor this
+    // `useEffect` into smaller blocks with more narrow dependencies.
     // biome-ignore lint/correctness/useExhaustiveDependencies: needs to run when `displayMarkdown` changes or else the buttons won't show up.
     useEffect(() => {
         if (!rootRef.current) {
@@ -181,7 +185,6 @@ export const ChatMessageContent: React.FunctionComponent<ChatMessageContentProps
         copyButtonOnSubmit,
         insertButtonOnSubmit,
         smartApplyEnabled,
-        smartApplyInterceptor,
         guardrails,
         displayMarkdown,
         isMessageLoading,

--- a/vscode/webviews/chat/Transcript.tsx
+++ b/vscode/webviews/chat/Transcript.tsx
@@ -192,6 +192,15 @@ const TranscriptInteraction: FC<TranscriptInteractionProps> = memo(props => {
             assistantMessage?.text === undefined
     )
 
+    const humanMessageInfo = useMemo(() => {
+        // See SRCH-942: it's critical to memoize this value to avoid repeated
+        // requests to our guardrails server.
+        if (assistantMessage && !isContextLoading) {
+            return makeHumanMessageInfo({ humanMessage, assistantMessage }, humanEditorRef)
+        }
+        return null
+    }, [humanMessage, assistantMessage, isContextLoading])
+
     return (
         <>
             <HumanMessageCell
@@ -230,10 +239,7 @@ const TranscriptInteraction: FC<TranscriptInteractionProps> = memo(props => {
                     insertButtonOnSubmit={insertButtonOnSubmit}
                     postMessage={postMessage}
                     guardrails={guardrails}
-                    humanMessage={makeHumanMessageInfo(
-                        { humanMessage, assistantMessage },
-                        humanEditorRef
-                    )}
+                    humanMessage={humanMessageInfo}
                     isLoading={assistantMessage.isLoading}
                     showFeedbackButtons={
                         !assistantMessage.isLoading &&


### PR DESCRIPTION
Fixes SRCH-942

Previously, if an enterprise user had a chat window open with a code block containing more than 10 lines of code, then Cody would send a request to our Guardrails server on every single editor event. This was caused by a `useEffect` block that has a large number of dependencies where one of the dependencies (`humanMessage`) was not memoized.

This PR fixes the bug by wrapping `humanMessage` in a `useMemo` block. Ideally, the code should be refactored a bit to have more narrow `useEffect` blocks with fewer dependencies.


## Test plan

* Sign into enterprise account (S2)
* Open chat in an editor
* Ask a question that generates a code block with >10 loc
* Open webview developer tools, network tab
* Select text in the editor
* Old behavior: the guardrails icon was spinning on every selection event.
* Expected: confirm that we don't send a guardrails network request on every editor selection. The icon no longer spins.

![CleanShot 2024-08-27 at 12 00 32@2x](https://github.com/user-attachments/assets/efd3a61d-983f-4b80-a650-ce410782b6b4)

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

## Changelog

* Fixed a bug where the guardrails icon was spinning on every editor selection event
<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
