### PR TITLE
Fix floating ui elements (tooltips and popovers)

### DIFF
--- a/lib/prompt-editor/src/nodes/MentionComponent.tsx
+++ b/lib/prompt-editor/src/nodes/MentionComponent.tsx
@@ -1,6 +1,7 @@
 import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext'
 import { useLexicalNodeSelection } from '@lexical/react/useLexicalNodeSelection'
 import { mergeRegister } from '@lexical/utils'
+import { clsx } from 'clsx'
 import {
     $getNodeByKey,
     $getSelection,
@@ -196,7 +197,7 @@ export const MentionComponent: FunctionComponent<{
 
     const content = (
         <span ref={ref} className={composedClassNames} title={tooltipComponents ? undefined : tooltip}>
-            {Icon && <Icon size={14} strokeWidth={2} className={iconClassName} />}
+            {Icon && <Icon size={14} strokeWidth={2} className={clsx(iconClassName, 'tw-shrink-0')} />}
             <span>{text}</span>
         </span>
     )

--- a/vscode/webviews/App.module.css
+++ b/vscode/webviews/App.module.css
@@ -5,7 +5,6 @@
     box-sizing: border-box;
     height: 100%;
     overflow: hidden;
-    isolation: isolate;
 }
 
 .error-container {

--- a/vscode/webviews/chat/cells/Cell.tsx
+++ b/vscode/webviews/chat/cells/Cell.tsx
@@ -1,36 +1,43 @@
 import { clsx } from 'clsx'
 import type React from 'react'
-import type { FunctionComponent, PropsWithChildren } from 'react'
+import type { PropsWithChildren } from 'react'
+import { forwardRef } from 'react'
 
+interface CellProps {
+    header: React.ReactNode
+    containerClassName?: string
+    contentClassName?: string
+    'aria-current'?: boolean
+    'aria-disabled'?: boolean
+    'data-testid'?: string
+}
 /**
  * A cell is a row in a chat, which can be a human message, assistant message, context, notice, etc.
  */
-export const Cell: FunctionComponent<
-    PropsWithChildren<{
-        header: React.ReactNode
-        containerClassName?: string
-        contentClassName?: string
-        'aria-current'?: boolean
-        'aria-disabled'?: boolean
-        'data-testid'?: string
-    }>
-> = ({
-    header,
-    containerClassName,
-    contentClassName,
-    'aria-current': ariaCurrent,
-    'aria-disabled': ariaDisabled,
-    'data-testid': dataTestID,
-    children,
-}) => (
-    <div
-        className={clsx('tw-flex tw-flex-col tw-gap-4', containerClassName)}
-        role="row"
-        aria-current={ariaCurrent}
-        aria-disabled={ariaDisabled}
-        data-testid={dataTestID}
-    >
-        <header className="tw-flex tw-gap-4 tw-items-center [&_>_*]:tw-flex-shrink-0">{header}</header>
-        <div className={clsx('tw-flex-1 tw-overflow-hidden', contentClassName)}>{children}</div>
-    </div>
-)
+export const Cell = forwardRef<HTMLDivElement, PropsWithChildren<CellProps>>((props, ref) => {
+    const {
+        header,
+        containerClassName,
+        contentClassName,
+        'aria-current': ariaCurrent,
+        'aria-disabled': ariaDisabled,
+        'data-testid': dataTestID,
+        children,
+    } = props
+
+    return (
+        <div
+            ref={ref}
+            className={clsx('tw-flex tw-flex-col tw-gap-4', containerClassName)}
+            role="row"
+            aria-current={ariaCurrent}
+            aria-disabled={ariaDisabled}
+            data-testid={dataTestID}
+        >
+            <header className="tw-flex tw-gap-4 tw-items-center [&_>_*]:tw-flex-shrink-0">
+                {header}
+            </header>
+            <div className={clsx('tw-flex-1 tw-overflow-hidden', contentClassName)}>{children}</div>
+        </div>
+    )
+})

--- a/vscode/webviews/tabs/TabsBar.module.css
+++ b/vscode/webviews/tabs/TabsBar.module.css
@@ -10,6 +10,9 @@
 .tabs-root {
     container-type: inline-size;
     container-name: tabs-container;
+
+    isolation: isolate;
+    z-index: 1;
 }
 
 .tabs-container {
@@ -43,6 +46,14 @@
 
 .tab-action-label {
     display: inline;
+}
+
+.tooltip {
+    /*
+        Hide tooltips by default, show them only for state when labels are hidden.
+        Important is needed to override standard tailwind styles in tooltip internals
+    */
+    display: none !important;
 }
 
 /*
@@ -88,6 +99,10 @@
 
     .sub-tabs {
         padding: 0;
+    }
+
+    .tooltip {
+        display: block !important;
     }
 }
 

--- a/vscode/webviews/tabs/TabsBar.tsx
+++ b/vscode/webviews/tabs/TabsBar.tsx
@@ -261,7 +261,7 @@ const TabButton = forwardRef<HTMLButtonElement, TabButtonProps>(
                     <span className={alwaysShowTitle ? '' : styles.tabActionLabel}>{title}</span>
                 </button>
             </TooltipTrigger>
-            <TooltipContent className="md:tw-hidden">
+            <TooltipContent className={styles.tooltip}>
                 {title} {tooltipExtra}
             </TooltipContent>
         </Tooltip>

--- a/web/CHANGELOG.md
+++ b/web/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.7.4 
+- Fix tabs UI tooltips for small screens 
+
 ## 0.7.3 
 - Increase toolbar text to 12px 
 - Improve textbox layout (make it partially sticky)

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sourcegraph/cody-web",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "description": "Cody standalone web app",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
Prior to this PR tabs UI tooltips were using just media query which doesn't work in the case of sharable webview where the client usually has a bigger viewport than actual cody chat UI sizes. 

This PR basically uses a container query to decide when we should show tooltips for tabs UI.

## Test plan
- Manual checks on Cody Chat UI 

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
