### PR TITLE
Chat: show correct model icons and deduplicate local models

### DIFF
--- a/lib/shared/src/models/index.ts
+++ b/lib/shared/src/models/index.ts
@@ -445,14 +445,18 @@ export class ModelsService {
     }
 
     /**
-     * Add new models for use.
+     * Add new models in addition to the primary models for use.
+     * NOTE: use setModels for a complete replacement of the primary models.
      */
     public addModels(models: Model[]): void {
-        const set = new Set(this.primaryModels)
-        for (const provider of models) {
-            set.add(provider)
-        }
-        this.primaryModels = Array.from(set)
+        const existingIds = new Set(
+            this.primaryModels.filter(m => m.tags.includes(ModelTag.BYOK)).map(m => m.id)
+        )
+        // Filter out any models that are already in the cache.
+        this.primaryModels = [
+            ...this.primaryModels,
+            ...models.filter(model => !existingIds.has(model.id)),
+        ]
     }
 
     private getModelsByType(usage: ModelUsage): Model[] {

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -9,6 +9,8 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 ### Fixed
 
 - Command: Fixed an issue where the experimental `Generate Commit Message` command would fail on Windows due to incorrect parsing of the git diff output. [pull/5449](https://github.com/sourcegraph/cody/pull/5449)
+- Chat: Model list now shows the correct icon based on the model provider. [pull/5469](https://github.com/sourcegraph/cody/pull/5469)
+- Chat: Fixed an issue where local models were duplicated in the model list. [pull/5469](https://github.com/sourcegraph/cody/pull/5469)
 
 ### Changed
 

--- a/vscode/webviews/components/ChatModelIcon.tsx
+++ b/vscode/webviews/components/ChatModelIcon.tsx
@@ -11,19 +11,19 @@ import {
 export function chatModelIconComponent(
     model: string
 ): FunctionComponent<{ size: number; className?: string }> {
-    if (model.startsWith('openai/')) {
+    if (model.startsWith('openai')) {
         return OpenAILogo
     }
-    if (model.startsWith('anthropic/')) {
+    if (model.startsWith('anthropic')) {
         return AnthropicLogo
     }
-    if (model.startsWith('google/')) {
+    if (model.startsWith('google')) {
         return GeminiLogo
     }
-    if (model.startsWith('ollama/')) {
+    if (model.startsWith('ollama')) {
         return OllamaLogo
     }
-    if (model.includes('mixtral')) {
+    if (model.startsWith('mistral')) {
         return MistralLogo
     }
     return CodyLogoBW

--- a/vscode/webviews/components/modelSelectField/ModelSelectField.tsx
+++ b/vscode/webviews/components/modelSelectField/ModelSelectField.tsx
@@ -296,7 +296,7 @@ const ModelTitleWithIcon: FunctionComponent<{
             [styles.disabled]: modelAvailability !== 'available',
         })}
     >
-        {showIcon && <ChatModelIcon model={model.id} className={styles.modelIcon} />}
+        {showIcon && <ChatModelIcon model={model.provider} className={styles.modelIcon} />}
         <span className={clsx('tw-flex-grow', styles.modelName)}>{model.title}</span>
         {modelAvailability === 'needs-cody-pro' && (
             <Badge variant="secondary" className={clsx(styles.badge, 'tw-opacity-75')}>


### PR DESCRIPTION
CLOSE https://linear.app/sourcegraph/issue/CODY-3628/bug-icon-display-incorrectly-for-anthropic-and-openai-models

PR to fix issues where local models are showing up twice in the model list, and the icons are not displayed correctly for openAI and Anthropic models.

- Updates the `ChatModelIcon` component to display the correct icon based on the model provider instead of the model ID.
- Fixes an issue where local models were being duplicated in the model list by filtering out any models that are already in the cache when adding new models.
- The `ChatModelIcon` component now expects the model provider instead of the model ID as the input.

## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

1. Icons are not displayed correctly for openAI and Anthropic models: 

#### After

![image](https://github.com/user-attachments/assets/aac31aca-19ef-4cc3-8d28-a5bdc9e22190)

#### Before

![image](https://github.com/user-attachments/assets/0ab8d121-14af-45f3-80e1-969a83e388e3)

2. Local Models are duplicated:

#### After

![image](https://github.com/user-attachments/assets/431cd22b-4b30-46d4-a6ad-d5fe95704bca)

#### Before

![image](https://github.com/user-attachments/assets/e9897444-706f-440d-9f8f-ee659ffca428)
## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
Fixed:
Chat: Model list now shows the correct icon based on the model provider. 
Chat: Fixed an issue where local models were duplicated in the model list.