### PR TITLE
CLI: fix error handling for invalid access tokens

### DIFF
--- a/agent/CHANGELOG.md
+++ b/agent/CHANGELOG.md
@@ -10,6 +10,11 @@ This is a log of all notable changes to the Cody command-line tool. [Unreleased]
 
 ### Changed
 
+## 5.5.13
+### Fixed
+
+- `cody chat` and `cody auth login` now report a helpful error message when trying to authenticate with an invalid access token.
+
 ## 5.5.12
 
 ### Fixed

--- a/agent/package.json
+++ b/agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sourcegraph/cody",
-  "version": "5.5.12",
+  "version": "5.5.13",
   "description": "Cody CLI is the same technology that powers Cody in the IDE but available from the command-line.",
   "license": "Apache-2.0",
   "repository": {
@@ -17,7 +17,7 @@
     "build:webviews": "pnpm -C ../vscode run -s _build:webviews --mode production --outDir ../../agent/dist/webviews",
     "build": "pnpm run -s build:root && pnpm run -s build:webviews && pnpm run -s build:agent",
     "build-minify": "pnpm run build --minify",
-    "agent": "pnpm run build && node --enable-source-maps dist/index.js",
+    "agent": "pnpm run build:for-tests && node --enable-source-maps dist/index.js",
     "agent:skip-root-build": "pnpm run build:agent && node --enable-source-maps dist/index.js",
     "agent:debug": "pnpm run build && CODY_AGENT_TRACE_PATH=/tmp/agent.json CODY_AGENT_DEBUG_REMOTE=true node --enable-source-maps ./dist/index.js api jsonrpc-stdio",
     "build-ts": "tsc --build",

--- a/agent/recordings/cody-chat_103640681/recording.har.yaml
+++ b/agent/recordings/cody-chat_103640681/recording.har.yaml
@@ -47,7 +47,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Tue, 13 Aug 2024 19:01:28 GMT
+            value: Mon, 02 Sep 2024 11:25:25 GMT
           - name: content-type
             value: text/plain; charset=utf-8
           - name: transfer-encoding
@@ -78,7 +78,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-08-13T19:01:28.077Z
+      startedDateTime: 2024-09-02T11:25:25.002Z
       time: 0
       timings:
         blocked: -1
@@ -88,11 +88,11 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: a760bf87999178632a0f589ff5e1a8a9
+    - _id: 709c04331ef053b321decb3b9eb8e0f0
       _order: 0
       cache: {}
       request:
-        bodySize: 421
+        bodySize: 518
         cookies: []
         headers:
           - name: content-type
@@ -108,7 +108,7 @@ log:
             value: keep-alive
           - name: host
             value: sourcegraph.sourcegraph.com
-        headersSize: 385
+        headersSize: 371
         httpVersion: HTTP/1.1
         method: POST
         postData:
@@ -117,33 +117,34 @@ log:
           textJSON:
             maxTokensToSample: 4000
             messages:
-              - speaker: system
+              - speaker: human
                 text: "You are Cody, an AI coding assistant from Sourcegraph.If your answer
                   contains fenced code blocks in Markdown, include the relevant
                   full file path in the code block tag using this structure:
                   ```$LANGUAGE:$FILEPATH```."
+              - speaker: assistant
+                text: I am Cody, an AI coding assistant from Sourcegraph.
               - speaker: human
                 text: respond with "hello" and nothing else
-            model: claude-3.5-sonnet
+              - speaker: assistant
+            model: gpt-4o
             temperature: 0.2
             topK: -1
             topP: -1
         queryString:
-          - name: api-version
-            value: "1"
           - name: client-name
             value: jetbrains
           - name: client-version
             value: 6.0.0-SNAPSHOT
-        url: https://sourcegraph.sourcegraph.com/.api/completions/stream?api-version=1&client-name=jetbrains&client-version=6.0.0-SNAPSHOT
+        url: https://sourcegraph.sourcegraph.com/.api/completions/stream?client-name=jetbrains&client-version=6.0.0-SNAPSHOT
       response:
-        bodySize: 158
+        bodySize: 213
         content:
           mimeType: text/event-stream
-          size: 158
+          size: 213
           text: |+
             event: completion
-            data: {"completion":"hello","stopReason":"end_turn"}
+            data: {"completion":"hello","stopReason":"stop"}
 
             event: done
             data: {}
@@ -151,7 +152,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Fri, 23 Aug 2024 09:43:06 GMT
+            value: Mon, 02 Sep 2024 11:25:27 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
@@ -180,7 +181,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-08-23T09:43:04.959Z
+      startedDateTime: 2024-09-02T11:25:26.416Z
       time: 0
       timings:
         blocked: -1
@@ -190,11 +191,11 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: 6429134c6421698cdc80f7359d7bcd68
+    - _id: 21d3252242deef34d2d38e9b0eff82c6
       _order: 0
       cache: {}
       request:
-        bodySize: 704
+        bodySize: 801
         cookies: []
         headers:
           - name: content-type
@@ -210,7 +211,7 @@ log:
             value: keep-alive
           - name: host
             value: sourcegraph.sourcegraph.com
-        headersSize: 385
+        headersSize: 371
         httpVersion: HTTP/1.1
         method: POST
         postData:
@@ -219,11 +220,13 @@ log:
           textJSON:
             maxTokensToSample: 4000
             messages:
-              - speaker: system
+              - speaker: human
                 text: "You are Cody, an AI coding assistant from Sourcegraph.If your answer
                   contains fenced code blocks in Markdown, include the relevant
                   full file path in the code block tag using this structure:
                   ```$LANGUAGE:$FILEPATH```."
+              - speaker: assistant
+                text: I am Cody, an AI coding assistant from Sourcegraph.
               - speaker: human
                 text: |-
                   Codebase context from file animal.ts:
@@ -240,27 +243,26 @@ log:
 
 
                   Question: implement a cow. Only print the code without any explanation.
-            model: claude-3.5-sonnet
+              - speaker: assistant
+            model: gpt-4o
             temperature: 0.2
             topK: -1
             topP: -1
         queryString:
-          - name: api-version
-            value: "1"
           - name: client-name
             value: jetbrains
           - name: client-version
             value: 6.0.0-SNAPSHOT
-        url: https://sourcegraph.sourcegraph.com/.api/completions/stream?api-version=1&client-name=jetbrains&client-version=6.0.0-SNAPSHOT
+        url: https://sourcegraph.sourcegraph.com/.api/completions/stream?client-name=jetbrains&client-version=6.0.0-SNAPSHOT
       response:
-        bodySize: 3646
+        bodySize: 4847
         content:
           mimeType: text/event-stream
-          size: 3646
+          size: 4847
           text: >+
             event: completion
 
-            data: {"completion":"Here's the implementation of a cow based on the provided `StrangeAnimal` interface:\n\n```typescript:animal.ts\nclass Cow implements StrangeAnimal {\n    makesSound(): 'coo' | 'moo' {\n        return 'moo';\n    }\n}\n```","stopReason":"end_turn"}
+            data: {"completion":"```typescript:animal.ts\nclass Cow implements StrangeAnimal {\n    makesSound(): 'coo' | 'moo' {\n        return 'moo';\n    }\n}\n```","stopReason":"stop"}
 
 
             event: done
@@ -270,7 +272,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Fri, 23 Aug 2024 09:43:07 GMT
+            value: Mon, 02 Sep 2024 11:25:30 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
@@ -299,7 +301,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-08-23T09:43:06.323Z
+      startedDateTime: 2024-09-02T11:25:29.989Z
       time: 0
       timings:
         blocked: -1
@@ -374,7 +376,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Tue, 13 Aug 2024 19:01:28 GMT
+            value: Mon, 02 Sep 2024 11:25:25 GMT
           - name: content-type
             value: application/json
           - name: transfer-encoding
@@ -405,7 +407,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-08-13T19:01:28.603Z
+      startedDateTime: 2024-09-02T11:25:25.575Z
       time: 0
       timings:
         blocked: -1
@@ -470,19 +472,19 @@ log:
             value: null
         url: https://sourcegraph.sourcegraph.com/.api/graphql?CurrentSiteCodyLlmConfiguration
       response:
-        bodySize: 227
+        bodySize: 223
         content:
           encoding: base64
           mimeType: application/json
-          size: 227
-          text: "[\"H4sIAAAAAAAAA4TOwQrCMAzG8XfJedPiFKTXXbfbXiC02VaczWhTUEbfXeZlygRPgY8/P\
-            7KARUHQC0QntF7D9tk0bc2+d0MKKI79ex9RWrY0\",\"gYbIKRgaAs7j0UyYLJXV4VJ\
-            G9p4Eiq1t8dHxjXwEXSmlVAE9Rqn/UBv0Ve8xw/d5ovXDX1wUDIYtBdiVH9RJna855/\
-            wCAAD//wMALGYOWAoBAAA=\"]"
+          size: 223
+          text: "[\"H4sIAAAAAAAAA3yOwQqDMBBE/2XPSgMWCl69mlt/YElWE7TZYDZgkfx70UuLpT0NDG8es\
+            4FFQWg3SF5oT8P22fe64zD4MS8onsPROxTNlmZo\",\"IXFeDI0LRncZo9RXhuoNaFz\
+            vPFFI0DZKKVXBgEm6H3szY7ZUN7VDP2U4wR+u26Ey/Igz7af+yhKHQAJf/PlbKaW8AA\
+            AA//8DANFSIVoEAQAA\"]"
         cookies: []
         headers:
           - name: date
-            value: Tue, 13 Aug 2024 19:01:27 GMT
+            value: Mon, 02 Sep 2024 11:25:24 GMT
           - name: content-type
             value: application/json
           - name: transfer-encoding
@@ -513,7 +515,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-08-13T19:01:27.603Z
+      startedDateTime: 2024-09-02T11:25:24.475Z
       time: 0
       timings:
         blocked: -1
@@ -584,7 +586,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Tue, 13 Aug 2024 19:01:27 GMT
+            value: Mon, 02 Sep 2024 11:25:24 GMT
           - name: content-type
             value: application/json
           - name: transfer-encoding
@@ -615,7 +617,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-08-13T19:01:27.641Z
+      startedDateTime: 2024-09-02T11:25:24.515Z
       time: 0
       timings:
         blocked: -1
@@ -685,7 +687,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Tue, 13 Aug 2024 19:01:27 GMT
+            value: Mon, 02 Sep 2024 11:25:24 GMT
           - name: content-type
             value: application/json
           - name: transfer-encoding
@@ -716,7 +718,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-08-13T19:01:27.622Z
+      startedDateTime: 2024-09-02T11:25:24.495Z
       time: 0
       timings:
         blocked: -1
@@ -799,7 +801,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Tue, 13 Aug 2024 19:01:27 GMT
+            value: Mon, 02 Sep 2024 11:25:24 GMT
           - name: content-type
             value: application/json
           - name: transfer-encoding
@@ -830,7 +832,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-08-13T19:01:27.661Z
+      startedDateTime: 2024-09-02T11:25:24.533Z
       time: 0
       timings:
         blocked: -1
@@ -893,13 +895,13 @@ log:
           encoding: base64
           mimeType: application/json
           size: 139
-          text: "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqzixJBdEFRfkppcklYalFxZn5eUpWSkYW5iYmRvFGB\
-            kYmugYWuobG8aZ6ZrrGpkZGKclpJolpKclKtbW1\",\"AAAAAP//AwD5OZ82SQAAAA==\
+          text: "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqzixJBdEFRfkppcklYalFxZn5eUpWSkYWlmaGZvFGB\
+            kYmugaWugZG8aZ6ZropaebJqckWacYWSeZKtbW1\",\"AAAAAP//AwAiXydqSQAAAA==\
             \"]"
         cookies: []
         headers:
           - name: date
-            value: Tue, 13 Aug 2024 19:01:27 GMT
+            value: Mon, 02 Sep 2024 11:25:24 GMT
           - name: content-type
             value: application/json
           - name: transfer-encoding
@@ -930,7 +932,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-08-13T19:01:27.565Z
+      startedDateTime: 2024-09-02T11:25:24.427Z
       time: 0
       timings:
         blocked: -1
@@ -968,35 +970,37 @@ log:
         queryString: []
         url: https://sourcegraph.sourcegraph.com/.api/modelconfig/supported-models.json
       response:
-        bodySize: 769
+        bodySize: 893
         content:
           encoding: base64
           mimeType: text/plain; charset=utf-8
-          size: 769
-          text: "[\"H4sIAAAAAAAA/+yZT1OjPhjH730VDNefYBqK9cfN7YyuB1dndXYPOx7S8LTNCAmThFrH8\
-            b3vQFoUSgutTl2tnpB8n28SPk/+9rFjWZZlKzqBmPw=\",\"AqmY4HZg2V0X2QemTMK\
-            ULV4jF7novxCmi8JEiikLQSo7sP7kr7K/x+IpF7EwiyVcT6RIGJ3HFsUhU0lEHn6QGD\
-            LdSaErZE8H661HTMK9kHeqwfq00LW2HgsxjqDB98yIWpuKBDhhDaaXCfCT8/amMVNak\
-            qjB9WKuerbNn27nPGMRQrQWZq74CaMS0iDACHsOOnJQNwhoRNIQHM9RgnPQDS0a5GrL\
-            s65r1Xl9C23F2cEI9xDG/1eDKEnIkEVMMyh3plCQVAsq4iQCXaVrHCZE26XXt0t1aBg\
-            L+ZC1a0giwimE1XYoTXSatSB7Gi7nkWYg8wSWsFRGBdcw078ZD8W9HVQ4mG9DZuc8Sf\
-            WNuAOeVeMhhFBNb2Iyu0z1S2UPIVTSPbVItA3Yu/5m9F1/I/5+KQOOMHrvDCCUppLQh\
-            20zIJHicyWAI5K0aT4uhv5ljbYefOb6zwz7L+hV6BPC7tK21L/Xieux576Gu4f6781d\
-            JbD9XP9G0Ps7Y17sroJg2g0CpYmkIgTZgPlaEzmo05UIr3TbkOmHYodR77gVO+wfvQq\
-            d2b0abmOIGWdO1/WdRAonIhpU0+p8lsdYXde3rpa7XgLZyv5rgq4K33qwriA+ioiabM\
-            z8NItqS31dFfs4Qe8Q+vzoZ6jHbJb94xzP+kOHcaVlSpuYX5gY63jW/7aWN6FUpFyrw\
-            2JRODRHxsNW1e5jHuxuoV6RBhhvkQcYvz4R1lW8pyvB7pLB3DHl2/Seg3C+TR8n2ukt\
-            9aM6/1/d1IjKs36tz54i3eE8v5Kpo1M5bAXWuqlTLtOtd/xo92qfZtR6rt+asef6LSm\
-            vdP1ap1/qNoDcedFTO4QRSSN9sbhTf26F+Tzb3aLaI6L0oF18TXR22B4YcPMfdVae7z\
-            umS0+dvwEAAP//+9VDaCYaAAA=\"]"
+          size: 893
+          text: "[\"H4sIAAAAAAAA/+yZz2/bNhzF7/krCJ02rFRo2koy3dps6QosS7EE3WHogaa+tglLJEFSr\
+            oMi//sgyVajH46kLHPWxD7J0uMjqc8TSVFfjxBCyLM=\",\"fAEJ+wTGCiW9EHkjn3h\
+            vimsGVmJ7mvjEJz9FsNpe1EatRATGeiH6Oz+V/b6WR7lIRFlZJt3CKC34pmx5ORJWx+\
+            z2D5ZApntb6krZ3ZuHrWfCwBdllrbD+qLU9baeKzWPocP3fSHqbao0SCY6TK80yLcf+\
+            psmwjrD4g7Xy43qm21+9HnDM1ERxA/CzBV/wqyCNAwpoWNMTjAZhSGPWRoBHmOrpATX\
+            0aLzXI3G6LpVnde31dacMSV0Qij9uV6IM82mIhZOQLUzpYKlTnGV6BhcnW7hsGDOq5z\
+            +3KjDwVyZ26xdUxYzySGqt8M65tKsBdnRtJkjJ8DkATbQuMaVdLB2fwkZqS9eWONQ3B\
+            u2/iB16m7UEmRWzZgQQlp6k7D1VeruKyeEkIrurkfQBrD3g2H0/WAQ/6CSgBNKnjsBj\
+            PPUMH772ARoo15WALDSadd4XD76Vy3advCZ6//msT9Ar0NfMLFM+1L/rU3cjj33LbiP\
+            yelzc7caHj/WPxH0070xL1dXYbgahaF1zHAVgenAfO2YOW/TVQjvdBvI9LtiR8nkrBc\
+            7Gpw8JboIQFuAJc7vOF5RHAsHeMps1wr3FwB9DbBEnyj6XThA71rKVMAyzlUqnT22Kj\
+            Uc5obpxXGxvDwe0I5DDJ4gBsVLTJGBOSRCCjzyA6yNwjFzYLsWae/zMmjkB+hjs+sV7\
+            L3sD/N0XfjUY/YO4rOY2cVg5hdZqb7UH6riNc7Te4S+2QEoqCdinf3BZ+vTKRbSOpPy\
+            LuaXRRl0tj59129wLyeY7dDeq9rXmIP9rdd2xIDSR+SA0n8fhIcqfqUzwf7CUGw15m9\
+            rE0xo/rY21w5PGv2oj/8fb1pE1VG/1eeVIt3jOL+TKXapmfYCi27alE267Y7f2/bqi3\
+            lqx37Qm/HYD3pS3ul6mKfv6/a9l9bY48YzZh2GSAzeVEc/XDDr0K+RcD8+coN9d+XdK\
+            clT0HJT/5NXd1hrMCIB6Zofw7ZZAenAaCNa9hueKzJH97rtRTBjaewut1/jvrWiuJd9\
+            J3Yvg3a+KTF079bjKoLzAs/m+2/PD35HRY/ujv4JAAD//5YyA4tfHgAA\"]"
         cookies: []
         headers:
           - name: date
-            value: Tue, 13 Aug 2024 19:01:28 GMT
+            value: Mon, 02 Sep 2024 11:25:25 GMT
           - name: content-type
             value: text/plain; charset=utf-8
           - name: content-length
-            value: "769"
+            value: "893"
           - name: connection
             value: keep-alive
           - name: access-control-allow-credentials
@@ -1023,7 +1027,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-08-13T19:01:28.257Z
+      startedDateTime: 2024-09-02T11:25:25.188Z
       time: 0
       timings:
         blocked: -1

--- a/agent/src/cli/__snapshots__/command-chat.test.ts.snap
+++ b/agent/src/cli/__snapshots__/command-chat.test.ts.snap
@@ -4,26 +4,19 @@ exports[`--context-file (animal test) 1`] = `
 "command: cody chat chat --context-file animal.ts --show-context -m implement a
   cow. Only print the code without any explanation.
 exitCode: 0
-stdout: >+
+stdout: |+
   > Context items:
-
 
   > 1. WORKING_DIRECTORY/animal.ts
 
 
 
-
-  Here's the implementation of a cow based on the provided \`StrangeAnimal\` interface:
-
-
   \`\`\`typescript:animal.ts
-
   class Cow implements StrangeAnimal {
       makesSound(): 'coo' | 'moo' {
           return 'moo';
       }
   }
-
   \`\`\`
 
 stderr: ""

--- a/agent/src/cli/command-auth/AuthenticatedAccount.ts
+++ b/agent/src/cli/command-auth/AuthenticatedAccount.ts
@@ -3,33 +3,23 @@ import type { Ora } from 'ora'
 import { readCodySecret } from './secrets'
 
 import type { CurrentUserInfo } from '@sourcegraph/cody-shared/src/sourcegraph-api/graphql/client'
+import { isError } from 'lodash'
+import type { AuthenticationOptions } from './command-login'
 import { type Account, loadUserSettings } from './settings'
+
+type AuthenticationSource = 'ENVIRONMENT_VARIABLE' | 'SECRET_STORAGE'
 
 /**
  * Wrapper around `Account` with the addition of an access token that's loaded
  * from the OS keychain.
  */
 export class AuthenticatedAccount {
-    public graphqlClient: SourcegraphGraphQLAPIClient
-
-    private userInfo: CurrentUserInfo | Error | null = null
     private constructor(
         public readonly account: Account,
-        public readonly accessToken: string
-    ) {
-        this.graphqlClient = new SourcegraphGraphQLAPIClient({
-            accessToken: this.accessToken,
-            customHeaders: this.account.customHeaders,
-            serverEndpoint: this.account.serverEndpoint,
-        })
-    }
-
-    public async getCurrentUserInfo(): Promise<CurrentUserInfo | null | Error> {
-        if (!this.userInfo) {
-            this.userInfo = await this.graphqlClient.getCurrentUserInfo()
-        }
-        return this.userInfo
-    }
+        public readonly accessToken: string,
+        public readonly userInfo: CurrentUserInfo,
+        public readonly source: AuthenticationSource
+    ) {}
 
     get id(): string {
         return this.account.id
@@ -39,7 +29,53 @@ export class AuthenticatedAccount {
         return this.account.serverEndpoint
     }
 
-    public static async fromUserSettings(spinner: Ora): Promise<AuthenticatedAccount | undefined> {
+    get username(): string {
+        return this.account.username
+    }
+
+    private static async fromCredentials(
+        options: AuthenticationOptions,
+        source: AuthenticationSource
+    ): Promise<AuthenticatedAccount | Error> {
+        const graphqlClient = new SourcegraphGraphQLAPIClient({
+            accessToken: options.accessToken,
+            serverEndpoint: options.endpoint,
+        })
+        const userInfo = await graphqlClient.getCurrentUserInfo()
+        if (isError(userInfo)) {
+            return userInfo
+        }
+        if (!userInfo?.username) {
+            return new Error(
+                'failed to authenticated with credentials from environment variable SRC_ACCESS_TOKEN'
+            )
+        }
+        return new AuthenticatedAccount(
+            {
+                id: userInfo.username,
+                username: userInfo.username,
+                serverEndpoint: options.endpoint,
+            },
+            options.accessToken,
+            userInfo,
+            source
+        )
+    }
+
+    public static async fromUserSettings(
+        spinner: Ora,
+        environmentVariables: AuthenticationOptions
+    ): Promise<AuthenticatedAccount | Error | undefined> {
+        if (environmentVariables.accessToken) {
+            const account = await AuthenticatedAccount.fromCredentials(
+                environmentVariables,
+                'ENVIRONMENT_VARIABLE'
+            )
+            if (isError(account)) {
+                return account
+            }
+            return account
+        }
         const settings = loadUserSettings()
         if (!settings.activeAccountID) {
             return undefined
@@ -55,11 +91,14 @@ export class AuthenticatedAccount {
     public static async fromUnauthenticated(
         spinner: Ora,
         account: Account
-    ): Promise<AuthenticatedAccount | undefined> {
+    ): Promise<AuthenticatedAccount | Error | undefined> {
         const accessToken = await readCodySecret(spinner, account)
         if (!accessToken) {
             return undefined
         }
-        return new AuthenticatedAccount(account, accessToken)
+        return AuthenticatedAccount.fromCredentials(
+            { accessToken, endpoint: account.serverEndpoint },
+            'SECRET_STORAGE'
+        )
     }
 }

--- a/agent/src/cli/command-auth/command-accounts.ts
+++ b/agent/src/cli/command-auth/command-accounts.ts
@@ -4,13 +4,16 @@ import Table from 'easy-table'
 import { isError } from 'lodash'
 import ora from 'ora'
 import { AuthenticatedAccount } from './AuthenticatedAccount'
-import { booleanToText, failSpinner } from './command-auth'
-import { notLoggedIn } from './messages'
+import { booleanToText } from './command-auth'
+import { type AuthenticationOptions, accessTokenOption, endpointOption } from './command-login'
+import { notLoggedIn, unknownErrorSpinner } from './messages'
 import { loadUserSettings } from './settings'
 
 export const accountsCommand = new Command('accounts')
     .description('Print all the authenticated accounts')
-    .action(async () => {
+    .addOption(accessTokenOption)
+    .addOption(endpointOption)
+    .action(async (options: AuthenticationOptions) => {
         const spinner = ora('Loading active accounts')
         try {
             const settings = loadUserSettings()
@@ -20,25 +23,23 @@ export const accountsCommand = new Command('accounts')
             }
             const t = new Table()
             for (const account of settings.accounts ?? []) {
-                const authenticated = await AuthenticatedAccount.fromUnauthenticated(spinner, account)
                 t.cell(chalk.bold('Name'), account.id)
                 t.cell(chalk.bold('Instance'), account.serverEndpoint)
                 const isActiveAccount = account.id === settings.activeAccountID
                 t.cell(chalk.bold('Active'), booleanToText(isActiveAccount))
-                const userInfo = await authenticated?.getCurrentUserInfo()
-                const isAuthenticated = Boolean(userInfo) && !isError(userInfo)
-                t.cell(chalk.bold('Authenticated'), booleanToText(isAuthenticated))
+                const authenticated = await AuthenticatedAccount.fromUnauthenticated(spinner, account)
+                t.cell(
+                    chalk.bold('Authenticated'),
+                    isError(authenticated)
+                        ? 'Invalid credentials'
+                        : booleanToText(Boolean(authenticated))
+                )
                 t.newRow()
             }
             console.log(t.toString())
             process.exit(0)
         } catch (error) {
-            if (error instanceof Error) {
-                failSpinner(spinner, 'Failed to load active accounts', error)
-            } else {
-                spinner.prefixText = String(error)
-                spinner.fail('Failed to load active account')
-            }
+            unknownErrorSpinner(spinner, error, options)
             process.exit(1)
         }
     })

--- a/agent/src/cli/command-auth/command-auth.ts
+++ b/agent/src/cli/command-auth/command-auth.ts
@@ -1,5 +1,4 @@
 import { Command } from 'commander'
-import type { Ora } from 'ora'
 import { accountsCommand } from './command-accounts'
 import { loginCommand } from './command-login'
 import { logoutCommand } from './command-logout'
@@ -24,9 +23,4 @@ export const authCommand = () =>
 
 export function booleanToText(value: boolean): string {
     return value ? 'Yes' : 'No'
-}
-
-export function failSpinner(spinner: Ora, text: string, error: Error): void {
-    spinner.prefixText = error.stack ?? error.message
-    spinner.fail(text)
 }

--- a/agent/src/cli/command-auth/command-login.ts
+++ b/agent/src/cli/command-auth/command-login.ts
@@ -1,45 +1,58 @@
 import http from 'node:http'
 import { input, select } from '@inquirer/prompts'
-import { SourcegraphGraphQLAPIClient, isError } from '@sourcegraph/cody-shared'
-import { Command } from 'commander'
+import { DOTCOM_URL, SourcegraphGraphQLAPIClient, isError } from '@sourcegraph/cody-shared'
+import { Command, Option } from 'commander'
 import open from 'open'
 import ora from 'ora'
 import type { Ora } from 'ora'
 import { formatURL } from '../../../../vscode/src/auth/auth'
 import { AuthenticatedAccount } from './AuthenticatedAccount'
+import { errorSpinner, unknownErrorSpinner } from './messages'
 import { writeCodySecret } from './secrets'
 import { type Account, type UserSettings, loadUserSettings, writeUserSettings } from './settings'
 
-interface LoginOptions {
+export interface AuthenticationOptions {
+    accessToken: string
+    endpoint: string
+}
+
+export const DEFAULT_AUTHENTICATION_OPTIONS: AuthenticationOptions = {
+    accessToken: '',
+    endpoint: DOTCOM_URL.toString(),
+}
+
+export const accessTokenOption = new Option('--access-token <token>', 'Manually provide an access token')
+    .env('SRC_ACCESS_TOKEN')
+    .default('')
+
+export const endpointOption = new Option(
+    '--endpoint <url>',
+    'Manually provide the URL of the Sourcegraph instance'
+)
+    .env('SRC_ENDPOINT')
+    .default(DEFAULT_AUTHENTICATION_OPTIONS.endpoint)
+
+interface LoginOptions extends AuthenticationOptions {
     web: boolean
-    accessToken?: string
-    endpoint?: string
 }
 
 export const loginCommand = new Command('login')
     .description('Log in to Sourcegraph')
     .option('--web', 'Open a browser to authenticate')
-    .option(
-        '--access-token <token>',
-        'Manually provide an access token (env SRC_ACCESS_TOKEN)',
-        process.env.SRC_ACCESS_TOKEN
-    )
-    .option(
-        '--endpoint <url>',
-        'Manually provide a server endpoint (env SRC_ENDPOINT)',
-        process.env.SRC_ENDPOINT ?? 'https://sourcegraph.com/'
-    )
+    .addOption(accessTokenOption)
+    .addOption(endpointOption)
     .action(async (options: LoginOptions) => {
         const spinner = ora('Logging in...').start()
-        const account = await AuthenticatedAccount.fromUserSettings(spinner)
-        if (!spinner.isSpinning) {
+        const account = await AuthenticatedAccount.fromUserSettings(spinner, options)
+        if (isError(account)) {
+            errorSpinner(spinner, account, options)
             process.exit(1)
         }
-        const userInfo = await account?.getCurrentUserInfo()
-        if (!isError(userInfo) && userInfo?.username) {
-            spinner.succeed('You are already logged in as ' + userInfo.username)
+        if (account?.userInfo.username && account.source === 'SECRET_STORAGE') {
+            spinner.succeed('You are already logged in as ' + account.userInfo.username)
             process.exit(0)
         }
+
         if (!options.web && !options.accessToken) {
             spinner
                 .start()
@@ -54,31 +67,24 @@ export const loginCommand = new Command('login')
         }
         try {
             const account = await loginAction(options, spinner)
-            if (!account) {
-                if (spinner.isSpinning) {
-                    spinner.fail('Failed to authenticate')
-                }
+            if (isError(account)) {
+                errorSpinner(spinner, account, options)
                 process.exit(1)
             }
-            const userInfo = await account.getCurrentUserInfo()
-            if (!userInfo || isError(userInfo)) {
-                spinner.fail(
-                    `Failed to fetch username for account ${account.id} in ${account.serverEndpoint}`
+            if (!account?.userInfo.username) {
+                errorSpinner(
+                    spinner,
+                    new Error(`failed to authenticate with credentials ${JSON.stringify(options)}`),
+                    options
                 )
                 process.exit(1)
             }
             spinner.succeed(
-                `Authenticated as ${userInfo.username} at Sourcegraph endpoint ${account.serverEndpoint}`
+                `Logged in as ${account.userInfo.username} at Sourcegraph endpoint ${account.serverEndpoint}. Run 'cody auth logout' to log out.`
             )
             process.exit(0)
         } catch (error) {
-            if (error instanceof Error) {
-                spinner.suffixText = error.stack ?? ''
-                spinner.fail(error.message)
-            } else {
-                spinner.suffixText = String(error)
-                spinner.fail('Failed to login')
-            }
+            unknownErrorSpinner(spinner, error, options)
             process.exit(1)
         }
     })
@@ -91,7 +97,7 @@ type LoginMethod = 'web-login' | 'cli-login'
 async function loginAction(
     options: LoginOptions,
     spinner: Ora
-): Promise<AuthenticatedAccount | undefined> {
+): Promise<AuthenticatedAccount | Error | undefined> {
     const loginMethod: LoginMethod =
         options.web && options.accessToken
             ? // Ambiguous, the user provided both --web and --access-token
@@ -139,8 +145,7 @@ async function loginAction(
     const newAccounts = [account, ...oldAccounts]
     const newSettings: UserSettings = { accounts: newAccounts, activeAccountID: account.id }
     writeUserSettings(newSettings)
-    const result = await AuthenticatedAccount.fromUserSettings(spinner)
-    return result
+    return AuthenticatedAccount.fromUserSettings(spinner, options)
 }
 
 /**

--- a/agent/src/cli/command-auth/command-whoami.ts
+++ b/agent/src/cli/command-auth/command-whoami.ts
@@ -2,39 +2,30 @@ import { Command } from 'commander'
 import { isError } from 'lodash'
 import ora from 'ora'
 import { AuthenticatedAccount } from './AuthenticatedAccount'
-import { failSpinner } from './command-auth'
-import { notLoggedIn } from './messages'
+import { type AuthenticationOptions, accessTokenOption, endpointOption } from './command-login'
+import { errorSpinner, notLoggedIn, unknownErrorSpinner } from './messages'
 
 export const whoamiCommand = new Command('whoami')
     .description('Print the active authenticated account')
-    .action(async () => {
+    .addOption(accessTokenOption)
+    .addOption(endpointOption)
+    .action(async (options: AuthenticationOptions) => {
         const spinner = ora('Loading active account')
         try {
-            const account = await AuthenticatedAccount.fromUserSettings(spinner)
-            if (!account) {
+            const account = await AuthenticatedAccount.fromUserSettings(spinner, options)
+            if (isError(account)) {
+                errorSpinner(spinner, account, options)
+                process.exit(1)
+            }
+            if (!account?.username) {
                 notLoggedIn(spinner)
                 process.exit(1)
             }
-            const userInfo = await account.getCurrentUserInfo()
-            if (!userInfo || isError(userInfo)) {
-                failSpinner(
-                    spinner,
-                    `Failed to fetch username for account ${account.id} in ${account.serverEndpoint}`,
-                    userInfo ?? new Error('no authenticated user')
-                )
-                process.exit(1)
-            } else {
-                spinner.succeed(`Authenticated as ${userInfo.username} on ${account.serverEndpoint}`)
-                process.exit(0)
-            }
+
+            spinner.succeed(`Authenticated as ${account.username} on ${account.serverEndpoint}`)
+            process.exit(0)
         } catch (error) {
-            if (error instanceof Error) {
-                spinner.prefixText = error.stack ?? ''
-                spinner.fail(error.message)
-            } else {
-                spinner.prefixText = String(error)
-                spinner.fail('Failed to load active account')
-            }
+            unknownErrorSpinner(spinner, error, options)
             process.exit(1)
         }
     })

--- a/agent/src/cli/command-auth/messages.ts
+++ b/agent/src/cli/command-auth/messages.ts
@@ -1,8 +1,32 @@
 import type { Ora } from 'ora'
+import type { AuthenticationOptions } from './command-login'
 
 export function notLoggedIn(spinner: Ora): void {
     if (!spinner.isSpinning) {
         return
     }
     spinner.fail('Not logged in. To fix this problem, run:\n\tcody auth login --web')
+}
+
+export function errorSpinner(spinner: Ora, error: Error, options: AuthenticationOptions): void {
+    if (error.message.includes('Invalid access token')) {
+        const createNewTokenURL = options.endpoint + '/user/settings/tokens/new?description=CodyCLI'
+        spinner.fail(
+            'The provided access token is invalid. ' +
+                'The most common cause for this is that the access token has expired. ' +
+                `If you are using SRC_ACCESS_TOKEN, create a new token at ${createNewTokenURL} and update the value of SRC_ACCESS_TOKEN. ` +
+                'If you are using `cody auth login --web`, run `cody auth logout` and try logging in again. '
+        )
+    } else {
+        spinner.suffixText = error.stack ?? ''
+        spinner.fail(error.message)
+    }
+}
+
+export function unknownErrorSpinner(spinner: Ora, error: unknown, options: AuthenticationOptions): void {
+    if (error instanceof Error) {
+        errorSpinner(spinner, error, options)
+    } else {
+        spinner.fail(String(error))
+    }
 }

--- a/agent/src/cli/command-chat.test.ts
+++ b/agent/src/cli/command-chat.test.ts
@@ -30,13 +30,18 @@ describe('cody chat', () => {
         args: string[]
         expectedExitCode?: number
     }): Promise<ChatCommandResult> {
-        // For some reason, I can't get the option parsing working with
-        // `--access-token` or `--endpoint` so we modify process.env instead.
-        process.env.SRC_ACCESS_TOKEN = credentials.token ?? credentials.redactedToken
-        process.env.SRC_ENDPOINT = credentials.serverEndpoint
         process.env.DISABLE_FEATURE_FLAGS = 'true'
         process.env.CODY_TELEMETRY_EXPORTER = 'testing'
-        const args = [...params.args, '--dir', tmp.rootPath, '--silent']
+        const args = [
+            ...params.args,
+            '--dir',
+            tmp.rootPath,
+            '--endpoint',
+            credentials.serverEndpoint,
+            '--access-token',
+            credentials.token ?? credentials.redactedToken,
+            '--silent',
+        ]
 
         const command = chatCommand()
         const parseResult = command.parseOptions(args)


### PR DESCRIPTION
Fixes Cody-3261.
Fixes CODY-2967.
Fixes CODY-2909.

Previously, Cody CLI users got a poor experience if they had provided expired credentials with `SRC_ACCESS_TOKEN`. The `cody chat` command reported that the user was "not logged in" and `cody auth login` confusingly reported that the user was already logged in.

Now, Cody CLI reports a helpful error message saying the user has invalid credentials and documents how to fix the problem by creating a new access token.

This fix ended up being harder to implement than I original expected because the code related to authentication was badly organized. Specifically, we didn't distinguish between error cases (invalid token) and unauthenticate cases (the user hasn't logged in yet). I used this issue as an opportunity to clean up the code so that all the validation is done in a single function that handles all cases.


## Test plan

Manually tested the following flows

- `cody chat` works with environment variable login and secret storage login
- `export SRC_ACCESS_TOKEN=foobar`, and confirm that `cody chat` and `cody auth login` give helpful error messages. Also confirm this happens when the secret storage has an invalid token (manually edited keychain item)
```
❯ export SRC_ACCESS_TOKEN=foobar
❯ pnpm agent auth login
...
✖ The provided access token is invalid. The most common cause for this is that the access token has expired. If you are using SRC_ACCESS_TOKEN, create a new token at https://sourcegraph.sourcegraph.com/user/settings/tokens/new?description=CodyCLI and update the value of SRC_ACCESS_TOKEN. If you are using `cody auth login --web`, run `cody auth logout` and try logging in again.
```
- Confirm that `cody auth logout` reports a helpful error message when `SRC_ACCESS_TOKEN` is set
```
❯ pnpm agent auth logout
...
✖ You cannot logout when using SRC_ACCESS_TOKEN with logout. To fix this problem, run `unset SRC_ACCESS_TOKEN` and try again.
```
<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

## Changelog

* Cody CLI now reports a helpful error message when authenticating with an invalid access token

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
