### PR TITLE
kill RemoteSearch, unify context fetching paths

### DIFF
--- a/agent/src/cli/command-chat.ts
+++ b/agent/src/cli/command-chat.ts
@@ -236,14 +236,6 @@ export async function chatAction(options: ChatOptions): Promise<number> {
             )
             return 1
         }
-
-        await client.request('webview/receiveMessage', {
-            id,
-            message: {
-                command: 'context/choose-remote-search-repo',
-                explicitRepos: repos,
-            },
-        })
     }
 
     const contextFiles: ContextItem[] = []

--- a/vscode/src/chat/chat-view/ChatController.ts
+++ b/vscode/src/chat/chat-view/ChatController.ts
@@ -1331,19 +1331,6 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
         return this.chatModel.sessionID
     }
 
-    // TODO(beyang) kill
-    //
-    // Sets the provider up for a new chat that is not being restored from a
-    // saved session.
-    public async newSession(): Promise<void> {
-        // Set the remote search's selected repos to the workspace repo list
-        // by default.
-        // this.remoteSearch?.setRepos(
-        //     (await this.repoPicker?.getDefaultRepos()) || [],
-        //     RepoInclusion.Manual
-        // )
-    }
-
     // Attempts to restore the chat to the given sessionID, if it exists in
     // history. If it does, then saves the current session and cancels the
     // current in-progress completion. If the chat does not exist, then this
@@ -1351,18 +1338,11 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
     public async restoreSession(sessionID: string): Promise<void> {
         const oldTranscript = chatHistory.getChat(this.authProvider.getAuthStatus(), sessionID)
         if (!oldTranscript) {
-            return this.newSession()
+            return
         }
         this.cancelSubmitOrEditOperation()
         const newModel = newChatModelFromSerializedChatTranscript(oldTranscript, this.chatModel.modelID)
         this.chatModel = newModel
-
-        // // Restore per-chat enhanced context settings
-        // if (this.remoteSearch) {
-        //     const repos =
-        //         this.chatModel.getSelectedRepos() || (await this.repoPicker?.getDefaultRepos()) || []
-        //     this.remoteSearch.setRepos(repos, RepoInclusion.Manual)
-        // }
 
         this.postViewTranscript()
     }

--- a/vscode/src/chat/chat-view/ChatController.ts
+++ b/vscode/src/chat/chat-view/ChatController.ts
@@ -62,11 +62,8 @@ import {
 import type { startTokenReceiver } from '../../auth/token-receiver'
 import { getContextFileFromUri } from '../../commands/context/file-path'
 import { getContextFileFromCursor, getContextFileFromSelection } from '../../commands/context/selection'
-import { getConfigWithEndpoint, getConfiguration } from '../../configuration'
+import { getConfigWithEndpoint } from '../../configuration'
 import type { EnterpriseContextFactory } from '../../context/enterprise-context-factory'
-import { type RemoteSearch, RepoInclusion } from '../../context/remote-search'
-import type { Repo } from '../../context/repo-fetcher'
-import type { RemoteRepoPicker } from '../../context/repo-picker'
 import { resolveContextItems } from '../../editor/utils/editor-context'
 import type { VSCodeEditor } from '../../editor/vscode-editor'
 import type { ExtensionClient } from '../../extension-client'
@@ -109,7 +106,7 @@ import { CodyChatEditorViewType } from './ChatsController'
 import { type ContextRetriever, toStructuredMentions } from './ContextRetriever'
 import { InitDoer } from './InitDoer'
 import { getChatPanelTitle, openFile } from './chat-helpers'
-import { type HumanInput, getPriorityContext, resolveContext } from './context'
+import { type HumanInput, getPriorityContext } from './context'
 import { DefaultPrompter, type PromptInfo } from './prompt'
 
 interface ChatControllerOptions {
@@ -201,8 +198,6 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
     private readonly chatClient: ChatClient
 
     private readonly retrievers: AuthDependentRetrievers
-    private remoteSearch: RemoteSearch | null
-    private repoPicker: RemoteRepoPicker | null
 
     private readonly contextRetriever: ContextRetriever
 
@@ -240,14 +235,6 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
         this.extensionClient = extensionClient
         this.contextRetriever = contextRetriever
 
-        this.repoPicker = this.retrievers.enterpriseContext?.repoPicker ?? null
-        this.remoteSearch = this.retrievers.enterpriseContext?.createRemoteSearch() ?? null
-        const authSubscription = this.authProvider.changes.subscribe(() => {
-            this.repoPicker = this.retrievers.enterpriseContext?.repoPicker ?? null
-            this.remoteSearch = this.retrievers.enterpriseContext?.createRemoteSearch() ?? null
-        })
-        this.disposables.push({ dispose: () => authSubscription.unsubscribe() })
-
         this.chatModel = new ChatModel(getDefaultModelID())
 
         this.guardrails = guardrails
@@ -271,7 +258,7 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
         this.disposables.push(
             startClientStateBroadcaster({
                 authProvider,
-                getRemoteSearch: () => this.remoteSearch,
+                useRemoteSearch: this.retrievers.enterpriseContext !== null,
                 postMessage: (message: ExtensionMessage) => this.postMessage(message),
                 chatModel: this.chatModel,
             })
@@ -403,13 +390,6 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
                 })
                 break
             }
