### PR TITLE
Move updateCodeLenses logic to AgentFixupControls

### DIFF
--- a/agent/src/AgentFixupControls.ts
+++ b/agent/src/AgentFixupControls.ts
@@ -1,10 +1,11 @@
+import type * as vscode from 'vscode'
 import type { QuickPickInput } from '../../vscode/src/edit/input/get-input'
 import type { FixupFile } from '../../vscode/src/non-stop/FixupFile'
 import type { FixupTask, FixupTaskID } from '../../vscode/src/non-stop/FixupTask'
 import { FixupCodeLenses } from '../../vscode/src/non-stop/codelenses/provider'
 import type { FixupActor, FixupFileCollection } from '../../vscode/src/non-stop/roles'
 import { type Agent, errorToCodyError } from './agent'
-import type { EditTask } from './protocol-alias'
+import type { EditTask, ProtocolCommand } from './protocol-alias'
 
 export class AgentFixupControls extends FixupCodeLenses {
     constructor(
@@ -59,6 +60,59 @@ export class AgentFixupControls extends FixupCodeLenses {
     visibleFilesWithTasksMaybeChanged(files: readonly FixupFile[]): void {}
 
     dispose() {}
+
+    override notifyCodeLensesChanged(uri: vscode.Uri, codeLenses: vscode.CodeLens[]) {
+        super.notifyCodeLensesChanged(uri, codeLenses)
+        void this.updateCodeLenses(uri, codeLenses)
+    }
+
+    private async updateCodeLenses(uri: vscode.Uri, codeLenses: vscode.CodeLens[]): Promise<void> {
+        // VS Code supports icons in code lenses, but we cannot render these through agent.
+        // We need to strip any icons from the title and provide those seperately, so the client can decide how to render them.
+        const agentLenses = codeLenses.map(lens => {
+            if (!lens.command) {
+                return {
+                    ...lens,
+                    command: undefined,
+                }
+            }
+
+            return {
+                ...lens,
+                command: {
+                    ...lens.command,
+                    title: this.splitIconsFromTitle(lens.command.title),
+                },
+            }
+        })
+
+        this.notify('codeLenses/display', {
+            uri: uri.toString(),
+            codeLenses: agentLenses,
+        })
+    }
+
+    /**
+     * Matches VS Code codicon syntax, e.g. $(cody-logo)
+     * Source: https://sourcegraph.com/github.com/microsoft/vscode@f34d4/-/blob/src/vs/base/browser/ui/iconLabel/iconLabels.ts?L9
+     */
+    private labelWithIconsRegex = /(\\)?\$\(([A-Za-z0-9-]+(?:~[A-Za-z]+)?)\)/g
+    /**
+     * Given a title, such as "$(cody-logo) Cody", returns the raw
+     * title without icons and the icons matched with their respective positions.
+     */
+    private splitIconsFromTitle(title: string): ProtocolCommand['title'] {
+        const icons: { value: string; position: number }[] = []
+        const matches = [...title.matchAll(this.labelWithIconsRegex)]
+
+        for (const match of matches) {
+            if (match.index !== undefined) {
+                icons.push({ value: match[0], position: match.index })
+            }
+        }
+
+        return { text: title.replace(this.labelWithIconsRegex, ''), icons }
+    }
 
     public static serialize(task: FixupTask): EditTask {
         return {

--- a/agent/src/AgentFixupControls.ts
+++ b/agent/src/AgentFixupControls.ts
@@ -69,22 +69,15 @@ export class AgentFixupControls extends FixupCodeLenses {
     private async updateCodeLenses(uri: vscode.Uri, codeLenses: vscode.CodeLens[]): Promise<void> {
         // VS Code supports icons in code lenses, but we cannot render these through agent.
         // We need to strip any icons from the title and provide those seperately, so the client can decide how to render them.
-        const agentLenses = codeLenses.map(lens => {
-            if (!lens.command) {
-                return {
-                    ...lens,
-                    command: undefined,
-                }
-            }
-
-            return {
-                ...lens,
-                command: {
-                    ...lens.command,
-                    title: this.splitIconsFromTitle(lens.command.title),
-                },
-            }
-        })
+        const agentLenses = codeLenses.map(lens => ({
+            ...lens,
+            command: lens.command
+                ? {
+                      ...lens.command,
+                      title: this.splitIconsFromTitle(lens.command.title),
+                  }
+                : undefined,
+        }))
 
         this.notify('codeLenses/display', {
             uri: uri.toString(),

--- a/agent/src/agent.ts
+++ b/agent/src/agent.ts
@@ -86,7 +86,6 @@ import type {
     GetDocumentsParams,
     GetDocumentsResult,
     GetFoldingRangeResult,
-    ProtocolCommand,
     ProtocolTextDocument,
     TextEdit,
 } from './protocol-alias'
@@ -393,11 +392,7 @@ export class Agent extends MessageHandler implements ExtensionClient {
             }
             if (clientInfo.capabilities?.codeLenses === 'enabled') {
                 vscode_shim.onDidRegisterNewCodeLensProvider(codeLensProvider => {
-                    this.codeLens.addProvider(
-                        codeLensProvider,
-                        codeLensProvider.onDidChangeCodeLenses?.(() => this.updateCodeLenses())
-                    )
-                    this.updateCodeLenses()
+                    this.codeLens.addProvider(codeLensProvider)
                 })
                 vscode_shim.onDidUnregisterNewCodeLensProvider(codeLensProvider =>
                     this.codeLens.removeProvider(codeLensProvider)
@@ -1527,78 +1522,6 @@ export class Agent extends MessageHandler implements ExtensionClient {
             throw new Error('Extension registration not yet complete')
         }
         return this.maybeExtension
-    }
-
-    private codeLensToken = new vscode.CancellationTokenSource()
-    /**
-     * Matches VS Code codicon syntax, e.g. $(cody-logo)
-     * Source: https://sourcegraph.com/github.com/microsoft/vscode@f34d4/-/blob/src/vs/base/browser/ui/iconLabel/iconLabels.ts?L9
-     */
-    private labelWithIconsRegex = /(\\)?\$\(([A-Za-z0-9-]+(?:~[A-Za-z]+)?)\)/g
-    /**
-     * Given a title, such as "$(cody-logo) Cody", returns the raw
-     * title without icons and the icons matched with their respective positions.
-     */
-    private splitIconsFromTitle(title: string): ProtocolCommand['title'] {
-        const icons: { value: string; position: number }[] = []
-        const matches = [...title.matchAll(this.labelWithIconsRegex)]
-
-        for (const match of matches) {
-            if (match.index !== undefined) {
-                icons.push({ value: match[0], position: match.index })
-            }
-        }
-
-        return { text: title.replace(this.labelWithIconsRegex, ''), icons }
-    }
-
-    private async updateCodeLenses(): Promise<void> {
-        const uri = this.workspace.activeDocumentFilePath
-        if (!uri) {
-            return
-        }
-        const document = this.workspace.getDocument(uri)
-        if (!document) {
-            return
-        }
-        this.codeLensToken.cancel()
-        this.codeLensToken = new vscode.CancellationTokenSource()
-        const promises: Promise<vscode.CodeLens[]>[] = []
-        for (const provider of this.codeLens.providers()) {
-            promises.push(this.provideCodeLenses(provider, document))
-        }
-        const lenses = (await Promise.all(promises)).flat()
-
-        // VS Code supports icons in code lenses, but we cannot render these through agent.
-        // We need to strip any icons from the title and provide those seperately, so the client can decide how to render them.
-        const agentLenses = lenses.map(lens => {
-            if (!lens.command) {
-                return {
-                    ...lens,
-                    command: undefined,
-                }
-            }
-
-            return {
-                ...lens,
-                command: {
-                    ...lens.command,
-                    title: this.splitIconsFromTitle(lens.command.title),
-                },
-            }
-        })
-
-        this.notify('codeLenses/display', {
-            uri: uri.toString(),
-            codeLenses: agentLenses,
-        })
-    }
-    private async provideCodeLenses(
-        provider: vscode.CodeLensProvider,
-        document: vscode.TextDocument
-    ): Promise<vscode.CodeLens[]> {
-        const result = await provider.provideCodeLenses(document, this.codeLensToken.token)
-        return result ?? []
     }
 
     private async handleConfigChanges(

--- a/agent/src/edit.test.ts
+++ b/agent/src/edit.test.ts
@@ -35,7 +35,8 @@ describe('Edit', () => {
         })
         await client.taskHasReachedAppliedPhase(task)
         const lenses = client.codeLenses.get(uri.toString()) ?? []
-        expect(lenses).toHaveLength(2)
+        expect(lenses).toHaveLength(4)
+        expect(lenses[0].command?.command).toBe('cody.fixup.codelens.accept')
         await client.request('editTask/accept', { id: task.id })
         const newContent = client.workspace.getDocument(uri)?.content
         expect(trimEndOfLine(newContent)).toMatchInlineSnapshot(

--- a/vscode/src/non-stop/codelenses/provider.ts
+++ b/vscode/src/non-stop/codelenses/provider.ts
@@ -157,8 +157,9 @@ export class FixupCodeLenses implements vscode.CodeLensProvider, FixupControlApp
             this.removeLensesFor(task)
             return
         }
-        this.taskLenses.set(task, getLensesForTask(task))
-        this.notifyCodeLensesChanged()
+        const value = getLensesForTask(task)
+        this.taskLenses.set(task, value)
+        this.notifyCodeLensesChanged(task.document.uri, value)
     }
 
     public didDeleteTask(task: FixupTask): void {
@@ -170,7 +171,7 @@ export class FixupCodeLenses implements vscode.CodeLensProvider, FixupControlApp
     private removeLensesFor(task: FixupTask): void {
         if (this.taskLenses.delete(task)) {
             // TODO: Clean up the fixup file when there are no remaining code lenses
-            this.notifyCodeLensesChanged()
+            this.notifyCodeLensesChanged(task.document.uri, [])
         }
     }
 
@@ -194,7 +195,7 @@ export class FixupCodeLenses implements vscode.CodeLensProvider, FixupControlApp
         void vscode.commands.executeCommand('setContext', 'cody.hasActionableEdit', hasActionableEdit)
     }
 
-    private notifyCodeLensesChanged(): void {
+    public notifyCodeLensesChanged(uri: vscode.Uri, codeLenses: vscode.CodeLens[]): void {
         this._onDidChangeCodeLenses.fire()
     }
 

--- a/vscode/src/non-stop/codelenses/provider.ts
+++ b/vscode/src/non-stop/codelenses/provider.ts
@@ -157,9 +157,9 @@ export class FixupCodeLenses implements vscode.CodeLensProvider, FixupControlApp
             this.removeLensesFor(task)
             return
         }
-        const value = getLensesForTask(task)
-        this.taskLenses.set(task, value)
-        this.notifyCodeLensesChanged(task.document.uri, value)
+        const lenses = getLensesForTask(task)
+        this.taskLenses.set(task, lenses)
+        this.notifyCodeLensesChanged(task.document.uri, lenses)
     }
 
     public didDeleteTask(task: FixupTask): void {


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/jetbrains/issues/2197.

## Test plan
Try to reproduce https://github.com/sourcegraph/jetbrains/issues/2197.

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

## Changelog
Move updateCodeLenses from agent.ts to AgentFixupControls.ts

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
