### PR TITLE
fix linux "cannot find local issuer certificate" auth error

### DIFF
--- a/vscode/src/certs.js
+++ b/vscode/src/certs.js
@@ -1,6 +1,7 @@
 import fspromises from 'node:fs/promises'
 import { globalAgent } from 'node:https'
 import path from 'node:path'
+import tls from 'node:tls'
 
 /**
  * Registers local root certificates onto the global HTTPS agent.
@@ -51,7 +52,8 @@ function addLinuxCerts() {
     if (process.platform !== 'linux') {
         return
     }
-    const originalCA = globalAgent.options.ca
+    const originalCA = [...globalAgent.options.ca, ...tls.rootCertificates]
+    /** @type {string[]} */
     let cas
     if (!Array.isArray(originalCA)) {
         cas = typeof originalCA !== 'undefined' ? [originalCA] : []


### PR DESCRIPTION
In a VS Code extension debug host on Linux, all GraphQL requests fail with a TLS error `cannot find local issuer certificate`. This fixes that issue.

This started occurring for me on VS Code 1.93.0. I can't find anything about it online, although https://github.com/microsoft/vscode/issues/187716 *might* be related. This fix seems harmless and has been a long-recommended way of adding CAs anyway (https://stackoverflow.com/questions/68896243/how-to-properly-configure-node-js-to-use-self-signed-root-certificates).



## Test plan

On Linux, run Cody in the debug extension host and ensure that the chat window signs in upon initial load.