### PR TITLE
Agent: add platform-specific secret storage implementation

### DIFF
--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/agent/protocol_generated/ClientCapabilities.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/agent/protocol_generated/ClientCapabilities.kt
@@ -19,7 +19,7 @@ data class ClientCapabilities(
   val codeActions: CodeActionsEnum? = null, // Oneof: none, enabled
   val webviewMessages: WebviewMessagesEnum? = null, // Oneof: object-encoded, string-encoded
   val globalState: GlobalStateEnum? = null, // Oneof: stateless, server-managed, client-managed
-  val secrets: SecretsEnum? = null, // Oneof: stateless, client-managed
+  val secrets: SecretsEnum? = null, // Oneof: stateless, server-managed, client-managed
   val webview: WebviewEnum? = null, // Oneof: agentic, native
   val webviewNativeConfig: WebviewNativeConfigParams? = null,
 ) {
@@ -101,6 +101,7 @@ data class ClientCapabilities(
 
   enum class SecretsEnum {
     @SerializedName("stateless") Stateless,
+    @SerializedName("server-managed") `Server-managed`,
     @SerializedName("client-managed") `Client-managed`,
   }
 

--- a/agent/src/AgentSecretStorage.ts
+++ b/agent/src/AgentSecretStorage.ts
@@ -1,3 +1,4 @@
+import { spawn } from 'node:child_process'
 import type * as vscode from 'vscode'
 import { emptyEvent } from '../../vscode/src/testutils/emptyEvent'
 import type { MessageHandler } from './jsonrpc-alias'
@@ -32,5 +33,155 @@ export class AgentClientManagedSecretStorage implements vscode.SecretStorage {
     }
     public async delete(key: string): Promise<void> {
         await this.agent.request('secrets/delete', { key })
+    }
+}
+
+// Store secrets in system keychain or equivalent based on platform.
+export class AgentStatefulSecretStorage implements vscode.SecretStorage {
+    private readonly platform = process.platform
+
+    constructor(public readonly onDidChange: vscode.Event<vscode.SecretStorageChangeEvent>) {}
+
+    public async get(key: string): Promise<string | undefined> {
+        switch (this.platform) {
+            case 'darwin':
+                return this.spawnAsync('security', [
+                    'find-generic-password',
+                    '-s',
+                    this.service(key),
+                    '-a',
+                    this.account(key),
+                    '-w',
+                ])
+            case 'win32': {
+                const powershellCommand = `(Get-StoredCredential -Target "${this.target(
+                    key
+                )}").GetNetworkCredential().Password`
+                return this.spawnAsync('powershell.exe', ['-Command', powershellCommand])
+            }
+            case 'linux':
+                return this.spawnAsync('secret-tool', [
+                    'lookup',
+                    'service',
+                    this.service(key),
+                    'account',
+                    this.account(key),
+                ])
+            default:
+                throw new Error(`Unsupported platform: ${this.platform}`)
+        }
+    }
+
+    public async store(key: string, value: string): Promise<void> {
+        switch (this.platform) {
+            case 'darwin':
+                await this.spawnAsync('security', [
+                    'add-generic-password',
+                    '-s',
+                    this.service(key),
+                    '-a',
+                    this.account(key),
+                    '-w',
+                    value,
+                ])
+                break
+            case 'win32': {
+                const powershellCommand = `& {New-StoredCredential -Target '${this.target(
+                    key
+                )}' -Password '${value}' -Persist LocalMachine}`
+                await this.spawnAsync('powershell.exe', ['-Command', powershellCommand])
+                break
+            }
+            case 'linux':
+                await this.spawnAsync(
+                    'secret-tool',
+                    [
+                        'store',
+                        '--label',
+                        this.service(key),
+                        'service',
+                        this.service(key),
+                        'account',
+                        this.account(key),
+                    ],
+                    { stdin: value }
+                )
+                break
+            default:
+                throw new Error(`Unsupported platform: ${this.platform}`)
+        }
+    }
+
+    public async delete(key: string): Promise<void> {
+        switch (this.platform) {
+            case 'darwin':
+                await this.spawnAsync('security', [
+                    'delete-generic-password',
+                    '-s',
+                    this.service(key),
+                    '-a',
+                    this.account(key),
+                ])
+                break
+            case 'win32':
+                await this.spawnAsync('powershell.exe', [
+                    '-Command',
+                    `& {Remove-StoredCredential -Target '${this.target(key)}'}`,
+                ])
+                break
+            case 'linux':
+                await this.spawnAsync('secret-tool', [
+                    'clear',
+                    'service',
+                    this.service(key),
+                    'account',
+                    this.account(key),
+                ])
+                break
+            default:
+                throw new Error(`Unsupported platform: ${this.platform}`)
+        }
+    }
+
+    private service(key: string): string {
+        return `Cody: ${key}`
+    }
+
+    private account(key: string): string {
+        return `cody_${key}`
+    }
+
+    private target(key: string): string {
+        return `${this.service(key)}:${this.account(key)}`.replaceAll('"', '_')
+    }
+
+    private spawnAsync(command: string, args: string[], options?: { stdin: string }): Promise<string> {
+        return new Promise<string>((resolve, reject) => {
+            const child = spawn(command, args, { stdio: 'pipe', ...options })
+            let stdout = ''
+            let stderr = ''
+            child.stdout.on('data', data => {
+                stdout += data
+            })
+
+            child.stderr.on('data', data => {
+                stderr += data
+            })
+
+            if (options?.stdin) {
+                child.stdin.write(options.stdin)
+                child.stdin.end()
+            }
+
+            child.on('exit', code => {
+                if (code !== 0) {
+                    reject(
+                        new Error(`command failed: ${command} ${args.join(' ')}\n${stdout}\n${stderr}`)
+                    )
+                } else {
+                    resolve(stdout.trim())
+                }
+            })
+        })
     }
 }

--- a/agent/src/AgentSecretStorage.ts
+++ b/agent/src/AgentSecretStorage.ts
@@ -1,5 +1,6 @@
 import { spawn } from 'node:child_process'
 import type * as vscode from 'vscode'
+import { logDebug } from '../../vscode/src/log'
 import { emptyEvent } from '../../vscode/src/testutils/emptyEvent'
 import type { MessageHandler } from './jsonrpc-alias'
 
@@ -205,7 +206,11 @@ export class AgentServerManagedSecretStorage implements vscode.SecretStorage {
                 'if (-not (Get-Module -ListAvailable -Name CredentialManager)) { Install-Module -Name CredentialManager -Force -Scope CurrentUser }',
             ])
         } catch (error) {
-            console.error('Failed to install CredentialManager module:', error)
+            logDebug(
+                'AgentServerManagedSecretStorage',
+                'Failed to install CredentialManager module:',
+                error
+            )
         }
     }
 }