-            case 'context/choose-remote-search-repo': {
-                await this.handleChooseRemoteSearchRepo(message.explicitRepos ?? undefined)
-                break
-            }
-            case 'context/remove-remote-search-repo':
-                void this.handleRemoveRemoteSearchRepo(message.repoId)
-                break
             case 'embeddings/index':
                 void this.retrievers.localEmbeddings?.index()
                 break
@@ -702,9 +682,9 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
                 // If the legacyAddEnhancedContext param is true, then pretend there is a `@repo` or `@tree`
                 // mention and a mention of the current selection to match the old behavior.
                 if (legacyAddEnhancedContext) {
-                    const corpusMentions = await getCorpusContextItemsForEditorState({
-                        remoteSearch: this.remoteSearch,
-                    })
+                    const corpusMentions = await getCorpusContextItemsForEditorState(
+                        this.retrievers.enterpriseContext !== null
+                    )
                     mentions = mentions.concat(corpusMentions)
 
                     const selectionContext = source === 'chat' ? await getContextFileFromSelection() : []
@@ -825,34 +805,6 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
         span: Span,
         signal?: AbortSignal
     ): Promise<RankedContext[]> {
-        const legacyContextPromise = this.legacyComputeContext(
-            { text, mentions },
-            requestID,
-            editorState,
-            span,
-            signal
-        )
-        if (!vscode.workspace.getConfiguration().get<boolean>('cody.internal.serverSideContext')) {
-            return legacyContextPromise
-        }
-
-        const contextPromise = this._computeContext(
-            { text, mentions },
-            requestID,
-            editorState,
-            span,
-            signal
-        )
-        return (await Promise.all([contextPromise, legacyContextPromise])).flat()
-    }
-
-    private async _computeContext(
-        { text, mentions }: HumanInput,
-        requestID: string,
-        editorState: SerializedPromptEditorState | null,
-        span: Span,
-        signal?: AbortSignal
-    ): Promise<RankedContext[]> {
         // Remove context chips (repo, @-mentions) from the input text for context retrieval.
         const inputTextWithoutContextChips = editorState
             ? PromptString.unsafe_fromUserQuery(
@@ -884,7 +836,9 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
         )
 
         const rankedContext: RankedContext[] = []
-        if (this.contextAPIClient && retrievedContext.length > 1) {
+        const useReranker =
+            vscode.workspace.getConfiguration().get<boolean>('cody.internal.useReranker') ?? false
+        if (useReranker && this.contextAPIClient && retrievedContext.length > 1) {
             const response = await this.contextAPIClient.rankContext(
                 requestID,
                 inputTextWithoutContextChips.toString(),
@@ -930,59 +884,6 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
             ),
         })
         return rankedContext
-    }
-
-    private async legacyComputeContext(
-        { text, mentions }: HumanInput,
-        requestID: string,
-        editorState: SerializedPromptEditorState | null,
-        span: Span,
-        signal?: AbortSignal
-    ): Promise<RankedContext[]> {
-        // Fetch using legacy context retrieval
-        const config = getConfiguration()
-        const contextStrategy = config.useContext
-        span.setAttribute('strategy', contextStrategy)
-
-        // Remove context chips (repo, @-mentions) from the input text for context retrieval.
-        const inputTextWithoutContextChips = editorState
-            ? PromptString.unsafe_fromUserQuery(
-                  inputTextWithoutContextChipsFromPromptEditorState(editorState)
-              )
-            : text
-
-        const context = (
-            await Promise.all([
-                resolveContext({
-                    strategy: contextStrategy,
-                    editor: this.editor,
-                    input: { text: inputTextWithoutContextChips, mentions },
-                    providers: {
-                        localEmbeddings: this.retrievers.localEmbeddings,
-                        symf: this.retrievers.symf,
-                        remoteSearch: this.remoteSearch,
-                    },
-                    signal,
-                }),
-                getContextForChatMessage(text.toString(), signal),
-            ])
-        ).flat()
-
-        if (context.length > 0) {
-            // Run in background.
-            void this.contextAPIClient?.rankContext(
-                requestID,
-                inputTextWithoutContextChips.toString(),
-                context
-            )
-        }
-
-        return [
-            {
-                strategy: `(legacy)${contextStrategy}`,
-                items: context.flat(),
-            },
-        ]
     }
 
     private submitOrEditOperation: AbortController | undefined
