### PR TITLE
Chat: fix bug where the "new chat" could crash the agent

### DIFF
--- a/vscode/src/chat/chat-view/ChatHistoryManager.ts
+++ b/vscode/src/chat/chat-view/ChatHistoryManager.ts
@@ -34,9 +34,12 @@ export class ChatHistoryManager implements vscode.Disposable {
 
     public async saveChat(
         authStatus: AuthStatus,
-        chat: SerializedChatTranscript
+        chat: SerializedChatTranscript | undefined
     ): Promise<UserLocalHistory> {
         const history = localStorage.getChatHistory(authStatus)
+        if (chat === undefined) {
+            return history
+        }
         history.chat[chat.id] = chat
         await localStorage.setChatHistory(authStatus, history)
         this.notifyChatHistoryChanged(authStatus)

--- a/vscode/src/chat/chat-view/ChatModel.ts
+++ b/vscode/src/chat/chat-view/ChatModel.ts
@@ -166,12 +166,18 @@ export class ChatModel {
     /**
      * Serializes to the transcript JSON format.
      */
-    public toSerializedChatTranscript(): SerializedChatTranscript {
+    public toSerializedChatTranscript(): SerializedChatTranscript | undefined {
         const interactions: SerializedChatInteraction[] = []
         for (let i = 0; i < this.messages.length; i += 2) {
             const humanMessage = this.messages[i]
+            if (humanMessage.error) {
+                // Ignore chats that have errors, we don't need to serialize them
+                return undefined
+            }
             const assistantMessage = this.messages.at(i + 1)
-            interactions.push(messageToSerializedChatInteraction(humanMessage, assistantMessage))
+            interactions.push(
+                messageToSerializedChatInteraction(humanMessage, assistantMessage, this.messages)
+            )
         }
         const result: SerializedChatTranscript = {
             id: this.sessionID,
@@ -190,18 +196,27 @@ export class ChatModel {
 
 function messageToSerializedChatInteraction(
     humanMessage: ChatMessage,
-    assistantMessage?: ChatMessage
+    assistantMessage: ChatMessage | undefined,
+    messages: ChatMessage[]
 ): SerializedChatInteraction {
     if (humanMessage?.speaker !== 'human') {
-        throw new Error('expected human message, got bot')
+        throw new Error(
+            `expected human message, got bot. Messages: ${JSON.stringify(messages, null, 2)}`
+        )
     }
 
     if (humanMessage.speaker !== 'human') {
-        throw new Error(`expected human message to have speaker == 'human', got ${humanMessage.speaker}`)
+        throw new Error(
+            `expected human message to have speaker == 'human', got ${
+                humanMessage.speaker
+            }. Messages: ${JSON.stringify(messages, null, 2)}`
+        )
     }
     if (assistantMessage && assistantMessage.speaker !== 'assistant') {
         throw new Error(
-            `expected bot message to have speaker == 'assistant', got ${assistantMessage.speaker}`
+            `expected bot message to have speaker == 'assistant', got ${
+                assistantMessage.speaker
+            }. Messages: ${JSON.stringify(messages, null, 2)}`
         )
     }
 


### PR DESCRIPTION
Fixes CODY-3510

While testing the Eclipse plugin, I was able to get the webview into a permanently broken state with the reproduction:

- Send message `@Hello.java explain`
- Press "New Chat" while it's streaming the reply

The root cause was that we threw an exception when trying to store the chat history with an error message. This PR works around the issue by not storing messages with errors. However, I'm not 100% satisfied with the fix because

- The process shouldn't permanently error if an exception is thrown
- I wasn't able to reproduce this in VS Code, only Eclipse and JetBrains. This indicates we're not 100% reproducing the VCS environment.

Either way, this should be a low-risk fix to merge.


## Test plan

Run reproduction steps in Eclipse.

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
