### PR TITLE
Adding trigger delay to the code

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -38,6 +38,7 @@ Chat: Fixed feedback buttons not working in chat. [pull/5509](https://github.com
 
 - Edit: Implemented cursor feedback for Generate Tests and Document Code commands to improve user experience by indicating command execution. [pull/5341](https://github.com/sourcegraph/cody/pull/5341)
 - Dev: Added support for configurable "options" field in locally configured LLM providers, available behind the `cody.dev.models` setting. [pull/5467](https://github.com/sourcegraph/cody/pull/5467)
+- Autocomplete Trigger Delay: Introduced a configurable setting to add a delay before returning autocomplete results, enhancing user control over completion suggestion timing. [pull/5350](https://github.com/sourcegraph/cody/pull/5350)
 
 ## 1.32.5
 

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -1025,6 +1025,12 @@
           "markdownDescription": "Enables code autocompletions.",
           "default": true
         },
+        "cody.autocomplete.triggerDelay": {
+          "order": 5,
+          "type": "number",
+          "markdownDescription": "Adds a delay in milliseconds before triggering autocomplete. This is useful for avoiding accidental autocomplete triggers when typing. Restart VS Code to apply changes.",
+          "default": 0
+        },
         "cody.autocomplete.languages": {
           "order": 5,
           "type": "object",

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -1028,7 +1028,7 @@
         "cody.autocomplete.triggerDelay": {
           "order": 5,
           "type": "number",
-          "markdownDescription": "Adds a delay in milliseconds before triggering autocomplete. This is useful for avoiding accidental autocomplete triggers when typing. Restart VS Code to apply changes.",
+          "markdownDescription": "The trigger delay ensures a minimum wait time before showing autocomplete suggestions to avoid accidental autocomplete triggers. Restart VS Code to apply changes.",
           "default": 0
         },
         "cody.autocomplete.languages": {

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -1028,7 +1028,7 @@
         "cody.autocomplete.triggerDelay": {
           "order": 5,
           "type": "number",
-          "markdownDescription": "The trigger delay ensures a minimum wait time before showing autocomplete suggestions to avoid accidental autocomplete triggers. Restart VS Code to apply changes.",
+          "markdownDescription": "The trigger delay ensures a minimum wait time before showing autocomplete suggestions to avoid accidental autocomplete triggers.",
           "default": 0
         },
         "cody.autocomplete.languages": {

--- a/vscode/src/completions/create-inline-completion-item-provider.ts
+++ b/vscode/src/completions/create-inline-completion-item-provider.ts
@@ -75,8 +75,13 @@ export function createInlineCompletionItemProvider({
                 createDisposables(provider => {
                     if (provider) {
                         const authStatus = authProvider.instance!.statusAuthed
+                        const triggerDelay =
+                            vscode.workspace
+                                .getConfiguration()
+                                .get<number>('cody.autocomplete.triggerDelay') ?? 0
                         const completionsProvider = new InlineCompletionItemProvider({
                             authStatus,
+                            triggerDelay,
                             provider,
                             config,
                             firstCompletionTimeout: config.autocompleteFirstCompletionTimeout,

--- a/vscode/src/completions/create-multi-model-inline-completion-provider.ts
+++ b/vscode/src/completions/create-multi-model-inline-completion-provider.ts
@@ -140,11 +140,15 @@ export async function createInlineCompletionItemFromMultipleProviders({
             config: newConfig,
         })
 
+        const triggerDelay = vscode.workspace
+            .getConfiguration()
+            .get<number>('cody.autocomplete.triggerDelay')
         if (provider) {
             const completionsProvider = new InlineCompletionItemProvider({
                 authStatus,
                 provider,
                 config: newConfig,
+                triggerDelay: triggerDelay ?? 0,
                 firstCompletionTimeout: config.autocompleteFirstCompletionTimeout,
                 statusBar,
                 completeSuggestWidgetSelection: config.autocompleteCompleteSuggestWidgetSelection,

--- a/vscode/src/completions/inline-completion-item-provider-config-singleton.ts
+++ b/vscode/src/completions/inline-completion-item-provider-config-singleton.ts
@@ -23,6 +23,7 @@ export interface CodyCompletionItemProviderConfig {
     // Settings
     formatOnAccept?: boolean
     disableInsideComments?: boolean
+    triggerDelay: number
 
     // Feature flags
     completeSuggestWidgetSelection?: boolean

--- a/vscode/src/completions/inline-completion-item-provider-e2e.test.ts
+++ b/vscode/src/completions/inline-completion-item-provider-e2e.test.ts
@@ -121,6 +121,7 @@ function getInlineCompletionProvider(
 ): InlineCompletionItemProvider {
     return new InlineCompletionItemProvider({
         completeSuggestWidgetSelection: true,
+        triggerDelay: 0,
         statusBar: { addError: () => {}, hasError: () => {}, startLoading: () => {} } as any,
         provider: createProvider({
             authStatus: AUTH_STATUS_FIXTURE_AUTHED,


### PR DESCRIPTION
[Solves Linear Issue
](https://linear.app/sourcegraph/issue/CODY-3331/introduce-option-to-control-suggestion-pause-time-in-vscode) to introduce configurable trigger delays before making autocomplete suggestions for people who might want to slow down autocomplete suggestions for different reasons
 
## Test plan
[Added a loom video](https://www.loom.com/share/30266970e3c640e4a3cd2accce8e1503) showing trigger delay in different cases with the debugger. 
The way I tested this was first setting the trigger delay to really high and saving it in the settings of Vscode(as shown in the video) and then the slow manifestation of completion suggestions was obvious and then I lowered the trigger delay to 0 in the settings and the completion suggestions were much much faster thereby proving that the setting for trigger delay can be useful for people who find the immediate trigger suggestions to be too cumbersome. 

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
