### PR TITLE
repro the hotstreak issue

### DIFF
--- a/vscode/src/completions/get-inline-completions-tests/helpers.ts
+++ b/vscode/src/completions/get-inline-completions-tests/helpers.ts
@@ -308,6 +308,7 @@ export function paramsWithInlinedCompletion(
 
 interface GetInlineCompletionResult extends Omit<ParamsResult & InlineCompletionsResult, 'logId'> {
     acceptFirstCompletionAndPressEnter(): Promise<GetInlineCompletionResult>
+    pressEnter(): Promise<GetInlineCompletionResult>
 }
 
 /**
@@ -330,12 +331,7 @@ export async function getInlineCompletionsWithInlinedChunks(
         throw new Error('This test helpers should always return a result')
     }
 
-    const acceptFirstCompletionAndPressEnter = () => {
-        let insertText = ''
-        if (result.items.length > 0) {
-            insertText = result.items[0].insertText
-        }
-
+    const pressEnter = (insertText = '') => {
         const newLineString = pressEnterAndGetIndentString(
             insertText,
             params.docContext.currentLinePrefix,
@@ -357,7 +353,11 @@ export async function getInlineCompletionsWithInlinedChunks(
         })
     }
 
-    return { ...params, ...result, acceptFirstCompletionAndPressEnter }
+    const acceptFirstCompletionAndPressEnter = () => {
+        return pressEnter(result.items[0].insertText)
+    }
+
+    return { ...params, ...result, acceptFirstCompletionAndPressEnter, pressEnter }
 }
 
 /**

--- a/vscode/src/completions/get-inline-completions-tests/helpers.ts
+++ b/vscode/src/completions/get-inline-completions-tests/helpers.ts
@@ -331,7 +331,10 @@ export async function getInlineCompletionsWithInlinedChunks(
     }
 
     const acceptFirstCompletionAndPressEnter = () => {
-        const [{ insertText }] = result.items
+        let insertText = ''
+        if (result.items.length > 0) {
+            insertText = result.items[0].insertText
+        }
 
         const newLineString = pressEnterAndGetIndentString(
             insertText,

--- a/vscode/src/completions/get-inline-completions-tests/hot-streak.test.ts
+++ b/vscode/src/completions/get-inline-completions-tests/hot-streak.test.ts
@@ -23,6 +23,33 @@ describe('[getInlineCompletions] hot streak', () => {
         vi.restoreAllMocks()
     })
 
+    describe('hot-streak issues', () => {
+        it('repro hotstreak issue when the generation is same as suffix', async () => {
+            let request = await getInlineCompletionsWithInlinedChunks(
+                `from experimental table
+                █where other_completion_provider_enabled = false
+                █
+                where other_completion_provider_enabled = false
+                and read = true
+                `,
+                {
+                    configuration: {
+                        autocompleteAdvancedProvider: 'fireworks',
+                    },
+                    delayBetweenChunks: 50,
+                }
+            )
+
+            await vi.runAllTimersAsync()
+
+            expect(request.items).toEqual([])
+
+            request = await request.acceptFirstCompletionAndPressEnter()
+            expect(request.items[0].insertText).toEqual('here other_completion_provider_enabled = false')
+            expect(request.source).toBe(InlineCompletionsResultSource.HotStreak)
+        })
+    })
+
     describe('static multiline', () => {
         it('caches hot streaks completions that are streamed in', async () => {
             const thousandConsoleLogLines = 'console.log(1)\n'.repeat(1000)

--- a/vscode/src/completions/providers/fetch-and-process-completions.ts
+++ b/vscode/src/completions/providers/fetch-and-process-completions.ts
@@ -75,12 +75,16 @@ export async function* fetchAndProcessDynamicMultilineCompletions(
             },
         }
 
-        hotStreakExtractor = createHotStreakExtractor({
-            completedCompletion,
-            ...params,
-        })
+        if (completedCompletion.insertText.length > 0) {
+            hotStreakExtractor = createHotStreakExtractor({
+                completedCompletion,
+                ...params,
+            })
 
-        yield* hotStreakExtractor.extract(rawCompletion, isFullResponse)
+            yield* hotStreakExtractor.extract(rawCompletion, isFullResponse)
+        } else {
+            abortController.abort()
+        }
     }
 
     const generatorStartTime = performance.now()


### PR DESCRIPTION
## Context
- When the generation is same as the suffix, the hot-streak logic trims the first correct. Adding the reproducer of the issue in the unit test.
- Closes https://linear.app/sourcegraph/issue/CODY-3542/autocomplete-suggestion-post-processing-check-for-additional-trimming

## Test plan
1. Added unit test to reproduce the issue