@@ -1118,24 +1019,6 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
                 error: `${error}`,
             })
         }
-    }
-
-    private async handleChooseRemoteSearchRepo(explicitRepos?: Repo[]): Promise<void> {
-        if (!this.remoteSearch) {
-            return
-        }
-        const repos =
-            explicitRepos ??
-            (await this.repoPicker?.show(this.remoteSearch.getRepos(RepoInclusion.Manual)))
-
-        if (repos) {
-            this.chatModel.setSelectedRepos(repos)
-            this.remoteSearch.setRepos(repos, RepoInclusion.Manual)
-        }
-    }
-
-    private handleRemoveRemoteSearchRepo(repoId: string): void {
-        this.remoteSearch?.removeRepo(repoId)
     }
 
     // #endregion
@@ -1448,15 +1331,17 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
         return this.chatModel.sessionID
     }
 
+    // TODO(beyang) kill
+    //
     // Sets the provider up for a new chat that is not being restored from a
     // saved session.
     public async newSession(): Promise<void> {
         // Set the remote search's selected repos to the workspace repo list
         // by default.
-        this.remoteSearch?.setRepos(
-            (await this.repoPicker?.getDefaultRepos()) || [],
-            RepoInclusion.Manual
-        )
+        // this.remoteSearch?.setRepos(
+        //     (await this.repoPicker?.getDefaultRepos()) || [],
+        //     RepoInclusion.Manual
+        // )
     }
 
     // Attempts to restore the chat to the given sessionID, if it exists in
@@ -1472,12 +1357,12 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
         const newModel = newChatModelFromSerializedChatTranscript(oldTranscript, this.chatModel.modelID)
         this.chatModel = newModel
 
-        // Restore per-chat enhanced context settings
-        if (this.remoteSearch) {
-            const repos =
-                this.chatModel.getSelectedRepos() || (await this.repoPicker?.getDefaultRepos()) || []
-            this.remoteSearch.setRepos(repos, RepoInclusion.Manual)
-        }
+        // // Restore per-chat enhanced context settings
+        // if (this.remoteSearch) {
+        //     const repos =
+        //         this.chatModel.getSelectedRepos() || (await this.repoPicker?.getDefaultRepos()) || []
+        //     this.remoteSearch.setRepos(repos, RepoInclusion.Manual)
+        // }
 
         this.postViewTranscript()
     }
