### PR TITLE
fix(chat): reorder feedback button submission logic

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -8,6 +8,8 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 
 ### Fixed
 
+Chat: Fixed feedback buttons not working in chat. [pull/5509](https://github.com/sourcegraph/cody/pull/5509)
+
 ### Changed
 
 ## 1.34.1

--- a/vscode/webviews/chat/components/FeedbackButtons.tsx
+++ b/vscode/webviews/chat/components/FeedbackButtons.tsx
@@ -18,8 +18,8 @@ export const FeedbackButtons: React.FunctionComponent<FeedbackButtonsProps> = ({
 
     const onFeedbackBtnSubmit = useCallback(
         (text: string) => {
-            feedbackButtonsOnSubmit(text)
             setFeedbackSubmitted(text)
+            feedbackButtonsOnSubmit(text)
         },
         [feedbackButtonsOnSubmit]
     )


### PR DESCRIPTION
CLOSE https://linear.app/sourcegraph/issue/CODY-3682/feedback-buttons-not-working

The order of the `setFeedbackSubmitted` and `feedbackButtonsOnSubmit` calls was reversed, which could lead to an inconsistent state. This commit fixes the order to ensure the feedback submission state is updated before the callback is invoked.

## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

Before and After: 

### Before

Click on the thumb up / down button underneath a LLM response, nothing happened:

![image](https://github.com/user-attachments/assets/bdb45d7f-a20d-418d-8c7b-25b99a820bba)

### After

Click on the thumb up / down button underneath a LLM response to verify there is now a "check" mark to indicate the feedback button was clicked and submitted successfully:

![image](https://github.com/user-attachments/assets/fdbebcc1-aa29-4807-9e26-222be8a2bf5a)


## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->

Chat: Fixed feedback buttons not working in chat. 
