### PR TITLE
Use singletons for most services

### DIFF
--- a/agent/src/agent.ts
+++ b/agent/src/agent.ts
@@ -404,7 +404,7 @@ export class Agent extends MessageHandler implements ExtensionClient {
                 )
             }
             if (clientInfo.capabilities?.ignore === 'enabled') {
-                contextFiltersProvider.onContextFiltersChanged(() => {
+                contextFiltersProvider.instance!.onContextFiltersChanged(() => {
                     // Forward policy change notifications to the client.
                     this.notify('ignore/didChange', null)
                 })
@@ -1413,14 +1413,14 @@ export class Agent extends MessageHandler implements ExtensionClient {
 
         this.registerAuthenticatedRequest('ignore/test', async ({ uri: uriString }) => {
             const uri = vscode.Uri.parse(uriString)
-            const isIgnored = await contextFiltersProvider.isUriIgnored(uri)
+            const isIgnored = await contextFiltersProvider.instance!.isUriIgnored(uri)
             return {
                 policy: isIgnored ? 'ignore' : 'use',
             } as const
         })
 
         this.registerAuthenticatedRequest('testing/ignore/overridePolicy', async contextFilters => {
-            contextFiltersProvider.setTestingContextFilters(contextFilters)
+            contextFiltersProvider.instance!.setTestingContextFilters(contextFilters)
             return null
         })
     }

--- a/agent/src/agent.ts
+++ b/agent/src/agent.ts
@@ -1107,7 +1107,7 @@ export class Agent extends MessageHandler implements ExtensionClient {
 
         this.registerAuthenticatedRequest('editTask/retry', params => {
             const instruction = PromptString.unsafe_fromUserQuery(params.instruction)
-            const models = getModelOptionItems(modelsService.getModels(ModelUsage.Edit), true)
+            const models = getModelOptionItems(modelsService.instance!.getModels(ModelUsage.Edit), true)
             const previousInput: QuickPickInput = {
                 instruction: instruction,
                 userContextFiles: [],
@@ -1218,7 +1218,7 @@ export class Agent extends MessageHandler implements ExtensionClient {
         // TODO: JetBrains no longer uses this, consider deleting it.
         this.registerAuthenticatedRequest('chat/restore', async ({ modelID, messages, chatID }) => {
             const authStatus = await vscode.commands.executeCommand<AuthStatus>('cody.auth.status')
-            modelID ??= modelsService.getDefaultChatModel() ?? ''
+            modelID ??= modelsService.instance!.getDefaultChatModel() ?? ''
             const chatMessages = messages?.map(PromptString.unsafe_deserializeChatMessage) ?? []
             const chatModel = new ChatModel(modelID, chatID, chatMessages)
             await chatHistory.saveChat(authStatus, chatModel.toSerializedChatTranscript())
@@ -1231,7 +1231,7 @@ export class Agent extends MessageHandler implements ExtensionClient {
         })
 
         this.registerAuthenticatedRequest('chat/models', async ({ modelUsage }) => {
-            const models = modelsService.getModels(modelUsage)
+            const models = modelsService.instance!.getModels(modelUsage)
             return { models }
         })
 

--- a/agent/src/agent.ts
+++ b/agent/src/agent.ts
@@ -1369,7 +1369,7 @@ export class Agent extends MessageHandler implements ExtensionClient {
         })
 
         this.registerAuthenticatedRequest('featureFlags/getFeatureFlag', async ({ flagName }) => {
-            return featureFlagProvider.evaluateFeatureFlag(
+            return featureFlagProvider.instance!.evaluateFeatureFlag(
                 FeatureFlag[flagName as keyof typeof FeatureFlag]
             )
         })

--- a/agent/src/cli/command-bench/command-bench.ts
+++ b/agent/src/cli/command-bench/command-bench.ts
@@ -360,7 +360,7 @@ async function evaluateWorkspace(options: CodyBenchOptions, recordingDirectory: 
         // There is no VSC setting yet to configure the base edit model. Users
         // can only modify this setting by changing it through the quickpick
         // menu in VSC.
-        const provider = modelsService.getModelByIDSubstringOrError(editModel)
+        const provider = modelsService.instance!.getModelByIDSubstringOrError(editModel)
         baseGlobalState.editModel = provider.id
     }
 

--- a/agent/src/edit.test.ts
+++ b/agent/src/edit.test.ts
@@ -16,7 +16,7 @@ describe('Edit', () => {
     })
 
     beforeAll(async () => {
-        modelsService.setModels(getDotComDefaultModels())
+        modelsService.instance!.setModels(getDotComDefaultModels())
         await workspace.beforeAll()
         await client.beforeAll()
         await client.request('command/execute', { command: 'cody.search.index-update' })
@@ -54,7 +54,9 @@ describe('Edit', () => {
         await client.openFile(uri)
         const task = await client.request('editCommands/code', {
             instruction: 'Add types to these props. Introduce new interfaces as necessary',
-            model: modelsService.getModelByIDSubstringOrError('anthropic/claude-3-5-sonnet-20240620').id,
+            model: modelsService.instance!.getModelByIDSubstringOrError(
+                'anthropic/claude-3-5-sonnet-20240620'
+            ).id,
         })
         await client.acceptEditTask(uri, task)
         expect(client.documentText(uri)).toMatchInlineSnapshot(
@@ -106,7 +108,9 @@ describe('Edit', () => {
         const task = await client.request('editCommands/code', {
             instruction:
                 'Create and export a Heading component that uses these props. Do not use default exports',
-            model: modelsService.getModelByIDSubstringOrError('anthropic/claude-3-5-sonnet-20240620').id,
+            model: modelsService.instance!.getModelByIDSubstringOrError(
+                'anthropic/claude-3-5-sonnet-20240620'
+            ).id,
         })
         await client.acceptEditTask(uri, task)
         expect(client.documentText(uri)).toMatchInlineSnapshot(
@@ -135,7 +139,7 @@ describe('Edit', () => {
         await client.openFile(uri, { removeCursor: true })
         const task = await client.request('editCommands/code', {
             instruction: 'Convert this to use a switch statement',
-            model: modelsService.getModelByIDSubstringOrError('anthropic/claude-3-opus').id,
+            model: modelsService.instance!.getModelByIDSubstringOrError('anthropic/claude-3-opus').id,
         })
         await client.acceptEditTask(uri, task)
         expect(client.documentText(uri)).toMatchInlineSnapshot(

--- a/lib/shared/src/cody-ignore/context-filters-provider.ts
+++ b/lib/shared/src/cody-ignore/context-filters-provider.ts
@@ -4,6 +4,7 @@ import { RE2JS as RE2 } from 're2js'
 import type * as vscode from 'vscode'
 import { isFileURI } from '../common/uri'
 import { logDebug, logError } from '../logger'
+import { setSingleton, singletonNotYetSet } from '../singletons'
 import { graphqlClient } from '../sourcegraph-api/graphql'
 import {
     type CodyContextFilterItem,
@@ -279,6 +280,7 @@ function parseContextFilterItem(item: CodyContextFilterItem): ParsedContextFilte
 
 /**
  * A singleton instance of the `ContextFiltersProvider` class.
- * `contextFiltersProvider.init` should be called and awaited on extension activation.
+ * `contextFiltersProvider.instance!.init` should be called and awaited on extension activation.
  */
-export const contextFiltersProvider = new ContextFiltersProvider()
+export const contextFiltersProvider = singletonNotYetSet<ContextFiltersProvider>()
+setSingleton(contextFiltersProvider, new ContextFiltersProvider())

--- a/lib/shared/src/experimentation/FeatureFlagProvider.ts
+++ b/lib/shared/src/experimentation/FeatureFlagProvider.ts
@@ -2,6 +2,7 @@ import { Observable } from 'observable-fns'
 import type { Event } from 'vscode'
 import { logDebug } from '../logger'
 import { fromVSCodeEvent } from '../misc/observable'
+import { setSingleton, singletonNotYetSet } from '../singletons'
 import { type SourcegraphGraphQLAPIClient, graphqlClient } from '../sourcegraph-api/graphql'
 import { wrapInActiveSpan } from '../tracing'
 import { isError } from '../utils'
@@ -286,7 +287,8 @@ export class FeatureFlagProvider {
 
 const NO_FLAGS: Record<string, never> = {}
 
-export const featureFlagProvider = new FeatureFlagProvider(graphqlClient)
+export const featureFlagProvider = singletonNotYetSet<FeatureFlagProvider>()
+setSingleton(featureFlagProvider, new FeatureFlagProvider(graphqlClient))
 
 function computeIfExistingFlagChanged(
     oldFlags: Record<string, boolean>,

--- a/lib/shared/src/index.ts
+++ b/lib/shared/src/index.ts
@@ -335,3 +335,4 @@ export {
     createMessageAPIForExtension,
 } from './misc/rpc/rpc'
 export * from './misc/observable'
+export * from './singletons'

--- a/lib/shared/src/llm-providers/anthropic/chat-client.ts
+++ b/lib/shared/src/llm-providers/anthropic/chat-client.ts
@@ -32,7 +32,7 @@ export async function anthropicChatClient({
         const messages = (await Promise.all(
             params.messages.map(async msg => ({
                 role: msg.speaker === 'human' ? 'user' : 'assistant',
-                content: (await msg.text?.toFilteredString(contextFiltersProvider)) ?? '',
+                content: (await msg.text?.toFilteredString(contextFiltersProvider.instance!)) ?? '',
             }))
         )) as MessageParam[]
         // Turns the first assistant message into a system prompt

--- a/lib/shared/src/llm-providers/clients.ts
+++ b/lib/shared/src/llm-providers/clients.ts
@@ -11,7 +11,7 @@ export async function useCustomChatClient({
     logger,
     signal,
 }: ChatNetworkClientParams): Promise<boolean> {
-    const model = modelsService.getModelByID(params.model ?? '')
+    const model = modelsService.instance!.getModelByID(params.model ?? '')
     if (!model || !isCustomModel(model)) {
         return false
     }

--- a/lib/shared/src/llm-providers/google/utils.ts
+++ b/lib/shared/src/llm-providers/google/utils.ts
@@ -19,7 +19,9 @@ export async function constructGeminiChatMessages(messages: Message[]): Promise<
         await Promise.all(
             messages.map(async msg => ({
                 role: msg.speaker === 'human' ? 'user' : 'model',
-                parts: [{ text: (await msg.text?.toFilteredString(contextFiltersProvider)) ?? '' }],
+                parts: [
+                    { text: (await msg.text?.toFilteredString(contextFiltersProvider.instance!)) ?? '' },
+                ],
             }))
         )
     ).filter((_, i, arr) => i !== arr.length - 1 || arr[i].role !== 'model')

--- a/lib/shared/src/llm-providers/groq/chat-client.ts
+++ b/lib/shared/src/llm-providers/groq/chat-client.ts
@@ -43,7 +43,7 @@ export async function groqChatClient({
             params.messages.map(async msg => {
                 return {
                     role: msg.speaker === 'human' ? 'user' : 'assistant',
-                    content: (await msg.text?.toFilteredString(contextFiltersProvider)) ?? '',
+                    content: (await msg.text?.toFilteredString(contextFiltersProvider.instance!)) ?? '',
                 }
             })
         ),

--- a/lib/shared/src/llm-providers/ollama/chat-client.ts
+++ b/lib/shared/src/llm-providers/ollama/chat-client.ts
@@ -39,7 +39,7 @@ export async function ollamaChatClient({
         const messages = await Promise.all(
             params.messages.map(async msg => ({
                 role: msg.speaker === 'human' ? 'user' : 'assistant',
-                content: (await msg.text?.toFilteredString(contextFiltersProvider)) ?? '',
+                content: (await msg.text?.toFilteredString(contextFiltersProvider.instance!)) ?? '',
             }))
         )
 

--- a/lib/shared/src/llm-providers/ollama/completions-client.ts
+++ b/lib/shared/src/llm-providers/ollama/completions-client.ts
@@ -33,7 +33,7 @@ export function createOllamaClient(
         const { signal } = abortController
 
         try {
-            const prompt = await params.prompt.toFilteredString(contextFiltersProvider)
+            const prompt = await params.prompt.toFilteredString(contextFiltersProvider.instance!)
 
             const res = await ollama.generate({
                 model,

--- a/lib/shared/src/llm-providers/utils.ts
+++ b/lib/shared/src/llm-providers/utils.ts
@@ -2,7 +2,7 @@ import type { CompletionsModelConfig } from '.'
 import { modelsService } from '../models'
 
 export function getCompletionsModelConfig(modelID: string): CompletionsModelConfig | undefined {
-    const provider = modelsService.getModelByID(modelID)
+    const provider = modelsService.instance!.getModelByID(modelID)
     if (!provider) {
         return undefined
     }

--- a/lib/shared/src/models/index.ts
+++ b/lib/shared/src/models/index.ts
@@ -2,6 +2,7 @@ import { type AuthStatus, isCodyProUser, isEnterpriseUser } from '../auth/types'
 import { type ClientConfiguration, CodyIDE } from '../configuration'
 import { fetchLocalOllamaModels } from '../llm-providers/ollama/utils'
 import { logDebug, logError } from '../logger'
+import { setSingleton, singletonNotYetSet } from '../singletons'
 import { CHAT_INPUT_TOKEN_BUDGET, CHAT_OUTPUT_TOKEN_BUDGET } from '../token/constants'
 import { ModelTag } from './tags'
 import { type ChatModel, type EditModel, type ModelContextWindow, ModelUsage } from './types'
@@ -567,7 +568,8 @@ export class ModelsService {
     }
 }
 
-export const modelsService = new ModelsService()
+export const modelsService = singletonNotYetSet<ModelsService>()
+setSingleton(modelsService, new ModelsService())
 
 interface Storage {
     get(key: string): string | null

--- a/lib/shared/src/singletons.ts
+++ b/lib/shared/src/singletons.ts
@@ -1,0 +1,13 @@
+type Singleton<T> = { instance: T | null }
+
+export function singletonNotYetSet<T>(): Singleton<T> {
+    return { instance: null }
+}
+
+export function setSingleton<T extends object>(container: Singleton<T>, instance: T): T {
+    if (container.instance !== null) {
+        throw new Error('singleton already set')
+    }
+    container.instance = instance
+    return instance
+}

--- a/lib/shared/src/sourcegraph-api/completions/utils.ts
+++ b/lib/shared/src/sourcegraph-api/completions/utils.ts
@@ -28,7 +28,7 @@ async function serializePrompts(
     return Promise.all(
         messages.map(async m => ({
             ...m,
-            text: await m.text?.toFilteredString(contextFiltersProvider),
+            text: await m.text?.toFilteredString(contextFiltersProvider.instance!),
         }))
     )
 }

--- a/vscode/src/chat/MessageProvider.ts
+++ b/vscode/src/chat/MessageProvider.ts
@@ -1,7 +1,6 @@
 import type { ChatClient, Guardrails } from '@sourcegraph/cody-shared'
 
 import type { VSCodeEditor } from '../editor/vscode-editor'
-import type { AuthProvider } from '../services/AuthProvider'
 
 /**
  * The types of errors that should be handled from MessageProvider.
@@ -14,5 +13,4 @@ export interface MessageProviderOptions {
     chat: ChatClient
     guardrails: Guardrails
     editor: VSCodeEditor
-    authProvider: AuthProvider
 }

--- a/vscode/src/chat/chat-view/ChatController.ts
+++ b/vscode/src/chat/chat-view/ChatController.ts
@@ -316,7 +316,7 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
             case 'chatModel':
                 // Because this was a user action to change the model we will set that
                 // as a global default for chat
-                await modelsService.setSelectedModel(ModelUsage.Chat, message.model)
+                await modelsService.instance!.setSelectedModel(ModelUsage.Chat, message.model)
                 this.handleSetChatModel(message.model)
                 break
             case 'get-chat-models':
@@ -1080,7 +1080,7 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
         if (!authStatus?.isLoggedIn) {
             return
         }
-        const models = modelsService.getModels(ModelUsage.Chat)
+        const models = modelsService.instance!.getModels(ModelUsage.Chat)
 
         void this.postMessage({
             type: 'chatModels',
@@ -1670,7 +1670,7 @@ export function revealWebviewViewOrPanel(viewOrPanel: vscode.WebviewView | vscod
 function getDefaultModelID(): string {
     const pending = ''
     try {
-        return modelsService.getDefaultChatModel() || pending
+        return modelsService.instance!.getDefaultChatModel() || pending
     } catch {
         return pending
     }

--- a/vscode/src/chat/chat-view/ChatController.ts
+++ b/vscode/src/chat/chat-view/ChatController.ts
@@ -250,7 +250,7 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
 
         // Keep feature flags updated.
         this.disposables.push({
-            dispose: featureFlagProvider.onFeatureFlagChanged('', () => {
+            dispose: featureFlagProvider.instance!.onFeatureFlagChanged('', () => {
                 void this.sendConfig()
             }),
         })
@@ -1488,7 +1488,8 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
                 }),
                 {
                     mentionMenuData: query => getMentionMenuData(query, this.chatModel),
-                    evaluatedFeatureFlag: flag => featureFlagProvider.evaluatedFeatureFlag(flag),
+                    evaluatedFeatureFlag: flag =>
+                        featureFlagProvider.instance!.evaluatedFeatureFlag(flag),
                     prompts: query =>
                         promiseFactoryToObservable(signal =>
                             mergedPromptsAndLegacyCommands(query, signal)

--- a/vscode/src/chat/chat-view/ChatModel.ts
+++ b/vscode/src/chat/chat-view/ChatModel.ts
@@ -27,12 +27,12 @@ export class ChatModel {
         private customChatTitle?: string,
         private selectedRepos?: Repo[]
     ) {
-        this.contextWindow = modelsService.getContextWindowByID(this.modelID)
+        this.contextWindow = modelsService.instance!.getContextWindowByID(this.modelID)
     }
 
     public updateModel(newModelID: string) {
         this.modelID = newModelID
-        this.contextWindow = modelsService.getContextWindowByID(this.modelID)
+        this.contextWindow = modelsService.instance!.getContextWindowByID(this.modelID)
     }
 
     public isEmpty(): boolean {

--- a/vscode/src/chat/chat-view/prompt.test.ts
+++ b/vscode/src/chat/chat-view/prompt.test.ts
@@ -23,7 +23,7 @@ describe('DefaultPrompter', () => {
     })
 
     it('constructs a prompt with no context', async () => {
-        modelsService.setModels([
+        modelsService.instance!.setModels([
             new Model({
                 id: 'a-model-id',
                 usage: [ModelUsage.Chat],
@@ -98,7 +98,7 @@ describe('DefaultPrompter', () => {
             update: vi.fn(() => Promise.resolve()),
         }))
 
-        modelsService.setModels([
+        modelsService.instance!.setModels([
             new Model({
                 id: 'a-model-id',
                 usage: [ModelUsage.Chat],
@@ -134,7 +134,7 @@ describe('DefaultPrompter', () => {
     })
 
     it('prefers latest enhanced context', async () => {
-        modelsService.setModels([
+        modelsService.instance!.setModels([
             new Model({
                 id: 'a-model-id',
                 usage: [ModelUsage.Chat],

--- a/vscode/src/chat/chat-view/prompt.test.ts
+++ b/vscode/src/chat/chat-view/prompt.test.ts
@@ -16,7 +16,7 @@ import { DefaultPrompter } from './prompt'
 
 describe('DefaultPrompter', () => {
     beforeEach(() => {
-        vi.spyOn(contextFiltersProvider, 'isUriIgnored').mockResolvedValue(false)
+        vi.spyOn(contextFiltersProvider.instance!, 'isUriIgnored').mockResolvedValue(false)
     })
     afterEach(() => {
         vi.restoreAllMocks()

--- a/vscode/src/chat/clientStateBroadcaster.ts
+++ b/vscode/src/chat/clientStateBroadcaster.ts
@@ -114,7 +114,7 @@ export async function getCorpusContextItemsForEditorState(useRemote: boolean): P
     if (useRemote && workspaceReposMonitor) {
         const repoMetadata = await workspaceReposMonitor.getRepoMetadata()
         for (const repo of repoMetadata) {
-            if (contextFiltersProvider.isRepoNameIgnored(repo.repoName)) {
+            if (contextFiltersProvider.instance!.isRepoNameIgnored(repo.repoName)) {
                 continue
             }
             if (repo.remoteID === undefined) {

--- a/vscode/src/chat/clientStateBroadcaster.ts
+++ b/vscode/src/chat/clientStateBroadcaster.ts
@@ -13,7 +13,7 @@ import * as vscode from 'vscode'
 import { getSelectionOrFileContext } from '../commands/context/selection'
 import { createRepositoryMention } from '../context/openctx/common/get-repository-mentions'
 import { workspaceReposMonitor } from '../repository/repo-metadata-from-git-api'
-import type { AuthProvider } from '../services/AuthProvider'
+import { authProvider } from '../services/AuthProvider'
 import type { ChatModel } from './chat-view/ChatModel'
 import { contextItemMentionFromOpenCtxItem } from './context/chatContext'
 import type { ExtensionMessage } from './protocol'
@@ -24,12 +24,10 @@ type PostMessage = (message: Extract<ExtensionMessage, { type: 'clientState' }>)
  * Listen for changes to the client (such as VS Code) state to send to the webview.
  */
 export function startClientStateBroadcaster({
-    authProvider,
     useRemoteSearch,
     postMessage: rawPostMessage,
     chatModel,
 }: {
-    authProvider: AuthProvider
     useRemoteSearch: boolean
     postMessage: PostMessage
     chatModel: ChatModel
@@ -92,7 +90,7 @@ export function startClientStateBroadcaster({
     )
     disposables.push(
         subscriptionDisposable(
-            authProvider.changes.subscribe(async () => {
+            authProvider.instance!.changes.subscribe(async () => {
                 // Infrequent action, so don't debounce and show immediately in the UI.
                 void sendClientState('immediate')
             })

--- a/vscode/src/chat/context/contextAPIClient.ts
+++ b/vscode/src/chat/context/contextAPIClient.ts
@@ -2,9 +2,9 @@ import {
     type ChatIntentResult,
     type ContextItem,
     FeatureFlag,
-    type FeatureFlagProvider,
     type InputContextItem,
     type SourcegraphGraphQLAPIClient,
+    featureFlagProvider,
     isError,
     logError,
 } from '@sourcegraph/cody-shared'
@@ -28,10 +28,7 @@ function notNull<T>(value: T | null | undefined): value is T {
 }
 
 export class ContextAPIClient {
-    constructor(
-        private readonly apiClient: SourcegraphGraphQLAPIClient,
-        private readonly featureFlagProvider: FeatureFlagProvider
-    ) {}
+    constructor(private readonly apiClient: SourcegraphGraphQLAPIClient) {}
 
     public async detectChatIntent(
         interactionID: string,
@@ -66,6 +63,8 @@ export class ContextAPIClient {
         if (vscode.workspace.getConfiguration().get<boolean>('cody.internal.serverSideContext')) {
             return true
         }
-        return await this.featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyServerSideContextAPI)
+        return await featureFlagProvider.instance!.evaluateFeatureFlag(
+            FeatureFlag.CodyServerSideContextAPI
+        )
     }
 }

--- a/vscode/src/cody-ignore/context-filter.ts
+++ b/vscode/src/cody-ignore/context-filter.ts
@@ -6,7 +6,7 @@ export async function isUriIgnoredByContextFilterWithNotification(
     uri: vscode.Uri,
     feature: CodyIgnoreFeature
 ): Promise<IsIgnored> {
-    const isIgnored = await contextFiltersProvider.isUriIgnored(uri)
+    const isIgnored = await contextFiltersProvider.instance!.isUriIgnored(uri)
     if (isIgnored) {
         showCodyIgnoreNotification(feature, 'context-filter')
     }

--- a/vscode/src/commands/GhostHintDecorator.ts
+++ b/vscode/src/commands/GhostHintDecorator.ts
@@ -358,7 +358,7 @@ export class GhostHintDecorator implements vscode.Disposable {
         variant: GhostVariant,
         textPadding = 0
     ): Promise<void> {
-        if (await contextFiltersProvider.isUriIgnored(editor.document.uri)) {
+        if (await contextFiltersProvider.instance!.isUriIgnored(editor.document.uri)) {
             // The current file is ignored, so do nothing
             return
         }

--- a/vscode/src/commands/context/current-file.ts
+++ b/vscode/src/commands/context/current-file.ts
@@ -16,7 +16,7 @@ export async function getContextFileFromCurrentFile(): Promise<ContextItem | nul
                 throw new Error('No active editor')
             }
 
-            if (await contextFiltersProvider.isUriIgnored(document.uri)) {
+            if (await contextFiltersProvider.instance!.isUriIgnored(document.uri)) {
                 return null
             }
 

--- a/vscode/src/commands/context/directory.ts
+++ b/vscode/src/commands/context/directory.ts
@@ -52,7 +52,7 @@ export async function getContextFileFromDirectory(directory?: URI): Promise<Cont
                 // Reconstruct the file URI with the file name and directory URI
                 const fileUri = Utils.joinPath(dirUri, name)
 
-                if (await contextFiltersProvider.isUriIgnored(fileUri)) {
+                if (await contextFiltersProvider.instance!.isUriIgnored(fileUri)) {
                     continue
                 }
 

--- a/vscode/src/commands/context/file-path.ts
+++ b/vscode/src/commands/context/file-path.ts
@@ -19,7 +19,7 @@ export async function getContextFileFromUri(
 ): Promise<ContextItem | null> {
     return wrapInActiveSpan('commands.context.filePath', async span => {
         try {
-            if (await contextFiltersProvider.isUriIgnored(file)) {
+            if (await contextFiltersProvider.instance!.isUriIgnored(file)) {
                 return null
             }
 

--- a/vscode/src/commands/context/selection.ts
+++ b/vscode/src/commands/context/selection.ts
@@ -32,7 +32,7 @@ export async function getContextFileFromCursor(
                 throw new Error('No active editor')
             }
 
-            if (await contextFiltersProvider.isUriIgnored(document.uri)) {
+            if (await contextFiltersProvider.instance!.isUriIgnored(document.uri)) {
                 return null
             }
 
@@ -136,5 +136,5 @@ export async function getSelectionOrFileContext(): Promise<ContextItem[]> {
 }
 
 async function shouldIgnore(uri: URI): Promise<boolean> {
-    return Boolean((await contextFiltersProvider.isUriIgnored(uri)) || isCodyIgnoredFile(uri))
+    return Boolean((await contextFiltersProvider.instance!.isUriIgnored(uri)) || isCodyIgnoredFile(uri))
 }

--- a/vscode/src/commands/context/workspace.ts
+++ b/vscode/src/commands/context/workspace.ts
@@ -41,7 +41,7 @@ export async function getWorkspaceFilesContext(
             return (
                 await Promise.all(
                     results.map(async result => {
-                        if (await contextFiltersProvider.isUriIgnored(result)) {
+                        if (await contextFiltersProvider.instance!.isUriIgnored(result)) {
                             return null
                         }
 

--- a/vscode/src/commands/scm/source-control.ts
+++ b/vscode/src/commands/scm/source-control.ts
@@ -232,7 +232,7 @@ export class CodySourceControl implements vscode.Disposable {
     }
 
     public setAuthStatus(_: AuthStatus): void {
-        const models = modelsService.getModels(ModelUsage.Chat)
+        const models = modelsService.instance!.getModels(ModelUsage.Chat)
         const preferredModel = models.find(p => p.id.includes('claude-3-haiku'))
         this.model = preferredModel ?? models[0]
     }

--- a/vscode/src/completions/context/context-mixer.test.ts
+++ b/vscode/src/completions/context/context-mixer.test.ts
@@ -59,7 +59,7 @@ const defaultOptions = {
 
 describe('ContextMixer', () => {
     beforeEach(() => {
-        vi.spyOn(contextFiltersProvider, 'isUriIgnored').mockResolvedValue(false)
+        vi.spyOn(contextFiltersProvider.instance!, 'isUriIgnored').mockResolvedValue(false)
     })
 
     describe('with no retriever', () => {
@@ -305,7 +305,7 @@ describe('ContextMixer', () => {
 
         describe('retrieved context is filtered by context filters', () => {
             beforeAll(() => {
-                vi.spyOn(contextFiltersProvider, 'isUriIgnored').mockImplementation(
+                vi.spyOn(contextFiltersProvider.instance!, 'isUriIgnored').mockImplementation(
                     async (uri: vscode.Uri) => {
                         if (uri.path.includes('foo.ts')) {
                             return 'repo:foo'

--- a/vscode/src/completions/context/context-mixer.ts
+++ b/vscode/src/completions/context/context-mixer.ts
@@ -199,7 +199,7 @@ async function filter(snippets: AutocompleteContextSnippet[]): Promise<Autocompl
                 if (isCodyIgnoredFile(snippet.uri)) {
                     return null
                 }
-                if (await contextFiltersProvider.isUriIgnored(snippet.uri)) {
+                if (await contextFiltersProvider.instance!.isUriIgnored(snippet.uri)) {
                     return null
                 }
                 return snippet

--- a/vscode/src/completions/create-inline-completion-item-provider.ts
+++ b/vscode/src/completions/create-inline-completion-item-provider.ts
@@ -1,7 +1,6 @@
 import {
     type ClientConfigurationWithAccessToken,
     type CodeCompletionsClient,
-    featureFlagProvider,
     isDotCom,
 } from '@sourcegraph/cody-shared'
 import * as vscode from 'vscode'
@@ -70,7 +69,7 @@ export async function createInlineCompletionItemProvider({
 
     const [providerConfig] = await Promise.all([
         createProviderConfig(config, client, authStatus),
-        completionProviderConfig.init(config, featureFlagProvider),
+        completionProviderConfig.init(config),
     ])
 
     if (providerConfig) {

--- a/vscode/src/completions/create-inline-completion-item-provider.ts
+++ b/vscode/src/completions/create-inline-completion-item-provider.ts
@@ -6,7 +6,7 @@ import {
 import * as vscode from 'vscode'
 
 import { logDebug } from '../log'
-import type { AuthProvider } from '../services/AuthProvider'
+import { authProvider } from '../services/AuthProvider'
 import type { CodyStatusBar } from '../services/StatusBar'
 
 import { completionProviderConfig } from './completion-provider-config'
@@ -19,7 +19,6 @@ export interface InlineCompletionItemProviderArgs {
     config: ClientConfigurationWithAccessToken
     client: CodeCompletionsClient
     statusBar: CodyStatusBar
-    authProvider: AuthProvider
     createBfgRetriever?: () => BfgRetriever
 }
 
@@ -43,10 +42,9 @@ export async function createInlineCompletionItemProvider({
     config,
     client,
     statusBar,
-    authProvider,
     createBfgRetriever,
 }: InlineCompletionItemProviderArgs): Promise<vscode.Disposable> {
-    const authStatus = authProvider.getAuthStatus()
+    const authStatus = authProvider.instance!.getAuthStatus()
     if (!authStatus.isLoggedIn) {
         logDebug('CodyCompletionProvider:notSignedIn', 'You are not signed in.')
 
@@ -73,7 +71,7 @@ export async function createInlineCompletionItemProvider({
     ])
 
     if (providerConfig) {
-        const authStatus = authProvider.getAuthStatus()
+        const authStatus = authProvider.instance!.getAuthStatus()
         const completionsProvider = new InlineCompletionItemProvider({
             authStatus,
             providerConfig,

--- a/vscode/src/completions/create-multi-model-inline-completion-provider.ts
+++ b/vscode/src/completions/create-multi-model-inline-completion-provider.ts
@@ -2,6 +2,7 @@ import { type MultimodelSingleModelConfig, isDotCom } from '@sourcegraph/cody-sh
 import _ from 'lodash'
 import * as vscode from 'vscode'
 import { logDebug } from '../log'
+import { authProvider } from '../services/AuthProvider'
 import type { InlineCompletionItemProviderArgs } from './create-inline-completion-item-provider'
 import type { MultiModelCompletionsResults } from './inline-completion-item-provider'
 import { InlineCompletionItemProvider } from './inline-completion-item-provider'
@@ -66,13 +67,12 @@ export async function createInlineCompletionItemFromMultipleProviders({
     config,
     client,
     statusBar,
-    authProvider,
     createBfgRetriever,
 }: InlineCompletionItemProviderArgs): Promise<vscode.Disposable> {
     // Creates multiple providers to get completions from.
     // The primary purpose of this method is to get the completions generated from multiple providers,
     // which helps judge the quality of code completions
-    const authStatus = authProvider.getAuthStatus()
+    const authStatus = authProvider.instance!.getAuthStatus()
     if (!authStatus.isLoggedIn || config.autocompleteExperimentalMultiModelCompletions === undefined) {
         return {
             dispose: () => {},
@@ -119,7 +119,7 @@ export async function createInlineCompletionItemFromMultipleProviders({
             config: newConfig,
         })
         if (providerConfig) {
-            const authStatus = authProvider.getAuthStatus()
+            const authStatus = authProvider.instance!.getAuthStatus()
             const completionsProvider = new InlineCompletionItemProvider({
                 authStatus,
                 providerConfig,

--- a/vscode/src/completions/default-client.ts
+++ b/vscode/src/completions/default-client.ts
@@ -52,7 +52,7 @@ export function createClient(
         return tracer.startActiveSpan(
             `POST ${url}`,
             async function* (span): CompletionResponseGenerator {
-                const tracingFlagEnabled = await featureFlagProvider.evaluateFeatureFlag(
+                const tracingFlagEnabled = await featureFlagProvider.instance!.evaluateFeatureFlag(
                     FeatureFlag.CodyAutocompleteTracing
                 )
 

--- a/vscode/src/completions/default-client.ts
+++ b/vscode/src/completions/default-client.ts
@@ -100,7 +100,7 @@ export function createClient(
                     messages: await Promise.all(
                         params.messages.map(async m => ({
                             ...m,
-                            text: await m.text?.toFilteredString(contextFiltersProvider),
+                            text: await m.text?.toFilteredString(contextFiltersProvider.instance!),
                         }))
                     ),
                 }

--- a/vscode/src/completions/fast-path-client.ts
+++ b/vscode/src/completions/fast-path-client.ts
@@ -76,7 +76,9 @@ export function createFastPathClient(
         }
 
         // Convert the SG instance messages array back to the original prompt
-        const prompt = await requestParams.messages[0]!.text!.toFilteredString(contextFiltersProvider)
+        const prompt = await requestParams.messages[0]!.text!.toFilteredString(
+            contextFiltersProvider.instance!
+        )
 
         // c.f. https://readme.fireworks.ai/reference/createcompletion
         const fireworksRequest = {

--- a/vscode/src/completions/get-inline-completions-tests/helpers.ts
+++ b/vscode/src/completions/get-inline-completions-tests/helpers.ts
@@ -1,6 +1,6 @@
 import dedent from 'dedent'
 import { isEqual } from 'lodash'
-import { expect } from 'vitest'
+import { expect, vi } from 'vitest'
 import type { URI } from 'vscode-uri'
 
 import {
@@ -11,7 +11,10 @@ import {
     type CompletionParameters,
     type CompletionResponse,
     CompletionStopReason,
+    type GraphQLAPIClientConfig,
     defaultAuthStatus,
+    featureFlagProvider,
+    graphqlClient,
     testFileUri,
 } from '@sourcegraph/cody-shared'
 
@@ -19,7 +22,7 @@ import type {
     CodeCompletionsParams,
     CompletionResponseWithMetaData,
 } from '@sourcegraph/cody-shared/src/inferenceClient/misc'
-import { DEFAULT_VSCODE_SETTINGS, emptyMockFeatureFlagProvider } from '../../testutils/mocks'
+import { DEFAULT_VSCODE_SETTINGS } from '../../testutils/mocks'
 import type { SupportedLanguage } from '../../tree-sitter/grammars'
 import { updateParseTreeCache } from '../../tree-sitter/parse-tree-cache'
 import { getParser } from '../../tree-sitter/parser'
@@ -407,7 +410,9 @@ export async function getInlineCompletionsInsertText(params: ParamsResult): Prom
 export type V = Awaited<ReturnType<typeof getInlineCompletions>>
 
 export function initCompletionProviderConfig(config: Partial<ClientConfiguration>) {
-    return completionProviderConfig.init(config as ClientConfiguration, emptyMockFeatureFlagProvider)
+    graphqlClient.setConfig({} as unknown as GraphQLAPIClientConfig)
+    vi.spyOn(featureFlagProvider.instance!, 'getFromCache').mockReturnValue(false)
+    return completionProviderConfig.init(config as ClientConfiguration)
 }
 
 expect.extend({

--- a/vscode/src/completions/inline-completion-item-provider-e2e.test.ts
+++ b/vscode/src/completions/inline-completion-item-provider-e2e.test.ts
@@ -199,7 +199,7 @@ describe.skip('InlineCompletionItemProvider E2E', () => {
         })
 
         beforeEach(() => {
-            vi.spyOn(contextFiltersProvider, 'isUriIgnored').mockResolvedValue(false)
+            vi.spyOn(contextFiltersProvider.instance!, 'isUriIgnored').mockResolvedValue(false)
             getCompletionProviderSpy = vi.spyOn(CompletionProvider, 'getCompletionProvider')
         })
 

--- a/vscode/src/completions/inline-completion-item-provider.test.ts
+++ b/vscode/src/completions/inline-completion-item-provider.test.ts
@@ -87,7 +87,7 @@ describe('InlineCompletionItemProvider', () => {
         } as any as vscode.Memento)
     })
     beforeEach(() => {
-        vi.spyOn(contextFiltersProvider, 'isUriIgnored').mockResolvedValue(false)
+        vi.spyOn(contextFiltersProvider.instance!, 'isUriIgnored').mockResolvedValue(false)
         CompletionLogger.reset_testOnly()
     })
 
@@ -244,7 +244,7 @@ describe('InlineCompletionItemProvider', () => {
     })
 
     it('no-ops on files that are ignored by the context filter policy', async () => {
-        vi.spyOn(contextFiltersProvider, 'isUriIgnored').mockResolvedValueOnce('repo:foo')
+        vi.spyOn(contextFiltersProvider.instance!, 'isUriIgnored').mockResolvedValueOnce('repo:foo')
         const completionParams = params('const foo = █', [completion`bar`])
         const fn = vi.fn()
         const provider = new MockableInlineCompletionItemProvider(fn)

--- a/vscode/src/completions/inline-completion-item-provider.ts
+++ b/vscode/src/completions/inline-completion-item-provider.ts
@@ -312,7 +312,7 @@ export class InlineCompletionItemProvider
                 return null
             }
 
-            if (await contextFiltersProvider.isUriIgnored(document.uri)) {
+            if (await contextFiltersProvider.instance!.isUriIgnored(document.uri)) {
                 logIgnored(document.uri, 'context-filter', isManualCompletion)
                 return null
             }

--- a/vscode/src/completions/logger.ts
+++ b/vscode/src/completions/logger.ts
@@ -1063,8 +1063,8 @@ function getSharedParams(event: CompletionBookkeepingEvent): SharedEventPayload 
         items: event.items.map(i => ({ ...i })),
         otherCompletionProviderEnabled: otherCompletionProviders.length > 0,
         otherCompletionProviders,
-        upstreamLatency: upstreamHealthProvider.getUpstreamLatency(),
-        gatewayLatency: upstreamHealthProvider.getGatewayLatency(),
+        upstreamLatency: upstreamHealthProvider.instance!.getUpstreamLatency(),
+        gatewayLatency: upstreamHealthProvider.instance!.getGatewayLatency(),
 
         // 🚨 SECURITY: Do not include any context by default
         inlineCompletionItemContext: undefined,

--- a/vscode/src/completions/providers/fireworks.ts
+++ b/vscode/src/completions/providers/fireworks.ts
@@ -56,7 +56,7 @@ export const DEEPSEEK_CODER_V2_LITE_BASE_DIRECT_ROUTE = 'deepseek-coder-v2-lite-
 export const DEEPSEEK_CODER_V2_LITE_BASE = 'deepseek-coder-v2-lite-base'
 
 // Context window experiments with DeepSeek Model
-const DEEPSEEK_CODER_V2_LITE_BASE_WINDOW_4096 = 'deepseek-coder-v2-lite-base-context-4096'
+export const DEEPSEEK_CODER_V2_LITE_BASE_WINDOW_4096 = 'deepseek-coder-v2-lite-base-context-4096'
 const DEEPSEEK_CODER_V2_LITE_BASE_WINDOW_8192 = 'deepseek-coder-v2-lite-base-context-8192'
 const DEEPSEEK_CODER_V2_LITE_BASE_WINDOW_16384 = 'deepseek-coder-v2-lite-base-context-16383'
 const DEEPSEEK_CODER_V2_LITE_BASE_WINDOW_32768 = 'deepseek-coder-v2-lite-base-context-32768'

--- a/vscode/src/completions/providers/get-experiment-model.ts
+++ b/vscode/src/completions/providers/get-experiment-model.ts
@@ -21,12 +21,14 @@ export async function getExperimentModel(
     isDotCom: boolean
 ): Promise<ProviderConfigFromFeatureFlags | null> {
     const [starCoderHybrid, claude3, fimModelExperimentFlag, deepseekV2LiteBase] = await Promise.all([
-        featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteStarCoderHybrid),
-        featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteClaude3),
-        featureFlagProvider.evaluateFeatureFlag(
+        featureFlagProvider.instance!.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteStarCoderHybrid),
+        featureFlagProvider.instance!.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteClaude3),
+        featureFlagProvider.instance!.evaluateFeatureFlag(
             FeatureFlag.CodyAutocompleteFIMModelExperimentBaseFeatureFlag
         ),
-        featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteDeepseekV2LiteBase),
+        featureFlagProvider.instance!.evaluateFeatureFlag(
+            FeatureFlag.CodyAutocompleteDeepseekV2LiteBase
+        ),
     ])
 
     // We run fine tuning experiment for VSC client only.
@@ -67,12 +69,22 @@ async function resolveFIMModelExperimentFromFeatureFlags(): ReturnType<typeof ge
         fimModelVariant4,
         fimModelCurrentBest,
     ] = await Promise.all([
-        featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteFIMModelExperimentControl),
-        featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteFIMModelExperimentVariant1),
-        featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteFIMModelExperimentVariant2),
-        featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteFIMModelExperimentVariant3),
-        featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteFIMModelExperimentVariant4),
-        featureFlagProvider.evaluateFeatureFlag(
+        featureFlagProvider.instance!.evaluateFeatureFlag(
+            FeatureFlag.CodyAutocompleteFIMModelExperimentControl
+        ),
+        featureFlagProvider.instance!.evaluateFeatureFlag(
+            FeatureFlag.CodyAutocompleteFIMModelExperimentVariant1
+        ),
+        featureFlagProvider.instance!.evaluateFeatureFlag(
+            FeatureFlag.CodyAutocompleteFIMModelExperimentVariant2
+        ),
+        featureFlagProvider.instance!.evaluateFeatureFlag(
+            FeatureFlag.CodyAutocompleteFIMModelExperimentVariant3
+        ),
+        featureFlagProvider.instance!.evaluateFeatureFlag(
+            FeatureFlag.CodyAutocompleteFIMModelExperimentVariant4
+        ),
+        featureFlagProvider.instance!.evaluateFeatureFlag(
             FeatureFlag.CodyAutocompleteFIMModelExperimentCurrentBest
         ),
     ])

--- a/vscode/src/completions/providers/get-model-info.ts
+++ b/vscode/src/completions/providers/get-model-info.ts
@@ -7,7 +7,7 @@ interface ModelInfo {
 }
 
 export function getModelInfo(authStatus: AuthStatus): ModelInfo | Error {
-    const model = modelsService.getDefaultModel(ModelUsage.Autocomplete)
+    const model = modelsService.instance!.getDefaultModel(ModelUsage.Autocomplete)
 
     if (model) {
         let provider = model.provider

--- a/vscode/src/configwatcher.ts
+++ b/vscode/src/configwatcher.ts
@@ -7,7 +7,7 @@ import {
 import type { Observable } from 'observable-fns'
 import * as vscode from 'vscode'
 import { getFullConfig } from './configuration'
-import type { AuthProvider } from './services/AuthProvider'
+import { authProvider } from './services/AuthProvider'
 
 export class BaseConfigWatcher implements ConfigWatcher<ClientConfigurationWithAccessToken> {
     private currentConfig: ClientConfigurationWithAccessToken
@@ -15,7 +15,6 @@ export class BaseConfigWatcher implements ConfigWatcher<ClientConfigurationWithA
     private configChangeEvent = new vscode.EventEmitter<ClientConfigurationWithAccessToken>()
 
     public static async create(
-        authProvider: AuthProvider,
         disposables: vscode.Disposable[]
     ): Promise<ConfigWatcher<ClientConfigurationWithAccessToken>> {
         const w = new BaseConfigWatcher(await getFullConfig())
@@ -30,7 +29,7 @@ export class BaseConfigWatcher implements ConfigWatcher<ClientConfigurationWithA
         )
         disposables.push(
             subscriptionDisposable(
-                authProvider.changes.subscribe(async () => {
+                authProvider.instance!.changes.subscribe(async () => {
                     w.set(await getFullConfig())
                 })
             )

--- a/vscode/src/context/openctx.test.ts
+++ b/vscode/src/context/openctx.test.ts
@@ -26,7 +26,9 @@ describe('getOpenCtxProviders', () => {
     }
 
     test('dotcom user', async () => {
-        vi.spyOn(featureFlagProvider, 'evaluatedFeatureFlag').mockReturnValue(Observable.of(false))
+        vi.spyOn(featureFlagProvider.instance!, 'evaluatedFeatureFlag').mockReturnValue(
+            Observable.of(false)
+        )
 
         const providers = await firstValueFrom(
             getOpenCtxProviders(mockConfig(false), mockAuthStatusIsDotCom(true), true)
@@ -36,7 +38,9 @@ describe('getOpenCtxProviders', () => {
     })
 
     test('enterprise user', async () => {
-        vi.spyOn(featureFlagProvider, 'evaluatedFeatureFlag').mockReturnValue(Observable.of(false))
+        vi.spyOn(featureFlagProvider.instance!, 'evaluatedFeatureFlag').mockReturnValue(
+            Observable.of(false)
+        )
 
         const providers = await firstValueFrom(
             getOpenCtxProviders(mockConfig(false), mockAuthStatusIsDotCom(false), true)
@@ -52,7 +56,9 @@ describe('getOpenCtxProviders', () => {
     })
 
     test('should include gitMentionsProvider when feature flag is true', async () => {
-        vi.spyOn(featureFlagProvider, 'evaluatedFeatureFlag').mockReturnValue(Observable.of(true))
+        vi.spyOn(featureFlagProvider.instance!, 'evaluatedFeatureFlag').mockReturnValue(
+            Observable.of(true)
+        )
 
         const providers = await firstValueFrom(
             getOpenCtxProviders(mockConfig(false), mockAuthStatusIsDotCom(false), true)

--- a/vscode/src/context/openctx.ts
+++ b/vscode/src/context/openctx.ts
@@ -23,7 +23,7 @@ import type {
 import type { createController } from '@openctx/vscode-lib'
 import { Observable } from 'observable-fns'
 import { logDebug, outputChannel } from '../log'
-import type { AuthProvider } from '../services/AuthProvider'
+import { authProvider } from '../services/AuthProvider'
 import CurrentRepositoryDirectoryProvider from './openctx/currentRepositoryDirectorySearch'
 import { gitMentionsProvider } from './openctx/git'
 import LinearIssuesProvider from './openctx/linear-issues'
@@ -35,7 +35,6 @@ import { createWebProvider } from './openctx/web'
 export async function exposeOpenCtxClient(
     context: Pick<vscode.ExtensionContext, 'extension' | 'secrets'>,
     config: ConfigWatcher<ClientConfiguration>,
-    authProvider: AuthProvider,
     createOpenCtxController: typeof createController | undefined
 ): Promise<void> {
     await warnIfOpenCtxExtensionConflict()
@@ -58,7 +57,11 @@ export async function exposeOpenCtxClient(
             features: isCodyWeb ? {} : { annotations: true, statusBar: true },
             providers: isCodyWeb
                 ? Observable.of(getCodyWebOpenCtxProviders())
-                : getOpenCtxProviders(config.changes, authProvider.changes, isValidSiteVersion),
+                : getOpenCtxProviders(
+                      config.changes,
+                      authProvider.instance!.changes,
+                      isValidSiteVersion
+                  ),
             mergeConfiguration,
         })
         setOpenCtx({

--- a/vscode/src/context/openctx.ts
+++ b/vscode/src/context/openctx.ts
@@ -78,7 +78,7 @@ export function getOpenCtxProviders(
     return combineLatest([
         configChanges,
         authStatusChanges,
-        featureFlagProvider.evaluatedFeatureFlag(FeatureFlag.GitMentionProvider),
+        featureFlagProvider.instance!.evaluatedFeatureFlag(FeatureFlag.GitMentionProvider),
     ]).map(
         ([config, authStatus, gitMentionProvider]: [
             ClientConfiguration,

--- a/vscode/src/context/openctx/common/get-repository-mentions.ts
+++ b/vscode/src/context/openctx/common/get-repository-mentions.ts
@@ -61,7 +61,7 @@ export function createRepositoryMention(repo: MinimalRepoMention, providerId: st
         data: {
             repoId: repo.id,
             repoName: repo.name,
-            isIgnored: contextFiltersProvider.isRepoNameIgnored(repo.name),
+            isIgnored: contextFiltersProvider.instance!.isRepoNameIgnored(repo.name),
         },
     }
 }

--- a/vscode/src/context/repo-picker.ts
+++ b/vscode/src/context/repo-picker.ts
@@ -103,7 +103,7 @@ export class RemoteRepoPicker implements vscode.Disposable {
             id: repo.id,
             label: repo.name,
             name: repo.name,
-            isIgnored: contextFiltersProvider.isRepoNameIgnored(repo.name),
+            isIgnored: contextFiltersProvider.instance!.isRepoNameIgnored(repo.name),
         }))
         this.handleRepoListChanged()
 
@@ -171,7 +171,7 @@ export class RemoteRepoPicker implements vscode.Disposable {
                 continue
             }
             displayedRepos.add(repo.id)
-            const isIgnored = contextFiltersProvider.isRepoNameIgnored(repo.name)
+            const isIgnored = contextFiltersProvider.instance!.isRepoNameIgnored(repo.name)
 
             const inWorkspace = workspaceRepos.has(repo.id)
             const shortName = repo.name.slice(repo.name.lastIndexOf('/') + 1)

--- a/vscode/src/edit/input/get-input.ts
+++ b/vscode/src/edit/input/get-input.ts
@@ -21,7 +21,7 @@ import { ACCOUNT_UPGRADE_URL } from '../../chat/protocol'
 import { executeDocCommand, executeTestEditCommand } from '../../commands/execute'
 import { getEditor } from '../../editor/active-editor'
 import { type TextChange, updateRangeMultipleChanges } from '../../non-stop/tracked-range'
-import type { AuthProvider } from '../../services/AuthProvider'
+import { authProvider } from '../../services/AuthProvider'
 import type { EditIntent, EditMode } from '../types'
 import { isGenerateIntent } from '../utils/edit-intent'
 import { CURSOR_RANGE_ITEM, EXPANDED_RANGE_ITEM, SELECTION_RANGE_ITEM } from './get-items/constants'
@@ -71,7 +71,6 @@ const PREVIEW_RANGE_DECORATION = vscode.window.createTextEditorDecorationType({
 
 export const getInput = async (
     document: vscode.TextDocument,
-    authProvider: AuthProvider,
     initialValues: EditInputInitialValues,
     source: EventSource
 ): Promise<QuickPickInput | null> => {
@@ -96,7 +95,7 @@ export const getInput = async (
               ? EXPANDED_RANGE_ITEM
               : SELECTION_RANGE_ITEM
 
-    const authStatus = authProvider.getAuthStatus()
+    const authStatus = authProvider.instance!.getAuthStatus()
     const isCodyPro = !authStatus.userCanUpgrade
     const modelOptions = modelsService.instance!.getModels(ModelUsage.Edit)
     const modelItems = getModelOptionItems(modelOptions, isCodyPro)

--- a/vscode/src/edit/input/get-input.ts
+++ b/vscode/src/edit/input/get-input.ts
@@ -98,7 +98,7 @@ export const getInput = async (
 
     const authStatus = authProvider.getAuthStatus()
     const isCodyPro = !authStatus.userCanUpgrade
-    const modelOptions = modelsService.getModels(ModelUsage.Edit)
+    const modelOptions = modelsService.instance!.getModels(ModelUsage.Edit)
     const modelItems = getModelOptionItems(modelOptions, isCodyPro)
     const showModelSelector = modelOptions.length > 1
 
@@ -106,7 +106,7 @@ export const getInput = async (
     let activeModelItem = modelItems.find(item => item.model === initialValues.initialModel)
 
     const getContextWindowOnModelChange = (model: EditModel) => {
-        const latestContextWindow = modelsService.getContextWindowByID(model)
+        const latestContextWindow = modelsService.instance!.getContextWindowByID(model)
         return latestContextWindow.input + (latestContextWindow.context?.user ?? 0)
     }
     let activeModelContextWindow = getContextWindowOnModelChange(activeModel)
@@ -210,7 +210,7 @@ export const getInput = async (
                     return
                 }
 
-                modelsService.setSelectedModel(ModelUsage.Edit, acceptedItem.model)
+                modelsService.instance!.setSelectedModel(ModelUsage.Edit, acceptedItem.model)
                 activeModelItem = acceptedItem
                 activeModel = acceptedItem.model
                 activeModelContextWindow = getContextWindowOnModelChange(acceptedItem.model)

--- a/vscode/src/edit/manager.ts
+++ b/vscode/src/edit/manager.ts
@@ -21,7 +21,7 @@ import { isUriIgnoredByContextFilterWithNotification } from '../cody-ignore/cont
 import { showCodyIgnoreNotification } from '../cody-ignore/notification'
 import type { ExtensionClient } from '../extension-client'
 import { ACTIVE_TASK_STATES } from '../non-stop/codelenses/constants'
-import type { AuthProvider } from '../services/AuthProvider'
+import { authProvider } from '../services/AuthProvider'
 import { splitSafeMetadata } from '../services/telemetry-v2'
 import type { ExecuteEditArguments } from './execute'
 import { SMART_APPLY_FILE_DECORATION, getSmartApplySelection } from './prompt/smart-apply'
@@ -35,7 +35,6 @@ export interface EditManagerOptions {
     editor: VSCodeEditor
     chat: ChatClient
     ghostHintDecorator: GhostHintDecorator
-    authProvider: AuthProvider
     extensionClient: ExtensionClient
 }
 
@@ -48,7 +47,7 @@ export class EditManager implements vscode.Disposable {
     private editProviders = new WeakMap<FixupTask, EditProvider>()
 
     constructor(public options: EditManagerOptions) {
-        this.controller = new FixupController(options.authProvider, options.extensionClient)
+        this.controller = new FixupController(options.extensionClient)
         /**
          * Entry point to triggering a new Edit.
          * Given a set or arguments, this will create a new LLM interaction
@@ -302,7 +301,7 @@ export class EditManager implements vscode.Disposable {
             configuration.document,
             model,
             this.options.chat,
-            this.options.authProvider.getAuthStatus().codyApiVersion
+            authProvider.instance!.getAuthStatus().codyApiVersion
         )
 
         // We finished prompting the LLM for the selection, we can now remove the "progress" decoration

--- a/vscode/src/edit/manager.ts
+++ b/vscode/src/edit/manager.ts
@@ -131,7 +131,7 @@ export class EditManager implements vscode.Disposable {
         // Set default edit configuration, if not provided
         // It is possible that these values may be overriden later, e.g. if the user changes them in the edit input.
         const range = getEditLineSelection(document, proposedRange)
-        const model = configuration.model || modelsService.getDefaultEditModel()
+        const model = configuration.model || modelsService.instance!.getDefaultEditModel()
         if (!model) {
             throw new Error('No default edit model found. Please set one.')
         }
@@ -240,7 +240,7 @@ export class EditManager implements vscode.Disposable {
             return
         }
 
-        const model = configuration.model || modelsService.getDefaultEditModel()
+        const model = configuration.model || modelsService.instance!.getDefaultEditModel()
         if (!model) {
             throw new Error('No default edit model found. Please set one.')
         }

--- a/vscode/src/edit/prompt/index.ts
+++ b/vscode/src/edit/prompt/index.ts
@@ -104,7 +104,7 @@ export const buildInteraction = async ({
             instruction: task.instruction,
             document,
         })
-    const promptBuilder = await PromptBuilder.create(modelsService.getContextWindowByID(model))
+    const promptBuilder = await PromptBuilder.create(modelsService.instance!.getContextWindowByID(model))
 
     const preamble = getSimplePreamble(model, codyApiVersion, 'Default', prompt.system)
     promptBuilder.tryAddToPrefix(preamble)

--- a/vscode/src/edit/prompt/smart-apply.ts
+++ b/vscode/src/edit/prompt/smart-apply.ts
@@ -74,7 +74,7 @@ const getPrompt = async (
     const documentRange = new vscode.Range(0, 0, document.lineCount - 1, 0)
     const documentText = PromptString.fromDocumentText(document, documentRange)
     const tokenCount = await TokenCounterUtils.countPromptString(documentText)
-    const contextWindow = modelsService.getContextWindowByID(model)
+    const contextWindow = modelsService.instance!.getContextWindowByID(model)
     if (tokenCount > contextWindow.input) {
         throw new Error("The amount of text in this document exceeds Cody's current capacity.")
     }
@@ -111,7 +111,7 @@ async function promptModelForOriginalCode(
     codyApiVersion: number
 ): Promise<string> {
     const multiplexer = new BotResponseMultiplexer()
-    const contextWindow = modelsService.getContextWindowByID(model)
+    const contextWindow = modelsService.instance!.getContextWindowByID(model)
 
     let text = ''
     multiplexer.sub(SMART_APPLY_TOPICS.REPLACE.toString(), {

--- a/vscode/src/edit/provider.ts
+++ b/vscode/src/edit/provider.ts
@@ -15,7 +15,7 @@ import {
 import { logError } from '../log'
 import type { FixupController } from '../non-stop/FixupController'
 import type { FixupTask } from '../non-stop/FixupTask'
-import { isNetworkError } from '../services/AuthProvider'
+import { authProvider, isNetworkError } from '../services/AuthProvider'
 
 import {
     DEFAULT_EVENT_SOURCE,
@@ -60,7 +60,7 @@ export class EditProvider {
                 responsePrefix = '',
             } = await buildInteraction({
                 model,
-                codyApiVersion: this.config.authProvider.getAuthStatus().codyApiVersion,
+                codyApiVersion: authProvider.instance!.getAuthStatus().codyApiVersion,
                 contextWindow: contextWindow.input,
                 task: this.config.task,
                 editor: this.config.editor,
@@ -215,7 +215,7 @@ export class EditProvider {
                 ...countCode(response),
             }
             const { metadata, privateMetadata } = splitSafeMetadata(legacyMetadata)
-            const endpoint = this.config.authProvider?.getAuthStatus()?.endpoint
+            const endpoint = authProvider.instance!.getAuthStatus()?.endpoint
             telemetryRecorder.recordEvent('cody.fixup.response', 'hasCode', {
                 metadata,
                 privateMetadata: {

--- a/vscode/src/edit/provider.ts
+++ b/vscode/src/edit/provider.ts
@@ -52,7 +52,7 @@ export class EditProvider {
         return wrapInActiveSpan('command.edit.start', async span => {
             this.config.controller.startTask(this.config.task)
             const model = this.config.task.model
-            const contextWindow = modelsService.getContextWindowByID(model)
+            const contextWindow = modelsService.instance!.getContextWindowByID(model)
             const {
                 messages,
                 stopSequences,

--- a/vscode/src/editor/utils/editor-context.test.ts
+++ b/vscode/src/editor/utils/editor-context.test.ts
@@ -24,7 +24,7 @@ afterEach(() => {
 
 describe('getFileContextFiles', () => {
     beforeEach(() => {
-        vi.spyOn(contextFiltersProvider, 'isUriIgnored').mockResolvedValue(false)
+        vi.spyOn(contextFiltersProvider.instance!, 'isUriIgnored').mockResolvedValue(false)
     })
     function setFiles(relativePaths: string[]) {
         vscode.workspace.findFiles = vi

--- a/vscode/src/editor/utils/editor-context.ts
+++ b/vscode/src/editor/utils/editor-context.ts
@@ -85,7 +85,7 @@ export async function getFileContextFiles(options: FileContextItemsOptions): Pro
             size: range ? 100 : item.file.byteSize,
             source: ContextItemSource.User,
             remoteRepositoryName: item.repository.name,
-            isIgnored: contextFiltersProvider.isRepoNameIgnored(item.repository.name),
+            isIgnored: contextFiltersProvider.instance!.isRepoNameIgnored(item.repository.name),
             uri: URI.file(`${item.repository.name}/${item.file.path}`),
         }))
     }
@@ -193,7 +193,7 @@ export async function getSymbolContextFiles(
                 type: 'symbol',
                 remoteRepositoryName: item.repository.name,
                 uri: URI.file(`${item.repository.name}/${symbol.location.resource.path}`),
-                isIgnored: contextFiltersProvider.isRepoNameIgnored(item.repository.name),
+                isIgnored: contextFiltersProvider.instance!.isRepoNameIgnored(item.repository.name),
                 source: ContextItemSource.User,
                 symbolName: symbol.name,
                 // TODO [VK] Support other symbols kind
@@ -304,7 +304,7 @@ async function createContextFileFromUri(
                   uri,
                   range,
                   source,
-                  isIgnored: Boolean(await contextFiltersProvider.isUriIgnored(uri)),
+                  isIgnored: Boolean(await contextFiltersProvider.instance!.isUriIgnored(uri)),
               }
             : {
                   type,

--- a/vscode/src/extension.node.ts
+++ b/vscode/src/extension.node.ts
@@ -20,7 +20,7 @@ import {
     createLocalEmbeddingsController,
 } from './local-context/local-embeddings'
 import { SymfRunner } from './local-context/symf'
-import { AuthProvider } from './services/AuthProvider'
+import { authProvider } from './services/AuthProvider'
 import { localStorage } from './services/LocalStorageProvider'
 import { OpenTelemetryService } from './services/open-telemetry/OpenTelemetryService.node'
 import { getExtensionDetails } from './services/telemetry-v2'
@@ -81,7 +81,7 @@ export function activate(
 // The vscode API is not available in the post-uninstall script.
 export async function deactivate(): Promise<void> {
     const config = localStorage.getConfig() ?? (await getFullConfig())
-    const authStatus = AuthProvider.instance?.getAuthStatus() ?? defaultAuthStatus
+    const authStatus = authProvider.instance?.getAuthStatus() ?? defaultAuthStatus
     const { anonymousUserID } = await localStorage.anonymousUserID()
     serializeConfigSnapshot({
         config,

--- a/vscode/src/external-services.ts
+++ b/vscode/src/external-services.ts
@@ -9,7 +9,6 @@ import {
     type GuardrailsClientConfig,
     type SourcegraphCompletionsClient,
     SourcegraphGuardrailsClient,
-    featureFlagProvider,
     graphqlClient,
     isError,
 } from '@sourcegraph/cody-shared'
@@ -86,7 +85,7 @@ export async function configureExternalServices(
 
     const guardrails = new SourcegraphGuardrailsClient(graphqlClient, initialConfig)
 
-    const contextAPIClient = new ContextAPIClient(graphqlClient, featureFlagProvider)
+    const contextAPIClient = new ContextAPIClient(graphqlClient)
 
     return {
         chatClient,

--- a/vscode/src/external-services.ts
+++ b/vscode/src/external-services.ts
@@ -19,7 +19,7 @@ import type { PlatformContext } from './extension.common'
 import type { LocalEmbeddingsConfig, LocalEmbeddingsController } from './local-context/local-embeddings'
 import type { SymfRunner } from './local-context/symf'
 import { logDebug, logger } from './log'
-import type { AuthProvider } from './services/AuthProvider'
+import { authProvider } from './services/AuthProvider'
 
 interface ExternalServices {
     chatClient: ChatClient
@@ -57,8 +57,7 @@ export async function configureExternalServices(
         | 'createSentryService'
         | 'createOpenTelemetryService'
         | 'createSymfRunner'
-    >,
-    authProvider: AuthProvider
+    >
 ): Promise<ExternalServices> {
     const initialConfig = config.get()
     const sentryService = platform.createSentryService?.(initialConfig)
@@ -66,7 +65,7 @@ export async function configureExternalServices(
     const completionsClient = platform.createCompletionsClient(initialConfig, logger)
     const codeCompletionsClient = createCodeCompletionsClient(initialConfig, logger)
 
-    const symfRunner = platform.createSymfRunner?.(context, completionsClient, authProvider)
+    const symfRunner = platform.createSymfRunner?.(context, completionsClient)
 
     if (initialConfig.codebase && isError(await graphqlClient.getRepoId(initialConfig.codebase))) {
         logDebug(
@@ -77,11 +76,12 @@ export async function configureExternalServices(
 
     // Disable local embeddings for enterprise users.
     const localEmbeddings =
-        authProvider.getAuthStatus().isLoggedIn && authProvider.getAuthStatus().isDotCom
+        authProvider.instance!.getAuthStatus().isLoggedIn &&
+        authProvider.instance!.getAuthStatus().isDotCom
             ? await platform.createLocalEmbeddingsController?.(initialConfig)
             : undefined
 
-    const chatClient = new ChatClient(completionsClient, () => authProvider.getAuthStatus())
+    const chatClient = new ChatClient(completionsClient, () => authProvider.instance!.getAuthStatus())
 
     const guardrails = new SourcegraphGuardrailsClient(graphqlClient, initialConfig)
 

--- a/vscode/src/local-context/local-embeddings.ts
+++ b/vscode/src/local-context/local-embeddings.ts
@@ -33,7 +33,9 @@ export async function createLocalEmbeddingsController(
 ): Promise<LocalEmbeddingsController> {
     const modelConfig =
         config.testingModelConfig ||
-        (await featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyEmbeddingsGenerateMetadata))
+        (await featureFlagProvider.instance!.evaluateFeatureFlag(
+            FeatureFlag.CodyEmbeddingsGenerateMetadata
+        ))
             ? sourcegraphMetadataModelConfig
             : sourcegraphModelConfig
 

--- a/vscode/src/local-context/symf.ts
+++ b/vscode/src/local-context/symf.ts
@@ -30,7 +30,7 @@ import { logDebug } from '../log'
 
 import path from 'node:path'
 import { getEditor } from '../editor/active-editor'
-import type { AuthProvider } from '../services/AuthProvider'
+import { authProvider } from '../services/AuthProvider'
 import { getSymfPath } from './download-symf'
 import { rewriteKeywordQuery } from './rewrite-keyword-query'
 
@@ -74,8 +74,7 @@ export class SymfRunner implements vscode.Disposable {
 
     constructor(
         private context: vscode.ExtensionContext,
-        private completionsClient: SourcegraphCompletionsClient,
-        authProvider: AuthProvider
+        private completionsClient: SourcegraphCompletionsClient
     ) {
         const indexRoot = vscode.Uri.joinPath(context.globalStorageUri, 'symf', 'indexroot').with(
             // On VS Code Desktop, this is a `vscode-userdata:` URI that actually just refers to
@@ -91,7 +90,7 @@ export class SymfRunner implements vscode.Disposable {
         let isInitialized = false
         this.disposables.push(
             subscriptionDisposable(
-                authProvider.changes.subscribe(authStatus => {
+                authProvider.instance!.changes.subscribe(authStatus => {
                     if (!isInitialized && authStatus.isLoggedIn && !isEnterpriseUser(authStatus)) {
                         // Only initialize symf after the user has authenticated AND it's not an enterprise account.
                         isInitialized = true

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -323,7 +323,7 @@ async function initializeSingletons(
                 next: config => {
                     void localStorage.setConfig(config)
                     graphqlClient.setConfig(config)
-                    void featureFlagProvider.refresh()
+                    void featureFlagProvider.instance!.refresh()
                     contextFiltersProvider.instance!.init(repoNameResolver.getRepoNamesFromWorkspaceUri)
                     void modelsService.instance!.onConfigChange(config)
                     upstreamHealthProvider.onConfigurationChange(config)
@@ -559,7 +559,6 @@ function registerUpgradeHandlers(
         new CodyProExpirationNotifications(
             graphqlClient,
             authProvider,
-            featureFlagProvider,
             vscode.window.showInformationMessage,
             vscode.env.openExternal
         )
@@ -676,10 +675,11 @@ function registerAutocomplete(
                 // completion provider.
                 disposeAutocomplete()
 
-                const autocompleteFeatureFlagChangeSubscriber = featureFlagProvider.onFeatureFlagChanged(
-                    'cody-autocomplete',
-                    setupAutocomplete
-                )
+                const autocompleteFeatureFlagChangeSubscriber =
+                    featureFlagProvider.instance!.onFeatureFlagChanged(
+                        'cody-autocomplete',
+                        setupAutocomplete
+                    )
                 autocompleteDisposables.push({
                     dispose: autocompleteFeatureFlagChangeSubscriber,
                 })

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -314,7 +314,7 @@ async function initializeSingletons(
     // Allow the VS Code app's instance of ModelsService to use local storage to persist
     // user's model choices
     modelsService.instance!.setStorage(localStorage)
-    disposables.push(upstreamHealthProvider, contextFiltersProvider)
+    disposables.push(upstreamHealthProvider, contextFiltersProvider.instance!)
     commandControllerInit(platform.createCommandsProvider?.(), platform.extensionClient.capabilities)
     repoNameResolver.init(authProvider)
     disposables.push(
@@ -324,7 +324,7 @@ async function initializeSingletons(
                     void localStorage.setConfig(config)
                     graphqlClient.setConfig(config)
                     void featureFlagProvider.refresh()
-                    contextFiltersProvider.init(repoNameResolver.getRepoNamesFromWorkspaceUri)
+                    contextFiltersProvider.instance!.init(repoNameResolver.getRepoNamesFromWorkspaceUri)
                     void modelsService.instance!.onConfigChange(config)
                     upstreamHealthProvider.onConfigurationChange(config)
                 },
@@ -584,7 +584,7 @@ async function registerTestCommands(
             }
             try {
                 const policy = JSON.parse(raw)
-                contextFiltersProvider.setTestingContextFilters(policy)
+                contextFiltersProvider.instance!.setTestingContextFilters(policy)
             } catch (error) {
                 vscode.window.showErrorMessage(
                     'Failed to parse context filters policy. Please check your JSON syntax.'

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -298,7 +298,7 @@ async function initializeSingletons(
     // Allow the VS Code app's instance of ModelsService to use local storage to persist
     // user's model choices
     modelsService.instance!.setStorage(localStorage)
-    disposables.push(upstreamHealthProvider, contextFiltersProvider.instance!)
+    disposables.push(upstreamHealthProvider.instance!, contextFiltersProvider.instance!)
     commandControllerInit(platform.createCommandsProvider?.(), platform.extensionClient.capabilities)
     repoNameResolver.init()
     disposables.push(
@@ -310,7 +310,7 @@ async function initializeSingletons(
                     void featureFlagProvider.instance!.refresh()
                     contextFiltersProvider.instance!.init(repoNameResolver.getRepoNamesFromWorkspaceUri)
                     void modelsService.instance!.onConfigChange(config)
-                    upstreamHealthProvider.onConfigurationChange(config)
+                    upstreamHealthProvider.instance!.onConfigurationChange(config)
                 },
             })
         )

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -17,6 +17,7 @@ import {
     modelsService,
     setClientNameVersion,
     setLogger,
+    setSingleton,
     subscriptionDisposable,
     telemetryRecorder,
 } from '@sourcegraph/cody-shared'
@@ -70,7 +71,7 @@ import { showSetupNotification } from './notifications/setup-notification'
 import { initVSCodeGitApi } from './repository/git-extension-api'
 import { initWorkspaceReposMonitor } from './repository/repo-metadata-from-git-api'
 import { repoNameResolver } from './repository/repo-name-resolver'
-import { AuthProvider } from './services/AuthProvider'
+import { AuthProvider, authProvider } from './services/AuthProvider'
 import { CharactersLogger } from './services/CharactersLogger'
 import { showFeedbackSupportQuickPick } from './services/FeedbackOptions'
 import { displayHistoryQuickPick } from './services/HistoryChat'
@@ -117,12 +118,12 @@ export async function start(
 
     const disposables: vscode.Disposable[] = []
 
-    const authProvider = AuthProvider.create(await getFullConfig())
-    const configWatcher = await BaseConfigWatcher.create(authProvider, disposables)
+    setSingleton(authProvider, new AuthProvider(await getFullConfig()))
+    const configWatcher = await BaseConfigWatcher.create(disposables)
     disposables.push(
         subscriptionDisposable(
             configWatcher.changes.subscribe({
-                next: config => configureEventsInfra(config, isExtensionModeDevOrTest, authProvider),
+                next: config => configureEventsInfra(config, isExtensionModeDevOrTest),
             })
         )
     )
@@ -132,7 +133,7 @@ export async function start(
     // is complete. It is also important that AuthProvider inintialization
     // completes before initializeSingletons is called, because many of
     // those assume an initialized AuthProvider
-    await authProvider.init()
+    await authProvider.instance!.init()
 
     disposables.push(
         subscriptionDisposable(
@@ -145,9 +146,7 @@ export async function start(
         )
     )
 
-    disposables.push(
-        await register(context, authProvider, configWatcher, platform, isExtensionModeDevOrTest)
-    )
+    disposables.push(await register(context, configWatcher, platform, isExtensionModeDevOrTest))
 
     return vscode.Disposable.from(...disposables)
 }
@@ -155,7 +154,6 @@ export async function start(
 // Registers commands and webview given the config.
 const register = async (
     context: vscode.ExtensionContext,
-    authProvider: AuthProvider,
     configWatcher: ConfigWatcher<ClientConfigurationWithAccessToken>,
     platform: PlatformContext,
     isExtensionModeDevOrTest: boolean
@@ -168,17 +166,11 @@ const register = async (
     disposables.push(manageDisplayPathEnvInfoForExtension())
 
     // Initialize singletons
-    await initializeSingletons(
-        platform,
-        authProvider,
-        configWatcher,
-        isExtensionModeDevOrTest,
-        disposables
-    )
+    await initializeSingletons(platform, configWatcher, isExtensionModeDevOrTest, disposables)
 
     // Ensure Git API is available
     disposables.push(await initVSCodeGitApi())
-    initWorkspaceReposMonitor(authProvider, disposables)
+    initWorkspaceReposMonitor(disposables)
 
     registerParserListeners(disposables)
     registerChatListeners(disposables)
@@ -193,7 +185,7 @@ const register = async (
         onConfigurationChange: externalServicesOnDidConfigurationChange,
         symfRunner,
         contextAPIClient,
-    } = await configureExternalServices(context, configWatcher, platform, authProvider)
+    } = await configureExternalServices(context, configWatcher, platform)
     disposables.push(
         subscriptionDisposable(
             configWatcher.changes.subscribe({
@@ -231,7 +223,6 @@ const register = async (
             chatClient,
             guardrails,
             editor,
-            authProvider,
             enterpriseContextFactory,
             localEmbeddings,
             symfRunner,
@@ -248,7 +239,7 @@ const register = async (
         statusBar,
         sourceControl,
         subscriptionDisposable(
-            authProvider.changes.subscribe({
+            authProvider.instance!.changes.subscribe({
                 next: authStatus => {
                     sourceControl.setAuthStatus(authStatus)
                     statusBar.setAuthStatus(authStatus)
@@ -260,30 +251,24 @@ const register = async (
     const autocompleteSetup = registerAutocomplete(
         configWatcher,
         platform,
-        authProvider,
         statusBar,
         codeCompletionsClient,
         disposables
     )
     const tutorialSetup = tryRegisterTutorial(context, disposables)
-    const openCtxSetup = exposeOpenCtxClient(
-        context,
-        configWatcher,
-        authProvider,
-        platform.createOpenCtxController
-    )
+    const openCtxSetup = exposeOpenCtxClient(context, configWatcher, platform.createOpenCtxController)
 
     registerCodyCommands(configWatcher, statusBar, sourceControl, chatClient, disposables)
-    registerAuthCommands(authProvider, disposables)
-    registerChatCommands(authProvider, disposables)
+    registerAuthCommands(disposables)
+    registerChatCommands(disposables)
     disposables.push(...registerSidebarCommands())
     disposables.push(...setUpCodyIgnore(configWatcher.get()))
     registerOtherCommands(disposables)
     if (isExtensionModeDevOrTest) {
-        await registerTestCommands(context, authProvider, disposables)
+        await registerTestCommands(context, disposables)
     }
     registerDebugCommands(context, disposables)
-    registerUpgradeHandlers(configWatcher, authProvider, disposables)
+    registerUpgradeHandlers(configWatcher, disposables)
     disposables.push(new CharactersLogger())
 
     // INC-267 do NOT await on this promise. This promise triggers
@@ -297,7 +282,7 @@ const register = async (
         autocompleteSetup,
         openCtxSetup,
         tutorialSetup,
-        registerMinion(context, configWatcher, authProvider, symfRunner, disposables),
+        registerMinion(context, configWatcher, symfRunner, disposables),
     ])
     disposables.push(extensionClientDispose)
 
@@ -306,7 +291,6 @@ const register = async (
 
 async function initializeSingletons(
     platform: PlatformContext,
-    authProvider: AuthProvider,
     configWatcher: ConfigWatcher<ClientConfigurationWithAccessToken>,
     isExtensionModeDevOrTest: boolean,
     disposables: vscode.Disposable[]
@@ -316,7 +300,7 @@ async function initializeSingletons(
     modelsService.instance!.setStorage(localStorage)
     disposables.push(upstreamHealthProvider, contextFiltersProvider.instance!)
     commandControllerInit(platform.createCommandsProvider?.(), platform.extensionClient.capabilities)
-    repoNameResolver.init(authProvider)
+    repoNameResolver.init()
     disposables.push(
         subscriptionDisposable(
             configWatcher.changes.subscribe({
@@ -472,7 +456,7 @@ function registerCodyCommands(
     )
 }
 
-function registerChatCommands(authProvider: AuthProvider, disposables: vscode.Disposable[]): void {
+function registerChatCommands(disposables: vscode.Disposable[]): void {
     disposables.push(
         // Chat
         vscode.commands.registerCommand('cody.settings.extension', () =>
@@ -484,7 +468,7 @@ function registerChatCommands(authProvider: AuthProvider, disposables: vscode.Di
             vscode.commands.executeCommand('workbench.action.moveEditorToNewWindow')
         }),
         vscode.commands.registerCommand('cody.chat.history.panel', async () => {
-            await displayHistoryQuickPick(authProvider.getAuthStatus())
+            await displayHistoryQuickPick(authProvider.instance!.getAuthStatus())
         }),
         vscode.commands.registerCommand('cody.settings.extension.chat', () =>
             vscode.commands.executeCommand('workbench.action.openSettings', {
@@ -497,13 +481,15 @@ function registerChatCommands(authProvider: AuthProvider, disposables: vscode.Di
     )
 }
 
-function registerAuthCommands(authProvider: AuthProvider, disposables: vscode.Disposable[]): void {
+function registerAuthCommands(disposables: vscode.Disposable[]): void {
     disposables.push(
-        vscode.commands.registerCommand('cody.auth.signin', () => authProvider.signinMenu()),
-        vscode.commands.registerCommand('cody.auth.signout', () => authProvider.signoutMenu()),
-        vscode.commands.registerCommand('cody.auth.account', () => authProvider.accountMenu()),
+        vscode.commands.registerCommand('cody.auth.signin', () => authProvider.instance!.signinMenu()),
+        vscode.commands.registerCommand('cody.auth.signout', () => authProvider.instance!.signoutMenu()),
+        vscode.commands.registerCommand('cody.auth.account', () => authProvider.instance!.accountMenu()),
         vscode.commands.registerCommand('cody.auth.support', () => showFeedbackSupportQuickPick()),
-        vscode.commands.registerCommand('cody.auth.status', () => authProvider.getAuthStatus()), // Used by the agent
+        vscode.commands.registerCommand('cody.auth.status', () =>
+            authProvider.instance!.getAuthStatus()
+        ), // Used by the agent
         vscode.commands.registerCommand(
             'cody.agent.auth.authenticate',
             async ({ serverEndpoint, accessToken, customHeaders }) => {
@@ -513,7 +499,7 @@ function registerAuthCommands(authProvider: AuthProvider, disposables: vscode.Di
                 if (typeof accessToken !== 'string') {
                     throw new TypeError('accessToken is required')
                 }
-                return await authProvider.auth({
+                return await authProvider.instance!.auth({
                     endpoint: serverEndpoint,
                     token: accessToken,
                     customHeaders,
@@ -525,7 +511,6 @@ function registerAuthCommands(authProvider: AuthProvider, disposables: vscode.Di
 
 function registerUpgradeHandlers(
     configWatcher: ConfigWatcher<ClientConfiguration>,
-    authProvider: AuthProvider,
     disposables: vscode.Disposable[]
 ): void {
     disposables.push(
@@ -535,14 +520,14 @@ function registerUpgradeHandlers(
                 if (uri.path === '/app-done') {
                     // This is an old re-entrypoint from App that is a no-op now.
                 } else {
-                    authProvider.tokenCallbackHandler(uri, configWatcher.get().customHeaders)
+                    authProvider.instance!.tokenCallbackHandler(uri, configWatcher.get().customHeaders)
                 }
             },
         }),
 
         // Check if user has just moved back from a browser window to upgrade cody pro
         vscode.window.onDidChangeWindowState(async ws => {
-            const authStatus = authProvider.getAuthStatus()
+            const authStatus = authProvider.instance!.getAuthStatus()
             if (ws.focused && authStatus.isDotCom && authStatus.isLoggedIn) {
                 const res = await graphqlClient.getCurrentUserCodyProEnabled()
                 if (res instanceof Error) {
@@ -552,13 +537,12 @@ function registerUpgradeHandlers(
                 // Re-auth if user's cody pro status has changed
                 const isCurrentCodyProUser = !authStatus.userCanUpgrade
                 if (res && res.codyProEnabled !== isCurrentCodyProUser) {
-                    authProvider.reloadAuthStatus()
+                    authProvider.instance!.reloadAuthStatus()
                 }
             }
         }),
         new CodyProExpirationNotifications(
             graphqlClient,
-            authProvider,
             vscode.window.showInformationMessage,
             vscode.env.openExternal
         )
@@ -570,7 +554,6 @@ function registerUpgradeHandlers(
  */
 async function registerTestCommands(
     context: vscode.ExtensionContext,
-    authProvider: AuthProvider,
     disposables: vscode.Disposable[]
 ): Promise<void> {
     await vscode.commands.executeCommand('setContext', 'cody.devOrTest', true)
@@ -592,7 +575,7 @@ async function registerTestCommands(
         }),
         // Access token - this is only used in configuration tests
         vscode.commands.registerCommand('cody.test.token', async (endpoint, token) =>
-            authProvider.auth({ endpoint, token })
+            authProvider.instance!.auth({ endpoint, token })
         )
     )
 }
@@ -633,7 +616,6 @@ async function tryRegisterTutorial(
 function registerAutocomplete(
     configWatcher: ConfigWatcher<ClientConfigurationWithEndpoint>,
     platform: PlatformContext,
-    authProvider: AuthProvider,
     statusBar: CodyStatusBar,
     codeCompletionsClient: CodeCompletionsClient,
     disposables: vscode.Disposable[]
@@ -688,7 +670,6 @@ function registerAutocomplete(
                         config,
                         client: codeCompletionsClient,
                         statusBar,
-                        authProvider: authProvider,
                         createBfgRetriever: platform.createBfgRetriever,
                     })
                 )
@@ -697,7 +678,6 @@ function registerAutocomplete(
                         config,
                         client: codeCompletionsClient,
                         statusBar,
-                        authProvider: authProvider,
                         createBfgRetriever: platform.createBfgRetriever,
                     }),
                     autocompleteStageCounterLogger
@@ -717,12 +697,11 @@ function registerAutocomplete(
 async function registerMinion(
     context: vscode.ExtensionContext,
     config: ConfigWatcher<ClientConfiguration>,
-    authProvider: AuthProvider,
     symfRunner: SymfRunner | undefined,
     disposables: vscode.Disposable[]
 ): Promise<void> {
     if (config.get().experimentalMinionAnthropicKey) {
-        const minionOrchestrator = new MinionOrchestrator(context.extensionUri, authProvider, symfRunner)
+        const minionOrchestrator = new MinionOrchestrator(context.extensionUri, symfRunner)
         disposables.push(minionOrchestrator)
         disposables.push(
             vscode.commands.registerCommand('cody.minion.panel.new', () =>
@@ -742,7 +721,6 @@ interface RegisterChatOptions {
     chatClient: ChatClient
     guardrails: Guardrails
     editor: VSCodeEditor
-    authProvider: AuthProvider
     enterpriseContextFactory: EnterpriseContextFactory
     localEmbeddings?: LocalEmbeddingsController
     symfRunner?: SymfRunner
@@ -757,7 +735,6 @@ function registerChat(
         chatClient,
         guardrails,
         editor,
-        authProvider,
         enterpriseContextFactory,
         localEmbeddings,
         symfRunner,
@@ -773,7 +750,6 @@ function registerChat(
         chat: chatClient,
         guardrails,
         editor,
-        authProvider,
     }
     const chatsController = new ChatsController(
         {
@@ -782,7 +758,6 @@ function registerChat(
             startTokenReceiver: platform.startTokenReceiver,
         },
         chatClient,
-        authProvider,
         enterpriseContextFactory,
         localEmbeddings || null,
         symfRunner || null,
@@ -793,12 +768,11 @@ function registerChat(
     )
     chatsController.registerViewsAndCommands()
 
-    const ghostHintDecorator = new GhostHintDecorator(authProvider)
+    const ghostHintDecorator = new GhostHintDecorator()
     const editorManager = new EditManager({
         chat: chatClient,
         editor,
         ghostHintDecorator,
-        authProvider,
         extensionClient: platform.extensionClient,
     })
     disposables.push(ghostHintDecorator, editorManager, new CodeActionProvider())
@@ -828,8 +802,7 @@ function registerChat(
  */
 async function configureEventsInfra(
     config: ClientConfigurationWithAccessToken,
-    isExtensionModeDevOrTest: boolean,
-    authProvider: AuthProvider
+    isExtensionModeDevOrTest: boolean
 ): Promise<void> {
-    await createOrUpdateTelemetryRecorderProvider(config, isExtensionModeDevOrTest, authProvider)
+    await createOrUpdateTelemetryRecorderProvider(config, isExtensionModeDevOrTest)
 }

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -313,7 +313,7 @@ async function initializeSingletons(
 ): Promise<void> {
     // Allow the VS Code app's instance of ModelsService to use local storage to persist
     // user's model choices
-    modelsService.setStorage(localStorage)
+    modelsService.instance!.setStorage(localStorage)
     disposables.push(upstreamHealthProvider, contextFiltersProvider)
     commandControllerInit(platform.createCommandsProvider?.(), platform.extensionClient.capabilities)
     repoNameResolver.init(authProvider)
@@ -325,7 +325,7 @@ async function initializeSingletons(
                     graphqlClient.setConfig(config)
                     void featureFlagProvider.refresh()
                     contextFiltersProvider.init(repoNameResolver.getRepoNamesFromWorkspaceUri)
-                    void modelsService.onConfigChange(config)
+                    void modelsService.instance!.onConfigChange(config)
                     upstreamHealthProvider.onConfigurationChange(config)
                 },
             })

--- a/vscode/src/minion/MinionController.ts
+++ b/vscode/src/minion/MinionController.ts
@@ -7,7 +7,7 @@ import type {
 } from '../../webviews/minion/webview_protocol'
 import { InitDoer } from '../chat/chat-view/InitDoer'
 import type { SymfRunner } from '../local-context/symf'
-import type { AuthProvider } from '../services/AuthProvider'
+import { authProvider } from '../services/AuthProvider'
 import { MinionStorage } from './MinionStorage'
 import { PlanController } from './PlanController'
 import type { Event, MinionSession, MinionTranscriptBlock, MinionTranscriptItem } from './action'
@@ -171,7 +171,6 @@ export class MinionController extends ReactPanelController<
     //
 
     constructor(
-        private authProvider: AuthProvider,
         private symf: SymfRunner | undefined,
         private anthropic: Anthropic,
         assetRoot: vscode.Uri,
@@ -392,7 +391,7 @@ export class MinionController extends ReactPanelController<
     }
 
     private async handleSetSession(id: string): Promise<void> {
-        const storedSessionState = await this.storage.load(this.authProvider.getAuthStatus(), id)
+        const storedSessionState = await this.storage.load(authProvider.instance!.getAuthStatus(), id)
         if (!storedSessionState) {
             throw new Error(`session not found with id: ${id}`)
         }
@@ -410,7 +409,7 @@ export class MinionController extends ReactPanelController<
     }
 
     private async handleClearHistory(): Promise<void> {
-        await this.storage.clear(this.authProvider.getAuthStatus())
+        await this.storage.clear(authProvider.instance!.getAuthStatus())
         if (this.sessionState) {
             await this.save()
         }
@@ -499,7 +498,7 @@ export class MinionController extends ReactPanelController<
         if (!this.sessionState) {
             throw new Error('no session to save')
         }
-        await this.storage.save(this.authProvider.getAuthStatus(), {
+        await this.storage.save(authProvider.instance!.getAuthStatus(), {
             session: this.sessionState.session,
         })
     }
@@ -563,7 +562,7 @@ export class MinionController extends ReactPanelController<
     private async postUpdateSessionIds(): Promise<void> {
         this.postMessage({
             type: 'update-session-ids',
-            sessionIds: await this.storage.listIds(this.authProvider.getAuthStatus()),
+            sessionIds: await this.storage.listIds(authProvider.instance!.getAuthStatus()),
             currentSessionId: this.sessionState?.session.id,
         })
     }

--- a/vscode/src/minion/MinionOrchestrator.ts
+++ b/vscode/src/minion/MinionOrchestrator.ts
@@ -2,7 +2,6 @@ import Anthropic from '@anthropic-ai/sdk'
 import * as vscode from 'vscode'
 import { getConfiguration } from '../configuration'
 import type { SymfRunner } from '../local-context/symf'
-import type { AuthProvider } from '../services/AuthProvider'
 import { MinionController, ReactPanelController } from './MinionController'
 
 export class MinionOrchestrator implements vscode.Disposable {
@@ -12,7 +11,6 @@ export class MinionOrchestrator implements vscode.Disposable {
 
     constructor(
         private extensionUri: vscode.Uri,
-        private authProvider: AuthProvider,
         private symf: SymfRunner | undefined
     ) {
         this.registerHumanListeners()
@@ -69,7 +67,7 @@ export class MinionOrchestrator implements vscode.Disposable {
 
         const minion = await ReactPanelController.createAndInit<MinionController>(
             (): MinionController => {
-                return new MinionController(this.authProvider, this.symf, anthropic, assetRoot, () => {})
+                return new MinionController(this.symf, anthropic, assetRoot, () => {})
             },
             panel
         )

--- a/vscode/src/models/modelMigrator.ts
+++ b/vscode/src/models/modelMigrator.ts
@@ -37,7 +37,7 @@ export function migrateAndNotifyForOutdatedModels(model: string | null): string 
     // Claude 2 to Claude 3 migration.
     const newModel = 'anthropic/claude-3-5-sonnet-20240620'
     // Verify that the new model is available before migrating.
-    if (modelsService.getModelByID(newModel)) {
+    if (modelsService.instance!.getModelByID(newModel)) {
         showNotificationIfNotShownYet(
             'Claude 2 model support has been removed in favor of the newer Claude 3 models. All chats that used Claude 2 have been upgraded to Claude 3.',
             'claude2-migration-notification-shown'

--- a/vscode/src/models/sync.test.ts
+++ b/vscode/src/models/sync.test.ts
@@ -15,7 +15,7 @@ import { syncModels } from './sync'
 import { getEnterpriseContextWindow } from './utils'
 
 describe('syncModels', () => {
-    const setModelsSpy = vi.spyOn(modelsService, 'setModels')
+    const setModelsSpy = vi.spyOn(modelsService.instance!, 'setModels')
 
     beforeEach(() => {
         setModelsSpy.mockClear()
@@ -93,10 +93,10 @@ describe('syncModels from the server', () => {
     // Unlike the other mocks, we define setModelsSpy here so that it can
     // be referenced by individual tests. (But like the other spys, it needs
     // to be reset/restored after each test.)
-    let setModelsSpy = vi.spyOn(modelsService, 'setModels')
+    let setModelsSpy = vi.spyOn(modelsService.instance!, 'setModels')
 
     beforeEach(() => {
-        setModelsSpy = vi.spyOn(modelsService, 'setModels')
+        setModelsSpy = vi.spyOn(modelsService.instance!, 'setModels')
 
         // Mock the /.api/client-config for these tests so that modelsAPIEnabled == true
         const mockClientConfig = {

--- a/vscode/src/models/sync.ts
+++ b/vscode/src/models/sync.ts
@@ -26,15 +26,15 @@ import { getEnterpriseContextWindow } from './utils'
  */
 export async function syncModels(authStatus: AuthStatus): Promise<void> {
     // Offline mode only support Ollama models, which would be synced seperately.
-    modelsService.setAuthStatus(authStatus)
+    modelsService.instance!.setAuthStatus(authStatus)
     if (authStatus.isOfflineMode) {
-        modelsService.setModels([])
+        modelsService.instance!.setModels([])
         return
     }
 
     // If you are not authenticated, you cannot use Cody. Sorry.
     if (!authStatus.authenticated) {
-        modelsService.setModels([])
+        modelsService.instance!.setModels([])
         return
     }
 
@@ -47,7 +47,7 @@ export async function syncModels(authStatus: AuthStatus): Promise<void> {
         const serverSideModels = await fetchServerSideModels(authStatus.endpoint || '')
         // If the request failed, fall back to using the default models
         if (serverSideModels) {
-            modelsService.setServerSentModels(serverSideModels)
+            modelsService.instance!.setServerSentModels(serverSideModels)
             // NOTE: Calling `registerModelsFromVSCodeConfiguration()` doesn't entirely make sense in
             // a world where LLM models are managed server-side. However, this is how Cody can be extended
             // to use locally running LLMs such as Ollama. (Though some more testing is needed.)
@@ -60,7 +60,7 @@ export async function syncModels(authStatus: AuthStatus): Promise<void> {
     // If you are connecting to Sourcegraph.com, we use the Cody Pro set of models.
     // (Only some of them may not be available if you are on the Cody Free plan.)
     if (authStatus.isDotCom) {
-        modelsService.setModels(getDotComDefaultModels())
+        modelsService.instance!.setModels(getDotComDefaultModels())
         registerModelsFromVSCodeConfiguration()
         return
     }
@@ -75,7 +75,7 @@ export async function syncModels(authStatus: AuthStatus): Promise<void> {
     // NOTE: If authStatus?.configOverwrites?.chatModel is empty,
     // automatically fallback to use the default model configured on the instance.
     if (authStatus?.configOverwrites?.chatModel) {
-        modelsService.setModels([
+        modelsService.instance!.setModels([
             new Model({
                 id: authStatus.configOverwrites.chatModel,
                 // TODO (umpox) Add configOverwrites.editModel for separate edit support
@@ -91,7 +91,7 @@ export async function syncModels(authStatus: AuthStatus): Promise<void> {
         // If the enterprise instance didn't have any configuration data for Cody,
         // clear the models available in the modelsService. Otherwise there will be
         // stale, defunct models available.
-        modelsService.setModels([])
+        modelsService.instance!.setModels([])
     }
 }
 
@@ -120,7 +120,7 @@ export function registerModelsFromVSCodeConfiguration() {
         return
     }
 
-    modelsService.addModels(
+    modelsService.instance!.addModels(
         modelsConfig.map(
             m =>
                 new Model({

--- a/vscode/src/non-stop/FixupController.ts
+++ b/vscode/src/non-stop/FixupController.ts
@@ -32,7 +32,7 @@ import { isStreamedIntent } from '../edit/utils/edit-intent'
 import { getOverridenModelForIntent } from '../edit/utils/edit-models'
 import type { ExtensionClient } from '../extension-client'
 import { isRunningInsideAgent } from '../jsonrpc/isRunningInsideAgent'
-import type { AuthProvider } from '../services/AuthProvider'
+import { authProvider } from '../services/AuthProvider'
 import { FixupDocumentEditObserver } from './FixupDocumentEditObserver'
 import type { FixupFile } from './FixupFile'
 import { FixupFileObserver } from './FixupFileObserver'
@@ -72,10 +72,7 @@ export class FixupController
 
     private _disposables: vscode.Disposable[] = []
 
-    constructor(
-        private readonly authProvider: AuthProvider,
-        private readonly client: ExtensionClient
-    ) {
+    constructor(private readonly client: ExtensionClient) {
         this.controlApplicator = client.createFixupControlApplicator(this)
         // Observe file renaming and deletion
         this.files = new FixupFileObserver()
@@ -376,7 +373,6 @@ export class FixupController
             previousInput ??
             (await getInput(
                 document,
-                this.authProvider,
                 {
                     initialInputValue: task.instruction,
                     initialRange: task.selectionRange,
@@ -455,7 +451,6 @@ export class FixupController
     ): Promise<FixupTask | null> {
         const input = await getInput(
             document,
-            this.authProvider,
             {
                 initialRange: range,
                 initialExpandedRange: expandedRange,
@@ -507,7 +502,7 @@ export class FixupController
         telemetryMetadata?: FixupTelemetryMetadata,
         taskId?: FixupTaskID
     ): Promise<FixupTask> {
-        const authStatus = this.authProvider.getAuthStatus()
+        const authStatus = authProvider.instance!.getAuthStatus()
         const overridenModel = getOverridenModelForIntent(intent, model, authStatus)
         const fixupFile = this.files.forUri(document.uri)
         const task = new FixupTask(

--- a/vscode/src/notifications/cody-pro-expiration.ts
+++ b/vscode/src/notifications/cody-pro-expiration.ts
@@ -1,8 +1,8 @@
 import {
     FeatureFlag,
-    type FeatureFlagProvider,
     type SourcegraphGraphQLAPIClient,
     type Unsubscribable,
+    featureFlagProvider,
 } from '@sourcegraph/cody-shared'
 import type * as vscode from 'vscode'
 import { URI } from 'vscode-uri'
@@ -51,9 +51,8 @@ export class CodyProExpirationNotifications implements vscode.Disposable {
      * about their Cody Pro subscription having expired (or expiring soon).
      */
     constructor(
-        private readonly apiClient: SourcegraphGraphQLAPIClient,
+        private readonly apiClient: Pick<SourcegraphGraphQLAPIClient, 'getCurrentUserCodySubscription'>,
         private readonly authProvider: AuthProvider,
-        private readonly featureFlagProvider: FeatureFlagProvider,
         private readonly showInformationMessage: (
             message: string,
             ...items: string[]
@@ -93,7 +92,7 @@ export class CodyProExpirationNotifications implements vscode.Disposable {
         const authStatus = this.authProvider.getAuthStatus()
         if (!authStatus.isLoggedIn || !authStatus.isDotCom) return
 
-        const useSscForCodySubscription = await this.featureFlagProvider.evaluateFeatureFlag(
+        const useSscForCodySubscription = await featureFlagProvider.instance!.evaluateFeatureFlag(
             FeatureFlag.UseSscForCodySubscription
         )
         if (this.shouldSuppressNotifications()) return // Status may have changed during await
@@ -122,7 +121,7 @@ export class CodyProExpirationNotifications implements vscode.Disposable {
     }
 
     private async showNotification(): Promise<void> {
-        const codyProTrialEnded = await this.featureFlagProvider.evaluateFeatureFlag(
+        const codyProTrialEnded = await featureFlagProvider.instance!.evaluateFeatureFlag(
             FeatureFlag.CodyProTrialEnded
         )
         if (this.shouldSuppressNotifications()) return // Status may have changed during await

--- a/vscode/src/notifications/cody-pro-expiration.ts
+++ b/vscode/src/notifications/cody-pro-expiration.ts
@@ -6,7 +6,7 @@ import {
 } from '@sourcegraph/cody-shared'
 import type * as vscode from 'vscode'
 import { URI } from 'vscode-uri'
-import type { AuthProvider } from '../services/AuthProvider'
+import { authProvider } from '../services/AuthProvider'
 import { localStorage } from '../services/LocalStorageProvider'
 
 export class CodyProExpirationNotifications implements vscode.Disposable {
@@ -52,7 +52,6 @@ export class CodyProExpirationNotifications implements vscode.Disposable {
      */
     constructor(
         private readonly apiClient: Pick<SourcegraphGraphQLAPIClient, 'getCurrentUserCodySubscription'>,
-        private readonly authProvider: AuthProvider,
         private readonly showInformationMessage: (
             message: string,
             ...items: string[]
@@ -83,13 +82,13 @@ export class CodyProExpirationNotifications implements vscode.Disposable {
             // right flags.
             //
             // See https://sourcegraph.slack.com/archives/C05AGQYD528/p1706872864488829
-            this.authProviderSubscription = this.authProvider.changes.subscribe(() =>
+            this.authProviderSubscription = authProvider.instance!.changes.subscribe(() =>
                 setTimeout(() => this.triggerExpirationCheck(), this.autoUpdateDelay)
             )
         }
 
         // Not logged in or not DotCom, don't show.
-        const authStatus = this.authProvider.getAuthStatus()
+        const authStatus = authProvider.instance!.getAuthStatus()
         if (!authStatus.isLoggedIn || !authStatus.isDotCom) return
 
         const useSscForCodySubscription = await featureFlagProvider.instance!.evaluateFeatureFlag(

--- a/vscode/src/prompt-builder/index.test.ts
+++ b/vscode/src/prompt-builder/index.test.ts
@@ -13,7 +13,7 @@ import { PromptBuilder } from './index'
 
 describe('PromptBuilder', () => {
     beforeEach(() => {
-        vi.spyOn(contextFiltersProvider, 'isUriIgnored').mockResolvedValue(false)
+        vi.spyOn(contextFiltersProvider.instance!, 'isUriIgnored').mockResolvedValue(false)
     })
 
     const preamble: Message[] = [{ speaker: 'system', text: ps`preamble` }]

--- a/vscode/src/prompt-builder/index.ts
+++ b/vscode/src/prompt-builder/index.ts
@@ -125,7 +125,10 @@ export class PromptBuilder {
 
         for (const item of contextItems) {
             // Skip context items that are in the Cody ignore list
-            if (isCodyIgnoredFile(item.uri) || (await contextFiltersProvider.isUriIgnored(item.uri))) {
+            if (
+                isCodyIgnoredFile(item.uri) ||
+                (await contextFiltersProvider.instance!.isUriIgnored(item.uri))
+            ) {
                 result.ignored.push(item)
                 continue
             }
@@ -137,7 +140,7 @@ export class PromptBuilder {
                 item.type === 'file' &&
                 (item.uri.scheme === 'https' || item.uri.scheme === 'http') &&
                 item.repoName &&
-                contextFiltersProvider.isRepoNameIgnored(item.repoName)
+                contextFiltersProvider.instance!.isRepoNameIgnored(item.repoName)
             ) {
                 result.ignored.push(item)
                 continue

--- a/vscode/src/repository/repo-metadata-from-git-api.ts
+++ b/vscode/src/repository/repo-metadata-from-git-api.ts
@@ -2,7 +2,7 @@ import { subscriptionDisposable } from '@sourcegraph/cody-shared'
 import * as vscode from 'vscode'
 import { WorkspaceRepoMapper } from '../context/workspace-repo-mapper'
 import { logDebug } from '../log'
-import type { AuthProvider } from '../services/AuthProvider'
+import { authProvider } from '../services/AuthProvider'
 import { gitCommitIdFromGitExtension, vscodeGitAPI } from './git-extension-api'
 import { repoNameResolver } from './repo-name-resolver'
 
@@ -18,7 +18,7 @@ class WorkspaceReposMonitor implements vscode.Disposable {
 
     private workspaceRepoMapper = new WorkspaceRepoMapper()
 
-    constructor(authProvider: AuthProvider) {
+    constructor() {
         for (const folderURI of this.getFolderURIs()) {
             this.addWorkspaceFolder(folderURI)
         }
@@ -28,7 +28,7 @@ class WorkspaceReposMonitor implements vscode.Disposable {
 
         this.disposables.push(
             subscriptionDisposable(
-                authProvider.changes.subscribe(() => {
+                authProvider.instance!.changes.subscribe(() => {
                     for (const folderURI of this.getFolderURIs()) {
                         this.addWorkspaceFolder(folderURI)
                     }
@@ -114,7 +114,6 @@ class WorkspaceReposMonitor implements vscode.Disposable {
 
 export let workspaceReposMonitor: WorkspaceReposMonitor | undefined = undefined
 export function initWorkspaceReposMonitor(
-    authProvider: AuthProvider,
     disposables: vscode.Disposable[]
 ): WorkspaceReposMonitor | undefined {
     if (!vscodeGitAPI) {
@@ -124,7 +123,7 @@ export function initWorkspaceReposMonitor(
         )
         return undefined
     }
-    workspaceReposMonitor = new WorkspaceReposMonitor(authProvider)
+    workspaceReposMonitor = new WorkspaceReposMonitor()
     disposables.push(workspaceReposMonitor)
     return workspaceReposMonitor
 }

--- a/vscode/src/repository/repo-name-resolver.test.ts
+++ b/vscode/src/repository/repo-name-resolver.test.ts
@@ -1,20 +1,25 @@
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
-import { EMPTY, defaultAuthStatus, graphqlClient } from '@sourcegraph/cody-shared'
+import { type AuthStatus, EMPTY, defaultAuthStatus, graphqlClient } from '@sourcegraph/cody-shared'
 
-import type { AuthProvider } from '../services/AuthProvider'
+import { type AuthProvider, authProvider } from '../services/AuthProvider'
 
 import * as gitExtensionAPI from './git-extension-api'
 import { RepoNameResolver } from './repo-name-resolver'
 import { mockFsCalls } from './test-helpers'
 
 describe('getRepoNamesFromWorkspaceUri', () => {
+    afterEach(() => {
+        authProvider.instance = null
+    })
     it('resolves the repo name using graphql for enterprise accounts', async () => {
         const repoNameResolver = new RepoNameResolver()
-        repoNameResolver.init({
+        authProvider.instance = {
             changes: EMPTY,
-            getAuthStatus: () => ({ ...defaultAuthStatus, isLoggedIn: true, isDotCom: false }),
-        } as unknown as AuthProvider)
+            getAuthStatus: () =>
+                ({ ...defaultAuthStatus, isLoggedIn: true, isDotCom: false }) satisfies AuthStatus,
+        } as unknown as AuthProvider
+        repoNameResolver.init()
 
         vi.spyOn(gitExtensionAPI, 'gitRemoteUrlsFromGitExtension').mockReturnValue([
             'git@github.com:sourcegraph/cody.git',
@@ -45,10 +50,12 @@ describe('getRepoNamesFromWorkspaceUri', () => {
 
     it('resolves the repo name using local conversion function for PLG accounts', async () => {
         const repoNameResolver = new RepoNameResolver()
-        repoNameResolver.init({
+        authProvider.instance = {
             changes: EMPTY,
-            getAuthStatus: () => ({ ...defaultAuthStatus, isLoggedIn: true, isDotCom: true }),
-        } as unknown as AuthProvider)
+            getAuthStatus: () =>
+                ({ ...defaultAuthStatus, isLoggedIn: true, isDotCom: true }) satisfies AuthStatus,
+        } as unknown as AuthProvider
+        repoNameResolver.init()
 
         vi.spyOn(gitExtensionAPI, 'gitRemoteUrlsFromGitExtension').mockReturnValue([
             'git@github.com:sourcegraph/cody.git',

--- a/vscode/src/services/AuthProvider.ts
+++ b/vscode/src/services/AuthProvider.ts
@@ -15,6 +15,7 @@ import {
     logError,
     networkErrorAuthStatus,
     offlineModeAuthStatus,
+    singletonNotYetSet,
     telemetryRecorder,
     unauthenticatedStatus,
 } from '@sourcegraph/cody-shared'
@@ -47,19 +48,7 @@ export class AuthProvider implements AuthStatusProvider, vscode.Disposable {
         new vscode.EventEmitter<AuthStatus>()
     private disposables: vscode.Disposable[] = [this.didChangeEvent]
 
-    private static _instance: AuthProvider | null = null
-    public static get instance(): AuthProvider | null {
-        return AuthProvider._instance
-    }
-
-    public static create(config: AuthConfig): AuthProvider {
-        if (!AuthProvider._instance) {
-            AuthProvider._instance = new AuthProvider(config)
-        }
-        return AuthProvider._instance
-    }
-
-    private constructor(private config: AuthConfig) {
+    constructor(private config: AuthConfig) {
         this.status.endpoint = 'init'
         this.loadEndpointHistory()
     }
@@ -500,6 +489,8 @@ export class AuthProvider implements AuthStatusProvider, vscode.Disposable {
         return localStorage.set(HAS_AUTHENTICATED_BEFORE_KEY, 'true')
     }
 }
+
+export const authProvider = singletonNotYetSet<AuthProvider>()
 
 export function isNetworkError(error: Error): boolean {
     const message = error.message

--- a/vscode/src/services/AuthProviderSimplified.ts
+++ b/vscode/src/services/AuthProviderSimplified.ts
@@ -4,22 +4,18 @@ import { DOTCOM_URL } from '@sourcegraph/cody-shared'
 
 import type { AuthMethod } from '../chat/protocol'
 
-import type { AuthProvider } from './AuthProvider'
+import { authProvider } from './AuthProvider'
 
 // An auth provider for simplified onboarding. This is a sidecar to AuthProvider
 // so we can deprecate the experiment later. AuthProviderSimplified only works
 // for dotcom, and doesn't work on VScode web. See LoginSimplified.
 
 export class AuthProviderSimplified {
-    public async openExternalAuthUrl(
-        classicAuthProvider: AuthProvider,
-        method: AuthMethod,
-        tokenReceiverUrl?: string
-    ): Promise<boolean> {
+    public async openExternalAuthUrl(method: AuthMethod, tokenReceiverUrl?: string): Promise<boolean> {
         if (!(await openExternalAuthUrl(method, tokenReceiverUrl))) {
             return false
         }
-        classicAuthProvider.authProviderSimplifiedWillAttemptAuth()
+        authProvider.instance!.authProviderSimplifiedWillAttemptAuth()
         return true
     }
 }

--- a/vscode/src/services/StatusBar.ts
+++ b/vscode/src/services/StatusBar.ts
@@ -72,7 +72,7 @@ export function createStatusBar(): CodyStatusBar {
         if (uri.scheme === 'file' && isCodyIgnoredFile(uri)) {
             return 'cody-ignore'
         }
-        if (await contextFiltersProvider.isUriIgnored(uri)) {
+        if (await contextFiltersProvider.instance!.isUriIgnored(uri)) {
             return 'context-filter'
         }
         return null

--- a/vscode/src/services/UpstreamHealthProvider.ts
+++ b/vscode/src/services/UpstreamHealthProvider.ts
@@ -5,6 +5,8 @@ import {
     addTraceparent,
     isDotCom,
     logDebug,
+    setSingleton,
+    singletonNotYetSet,
     wrapInActiveSpan,
 } from '@sourcegraph/cody-shared'
 import { fetch } from '@sourcegraph/cody-shared'
@@ -152,7 +154,8 @@ class UpstreamHealthProvider implements vscode.Disposable {
     }
 }
 
-export const upstreamHealthProvider = new UpstreamHealthProvider()
+export const upstreamHealthProvider = singletonNotYetSet<UpstreamHealthProvider>()
+setSingleton(upstreamHealthProvider, new UpstreamHealthProvider())
 
 function headersToObject(headers: BrowserOrNodeResponse['headers']) {
     const result: Record<string, string> = {}

--- a/vscode/src/services/open-telemetry/OpenTelemetryService.node.ts
+++ b/vscode/src/services/open-telemetry/OpenTelemetryService.node.ts
@@ -43,7 +43,9 @@ export class OpenTelemetryService {
     private async reconfigure(): Promise<void> {
         this.isTracingEnabled =
             this.config.experimentalTracing ||
-            (await featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteTracing))
+            (await featureFlagProvider.instance!.evaluateFeatureFlag(
+                FeatureFlag.CodyAutocompleteTracing
+            ))
 
         const traceUrl = new URL('/-/debug/otlp/v1/traces', this.config.serverEndpoint).toString()
         if (this.lastTraceUrl === traceUrl) {

--- a/vscode/src/services/open-telemetry/utils.ts
+++ b/vscode/src/services/open-telemetry/utils.ts
@@ -8,7 +8,7 @@ import { getExtensionDetails } from '../telemetry-v2'
 // Ensure to ad exposed experiments at the very end to make sure we include experiments that the
 // user is being exposed to while the span was generated
 export function recordExposedExperimentsToSpan(span: Span): void {
-    span.setAttributes(featureFlagProvider.getExposedExperiments())
+    span.setAttributes(featureFlagProvider.instance!.getExposedExperiments())
     const extensionDetails = getExtensionDetails(getConfiguration(vscode.workspace.getConfiguration()))
     span.setAttributes(extensionDetails as any)
 

--- a/vscode/src/services/telemetry-v2.ts
+++ b/vscode/src/services/telemetry-v2.ts
@@ -1,5 +1,4 @@
 import {
-    type AuthStatusProvider,
     type ClientConfiguration,
     type ClientConfigurationWithAccessToken,
     CodyIDE,
@@ -18,6 +17,7 @@ import { logDebug } from '../log'
 import { getOSArch } from '../os'
 import { version } from '../version'
 
+import { authProvider } from './AuthProvider'
 import { localStorage } from './LocalStorageProvider'
 
 const { platform, arch } = getOSArch()
@@ -61,8 +61,7 @@ export async function createOrUpdateTelemetryRecorderProvider(
      * Hardcode isExtensionModeDevOrTest to false to test real exports - when
      * true, exports are logged to extension output instead.
      */
-    isExtensionModeDevOrTest: boolean,
-    authStatusProvider: AuthStatusProvider
+    isExtensionModeDevOrTest: boolean
 ): Promise<void> {
     const extensionDetails = getExtensionDetails(config)
 
@@ -86,7 +85,7 @@ export async function createOrUpdateTelemetryRecorderProvider(
             new MockServerTelemetryRecorderProvider(
                 extensionDetails,
                 config,
-                authStatusProvider,
+                authProvider.instance!,
                 anonymousUserID
             )
         )
@@ -98,7 +97,7 @@ export async function createOrUpdateTelemetryRecorderProvider(
             new TelemetryRecorderProvider(
                 extensionDetails,
                 config,
-                authStatusProvider,
+                authProvider.instance!,
                 anonymousUserID,
                 legacyBackcompatLogEventMode
             )

--- a/vscode/src/services/tree-views/TreeViewProvider.ts
+++ b/vscode/src/services/tree-views/TreeViewProvider.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode'
 
-import { type AuthStatus, type FeatureFlagProvider, isDotCom } from '@sourcegraph/cody-shared'
+import { type AuthStatus, featureFlagProvider, isDotCom } from '@sourcegraph/cody-shared'
 
 import type { CodyTreeItem } from './TreeItemProvider'
 import { initializeGroupedChats } from './chat-history'
@@ -13,10 +13,7 @@ export class TreeViewProvider implements vscode.TreeDataProvider<vscode.TreeItem
     public readonly onDidChangeTreeData = this._onDidChangeTreeData.event
     private authStatus: AuthStatus | undefined
     private treeItems: CodySidebarTreeItem[]
-    constructor(
-        private type: CodyTreeItemType,
-        private readonly featureFlagProvider: FeatureFlagProvider
-    ) {
+    constructor(private type: CodyTreeItemType) {
         this.treeItems = getCodyTreeItems(type)
     }
 
@@ -70,7 +67,7 @@ export class TreeViewProvider implements vscode.TreeDataProvider<vscode.TreeItem
 
             if (
                 item.requireFeature &&
-                !(await this.featureFlagProvider.evaluateFeatureFlag(item.requireFeature))
+                !(await featureFlagProvider.instance!.evaluateFeatureFlag(item.requireFeature))
             ) {
                 continue
             }

--- a/vscode/src/supercompletions/get-supercompletion.ts
+++ b/vscode/src/supercompletions/get-supercompletion.ts
@@ -39,7 +39,7 @@ export async function* getSupercompletions({
     recentEditsRetriever,
     chat,
 }: SuperCompletionsParams): AsyncGenerator<Supercompletion> {
-    if (await contextFiltersProvider.isUriIgnored(document.uri)) {
+    if (await contextFiltersProvider.instance!.isUriIgnored(document.uri)) {
         return null
     }
 

--- a/vscode/src/supercompletions/recent-edits/recent-edits-retriever.test.ts
+++ b/vscode/src/supercompletions/recent-edits/recent-edits-retriever.test.ts
@@ -17,7 +17,7 @@ describe('RecentEditsRetriever', () => {
     let onDidDeleteFiles: (event: vscode.FileDeleteEvent) => void
     beforeEach(() => {
         vi.useFakeTimers()
-        vi.spyOn(contextFiltersProvider, 'isUriIgnored').mockResolvedValue(false)
+        vi.spyOn(contextFiltersProvider.instance!, 'isUriIgnored').mockResolvedValue(false)
 
         retriever = new RecentEditsRetriever(FIVE_MINUTES, {
             onDidChangeTextDocument(listener) {
@@ -115,7 +115,7 @@ describe('RecentEditsRetriever', () => {
     })
 
     it('no-ops for blocked files due to the context filter', async () => {
-        vi.spyOn(contextFiltersProvider, 'isUriIgnored').mockResolvedValueOnce('repo:foo')
+        vi.spyOn(contextFiltersProvider.instance!, 'isUriIgnored').mockResolvedValueOnce('repo:foo')
 
         replaceFooLogWithNumber()
 

--- a/vscode/src/supercompletions/recent-edits/recent-edits-retriever.ts
+++ b/vscode/src/supercompletions/recent-edits/recent-edits-retriever.ts
@@ -25,7 +25,7 @@ export class RecentEditsRetriever implements vscode.Disposable {
     }
 
     public async getDiff(uri: vscode.Uri): Promise<PromptString | null> {
-        if (await contextFiltersProvider.isUriIgnored(uri)) {
+        if (await contextFiltersProvider.instance!.isUriIgnored(uri)) {
             return null
         }
 

--- a/vscode/src/tutorial/helpers.ts
+++ b/vscode/src/tutorial/helpers.ts
@@ -27,8 +27,10 @@ export const isInTutorial = (document: vscode.TextDocument): boolean => {
 // This will either noop or open the tutorial depending on the feature flag.
 export const maybeStartInteractiveTutorial = async () => {
     telemetryRecorder.recordEvent('cody.interactiveTutorial', 'attemptingStart')
-    await featureFlagProvider.refresh()
-    const enabled = await featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyInteractiveTutorial)
+    await featureFlagProvider.instance!.refresh()
+    const enabled = await featureFlagProvider.instance!.evaluateFeatureFlag(
+        FeatureFlag.CodyInteractiveTutorial
+    )
     logFirstEnrollmentEvent(FeatureFlag.CodyInteractiveTutorial, enabled)
     if (!enabled) {
         return


### PR DESCRIPTION
> NOTE: Big dumb refactor, no behavior change!

The following services now use exported global singletons:

- upstreamHealthProvider
- authProvider
- featureFlagProvider
- contextFiltersProvider
- modelsService

Some of them used `export const foo = new Foo()` singletons before but then relied on ad-hoc "actual initialization" to be called in the `activate` func of the VS Code extension. This was confusing to follow and meant that each class had to manage a weird "pre-initialization" state (such as before `activate` called its `init` method to inject some deps). Now, the classes' constructors are called only once their deps are available in the `activate` func.

I tried a few other ways to avoid the `xyzProvider.instance!` incantation, such as using `Proxy`, but those had other weird issues. Because these classes depend on information that's only available when `activate` is called or later, and not at static init time, we can't just have these as bare singletons.

There is no behavior change from this code change.

This will pave the way for better reactivity to config and auth changes by standardizing how these services/providers receive config (instead of the ad-hoc methods mentioned above).

## Test plan

CI