### PR TITLE
VS Code: disable logger in unit tests

### DIFF
--- a/lib/shared/src/logger.ts
+++ b/lib/shared/src/logger.ts
@@ -26,7 +26,13 @@ const consoleLogger: CodyLogger = {
     },
 }
 
-let _logger = consoleLogger
+const noopLogger: CodyLogger = {
+    logDebug() {},
+    logError() {},
+}
+
+// Disable logger in vitest tests by default to unclutter CI output.
+let _logger = process.env.VITEST ? noopLogger : consoleLogger
 export function setLogger(newLogger: CodyLogger): void {
     _logger = newLogger
 }


### PR DESCRIPTION
- No functional changes
- Disabled logger to unclutter CI output. Example [here](https://github.com/sourcegraph/cody/actions/runs/10786462290/job/29913368825).

## Test plan

CI