### PR TITLE
fix(Generate Commit Message): handle file paths in git diff on Windows

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -9,6 +9,7 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 ### Fixed
 
 - Cody Ignore: Fixed an issue where Cody would treat Notebook cells as ignored files when .cody/ignore is enabled. [pull/5473](https://github.com/sourcegraph/cody/pull/5473)
+- Command: Fixed the `Generate Commit Message` command on Windows caused by file path. [pull/5555](https://github.com/sourcegraph/cody/pull/5555)
 
 ### Changed
 

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -9,7 +9,7 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 ### Fixed
 
 - Cody Ignore: Fixed an issue where Cody would treat Notebook cells as ignored files when .cody/ignore is enabled. [pull/5473](https://github.com/sourcegraph/cody/pull/5473)
-- Command: Fixed the `Generate Commit Message` command on Windows caused by file path. [pull/5555](https://github.com/sourcegraph/cody/pull/5555)
+- Command: Fixed the `Generate Commit Message` command on Windows caused by file path. [pull/5483](https://github.com/sourcegraph/cody/pull/5483)
 
 ### Changed
 

--- a/vscode/src/commands/context/git-api.test.ts
+++ b/vscode/src/commands/context/git-api.test.ts
@@ -1,0 +1,158 @@
+import { ContextItemSource } from '@sourcegraph/cody-shared'
+import { type Mock, beforeEach, describe, expect, it, vi } from 'vitest'
+import { URI } from 'vscode-uri'
+import type { Repository } from '../../repository/builtinGitExtension'
+import { doesFileExist } from '../utils/workspace-files'
+import { getContextFilesFromGitDiff } from './git-api'
+
+vi.mock('../repository')
+vi.mock('../utils')
+vi.mock('../utils/workspace-files', () => ({
+    doesFileExist: vi.fn(),
+}))
+
+describe('getContextFilesFromGitDiff', () => {
+    const mockGitRepo = {
+        diffIndexWithHEAD: vi.fn(),
+        diffWithHEAD: vi.fn(),
+        diff: vi.fn(),
+    } as unknown as Repository
+
+    const mockTokenCounter = {
+        countTokens: vi.fn(),
+    }
+
+    const diffIndexWithHEAD = mockGitRepo.diffIndexWithHEAD as Mock
+    const diffWithHEAD = mockGitRepo.diffWithHEAD as Mock
+    const diff = mockGitRepo.diff as Mock
+    const mockDoesFileExist = doesFileExist as Mock
+
+    beforeEach(() => {
+        vi.clearAllMocks()
+    })
+
+    it('should return diffs for staged changes', async () => {
+        diffIndexWithHEAD.mockResolvedValue([{ uri: URI.parse('file:///path/file1.ts') }])
+        diffWithHEAD.mockResolvedValue([])
+        diff.mockResolvedValue(
+            'diff --git a/file1.ts b/file1.ts\n' +
+                '--- a/file1.ts\n' +
+                '+++ b/file1.ts\n' +
+                '@@ -1,1 +1,2 @@\n' +
+                '+console.log("Hello World");\n'
+        )
+
+        mockDoesFileExist.mockResolvedValue(true)
+
+        const result = await getContextFilesFromGitDiff(mockGitRepo)
+
+        expect(result).toHaveLength(1)
+        expect(result[0]).toMatchObject({
+            type: 'file',
+            title: 'git diff --cached',
+            uri: URI.parse('file:///path/file1.ts'),
+            source: ContextItemSource.Terminal,
+            size: 56,
+        })
+    })
+
+    it('should return diffs for unstaged changes when no staged changes', async () => {
+        diffIndexWithHEAD.mockResolvedValue([])
+        diffWithHEAD.mockResolvedValue([{ uri: URI.parse('file:///path/to/file2.ts') }])
+        diff.mockResolvedValue(
+            'diff --git a/file2.ts b/file2.ts\n' +
+                '--- a/file2.ts\n' +
+                '+++ b/file2.ts\n' +
+                '@@ -1,1 +1,2 @@\n' +
+                '+console.log("Unstaged change");\n'
+        )
+
+        mockDoesFileExist.mockResolvedValue(true)
+        mockTokenCounter.countTokens.mockResolvedValue(57)
+
+        const result = await getContextFilesFromGitDiff(mockGitRepo)
+
+        expect(result).toHaveLength(1)
+        expect(result[0]).toMatchObject({
+            type: 'file',
+            title: 'git diff',
+            uri: URI.parse('file:///path/to/file2.ts'),
+            source: ContextItemSource.Terminal,
+            size: 57,
+        })
+    })
+
+    it('should throw error if diff output is empty', async () => {
+        diffIndexWithHEAD.mockResolvedValue([])
+        diffWithHEAD.mockResolvedValue([])
+        diff.mockResolvedValue('')
+
+        await expect(getContextFilesFromGitDiff(mockGitRepo)).rejects.toThrow('Failed to get git diff.')
+    })
+
+    it('should handle multiple files in diffs', async () => {
+        diffIndexWithHEAD.mockResolvedValue([
+            { uri: URI.parse('file:///path/to/file1.ts') },
+            { uri: URI.parse('file:///path/to/file2.ts') },
+        ])
+        diffWithHEAD.mockResolvedValue([])
+        diff.mockResolvedValue(
+            'diff --git a/file1.ts b/file1.ts\n' +
+                '--- a/file1.ts\n' +
+                '+++ b/file1.ts\n' +
+                '@@ -1,1 +1,2 @@\n' +
+                '+console.log("File 1");\n' +
+                'diff --git a/file2.ts b/file2.ts\n' +
+                '--- a/file2.ts\n' +
+                '+++ b/file2.ts\n' +
+                '@@ -1,1 +1,2 @@\n' +
+                '+console.log("File 2");\n'
+        )
+
+        mockDoesFileExist.mockResolvedValue(true)
+
+        const result = await getContextFilesFromGitDiff(mockGitRepo)
+
+        expect(result).toHaveLength(2)
+    })
+
+    it('should skip files that do not exist', async () => {
+        diffIndexWithHEAD.mockResolvedValue([{ uri: URI.parse('file:///path/to/nonexistent.ts') }])
+        diffWithHEAD.mockResolvedValue([])
+        diff.mockResolvedValue(
+            'diff --git a/nonexistent.ts b/nonexistent.ts\n' +
+                '--- a/nonexistent.ts\n' +
+                '+++ b/nonexistent.ts\n' +
+                '@@ -0,0 +1 @@\n' +
+                '+This file does not exist\n'
+        )
+
+        mockDoesFileExist.mockResolvedValue(false)
+        await expect(getContextFilesFromGitDiff(mockGitRepo)).rejects.toThrow('Failed to get git diff.')
+    })
+
+    it('should handle Windows OS paths', async () => {
+        diffIndexWithHEAD.mockResolvedValue([{ uri: URI.parse('file:///c:/path/to/file3.ts') }])
+        diffWithHEAD.mockResolvedValue([])
+        diff.mockResolvedValue(
+            'diff --git a/path/to/file3.ts b/path/to/file3.ts\n' +
+                '--- a/file3.ts\n' +
+                '+++ b/file3.ts\n' +
+                '@@ -1,1 +1,2 @@\n' +
+                '+console.log("Windows path");\n'
+        )
+
+        mockDoesFileExist.mockResolvedValue(true)
+
+        const result = await getContextFilesFromGitDiff(mockGitRepo)
+
+        expect(result).toHaveLength(1)
+        expect(result[0]).toMatchObject({
+            type: 'file',
+            title: 'git diff --cached',
+            uri: URI.parse('file:///c:/path/to/file3.ts'),
+            source: ContextItemSource.Terminal,
+            size: 61,
+        })
+    })
+})

--- a/vscode/src/commands/context/git-api.test.ts
+++ b/vscode/src/commands/context/git-api.test.ts
@@ -17,9 +17,6 @@ describe('getContextFilesFromGitDiff', () => {
         diffWithHEAD: vi.fn(),
         diff: vi.fn(),
     } as unknown as Repository
-    const mockTokenCounter = {
-        countTokens: vi.fn(),
-    }
 
     const diffIndexWithHEAD = mockGitRepo.diffIndexWithHEAD as Mock
     const diffWithHEAD = mockGitRepo.diffWithHEAD as Mock
@@ -51,7 +48,6 @@ describe('getContextFilesFromGitDiff', () => {
             title: 'git diff --cached',
             uri: URI.parse('file:///path/file1.ts'),
             source: ContextItemSource.Terminal,
-            size: 57,
         })
     })
 
@@ -67,7 +63,6 @@ describe('getContextFilesFromGitDiff', () => {
         )
 
         mockDoesFileExist.mockResolvedValue(true)
-        mockTokenCounter.countTokens.mockResolvedValue(59)
 
         const result = await getContextFilesFromGitDiff(mockGitRepo)
 
@@ -77,7 +72,6 @@ describe('getContextFilesFromGitDiff', () => {
             title: 'git diff',
             uri: URI.parse('file:///path/to/file2.ts'),
             source: ContextItemSource.Terminal,
-            size: 59,
         })
     })
 
@@ -109,9 +103,7 @@ describe('getContextFilesFromGitDiff', () => {
         )
 
         mockDoesFileExist.mockResolvedValue(true)
-
         const result = await getContextFilesFromGitDiff(mockGitRepo)
-
         expect(result).toHaveLength(2)
     })
 
@@ -147,7 +139,6 @@ describe('getContextFilesFromGitDiff', () => {
         }))
 
         mockDoesFileExist.mockResolvedValue(true)
-
         const result = await getContextFilesFromGitDiff(mockGitRepo)
         expect(result).toHaveLength(1)
         expect(result[0]).toMatchObject({
@@ -155,7 +146,6 @@ describe('getContextFilesFromGitDiff', () => {
             title: 'git diff --cached',
             uri: URI.parse('file:///c:/path/to/file3.ts'),
             source: ContextItemSource.Terminal,
-            size: 61,
         })
     })
 })

