### PR TITLE
Agent: bump to version 5.5.14

### DIFF
--- a/agent/CHANGELOG.md
+++ b/agent/CHANGELOG.md
@@ -10,7 +10,8 @@ This is a log of all notable changes to the Cody command-line tool. [Unreleased]
 
 ### Changed
 
-## 5.5.13
+## 5.5.14
+
 ### Fixed
 
 - `cody chat` and `cody auth login` now report a helpful error message when trying to authenticate with an invalid access token.

--- a/agent/package.json
+++ b/agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sourcegraph/cody",
-  "version": "5.5.13",
+  "version": "5.5.14",
   "description": "Cody CLI is the same technology that powers Cody in the IDE but available from the command-line.",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
I was going to release 5.5.13 but found out that this version was already released
https://github.com/sourcegraph/cody/actions/runs/10550894460 so I'm bumping up to 5.5.14 instead.


## Test plan
n/a
<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
