### PR TITLE
Testing the Removal of Artificial Latency behind a feature flag

### DIFF
--- a/lib/shared/src/experimentation/FeatureFlagProvider.ts
+++ b/lib/shared/src/experimentation/FeatureFlagProvider.ts
@@ -40,7 +40,7 @@ export enum FeatureFlag {
     CodyAutocompleteFIMModelExperimentVariant2 = 'cody-autocomplete-fim-model-experiment-variant-2-v2',
     CodyAutocompleteFIMModelExperimentVariant3 = 'cody-autocomplete-fim-model-experiment-variant-3-v2',
     CodyAutocompleteFIMModelExperimentVariant4 = 'cody-autocomplete-fim-model-experiment-variant-4-v2',
-
+    CodyAutocompleteDisableLowPerfLangDelay = 'cody-autocomplete-disable-low-perf-lang-delay',
     // Enables Claude 3 if the user is in our holdout group
     CodyAutocompleteClaude3 = 'cody-autocomplete-claude-3',
     // Enable latency adjustments based on accept/reject streaks

--- a/vscode/src/completions/artificial-delay.test.ts
+++ b/vscode/src/completions/artificial-delay.test.ts
@@ -1,7 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { getArtificialDelay, lowPerformanceLanguageIds, resetArtificialDelay } from './artificial-delay'
-
 const featureFlags = {
     user: true,
 }
@@ -10,9 +9,26 @@ describe('getArtificialDelay', () => {
     beforeEach(() => {
         vi.useFakeTimers()
     })
+
     afterEach(() => {
         vi.restoreAllMocks()
         resetArtificialDelay()
+    })
+
+    it('returns no artificial delay when codyAutocompleteDisableLowPerfLangDelay is true for a low performance language', () => {
+        const uri = 'file://foo/bar/test.css'
+        // css is a low performance language
+        const languageId = 'css'
+        expect(lowPerformanceLanguageIds.has(languageId)).toBe(true)
+        const params = {
+            featureFlags,
+            uri,
+            languageId,
+            codyAutocompleteDisableLowPerfLangDelay: true,
+        }
+
+        // expect no artificial delay when codyAutocompleteDisableLowPerfLangDelay is true
+        expect(getArtificialDelay(params)).toBe(0)
     })
 
     it('returns gradually increasing latency up to max for CSS when suggestions are rejected', () => {
@@ -21,51 +37,57 @@ describe('getArtificialDelay', () => {
         // css is a low performance language
         const languageId = 'css'
         expect(lowPerformanceLanguageIds.has(languageId)).toBe(true)
-
+        const codyAutocompleteDisableLowPerfLangDelay = false
+        const params = {
+            featureFlags,
+            uri,
+            languageId,
+            codyAutocompleteDisableLowPerfLangDelay,
+        }
         // start with default high latency for low performance lang with default user latency added
-        expect(getArtificialDelay(featureFlags, uri, languageId)).toBe(1000)
-        expect(getArtificialDelay(featureFlags, uri, languageId)).toBe(1000)
-        expect(getArtificialDelay(featureFlags, uri, languageId)).toBe(1000)
-        expect(getArtificialDelay(featureFlags, uri, languageId)).toBe(1000)
-        expect(getArtificialDelay(featureFlags, uri, languageId)).toBe(1000)
+        expect(getArtificialDelay(params)).toBe(1000)
+        expect(getArtificialDelay(params)).toBe(1000)
+        expect(getArtificialDelay(params)).toBe(1000)
+        expect(getArtificialDelay(params)).toBe(1000)
+        expect(getArtificialDelay(params)).toBe(1000)
         // start at default, but gradually increasing latency after 5 rejected suggestions
-        expect(getArtificialDelay(featureFlags, uri, languageId)).toBe(1050)
-        expect(getArtificialDelay(featureFlags, uri, languageId)).toBe(1100)
-        expect(getArtificialDelay(featureFlags, uri, languageId)).toBe(1150)
-        expect(getArtificialDelay(featureFlags, uri, languageId)).toBe(1200)
-        expect(getArtificialDelay(featureFlags, uri, languageId)).toBe(1250)
-        expect(getArtificialDelay(featureFlags, uri, languageId)).toBe(1300)
-        expect(getArtificialDelay(featureFlags, uri, languageId)).toBe(1350)
-        expect(getArtificialDelay(featureFlags, uri, languageId)).toBe(1400)
+        expect(getArtificialDelay(params)).toBe(1050)
+        expect(getArtificialDelay(params)).toBe(1100)
+        expect(getArtificialDelay(params)).toBe(1150)
+        expect(getArtificialDelay(params)).toBe(1200)
+        expect(getArtificialDelay(params)).toBe(1250)
+        expect(getArtificialDelay(params)).toBe(1300)
+        expect(getArtificialDelay(params)).toBe(1350)
+        expect(getArtificialDelay(params)).toBe(1400)
         // max latency at 1400
-        expect(getArtificialDelay(featureFlags, uri, languageId)).toBe(1400)
+        expect(getArtificialDelay(params)).toBe(1400)
         // after the suggestion was accepted, user latency resets to 0, using baseline only
         resetArtificialDelay()
-        expect(getArtificialDelay(featureFlags, uri, languageId)).toBe(1000)
+        expect(getArtificialDelay(params)).toBe(1000)
         resetArtificialDelay()
-        expect(getArtificialDelay(featureFlags, uri, languageId)).toBe(1000)
-        expect(getArtificialDelay(featureFlags, uri, languageId)).toBe(1000)
-        expect(getArtificialDelay(featureFlags, uri, languageId)).toBe(1000)
-        expect(getArtificialDelay(featureFlags, uri, languageId)).toBe(1000)
-        expect(getArtificialDelay(featureFlags, uri, languageId)).toBe(1000)
+        expect(getArtificialDelay(params)).toBe(1000)
+        expect(getArtificialDelay(params)).toBe(1000)
+        expect(getArtificialDelay(params)).toBe(1000)
+        expect(getArtificialDelay(params)).toBe(1000)
+        expect(getArtificialDelay(params)).toBe(1000)
         // gradually increasing latency after 5 rejected suggestions
-        expect(getArtificialDelay(featureFlags, uri, languageId)).toBe(1050)
-        expect(getArtificialDelay(featureFlags, uri, languageId)).toBe(1100)
-        expect(getArtificialDelay(featureFlags, uri, languageId)).toBe(1150)
-        expect(getArtificialDelay(featureFlags, uri, languageId)).toBe(1200)
-        expect(getArtificialDelay(featureFlags, uri, languageId)).toBe(1250)
-        expect(getArtificialDelay(featureFlags, uri, languageId)).toBe(1300)
-        expect(getArtificialDelay(featureFlags, uri, languageId)).toBe(1350)
-        expect(getArtificialDelay(featureFlags, uri, languageId)).toBe(1400)
+        expect(getArtificialDelay(params)).toBe(1050)
+        expect(getArtificialDelay(params)).toBe(1100)
+        expect(getArtificialDelay(params)).toBe(1150)
+        expect(getArtificialDelay(params)).toBe(1200)
+        expect(getArtificialDelay(params)).toBe(1250)
+        expect(getArtificialDelay(params)).toBe(1300)
+        expect(getArtificialDelay(params)).toBe(1350)
+        expect(getArtificialDelay(params)).toBe(1400)
         // Latency will not reset before 5 minutes
         vi.advanceTimersByTime(3 * 60 * 1000)
-        expect(getArtificialDelay(featureFlags, uri, languageId)).toBe(1400)
+        expect(getArtificialDelay(params)).toBe(1400)
         // Latency will be reset after 5 minutes
         vi.advanceTimersByTime(5 * 60 * 1000)
-        expect(getArtificialDelay(featureFlags, uri, languageId)).toBe(1000)
+        expect(getArtificialDelay(params)).toBe(1000)
         // reset latency on accepted suggestion
         resetArtificialDelay()
-        expect(getArtificialDelay(featureFlags, uri, languageId)).toBe(1000)
+        expect(getArtificialDelay(params)).toBe(1000)
     })
 
     it('returns increasing latency after rejecting suggestions', () => {
@@ -73,23 +95,45 @@ describe('getArtificialDelay', () => {
 
         // Confirm typescript is not a low performance language
         const languageId = 'typescript'
-        expect(lowPerformanceLanguageIds.has(languageId)).toBe(false)
+        const codyAutocompleteDisableLowPerfLangDelay = false
+        expect(lowPerformanceLanguageIds.has(languageId)).toBe(codyAutocompleteDisableLowPerfLangDelay)
+        const params = {
+            featureFlags,
+            uri,
+            languageId,
+            codyAutocompleteDisableLowPerfLangDelay,
+        }
 
         // start at default, but gradually increasing latency after 5 rejected suggestions
-        expect(getArtificialDelay(featureFlags, uri, languageId, 'arguments')).toBe(0)
-        expect(getArtificialDelay(featureFlags, uri, languageId, 'function.body')).toBe(0)
+        expect(
+            getArtificialDelay({
+                ...params,
+                completionIntent: 'arguments',
+            })
+        ).toBe(0)
+        expect(
+            getArtificialDelay({
+                ...params,
+                completionIntent: 'function.body',
+            })
+        ).toBe(0)
         // baseline latency increased to 1000 due to comment node type
-        expect(getArtificialDelay(featureFlags, uri, languageId, 'comment')).toBe(1000)
-        expect(getArtificialDelay(featureFlags, uri, languageId)).toBe(0)
-        expect(getArtificialDelay(featureFlags, uri, languageId)).toBe(0)
+        expect(
+            getArtificialDelay({
+                ...params,
+                completionIntent: 'comment',
+            })
+        ).toBe(1000)
+        expect(getArtificialDelay(params)).toBe(0)
+        expect(getArtificialDelay(params)).toBe(0)
         // gradually increasing latency after 5 rejected suggestions
-        expect(getArtificialDelay(featureFlags, uri, languageId)).toBe(50)
-        expect(getArtificialDelay(featureFlags, uri, languageId)).toBe(100)
-        expect(getArtificialDelay(featureFlags, uri, languageId)).toBe(150)
-        expect(getArtificialDelay(featureFlags, uri, languageId)).toBe(200)
+        expect(getArtificialDelay(params)).toBe(50)
+        expect(getArtificialDelay(params)).toBe(100)
+        expect(getArtificialDelay(params)).toBe(150)
+        expect(getArtificialDelay(params)).toBe(200)
         // after the suggestion was accepted, user latency resets to 0, using baseline only
         resetArtificialDelay()
-        expect(getArtificialDelay(featureFlags, uri, languageId)).toBe(0)
+        expect(getArtificialDelay(params)).toBe(0)
     })
 
     it('returns default latency for CSS after accepting suggestion and resets after 5 minutes', () => {
@@ -98,67 +142,80 @@ describe('getArtificialDelay', () => {
         // css is a low performance language
         const languageId = 'css'
         expect(lowPerformanceLanguageIds.has(languageId)).toBe(true)
-
+        const codyAutocompleteDisableLowPerfLangDelay = false
+        const params = {
+            featureFlags,
+            uri,
+            languageId,
+            codyAutocompleteDisableLowPerfLangDelay,
+        }
         // start with default baseline latency for low performance lang
-        expect(getArtificialDelay(featureFlags, uri, languageId)).toBe(1000)
+        expect(getArtificialDelay(params)).toBe(1000)
         // reset to starting point on every accepted suggestion
         resetArtificialDelay()
-        expect(getArtificialDelay(featureFlags, uri, languageId)).toBe(1000)
+        expect(getArtificialDelay(params)).toBe(1000)
         resetArtificialDelay()
-        expect(getArtificialDelay(featureFlags, uri, languageId)).toBe(1000)
-        expect(getArtificialDelay(featureFlags, uri, languageId)).toBe(1000)
+        expect(getArtificialDelay(params)).toBe(1000)
+        expect(getArtificialDelay(params)).toBe(1000)
         // Latency will not reset before 5 minutes
         vi.advanceTimersByTime(3 * 60 * 1000)
-        expect(getArtificialDelay(featureFlags, uri, languageId)).toBe(1000)
-        expect(getArtificialDelay(featureFlags, uri, languageId)).toBe(1000)
-        expect(getArtificialDelay(featureFlags, uri, languageId)).toBe(1000)
-        expect(getArtificialDelay(featureFlags, uri, languageId)).toBe(1050)
+        expect(getArtificialDelay(params)).toBe(1000)
+        expect(getArtificialDelay(params)).toBe(1000)
+        expect(getArtificialDelay(params)).toBe(1000)
+        expect(getArtificialDelay(params)).toBe(1050)
         // Latency will be reset after 5 minutes
         vi.advanceTimersByTime(5 * 60 * 1000)
-        expect(getArtificialDelay(featureFlags, uri, languageId)).toBe(1000)
+        expect(getArtificialDelay(params)).toBe(1000)
     })
 
     it('returns increasing latency up to max after rejecting multiple suggestions, resets after file change and accept', () => {
         const uri = 'file://foo/bar/test.ts'
         const languageId = 'typescript'
-        expect(lowPerformanceLanguageIds.has(languageId)).toBe(false)
-
+        const codyAutocompleteDisableLowPerfLangDelay = false
+        expect(lowPerformanceLanguageIds.has(languageId)).toBe(codyAutocompleteDisableLowPerfLangDelay)
+        const params = {
+            featureFlags,
+            uri,
+            languageId,
+            codyAutocompleteDisableLowPerfLangDelay,
+        }
         // reject the first 5 suggestions, and confirm latency remains unchanged
-        expect(getArtificialDelay(featureFlags, uri, languageId)).toBe(0)
-        expect(getArtificialDelay(featureFlags, uri, languageId)).toBe(0)
-        expect(getArtificialDelay(featureFlags, uri, languageId)).toBe(0)
-        expect(getArtificialDelay(featureFlags, uri, languageId)).toBe(0)
-        expect(getArtificialDelay(featureFlags, uri, languageId)).toBe(0)
+        expect(getArtificialDelay(params)).toBe(0)
+        expect(getArtificialDelay(params)).toBe(0)
+        expect(getArtificialDelay(params)).toBe(0)
+        expect(getArtificialDelay(params)).toBe(0)
+        expect(getArtificialDelay(params)).toBe(0)
         // latency should start increasing after 5 rejections, but max at 1400
-        expect(getArtificialDelay(featureFlags, uri, languageId)).toBe(50)
+        expect(getArtificialDelay(params)).toBe(50)
         // line is a comment, so latency should be increased where:
         // base is 1000 due to line is a comment, and user latency is 400 as this is the 7th rejection
-        expect(getArtificialDelay(featureFlags, uri, languageId, 'comment')).toBe(1100)
+        expect(getArtificialDelay({ ...params, completionIntent: 'comment' })).toBe(1100)
         for (let i = 150; i <= 1400; i += 50) {
-            expect(getArtificialDelay(featureFlags, uri, languageId)).toBe(i)
+            expect(getArtificialDelay(params)).toBe(i)
         }
         // max at 1400 after multiple rejection
-        expect(getArtificialDelay(featureFlags, uri, languageId)).toBe(1400)
+        expect(getArtificialDelay(params)).toBe(1400)
 
         // reset latency on file change to default
         const newUri = 'foo/test.ts'
         // latency should start increasing again after 5 rejections
-        expect(getArtificialDelay(featureFlags, newUri, languageId)).toBe(0)
-        expect(getArtificialDelay(featureFlags, newUri, languageId)).toBe(0)
+        expect(getArtificialDelay({ ...params, uri: newUri })).toBe(0)
+        expect(getArtificialDelay({ ...params, uri: newUri })).toBe(0)
         // line is a comment, so latency should be increased
-        expect(getArtificialDelay(featureFlags, newUri, languageId, 'comment')).toBe(1000)
-        expect(getArtificialDelay(featureFlags, newUri, languageId)).toBe(0)
-        expect(getArtificialDelay(featureFlags, newUri, languageId)).toBe(0)
+        expect(getArtificialDelay({ ...params, uri: newUri, completionIntent: 'comment' })).toBe(1000)
+        expect(getArtificialDelay({ ...params, uri: newUri })).toBe(0)
+        expect(getArtificialDelay({ ...params, uri: newUri })).toBe(0)
         // Latency will not reset before 5 minutes
         vi.advanceTimersByTime(3 * 60 * 1000)
-        expect(getArtificialDelay(featureFlags, newUri, languageId)).toBe(50)
+        expect(getArtificialDelay({ ...params, uri: newUri })).toBe(50)
         // reset latency on accepted suggestion
         resetArtificialDelay()
-        expect(getArtificialDelay(featureFlags, newUri, languageId)).toBe(0)
+        expect(getArtificialDelay({ ...params, uri: newUri })).toBe(0)
     })
 
     it('returns default latency for low performance language only when only language flag is enabled', () => {
         const uri = 'file://foo/bar/test.css'
+        const codyAutocompleteDisableLowPerfLangDelay = false
 
         const featureFlagsLangOnly = {
             user: false,
@@ -171,17 +228,23 @@ describe('getArtificialDelay', () => {
         // go is not a low performance language
         const languageId = 'go'
         const goUri = 'foo/bar/test.go'
-        expect(lowPerformanceLanguageIds.has(languageId)).toBe(false)
+        expect(lowPerformanceLanguageIds.has(languageId)).toBe(codyAutocompleteDisableLowPerfLangDelay)
 
+        const params = {
+            featureFlags: featureFlagsLangOnly,
+            uri,
+            languageId,
+            codyAutocompleteDisableLowPerfLangDelay,
+        }
         // latency should only change based on language id when only the language flag is enabled
-        expect(getArtificialDelay(featureFlagsLangOnly, uri, lowPerformLanguageId)).toBe(1000)
-        expect(getArtificialDelay(featureFlagsLangOnly, uri, lowPerformLanguageId)).toBe(1000)
-        expect(getArtificialDelay(featureFlagsLangOnly, uri, lowPerformLanguageId)).toBe(1000)
-        expect(getArtificialDelay(featureFlagsLangOnly, uri, lowPerformLanguageId)).toBe(1000)
-        expect(getArtificialDelay(featureFlagsLangOnly, uri, lowPerformLanguageId)).toBe(1000)
-        expect(getArtificialDelay(featureFlagsLangOnly, uri, lowPerformLanguageId)).toBe(1000)
+        expect(getArtificialDelay({ ...params, languageId: lowPerformLanguageId })).toBe(1000)
+        expect(getArtificialDelay({ ...params, languageId: lowPerformLanguageId })).toBe(1000)
+        expect(getArtificialDelay({ ...params, languageId: lowPerformLanguageId })).toBe(1000)
+        expect(getArtificialDelay({ ...params, languageId: lowPerformLanguageId })).toBe(1000)
+        expect(getArtificialDelay({ ...params, languageId: lowPerformLanguageId })).toBe(1000)
+        expect(getArtificialDelay({ ...params, languageId: lowPerformLanguageId })).toBe(1000)
         // latency back to 0 when language is no longer low-performance
-        expect(getArtificialDelay(featureFlagsLangOnly, goUri, languageId)).toBe(0)
+        expect(getArtificialDelay({ ...params, uri: goUri, languageId })).toBe(0)
     })
 
     it('returns latency based on language only when user flag is disabled', () => {
@@ -189,28 +252,42 @@ describe('getArtificialDelay', () => {
 
         // css is a low performance language
         const languageId = 'css'
+        const codyAutocompleteDisableLowPerfLangDelay = false
         expect(lowPerformanceLanguageIds.has(languageId)).toBe(true)
 
         const featureFlagsNoUser = {
             user: false,
         }
 
+        const params = {
+            featureFlags: featureFlagsNoUser,
+            uri,
+            languageId,
+            codyAutocompleteDisableLowPerfLangDelay,
+        }
+
         // latency starts with language latency
-        expect(getArtificialDelay(featureFlagsNoUser, uri, languageId)).toBe(1000)
-        expect(getArtificialDelay(featureFlagsNoUser, uri, languageId)).toBe(1000)
-        expect(getArtificialDelay(featureFlagsNoUser, uri, languageId)).toBe(1000)
-        expect(getArtificialDelay(featureFlagsNoUser, uri, languageId)).toBe(1000)
-        expect(getArtificialDelay(featureFlagsNoUser, uri, languageId)).toBe(1000)
+        expect(getArtificialDelay(params)).toBe(1000)
+        expect(getArtificialDelay(params)).toBe(1000)
+        expect(getArtificialDelay(params)).toBe(1000)
+        expect(getArtificialDelay(params)).toBe(1000)
+        expect(getArtificialDelay(params)).toBe(1000)
         // latency should remains unchanged after 5 rejections
-        expect(getArtificialDelay(featureFlagsNoUser, uri, languageId)).toBe(1000)
-        expect(getArtificialDelay(featureFlagsNoUser, uri, languageId)).toBe(1000)
-        expect(getArtificialDelay(featureFlagsNoUser, uri, languageId)).toBe(1000)
+        expect(getArtificialDelay(params)).toBe(1000)
+        expect(getArtificialDelay(params)).toBe(1000)
+        expect(getArtificialDelay(params)).toBe(1000)
 
         // switch to a non-low-performance language - go is not a low performance language
         const goLanguageId = 'go'
         const goUri = 'foo/bar/test.go'
-        expect(lowPerformanceLanguageIds.has(goLanguageId)).toBe(false)
+        expect(lowPerformanceLanguageIds.has(goLanguageId)).toBe(codyAutocompleteDisableLowPerfLangDelay)
         // reset to provider latency because language latency is ignored for non-low-performance languages
-        expect(getArtificialDelay(featureFlagsNoUser, goUri, goLanguageId)).toBe(0)
+        const goParams = {
+            featureFlags: featureFlagsNoUser,
+            uri: goUri,
+            languageId: goLanguageId,
+            codyAutocompleteDisableLowPerfLangDelay,
+        }
+        expect(getArtificialDelay(goParams)).toBe(0)
     })
 })

--- a/vscode/src/completions/completion-provider-config.ts
+++ b/vscode/src/completions/completion-provider-config.ts
@@ -26,6 +26,7 @@ class CompletionProviderConfig {
             FeatureFlag.CodyAutocompletePreloadingExperimentVariant1,
             FeatureFlag.CodyAutocompletePreloadingExperimentVariant2,
             FeatureFlag.CodyAutocompletePreloadingExperimentVariant3,
+            FeatureFlag.CodyAutocompleteDisableLowPerfLangDelay,
         ]
         await Promise.all(featureFlagsUsed.map(flag => featureFlagProvider.evaluateFeatureFlag(flag)))
     }
@@ -182,6 +183,12 @@ class CompletionProviderConfig {
                 )
             })
         )
+    }
+
+    public get completionDisableLowPerfLangDelay(): Observable<boolean> {
+        return featureFlagProvider
+            .evaluatedFeatureFlag(FeatureFlag.CodyAutocompleteDisableLowPerfLangDelay)
+            .pipe(distinctUntilChanged())
     }
 }
 


### PR DESCRIPTION
This PR aims to remove the artificial delay introduced for low-performance languages and specific AST nodes, as outlined in th [issue](https://linear.app/sourcegraph/issue/CODY-3315/delete-the-artificial-latency). The artificial delay was originally implemented for low performance languages so that users are not spammed with unhelpful suggestions. , but it has become less relevant over time, and it may now impact the predictability of autocomplete latency and user experience (UX).

# Changes:

## Introduce a feature flag:
A new feature flag has been added to toggle the artificial delay.
- Objective: The main objective is to achieve predictable latency and a consistent autocomplete UX for all languages.

- After merging this PR, the feature flag will be enabled for controlled testing, and data will be collected to assess the impact on CAR and latency for all languages
- Depending on the results, the team will decide whether to remove the artificial delay logic entirely.

## Test Plan:
I tested this PR locally by enabling and disabling the feature flag on my local Sourcegraph instance(I added the feature flag on it and then set the true/false values). I also used the debugger to run VS Code Extension on Desktop



## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
