### PR TITLE
Hitesh/vscode 1.32.6 patch release

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -3,6 +3,12 @@
 This is a log of all notable changes to Cody for VS Code. [Unreleased] changes are included in the nightly pre-release builds.
 
 
+## 1.32.6
+
+### Added
+- Autocomplete: Add direct routing for experimental models. [pull/5356](https://github.com/sourcegraph/cody/pull/5356)
+- Autocomplete: Split create provider into seperate files. [pull/5394](https://github.com/sourcegraph/cody/pull/5394)
+
 ## 1.32.5
 
 ### Fixed

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -3,7 +3,7 @@
   "name": "cody-ai",
   "private": true,
   "displayName": "Cody: AI Coding Assistant with Autocomplete & Chat",
-  "version": "1.32.5",
+  "version": "1.32.6",
   "publisher": "sourcegraph",
   "license": "Apache-2.0",
   "icon": "resources/cody.png",

--- a/vscode/src/completions/providers/fireworks.ts
+++ b/vscode/src/completions/providers/fireworks.ts
@@ -190,7 +190,14 @@ class FireworksProvider extends Provider {
     }
 
     private checkIfDirectRouteShouldBeEnabled(): boolean {
-        return this.model === DEEPSEEK_CODER_V2_LITE_BASE_DIRECT_ROUTE
+        const directRouteModels = [
+            DEEPSEEK_CODER_V2_LITE_BASE_DIRECT_ROUTE,
+            DEEPSEEK_CODER_V2_LITE_BASE_WINDOW_4096,
+            FIREWORKS_DEEPSEEK_7B_LANG_ALL,
+            FIREWORKS_DEEPSEEK_7B_LANG_SPECIFIC_V0,
+            FIREWORKS_DEEPSEEK_7B_LANG_SPECIFIC_V1,
+        ]
+        return directRouteModels.includes(this.model)
     }
 
     public generateCompletions(

--- a/vscode/src/completions/providers/get-experiment-model.ts
+++ b/vscode/src/completions/providers/get-experiment-model.ts
@@ -1,0 +1,100 @@
+import { FeatureFlag, featureFlagProvider } from '@sourcegraph/cody-shared'
+
+import * as vscode from 'vscode'
+import type { AnthropicOptions } from './anthropic'
+import {
+    DEEPSEEK_CODER_V2_LITE_BASE,
+    DEEPSEEK_CODER_V2_LITE_BASE_DIRECT_ROUTE,
+    FIREWORKS_DEEPSEEK_7B_LANG_ALL,
+    FIREWORKS_DEEPSEEK_7B_LANG_SPECIFIC_V0,
+    FIREWORKS_DEEPSEEK_7B_LANG_SPECIFIC_V1,
+    type FireworksOptions,
+} from './fireworks'
+
+interface ProviderConfigFromFeatureFlags {
+    provider: string
+    model?: FireworksOptions['model'] | AnthropicOptions['model']
+}
+
+export async function getExperimentModel(
+    isDotCom: boolean
+): Promise<ProviderConfigFromFeatureFlags | null> {
+    const [starCoderHybrid, claude3, fimModelExperimentFlag, deepseekV2LiteBase] = await Promise.all([
+        featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteStarCoderHybrid),
+        featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteClaude3),
+        featureFlagProvider.evaluateFeatureFlag(
+            FeatureFlag.CodyAutocompleteFIMModelExperimentBaseFeatureFlag
+        ),
+        featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteDeepseekV2LiteBase),
+    ])
+
+    // We run fine tuning experiment for VSC client only.
+    // We disable for all agent clients like the JetBrains plugin.
+    const isFinetuningExperimentDisabled = vscode.workspace
+        .getConfiguration()
+        .get<boolean>('cody.advanced.agent.running', false)
+
+    if (!isFinetuningExperimentDisabled && fimModelExperimentFlag && isDotCom) {
+        // The traffic in this feature flag is interpreted as a traffic allocated to the fine-tuned experiment.
+        return resolveFIMModelExperimentFromFeatureFlags()
+    }
+
+    if (isDotCom && deepseekV2LiteBase) {
+        return { provider: 'fireworks', model: DEEPSEEK_CODER_V2_LITE_BASE }
+    }
+
+    if (starCoderHybrid) {
+        return { provider: 'fireworks', model: 'starcoder-hybrid' }
+    }
+
+    if (claude3) {
+        return { provider: 'anthropic', model: 'anthropic/claude-3-haiku-20240307' }
+    }
+
+    return null
+}
+
+async function resolveFIMModelExperimentFromFeatureFlags(): ReturnType<typeof getExperimentModel> {
+    /**
+     * The traffic allocated to the fine-tuned-base feature flag is further split between multiple feature flag in function.
+     */
+    const [
+        fimModelControl,
+        fimModelVariant1,
+        fimModelVariant2,
+        fimModelVariant3,
+        fimModelVariant4,
+        fimModelCurrentBest,
+    ] = await Promise.all([
+        featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteFIMModelExperimentControl),
+        featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteFIMModelExperimentVariant1),
+        featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteFIMModelExperimentVariant2),
+        featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteFIMModelExperimentVariant3),
+        featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteFIMModelExperimentVariant4),
+        featureFlagProvider.evaluateFeatureFlag(
+            FeatureFlag.CodyAutocompleteFIMModelExperimentCurrentBest
+        ),
+    ])
+    if (fimModelVariant1) {
+        return { provider: 'fireworks', model: DEEPSEEK_CODER_V2_LITE_BASE_DIRECT_ROUTE }
+    }
+    if (fimModelVariant2) {
+        return { provider: 'fireworks', model: FIREWORKS_DEEPSEEK_7B_LANG_SPECIFIC_V0 }
+    }
+    if (fimModelVariant3) {
+        return { provider: 'fireworks', model: FIREWORKS_DEEPSEEK_7B_LANG_SPECIFIC_V1 }
+    }
+    if (fimModelVariant4) {
+        return { provider: 'fireworks', model: FIREWORKS_DEEPSEEK_7B_LANG_ALL }
+    }
+    if (fimModelCurrentBest) {
+        return { provider: 'fireworks', model: DEEPSEEK_CODER_V2_LITE_BASE }
+    }
+    if (fimModelControl) {
+        // Current production model
+        return { provider: 'fireworks', model: DEEPSEEK_CODER_V2_LITE_BASE }
+    }
+
+    // Extra free traffic - redirect to the current production model which could be different than control
+    return { provider: 'fireworks', model: DEEPSEEK_CODER_V2_LITE_BASE }
+}

