### PR TITLE
Telemetry: Update naming for smart-apply

### DIFF
--- a/vscode/src/edit/manager.ts
+++ b/vscode/src/edit/manager.ts
@@ -319,7 +319,11 @@ export class EditManager implements vscode.Disposable {
             return
         }
 
-        telemetryRecorder.recordEvent('cody.smart-apply.selection', selection.type)
+        telemetryRecorder.recordEvent('cody.smart-apply', 'selected', {
+            metadata: {
+                [selection.type]: 1,
+            },
+        })
 
         // Move focus to the determined selection
         editor.revealRange(selection.range, vscode.TextEditorRevealType.InCenter)


### PR DESCRIPTION
This PR refactors the telemetry event for 'cody.smart-apply...' event to use a consistent name for the various `selectionType` and update the action to be a verb as it's intended.

Changes:
- Standardized the event name to `cody.smart-apply:selected` for all selection types.
- Updated the `action` to `selected` to indicate the action being recorded.
- Included a metadata object to capture the `selectionType` with a value of 1.

<img width="560" alt="image" src="https://github.com/user-attachments/assets/8679ab0e-395c-4a74-87fa-9d3d7af1593d">

## Test plan
Tested locally

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
