### PR TITLE
Bring badge UI a bit closer to the new shadcn UI

### DIFF
--- a/vscode/webviews/components/promptList/PromptList.tsx
+++ b/vscode/webviews/components/promptList/PromptList.tsx
@@ -318,7 +318,7 @@ const PromptCommandItem: FunctionComponent<{
                     <strong>{prompt.name}</strong>
                 </span>
                 {prompt.draft && (
-                    <Badge variant="outline" className="tw-text-xxs tw-mt-0.5">
+                    <Badge variant="secondary" className="tw-text-xxs tw-mt-0.5">
                         Draft
                     </Badge>
                 )}
@@ -351,7 +351,7 @@ const CodyCommandItem: FunctionComponent<{
                     {command.type === 'default' ? command.description : command.key}
                 </strong>
                 {showCommandOrigins && command.type !== 'default' && (
-                    <Badge variant="outline" className="tw-text-xxs tw-mt-0.5 tw-whitespace-nowrap">
+                    <Badge variant="secondary" className="tw-text-xxs tw-mt-0.5 tw-whitespace-nowrap">
                         {command.type === CustomCommandType.User
                             ? 'Local User Settings'
                             : 'Workspace Settings'}

--- a/vscode/webviews/components/shadcn/ui/badge.tsx
+++ b/vscode/webviews/components/shadcn/ui/badge.tsx
@@ -3,11 +3,11 @@ import type * as React from 'react'
 import { cn } from '../utils'
 
 const badgeVariants = cva(
-    'tw-inline-flex tw-items-center tw-rounded-[2px] tw-border-w-1 tw-border-solid tw-px-[5px] tw-py-0 tw-text-xs focus:tw-outline-none focus:tw-ring-2 focus:tw-ring-ring focus:tw-ring-offset-2',
+    'tw-inline-flex tw-items-center tw-rounded-[6px] tw-px-[5px] tw-py-0 tw-text-xs focus:tw-outline-none focus:tw-ring-2 focus:tw-ring-ring focus:tw-ring-offset-2',
     {
         variants: {
             variant: {
-                secondary: 'tw-border tw-border-border tw-bg-badge-background tw-text-badge-foreground',
+                secondary: 'tw-bg-badge-background tw-text-badge-foreground',
                 outline: 'tw-border tw-border-muted-transparent tw-bg-[unset] tw-text-muted-foreground',
             },
         },


### PR DESCRIPTION
Part of SRCH-876

This small change is about making our badge UI a bit closer to the new badge that we have in new designs. Note that I didn't touch colors, for Cody Web color override will happen on the Sourcegraph side anyway and I don't want to change colors for all vscode themes we have while we don't have it in our design system. 

| Before | After |
| ------- | ----- |
| <img width="411" alt="Screenshot 2024-08-28 at 21 38 28" src="https://github.com/user-attachments/assets/04330abc-3b56-4316-b10c-ed3995990b59"> | <img width="418" alt="Screenshot 2024-08-28 at 21 37 29" src="https://github.com/user-attachments/assets/6d5a1208-f175-4e61-9058-6a42e0940dbe"> | 

## Test plan
- Check that badges look fine for Cody Chat UI 

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
