### PR TITLE
Autocomplete: split `createProvider` into multiple files

### DIFF
--- a/vscode/src/completions/providers/create-provider.ts
+++ b/vscode/src/completions/providers/create-provider.ts
@@ -1,37 +1,74 @@
-import {
-    type AuthStatus,
-    type ClientConfigurationWithAccessToken,
-    type CodeCompletionsClient,
-    FeatureFlag,
-    type Model,
-    ModelUsage,
-    featureFlagProvider,
-    modelsService,
+import type {
+    AuthStatus,
+    ClientConfigurationWithAccessToken,
+    CodeCompletionsClient,
+    Model,
 } from '@sourcegraph/cody-shared'
 
-import * as vscode from 'vscode'
 import { logError } from '../../log'
 import { localStorage } from '../../services/LocalStorageProvider'
 import {
-    type AnthropicOptions,
     DEFAULT_PLG_ANTHROPIC_MODEL,
     createProviderConfig as createAnthropicProviderConfig,
 } from './anthropic'
 import { createProviderConfig as createExperimentalOllamaProviderConfig } from './experimental-ollama'
 import { createProviderConfig as createExperimentalOpenAICompatibleProviderConfig } from './expopenaicompatible'
-import {
-    DEEPSEEK_CODER_V2_LITE_BASE,
-    DEEPSEEK_CODER_V2_LITE_BASE_DIRECT_ROUTE,
-    FIREWORKS_DEEPSEEK_7B_LANG_ALL,
-    FIREWORKS_DEEPSEEK_7B_LANG_SPECIFIC_V0,
-    FIREWORKS_DEEPSEEK_7B_LANG_SPECIFIC_V1,
-    type FireworksOptions,
-    createProviderConfig as createFireworksProviderConfig,
-} from './fireworks'
+import { createProviderConfig as createFireworksProviderConfig } from './fireworks'
+import { getExperimentModel } from './get-experiment-model'
+import { getModelInfo } from './get-model-info'
 import { createProviderConfig as createGeminiProviderConfig } from './google'
 import { createProviderConfig as createOpenAICompatibleProviderConfig } from './openaicompatible'
 import type { ProviderConfig } from './provider'
 import { createProviderConfig as createUnstableOpenAIProviderConfig } from './unstable-openai'
+
+export async function createProviderConfig(
+    config: ClientConfigurationWithAccessToken,
+    client: CodeCompletionsClient,
+    authStatus: AuthStatus
+): Promise<ProviderConfig | null> {
+    // Resolve the provider config from the VS Code config.
+    if (config.autocompleteAdvancedProvider) {
+        return createProviderConfigHelper({
+            client,
+            authStatus,
+            modelId: config.autocompleteAdvancedModel || undefined,
+            provider: config.autocompleteAdvancedProvider,
+            config,
+        })
+    }
+
+    // Check if a user participates in autocomplete model experiments.
+    const configFromFeatureFlags = await getExperimentModel(authStatus.isDotCom)
+
+    // Use the experiment model if available.
+    if (configFromFeatureFlags) {
+        return createProviderConfigHelper({
+            client,
+            authStatus,
+            modelId: configFromFeatureFlags.model,
+            provider: configFromFeatureFlags.provider,
+            config,
+        })
+    }
+
+    const modelInfoOrError = getModelInfo(authStatus)
+
+    if (modelInfoOrError instanceof Error) {
+        logError('createProviderConfig', modelInfoOrError.message)
+        return null
+    }
+
+    const { provider, modelId, model } = modelInfoOrError
+
+    return createProviderConfigHelper({
+        client,
+        authStatus,
+        modelId,
+        model,
+        provider,
+        config,
+    })
+}
 
 interface CreateConfigHelperParams {
     client: CodeCompletionsClient
@@ -141,216 +178,4 @@ export async function createProviderConfigHelper(
             )
             return null
     }
-}
-
-async function resolveFIMModelExperimentFromFeatureFlags(): ReturnType<
-    typeof resolveConfigFromFeatureFlags
-> {
-    /**
-     * The traffic allocated to the fine-tuned-base feature flag is further split between multiple feature flag in function.
-     */
-    const [
-        fimModelControl,
-        fimModelVariant1,
-        fimModelVariant2,
-        fimModelVariant3,
-        fimModelVariant4,
-        fimModelCurrentBest,
-    ] = await Promise.all([
-        featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteFIMModelExperimentControl),
-        featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteFIMModelExperimentVariant1),
-        featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteFIMModelExperimentVariant2),
-        featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteFIMModelExperimentVariant3),
-        featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteFIMModelExperimentVariant4),
-        featureFlagProvider.evaluateFeatureFlag(
-            FeatureFlag.CodyAutocompleteFIMModelExperimentCurrentBest
-        ),
-    ])
-    if (fimModelVariant1) {
-        return { provider: 'fireworks', model: DEEPSEEK_CODER_V2_LITE_BASE_DIRECT_ROUTE }
-    }
-    if (fimModelVariant2) {
-        return { provider: 'fireworks', model: FIREWORKS_DEEPSEEK_7B_LANG_SPECIFIC_V0 }
-    }
-    if (fimModelVariant3) {
-        return { provider: 'fireworks', model: FIREWORKS_DEEPSEEK_7B_LANG_SPECIFIC_V1 }
-    }
-    if (fimModelVariant4) {
-        return { provider: 'fireworks', model: FIREWORKS_DEEPSEEK_7B_LANG_ALL }
-    }
-    if (fimModelCurrentBest) {
-        return { provider: 'fireworks', model: DEEPSEEK_CODER_V2_LITE_BASE }
-    }
-    if (fimModelControl) {
-        // Current production model
-        return { provider: 'fireworks', model: DEEPSEEK_CODER_V2_LITE_BASE }
-    }
-    // Extra free traffic - redirect to the current production model which could be different than control
-    return { provider: 'fireworks', model: DEEPSEEK_CODER_V2_LITE_BASE }
-}
-
-interface ProviderConfigFromFeatureFlags {
-    provider: string
-    model?: FireworksOptions['model'] | AnthropicOptions['model']
-}
-
-async function resolveConfigFromFeatureFlags(
-    isDotCom: boolean
-): Promise<ProviderConfigFromFeatureFlags | null> {
-    const [starCoderHybrid, claude3, fimModelExperimentFlag, deepseekV2LiteBase] = await Promise.all([
-        featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteStarCoderHybrid),
-        featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteClaude3),
-        featureFlagProvider.evaluateFeatureFlag(
-            FeatureFlag.CodyAutocompleteFIMModelExperimentBaseFeatureFlag
-        ),
-        featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteDeepseekV2LiteBase),
-    ])
-
-    // We run fine tuning experiment for VSC client only.
-    // We disable for all agent clients like the JetBrains plugin.
-    const isFinetuningExperimentDisabled = vscode.workspace
-        .getConfiguration()
-        .get<boolean>('cody.advanced.agent.running', false)
-
-    if (!isFinetuningExperimentDisabled && fimModelExperimentFlag && isDotCom) {
-        // The traffic in this feature flag is interpreted as a traffic allocated to the fine-tuned experiment.
-        return resolveFIMModelExperimentFromFeatureFlags()
-    }
-
-    if (isDotCom && deepseekV2LiteBase) {
-        return { provider: 'fireworks', model: DEEPSEEK_CODER_V2_LITE_BASE }
-    }
-
-    if (starCoderHybrid) {
-        return { provider: 'fireworks', model: 'starcoder-hybrid' }
-    }
-
-    if (claude3) {
-        return { provider: 'anthropic', model: 'anthropic/claude-3-haiku-20240307' }
-    }
-
-    return null
-}
-
-const delimiters: Record<string, string> = {
-    sourcegraph: '/',
-    'aws-bedrock': '.',
-}
-
-interface AutocompleteModelInfo {
-    provider: string
-    modelId?: string
-    model?: Model
-}
-
-function getAutocompleteModelInfo(authStatus: AuthStatus): AutocompleteModelInfo | Error {
-    const model = modelsService.getDefaultModel(ModelUsage.Autocomplete)
-
-    if (model) {
-        let provider = model.provider
-        if (model.clientSideConfig?.openAICompatible) {
-            provider = 'openaicompatible'
-        }
-        return { provider, modelId: model.id, model }
-    }
-
-    if (authStatus.configOverwrites?.provider) {
-        return parseProviderAndModel({
-            provider: authStatus.configOverwrites.provider,
-            modelId: authStatus.configOverwrites.completionModel,
-        })
-    }
-
-    // Fail with error if no `completionModel` is configured.
-    return new Error(
-        'Failed to get autocomplete model info. Please configure the `completionModel` using site configuration.'
-    )
-}
-/**
- * For certain completions providers configured in the Sourcegraph instance site config
- * the model name consists MODEL_PROVIDER and MODEL_NAME separated by a specific delimiter (see {@link delimiters}).
- *
- * This function checks if the given provider has a specific model naming format and:
- *   - if it does, parses the model name and returns the parsed provider and model names;
- *   - if it doesn't, returns the original provider and model names.
- *
- * E.g. for "sourcegraph" provider the completions model name consists of model provider and model name separated by "/".
- * So when received `{ provider: "sourcegraph", model: "anthropic/claude-instant-1" }` the expected output would be `{ provider: "anthropic", model: "claude-instant-1" }`.
- */
-function parseProviderAndModel({
-    provider,
-    modelId,
-}: {
-    provider: string
-    modelId?: string
-}): AutocompleteModelInfo | Error {
-    const delimiter = delimiters[provider]
-    if (!delimiter) {
-        return { provider, modelId }
-    }
-
-    if (modelId) {
-        const index = modelId.indexOf(delimiter)
-        const parsedProvider = modelId.slice(0, index)
-        const parsedModel = modelId.slice(index + 1)
-        if (parsedProvider && parsedModel) {
-            return { provider: parsedProvider, modelId: parsedModel }
-        }
-    }
-
-    return new Error(
-        (modelId
-            ? `Failed to parse the model name ${modelId}`
-            : `Model missing but delimiter ${delimiter} expected`) +
-            `for '${provider}' completions provider.`
-    )
-}
-
-export async function createProviderConfig(
-    config: ClientConfigurationWithAccessToken,
-    client: CodeCompletionsClient,
-    authStatus: AuthStatus
-): Promise<ProviderConfig | null> {
-    // Resolve the provider config from the VS Code config.
-    if (config.autocompleteAdvancedProvider) {
-        return createProviderConfigHelper({
-            client,
-            authStatus,
-            modelId: config.autocompleteAdvancedModel || undefined,
-            provider: config.autocompleteAdvancedProvider,
-            config,
-        })
-    }
-
-    // Check if a user participates in autocomplete model experiments.
-    const configFromFeatureFlags = await resolveConfigFromFeatureFlags(authStatus.isDotCom)
-
-    // Use the experiment model if available.
-    if (configFromFeatureFlags) {
-        return createProviderConfigHelper({
-            client,
-            authStatus,
-            modelId: configFromFeatureFlags.model,
-            provider: configFromFeatureFlags.provider,
-            config,
-        })
-    }
-
-    const modelInfoOrError = getAutocompleteModelInfo(authStatus)
-
-    if (modelInfoOrError instanceof Error) {
-        logError('createProviderConfig', modelInfoOrError.message)
-        return null
-    }
-
-    const { provider, modelId, model } = modelInfoOrError
-
-    return createProviderConfigHelper({
-        client,
-        authStatus,
-        modelId,
-        model,
-        provider,
-        config,
-    })
 }

