### PR TITLE
update blog to new changelog URL

### DIFF
--- a/vscode/src/chat/protocol.ts
+++ b/vscode/src/chat/protocol.ts
@@ -303,6 +303,7 @@ export interface ConfigurationSubsetForWebview
  */
 export const CODY_DOC_URL = new URL('https://sourcegraph.com/docs/cody')
 export const SG_BLOG_URL = new URL('https://sourcegraph.com/blog/')
+export const SG_CHANGELOG_URL = new URL('https://sourcegraph.com/changelog?topics=VS+Code')
 
 // Community and support
 export const DISCORD_URL = new URL('https://discord.gg/s2qDtYGnAE')

--- a/vscode/src/chat/protocol.ts
+++ b/vscode/src/chat/protocol.ts
@@ -303,7 +303,7 @@ export interface ConfigurationSubsetForWebview
  */
 export const CODY_DOC_URL = new URL('https://sourcegraph.com/docs/cody')
 export const SG_BLOG_URL = new URL('https://sourcegraph.com/blog/')
-export const SG_CHANGELOG_URL = new URL('https://sourcegraph.com/changelog?topics=VS+Code')
+export const SG_CHANGELOG_URL = new URL('https://sourcegraph.com/changelog')
 
 // Community and support
 export const DISCORD_URL = new URL('https://discord.gg/s2qDtYGnAE')

