### PR TITLE
Include initial context from OpenCtx providers. 

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "vitest": "^2.0.5"
   },
   "dependencies": {
-    "@openctx/client": "^0.0.25",
+    "@openctx/client": "^0.0.26",
     "@sourcegraph/telemetry": "^0.18.0",
     "ignore": "^5.3.1",
     "observable-fns": "^0.6.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,6 +9,7 @@ neverBuiltDependencies:
   - playwright
 
 overrides:
+  tslib: 2.1.0
   '@lexical/react': https://storage.googleapis.com/sourcegraph-assets/npm/lexical-react-sourcegraph-fork-31065486.tgz
 
 packageExtensionsChecksum: bc809394d179d8460f9d473fc54e379a
@@ -18,8 +19,8 @@ importers:
   .:
     dependencies:
       '@openctx/client':
-        specifier: ^0.0.25
-        version: 0.0.25
+        specifier: ^0.0.26
+        version: 0.0.26
       '@sourcegraph/telemetry':
         specifier: ^0.18.0
         version: 0.18.0
@@ -421,11 +422,11 @@ importers:
         specifier: ^0.20.8
         version: 0.20.8
       '@openctx/provider-linear-issues':
-        specifier: ^0.0.6
-        version: 0.0.6
+        specifier: ^0.0.7
+        version: 0.0.7
       '@openctx/vscode-lib':
-        specifier: ^0.0.21
-        version: 0.0.21
+        specifier: ^0.0.22
+        version: 0.0.22
       '@opentelemetry/api':
         specifier: ^1.7.0
         version: 1.7.0
@@ -821,8 +822,8 @@ importers:
   web:
     devDependencies:
       '@openctx/vscode-lib':
-        specifier: ^0.0.21
-        version: 0.0.21
+        specifier: ^0.0.22
+        version: 0.0.22
       '@sourcegraph/cody':
         specifier: workspace:*
         version: link:../agent
@@ -3278,7 +3279,7 @@ packages:
       '@microsoft/fast-element': 1.13.0
       '@microsoft/fast-web-utilities': 5.4.1
       tabbable: 5.3.3
-      tslib: 1.14.1
+      tslib: 2.1.0
     dev: false
 
   /@microsoft/fast-react-wrapper@0.1.48(react@18.2.0):
@@ -3357,12 +3358,12 @@ packages:
       which: 4.0.0
     dev: true
 
-  /@openctx/client@0.0.25:
-    resolution: {integrity: sha512-jvwuLBfJrokzF1o/b155rLN18+YOQS3xttw+f1ZpKlC470u1aUHS+pasEcQ9Ty5ygBRoUVkKjRKkRTXgZ45foQ==}
+  /@openctx/client@0.0.26:
+    resolution: {integrity: sha512-PapkkZVGZBbYjOnMeqFhy5H4VzAtD0+3vAyLClXn2w6N5rhoJeGdNhQyyBuDnB5doJDY8RWV7paWbCCRZ2FYNg==}
     dependencies:
-      '@openctx/protocol': 0.0.16
-      '@openctx/provider': 0.0.15
-      '@openctx/schema': 0.0.12
+      '@openctx/protocol': 0.0.17
+      '@openctx/provider': 0.0.16
+      '@openctx/schema': 0.0.13
       lru-cache: 10.2.2
       observable-fns: 0.6.1
       picomatch: 3.0.1
@@ -3373,13 +3374,13 @@ packages:
       '@openctx/schema': 0.0.12
     dev: false
 
-  /@openctx/protocol@0.0.16:
-    resolution: {integrity: sha512-W8kRJPpbYVCK0vfel4NByq7wfpTwa1+1TpsA79X12Eta+PstPqCbMUEGjwTeruilzVpIdros26rm4nCsx7MctA==}
+  /@openctx/protocol@0.0.17:
+    resolution: {integrity: sha512-wTRDeubjgcNEaKu2hretjl57QSpafAEWO9TxjYfdnxBRSxOmWz/QHgm+vqTZKNyAAc38f3apL0G3jGQJGQ2fQQ==}
     dependencies:
-      '@openctx/schema': 0.0.12
+      '@openctx/schema': 0.0.13
 
-  /@openctx/provider-linear-issues@0.0.6:
-    resolution: {integrity: sha512-h1N8OtATRDIVB/VJ/m3WBFdVQBwFpa1RHlDiNhg8znCAK9qhw6Y/GMTl89Q6IBZwIdFQ2uxxzF7d8bkyBIiEDQ==}
+  /@openctx/provider-linear-issues@0.0.7:
+    resolution: {integrity: sha512-8NzRAoojj4o1c7+KaMTIc/e/cdVgiRbY4j2U5rn9K0qF2InZ6XNajdbvFdPT+PGrOzNOSvPiVFSM5OX/jKesSg==}
     dependencies:
       '@openctx/provider': 0.0.14
       dedent: 1.5.3
@@ -3396,29 +3397,33 @@ packages:
       picomatch: 3.0.1
     dev: false
 
-  /@openctx/provider@0.0.15:
-    resolution: {integrity: sha512-7jEBI7EcExFOKk1OE91YJhYxLlqzFGWDuu01YHd6CBmq0Eo5IxezEosUn7FvKnTyA0ywoRpT27PI9OX0Lqu/Ag==}
+  /@openctx/provider@0.0.16:
+    resolution: {integrity: sha512-5fK/UXPyBbeW1xE8nBOhu3xJhNNT2E+8mLsHb7tCdcRArgapk9+MsJaFiUGUZMbZ+f839c8YaZhN0CXo84No1Q==}
     dependencies:
-      '@openctx/protocol': 0.0.16
-      '@openctx/schema': 0.0.12
+      '@openctx/protocol': 0.0.17
+      '@openctx/schema': 0.0.13
       picomatch: 3.0.1
 
   /@openctx/schema@0.0.12:
     resolution: {integrity: sha512-YEqmuasaOeAtcrhlN3/D6r+76J/omRbSBUPbv4azKQA7CDvG9MnfgV1Gv8JbFSz33XzI1h9wGbPi5uzb6o6peQ==}
+    dev: false
 
-  /@openctx/ui-common@0.0.11:
-    resolution: {integrity: sha512-3HESG+9UyAra9grHkyI9Fh6d6U5GAcz/kQ3cgOJgICR9Rx0WoTHrr3wgs7V0gOY3fJaL5f6wXEATBbRK3wOwqg==}
+  /@openctx/schema@0.0.13:
+    resolution: {integrity: sha512-P7pi+zkmq+gQkFWZTOjREnQQGmWtMRtHWSFEUt+G3B4Du1D8qFYxOWE4gH4gqlgNISeFS1UrbvGfSAds4jx0yA==}
+
+  /@openctx/ui-common@0.0.12:
+    resolution: {integrity: sha512-FhKswG4GEVWI3YxIIweNywQr+7yjLxjKj0+OiYHvyjg108XKVSWb1TyqPiMjpYVJNFnKLHGKQqe7V9K3vDbCyQ==}
     dependencies:
-      '@openctx/schema': 0.0.12
+      '@openctx/schema': 0.0.13
       marked: 12.0.2
       sanitize-html: 2.13.0
       xss: 1.0.15
 
-  /@openctx/vscode-lib@0.0.21:
-    resolution: {integrity: sha512-WFV3GQz8aB0bri4YRKTNcav2OFLlqNDEb9H1fIFqxZ8lg12S53xjye/VdyMg96y0be5TSImpPwGekG0qP8oFOQ==}
+  /@openctx/vscode-lib@0.0.22:
+    resolution: {integrity: sha512-FrjY39+qIr4fW69HThN3VNgfUsZDPCBvI5NZhwuI6TExKc5rWsDT/rFNyR5vlkesS/xRJ0B6wlFuYGK5JSY6Xg==}
     dependencies:
-      '@openctx/client': 0.0.25
-      '@openctx/ui-common': 0.0.11
+      '@openctx/client': 0.0.26
+      '@openctx/ui-common': 0.0.12
       observable-fns: 0.6.1
 
   /@opentelemetry/api-logs@0.45.1:
@@ -6911,7 +6916,7 @@ packages:
       esbuild: '>=0.10.0'
     dependencies:
       esbuild: 0.18.20
-      tslib: 2.6.3
+      tslib: 2.1.0
     dev: true
 
   /@yarnpkg/fslib@2.10.3:
@@ -6919,7 +6924,7 @@ packages:
     engines: {node: '>=12 <14 || 14.2 - 14.9 || >14.10.0'}
     dependencies:
       '@yarnpkg/libzip': 2.3.0
-      tslib: 1.14.1
+      tslib: 2.1.0
     dev: true
 
   /@yarnpkg/libzip@2.3.0:
@@ -6927,7 +6932,7 @@ packages:
     engines: {node: '>=12 <14 || 14.2 - 14.9 || >14.10.0'}
     dependencies:
       '@types/emscripten': 1.39.10
-      tslib: 1.14.1
+      tslib: 2.1.0
     dev: true
 
   /abab@2.0.6:
@@ -7147,7 +7152,7 @@ packages:
     resolution: {integrity: sha512-y+CcFFwelSXpLZk/7fMB2mUbGtX9lKycf1MWJ7CaTIERyitVlyQx6C+sxcROU2BAJ24OiZyK+8wj2i8AlBoS3A==}
     engines: {node: '>=10'}
     dependencies:
-      tslib: 2.6.3
+      tslib: 2.1.0
     dev: false
 
   /aria-query@5.1.3:
@@ -7231,7 +7236,7 @@ packages:
     resolution: {integrity: sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg==}
     engines: {node: '>=4'}
     dependencies:
-      tslib: 2.6.3
+      tslib: 2.1.0
     dev: true
 
   /astral-regex@2.0.0:
@@ -7242,7 +7247,7 @@ packages:
   /async-mutex@0.4.0:
     resolution: {integrity: sha512-eJFZ1YhRR8UN8eBLoNzcDPcy/jqjsg6I1AP+KvWQX80BqOSW1oJPJXDylPUEeMr2ZQvHgnQ//Lp6f3RQ1zI7HA==}
     dependencies:
-      tslib: 2.6.3
+      tslib: 2.1.0
     dev: false
 
   /async@3.2.5:
@@ -8729,7 +8734,7 @@ packages:
     resolution: {integrity: sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==}
     dependencies:
       no-case: 3.0.4
-      tslib: 2.6.3
+      tslib: 2.1.0
     dev: true
 
   /dotenv-expand@10.0.0:
@@ -11374,7 +11379,7 @@ packages:
   /lower-case@2.0.2:
     resolution: {integrity: sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==}
     dependencies:
-      tslib: 2.6.3
+      tslib: 2.1.0
     dev: true
 
   /lowlight@2.9.0:
@@ -12417,7 +12422,7 @@ packages:
     resolution: {integrity: sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==}
     dependencies:
       lower-case: 2.0.2
-      tslib: 2.6.3
+      tslib: 2.1.0
     dev: true
 
   /nocache@3.0.4:
@@ -13620,7 +13625,7 @@ packages:
       '@types/react': 18.2.37
       react: 18.2.0
       react-style-singleton: 2.2.1(@types/react@18.2.37)(react@18.2.0)
-      tslib: 2.6.3
+      tslib: 2.1.0
     dev: false
 
   /react-remove-scroll-bar@2.3.6(@types/react@18.2.79)(react@18.2.0):
@@ -13636,7 +13641,7 @@ packages:
       '@types/react': 18.2.79
       react: 18.2.0
       react-style-singleton: 2.2.1(@types/react@18.2.79)(react@18.2.0)
-      tslib: 2.6.3
+      tslib: 2.1.0
     dev: false
 
   /react-remove-scroll@2.5.5(@types/react@18.2.37)(react@18.2.0):
@@ -13653,7 +13658,7 @@ packages:
       react: 18.2.0
       react-remove-scroll-bar: 2.3.6(@types/react@18.2.37)(react@18.2.0)
       react-style-singleton: 2.2.1(@types/react@18.2.37)(react@18.2.0)
-      tslib: 2.6.3
+      tslib: 2.1.0
       use-callback-ref: 1.3.2(@types/react@18.2.37)(react@18.2.0)
       use-sidecar: 1.1.2(@types/react@18.2.37)(react@18.2.0)
     dev: false
@@ -13672,7 +13677,7 @@ packages:
       react: 18.2.0
       react-remove-scroll-bar: 2.3.6(@types/react@18.2.79)(react@18.2.0)
       react-style-singleton: 2.2.1(@types/react@18.2.79)(react@18.2.0)
-      tslib: 2.6.3
+      tslib: 2.1.0
       use-callback-ref: 1.3.2(@types/react@18.2.79)(react@18.2.0)
       use-sidecar: 1.1.2(@types/react@18.2.79)(react@18.2.0)
     dev: false
@@ -13691,7 +13696,7 @@ packages:
       get-nonce: 1.0.1
       invariant: 2.2.4
       react: 18.2.0
-      tslib: 2.6.3
+      tslib: 2.1.0
     dev: false
 
   /react-style-singleton@2.2.1(@types/react@18.2.79)(react@18.2.0):
@@ -13708,7 +13713,7 @@ packages:
       get-nonce: 1.0.1
       invariant: 2.2.4
       react: 18.2.0
-      tslib: 2.6.3
+      tslib: 2.1.0
     dev: false
 
   /react@18.2.0:
@@ -13818,7 +13823,7 @@ packages:
       esprima: 4.0.1
       source-map: 0.6.1
       tiny-invariant: 1.3.3
-      tslib: 2.6.3
+      tslib: 2.1.0
     dev: true
 
   /redent@3.0.0:
@@ -14159,7 +14164,7 @@ packages:
   /rxjs@7.8.1:
     resolution: {integrity: sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==}
     dependencies:
-      tslib: 2.6.3
+      tslib: 2.1.0
     dev: true
 
   /safe-buffer@5.1.2:
@@ -14408,7 +14413,7 @@ packages:
     resolution: {integrity: sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==}
     dependencies:
       dot-case: 3.0.4
-      tslib: 2.6.3
+      tslib: 2.1.0
     dev: true
 
   /snapdragon-node@2.1.1:
@@ -15330,15 +15335,8 @@ packages:
       strip-bom: 3.0.0
     dev: true
 
-  /tslib@1.14.1:
-    resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
-
   /tslib@2.1.0:
     resolution: {integrity: sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==}
-    dev: false
-
-  /tslib@2.6.3:
-    resolution: {integrity: sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==}
 
   /tsscmp@1.0.6:
     resolution: {integrity: sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA==}
@@ -15735,7 +15733,7 @@ packages:
     dependencies:
       '@types/react': 18.2.37
       react: 18.2.0
-      tslib: 2.6.3
+      tslib: 2.1.0
     dev: false
 
   /use-callback-ref@1.3.2(@types/react@18.2.79)(react@18.2.0):
@@ -15750,7 +15748,7 @@ packages:
     dependencies:
       '@types/react': 18.2.79
       react: 18.2.0
-      tslib: 2.6.3
+      tslib: 2.1.0
     dev: false
 
   /use-sidecar@1.1.2(@types/react@18.2.37)(react@18.2.0):
@@ -15766,7 +15764,7 @@ packages:
       '@types/react': 18.2.37
       detect-node-es: 1.1.0
       react: 18.2.0
-      tslib: 2.6.3
+      tslib: 2.1.0
     dev: false
 
   /use-sidecar@1.1.2(@types/react@18.2.79)(react@18.2.0):
@@ -15782,7 +15780,7 @@ packages:
       '@types/react': 18.2.79
       detect-node-es: 1.1.0
       react: 18.2.0
-      tslib: 2.6.3
+      tslib: 2.1.0
     dev: false
 
   /use@3.1.1:
@@ -16492,7 +16490,7 @@ packages:
     dev: false
 
   '@storage.googleapis.com/sourcegraph-assets/npm/lexical-react-sourcegraph-fork-31065486.tgz(react-dom@18.2.0)(react@18.2.0)(yjs@13.6.18)':
-    resolution: {tarball: https://storage.googleapis.com/sourcegraph-assets/npm/lexical-react-sourcegraph-fork-31065486.tgz}
+    resolution: {registry: https://registry.npmjs.org/, tarball: https://storage.googleapis.com/sourcegraph-assets/npm/lexical-react-sourcegraph-fork-31065486.tgz}
     id: '@storage.googleapis.com/sourcegraph-assets/npm/lexical-react-sourcegraph-fork-31065486.tgz'
     name: '@lexical/react'
     version: 0.17.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,6 @@ neverBuiltDependencies:
   - playwright
 
 overrides:
-  tslib: 2.1.0
   '@lexical/react': https://storage.googleapis.com/sourcegraph-assets/npm/lexical-react-sourcegraph-fork-31065486.tgz
 
 packageExtensionsChecksum: bc809394d179d8460f9d473fc54e379a
@@ -3279,7 +3278,7 @@ packages:
       '@microsoft/fast-element': 1.13.0
       '@microsoft/fast-web-utilities': 5.4.1
       tabbable: 5.3.3
-      tslib: 2.1.0
+      tslib: 1.14.1
     dev: false
 
   /@microsoft/fast-react-wrapper@0.1.48(react@18.2.0):
@@ -6916,7 +6915,7 @@ packages:
       esbuild: '>=0.10.0'
     dependencies:
       esbuild: 0.18.20
-      tslib: 2.1.0
+      tslib: 2.7.0
     dev: true
 
   /@yarnpkg/fslib@2.10.3:
@@ -6924,7 +6923,7 @@ packages:
     engines: {node: '>=12 <14 || 14.2 - 14.9 || >14.10.0'}
     dependencies:
       '@yarnpkg/libzip': 2.3.0
-      tslib: 2.1.0
+      tslib: 1.14.1
     dev: true
 
   /@yarnpkg/libzip@2.3.0:
@@ -6932,7 +6931,7 @@ packages:
     engines: {node: '>=12 <14 || 14.2 - 14.9 || >14.10.0'}
     dependencies:
       '@types/emscripten': 1.39.10
-      tslib: 2.1.0
+      tslib: 1.14.1
     dev: true
 
   /abab@2.0.6:
@@ -7247,7 +7246,7 @@ packages:
   /async-mutex@0.4.0:
     resolution: {integrity: sha512-eJFZ1YhRR8UN8eBLoNzcDPcy/jqjsg6I1AP+KvWQX80BqOSW1oJPJXDylPUEeMr2ZQvHgnQ//Lp6f3RQ1zI7HA==}
     dependencies:
-      tslib: 2.1.0
+      tslib: 2.7.0
     dev: false
 
   /async@3.2.5:
@@ -15335,8 +15334,14 @@ packages:
       strip-bom: 3.0.0
     dev: true
 
+  /tslib@1.14.1:
+    resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
+
   /tslib@2.1.0:
     resolution: {integrity: sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==}
+
+  /tslib@2.7.0:
+    resolution: {integrity: sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==}
 
   /tsscmp@1.0.6:
     resolution: {integrity: sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA==}
@@ -16490,7 +16495,7 @@ packages:
     dev: false
 
   '@storage.googleapis.com/sourcegraph-assets/npm/lexical-react-sourcegraph-fork-31065486.tgz(react-dom@18.2.0)(react@18.2.0)(yjs@13.6.18)':
-    resolution: {registry: https://registry.npmjs.org/, tarball: https://storage.googleapis.com/sourcegraph-assets/npm/lexical-react-sourcegraph-fork-31065486.tgz}
+    resolution: {tarball: https://storage.googleapis.com/sourcegraph-assets/npm/lexical-react-sourcegraph-fork-31065486.tgz}
     id: '@storage.googleapis.com/sourcegraph-assets/npm/lexical-react-sourcegraph-fork-31065486.tgz'
     name: '@lexical/react'
     version: 0.17.0

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -1354,8 +1354,8 @@
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.20.8",
-    "@openctx/provider-linear-issues": "^0.0.6",
-    "@openctx/vscode-lib": "^0.0.21",
+    "@openctx/provider-linear-issues": "^0.0.7",
+    "@openctx/vscode-lib": "^0.0.22",
     "@opentelemetry/api": "^1.7.0",
     "@opentelemetry/core": "^1.18.1",
     "@opentelemetry/exporter-trace-otlp-http": "^0.45.1",

--- a/vscode/src/repository/repo-metadata-from-git-api.ts
+++ b/vscode/src/repository/repo-metadata-from-git-api.ts
@@ -64,7 +64,7 @@ class WorkspaceReposMonitor implements vscode.Disposable {
         return repoMetadata.flat()
     }
 
-    private getFolderURIs(): vscode.Uri[] {
+    public getFolderURIs(): vscode.Uri[] {
         return vscode.workspace.workspaceFolders?.map(f => f.uri) ?? []
     }
 
@@ -128,7 +128,9 @@ export function initWorkspaceReposMonitor(
     return workspaceReposMonitor
 }
 
-async function fetchRepoMetadataForFolder(folderURI: vscode.Uri): Promise<GitHubDotComRepoMetaData[]> {
+export async function fetchRepoMetadataForFolder(
+    folderURI: vscode.Uri
+): Promise<GitHubDotComRepoMetaData[]> {
     const repoNames = await repoNameResolver.getRepoNamesFromWorkspaceUri(folderURI)
     if (repoNames.length === 0) {
         return []

--- a/web/package.json
+++ b/web/package.json
@@ -19,7 +19,7 @@
     "build-ts": "tsc --build"
   },
   "devDependencies": {
-    "@openctx/vscode-lib": "^0.0.21",
+    "@openctx/vscode-lib": "^0.0.22",
     "@sourcegraph/cody": "workspace:*",
     "@sourcegraph/cody-shared": "workspace:*",
     "@sourcegraph/prompt-editor": "workspace:*",


### PR DESCRIPTION
context: https://linear.app/sourcegraph/issue/PROD-264/one-pager-for-how-to-get-this-set-up-using-openctx

We have [added](https://github.com/sourcegraph/openctx/pull/199) `meta.mentions.autoInclude` property for OpenCtx providers. The providers which set that to `true` will be used to include the mentions they return as initial context items. We are also passing the active file uri and codebase names to the `mentions` function. 


## Test plan
Set the following as the vs code setting and see the hello world mention item chip appearing as the default context item. 
```json
"openctx.providers": {
        "https://openctx.org/npm/@openctx/provider-hello-world": true
}
```

## Changelog

Include initial context from OpenCtx providers. 
