### PR TITLE
make ClientConfiguration readonly to prevent mistakes

### DIFF
--- a/lib/shared/src/configuration.ts
+++ b/lib/shared/src/configuration.ts
@@ -3,6 +3,7 @@ import type { EmbeddingsProvider } from './codebase-context/context-status'
 import type { FileURI } from './common/uri'
 
 import type { PromptString } from './prompt/prompt-string'
+import type { ReadonlyDeep } from './utils'
 
 export type ConfigurationUseContext = 'embeddings' | 'keyword' | 'none' | 'blended' | 'unified'
 
@@ -26,10 +27,7 @@ export interface ConfigWatcher<C> {
     get(): C
 }
 
-/**
- * Client configuration, such as VS Code settings.
- */
-export interface ClientConfiguration {
+interface RawClientConfiguration {
     proxy?: string | null
     codebase?: string
     debugFilter: RegExp | null
@@ -101,6 +99,11 @@ export interface ClientConfiguration {
     testingModelConfig: EmbeddingsModelConfig | undefined
 }
 
+/**
+ * Client configuration, such as VS Code settings.
+ */
+export type ClientConfiguration = ReadonlyDeep<RawClientConfiguration>
+
 export enum CodyIDE {
     VSCode = 'VSCode',
     JetBrains = 'JetBrains',
@@ -113,10 +116,10 @@ export enum CodyIDE {
 
 export type ClientConfigurationWithEndpoint = Omit<ClientConfigurationWithAccessToken, 'accessToken'>
 
-export interface ClientConfigurationWithAccessToken extends ClientConfiguration {
-    serverEndpoint: string
+export interface ClientConfigurationWithAccessToken extends ReadonlyDeep<RawClientConfiguration> {
+    readonly serverEndpoint: string
     /** The access token, which is stored in the secret storage (not configuration). */
-    accessToken: string | null
+    readonly accessToken: string | null
 }
 
 export interface OllamaOptions {

--- a/lib/shared/src/index.ts
+++ b/lib/shared/src/index.ts
@@ -270,6 +270,7 @@ export {
     createSubscriber,
     isError,
     nextTick,
+    type ReadonlyDeep,
 } from './utils'
 export type { CurrentUserCodySubscription } from './sourcegraph-api/graphql/client'
 export * from './auth/types'

--- a/lib/shared/src/utils.ts
+++ b/lib/shared/src/utils.ts
@@ -129,3 +129,12 @@ type TupleFromUnion<T, U = T> = [T] extends [never]
 
 // Helper type to ensure an array contains all members of T
 export type ArrayContainsAll<T extends string> = TupleFromUnion<T>
+
+/** Make T readonly (recursively). */
+export type ReadonlyDeep<T> = {
+    readonly [P in keyof T]: T[P] extends (infer U)[]
+        ? ReadonlyArray<ReadonlyDeep<U>>
+        : T[P] extends object
+          ? ReadonlyDeep<T[P]>
+          : T[P]
+}

--- a/vscode/src/completions/create-multi-model-inline-completion-provider.ts
+++ b/vscode/src/completions/create-multi-model-inline-completion-provider.ts
@@ -1,5 +1,5 @@
 import { type MultimodelSingleModelConfig, isDotCom } from '@sourcegraph/cody-shared'
-import _ from 'lodash'
+import { cloneDeep } from 'lodash'
 import * as vscode from 'vscode'
 import { logDebug } from '../log'
 import { authProvider } from '../services/AuthProvider'
@@ -103,16 +103,18 @@ export async function createInlineCompletionItemFromMultipleProviders({
     }
 
     const allPromises = multiModelConfigsList.map(async currentProviderConfig => {
-        const newConfig = _.cloneDeep(config)
-        // Override some config to ensure we are not logging extra events.
-        newConfig.telemetryLevel = 'off'
-        // We should only override the fireworks "cody.autocomplete.experimental.fireworksOptions" when added in the config.
-        newConfig.autocompleteExperimentalFireworksOptions =
-            currentProviderConfig.enableExperimentalFireworksOverrides
-                ? config.autocompleteExperimentalFireworksOptions
-                : undefined
-        // Don't use the advanced provider config to get the model
-        newConfig.autocompleteAdvancedModel = null
+        const newConfig: typeof config = {
+            ...cloneDeep(config),
+            // Override some config to ensure we are not logging extra events.
+            telemetryLevel: 'off',
+            // We should only override the fireworks "cody.autocomplete.experimental.fireworksOptions" when added in the config.
+            autocompleteExperimentalFireworksOptions:
+                currentProviderConfig.enableExperimentalFireworksOverrides
+                    ? config.autocompleteExperimentalFireworksOptions
+                    : undefined,
+            // Don't use the advanced provider config to get the model
+            autocompleteAdvancedModel: null,
+        }
 
         const providerConfig = await createProviderConfigHelper({
             client,


### PR DESCRIPTION
Mutating the fields in this object will not do anything. The `ReadonlyDeep<T>` type helper helps us avoid mistakes where the fields were mutated and someone expected that to do something.

No behavior change.

## Test plan

CI