### PR TITLE
Fix account switching and chat history issue

### DIFF
--- a/vscode/src/chat/chat-view/ChatController.ts
+++ b/vscode/src/chat/chat-view/ChatController.ts
@@ -1511,7 +1511,7 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
 
     private async saveSession(authStatus?: AuthStatus): Promise<void> {
         const allHistory = await chatHistory.saveChat(
-            authStatus ? authStatus : this.authProvider.getAuthStatus(),
+            authStatus || this.authProvider.getAuthStatus(),
             this.chatModel.toSerializedChatTranscript()
         )
         if (allHistory) {

--- a/vscode/src/chat/chat-view/ChatController.ts
+++ b/vscode/src/chat/chat-view/ChatController.ts
@@ -588,7 +588,7 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
     // #region top-level view action handlers
     // =======================================================================
 
-    public setAuthStatus(status: AuthStatus): void {
+    public async setAuthStatus(status: AuthStatus): Promise<void> {
         // Run this async because this method may be called during initialization
         // and awaiting on this.postMessage may result in a deadlock
         void this.sendConfig()
@@ -596,6 +596,7 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
         // Get the latest model list available to the current user to update the ChatModel.
         if (status.isLoggedIn) {
             this.handleSetChatModel(getDefaultModelID())
+            return await this.saveSession()
         }
     }
 
@@ -1508,9 +1509,9 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
         this.postViewTranscript()
     }
 
-    private async saveSession(): Promise<void> {
+    private async saveSession(authStatus?: AuthStatus): Promise<void> {
         const allHistory = await chatHistory.saveChat(
-            this.authProvider.getAuthStatus(),
+            authStatus ? authStatus : this.authProvider.getAuthStatus(),
             this.chatModel.toSerializedChatTranscript()
         )
         if (allHistory) {
@@ -1521,9 +1522,9 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
         }
     }
 
-    public async clearAndRestartSession(): Promise<void> {
+    public async clearAndRestartSession(authStatus?: AuthStatus): Promise<void> {
         this.cancelSubmitOrEditOperation()
-        await this.saveSession()
+        await this.saveSession(authStatus)
 
         this.chatModel = new ChatModel(this.chatModel.modelID)
         this.postViewTranscript()

--- a/vscode/src/chat/chat-view/ChatsController.ts
+++ b/vscode/src/chat/chat-view/ChatsController.ts
@@ -494,7 +494,6 @@ export class ChatsController implements vscode.Disposable {
             extensionClient: this.extensionClient,
         })
     }
-    play
 
     private disposeChat(chatID: string, includePanel: boolean): void {
         if (chatID === this.activeEditor?.sessionID) {

--- a/vscode/src/chat/chat-view/ChatsController.ts
+++ b/vscode/src/chat/chat-view/ChatsController.ts
@@ -58,7 +58,7 @@ export class ChatsController implements vscode.Disposable {
     private activeEditor: ChatController | undefined = undefined
 
     // We keep track of the currently authenticated account and dispose open chats when it changes
-    private currentAuthAccount: undefined | { endpoint: string; primaryEmail?: string; username: string }
+    private currentAuthStatus: undefined | AuthStatus
 
     protected disposables: vscode.Disposable[] = []
 
@@ -90,19 +90,13 @@ export class ChatsController implements vscode.Disposable {
     private async setAuthStatus(authStatus: AuthStatus): Promise<void> {
         const hasLoggedOut = !authStatus.isLoggedIn
         const hasSwitchedAccount =
-            this.currentAuthAccount && this.currentAuthAccount.endpoint !== authStatus.endpoint
+            this.currentAuthStatus && this.currentAuthStatus.endpoint !== authStatus.endpoint
         if (hasLoggedOut || hasSwitchedAccount) {
-            this.disposeAllChats()
+            await this.disposeAllChats()
         }
 
-        const endpoint = authStatus.endpoint ?? ''
-        this.currentAuthAccount = {
-            endpoint,
-            primaryEmail: authStatus.primaryEmail,
-            username: authStatus.username,
-        }
-
-        this.panel.setAuthStatus(authStatus)
+        this.currentAuthStatus = authStatus
+        await this.panel.setAuthStatus(authStatus)
     }
 
     public async restoreToPanel(panel: vscode.WebviewPanel, chatID: string): Promise<void> {
@@ -500,6 +494,7 @@ export class ChatsController implements vscode.Disposable {
             extensionClient: this.extensionClient,
         })
     }
+    play
 
     private disposeChat(chatID: string, includePanel: boolean): void {
         if (chatID === this.activeEditor?.sessionID) {
@@ -521,7 +516,7 @@ export class ChatsController implements vscode.Disposable {
     }
 
     // Dispose all open chat panels
-    private disposeAllChats(): void {
+    private async disposeAllChats(): Promise<void> {
         this.activeEditor = undefined
 
         // loop through the panel provider map
@@ -534,11 +529,11 @@ export class ChatsController implements vscode.Disposable {
             editor.dispose()
         }
 
-        this.panel.clearAndRestartSession()
+        await this.panel.clearAndRestartSession(this.currentAuthStatus)
     }
 
     public dispose(): void {
-        this.disposeAllChats()
+        void this.disposeAllChats()
         vscode.Disposable.from(...this.disposables).dispose()
     }
 }


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/jetbrains/issues/2173.

## Test plan
See the issue: https://github.com/sourcegraph/jetbrains/issues/2173

1. log in to an account 
2. write something in chat
3. switch account
4. review the chat history
expected:
The chat from the first account should not appear in the account switched into.

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
