### PR TITLE
fix(webviews): update visual-studio.css scrollbar color

### DIFF
--- a/vscode/webviews/themes/visual-studio.css
+++ b/vscode/webviews/themes/visual-studio.css
@@ -399,9 +399,9 @@ html[data-ide='VisualStudio'] {
     /* --vscode-remoteHub-decorations-workspaceRepositoriesView-hasUncommittedChangesForegroundColor: var(); */
     --vscode-scm-historyItemStatisticsBorder: var(--visualstudio-scrollbararrowglyph);
     --vscode-scrollbar-shadow: var(--visualstudio-scrollbarthumbglyph);
-    --vscode-scrollbarSlider-activeBackground: var(--visualstudio-scrollbarthumbpressedbackground);
-    --vscode-scrollbarSlider-background: var(--visualstudio-scrollbarbackground);
-    --vscode-scrollbarSlider-hoverBackground: var(--visualstudio-scrollbarthumbmouseoverbackground);
+    --vscode-scrollbarSlider-activeBackground: var(--visualstudio-toolwindowbackground);
+    --vscode-scrollbarSlider-background: var(--visualstudio-toolwindowbackground);
+    --vscode-scrollbarSlider-hoverBackground: var(--visualstudio-toolwindowbackground);
     /* --vscode-search-resultsInfoForeground: var(); */
     /* --vscode-searchEditor-findMatchBorder: var(); */
     /* --vscode-searchEditor-textInputBorder: var(); */
@@ -596,7 +596,7 @@ html[data-ide='VisualStudio'] {
     --vscode-widget-shadow: var(--visualstudio-buttonshadow);
 
     /* Mimic rules injected by VSCode */
-    scrollbar-color: var(--vscode-scrollbarSlider-background) var(--vscode-editor-background);
+    scrollbar-color: var(--vscode-editor-background) var(--vscode-scrollbarSlider-background);
 
 }
 

--- a/vscode/webviews/themes/visual-studio.css
+++ b/vscode/webviews/themes/visual-studio.css
@@ -596,7 +596,7 @@ html[data-ide='VisualStudio'] {
     --vscode-widget-shadow: var(--visualstudio-buttonshadow);
 
     /* Mimic rules injected by VSCode */
-    scrollbar-color: var(--vscode-editor-background) var(--vscode-scrollbarSlider-background);
+    scrollbar-color: var(--visualstudio-scrollbarthumbbackground) var(--visualstudio-toolwindowbackground);
 
 }
 


### PR DESCRIPTION
CLOSE https://linear.app/sourcegraph/issue/CODY-3685

This commit updates the scrollbar color in the visual-studio.css file to better match the Visual Studio theme. Specifically, it changes the background colors of the scrollbar slider to use the `--visualstudio-toolwindowbackground` variable instead of the previous values.

## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

Manually test the appearance of the webviews in the Visual Studio theme to ensure the scrollbar styles are updated as expected.

![Screenshot 2024-09-09 140031](https://github.com/user-attachments/assets/611be662-96ff-463b-822e-b93cebf227d3)

Before

![Screenshot 2024-09-09 140212](https://github.com/user-attachments/assets/ccbcd403-379d-46a3-9d53-40c608f3c759)

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