@@ -1622,8 +1507,7 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
                     },
                 }),
                 {
-                    mentionMenuData: query =>
-                        getMentionMenuData(query, this.remoteSearch, this.chatModel),
+                    mentionMenuData: query => getMentionMenuData(query, this.chatModel),
                     evaluatedFeatureFlag: flag => featureFlagProvider.evaluatedFeatureFlag(flag),
                     prompts: query =>
                         promiseFactoryToObservable(signal =>

--- a/vscode/src/chat/chat-view/ChatsController.ts
+++ b/vscode/src/chat/chat-view/ChatsController.ts
@@ -439,8 +439,6 @@ export class ChatsController implements vscode.Disposable {
         const chatController = this.createChatController()
         if (chatID) {
             await chatController.restoreSession(chatID)
-        } else {
-            await chatController.newSession()
         }
 
         if (panel) {

--- a/vscode/src/chat/chat-view/ContextRetriever.ts
+++ b/vscode/src/chat/chat-view/ContextRetriever.ts
@@ -120,12 +120,13 @@ async function codebaseRootsFromMentions(
     )
     const localRepoNames = treesToRepoNames.flatMap(t => t.names)
 
-    const localRepoIDs =
+    let localRepoIDs =
         localRepoNames.length === 0
             ? []
             : await graphqlClient.getRepoIds(localRepoNames, localRepoNames.length, signal)
     if (isError(localRepoIDs)) {
-        throw localRepoIDs
+        logError('codebaseRootFromMentions', 'Failed to get repo IDs from Sourcegraph', localRepoIDs)
+        localRepoIDs = []
     }
     const uriToId: { [uri: string]: string } = {}
     for (const r of localRepoIDs) {

--- a/vscode/src/chat/chat-view/context.ts
+++ b/vscode/src/chat/chat-view/context.ts
@@ -234,7 +234,7 @@ export async function searchSymf(
     })
 }
 
-async function searchEmbeddingsLocal(
+export async function searchEmbeddingsLocal(
     localEmbeddings: LocalEmbeddingsController,
     text: PromptString,
     numResults: number = NUM_CODE_RESULTS + NUM_TEXT_RESULTS

--- a/vscode/src/chat/context/chatContext.ts
+++ b/vscode/src/chat/context/chatContext.ts
@@ -22,7 +22,6 @@ import * as vscode from 'vscode'
 import { URI } from 'vscode-uri'
 import { getContextFileFromUri } from '../../commands/context/file-path'
 import { getConfiguration } from '../../configuration'
-import type { RemoteSearch } from '../../context/remote-search'
 import {
     getFileContextFiles,
     getOpenTabsContextFile,
@@ -37,7 +36,6 @@ export interface GetContextItemsTelemetry {
 
 export function getMentionMenuData(
     query: MentionQuery,
-    remoteSearch: RemoteSearch | null,
     chatModel: ChatModel
 ): Observable<MentionMenuData> {
     const source = 'chat'
@@ -74,9 +72,6 @@ export function getMentionMenuData(
                     mentionQuery: query,
                     telemetryRecorder: scopedTelemetryRecorder,
                     rangeFilter: !isCodyWeb,
-                    remoteRepositoriesNames: query.includeRemoteRepositories
-                        ? remoteSearch?.getRepos('all')?.map(repo => repo.name)
-                        : undefined,
                 },
                 signal
             ).then(items =>
@@ -122,7 +117,7 @@ interface GetContextItemsOptions {
 
 export async function getChatContextItemsForMention(
     options: GetContextItemsOptions,
-    signal?: AbortSignal
+    _?: AbortSignal
 ): Promise<ContextItem[]> {
     const MAX_RESULTS = 20
     const { mentionQuery, telemetryRecorder, remoteRepositoriesNames, rangeFilter = true } = options

--- a/vscode/src/chat/protocol.ts
+++ b/vscode/src/chat/protocol.ts
@@ -126,8 +126,6 @@ export type WebviewMessage =
       }
     | ({ command: 'edit' } & WebviewEditMessage)
     | { command: 'context/get-remote-search-repos' }
-    | { command: 'context/choose-remote-search-repo'; explicitRepos?: Repo[] | undefined | null }
-    | { command: 'context/remove-remote-search-repo'; repoId: string }
     | { command: 'embeddings/index' }
     | { command: 'insert'; text: string }
     | { command: 'newFile'; text: string }

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -222,7 +222,7 @@ const register = async (
     )
 
     const editor = new VSCodeEditor()
-    const contextRetriever = new ContextRetriever(editor, symfRunner, completionsClient)
+    const contextRetriever = new ContextRetriever(editor, symfRunner, localEmbeddings, completionsClient)
 
     const { chatsController } = registerChat(
         {

--- a/vscode/src/repository/git-extension-api.ts
+++ b/vscode/src/repository/git-extension-api.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode'
+import { logDebug } from '../log'
 import type { API, GitExtension } from './builtinGitExtension'
 
 /**
@@ -75,15 +76,19 @@ export function gitRemoteUrlsFromGitExtension(uri: vscode.Uri): string[] | undef
  * This is defined as the list of files modified since the merge base of the current
  * branch with its upstream. If the upstream doesn't exist, then we use the list of
  * files modified since the last commit.
+ *
+ * If the uri is not part of a Git repository, this method returns an empty array.
  */
 export async function gitLocallyModifiedFiles(uri: vscode.Uri, signal?: AbortSignal): Promise<string[]> {
     const repo = vscodeGitAPI?.getRepository(uri)
     if (!repo) {
-        throw new Error(`repository does not exist at ${uri.toString}`)
+        logDebug('gitLocallyModifiedFiles', 'no git repository found at', uri.toString())
+        return []
     }
 
     if (!repo.state.HEAD?.commit) {
-        throw new Error('could not get locally modified files, HEAD commit was undefined')
+        logDebug('gitLocallyModifiedFiles', 'HEAD commit was undefined for git repo at', uri.toString())
+        return []
     }
     let diffBase = repo.state.HEAD.commit
     if (repo.state.HEAD?.upstream) {

--- a/vscode/src/repository/repo-metadata-from-git-api.ts
+++ b/vscode/src/repository/repo-metadata-from-git-api.ts
@@ -1,3 +1,4 @@
+import { subscriptionDisposable } from '@sourcegraph/cody-shared'
 import * as vscode from 'vscode'
 import { WorkspaceRepoMapper } from '../context/workspace-repo-mapper'
 import { logDebug } from '../log'
@@ -25,12 +26,15 @@ export class WorkspaceReposMonitor implements vscode.Disposable {
             vscode.workspace.onDidChangeWorkspaceFolders(evt => this.onDidChangeWorkspaceFolders(evt))
         )
 
-        const subscription = authProvider.changes.subscribe(() => {
-            for (const folderURI of this.getFolderURIs()) {
-                this.addWorkspaceFolder(folderURI)
-            }
-        })
-        this.disposables.push({ dispose: () => subscription.unsubscribe() })
+        this.disposables.push(
+            subscriptionDisposable(
+                authProvider.changes.subscribe(() => {
+                    for (const folderURI of this.getFolderURIs()) {
+                        this.addWorkspaceFolder(folderURI)
+                    }
+                })
+            )
+        )
     }
 
     public dispose(): void {

--- a/web/lib/components/use-cody-agent.ts
+++ b/web/lib/components/use-cody-agent.ts
@@ -51,14 +51,7 @@ interface UseCodyWebAgentResult {
  * main and web-worker threads, see agent.client.ts for more details
  */
 export function useCodyWebAgent(input: UseCodyWebAgentInput): UseCodyWebAgentResult {
-    const {
-        serverEndpoint,
-        accessToken,
-        telemetryClientName,
-        customHeaders,
-        initialContext,
-        createAgentWorker,
-    } = input
+    const { serverEndpoint, accessToken, telemetryClientName, customHeaders, createAgentWorker } = input
 
     const activeWebviewPanelIDRef = useRef<string>('')
     const [client, setClient] = useState<AgentClient | Error | null>(null)
@@ -81,38 +74,23 @@ export function useCodyWebAgent(input: UseCodyWebAgentInput): UseCodyWebAgentRes
 
     // Special override for chat creating for Cody Web, otherwise the create new chat doesn't work
     // TODO: Move this special logic to the Cody Web agent handle "chat/web/new"
-    const createNewChat = useCallback(
-        async (agent: AgentClient | Error | null) => {
-            if (!agent || isErrorLike(agent)) {
-                return
-            }
+    const createNewChat = useCallback(async (agent: AgentClient | Error | null) => {
+        if (!agent || isErrorLike(agent)) {
+            return
+        }
 
-            const { panelId, chatId } = await agent.rpc.sendRequest<{
-                panelId: string
-                chatId: string
-            }>('chat/web/new', null)
+        const { panelId, chatId } = await agent.rpc.sendRequest<{
+            panelId: string
+            chatId: string
+        }>('chat/web/new', null)
 
-            activeWebviewPanelIDRef.current = panelId
+        activeWebviewPanelIDRef.current = panelId
 
-            await agent.rpc.sendRequest('webview/receiveMessage', {
-                id: activeWebviewPanelIDRef.current,
-                message: { chatID: chatId, command: 'restoreHistory' },
-            })
-
-            // Set initial context after we restore history so context won't be
-            // overridden by the previous chat session context
-            if (initialContext?.repository) {
-                void agent.rpc.sendRequest('webview/receiveMessage', {
-                    id: activeWebviewPanelIDRef.current,
-                    message: {
-                        command: 'context/choose-remote-search-repo',
-                        explicitRepos: [initialContext.repository],
-                    },
-                })
-            }
-        },
-        [initialContext]
-    )
+        await agent.rpc.sendRequest('webview/receiveMessage', {
+            id: activeWebviewPanelIDRef.current,
+            message: { chatID: chatId, command: 'restoreHistory' },
+        })
+    }, [])
 
     const vscodeAPI = useVSCodeAPI({ activeWebviewPanelIDRef, createNewChat, client })
 


### PR DESCRIPTION
Kills off RemoteSearch and separate code path for enterprise context. Also kills off the legacy context for PLG. Both are replaced by a unified context-fetching path that runs through the `ContextRetriever` class.

This maintains behavioral parity, as verified by this spreadsheet: https://docs.google.com/spreadsheets/d/1DWxPW6ktY4XgM_IEBw10hjpI00mqcv08-APOtpNfaAY/edit

This also inadvertently fixes a bug where we can return empty context if we receive a context result from the server with a negative end line.

## Test plan

Run against s2 and dotcom with new and old context with example queries.