### PR TITLE
Cody visual tweaks and polish

### DIFF
--- a/vscode/webviews/chat/components/WelcomeMessage.tsx
+++ b/vscode/webviews/chat/components/WelcomeMessage.tsx
@@ -3,7 +3,7 @@ import {
     AtSignIcon,
     type LucideProps,
     MessageSquarePlusIcon,
-    SettingsIcon,
+    BookOpenTextIcon,
     TextIcon,
 } from 'lucide-react'
 import type { FunctionComponent } from 'react'
@@ -16,7 +16,7 @@ import { onPromptSelectInPanel, onPromptSelectInPanelActionLabels } from '../../
 import type { View } from '../../tabs'
 
 const MenuExample: FunctionComponent<{ children: React.ReactNode }> = ({ children }) => (
-    <span className="tw-p-1 tw-rounded tw-text-keybinding-foreground tw-border tw-border-keybinding-border tw-bg-keybinding-background tw-whitespace-nowrap">
+    <span className="tw-p-1 tw-rounded tw-border tw-border-keybinding-border tw-bg-keybinding-background tw-whitespace-nowrap">
         {children}
     </span>
 )
@@ -74,9 +74,16 @@ export const WelcomeMessage: FunctionComponent<{ IDE: CodyIDE; setView: (view: V
             <CollapsiblePanel
                 storageKey="chat-help"
                 title="Chat Help"
-                className="tw-mb-6 tw-mt-2"
+                className="tw-mb-12 tw-mt-8"
                 initialOpen={true}
             >
+                {IDE === CodyIDE.VSCode && (
+                    <>
+                        <FeatureRow icon={MessageSquarePlusIcon}>
+                            Start a new chat using <Kbd macOS="opt+L" linuxAndWindows="alt+L" /> or the command <MenuExample>Cody: New Chat</MenuExample>
+                        </FeatureRow>
+                    </>
+                )}
                 <FeatureRow icon={AtSignIcon}>
                     Type <Kbd macOS="@" linuxAndWindows="@" /> to add context to your chat
                 </FeatureRow>
@@ -86,16 +93,26 @@ export const WelcomeMessage: FunctionComponent<{ IDE: CodyIDE; setView: (view: V
                             To add code context from an editor, right click and use{' '}
                             <MenuExample>Cody &gt; Add File/Selection to Cody Chat</MenuExample>
                         </FeatureRow>
-                        <FeatureRow icon={MessageSquarePlusIcon}>
-                            Start a new chat using <Kbd macOS="opt+L" linuxAndWindows="alt+L" />
-                        </FeatureRow>
-                        <FeatureRow icon={SettingsIcon}>
-                            Customize chat settings with the <FeatureRowInlineIcon Icon={SettingsIcon} />{' '}
-                            button, or see the{' '}
-                            <a href="https://sourcegraph.com/docs/cody">documentation</a>
-                        </FeatureRow>
                     </>
                 )}
+                <div className="tw-flex tw-justify-center tw-items-center tw-w-full tw-gap-10 tw-px-4 tw-pt-4 tw-pb-3 tw-mt-6 tw-border-t tw-border-button-border tw-transition-all">
+                    <a
+                        href="https://docs.sourcegraph.com/cody"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="tw-text-muted-foreground hover:tw-text-button-foreground"
+                    >
+                        Documentation
+                    </a>
+                    <a
+                        href="https://help.sourcegraph.com"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="tw-text-muted-foreground hover:tw-text-button-foreground"
+                    >
+                        Help & Support
+                    </a>
+                </div>
             </CollapsiblePanel>
         </div>
     )

--- a/vscode/webviews/components/promptList/PromptList.tsx
+++ b/vscode/webviews/components/promptList/PromptList.tsx
@@ -135,10 +135,14 @@ export const PromptList: React.FunctionComponent<{
 
     const endpointURL = new URL(useConfig().authStatus.endpoint)
 
+<<<<<<< Updated upstream
     // Don't show builtin commands to insert in the prompt editor.
     const filteredCommands = showOnlyPromptInsertableCommands
         ? result?.commands.filter(c => c.type !== 'default')
         : result?.commands
+=======
+    const itemClassName = 'tw-border tw-border-button-border !tw-rounded-lg !tw-p-4'
+>>>>>>> Stashed changes
 
     return (
         <Command
@@ -283,6 +287,24 @@ export const PromptList: React.FunctionComponent<{
                         Error: {error.message || 'unknown'}
                     </CommandLoading>
                 )}
+<<<<<<< Updated upstream
+=======
+                <CommandRow className="tw-items-center tw-justify-center tw-py-4">
+                    <Button variant="ghost" size="sm" asChild>
+                        <a
+                            href={new URL('/prompts', endpointURL).toString()}
+                            target="_blank"
+                            rel="noreferrer"
+                            className="!tw-text-muted-foreground !hover:tw-text-button-foreground"
+                        >
+                            Switch to Prompt Library
+                            {IDE === CodyIDE.VSCode && (
+                                <Kbd macOS="Opt+Q" linuxAndWindows="Alt+Q" className="tw-ml-2" />
+                            )}
+                        </a>
+                    </Button>
+                </CommandRow>
+>>>>>>> Stashed changes
             </CommandList>
         </Command>
     )

--- a/vscode/webviews/components/shadcn/ui/command.tsx
+++ b/vscode/webviews/components/shadcn/ui/command.tsx
@@ -110,7 +110,7 @@ const CommandItem = React.forwardRef<
         <CommandPrimitive.Item
             ref={ref}
             className={cn(
-                'tw-relative tw-flex tw-cursor-pointer tw-select-none tw-items-center tw-rounded-sm tw-py-3 tw-px-2 tw-text-md tw-outline-none aria-selected:tw-bg-accent aria-selected:tw-text-accent-foreground hover:tw-bg-accent hover:tw-text-accent-foreground data-[disabled=true]:tw-pointer-events-none data-[disabled=true]:tw-opacity-50',
+                'tw-relative tw-flex tw-cursor-pointer tw-select-none tw-items-center tw-rounded-sm tw-py-3 tw-px-2 tw-text-md tw-outline-none aria-selected:tw-bg-accent aria-selected:tw-text-accent-foreground hover:tw-bg-accent hover:tw-text-accent-foreground hover:tw-border-accent data-[disabled=true]:tw-pointer-events-none data-[disabled=true]:tw-opacity-50',
                 className
             )}
             title={tooltip}


### PR DESCRIPTION
A few updates on top of https://github.com/sourcegraph/cody/pull/5438

Needs thorough testing on web.

@vovakulikov a few things I still wanna update (if you could help me out):
- Have "Switch Prompt Library" button on welcome message switch you to the Prompts tab
- Change "Switch Prompt Library" button in Prompts tab only to "Manage prompts" with a link to `/prompts`

## Before
<img width="442" alt="CleanShot 2024-09-03 at 06 11 47@2x" src="https://github.com/user-attachments/assets/2a4d6739-afb5-41bf-b65d-c0849b64d9a0">


## After
<img width="440" alt="CleanShot 2024-09-03 at 06 08 15@2x" src="https://github.com/user-attachments/assets/4cfdd1a7-9e38-4c37-81d1-c26776a89813">

## Test plan
Visual testing.