--- a/vscode/src/completions/providers/get-experiment-model.ts
+++ b/vscode/src/completions/providers/get-experiment-model.ts
@@ -1,0 +1,100 @@
+import { FeatureFlag, featureFlagProvider } from '@sourcegraph/cody-shared'
+
+import * as vscode from 'vscode'
+import type { AnthropicOptions } from './anthropic'
+import {
+    DEEPSEEK_CODER_V2_LITE_BASE,
+    DEEPSEEK_CODER_V2_LITE_BASE_DIRECT_ROUTE,
+    FIREWORKS_DEEPSEEK_7B_LANG_ALL,
+    FIREWORKS_DEEPSEEK_7B_LANG_SPECIFIC_V0,
+    FIREWORKS_DEEPSEEK_7B_LANG_SPECIFIC_V1,
+    type FireworksOptions,
+} from './fireworks'
+
+interface ProviderConfigFromFeatureFlags {
+    provider: string
+    model?: FireworksOptions['model'] | AnthropicOptions['model']
+}
+
+export async function getExperimentModel(
+    isDotCom: boolean
+): Promise<ProviderConfigFromFeatureFlags | null> {
+    const [starCoderHybrid, claude3, fimModelExperimentFlag, deepseekV2LiteBase] = await Promise.all([
+        featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteStarCoderHybrid),
+        featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteClaude3),
+        featureFlagProvider.evaluateFeatureFlag(
+            FeatureFlag.CodyAutocompleteFIMModelExperimentBaseFeatureFlag
+        ),
+        featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteDeepseekV2LiteBase),
+    ])
+
+    // We run fine tuning experiment for VSC client only.
+    // We disable for all agent clients like the JetBrains plugin.
+    const isFinetuningExperimentDisabled = vscode.workspace
+        .getConfiguration()
+        .get<boolean>('cody.advanced.agent.running', false)
+
+    if (!isFinetuningExperimentDisabled && fimModelExperimentFlag && isDotCom) {
+        // The traffic in this feature flag is interpreted as a traffic allocated to the fine-tuned experiment.
+        return resolveFIMModelExperimentFromFeatureFlags()
+    }
+
+    if (isDotCom && deepseekV2LiteBase) {
+        return { provider: 'fireworks', model: DEEPSEEK_CODER_V2_LITE_BASE }
+    }
+
+    if (starCoderHybrid) {
+        return { provider: 'fireworks', model: 'starcoder-hybrid' }
+    }
+
+    if (claude3) {
+        return { provider: 'anthropic', model: 'anthropic/claude-3-haiku-20240307' }
+    }
+
+    return null
+}
+
+async function resolveFIMModelExperimentFromFeatureFlags(): ReturnType<typeof getExperimentModel> {
+    /**
+     * The traffic allocated to the fine-tuned-base feature flag is further split between multiple feature flag in function.
+     */
+    const [
+        fimModelControl,
+        fimModelVariant1,
+        fimModelVariant2,
+        fimModelVariant3,
+        fimModelVariant4,
+        fimModelCurrentBest,
+    ] = await Promise.all([
+        featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteFIMModelExperimentControl),
+        featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteFIMModelExperimentVariant1),
+        featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteFIMModelExperimentVariant2),
+        featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteFIMModelExperimentVariant3),
+        featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteFIMModelExperimentVariant4),
+        featureFlagProvider.evaluateFeatureFlag(
+            FeatureFlag.CodyAutocompleteFIMModelExperimentCurrentBest
+        ),
+    ])
+    if (fimModelVariant1) {
+        return { provider: 'fireworks', model: DEEPSEEK_CODER_V2_LITE_BASE_DIRECT_ROUTE }
+    }
+    if (fimModelVariant2) {
+        return { provider: 'fireworks', model: FIREWORKS_DEEPSEEK_7B_LANG_SPECIFIC_V0 }
+    }
+    if (fimModelVariant3) {
+        return { provider: 'fireworks', model: FIREWORKS_DEEPSEEK_7B_LANG_SPECIFIC_V1 }
+    }
+    if (fimModelVariant4) {
+        return { provider: 'fireworks', model: FIREWORKS_DEEPSEEK_7B_LANG_ALL }
+    }
+    if (fimModelCurrentBest) {
+        return { provider: 'fireworks', model: DEEPSEEK_CODER_V2_LITE_BASE }
+    }
+    if (fimModelControl) {
+        // Current production model
+        return { provider: 'fireworks', model: DEEPSEEK_CODER_V2_LITE_BASE }
+    }
+
+    // Extra free traffic - redirect to the current production model which could be different than control
+    return { provider: 'fireworks', model: DEEPSEEK_CODER_V2_LITE_BASE }
+}

