### PR TITLE
Add 'Switch account' option to webview panel

### DIFF
--- a/vscode/webviews/tabs/AccountTab.tsx
+++ b/vscode/webviews/tabs/AccountTab.tsx
@@ -19,8 +19,18 @@ export const AccountTab: React.FC = () => {
         return null
     }
 
-    const actions = [
-        {
+    const actions: any[] = []
+
+    actions.push({
+        text: 'Switch Account...',
+        onClick: useCallback(() => {
+            if (userInfo.user.username) {
+                getVSCodeAPI().postMessage({ command: 'command', id: 'cody.auth.switchAccount' })
+            }
+        }, [userInfo]),
+    })
+    if (isDotComUser) {
+        actions.push({
             text: 'Manage Account',
             onClick: useCallback(() => {
                 if (userInfo.user.username) {
@@ -30,17 +40,17 @@ export const AccountTab: React.FC = () => {
                     getVSCodeAPI().postMessage({ command: 'links', value: uri.toString() })
                 }
             }, [userInfo]),
-        },
-        {
-            text: 'Settings',
-            onClick: () =>
-                getVSCodeAPI().postMessage({ command: 'command', id: 'cody.status-bar.interacted' }),
-        },
-        {
-            text: 'Sign Out',
-            onClick: () => getVSCodeAPI().postMessage({ command: 'auth', authKind: 'signout' }),
-        },
-    ]
+        })
+    }
+    actions.push({
+        text: 'Settings',
+        onClick: () =>
+            getVSCodeAPI().postMessage({ command: 'command', id: 'cody.status-bar.interacted' }),
+    })
+    actions.push({
+        text: 'Sign Out',
+        onClick: () => getVSCodeAPI().postMessage({ command: 'auth', authKind: 'signout' }),
+    })
 
     return (
         <div className="tw-overflow-auto tw-flex-1 tw-flex tw-flex-col tw-items-start tw-w-full tw-px-8 tw-py-6 tw-gap-6">


### PR DESCRIPTION
## Changes

1. `Manage Account`  is no longer visible for enterprise accounts
2. New option `Switch Account...` was added

## Test plan

Run with this JetBrains PR:

**For free/pro account:**
1. Go to the Account panel and check if both `Switch Account...` and `Manage Account` options are present
3. Make sure `Manage Account` redirects you to the account web management page
4. Make sure `Switch Account...`  opens native account management panel

**For enterprise account:**
1. Go to the Account panel and check if both `Switch Account...` and `Manage Account` options are present
2. Make sure `Manage Account` is not visible
3. Make sure `Switch Account...`  opens native account management panel

![image](https://github.com/user-attachments/assets/5fe32017-ddfe-46c0-8a66-d2ce523bf70e)
