### PR TITLE
Fix initial context

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "vitest": "^2.0.5"
   },
   "dependencies": {
-    "@openctx/client": "^0.0.26",
+    "@openctx/client": "^0.0.27",
     "@sourcegraph/telemetry": "^0.18.0",
     "ignore": "^5.3.1",
     "observable-fns": "^0.6.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,8 +18,8 @@ importers:
   .:
     dependencies:
       '@openctx/client':
-        specifier: ^0.0.26
-        version: 0.0.26
+        specifier: ^0.0.27
+        version: 0.0.27
       '@sourcegraph/telemetry':
         specifier: ^0.18.0
         version: 0.18.0
@@ -421,11 +421,11 @@ importers:
         specifier: ^0.20.8
         version: 0.20.8
       '@openctx/provider-linear-issues':
-        specifier: ^0.0.7
-        version: 0.0.7
+        specifier: ^0.0.8
+        version: 0.0.8
       '@openctx/vscode-lib':
-        specifier: ^0.0.22
-        version: 0.0.22
+        specifier: ^0.0.23
+        version: 0.0.23
       '@opentelemetry/api':
         specifier: ^1.7.0
         version: 1.7.0
@@ -821,8 +821,8 @@ importers:
   web:
     devDependencies:
       '@openctx/vscode-lib':
-        specifier: ^0.0.22
-        version: 0.0.22
+        specifier: ^0.0.23
+        version: 0.0.23
       '@sourcegraph/cody':
         specifier: workspace:*
         version: link:../agent
@@ -3357,43 +3357,35 @@ packages:
       which: 4.0.0
     dev: true
 
-  /@openctx/client@0.0.26:
-    resolution: {integrity: sha512-PapkkZVGZBbYjOnMeqFhy5H4VzAtD0+3vAyLClXn2w6N5rhoJeGdNhQyyBuDnB5doJDY8RWV7paWbCCRZ2FYNg==}
+  /@openctx/client@0.0.27:
+    resolution: {integrity: sha512-2/WiYTGqo7CzFgFiqZc/VN7nYA/Hq/HEF3xyQm0sNvz6pMlNxXxHEtC8EzeEDRL9jGdto0U5V0OasgOmDiCfwg==}
     dependencies:
-      '@openctx/protocol': 0.0.17
-      '@openctx/provider': 0.0.16
-      '@openctx/schema': 0.0.13
+      '@openctx/protocol': 0.0.18
+      '@openctx/provider': 0.0.17
+      '@openctx/schema': 0.0.14
       lru-cache: 10.2.2
       observable-fns: 0.6.1
       picomatch: 3.0.1
-
-  /@openctx/protocol@0.0.15:
-    resolution: {integrity: sha512-mT1iIb+tAdY0SUwFoM8xscvrC9c5wbCQ3hbzQgI5LKaXIULmPdQa478MtGxNto2zfp8QD6VKrySsKbzQ3JFfrA==}
-    dependencies:
-      '@openctx/schema': 0.0.12
-    dev: false
 
   /@openctx/protocol@0.0.17:
     resolution: {integrity: sha512-wTRDeubjgcNEaKu2hretjl57QSpafAEWO9TxjYfdnxBRSxOmWz/QHgm+vqTZKNyAAc38f3apL0G3jGQJGQ2fQQ==}
     dependencies:
       '@openctx/schema': 0.0.13
+    dev: false
 
-  /@openctx/provider-linear-issues@0.0.7:
-    resolution: {integrity: sha512-8NzRAoojj4o1c7+KaMTIc/e/cdVgiRbY4j2U5rn9K0qF2InZ6XNajdbvFdPT+PGrOzNOSvPiVFSM5OX/jKesSg==}
+  /@openctx/protocol@0.0.18:
+    resolution: {integrity: sha512-B14mIeY3L43fEcfgFMH4+AzUOyKZZ5kgZJrPJGSOz/p8qntDUCT2tkq13/hb5d8qp9LTFut12J3hk9HJ8EHmkg==}
     dependencies:
-      '@openctx/provider': 0.0.14
+      '@openctx/schema': 0.0.14
+
+  /@openctx/provider-linear-issues@0.0.8:
+    resolution: {integrity: sha512-UEQxpRAP7YT95iGOUX1RFS+GxQcLNmIbUYe+Q91oPP2C04TxTLKipTZkyDI0jFa+lZ4v1UJiMupUHmLYW4lllQ==}
+    dependencies:
+      '@openctx/provider': 0.0.16
       dedent: 1.5.3
       fast-xml-parser: 4.4.0
     transitivePeerDependencies:
       - babel-plugin-macros
-    dev: false
-
-  /@openctx/provider@0.0.14:
-    resolution: {integrity: sha512-jROzpxMIzh4qmLGIfPa+7iwFwrb28gEa2gdveTTIOYGYuAzqcmzURjDofrLM5i32ftxbk/gyWxJbv5bXe31l2w==}
-    dependencies:
-      '@openctx/protocol': 0.0.15
-      '@openctx/schema': 0.0.12
-      picomatch: 3.0.1
     dev: false
 
   /@openctx/provider@0.0.16:
@@ -3402,27 +3394,35 @@ packages:
       '@openctx/protocol': 0.0.17
       '@openctx/schema': 0.0.13
       picomatch: 3.0.1
-
-  /@openctx/schema@0.0.12:
-    resolution: {integrity: sha512-YEqmuasaOeAtcrhlN3/D6r+76J/omRbSBUPbv4azKQA7CDvG9MnfgV1Gv8JbFSz33XzI1h9wGbPi5uzb6o6peQ==}
     dev: false
+
+  /@openctx/provider@0.0.17:
+    resolution: {integrity: sha512-R4C0i646X/xVJPwWgeUee7h1eOPen4RATO2dzo5D1Bp804PqTied7wo5zlIjNX3S2vSN1nRZY39WkLZb8oeRnQ==}
+    dependencies:
+      '@openctx/protocol': 0.0.18
+      '@openctx/schema': 0.0.14
+      picomatch: 3.0.1
 
   /@openctx/schema@0.0.13:
     resolution: {integrity: sha512-P7pi+zkmq+gQkFWZTOjREnQQGmWtMRtHWSFEUt+G3B4Du1D8qFYxOWE4gH4gqlgNISeFS1UrbvGfSAds4jx0yA==}
+    dev: false
 
-  /@openctx/ui-common@0.0.12:
-    resolution: {integrity: sha512-FhKswG4GEVWI3YxIIweNywQr+7yjLxjKj0+OiYHvyjg108XKVSWb1TyqPiMjpYVJNFnKLHGKQqe7V9K3vDbCyQ==}
+  /@openctx/schema@0.0.14:
+    resolution: {integrity: sha512-pqoO5T6Q13E9wfJ/qsMaF3VDssnT0stfLyuvE0khfXABfDfO8KHgs9UqKQjkB0XrykjQYiSZZYWWMb9346i+ug==}
+
+  /@openctx/ui-common@0.0.13:
+    resolution: {integrity: sha512-S9s0gpEyZw4nNTDg9oTqJLb0nAPTK8P8tEZQv8kwpoL1rNtzu/O4cyoYWl5lIRH9KRURnvD2wgpgoVkfrVSMRw==}
     dependencies:
-      '@openctx/schema': 0.0.13
+      '@openctx/schema': 0.0.14
       marked: 12.0.2
       sanitize-html: 2.13.0
       xss: 1.0.15
 
-  /@openctx/vscode-lib@0.0.22:
-    resolution: {integrity: sha512-FrjY39+qIr4fW69HThN3VNgfUsZDPCBvI5NZhwuI6TExKc5rWsDT/rFNyR5vlkesS/xRJ0B6wlFuYGK5JSY6Xg==}
+  /@openctx/vscode-lib@0.0.23:
+    resolution: {integrity: sha512-JXRuegrXxk5vTUecYINzOFCJga1AWd+vFYu/8BLNHh9FFdv7K8q6yjpFDxk9sNHm5tI/LP9H0pvyszXYEYT3OA==}
     dependencies:
-      '@openctx/client': 0.0.26
-      '@openctx/ui-common': 0.0.12
+      '@openctx/client': 0.0.27
+      '@openctx/ui-common': 0.0.13
       observable-fns: 0.6.1
 
   /@opentelemetry/api-logs@0.45.1:

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -1360,8 +1360,8 @@
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.20.8",
-    "@openctx/provider-linear-issues": "^0.0.7",
-    "@openctx/vscode-lib": "^0.0.22",
+    "@openctx/provider-linear-issues": "^0.0.8",
+    "@openctx/vscode-lib": "^0.0.23",
     "@opentelemetry/api": "^1.7.0",
     "@opentelemetry/core": "^1.18.1",
     "@opentelemetry/exporter-trace-otlp-http": "^0.45.1",

--- a/vscode/src/chat/clientStateBroadcaster.ts
+++ b/vscode/src/chat/clientStateBroadcaster.ts
@@ -190,13 +190,18 @@ export async function getCorpusContextItemsForEditorState(useRemote: boolean): P
         await Promise.all(
             providers.map(async (provider): Promise<ContextItemOpenCtx[]> => {
                 const mentions =
-                    (await openCtx?.controller?.mentions(activeEditorContext, provider)) || []
+                    (await openCtx?.controller?.mentions(
+                        { ...activeEditorContext, autoInclude: true },
+                        provider
+                    )) || []
 
                 return mentions.map(mention => ({
                     ...mention,
                     provider: 'openctx',
                     type: 'openctx',
                     uri: URI.parse(mention.uri),
+                    source: ContextItemSource.Initial,
+                    mention, // include the original mention to pass to `items` later
                 }))
             })
         )

--- a/web/package.json
+++ b/web/package.json
@@ -19,7 +19,7 @@
     "build-ts": "tsc --build"
   },
   "devDependencies": {
-    "@openctx/vscode-lib": "^0.0.22",
+    "@openctx/vscode-lib": "^0.0.23",
     "@sourcegraph/cody": "workspace:*",
     "@sourcegraph/cody-shared": "workspace:*",
     "@sourcegraph/prompt-editor": "workspace:*",


### PR DESCRIPTION
Currently, the initial context mentions from the OpenCtx providers are included in the editor, but due to a bug, the context items are not retrieved at the message submission time. 

Basically, `ContextItemOpenCtx.mention` is required to be passed for the context rehydration to work. `ContextItemOpenCtx.mention` is sent to the `items` method and not the `ContextItemOpenCtx` itself. 

This was missed earlier because the provider I tested the whole flow with, also implemented example annotation context, so the context items from the provider were visible. 

## Test plan

- Add a provider with auto include set to true.
- The provider should add an initial context item. 
- The mentioned initial item should include the context items in the response.

## Changelog

- Fix OpenCtx initial context integration.