### PR TITLE
add suggestions diff tracker for online context and nes dataset

### DIFF
--- a/vscode/src/common/persistence-tracker/index.test.ts
+++ b/vscode/src/common/persistence-tracker/index.test.ts
@@ -26,23 +26,20 @@ describe('PersistenceTracker', () => {
     beforeEach(() => {
         vi.useFakeTimers()
 
-        tracker = new PersistenceTracker(
-            {
-                onDidChangeTextDocument(listener) {
-                    onDidChangeTextDocument = listener
-                    return { dispose: () => {} }
-                },
-                onDidRenameFiles(listener) {
-                    onDidRenameFiles = listener
-                    return { dispose: () => {} }
-                },
-                onDidDeleteFiles(listener) {
-                    onDidDeleteFiles = listener
-                    return { dispose: () => {} }
-                },
+        tracker = new PersistenceTracker({
+            onDidChangeTextDocument(listener) {
+                onDidChangeTextDocument = listener
+                return { dispose: () => {} }
             },
-            { onPresent: onPresentSpy, onRemoved: onRemoveSpy }
-        )
+            onDidRenameFiles(listener) {
+                onDidRenameFiles = listener
+                return { dispose: () => {} }
+            },
+            onDidDeleteFiles(listener) {
+                onDidDeleteFiles = listener
+                return { dispose: () => {} }
+            },
+        })
     })
     afterEach(() => {
         onPresentSpy.mockReset()
@@ -60,6 +57,7 @@ describe('PersistenceTracker', () => {
             insertText: 'foo',
             insertRange: getDocumentRange(doc),
             document: doc,
+            logger: { onPresent: onPresentSpy, onRemoved: onRemoveSpy },
         })
 
         const sharedArgs = {
@@ -108,6 +106,7 @@ describe('PersistenceTracker', () => {
             insertText: 'foo',
             insertRange: getDocumentRange(doc),
             document: doc,
+            logger: { onPresent: onPresentSpy, onRemoved: onRemoveSpy },
         })
 
         const sharedArgs = {
@@ -157,6 +156,7 @@ describe('PersistenceTracker', () => {
             insertText: 'foo',
             insertRange: getDocumentRange(doc),
             document: doc,
+            logger: { onPresent: onPresentSpy, onRemoved: onRemoveSpy },
         })
 
         const renamedDoc = document('fo0', 'typescript', 'file:///test2.ts')
@@ -204,6 +204,7 @@ describe('PersistenceTracker', () => {
             insertText: 'foo',
             insertRange: getDocumentRange(doc),
             document: doc,
+            logger: { onPresent: onPresentSpy, onRemoved: onRemoveSpy },
         })
 
         onDidDeleteFiles({ files: [doc.uri] })
@@ -223,6 +224,7 @@ describe('PersistenceTracker', () => {
             insertText: 'foo',
             insertRange: getDocumentRange(doc),
             document: doc,
+            logger: { onPresent: onPresentSpy, onRemoved: onRemoveSpy },
         })
 
         vi.advanceTimersToNextTimer()

--- a/vscode/src/common/persistence-tracker/types.ts
+++ b/vscode/src/common/persistence-tracker/types.ts
@@ -13,7 +13,8 @@ export interface PersistencePresentEventPayload<T = string> {
     charCount: number
     /** Attached metadata to the insertion */
     metadata?: PersistenceEventMetadata
-
+    /** The diff between the current document state and the accepted completion */
+    // 🚨 SECURITY: We diff calculated here should only be logged for dotCom users with public repos.
     diff?: string
 }
 

--- a/vscode/src/common/persistence-tracker/types.ts
+++ b/vscode/src/common/persistence-tracker/types.ts
@@ -13,6 +13,8 @@ export interface PersistencePresentEventPayload<T = string> {
     charCount: number
     /** Attached metadata to the insertion */
     metadata?: PersistenceEventMetadata
+
+    diff?: string
 }
 
 export interface PersistenceRemovedEventPayload<T = string> {

--- a/vscode/src/completions/inline-completion-item-provider.ts
+++ b/vscode/src/completions/inline-completion-item-provider.ts
@@ -11,7 +11,6 @@ import {
     telemetryRecorder,
     wrapInActiveSpan,
 } from '@sourcegraph/cody-shared'
-
 import { logDebug } from '../log'
 import { localStorage } from '../services/LocalStorageProvider'
 
@@ -736,7 +735,6 @@ export class InlineCompletionItemProvider
         if (!suggestionEvent) {
             return
         }
-
         // Clear any existing timeouts, only one completion can be shown at a time
         clearTimeout(this.completionSuggestedTimeoutId)
 
@@ -811,9 +809,11 @@ export class InlineCompletionItemProvider
                 takeSuggestWidgetSelectionIntoAccount,
                 undefined
             )
-
             if (isStillVisible) {
-                suggestionEvent.markAsRead()
+                suggestionEvent.markAsRead({
+                    document: invokedDocument,
+                    position: invokedPosition,
+                })
             }
         }, this.COMPLETION_VISIBLE_DELAY_MS)
     }

--- a/vscode/src/completions/logger.test.ts
+++ b/vscode/src/completions/logger.test.ts
@@ -75,7 +75,7 @@ describe('logger', () => {
             isDotComUser: false,
         })
         const suggestionEvent = CompletionLogger.prepareSuggestionEvent(id)
-        suggestionEvent?.markAsRead()
+        suggestionEvent?.markAsRead({ document, position })
         CompletionLogger.accepted(id, document, item, range(0, 0, 0, 0), false)
 
         expect(recordSpy).toHaveBeenCalledWith('cody.completion', 'suggested', {
@@ -108,7 +108,7 @@ describe('logger', () => {
             isDotComUser: false,
         })
         const firstSuggestionEvent = CompletionLogger.prepareSuggestionEvent(id1)
-        firstSuggestionEvent?.markAsRead()
+        firstSuggestionEvent?.markAsRead({ document, position })
 
         const loggerItem = CompletionLogger.getCompletionEvent(id1)
         const completionId = loggerItem?.params.id
@@ -126,7 +126,7 @@ describe('logger', () => {
             isDotComUser: false,
         })
         const secondSuggestionEvent = CompletionLogger.prepareSuggestionEvent(id2)
-        secondSuggestionEvent?.markAsRead()
+        secondSuggestionEvent?.markAsRead({ document, position })
         CompletionLogger.accepted(id2, document, item, range(0, 0, 0, 0), false)
 
         const loggerItem2 = CompletionLogger.getCompletionEvent(id2)
@@ -151,7 +151,7 @@ describe('logger', () => {
             isDotComUser: false,
         })
         const thirdSuggestionEvent = CompletionLogger.prepareSuggestionEvent(id3)
-        thirdSuggestionEvent?.markAsRead()
+        thirdSuggestionEvent?.markAsRead({ document, position })
 
         const loggerItem3 = CompletionLogger.getCompletionEvent(id3)
         expect(loggerItem3?.params.id).not.toBe(completionId)

--- a/vscode/src/completions/logger.ts
+++ b/vscode/src/completions/logger.ts
@@ -321,7 +321,7 @@ function logCompletionPartiallyAcceptedEvent(params: PartiallyAcceptedEventPaylo
 }
 
 function logSuggestionsDocumentDiffEvent(params: PersistencePresentEventPayload): void {
-    if (params.diff && Buffer.byteLength(params.diff, 'utf8') <= 256 * 1024) {
+    if (params.diff && Buffer.byteLength(params.diff, 'utf8') >= 256 * 1024) {
         // Don't log large diffs
         return
     }

--- a/vscode/src/completions/logger.ts
+++ b/vscode/src/completions/logger.ts
@@ -842,12 +842,12 @@ export function prepareSuggestionEvent(
                 completionIdsMarkedAsSuggested.set(completionId, true)
                 event.suggestionAnalyticsLoggedAt = performance.now()
 
-                const authStatus = authProvider.instance!.statusAuthed
-                const isDotComUser = isDotCom(authStatus.endpoint || '')
+                const authStatus = authProvider.instance?.statusAuthed
                 // 🚨 SECURITY: Track the diff in the document after suggestion is shown for DotCom users and public repos.
                 if (
                     event.params.id &&
-                    isDotComUser &&
+                    authStatus &&
+                    isDotCom(authStatus.endpoint || '') &&
                     event.params.inlineCompletionItemContext?.isRepoPublic
                 ) {
                     suggestionDocumentDiffTracker(event.params.id, param.document, param.position)

--- a/vscode/src/completions/logger.ts
+++ b/vscode/src/completions/logger.ts
@@ -770,7 +770,7 @@ export function suggestionDocumentDiffTracker(
     const documentText = document.getText(trackingRange)
 
     const persistenceTimeoutList = [
-        30 * 1000, // 30 seconds
+        60 * 1000, // 60 seconds
     ]
     persistenceTracker.track({
         id: interactionId,

--- a/vscode/src/non-stop/FixupController.ts
+++ b/vscode/src/non-stop/FixupController.ts
@@ -54,16 +54,7 @@ export class FixupController
     private readonly editObserver: FixupDocumentEditObserver
     private readonly decorator = new FixupDecorator()
     private readonly controlApplicator
-    private readonly persistenceTracker = new PersistenceTracker(vscode.workspace, {
-        onPresent: ({ metadata, ...event }) => {
-            const safeMetadata = splitSafeMetadata({ ...event, ...metadata })
-            telemetryRecorder.recordEvent('cody.fixup.persistence', 'present', safeMetadata)
-        },
-        onRemoved: ({ metadata, ...event }) => {
-            const safeMetadata = splitSafeMetadata({ ...event, ...metadata })
-            telemetryRecorder.recordEvent('cody.fixup.persistence', 'present', safeMetadata)
-        },
-    })
+    private readonly persistenceTracker = new PersistenceTracker(vscode.workspace)
     /**
      * The event that fires when the user clicks the undo button on a code lens.
      * Used to help track the Edit rejection rate.
@@ -651,6 +642,16 @@ export class FixupController
             insertRange: trackedRange,
             document,
             metadata: legacyMetadata,
+            logger: {
+                onPresent: ({ metadata, ...event }) => {
+                    const safeMetadata = splitSafeMetadata({ ...event, ...metadata })
+                    telemetryRecorder.recordEvent('cody.fixup.persistence', 'present', safeMetadata)
+                },
+                onRemoved: ({ metadata, ...event }) => {
+                    const safeMetadata = splitSafeMetadata({ ...event, ...metadata })
+                    telemetryRecorder.recordEvent('cody.fixup.persistence', 'present', safeMetadata)
+                },
+            },
         })
 
         const logAcceptance = (acceptance: 'rejected' | 'accepted') => {


### PR DESCRIPTION
## Context
This PR adds a persistence telemetry event which logs the git diff of the file for each suggestion after 30 seconds **only for dotCom users and public github Repos** in the private metadata field.
The utility of this data is:
1. For the completions with `negative CAR` values, this event can give the actual code typed by the user after rejecting cody suggestions. These are typically called `negative examples` which can be used to improve the completions quality.
2. The `git diff` at different location than the suggestion one can give us an initial dataset for `next-edit-suggestion`. This data can be used to draw insights into `next-edits` (for the same file).
3. All the online datasets typically uses BM25/Embeddings as the context sampler but ignores the user activity like recent edits. Having this information along with context items logging can give us a ground truth sampled from online user queries for context improvements. 

## Test plan
1. Manual debugging and checking the events logged on vscode output channel.
2. The telemetry output is of the following format (Note the `field` `diff` in `privateMetadata`)

```
█ telemetry-v2: recordEvent: cody.completion.suggestion/documentDiff  {
  "parameters": {
    "version": 0,
    "interactionID": "14bd590d-e7cc-4d2a-a67c-e3900d8a0cf5",
    "metadata": [
      {
        "key": "afterSec",
        "value": 10
      },
      {
        "key": "difference",
        "value": 0.014861213461066078
      },
      {
        "key": "lineCount",
        "value": 665
      },
      {
        "key": "charCount",
        "value": 24426
      }
    ],
    "privateMetadata": {
      "id": "14bd590d-e7cc-4d2a-a67c-e3900d8a0cf5",
      "diff": "--- a/file:///Users/hiteshsagtani/dev/Compiler-Project-BITS-Pilani/symboltable.c\n+++ b/file:///Users/hiteshsagtani/dev/Compiler-Project-BITS-Pilani/symboltable.c\n@@ -523,8 +523,14 @@\n             if(strcmp(gettype(head->Lex->tk->value, scope), \"INTEGER\")!=0)\n                 fprintf(fp,\"ERROR 6: Array index should be of type integer but here, %s has type %s, line number %d\\n\", head->Lex->tk->value, gettype(head->Lex->tk->value, scope), head->Lex->tk->line);\n             }\n         \n+        if(head->parent->value==24){\n+            //assert(0);\n+            if(strcmp(gettype(head->Lex->tk->value, scope), \"INTEGER\")!=0)\n+                fprintf(fp,\"ERROR 6: Array index should be of type integer but here, %s has type %s, line number %d\\n\", head->Lex->tk->value, gettype(head->Lex->tk->value, scope), head->Lex->tk->line);\n+            }\n+        }\n         \n \n \n           if(head->parent->rule == 41 && head->right->rule==44)\n"
    }
  },
  "timestamp": "2024-09-03T23:10:32.184Z"
}
```

 
