### PR TITLE
Auth: use getCodyAuthReferralCode

### DIFF
--- a/vscode/src/auth/auth.ts
+++ b/vscode/src/auth/auth.ts
@@ -1,10 +1,16 @@
 import * as vscode from 'vscode'
 
-import { type AuthStatus, DOTCOM_URL, isDotCom, telemetryRecorder } from '@sourcegraph/cody-shared'
+import {
+    type AuthStatus,
+    CodyIDE,
+    DOTCOM_URL,
+    getCodyAuthReferralCode,
+    isDotCom,
+    telemetryRecorder,
+} from '@sourcegraph/cody-shared'
 import { isSourcegraphToken } from '../chat/protocol'
 import { logDebug } from '../log'
 import { authProvider } from '../services/AuthProvider'
-import { getAuthReferralCode } from '../services/AuthProviderSimplified'
 import { localStorage } from '../services/LocalStorageProvider'
 import { secretStorage } from '../services/SecretStorageProvider'
 import { closeAuthProgressIndicator } from './auth-progress-indicator'
@@ -14,7 +20,8 @@ import { closeAuthProgressIndicator } from './auth-progress-indicator'
  */
 export async function showSignInMenu(
     type?: 'enterprise' | 'dotcom' | 'token',
-    uri?: string
+    uri?: string,
+    agentIDE: CodyIDE = CodyIDE.VSCode
 ): Promise<void> {
     const authStatus = authProvider.instance!.status
     const mode = authStatus.authenticated ? 'switch' : 'signin'
@@ -35,11 +42,11 @@ export async function showSignInMenu(
                 return
             }
             authProvider.instance!.setAuthPendingToEndpoint(instanceUrl)
-            redirectToEndpointLogin(instanceUrl)
+            redirectToEndpointLogin(instanceUrl, agentIDE)
             break
         }
         case 'dotcom':
-            redirectToEndpointLogin(DOTCOM_URL.href)
+            redirectToEndpointLogin(DOTCOM_URL.href, agentIDE)
             break
         case 'token': {
             const instanceUrl = await showInstanceURLInputBox(uri || item.uri)
@@ -220,13 +227,13 @@ async function signinMenuForInstanceUrl(instanceUrl: string): Promise<void> {
 }
 
 /** Open callback URL in browser to get token from instance. */
-export function redirectToEndpointLogin(uri: string): void {
+export function redirectToEndpointLogin(uri: string, agentIDE: CodyIDE = CodyIDE.VSCode): void {
     const endpoint = formatURL(uri)
     if (!endpoint) {
         return
     }
 
-    if (vscode.env.uiKind === vscode.UIKind.Web) {
+    if (agentIDE === CodyIDE.VSCode && vscode.env.uiKind === vscode.UIKind.Web) {
         // VS Code Web needs a different kind of callback using asExternalUri and changes to our
         // UserSettingsCreateAccessTokenCallbackPage.tsx page in the Sourcegraph web app. So,
         // just require manual token entry for now.
@@ -237,7 +244,10 @@ export function redirectToEndpointLogin(uri: string): void {
     }
 
     const newTokenCallbackUrl = new URL('/user/settings/tokens/new/callback', endpoint)
-    newTokenCallbackUrl.searchParams.append('requestFrom', getAuthReferralCode())
+    newTokenCallbackUrl.searchParams.append(
+        'requestFrom',
+        getCodyAuthReferralCode(agentIDE, vscode.env.uriScheme) ?? 'Cody'
+    )
     authProvider.instance!.setAuthPendingToEndpoint(endpoint)
     void vscode.env.openExternal(vscode.Uri.parse(newTokenCallbackUrl.href))
 }

--- a/vscode/src/chat/chat-view/ChatController.ts
+++ b/vscode/src/chat/chat-view/ChatController.ts
@@ -433,8 +433,9 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
                 )
                 break
             case 'auth': {
+                const config = getConfigWithEndpoint()
                 if (message.authKind === 'callback' && message.endpoint) {
-                    redirectToEndpointLogin(message.endpoint)
+                    redirectToEndpointLogin(message.endpoint, config.agentIDE)
                     break
                 }
                 if (message.authKind === 'offline') {
@@ -471,7 +472,6 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
 
                     const authProviderSimplified = new AuthProviderSimplified()
                     const authMethod = message.authMethod || 'dotcom'
-                    const config = getConfigWithEndpoint()
                     const successfullyOpenedUrl = await authProviderSimplified.openExternalAuthUrl(
                         authMethod,
                         tokenReceiverUrl,

--- a/vscode/src/services/AuthProviderSimplified.ts
+++ b/vscode/src/services/AuthProviderSimplified.ts
@@ -24,19 +24,6 @@ export class AuthProviderSimplified {
     }
 }
 
-/**
- * Returns a known referral code to use based on the current VS Code environment.
- */
-export function getAuthReferralCode(): string {
-    return (
-        {
-            'vscode-insiders': 'CODY_INSIDERS',
-            vscodium: 'CODY_VSCODIUM',
-            cursor: 'CODY_CURSOR',
-        }[vscode.env.uriScheme] || 'CODY'
-    )
-}
-
 // Opens authentication URLs for simplified onboarding.
 function openExternalAuthUrl(
     provider: AuthMethod,


### PR DESCRIPTION
Follow https://github.com/sourcegraph/cody/pull/5325

This PR updates the current auth to replace getAuthReferralCode with the new getCodyAuthReferralCode added in https://github.com/sourcegraph/cody/pull/5325

## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

All the current tests should pass to confirm this change works the same as before.

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
