### PR TITLE
Revert "Improve Prompts & Commands list UI #5438"

### DIFF
--- a/lib/shared/src/misc/rpc/webviewAPI.ts
+++ b/lib/shared/src/misc/rpc/webviewAPI.ts
@@ -75,7 +75,7 @@ export interface PromptsResult {
      * `undefined` means that commands should not be shown at all (not even as an empty
      * list). Builtin and custom commands are deprecated in favor of the Prompt Library.
      */
-    commands: CodyCommand[] | undefined
+    commands: CodyCommand[]
 
     /** The original query used to fetch this result. */
     query: string

--- a/lib/shared/src/sourcegraph-api/graphql/client.ts
+++ b/lib/shared/src/sourcegraph-api/graphql/client.ts
@@ -418,7 +418,6 @@ export interface Prompt {
     nameWithOwner: string
     owner: {
         namespaceName: string
-        displayName?: string | null
     }
     description?: string
     draft: boolean

--- a/vscode/test/e2e/command-core.test.ts
+++ b/vscode/test/e2e/command-core.test.ts
@@ -106,13 +106,7 @@ test.extend<ExpectedV2Events>({
         'cody.auth:connected',
         'cody.command.explain:executed',
     ],
-})('Explain Command from Prompts Tab', async ({ page, sidebar, server }) => {
-    server.onGraphQl('ViewerPrompts').replyJson({
-        data: {
-            prompts: { nodes: [] },
-        },
-    })
-
+})('Explain Command from Prompts Tab', async ({ page, sidebar }) => {
     // Sign into Cody
     await sidebarSignin(page, sidebar)
 

--- a/vscode/webviews/AppWrapperForTest.tsx
+++ b/vscode/webviews/AppWrapperForTest.tsx
@@ -14,11 +14,8 @@ import { Observable } from 'observable-fns'
 import { type ComponentProps, type FunctionComponent, type ReactNode, useMemo } from 'react'
 import { URI } from 'vscode-uri'
 import { COMMON_WRAPPERS } from './AppWrapper'
-import {
-    FIXTURE_COMMANDS,
-    FIXTURE_PROMPTS,
-    makePromptsAPIWithData,
-} from './components/promptList/fixtures'
+import { FIXTURE_COMMANDS, makePromptsAPIWithData } from './components/promptList/fixtures'
+import { FIXTURE_PROMPTS } from './components/promptSelectField/fixtures'
 import { ComposedWrappers, type Wrapper } from './utils/composeWrappers'
 import { TelemetryRecorderContext } from './utils/telemetry'
 import { ConfigProvider } from './utils/useConfig'

--- a/vscode/webviews/Chat.story.tsx
+++ b/vscode/webviews/Chat.story.tsx
@@ -1,4 +1,3 @@
-import { CodyIDE } from '@sourcegraph/cody-shared'
 import { ExtensionAPIProviderForTestsOnly, MOCK_API } from '@sourcegraph/prompt-editor'
 import type { Meta, StoryObj } from '@storybook/react'
 import { Observable } from 'observable-fns'
@@ -20,7 +19,6 @@ const meta: Meta<typeof Chat> = {
         },
     },
     args: {
-        IDE: CodyIDE.VSCode,
         transcript: FIXTURE_TRANSCRIPT.simple2,
         messageInProgress: null,
         chatEnabled: true,

--- a/vscode/webviews/Chat.tsx
+++ b/vscode/webviews/Chat.tsx
@@ -15,16 +15,12 @@ import { truncateTextStart } from '@sourcegraph/cody-shared/src/prompt/truncatio
 import { CHAT_INPUT_TOKEN_BUDGET } from '@sourcegraph/cody-shared/src/token/constants'
 import styles from './Chat.module.css'
 import { WelcomeMessage } from './chat/components/WelcomeMessage'
-import { useClientActionDispatcher } from './client/clientState'
 import { ScrollDown } from './components/ScrollDown'
-import { PromptList } from './components/promptList/PromptList'
-import { onPromptSelectInPanel, onPromptSelectInPanelActionLabels } from './prompts/PromptsTab'
-import { View } from './tabs'
+import type { View } from './tabs'
 import { useTelemetryRecorder } from './utils/telemetry'
 import { useUserAccountInfo } from './utils/useConfig'
 
 interface ChatboxProps {
-    IDE: CodyIDE
     chatEnabled: boolean
     messageInProgress: ChatMessage | null
     transcript: ChatMessage[]
@@ -39,7 +35,6 @@ interface ChatboxProps {
 }
 
 export const Chat: React.FunctionComponent<React.PropsWithChildren<ChatboxProps>> = ({
-    IDE,
     messageInProgress,
     transcript,
     vscodeAPI,
@@ -201,19 +196,6 @@ export const Chat: React.FunctionComponent<React.PropsWithChildren<ChatboxProps>
         }
     }, [])
 
-    const dispatchClientAction = useClientActionDispatcher()
-
-    const handleScrollDownClick = useCallback(() => {
-        // Scroll to the bottom instead of focus input for unsent message
-        // it's possible that we just want to scroll to the bottom in case of
-        // welcome message screen
-        if (transcript.length === 0) {
-            return
-        }
-
-        focusLastHumanMessageEditor()
-    }, [transcript])
-
     return (
         <>
             {!chatEnabled && (
@@ -235,25 +217,11 @@ export const Chat: React.FunctionComponent<React.PropsWithChildren<ChatboxProps>
                 guardrails={guardrails}
                 smartApplyEnabled={smartApplyEnabled}
             />
-            {transcript.length === 0 && (
-                <PromptList
-                    telemetryLocation="ChatTab"
-                    showSearch={false}
-                    showSwitchToPromptAction={true}
-                    showInitialSelectedItem={false}
-                    showCommandOrigins={true}
-                    showPromptLibraryUnsupportedMessage={false}
-                    className="tw-rounded-none tw-px-4 tw-flex-shrink-0"
-                    onSelectActionLabels={onPromptSelectInPanelActionLabels}
-                    onSwitchToPromptsTab={() => setView(View.Prompts)}
-                    onSelect={item => onPromptSelectInPanel(item, setView, dispatchClientAction)}
-                />
-            )}
             {transcript.length === 0 && showWelcomeMessage && (
                 <WelcomeMessage IDE={userInfo.ide} setView={setView} />
             )}
             {scrollableParent && (
-                <ScrollDown scrollableParent={scrollableParent} onClick={handleScrollDownClick} />
+                <ScrollDown scrollableParent={scrollableParent} onClick={focusLastHumanMessageEditor} />
             )}
         </>
     )

--- a/vscode/webviews/Chat.tsx
+++ b/vscode/webviews/Chat.tsx
@@ -196,6 +196,17 @@ export const Chat: React.FunctionComponent<React.PropsWithChildren<ChatboxProps>
         }
     }, [])
 
+    const handleScrollDownClick = useCallback(() => {
+        // Scroll to the bottom instead of focus input for unsent message
+        // it's possible that we just want to scroll to the bottom in case of
+        // welcome message screen
+        if (transcript.length === 0) {
+            return
+        }
+
+        focusLastHumanMessageEditor()
+    }, [transcript])
+
     return (
         <>
             {!chatEnabled && (
@@ -221,7 +232,7 @@ export const Chat: React.FunctionComponent<React.PropsWithChildren<ChatboxProps>
                 <WelcomeMessage IDE={userInfo.ide} setView={setView} />
             )}
             {scrollableParent && (
-                <ScrollDown scrollableParent={scrollableParent} onClick={focusLastHumanMessageEditor} />
+                <ScrollDown scrollableParent={scrollableParent} onClick={handleScrollDownClick} />
             )}
         </>
     )

--- a/vscode/webviews/CodyPanel.tsx
+++ b/vscode/webviews/CodyPanel.tsx
@@ -82,7 +82,6 @@ export const CodyPanel: FunctionComponent<
             <TabContainer value={view} ref={tabContainerRef}>
                 {view === View.Chat && (
                     <Chat
-                        IDE={config.agentIDE || CodyIDE.VSCode}
                         chatEnabled={chatEnabled}
                         messageInProgress={messageInProgress}
                         transcript={transcript}
@@ -105,9 +104,7 @@ export const CodyPanel: FunctionComponent<
                         userHistory={userHistory}
                     />
                 )}
-                {view === View.Prompts && (
-                    <PromptsTab setView={setView} IDE={config.agentIDE || CodyIDE.VSCode} />
-                )}
+                {view === View.Prompts && <PromptsTab setView={setView} />}
                 {view === View.Account && <AccountTab />}
                 {view === View.Settings && <SettingsTab />}
             </TabContainer>

--- a/vscode/webviews/chat/cells/messageCell/human/editor/HumanMessageEditor.tsx
+++ b/vscode/webviews/chat/cells/messageCell/human/editor/HumanMessageEditor.tsx
@@ -254,9 +254,14 @@ export const HumanMessageEditor: FunctionComponent<{
                     if (isSent) {
                         return
                     }
-                    if (editorRef.current) {
-                        editorRef.current.appendText(appendTextToLastPromptEditor)
-                    }
+
+                    // Schedule append text task to the next tick to avoid collisions with
+                    // initial text set (add initial mentions first then append text from prompt)
+                    requestAnimationFrame(() => {
+                        if (editorRef.current) {
+                            editorRef.current.appendText(appendTextToLastPromptEditor)
+                        }
+                    })
                 }
             },
             [isSent]

--- a/vscode/webviews/chat/cells/messageCell/human/editor/HumanMessageEditor.tsx
+++ b/vscode/webviews/chat/cells/messageCell/human/editor/HumanMessageEditor.tsx
@@ -198,6 +198,13 @@ export const HumanMessageEditor: FunctionComponent<{
         [onGapClick]
     )
 
+    const appendTextToEditor = useCallback((text: string): void => {
+        if (!editorRef.current) {
+            throw new Error('No editorRef')
+        }
+        editorRef.current.appendText(text)
+    }, [])
+
     const onMentionClick = useCallback((): void => {
         if (!editorRef.current) {
             throw new Error('No editorRef')
@@ -247,14 +254,9 @@ export const HumanMessageEditor: FunctionComponent<{
                     if (isSent) {
                         return
                     }
-
-                    // Schedule append text task to the next tick to avoid collisions with
-                    // initial text set (add initial mentions first then append text from prompt)
-                    requestAnimationFrame(() => {
-                        if (editorRef.current) {
-                            editorRef.current.appendText(appendTextToLastPromptEditor)
-                        }
-                    })
+                    if (editorRef.current) {
+                        editorRef.current.appendText(appendTextToLastPromptEditor)
+                    }
                 }
             },
             [isSent]
@@ -327,6 +329,7 @@ export const HumanMessageEditor: FunctionComponent<{
                     submitState={submitState}
                     onGapClick={onGapClick}
                     focusEditor={focusEditor}
+                    appendTextToEditor={appendTextToEditor}
                     hidden={!focused && isSent}
                     className={styles.toolbar}
                 />

--- a/vscode/webviews/chat/cells/messageCell/human/editor/toolbar/Toolbar.tsx
+++ b/vscode/webviews/chat/cells/messageCell/human/editor/toolbar/Toolbar.tsx
@@ -4,6 +4,8 @@ import clsx from 'clsx'
 import { type FunctionComponent, useCallback, useMemo } from 'react'
 import type { UserAccountInfo } from '../../../../../../Chat'
 import { ModelSelectField } from '../../../../../../components/modelSelectField/ModelSelectField'
+import type { PromptOrDeprecatedCommand } from '../../../../../../components/promptList/PromptList'
+import { PromptSelectField } from '../../../../../../components/promptSelectField/PromptSelectField'
 import { useConfig } from '../../../../../../utils/useConfig'
 import { AddContextButton } from './AddContextButton'
 import { SubmitButton, type SubmitButtonState } from './SubmitButton'
@@ -25,6 +27,7 @@ export const Toolbar: FunctionComponent<{
     onGapClick?: () => void
 
     focusEditor?: () => void
+    appendTextToEditor: (text: string) => void
 
     hidden?: boolean
     className?: string
@@ -36,6 +39,7 @@ export const Toolbar: FunctionComponent<{
     submitState,
     onGapClick,
     focusEditor,
+    appendTextToEditor,
     hidden,
     className,
 }) => {
@@ -76,6 +80,11 @@ export const Toolbar: FunctionComponent<{
                         className="tw-opacity-60 focus-visible:tw-opacity-100 hover:tw-opacity-100 tw-mr-2"
                     />
                 )}
+                <PromptSelectFieldToolbarItem
+                    focusEditor={focusEditor}
+                    appendTextToEditor={appendTextToEditor}
+                    className="tw-ml-1 tw-mr-1"
+                />
                 <ModelSelectFieldToolbarItem
                     userInfo={userInfo}
                     focusEditor={focusEditor}
@@ -91,6 +100,22 @@ export const Toolbar: FunctionComponent<{
             </div>
         </menu>
     )
+}
+
+const PromptSelectFieldToolbarItem: FunctionComponent<{
+    focusEditor?: () => void
+    appendTextToEditor: (text: string) => void
+    className?: string
+}> = ({ focusEditor, appendTextToEditor, className }) => {
+    const onSelect = useCallback(
+        (item: PromptOrDeprecatedCommand) => {
+            appendTextToEditor(item.type === 'prompt' ? item.value.definition.text : item.value.prompt)
+            focusEditor?.()
+        },
+        [appendTextToEditor, focusEditor]
+    )
+
+    return <PromptSelectField onSelect={onSelect} onCloseByEscape={focusEditor} className={className} />
 }
 
 const ModelSelectFieldToolbarItem: FunctionComponent<{

--- a/vscode/webviews/chat/components/WelcomeMessage.test.tsx
+++ b/vscode/webviews/chat/components/WelcomeMessage.test.tsx
@@ -1,8 +1,21 @@
 import { CodyIDE } from '@sourcegraph/cody-shared'
 import { fireEvent, render, screen } from '@testing-library/react'
-import { describe, expect, test } from 'vitest'
+import { describe, expect, test, vi } from 'vitest'
 import { AppWrapperForTest } from '../../AppWrapperForTest'
+import { usePromptsQuery } from '../../components/promptList/usePromptsQuery'
+import { FIXTURE_PROMPTS } from '../../components/promptSelectField/fixtures'
 import { WelcomeMessage } from './WelcomeMessage'
+
+vi.mock('../../components/promptList/usePromptsQuery')
+vi.mocked(usePromptsQuery).mockReturnValue({
+    value: {
+        query: '',
+        commands: [],
+        prompts: { type: 'results', results: [FIXTURE_PROMPTS[0]] },
+    },
+    done: false,
+    error: null,
+})
 
 describe('WelcomeMessage', () => {
     function openCollapsiblePanels(): void {
@@ -19,12 +32,12 @@ describe('WelcomeMessage', () => {
 
         // Check common elements
         expect(screen.getByText(/Chat Help/)).toBeInTheDocument()
+        expect(screen.getByText(FIXTURE_PROMPTS[0].name)).toBeInTheDocument()
 
         // Check elements specific to CodyIDE.VSCode
         expect(screen.getByText(/To add code context from an editor/)).toBeInTheDocument()
         expect(screen.getByText(/Start a new chat using/)).toBeInTheDocument()
-        expect(screen.getByText(/Documentation/)).toBeInTheDocument()
-        expect(screen.getByText(/Help & Support/)).toBeInTheDocument()
+        expect(screen.getByText(/Customize chat settings/)).toBeInTheDocument()
     })
 
     test('renders for CodyIDE.JetBrains', () => {
@@ -35,11 +48,11 @@ describe('WelcomeMessage', () => {
 
         // Check common elements
         expect(screen.getByText(/Chat Help/)).toBeInTheDocument()
+        expect(screen.getByText(FIXTURE_PROMPTS[0].name)).toBeInTheDocument()
 
         // Check elements specific to CodyIDE.JetBrains
         expect(screen.queryByText(/To add code context from an editor/)).not.toBeInTheDocument()
         expect(screen.queryByText(/Start a new chat using/)).not.toBeInTheDocument()
-        expect(screen.getByText(/Documentation/)).toBeInTheDocument()
-        expect(screen.getByText(/Help & Support/)).toBeInTheDocument()
+        expect(screen.queryByText(/Customize chat settings/)).not.toBeInTheDocument()
     })
 })

--- a/vscode/webviews/chat/components/WelcomeMessage.tsx
+++ b/vscode/webviews/chat/components/WelcomeMessage.tsx
@@ -1,13 +1,22 @@
 import { CodyIDE } from '@sourcegraph/cody-shared'
-import { AtSignIcon, type LucideProps, MessageSquarePlusIcon, TextIcon } from 'lucide-react'
+import {
+    AtSignIcon,
+    type LucideProps,
+    MessageSquarePlusIcon,
+    SettingsIcon,
+    TextIcon,
+} from 'lucide-react'
 import type { FunctionComponent } from 'react'
 import type React from 'react'
+import { useClientActionDispatcher } from '../../client/clientState'
 import { CollapsiblePanel } from '../../components/CollapsiblePanel'
 import { Kbd } from '../../components/Kbd'
+import { PromptListSuitedForNonPopover } from '../../components/promptList/PromptList'
+import { onPromptSelectInPanel, onPromptSelectInPanelActionLabels } from '../../prompts/PromptsTab'
 import type { View } from '../../tabs'
 
 const MenuExample: FunctionComponent<{ children: React.ReactNode }> = ({ children }) => (
-    <span className="tw-p-1 tw-rounded tw-border tw-border-keybinding-border tw-bg-keybinding-background tw-whitespace-nowrap">
+    <span className="tw-p-1 tw-rounded tw-text-keybinding-foreground tw-border tw-border-keybinding-border tw-bg-keybinding-background tw-whitespace-nowrap">
         {children}
     </span>
 )
@@ -36,58 +45,57 @@ const localStorageKey = 'chat.welcome-message-dismissed'
 
 export const WelcomeMessage: FunctionComponent<{ IDE: CodyIDE; setView: (view: View) => void }> = ({
     IDE,
+    setView,
 }) => {
     // Remove the old welcome message dismissal key that is no longer used.
     localStorage.removeItem(localStorageKey)
 
+    const dispatchClientAction = useClientActionDispatcher()
+
     return (
-        <div className="tw-flex-1 tw-w-full tw-px-6 tw-transition-all">
+        <div className="tw-flex-1 tw-flex tw-flex-col tw-items-start tw-w-full tw-px-6 tw-gap-6 tw-transition-all">
+            <CollapsiblePanel
+                storageKey="prompts"
+                title="Prompts & Commands"
+                className="tw-mb-6"
+                contentClassName="!tw-p-0 tw-overflow-clip"
+                initialOpen={true}
+            >
+                <PromptListSuitedForNonPopover
+                    onSelect={item => onPromptSelectInPanel(item, setView, dispatchClientAction)}
+                    onSelectActionLabels={onPromptSelectInPanelActionLabels}
+                    telemetryLocation="PromptsTab"
+                    showCommandOrigins={true}
+                    showPromptLibraryUnsupportedMessage={false}
+                    showOnlyPromptInsertableCommands={false}
+                    className="tw-rounded-none"
+                />
+            </CollapsiblePanel>
             <CollapsiblePanel
                 storageKey="chat-help"
                 title="Chat Help"
-                className="tw-mb-12 tw-mt-8"
+                className="tw-mb-6 tw-mt-2"
                 initialOpen={true}
             >
-                {IDE === CodyIDE.VSCode && (
-                    <>
-                        <FeatureRow icon={MessageSquarePlusIcon}>
-                            Start a new chat using <Kbd macOS="opt+L" linuxAndWindows="alt+L" /> or the
-                            command <MenuExample>Cody: New Chat</MenuExample>
-                        </FeatureRow>
-                    </>
-                )}
-
                 <FeatureRow icon={AtSignIcon}>
                     Type <Kbd macOS="@" linuxAndWindows="@" /> to add context to your chat
                 </FeatureRow>
-
                 {IDE === CodyIDE.VSCode && (
                     <>
                         <FeatureRow icon={TextIcon}>
                             To add code context from an editor, right click and use{' '}
                             <MenuExample>Cody &gt; Add File/Selection to Cody Chat</MenuExample>
                         </FeatureRow>
+                        <FeatureRow icon={MessageSquarePlusIcon}>
+                            Start a new chat using <Kbd macOS="opt+L" linuxAndWindows="alt+L" />
+                        </FeatureRow>
+                        <FeatureRow icon={SettingsIcon}>
+                            Customize chat settings with the <FeatureRowInlineIcon Icon={SettingsIcon} />{' '}
+                            button, or see the{' '}
+                            <a href="https://sourcegraph.com/docs/cody">documentation</a>
+                        </FeatureRow>
                     </>
                 )}
-
-                <div className="tw-flex tw-justify-center tw-items-center tw-w-full tw-gap-10 tw-px-4 tw-pt-4 tw-pb-3 tw-mt-2 tw-border-t tw-border-button-border tw-transition-all">
-                    <a
-                        href="https://docs.sourcegraph.com/cody"
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="tw-text-muted-foreground hover:tw-text-foreground"
-                    >
-                        Documentation
-                    </a>
-                    <a
-                        href="https://help.sourcegraph.com"
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="tw-text-muted-foreground hover:tw-text-foreground"
-                    >
-                        Help & Support
-                    </a>
-                </div>
             </CollapsiblePanel>
         </div>
     )

--- a/vscode/webviews/components/UserAvatar.module.css
+++ b/vscode/webviews/components/UserAvatar.module.css
@@ -2,6 +2,8 @@
     isolation: isolate;
     display: inline-flex;
     border-radius: 50%;
+    background-color: var(--vscode-inputOption-activeBackground);
+    color: var(--vscode-inputOption-activeForeground);
     align-items: center;
     justify-content: center;
     height: fit-content;

--- a/vscode/webviews/components/UserAvatar.story.tsx
+++ b/vscode/webviews/components/UserAvatar.story.tsx
@@ -22,6 +22,7 @@ export const Image: Story = {
         user: {
             username: 'sqs',
             avatarURL: 'https://avatars.githubusercontent.com/u/1976',
+            endpoint: '',
         },
     },
 }
@@ -30,6 +31,7 @@ export const Text1Letter: Story = {
     args: {
         user: {
             username: 'sqs',
+            endpoint: '',
         },
     },
 }
@@ -39,6 +41,7 @@ export const Text2Letters: Story = {
         user: {
             username: 'sqs',
             displayName: 'Quinn Slack',
+            endpoint: '',
         },
     },
 }
@@ -48,6 +51,7 @@ export const SourcegraphGradientBorder: Story = {
         user: {
             username: 'sqs',
             avatarURL: 'https://avatars.githubusercontent.com/u/1976',
+            endpoint: '',
         },
         sourcegraphGradientBorder: true,
     },

--- a/vscode/webviews/components/UserAvatar.tsx
+++ b/vscode/webviews/components/UserAvatar.tsx
@@ -4,7 +4,7 @@ import type { UserAccountInfo } from '../Chat'
 import styles from './UserAvatar.module.css'
 
 interface Props {
-    user: Pick<UserAccountInfo['user'], 'username' | 'avatarURL' | 'displayName'>
+    user: NonNullable<UserAccountInfo['user']>
     size: number
     sourcegraphGradientBorder?: boolean
     className?: string
@@ -74,9 +74,8 @@ const InnerUserAvatar: FunctionComponent<Omit<Props, 'sourcegraphGradientBorder'
     return (
         <div
             title={title}
-            className={clsx(styles.userAvatar, 'tw-bg-muted tw-text-muted-foreground', className)}
+            className={clsx(styles.userAvatar, className)}
             style={{ width: `${size}px`, height: `${size}px` }}
-            data-user-avatar={true}
         >
             <span className={styles.initials}>
                 {getInitials(user?.displayName || user?.username || '')}

--- a/vscode/webviews/components/promptList/PromptList.story.tsx
+++ b/vscode/webviews/components/promptList/PromptList.story.tsx
@@ -1,7 +1,7 @@
 import { ExtensionAPIProviderForTestsOnly, MOCK_API } from '@sourcegraph/prompt-editor'
 import type { Meta, StoryObj } from '@storybook/react'
 import { VSCodeStandaloneComponent } from '../../storybook/VSCodeStoryDecorator'
-import { FIXTURE_PROMPTS } from '../promptList/fixtures'
+import { FIXTURE_PROMPTS } from '../promptSelectField/fixtures'
 import { PromptList } from './PromptList'
 import { FIXTURE_COMMANDS } from './fixtures'
 import { makePromptsAPIWithData } from './fixtures'
@@ -53,22 +53,6 @@ export const WithOnlyCommands: Story = {
                 prompts: makePromptsAPIWithData({
                     prompts: { type: 'unsupported' },
                     commands: FIXTURE_COMMANDS,
-                }),
-            }}
-        >
-            <PromptList {...args} />
-        </ExtensionAPIProviderForTestsOnly>
-    ),
-}
-
-export const WithOnlyPrompts: Story = {
-    render: args => (
-        <ExtensionAPIProviderForTestsOnly
-            value={{
-                ...MOCK_API,
-                prompts: makePromptsAPIWithData({
-                    prompts: { type: 'results', results: FIXTURE_PROMPTS },
-                    commands: undefined,
                 }),
             }}
         >

--- a/vscode/webviews/components/promptList/PromptList.tsx
+++ b/vscode/webviews/components/promptList/PromptList.tsx
@@ -1,22 +1,10 @@
-import type { CodyCommand, Prompt } from '@sourcegraph/cody-shared'
+import { type CodyCommand, CustomCommandType, type Prompt } from '@sourcegraph/cody-shared'
 import clsx from 'clsx'
-import {
-    BookOpenIcon,
-    BugIcon,
-    CombineIcon,
-    FileQuestionIcon,
-    HammerIcon,
-    type LucideIcon,
-    MessageCircleCode,
-    PencilIcon,
-    PlayIcon,
-    ShieldCheckIcon,
-} from 'lucide-react'
-import { type FunctionComponent, useCallback, useState } from 'react'
+import { PlusIcon } from 'lucide-react'
+import { type ComponentProps, type FunctionComponent, useCallback, useState } from 'react'
 import { useTelemetryRecorder } from '../../utils/telemetry'
 import { useConfig } from '../../utils/useConfig'
 import { useDebounce } from '../../utils/useDebounce'
-import { UserAvatar } from '../UserAvatar'
 import { Badge } from '../shadcn/ui/badge'
 import { Button } from '../shadcn/ui/button'
 import {
@@ -26,9 +14,9 @@ import {
     CommandItem,
     CommandList,
     CommandLoading,
-    CommandRow,
     CommandSeparator,
 } from '../shadcn/ui/command'
+import { Tooltip, TooltipContent, TooltipTrigger } from '../shadcn/ui/tooltip'
 import { usePromptsQuery } from './usePromptsQuery'
 
 export type PromptOrDeprecatedCommand =
@@ -40,30 +28,31 @@ type SelectActionLabel = 'insert' | 'run'
 /**
  * A list of prompts from the Prompt Library. For backcompat, it also displays built-in commands and
  * custom commands (which are both deprecated in favor of the Prompt Library).
+ *
+ * It is used in the {@link PromptSelectField} in a popover and in {@link PromptsTab} as a list (not
+ * in a popover).
  */
 export const PromptList: React.FunctionComponent<{
+    onSelect: (item: PromptOrDeprecatedCommand) => void
+    onSelectActionLabels?: { prompt: SelectActionLabel; command: SelectActionLabel }
     showSearch?: boolean
+    showOnlyPromptInsertableCommands?: boolean
     showInitialSelectedItem?: boolean
     showPromptLibraryUnsupportedMessage?: boolean
     showCommandOrigins?: boolean
     className?: string
     commandListClassName?: string
-    showSwitchToPromptAction?: boolean
-    telemetryLocation: 'ChatTab' | 'PromptsTab'
-    onSelect: (item: PromptOrDeprecatedCommand) => void
-    onSwitchToPromptsTab?: () => void
-    onSelectActionLabels?: { prompt: SelectActionLabel; command: SelectActionLabel }
+    telemetryLocation: 'PromptSelectField' | 'PromptsTab'
 }> = ({
     onSelect: parentOnSelect,
-    onSwitchToPromptsTab,
     onSelectActionLabels,
     showSearch = true,
-    showInitialSelectedItem = false,
+    showOnlyPromptInsertableCommands,
+    showInitialSelectedItem = true,
     showPromptLibraryUnsupportedMessage = true,
     showCommandOrigins = false,
     className,
     commandListClassName,
-    showSwitchToPromptAction = false,
     telemetryLocation,
 }) => {
     const telemetryRecorder = useTelemetryRecorder()
@@ -146,25 +135,22 @@ export const PromptList: React.FunctionComponent<{
 
     const endpointURL = new URL(useConfig().authStatus.endpoint)
 
-    const itemClassName = 'tw-border tw-border-border !tw-rounded-lg !tw-p-4'
+    // Don't show builtin commands to insert in the prompt editor.
+    const filteredCommands = showOnlyPromptInsertableCommands
+        ? result?.commands.filter(c => c.type !== 'default')
+        : result?.commands
 
     return (
         <Command
             loop={true}
             tabIndex={0}
-            className={clsx(
-                '!tw-overflow-visible focus:tw-outline-none tw-border-0 !tw-max-w-[unset] tw-w-full !tw-h-[unset] !tw-bg-[unset]',
-                className
-            )}
+            className={clsx('focus:tw-outline-none', className)}
             shouldFilter={false}
-            // Makes it so that if you hover over a command, it doesn't remain selected after you
-            // move your mouse entirely away from the list.
-            disablePointerSelection={true}
             defaultValue={showInitialSelectedItem ? undefined : 'xxx-no-item'}
         >
             <CommandList
                 className={clsx(
-                    '!tw-max-h-[unset] !tw-overflow-visible [&_[cmdk-group]]:tw-pt-0 [&_[cmdk-group-heading]]:tw-flex [&_[cmdk-group-heading]]:tw-gap-2 [&_[cmdk-group-heading]]:tw-items-center [&_[cmdk-group-heading]]:!tw-min-h-[30px] [&_[cmdk-group-heading]]:tw--mx-2 [&_[cmdk-group-heading]]:tw-px-4 [&_[cmdk-group-heading]]:tw-mb-2 [&_[cmdk-group-heading]]:tw-bg-muted [&_[cmdk-group]]:!tw-border-0',
+                    '[&_[cmdk-group]]:tw-pt-0 [&_[cmdk-group-heading]]:tw-flex [&_[cmdk-group-heading]]:tw-gap-2 [&_[cmdk-group-heading]]:tw-items-center [&_[cmdk-group-heading]]:!tw-min-h-[30px] [&_[cmdk-group-heading]]:tw--mx-2 [&_[cmdk-group-heading]]:tw-px-4 [&_[cmdk-group-heading]]:tw-mb-2 [&_[cmdk-group-heading]]:tw-bg-muted [&_[cmdk-group]]:!tw-border-0',
                     commandListClassName
                 )}
             >
@@ -174,12 +160,43 @@ export const PromptList: React.FunctionComponent<{
                         onValueChange={setQuery}
                         placeholder="Search..."
                         autoFocus={true}
-                        wrapperClassName="!tw-border-0 tw-mb-3 tw-px-2"
-                        className="!tw-border-border tw-rounded-md focus:!tw-border-ring !tw-py-3"
                     />
                 )}
                 {result && result.prompts.type !== 'unsupported' && (
-                    <CommandGroup className="[&_[cmdk-group-items]]:tw-space-y-4">
+                    <CommandGroup
+                        heading={
+                            <>
+                                <span>Prompt Library</span>
+                                <div className="tw-flex-grow" />
+                                <Button variant="ghost" size="sm" asChild>
+                                    <a
+                                        href={new URL('/prompts', endpointURL).toString()}
+                                        target="_blank"
+                                        rel="noreferrer"
+                                        className="!tw-text-[unset]"
+                                    >
+                                        Manage
+                                    </a>
+                                </Button>
+                                <Button
+                                    variant="ghost"
+                                    size="sm"
+                                    className="tw-flex tw-items-center tw-gap-0.5"
+                                    asChild
+                                >
+                                    <a
+                                        href={new URL('/prompts/new', endpointURL).toString()}
+                                        target="_blank"
+                                        rel="noreferrer"
+                                        className="!tw-text-[unset]"
+                                    >
+                                        <PlusIcon size={12} strokeWidth={1.25} />
+                                        New
+                                    </a>
+                                </Button>
+                            </>
+                        }
+                    >
                         {result.prompts.type === 'results' ? (
                             <>
                                 {result.prompts.results.length === 0 && (
@@ -210,17 +227,6 @@ export const PromptList: React.FunctionComponent<{
                                         prompt={prompt}
                                         onSelect={onSelect}
                                         selectActionLabel={onSelectActionLabels?.prompt}
-                                        className={itemClassName}
-                                    />
-                                ))}
-                                {result?.commands?.map(command => (
-                                    <CodyCommandItem
-                                        key={command.key}
-                                        command={command}
-                                        onSelect={onSelect}
-                                        selectActionLabel={onSelectActionLabels?.command}
-                                        showCommandOrigins={showCommandOrigins}
-                                        className={itemClassName}
                                     />
                                 ))}
                             </>
@@ -230,7 +236,36 @@ export const PromptList: React.FunctionComponent<{
                         )}
                     </CommandGroup>
                 )}
-
+                {result && filteredCommands && filteredCommands.length > 0 && (
+                    <CommandGroup
+                        heading={
+                            <>
+                                <span>Commands</span>
+                                <div className="tw-flex-grow" />
+                                {hasCustomCommands(filteredCommands) && (
+                                    <Button variant="ghost" size="sm" asChild>
+                                        <a
+                                            className="!tw-text-[unset]"
+                                            href="command:cody.menu.commands-settings"
+                                        >
+                                            Manage
+                                        </a>
+                                    </Button>
+                                )}
+                            </>
+                        }
+                    >
+                        {filteredCommands.map(command => (
+                            <CodyCommandItem
+                                key={command.key}
+                                command={command}
+                                onSelect={onSelect}
+                                selectActionLabel={onSelectActionLabels?.command}
+                                showCommandOrigins={showCommandOrigins}
+                            />
+                        ))}
+                    </CommandGroup>
+                )}
                 {showPromptLibraryUnsupportedMessage &&
                     result &&
                     result.prompts.type === 'unsupported' && (
@@ -248,22 +283,15 @@ export const PromptList: React.FunctionComponent<{
                         Error: {error.message || 'unknown'}
                     </CommandLoading>
                 )}
-
-                {showSwitchToPromptAction && (
-                    <CommandRow className="tw-items-center tw-justify-center tw-py-4">
-                        <Button variant="ghost" size="sm" asChild>
-                            <button
-                                type="button"
-                                className="!tw-text-muted-foreground !hover:tw-text-button-foreground"
-                                onClick={onSwitchToPromptsTab}
-                            >
-                                Switch to Prompt Library
-                            </button>
-                        </Button>
-                    </CommandRow>
-                )}
             </CommandList>
         </Command>
+    )
+}
+
+function hasCustomCommands(commands: CodyCommand[]): boolean {
+    return commands.some(
+        command =>
+            command.type === CustomCommandType.Workspace || command.type === CustomCommandType.User
     )
 }
 
@@ -275,24 +303,18 @@ const PromptCommandItem: FunctionComponent<{
     prompt: Prompt
     onSelect: (value: string) => void
     selectActionLabel: SelectActionLabel | undefined
-    className?: string
-}> = ({ prompt, onSelect, selectActionLabel, className }) => (
+}> = ({ prompt, onSelect, selectActionLabel }) => (
     <CommandItem
         value={commandRowValue({ type: 'prompt', value: prompt })}
         onSelect={onSelect}
-        className={clsx('!tw-items-start tw-overflow-hidden tw-gap-3 tw-group/[cmdk-item]', className)}
+        className="!tw-items-start tw-group/[cmdk-item]"
     >
-        <UserAvatar
-            user={{
-                username: prompt.owner.namespaceName,
-                displayName: prompt.owner.displayName ?? undefined,
-            }}
-            size={22}
-            className="tw-flex-shrink-0 tw-text-xxs"
-        />
-        <div className="tw-text-nowrap tw-text-ellipsis tw-overflow-hidden">
-            <div className="tw-flex tw-text-nowrap tw-gap-3 tw-w-full tw-items-start tw-overflow-hidden">
-                <span className="">{prompt.name}</span>
+        <div>
+            <div className="tw-flex tw-gap-3 tw-w-full tw-items-start">
+                <span>
+                    <span className="tw-text-muted-foreground">{prompt.owner.namespaceName} / </span>
+                    <strong>{prompt.name}</strong>
+                </span>
                 {prompt.draft && (
                     <Badge variant="secondary" className="tw-text-xxs tw-mt-0.5">
                         Draft
@@ -300,9 +322,13 @@ const PromptCommandItem: FunctionComponent<{
                 )}
             </div>
             {prompt.description && (
-                <span className="tw-text-muted-foreground tw-w-full">{prompt.description}</span>
+                <span className="tw-text-xs tw-text-muted-foreground tw-text-nowrap tw-overflow-hidden tw-text-ellipsis tw-w-full">
+                    {prompt.description}
+                </span>
             )}
         </div>
+        <div className="tw-flex-grow" />
+        {selectActionLabel && <CommandItemAction label={selectActionLabel} />}
     </CommandItem>
 )
 
@@ -311,28 +337,22 @@ const CodyCommandItem: FunctionComponent<{
     onSelect: (value: string) => void
     selectActionLabel: SelectActionLabel | undefined
     showCommandOrigins: boolean
-    className?: string
-}> = ({ command, onSelect, selectActionLabel, showCommandOrigins, className }) => (
+}> = ({ command, onSelect, selectActionLabel, showCommandOrigins }) => (
     <CommandItem
         value={commandRowValue({ type: 'command', value: command })}
         onSelect={onSelect}
-        className={clsx('!tw-items-start tw-overflow-hidden tw-gap-3 tw-group/[cmdk-item]', className)}
+        className="!tw-items-start tw-group/[cmdk-item]"
     >
-        <div className="tw-w-[22px] tw-flex-shrink-0">
-            <CommandItemIcon
-                command={command}
-                size={13}
-                className="tw-text-muted-foreground tw-mt-2 tw-mx-auto"
-            />
-        </div>
-        <div className="tw-text-nowrap tw-text-ellipsis tw-overflow-hidden">
+        <div>
             <div className="tw-flex tw-flex-wrap tw-gap-3 tw-w-full tw-items-start">
-                <span className="tw-whitespace-nowrap">
+                <strong className="tw-whitespace-nowrap">
                     {command.type === 'default' ? command.description : command.key}
-                </span>
+                </strong>
                 {showCommandOrigins && command.type !== 'default' && (
                     <Badge variant="secondary" className="tw-text-xxs tw-mt-0.5 tw-whitespace-nowrap">
-                        Custom Command
+                        {command.type === CustomCommandType.User
+                            ? 'Local User Settings'
+                            : 'Workspace Settings'}
                     </Badge>
                 )}
             </div>
@@ -342,30 +362,49 @@ const CodyCommandItem: FunctionComponent<{
                 </span>
             )}
         </div>
+        <div className="tw-flex-grow" />
+        {selectActionLabel && <CommandItemAction label={selectActionLabel} />}
     </CommandItem>
 )
 
-const CommandItemIcon: FunctionComponent<{ command: CodyCommand; size: number; className?: string }> = ({
-    command,
-    size,
+/** Indicator for what will occur when a CommandItem is selected. */
+const CommandItemAction: FunctionComponent<{ label: SelectActionLabel; className?: string }> = ({
+    label,
     className,
-}) => {
-    const Icon = iconForCommand(command)
-    return <Icon size={size} className={className} />
-}
+}) => (
+    <Tooltip>
+        <TooltipTrigger asChild>
+            <Button
+                type="button"
+                variant="default"
+                size="xs"
+                className={clsx(
+                    'tw-tracking-tight tw-text-accent-foreground tw-opacity-30 tw-bg-transparent hover:tw-bg-transparent tw-invisible group-[[aria-selected="true"]]/[cmdk-item]:tw-visible group-hover/[cmdk-item]:tw-visible',
+                    className
+                )}
+            >
+                {label === 'insert' ? 'Insert' : 'Run'}
+            </Button>
+        </TooltipTrigger>
+        <TooltipContent>
+            {label === 'insert'
+                ? 'Append prompt text to chat message'
+                : 'Run command on current selection in editor'}
+        </TooltipContent>
+    </Tooltip>
+)
 
-function iconForCommand(command: CodyCommand): (typeof ICON_KEYWORDS)[number]['icon'] {
-    return ICON_KEYWORDS.find(icon => command.key.toLowerCase().includes(icon.keyword))?.icon ?? PlayIcon
-}
-
-const ICON_KEYWORDS: { keyword: string; icon: LucideIcon }[] = [
-    { keyword: 'edit', icon: PencilIcon },
-    { keyword: 'doc', icon: BookOpenIcon },
-    { keyword: 'explain', icon: FileQuestionIcon },
-    { keyword: 'test', icon: HammerIcon },
-    { keyword: 'fix', icon: BugIcon },
-    { keyword: 'debug', icon: BugIcon },
-    { keyword: 'secur', icon: ShieldCheckIcon },
-    { keyword: 'refactor', icon: CombineIcon },
-    { keyword: 'review', icon: MessageCircleCode },
-]
+/**
+ * A variant of {@link PromptList} that is visually more suited for a non-popover.
+ */
+export const PromptListSuitedForNonPopover: FunctionComponent<
+    Omit<ComponentProps<typeof PromptList>, 'showSearch' | 'showInitialSelectedItem'>
+> = ({ className, commandListClassName, ...props }) => (
+    <PromptList
+        {...props}
+        showSearch={false}
+        showInitialSelectedItem={false}
+        className={clsx('tw-w-full !tw-max-w-[unset] !tw-bg-[unset]', className)}
+        commandListClassName={clsx('!tw-max-h-[unset]', commandListClassName)}
+    />
+)

--- a/vscode/webviews/components/promptList/fixtures.ts
+++ b/vscode/webviews/components/promptList/fixtures.ts
@@ -1,62 +1,10 @@
 import {
     type CodyCommand,
     CustomCommandType,
-    type Prompt,
     type PromptsResult,
     type WebviewToExtensionAPI,
     promiseFactoryToObservable,
 } from '@sourcegraph/cody-shared'
-
-export const FIXTURE_PROMPTS: Prompt[] = [
-    {
-        id: '1',
-        name: 'TypeScript Vitest Test',
-        nameWithOwner: 'alice/TypeScript Vitest Test',
-        owner: { namespaceName: 'alice', displayName: 'Alice Zhao' },
-        description: 'Generate unit tests for a given function',
-        draft: false,
-        definition: { text: 'Generate unit tests for vitest' },
-        url: 'https://example.com',
-    },
-    {
-        id: '2',
-        name: 'Review OpenCtx Provider',
-        nameWithOwner: 'alice/Review OpenCtx Provider',
-        owner: { namespaceName: 'alice', displayName: 'Alice Zhao' },
-        description: 'Suggest improvements for an OpenCtx provider',
-        draft: true,
-        definition: { text: 'Review the following OpenCtx provider code' },
-        url: 'https://example.com',
-    },
-    {
-        id: '3',
-        name: 'Generate JUnit Integration Test',
-        nameWithOwner: 'myorg/Generate JUnit Integration Test',
-        owner: { namespaceName: 'myorg', displayName: 'My Org' },
-        draft: false,
-        definition: { text: 'Generate a JUnit integration test' },
-        url: 'https://example.com',
-    },
-    {
-        id: '4',
-        name: 'Fix Bazel Build File',
-        nameWithOwner: 'myorg/Fix Bazel Build File',
-        owner: { namespaceName: 'myorg', displayName: 'My Org' },
-        draft: false,
-        definition: { text: 'Fix common issues in this Bazel BUILD file' },
-        url: 'https://example.com',
-    },
-    {
-        id: '5',
-        name: 'Convert from React Class to Function Component',
-        nameWithOwner: 'abc-corp/Convert from React Class to Function Component',
-        owner: { namespaceName: 'abc-corp', displayName: 'ABC Corp' },
-        description: 'Convert from a React class component to a function component',
-        draft: false,
-        definition: { text: 'Convert from a React class component to a function component' },
-        url: 'https://example.com',
-    },
-]
 
 export const FIXTURE_COMMANDS: CodyCommand[] = [
     {

--- a/vscode/webviews/components/promptSelectField/PromptSelectField.story.tsx
+++ b/vscode/webviews/components/promptSelectField/PromptSelectField.story.tsx
@@ -1,0 +1,24 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { VSCodeStandaloneComponent } from '../../storybook/VSCodeStoryDecorator'
+import { PromptSelectField } from './PromptSelectField'
+
+const meta: Meta<typeof PromptSelectField> = {
+    title: 'cody/PromptSelectField',
+    component: PromptSelectField,
+    decorators: [
+        story => <div style={{ width: '400px', maxHeight: 'max(300px, 80vh)' }}> {story()} </div>,
+        VSCodeStandaloneComponent,
+    ],
+    args: {
+        __storybook__open: true,
+        onSelect: () => {},
+    },
+}
+
+export default meta
+
+type Story = StoryObj<typeof PromptSelectField>
+
+export const Default: Story = {
+    args: {},
+}

--- a/vscode/webviews/components/promptSelectField/PromptSelectField.tsx
+++ b/vscode/webviews/components/promptSelectField/PromptSelectField.tsx
@@ -1,0 +1,70 @@
+import { useCallback } from 'react'
+import { useTelemetryRecorder } from '../../utils/telemetry'
+import { PromptList, type PromptOrDeprecatedCommand } from '../promptList/PromptList'
+import { ToolbarPopoverItem } from '../shadcn/ui/toolbar'
+import { cn } from '../shadcn/utils'
+
+export const PromptSelectField: React.FunctionComponent<{
+    onSelect: (item: PromptOrDeprecatedCommand) => void
+    onCloseByEscape?: () => void
+    className?: string
+
+    /** For storybooks only. */
+    __storybook__open?: boolean
+}> = ({ onSelect, onCloseByEscape, className, __storybook__open }) => {
+    const telemetryRecorder = useTelemetryRecorder()
+
+    const onOpenChange = useCallback(
+        (open: boolean): void => {
+            if (open) {
+                telemetryRecorder.recordEvent('cody.promptSelectField', 'open', {})
+            }
+        },
+        [telemetryRecorder.recordEvent]
+    )
+
+    const onKeyDown = useCallback(
+        (event: React.KeyboardEvent<HTMLDivElement>) => {
+            if (event.key === 'Escape') {
+                onCloseByEscape?.()
+            }
+        },
+        [onCloseByEscape]
+    )
+
+    return (
+        <ToolbarPopoverItem
+            role="combobox"
+            iconEnd="chevron"
+            className={cn('tw-justify-between', className)}
+            __storybook__open={__storybook__open}
+            tooltip="Insert prompt from Prompt Library"
+            aria-label="Insert prompt"
+            popoverContent={close => (
+                <PromptList
+                    onSelect={item => {
+                        onSelect(item)
+                        close()
+                    }}
+                    onSelectActionLabels={{ prompt: 'insert', command: 'insert' }}
+                    showSearch={true}
+                    showOnlyPromptInsertableCommands={true}
+                    showPromptLibraryUnsupportedMessage={true}
+                    telemetryLocation="PromptSelectField"
+                />
+            )}
+            popoverRootProps={{ onOpenChange }}
+            popoverContentProps={{
+                className: 'tw-min-w-[325px] tw-w-[75vw] tw-max-w-[550px] !tw-p-0',
+                onKeyDown: onKeyDown,
+                onCloseAutoFocus: event => {
+                    // Prevent the popover trigger from stealing focus after the user selects an
+                    // item. We want the focus to return to the editor.
+                    event.preventDefault()
+                },
+            }}
+        >
+            Prompts
+        </ToolbarPopoverItem>
+    )
+}

--- a/vscode/webviews/components/promptSelectField/fixtures.ts
+++ b/vscode/webviews/components/promptSelectField/fixtures.ts
@@ -1,0 +1,53 @@
+import type { Prompt } from '@sourcegraph/cody-shared'
+
+export const FIXTURE_PROMPTS: Prompt[] = [
+    {
+        id: '1',
+        name: 'typescript-vitest-test',
+        nameWithOwner: 'alice/typescript-vitest-test',
+        owner: { namespaceName: 'alice' },
+        description: 'Generate unit tests for a given function',
+        draft: false,
+        definition: { text: 'Generate unit tests for vitest' },
+        url: 'https://example.com',
+    },
+    {
+        id: '2',
+        name: 'review-openctx-provider',
+        nameWithOwner: 'alice/review-openctx-provider',
+        owner: { namespaceName: 'alice' },
+        description: 'Suggest improvements for an OpenCtx provider',
+        draft: true,
+        definition: { text: 'Review the following OpenCtx provider code' },
+        url: 'https://example.com',
+    },
+    {
+        id: '3',
+        name: 'generate-junit-integration-test',
+        nameWithOwner: 'myorg/generate-junit-integration-test',
+        owner: { namespaceName: 'myorg' },
+        draft: false,
+        definition: { text: 'Generate a JUnit integration test' },
+        url: 'https://example.com',
+    },
+    {
+        id: '4',
+        name: 'fix-bazel-build-file',
+        nameWithOwner: 'myorg/fix-bazel-build-file',
+        owner: { namespaceName: 'myorg' },
+        draft: false,
+        definition: { text: 'Fix common issues in this Bazel BUILD file' },
+        url: 'https://example.com',
+    },
+    {
+        id: '5',
+        name: 'convert-from-react-class-to-fc',
+        nameWithOwner: 'abc-corp/convert-from-react-class-to-fc',
+        owner: { namespaceName: 'abc-corp' },
+        // Long text to test wrapping.
+        description: 'Convert from a React class component to a function component',
+        draft: false,
+        definition: { text: 'Convert from a React class component to a function component' },
+        url: 'https://example.com',
+    },
+]

--- a/vscode/webviews/components/shadcn/ui/command.tsx
+++ b/vscode/webviews/components/shadcn/ui/command.tsx
@@ -20,12 +20,9 @@ Command.displayName = CommandPrimitive.displayName
 
 const CommandInput = React.forwardRef<
     React.ElementRef<typeof CommandPrimitive.Input>,
-    React.ComponentPropsWithoutRef<typeof CommandPrimitive.Input> & { wrapperClassName?: string }
->(({ wrapperClassName, className, ...props }, ref) => (
-    <div
-        className={cn('tw-flex tw-items-center tw-border-b tw-border-b-border', wrapperClassName)}
-        cmdk-input-wrapper=""
-    >
+    React.ComponentPropsWithoutRef<typeof CommandPrimitive.Input>
+>(({ className, ...props }, ref) => (
+    <div className="tw-flex tw-items-center tw-border-b tw-border-b-border" cmdk-input-wrapper="">
         <CommandPrimitive.Input
             ref={ref}
             className={cn(
@@ -113,7 +110,7 @@ const CommandItem = React.forwardRef<
         <CommandPrimitive.Item
             ref={ref}
             className={cn(
-                'tw-relative tw-flex tw-cursor-pointer tw-select-none tw-items-center tw-rounded-sm tw-py-3 tw-px-2 tw-text-md tw-outline-none aria-selected:tw-bg-accent aria-selected:tw-text-accent-foreground hover:tw-bg-accent hover:tw-text-accent-foreground hover:tw-border-accent data-[disabled=true]:tw-pointer-events-none data-[disabled=true]:tw-opacity-50',
+                'tw-relative tw-flex tw-cursor-pointer tw-select-none tw-items-center tw-rounded-sm tw-py-3 tw-px-2 tw-text-md tw-outline-none aria-selected:tw-bg-accent aria-selected:tw-text-accent-foreground hover:tw-bg-accent hover:tw-text-accent-foreground data-[disabled=true]:tw-pointer-events-none data-[disabled=true]:tw-opacity-50',
                 className
             )}
             title={tooltip}

--- a/vscode/webviews/prompts/PromptsTab.story.tsx
+++ b/vscode/webviews/prompts/PromptsTab.story.tsx
@@ -1,10 +1,7 @@
 import { ExtensionAPIProviderForTestsOnly, MOCK_API } from '@sourcegraph/prompt-editor'
 import type { Meta, StoryObj } from '@storybook/react'
-import {
-    FIXTURE_COMMANDS,
-    FIXTURE_PROMPTS,
-    makePromptsAPIWithData,
-} from '../components/promptList/fixtures'
+import { FIXTURE_COMMANDS, makePromptsAPIWithData } from '../components/promptList/fixtures'
+import { FIXTURE_PROMPTS } from '../components/promptSelectField/fixtures'
 import { VSCodeStandaloneComponent } from '../storybook/VSCodeStoryDecorator'
 import { PromptsTab } from './PromptsTab'
 
@@ -47,22 +44,6 @@ export const WithOnlyCommands: Story = {
                 prompts: makePromptsAPIWithData({
                     prompts: { type: 'unsupported' },
                     commands: FIXTURE_COMMANDS,
-                }),
-            }}
-        >
-            <PromptsTab {...args} />
-        </ExtensionAPIProviderForTestsOnly>
-    ),
-}
-
-export const WithOnlyPrompts: Story = {
-    render: args => (
-        <ExtensionAPIProviderForTestsOnly
-            value={{
-                ...MOCK_API,
-                prompts: makePromptsAPIWithData({
-                    prompts: { type: 'results', results: FIXTURE_PROMPTS },
-                    commands: undefined,
                 }),
             }}
         >

--- a/vscode/webviews/prompts/PromptsTab.tsx
+++ b/vscode/webviews/prompts/PromptsTab.tsx
@@ -1,26 +1,27 @@
-import type { CodyIDE } from '@sourcegraph/cody-shared'
 import type { ComponentProps } from 'react'
 import { useClientActionDispatcher } from '../client/clientState'
-import { PromptList, type PromptOrDeprecatedCommand } from '../components/promptList/PromptList'
+import {
+    type PromptList,
+    PromptListSuitedForNonPopover,
+    type PromptOrDeprecatedCommand,
+} from '../components/promptList/PromptList'
 import { View } from '../tabs/types'
 import { getVSCodeAPI } from '../utils/VSCodeApi'
 
 export const PromptsTab: React.FC<{
-    IDE: CodyIDE
     setView: (view: View) => void
 }> = ({ setView }) => {
     const dispatchClientAction = useClientActionDispatcher()
     return (
         <div className="tw-overflow-auto tw-p-8">
-            <PromptList
+            <PromptListSuitedForNonPopover
                 onSelect={item => onPromptSelectInPanel(item, setView, dispatchClientAction)}
                 onSelectActionLabels={onPromptSelectInPanelActionLabels}
                 showCommandOrigins={true}
-                showSearch={true}
-                showInitialSelectedItem={false}
-                showSwitchToPromptAction={false}
                 showPromptLibraryUnsupportedMessage={true}
+                showOnlyPromptInsertableCommands={false}
                 telemetryLocation="PromptsTab"
+                className="tw-border tw-border-border"
             />
         </div>
     )

--- a/vscode/webviews/tabs/TabsBar.tsx
+++ b/vscode/webviews/tabs/TabsBar.tsx
@@ -6,12 +6,10 @@ import {
     BookTextIcon,
     CircleUserIcon,
     DownloadIcon,
-    ExternalLink,
     HistoryIcon,
     type LucideProps,
     MessageSquarePlusIcon,
     MessagesSquareIcon,
-    PlusCircle,
     SettingsIcon,
     Trash2Icon,
 } from 'lucide-react'
@@ -25,7 +23,6 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '../components/shadcn/ui
 import { useConfig } from '../utils/useConfig'
 
 import { Button } from '../components/shadcn/ui/button'
-
 import styles from './TabsBar.module.css'
 import { getCreateNewChatCommand } from './utils'
 
@@ -49,7 +46,6 @@ interface TabSubAction {
     command: string
     arg?: string | undefined | null
     callback?: () => void
-    uri?: string
     confirmation?: {
         title: string
         description: string
@@ -146,7 +142,7 @@ export const TabsBar: React.FC<TabsBarProps> = ({ currentView, setView, IDE, onD
                 </div>
                 <div className={styles.subTabs}>
                     {currentViewSubActions.map(subAction => (
-                        <Fragment key={`${subAction.command}/${subAction.uri ?? ''}`}>
+                        <Fragment key={subAction.command}>
                             {subAction.confirmation ? (
                                 <ActionButtonWithConfirmation
                                     title={subAction.title}
@@ -163,7 +159,6 @@ export const TabsBar: React.FC<TabsBarProps> = ({ currentView, setView, IDE, onD
                                 <TabButton
                                     Icon={subAction.Icon}
                                     title={subAction.title}
-                                    uri={subAction.uri}
                                     IDE={IDE}
                                     alwaysShowTitle={true}
                                     tooltipExtra={subAction.tooltipExtra}
@@ -258,7 +253,6 @@ interface TabButtonProps {
     title: string
     Icon: IconComponent
     IDE: CodyIDE
-    uri?: string
     view?: View
     isActive?: boolean
     onClick?: () => void
@@ -276,7 +270,6 @@ export const TabButton = forwardRef<HTMLButtonElement, TabButtonProps>((props, r
         Icon,
         isActive,
         onClick,
-        uri,
         title,
         alwaysShowTitle,
         tooltipExtra,
@@ -284,20 +277,15 @@ export const TabButton = forwardRef<HTMLButtonElement, TabButtonProps>((props, r
         'data-testid': dataTestId,
     } = props
 
-    const Component = uri ? 'a' : 'button'
-
     return (
         <Tooltip>
             <TooltipTrigger asChild>
-                <Component
-                    type={uri ? undefined : 'button'}
-                    onClick={uri ? undefined : onClick}
-                    href={uri}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    ref={ref as any}
+                <button
+                    type="button"
+                    onClick={onClick}
+                    ref={ref}
                     className={clsx(
-                        'tw-flex tw-gap-3 tw-items-center tw-leading-none tw-py-3 tw-px-2 !tw-font-normal !tw-text-inherit tw-opacity-80 hover:tw-opacity-100 tw-border-b-[1px] tw-border-transparent tw-transition tw-translate-y-[1px]',
+                        'tw-flex tw-gap-3 tw-items-center tw-leading-none tw-py-3 tw-px-2 tw-opacity-80 hover:tw-opacity-100 tw-border-b-[1px] tw-border-transparent tw-transition tw-translate-y-[1px]',
                         {
                             '!tw-opacity-100 !tw-border-[var(--vscode-tab-activeBorderTop)]': isActive,
                             '!tw-opacity-100': prominent,
@@ -307,7 +295,7 @@ export const TabButton = forwardRef<HTMLButtonElement, TabButtonProps>((props, r
                 >
                     <Icon size={16} strokeWidth={1.25} className="tw-w-8 tw-h-8" />
                     <span className={alwaysShowTitle ? '' : styles.tabActionLabel}>{title}</span>
-                </Component>
+                </button>
             </TooltipTrigger>
             <TooltipContent portal={IDE === CodyIDE.Web}>
                 {title} {tooltipExtra}
@@ -325,7 +313,7 @@ TabButton.displayName = 'TabButton'
 function useTabs(input: Pick<TabsBarProps, 'IDE' | 'onDownloadChatClick'>): TabConfig[] {
     const { IDE, onDownloadChatClick } = input
     const {
-        config: { multipleWebviewsEnabled, serverEndpoint },
+        config: { multipleWebviewsEnabled },
     } = useConfig()
 
     return useMemo<TabConfig[]>(
@@ -380,20 +368,6 @@ function useTabs(input: Pick<TabsBarProps, 'IDE' | 'onDownloadChatClick'>): TabC
                         title: IDE === CodyIDE.Web ? 'Prompts' : 'Prompts & Commands',
                         Icon: BookTextIcon,
                         changesView: true,
-                        subActions: [
-                            {
-                                title: 'Create prompt',
-                                Icon: PlusCircle,
-                                command: '',
-                                uri: `${serverEndpoint}prompts/new`,
-                            },
-                            {
-                                title: 'Open prompts library',
-                                Icon: ExternalLink,
-                                command: '',
-                                uri: `${serverEndpoint}prompts`,
-                            },
-                        ],
                     },
                     multipleWebviewsEnabled
                         ? {
@@ -414,6 +388,6 @@ function useTabs(input: Pick<TabsBarProps, 'IDE' | 'onDownloadChatClick'>): TabC
                         : null,
                 ] as (TabConfig | null)[]
             ).filter(isDefined),
-        [IDE, onDownloadChatClick, multipleWebviewsEnabled, serverEndpoint]
+        [IDE, onDownloadChatClick, multipleWebviewsEnabled]
     )
 }

--- a/web/CHANGELOG.md
+++ b/web/CHANGELOG.md
@@ -1,4 +1,7 @@
-# 0.7.6
+## 0.7.7 
+- Revert "prompts and commands" new UI 
+
+## 0.7.6
 - The "Prompts" toolbar item in chat is no longer displayed. To use a prompt from the prompt library, select it from the list shown on the chat tab or prompts tab.
 
 ## 0.7.5 

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sourcegraph/cody-web",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "description": "Cody standalone web app",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
Revert https://github.com/sourcegraph/cody/pull/5438

This PR reverts new prompts UI, reasoning 
- The new UI doesn't take into account a good zero/empty state
- The current JetBrains integration doesn't use the new prompt UI due to a release freeze in the JetBrains integration repository 

We will include a new polished UI in the next stable release

| Before | After |
| ------ | ------ |
| <img width="408" alt="Screenshot 2024-09-02 at 20 24 49" src="https://github.com/user-attachments/assets/305df1fb-63cc-4fe3-9e18-12b685257395"> | <img width="408" alt="Screenshot 2024-09-02 at 20 25 42" src="https://github.com/user-attachments/assets/018f833e-83b1-443c-9dbe-ec66328c2014"> |

## Test plan
- CI is green 

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
