### PR TITLE
Improve Tabs UI layout for mid-size and small container width

### DIFF
--- a/lib/prompt-editor/src/mentions/mentionMenu/MentionMenuItem.tsx
+++ b/lib/prompt-editor/src/mentions/mentionMenu/MentionMenuItem.tsx
@@ -143,7 +143,7 @@ export const iconForProvider: Record<
     'https://openctx.org/npm/@openctx/provider-sourcegraph-search': SourcegraphLogo,
     'internal-linear-issues': LinearLogo, // Can't import LinearIssuesProvider due to transitive dep on vscode.
     [REMOTE_REPOSITORY_PROVIDER_URI]: FolderGitIcon,
-    [REMOTE_FILE_PROVIDER_URI]: FolderGitIcon,
+    [REMOTE_FILE_PROVIDER_URI]: FileIcon,
     [REMOTE_DIRECTORY_PROVIDER_URI]: FolderGitIcon,
     [CURRENT_REPOSITORY_DIRECTORY_PROVIDER_URI]: FolderGitIcon,
     [WEB_PROVIDER_URI]: LinkIcon,

--- a/vscode/webviews/chat/components/WelcomeMessage.tsx
+++ b/vscode/webviews/chat/components/WelcomeMessage.tsx
@@ -53,11 +53,11 @@ export const WelcomeMessage: FunctionComponent<{ IDE: CodyIDE; setView: (view: V
     const dispatchClientAction = useClientActionDispatcher()
 
     return (
-        <div className="tw-flex-1 tw-flex tw-flex-col tw-items-start tw-w-full tw-pt-4 tw-px-6 tw-gap-10 tw-transition-all">
+        <div className="tw-flex-1 tw-flex tw-flex-col tw-items-start tw-w-full tw-px-6 tw-gap-6 tw-transition-all">
             <CollapsiblePanel
                 storageKey="prompts"
                 title="Prompts & Commands"
-                className="tw-mb-6 tw-mt-2"
+                className="tw-mb-6"
                 contentClassName="!tw-p-0 tw-overflow-clip"
                 initialOpen={true}
             >

--- a/vscode/webviews/tabs/TabsBar.module.css
+++ b/vscode/webviews/tabs/TabsBar.module.css
@@ -1,18 +1,94 @@
-.tabs-container {
-    background-color: var(--vscode-sideBar-background);
-    display: inline-flex;
-    justify-content: space-between;
-}
-
-.active-tab {
-    border-color: var(--vscode-button-background);
-    color: var(--vscode-button-background);
-    border-width: 1.25px;
-}
-
 :root {
     --vscode-overlay-background: rgba(0, 0, 0, 0.5);
     --vscode-modal-background: var(--vscode-sideBar-background);
+}
+
+/*
+    Root element which only exists to use container query
+    for changing header tabs layout.
+*/
+.tabs-root {
+    container-type: inline-size;
+    container-name: tabs-container;
+}
+
+.tabs-container {
+    display: flex;
+    justify-content: space-between;
+    position: sticky;
+    padding: 0 8px;
+    border-bottom: 1px solid var(--vscode-dropdown-border);
+    background-color: var(--vscode-sideBar-background);
+}
+
+.tabs {
+    display: flex;
+    flex-shrink: 0;
+    gap: 2px;
+
+    & > * {
+        flex-shrink: 0;
+    }
+}
+
+.sub-tabs {
+    display: flex;
+    flex-shrink: 0;
+    gap: 8px;
+
+    & > * {
+        flex-shrink: 0;
+    }
+}
+
+.tab-action-label {
+    display: inline;
+}
+
+/*
+    By default if we have enough space we render tabs and its
+    sub action tabs in one row but if we don't have enough space
+    which currently is just static value we switch to two rows
+    layout (one for tab and one below for sub-actions)
+ */
+@container tabs-container (width < 750px) {
+    .tabs-container {
+        padding: 0;
+        flex-direction: column;
+    }
+
+    .tabs {
+        padding: 0 8px;
+        border-bottom: 1px solid var(--vscode-dropdown-border);
+    }
+
+    .sub-tabs {
+        padding: 0 8px;
+    }
+}
+
+/*
+    For small container turn off tabs labels completely and go back
+    to one row layout for tabs and its sub actions
+*/
+@container tabs-container (width < 475px) {
+    .tab-action-label {
+        display: none;
+    }
+
+    .tabs-container {
+        padding: 0 8px;
+        flex-direction: row;
+    }
+
+    .tabs {
+        padding: 0;
+        border-bottom: none;
+    }
+
+    .sub-tabs {
+        padding: 0;
+    }
 }
 
 .dialog {
@@ -23,17 +99,18 @@
     }
 
     &-content {
-        background-color: var(--vscode-modal-background);
-        border-radius: 6px;
-        box-shadow: hsl(206 22% 7% / 35%) 0 10px 38px -10px, hsl(206 22% 7% / 20%) 0 10px 20px -15px;
+        width: 90vw;
+        max-width: 450px;
+        max-height: 85vh;
         position: fixed;
         top: 50%;
         left: 50%;
         transform: translate(-50%, -50%);
-        width: 90vw;
-        max-width: 450px;
-        max-height: 85vh;
         padding: 25px;
+
+        border-radius: 6px;
+        background-color: var(--vscode-modal-background);
+        box-shadow: hsl(206 22% 7% / 35%) 0 10px 38px -10px, hsl(206 22% 7% / 20%) 0 10px 20px -15px;
 
         &:focus {
             outline: none;

--- a/web/CHANGELOG.md
+++ b/web/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.7.2 
+- Improve Tabs UI layout for mid-size and small container width
+
 ## 0.7.1
 - Add support for built-in confirmation UI for actions like Clear Chat History
 

--- a/web/demo/App.module.css
+++ b/web/demo/App.module.css
@@ -21,5 +21,5 @@ body {
 
 .root {
     font-size: 13px;
-    height: 100%;
+    height: 100vh;
 }

--- a/web/lib/components/CodyWebChat.tsx
+++ b/web/lib/components/CodyWebChat.tsx
@@ -229,7 +229,7 @@ const CodyWebPanel: FC<CodyWebPanelProps> = props => {
                     title: fileURL,
                     uri: URI.file(`${repository.name}/${fileURL}/`),
                     providerUri: REMOTE_DIRECTORY_PROVIDER_URI,
-                    description: ' ',
+                    description: 'Current directory',
                     source: ContextItemSource.Initial,
                     mention: {
                         data: {
@@ -237,7 +237,7 @@ const CodyWebPanel: FC<CodyWebPanelProps> = props => {
                             repoID: repository.id,
                             directoryPath: `${fileURL}/`,
                         },
-                        description: ' ',
+                        description: fileURL,
                     },
                 } as ContextItemOpenCtx)
             } else {

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sourcegraph/cody-web",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Cody standalone web app",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
Part of https://linear.app/sourcegraph/issue/SRCH-810/make-updates-to-cody-chat-ui-as-per-taiyabs-designs

This is the first PR of polishing Chat UI before the Sep Cody Web release; changes come from @taiyab's suggestions to make UI more generic and adaptive for Cody Web and other consumers who use Chat UI as a sharable webview.

This PR 
- Fixes mention icon for the remote files openctx (it was probably by mistake folder, now it's a plain file icon)
- Improves Tabs UI layout for different container widths (prior it was using media query which didn't solve problems with layout for Cody Web and JetBrains integration webview) now it renders tabs and their sub-actions in one row if there is enough space, then two rows if there is not enough space and one row with no labels for small container width 
- Fixes spacing for the welcome message collapsable panels 

## Test plan
- Manual testing on Cody Chat UI 
- I recorded a quick demo video with the new tabs' ui layout [here](https://www.loom.com/share/637425cd65e142e696fc5d8f19ea71c9?sid=5f6ce8df-b837-4bda-80c8-31157409291c)