--- a/vscode/src/completions/providers/get-model-info.ts
+++ b/vscode/src/completions/providers/get-model-info.ts
@@ -1,0 +1,70 @@
+import { type AuthStatus, type Model, ModelUsage, modelsService } from '@sourcegraph/cody-shared'
+
+interface ModelInfo {
+    provider: string
+    modelId?: string
+    model?: Model
+}
+
+export function getModelInfo(authStatus: AuthStatus): ModelInfo | Error {
+    const model = modelsService.getDefaultModel(ModelUsage.Autocomplete)
+
+    if (model) {
+        let provider = model.provider
+        if (model.clientSideConfig?.openAICompatible) {
+            provider = 'openaicompatible'
+        }
+        return { provider, modelId: model.id, model }
+    }
+
+    if (authStatus.configOverwrites?.provider) {
+        return parseProviderAndModel({
+            provider: authStatus.configOverwrites.provider,
+            modelId: authStatus.configOverwrites.completionModel,
+        })
+    }
+
+    // Fail with error if no `completionModel` is configured.
+    return new Error(
+        'Failed to get autocomplete model info. Please configure the `completionModel` using site configuration.'
+    )
+}
+
+const delimiters: Record<string, string> = {
+    sourcegraph: '/',
+    'aws-bedrock': '.',
+}
+
+/**
+ * For certain completions providers configured in the Sourcegraph instance site config
+ * the model name consists MODEL_PROVIDER and MODEL_NAME separated by a specific delimiter (see {@link delimiters}).
+ *
+ * This function checks if the given provider has a specific model naming format and:
+ *   - if it does, parses the model name and returns the parsed provider and model names;
+ *   - if it doesn't, returns the original provider and model names.
+ *
+ * E.g. for "sourcegraph" provider the completions model name consists of model provider and model name separated by "/".
+ * So when received `{ provider: "sourcegraph", model: "anthropic/claude-instant-1" }` the expected output would be `{ provider: "anthropic", model: "claude-instant-1" }`.
+ */
+function parseProviderAndModel({ provider, modelId }: ModelInfo): ModelInfo | Error {
+    const delimiter = delimiters[provider]
+    if (!delimiter) {
+        return { provider, modelId }
+    }
+
+    if (modelId) {
+        const index = modelId.indexOf(delimiter)
+        const parsedProvider = modelId.slice(0, index)
+        const parsedModel = modelId.slice(index + 1)
+        if (parsedProvider && parsedModel) {
+            return { provider: parsedProvider, modelId: parsedModel }
+        }
+    }
+
+    return new Error(
+        (modelId
+            ? `Failed to parse the model name ${modelId}`
+            : `Model missing but delimiter ${delimiter} expected`) +
+            `for '${provider}' completions provider.`
+    )
+}


### PR DESCRIPTION
- Moving code around to make `createProvider` less intimidating and easier to scan:
    - Extracted model parsing logic into a separate module
    - Extracted experiment-model resolution into a separate module.
- No functional changes.
- Part of https://linear.app/sourcegraph/issue/CODY-3409/self-hosted-models-openaicompatible-autocomplete-provider-supports

## Test plan

CI