### PR TITLE
Make textbox partially sticky to the bottom

### DIFF
--- a/vscode/webviews/chat/Transcript.tsx
+++ b/vscode/webviews/chat/Transcript.tsx
@@ -6,6 +6,7 @@ import {
     isAbortErrorOrSocketHangUp,
 } from '@sourcegraph/cody-shared'
 import type { PromptEditorRefAPI } from '@sourcegraph/prompt-editor'
+import { clsx } from 'clsx'
 import isEqual from 'lodash/isEqual'
 import { type FC, memo, useCallback, useMemo, useRef } from 'react'
 import type { UserAccountInfo } from '../Chat'
@@ -58,7 +59,11 @@ export const Transcript: FC<TranscriptProps> = props => {
     )
 
     return (
-        <div className="tw-px-6 tw-pt-8 tw-pb-12 tw-flex tw-flex-col tw-gap-8">
+        <div
+            className={clsx('tw-px-6 tw-pt-8 tw-pb-12 tw-flex tw-flex-col tw-gap-8', {
+                'tw-flex-grow': transcript.length > 0,
+            })}
+        >
             {interactions.map((interaction, i) => (
                 <TranscriptInteraction
                     // biome-ignore lint/suspicious/noArrayIndexKey: <explanation>
@@ -217,6 +222,7 @@ const TranscriptInteraction: FC<TranscriptInteractionProps> = memo(props => {
                 isLastInteraction={isLastInteraction}
                 isEditorInitiallyFocused={isLastInteraction}
                 editorRef={humanEditorRef}
+                className={!isFirstInteraction && isLastInteraction ? 'tw-mt-auto' : ''}
             />
             {((humanMessage.contextFiles && humanMessage.contextFiles.length > 0) ||
                 isContextLoading) && (

--- a/vscode/webviews/chat/cells/messageCell/human/editor/toolbar/SubmitButton.tsx
+++ b/vscode/webviews/chat/cells/messageCell/human/editor/toolbar/SubmitButton.tsx
@@ -21,7 +21,7 @@ export const SubmitButton: FunctionComponent<{
                         type="submit"
                         variant="ghostRoundedIcon"
                         className={clsx(
-                            'tw-relative tw-w-[20px] tw-h-[20px] tw-bg-transparent tw-group',
+                            'tw-relative tw-overflow-hidden tw-w-[20px] tw-h-[20px] tw-bg-transparent tw-group',
                             className
                         )}
                         title="Stop"

--- a/vscode/webviews/chat/cells/messageCell/human/editor/toolbar/Toolbar.tsx
+++ b/vscode/webviews/chat/cells/messageCell/human/editor/toolbar/Toolbar.tsx
@@ -90,7 +90,7 @@ export const Toolbar: FunctionComponent<{
                     className="tw-mr-1"
                 />
             </div>
-            <div className="tw-flex-1 tw-text-right">
+            <div className="tw-flex tw-justify-end tw-flex-1 tw-text-right">
                 <SubmitButton
                     onClick={onSubmitClick}
                     isEditorFocused={isEditorFocused}

--- a/vscode/webviews/components/shadcn/ui/toolbar.module.css
+++ b/vscode/webviews/components/shadcn/ui/toolbar.module.css
@@ -1,5 +1,5 @@
 :root {
-    --toolbar-button-font-size: 11px;
+    --toolbar-button-font-size: 12px;
 }
 
 .button {

--- a/web/CHANGELOG.md
+++ b/web/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.7.3 
+- Increase toolbar text to 12px 
+- Improve textbox layout (make it partially sticky)
+
 ## 0.7.2 
 - Improve Tabs UI layout for mid-size and small container width
 

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sourcegraph/cody-web",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "Cody standalone web app",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
Part of SRCH-810

This PR improves the search box position based on @taiyab suggestion. The logic is 
- When you submit your very first message the next textbox sticks to the bottom of the container 
- And it stays there if the content doesn't push it below 
- If there is enough content it pushes the textbox further 
- So the last textbox is always at the bottom of the container 

Note that this logic isn't standard sticky position; you still can scroll the whole container, and the textbox will scroll along with the content. 

The reason for this is that it is less jumpy at the beginning with your first message is resolving (textbox is in one place) but it doesn't take additional space from the actual content because it scrolls with the content


| Before | After |
| ------ | ------ | 
| <video src="https://github.com/user-attachments/assets/f683e2d0-30e8-49aa-a4e0-c98fdab40c09" />  | <video src="https://github.com/user-attachments/assets/fc89108c-76c6-4179-a6e9-850f6efb9c54" /> |

## Test plan
- VSCode Cody 
- Check that after you submit the message the next search box is sticky to the bottom of the chat container
- But this textbox is still scrollable if the content makes the whole block scroll 
