### PR TITLE
CLI: use client name "cody-cli" instead of "jetbrains"

### DIFF
--- a/agent/src/agent.ts
+++ b/agent/src/agent.ts
@@ -1516,6 +1516,10 @@ export class Agent extends MessageHandler implements ExtensionClient {
         return this.clientInfo?.name.toLowerCase() || 'uninitialized-agent'
     }
 
+    get httpClientNameForLegacyReasons(): string | undefined {
+        return this.clientInfo?.legacyNameForServerIdentification ?? undefined
+    }
+
     get clientVersion(): string {
         return this.clientInfo?.version || '0.0.0'
     }

--- a/agent/src/cli/command-chat.ts
+++ b/agent/src/cli/command-chat.ts
@@ -16,7 +16,6 @@ import packageJson from '../../package.json'
 import { newEmbeddedAgentClient } from '../agent'
 import type { ClientInfo } from '../protocol-alias'
 import { Streams } from './Streams'
-import { codyCliClientName } from './codyCliClientName'
 import { AuthenticatedAccount } from './command-auth/AuthenticatedAccount'
 import {
     type AuthenticationOptions,
@@ -124,12 +123,13 @@ export async function chatAction(options: ChatOptions): Promise<number> {
     }
     const workspaceRootUri = vscode.Uri.file(path.resolve(options.dir))
     const clientInfo: ClientInfo = {
-        name: codyCliClientName,
+        name: 'cody-cli',
         version: options.isTesting ? '6.0.0-SNAPSHOT' : packageJson.version,
         workspaceRootUri: workspaceRootUri.toString(),
         capabilities: {
             completions: 'none',
         },
+        legacyNameForServerIdentification: 'jetbrains',
         extensionConfiguration: {
             serverEndpoint: options.endpoint,
             accessToken: options.accessToken,

--- a/agent/src/cli/command-chat.ts
+++ b/agent/src/cli/command-chat.ts
@@ -24,6 +24,7 @@ import {
 } from './command-auth/command-login'
 import { errorSpinner, notAuthenticated } from './command-auth/messages'
 import { isNonEmptyArray } from './isNonEmptyArray'
+import { legacyCodyClientName } from './legacyCodyClientName'
 
 declare const process: { pkg: { entrypoint: string } } & NodeJS.Process
 export interface ChatOptions extends AuthenticationOptions {
@@ -129,7 +130,7 @@ export async function chatAction(options: ChatOptions): Promise<number> {
         capabilities: {
             completions: 'none',
         },
-        legacyNameForServerIdentification: 'jetbrains',
+        legacyNameForServerIdentification: legacyCodyClientName,
         extensionConfiguration: {
             serverEndpoint: options.endpoint,
             accessToken: options.accessToken,

--- a/agent/src/cli/legacyCodyClientName.ts
+++ b/agent/src/cli/legacyCodyClientName.ts
@@ -1,4 +1,4 @@
-// Context https://github.com/sourcegraph/sourcegraph/pull/63855
+// Context https://github.com/sourcegraph/sourcegraph-public-snapshot/issues/63855
 // The Sourcegraph Enterprise backend rejects requests from unknown clients on
 // the assumption that they may not support context filters. This logic is flawed because
 // it has both false positives and false negatives.

--- a/agent/src/cli/legacyCodyClientName.ts
+++ b/agent/src/cli/legacyCodyClientName.ts
@@ -19,4 +19,4 @@
 // back to cody-cli once all Enterprise instances have upgraded to a release
 // that includes this PR https://github.com/sourcegraph/sourcegraph/pull/63855
 
-export const codyCliClientName = 'jetbrains'
+export const legacyCodyClientName = 'jetbrains'

--- a/agent/src/vscode-shim.ts
+++ b/agent/src/vscode-shim.ts
@@ -1,7 +1,7 @@
 import { execSync } from 'node:child_process'
 import path from 'node:path'
 
-import { extensionForLanguage, logDebug, logError, setClientNameVersion } from '@sourcegraph/cody-shared'
+import { extensionForLanguage, logDebug, logError } from '@sourcegraph/cody-shared'
 import * as uuid from 'uuid'
 import type * as vscode from 'vscode'
 
@@ -120,10 +120,6 @@ const emptyFileWatcher: vscode.FileSystemWatcher = {
 export let clientInfo: ClientInfo | undefined
 export function setClientInfo(newClientInfo: ClientInfo): void {
     clientInfo = newClientInfo
-    setClientNameVersion(
-        clientInfo.legacyNameForServerIdentification ?? clientInfo.name,
-        clientInfo.version
-    )
     if (newClientInfo.extensionConfiguration) {
         setExtensionConfiguration(newClientInfo.extensionConfiguration)
     }

--- a/vscode/src/extension-client.ts
+++ b/vscode/src/extension-client.ts
@@ -41,6 +41,11 @@ export interface ExtensionClient {
     get clientName(): string
     get clientVersion(): string
     get capabilities(): ClientCapabilities | undefined
+
+    // Override this to customize the "client-name" that is sent in HTTP requests to /.api/completions/stream
+    // For historical reasons, older SG instances reject requests from unknown client names.
+    // See https://github.com/sourcegraph/sourcegraph-public-snapshot/pull/63855 for more details.
+    httpClientNameForLegacyReasons?: string
 }
 
 /**

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -162,7 +162,10 @@ const register = async (
     isExtensionModeDevOrTest: boolean
 ): Promise<vscode.Disposable> => {
     const disposables: vscode.Disposable[] = []
-    setClientNameVersion(platform.extensionClient.clientName, platform.extensionClient.clientVersion)
+    setClientNameVersion(
+        platform.extensionClient.httpClientNameForLegacyReasons ?? platform.extensionClient.clientName,
+        platform.extensionClient.clientVersion
+    )
 
     // Initialize `displayPath` first because it might be used to display paths in error messages
     // from the subsequent initialization.


### PR DESCRIPTION
Fixes CODY-3597

Previously, Cody CLI used the client name "jetbrains" to work around an issue where old SG instances would reject LLM requests for unknown client names. This issue was fixed in July but it will take some months until we can assume all users have upgraded their instances.

Now, we can use the client name "cody-cli" for telemetry and only "jetbrains" for the LLM requests.


## Test plan
n/a

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
