### PR TITLE
Chat: make "insert code at cursor" replace selection

### DIFF
--- a/vscode/src/services/utils/codeblock-action-tracker.ts
+++ b/vscode/src/services/utils/codeblock-action-tracker.ts
@@ -105,7 +105,11 @@ export async function handleCodeFromInsertAtCursor(text: string): Promise<void> 
 
     const edit = new vscode.WorkspaceEdit()
     // trimEnd() to remove new line added by Cody
-    edit.insert(activeEditor.document.uri, selectionRange.start, `${text}\n`)
+    if (selectionRange.isEmpty) {
+        edit.insert(activeEditor.document.uri, selectionRange.start, text.trimEnd())
+    } else {
+        edit.replace(activeEditor.document.uri, selectionRange, text.trimEnd())
+    }
     setLastStoredCode(text, 'insertButton')
     await vscode.workspace.applyEdit(edit)
 }


### PR DESCRIPTION
Previously, the "Insert code at cursor" button always added the code at the start of the cursor or text selection. This was problematic because when you have a text selection, you intuitively expect it to replace the whole selection, not add the code. This PR fixes the issue by replacing when there is a text selection, and adding when there is a cursor.


## Test plan

Manually tested this with a text selection and with a cursor.

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

## Changelog

* The "Insert code at cursor" action now replaces the selected text instead of adding it to the start of the selection. The behavior is unchanged when there is a cursor (no text selection). 

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
