### PR TITLE
Fix crash on account switching

### DIFF
--- a/vscode/webviews/tabs/AccountTab.tsx
+++ b/vscode/webviews/tabs/AccountTab.tsx
@@ -23,11 +23,7 @@ export const AccountTab: React.FC = () => {
 
     actions.push({
         text: 'Switch Account...',
-        onClick: useCallback(() => {
-            if (userInfo.user.username) {
-                getVSCodeAPI().postMessage({ command: 'command', id: 'cody.auth.switchAccount' })
-            }
-        }, [userInfo]),
+        onClick: () => getVSCodeAPI().postMessage({ command: 'command', id: 'cody.auth.switchAccount' }),
     })
     if (isDotComUser) {
         actions.push({


### PR DESCRIPTION
Backport of the https://github.com/sourcegraph/cody/pull/5404
Fixes CODY-3549

## Test plan

1. Build with JetBrains using CODY_DIR
2. Open `Accounts` tab
3. Click `Switch account...`
4. Make sure after the switch webui is not crashing and `Accounts` tab is still visible