### PR TITLE
Add 'Upgrade' button to Accounts panel for free users

### DIFF
--- a/vscode/webviews/tabs/AccountTab.tsx
+++ b/vscode/webviews/tabs/AccountTab.tsx
@@ -1,7 +1,7 @@
 import { CodyIDE } from '@sourcegraph/cody-shared'
 import { useCallback } from 'react'
 import { URI } from 'vscode-uri'
-import { ACCOUNT_USAGE_URL } from '../../src/chat/protocol'
+import { ACCOUNT_UPGRADE_URL, ACCOUNT_USAGE_URL } from '../../src/chat/protocol'
 import { MESSAGE_CELL_AVATAR_SIZE } from '../chat/cells/messageCell/BaseMessageCell'
 import { UserAvatar } from '../components/UserAvatar'
 import { Button } from '../components/shadcn/ui/button'
@@ -21,6 +21,13 @@ export const AccountTab: React.FC = () => {
 
     const actions: any[] = []
 
+    if (isDotComUser && !isCodyProUser) {
+        actions.push({
+            text: 'Upgrade',
+            onClick: () =>
+                getVSCodeAPI().postMessage({ command: 'links', value: ACCOUNT_UPGRADE_URL.toString() }),
+        })
+    }
     actions.push({
         text: 'Switch Account...',
         onClick: () => getVSCodeAPI().postMessage({ command: 'command', id: 'cody.auth.switchAccount' }),


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/jetbrains/issues/2174

## Test plan

1. Login to Cody ad free user
2. Switch to `Accounts` panel
3. `Upgrade` button should be visible
4. clicking it should open [https://sourcegraph.com/cody/subscription](https://sourcegraph.com/cody/subscription)