### PR TITLE
Cody Web: Fix mention selection in Safari

### DIFF
--- a/lib/prompt-editor/src/mentions/mentionMenu/MentionMenu.tsx
+++ b/lib/prompt-editor/src/mentions/mentionMenu/MentionMenu.tsx
@@ -95,6 +95,22 @@ export const MentionMenu: FunctionComponent<
         return () => window.removeEventListener('keydown', listener, { capture: true })
     }, [])
 
+    // Mouse down events cause input blur event and as a result in Safari
+    // where this problem came up originally (I suspect that for Safari typehead plugin
+    // has some special logic), it moves cursor to the very beginning of input and hence
+    // it loses state and breaks the flow of mention picking.
+    // Ignore mousedown events to prevent input focus lose.
+
+    // See issue for more details https://github.com/facebook/lexical/issues/3998
+    useEffect(() => {
+        const listener = (e: Event) => {
+            e.preventDefault()
+            e.stopPropagation()
+        }
+        window.addEventListener('mousedown', listener, { capture: true })
+        return () => window.removeEventListener('mousedown', listener, { capture: true })
+    }, [])
+
     const onProviderSelect = useCallback(
         (value: string): void => {
             const provider = data.providers.find(p => commandRowValue(p) === value)


### PR DESCRIPTION
Fixes [SRCH-698](https://linear.app/sourcegraph/issue/SRCH-698/cursor-jumping-in-safari-when-you-try-to-pick-suggestions-with-cursor)

| Before | After |
| --------  | ------- |
| <video src="https://github.com/user-attachments/assets/027a71ac-1f06-4f1c-aaa6-cc90028426a3" /> | <video src="https://github.com/user-attachments/assets/b7a039b8-04d2-426c-908f-fead0267d750" /> |

Safari has a weird problem with focus handling and event propagation; as a result, when you try to select an item in the mentioned menu, a down event triggers focus loss on the contenteditable area (makes sense) and moves the cursor at the beginning of the input. It happens only in Safari, which makes me think that event dispatching to handle portal anchor element propagation doesn't work right in Safari. 

This PR simply adds logic to ignore mouse-down events while the mention menu is rendered (which allows Safari to catch click events and doesn't close the mention plugin when it's not needed) 

## Test plan
- Run Cody Web demo 
- Check that you can use the mention picker with your mouse in Safari and your cursor stays in the right position after you pick an item 

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