--- a/vscode/src/completions/providers/get-experiment-model.ts
+++ b/vscode/src/completions/providers/get-experiment-model.ts
@@ -5,6 +5,7 @@ import type { AnthropicOptions } from './anthropic'
 import {
     DEEPSEEK_CODER_V2_LITE_BASE,
     DEEPSEEK_CODER_V2_LITE_BASE_DIRECT_ROUTE,
+    DEEPSEEK_CODER_V2_LITE_BASE_WINDOW_4096,
     FIREWORKS_DEEPSEEK_7B_LANG_ALL,
     FIREWORKS_DEEPSEEK_7B_LANG_SPECIFIC_V0,
     FIREWORKS_DEEPSEEK_7B_LANG_SPECIFIC_V1,
@@ -88,7 +89,7 @@ async function resolveFIMModelExperimentFromFeatureFlags(): ReturnType<typeof ge
         return { provider: 'fireworks', model: FIREWORKS_DEEPSEEK_7B_LANG_ALL }
     }
     if (fimModelCurrentBest) {
-        return { provider: 'fireworks', model: DEEPSEEK_CODER_V2_LITE_BASE }
+        return { provider: 'fireworks', model: DEEPSEEK_CODER_V2_LITE_BASE_WINDOW_4096 }
     }
     if (fimModelControl) {
         // Current production model

--- a/vscode/src/completions/providers/get-model-info.ts
+++ b/vscode/src/completions/providers/get-model-info.ts
@@ -1,0 +1,70 @@
+import { type AuthStatus, type Model, ModelUsage, modelsService } from '@sourcegraph/cody-shared'
+
+interface ModelInfo {
+    provider: string
+    modelId?: string
+    model?: Model
+}
+
+export function getModelInfo(authStatus: AuthStatus): ModelInfo | Error {
+    const model = modelsService.getDefaultModel(ModelUsage.Autocomplete)
+
+    if (model) {
+        let provider = model.provider
+        if (model.clientSideConfig?.openAICompatible) {
+            provider = 'openaicompatible'
+        }
+        return { provider, modelId: model.id, model }
+    }
+
+    if (authStatus.configOverwrites?.provider) {
+        return parseProviderAndModel({
+            provider: authStatus.configOverwrites.provider,
+            modelId: authStatus.configOverwrites.completionModel,
+        })
+    }
+
+    // Fail with error if no `completionModel` is configured.
+    return new Error(
+        'Failed to get autocomplete model info. Please configure the `completionModel` using site configuration.'
+    )
+}
+
+const delimiters: Record<string, string> = {
+    sourcegraph: '/',
+    'aws-bedrock': '.',
+}
+
+/**
+ * For certain completions providers configured in the Sourcegraph instance site config
+ * the model name consists MODEL_PROVIDER and MODEL_NAME separated by a specific delimiter (see {@link delimiters}).
+ *
+ * This function checks if the given provider has a specific model naming format and:
+ *   - if it does, parses the model name and returns the parsed provider and model names;
+ *   - if it doesn't, returns the original provider and model names.
+ *
+ * E.g. for "sourcegraph" provider the completions model name consists of model provider and model name separated by "/".
+ * So when received `{ provider: "sourcegraph", model: "anthropic/claude-instant-1" }` the expected output would be `{ provider: "anthropic", model: "claude-instant-1" }`.
+ */
+function parseProviderAndModel({ provider, modelId }: ModelInfo): ModelInfo | Error {
+    const delimiter = delimiters[provider]
+    if (!delimiter) {
+        return { provider, modelId }
+    }
+
+    if (modelId) {
+        const index = modelId.indexOf(delimiter)
+        const parsedProvider = modelId.slice(0, index)
+        const parsedModel = modelId.slice(index + 1)
+        if (parsedProvider && parsedModel) {
+            return { provider: parsedProvider, modelId: parsedModel }
+        }
+    }
+
+    return new Error(
+        (modelId
+            ? `Failed to parse the model name ${modelId}`
+            : `Model missing but delimiter ${delimiter} expected`) +
+            `for '${provider}' completions provider.`
+    )
+}


### PR DESCRIPTION
## Context
Cherry-pick
- Autocomplete: Add direct routing for experimental models. [pull/5356](https://github.com/sourcegraph/cody/pull/5356)
- Autocomplete: Split create provider into seperate files. [pull/5394](https://github.com/sourcegraph/cody/pull/5394)

## Test plan
updated version and changelog