### PR TITLE
CLI: fix `--context-repo`

### DIFF
--- a/agent/CHANGELOG.md
+++ b/agent/CHANGELOG.md
@@ -10,6 +10,13 @@ This is a log of all notable changes to the Cody command-line tool. [Unreleased]
 
 ### Changed
 
+## 5.5.15
+
+### Fixed
+
+- `cody chat --context-repo` now works again as expected. The version 5.5.14 had
+  a regression where `--context-repo` did not work at all.
+
 ## 5.5.14
 
 ### Fixed

--- a/agent/package.json
+++ b/agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sourcegraph/cody",
-  "version": "5.5.14",
+  "version": "5.5.15",
   "description": "Cody CLI is the same technology that powers Cody in the IDE but available from the command-line.",
   "license": "Apache-2.0",
   "repository": {

--- a/agent/recordings/cody-chat_103640681/recording.har.yaml
+++ b/agent/recordings/cody-chat_103640681/recording.har.yaml
@@ -88,229 +88,6 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: 709c04331ef053b321decb3b9eb8e0f0
-      _order: 0
-      cache: {}
-      request:
-        bodySize: 518
-        cookies: []
-        headers:
-          - name: content-type
-            value: application/json
-          - name: accept-encoding
-            value: gzip;q=0
-          - name: authorization
-            value: token
-              REDACTED_964f5256e709a8c5c151a63d8696d5c7ac81604d179405864d88ff48a9232364
-          - name: user-agent
-            value: jetbrains / 6.0.0-SNAPSHOT
-          - name: connection
-            value: keep-alive
-          - name: host
-            value: sourcegraph.sourcegraph.com
-        headersSize: 371
-        httpVersion: HTTP/1.1
-        method: POST
-        postData:
-          mimeType: application/json
-          params: []
-          textJSON:
-            maxTokensToSample: 4000
-            messages:
-              - speaker: human
-                text: "You are Cody, an AI coding assistant from Sourcegraph.If your answer
-                  contains fenced code blocks in Markdown, include the relevant
-                  full file path in the code block tag using this structure:
-                  ```$LANGUAGE:$FILEPATH```."
-              - speaker: assistant
-                text: I am Cody, an AI coding assistant from Sourcegraph.
-              - speaker: human
-                text: respond with "hello" and nothing else
-              - speaker: assistant
-            model: gpt-4o
-            temperature: 0.2
-            topK: -1
-            topP: -1
-        queryString:
-          - name: client-name
-            value: jetbrains
-          - name: client-version
-            value: 6.0.0-SNAPSHOT
-        url: https://sourcegraph.sourcegraph.com/.api/completions/stream?client-name=jetbrains&client-version=6.0.0-SNAPSHOT
-      response:
-        bodySize: 213
-        content:
-          mimeType: text/event-stream
-          size: 213
-          text: |+
-            event: completion
-            data: {"completion":"hello","stopReason":"stop"}
-
-            event: done
-            data: {}
-
-        cookies: []
-        headers:
-          - name: date
-            value: Mon, 02 Sep 2024 11:25:27 GMT
-          - name: content-type
-            value: text/event-stream
-          - name: transfer-encoding
-            value: chunked
-          - name: connection
-            value: keep-alive
-          - name: access-control-allow-credentials
-            value: "true"
-          - name: access-control-allow-origin
-            value: ""
-          - name: cache-control
-            value: no-cache
-          - name: vary
-            value: Accept-Encoding, Authorization, Cookie, Authorization, X-Requested-With,
-              Cookie
-          - name: x-content-type-options
-            value: nosniff
-          - name: x-frame-options
-            value: DENY
-          - name: x-xss-protection
-            value: 1; mode=block
-          - name: strict-transport-security
-            value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1215
-        httpVersion: HTTP/1.1
-        redirectURL: ""
-        status: 200
-        statusText: OK
-      startedDateTime: 2024-09-02T11:25:26.416Z
-      time: 0
-      timings:
-        blocked: -1
-        connect: -1
-        dns: -1
-        receive: 0
-        send: 0
-        ssl: -1
-        wait: 0
-    - _id: 21d3252242deef34d2d38e9b0eff82c6
-      _order: 0
-      cache: {}
-      request:
-        bodySize: 801
-        cookies: []
-        headers:
-          - name: content-type
-            value: application/json
-          - name: accept-encoding
-            value: gzip;q=0
-          - name: authorization
-            value: token
-              REDACTED_964f5256e709a8c5c151a63d8696d5c7ac81604d179405864d88ff48a9232364
-          - name: user-agent
-            value: jetbrains / 6.0.0-SNAPSHOT
-          - name: connection
-            value: keep-alive
-          - name: host
-            value: sourcegraph.sourcegraph.com
-        headersSize: 371
-        httpVersion: HTTP/1.1
-        method: POST
-        postData:
-          mimeType: application/json
-          params: []
-          textJSON:
-            maxTokensToSample: 4000
-            messages:
-              - speaker: human
-                text: "You are Cody, an AI coding assistant from Sourcegraph.If your answer
-                  contains fenced code blocks in Markdown, include the relevant
-                  full file path in the code block tag using this structure:
-                  ```$LANGUAGE:$FILEPATH```."
-              - speaker: assistant
-                text: I am Cody, an AI coding assistant from Sourcegraph.
-              - speaker: human
-                text: |-
-                  Codebase context from file animal.ts:
-                  ```typescript:animal.ts
-                  interface StrangeAnimal {
-                      makesSound(): 'coo' | 'moo'
-                  }
-                  ```
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: >-
-                  You have access to the provided codebase context. 
-
-
-                  Question: implement a cow. Only print the code without any explanation.
-              - speaker: assistant
-            model: gpt-4o
-            temperature: 0.2
-            topK: -1
-            topP: -1
-        queryString:
-          - name: client-name
-            value: jetbrains
-          - name: client-version
-            value: 6.0.0-SNAPSHOT
-        url: https://sourcegraph.sourcegraph.com/.api/completions/stream?client-name=jetbrains&client-version=6.0.0-SNAPSHOT
-      response:
-        bodySize: 4847
-        content:
-          mimeType: text/event-stream
-          size: 4847
-          text: >+
-            event: completion
-
-            data: {"completion":"```typescript:animal.ts\nclass Cow implements StrangeAnimal {\n    makesSound(): 'coo' | 'moo' {\n        return 'moo';\n    }\n}\n```","stopReason":"stop"}
-
-
-            event: done
-
-            data: {}
-
-        cookies: []
-        headers:
-          - name: date
-            value: Mon, 02 Sep 2024 11:25:30 GMT
-          - name: content-type
-            value: text/event-stream
-          - name: transfer-encoding
-            value: chunked
-          - name: connection
-            value: keep-alive
-          - name: access-control-allow-credentials
-            value: "true"
-          - name: access-control-allow-origin
-            value: ""
-          - name: cache-control
-            value: no-cache
-          - name: vary
-            value: Accept-Encoding, Authorization, Cookie, Authorization, X-Requested-With,
-              Cookie
-          - name: x-content-type-options
-            value: nosniff
-          - name: x-frame-options
-            value: DENY
-          - name: x-xss-protection
-            value: 1; mode=block
-          - name: strict-transport-security
-            value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1215
-        httpVersion: HTTP/1.1
-        redirectURL: ""
-        status: 200
-        statusText: OK
-      startedDateTime: 2024-09-02T11:25:29.989Z
-      time: 0
-      timings:
-        blocked: -1
-        connect: -1
-        dns: -1
-        receive: 0
-        send: 0
-        ssl: -1
-        wait: 0
     - _id: 204d8b5f0f47e53e25b515318b0b5aa6
       _order: 0
       cache: {}
@@ -833,6 +610,107 @@ log:
         status: 200
         statusText: OK
       startedDateTime: 2024-09-02T11:25:24.533Z
+      time: 0
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 0
+    - _id: b4499992cdf92807c09248d1e216cbdb
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 253
+        cookies: []
+        headers:
+          - _fromType: array
+            name: authorization
+            value: token
+              REDACTED_964f5256e709a8c5c151a63d8696d5c7ac81604d179405864d88ff48a9232364
+          - _fromType: array
+            name: content-type
+            value: application/json; charset=utf-8
+          - _fromType: array
+            name: user-agent
+            value: cody-cli / 6.0.0-SNAPSHOT
+          - _fromType: array
+            name: accept
+            value: "*/*"
+          - _fromType: array
+            name: content-length
+            value: "253"
+          - _fromType: array
+            name: accept-encoding
+            value: gzip,deflate
+          - name: host
+            value: sourcegraph.sourcegraph.com
+        headersSize: 349
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json; charset=utf-8
+          params: []
+          textJSON:
+            query: |
+              
+              query Repositories($names: [String!]!, $first: Int!) {
+                  repositories(names: $names, first: $first) {
+                    nodes {
+                      name
+                      id
+                    }
+                  }
+                }
+            variables:
+              first: 1
+              names:
+                - github.com/sourcegraph/sourcegraph
+        queryString:
+          - name: Repositories
+            value: null
+        url: https://sourcegraph.sourcegraph.com/.api/graphql?Repositories
+      response:
+        bodySize: 38
+        content:
+          mimeType: application/json
+          size: 38
+          text: "{\"data\":{\"repositories\":{\"nodes\":[]}}}"
+        cookies: []
+        headers:
+          - name: date
+            value: Mon, 09 Sep 2024 18:51:41 GMT
+          - name: content-type
+            value: application/json
+          - name: content-length
+            value: "38"
+          - name: connection
+            value: keep-alive
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache, max-age=0
+          - name: vary
+            value: Accept-Encoding, Authorization, Cookie, Authorization, X-Requested-With,
+              Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+        headersSize: 1217
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: 2024-09-09T18:51:41.537Z
       time: 0
       timings:
         blocked: -1

--- a/agent/recordings/cody-chat_103640681/recording.har.yaml
+++ b/agent/recordings/cody-chat_103640681/recording.har.yaml
@@ -88,6 +88,229 @@ log:
         send: 0
         ssl: -1
         wait: 0
+    - _id: 709c04331ef053b321decb3b9eb8e0f0
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 518
+        cookies: []
+        headers:
+          - name: content-type
+            value: application/json
+          - name: accept-encoding
+            value: gzip;q=0
+          - name: authorization
+            value: token
+              REDACTED_964f5256e709a8c5c151a63d8696d5c7ac81604d179405864d88ff48a9232364
+          - name: user-agent
+            value: jetbrains / 6.0.0-SNAPSHOT
+          - name: connection
+            value: keep-alive
+          - name: host
+            value: sourcegraph.sourcegraph.com
+        headersSize: 371
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json
+          params: []
+          textJSON:
+            maxTokensToSample: 4000
+            messages:
+              - speaker: human
+                text: "You are Cody, an AI coding assistant from Sourcegraph.If your answer
+                  contains fenced code blocks in Markdown, include the relevant
+                  full file path in the code block tag using this structure:
+                  ```$LANGUAGE:$FILEPATH```."
+              - speaker: assistant
+                text: I am Cody, an AI coding assistant from Sourcegraph.
+              - speaker: human
+                text: respond with "hello" and nothing else
+              - speaker: assistant
+            model: gpt-4o
+            temperature: 0.2
+            topK: -1
+            topP: -1
+        queryString:
+          - name: client-name
+            value: jetbrains
+          - name: client-version
+            value: 6.0.0-SNAPSHOT
+        url: https://sourcegraph.sourcegraph.com/.api/completions/stream?client-name=jetbrains&client-version=6.0.0-SNAPSHOT
+      response:
+        bodySize: 213
+        content:
+          mimeType: text/event-stream
+          size: 213
+          text: |+
+            event: completion
+            data: {"completion":"hello","stopReason":"stop"}
+
+            event: done
+            data: {}
+
+        cookies: []
+        headers:
+          - name: date
+            value: Mon, 02 Sep 2024 11:25:27 GMT
+          - name: content-type
+            value: text/event-stream
+          - name: transfer-encoding
+            value: chunked
+          - name: connection
+            value: keep-alive
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache
+          - name: vary
+            value: Accept-Encoding, Authorization, Cookie, Authorization, X-Requested-With,
+              Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+        headersSize: 1215
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: 2024-09-02T11:25:26.416Z
+      time: 0
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 0
+    - _id: 21d3252242deef34d2d38e9b0eff82c6
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 801
+        cookies: []
+        headers:
+          - name: content-type
+            value: application/json
+          - name: accept-encoding
+            value: gzip;q=0
+          - name: authorization
+            value: token
+              REDACTED_964f5256e709a8c5c151a63d8696d5c7ac81604d179405864d88ff48a9232364
+          - name: user-agent
+            value: jetbrains / 6.0.0-SNAPSHOT
+          - name: connection
+            value: keep-alive
+          - name: host
+            value: sourcegraph.sourcegraph.com
+        headersSize: 371
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json
+          params: []
+          textJSON:
+            maxTokensToSample: 4000
+            messages:
+              - speaker: human
+                text: "You are Cody, an AI coding assistant from Sourcegraph.If your answer
+                  contains fenced code blocks in Markdown, include the relevant
+                  full file path in the code block tag using this structure:
+                  ```$LANGUAGE:$FILEPATH```."
+              - speaker: assistant
+                text: I am Cody, an AI coding assistant from Sourcegraph.
+              - speaker: human
+                text: |-
+                  Codebase context from file animal.ts:
+                  ```typescript:animal.ts
+                  interface StrangeAnimal {
+                      makesSound(): 'coo' | 'moo'
+                  }
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: >-
+                  You have access to the provided codebase context. 
+
+
+                  Question: implement a cow. Only print the code without any explanation.
+              - speaker: assistant
+            model: gpt-4o
+            temperature: 0.2
+            topK: -1
+            topP: -1
+        queryString:
+          - name: client-name
+            value: jetbrains
+          - name: client-version
+            value: 6.0.0-SNAPSHOT
+        url: https://sourcegraph.sourcegraph.com/.api/completions/stream?client-name=jetbrains&client-version=6.0.0-SNAPSHOT
+      response:
+        bodySize: 4847
+        content:
+          mimeType: text/event-stream
+          size: 4847
+          text: >+
+            event: completion
+
+            data: {"completion":"```typescript:animal.ts\nclass Cow implements StrangeAnimal {\n    makesSound(): 'coo' | 'moo' {\n        return 'moo';\n    }\n}\n```","stopReason":"stop"}
+
+
+            event: done
+
+            data: {}
+
+        cookies: []
+        headers:
+          - name: date
+            value: Mon, 02 Sep 2024 11:25:30 GMT
+          - name: content-type
+            value: text/event-stream
+          - name: transfer-encoding
+            value: chunked
+          - name: connection
+            value: keep-alive
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache
+          - name: vary
+            value: Accept-Encoding, Authorization, Cookie, Authorization, X-Requested-With,
+              Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+        headersSize: 1215
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: 2024-09-02T11:25:29.989Z
+      time: 0
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 0
     - _id: 204d8b5f0f47e53e25b515318b0b5aa6
       _order: 0
       cache: {}
@@ -610,107 +833,6 @@ log:
         status: 200
         statusText: OK
       startedDateTime: 2024-09-02T11:25:24.533Z
-      time: 0
-      timings:
-        blocked: -1
-        connect: -1
-        dns: -1
-        receive: 0
-        send: 0
-        ssl: -1
-        wait: 0
-    - _id: b4499992cdf92807c09248d1e216cbdb
-      _order: 0
-      cache: {}
-      request:
-        bodySize: 253
-        cookies: []
-        headers:
-          - _fromType: array
-            name: authorization
-            value: token
-              REDACTED_964f5256e709a8c5c151a63d8696d5c7ac81604d179405864d88ff48a9232364
-          - _fromType: array
-            name: content-type
-            value: application/json; charset=utf-8
-          - _fromType: array
-            name: user-agent
-            value: cody-cli / 6.0.0-SNAPSHOT
-          - _fromType: array
-            name: accept
-            value: "*/*"
-          - _fromType: array
-            name: content-length
-            value: "253"
-          - _fromType: array
-            name: accept-encoding
-            value: gzip,deflate
-          - name: host
-            value: sourcegraph.sourcegraph.com
-        headersSize: 349
-        httpVersion: HTTP/1.1
-        method: POST
-        postData:
-          mimeType: application/json; charset=utf-8
-          params: []
-          textJSON:
-            query: |
-              
-              query Repositories($names: [String!]!, $first: Int!) {
-                  repositories(names: $names, first: $first) {
-                    nodes {
-                      name
-                      id
-                    }
-                  }
-                }
-            variables:
-              first: 1
-              names:
-                - github.com/sourcegraph/sourcegraph
-        queryString:
-          - name: Repositories
-            value: null
-        url: https://sourcegraph.sourcegraph.com/.api/graphql?Repositories
-      response:
-        bodySize: 38
-        content:
-          mimeType: application/json
-          size: 38
-          text: "{\"data\":{\"repositories\":{\"nodes\":[]}}}"
-        cookies: []
-        headers:
-          - name: date
-            value: Mon, 09 Sep 2024 18:51:41 GMT
-          - name: content-type
-            value: application/json
-          - name: content-length
-            value: "38"
-          - name: connection
-            value: keep-alive
-          - name: access-control-allow-credentials
-            value: "true"
-          - name: access-control-allow-origin
-            value: ""
-          - name: cache-control
-            value: no-cache, max-age=0
-          - name: vary
-            value: Accept-Encoding, Authorization, Cookie, Authorization, X-Requested-With,
-              Cookie
-          - name: x-content-type-options
-            value: nosniff
-          - name: x-frame-options
-            value: DENY
-          - name: x-xss-protection
-            value: 1; mode=block
-          - name: strict-transport-security
-            value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1217
-        httpVersion: HTTP/1.1
-        redirectURL: ""
-        status: 200
-        statusText: OK
-      startedDateTime: 2024-09-09T18:51:41.537Z
       time: 0
       timings:
         blocked: -1

--- a/agent/src/TestClient.ts
+++ b/agent/src/TestClient.ts
@@ -762,7 +762,7 @@ export class TestClient extends MessageHandler {
                     command: 'edit',
                     text,
                     index: params?.index,
-                    contextFiles: params?.contextFiles ?? [],
+                    contextItems: params?.contextFiles ?? [],
                     addEnhancedContext: params?.addEnhancedContext ?? false,
                 },
             })
@@ -818,7 +818,7 @@ export class TestClient extends MessageHandler {
                     text,
                     submitType: 'user',
                     addEnhancedContext: params?.addEnhancedContext ?? false,
-                    contextFiles: params?.contextFiles,
+                    contextItems: params?.contextFiles,
                 },
             })
         )

--- a/agent/src/cli/command-bench/strategy-chat.ts
+++ b/agent/src/cli/command-bench/strategy-chat.ts
@@ -75,7 +75,7 @@ export async function evaluateChatStrategy(
                     range,
                     chatReply: reply.text,
                     chatQuestion: task.question,
-                    contextItems: contextItems,
+                    contextItems,
                     questionClass: task.class,
                     llmJudgeScore: score.scoreNumeric,
                     concisenessScore: concisenessScore.scoreNumeric,

--- a/agent/src/cli/command-bench/strategy-chat.ts
+++ b/agent/src/cli/command-bench/strategy-chat.ts
@@ -39,10 +39,10 @@ export async function evaluateChatStrategy(
         const task: ChatTask = YAML.parse(params.content)
         const id = await client.request('chat/new', null)
         client.request('chat/setModel', { id, model: chatModel })
-        const contextFiles: ContextItem[] = []
+        const contextItems: ContextItem[] = []
         for (const relativePath of task.files ?? []) {
             const uri = vscode.Uri.file(path.join(path.dirname(params.uri.fsPath), relativePath))
-            contextFiles.push({
+            contextItems.push({
                 type: 'file',
                 uri,
             })
@@ -53,7 +53,7 @@ export async function evaluateChatStrategy(
                 command: 'submit',
                 submitType: 'user',
                 text: task.question,
-                contextFiles,
+                contextItems,
                 addEnhancedContext: isDefined(options.context),
             },
         })

--- a/agent/src/cli/command-chat.ts
+++ b/agent/src/cli/command-chat.ts
@@ -227,7 +227,6 @@ export async function chatAction(options: ChatOptions): Promise<number> {
         }
         for (const repo of repos) {
             const repoUri = vscode.Uri.parse(`https://${endpoint}/${repo.name}`)
-            console.log('repoUri', repoUri.toString())
             contextItems.push({
                 type: 'repository',
                 // TODO: confirm syntax for repo

--- a/vscode/src/chat/chat-view/ChatController.ts
+++ b/vscode/src/chat/chat-view/ChatController.ts
@@ -287,7 +287,7 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
                     uuid.v4(),
                     PromptString.unsafe_fromUserQuery(message.text),
                     message.submitType,
-                    message.contextFiles ?? [],
+                    message.contextItems ?? [],
                     message.editorState as SerializedPromptEditorState,
                     message.addEnhancedContext ?? false,
                     this.startNewSubmitOrEditOperation(),
@@ -300,7 +300,7 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
                     uuid.v4(),
                     PromptString.unsafe_fromUserQuery(message.text),
                     message.index ?? undefined,
-                    message.contextFiles ?? [],
+                    message.contextItems ?? [],
                     message.editorState as SerializedPromptEditorState,
                     message.addEnhancedContext || false
                 )

--- a/vscode/src/chat/chat-view/ChatsController.ts
+++ b/vscode/src/chat/chat-view/ChatsController.ts
@@ -316,7 +316,7 @@ export class ChatsController implements vscode.Disposable {
     private async submitChat({
         text,
         submitType,
-        contextFiles,
+        contextItems,
         addEnhancedContext,
         source = DEFAULT_EVENT_SOURCE,
         command,
@@ -334,7 +334,7 @@ export class ChatsController implements vscode.Disposable {
             uuid.v4(),
             text,
             submitType,
-            contextFiles ?? [],
+            contextItems ?? [],
             editorState,
             addEnhancedContext ?? true,
             abortSignal,

--- a/vscode/src/chat/clientStateBroadcaster.ts
+++ b/vscode/src/chat/clientStateBroadcaster.ts
@@ -8,6 +8,7 @@ import {
     displayLineRange,
     displayPathBasename,
     expandToLineRange,
+    logDebug,
     openCtx,
     subscriptionDisposable,
 } from '@sourcegraph/cody-shared'
@@ -78,6 +79,7 @@ export function startClientStateBroadcaster({
             }
         }
         const corpusItems = getCorpusContextItemsForEditorState(useRemoteSearch)
+        logDebug('corpusItems', JSON.stringify(await corpusItems, null, 2))
         items.push(...(await corpusItems))
 
         postMessage({ type: 'clientState', value: { initialContext: items } })

--- a/vscode/src/chat/protocol.ts
+++ b/vscode/src/chat/protocol.ts
@@ -257,7 +257,7 @@ interface WebviewEditMessage extends WebviewContextMessage {
 
 interface WebviewContextMessage {
     addEnhancedContext?: boolean | undefined | null
-    contextFiles?: ContextItem[] | undefined | null
+    contextItems?: ContextItem[] | undefined | null
 }
 
 export interface ExtensionTranscriptMessage {

--- a/vscode/src/commands/execute/explain-history.ts
+++ b/vscode/src/commands/execute/explain-history.ts
@@ -39,10 +39,10 @@ async function explainHistoryCommand(
 
     logDebug('explainHistoryCommand', 'computed history options', JSON.stringify(historyOptions))
 
-    let contextFiles: ContextItem[] = []
+    let contextItems: ContextItem[] = []
     try {
-        contextFiles = await commandsProvider.history(historyOptions.uri, historyOptions)
-        if (contextFiles.length === 0) {
+        contextItems = await commandsProvider.history(historyOptions.uri, historyOptions)
+        if (contextItems.length === 0) {
             return {
                 level: 'warn',
                 reason: 'git-no-match',
@@ -63,7 +63,7 @@ async function explainHistoryCommand(
         text: prompt,
         submitType: 'user-newchat',
         addEnhancedContext: false,
-        contextFiles,
+        contextItems,
         source: args?.source,
     }
 }

--- a/vscode/src/commands/execute/explain.ts
+++ b/vscode/src/commands/execute/explain.ts
@@ -51,7 +51,7 @@ export async function explainCommand(
     return {
         text: prompt,
         submitType: 'user-newchat',
-        contextItems: contextItems,
+        contextItems,
         addEnhancedContext: false,
         source: args?.source,
         command: DefaultChatCommands.Explain,

--- a/vscode/src/commands/execute/explain.ts
+++ b/vscode/src/commands/execute/explain.ts
@@ -51,7 +51,7 @@ export async function explainCommand(
     return {
         text: prompt,
         submitType: 'user-newchat',
-        contextFiles: contextItems,
+        contextItems: contextItems,
         addEnhancedContext: false,
         source: args?.source,
         command: DefaultChatCommands.Explain,

--- a/vscode/src/commands/execute/smell.ts
+++ b/vscode/src/commands/execute/smell.ts
@@ -51,7 +51,7 @@ async function smellCommand(
     return {
         text: prompt,
         submitType: 'user-newchat',
-        contextItems: contextItems,
+        contextItems,
         addEnhancedContext: false,
         source: args?.source,
         command: DefaultChatCommands.Smell,

--- a/vscode/src/commands/execute/smell.ts
+++ b/vscode/src/commands/execute/smell.ts
@@ -51,7 +51,7 @@ async function smellCommand(
     return {
         text: prompt,
         submitType: 'user-newchat',
-        contextFiles: contextItems,
+        contextItems: contextItems,
         addEnhancedContext: false,
         source: args?.source,
         command: DefaultChatCommands.Smell,

--- a/vscode/src/commands/execute/terminal.ts
+++ b/vscode/src/commands/execute/terminal.ts
@@ -57,7 +57,7 @@ export async function executeExplainOutput(
             session: await executeChat({
                 text: prompt,
                 submitType: 'user-newchat',
-                contextFiles: [],
+                contextItems: [],
                 addEnhancedContext,
                 source,
             }),

--- a/vscode/src/commands/execute/test-chat.ts
+++ b/vscode/src/commands/execute/test-chat.ts
@@ -28,7 +28,7 @@ async function unitTestCommand(
 
     const editor = getEditor()?.active
     const document = editor?.document
-    const contextFiles: ContextItem[] = []
+    const contextItems: ContextItem[] = []
 
     if (document) {
         try {
@@ -38,9 +38,9 @@ async function unitTestCommand(
                     'Selection content is empty. Please select some code to generate tests for.'
                 )
             }
-            contextFiles.push(cursorContext)
+            contextItems.push(cursorContext)
 
-            contextFiles.push(...(await getContextFilesForTestCommand(document.uri)))
+            contextItems.push(...(await getContextFilesForTestCommand(document.uri)))
         } catch (error) {
             logError('testCommand', 'failed to fetch context', { verbose: error })
         }
@@ -48,7 +48,7 @@ async function unitTestCommand(
 
     return {
         text: prompt,
-        contextFiles,
+        contextItems,
         addEnhancedContext: false,
         source: args?.source,
         submitType: 'user-newchat',

--- a/vscode/src/commands/services/runner.ts
+++ b/vscode/src/commands/services/runner.ts
@@ -116,7 +116,7 @@ export class CommandRunner implements vscode.Disposable {
         const prompt = PromptString.unsafe_fromUserQuery(this.command.prompt)
 
         // Fetch context for the command
-        const contextFiles = await this.getContextFiles()
+        const contextItems = await this.getContextFiles()
 
         // NOTE: (bee) codebase context is not supported for custom commands
         return {
@@ -124,7 +124,7 @@ export class CommandRunner implements vscode.Disposable {
             session: await executeChat({
                 text: prompt,
                 submitType: 'user',
-                contextFiles,
+                contextItems,
                 addEnhancedContext: this.command.context?.codebase ?? false,
                 source: 'custom-commands',
                 command: DefaultChatCommands.Custom,

--- a/vscode/webviews/chat/Transcript.tsx
+++ b/vscode/webviews/chat/Transcript.tsx
@@ -278,7 +278,7 @@ export function editHumanMessage(
         index: messageIndexInTranscript,
         text: editorValue.text,
         editorState: editorValue.editorState,
-        contextFiles: editorValue.contextItems.map(deserializeContextItem),
+        contextItems: editorValue.contextItems.map(deserializeContextItem),
     })
     focusLastHumanMessageEditor()
 }
@@ -289,7 +289,7 @@ function onFollowupSubmit(editorValue: SerializedPromptEditorValue): void {
         submitType: 'user',
         text: editorValue.text,
         editorState: editorValue.editorState,
-        contextFiles: editorValue.contextItems.map(deserializeContextItem),
+        contextItems: editorValue.contextItems.map(deserializeContextItem),
     })
     focusLastHumanMessageEditor()
 }


### PR DESCRIPTION
Fixes CODY-3687

Previously, `cody chat --context-repo REPO` didn't use the provided repo as context due to a regresion in the PR https://github.com/sourcegraph/cody/pull/5379 This bug was limited to version 5.5.14 of the CLI, it was not part of 5.5.13.

This PR fixes the bug by adding repo context to the `'submit'` `contextItem` property where we previously only sent files.


## Test plan
Manually tested with this command
```
❯ pnpm agent chat --show-context --context-file agent/README.md --context-repo github.com/sourcegraph/cody -m 'what is the agent?'
 ...
> Context items:

> 1. /Users/olafurpg/dev/sourcegraph/cody/agent/agent/README.md

> 2. https://sourcegraph.sourcegraph.com/github.com/sourcegraph/cody/-/blob/agent/src/__tests__/graph-test/README.md

> 3. https://sourcegraph.sourcegraph.com/github.com/sourcegraph/cody/-/blob/cli/README.md

> 4. https://sourcegraph.sourcegraph.com/github.com/sourcegraph/cody/-/blob/agent/src/local-e2e/README.md
...

```

We have an integration test for `--context-repo` but it got disabled a couple months ago due to it being flaky.

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

## Changelog



<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
