### PR TITLE
fix: handle git diff path parsing on Windows

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -8,12 +8,14 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 
 ### Fixed
 
-### Changed
+Command: Fixed an issue where the experimental `Generate Commit Message` command would fail on Windows due to incorrect parsing of the git diff output.
 
+### Changed
 
 ## 1.32.5
 
 ### Fixed
+
 - Autocomplete: Fix autocomplete character trimming from hot-streak. [pull/5378](https://github.com/sourcegraph/cody/pull/5378)
 - Autocomplete: Fix anthropic model for PLG users. [pull/5380](https://github.com/sourcegraph/cody/pull/5380)
 - Adjust context windows for Mistral models configured in the site config. [pull/5434](https://github.com/sourcegraph/cody/pull/5434)
@@ -21,6 +23,7 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 ## 1.32.4
 
 ### Added
+
 - Refactoring: refactoring configurations to make more reactive. [pull/5330](https://github.com/sourcegraph/cody/pull/5330)
 - Autocomplete: Enable smart throttle and hot streak. [pull/5339](https://github.com/sourcegraph/cody/pull/5339)
 - Autocomplete: Fix model mapping for deepseek-coder-v2. [pull/5272](https://github.com/sourcegraph/cody/pull/5272)
@@ -29,6 +32,7 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 ## 1.32.3
 
 ### Added
+
 - Autocomplete Refactoring: Extract fast-path client for the fireworks provider. [pull/5284](https://github.com/sourcegraph/cody/pull/5284)
 - Autocomplete Refactoring: Reduce `createProviderConfig` duplication. [pull/5282](https://github.com/sourcegraph/cody/pull/5282)
 - Autocomplete Refactoring: Remove starcoder2. [pull/5283](https://github.com/sourcegraph/cody/pull/5283)
@@ -38,8 +42,8 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 ## 1.32.2
 
 ### Fixed
-- Fixed an issue where chats could hang if there have been no changes since the last local indexing. [pull/5319](https://github.com/sourcegraph/cody/pull/5319)
 
+- Fixed an issue where chats could hang if there have been no changes since the last local indexing. [pull/5319](https://github.com/sourcegraph/cody/pull/5319)
 
 ## 1.32.1
 

--- a/vscode/src/commands/context/git-api.ts
+++ b/vscode/src/commands/context/git-api.ts
@@ -77,14 +77,13 @@ async function getContextFilesFromGitDiff(gitRepo: Repository): Promise<ContextI
             const uri = diffFiles.find(p => {
                 //todo: maybe better with a proper diff parser
                 const diffPath = diff.split('\n')?.[0]
-                return (
-                    p.uri ??
-                    diffPath
-                        .split('')
-                        .reverse()
-                        .join('')
-                        .startsWith(displayPath(p.uri).split('').reverse().join(''))
-                )
+                return diffPath
+                    ? diffPath
+                          .split('')
+                          .reverse()
+                          .join('')
+                          .startsWith(displayPath(p.uri).split('').reverse().join(''))
+                    : p.uri
             })?.uri
             if (!uri || !(await doesFileExist(uri))) {
                 continue

--- a/vscode/src/commands/context/git-api.ts
+++ b/vscode/src/commands/context/git-api.ts
@@ -77,7 +77,7 @@ async function getContextFilesFromGitDiff(gitRepo: Repository): Promise<ContextI
             const uri = diffFiles.find(p => {
                 //todo: maybe better with a proper diff parser
                 const diffPath = diff.split('\n')[0]
-                return diffPath
+                return p.uri ?? diffPath
                     .split('')
                     .reverse()
                     .join('')

--- a/vscode/src/commands/context/git-api.ts
+++ b/vscode/src/commands/context/git-api.ts
@@ -76,12 +76,15 @@ async function getContextFilesFromGitDiff(gitRepo: Repository): Promise<ContextI
             // we do this by checking the reverse path because of how nested workspaces might add unknown prefixes
             const uri = diffFiles.find(p => {
                 //todo: maybe better with a proper diff parser
-                const diffPath = diff.split('\n')[0]
-                return p.uri ?? diffPath
-                    .split('')
-                    .reverse()
-                    .join('')
-                    .startsWith(displayPath(p.uri).split('').reverse().join(''))
+                const diffPath = diff.split('\n')?.[0]
+                return (
+                    p.uri ??
+                    diffPath
+                        .split('')
+                        .reverse()
+                        .join('')
+                        .startsWith(displayPath(p.uri).split('').reverse().join(''))
+                )
             })?.uri
             if (!uri || !(await doesFileExist(uri))) {
                 continue

--- a/vscode/src/commands/scm/source-control.ts
+++ b/vscode/src/commands/scm/source-control.ts
@@ -72,7 +72,7 @@ export class CodySourceControl implements vscode.Disposable {
     public async generate(scm?: vscode.SourceControl): Promise<void> {
         telemetryRecorder.recordEvent('cody.command.generate-commit', 'executed')
 
-        const currentWorkspaceUri = vscode.workspace.workspaceFolders?.[0]?.uri
+        const currentWorkspaceUri = scm?.rootUri ?? vscode.workspace.workspaceFolders?.[0]?.uri
         if (!this.gitAPI || !currentWorkspaceUri) {
             vscode.window.showInformationMessage('Git is not available in the current workspace.')
             return


### PR DESCRIPTION
CLOSE  https://linear.app/sourcegraph/issue/CODY-3601/bug-error-failed-to-get-git-output-when-using-commit-generation-on https://github.com/sourcegraph/cody/issues/4863

This commit fixes an issue where the `Generate Commit Message` command would fail on Windows due to incorrect parsing of the git diff output. The change ensures that the file path is correctly identified even when the diff output does not contain the full file path specifically on Windows

## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

Manually tested the `Generate Commit Message` command on both Windows and Mac to ensure it works as expected.

We also have an e2e test covering this command on all platforms, will look into it separately on why this error didn't happen during the e2e tests

### Windows

#### After

![Screenshot 2024-09-03 083325](https://github.com/user-attachments/assets/d11e1c8b-49e8-4a41-a700-e60457e20075)

#### Before

![image](https://github.com/user-attachments/assets/8e2910eb-03ee-4014-9fb7-071d9bac7fd7)


### Mac

Confirmed the command still works correctly on Mac:

![image](https://github.com/user-attachments/assets/f0a4a4df-6a2d-49f6-acb0-5caf56a009fe)

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->

Command: Fixed an issue where the experimental `Generate Commit Message` command would fail on Windows due to incorrect parsing of the git diff output.