### PR TITLE
Trigger `cody.chat.history.export` command when the IDE is not VSC

### DIFF
--- a/vscode/src/chat/chat-view/ChatsController.ts
+++ b/vscode/src/chat/chat-view/ChatsController.ts
@@ -352,6 +352,7 @@ export class ChatsController implements vscode.Disposable {
             try {
                 const historyJson = chatHistory.getLocalHistory(authStatus)
                 const exportPath = await vscode.window.showSaveDialog({
+                    title: 'Cody: Export Chat History',
                     filters: { 'Chat History': ['json'] },
                 })
                 if (!exportPath || !historyJson) {

--- a/vscode/webviews/tabs/TabsBar.tsx
+++ b/vscode/webviews/tabs/TabsBar.tsx
@@ -168,7 +168,7 @@ export const TabsBar: React.FC<TabsBarProps> = ({ currentView, setView, IDE, onD
                                 title: 'Export History',
                                 Icon: DownloadIcon,
                                 command: 'cody.chat.history.export',
-                                callback: IDE === CodyIDE.VSCode ? onDownloadChatClick : undefined,
+                                callback: IDE === CodyIDE.JetBrains ? undefined : onDownloadChatClick,
                             },
                             {
                                 title: 'Clear Chat History',

--- a/vscode/webviews/tabs/TabsBar.tsx
+++ b/vscode/webviews/tabs/TabsBar.tsx
@@ -168,7 +168,7 @@ export const TabsBar: React.FC<TabsBarProps> = ({ currentView, setView, IDE, onD
                                 title: 'Export History',
                                 Icon: DownloadIcon,
                                 command: 'cody.chat.history.export',
-                                callback: onDownloadChatClick,
+                                callback: IDE === CodyIDE.VSCode ? onDownloadChatClick : undefined,
                             },
                             {
                                 title: 'Clear Chat History',


### PR DESCRIPTION
Fixes https://linear.app/sourcegraph/issue/CODY-3530/export-chat-history-doesnt-do-anything.

## Test plan
Try chat export in JetBrains.

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

## Changelog
Send the command notification when the IDE is not VSC.

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
