### PR TITLE
feat(chat): improve context item display in client state broadcaster

### DIFF
--- a/vscode/src/chat/clientStateBroadcaster.ts
+++ b/vscode/src/chat/clientStateBroadcaster.ts
@@ -50,22 +50,33 @@ export function startClientStateBroadcaster({
         signal?.throwIfAborted()
         if (contextFile) {
             const range = contextFile.range ? expandToLineRange(contextFile.range) : undefined
-            const item = {
+
+            // Always add the current file item
+            items.push({
                 ...contextFile,
                 type: 'file',
-                title: range ? 'Current Selection' : 'Current File',
-                description: `${displayPathBasename(contextFile.uri)}${
-                    range ? `:${displayLineRange(range)}` : ''
-                }`,
-                range,
+                title: 'Current File',
+                description: displayPathBasename(contextFile.uri),
+                range: undefined,
                 isTooLarge: contextFile.size !== undefined && contextFile.size > userContextSize,
                 source: ContextItemSource.Initial,
-                icon: range ? 'list-selection' : 'file',
-            } satisfies ContextItem
+                icon: 'file',
+            })
 
-            items.push(item)
+            // Add the current selection item if there's a range
+            if (range) {
+                items.push({
+                    ...contextFile,
+                    type: 'file',
+                    title: 'Current Selection',
+                    description: `${displayPathBasename(contextFile.uri)}:${displayLineRange(range)}`,
+                    range,
+                    isTooLarge: contextFile.size !== undefined && contextFile.size > userContextSize,
+                    source: ContextItemSource.Initial,
+                    icon: 'list-selection',
+                })
+            }
         }
-
         const corpusItems = getCorpusContextItemsForEditorState(useRemoteSearch)
         items.push(...(await corpusItems))
 

--- a/vscode/src/prompt-builder/utils.ts
+++ b/vscode/src/prompt-builder/utils.ts
@@ -67,6 +67,7 @@ export function renderContextItem(contextItem: ContextItem): ContextMessage | nu
 export function getContextItemTokenUsageType(item: ContextItem): ContextTokenUsageType {
     switch (item.source) {
         case 'user':
+        case 'initial':
         case 'selection':
             return 'user'
         default:

--- a/vscode/test/e2e/chat-atFile.test.ts
+++ b/vscode/test/e2e/chat-atFile.test.ts
@@ -377,5 +377,5 @@ test.extend<ExpectedV2Events>({
     await lastChatInput.press('x')
     await selectLineRangeInEditorTab(page, 7, 10)
     await executeCommandInPalette(page, 'Cody: Add Selection to Cody Chat')
-    await expect(chatInputMentions(lastChatInput)).toHaveText(['buzz.ts:2-5', 'buzz.ts:7-10'])
+    await expect(chatInputMentions(lastChatInput)).toHaveText(['buzz.ts', 'buzz.ts:2-5', 'buzz.ts:7-10'])
 })

--- a/vscode/test/e2e/command-custom.test.ts
+++ b/vscode/test/e2e/command-custom.test.ts
@@ -183,11 +183,11 @@ test.extend<ExpectedV2Events>({
     await expectContextCellCounts(contextCell, { files: 2 })
     await openContextCell(contextCell)
     await expect(
-        chatPanel.getByRole('button', { name: withPlatformSlashes('lib/batches/env/var.go:1') })
+        chatPanel.getByRole('button', { name: withPlatformSlashes('lib/batches/env/var.go') })
     ).toBeVisible()
     // Click on the file link should open the 'var.go file in the editor
     await contextCell
-        .getByRole('button', { name: withPlatformSlashes('lib/batches/env/var.go:1') })
+        .getByRole('button', { name: withPlatformSlashes('lib/batches/env/var.go') })
         .click()
     await expect(page.getByRole('tab', { name: 'var.go' })).toBeVisible()
 

--- a/vscode/test/e2e/initial-context.test.ts
+++ b/vscode/test/e2e/initial-context.test.ts
@@ -64,12 +64,20 @@ testWithGitRemote('initial context - file', async ({ page, sidebar, server }) =>
     await expect(chatInputMentions(lastChatInput)).toHaveText(['README.md', 'host.example/user/myrepo'])
 
     await clickEditorTab(page, 'main.c')
-    await expect(chatInputMentions(lastChatInput)).toHaveText(['main.c:1-3', 'host.example/user/myrepo'])
+    await expect(chatInputMentions(lastChatInput)).toHaveText([
+        'main.c',
+        'main.c:1-3',
+        'host.example/user/myrepo',
+    ])
 
     // After typing into the input, it no longer updates the initial context.
     await lastChatInput.press('x')
     await clickEditorTab(page, 'README.md')
-    await expect(chatInputMentions(lastChatInput)).toHaveText(['main.c:1-3', 'host.example/user/myrepo'])
+    await expect(chatInputMentions(lastChatInput)).toHaveText([
+        'main.c',
+        'main.c:1-3',
+        'host.example/user/myrepo',
+    ])
 })
 
 testWithGitRemote.extend<DotcomUrlOverride>({ dotcomUrl: mockServer.SERVER_URL })(

--- a/vscode/test/e2e/initial-context.test.ts
+++ b/vscode/test/e2e/initial-context.test.ts
@@ -47,10 +47,18 @@ testWithGitRemote('initial context - file', async ({ page, sidebar, server }) =>
     await expect(chatInputMentions(lastChatInput)).toHaveText(['main.c', 'host.example/user/myrepo'])
 
     await selectLineRangeInEditorTab(page, 2, 4)
-    await expect(chatInputMentions(lastChatInput)).toHaveText(['main.c:2-4', 'host.example/user/myrepo'])
+    await expect(chatInputMentions(lastChatInput)).toHaveText([
+        'main.c',
+        'main.c:2-4',
+        'host.example/user/myrepo',
+    ])
 
     await selectLineRangeInEditorTab(page, 1, 3)
-    await expect(chatInputMentions(lastChatInput)).toHaveText(['main.c:1-3', 'host.example/user/myrepo'])
+    await expect(chatInputMentions(lastChatInput)).toHaveText([
+        'main.c',
+        'main.c:1-3',
+        'host.example/user/myrepo',
+    ])
 
     await openFileInEditorTab(page, 'README.md')
     await expect(chatInputMentions(lastChatInput)).toHaveText(['README.md', 'host.example/user/myrepo'])


### PR DESCRIPTION
Closes SRCH-1013.

This change enhances the display of context items in the client state broadcaster by:

- Always adding the current file item, with the file name as the description

https://linear.app/sourcegraph/issue/SRCH-1013/always-show-current-file-mention-option-even-if-there-is-a-selection


## Test plan

Manual testing.