### PR TITLE
Fix how smart apply handles various absolute paths and spaces in paths

### DIFF
--- a/agent/src/agent.ts
+++ b/agent/src/agent.ts
@@ -39,7 +39,7 @@ import type { ExtensionMessage, WebviewMessage } from '../../vscode/src/chat/pro
 import { ProtocolTextDocumentWithUri } from '../../vscode/src/jsonrpc/TextDocumentWithUri'
 import type * as agent_protocol from '../../vscode/src/jsonrpc/agent-protocol'
 
-import { mkdirSync, statSync } from 'node:fs'
+import fs, { mkdirSync, statSync } from 'node:fs'
 import { PassThrough } from 'node:stream'
 import type { Har } from '@pollyjs/persister'
 import { TESTING_TELEMETRY_EXPORTER } from '@sourcegraph/cody-shared/src/telemetry-v2/TelemetryRecorderProvider'
@@ -384,6 +384,12 @@ export class Agent extends MessageHandler implements ExtensionClient {
                       scheme: 'file',
                       path: clientInfo.workspaceRootPath ?? undefined,
                   })
+
+            if (!fs.existsSync(this.workspace.workspaceRootUri.fsPath)) {
+                throw new Error(
+                    `Workspace root '${this.workspace.workspaceRootUri.fsPath}' does not exist`
+                )
+            }
 
             vscode_shim.setWorkspaceDocuments(this.workspace)
             if (clientInfo.capabilities?.codeActions === 'enabled') {

--- a/agent/src/agent.ts
+++ b/agent/src/agent.ts
@@ -39,7 +39,7 @@ import type { ExtensionMessage, WebviewMessage } from '../../vscode/src/chat/pro
 import { ProtocolTextDocumentWithUri } from '../../vscode/src/jsonrpc/TextDocumentWithUri'
 import type * as agent_protocol from '../../vscode/src/jsonrpc/agent-protocol'
 
-import fs, { mkdirSync, statSync } from 'node:fs'
+import { mkdirSync, statSync } from 'node:fs'
 import { PassThrough } from 'node:stream'
 import type { Har } from '@pollyjs/persister'
 import { TESTING_TELEMETRY_EXPORTER } from '@sourcegraph/cody-shared/src/telemetry-v2/TelemetryRecorderProvider'
@@ -384,12 +384,6 @@ export class Agent extends MessageHandler implements ExtensionClient {
                       scheme: 'file',
                       path: clientInfo.workspaceRootPath ?? undefined,
                   })
-
-            if (!fs.existsSync(this.workspace.workspaceRootUri.fsPath)) {
-                throw new Error(
-                    `Workspace root '${this.workspace.workspaceRootUri.fsPath}' does not exist`
-                )
-            }
 
             vscode_shim.setWorkspaceDocuments(this.workspace)
             if (clientInfo.capabilities?.codeActions === 'enabled') {

--- a/lib/shared/src/prompt/prompt-string.ts
+++ b/lib/shared/src/prompt/prompt-string.ts
@@ -235,13 +235,19 @@ export class PromptString {
         return internal_createPromptString(indentString, [])
     }
 
+    // We need to sanitize paths used for prompts as they are often used in a markdown
+    //  in a way which does not support spaces in the file paths
+    private static sanitizeDisplayPath(path: string) {
+        return path.replaceAll(' ', '%20')
+    }
+
     public static fromDisplayPath(uri: vscode.Uri) {
-        return internal_createPromptString(displayPath(uri), [uri])
+        return internal_createPromptString(PromptString.sanitizeDisplayPath(displayPath(uri)), [uri])
     }
 
     public static fromDisplayPathLineRange(uri: vscode.Uri, range?: RangeData) {
         const pathToDisplay = range ? displayPathWithLines(uri, range) : displayPath(uri)
-        return internal_createPromptString(pathToDisplay, [uri])
+        return internal_createPromptString(PromptString.sanitizeDisplayPath(pathToDisplay), [uri])
     }
 
     public static fromDocumentText(document: vscode.TextDocument, range?: vscode.Range): PromptString {

--- a/vscode/src/services/utils/codeblock-action-tracker.ts
+++ b/vscode/src/services/utils/codeblock-action-tracker.ts
@@ -9,6 +9,7 @@ import {
 } from '@sourcegraph/cody-shared'
 import { getEditor } from '../../editor/active-editor'
 
+import path from 'node:path'
 import { Utils } from 'vscode-uri'
 import { doesFileExist } from '../../commands/utils/workspace-files'
 import { executeSmartApply } from '../../edit/smart-apply'
@@ -148,8 +149,13 @@ export async function handleSmartApply(
 ): Promise<void> {
     const activeEditor = getEditor()?.active
     const workspaceUri = vscode.workspace.workspaceFolders?.[0].uri
+
     const uri =
-        fileUri && workspaceUri ? Utils.joinPath(workspaceUri, fileUri) : activeEditor?.document.uri
+        fileUri && workspaceUri
+            ? path.isAbsolute(fileUri)
+                ? vscode.Uri.file(fileUri)
+                : Utils.joinPath(workspaceUri, fileUri)
+            : activeEditor?.document.uri
 
     const isNewFile = uri && !(await doesFileExist(uri))
     if (isNewFile) {

--- a/vscode/webviews/chat/extract-file-path.ts
+++ b/vscode/webviews/chat/extract-file-path.ts
@@ -41,7 +41,8 @@ export const remarkAttachFilePathToCodeBlocks: Plugin<[], Root> = () => {
                     ...node.data,
                     hProperties: {
                         ...(node.data as CodeNodeData)?.hProperties,
-                        'data-file-path': filePath.trim(),
+                        // We sanitize spaces in markdown path files using `PromptString` class, now we can convert them back
+                        'data-file-path': filePath.trim().replaceAll('%20', ' '),
                     },
                 }
             }


### PR DESCRIPTION
Backport of https://github.com/sourcegraph/cody/pull/5466
Fixes https://github.com/sourcegraph/jetbrains/issues/2195

## Changes

Fixes for Smart Apply:

1. Add proper support for paths with spaces
2. Add support for absolute paths

## Test plan

* Build with JetBrains plugin and:

1. Create new `quicksort.py` file outside of your workspace, in directory with space in name
3. Open that file and ask Cody to give you an quicksort imlementation
4. Use Smart Apply
5. Make sure code was inserted in `quicksort.py` properly