--- a/vscode/src/release.test.ts
+++ b/vscode/src/release.test.ts
@@ -43,31 +43,37 @@ describe('getReleaseTypeByIDE', () => {
 describe('getReleaseNotesURLByIDE', () => {
     it('returns stable release blog post URL for VS Code stable builds', () => {
         expect(getReleaseNotesURLByIDE('1.24.0', CodyIDE.VSCode)).toEqual(
-            'https://sourcegraph.com/blog/cody-vscode-1-24-0-release'
+            'https://sourcegraph.com/changelog?topics=VS+Code'
         )
     })
 
     it('returns stable release blog post URL for VS Code patch release', () => {
         expect(getReleaseNotesURLByIDE('1.24.2', CodyIDE.VSCode)).toEqual(
-            'https://sourcegraph.com/blog/cody-vscode-1-24-0-release'
+            'https://sourcegraph.com/changelog?topics=VS+Code'
         )
     })
 
     it('returns stable release blog post URL for VS Code insiders builds', () => {
         expect(getReleaseNotesURLByIDE('1.25.1720624657', CodyIDE.VSCode)).toEqual(
-            'https://sourcegraph.com/blog/cody-vscode-1-24-0-release'
+            'https://sourcegraph.com/changelog?topics=VS+Code'
         )
     })
 
     it('returns GitHub release notes for JetBrains stable builds', () => {
         expect(getReleaseNotesURLByIDE('5.5.10', CodyIDE.JetBrains)).toEqual(
-            'https://github.com/sourcegraph/jetbrains/releases/tag/v5.5.10'
+            'https://sourcegraph.com/changelog?topics=JetBrains'
         )
     })
 
     it('returns GitHub release notes homepage for JetBrains nightly builds', () => {
         expect(getReleaseNotesURLByIDE('5.5.1-nightly', CodyIDE.JetBrains)).toEqual(
-            'https://github.com/sourcegraph/jetbrains/releases'
+            'https://sourcegraph.com/changelog?topics=JetBrains'
+        )
+    })
+
+    it('returns GitHub release notes homepage for Visual Studio', () => {
+        expect(getReleaseNotesURLByIDE('', CodyIDE.VisualStudio)).toEqual(
+            'https://sourcegraph.com/changelog?topics=Visual+Studio'
         )
     })
 })

--- a/vscode/src/release.ts
+++ b/vscode/src/release.ts
@@ -1,5 +1,5 @@
 import { CodyIDE } from '@sourcegraph/cody-shared'
-import { SG_BLOG_URL } from './chat/protocol'
+import { SG_CHANGELOG_URL } from './chat/protocol'
 
 type ReleaseType = 'stable' | 'insiders'
 
@@ -83,7 +83,7 @@ function getReleaseBlogPostURL(version: string, IDE: CodyIDE): string {
     // }
     
     // TODO @KALAN CLEANUP ONCE WE HAVE A PROPER URL structure for VS Code changelogs
-    const blogURL = new URL('https://sourcegraph.com/changelog?topics=VS+Code')
+    const blogURL = new URL(SG_CHANGELOG_URL)
 
     return blogURL.href
 }

--- a/vscode/src/release.ts
+++ b/vscode/src/release.ts
@@ -41,7 +41,7 @@ const IDE_BLOG_TOPICS = {
     [CodyIDE.Neovim]: 'Cody',
     [CodyIDE.Emacs]: 'Cody',
     [CodyIDE.Web]: 'Cody',
-};
+}
 
 /**
  * Determines the URL for the release notes for the given IDE and version.
@@ -56,15 +56,15 @@ const IDE_BLOG_TOPICS = {
  * @returns The URL for the release notes for the given IDE and version.
  */
 export function getReleaseNotesURLByIDE(version: string, IDE: CodyIDE): string {
-    const blogTopic =  IDE in IDE_BLOG_TOPICS && IDE_BLOG_TOPICS[IDE as keyof typeof IDE_BLOG_TOPICS];
+    const blogTopic = IDE in IDE_BLOG_TOPICS && IDE_BLOG_TOPICS[IDE as keyof typeof IDE_BLOG_TOPICS]
     if (IDE in IDE_BLOG_TOPICS && blogTopic) {
-        const blogURL = new URL(SG_CHANGELOG_URL);
-        blogURL.searchParams.set('topics', blogTopic);
-        return blogURL.href;
+        const blogURL = new URL(SG_CHANGELOG_URL)
+        blogURL.searchParams.set('topics', blogTopic)
+        return blogURL.href
     }
 
-    const isStable = getReleaseTypeByIDE(IDE, version) === 'stable';
+    const isStable = getReleaseTypeByIDE(IDE, version) === 'stable'
     return isStable
         ? `https://github.com/sourcegraph/cody/releases/tag/v${version}`
-        : 'https://github.com/sourcegraph/cody/releases';
+        : 'https://github.com/sourcegraph/cody/releases'
 }

--- a/vscode/src/release.ts
+++ b/vscode/src/release.ts
@@ -70,7 +70,8 @@ export function getReleaseNotesURLByIDE(version: string, IDE: CodyIDE): string {
  * @returns The release blog post URL for the given IDE and version.
  */
 function getReleaseBlogPostURL(version: string, IDE: CodyIDE): string {
-    // const blogURL = new URL(SG_BLOG_URL)
+    // TODO @KALAN CLEANUP ONCE WE HAVE A PROPER URL structure for VS Code changelogs
+    const blogURL = new URL(SG_CHANGELOG_URL)
 
     // if (IDE === CodyIDE.VSCode) {
     //     // Examples of version:
@@ -82,8 +83,6 @@ function getReleaseBlogPostURL(version: string, IDE: CodyIDE): string {
     //     blogURL.pathname += `cody-vscode-${versionNums[0]}-${minor}-0-release`
     // }
     
-    // TODO @KALAN CLEANUP ONCE WE HAVE A PROPER URL structure for VS Code changelogs
-    const blogURL = new URL(SG_CHANGELOG_URL)
 
     return blogURL.href
 }

--- a/vscode/src/release.ts
+++ b/vscode/src/release.ts
@@ -46,6 +46,7 @@ export function getReleaseNotesURLByIDE(version: string, IDE: CodyIDE): string {
 
     switch (IDE) {
         case CodyIDE.VSCode:
+            // TODO need to fix this once we get proper tagged versions 
             return getReleaseBlogPostURL(version, IDE)
 
         case CodyIDE.JetBrains:
@@ -69,17 +70,20 @@ export function getReleaseNotesURLByIDE(version: string, IDE: CodyIDE): string {
  * @returns The release blog post URL for the given IDE and version.
  */
 function getReleaseBlogPostURL(version: string, IDE: CodyIDE): string {
-    const blogURL = new URL(SG_BLOG_URL)
+    // const blogURL = new URL(SG_BLOG_URL)
 
-    if (IDE === CodyIDE.VSCode) {
-        // Examples of version:
-        // 1.24.3 (stable), 1.25.123143 (pre-release)
-        const versionNums = version.split('.')
-        // NOTE: We do not generate blog post for pre-releases (odd minor number).
-        const minor = Number(versionNums[1]) % 2 === 0 ? versionNums[1] : `${Number(versionNums[1]) - 1}`
-        // Example: https://sourcegraph.com/blog/cody-vscode-1-24-0-release
-        blogURL.pathname += `cody-vscode-${versionNums[0]}-${minor}-0-release`
-    }
+    // if (IDE === CodyIDE.VSCode) {
+    //     // Examples of version:
+    //     // 1.24.3 (stable), 1.25.123143 (pre-release)
+    //     const versionNums = version.split('.')
+    //     // NOTE: We do not generate blog post for pre-releases (odd minor number).
+    //     const minor = Number(versionNums[1]) % 2 === 0 ? versionNums[1] : `${Number(versionNums[1]) - 1}`
+    //     // Example: https://sourcegraph.com/blog/cody-vscode-1-24-0-release
+    //     blogURL.pathname += `cody-vscode-${versionNums[0]}-${minor}-0-release`
+    // }
+    
+    // TODO @KALAN CLEANUP ONCE WE HAVE A PROPER URL structure for VS Code changelogs
+    const blogURL = new URL('https://sourcegraph.com/changelog?topics=VS+Code')
 
     return blogURL.href
 }


### PR DESCRIPTION
updating the blog URL to the new changelog format. Hoping it will be a temp change for now, I think we should send users to a tagged version instead of a general landing page but we will need to coordinate with PMM to figure that out

## Test plan
N/A
<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