--- a/agent/src/AgentSecretStorage.ts
+++ b/agent/src/AgentSecretStorage.ts
@@ -36,8 +36,7 @@ export class AgentClientManagedSecretStorage implements vscode.SecretStorage {
     }
 }
 
-// Store secrets in system keychain or equivalent based on platform.
-export class AgentStatefulSecretStorage implements vscode.SecretStorage {
+export class AgentServerManagedSecretStorage implements vscode.SecretStorage {
     private readonly platform = process.platform
 
     constructor(public readonly onDidChange: vscode.Event<vscode.SecretStorageChangeEvent>) {

--- a/agent/src/agent.ts
+++ b/agent/src/agent.ts
@@ -64,7 +64,11 @@ import { AgentWorkspaceEdit } from '../../vscode/src/testutils/AgentWorkspaceEdi
 import { AgentAuthHandler } from './AgentAuthHandler'
 import { AgentFixupControls } from './AgentFixupControls'
 import { AgentProviders } from './AgentProviders'
-import { AgentClientManagedSecretStorage, AgentStatelessSecretStorage } from './AgentSecretStorage'
+import {
+    AgentClientManagedSecretStorage,
+    AgentStatefulSecretStorage,
+    AgentStatelessSecretStorage,
+} from './AgentSecretStorage'
 import { AgentWebviewPanel, AgentWebviewPanels } from './AgentWebviewPanel'
 import { AgentWorkspaceDocuments } from './AgentWorkspaceDocuments'
 import { registerNativeWebviewHandlers, resolveWebviewView } from './NativeWebview'
@@ -429,7 +433,9 @@ export class Agent extends MessageHandler implements ExtensionClient {
                 const secrets =
                     clientInfo.capabilities?.secrets === 'client-managed'
                         ? new AgentClientManagedSecretStorage(this, this.secretsDidChange.event)
-                        : new AgentStatelessSecretStorage()
+                        : clientInfo.capabilities?.secrets === 'server-managed'
+                          ? new AgentStatefulSecretStorage(this.secretsDidChange.event)
+                          : new AgentStatelessSecretStorage()
 
                 await initializeVscodeExtension(
                     this.workspace.workspaceRootUri,

--- a/agent/src/agent.ts
+++ b/agent/src/agent.ts
@@ -66,7 +66,7 @@ import { AgentFixupControls } from './AgentFixupControls'
 import { AgentProviders } from './AgentProviders'
 import {
     AgentClientManagedSecretStorage,
-    AgentStatefulSecretStorage,
+    AgentServerManagedSecretStorage,
     AgentStatelessSecretStorage,
 } from './AgentSecretStorage'
 import { AgentWebviewPanel, AgentWebviewPanels } from './AgentWebviewPanel'
@@ -434,7 +434,7 @@ export class Agent extends MessageHandler implements ExtensionClient {
                     clientInfo.capabilities?.secrets === 'client-managed'
                         ? new AgentClientManagedSecretStorage(this, this.secretsDidChange.event)
                         : clientInfo.capabilities?.secrets === 'server-managed'
-                          ? new AgentStatefulSecretStorage(this.secretsDidChange.event)
+                          ? new AgentServerManagedSecretStorage(this.secretsDidChange.event)
                           : new AgentStatelessSecretStorage()
 
                 await initializeVscodeExtension(

--- a/vscode/src/jsonrpc/agent-protocol.ts
+++ b/vscode/src/jsonrpc/agent-protocol.ts
@@ -645,7 +645,7 @@ export interface ClientCapabilities {
     // - Stateless: the secrets are not persisted between agent processes.
     // - Client managed: the client must implement the 'secrets/get',
     // 'secrets/store', and 'secrets/delete' requests.
-    secrets?: 'stateless' | 'client-managed' | undefined | null
+    secrets?: 'stateless' | 'server-managed' | 'client-managed' | undefined | null
     // Whether the client supports the VSCode WebView API. If 'agentic', uses
     // AgentWebViewPanel which just delegates bidirectional postMessage over
     // the Agent protocol. If 'native', implements a larger subset of the VSCode


### PR DESCRIPTION
This change adds a new `AgentServerManagedSecretStorage` class that implements the `vscode.SecretStorage` interface and uses the system keychain or equivalent to store secrets based on the current platform (macOS, Windows, or Linux). 

The new implementation supports the following operations: 
- `get(key)`: Retrieves the secret value for the given key. 
- `store(key, value)`: Stores the secret value for the given key. 
- `delete(key)`: Deletes the secret value for the given key. 

The `AgentClientManagedSecretStorage` implementation is retained for cases where the client is responsible for managing the secrets, while the `AgentServerManagedSecretStorage` implementation is for cases where the client does not have access to secret storage API.

NOTE: The  `AgentClientManagedSecretStorage` was implemented using the current secret storage implementation in Cody CLI as reference: https://sourcegraph.com/github.com/sourcegraph/cody/-/blob/agent/src/cli/command-auth/secrets.ts. The powershell commands were however updated after testing in a native Windows env.

## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

- [x] Test it on Windows with Eclipse/Visual Studio to confirm the secret storage is working as expected
- [ ] Test it on Mac with JetBrains to confirm the secret storage is working as expected

I don't have access to Linux machine to confirm if this would work on Linux, but right now this is using the existing implementation we have for CLI so if it is working there it should work here?

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
