### PR TITLE
Increase default LocalStorage size from 5MB to 256MB (#5504)

### DIFF
--- a/agent/src/global-state/AgentGlobalState.ts
+++ b/agent/src/global-state/AgentGlobalState.ts
@@ -114,7 +114,8 @@ class LocalStorageDB implements DB {
     storage: LocalStorage
 
     constructor(ide: string, dir: string) {
-        this.storage = new LocalStorage(path.join(dir, `${ide}-globalState`))
+        const quota = 1024 * 1024 * 256 // 256 MB
+        this.storage = new LocalStorage(path.join(dir, `${ide}-globalState`), quota)
     }
 
     get(key: string): any {


### PR DESCRIPTION
Backport of https://github.com/sourcegraph/cody/pull/5504
Fixes CODY-3675

## Changes

`LocalStorage` by default have quota of 5MB.
It is easy to exceed that, as chat history contains content of the context files, which sometimes can be large.
For now I bumped quota ro 256MB, but we should also implement some cleanup strategy.

## Test plan

1. I checked my existing history size: ➜ jetbrains git:(main) ✗ ls -lh ~/Library/Application\ Support/Cody-nodejs/JetBrains-globalState/ | grep chatHistory -rw-r--r-- 1 pkukielka staff 2,6M 9 wrz 14:36 cody-local-chatHistory-v2
2. I decreased quota to 2MB, and run this PR with JetBrains - it failed to start throwing `QUOTA_EXCEEDED_ERR` error.
3. I changed it to 256MB and rebuilded - it starts fine now.
