### PR TITLE
Temporarily do not show symbols provider for jetbrains

### DIFF
--- a/lib/shared/src/index.ts
+++ b/lib/shared/src/index.ts
@@ -282,6 +282,7 @@ export {
     type ContextItemProps,
     allMentionProvidersMetadata,
     webMentionProvidersMetadata,
+    jetbrainsMentionProvidersMetadata,
     openCtxProviderMetadata,
     FILE_CONTEXT_MENTION_PROVIDER,
     SYMBOL_CONTEXT_MENTION_PROVIDER,

--- a/lib/shared/src/mentions/api.ts
+++ b/lib/shared/src/mentions/api.ts
@@ -60,6 +60,11 @@ export function allMentionProvidersMetadata(): Observable<ContextMentionProvider
     ])
 }
 
+// TODO: CODY-3047 - Implement symbol context (@#) in JetBrains
+export function jetbrainsMentionProvidersMetadata(): Observable<ContextMentionProviderMetadata[]> {
+    return openCtxMentionProviders().map(providers => [FILE_CONTEXT_MENTION_PROVIDER, ...providers])
+}
+
 // Cody Web providers don't include standard file provider since
 // it uses openctx remote file provider instead
 export function webMentionProvidersMetadata(): Observable<ContextMentionProviderMetadata[]> {

--- a/vscode/src/chat/context/chatContext.ts
+++ b/vscode/src/chat/context/chatContext.ts
@@ -12,6 +12,7 @@ import {
     allMentionProvidersMetadata,
     combineLatest,
     isAbortError,
+    jetbrainsMentionProvidersMetadata,
     openCtx,
     promiseFactoryToObservable,
     telemetryRecorder,
@@ -65,6 +66,8 @@ export function getMentionMenuData(
     }
 
     const isCodyWeb = getConfiguration().agentIDE === CodyIDE.Web
+    const isJetBrains = getConfiguration().agentIDE === CodyIDE.JetBrains
+
     const { input, context } = chatModel.contextWindow
 
     try {
@@ -88,11 +91,14 @@ export function getMentionMenuData(
         )
 
         const queryLower = query.text.toLowerCase()
+
         const providers = (
             query.provider === null
                 ? isCodyWeb
                     ? webMentionProvidersMetadata()
-                    : allMentionProvidersMetadata()
+                    : isJetBrains
+                      ? jetbrainsMentionProvidersMetadata()
+                      : allMentionProvidersMetadata()
                 : Observable.of([])
         ).pipe(map(providers => providers.filter(p => p.title.toLowerCase().includes(queryLower))))
 


### PR DESCRIPTION
Fixes CODY-3554

## Test plan

1. Launch JetBrains instance with `CODY_DIR` pointing to cody repo with those changes checked out.
2. Make sure no `Symbols` provider is visible in chat context.
