### PR TITLE
Fix Cody Web remote context for mentions

### DIFF
--- a/lib/prompt-editor/src/mentions/mentionMenu/useMentionMenuData.ts
+++ b/lib/prompt-editor/src/mentions/mentionMenu/useMentionMenuData.ts
@@ -157,7 +157,7 @@ export function useCallMentionMenuData({
     const mentionQuery: MentionQuery = useMemo(
         () => ({
             ...parseMentionQuery(query ?? '', provider),
-            includeRemoteRepositories: mentionSettings.resolutionMode === 'remote',
+            contextRemoteRepositoriesNames: mentionSettings.remoteRepositoriesNames,
         }),
         [query, provider, mentionSettings]
     )

--- a/lib/prompt-editor/src/plugins/atMentions/useChatContextItems.tsx
+++ b/lib/prompt-editor/src/plugins/atMentions/useChatContextItems.tsx
@@ -2,6 +2,7 @@ import { createContext } from 'react'
 
 export interface ChatMentionsSettings {
     resolutionMode: 'remote' | 'local'
+    remoteRepositoriesNames?: string[]
 }
 
 export const ChatMentionContext = createContext<ChatMentionsSettings>({

--- a/lib/shared/src/mentions/query.ts
+++ b/lib/shared/src/mentions/query.ts
@@ -33,11 +33,11 @@ export interface MentionQuery {
     maybeHasRangeSuffix?: boolean
 
     /**
-     * To control source of mention suggestions, if it's set to true
-     * search logic will try to find suggestions across remote repositories
+     * To control source of standard mention suggestions (files and symbols),
+     * search API will try to find suggestions across remote repositories
      * user has on their instance. (Cody Web use case)
      */
-    includeRemoteRepositories?: boolean
+    contextRemoteRepositoriesNames?: string[]
 }
 
 /**

--- a/vscode/src/chat/context/chatContext.ts
+++ b/vscode/src/chat/context/chatContext.ts
@@ -114,8 +114,6 @@ interface GetContextItemsOptions {
     // character is typed). Don't log otherwise because we would be logging prefixes of the same
     // query repeatedly, which is not needed.
     telemetryRecorder?: GetContextItemsTelemetry
-
-    remoteRepositoriesNames?: string[]
     rangeFilter?: boolean
 }
 
@@ -124,7 +122,7 @@ export async function getChatContextItemsForMention(
     _?: AbortSignal
 ): Promise<ContextItem[]> {
     const MAX_RESULTS = 20
-    const { mentionQuery, telemetryRecorder, remoteRepositoriesNames, rangeFilter = true } = options
+    const { mentionQuery, telemetryRecorder, rangeFilter = true } = options
 
     switch (mentionQuery.provider) {
         case null:
@@ -133,7 +131,11 @@ export async function getChatContextItemsForMention(
         case SYMBOL_CONTEXT_MENTION_PROVIDER.id:
             telemetryRecorder?.withProvider(mentionQuery.provider)
             // It would be nice if the VS Code symbols API supports cancellation, but it doesn't
-            return getSymbolContextFiles(mentionQuery.text, MAX_RESULTS, remoteRepositoriesNames)
+            return getSymbolContextFiles(
+                mentionQuery.text,
+                MAX_RESULTS,
+                mentionQuery.contextRemoteRepositoriesNames
+            )
         case FILE_CONTEXT_MENTION_PROVIDER.id: {
             telemetryRecorder?.withProvider(mentionQuery.provider)
             const files = mentionQuery.text
@@ -141,7 +143,7 @@ export async function getChatContextItemsForMention(
                       query: mentionQuery.text,
                       range: mentionQuery.range,
                       maxResults: MAX_RESULTS,
-                      repositoriesNames: remoteRepositoriesNames,
+                      repositoriesNames: mentionQuery.contextRemoteRepositoriesNames,
                   })
                 : await getOpenTabsContextFile()
 

--- a/web/lib/components/CodyWebChat.tsx
+++ b/web/lib/components/CodyWebChat.tsx
@@ -100,10 +100,6 @@ export const CodyWebChat: FunctionComponent<CodyWebChatProps> = ({
     )
 }
 
-const CONTEXT_MENTIONS_SETTINGS: ChatMentionsSettings = {
-    resolutionMode: 'remote',
-}
-
 interface CodyWebPanelProps {
     vscodeAPI: VSCodeWrapper
     initialContext: InitialContext | undefined
@@ -240,6 +236,15 @@ const CodyWebPanel: FC<CodyWebPanelProps> = props => {
         () => getAppWrappers(vscodeAPI, telemetryRecorder, clientState, config, envVars),
         [vscodeAPI, telemetryRecorder, clientState, config, envVars]
     )
+
+    const CONTEXT_MENTIONS_SETTINGS = useMemo<ChatMentionsSettings>(() => {
+        const { repository } = initialContext ?? {}
+
+        return {
+            resolutionMode: 'remote',
+            remoteRepositoriesNames: repository?.name ? [repository.name] : [],
+        }
+    }, [initialContext])
 
     const isLoading = !config || !view || !userHistory
 


### PR DESCRIPTION
This PR fixes regression after https://github.com/sourcegraph/cody/pull/5379

In https://github.com/sourcegraph/cody/pull/5379 remote repository context logic was removed, which was important for Cody Web. 

When you start typing `@<mention-term>` by default, we do a file mention search; in Cody Web world, we rely on remote context repository API to look for files within these repositories from remote context API. This is convenient when you open Cody Web on the repository page, and automatically, your file and symbol mentions will be scoped to this repo. 

Since this context remote repository has been removed this PR passes remote repositories info for mentions directly through API (it's even better because we don't rely on the internal chat controller state anymore) 

Note that this change has no effect on VSCode and only fixes logic for Cody Web

## Test plan
- Run Cody Web demo
- Check that file mentions and symbol mentions are scoped to the cody repository (we use it as scope repository in the demo)


