### PR TITLE
fixed(chat): Added a migration to local storage to update chat histor…

### DIFF
--- a/agent/src/agent.ts
+++ b/agent/src/agent.ts
@@ -361,7 +361,7 @@ export class Agent extends MessageHandler implements ExtensionClient {
                 '*',
                 new IndentationBasedFoldingRangeProvider()
             )
-            this.globalState = this.newGlobalState(clientInfo)
+            this.globalState = await this.newGlobalState(clientInfo)
 
             if (clientInfo.capabilities && clientInfo.capabilities?.webview === undefined) {
                 // Make it possible to do `capabilities.webview === 'agentic'`
@@ -1432,17 +1432,17 @@ export class Agent extends MessageHandler implements ExtensionClient {
         }
     }
 
-    private newGlobalState(clientInfo: ClientInfo): AgentGlobalState {
+    private async newGlobalState(clientInfo: ClientInfo): Promise<AgentGlobalState> {
         switch (clientInfo.capabilities?.globalState) {
             case 'server-managed':
-                return new AgentGlobalState(
+                return AgentGlobalState.initialize(
                     clientInfo.name,
                     clientInfo.globalStateDir ?? codyPaths().data
                 )
             case 'client-managed':
                 throw new Error('client-managed global state is not supported')
             default:
-                return new AgentGlobalState(clientInfo.name)
+                return AgentGlobalState.initialize(clientInfo.name)
         }
     }
 

--- a/agent/src/bfg/BfgRetriever.test.ts
+++ b/agent/src/bfg/BfgRetriever.test.ts
@@ -42,7 +42,7 @@ describe('BfgRetriever', async () => {
             vscode.Uri.file(process.cwd()),
             activate,
             defaultVSCodeExtensionClient(),
-            new AgentGlobalState('vscode'),
+            await AgentGlobalState.initialize('vscode'),
             new AgentStatelessSecretStorage()
         )
 

--- a/agent/src/global-state/AgentGlobalState.test.ts
+++ b/agent/src/global-state/AgentGlobalState.test.ts
@@ -5,8 +5,8 @@ import { AgentGlobalState } from './AgentGlobalState'
 describe('AgentGlobalState', () => {
     let globalState: AgentGlobalState
 
-    beforeEach(() => {
-        globalState = new AgentGlobalState(CodyIDE.VSCode)
+    beforeEach(async () => {
+        globalState = await AgentGlobalState.initialize(CodyIDE.VSCode)
     })
 
     it('should store and retrieve values', () => {

--- a/agent/src/global-state/AgentGlobalState.ts
+++ b/agent/src/global-state/AgentGlobalState.ts
@@ -5,11 +5,20 @@ import * as vscode_shim from '../vscode-shim'
 
 import path from 'node:path'
 import { localStorage } from '../../../vscode/src/services/LocalStorageProvider'
+import migrate from './migrations/migrate'
 
 export class AgentGlobalState implements vscode.Memento {
     private db: DB
 
-    constructor(ide: string, dir?: string) {
+    static async initialize(ide: string, dir?: string): Promise<AgentGlobalState> {
+        const globalState = new AgentGlobalState(ide, dir)
+        if (globalState.db instanceof LocalStorageDB) {
+            await migrate(globalState)
+        }
+        return globalState
+    }
+
+    private constructor(ide: string, dir?: string) {
         // If not provided, will default to an in-memory database
         if (dir) {
             this.db = new LocalStorageDB(ide, dir)

--- a/agent/src/global-state/migrations/chat-id-migration-CODY3538.test.ts
+++ b/agent/src/global-state/migrations/chat-id-migration-CODY3538.test.ts
@@ -1,0 +1,110 @@
+import type { AccountKeyedChatHistory } from '@sourcegraph/cody-shared'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type * as vscode from 'vscode'
+import { migrateChatHistoryCODY3538 } from './chat-id-migration-CODY3538'
+
+class MockMemento implements vscode.Memento {
+    public data: { [key: string]: unknown } = {}
+
+    keys(): readonly string[] {
+        return Object.keys(this.data)
+    }
+
+    get<T>(key: string): T | undefined {
+        return this.data[key] as T
+    }
+
+    async update(key: string, value: unknown): Promise<void> {
+        this.data[key] = value
+    }
+}
+
+describe('migrateChatHistoryCODY3538', () => {
+    let storage: vscode.Memento
+    beforeEach(() => {
+        storage = new MockMemento()
+    })
+
+    it('should not migrate if already migrated', async () => {
+        const storage = {
+            get: vi.fn().mockReturnValue(true),
+            update: vi.fn(),
+        } as unknown as vscode.Memento
+
+        await migrateChatHistoryCODY3538(storage)
+
+        expect(storage.get).toHaveBeenCalledWith(MIGRATION_MARKER)
+        expect(storage.update).not.toHaveBeenCalled()
+    })
+
+    it('should migrate UUID chat IDs to UTC string format', async () => {
+        const mockHistory: AccountKeyedChatHistory = {
+            'endpoint-account1': {
+                chat: {
+                    '46147b93-a7eb-4b24-bef3-5b1acf23a8ed': {
+                        id: '46147b93-a7eb-4b24-bef3-5b1acf23a8ed',
+                        lastInteractionTimestamp: '2023-05-01T12:00:00.000Z',
+                        interactions: [],
+                    },
+                },
+            },
+        }
+
+        await storage.update(LOCAL_HISTORY, mockHistory)
+
+        await migrateChatHistoryCODY3538(storage)
+
+        expect(storage.get(MIGRATION_MARKER)).toBe(true)
+
+        const updatedHistory = storage.get(LOCAL_HISTORY) as AccountKeyedChatHistory
+        expect(updatedHistory).toBeDefined()
+
+        const [newChat] = Object.values(updatedHistory['endpoint-account1'].chat)
+        expect(Date.parse(newChat.id)).toBe(1682942400000)
+        expect(newChat.lastInteractionTimestamp).toBe(newChat.id)
+    })
+
+    it('should handle invalid lastInteractionTimestamp', async () => {
+        const mockHistory: AccountKeyedChatHistory = {
+            'endpoint-account1': {
+                chat: {
+                    '46147b93-a7eb-4b24-bef3-5b1acf23a8ed': {
+                        id: '46147b93-a7eb-4b24-bef3-5b1acf23a8ed',
+                        lastInteractionTimestamp: '46147b93-a7eb-4b24-bef3-5b1acf23a8ed',
+                        interactions: [],
+                    },
+                },
+            },
+        }
+
+        await storage.update(LOCAL_HISTORY, mockHistory)
+
+        await migrateChatHistoryCODY3538(storage)
+
+        const updatedHistory = storage.get<AccountKeyedChatHistory>(LOCAL_HISTORY)
+        const [newChat] = Object.values(updatedHistory?.['endpoint-account1'].chat ?? {})
+        expect(Number.isNaN(Date.parse(newChat.lastInteractionTimestamp))).toBe(false)
+    })
+
+    it('should not modify non-UUID chat IDs', async () => {
+        const mockHistory = {
+            account1: {
+                chat: {
+                    'non-uuid-id': {
+                        id: 'non-uuid-id',
+                        lastInteractionTimestamp: '2023-05-01T12:00:00.000Z',
+                    },
+                },
+            },
+        }
+        await storage.update(LOCAL_HISTORY, mockHistory)
+
+        await migrateChatHistoryCODY3538(storage)
+        expect(storage.get(MIGRATION_MARKER)).toBe(true)
+        expect(storage.get(LOCAL_HISTORY)).toBe(mockHistory)
+    })
+})
+
+const MIGRATION_MARKER = 'migrated-chat-history-cody-3538'
+
+const LOCAL_HISTORY = 'cody-local-chatHistory-v2'

--- a/agent/src/global-state/migrations/chat-id-migration-CODY3538.ts
+++ b/agent/src/global-state/migrations/chat-id-migration-CODY3538.ts
@@ -1,0 +1,49 @@
+import type * as vscode from 'vscode'
+
+import type { AccountKeyedChatHistory } from '@sourcegraph/cody-shared'
+
+// Fixes a bug from https://github.com/sourcegraph/jetbrains/pull/2108 where the chat ID
+// was being imported as a UUID instead of a date.
+export async function migrateChatHistoryCODY3538(storage: vscode.Memento): Promise<void> {
+    const hasMigrated = storage.get<string | null>(MIGRATED_CHAT_HISTORY_KEY_CODY_3538)
+    if (hasMigrated) {
+        return
+    }
+    const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+    const history = storage.get<AccountKeyedChatHistory | null>(KEY_LOCAL_HISTORY, null)
+    for (const accountHistory of Object.values(history ?? {})) {
+        for (const [chatId, chat] of Object.entries(accountHistory.chat)) {
+            // If the ID is a UUID, then this chat came from the JetBrains migration and needs to be fixed.
+            if (uuidRegex.test(chatId) || uuidRegex.test(chat.lastInteractionTimestamp)) {
+                let lastInteraction: Date
+                const timestamp = Date.parse(chat.lastInteractionTimestamp)
+                // If the timestamp can't be parsed, then this chat was restored and continued with a bad
+                // ID, so the date was lost. But since we know it must have been interacted with since the
+                // latest JetBrains release, it can't be too far in the past. So we'll just use the current
+                // date.
+                if (Number.isNaN(timestamp)) {
+                    lastInteraction = new Date()
+                } else {
+                    lastInteraction = new Date(timestamp)
+                }
+
+                // Update the ID in the chat history.
+                const newId = lastInteraction.toUTCString()
+                chat.id = newId
+                chat.lastInteractionTimestamp = newId
+                delete accountHistory.chat[chatId]
+                accountHistory.chat[newId] = chat
+            }
+        }
+    }
+
+    await storage.update(KEY_LOCAL_HISTORY, history)
+    await storage.update(MIGRATED_CHAT_HISTORY_KEY_CODY_3538, true)
+}
+
+const MIGRATED_CHAT_HISTORY_KEY_CODY_3538 = 'migrated-chat-history-cody-3538'
+// This is duplicated because we only want to run this migration if this specific
+// key was incorrectly mutated. If the corresponding key in LocalStorageProvider
+// has updated, by the time this migration runs, we won't need to run it on the
+// new chat history.
+const KEY_LOCAL_HISTORY = 'cody-local-chatHistory-v2'

--- a/agent/src/global-state/migrations/migrate.ts
+++ b/agent/src/global-state/migrations/migrate.ts
@@ -1,0 +1,6 @@
+import type * as vscode from 'vscode'
+import { migrateChatHistoryCODY3538 } from './chat-id-migration-CODY3538'
+
+export default async function migrate(storage: vscode.Memento): Promise<void> {
+    await migrateChatHistoryCODY3538(storage)
+}

--- a/vscode/tsconfig.json
+++ b/vscode/tsconfig.json
@@ -6,12 +6,10 @@
     "outDir": "dist/tsc",
     "jsx": "react-jsx",
     "lib": ["ESNext", "DOM", "DOM.Iterable"],
-    "types": [
-      "@testing-library/jest-dom"
-    ],
+    "types": ["@testing-library/jest-dom"],
     "paths": {
-      "@/*": ["./webviews/*"],
-    },
+      "@/*": ["./webviews/*"]
+    }
   },
   "include": [
     "src",
@@ -23,7 +21,7 @@
     "e2e",
     "webviews",
     "webviews/*.d.ts",
-    "package.json",
+    "package.json"
   ],
   "exclude": [
     "typehacks",
@@ -31,7 +29,7 @@
     "dist",
     "test/integration",
     "**/test-data",
-    "webviews/vite.config.mts",
+    "webviews/vite.config.mts"
   ],
   "references": [
     {


### PR DESCRIPTION
Cherry pick of the merge commit from https://github.com/sourcegraph/cody/pull/5407

## Changes

There was a bug in https://github.com/sourcegraph/jetbrains/pull/2108 where we imported chat's with ID's but the app actually expected them to be UTC date strings. This caused some errors where it tried to do time grouping on the UUID's and if those conversations were continued, they would actually lose all of their timestamps.

![image](https://github.com/user-attachments/assets/d900a45c-f21c-4c6b-9b57-58e3a5b45d46)

This adds a migration that will be run once at startup to try to detect and patch any corrupted conversations. Additionally this PR should fix the migration for newer users.

## Test plan
Unit Tests and manually ran in JB

## Changelog
Fixed a bug in continuing conversations from JB in the webview that caused them to be displayed as NaN weeks ago

