### PR TITLE
Chat: flip order of initial context chips

### DIFF
--- a/vscode/src/chat/clientStateBroadcaster.ts
+++ b/vscode/src/chat/clientStateBroadcaster.ts
@@ -35,9 +35,6 @@ export function startClientStateBroadcaster({
     async function rawSendClientState(signal: AbortSignal | null): Promise<void> {
         const items: ContextItem[] = []
 
-        const corpusItems = getCorpusContextItemsForEditorState({ remoteSearch })
-        items.push(...corpusItems)
-
         const { input, context } = chatModel.contextWindow
         const userContextSize = context?.user ?? input
 
@@ -60,6 +57,9 @@ export function startClientStateBroadcaster({
 
             items.push(item)
         }
+
+        const corpusItems = getCorpusContextItemsForEditorState({ remoteSearch })
+        items.push(...corpusItems)
 
         postMessage({ type: 'clientState', value: { initialContext: items } })
     }

--- a/vscode/test/e2e/chat-keyboard-shortcuts.test.ts
+++ b/vscode/test/e2e/chat-keyboard-shortcuts.test.ts
@@ -27,5 +27,5 @@ test('chat keyboard shortcuts for sidebar chat', async ({ page, sidebar }) => {
     // Alt+L with a selection opens a new chat (with selection mention).
     await selectLineRangeInEditorTab(page, 3, 5)
     await page.keyboard.press('Alt+/')
-    await expect(chatSidebarInput).toContainText('buzz.ts buzz.ts:3-5 ')
+    await expect(chatSidebarInput).toContainText('buzz.ts workspace buzz.ts:3-5 ')
 })

--- a/vscode/test/e2e/initial-context.test.ts
+++ b/vscode/test/e2e/initial-context.test.ts
@@ -44,24 +44,24 @@ testWithGitRemote('initial context - file', async ({ page, sidebar, server }) =>
 
     const [, lastChatInput] = await createEmptyChatPanel(page)
 
-    await expect(chatInputMentions(lastChatInput)).toHaveText(['host.example/user/myrepo', 'main.c'])
+    await expect(chatInputMentions(lastChatInput)).toHaveText(['main.c', 'host.example/user/myrepo'])
 
     await selectLineRangeInEditorTab(page, 2, 4)
-    await expect(chatInputMentions(lastChatInput)).toHaveText(['host.example/user/myrepo', 'main.c:2-4'])
+    await expect(chatInputMentions(lastChatInput)).toHaveText(['main.c:2-4', 'host.example/user/myrepo'])
 
     await selectLineRangeInEditorTab(page, 1, 3)
-    await expect(chatInputMentions(lastChatInput)).toHaveText(['host.example/user/myrepo', 'main.c:1-3'])
+    await expect(chatInputMentions(lastChatInput)).toHaveText(['main.c:1-3', 'host.example/user/myrepo'])
 
     await openFileInEditorTab(page, 'README.md')
-    await expect(chatInputMentions(lastChatInput)).toHaveText(['host.example/user/myrepo', 'README.md'])
+    await expect(chatInputMentions(lastChatInput)).toHaveText(['README.md', 'host.example/user/myrepo'])
 
     await clickEditorTab(page, 'main.c')
-    await expect(chatInputMentions(lastChatInput)).toHaveText(['host.example/user/myrepo', 'main.c:1-3'])
+    await expect(chatInputMentions(lastChatInput)).toHaveText(['main.c:1-3', 'host.example/user/myrepo'])
 
     // After typing into the input, it no longer updates the initial context.
     await lastChatInput.press('x')
     await clickEditorTab(page, 'README.md')
-    await expect(chatInputMentions(lastChatInput)).toHaveText(['host.example/user/myrepo', 'main.c:1-3'])
+    await expect(chatInputMentions(lastChatInput)).toHaveText(['main.c:1-3', 'host.example/user/myrepo'])
 })
 
 testWithGitRemote.extend<DotcomUrlOverride>({ dotcomUrl: mockServer.SERVER_URL })(
@@ -72,7 +72,7 @@ testWithGitRemote.extend<DotcomUrlOverride>({ dotcomUrl: mockServer.SERVER_URL }
 
         const chatPanel = getChatSidebarPanel(page)
         const firstChatInput = getChatInputs(chatPanel).first()
-        await expect(chatInputMentions(firstChatInput)).toHaveText(['myrepo', 'main.c'])
+        await expect(chatInputMentions(firstChatInput)).toHaveText(['main.c', 'myrepo'])
         await firstChatInput.pressSequentially('xyz')
         await firstChatInput.press('Enter')
 


### PR DESCRIPTION
Previously, the chat input defaulted to using the chips REPO_CONTEXT FILE_CONTEXT. This PR flips the order so that REPO_CONTEXT appears after FILE_CONTEXT. The motivation for this change is to make it easier for users to disable repo context (press backspace twice). The reasoning is that users more frequently disable repo context than file context.


**Before**: observe how many keystrokes I need to perform to remove the repo chip

https://github.com/user-attachments/assets/76d6850f-4fe3-4f62-9b7b-e058a4288d54


**After**: only two backspaces needed to remove the repo chip

https://github.com/user-attachments/assets/180abcd0-f41b-4127-a8d6-c0b0e25098e2


## Test plan

* Select text
* Press option-shift-l to start new chat
* Confirm that the repo chip appears after the file chip
<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

## Changelog

* Chat: the order of the initial repo and file/selection context items has been flipped making it easier to remove repo context while keeping file/selection context.
<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
