### PR TITLE
Dev: add support for configurable model options

### DIFF
--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/agent/protocol_generated/ClientSideConfig.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/agent/protocol_generated/ClientSideConfig.kt
@@ -5,5 +5,6 @@ data class ClientSideConfig(
   val apiKey: String? = null,
   val apiEndpoint: String? = null,
   val openAICompatible: OpenAICompatible? = null,
+  val options: Map<String, Any>? = null,
 )
 

--- a/lib/shared/src/llm-providers/anthropic/chat-client.ts
+++ b/lib/shared/src/llm-providers/anthropic/chat-client.ts
@@ -47,8 +47,9 @@ export async function anthropicChatClient({
                 top_k: params.topK,
                 top_p: params.topP,
                 stop_sequences: params.stopSequences,
-                stream: true,
+                stream: config?.stream || true,
                 system: `${systemPrompt}`,
+                ...config?.options,
             })
             .then(async stream => {
                 onAbort(signal, () => stream.controller.abort())

--- a/lib/shared/src/llm-providers/groq/chat-client.ts
+++ b/lib/shared/src/llm-providers/groq/chat-client.ts
@@ -43,7 +43,7 @@ export async function groqChatClient({
         messages: await Promise.all(
             params.messages.map(async msg => ({
                 role: msg.speaker === 'human' ? 'user' : 'assistant',
-                content: await msg.text?.toFilteredString(contextFiltersProvider.instance!) ?? '',
+                content: (await msg.text?.toFilteredString(contextFiltersProvider.instance!)) ?? '',
             }))
         ),
         ...(isCortex && {

--- a/lib/shared/src/llm-providers/groq/chat-client.ts
+++ b/lib/shared/src/llm-providers/groq/chat-client.ts
@@ -38,31 +38,61 @@ export async function groqChatClient({
     const isCortex = config?.endpoint?.includes(':1337')
 
     const chatParams = {
+        ...config?.options,
         model: config?.model,
         messages: await Promise.all(
-            params.messages.map(async msg => {
-                return {
-                    role: msg.speaker === 'human' ? 'user' : 'assistant',
-                    content: (await msg.text?.toFilteredString(contextFiltersProvider.instance!)) ?? '',
-                }
-            })
+            params.messages.map(async msg => ({
+                role: msg.speaker === 'human' ? 'user' : 'assistant',
+                content: await msg.text?.toFilteredString(contextFiltersProvider.instance!) ?? '',
+            }))
         ),
-        stream: true,
-        ...(isCortex
-            ? {
-                  max_tokens: 1000,
-                  stop: [],
-                  frequency_penalty: 0,
-                  presence_penalty: 0,
-                  temperature: 0.1,
-                  top_p: -1,
-              }
-            : {}),
+        ...(isCortex && {
+            max_tokens: 1000,
+            stop: [],
+            frequency_penalty: 0,
+            presence_penalty: 0,
+            temperature: 0.1,
+            top_p: -1,
+        }),
     }
 
+    const completionResponse: CompletionResponse = {
+        completion: '',
+        stopReason: CompletionStopReason.RequestFinished,
+    }
+
+    // Non-stream requests
+    if (!config?.stream) {
+        try {
+            const response = await fetch(config?.endpoint ?? GROQ_CHAT_API_URL, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    Authorization: `Bearer ${config.key}`,
+                },
+                body: JSON.stringify(chatParams),
+                signal,
+            })
+
+            if (!response.ok) {
+                throw new Error(`HTTP error! status: ${response.status}`)
+            }
+
+            const { choices } = await response.json()
+            completionResponse.completion = choices[0]?.message?.content ?? ''
+            cb.onChange(completionResponse.completion)
+            cb.onComplete()
+        } catch (error) {
+            cb.onError(error instanceof Error ? error : new Error('Unknown error occurred'))
+        }
+        log?.onComplete(completionResponse)
+        return
+    }
+
+    // Stream requests
     fetch(config?.endpoint ?? GROQ_CHAT_API_URL, {
         method: 'POST',
-        body: JSON.stringify(chatParams),
+        body: JSON.stringify({ chatParams, stream: true }),
         headers: {
             'Content-Type': 'application/json',
             Authorization: `Bearer ${config.key}`,
@@ -85,14 +115,13 @@ export async function groqChatClient({
 
             onAbort(signal, () => reader.cancel())
 
-            let responseText = ''
             const textDecoder = new TextDecoder()
 
             // Handles the response stream to accumulate the full completion text.
             while (true) {
                 const { done, value } = await reader.read()
                 if (done) {
-                    cb.onChange(responseText)
+                    cb.onChange(completionResponse.completion)
                     cb.onComplete()
                     break
                 }
@@ -109,8 +138,8 @@ export async function groqChatClient({
                             const message = parsedData.choices?.[0]?.delta?.content
 
                             if (message) {
-                                responseText += message
-                                cb.onChange(responseText)
+                                completionResponse.completion += message
+                                cb.onChange(completionResponse.completion)
                             }
 
                             if (parsedData.error) {
@@ -121,11 +150,6 @@ export async function groqChatClient({
                         }
                     }
                 }
-            }
-
-            const completionResponse: CompletionResponse = {
-                completion: responseText,
-                stopReason: CompletionStopReason.RequestFinished,
             }
             log?.onComplete(completionResponse)
         })

--- a/lib/shared/src/llm-providers/index.ts
+++ b/lib/shared/src/llm-providers/index.ts
@@ -8,7 +8,7 @@ export type CompletionsModelConfig = {
     key: string
     endpoint?: string
     stream?: boolean
-    options?: Record<string, string | number | boolean>
+    options?: Record<string, any>
 }
 
 export interface ChatNetworkClientParams {

--- a/lib/shared/src/llm-providers/index.ts
+++ b/lib/shared/src/llm-providers/index.ts
@@ -7,6 +7,8 @@ export type CompletionsModelConfig = {
     model: string
     key: string
     endpoint?: string
+    stream?: boolean
+    options?: Record<string, string | number | boolean>
 }
 
 export interface ChatNetworkClientParams {

--- a/lib/shared/src/llm-providers/ollama/chat-client.ts
+++ b/lib/shared/src/llm-providers/ollama/chat-client.ts
@@ -52,8 +52,9 @@ export async function ollamaChatClient({
                     top_k: params.topK,
                     top_p: params.topP,
                     tfs_z: params.maxTokensToSample,
+                    ...config?.options,
                 },
-                stream: true,
+                stream: config?.stream || true,
             })
             .then(
                 async res => {

--- a/lib/shared/src/llm-providers/utils.ts
+++ b/lib/shared/src/llm-providers/utils.ts
@@ -2,20 +2,24 @@ import type { CompletionsModelConfig } from '.'
 import { modelsService } from '../models'
 
 export function getCompletionsModelConfig(modelID: string): CompletionsModelConfig | undefined {
-    const provider = modelsService.instance!.getModelByID(modelID)
+    const provider = modelsService.instance?.getModelByID(modelID)
     if (!provider) {
         return undefined
     }
 
-    const {
-        id: model,
-        clientSideConfig: { apiKey = '', apiEndpoint } = {},
-    } = provider
-    const strippedModelName = model.split('/').pop() || model
+    const { id, clientSideConfig = {} } = provider
+    const { apiKey = '', apiEndpoint, options = {} } = clientSideConfig
+
+    const model = id.split('/').pop() || id
+    const stream = Boolean(options.stream ?? true)
+
+    const { stream: _, ...restOptions } = options
 
     return {
-        model: strippedModelName,
+        model,
         key: apiKey,
         endpoint: apiEndpoint,
+        stream,
+        options: restOptions,
     }
 }

--- a/lib/shared/src/llm-providers/utils.ts
+++ b/lib/shared/src/llm-providers/utils.ts
@@ -11,9 +11,9 @@ export function getCompletionsModelConfig(modelID: string): CompletionsModelConf
     const { apiKey = '', apiEndpoint, options = {} } = clientSideConfig
 
     const model = id.split('/').pop() || id
-    const stream = Boolean(options.stream ?? true)
+    const stream = Boolean(options?.stream ?? true)
 
-    const { stream: _, ...restOptions } = options
+    const { stream: _, ...restOptions } = options || {}
 
     return {
         model,

--- a/lib/shared/src/models/index.ts
+++ b/lib/shared/src/models/index.ts
@@ -44,6 +44,11 @@ interface ClientSideConfig {
      * allow the site admin to set configuration params
      */
     openAICompatible?: OpenAICompatible
+    /**
+     * The additional setting options for the model.
+     * E.g. `{"temperature": 0.5, "max_tokens": 100, "stream": false}`
+     */
+    options?: Record<string, string | number | boolean>
 }
 
 interface OpenAICompatible {

--- a/lib/shared/src/models/index.ts
+++ b/lib/shared/src/models/index.ts
@@ -46,9 +46,9 @@ interface ClientSideConfig {
     openAICompatible?: OpenAICompatible
     /**
      * The additional setting options for the model.
-     * E.g. `{"temperature": 0.5, "max_tokens": 100, "stream": false}`
+     * E.g. "temperature": 0.5, "max_tokens": 100, "stream": false
      */
-    options?: Record<string, string | number | boolean>
+    options?: Record<string, any>
 }
 
 interface OpenAICompatible {

--- a/vscode/src/models/sync.ts
+++ b/vscode/src/models/sync.ts
@@ -106,6 +106,11 @@ interface ChatModelProviderConfig {
     outputTokens?: number
     apiKey?: string
     apiEndpoint?: string
+    /**
+     * The additional setting options for the model.
+     * E.g. `{"temperature": 0.5, "max_tokens": 100, "stream": false}`
+     */
+    options?: Record<string, string | number | boolean>
 }
 
 /**
@@ -134,7 +139,11 @@ export function registerModelsFromVSCodeConfiguration() {
                         input: m.inputTokens ?? CHAT_INPUT_TOKEN_BUDGET,
                         output: m.outputTokens ?? ANSWER_TOKENS,
                     },
-                    clientSideConfig: { apiKey: m.apiKey, apiEndpoint: m.apiEndpoint },
+                    clientSideConfig: {
+                        apiKey: m.apiKey,
+                        apiEndpoint: m.apiEndpoint,
+                        options: m.options,
+                    },
                     tags: [ModelTag.Local, ModelTag.BYOK, ModelTag.Experimental],
                 })
         )

--- a/vscode/src/models/sync.ts
+++ b/vscode/src/models/sync.ts
@@ -106,11 +106,7 @@ interface ChatModelProviderConfig {
     outputTokens?: number
     apiKey?: string
     apiEndpoint?: string
-    /**
-     * The additional setting options for the model.
-     * E.g. `{"temperature": 0.5, "max_tokens": 100, "stream": false}`
-     */
-    options?: Record<string, string | number | boolean>
+    options?: Record<string, any>
 }
 
 /**


### PR DESCRIPTION
This change adds support for configurable model options in the local configured LLM providers available behind `cody.dev.models` feature. 

The `CompletionsModelConfig` type has been extended to include an `options` field, which allows users to specify additional settings for the model, such as temperature, max tokens, and whether to use streaming.

The changes have been implemented across the various LLM provider chat clients (Anthropic, GROQ, and Ollama) to handle the new configuration options.

Additionally, the `getCompletionsModelConfig` utility function has been updated to extract the `options` field from the model's client-side configuration.

Finally, the `ChatModelProviderConfig` interface in the VSCode extension has also been updated to include the `options` field, allowing users to configure these settings in the VSCode extension.

The `CompletionsModelConfig` and `ChatModelProviderConfig` interfaces have been updated to include the `options` field, which i've also made the required changes to existing code that uses these interfaces.

## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

This change only affects an internal feature that's hidden behind the 'cody.dev.models' setting.

1. Confirm ollama models are working
2. In your user settings,  add the cody.dev.models settings with the new "options" config:
```
	"cody.dev.models": [
		{
			"provider": "openaicompatible",
			"model": "gpt-4o-mini",
			"apiEndpoint": "https://api.openai.com/v1/chat/completions",
			"apiKey": "YOUR OPENAI API key",
			"options": {
				"stream": false
			}
		},
		{
			"provider": "openaicompatible",
			"model": "gpt-4o-latest",
			"tokens": 30000,
			"apiEndpoint": "https://api.openai.com/v1/chat/completions",
			"apiKey": "YOUR OPENAI API key",
			"options": {
				"stream": true
			}
		},
	],
```

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->

`cody.dev.models` now supports "options" parameter.