### PR TITLE
Improve tabs UI for different consumers

### DIFF
--- a/vscode/webviews/chat/Transcript.test.tsx
+++ b/vscode/webviews/chat/Transcript.test.tsx
@@ -33,7 +33,7 @@ function render(element: JSX.Element): ReturnType<typeof render_> {
     return render_(element, { wrapper: AppWrapperForTest })
 }
 
-describe('Transcript', () => {
+describe.only('Transcript', () => {
     test('empty', () => {
         render(<Transcript {...PROPS} transcript={[]} />)
         expectCells([{ message: '' }])
@@ -203,7 +203,7 @@ describe('Transcript', () => {
                 ]}
             />
         )
-        expectCells([{ message: 'Foo' }, { message: 'Model\nRequest Failed: some error' }])
+        expectCells([{ message: 'Foo' }, { message: 'Model\n\nRequest Failed: some error' }])
         expect(screen.queryByText('Try again with different context')).toBeNull()
     })
 

--- a/vscode/webviews/chat/Transcript.test.tsx
+++ b/vscode/webviews/chat/Transcript.test.tsx
@@ -33,7 +33,7 @@ function render(element: JSX.Element): ReturnType<typeof render_> {
     return render_(element, { wrapper: AppWrapperForTest })
 }
 
-describe.only('Transcript', () => {
+describe('Transcript', () => {
     test('empty', () => {
         render(<Transcript {...PROPS} transcript={[]} />)
         expectCells([{ message: '' }])

--- a/vscode/webviews/chat/cells/messageCell/BaseMessageCell.tsx
+++ b/vscode/webviews/chat/cells/messageCell/BaseMessageCell.tsx
@@ -7,15 +7,17 @@ import { Cell } from '../Cell'
 export const BaseMessageCell: FunctionComponent<{
     speakerIcon?: React.ReactNode
     speakerTitle?: React.ReactNode
+    cellAction?: React.ReactNode
     content: React.ReactNode
     contentClassName?: string
     footer?: React.ReactNode
     className?: string
-}> = ({ speakerIcon, speakerTitle, content, contentClassName, footer, className }) => (
+}> = ({ speakerIcon, speakerTitle, cellAction, content, contentClassName, footer, className }) => (
     <Cell
         header={
             <>
                 {speakerIcon} <span className="tw-mt-[-1px] tw-font-semibold">{speakerTitle}</span>
+                <div className="tw-ml-auto">{cellAction}</div>
             </>
         }
         containerClassName={className}

--- a/vscode/webviews/chat/cells/messageCell/human/HumanMessageCell.tsx
+++ b/vscode/webviews/chat/cells/messageCell/human/HumanMessageCell.tsx
@@ -5,11 +5,16 @@ import {
 } from '@sourcegraph/cody-shared'
 import type { PromptEditorRefAPI } from '@sourcegraph/prompt-editor'
 import isEqual from 'lodash/isEqual'
+import { ColumnsIcon } from 'lucide-react'
 import { type FunctionComponent, memo, useMemo } from 'react'
 import type { UserAccountInfo } from '../../../../Chat'
 import { UserAvatar } from '../../../../components/UserAvatar'
 import { BaseMessageCell, MESSAGE_CELL_AVATAR_SIZE } from '../BaseMessageCell'
 import { HumanMessageEditor } from './editor/HumanMessageEditor'
+
+import { Tooltip, TooltipContent, TooltipTrigger } from '../../../../components/shadcn/ui/tooltip'
+import { getVSCodeAPI } from '../../../../utils/VSCodeApi'
+import { useConfig } from '../../../../utils/useConfig'
 
 /**
  * A component that displays a chat message from the human.
@@ -75,6 +80,7 @@ export const HumanMessageCell: FunctionComponent<{
                     />
                 }
                 speakerTitle={userInfo.user.displayName ?? userInfo.user.username}
+                cellAction={isFirstMessage && <OpenInNewEditorAction />}
                 content={
                     <HumanMessageEditor
                         userInfo={userInfo}
@@ -100,3 +106,33 @@ export const HumanMessageCell: FunctionComponent<{
     },
     isEqual
 )
+
+const OpenInNewEditorAction = () => {
+    const {
+        config: { multipleWebviewsEnabled },
+    } = useConfig()
+
+    if (!multipleWebviewsEnabled) {
+        return null
+    }
+
+    return (
+        <Tooltip>
+            <TooltipTrigger asChild>
+                <button
+                    type="button"
+                    onClick={() => {
+                        getVSCodeAPI().postMessage({
+                            command: 'command',
+                            id: 'cody.chat.moveToEditor',
+                        })
+                    }}
+                    className="tw-flex tw-gap-3 tw-items-center tw-leading-none tw-opacity-80 hover:tw-opacity-100 tw-border-b-[1px] tw-border-transparent tw-transition tw-translate-y-[1px]"
+                >
+                    <ColumnsIcon size={16} strokeWidth={1.25} className="tw-w-8 tw-h-8" />
+                </button>
+            </TooltipTrigger>
+            <TooltipContent>Open in Editor</TooltipContent>
+        </Tooltip>
+    )
+}

--- a/vscode/webviews/components/shadcn/ui/tooltip.tsx
+++ b/vscode/webviews/components/shadcn/ui/tooltip.tsx
@@ -8,21 +8,27 @@ const Tooltip = TooltipPrimitive.Root
 
 const TooltipTrigger = TooltipPrimitive.Trigger
 
+interface TooltipContentProps extends React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Content> {
+    portal?: boolean
+}
+
 const TooltipContent = React.forwardRef<
     React.ElementRef<typeof TooltipPrimitive.Content>,
-    React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Content>
->(({ className, sideOffset = 4, ...props }, ref) => (
-    <TooltipPrimitive.Content
-        ref={ref}
-        sideOffset={sideOffset}
-        className={cn(
-            'tw-z-50 tw-overflow-hidden tw-flex tw-items-center tw-rounded-md tw-border tw-border-border tw-leading-tight tw-bg-popover tw-px-3 tw-py-2 tw-text-sm tw-text-popover-foreground tw-max-w-72 tw-text-center tw-whitespace-pre-line tw-shadow-lg [&_kbd]:tw-ml-3 [&_kbd]:-tw-mr-1 [&_kbd]:tw-mt-[-4px] [&_kbd]:tw-mb-[-4px]',
-            className
-        )}
-        {...props}
-    >
-        {props.children}
-    </TooltipPrimitive.Content>
+    TooltipContentProps
+>(({ portal, className, sideOffset = 4, ...props }, ref) => (
+    <TooltipPrimitive.Portal>
+        <TooltipPrimitive.Content
+            ref={ref}
+            sideOffset={sideOffset}
+            className={cn(
+                'tw-z-50 tw-overflow-hidden tw-flex tw-items-center tw-rounded-md tw-border tw-border-border tw-leading-tight tw-bg-popover tw-px-3 tw-py-2 tw-text-sm tw-text-popover-foreground tw-max-w-72 tw-text-center tw-whitespace-pre-line tw-shadow-lg [&_kbd]:tw-ml-3 [&_kbd]:-tw-mr-1 [&_kbd]:tw-mt-[-4px] [&_kbd]:tw-mb-[-4px]',
+                className
+            )}
+            {...props}
+        >
+            {props.children}
+        </TooltipPrimitive.Content>
+    </TooltipPrimitive.Portal>
 ))
 
 TooltipContent.displayName = TooltipPrimitive.Content.displayName

--- a/vscode/webviews/components/shadcn/ui/tooltip.tsx
+++ b/vscode/webviews/components/shadcn/ui/tooltip.tsx
@@ -15,21 +15,25 @@ interface TooltipContentProps extends React.ComponentPropsWithoutRef<typeof Tool
 const TooltipContent = React.forwardRef<
     React.ElementRef<typeof TooltipPrimitive.Content>,
     TooltipContentProps
->(({ portal, className, sideOffset = 4, ...props }, ref) => (
-    <TooltipPrimitive.Portal>
-        <TooltipPrimitive.Content
-            ref={ref}
-            sideOffset={sideOffset}
-            className={cn(
-                'tw-z-50 tw-overflow-hidden tw-flex tw-items-center tw-rounded-md tw-border tw-border-border tw-leading-tight tw-bg-popover tw-px-3 tw-py-2 tw-text-sm tw-text-popover-foreground tw-max-w-72 tw-text-center tw-whitespace-pre-line tw-shadow-lg [&_kbd]:tw-ml-3 [&_kbd]:-tw-mr-1 [&_kbd]:tw-mt-[-4px] [&_kbd]:tw-mb-[-4px]',
-                className
-            )}
-            {...props}
-        >
-            {props.children}
-        </TooltipPrimitive.Content>
-    </TooltipPrimitive.Portal>
-))
+>(({ portal, className, sideOffset = 4, ...props }, ref) => {
+    const Portal = portal ? TooltipPrimitive.Portal : React.Fragment
+
+    return (
+        <Portal>
+            <TooltipPrimitive.Content
+                ref={ref}
+                sideOffset={sideOffset}
+                className={cn(
+                    'tw-z-50 tw-overflow-hidden tw-flex tw-items-center tw-rounded-md tw-border tw-border-border tw-leading-tight tw-bg-popover tw-px-3 tw-py-2 tw-text-sm tw-text-popover-foreground tw-max-w-72 tw-text-center tw-whitespace-pre-line tw-shadow-lg [&_kbd]:tw-ml-3 [&_kbd]:-tw-mr-1 [&_kbd]:tw-mt-[-4px] [&_kbd]:tw-mb-[-4px]',
+                    className
+                )}
+                {...props}
+            >
+                {props.children}
+            </TooltipPrimitive.Content>
+        </Portal>
+    )
+})
 
 TooltipContent.displayName = TooltipPrimitive.Content.displayName
 

--- a/vscode/webviews/tabs/TabsBar.module.css
+++ b/vscode/webviews/tabs/TabsBar.module.css
@@ -12,6 +12,7 @@
     container-name: tabs-container;
 
     isolation: isolate;
+    z-index: 1;
 }
 
 .tabs-container {

--- a/vscode/webviews/tabs/TabsBar.module.css
+++ b/vscode/webviews/tabs/TabsBar.module.css
@@ -12,14 +12,15 @@
     container-name: tabs-container;
 
     isolation: isolate;
-    z-index: 1;
 }
 
 .tabs-container {
     display: flex;
+    width: 100%;
+    padding: 0;
+    flex-direction: column;
     justify-content: space-between;
     position: sticky;
-    padding: 0 8px;
     border-bottom: 1px solid var(--vscode-dropdown-border);
     background-color: var(--vscode-sideBar-background);
 }
@@ -28,6 +29,9 @@
     display: flex;
     flex-shrink: 0;
     gap: 2px;
+    width: 100%;
+    padding: 0 8px;
+    border-bottom: 1px solid var(--vscode-dropdown-border);
 
     & > * {
         flex-shrink: 0;
@@ -38,6 +42,7 @@
     display: flex;
     flex-shrink: 0;
     gap: 8px;
+    padding: 0 8px;
 
     & > * {
         flex-shrink: 0;
@@ -48,61 +53,25 @@
     display: inline;
 }
 
-.tooltip {
-    /*
-        Hide tooltips by default, show them only for state when labels are hidden.
-        Important is needed to override standard tailwind styles in tooltip internals
-    */
-    display: none !important;
-}
-
-/*
-    By default if we have enough space we render tabs and its
-    sub action tabs in one row but if we don't have enough space
-    which currently is just static value we switch to two rows
-    layout (one for tab and one below for sub-actions)
- */
-@container tabs-container (width < 750px) {
-    .tabs-container {
-        padding: 0;
-        flex-direction: column;
-    }
-
-    .tabs {
-        padding: 0 8px;
-        border-bottom: 1px solid var(--vscode-dropdown-border);
-    }
-
-    .sub-tabs {
-        padding: 0 8px;
-    }
-}
-
 /*
     For small container turn off tabs labels completely and go back
-    to one row layout for tabs and its sub actions
+    to one row layout for tabs and its sub actions. Note that for
+    Cody Web we have a special override since it has different tabs
+    configurations (later we switch to dynamic items query and remove
+    this override)
 */
-@container tabs-container (width < 475px) {
-    .tab-action-label {
+@container tabs-container (width < 575px) {
+    .tabs-root:not(.tabs-root--cody-web) {
+        .tab-action-label {
+            display: none;
+        }
+    }
+}
+
+/* Special override for Cody Web tabs */
+@container tabs-container (width < 375px) {
+    .tabs-root--cody-web .tab-action-label {
         display: none;
-    }
-
-    .tabs-container {
-        padding: 0 8px;
-        flex-direction: row;
-    }
-
-    .tabs {
-        padding: 0;
-        border-bottom: none;
-    }
-
-    .sub-tabs {
-        padding: 0;
-    }
-
-    .tooltip {
-        display: block !important;
     }
 }
 

--- a/web/CHANGELOG.md
+++ b/web/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.7.5 
+- Improve tabs UI layout for Cody Web tabs configuration 
+- Fix Safari not working cursor click on mention panel problem  
+
 ## 0.7.4 
 - Fix tabs UI tooltips for small screens 
 

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sourcegraph/cody-web",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "description": "Cody standalone web app",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
This PR updates tabs UI based on the latest suggestions from @taiyab 

| Before | After |
| ----- | ------ |
| <video src="https://github.com/user-attachments/assets/f8fdc326-f109-4943-8b93-5da46d87ed7d" /> | <video src="https://github.com/user-attachments/assets/700f417f-6c7e-4d97-b7a6-f4e1a3b0f064" /> |

- Show the "New chat" button unconditionally as global actions on the right side 
- Always show subactions in separate rows below the main tabs row
- Don't hide labels for sub-actions 
- Change label text for sub-actions like export and delete

We still rely on containers query for showing/hiding labels for tab items, but this PR makes breakpoints for Cody Web different (since Cody Web has different tab configurations it makes sense to hide labels with a bit smaller screens)

Also, I've noticed that the container query root element creates some sort of isolation layer that restricts position-fixed elements from visually leaving this container (and as a result, they are completely visually cut off). To avoid this problem, tooltips for tabs UI are rendered outside of the DOM tree with the portal in case of Cody Web review.

## Test plan
- Check tabs UI in VSCode 
- Check tabs UI in Cody Web (demo or full instance check)

