### PR TITLE
simplify the "authed but Cody is not enabled" state

### DIFF
--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/agent/protocol_generated/AuthStatus.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/agent/protocol_generated/AuthStatus.kt
@@ -11,7 +11,6 @@ data class AuthStatus(
   val authenticated: Boolean,
   val hasVerifiedEmail: Boolean,
   val requiresVerifiedEmail: Boolean,
-  val siteHasCodyEnabled: Boolean,
   val siteVersion: String,
   val codyApiVersion: Long,
   val configOverwrites: CodyLLMSiteConfiguration? = null,

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/agent/protocol_generated/AuthStatus.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/agent/protocol_generated/AuthStatus.kt
@@ -6,7 +6,6 @@ import com.google.gson.annotations.SerializedName;
 data class AuthStatus(
   val username: String,
   val endpoint: EndpointEnum, // Oneof: 
-  val isLoggedIn: Boolean,
   val isFireworksTracingEnabled: Boolean,
   val showInvalidAccessTokenError: Boolean,
   val authenticated: Boolean,

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/agent/protocol_generated/ServerInfo.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/agent/protocol_generated/ServerInfo.kt
@@ -4,7 +4,6 @@ package com.sourcegraph.cody.agent.protocol_generated;
 data class ServerInfo(
   val name: String,
   val authenticated: Boolean? = null,
-  val codyEnabled: Boolean? = null,
   val codyVersion: String? = null,
   val authStatus: AuthStatus? = null,
 )

--- a/agent/src/TestClient.ts
+++ b/agent/src/TestClient.ts
@@ -900,7 +900,7 @@ ${patch}`
 
     public async beforeAll(additionalConfig?: Partial<ExtensionConfiguration>) {
         const info = await this.initialize(additionalConfig)
-        if (!info.authStatus?.isLoggedIn) {
+        if (!info.authStatus?.authenticated) {
             throw new Error('Could not log in')
         }
     }

--- a/agent/src/agent.ts
+++ b/agent/src/agent.ts
@@ -463,7 +463,6 @@ export class Agent extends MessageHandler implements ExtensionClient {
                 return {
                     name: 'cody-agent',
                     authenticated: authStatus?.authenticated,
-                    codyEnabled: authStatus?.siteHasCodyEnabled,
                     codyVersion: authStatus?.siteVersion,
                     authStatus,
                 }

--- a/agent/src/cli/command-auth/command-accounts.ts
+++ b/agent/src/cli/command-auth/command-accounts.ts
@@ -6,7 +6,7 @@ import ora from 'ora'
 import { AuthenticatedAccount } from './AuthenticatedAccount'
 import { booleanToText } from './command-auth'
 import { type AuthenticationOptions, accessTokenOption, endpointOption } from './command-login'
-import { notLoggedIn, unknownErrorSpinner } from './messages'
+import { notAuthenticated, unknownErrorSpinner } from './messages'
 import { loadUserSettings } from './settings'
 
 export const accountsCommand = new Command('accounts')
@@ -18,7 +18,7 @@ export const accountsCommand = new Command('accounts')
         try {
             const settings = loadUserSettings()
             if (!settings?.accounts || settings.accounts.length === 0) {
-                notLoggedIn(spinner)
+                notAuthenticated(spinner)
                 process.exit(1)
             }
             const t = new Table()

--- a/agent/src/cli/command-auth/command-whoami.ts
+++ b/agent/src/cli/command-auth/command-whoami.ts
@@ -3,7 +3,7 @@ import { isError } from 'lodash'
 import ora from 'ora'
 import { AuthenticatedAccount } from './AuthenticatedAccount'
 import { type AuthenticationOptions, accessTokenOption, endpointOption } from './command-login'
-import { errorSpinner, notLoggedIn, unknownErrorSpinner } from './messages'
+import { errorSpinner, notAuthenticated, unknownErrorSpinner } from './messages'
 
 export const whoamiCommand = new Command('whoami')
     .description('Print the active authenticated account')
@@ -18,7 +18,7 @@ export const whoamiCommand = new Command('whoami')
                 process.exit(1)
             }
             if (!account?.username) {
-                notLoggedIn(spinner)
+                notAuthenticated(spinner)
                 process.exit(1)
             }
 

--- a/agent/src/cli/command-auth/messages.ts
+++ b/agent/src/cli/command-auth/messages.ts
@@ -1,7 +1,7 @@
 import type { Ora } from 'ora'
 import type { AuthenticationOptions } from './command-login'
 
-export function notLoggedIn(spinner: Ora): void {
+export function notAuthenticated(spinner: Ora): void {
     if (!spinner.isSpinning) {
         return
     }

--- a/agent/src/cli/command-chat.ts
+++ b/agent/src/cli/command-chat.ts
@@ -23,7 +23,7 @@ import {
     accessTokenOption,
     endpointOption,
 } from './command-auth/command-login'
-import { errorSpinner, notLoggedIn } from './command-auth/messages'
+import { errorSpinner, notAuthenticated } from './command-auth/messages'
 import { isNonEmptyArray } from './isNonEmptyArray'
 
 declare const process: { pkg: { entrypoint: string } } & NodeJS.Process
@@ -89,7 +89,7 @@ Enterprise Only:
                 process.exit(1)
             }
             if (!account?.username) {
-                notLoggedIn(spinner)
+                notAuthenticated(spinner)
                 process.exit(1)
             }
             options.accessToken = account.accessToken
@@ -143,8 +143,8 @@ export async function chatAction(options: ChatOptions): Promise<number> {
     }
     spinner.text = 'Initializing...'
     const { serverInfo, client, messageHandler } = await newEmbeddedAgentClient(clientInfo, activate)
-    if (!serverInfo.authStatus?.isLoggedIn) {
-        notLoggedIn(spinner)
+    if (!serverInfo.authStatus?.authenticated) {
+        notAuthenticated(spinner)
         return 1
     }
 

--- a/agent/src/enterprise-demo.test.ts
+++ b/agent/src/enterprise-demo.test.ts
@@ -19,7 +19,7 @@ describe('Enterprise', () => {
     beforeAll(async () => {
         const serverInfo = await demoEnterpriseClient.initialize()
 
-        expect(serverInfo.authStatus?.isLoggedIn).toBeTruthy()
+        expect(serverInfo.authStatus?.authenticated).toBeTruthy()
         expect(serverInfo.authStatus?.username).toStrictEqual('codytesting')
     }, 10_000)
 

--- a/agent/src/enterprise-s2.test.ts
+++ b/agent/src/enterprise-s2.test.ts
@@ -34,7 +34,7 @@ describe('Enterprise - S2 (close main branch)', () => {
             autocompleteAdvancedProvider: 'fireworks',
         })
 
-        expect(serverInfo.authStatus?.isLoggedIn).toBeTruthy()
+        expect(serverInfo.authStatus?.authenticated).toBeTruthy()
         expect(serverInfo.authStatus?.username).toStrictEqual('codytesting')
     }, 10_000)
 

--- a/agent/src/index.test.ts
+++ b/agent/src/index.test.ts
@@ -63,7 +63,7 @@ describe('Agent', () => {
             // with a new access token.
             accessToken: 'sgp_INVALIDACCESSTOK_ENTHISSHOULDFAILEEEEEEEEEEEEEEEEEEEEEEE2',
         })
-        expect(serverInfo?.authStatus?.isLoggedIn).toBeFalsy()
+        expect(serverInfo?.authStatus?.authenticated).toBeFalsy()
 
         // Log in so test cases are authenticated by default
         const valid = await client.request('extensionConfiguration/change', {
@@ -73,7 +73,7 @@ describe('Agent', () => {
             serverEndpoint: client.info.extensionConfiguration?.serverEndpoint ?? DOTCOM_URL.toString(),
             customHeaders: {},
         })
-        expect(valid?.isLoggedIn).toBeTruthy()
+        expect(valid?.authenticated).toBeTruthy()
 
         for (const name of [
             'src/animal.ts',
@@ -166,7 +166,7 @@ describe('Agent', () => {
             serverEndpoint: 'https://sourcegraph.com/',
             customHeaders: {},
         })
-        expect(invalid?.isLoggedIn).toBeFalsy()
+        expect(invalid?.authenticated).toBeFalsy()
         const invalidModels = await client.request('chat/models', { modelUsage: ModelUsage.Chat })
         const remoteInvalidModels = invalidModels.models.filter(model => model.provider !== 'Ollama')
         expect(remoteInvalidModels).toStrictEqual([])
@@ -178,7 +178,7 @@ describe('Agent', () => {
             serverEndpoint: client.info.extensionConfiguration?.serverEndpoint ?? DOTCOM_URL.toString(),
             customHeaders: {},
         })
-        expect(valid?.isLoggedIn).toBeTruthy()
+        expect(valid?.authenticated).toBeTruthy()
 
         const reauthenticatedModels = await client.request('chat/models', {
             modelUsage: ModelUsage.Chat,
@@ -1234,7 +1234,7 @@ describe('Agent', () => {
         beforeAll(async () => {
             const serverInfo = await rateLimitedClient.initialize()
 
-            expect(serverInfo.authStatus?.isLoggedIn).toBeTruthy()
+            expect(serverInfo.authStatus?.authenticated).toBeTruthy()
             expect(serverInfo.authStatus?.username).toStrictEqual('sourcegraphcodyclients-1-efapb')
         }, 10_000)
 

--- a/lib/shared/src/auth/types.ts
+++ b/lib/shared/src/auth/types.ts
@@ -8,7 +8,6 @@ import type { CodyLLMSiteConfiguration } from '../sourcegraph-api/graphql/client
 export interface AuthStatus {
     username: string
     endpoint: string
-    isLoggedIn: boolean
     /**
      * Used to enable Fireworks tracing for Sourcegraph teammates on DotCom.
      * https://readme.fireworks.ai/docs/enabling-tracing
@@ -44,7 +43,6 @@ export interface AuthStatusProvider {
 
 export const defaultAuthStatus: AuthStatus = {
     endpoint: '',
-    isLoggedIn: false,
     isFireworksTracingEnabled: false,
     showInvalidAccessTokenError: false,
     authenticated: false,
@@ -59,7 +57,6 @@ export const defaultAuthStatus: AuthStatus = {
 
 export const unauthenticatedStatus: AuthStatus = {
     endpoint: '',
-    isLoggedIn: false,
     isFireworksTracingEnabled: false,
     showInvalidAccessTokenError: true,
     authenticated: false,
@@ -75,7 +72,6 @@ export const unauthenticatedStatus: AuthStatus = {
 export const networkErrorAuthStatus: Omit<AuthStatus, 'endpoint'> = {
     showInvalidAccessTokenError: false,
     authenticated: false,
-    isLoggedIn: false,
     isFireworksTracingEnabled: false,
     hasVerifiedEmail: false,
     showNetworkError: true,
@@ -88,7 +84,6 @@ export const networkErrorAuthStatus: Omit<AuthStatus, 'endpoint'> = {
 }
 
 export const offlineModeAuthStatus: Omit<AuthStatus, 'endpoint'> = {
-    isLoggedIn: true,
     isOfflineMode: true,
     isFireworksTracingEnabled: false,
     showInvalidAccessTokenError: false,

--- a/lib/shared/src/auth/types.ts
+++ b/lib/shared/src/auth/types.ts
@@ -17,7 +17,6 @@ export interface AuthStatus {
     authenticated: boolean
     hasVerifiedEmail: boolean
     requiresVerifiedEmail: boolean
-    siteHasCodyEnabled: boolean
     siteVersion: string
     codyApiVersion: number
     configOverwrites?: CodyLLMSiteConfiguration
@@ -48,7 +47,6 @@ export const defaultAuthStatus: AuthStatus = {
     authenticated: false,
     hasVerifiedEmail: false,
     requiresVerifiedEmail: false,
-    siteHasCodyEnabled: false,
     siteVersion: '',
     userCanUpgrade: false,
     username: '',
@@ -62,7 +60,6 @@ export const unauthenticatedStatus: AuthStatus = {
     authenticated: false,
     hasVerifiedEmail: false,
     requiresVerifiedEmail: false,
-    siteHasCodyEnabled: false,
     siteVersion: '',
     userCanUpgrade: false,
     username: '',
@@ -76,7 +73,6 @@ export const networkErrorAuthStatus: Omit<AuthStatus, 'endpoint'> = {
     hasVerifiedEmail: false,
     showNetworkError: true,
     requiresVerifiedEmail: false,
-    siteHasCodyEnabled: false,
     siteVersion: '',
     userCanUpgrade: false,
     username: '',
@@ -90,7 +86,6 @@ export const offlineModeAuthStatus: Omit<AuthStatus, 'endpoint'> = {
     authenticated: true,
     hasVerifiedEmail: true,
     requiresVerifiedEmail: true,
-    siteHasCodyEnabled: true,
     siteVersion: '',
     userCanUpgrade: false,
     username: 'offline',

--- a/lib/shared/src/sourcegraph-api/graphql/client.ts
+++ b/lib/shared/src/sourcegraph-api/graphql/client.ts
@@ -1542,7 +1542,7 @@ export class ClientConfigSingleton {
     }
 
     public async setAuthStatus(authStatus: AuthStatus): Promise<void> {
-        this.isSignedIn = authStatus.authenticated && authStatus.isLoggedIn
+        this.isSignedIn = authStatus.authenticated
         if (this.isSignedIn) {
             await this.refreshConfig()
         } else {

--- a/lib/shared/src/sourcegraph-api/graphql/client.ts
+++ b/lib/shared/src/sourcegraph-api/graphql/client.ts
@@ -178,9 +178,6 @@ interface CurrentUserInfoResponse {
 //
 // For the canonical type definition, see https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/internal/clientconfig/types.go
 interface CodyClientConfig {
-    // Whether the site admin allows this user to make use of Cody at all.
-    codyEnabled: boolean
-
     // Whether the site admin allows this user to make use of the Cody chat feature.
     chatEnabled: boolean
 
@@ -1663,7 +1660,6 @@ export class ClientConfigSingleton {
         const features = await this.fetchConfigFeaturesLegacy(this.featuresLegacy)
 
         return graphqlClient.isCodyEnabled().then(isCodyEnabled => ({
-            codyEnabled: isCodyEnabled.enabled,
             chatEnabled: features.chat,
             autoCompleteEnabled: features.autoComplete,
             customCommandsEnabled: features.commands,

--- a/vscode/src/auth/auth.ts
+++ b/vscode/src/auth/auth.ts
@@ -17,7 +17,7 @@ export async function showSignInMenu(
     uri?: string
 ): Promise<void> {
     const authStatus = authProvider.instance!.status
-    const mode = authStatus.isLoggedIn ? 'switch' : 'signin'
+    const mode = authStatus.authenticated ? 'switch' : 'signin'
     logDebug('AuthProvider:signinMenu', mode)
     telemetryRecorder.recordEvent('cody.auth.login', 'clicked')
     const item = await showAuthMenu(mode)
@@ -57,7 +57,7 @@ export async function showSignInMenu(
                 endpoint: selectedEndpoint,
                 token: token || null,
             })
-            if (!authStatus?.isLoggedIn) {
+            if (!authStatus?.authenticated) {
                 const newToken = await showAccessTokenInputBox(item.uri)
                 if (!newToken) {
                     return
@@ -213,7 +213,7 @@ async function signinMenuForInstanceUrl(instanceUrl: string): Promise<void> {
     })
     telemetryRecorder.recordEvent('cody.auth.signin.token', 'clicked', {
         metadata: {
-            success: authState.isLoggedIn ? 1 : 0,
+            success: authState.authenticated ? 1 : 0,
         },
     })
     await showAuthResultMessage(instanceUrl, authState)
@@ -246,7 +246,7 @@ async function showAuthResultMessage(
     endpoint: string,
     authStatus: AuthStatus | undefined
 ): Promise<void> {
-    if (authStatus?.isLoggedIn) {
+    if (authStatus?.authenticated) {
         const authority = vscode.Uri.parse(endpoint).authority
         await vscode.window.showInformationMessage(`Signed in to ${authority || endpoint}`)
     } else {
@@ -280,10 +280,10 @@ export async function tokenCallbackHandler(
     const authState = await authProvider.instance!.auth({ endpoint, token, customHeaders })
     telemetryRecorder.recordEvent('cody.auth.fromCallback.web', 'succeeded', {
         metadata: {
-            success: authState?.isLoggedIn ? 1 : 0,
+            success: authState?.authenticated ? 1 : 0,
         },
     })
-    if (authState?.isLoggedIn) {
+    if (authState?.authenticated) {
         await vscode.window.showInformationMessage(`Signed in to ${endpoint}`)
     } else {
         await showAuthFailureMessage(endpoint)

--- a/vscode/src/chat/chat-view/ChatController.ts
+++ b/vscode/src/chat/chat-view/ChatController.ts
@@ -457,11 +457,11 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
                                 'succeeded',
                                 {
                                     metadata: {
-                                        success: authStatus?.isLoggedIn ? 1 : 0,
+                                        success: authStatus?.authenticated ? 1 : 0,
                                     },
                                 }
                             )
-                            if (!authStatus?.isLoggedIn) {
+                            if (!authStatus?.authenticated) {
                                 void vscode.window.showErrorMessage(
                                     'Authentication failed. Please check your token and try again.'
                                 )
@@ -508,7 +508,7 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
                                 endpoint: DOTCOM_URL.href,
                                 token,
                             })
-                            if (!authStatus?.isLoggedIn) {
+                            if (!authStatus?.authenticated) {
                                 void vscode.window.showErrorMessage(
                                     'Authentication failed. Please check your token and try again.'
                                 )
@@ -523,7 +523,7 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
                 const nextAuth = authProvider.instance!.status
                 telemetryRecorder.recordEvent('cody.troubleshoot', 'reloadAuth', {
                     metadata: {
-                        success: nextAuth.isLoggedIn ? 1 : 0,
+                        success: nextAuth.authenticated ? 1 : 0,
                     },
                 })
                 break
@@ -566,7 +566,7 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
         void this.sendConfig()
 
         // Get the latest model list available to the current user to update the ChatModel.
-        if (status.isLoggedIn) {
+        if (status.authenticated) {
             this.chatModel.updateModel(getDefaultModelID())
         }
     }

--- a/vscode/src/chat/chat-view/ChatsController.ts
+++ b/vscode/src/chat/chat-view/ChatsController.ts
@@ -90,7 +90,7 @@ export class ChatsController implements vscode.Disposable {
     }
 
     private async setAuthStatus(authStatus: AuthStatus): Promise<void> {
-        const hasLoggedOut = !authStatus.isLoggedIn
+        const hasLoggedOut = !authStatus.authenticated
         const hasSwitchedAccount =
             this.currentAuthAccount && this.currentAuthAccount.endpoint !== authStatus.endpoint
         if (hasLoggedOut || hasSwitchedAccount) {
@@ -350,7 +350,7 @@ export class ChatsController implements vscode.Disposable {
     private async exportHistory(): Promise<void> {
         telemetryRecorder.recordEvent('cody.exportChatHistoryButton', 'clicked')
         const authStatus = authProvider.instance!.status
-        if (authStatus.isLoggedIn) {
+        if (authStatus.authenticated) {
             try {
                 const historyJson = chatHistory.getLocalHistory(authStatus)
                 const exportPath = await vscode.window.showSaveDialog({

--- a/vscode/src/chat/utils.test.ts
+++ b/vscode/src/chat/utils.test.ts
@@ -1,10 +1,15 @@
 import { describe, expect, it } from 'vitest'
 
-import { DOTCOM_URL, defaultAuthStatus, unauthenticatedStatus } from '@sourcegraph/cody-shared'
+import {
+    type AuthStatus,
+    DOTCOM_URL,
+    defaultAuthStatus,
+    unauthenticatedStatus,
+} from '@sourcegraph/cody-shared'
 import { newAuthStatus } from './utils'
 
 describe('validateAuthStatus', () => {
-    const options = {
+    const options: AuthStatus = {
         ...defaultAuthStatus,
         siteVersion: '',
         hasVerifiedEmail: true,
@@ -19,7 +24,7 @@ describe('validateAuthStatus', () => {
     }
 
     it('returns auth state for invalid user on dotcom instance', () => {
-        const expected = { ...unauthenticatedStatus, endpoint: options.endpoint }
+        const expected: AuthStatus = { ...unauthenticatedStatus, endpoint: options.endpoint }
         expect(
             newAuthStatus({
                 ...options,
@@ -30,21 +35,20 @@ describe('validateAuthStatus', () => {
     })
 
     it('returns auth status for valid user with verified email on dotcom instance', () => {
-        const expected = {
+        const expected: AuthStatus = {
             ...options,
             authenticated: true,
             hasVerifiedEmail: true,
             showInvalidAccessTokenError: false,
             requiresVerifiedEmail: true,
             siteHasCodyEnabled: true,
-            isLoggedIn: true,
             codyApiVersion: 1,
         }
         expect(newAuthStatus(options)).toEqual(expected)
     })
 
     it('returns auth status for valid user without verified email on dotcom instance', () => {
-        const expected = {
+        const expected: AuthStatus = {
             ...options,
             authenticated: true,
             hasVerifiedEmail: false,
@@ -61,12 +65,11 @@ describe('validateAuthStatus', () => {
     })
 
     it('returns auth status for valid user on enterprise instance with Cody enabled', () => {
-        const expected = {
+        const expected: AuthStatus = {
             ...options,
             authenticated: true,
             siteHasCodyEnabled: true,
             hasVerifiedEmail: false,
-            isLoggedIn: true,
             endpoint: 'https://example.com',
             codyApiVersion: 1,
         }
@@ -80,7 +83,7 @@ describe('validateAuthStatus', () => {
     })
 
     it('returns auth status for invalid user on enterprise instance with Cody enabled', () => {
-        const expected = { ...unauthenticatedStatus, endpoint: 'https://example.com' }
+        const expected: AuthStatus = { ...unauthenticatedStatus, endpoint: 'https://example.com' }
         expect(
             newAuthStatus({
                 ...options,
@@ -93,7 +96,7 @@ describe('validateAuthStatus', () => {
     })
 
     it('returns auth status for valid user on enterprise instance with Cody disabled', () => {
-        const expected = {
+        const expected: AuthStatus = {
             ...options,
             authenticated: true,
             siteHasCodyEnabled: false,
@@ -112,7 +115,7 @@ describe('validateAuthStatus', () => {
     })
 
     it('returns auth status for invalid user on enterprise instance with Cody disabled', () => {
-        const expected = { ...unauthenticatedStatus, endpoint: 'https://example.com' }
+        const expected: AuthStatus = { ...unauthenticatedStatus, endpoint: 'https://example.com' }
         expect(
             newAuthStatus({
                 ...options,
@@ -125,11 +128,10 @@ describe('validateAuthStatus', () => {
     })
 
     it('returns auth status for signed in user without email and displayName on enterprise instance', () => {
-        const expected = {
+        const expected: AuthStatus = {
             ...options,
             authenticated: true,
             siteHasCodyEnabled: true,
-            isLoggedIn: true,
             endpoint: 'https://example.com',
             hasVerifiedEmail: false,
             codyApiVersion: 1,
@@ -143,12 +145,11 @@ describe('validateAuthStatus', () => {
     })
 
     it('returns API version 0 for a legacy instance', () => {
-        const expected = {
+        const expected: AuthStatus = {
             ...options,
             authenticated: true,
             siteHasCodyEnabled: true,
             hasVerifiedEmail: false,
-            isLoggedIn: true,
             codyApiVersion: 0,
             siteVersion: '5.2.0',
             endpoint: 'https://example.com',

--- a/vscode/src/chat/utils.test.ts
+++ b/vscode/src/chat/utils.test.ts
@@ -13,7 +13,6 @@ describe('validateAuthStatus', () => {
         ...defaultAuthStatus,
         siteVersion: '',
         hasVerifiedEmail: true,
-        siteHasCodyEnabled: true,
         authenticated: true,
         endpoint: DOTCOM_URL.toString(),
         userCanUpgrade: false,
@@ -41,7 +40,6 @@ describe('validateAuthStatus', () => {
             hasVerifiedEmail: true,
             showInvalidAccessTokenError: false,
             requiresVerifiedEmail: true,
-            siteHasCodyEnabled: true,
             codyApiVersion: 1,
         }
         expect(newAuthStatus(options)).toEqual(expected)
@@ -53,7 +51,6 @@ describe('validateAuthStatus', () => {
             authenticated: true,
             hasVerifiedEmail: false,
             requiresVerifiedEmail: true,
-            siteHasCodyEnabled: true,
             codyApiVersion: 1,
         }
         expect(
@@ -68,7 +65,6 @@ describe('validateAuthStatus', () => {
         const expected: AuthStatus = {
             ...options,
             authenticated: true,
-            siteHasCodyEnabled: true,
             hasVerifiedEmail: false,
             endpoint: 'https://example.com',
             codyApiVersion: 1,
@@ -90,7 +86,6 @@ describe('validateAuthStatus', () => {
                 endpoint: 'https://example.com',
                 authenticated: false,
                 hasVerifiedEmail: false,
-                siteHasCodyEnabled: false,
             })
         ).toEqual(expected)
     })
@@ -99,7 +94,6 @@ describe('validateAuthStatus', () => {
         const expected: AuthStatus = {
             ...options,
             authenticated: true,
-            siteHasCodyEnabled: false,
             hasVerifiedEmail: false,
             endpoint: 'https://example.com',
             codyApiVersion: 1,
@@ -108,7 +102,6 @@ describe('validateAuthStatus', () => {
             newAuthStatus({
                 ...options,
                 endpoint: 'https://example.com',
-                siteHasCodyEnabled: false,
                 hasVerifiedEmail: false,
             })
         ).toEqual(expected)
@@ -122,7 +115,6 @@ describe('validateAuthStatus', () => {
                 endpoint: 'https://example.com',
                 authenticated: false,
                 hasVerifiedEmail: false,
-                siteHasCodyEnabled: false,
             })
         ).toEqual(expected)
     })
@@ -131,7 +123,6 @@ describe('validateAuthStatus', () => {
         const expected: AuthStatus = {
             ...options,
             authenticated: true,
-            siteHasCodyEnabled: true,
             endpoint: 'https://example.com',
             hasVerifiedEmail: false,
             codyApiVersion: 1,
@@ -148,7 +139,6 @@ describe('validateAuthStatus', () => {
         const expected: AuthStatus = {
             ...options,
             authenticated: true,
-            siteHasCodyEnabled: true,
             hasVerifiedEmail: false,
             codyApiVersion: 0,
             siteVersion: '5.2.0',

--- a/vscode/src/chat/utils.ts
+++ b/vscode/src/chat/utils.ts
@@ -10,7 +10,6 @@ import type { CurrentUserInfo } from '@sourcegraph/cody-shared/src/sourcegraph-a
 
 type NewAuthStatusOptions = Omit<
     AuthStatus,
-    | 'isLoggedIn'
     | 'isFireworksTracingEnabled'
     | 'codyApiVersion'
     | 'showInvalidAccessToken'
@@ -28,15 +27,7 @@ type NewAuthStatusOptions = Omit<
 }
 
 export function newAuthStatus(options: NewAuthStatusOptions): AuthStatus {
-    const {
-        isOfflineMode,
-        endpoint,
-        siteHasCodyEnabled,
-        username,
-        authenticated,
-        siteVersion,
-        userOrganizations,
-    } = options
+    const { isOfflineMode, endpoint, username, authenticated, siteVersion, userOrganizations } = options
 
     if (isOfflineMode) {
         return { ...offlineModeAuthStatus, endpoint, username }
@@ -51,7 +42,6 @@ export function newAuthStatus(options: NewAuthStatusOptions): AuthStatus {
             : options.primaryEmail?.email || ''
     const requiresVerifiedEmail = isDotCom_
     const hasVerifiedEmail = requiresVerifiedEmail && options.hasVerifiedEmail
-    const isAllowed = !requiresVerifiedEmail || hasVerifiedEmail
     return {
         ...options,
         showInvalidAccessTokenError: false,
@@ -59,7 +49,6 @@ export function newAuthStatus(options: NewAuthStatusOptions): AuthStatus {
         primaryEmail,
         requiresVerifiedEmail,
         hasVerifiedEmail,
-        isLoggedIn: siteHasCodyEnabled && authenticated && isAllowed,
         codyApiVersion: inferCodyApiVersion(siteVersion, isDotCom_),
         isFireworksTracingEnabled:
             isDotCom_ && !!userOrganizations?.nodes.find(org => org.name === 'sourcegraph'),

--- a/vscode/src/commands/GhostHintDecorator.ts
+++ b/vscode/src/commands/GhostHintDecorator.ts
@@ -416,7 +416,7 @@ export class GhostHintDecorator implements vscode.Disposable {
     private async updateEnablement(authStatus: AuthStatus): Promise<void> {
         const featureEnablement = await getGhostHintEnablement()
         if (
-            !authStatus.isLoggedIn ||
+            !authStatus.authenticated ||
             !(featureEnablement.Document || featureEnablement.EditOrChat || featureEnablement.Generate)
         ) {
             this.disposeActive()

--- a/vscode/src/completions/create-inline-completion-item-provider.ts
+++ b/vscode/src/completions/create-inline-completion-item-provider.ts
@@ -45,7 +45,7 @@ export async function createInlineCompletionItemProvider({
     createBfgRetriever,
 }: InlineCompletionItemProviderArgs): Promise<vscode.Disposable> {
     const authStatus = authProvider.instance!.status
-    if (!authStatus.isLoggedIn) {
+    if (!authStatus.authenticated) {
         logDebug('CodyCompletionProvider:notSignedIn', 'You are not signed in.')
 
         if (config.isRunningInsideAgent) {

--- a/vscode/src/completions/create-multi-model-inline-completion-provider.ts
+++ b/vscode/src/completions/create-multi-model-inline-completion-provider.ts
@@ -73,7 +73,10 @@ export async function createInlineCompletionItemFromMultipleProviders({
     // The primary purpose of this method is to get the completions generated from multiple providers,
     // which helps judge the quality of code completions
     const authStatus = authProvider.instance!.status
-    if (!authStatus.isLoggedIn || config.autocompleteExperimentalMultiModelCompletions === undefined) {
+    if (
+        !authStatus.authenticated ||
+        config.autocompleteExperimentalMultiModelCompletions === undefined
+    ) {
         return {
             dispose: () => {},
         }

--- a/vscode/src/completions/inline-completion-item-provider-e2e.test.ts
+++ b/vscode/src/completions/inline-completion-item-provider-e2e.test.ts
@@ -47,7 +47,6 @@ const DUMMY_AUTH_STATUS: AuthStatus = {
     authenticated: true,
     hasVerifiedEmail: true,
     requiresVerifiedEmail: true,
-    siteHasCodyEnabled: true,
     siteVersion: '1234',
     username: 'uwu',
     userCanUpgrade: false,

--- a/vscode/src/completions/inline-completion-item-provider-e2e.test.ts
+++ b/vscode/src/completions/inline-completion-item-provider-e2e.test.ts
@@ -41,7 +41,6 @@ const DUMMY_CONTEXT: vscode.InlineCompletionContext = {
 }
 
 const DUMMY_AUTH_STATUS: AuthStatus = {
-    isLoggedIn: true,
     endpoint: DOTCOM_URL.toString(),
     isFireworksTracingEnabled: false,
     showInvalidAccessTokenError: false,

--- a/vscode/src/completions/inline-completion-item-provider.test.ts
+++ b/vscode/src/completions/inline-completion-item-provider.test.ts
@@ -41,7 +41,6 @@ const DUMMY_AUTH_STATUS: AuthStatus = {
     authenticated: true,
     hasVerifiedEmail: true,
     requiresVerifiedEmail: true,
-    siteHasCodyEnabled: true,
     siteVersion: '1234',
     username: 'uwu',
     userCanUpgrade: false,

--- a/vscode/src/completions/inline-completion-item-provider.test.ts
+++ b/vscode/src/completions/inline-completion-item-provider.test.ts
@@ -35,7 +35,6 @@ const DUMMY_CONTEXT: vscode.InlineCompletionContext = {
 }
 
 const DUMMY_AUTH_STATUS: AuthStatus = {
-    isLoggedIn: true,
     endpoint: DOTCOM_URL.toString(),
     isFireworksTracingEnabled: false,
     showInvalidAccessTokenError: false,

--- a/vscode/src/external-services.ts
+++ b/vscode/src/external-services.ts
@@ -77,7 +77,7 @@ export async function configureExternalServices(
 
     // Disable local embeddings for enterprise users.
     const localEmbeddings =
-        authProvider.instance!.status.isLoggedIn && isDotCom(authProvider.instance!.status)
+        authProvider.instance!.status.authenticated && isDotCom(authProvider.instance!.status)
             ? await platform.createLocalEmbeddingsController?.(initialConfig)
             : undefined
 

--- a/vscode/src/jsonrpc/agent-protocol.ts
+++ b/vscode/src/jsonrpc/agent-protocol.ts
@@ -671,7 +671,6 @@ export interface ClientCapabilities {
 export interface ServerInfo {
     name: string
     authenticated?: boolean | undefined | null
-    codyEnabled?: boolean | undefined | null
     codyVersion?: string | undefined | null
     authStatus?: AuthStatus | undefined | null
 }

--- a/vscode/src/local-context/symf.ts
+++ b/vscode/src/local-context/symf.ts
@@ -91,7 +91,7 @@ export class SymfRunner implements vscode.Disposable {
         this.disposables.push(
             subscriptionDisposable(
                 authProvider.instance!.changes.subscribe(authStatus => {
-                    if (!isInitialized && authStatus.isLoggedIn && !isEnterpriseUser(authStatus)) {
+                    if (!isInitialized && authStatus.authenticated && !isEnterpriseUser(authStatus)) {
                         // Only initialize symf after the user has authenticated AND it's not an enterprise account.
                         isInitialized = true
                         this.disposables.push(initializeSymfIndexManagement(this))

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -533,7 +533,7 @@ function registerUpgradeHandlers(
         // Check if user has just moved back from a browser window to upgrade cody pro
         vscode.window.onDidChangeWindowState(async ws => {
             const authStatus = authProvider.instance!.status
-            if (ws.focused && isDotCom(authStatus) && authStatus.isLoggedIn) {
+            if (ws.focused && isDotCom(authStatus) && authStatus.authenticated) {
                 const res = await graphqlClient.getCurrentUserCodyProEnabled()
                 if (res instanceof Error) {
                     logError('onDidChangeWindowState', 'getCurrentUserCodyProEnabled', res)

--- a/vscode/src/models/sync.test.ts
+++ b/vscode/src/models/sync.test.ts
@@ -25,16 +25,14 @@ describe('syncModels', () => {
         setModelsSpy.mockClear()
 
         // Mock the /.api/client-config for these tests so that modelsAPIEnabled == false
-        const mockClientConfig = {
-            codyEnabled: true,
+        vi.spyOn(ClientConfigSingleton.prototype, 'getConfig').mockResolvedValue({
             chatEnabled: true,
             autoCompleteEnabled: true,
             customCommandsEnabled: true,
             attributionEnabled: true,
             smartContextWindowEnabled: true,
             modelsAPIEnabled: false,
-        }
-        vi.spyOn(ClientConfigSingleton.prototype, 'getConfig').mockResolvedValue(mockClientConfig)
+        })
     })
     afterEach(() => {
         // SUPER IMPORTANT: We need to call restoreAllMocks (instead of resetAllMocks)
@@ -112,7 +110,6 @@ describe('syncModels from the server', () => {
 
         // Mock the /.api/client-config for these tests so that modelsAPIEnabled == true
         const mockClientConfig = {
-            codyEnabled: true,
             chatEnabled: true,
             autoCompleteEnabled: true,
             customCommandsEnabled: true,

--- a/vscode/src/notifications/cody-pro-expiration.test.ts
+++ b/vscode/src/notifications/cody-pro-expiration.test.ts
@@ -72,7 +72,7 @@ describe('Cody Pro expiration notifications', () => {
                 return authStatus
             },
         } as AuthProvider
-        authStatus = { ...defaultAuthStatus, isLoggedIn: true, endpoint: DOTCOM_URL.toString() }
+        authStatus = { ...defaultAuthStatus, authenticated: true, endpoint: DOTCOM_URL.toString() }
         localStorageData = {}
     })
 
@@ -164,8 +164,8 @@ describe('Cody Pro expiration notifications', () => {
         expect(localStorageData[localStorageKey]).toBeTruthy()
     })
 
-    it('does not show if not logged in', async () => {
-        authStatus.isLoggedIn = false
+    it('does not show if not authenticated', async () => {
+        authStatus.authenticated = false
         await createNotifier().triggerExpirationCheck()
         expectNoNotification()
     })
@@ -212,12 +212,12 @@ describe('Cody Pro expiration notifications', () => {
 
     it('shows later if auth status changes', async () => {
         // Not shown initially because not logged in
-        authStatus.isLoggedIn = false
+        authStatus.authenticated = false
         await createNotifier().triggerExpirationCheck()
         expectNoNotification()
 
         // Simulate login status change.
-        authStatus.isLoggedIn = true
+        authStatus.authenticated = true
         authChangeListener()
 
         // Allow time async operations (checking feature flags) to run as part of the check

--- a/vscode/src/notifications/cody-pro-expiration.ts
+++ b/vscode/src/notifications/cody-pro-expiration.ts
@@ -90,7 +90,7 @@ export class CodyProExpirationNotifications implements vscode.Disposable {
 
         // Not logged in or not DotCom, don't show.
         const authStatus = authProvider.instance!.status
-        if (!authStatus.isLoggedIn || !isDotCom(authStatus)) return
+        if (!authStatus.authenticated || !isDotCom(authStatus)) return
 
         const useSscForCodySubscription = await featureFlagProvider.instance!.evaluateFeatureFlag(
             FeatureFlag.UseSscForCodySubscription

--- a/vscode/src/repository/repo-name-resolver.test.ts
+++ b/vscode/src/repository/repo-name-resolver.test.ts
@@ -18,7 +18,7 @@ describe('getRepoNamesFromWorkspaceUri', () => {
             changes: EMPTY,
             status: {
                 ...defaultAuthStatus,
-                isLoggedIn: true,
+                authenticated: true,
                 endpoint: 'https://example.com',
             },
         } as Pick<AuthProvider, 'changes' | 'status'> as unknown as AuthProvider
@@ -57,7 +57,7 @@ describe('getRepoNamesFromWorkspaceUri', () => {
             changes: EMPTY,
             status: {
                 ...defaultAuthStatus,
-                isLoggedIn: true,
+                authenticated: true,
                 endpoint: DOTCOM_URL.toString(),
             },
         } as Pick<AuthProvider, 'changes' | 'status'> as unknown as AuthProvider

--- a/vscode/src/services/AuthProvider.ts
+++ b/vscode/src/services/AuthProvider.ts
@@ -128,6 +128,12 @@ export class AuthProvider implements AuthStatusProvider, vscode.Disposable {
         if (!userInfo || isError(userInfo)) {
             return { ...unauthenticatedStatus, endpoint }
         }
+        if (!siteHasCodyEnabled) {
+            vscode.window.showErrorMessage(
+                `Cody is not enabled on this Sourcegraph instance (${endpoint}). Ask a site administrator to enable it.`
+            )
+            return { ...unauthenticatedStatus, endpoint }
+        }
 
         const configOverwrites = isError(codyLLMConfiguration) ? undefined : codyLLMConfiguration
 
@@ -139,7 +145,6 @@ export class AuthProvider implements AuthStatusProvider, vscode.Disposable {
                 configOverwrites,
                 authenticated: true,
                 hasVerifiedEmail: false,
-                siteHasCodyEnabled,
                 userCanUpgrade: false,
             })
         }
@@ -157,7 +162,6 @@ export class AuthProvider implements AuthStatusProvider, vscode.Disposable {
         return newAuthStatus({
             ...userInfo,
             endpoint,
-            siteHasCodyEnabled,
             siteVersion,
             configOverwrites,
             authenticated: !!userInfo.id,

--- a/vscode/src/services/AuthProvider.ts
+++ b/vscode/src/services/AuthProvider.ts
@@ -200,16 +200,20 @@ export class AuthProvider implements AuthStatusProvider, vscode.Disposable {
                 await this.storeAuthInfo(config.serverEndpoint, config.accessToken)
             }
 
-            await vscode.commands.executeCommand('setContext', 'cody.activated', authStatus.isLoggedIn)
+            await vscode.commands.executeCommand(
+                'setContext',
+                'cody.activated',
+                authStatus.authenticated
+            )
 
             await this.setAuthStatus(authStatus)
 
             // If the extension is authenticated on startup, it can't be a user's first
             // ever authentication. We store this to prevent logging first-ever events
             // for already existing users.
-            if (isExtensionStartup && authStatus.isLoggedIn) {
+            if (isExtensionStartup && authStatus.authenticated) {
                 await this.setHasAuthenticatedBefore()
-            } else if (authStatus.isLoggedIn) {
+            } else if (authStatus.authenticated) {
                 this.handleFirstEverAuthentication()
             }
 
@@ -258,7 +262,7 @@ export class AuthProvider implements AuthStatusProvider, vscode.Disposable {
             let eventValue: 'disconnected' | 'connected' | 'failed'
             if (authStatus.showNetworkError || authStatus.showInvalidAccessTokenError) {
                 eventValue = 'failed'
-            } else if (authStatus.isLoggedIn) {
+            } else if (authStatus.authenticated) {
                 eventValue = 'connected'
             } else {
                 eventValue = 'disconnected'

--- a/vscode/src/services/LocalStorageProvider.test.ts
+++ b/vscode/src/services/LocalStorageProvider.test.ts
@@ -33,7 +33,6 @@ describe('LocalStorageProvider', () => {
 })
 
 const DUMMY_AUTH_STATUS: AuthStatus = {
-    isLoggedIn: true,
     endpoint: DOTCOM_URL.toString(),
     isFireworksTracingEnabled: false,
     showInvalidAccessTokenError: false,

--- a/vscode/src/services/LocalStorageProvider.test.ts
+++ b/vscode/src/services/LocalStorageProvider.test.ts
@@ -39,7 +39,6 @@ const DUMMY_AUTH_STATUS: AuthStatus = {
     authenticated: true,
     hasVerifiedEmail: true,
     requiresVerifiedEmail: true,
-    siteHasCodyEnabled: true,
     siteVersion: '1234',
     username: 'uwu',
     userCanUpgrade: false,

--- a/vscode/src/services/StatusBar.ts
+++ b/vscode/src/services/StatusBar.ts
@@ -100,10 +100,10 @@ export function createStatusBar(): CodyStatusBar {
     let authStatus: AuthStatus | undefined
     const command = vscode.commands.registerCommand(STATUS_BAR_INTERACTION_COMMAND, async () => {
         telemetryRecorder.recordEvent('cody.statusbarIcon', 'clicked', {
-            privateMetadata: { loggedIn: Boolean(authStatus?.isLoggedIn) },
+            privateMetadata: { loggedIn: Boolean(authStatus?.authenticated) },
         })
 
-        if (!authStatus?.isLoggedIn) {
+        if (!authStatus?.authenticated) {
             // Bring up the sidebar view
             void vscode.commands.executeCommand('cody.chat.focus')
             return
@@ -325,7 +325,7 @@ export function createStatusBar(): CodyStatusBar {
                 statusBarItem.backgroundColor = new vscode.ThemeColor('statusBarItem.errorBackground')
                 return
             }
-            if (!authStatus.isLoggedIn) {
+            if (!authStatus.authenticated) {
                 statusBarItem.text = '$(cody-logo-heavy) Sign In'
                 statusBarItem.tooltip = 'Sign in to get started with Cody'
                 statusBarItem.backgroundColor = new vscode.ThemeColor('statusBarItem.warningBackground')

--- a/vscode/webviews/App.story.tsx
+++ b/vscode/webviews/App.story.tsx
@@ -32,7 +32,6 @@ const dummyVSCodeAPI: VSCodeWrapper = {
                 ...defaultAuthStatus,
                 displayName: 'Tim Lucas',
                 avatarURL: 'https://avatars.githubusercontent.com/u/153?v=4',
-                isLoggedIn: true,
                 authenticated: true,
                 hasVerifiedEmail: true,
                 requiresVerifiedEmail: false,

--- a/vscode/webviews/App.story.tsx
+++ b/vscode/webviews/App.story.tsx
@@ -35,7 +35,6 @@ const dummyVSCodeAPI: VSCodeWrapper = {
                 authenticated: true,
                 hasVerifiedEmail: true,
                 requiresVerifiedEmail: false,
-                siteHasCodyEnabled: true,
                 siteVersion: '5.1.0',
                 endpoint: 'https://example.com',
             },

--- a/vscode/webviews/App.tsx
+++ b/vscode/webviews/App.tsx
@@ -195,7 +195,7 @@ export const App: React.FunctionComponent<{ vscodeAPI: VSCodeWrapper }> = ({ vsc
                         vscodeAPI={vscodeAPI}
                     />
                 </div>
-            ) : view === View.Login || !config.authStatus.isLoggedIn ? (
+            ) : view === View.Login || !config.authStatus.authenticated ? (
                 <div className={styles.outerContainer}>
                     <LoginSimplified
                         simplifiedLoginRedirect={loginRedirect}


### PR DESCRIPTION
Previously, we had 2 fields on AuthState: `authenticated` and `isLoggedIn`. These are synonyms but actually meant 2 different things:

- `authenticated`: whether the user is authenticated
- `isLoggedIn`: whether the user is authenticated AND Cody is enabled on the instance AND the user has a verified email if the instance requires such

Neither of the additional constraints for `isLoggedIn` were handled cleanly in the UI. So, this change makes it so that users are prevented from signing in if Cody is not enabled (and are shown an error message during sign-in). The verified email issue is a much lesser issue now (it was an issue when we had different signup methods ~11 months ago) and is handled by the server returning an error. In general, we should implement these checks on the server not the client since the auth flow is on the server already (and that is how similar things would be implemented today now that we have the nice non-raw-access-token flow).

## Test plan

Set `{"cody.enabled": false}` in site config and try signing in. Confirm that an error message is shown.