### PR TITLE
Correct typo 3.3 -> 3.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ See [cody.dev](https://about.sourcegraph.com/cody?utm_source=github.com&utm_medi
 - **Autocomplete:** Cody makes single-line and multi-line suggestions as you type, speeding up your coding and shortcutting the need for you to hunt down function and variable names as you type.
 - **Inline Edit:** Ask Cody to fix or refactor code from anywhere in a file.
 - **Commands:** Cody has quick commands for common actions. Simply highlight a code snippet and run a command, like “Document code,” “Explain code,” or “Generate Unit Tests.”
-- **Swappable LLMs:** Support for Anthropic Claude 3.3 Sonnet, OpenAI GPT-4o, Mixtral, Gemini 1.5, and more.
+- **Swappable LLMs:** Support for Anthropic Claude 3.5 Sonnet, OpenAI GPT-4o, Mixtral, Gemini 1.5, and more.
   - **Free LLM usage included** Cody Free gives you access to Anthropic Claude 3.5 Sonnet and other models. It's available for individual devs on both personal and work code, subject to reasonable per-user rate limits ([more info](#usage)).
 
 ## Demos


### PR DESCRIPTION
Claude 3.5 Sonnet, not Claude 3.3 Sonnet

## Test Plan

CI, this is a docs only change


