### PR TITLE
Add zero state for history tab

### DIFF
--- a/vscode/webviews/CodyPanel.tsx
+++ b/vscode/webviews/CodyPanel.tsx
@@ -95,7 +95,15 @@ export const CodyPanel: FunctionComponent<
                         setView={setView}
                     />
                 )}
-                {view === View.History && <HistoryTab userHistory={userHistory} />}
+                {view === View.History && (
+                    <HistoryTab
+                        IDE={config.agentIDE || CodyIDE.VSCode}
+                        setView={setView}
+                        webviewType={config.webviewType}
+                        multipleWebviewsEnabled={config.multipleWebviewsEnabled}
+                        userHistory={userHistory}
+                    />
+                )}
                 {view === View.Prompts && <PromptsTab setView={setView} />}
                 {view === View.Account && <AccountTab />}
                 {view === View.Settings && <SettingsTab />}

--- a/vscode/webviews/tabs/HistoryTab.story.tsx
+++ b/vscode/webviews/tabs/HistoryTab.story.tsx
@@ -1,3 +1,4 @@
+import { CodyIDE } from '@sourcegraph/cody-shared'
 import type { Meta, StoryObj } from '@storybook/react'
 import { VSCodeStandaloneComponent } from '../storybook/VSCodeStoryDecorator'
 import { HistoryTab } from './HistoryTab'
@@ -19,6 +20,8 @@ type Story = StoryObj<typeof HistoryTab>
 
 export const Empty: Story = {
     args: {
+        IDE: CodyIDE.VSCode,
+        setView: () => {},
         userHistory: [],
     },
 }

--- a/vscode/webviews/tabs/TabsBar.tsx
+++ b/vscode/webviews/tabs/TabsBar.tsx
@@ -25,6 +25,7 @@ import { useConfig } from '../utils/useConfig'
 
 import { Button } from '../components/shadcn/ui/button'
 import styles from './TabsBar.module.css'
+import { getCreateNewChatCommand } from './utils'
 
 interface TabsBarProps {
     IDE: CodyIDE
@@ -299,12 +300,11 @@ function useTabs(input: Pick<TabsBarProps, 'IDE' | 'onDownloadChatClick'>): TabC
                                     </>
                                 ),
                                 Icon: MessageSquarePlusIcon,
-                                command:
-                                    IDE === CodyIDE.Web
-                                        ? 'cody.chat.new'
-                                        : webviewType === 'sidebar' || !multipleWebviewsEnabled
-                                          ? 'cody.chat.newPanel'
-                                          : 'cody.chat.newEditorPanel',
+                                command: getCreateNewChatCommand({
+                                    IDE,
+                                    webviewType,
+                                    multipleWebviewsEnabled,
+                                }),
                             },
                             multipleWebviewsEnabled
                                 ? {

--- a/vscode/webviews/tabs/utils.ts
+++ b/vscode/webviews/tabs/utils.ts
@@ -1,0 +1,25 @@
+import { CodyIDE } from '@sourcegraph/cody-shared'
+import type { WebviewType } from '../../src/chat/protocol'
+
+interface NewChatCommandInput {
+    IDE: CodyIDE
+    // Type/location of the current webview.
+    webviewType?: WebviewType | undefined | null
+    // Whether support running multiple webviews (e.g. sidebar w/ multiple editor panels).
+    multipleWebviewsEnabled?: boolean | undefined | null
+}
+
+/**
+ * Returns a proper command for vscode API, different IDE and enviroments where we
+ * run Cody Chat UI require different commands at the moment. This utility hides
+ * complexity about exact command that would be run.
+ */
+export function getCreateNewChatCommand(options: NewChatCommandInput): string {
+    const { IDE, webviewType, multipleWebviewsEnabled } = options
+
+    return IDE === CodyIDE.Web
+        ? 'cody.chat.new'
+        : webviewType === 'sidebar' || !multipleWebviewsEnabled
+          ? 'cody.chat.newPanel'
+          : 'cody.chat.newEditorPanel'
+}


### PR DESCRIPTION
Part of SRCH-810

This PR adds zero state for the history tab by @taiyab designs listed [here](https://www.figma.com/design/f078wFMKsIOaEwj7Iwj5xy/⬜%EF%B8%8F--Unified-Cody?node-id=5081-155750&node-type=FRAME&t=E311cWtgz19OTYip-0) 

Note that colors might be different compared to what we have in Figma since Figma designs operate with updated design components (we will update our component implementation after the release), for now, I used the standard UI that we have in the current cody chat implementation

<img width="600" alt="Screenshot 2024-08-29 at 17 10 45" src="https://github.com/user-attachments/assets/96674e3f-09ba-4487-b405-8899145db13c">


## Test plan
- Go to the history tab
- Remove all chats
- Check that zero state look good and start a new chat button works as expected

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
