### PR TITLE
fix(dev): fix params used by groqChatClient

### DIFF
--- a/lib/shared/src/llm-providers/groq/chat-client.ts
+++ b/lib/shared/src/llm-providers/groq/chat-client.ts
@@ -92,7 +92,7 @@ export async function groqChatClient({
     // Stream requests
     fetch(config?.endpoint ?? GROQ_CHAT_API_URL, {
         method: 'POST',
-        body: JSON.stringify({ chatParams, stream: true }),
+        body: JSON.stringify({ ...chatParams, stream: true }),
         headers: {
             'Content-Type': 'application/json',
             Authorization: `Bearer ${config.key}`,

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -10,7 +10,7 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 
 - Cody Ignore: Fixed an issue where Cody would treat Notebook cells as ignored files when .cody/ignore is enabled. [pull/5473](https://github.com/sourcegraph/cody/pull/5473)
 - Command: Fixed the `Generate Commit Message` command on Windows caused by file path. [pull/5483](https://github.com/sourcegraph/cody/pull/5483)
-- Dev: Fixed an issue where incorrect request parameters caused stream requests to fail when using BYOK OpenAI-compatible models.
+- Dev: Fixed an issue where incorrect request parameters caused stream requests to fail when using BYOK OpenAI-compatible models. [pull/5490](https://github.com/sourcegraph/cody/pull/5490)
 
 ### Changed
 

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -10,6 +10,7 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 
 - Cody Ignore: Fixed an issue where Cody would treat Notebook cells as ignored files when .cody/ignore is enabled. [pull/5473](https://github.com/sourcegraph/cody/pull/5473)
 - Command: Fixed the `Generate Commit Message` command on Windows caused by file path. [pull/5483](https://github.com/sourcegraph/cody/pull/5483)
+- Dev: Fixed an issue where incorrect request parameters caused stream requests to fail when using BYOK OpenAI-compatible models.
 
 ### Changed
 


### PR DESCRIPTION
Fix: https://linear.app/sourcegraph/issue/CODY-3672

This PR fixes an issue where the `chatParams` was being passed as a parameter object when using the local GROQ model provider, causing all network requests to fail when using the local config models.

The fix is to properly destructure the `chatParams` object before passing it to the fetch request.

## Changes

- Destructure the `chatParams` object before passing it to the fetch request in the `groqChatClient` function.

## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

- Verified that the local GROQ model provider now works correctly when using the `chatParams` object.

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->

Dev: Fixed an issue where incorrect request parameters caused stream requests to fail when using local OpenAI-compatible model provider through the groqChatClients.