### PR TITLE
Focus textbox after we submit a follow-up message

### DIFF
--- a/vscode/webviews/chat/Transcript.tsx
+++ b/vscode/webviews/chat/Transcript.tsx
@@ -266,6 +266,7 @@ export function focusLastHumanMessageEditor(): void {
     const elements = document.querySelectorAll<HTMLElement>('[data-lexical-editor]')
     const lastEditor = elements.item(elements.length - 1)
     lastEditor?.focus()
+    lastEditor?.scrollIntoView()
 }
 
 export function editHumanMessage(

--- a/vscode/webviews/components/ScrollDown.tsx
+++ b/vscode/webviews/components/ScrollDown.tsx
@@ -5,7 +5,7 @@ import { Button } from './shadcn/ui/button'
 const MARGIN = 200 /* px */
 
 interface Scroller {
-    root: HTMLElement | Window
+    root: HTMLElement
     getObserveElement: () => Element
     getScrollTop: () => number
     getScrollHeight: () => number
@@ -38,25 +38,26 @@ export const ScrollDown: FC<ScrollDownProps> = props => {
     const scrollerAPI = useMemo(() => createScrollerAPI(scrollableParent), [scrollableParent])
 
     useEffect(() => {
-        function handleScroll() {
-            const scrollPosition = scrollerAPI.getScrollTop()
+        function calculateScrollState() {
+            const scrollTop = scrollerAPI.getScrollTop()
             const scrollHeight = scrollerAPI.getScrollHeight()
             const clientHeight = scrollerAPI.getClientHeight()
-            setCanScrollDown(scrollPosition + clientHeight < scrollHeight - MARGIN)
+
+            setCanScrollDown(scrollTop + clientHeight < scrollHeight - MARGIN)
         }
-        handleScroll()
-        scrollerAPI.root.addEventListener('scroll', handleScroll)
-        scrollerAPI.root.addEventListener('resize', handleScroll)
+
+        calculateScrollState()
 
         const resizeObserver = new ResizeObserver(() => {
-            handleScroll()
+            calculateScrollState()
         })
+
         resizeObserver.observe(scrollerAPI.getObserveElement())
+        scrollerAPI.root.addEventListener('scroll', calculateScrollState)
 
         return () => {
-            scrollerAPI.root.removeEventListener('scroll', handleScroll)
-            scrollerAPI.root.removeEventListener('resize', handleScroll)
             resizeObserver.disconnect()
+            scrollerAPI.root.removeEventListener('scroll', calculateScrollState)
         }
     }, [scrollerAPI])
 
@@ -70,13 +71,8 @@ export const ScrollDown: FC<ScrollDownProps> = props => {
 
     return canScrollDown ? (
         <div className="tw-sticky tw-bottom-0 tw-w-full tw-text-center tw-py-4">
-            <Button
-                variant="outline"
-                size="lg"
-                onClick={onClick}
-                className="tw-py-3 hover:tw-bg-primary-hover"
-            >
-                <ArrowDownIcon size={24} />
+            <Button variant="outline" onClick={onClick} className="tw-py-3 hover:tw-bg-primary-hover">
+                <ArrowDownIcon size={16} /> Skip to end
             </Button>
         </div>
     ) : null


### PR DESCRIPTION
Part of SRCH-810

This PR updates scroll-down button styles and makes that after you send a follow-up message we focus and scroll to view the last textbox element

Visual change has done by @taiyab designs 

| Before | After |
| ----- | ------ |
| <img width="369" alt="Screenshot 2024-08-29 at 15 36 39" src="https://github.com/user-attachments/assets/5e375cf4-f81a-4878-9020-b8671edbdb95">  | <img width="379" alt="Screenshot 2024-08-29 at 15 36 30" src="https://github.com/user-attachments/assets/0d33a4c7-d9e8-4639-af05-c9f3a488c2ce"> |


## Test plan
- Manual checks on Cody Chat UI 


