### PR TITLE
strongly typed {Authenticated,Unauthenticated}AuthState

### DIFF
--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/agent/protocol_generated/AuthStatus.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/agent/protocol_generated/AuthStatus.kt
@@ -2,28 +2,55 @@
 package com.sourcegraph.cody.agent.protocol_generated;
 
 import com.google.gson.annotations.SerializedName;
+import com.google.gson.Gson;
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import java.lang.reflect.Type;
 
-data class AuthStatus(
-  val username: String,
-  val endpoint: EndpointEnum, // Oneof: 
-  val isFireworksTracingEnabled: Boolean,
-  val showInvalidAccessTokenError: Boolean,
+sealed class AuthStatus {
+  companion object {
+    val deserializer: JsonDeserializer<AuthStatus> =
+      JsonDeserializer { element: JsonElement, _: Type, context: JsonDeserializationContext ->
+        when (element.getAsJsonObject().get("endpoint").getAsString()) {
+          "https://example.com" -> context.deserialize<UnauthenticatedAuthStatus>(element, UnauthenticatedAuthStatus::class.java)
+          else -> throw Exception("Unknown discriminator ${element}")
+        }
+      }
+  }
+}
+
+data class UnauthenticatedAuthStatus(
+  val endpoint: EndpointEnum, // Oneof: https://example.com
   val authenticated: Boolean,
-  val hasVerifiedEmail: Boolean,
-  val requiresVerifiedEmail: Boolean,
+  val showNetworkError: Boolean? = null,
+  val showInvalidAccessTokenError: Boolean? = null,
+) : AuthStatus() {
+
+  enum class EndpointEnum {
+    @SerializedName("https://example.com") `Https__/example.com`,
+  }
+}
+
+data class AuthenticatedAuthStatus(
+  val endpoint: EndpointEnum, // Oneof: https://example.com
+  val authenticated: Boolean,
+  val username: String,
+  val isFireworksTracingEnabled: Boolean? = null,
+  val hasVerifiedEmail: Boolean? = null,
+  val requiresVerifiedEmail: Boolean? = null,
   val siteVersion: String,
   val codyApiVersion: Long,
   val configOverwrites: CodyLLMSiteConfiguration? = null,
-  val showNetworkError: Boolean? = null,
   val primaryEmail: String? = null,
   val displayName: String? = null,
   val avatarURL: String? = null,
-  val userCanUpgrade: Boolean,
+  val userCanUpgrade: Boolean? = null,
   val isOfflineMode: Boolean? = null,
-) {
+) : AuthStatus() {
 
   enum class EndpointEnum {
-    @SerializedName("") ``,
+    @SerializedName("https://example.com") `Https__/example.com`,
   }
 }
 

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/agent/protocol_generated/Constants.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/agent/protocol_generated/Constants.kt
@@ -2,7 +2,6 @@
 package com.sourcegraph.cody.agent.protocol_generated;
 
 object Constants {
-  const val `` = ""
   const val Applied = "Applied"
   const val Applying = "Applying"
   const val Automatic = "Automatic"
@@ -45,6 +44,7 @@ object Constants {
   const val function = "function"
   const val gateway = "gateway"
   const val history = "history"
+  const val `https__/example.com` = "https://example.com"
   const val human = "human"
   const val ignore = "ignore"
   const val indentation = "indentation"

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/agent/protocol_generated/ProtocolTypeAdapters.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/agent/protocol_generated/ProtocolTypeAdapters.kt
@@ -3,6 +3,7 @@ package com.sourcegraph.cody.agent.protocol_generated;
 
 object ProtocolTypeAdapters {
   fun register(gson: com.google.gson.GsonBuilder) {
+    gson.registerTypeAdapter(AuthStatus::class.java, AuthStatus.deserializer)
     gson.registerTypeAdapter(ContextItem::class.java, ContextItem.deserializer)
     gson.registerTypeAdapter(CustomCommandResult::class.java, CustomCommandResult.deserializer)
     gson.registerTypeAdapter(TextEdit::class.java, TextEdit.deserializer)

--- a/agent/src/agent.ts
+++ b/agent/src/agent.ts
@@ -463,7 +463,7 @@ export class Agent extends MessageHandler implements ExtensionClient {
                 return {
                     name: 'cody-agent',
                     authenticated: authStatus?.authenticated,
-                    codyVersion: authStatus?.siteVersion,
+                    codyVersion: authStatus?.authenticated ? authStatus.siteVersion : undefined,
                     authStatus,
                 }
             } catch (error) {
@@ -1218,6 +1218,9 @@ export class Agent extends MessageHandler implements ExtensionClient {
         // TODO: JetBrains no longer uses this, consider deleting it.
         this.registerAuthenticatedRequest('chat/restore', async ({ modelID, messages, chatID }) => {
             const authStatus = await vscode.commands.executeCommand<AuthStatus>('cody.auth.status')
+            if (!authStatus.authenticated) {
+                throw new Error('Not authenticated')
+            }
             modelID ??= modelsService.instance!.getDefaultChatModel() ?? ''
             const chatMessages = messages?.map(PromptString.unsafe_deserializeChatMessage) ?? []
             const chatModel = new ChatModel(modelID, chatID, chatMessages)
@@ -1238,6 +1241,9 @@ export class Agent extends MessageHandler implements ExtensionClient {
         this.registerAuthenticatedRequest('chat/export', async input => {
             const { fullHistory = false } = input ?? {}
             const authStatus = await vscode.commands.executeCommand<AuthStatus>('cody.auth.status')
+            if (!authStatus.authenticated) {
+                throw new Error('Not authenticated')
+            }
             const localHistory = chatHistory.getLocalHistory(authStatus)
 
             if (localHistory != null) {
@@ -1275,6 +1281,9 @@ export class Agent extends MessageHandler implements ExtensionClient {
             })
 
             const authStatus = await vscode.commands.executeCommand<AuthStatus>('cody.auth.status')
+            if (!authStatus.authenticated) {
+                throw new Error('Not authenticated')
+            }
             const localHistory = await chatHistory.getLocalHistory(authStatus)
 
             if (localHistory != null) {

--- a/agent/src/enterprise-demo.test.ts
+++ b/agent/src/enterprise-demo.test.ts
@@ -20,6 +20,9 @@ describe('Enterprise', () => {
         const serverInfo = await demoEnterpriseClient.initialize()
 
         expect(serverInfo.authStatus?.authenticated).toBeTruthy()
+        if (!serverInfo.authStatus?.authenticated) {
+            throw new Error('unreachable')
+        }
         expect(serverInfo.authStatus?.username).toStrictEqual('codytesting')
     }, 10_000)
 

--- a/agent/src/enterprise-s2.test.ts
+++ b/agent/src/enterprise-s2.test.ts
@@ -35,6 +35,9 @@ describe('Enterprise - S2 (close main branch)', () => {
         })
 
         expect(serverInfo.authStatus?.authenticated).toBeTruthy()
+        if (!serverInfo.authStatus?.authenticated) {
+            throw new Error('unreachable')
+        }
         expect(serverInfo.authStatus?.username).toStrictEqual('codytesting')
     }, 10_000)
 

--- a/agent/src/index.test.ts
+++ b/agent/src/index.test.ts
@@ -179,6 +179,9 @@ describe('Agent', () => {
             customHeaders: {},
         })
         expect(valid?.authenticated).toBeTruthy()
+        if (!valid?.authenticated) {
+            throw new Error('unreachable')
+        }
 
         const reauthenticatedModels = await client.request('chat/models', {
             modelUsage: ModelUsage.Chat,
@@ -447,6 +450,10 @@ describe('Agent', () => {
                 transcript: transcript,
             })
             const auth = await client.request('extensionConfiguration/status', null)
+            expect(auth?.authenticated).toBeTruthy()
+            if (!auth?.authenticated) {
+                throw new Error('unreachable')
+            }
 
             const transcript1: SerializedChatTranscript = {
                 id: 'transcript1',
@@ -1235,6 +1242,9 @@ describe('Agent', () => {
             const serverInfo = await rateLimitedClient.initialize()
 
             expect(serverInfo.authStatus?.authenticated).toBeTruthy()
+            if (!serverInfo.authStatus?.authenticated) {
+                throw new Error('unreachable')
+            }
             expect(serverInfo.authStatus?.username).toStrictEqual('sourcegraphcodyclients-1-efapb')
         }, 10_000)
 

--- a/lib/shared/src/chat/chat.ts
+++ b/lib/shared/src/chat/chat.ts
@@ -1,4 +1,4 @@
-import type { AuthStatus } from '../auth/types'
+import type { AuthenticatedAuthStatus } from '../auth/types'
 import type { Message } from '../sourcegraph-api'
 import type { SourcegraphCompletionsClient } from '../sourcegraph-api/completions/client'
 import type {
@@ -18,8 +18,12 @@ export class ChatClient {
     constructor(
         private completions: SourcegraphCompletionsClient,
         private getAuthStatus: () => Pick<
-            AuthStatus,
-            'userCanUpgrade' | 'endpoint' | 'codyApiVersion' | 'isFireworksTracingEnabled'
+            AuthenticatedAuthStatus,
+            | 'authenticated'
+            | 'userCanUpgrade'
+            | 'endpoint'
+            | 'codyApiVersion'
+            | 'isFireworksTracingEnabled'
         >
     ) {}
 
@@ -56,9 +60,7 @@ export class ChatClient {
         // Enabled Fireworks tracing for Sourcegraph teammates.
         // https://readme.fireworks.ai/docs/enabling-tracing
         const customHeaders: Record<string, string> =
-            isFireworks && this.getAuthStatus().isFireworksTracingEnabled
-                ? { 'X-Fireworks-Genie': 'true' }
-                : {}
+            isFireworks && authStatus.isFireworksTracingEnabled ? { 'X-Fireworks-Genie': 'true' } : {}
 
         return this.completions.stream(
             completionParams,

--- a/lib/shared/src/models/index.test.ts
+++ b/lib/shared/src/models/index.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it } from 'vitest'
-import { type AuthStatus, defaultAuthStatus } from '../auth/types'
+import { AUTH_STATUS_FIXTURE_AUTHED, type AuthenticatedAuthStatus } from '../auth/types'
 import {
     Model,
     type ModelCategory,
@@ -16,20 +16,20 @@ import { ModelTag } from './tags'
 import { ModelUsage } from './types'
 
 describe('Model Provider', () => {
-    const freeUserAuthStatus: AuthStatus = {
-        ...defaultAuthStatus,
+    const freeUserAuthStatus: AuthenticatedAuthStatus = {
+        ...AUTH_STATUS_FIXTURE_AUTHED,
         endpoint: DOTCOM_URL.toString(),
         authenticated: true,
         userCanUpgrade: true,
     }
 
-    const codyProAuthStatus: AuthStatus = {
+    const codyProAuthStatus: AuthenticatedAuthStatus = {
         ...freeUserAuthStatus,
         userCanUpgrade: false,
     }
 
-    const enterpriseAuthStatus: AuthStatus = {
-        ...defaultAuthStatus,
+    const enterpriseAuthStatus: AuthenticatedAuthStatus = {
+        ...AUTH_STATUS_FIXTURE_AUTHED,
         endpoint: 'https://sourcegraph.example.com',
         authenticated: true,
     }

--- a/lib/shared/src/telemetry-v2/cody-tier.ts
+++ b/lib/shared/src/telemetry-v2/cody-tier.ts
@@ -7,10 +7,12 @@ enum CodyTier {
     Enterprise = 2,
 }
 
-export function getTier(authStatus: AuthStatus): CodyTier {
-    return !isDotCom(authStatus)
-        ? CodyTier.Enterprise
-        : authStatus.userCanUpgrade
-          ? CodyTier.Free
-          : CodyTier.Pro
+export function getTier(authStatus: AuthStatus): CodyTier | undefined {
+    return !authStatus.authenticated
+        ? undefined
+        : !isDotCom(authStatus)
+          ? CodyTier.Enterprise
+          : authStatus.userCanUpgrade
+            ? CodyTier.Free
+            : CodyTier.Pro
 }

--- a/vscode/src/auth/account-menu.ts
+++ b/vscode/src/auth/account-menu.ts
@@ -1,11 +1,11 @@
-import { type AuthStatus, isDotCom } from '@sourcegraph/cody-shared'
+import { type AuthenticatedAuthStatus, isDotCom } from '@sourcegraph/cody-shared'
 import * as vscode from 'vscode'
 import { ACCOUNT_USAGE_URL } from '../chat/protocol'
 import { authProvider } from '../services/AuthProvider'
 import { showSignInMenu, showSignOutMenu } from './auth'
 
 export async function showAccountMenu(): Promise<void> {
-    const authStatus = authProvider.instance!.status
+    const authStatus = authProvider.instance!.statusAuthed
     const selected = await openAccountMenuFirstStep(authStatus)
     if (selected === undefined) {
         return
@@ -36,13 +36,9 @@ enum AccountMenuOptions {
 }
 
 async function openAccountMenuFirstStep(
-    authStatus: AuthStatus
+    authStatus: AuthenticatedAuthStatus
 ): Promise<AccountMenuOptions | undefined> {
-    if (!authStatus.authenticated || !authStatus.endpoint) {
-        return
-    }
-
-    const isOffline = authStatus.isOfflineMode
+    const isOffline = !!authStatus.isOfflineMode
     const isDotComInstance = isDotCom(authStatus.endpoint) && !isOffline
 
     const displayName = authStatus.displayName || authStatus.username

--- a/vscode/src/auth/auth.ts
+++ b/vscode/src/auth/auth.ts
@@ -331,6 +331,6 @@ export async function showSignOutMenu(): Promise<void> {
 async function signOut(endpoint: string): Promise<void> {
     await secretStorage.deleteToken(endpoint)
     await localStorage.deleteEndpoint()
-    await authProvider.instance!.auth({ endpoint: '', token: null })
+    await authProvider.instance!.auth({ endpoint, token: null })
     await vscode.commands.executeCommand('setContext', 'cody.activated', false)
 }

--- a/vscode/src/auth/auth.ts
+++ b/vscode/src/auth/auth.ts
@@ -34,7 +34,7 @@ export async function showSignInMenu(
             if (!instanceUrl) {
                 return
             }
-            authStatus.endpoint = instanceUrl
+            authProvider.instance!.setAuthPendingToEndpoint(instanceUrl)
             redirectToEndpointLogin(instanceUrl)
             break
         }
@@ -238,7 +238,7 @@ export function redirectToEndpointLogin(uri: string): void {
 
     const newTokenCallbackUrl = new URL('/user/settings/tokens/new/callback', endpoint)
     newTokenCallbackUrl.searchParams.append('requestFrom', getAuthReferralCode())
-    authProvider.instance!.status.endpoint = endpoint
+    authProvider.instance!.setAuthPendingToEndpoint(endpoint)
     void vscode.env.openExternal(vscode.Uri.parse(newTokenCallbackUrl.href))
 }
 

--- a/vscode/src/chat/chat-view/ChatHistoryManager.ts
+++ b/vscode/src/chat/chat-view/ChatHistoryManager.ts
@@ -1,6 +1,7 @@
 import type {
     AccountKeyedChatHistory,
     AuthStatus,
+    AuthenticatedAuthStatus,
     SerializedChatTranscript,
     UserLocalHistory,
 } from '@sourcegraph/cody-shared'
@@ -23,17 +24,20 @@ class ChatHistoryManager implements vscode.Disposable {
         }
     }
 
-    public getLocalHistory(authStatus: AuthStatus): UserLocalHistory | null {
+    public getLocalHistory(authStatus: AuthenticatedAuthStatus): UserLocalHistory | null {
         return localStorage.getChatHistory(authStatus)
     }
 
-    public getChat(authStatus: AuthStatus, sessionID: string): SerializedChatTranscript | null {
+    public getChat(
+        authStatus: AuthenticatedAuthStatus,
+        sessionID: string
+    ): SerializedChatTranscript | null {
         const chatHistory = this.getLocalHistory(authStatus)
         return chatHistory?.chat ? chatHistory.chat[sessionID] : null
     }
 
     public async saveChat(
-        authStatus: AuthStatus,
+        authStatus: AuthenticatedAuthStatus,
         chat: SerializedChatTranscript | undefined
     ): Promise<UserLocalHistory> {
         const history = localStorage.getChatHistory(authStatus)
@@ -55,13 +59,13 @@ class ChatHistoryManager implements vscode.Disposable {
         this.notifyChatHistoryChanged(authStatus)
     }
 
-    public async deleteChat(authStatus: AuthStatus, chatID: string): Promise<void> {
+    public async deleteChat(authStatus: AuthenticatedAuthStatus, chatID: string): Promise<void> {
         await localStorage.deleteChatHistory(authStatus, chatID)
         this.notifyChatHistoryChanged(authStatus)
     }
 
     // Remove chat history and input history
-    public async clear(authStatus: AuthStatus): Promise<void> {
+    public async clear(authStatus: AuthenticatedAuthStatus): Promise<void> {
         await localStorage.removeChatHistory(authStatus)
         this.notifyChatHistoryChanged(authStatus)
     }

--- a/vscode/src/chat/chat-view/ChatsController.ts
+++ b/vscode/src/chat/chat-view/ChatsController.ts
@@ -3,6 +3,7 @@ import * as vscode from 'vscode'
 
 import {
     type AuthStatus,
+    type AuthenticatedAuthStatus,
     CODY_PASSTHROUGH_VSCODE_OPEN_COMMAND_ID,
     type ChatClient,
     type ClientConfigurationWithAccessToken,
@@ -60,7 +61,9 @@ export class ChatsController implements vscode.Disposable {
     private activeEditor: ChatController | undefined = undefined
 
     // We keep track of the currently authenticated account and dispose open chats when it changes
-    private currentAuthAccount: undefined | { endpoint: string; primaryEmail?: string; username: string }
+    private currentAuthAccount:
+        | undefined
+        | Pick<AuthenticatedAuthStatus, 'endpoint' | 'primaryEmail' | 'username'>
 
     protected disposables: vscode.Disposable[] = []
 
@@ -97,13 +100,7 @@ export class ChatsController implements vscode.Disposable {
             this.disposeAllChats()
         }
 
-        const endpoint = authStatus.endpoint ?? ''
-        this.currentAuthAccount = {
-            endpoint,
-            primaryEmail: authStatus.primaryEmail,
-            username: authStatus.username,
-        }
-
+        this.currentAuthAccount = authStatus.authenticated ? { ...authStatus } : undefined
         this.panel.setAuthStatus(authStatus)
     }
 
@@ -379,7 +376,7 @@ export class ChatsController implements vscode.Disposable {
         // The chat ID for client to pass in to clear all chats without showing window pop-up for confirmation.
         const ClearWithoutConfirmID = 'clear-all-no-confirm'
         const isClearAll = !chatID || chatID === ClearWithoutConfirmID
-        const authStatus = authProvider.instance!.status
+        const authStatus = authProvider.instance!.statusAuthed
 
         if (isClearAll) {
             if (chatID !== ClearWithoutConfirmID) {

--- a/vscode/src/chat/utils.ts
+++ b/vscode/src/chat/utils.ts
@@ -1,50 +1,57 @@
 import semver from 'semver'
 
-import {
-    type AuthStatus,
-    isDotCom,
-    offlineModeAuthStatus,
-    unauthenticatedStatus,
-} from '@sourcegraph/cody-shared'
+import { type AuthStatus, type AuthenticatedAuthStatus, isDotCom } from '@sourcegraph/cody-shared'
 import type { CurrentUserInfo } from '@sourcegraph/cody-shared/src/sourcegraph-api/graphql/client'
 
-type NewAuthStatusOptions = Omit<
-    AuthStatus,
-    | 'isFireworksTracingEnabled'
-    | 'codyApiVersion'
-    | 'showInvalidAccessToken'
-    | 'showInvalidAccessTokenError'
-    | 'requiresVerifiedEmail'
-    | 'primaryEmail'
-> & {
-    userOrganizations?: CurrentUserInfo['organizations']
-    primaryEmail?:
-        | string
-        | {
-              email: string
-          }
-        | null
-}
+type NewAuthStatusOptions = { endpoint: string } & (
+    | { authenticated: false; showNetworkError?: boolean; showInvalidAccessTokenError?: boolean }
+    | (Pick<
+          AuthenticatedAuthStatus,
+          | 'authenticated'
+          | 'username'
+          | 'siteVersion'
+          | 'configOverwrites'
+          | 'hasVerifiedEmail'
+          | 'displayName'
+          | 'avatarURL'
+          | 'userCanUpgrade'
+          | 'isOfflineMode'
+      > & {
+          userOrganizations?: CurrentUserInfo['organizations']
+          primaryEmail?:
+              | string
+              | {
+                    email: string
+                }
+              | null
+      })
+)
 
 export function newAuthStatus(options: NewAuthStatusOptions): AuthStatus {
-    const { isOfflineMode, endpoint, username, authenticated, siteVersion, userOrganizations } = options
+    if (!options.authenticated) {
+        return { authenticated: false, endpoint: options.endpoint, showInvalidAccessTokenError: true }
+    }
+
+    const { isOfflineMode, username, endpoint, siteVersion, userOrganizations } = options
 
     if (isOfflineMode) {
-        return { ...offlineModeAuthStatus, endpoint, username }
+        return {
+            authenticated: true,
+            endpoint,
+            username,
+            codyApiVersion: 0,
+            siteVersion: 'offline',
+            isOfflineMode: true,
+        }
     }
-    if (!authenticated) {
-        return { ...unauthenticatedStatus, endpoint }
-    }
+
     const isDotCom_ = isDotCom(endpoint)
     const primaryEmail =
-        typeof options.primaryEmail === 'string'
-            ? options.primaryEmail
-            : options.primaryEmail?.email || ''
+        typeof options.primaryEmail === 'string' ? options.primaryEmail : options.primaryEmail?.email
     const requiresVerifiedEmail = isDotCom_
-    const hasVerifiedEmail = requiresVerifiedEmail && options.hasVerifiedEmail
+    const hasVerifiedEmail = requiresVerifiedEmail && options.authenticated && options.hasVerifiedEmail
     return {
         ...options,
-        showInvalidAccessTokenError: false,
         endpoint,
         primaryEmail,
         requiresVerifiedEmail,

--- a/vscode/src/completions/create-inline-completion-item-provider.ts
+++ b/vscode/src/completions/create-inline-completion-item-provider.ts
@@ -71,7 +71,7 @@ export async function createInlineCompletionItemProvider({
     ])
 
     if (providerConfig) {
-        const authStatus = authProvider.instance!.status
+        const authStatus = authProvider.instance!.statusAuthed
         const completionsProvider = new InlineCompletionItemProvider({
             authStatus,
             providerConfig,

--- a/vscode/src/completions/create-multi-model-inline-completion-provider.ts
+++ b/vscode/src/completions/create-multi-model-inline-completion-provider.ts
@@ -124,7 +124,7 @@ export async function createInlineCompletionItemFromMultipleProviders({
             config: newConfig,
         })
         if (providerConfig) {
-            const authStatus = authProvider.instance!.status
+            const authStatus = authProvider.instance!.statusAuthed
             const completionsProvider = new InlineCompletionItemProvider({
                 authStatus,
                 providerConfig,

--- a/vscode/src/completions/fast-path-client.ts
+++ b/vscode/src/completions/fast-path-client.ts
@@ -120,7 +120,7 @@ export function createFastPathClient(
         // identical to the SG instance response but does not contain information on whether a user
         // is eligible to upgrade to the pro plan. We get this from the authState instead.
         if (response.status === 429) {
-            const upgradeIsAvailable = authStatus.userCanUpgrade
+            const upgradeIsAvailable = !!authStatus.userCanUpgrade
 
             throw recordErrorToSpan(
                 span,

--- a/vscode/src/completions/get-inline-completions-tests/helpers.ts
+++ b/vscode/src/completions/get-inline-completions-tests/helpers.ts
@@ -4,7 +4,7 @@ import { expect, vi } from 'vitest'
 import type { URI } from 'vscode-uri'
 
 import {
-    type AuthStatus,
+    AUTH_STATUS_FIXTURE_AUTHED,
     type ClientConfiguration,
     type ClientConfigurationWithAccessToken,
     type CodeCompletionsClient,
@@ -12,7 +12,6 @@ import {
     type CompletionResponse,
     CompletionStopReason,
     type GraphQLAPIClientConfig,
-    defaultAuthStatus,
     featureFlagProvider,
     graphqlClient,
     testFileUri,
@@ -55,7 +54,6 @@ import { sleep } from '../utils'
 // mimicking the default indentation of four spaces
 export const T = '\t'
 
-const dummyAuthStatus: AuthStatus = defaultAuthStatus
 const getVSCodeConfigurationWithAccessToken = (
     config: Partial<ClientConfiguration> = {}
 ): ClientConfigurationWithAccessToken => ({
@@ -167,7 +165,7 @@ export function params(
     const providerConfig = createProviderConfig({
         client,
         providerOptions,
-        authStatus: dummyAuthStatus,
+        authStatus: AUTH_STATUS_FIXTURE_AUTHED,
         model: configuration?.autocompleteAdvancedModel!,
         config: configWithAccessToken,
     })

--- a/vscode/src/completions/inline-completion-item-provider-config-singleton.ts
+++ b/vscode/src/completions/inline-completion-item-provider-config-singleton.ts
@@ -1,4 +1,4 @@
-import type { AuthStatus } from '@sourcegraph/cody-shared'
+import type { AuthenticatedAuthStatus } from '@sourcegraph/cody-shared'
 import type { CodyStatusBar } from '../services/StatusBar'
 import type { BfgRetriever } from './context/retrievers/bfg/bfg-retriever'
 import type { ProviderConfig } from './providers/provider'
@@ -11,7 +11,7 @@ export interface CodyCompletionItemProviderConfig {
     tracer?: ProvideInlineCompletionItemsTracer | null
     isRunningInsideAgent?: boolean
 
-    authStatus: AuthStatus
+    authStatus: AuthenticatedAuthStatus
     isDotComUser?: boolean
 
     createBfgRetriever?: () => BfgRetriever

--- a/vscode/src/completions/inline-completion-item-provider-e2e.test.ts
+++ b/vscode/src/completions/inline-completion-item-provider-e2e.test.ts
@@ -1,5 +1,5 @@
 import {
-    type AuthStatus,
+    type AuthenticatedAuthStatus,
     type ClientConfiguration,
     DOTCOM_URL,
     type GraphQLAPIClientConfig,
@@ -40,10 +40,9 @@ const DUMMY_CONTEXT: vscode.InlineCompletionContext = {
     triggerKind: vsCodeMocks.InlineCompletionTriggerKind.Automatic,
 }
 
-const DUMMY_AUTH_STATUS: AuthStatus = {
+const DUMMY_AUTH_STATUS: AuthenticatedAuthStatus = {
     endpoint: DOTCOM_URL.toString(),
     isFireworksTracingEnabled: false,
-    showInvalidAccessTokenError: false,
     authenticated: true,
     hasVerifiedEmail: true,
     requiresVerifiedEmail: true,

--- a/vscode/src/completions/inline-completion-item-provider.test.ts
+++ b/vscode/src/completions/inline-completion-item-provider.test.ts
@@ -3,7 +3,7 @@ import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vite
 import * as vscode from 'vscode'
 
 import {
-    type AuthStatus,
+    type AuthenticatedAuthStatus,
     DOTCOM_URL,
     type GraphQLAPIClientConfig,
     RateLimitError,
@@ -34,10 +34,9 @@ const DUMMY_CONTEXT: vscode.InlineCompletionContext = {
     triggerKind: vscode.InlineCompletionTriggerKind.Automatic,
 }
 
-const DUMMY_AUTH_STATUS: AuthStatus = {
+const DUMMY_AUTH_STATUS: AuthenticatedAuthStatus = {
     endpoint: DOTCOM_URL.toString(),
     isFireworksTracingEnabled: false,
-    showInvalidAccessTokenError: false,
     authenticated: true,
     hasVerifiedEmail: true,
     requiresVerifiedEmail: true,

--- a/vscode/src/completions/providers/create-provider.test.ts
+++ b/vscode/src/completions/providers/create-provider.test.ts
@@ -1,12 +1,12 @@
 import {
-    type AuthStatus,
+    AUTH_STATUS_FIXTURE_AUTHED,
+    type AuthenticatedAuthStatus,
     type ClientConfiguration,
     type ClientConfigurationWithAccessToken,
     type CodeCompletionsClient,
     type CodyLLMSiteConfiguration,
     DOTCOM_URL,
     type GraphQLAPIClientConfig,
-    defaultAuthStatus,
     graphqlClient,
 } from '@sourcegraph/cody-shared'
 import { beforeAll, describe, expect, it } from 'vitest'
@@ -34,8 +34,8 @@ const dummyCodeCompletionsClient: CodeCompletionsClient = {
     onConfigurationChange: () => undefined,
 }
 
-const dummyAuthStatus: AuthStatus = {
-    ...defaultAuthStatus,
+const dummyAuthStatus: AuthenticatedAuthStatus = {
+    ...AUTH_STATUS_FIXTURE_AUTHED,
     endpoint: DOTCOM_URL.toString(),
     configOverwrites: {
         provider: 'sourcegraph',
@@ -61,7 +61,7 @@ describe('createProviderConfig', () => {
                         'nasa-ai' as ClientConfiguration['autocompleteAdvancedProvider'],
                 }),
                 dummyCodeCompletionsClient,
-                defaultAuthStatus
+                AUTH_STATUS_FIXTURE_AUTHED
             )
             expect(provider).toBeNull()
         })
@@ -75,7 +75,7 @@ describe('createProviderConfig', () => {
                         null as ClientConfiguration['autocompleteAdvancedProvider'],
                 }),
                 dummyCodeCompletionsClient,
-                defaultAuthStatus
+                AUTH_STATUS_FIXTURE_AUTHED
             )
             expect(provider).toBeNull()
         })

--- a/vscode/src/completions/providers/create-provider.ts
+++ b/vscode/src/completions/providers/create-provider.ts
@@ -1,5 +1,5 @@
 import {
-    type AuthStatus,
+    type AuthenticatedAuthStatus,
     type ClientConfigurationWithAccessToken,
     type CodeCompletionsClient,
     type Model,
@@ -25,7 +25,7 @@ import { createProviderConfig as createUnstableOpenAIProviderConfig } from './un
 export async function createProviderConfig(
     config: ClientConfigurationWithAccessToken,
     client: CodeCompletionsClient,
-    authStatus: AuthStatus
+    authStatus: AuthenticatedAuthStatus
 ): Promise<ProviderConfig | null> {
     // Resolve the provider config from the VS Code config.
     if (config.autocompleteAdvancedProvider) {
@@ -73,7 +73,7 @@ export async function createProviderConfig(
 
 interface CreateConfigHelperParams {
     client: CodeCompletionsClient
-    authStatus: AuthStatus
+    authStatus: AuthenticatedAuthStatus
     modelId: string | undefined
     provider: string
     config: ClientConfigurationWithAccessToken

--- a/vscode/src/completions/providers/expopenaicompatible.ts
+++ b/vscode/src/completions/providers/expopenaicompatible.ts
@@ -2,7 +2,7 @@
 // to non-experimental version
 
 import {
-    type AuthStatus,
+    type AuthenticatedAuthStatus,
     type AutocompleteContextSnippet,
     type ClientConfigurationWithAccessToken,
     type CodeCompletionsClient,
@@ -45,7 +45,7 @@ interface OpenAICompatibleOptions {
     maxContextTokens?: number
     client: CodeCompletionsClient
     config: Pick<ClientConfigurationWithAccessToken, 'accessToken'>
-    authStatus: Pick<AuthStatus, 'userCanUpgrade' | 'endpoint'>
+    authStatus: Pick<AuthenticatedAuthStatus, 'userCanUpgrade' | 'endpoint'>
 }
 
 const PROVIDER_IDENTIFIER = 'experimental-openaicompatible'

--- a/vscode/src/completions/providers/fireworks.ts
+++ b/vscode/src/completions/providers/fireworks.ts
@@ -1,5 +1,5 @@
 import {
-    type AuthStatus,
+    type AuthenticatedAuthStatus,
     type AutocompleteContextSnippet,
     type ClientConfiguration,
     type ClientConfigurationWithAccessToken,
@@ -41,7 +41,10 @@ export interface FireworksOptions {
         ClientConfigurationWithAccessToken,
         'accessToken' | 'autocompleteExperimentalFireworksOptions'
     >
-    authStatus: Pick<AuthStatus, 'userCanUpgrade' | 'endpoint' | 'isFireworksTracingEnabled'>
+    authStatus: Pick<
+        AuthenticatedAuthStatus,
+        'userCanUpgrade' | 'endpoint' | 'isFireworksTracingEnabled'
+    >
 }
 
 const PROVIDER_IDENTIFIER = 'fireworks'
@@ -133,7 +136,10 @@ class FireworksProvider extends Provider {
     private promptChars: number
     private client: CodeCompletionsClient
     private fastPathAccessToken?: string
-    private authStatus: Pick<AuthStatus, 'userCanUpgrade' | 'endpoint' | 'isFireworksTracingEnabled'>
+    private authStatus: Pick<
+        AuthenticatedAuthStatus,
+        'userCanUpgrade' | 'endpoint' | 'isFireworksTracingEnabled'
+    >
     private isLocalInstance: boolean
     private fireworksConfig?: ClientConfiguration['autocompleteExperimentalFireworksOptions']
     private modelHelper: DefaultModel

--- a/vscode/src/completions/providers/get-model-info.ts
+++ b/vscode/src/completions/providers/get-model-info.ts
@@ -1,4 +1,9 @@
-import { type AuthStatus, type Model, ModelUsage, modelsService } from '@sourcegraph/cody-shared'
+import {
+    type AuthenticatedAuthStatus,
+    type Model,
+    ModelUsage,
+    modelsService,
+} from '@sourcegraph/cody-shared'
 
 interface ModelInfo {
     provider: string
@@ -6,7 +11,7 @@ interface ModelInfo {
     model?: Model
 }
 
-export function getModelInfo(authStatus: AuthStatus): ModelInfo | Error {
+export function getModelInfo(authStatus: AuthenticatedAuthStatus): ModelInfo | Error {
     const model = modelsService.instance!.getDefaultModel(ModelUsage.Autocomplete)
 
     if (model) {

--- a/vscode/src/completions/providers/openaicompatible.ts
+++ b/vscode/src/completions/providers/openaicompatible.ts
@@ -1,5 +1,5 @@
 import {
-    type AuthStatus,
+    type AuthenticatedAuthStatus,
     type AutocompleteContextSnippet,
     type ClientConfigurationWithAccessToken,
     type CodeCompletionsClient,
@@ -35,7 +35,7 @@ interface OpenAICompatibleOptions {
     maxContextTokens?: number
     client: CodeCompletionsClient
     config: Pick<ClientConfigurationWithAccessToken, 'accessToken'>
-    authStatus: Pick<AuthStatus, 'userCanUpgrade' | 'endpoint'>
+    authStatus: Pick<AuthenticatedAuthStatus, 'userCanUpgrade' | 'endpoint'>
 }
 
 const lineNumberDependentCompletionParams = getLineNumberDependentCompletionParams({

--- a/vscode/src/edit/input/get-input.ts
+++ b/vscode/src/edit/input/get-input.ts
@@ -95,7 +95,7 @@ export const getInput = async (
               ? EXPANDED_RANGE_ITEM
               : SELECTION_RANGE_ITEM
 
-    const authStatus = authProvider.instance!.status
+    const authStatus = authProvider.instance!.statusAuthed
     const isCodyPro = !authStatus.userCanUpgrade
     const modelOptions = modelsService.instance!.getModels(ModelUsage.Edit)
     const modelItems = getModelOptionItems(modelOptions, isCodyPro)

--- a/vscode/src/edit/manager.ts
+++ b/vscode/src/edit/manager.ts
@@ -294,6 +294,7 @@ export class EditManager implements vscode.Disposable {
         // queries to ask the LLM to generate a selection, and then ultimately apply the edit.
         const replacementCode = PromptString.unsafe_fromLLMResponse(configuration.replacement)
 
+        const authStatus = authProvider.instance!.statusAuthed
         const selection = await getSmartApplySelection(
             configuration.id,
             configuration.instruction,
@@ -301,7 +302,7 @@ export class EditManager implements vscode.Disposable {
             configuration.document,
             model,
             this.options.chat,
-            authProvider.instance!.status.codyApiVersion
+            authStatus.codyApiVersion
         )
 
         // We finished prompting the LLM for the selection, we can now remove the "progress" decoration

--- a/vscode/src/edit/provider.ts
+++ b/vscode/src/edit/provider.ts
@@ -54,6 +54,7 @@ export class EditProvider {
             this.config.controller.startTask(this.config.task)
             const model = this.config.task.model
             const contextWindow = modelsService.instance!.getContextWindowByID(model)
+            const authStatus = authProvider.instance!.statusAuthed
             const {
                 messages,
                 stopSequences,
@@ -61,7 +62,7 @@ export class EditProvider {
                 responsePrefix = '',
             } = await buildInteraction({
                 model,
-                codyApiVersion: authProvider.instance!.status.codyApiVersion,
+                codyApiVersion: authStatus.codyApiVersion,
                 contextWindow: contextWindow.input,
                 task: this.config.task,
                 editor: this.config.editor,

--- a/vscode/src/extension.node.ts
+++ b/vscode/src/extension.node.ts
@@ -2,8 +2,6 @@
 import { NodeSentryService } from './services/sentry/sentry.node'
 
 import * as vscode from 'vscode'
-
-import { defaultAuthStatus } from '@sourcegraph/cody-shared'
 import { startTokenReceiver } from './auth/token-receiver'
 import { CommandsProvider } from './commands/services/provider'
 import { BfgRetriever } from './completions/context/retrievers/bfg/bfg-retriever'
@@ -81,7 +79,7 @@ export function activate(
 // The vscode API is not available in the post-uninstall script.
 export async function deactivate(): Promise<void> {
     const config = localStorage.getConfig() ?? (await getFullConfig())
-    const authStatus = authProvider.instance?.status ?? defaultAuthStatus
+    const authStatus = authProvider.instance?.status
     const { anonymousUserID } = await localStorage.anonymousUserID()
     serializeConfigSnapshot({
         config,

--- a/vscode/src/external-services.ts
+++ b/vscode/src/external-services.ts
@@ -81,7 +81,7 @@ export async function configureExternalServices(
             ? await platform.createLocalEmbeddingsController?.(initialConfig)
             : undefined
 
-    const chatClient = new ChatClient(completionsClient, () => authProvider.instance!.status)
+    const chatClient = new ChatClient(completionsClient, () => authProvider.instance!.statusAuthed)
 
     const guardrails = new SourcegraphGuardrailsClient(graphqlClient, initialConfig)
 

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -494,7 +494,10 @@ function registerAuthCommands(disposables: vscode.Disposable[]): void {
         vscode.commands.registerCommand('cody.auth.signout', () => showSignOutMenu()),
         vscode.commands.registerCommand('cody.auth.account', () => showAccountMenu()),
         vscode.commands.registerCommand('cody.auth.support', () => showFeedbackSupportQuickPick()),
-        vscode.commands.registerCommand('cody.auth.status', () => authProvider.instance!.status), // Used by the agent
+        vscode.commands.registerCommand(
+            'cody.auth.status',
+            () => authProvider.instance?.statusOrNotReadyYet ?? null
+        ), // Used by the agent
         vscode.commands.registerCommand(
             'cody.agent.auth.authenticate',
             async ({ serverEndpoint, accessToken, customHeaders }) => {

--- a/vscode/src/models/sync.ts
+++ b/vscode/src/models/sync.ts
@@ -28,7 +28,7 @@ import { getEnterpriseContextWindow } from './utils'
 export async function syncModels(authStatus: AuthStatus): Promise<void> {
     // Offline mode only support Ollama models, which would be synced seperately.
     modelsService.instance!.setAuthStatus(authStatus)
-    if (authStatus.isOfflineMode) {
+    if (authStatus.authenticated && authStatus.isOfflineMode) {
         modelsService.instance!.setModels([])
         return
     }

--- a/vscode/src/notifications/cody-pro-expiration.test.ts
+++ b/vscode/src/notifications/cody-pro-expiration.test.ts
@@ -2,13 +2,13 @@ import { afterEach, beforeEach, describe, expect, it, vi, vitest } from 'vitest'
 import { localStorage } from '../services/LocalStorageProvider'
 
 import {
+    AUTH_STATUS_FIXTURE_AUTHED,
     type AuthStatus,
     DOTCOM_URL,
     FeatureFlag,
     type FeatureFlagProvider,
     type GraphQLAPIClientConfig,
     type SourcegraphGraphQLAPIClient,
-    defaultAuthStatus,
     featureFlagProvider,
     graphqlClient,
 } from '@sourcegraph/cody-shared'
@@ -72,7 +72,7 @@ describe('Cody Pro expiration notifications', () => {
                 return authStatus
             },
         } as AuthProvider
-        authStatus = { ...defaultAuthStatus, authenticated: true, endpoint: DOTCOM_URL.toString() }
+        authStatus = { ...AUTH_STATUS_FIXTURE_AUTHED, endpoint: DOTCOM_URL.toString() }
         localStorageData = {}
     })
 

--- a/vscode/src/repository/repo-name-resolver.test.ts
+++ b/vscode/src/repository/repo-name-resolver.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
-import { DOTCOM_URL, EMPTY, defaultAuthStatus, graphqlClient } from '@sourcegraph/cody-shared'
+import { AUTH_STATUS_FIXTURE_AUTHED, DOTCOM_URL, EMPTY, graphqlClient } from '@sourcegraph/cody-shared'
 
 import { type AuthProvider, authProvider } from '../services/AuthProvider'
 
@@ -17,7 +17,7 @@ describe('getRepoNamesFromWorkspaceUri', () => {
         authProvider.instance = {
             changes: EMPTY,
             status: {
-                ...defaultAuthStatus,
+                ...AUTH_STATUS_FIXTURE_AUTHED,
                 authenticated: true,
                 endpoint: 'https://example.com',
             },
@@ -56,7 +56,7 @@ describe('getRepoNamesFromWorkspaceUri', () => {
         authProvider.instance = {
             changes: EMPTY,
             status: {
-                ...defaultAuthStatus,
+                ...AUTH_STATUS_FIXTURE_AUTHED,
                 authenticated: true,
                 endpoint: DOTCOM_URL.toString(),
             },

--- a/vscode/src/services/AuthProviderSimplified.ts
+++ b/vscode/src/services/AuthProviderSimplified.ts
@@ -15,7 +15,7 @@ export class AuthProviderSimplified {
         if (!(await openExternalAuthUrl(method, tokenReceiverUrl))) {
             return false
         }
-        authProvider.instance!.authProviderSimplifiedWillAttemptAuth()
+        authProvider.instance!.setAuthPendingToEndpoint(DOTCOM_URL.toString())
         return true
     }
 }

--- a/vscode/src/services/HistoryChat.ts
+++ b/vscode/src/services/HistoryChat.ts
@@ -25,7 +25,7 @@ interface HistoryItem {
 export function groupCodyChats(authStatus: AuthStatus | undefined): GroupedChats | null {
     const chatHistoryGroups = new Map<string, CodySidebarTreeItem[]>()
 
-    if (!authStatus) {
+    if (!authStatus || !authStatus.authenticated) {
         return null
     }
 

--- a/vscode/src/services/LocalStorageProvider.test.ts
+++ b/vscode/src/services/LocalStorageProvider.test.ts
@@ -1,7 +1,11 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 import type * as vscode from 'vscode'
 
-import { type AuthStatus, DOTCOM_URL, type UserLocalHistory } from '@sourcegraph/cody-shared'
+import {
+    type AuthenticatedAuthStatus,
+    DOTCOM_URL,
+    type UserLocalHistory,
+} from '@sourcegraph/cody-shared'
 
 import { localStorage } from './LocalStorageProvider'
 
@@ -32,10 +36,9 @@ describe('LocalStorageProvider', () => {
     })
 })
 
-const DUMMY_AUTH_STATUS: AuthStatus = {
+const DUMMY_AUTH_STATUS: AuthenticatedAuthStatus = {
     endpoint: DOTCOM_URL.toString(),
     isFireworksTracingEnabled: false,
-    showInvalidAccessTokenError: false,
     authenticated: true,
     hasVerifiedEmail: true,
     requiresVerifiedEmail: true,

--- a/vscode/src/services/LocalStorageProvider.ts
+++ b/vscode/src/services/LocalStorageProvider.ts
@@ -5,6 +5,7 @@ import type { Memento } from 'vscode'
 import type {
     AccountKeyedChatHistory,
     AuthStatus,
+    AuthenticatedAuthStatus,
     ChatHistoryKey,
     ClientConfigurationWithAccessToken,
     UserLocalHistory,
@@ -100,13 +101,16 @@ class LocalStorage {
         return username && endpoint ? { endpoint, username } : null
     }
 
-    public getChatHistory(authStatus: AuthStatus): UserLocalHistory {
+    public getChatHistory(authStatus: AuthenticatedAuthStatus): UserLocalHistory {
         const history = this.storage.get<AccountKeyedChatHistory | null>(this.KEY_LOCAL_HISTORY, null)
         const accountKey = getKeyForAuthStatus(authStatus)
         return history?.[accountKey] ?? { chat: {} }
     }
 
-    public async setChatHistory(authStatus: AuthStatus, history: UserLocalHistory): Promise<void> {
+    public async setChatHistory(
+        authStatus: AuthenticatedAuthStatus,
+        history: UserLocalHistory
+    ): Promise<void> {
         try {
             const key = getKeyForAuthStatus(authStatus)
             let fullHistory = this.storage.get<AccountKeyedChatHistory | null>(
@@ -146,7 +150,7 @@ class LocalStorage {
         await this.storage.update(this.KEY_LOCAL_HISTORY, history)
     }
 
-    public async deleteChatHistory(authStatus: AuthStatus, chatID: string): Promise<void> {
+    public async deleteChatHistory(authStatus: AuthenticatedAuthStatus, chatID: string): Promise<void> {
         const userHistory = this.getChatHistory(authStatus)
         if (userHistory) {
             try {
@@ -168,7 +172,7 @@ class LocalStorage {
         return this.storage.get<string | null>(this.KEY_LOCAL_MINION_HISTORY, null)
     }
 
-    public async removeChatHistory(authStatus: AuthStatus): Promise<void> {
+    public async removeChatHistory(authStatus: AuthenticatedAuthStatus): Promise<void> {
         try {
             await this.setChatHistory(authStatus, { chat: {} })
         } catch (error) {
@@ -252,6 +256,6 @@ class LocalStorage {
  */
 export const localStorage = new LocalStorage()
 
-function getKeyForAuthStatus(authStatus: AuthStatus): ChatHistoryKey {
+function getKeyForAuthStatus(authStatus: AuthenticatedAuthStatus): ChatHistoryKey {
     return `${authStatus.endpoint}-${authStatus.username}`
 }

--- a/vscode/src/services/StatusBar.ts
+++ b/vscode/src/services/StatusBar.ts
@@ -313,13 +313,13 @@ export function createStatusBar(): CodyStatusBar {
         // yellow status bar icon when extension first loads but login hasn't
         // initialized yet
         if (authStatus) {
-            if (authStatus.isOfflineMode) {
+            if (authStatus.authenticated && authStatus.isOfflineMode) {
                 statusBarItem.text = '$(cody-logo-heavy) Offline'
                 statusBarItem.tooltip = 'Cody is in offline mode'
                 statusBarItem.backgroundColor = new vscode.ThemeColor('statusBarItem.warningBackground')
                 return
             }
-            if (authStatus.showNetworkError) {
+            if (!authStatus.authenticated && authStatus.showNetworkError) {
                 statusBarItem.text = '$(cody-logo-heavy) Connection Issues'
                 statusBarItem.tooltip = 'Resolve network issues for Cody to work again'
                 statusBarItem.backgroundColor = new vscode.ThemeColor('statusBarItem.errorBackground')

--- a/vscode/src/uninstall/post-uninstall.ts
+++ b/vscode/src/uninstall/post-uninstall.ts
@@ -2,7 +2,6 @@ import {
     type AuthStatus,
     type AuthStatusProvider,
     TelemetryRecorderProvider,
-    defaultAuthStatus,
 } from '@sourcegraph/cody-shared'
 import { deleteUninstallerDirectory, readConfig } from './serializeConfig'
 
@@ -22,11 +21,11 @@ async function main() {
     const uninstaller = readConfig()
     if (uninstaller) {
         const { config, extensionDetails, authStatus, anonymousUserID } = uninstaller
-        if (config) {
+        if (config && authStatus) {
             const provider = new TelemetryRecorderProvider(
                 extensionDetails,
                 config,
-                new StaticAuthStatusProvider(authStatus ?? defaultAuthStatus),
+                new StaticAuthStatusProvider(authStatus),
                 anonymousUserID,
                 'connected-instance-only'
             )

--- a/vscode/src/uninstall/serializeConfig.ts
+++ b/vscode/src/uninstall/serializeConfig.ts
@@ -45,7 +45,7 @@ function writeSnapshot(directory: string, filename: string, content: any) {
 
 interface UninstallerConfig {
     config?: ClientConfigurationWithAccessToken
-    authStatus?: AuthStatus
+    authStatus: AuthStatus | undefined
     extensionDetails: ExtensionDetails
     anonymousUserID: string
 }

--- a/vscode/test/integration/helpers.ts
+++ b/vscode/test/integration/helpers.ts
@@ -28,7 +28,7 @@ export async function beforeIntegrationTest(): Promise<void> {
  * Teardown (`afterEach`) function for integration tests that use {@link beforeIntegrationTest}.
  */
 export async function afterIntegrationTest(): Promise<void> {
-    await ensureExecuteCommand('cody.test.token', null)
+    await ensureExecuteCommand('cody.test.token', mockServer.SERVER_URL, null)
 }
 
 // executeCommand specifies ...any[] https://code.visualstudio.com/api/references/vscode-api#commands

--- a/vscode/webviews/App.story.tsx
+++ b/vscode/webviews/App.story.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react'
 
-import { defaultAuthStatus } from '@sourcegraph/cody-shared'
+import { AUTH_STATUS_FIXTURE_AUTHED } from '@sourcegraph/cody-shared'
 import { App } from './App'
 import { VSCodeWebview } from './storybook/VSCodeStoryDecorator'
 import type { VSCodeWrapper } from './utils/VSCodeApi'
@@ -29,7 +29,7 @@ const dummyVSCodeAPI: VSCodeWrapper = {
                 smartApply: false,
             },
             authStatus: {
-                ...defaultAuthStatus,
+                ...AUTH_STATUS_FIXTURE_AUTHED,
                 displayName: 'Tim Lucas',
                 avatarURL: 'https://avatars.githubusercontent.com/u/153?v=4',
                 authenticated: true,

--- a/vscode/webviews/App.tsx
+++ b/vscode/webviews/App.tsx
@@ -182,13 +182,13 @@ export const App: React.FunctionComponent<{ vscodeAPI: VSCodeWrapper }> = ({ vsc
     )
 
     // Wait for all the data to be loaded before rendering Chat View
-    if (!view || !config || !userHistory) {
+    if (!view || !config) {
         return <LoadingPage />
     }
 
     return (
         <ComposedWrappers wrappers={wrappers}>
-            {config.authStatus.showNetworkError ? (
+            {!config.authStatus.authenticated && config.authStatus.showNetworkError ? (
                 <div className={styles.outerContainer}>
                     <ConnectionIssuesPage
                         configuredEndpoint={config.authStatus.endpoint}
@@ -218,7 +218,7 @@ export const App: React.FunctionComponent<{ vscodeAPI: VSCodeWrapper }> = ({ vsc
                     vscodeAPI={vscodeAPI}
                     isTranscriptError={isTranscriptError}
                     guardrails={guardrails}
-                    userHistory={userHistory}
+                    userHistory={userHistory ?? []}
                     smartApplyEnabled={config.config.smartApply}
                 />
             )}

--- a/vscode/webviews/Chat.tsx
+++ b/vscode/webviews/Chat.tsx
@@ -2,7 +2,7 @@ import type React from 'react'
 import { useCallback, useEffect, useMemo, useRef } from 'react'
 
 import type {
-    AuthStatus,
+    AuthenticatedAuthStatus,
     ChatMessage,
     CodyIDE,
     Guardrails,
@@ -230,7 +230,10 @@ export const Chat: React.FunctionComponent<React.PropsWithChildren<ChatboxProps>
 export interface UserAccountInfo {
     isDotComUser: boolean
     isCodyProUser: boolean
-    user: Pick<AuthStatus, 'username' | 'displayName' | 'avatarURL' | 'endpoint' | 'primaryEmail'>
+    user: Pick<
+        AuthenticatedAuthStatus,
+        'username' | 'displayName' | 'avatarURL' | 'endpoint' | 'primaryEmail'
+    >
     ide: CodyIDE
 }
 

--- a/vscode/webviews/components/ClientSignInForm.tsx
+++ b/vscode/webviews/components/ClientSignInForm.tsx
@@ -71,7 +71,7 @@ export const ClientSignInForm: React.FC<ClientSignInFormProps> = ({ className, a
             <FormField
                 name="accessToken"
                 className={styles.section}
-                serverInvalid={authStatus?.showNetworkError}
+                serverInvalid={authStatus && !authStatus.authenticated && authStatus.showNetworkError}
             >
                 <FormLabel title="Access Token" />
                 <FormControl

--- a/vscode/webviews/utils/useConfig.tsx
+++ b/vscode/webviews/utils/useConfig.tsx
@@ -39,6 +39,11 @@ export function useConfig(): Config {
 
 export function useUserAccountInfo(): UserAccountInfo {
     const value = useConfig()
+    if (!value.authStatus.authenticated) {
+        throw new Error(
+            'useUserAccountInfo must be used within a ConfigProvider with authenticated user'
+        )
+    }
     return {
         isCodyProUser: isCodyProUser(value.authStatus),
         // Receive this value from the extension backend to make it work


### PR DESCRIPTION
Most places in code assume that AuthState represents an authenticated user. When unauthenticated, values for the AuthStatus fields were misleading, such as `username: ''` and `endpoint: ''`. Now, those fields are not even available on the type if `authenticated: false`.

(No behavior change. Just a code refactor.)

## Test plan

CI