### PR TITLE
react to config/feature-flag changes using Observables in autocomplete

### DIFF
--- a/agent/src/autocomplete.test.ts
+++ b/agent/src/autocomplete.test.ts
@@ -68,7 +68,7 @@ describe('Autocomplete', () => {
     }, 10_000)
 
     // TODO: use `vi.useFakeTimers()` instead of `sleep()` once it's supported by the agent tests.
-    it('autocomplete/execute multiline(non-empty result)', async () => {
+    it('autocomplete/execute multiline (non-empty result)', async () => {
         const uri = workspace.file('src', 'bubbleSort.ts')
         await client.openFile(uri)
 

--- a/lib/shared/src/experimentation/FeatureFlagProvider.test.ts
+++ b/lib/shared/src/experimentation/FeatureFlagProvider.test.ts
@@ -116,189 +116,116 @@ describe('FeatureFlagProvider', () => {
     })
 
     describe('evaluatedFeatureFlag', () => {
-        function promiseResolveOnNextTick<T>(value: T): Promise<T> {
-            return new Promise(resolve => {
-                setTimeout(() => {
-                    resolve(value)
-                }, 0)
-            })
+        async function testEvaluatedFeatureFlag(
+            apiClient: Pick<
+                SourcegraphGraphQLAPIClient,
+                'getEvaluatedFeatureFlags' | 'evaluateFeatureFlag'
+            >,
+            expectInitialValues: (boolean | undefined)[],
+            update?: (
+                mockAPIClient: { [K in keyof typeof apiClient]: ReturnType<typeof vitest.fn> }
+            ) => void,
+            expectFinalValues?: (boolean | undefined)[]
+        ): Promise<void> {
+            vitest.useFakeTimers()
+            const provider = new FeatureFlagProvider({
+                ...apiClient,
+                endpoint: 'http://example.com',
+            } as SourcegraphGraphQLAPIClient)
+
+            const flag$ = provider.evaluatedFeatureFlag(FeatureFlag.TestFlagDoNotUse)
+
+            const { values, done, unsubscribe } = readValuesFrom(flag$)
+            vitest.runAllTimers()
+
+            // Test the initial emissions.
+            await nextTick()
+            expect(values).toEqual<typeof values>(expectInitialValues)
+            values.length = 0
+
+            if (!update) {
+                return
+            }
+
+            // Test that the observable emits updated values when flags change.
+            update(apiClient as any)
+            provider.refresh()
+            await nextTick()
+            expect(values).toEqual<typeof values>(expectFinalValues!)
+            values.length = 0
+
+            // Ensure there are no emissions after unsubscribing.
+            unsubscribe()
+            await done
+            expect(values).toEqual<typeof values>([])
         }
 
-        it(
-            'should yield feature flags from evaluatedFeatureFlag generator',
-            { timeout: 1000 },
-            async () => {
-                vitest.useFakeTimers()
-                const apiClient = {
-                    getEvaluatedFeatureFlags: vitest.fn().mockReturnValue(
-                        promiseResolveOnNextTick({
-                            [FeatureFlag.TestFlagDoNotUse]: true,
-                        })
-                    ),
-                    evaluateFeatureFlag: vitest.fn().mockResolvedValue(true),
-                    endpoint: 'http://example.com',
-                }
-
-                const provider = new FeatureFlagProvider(
-                    apiClient as unknown as SourcegraphGraphQLAPIClient
-                )
-
-                const generator = provider.evaluatedFeatureFlag(FeatureFlag.TestFlagDoNotUse)
-
-                const { values, done, unsubscribe } = readValuesFrom(generator)
-                vitest.runAllTimers()
-
-                await nextTick()
-                expect(values).toEqual<typeof values>([true, true])
-                values.pop()
-                values.pop()
-
-                // Test that the generator yields updated values when flags change.
-                apiClient.getEvaluatedFeatureFlags.mockResolvedValue({
-                    [FeatureFlag.TestFlagDoNotUse]: false,
-                })
-                provider.refresh()
-                await nextTick()
-                expect(values).toEqual<typeof values>([false])
-                values.pop()
-
-                unsubscribe()
-                await done
-                expect(values).toEqual<typeof values>([])
-            }
+        it('should emit when a new flag is evaluated', { timeout: 1000 }, () =>
+            testEvaluatedFeatureFlag(
+                {
+                    getEvaluatedFeatureFlags: vitest.fn().mockResolvedValue({}),
+                    evaluateFeatureFlag: vitest.fn().mockResolvedValue(false),
+                },
+                [undefined, false]
+            )
         )
-    })
 
-    describe('onFeatureFlagChanged', () => {
-        it('should call the callback when a feature flag changes from true to false', async () => {
-            vitest.useFakeTimers()
-            const apiClient = {
-                getEvaluatedFeatureFlags: vitest.fn().mockResolvedValue({
-                    [FeatureFlag.TestFlagDoNotUse]: true,
-                }),
-                evaluateFeatureFlag: vitest.fn().mockResolvedValue(true),
-            }
-            const provider = new FeatureFlagProvider(apiClient as unknown as SourcegraphGraphQLAPIClient)
+        it('should emit when value changes from true to false', { timeout: 1000 }, () =>
+            testEvaluatedFeatureFlag(
+                {
+                    getEvaluatedFeatureFlags: vitest.fn().mockResolvedValue({
+                        [FeatureFlag.TestFlagDoNotUse]: true,
+                    }),
+                    evaluateFeatureFlag: vitest.fn().mockResolvedValue(true),
+                },
+                [true],
+                apiClient => {
+                    apiClient.getEvaluatedFeatureFlags.mockResolvedValue({
+                        [FeatureFlag.TestFlagDoNotUse]: false,
+                    })
+                    apiClient.evaluateFeatureFlag.mockResolvedValue(false)
+                },
+                [false]
+            )
+        )
 
-            // Evaluate a flag so we know that this one is being tracked
-            await provider.evaluateFeatureFlag(FeatureFlag.TestFlagDoNotUse)
+        it('should emit when value changes from false to true', { timeout: 1000 }, () =>
+            testEvaluatedFeatureFlag(
+                {
+                    getEvaluatedFeatureFlags: vitest.fn().mockResolvedValue({
+                        [FeatureFlag.TestFlagDoNotUse]: false,
+                    }),
+                    evaluateFeatureFlag: vitest.fn().mockResolvedValue(false),
+                },
+                [false],
+                apiClient => {
+                    apiClient.getEvaluatedFeatureFlags.mockResolvedValue({
+                        [FeatureFlag.TestFlagDoNotUse]: true,
+                    })
+                    apiClient.evaluateFeatureFlag.mockResolvedValue(true)
+                },
+                [true]
+            )
+        )
 
-            const callback = vitest.fn()
-            provider.onFeatureFlagChanged('test', callback)
-
-            apiClient.getEvaluatedFeatureFlags.mockResolvedValue({
-                [FeatureFlag.TestFlagDoNotUse]: false,
-            })
-            vitest.runAllTimers()
-            // The feature flags are being refreshed asynchronous, so we need to wait for the next
-            // micro queue flush.
-            vitest.useRealTimers()
-            await nextTick()
-
-            expect(callback).toHaveBeenCalled()
-        })
-
-        it('should call the callback when a feature flag changes from false to true', async () => {
-            vitest.useFakeTimers()
-            const apiClient = {
-                getEvaluatedFeatureFlags: vitest.fn().mockResolvedValue({
-                    [FeatureFlag.TestFlagDoNotUse]: false,
-                }),
-                evaluateFeatureFlag: vitest.fn().mockResolvedValue(false),
-            }
-            const provider = new FeatureFlagProvider(apiClient as unknown as SourcegraphGraphQLAPIClient)
-
-            // Evaluate a flag so we know that this one is being tracked
-            await provider.evaluateFeatureFlag(FeatureFlag.TestFlagDoNotUse)
-
-            const callback = vitest.fn()
-            provider.onFeatureFlagChanged('test', callback)
-
-            apiClient.getEvaluatedFeatureFlags.mockResolvedValue({
-                [FeatureFlag.TestFlagDoNotUse]: true,
-            })
-            vitest.runAllTimers()
-            // The feature flags are being refreshed asynchronous, so we need to wait for the next
-            // micro queue flush.
-            vitest.useRealTimers()
-            await nextTick()
-
-            expect(callback).toHaveBeenCalled()
-        })
-
-        it('should call the callback when a new flag is evaluated', async () => {
-            vitest.useFakeTimers()
-            const apiClient = {
-                getEvaluatedFeatureFlags: vitest.fn().mockResolvedValue({}),
-                evaluateFeatureFlag: vitest.fn().mockResolvedValue(true),
-            }
-            const provider = new FeatureFlagProvider(apiClient as unknown as SourcegraphGraphQLAPIClient)
-
-            const callback = vitest.fn()
-            provider.onFeatureFlagChanged('test', callback)
-
-            // Evaluate a flag so we know that this one is being tracked
-            await provider.evaluateFeatureFlag(FeatureFlag.TestFlagDoNotUse)
-
-            vitest.runAllTimers()
-            // The feature flags are being refreshed asynchronous, so we need to wait for the next
-            // micro queue flush.
-            vitest.useRealTimers()
-            await nextTick()
-
-            expect(callback).toHaveBeenCalled()
-        })
-
-        it('should not call the callback when a new flag is evaluated when not subscribed', async () => {
-            vitest.useFakeTimers()
-            const apiClient = {
-                getEvaluatedFeatureFlags: vitest.fn().mockResolvedValue({
-                    [FeatureFlag.TestFlagDoNotUse]: true,
-                }),
-                evaluateFeatureFlag: vitest.fn().mockResolvedValue(true),
-            }
-            const provider = new FeatureFlagProvider(apiClient as unknown as SourcegraphGraphQLAPIClient)
-
-            // Evaluate a flag so we know that this one is being tracked
-            await provider.evaluateFeatureFlag(FeatureFlag.TestFlagDoNotUse)
-
-            const callback = vitest.fn()
-            const unsubscribe = provider.onFeatureFlagChanged('test', callback)
-            unsubscribe()
-
-            apiClient.getEvaluatedFeatureFlags.mockResolvedValue({
-                [FeatureFlag.TestFlagDoNotUse]: false,
-            })
-            vitest.runAllTimers()
-            // The feature flags are being refreshed asynchronous, so we need to wait for the next
-            // micro queue flush.
-            vitest.useRealTimers()
-            await nextTick()
-
-            expect(callback).not.toHaveBeenCalled()
-        })
-
-        it('should not call the callback if a previously false feature flag is no longer set in the new evaluatedFeatureFlag list. This flag is likely not defined upstream', async () => {
-            vitest.useFakeTimers()
-            const apiClient = {
-                getEvaluatedFeatureFlags: () => Promise.resolve({}),
-                evaluateFeatureFlag: vitest.fn().mockResolvedValue(null),
-            }
-            const provider = new FeatureFlagProvider(apiClient as unknown as SourcegraphGraphQLAPIClient)
-
-            // Evaluate a flag so we know that this one is being tracked
-            await provider.evaluateFeatureFlag(FeatureFlag.TestFlagDoNotUse)
-
-            const callback = vitest.fn()
-            provider.onFeatureFlagChanged('test', callback)
-
-            vitest.runAllTimers()
-            // The feature flags are being refreshed asynchronous, so we need to wait for the next
-            // micro queue flush.
-            vitest.useRealTimers()
-            await nextTick()
-
-            expect(callback).not.toHaveBeenCalled()
-        })
+        it(
+            'should emit undefined when a previously false flag is no longer in the exposed list',
+            { timeout: 1000 },
+            () =>
+                testEvaluatedFeatureFlag(
+                    {
+                        getEvaluatedFeatureFlags: vitest.fn().mockResolvedValue({
+                            [FeatureFlag.TestFlagDoNotUse]: false,
+                        }),
+                        evaluateFeatureFlag: vitest.fn().mockResolvedValue(false),
+                    },
+                    [false],
+                    apiClient => {
+                        apiClient.getEvaluatedFeatureFlags.mockResolvedValue({})
+                        apiClient.evaluateFeatureFlag.mockResolvedValue(null)
+                    },
+                    [undefined]
+                )
+        )
     })
 })

--- a/lib/shared/src/experimentation/FeatureFlagProvider.test.ts
+++ b/lib/shared/src/experimentation/FeatureFlagProvider.test.ts
@@ -166,15 +166,13 @@ describe('FeatureFlagProvider', () => {
         }
 
         it('should emit when a new flag is evaluated', { timeout: 1000 }, () =>
-            testEvaluatedFeatureFlag(
-                {
-                    apiClient: {
-                        getEvaluatedFeatureFlags: vitest.fn().mockResolvedValue({}),
-                        evaluateFeatureFlag: vitest.fn().mockResolvedValue(false),
-                    },
-                    expectInitialValues: [undefined, false],
-                }
-            )
+            testEvaluatedFeatureFlag({
+                apiClient: {
+                    getEvaluatedFeatureFlags: vitest.fn().mockResolvedValue({}),
+                    evaluateFeatureFlag: vitest.fn().mockResolvedValue(false),
+                },
+                expectInitialValues: [undefined, false],
+            })
         )
 
         it('should emit when value changes from true to false', { timeout: 1000 }, () =>

--- a/lib/shared/src/experimentation/FeatureFlagProvider.ts
+++ b/lib/shared/src/experimentation/FeatureFlagProvider.ts
@@ -95,7 +95,14 @@ export class FeatureFlagProvider {
 
     constructor(private apiClient: SourcegraphGraphQLAPIClient) {}
 
-    public getFromCache(flagName: FeatureFlag): boolean | undefined {
+    /**
+     * Get a flag's value from the cache. The returned value could be stale. You must have
+     * previously called {@link FeatureFlagProvider.evaluateFeatureFlag} or
+     * {@link FeatureFlagProvider.evaluatedFeatureFlag} to ensure that this feature flag's value is
+     * present in the cache. For that reason, this method is private because it is easy for external
+     * callers to mess that up when calling it.
+     */
+    private getFromCache(flagName: FeatureFlag): boolean | undefined {
         void this.refreshIfStale()
 
         const endpoint = this.apiClient.endpoint
@@ -172,7 +179,7 @@ export class FeatureFlagProvider {
         await this.refreshFeatureFlags()
     }
 
-    public async refreshIfStale(): Promise<void> {
+    private async refreshIfStale(): Promise<void> {
         const now = Date.now()
         if (now - this.lastRefreshTimestamp > ONE_HOUR) {
             // Cache expired, refresh

--- a/lib/shared/src/experimentation/FeatureFlagProvider.ts
+++ b/lib/shared/src/experimentation/FeatureFlagProvider.ts
@@ -1,7 +1,7 @@
 import { Observable } from 'observable-fns'
 import type { Event } from 'vscode'
 import { logDebug } from '../logger'
-import { fromVSCodeEvent } from '../misc/observable'
+import { distinctUntilChanged, fromVSCodeEvent } from '../misc/observable'
 import { setSingleton, singletonNotYetSet } from '../singletons'
 import { type SourcegraphGraphQLAPIClient, graphqlClient } from '../sourcegraph-api/graphql'
 import { wrapInActiveSpan } from '../tracing'
@@ -86,7 +86,7 @@ export class FeatureFlagProvider {
     // flags are updated in the background.
     private unexposedFeatureFlags: Record<string, Set<string>> = {}
 
-    private subscriptions: Map<
+    private subscriptionsForEndpoint: Map<
         string, // ${endpoint}#${prefix filter}
         { lastSnapshot: Record<string, boolean>; callbacks: Set<() => void> }
     > = new Map()
@@ -167,10 +167,12 @@ export class FeatureFlagProvider {
         const onChangeEvent: Event<boolean | undefined> = (
             listener: (value: boolean | undefined) => void
         ) => {
-            const dispose = this.onFeatureFlagChanged('', () => listener(this.getFromCache(flagName)))
+            const dispose = this.onFeatureFlagChanged(() => listener(this.getFromCache(flagName)))
             return { dispose }
         }
-        return fromVSCodeEvent(onChangeEvent, () => this.evaluateFeatureFlag(flagName))
+        return fromVSCodeEvent(onChangeEvent, () => this.evaluateFeatureFlag(flagName)).pipe(
+            distinctUntilChanged()
+        )
     }
 
     public async refresh(): Promise<void> {
@@ -203,29 +205,30 @@ export class FeatureFlagProvider {
                 clearTimeout(this.nextRefreshTimeout)
                 this.nextRefreshTimeout = undefined
             }
-            if (this.subscriptions.size > 0) {
+            if (this.subscriptionsForEndpoint.size > 0) {
                 this.nextRefreshTimeout = setTimeout(() => this.refreshFeatureFlags(), ONE_HOUR)
             }
         })
     }
 
-    // Allows you to subscribe to a change event that is triggered when feature flags with a
-    // predefined prefix are updated. Can be used to sync code that only queries flags at startup
-    // to outside changes.
-    //
-    // Note this will only update feature flags that a user is currently exposed to. For feature
-    // flags not defined upstream, the changes will require a new call to `evaluateFeatureFlag` to
-    // be picked up.
-    public onFeatureFlagChanged(prefixFilter: string, callback: () => void): () => void {
+    /**
+     * Allows you to subscribe to a change event that is triggered when feature flags change that
+     * the user is currently exposed to.
+     *
+     * Note this will only update feature flags that a user is currently exposed to. For feature
+     * flags not defined upstream, the changes will require a new call to
+     * {@link FeatureFlagProvider.evaluateFeatureFlag} or
+     * {@link FeatureFlagProvider.evaluatedFeatureFlag} to be picked up.
+     */
+    private onFeatureFlagChanged(callback: () => void): () => void {
         const endpoint = this.apiClient.endpoint
-        const key = endpoint + '#' + prefixFilter
-        const subscription = this.subscriptions.get(key)
+        const subscription = this.subscriptionsForEndpoint.get(endpoint)
         if (subscription) {
             subscription.callbacks.add(callback)
             return () => subscription.callbacks.delete(callback)
         }
-        this.subscriptions.set(key, {
-            lastSnapshot: this.computeFeatureFlagSnapshot(endpoint, prefixFilter),
+        this.subscriptionsForEndpoint.set(endpoint, {
+            lastSnapshot: this.computeFeatureFlagSnapshot(endpoint),
             callbacks: new Set([callback]),
         })
 
@@ -237,14 +240,14 @@ export class FeatureFlagProvider {
         }
 
         return () => {
-            const subscription = this.subscriptions.get(key)
+            const subscription = this.subscriptionsForEndpoint.get(endpoint)
             if (subscription) {
                 subscription.callbacks.delete(callback)
                 if (subscription.callbacks.size === 0) {
-                    this.subscriptions.delete(key)
+                    this.subscriptionsForEndpoint.delete(endpoint)
                 }
 
-                if (this.subscriptions.size === 0 && this.nextRefreshTimeout) {
+                if (this.subscriptionsForEndpoint.size === 0 && this.nextRefreshTimeout) {
                     clearTimeout(this.nextRefreshTimeout)
                     this.nextRefreshTimeout = undefined
                 }
@@ -254,12 +257,8 @@ export class FeatureFlagProvider {
 
     private notifyFeatureFlagChanged(): void {
         const callbacksToTrigger: (() => void)[] = []
-        for (const [key, subs] of this.subscriptions) {
-            const parts = key.split('#')
-            const endpoint = parts[0]
-            const prefixFilter = parts[1]
-
-            const currentSnapshot = this.computeFeatureFlagSnapshot(endpoint, prefixFilter)
+        for (const [endpoint, subs] of this.subscriptionsForEndpoint) {
+            const currentSnapshot = this.computeFeatureFlagSnapshot(endpoint)
             // We only care about flags being changed that we previously already captured. A new
             // evaluation should not trigger a change event unless that new value is later changed.
             if (
@@ -281,18 +280,8 @@ export class FeatureFlagProvider {
         }
     }
 
-    private computeFeatureFlagSnapshot(endpoint: string, prefixFilter: string): Record<string, boolean> {
-        const featureFlags = this.exposedFeatureFlags[endpoint]
-        if (!featureFlags) {
-            return NO_FLAGS
-        }
-        const keys = Object.keys(featureFlags)
-        const filteredKeys = keys.filter(key => key.startsWith(prefixFilter))
-        const filteredFeatureFlags = filteredKeys.reduce((acc: any, key) => {
-            acc[key] = featureFlags[key]
-            return acc
-        }, {})
-        return filteredFeatureFlags
+    private computeFeatureFlagSnapshot(endpoint: string): Record<string, boolean> {
+        return this.exposedFeatureFlags[endpoint] ?? NO_FLAGS
     }
 }
 

--- a/lib/shared/src/misc/observable.ts
+++ b/lib/shared/src/misc/observable.ts
@@ -4,6 +4,7 @@ import {
     type ObservableLike,
     Subject,
     type Subscription,
+    type SubscriptionObserver,
     map,
     unsubscribe,
 } from 'observable-fns'
@@ -126,22 +127,33 @@ export function readValuesFrom<T>(observable: Observable<T>): {
     values: T[]
     done: Promise<void>
     unsubscribe(): void
+    status: () => 'pending' | 'complete' | 'error' | 'unsubscribed'
 } {
     const values: T[] = []
     const { promise, resolve, reject } = promiseWithResolvers<void>()
+    let status: ReturnType<ReturnType<typeof readValuesFrom<T>>['status']> = 'pending'
     const subscription = observable.subscribe({
         next: value => values.push(value),
-        error: reject,
-        complete: resolve,
+        error: err => {
+            reject(err)
+            status = 'error'
+        },
+        complete: () => {
+            resolve()
+            status = 'complete'
+        },
     })
-    return {
+    const result: ReturnType<typeof readValuesFrom<T>> = {
         values,
         done: promise,
         unsubscribe: () => {
             subscription.unsubscribe()
             resolve()
+            status = 'unsubscribed'
         },
+        status: () => status,
     }
+    return result
 }
 
 /**
@@ -202,11 +214,61 @@ export function promiseFactoryToObservable<T>(
 }
 
 /**
+ * Create an {@link Observable} that initially does not emit, but after {@link setSource} is called
+ * with a source, all subscribers subscribe to that source observable.
+ */
+export function fromLateSetSource<T>(): {
+    observable: Observable<T>
+    setSource: (input: Observable<T>, throwErrorIfAlreadySet?: boolean) => void
+} {
+    let source: Observable<T> | null = null
+    const pendingObservers: {
+        observer: SubscriptionObserver<T> | null
+        subscription: Unsubscribable | null
+    }[] = []
+
+    const observable = new Observable<T>(observer => {
+        if (source) {
+            return source.subscribe(observer)
+        }
+
+        const entry: (typeof pendingObservers)[number] = { observer, subscription: null }
+        pendingObservers.push(entry)
+        return () => {
+            entry.subscription?.unsubscribe()
+            const index = pendingObservers.indexOf(entry)
+            if (index !== -1) {
+                pendingObservers.splice(index, 1)
+            }
+        }
+    })
+
+    const setSource = (input: Observable<T>, throwErrorIfAlreadySet = true) => {
+        if (source && throwErrorIfAlreadySet) {
+            throw new Error('source is already set')
+        }
+        source = input
+        for (const entry of pendingObservers) {
+            if (!entry.subscription) {
+                entry.subscription = source.subscribe(entry.observer!)
+                entry.observer = null
+            }
+        }
+    }
+
+    return { observable, setSource }
+}
+/**
  * An empty {@link Observable}, which emits no values and completes immediately.
  */
 export const EMPTY = new Observable<never>(observer => {
     observer.complete()
 })
+
+/**
+ * An observable that never emits, errors, nor completes.
+ */
+export const NEVER: Observable<never> = new Observable<never>(() => {})
 
 /**
  * Combine the latest values from multiple {@link Observable}s into a single {@link Observable} that
@@ -368,6 +430,82 @@ export function fromVSCodeEvent<T>(
     })
 }
 
+/**
+ * Create a VS Code resource while the observable is subscribed, and dispose of it when the
+ * subscription is unsubscribed. The returned {@link Observable} never emits.
+ */
+export function vscodeResource(create: () => VSCodeDisposable): Observable<void> {
+    return new Observable(() => {
+        const disposable = create()
+        return () => {
+            disposable.dispose()
+        }
+    })
+}
+
+/**
+ * Dispose of the given VS Code disposables when the returned {@link Observable} is unsubscribed.
+ * The observable never emits.
+ */
+export function disposeOnUnsubscribe(...disposables: VSCodeDisposable[]): Observable<void> {
+    return new Observable(() => {
+        return () => {
+            for (const disposable of disposables) {
+                disposable.dispose()
+            }
+        }
+    })
+}
+
+/**
+ * Create VS Code disposables for each emission, and dispose them upon the next emission or error or
+ * when the returned observable is unsubscribed. The returned observable never completes.
+ */
+export function createDisposables<T>(
+    create: (value: T) => VSCodeDisposable | VSCodeDisposable[] | undefined
+): (input: ObservableLike<T>) => Observable<T> {
+    let disposables: VSCodeDisposable | VSCodeDisposable[] | undefined
+    function disposeAll(): void {
+        if (disposables) {
+            if (Array.isArray(disposables)) {
+                for (const d of disposables) {
+                    try {
+                        d.dispose()
+                    } catch {}
+                }
+            } else {
+                try {
+                    disposables.dispose()
+                } catch {}
+            }
+        }
+        disposables = undefined
+    }
+    return (observable: ObservableLike<T>): Observable<T> =>
+        new Observable<T>(observer => {
+            const subscription = observable.subscribe({
+                next: value => {
+                    disposeAll()
+                    try {
+                        disposables = create(value)
+                        observer.next(value)
+                    } catch (error) {
+                        observer.error(error)
+                    }
+                },
+                error: (error: any) => {
+                    disposeAll()
+                    observer.error(error)
+                },
+                complete: () => {},
+            })
+            return () => {
+                unsubscribe(subscription)
+                disposeAll()
+            }
+        })
+}
+
 export function pluck<T, K extends keyof T>(key: K): (input: ObservableLike<T>) => Observable<T[K]>
 export function pluck<T, K1 extends keyof T, K2 extends keyof T[K1]>(
     key1: K1,
@@ -527,4 +665,86 @@ export function startWith<T, R>(value: R): (source: ObservableLike<T>) => Observ
                 }
             }
         })
+}
+
+export function take<T>(count: number): (source: ObservableLike<T>) => Observable<T> {
+    return (source: ObservableLike<T>) =>
+        new Observable<T>(observer => {
+            let taken = 0
+            const sourceSubscription = source.subscribe({
+                next(value) {
+                    if (taken < count) {
+                        observer.next(value)
+                        taken++
+                        if (taken === count) {
+                            observer.complete()
+                            unsubscribe(sourceSubscription)
+                        }
+                    }
+                },
+                error(err) {
+                    observer.error(err)
+                },
+                complete() {
+                    observer.complete()
+                },
+            })
+
+            return () => {
+                unsubscribe(sourceSubscription)
+            }
+        })
+}
+
+export function mergeMap<T, R>(
+    project: (value: T, index: number) => ObservableLike<R>
+): (observable: ObservableLike<T>) => Observable<R> {
+    return (observable: ObservableLike<T>): Observable<R> => {
+        return new Observable<R>(observer => {
+            let index = 0
+            const innerSubscriptions = new Set<UnsubscribableLike>()
+            let outerCompleted = false
+
+            const checkComplete = () => {
+                if (outerCompleted && innerSubscriptions.size === 0) {
+                    observer.complete()
+                }
+            }
+
+            const outerSubscription = observable.subscribe({
+                next(value) {
+                    const innerObservable = project(value, index++)
+                    const innerSubscription = innerObservable.subscribe({
+                        next(innerValue) {
+                            observer.next(innerValue)
+                        },
+                        error(err) {
+                            observer.error(err)
+                        },
+                        complete() {
+                            innerSubscriptions.delete(innerSubscription)
+                            checkComplete()
+                        },
+                    })
+                    innerSubscriptions.add(innerSubscription)
+                },
+                error(err) {
+                    observer.error(err)
+                },
+                complete() {
+                    outerCompleted = true
+                    checkComplete()
+                },
+            })
+
+            return () => {
+                unsubscribe(outerSubscription)
+                for (const innerSubscription of innerSubscriptions) {
+                    if (innerSubscription) {
+                        unsubscribe(innerSubscription)
+                    }
+                }
+            }
+        })
+    }
 }

--- a/vscode/src/chat/chat-view/ChatController.ts
+++ b/vscode/src/chat/chat-view/ChatController.ts
@@ -252,13 +252,6 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
         // Advise local embeddings to start up if necessary.
         void this.retrievers.localEmbeddings?.start()
 
-        // Keep feature flags updated.
-        this.disposables.push({
-            dispose: featureFlagProvider.instance!.onFeatureFlagChanged('', () => {
-                void this.sendConfig()
-            }),
-        })
-
         this.disposables.push(
             startClientStateBroadcaster({
                 useRemoteSearch: this.retrievers.allowRemoteContext,

--- a/vscode/src/completions/completion-provider-config.ts
+++ b/vscode/src/completions/completion-provider-config.ts
@@ -27,6 +27,25 @@ class CompletionProviderConfig {
      */
     public async init(config: ClientConfiguration): Promise<void> {
         this._config = config
+
+        // Pre-fetch the feature flags we need so they are cached and immediately available when the
+        // user performs their first autocomplete, and so that our performance metrics are not
+        // skewed by the 1st autocomplete's feature flag evaluation time.
+        const featureFlagsUsed: FeatureFlag[] = [
+            FeatureFlag.CodyAutocompleteContextExperimentBaseFeatureFlag,
+            FeatureFlag.CodyAutocompleteContextExperimentVariant1,
+            FeatureFlag.CodyAutocompleteContextExperimentVariant2,
+            FeatureFlag.CodyAutocompleteContextExperimentVariant3,
+            FeatureFlag.CodyAutocompleteContextExperimentVariant4,
+            FeatureFlag.CodyAutocompleteContextExperimentControl,
+            FeatureFlag.CodyAutocompletePreloadingExperimentBaseFeatureFlag,
+            FeatureFlag.CodyAutocompletePreloadingExperimentVariant1,
+            FeatureFlag.CodyAutocompletePreloadingExperimentVariant2,
+            FeatureFlag.CodyAutocompletePreloadingExperimentVariant3,
+        ]
+        await Promise.all(
+            featureFlagsUsed.map(flag => featureFlagProvider.instance!.evaluateFeatureFlag(flag))
+        )
     }
 
     public setConfig(config: ClientConfiguration) {

--- a/vscode/src/completions/context/context-mixer.test.ts
+++ b/vscode/src/completions/context/context-mixer.test.ts
@@ -35,7 +35,7 @@ function createMockStrategy(resultSets: AutocompleteContextSnippet[][]): Context
     }
 
     const mockStrategyFactory = {
-        getStrategy: vi.fn().mockReturnValue({
+        getStrategy: vi.fn().mockResolvedValue({
             name: retrievers.length > 0 ? 'jaccard-similarity' : 'none',
             retrievers,
         }),

--- a/vscode/src/completions/context/context-mixer.ts
+++ b/vscode/src/completions/context/context-mixer.ts
@@ -72,13 +72,13 @@ export interface GetContextResult {
  * ranged for the top ranked document from all retrieval sources before we move on to the second
  * document).
  */
-export class ContextMixer implements vscode.Disposable {
+export class ContextMixer {
     constructor(private strategyFactory: ContextStrategyFactory) {}
 
     public async getContext(options: GetContextOptions): Promise<GetContextResult> {
         const start = performance.now()
 
-        const { name: strategy, retrievers } = this.strategyFactory.getStrategy(options.document)
+        const { name: strategy, retrievers } = await this.strategyFactory.getStrategy(options.document)
         if (retrievers.length === 0) {
             return {
                 context: [],
@@ -173,10 +173,6 @@ export class ContextMixer implements vscode.Disposable {
             context: mixedContext,
             logSummary,
         }
-    }
-
-    public dispose(): void {
-        this.strategyFactory.dispose()
     }
 }
 

--- a/vscode/src/completions/context/retrievers/jaccard-similarity/history.ts
+++ b/vscode/src/completions/context/retrievers/jaccard-similarity/history.ts
@@ -1,6 +1,5 @@
-import { FeatureFlag } from '@sourcegraph/cody-shared'
+import { FeatureFlag, featureFlagProvider } from '@sourcegraph/cody-shared'
 import * as vscode from 'vscode'
-import { completionProviderConfig } from '../../../completion-provider-config'
 import { type ShouldUseContextParams, shouldBeUsedAsContext } from '../../utils'
 
 interface HistoryItem {
@@ -9,7 +8,7 @@ interface HistoryItem {
 
 export interface DocumentHistory {
     addItem(newItem: HistoryItem): void
-    lastN(n: number, languageId?: string, ignoreUris?: vscode.Uri[]): HistoryItem[]
+    lastN(n: number, languageId?: string, ignoreUris?: vscode.Uri[]): Promise<HistoryItem[]>
 }
 
 export class VSCodeDocumentHistory implements DocumentHistory, vscode.Disposable {
@@ -63,7 +62,17 @@ export class VSCodeDocumentHistory implements DocumentHistory, vscode.Disposable
     /**
      * Returns the last n items of history in reverse chronological order (latest item at the front)
      */
-    public lastN(n: number, baseLanguageId: string, ignoreUris?: vscode.Uri[]): HistoryItem[] {
+    public async lastN(
+        n: number,
+        baseLanguageId: string,
+        ignoreUris?: vscode.Uri[]
+    ): Promise<HistoryItem[]> {
+        const enableExtendedLanguagePool = Boolean(
+            await featureFlagProvider.instance!.evaluateFeatureFlag(
+                FeatureFlag.CodyAutocompleteContextExtendLanguagePool
+            )
+        )
+
         const ret: HistoryItem[] = []
         const ignoreSet = new Set(ignoreUris || [])
         for (let i = this.history.length - 1; i >= 0; i--) {
@@ -75,9 +84,7 @@ export class VSCodeDocumentHistory implements DocumentHistory, vscode.Disposable
                 continue
             }
             const params: ShouldUseContextParams = {
-                enableExtendedLanguagePool: completionProviderConfig.getPrefetchedFlag(
-                    FeatureFlag.CodyAutocompleteContextExtendLanguagePool
-                ),
+                enableExtendedLanguagePool,
                 baseLanguageId: baseLanguageId,
                 languageId: item.document.languageId,
             }

--- a/vscode/src/completions/create-multi-model-inline-completion-provider.ts
+++ b/vscode/src/completions/create-multi-model-inline-completion-provider.ts
@@ -133,7 +133,7 @@ export async function createInlineCompletionItemFromMultipleProviders({
 
         // Use the experimental config to get the context provider
         completionProviderConfig.setConfig(newConfig)
-        const provider = await createProviderHelper({
+        const provider = createProviderHelper({
             authStatus,
             legacyModel: currentProviderConfig.model,
             provider: currentProviderConfig.provider,

--- a/vscode/src/completions/get-inline-completions-tests/helpers.ts
+++ b/vscode/src/completions/get-inline-completions-tests/helpers.ts
@@ -22,6 +22,7 @@ import type {
     CodeCompletionsParams,
     CompletionResponseWithMetaData,
 } from '@sourcegraph/cody-shared/src/inferenceClient/misc'
+import { Observable } from 'observable-fns'
 import { DEFAULT_VSCODE_SETTINGS } from '../../testutils/mocks'
 import type { SupportedLanguage } from '../../tree-sitter/grammars'
 import { updateParseTreeCache } from '../../tree-sitter/parse-tree-cache'
@@ -211,7 +212,7 @@ export function params(
             configuration?.autocompleteFirstCompletionTimeout ??
             DEFAULT_VSCODE_SETTINGS.autocompleteFirstCompletionTimeout,
         requestManager: new RequestManager(),
-        contextMixer: new ContextMixer(new DefaultContextStrategyFactory('none')),
+        contextMixer: new ContextMixer(new DefaultContextStrategyFactory(Observable.of('none'))),
         smartThrottleService: null,
         completionIntent: getCompletionIntent({
             document,

--- a/vscode/src/completions/get-inline-completions-tests/helpers.ts
+++ b/vscode/src/completions/get-inline-completions-tests/helpers.ts
@@ -415,7 +415,7 @@ export type V = Awaited<ReturnType<typeof getInlineCompletions>>
 
 export function initCompletionProviderConfig(config: Partial<ClientConfiguration>) {
     graphqlClient.setConfig({} as unknown as GraphQLAPIClientConfig)
-    vi.spyOn(featureFlagProvider.instance!, 'getFromCache').mockReturnValue(false)
+    vi.spyOn(featureFlagProvider.instance!, 'evaluateFeatureFlag').mockResolvedValue(false)
     return completionProviderConfig.init(config as ClientConfiguration)
 }
 

--- a/vscode/src/completions/get-inline-completions-tests/hot-streak.test.ts
+++ b/vscode/src/completions/get-inline-completions-tests/hot-streak.test.ts
@@ -4,6 +4,7 @@ import { resetParsersCache } from '../../tree-sitter/parser'
 import { InlineCompletionsResultSource } from '../get-inline-completions'
 import { initTreeSitterParser } from '../test-helpers'
 
+import { nextTick } from '@sourcegraph/cody-shared'
 import { getInlineCompletionsWithInlinedChunks } from './helpers'
 
 describe('[getInlineCompletions] hot streak', () => {
@@ -110,6 +111,7 @@ describe('[getInlineCompletions] hot streak', () => {
             expect(request.items[0].insertText).toEqual('console.log(3)')
             expect(request.source).toBe(InlineCompletionsResultSource.HotStreak)
 
+            await nextTick()
             request = await request.acceptFirstCompletionAndPressEnter()
             expect(request.items[0].insertText).toEqual('console.log(4)')
             expect(request.source).toBe(InlineCompletionsResultSource.HotStreak)
@@ -139,6 +141,7 @@ describe('[getInlineCompletions] hot streak', () => {
             expect(request.items[0].insertText).toEqual('console.log(4)')
             expect(request.source).toBe(InlineCompletionsResultSource.HotStreak)
 
+            await nextTick()
             request = await request.acceptFirstCompletionAndPressEnter()
             expect(request.items[0].insertText).toEqual('return foo')
             expect(request.source).toBe(InlineCompletionsResultSource.HotStreak)

--- a/vscode/src/completions/inline-completion-item-provider-e2e.test.ts
+++ b/vscode/src/completions/inline-completion-item-provider-e2e.test.ts
@@ -4,6 +4,7 @@ import {
     type GraphQLAPIClientConfig,
     contextFiltersProvider,
     graphqlClient,
+    nextTick,
     telemetryRecorder,
 } from '@sourcegraph/cody-shared'
 import { type MockInstance, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -411,6 +412,7 @@ describe('InlineCompletionItemProvider preloading', () => {
         const provider = getInlineCompletionProvider(autocompleteParams)
         await vi.runOnlyPendingTimersAsync()
         const provideCompletionSpy = vi.spyOn(provider, 'provideInlineCompletionItems')
+        await nextTick()
 
         const [handler] = onDidChangeTextEditorSelection.mock.calls[0] as any
 
@@ -442,6 +444,7 @@ describe('InlineCompletionItemProvider preloading', () => {
 
         const { document, position } = autocompleteParams
         const provider = getInlineCompletionProvider(autocompleteParams)
+        await vi.runOnlyPendingTimersAsync()
         const provideCompletionSpy = vi.spyOn(provider, 'provideInlineCompletionItems')
         const [handler] = onDidChangeTextEditorSelection.mock.lastCall as any
 
@@ -490,6 +493,7 @@ describe('InlineCompletionItemProvider preloading', () => {
 
         const { document, position } = autocompleteParams
         const provider = getInlineCompletionProvider(autocompleteParams)
+        await vi.runOnlyPendingTimersAsync()
         const provideCompletionSpy = vi.spyOn(provider, 'provideInlineCompletionItems')
         const [handler] = onDidChangeTextEditorSelection.mock.lastCall as any
 

--- a/vscode/src/completions/inline-completion-item-provider-e2e.test.ts
+++ b/vscode/src/completions/inline-completion-item-provider-e2e.test.ts
@@ -387,6 +387,10 @@ describe('InlineCompletionItemProvider preloading', () => {
 
     const onDidChangeTextEditorSelection = vi.spyOn(vsCodeMocks.window, 'onDidChangeTextEditorSelection')
 
+    beforeEach(() => {
+        onDidChangeTextEditorSelection.mockClear()
+    })
+
     beforeAll(async () => {
         vi.useFakeTimers()
 
@@ -405,9 +409,10 @@ describe('InlineCompletionItemProvider preloading', () => {
 
         const { document, position } = autocompleteParams
         const provider = getInlineCompletionProvider(autocompleteParams)
+        await vi.runOnlyPendingTimersAsync()
         const provideCompletionSpy = vi.spyOn(provider, 'provideInlineCompletionItems')
 
-        const [handler] = onDidChangeTextEditorSelection.mock.lastCall as any
+        const [handler] = onDidChangeTextEditorSelection.mock.calls[0] as any
 
         // Simulate a cursor movement event
         await handler({
@@ -459,8 +464,9 @@ describe('InlineCompletionItemProvider preloading', () => {
 
         const { document, position } = autocompleteParams
         const provider = getInlineCompletionProvider(autocompleteParams)
+        await vi.runOnlyPendingTimersAsync()
         const provideCompletionSpy = vi.spyOn(provider, 'provideInlineCompletionItems')
-        const [handler] = onDidChangeTextEditorSelection.mock.lastCall as any
+        const [handler] = onDidChangeTextEditorSelection.mock.calls[0] as any
 
         await handler({
             textEditor: { document },

--- a/vscode/src/completions/inline-completion-item-provider.ts
+++ b/vscode/src/completions/inline-completion-item-provider.ts
@@ -752,11 +752,11 @@ export class InlineCompletionItemProvider
      * Will confirm that the completion is _still_ visible before firing the event.
      */
     public markCompletionAsSuggestedAfterDelay(completion: AutocompleteItem): void {
-        const suggestionEvent = CompletionLogger.prepareSuggestionEvent(
-            completion.logId,
-            completion.span,
-            this.shouldSample
-        )
+        const suggestionEvent = CompletionLogger.prepareSuggestionEvent({
+            id: completion.logId,
+            span: completion.span,
+            shouldSample: this.shouldSample,
+        })
         if (!suggestionEvent) {
             return
         }

--- a/vscode/src/completions/logger.test.ts
+++ b/vscode/src/completions/logger.test.ts
@@ -74,7 +74,7 @@ describe('logger', () => {
             isFuzzyMatch: false,
             isDotComUser: false,
         })
-        const suggestionEvent = CompletionLogger.prepareSuggestionEvent(id, undefined)
+        const suggestionEvent = CompletionLogger.prepareSuggestionEvent({ id })
         suggestionEvent?.markAsRead({ document, position })
         CompletionLogger.accepted(id, document, item, range(0, 0, 0, 0), false)
 
@@ -107,7 +107,7 @@ describe('logger', () => {
             isFuzzyMatch: false,
             isDotComUser: false,
         })
-        const firstSuggestionEvent = CompletionLogger.prepareSuggestionEvent(id1, undefined)
+        const firstSuggestionEvent = CompletionLogger.prepareSuggestionEvent({ id: id1 })
         firstSuggestionEvent?.markAsRead({ document, position })
 
         const loggerItem = CompletionLogger.getCompletionEvent(id1)
@@ -125,7 +125,7 @@ describe('logger', () => {
             isFuzzyMatch: false,
             isDotComUser: false,
         })
-        const secondSuggestionEvent = CompletionLogger.prepareSuggestionEvent(id2, undefined)
+        const secondSuggestionEvent = CompletionLogger.prepareSuggestionEvent({ id: id2 })
         secondSuggestionEvent?.markAsRead({ document, position })
         CompletionLogger.accepted(id2, document, item, range(0, 0, 0, 0), false)
 
@@ -150,7 +150,7 @@ describe('logger', () => {
             isFuzzyMatch: false,
             isDotComUser: false,
         })
-        const thirdSuggestionEvent = CompletionLogger.prepareSuggestionEvent(id3, undefined)
+        const thirdSuggestionEvent = CompletionLogger.prepareSuggestionEvent({ id: id3 })
         thirdSuggestionEvent?.markAsRead({ document, position })
 
         const loggerItem3 = CompletionLogger.getCompletionEvent(id3)

--- a/vscode/src/completions/logger.test.ts
+++ b/vscode/src/completions/logger.test.ts
@@ -74,7 +74,7 @@ describe('logger', () => {
             isFuzzyMatch: false,
             isDotComUser: false,
         })
-        const suggestionEvent = CompletionLogger.prepareSuggestionEvent(id)
+        const suggestionEvent = CompletionLogger.prepareSuggestionEvent(id, undefined)
         suggestionEvent?.markAsRead({ document, position })
         CompletionLogger.accepted(id, document, item, range(0, 0, 0, 0), false)
 
@@ -107,7 +107,7 @@ describe('logger', () => {
             isFuzzyMatch: false,
             isDotComUser: false,
         })
-        const firstSuggestionEvent = CompletionLogger.prepareSuggestionEvent(id1)
+        const firstSuggestionEvent = CompletionLogger.prepareSuggestionEvent(id1, undefined)
         firstSuggestionEvent?.markAsRead({ document, position })
 
         const loggerItem = CompletionLogger.getCompletionEvent(id1)
@@ -125,7 +125,7 @@ describe('logger', () => {
             isFuzzyMatch: false,
             isDotComUser: false,
         })
-        const secondSuggestionEvent = CompletionLogger.prepareSuggestionEvent(id2)
+        const secondSuggestionEvent = CompletionLogger.prepareSuggestionEvent(id2, undefined)
         secondSuggestionEvent?.markAsRead({ document, position })
         CompletionLogger.accepted(id2, document, item, range(0, 0, 0, 0), false)
 
@@ -150,7 +150,7 @@ describe('logger', () => {
             isFuzzyMatch: false,
             isDotComUser: false,
         })
-        const thirdSuggestionEvent = CompletionLogger.prepareSuggestionEvent(id3)
+        const thirdSuggestionEvent = CompletionLogger.prepareSuggestionEvent(id3, undefined)
         thirdSuggestionEvent?.markAsRead({ document, position })
 
         const loggerItem3 = CompletionLogger.getCompletionEvent(id3)

--- a/vscode/src/completions/logger.ts
+++ b/vscode/src/completions/logger.ts
@@ -6,7 +6,6 @@ import {
     type AutocompleteContextSnippet,
     type BillingCategory,
     type BillingProduct,
-    FeatureFlag,
     isDotCom,
     isNetworkError,
     telemetryRecorder,
@@ -32,7 +31,6 @@ import {
     autocompleteStageCounterLogger,
 } from '../services/autocomplete-stage-counter-logger'
 import { type CompletionIntent, CompletionIntentTelemetryMetadataMapping } from '../tree-sitter/queries'
-import { completionProviderConfig } from './completion-provider-config'
 import type { ContextSummary } from './context/context-mixer'
 import {
     InlineCompletionsResultSource,
@@ -800,7 +798,8 @@ export type SuggestionMarkReadParam = {
 // suggested completion count as soon as we count it as such.
 export function prepareSuggestionEvent(
     id: CompletionLogID,
-    span?: Span
+    span: Span | undefined,
+    shouldSample?: boolean
 ): {
     getEvent: () => CompletionBookkeepingEvent | undefined
     markAsRead: (param: SuggestionMarkReadParam) => void
@@ -822,10 +821,6 @@ export function prepareSuggestionEvent(
         span?.addEvent('suggested')
 
         // Mark the completion as sampled if tracing is enable for this user
-        const shouldSample = completionProviderConfig.getPrefetchedFlag(
-            FeatureFlag.CodyAutocompleteTracing
-        )
-
         if (shouldSample && span) {
             span.setAttribute('sampled', true)
         }

--- a/vscode/src/completions/logger.ts
+++ b/vscode/src/completions/logger.ts
@@ -796,11 +796,11 @@ export type SuggestionMarkReadParam = {
 //
 // For statistics logging we start a timeout matching the READ_TIMEOUT_MS so we can increment the
 // suggested completion count as soon as we count it as such.
-export function prepareSuggestionEvent(
-    id: CompletionLogID,
-    span: Span | undefined,
-    shouldSample?: boolean
-): {
+export function prepareSuggestionEvent({
+    id,
+    span,
+    shouldSample,
+}: { id: CompletionLogID; span?: Span; shouldSample?: boolean }): {
     getEvent: () => CompletionBookkeepingEvent | undefined
     markAsRead: (param: SuggestionMarkReadParam) => void
 } | null {

--- a/vscode/src/completions/providers/create-provider.test.ts
+++ b/vscode/src/completions/providers/create-provider.test.ts
@@ -6,6 +6,8 @@ import {
     type CodyLLMSiteConfiguration,
     DOTCOM_URL,
     type GraphQLAPIClientConfig,
+    type ObservableValue,
+    firstValueFrom,
     graphqlClient,
 } from '@sourcegraph/cody-shared'
 import { beforeAll, describe, expect, it } from 'vitest'
@@ -43,9 +45,15 @@ describe('createProvider', () => {
         } as any as vscode.Memento)
     })
 
+    function createProviderForTest(
+        ...args: Parameters<typeof createProvider>
+    ): Promise<ObservableValue<ReturnType<typeof createProvider>>> {
+        return firstValueFrom(createProvider(...args))
+    }
+
     describe('if completions provider fields are defined in VSCode settings', () => {
         it('returns null if completions provider is not supported', async () => {
-            const provider = await createProvider(
+            const provider = await createProviderForTest(
                 getVSCodeConfigurationWithAccessToken({
                     autocompleteAdvancedProvider:
                         'nasa-ai' as ClientConfiguration['autocompleteAdvancedProvider'],
@@ -58,7 +66,7 @@ describe('createProvider', () => {
 
     describe('if completions provider field is not defined in VSCode settings', () => {
         it('returns `null` if completions provider is not configured', async () => {
-            const provider = await createProvider(
+            const provider = await createProviderForTest(
                 getVSCodeConfigurationWithAccessToken({
                     autocompleteAdvancedProvider:
                         null as ClientConfiguration['autocompleteAdvancedProvider'],
@@ -69,7 +77,7 @@ describe('createProvider', () => {
         })
 
         it('returns "fireworks" provider config and corresponding model if specified', async () => {
-            const provider = await createProvider(
+            const provider = await createProviderForTest(
                 getVSCodeConfigurationWithAccessToken({
                     autocompleteAdvancedProvider: 'fireworks',
                     autocompleteAdvancedModel: 'starcoder-7b',
@@ -81,7 +89,7 @@ describe('createProvider', () => {
         })
 
         it('returns "fireworks" provider config if specified in settings and default model', async () => {
-            const provider = await createProvider(
+            const provider = await createProviderForTest(
                 getVSCodeConfigurationWithAccessToken({ autocompleteAdvancedProvider: 'fireworks' }),
                 dummyAuthStatus
             )
@@ -90,7 +98,7 @@ describe('createProvider', () => {
         })
 
         it('returns "experimental-openaicompatible" provider config and corresponding model if specified', async () => {
-            const provider = await createProvider(
+            const provider = await createProviderForTest(
                 getVSCodeConfigurationWithAccessToken({
                     autocompleteAdvancedProvider: 'experimental-openaicompatible',
                     autocompleteAdvancedModel: 'starchat-16b-beta',
@@ -102,7 +110,7 @@ describe('createProvider', () => {
         })
 
         it('returns "experimental-openaicompatible" provider config if specified in settings and default model', async () => {
-            const provider = await createProvider(
+            const provider = await createProviderForTest(
                 getVSCodeConfigurationWithAccessToken({
                     autocompleteAdvancedProvider: 'experimental-openaicompatible',
                 }),
@@ -115,7 +123,7 @@ describe('createProvider', () => {
         })
 
         it('returns "unstable-openai" provider config if specified in VSCode settings; model is ignored', async () => {
-            const provider = await createProvider(
+            const provider = await createProviderForTest(
                 getVSCodeConfigurationWithAccessToken({
                     autocompleteAdvancedProvider: 'unstable-openai',
                     autocompleteAdvancedModel: 'hello-world',
@@ -127,7 +135,7 @@ describe('createProvider', () => {
         })
 
         it('returns "anthropic" provider config if specified in VSCode settings', async () => {
-            const provider = await createProvider(
+            const provider = await createProviderForTest(
                 getVSCodeConfigurationWithAccessToken({
                     autocompleteAdvancedProvider: 'anthropic',
                 }),
@@ -138,7 +146,7 @@ describe('createProvider', () => {
         })
 
         it('provider specified in VSCode settings takes precedence over the one defined in the site config', async () => {
-            const provider = await createProvider(
+            const provider = await createProviderForTest(
                 getVSCodeConfigurationWithAccessToken({
                     autocompleteAdvancedProvider: 'unstable-openai',
                 }),
@@ -266,10 +274,13 @@ describe('createProvider', () => {
                 it(`returns ${JSON.stringify(expected)} when cody LLM config is ${JSON.stringify(
                     configOverwrites
                 )}`, async () => {
-                    const provider = await createProvider(getVSCodeConfigurationWithAccessToken(), {
-                        ...dummyAuthStatus,
-                        configOverwrites,
-                    })
+                    const provider = await createProviderForTest(
+                        getVSCodeConfigurationWithAccessToken(),
+                        {
+                            ...dummyAuthStatus,
+                            configOverwrites,
+                        }
+                    )
                     if (expected === null) {
                         expect(provider).toBeNull()
                     } else {

--- a/vscode/src/completions/providers/get-experiment-model.ts
+++ b/vscode/src/completions/providers/get-experiment-model.ts
@@ -1,5 +1,12 @@
-import { FeatureFlag, featureFlagProvider } from '@sourcegraph/cody-shared'
+import {
+    FeatureFlag,
+    combineLatest,
+    distinctUntilChanged,
+    featureFlagProvider,
+    mergeMap,
+} from '@sourcegraph/cody-shared'
 
+import { Observable, map } from 'observable-fns'
 import * as vscode from 'vscode'
 import {
     DEEPSEEK_CODER_V2_LITE_BASE,
@@ -15,97 +22,110 @@ interface ProviderConfigFromFeatureFlags {
     model?: string
 }
 
-export async function getExperimentModel(
+export function getExperimentModel(
     isDotCom: boolean
-): Promise<ProviderConfigFromFeatureFlags | null> {
-    const [starCoderHybrid, claude3, fimModelExperimentFlag, deepseekV2LiteBase] = await Promise.all([
-        featureFlagProvider.instance!.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteStarCoderHybrid),
-        featureFlagProvider.instance!.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteClaude3),
-        featureFlagProvider.instance!.evaluateFeatureFlag(
+): Observable<ProviderConfigFromFeatureFlags | null> {
+    return combineLatest([
+        featureFlagProvider.instance!.evaluatedFeatureFlag(FeatureFlag.CodyAutocompleteStarCoderHybrid),
+        featureFlagProvider.instance!.evaluatedFeatureFlag(FeatureFlag.CodyAutocompleteClaude3),
+        featureFlagProvider.instance!.evaluatedFeatureFlag(
             FeatureFlag.CodyAutocompleteFIMModelExperimentBaseFeatureFlag
         ),
-        featureFlagProvider.instance!.evaluateFeatureFlag(
+        featureFlagProvider.instance!.evaluatedFeatureFlag(
             FeatureFlag.CodyAutocompleteDeepseekV2LiteBase
         ),
-    ])
+    ]).pipe(
+        mergeMap(([starCoderHybrid, claude3, fimModelExperimentFlag, deepseekV2LiteBase]) => {
+            // We run fine tuning experiment for VSC client only.
+            // We disable for all agent clients like the JetBrains plugin.
+            const isFinetuningExperimentDisabled = vscode.workspace
+                .getConfiguration()
+                .get<boolean>('cody.advanced.agent.running', false)
 
-    // We run fine tuning experiment for VSC client only.
-    // We disable for all agent clients like the JetBrains plugin.
-    const isFinetuningExperimentDisabled = vscode.workspace
-        .getConfiguration()
-        .get<boolean>('cody.advanced.agent.running', false)
+            if (!isFinetuningExperimentDisabled && fimModelExperimentFlag && isDotCom) {
+                // The traffic in this feature flag is interpreted as a traffic allocated to the fine-tuned experiment.
+                return resolveFIMModelExperimentFromFeatureFlags()
+            }
 
-    if (!isFinetuningExperimentDisabled && fimModelExperimentFlag && isDotCom) {
-        // The traffic in this feature flag is interpreted as a traffic allocated to the fine-tuned experiment.
-        return resolveFIMModelExperimentFromFeatureFlags()
-    }
+            if (isDotCom && deepseekV2LiteBase) {
+                return Observable.of({ provider: 'fireworks', model: DEEPSEEK_CODER_V2_LITE_BASE })
+            }
 
-    if (isDotCom && deepseekV2LiteBase) {
-        return { provider: 'fireworks', model: DEEPSEEK_CODER_V2_LITE_BASE }
-    }
+            if (starCoderHybrid) {
+                return Observable.of({ provider: 'fireworks', model: 'starcoder-hybrid' })
+            }
 
-    if (starCoderHybrid) {
-        return { provider: 'fireworks', model: 'starcoder-hybrid' }
-    }
+            if (claude3) {
+                return Observable.of({
+                    provider: 'anthropic',
+                    model: 'anthropic/claude-3-haiku-20240307',
+                })
+            }
 
-    if (claude3) {
-        return { provider: 'anthropic', model: 'anthropic/claude-3-haiku-20240307' }
-    }
-
-    return null
+            return Observable.of(null)
+        }),
+        distinctUntilChanged()
+    )
 }
 
-async function resolveFIMModelExperimentFromFeatureFlags(): ReturnType<typeof getExperimentModel> {
-    /**
-     * The traffic allocated to the fine-tuned-base feature flag is further split between multiple feature flag in function.
-     */
-    const [
-        fimModelControl,
-        fimModelVariant1,
-        fimModelVariant2,
-        fimModelVariant3,
-        fimModelVariant4,
-        fimModelCurrentBest,
-    ] = await Promise.all([
-        featureFlagProvider.instance!.evaluateFeatureFlag(
+/**
+ * The traffic allocated to the fine-tuned-base feature flag is further split between multiple
+ * feature flag in this function.
+ */
+function resolveFIMModelExperimentFromFeatureFlags(): ReturnType<typeof getExperimentModel> {
+    return combineLatest([
+        featureFlagProvider.instance!.evaluatedFeatureFlag(
             FeatureFlag.CodyAutocompleteFIMModelExperimentControl
         ),
-        featureFlagProvider.instance!.evaluateFeatureFlag(
+        featureFlagProvider.instance!.evaluatedFeatureFlag(
             FeatureFlag.CodyAutocompleteFIMModelExperimentVariant1
         ),
-        featureFlagProvider.instance!.evaluateFeatureFlag(
+        featureFlagProvider.instance!.evaluatedFeatureFlag(
             FeatureFlag.CodyAutocompleteFIMModelExperimentVariant2
         ),
-        featureFlagProvider.instance!.evaluateFeatureFlag(
+        featureFlagProvider.instance!.evaluatedFeatureFlag(
             FeatureFlag.CodyAutocompleteFIMModelExperimentVariant3
         ),
-        featureFlagProvider.instance!.evaluateFeatureFlag(
+        featureFlagProvider.instance!.evaluatedFeatureFlag(
             FeatureFlag.CodyAutocompleteFIMModelExperimentVariant4
         ),
-        featureFlagProvider.instance!.evaluateFeatureFlag(
+        featureFlagProvider.instance!.evaluatedFeatureFlag(
             FeatureFlag.CodyAutocompleteFIMModelExperimentCurrentBest
         ),
-    ])
-    if (fimModelVariant1) {
-        return { provider: 'fireworks', model: DEEPSEEK_CODER_V2_LITE_BASE_DIRECT_ROUTE }
-    }
-    if (fimModelVariant2) {
-        return { provider: 'fireworks', model: FIREWORKS_DEEPSEEK_7B_LANG_SPECIFIC_V0 }
-    }
-    if (fimModelVariant3) {
-        return { provider: 'fireworks', model: FIREWORKS_DEEPSEEK_7B_LANG_SPECIFIC_V1 }
-    }
-    if (fimModelVariant4) {
-        return { provider: 'fireworks', model: FIREWORKS_DEEPSEEK_7B_LANG_ALL }
-    }
-    if (fimModelCurrentBest) {
-        return { provider: 'fireworks', model: DEEPSEEK_CODER_V2_LITE_BASE_WINDOW_4096 }
-    }
-    if (fimModelControl) {
-        // Current production model
-        return { provider: 'fireworks', model: DEEPSEEK_CODER_V2_LITE_BASE }
-    }
+    ]).pipe(
+        map(
+            ([
+                fimModelControl,
+                fimModelVariant1,
+                fimModelVariant2,
+                fimModelVariant3,
+                fimModelVariant4,
+                fimModelCurrentBest,
+            ]) => {
+                if (fimModelVariant1) {
+                    return { provider: 'fireworks', model: DEEPSEEK_CODER_V2_LITE_BASE_DIRECT_ROUTE }
+                }
+                if (fimModelVariant2) {
+                    return { provider: 'fireworks', model: FIREWORKS_DEEPSEEK_7B_LANG_SPECIFIC_V0 }
+                }
+                if (fimModelVariant3) {
+                    return { provider: 'fireworks', model: FIREWORKS_DEEPSEEK_7B_LANG_SPECIFIC_V1 }
+                }
+                if (fimModelVariant4) {
+                    return { provider: 'fireworks', model: FIREWORKS_DEEPSEEK_7B_LANG_ALL }
+                }
+                if (fimModelCurrentBest) {
+                    return { provider: 'fireworks', model: DEEPSEEK_CODER_V2_LITE_BASE_WINDOW_4096 }
+                }
+                if (fimModelControl) {
+                    // Current production model
+                    return { provider: 'fireworks', model: DEEPSEEK_CODER_V2_LITE_BASE }
+                }
 
-    // Extra free traffic - redirect to the current production model which could be different than control
-    return { provider: 'fireworks', model: DEEPSEEK_CODER_V2_LITE_BASE }
+                // Extra free traffic - redirect to the current production model which could be different than control
+                return { provider: 'fireworks', model: DEEPSEEK_CODER_V2_LITE_BASE }
+            }
+        ),
+        distinctUntilChanged()
+    )
 }

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -644,20 +644,14 @@ function registerAutocomplete(
                 // completion provider.
                 disposeAutocomplete()
 
-                const autocompleteFeatureFlagChangeSubscriber =
-                    featureFlagProvider.instance!.onFeatureFlagChanged(
-                        'cody-autocomplete',
-                        setupAutocomplete
-                    )
-                autocompleteDisposables.push({
-                    dispose: autocompleteFeatureFlagChangeSubscriber,
-                })
                 autocompleteDisposables.push(
-                    await createInlineCompletionItemProvider({
-                        config,
-                        statusBar,
-                        createBfgRetriever: platform.createBfgRetriever,
-                    })
+                    subscriptionDisposable(
+                        createInlineCompletionItemProvider({
+                            config,
+                            statusBar,
+                            createBfgRetriever: platform.createBfgRetriever,
+                        }).subscribe({})
+                    )
                 )
                 autocompleteDisposables.push(
                     await createInlineCompletionItemFromMultipleProviders({

--- a/vscode/src/testutils/mocks.ts
+++ b/vscode/src/testutils/mocks.ts
@@ -879,10 +879,6 @@ export class MockFeatureFlagProvider extends FeatureFlagProvider {
         return Promise.resolve(this.enabledFlags.has(flag))
     }
 
-    public getFromCache(flag: FeatureFlag): boolean {
-        return this.enabledFlags.has(flag)
-    }
-
     public refresh(): Promise<void> {
         return Promise.resolve()
     }


### PR DESCRIPTION
Make it so our autocomplete logic reacts to config and feature flag changes using Observables, instead of the current situation where there are many different ad-hoc ways configuration and feature flag values are passed through. This simplifies (or at least standardizes) the code, reduces bugs, and (once this kind of change is applied everywhere in our code) eliminates the need for users to reload the editor to pick up new config.

## Test plan

e2e tests. Also try changing Cody autocomplete configs and signing in/out and ensure that the right config is loaded.