--- a/vscode/src/commands/context/git-api.test.ts
+++ b/vscode/src/commands/context/git-api.test.ts
@@ -17,7 +17,6 @@ describe('getContextFilesFromGitDiff', () => {
         diffWithHEAD: vi.fn(),
         diff: vi.fn(),
     } as unknown as Repository
-
     const mockTokenCounter = {
         countTokens: vi.fn(),
     }
@@ -52,7 +51,7 @@ describe('getContextFilesFromGitDiff', () => {
             title: 'git diff --cached',
             uri: URI.parse('file:///path/file1.ts'),
             source: ContextItemSource.Terminal,
-            size: 56,
+            size: 57,
         })
     })
 
@@ -68,7 +67,7 @@ describe('getContextFilesFromGitDiff', () => {
         )
 
         mockDoesFileExist.mockResolvedValue(true)
-        mockTokenCounter.countTokens.mockResolvedValue(57)
+        mockTokenCounter.countTokens.mockResolvedValue(59)
 
         const result = await getContextFilesFromGitDiff(mockGitRepo)
 
@@ -78,7 +77,7 @@ describe('getContextFilesFromGitDiff', () => {
             title: 'git diff',
             uri: URI.parse('file:///path/to/file2.ts'),
             source: ContextItemSource.Terminal,
-            size: 57,
+            size: 59,
         })
     })
 
