### PR TITLE
Fixes Light theme list colors, fixes scroll bars fixes paddings

### DIFF
--- a/lib/prompt-editor/src/BaseEditor.module.css
+++ b/lib/prompt-editor/src/BaseEditor.module.css
@@ -30,6 +30,4 @@
     margin: 0;
 }
 
-html[data-ide='JetBrains'] .theme-paragraph {
-    padding: 0.5rem;
-}
+

--- a/vscode/webviews/themes/jetbrains.css
+++ b/vscode/webviews/themes/jetbrains.css
@@ -376,7 +376,7 @@ html[data-ide='JetBrains'] {
     --vscode-profileBadge-background: var(--jetbrains-ProgressBar-background);
     --vscode-profileBadge-foreground: var(--jetbrains-ProgressBar-foreground);
     --vscode-progressBar-background: var(--jetbrains-ProgressBar-background);
-    --vscode-quickInput-background: var(--jetbrains-MainToolbar-Icon-pressedBackground);
+    --vscode-quickInput-background: var(--jetbrains-CheckBox-background);
     --vscode-quickInput-foreground: var(--jetbrains-ToolBar-foreground);
     --vscode-quickInputTitle-background: var(--jetbrains-ToolBar-background);
     --vscode-remoteHub-decorations-addedForegroundColor: var(--jetbrains-ActionButton-hoverBackground);
@@ -659,4 +659,12 @@ html[data-ide='JetBrains'] .container {
 
 html[data-ide='JetBrains'] .tw-bg-muted-transparent:hover {
     background-color: var(--jetbrains-ActionButton-hoverBackground);
+}
+
+/* Custom rule for cmdk heading:
+ * VSCode uses input background for headings.
+ * JetBrains needs different styling to distinguish headings because input background are the same as pane background. */
+
+html[data-ide='JetBrains'] [cmdk-group-heading] {
+    background: var(--jetbrains-EditorPane-inactiveBackground);
 }

--- a/vscode/webviews/themes/jetbrains.css
+++ b/vscode/webviews/themes/jetbrains.css
@@ -670,13 +670,13 @@ html[data-ide='JetBrains'] [cmdk-group-heading] {
     background: var(--jetbrains-EditorPane-inactiveBackground);
 }
 
-html[data-ide='JetBrains'] body div[role="tabpanel"]::-webkit-scrollbar {
+html[data-ide='JetBrains'] body *::-webkit-scrollbar {
     width: 14px;
     height: 8px;
     background-color: transparent;
 }
 
-html[data-ide='JetBrains'] body div[role="tabpanel"]::-webkit-scrollbar-thumb {
+html[data-ide='JetBrains'] body *::-webkit-scrollbar-thumb {
     background: var(--scrollbar-slider-active-background);
     border-radius: 100px;
     border: 3px solid var(--jetbrains-Desktop-background);

--- a/vscode/webviews/themes/jetbrains.css
+++ b/vscode/webviews/themes/jetbrains.css
@@ -636,6 +636,7 @@ html[data-ide='JetBrains'] pre code {
     padding: 0;
 }
 
+
 html[data-ide='JetBrains'] blockquote {
     background: var(--vscode-textBlockQuote-background);
     border-color: var(--vscode-textBlockQuote-border);
@@ -667,4 +668,28 @@ html[data-ide='JetBrains'] .tw-bg-muted-transparent:hover {
 
 html[data-ide='JetBrains'] [cmdk-group-heading] {
     background: var(--jetbrains-EditorPane-inactiveBackground);
+}
+
+html[data-ide='JetBrains'] body div[role="tabpanel"]::-webkit-scrollbar {
+    width: 14px;
+    height: 8px;
+    background-color: transparent;
+}
+
+html[data-ide='JetBrains'] body div[role="tabpanel"]::-webkit-scrollbar-thumb {
+    background: var(--scrollbar-slider-active-background);
+    border-radius: 100px;
+    border: 3px solid var(--jetbrains-Desktop-background);
+}
+
+html[data-ide='JetBrains'] pre::-webkit-scrollbar {
+    width: 14px;
+    height: 14px;
+    background-color: transparent;
+}
+
+html[data-ide='JetBrains'] pre::-webkit-scrollbar-thumb {
+    background: rgba(255, 255, 255, 0.15);
+    border-radius: 100px;
+    border: 3px solid var(--code-background);
 }


### PR DESCRIPTION
Closes:
https://linear.app/sourcegraph/issue/CODY-3564/consistent-styling-issues-with-light-theme-on-windows

Also:
- Adds a native look to scrollbars
- fixes padding on input box

## Test plan

Tested locally with IntelliJ 2023.2 on multiple theme

| Theme | Before | After |
|--------|--------|--------|
| Light | <img width="300" alt="Screenshot 2024-08-30 at 12 52 06" src="https://github.com/user-attachments/assets/3b392ff7-82b9-4bf8-9583-b389333b5308"> | <img width="300" alt="Screenshot 2024-08-30 at 12 52 25" src="https://github.com/user-attachments/assets/d04f6bae-4dbb-4b31-99cf-fd0422b09980"> |
| Dark | <img width="300" alt="Screenshot 2024-08-30 at 12 52 45" src="https://github.com/user-attachments/assets/c64f9cf2-d7a3-44e2-80bb-e61a31b98afb"> |<img width="300" alt="Screenshot 2024-08-30 at 12 52 56" src="https://github.com/user-attachments/assets/781a545e-2d50-4e14-af14-a2d7ff698c06">|
| Darcula | <img width="300" alt="Screenshot 2024-08-30 at 12 53 22" src="https://github.com/user-attachments/assets/63cb20a5-cf92-41d8-b208-9c4843e1d212"> | <img width="300" alt="Screenshot 2024-08-30 at 12 53 09" src="https://github.com/user-attachments/assets/bb48c738-b324-4cc7-aa35-426b1036932a"> |
| High Contrast | <img width="300" alt="Screenshot 2024-08-30 at 12 53 49" src="https://github.com/user-attachments/assets/f5bf1e8d-7462-403c-a75c-bf6c063a3c54"> | <img width="300" alt="Screenshot 2024-08-30 at 12 53 41" src="https://github.com/user-attachments/assets/cd3159ba-f173-4065-bdf3-035693ae2bc4"> |
|padding| <img width="300" alt="Screenshot 2024-08-30 at 13 01 14" src="https://github.com/user-attachments/assets/9dda8ffd-57cc-4196-8b91-472b799275a9">|<img width="219" alt="Screenshot 2024-08-30 at 12 59 36" src="https://github.com/user-attachments/assets/cd505649-a88b-4f5b-8e32-90094a7821a0">|

