### PR TITLE
Autocomplete: fix Anthropic model for PLG users

### DIFF
--- a/vscode/src/completions/providers/create-provider.test.ts
+++ b/vscode/src/completions/providers/create-provider.test.ts
@@ -33,7 +33,13 @@ const dummyCodeCompletionsClient: CodeCompletionsClient = {
     onConfigurationChange: () => undefined,
 }
 
-const dummyAuthStatus: AuthStatus = defaultAuthStatus
+const dummyAuthStatus: AuthStatus = {
+    ...defaultAuthStatus,
+    configOverwrites: {
+        provider: 'sourcegraph',
+        completionModel: 'fireworks/starcoder-hybrid',
+    },
+}
 
 graphqlClient.setConfig({} as unknown as GraphQLAPIClientConfig)
 
@@ -53,7 +59,7 @@ describe('createProviderConfig', () => {
                         'nasa-ai' as ClientConfiguration['autocompleteAdvancedProvider'],
                 }),
                 dummyCodeCompletionsClient,
-                dummyAuthStatus
+                defaultAuthStatus
             )
             expect(provider).toBeNull()
         })
@@ -67,7 +73,7 @@ describe('createProviderConfig', () => {
                         null as ClientConfiguration['autocompleteAdvancedProvider'],
                 }),
                 dummyCodeCompletionsClient,
-                dummyAuthStatus
+                defaultAuthStatus
             )
             expect(provider).toBeNull()
         })

--- a/vscode/src/completions/providers/create-provider.ts
+++ b/vscode/src/completions/providers/create-provider.ts
@@ -141,15 +141,23 @@ export async function createProviderConfigHelper(
         }
         case 'aws-bedrock':
         case 'anthropic': {
+            function getAnthropicModel() {
+                // Always use the default PLG model on DotCom
+                if (authStatus.isDotCom) {
+                    return DEFAULT_PLG_ANTHROPIC_MODEL
+                }
+
+                // Only pass through the upstream-defined model if we're using Cody Gateway
+                if (authStatus.configOverwrites?.provider === 'sourcegraph') {
+                    return authStatus.configOverwrites.completionModel
+                }
+
+                return undefined
+            }
+
             return createAnthropicProviderConfig({
                 client,
-                // Only pass through the upstream-defined model if we're using Cody Gateway
-                model:
-                    authStatus.configOverwrites?.provider === 'sourcegraph'
-                        ? authStatus.configOverwrites.completionModel
-                        : authStatus.isDotCom
-                          ? DEFAULT_PLG_ANTHROPIC_MODEL
-                          : undefined,
+                model: getAnthropicModel(),
             })
         }
         case 'google': {


### PR DESCRIPTION
- This fixes the issue of using the `codeCompletion` model from site configuration with the Anthropic provider for PLG users. In the current state of things, we should always default to the `DEFAULT_PLG_ANTHROPIC_MODEL` on DotCom.
- Closes https://github.com/sourcegraph/cody/issues/4639
- Follow up: we should deprecate `cody.autocomplete.advanced.*` settings to avoid such cases and ensure that Cody users always use the recommended setup. 

## Test plan

Updated unit tests to account for this case.