### PR TITLE
prevent invalid ranges from borking context

### DIFF
--- a/vscode/src/chat/chat-view/context.ts
+++ b/vscode/src/chat/chat-view/context.ts
@@ -134,7 +134,10 @@ async function searchRemote(
         if (!remoteSearch) {
             return []
         }
-        return (await remoteSearch.query(input, repoIDs, signal)).map(result => {
+        return (await remoteSearch.query(input, repoIDs, signal)).flatMap(result => {
+            if (result.startLine < 0 || result.endLine < 0) {
+                return []
+            }
             return {
                 type: 'file',
                 content: result.content,
@@ -417,7 +420,7 @@ export async function retrieveContextGracefully<T>(
             logError('ChatController', `resolveContext > ${strategy}' (aborted)`)
             throw error
         }
-        logError('ChatController', `resolveContext > ${strategy}' (error)`, error)
+        logError('ChatController', `resolveContext > ${strategy} (error)`, error)
         return []
     } finally {
         logDebug('ChatController', `resolveContext > ${strategy} (end)`)


### PR DESCRIPTION
## Test plan

Test locally with the following query against s2: `@sourcegraph/cody where do we check for content attribution?`

![image](https://github.com/user-attachments/assets/15971166-877e-478b-8e6a-396e71de5151)

s2 returns a result with a negative end line, which causes the rest of the context items to be discarded. This should not happen with this change.