### PR TITLE
Cody Ignore: handle notebook cell URIs

### DIFF
--- a/lib/shared/src/cody-ignore/ignore-helper.ts
+++ b/lib/shared/src/cody-ignore/ignore-helper.ts
@@ -112,12 +112,16 @@ export class IgnoreHelper {
         // Return all https URIs on the assumption that they origin from
         // remote context (e.g. unified, multi-repo) files, which are already
         // filtered by the backend to respect codyignore files during sync time.
-        if (uri.scheme === 'https') {
+        const allowedNonFileSchemes = new Set(['https', 'http'])
+        if (allowedNonFileSchemes.has(uri.scheme)) {
             return false
         }
 
-        if (uri.scheme === 'http') {
-            return false
+        // For notebook cells, we want to ignore the cell itself, but not the file it's in.
+        if (uri.scheme === 'vscode-notebook-cell') {
+            // Replace the scheme with the file scheme and remove the fragment that
+            // contains the cell id so we can use the same logic as for files.
+            uri = uri.with({ scheme: 'file', fragment: undefined })
         }
 
         // Ignore all other non-file URIs

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -8,7 +8,7 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 
 ### Fixed
 
-- Cody Ignore: Fixed an issue where Cody would treat Notebook cells as ignored files when .cody/ignore is enabled. [pull/](https://github.com/sourcegraph/cody/pull/)
+- Cody Ignore: Fixed an issue where Cody would treat Notebook cells as ignored files when .cody/ignore is enabled. [pull/5473](https://github.com/sourcegraph/cody/pull/5473)
 
 ### Changed
 

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -8,6 +8,8 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 
 ### Fixed
 
+- Cody Ignore: Fixed an issue where Cody would treat Notebook cells as ignored files when .cody/ignore is enabled. [pull/](https://github.com/sourcegraph/cody/pull/)
+
 ### Changed
 
 ## 1.34.0


### PR DESCRIPTION
CLOSE https://linear.app/sourcegraph/issue/CODY-3448/auto-edit-does-not-work-with-ipynb-files

This change updates the IgnoreHelper to properly handle notebook cell URIs when the .cody/ignore file is enabled. Previously, Cody would treat notebook cells as ignored files, which was incorrect. This fix replaces the notebook cell scheme with the file scheme and removes the fragment containing the cell ID, so that the same logic can be used for regular files.


## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

1. Try running the Document Command in an `ipynb` file and verified that it works and you no longer see the pop-up about file being ignored:

![image](https://github.com/user-attachments/assets/faa5fe86-bec7-48e8-bc9a-10fb82c00f40)

2. Create a .cody/ignore file and set it to ignore all .ipynb files:

```
*.ipynb
```

3. Try running the Document Command again in an `ipynb` file and verified that you are now seeing the pop-up about file is ignored:

![image](https://github.com/user-attachments/assets/3717125a-79c2-4157-961c-69ea2120060e)



#### Before

`ipynb` files are always ignored if cody ignore is enabled

![image](https://github.com/user-attachments/assets/ef2cb914-4828-480f-94a1-671ec306b408)

![image](https://github.com/user-attachments/assets/f9af8cec-3086-4d81-88b0-8640a80a20eb)


## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