@@ -142,10 +141,14 @@ describe('getContextFilesFromGitDiff', () => {
                 '+console.log("Windows path");\n'
         )
 
+        // Windows path
+        vi.mock('../../utils/path-utils', () => ({
+            displayPath: vi.fn().mockReturnValue('path\\to\\file3.ts'),
+        }))
+
         mockDoesFileExist.mockResolvedValue(true)
 
         const result = await getContextFilesFromGitDiff(mockGitRepo)
-
         expect(result).toHaveLength(1)
         expect(result[0]).toMatchObject({
             type: 'file',

--- a/vscode/src/commands/context/git-api.ts
+++ b/vscode/src/commands/context/git-api.ts
@@ -85,7 +85,6 @@ export async function getContextFilesFromGitDiff(gitRepo: Repository): Promise<C
             const normalizedDiffPath = normalizePath(diffPath)
             const matchingFile = diffFiles.find(file => {
                 const filePath = normalizePath(displayPath(file.uri))
-                console.log(filePath)
                 return filePath.endsWith(normalizedDiffPath)
             })
             if (!matchingFile || !(await doesFileExist(matchingFile.uri))) {
@@ -116,7 +115,7 @@ export async function getContextFilesFromGitDiff(gitRepo: Repository): Promise<C
         return diffs.sort((a, b) => a.size! - b.size!)
     } catch (error) {
         logError('getContextFileFromGitDiff', 'failed', { verbose: error })
-        throw new Error(`Failed to get git diff: ${error}`)
+        throw new Error('Failed to get git diff.')
     }
 }
 

--- a/vscode/src/commands/context/git-api.ts
+++ b/vscode/src/commands/context/git-api.ts
@@ -41,7 +41,7 @@ export async function getContextFilesFromGitApi(
  * @returns A promise that resolves to an array of ContextItem objects representing the git diff.
  * @throws If the git diff output is empty or if there is an error retrieving the git diff.
  */
-async function getContextFilesFromGitDiff(gitRepo: Repository): Promise<ContextItem[]> {
+export async function getContextFilesFromGitDiff(gitRepo: Repository): Promise<ContextItem[]> {
     try {
         // Get the list of files that currently have staged and unstaged changes.
         const [stagedFiles, unstagedFiles] = await Promise.all([
@@ -67,31 +67,34 @@ async function getContextFilesFromGitDiff(gitRepo: Repository): Promise<ContextI
         }
 
         const diffs: ContextItem[] = []
-        for (const diff of diffOutputByFiles) {
-            if (!diff) {
+
+        for (const diffOutput of diffOutputByFiles) {
+            if (!diffOutput) {
                 continue // Skip this iteration if no file path is found
             }
 
+            const diffPath = diffOutput.split('\n')[0]
+            if (!diffPath) {
+                continue
+            }
+
+            const normalizePath = (path: string) => path.replace(/\\/g, '/')
+
             // Verify the file exists before adding it as context.
             // we do this by checking the reverse path because of how nested workspaces might add unknown prefixes
-            const uri = diffFiles.find(p => {
-                //todo: maybe better with a proper diff parser
-                const diffPath = diff.split('\n')?.[0]
-                return diffPath
-                    ? diffPath
-                          .split('')
-                          .reverse()
-                          .join('')
-                          .startsWith(displayPath(p.uri).split('').reverse().join(''))
-                    : p.uri
-            })?.uri
-            if (!uri || !(await doesFileExist(uri))) {
+            const normalizedDiffPath = normalizePath(diffPath)
+            const matchingFile = diffFiles.find(file => {
+                const filePath = normalizePath(displayPath(file.uri))
+                console.log(filePath)
+                return filePath.endsWith(normalizedDiffPath)
+            })
+            if (!matchingFile || !(await doesFileExist(matchingFile.uri))) {
                 continue
             }
 
             const content = diffTemplate
                 .replace('{command}', command)
-                .replace('<output>', `<output file="${displayPath(uri)}">`)
+                .replace('<output>', `<output file="${displayPath(matchingFile.uri)}">`)
                 .replace('{output}', diffOutput.trim())
 
             diffs.push({
@@ -99,7 +102,7 @@ async function getContextFilesFromGitDiff(gitRepo: Repository): Promise<ContextI
                 content,
                 title: command,
                 // Using the uri by file enables Cody Ignore checks during prompt-building step.
-                uri,
+                uri: matchingFile.uri,
                 source: ContextItemSource.Terminal,
                 size: await TokenCounterUtils.countTokens(content),
             })
@@ -113,7 +116,7 @@ async function getContextFilesFromGitDiff(gitRepo: Repository): Promise<ContextI
         return diffs.sort((a, b) => a.size! - b.size!)
     } catch (error) {
         logError('getContextFileFromGitDiff', 'failed', { verbose: error })
-        throw new Error('Failed to get git diff.')
+        throw new Error(`Failed to get git diff: ${error}`)
     }
 }
 

--- a/vscode/test/e2e/command-commit.test.ts
+++ b/vscode/test/e2e/command-commit.test.ts
@@ -27,7 +27,7 @@ testGitWorkspace.extend<ExtraWorkspaceSettings>({
     // Open the Source Control View to confirm this is a git workspace
     const sourceControlView = page.getByLabel(/Source Control/).nth(2)
     await sourceControlView.click()
-    await expect(page.getByRole('heading', { name: 'Source Control' })).toBeVisible()
+    await expect(page.locator('h2').filter({ hasText: 'Source Control' })).toBeVisible()
     await expect(page.getByText('index.js')).toBeVisible()
 
     // Disable do-not-disturb

--- a/vscode/test/e2e/command-commit.test.ts
+++ b/vscode/test/e2e/command-commit.test.ts
@@ -61,7 +61,6 @@ testGitWorkspace.extend<ExtraWorkspaceSettings>({
     // Commit the change so we empty the input box
     page.getByRole('button', { name: 'Commit' })
 
-    // await page.getByRole('heading', { name: 'Source Control' }).hover()
     await page.getByText('Changes3').click()
     await page.getByText('Changes3').getByLabel('Stage All Changes').click()
 

--- a/vscode/test/e2e/command-custom.test.ts
+++ b/vscode/test/e2e/command-custom.test.ts
@@ -281,7 +281,7 @@ testGitWorkspace('use terminal output as context', async ({ page, sidebar }) => 
     // Check the change is showing as a Git file in the sidebar
     const sourceControlView = page.getByLabel(/Source Control/).nth(2)
     await sourceControlView.click()
-    await page.getByRole('heading', { name: 'Source Control' }).hover()
+    await page.locator('h2').filter({ hasText: 'Source Control' }).hover()
     await page.getByText('index.js').hover()
     await page.locator('a').filter({ hasText: 'index.js' }).click()
 


### PR DESCRIPTION
FIX https://github.com/sourcegraph/cody/issues/4863

This PR fixes an issue where the generate commit message doesn't work on Windows:

![image](https://github.com/user-attachments/assets/9dce7b66-69f3-460d-b797-548510b7896e)

Root cause: the displayPath function returns file path native to the OS system, while the file path returned by the diff output is following the unix one, causing the file match logic to always be false.

![image](https://github.com/user-attachments/assets/fccca426-de38-4190-91e9-0d609672b7b3)

This PR fixed this by always replace all \\ used by Windows with '/' before doing matching.

Summary:

- Fixed an issue where the `Generate Commit Message` command would fail on Windows due to file path handling in the `getContextFilesFromGitDiff` function.
- Normalized file paths to use forward slashes instead of backslashes to ensure consistent handling across platforms.
- Improved the logic for matching the git diff output to the actual file URIs to handle nested workspaces and other edge cases.


## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

Added new unit tests to cover this feature.

Tested in Window:

![image](https://github.com/user-attachments/assets/704330de-3a5e-4fe6-a53c-deaa446d98f9)


## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->

Command: Fixed the `Generate Commit Message` command on Windows caused by file path. [pull/5483](https://github.com/sourcegraph/cody/pull/5483) ?