### PR TITLE
One box: Add search like code snippets

### DIFF
--- a/lib/shared/src/misc/rpc/webviewAPI.ts
+++ b/lib/shared/src/misc/rpc/webviewAPI.ts
@@ -6,7 +6,7 @@ import type { FeatureFlag } from '../../experimentation/FeatureFlagProvider'
 import type { ContextMentionProviderMetadata } from '../../mentions/api'
 import type { MentionQuery } from '../../mentions/query'
 import type { Model } from '../../models'
-import type { Prompt } from '../../sourcegraph-api/graphql/client'
+import type { FetchHighlightFileParameters, Prompt } from '../../sourcegraph-api/graphql/client'
 import { type createMessageAPIForWebview, proxyExtensionAPI } from './rpc'
 
 export interface WebviewToExtensionAPI {
@@ -33,6 +33,8 @@ export interface WebviewToExtensionAPI {
      */
     models(): Observable<Model[]>
 
+    highlights(query: FetchHighlightFileParameters): Observable<string[][]>
+
     /**
      * Set the chat model.
      */
@@ -49,6 +51,7 @@ export function createExtensionAPI(
         evaluatedFeatureFlag: proxyExtensionAPI(messageAPI, 'evaluatedFeatureFlag'),
         prompts: proxyExtensionAPI(messageAPI, 'prompts'),
         models: proxyExtensionAPI(messageAPI, 'models'),
+        highlights: proxyExtensionAPI(messageAPI, 'highlights'),
         setChatModel: proxyExtensionAPI(messageAPI, 'setChatModel'),
         detectIntent: proxyExtensionAPI(messageAPI, 'detectIntent'),
     }

--- a/lib/shared/src/sourcegraph-api/graphql/queries.ts
+++ b/lib/shared/src/sourcegraph-api/graphql/queries.ts
@@ -499,3 +499,27 @@ query ViewerSettings {
   }
 }
 `
+
+export const HIGHLIGHTED_FILE_QUERY = `
+   query HighlightedFile(
+        $repoName: String!
+        $commitID: String!
+        $filePath: String!
+        $disableTimeout: Boolean!
+        $ranges: [HighlightLineRange!]!
+        $format: HighlightResponseFormat!
+    ) {
+        repository(name: $repoName) {
+            commit(rev: $commitID) {
+                file(path: $filePath) {
+                    isDirectory
+                    richHTML
+                    highlight(disableTimeout: $disableTimeout, format: $format) {
+                        aborted
+                        lineRanges(ranges: $ranges)
+                    }
+                }
+            }
+        }
+    }
+`

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,6 +9,7 @@ neverBuiltDependencies:
   - playwright
 
 overrides:
+  tslib: 2.1.0
   '@lexical/react': https://storage.googleapis.com/sourcegraph-assets/npm/lexical-react-sourcegraph-fork-31065486.tgz
 
 packageExtensionsChecksum: bc809394d179d8460f9d473fc54e379a
@@ -591,6 +592,9 @@ importers:
       os-browserify:
         specifier: ^0.3.0
         version: 0.3.0
+      postcss-scss:
+        specifier: ^4.0.9
+        version: 4.0.9(postcss@8.4.38)
       react-markdown:
         specifier: ^9.0.1
         version: 9.0.1(@types/react@18.2.79)(react@18.2.0)
@@ -3278,7 +3282,7 @@ packages:
       '@microsoft/fast-element': 1.13.0
       '@microsoft/fast-web-utilities': 5.4.1
       tabbable: 5.3.3
-      tslib: 1.14.1
+      tslib: 2.1.0
     dev: false
 
   /@microsoft/fast-react-wrapper@0.1.48(react@18.2.0):
@@ -6915,7 +6919,7 @@ packages:
       esbuild: '>=0.10.0'
     dependencies:
       esbuild: 0.18.20
-      tslib: 2.7.0
+      tslib: 2.1.0
     dev: true
 
   /@yarnpkg/fslib@2.10.3:
@@ -6923,7 +6927,7 @@ packages:
     engines: {node: '>=12 <14 || 14.2 - 14.9 || >14.10.0'}
     dependencies:
       '@yarnpkg/libzip': 2.3.0
-      tslib: 1.14.1
+      tslib: 2.1.0
     dev: true
 
   /@yarnpkg/libzip@2.3.0:
@@ -6931,7 +6935,7 @@ packages:
     engines: {node: '>=12 <14 || 14.2 - 14.9 || >14.10.0'}
     dependencies:
       '@types/emscripten': 1.39.10
-      tslib: 1.14.1
+      tslib: 2.1.0
     dev: true
 
   /abab@2.0.6:
@@ -7246,7 +7250,7 @@ packages:
   /async-mutex@0.4.0:
     resolution: {integrity: sha512-eJFZ1YhRR8UN8eBLoNzcDPcy/jqjsg6I1AP+KvWQX80BqOSW1oJPJXDylPUEeMr2ZQvHgnQ//Lp6f3RQ1zI7HA==}
     dependencies:
-      tslib: 2.7.0
+      tslib: 2.1.0
     dev: false
 
   /async@3.2.5:
@@ -13153,6 +13157,15 @@ packages:
       postcss: 8.4.38
     dev: true
 
+  /postcss-scss@4.0.9(postcss@8.4.38):
+    resolution: {integrity: sha512-AjKOeiwAitL/MXxQW2DliT28EKukvvbEWx3LBmJIRN8KfBGZbRTxNYW0kSqi1COiTZ57nZ9NW06S6ux//N1c9A==}
+    engines: {node: '>=12.0'}
+    peerDependencies:
+      postcss: ^8.4.29
+    dependencies:
+      postcss: 8.4.38
+    dev: false
+
   /postcss-selector-parser@6.0.16:
     resolution: {integrity: sha512-A0RVJrX+IUkVZbW3ClroRWurercFhieevHB38sr2+l9eUClMqome3LmEmnhlNy+5Mr2EYN6B2Kaw9wYdd+VHiw==}
     engines: {node: '>=4'}
@@ -15334,14 +15347,8 @@ packages:
       strip-bom: 3.0.0
     dev: true
 
-  /tslib@1.14.1:
-    resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
-
   /tslib@2.1.0:
     resolution: {integrity: sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==}
-
-  /tslib@2.7.0:
-    resolution: {integrity: sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==}
 
   /tsscmp@1.0.6:
     resolution: {integrity: sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA==}
@@ -16495,7 +16502,7 @@ packages:
     dev: false
 
   '@storage.googleapis.com/sourcegraph-assets/npm/lexical-react-sourcegraph-fork-31065486.tgz(react-dom@18.2.0)(react@18.2.0)(yjs@13.6.18)':
-    resolution: {tarball: https://storage.googleapis.com/sourcegraph-assets/npm/lexical-react-sourcegraph-fork-31065486.tgz}
+    resolution: {registry: https://registry.npmjs.org/, tarball: https://storage.googleapis.com/sourcegraph-assets/npm/lexical-react-sourcegraph-fork-31065486.tgz}
     id: '@storage.googleapis.com/sourcegraph-assets/npm/lexical-react-sourcegraph-fork-31065486.tgz'
     name: '@lexical/react'
     version: 0.17.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,6 @@ neverBuiltDependencies:
   - playwright
 
 overrides:
-  tslib: 2.1.0
   '@lexical/react': https://storage.googleapis.com/sourcegraph-assets/npm/lexical-react-sourcegraph-fork-31065486.tgz
 
 packageExtensionsChecksum: bc809394d179d8460f9d473fc54e379a
@@ -3282,7 +3281,7 @@ packages:
       '@microsoft/fast-element': 1.13.0
       '@microsoft/fast-web-utilities': 5.4.1
       tabbable: 5.3.3
-      tslib: 2.1.0
+      tslib: 1.14.1
     dev: false
 
   /@microsoft/fast-react-wrapper@0.1.48(react@18.2.0):
@@ -6919,7 +6918,7 @@ packages:
       esbuild: '>=0.10.0'
     dependencies:
       esbuild: 0.18.20
-      tslib: 2.1.0
+      tslib: 2.7.0
     dev: true
 
   /@yarnpkg/fslib@2.10.3:
@@ -6927,7 +6926,7 @@ packages:
     engines: {node: '>=12 <14 || 14.2 - 14.9 || >14.10.0'}
     dependencies:
       '@yarnpkg/libzip': 2.3.0
-      tslib: 2.1.0
+      tslib: 1.14.1
     dev: true
 
   /@yarnpkg/libzip@2.3.0:
@@ -6935,7 +6934,7 @@ packages:
     engines: {node: '>=12 <14 || 14.2 - 14.9 || >14.10.0'}
     dependencies:
       '@types/emscripten': 1.39.10
-      tslib: 2.1.0
+      tslib: 1.14.1
     dev: true
 
   /abab@2.0.6:
@@ -7250,7 +7249,7 @@ packages:
   /async-mutex@0.4.0:
     resolution: {integrity: sha512-eJFZ1YhRR8UN8eBLoNzcDPcy/jqjsg6I1AP+KvWQX80BqOSW1oJPJXDylPUEeMr2ZQvHgnQ//Lp6f3RQ1zI7HA==}
     dependencies:
-      tslib: 2.1.0
+      tslib: 2.7.0
     dev: false
 
   /async@3.2.5:
@@ -15347,8 +15346,14 @@ packages:
       strip-bom: 3.0.0
     dev: true
 
+  /tslib@1.14.1:
+    resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
+
   /tslib@2.1.0:
     resolution: {integrity: sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==}
+
+  /tslib@2.7.0:
+    resolution: {integrity: sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==}
 
   /tsscmp@1.0.6:
     resolution: {integrity: sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA==}
@@ -16502,7 +16507,7 @@ packages:
     dev: false
 
   '@storage.googleapis.com/sourcegraph-assets/npm/lexical-react-sourcegraph-fork-31065486.tgz(react-dom@18.2.0)(react@18.2.0)(yjs@13.6.18)':
-    resolution: {registry: https://registry.npmjs.org/, tarball: https://storage.googleapis.com/sourcegraph-assets/npm/lexical-react-sourcegraph-fork-31065486.tgz}
+    resolution: {tarball: https://storage.googleapis.com/sourcegraph-assets/npm/lexical-react-sourcegraph-fork-31065486.tgz}
     id: '@storage.googleapis.com/sourcegraph-assets/npm/lexical-react-sourcegraph-fork-31065486.tgz'
     name: '@lexical/react'
     version: 0.17.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -597,6 +597,9 @@ importers:
       react-markdown:
         specifier: ^9.0.1
         version: 9.0.1(@types/react@18.2.79)(react@18.2.0)
+      react-visibility-sensor:
+        specifier: ^5.1.1
+        version: 5.1.1(react-dom@18.2.0)(react@18.2.0)
       rehype-highlight:
         specifier: ^6.0.0
         version: 6.0.0
@@ -13304,7 +13307,6 @@ packages:
       loose-envify: 1.4.0
       object-assign: 4.1.1
       react-is: 16.13.1
-    dev: true
 
   /propagate@2.0.1:
     resolution: {integrity: sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==}
@@ -13586,7 +13588,6 @@ packages:
 
   /react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
-    dev: true
 
   /react-is@17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
@@ -13725,6 +13726,17 @@ packages:
       invariant: 2.2.4
       react: 18.2.0
       tslib: 2.1.0
+    dev: false
+
+  /react-visibility-sensor@5.1.1(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-cTUHqIK+zDYpeK19rzW6zF9YfT4486TIgizZW53wEZ+/GPBbK7cNS0EHyJVyHYacwFEvvHLEKfgJndbemWhB/w==}
+    peerDependencies:
+      react: '>=16.0.0'
+      react-dom: '>=16.0.0'
+    dependencies:
+      prop-types: 15.8.1
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
     dev: false
 
   /react@18.2.0:

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -1419,6 +1419,7 @@
     "os-browserify": "^0.3.0",
     "postcss-scss": "^4.0.9",
     "react-markdown": "^9.0.1",
+    "react-visibility-sensor": "^5.1.1",
     "rehype-highlight": "^6.0.0",
     "rehype-sanitize": "^6.0.0",
     "remark-gfm": "^4.0.0",

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -55,14 +55,7 @@
     "version-bump:patch": "RELEASE_TYPE=patch ts-node-transpile-only ./scripts/version-bump.ts",
     "version-bump:dry-run": "RELEASE_TYPE=prerelease ts-node-transpile-only ./scripts/version-bump.ts"
   },
-  "categories": [
-    "AI",
-    "Chat",
-    "Programming Languages",
-    "Machine Learning",
-    "Snippets",
-    "Education"
-  ],
+  "categories": ["AI", "Chat", "Programming Languages", "Machine Learning", "Snippets", "Education"],
   "keywords": [
     "cody",
     "codey",
@@ -126,11 +119,7 @@
   },
   "main": "./dist/extension.node.js",
   "browser": "./dist/extension.web.js",
-  "activationEvents": [
-    "onLanguage",
-    "onStartupFinished",
-    "onWebviewPanel:cody.editorPanel"
-  ],
+  "activationEvents": ["onLanguage", "onStartupFinished", "onWebviewPanel:cody.editorPanel"],
   "contributes": {
     "walkthroughs": [
       {
@@ -741,17 +730,13 @@
       },
       {
         "command": "cody.supercompletion.jumpTo",
-        "args": [
-          "next"
-        ],
+        "args": ["next"],
         "key": "shift+ctrl+down",
         "when": "cody.activated && !editorReadonly && cody.hasActionableSupercompletion"
       },
       {
         "command": "cody.supercompletion.jumpTo",
-        "args": [
-          "previous"
-        ],
+        "args": ["previous"],
         "key": "shift+ctrl+up",
         "when": "cody.activated && !editorReadonly && cody.hasActionableSupercompletion"
       }
@@ -1013,20 +998,12 @@
           "order": 2,
           "type": "string",
           "markdownDescription": "A Git repository URL to use instead of allowing Cody to infer the Git repository from the workspace.",
-          "examples": [
-            "https://github.com/sourcegraph/cody",
-            "ssh://git@github.com/sourcegraph/cody"
-          ]
+          "examples": ["https://github.com/sourcegraph/cody", "ssh://git@github.com/sourcegraph/cody"]
         },
         "cody.useContext": {
           "order": 99,
           "type": "string",
-          "enum": [
-            "embeddings",
-            "keyword",
-            "blended",
-            "none"
-          ],
+          "enum": ["embeddings", "keyword", "blended", "none"],
           "default": "blended",
           "markdownDescription": "Controls which context providers Cody uses for chat, commands and inline edits. Use 'blended' for best results. For debugging other context sources, 'embeddings' will use an embeddings-based index if available. 'keyword' will use a search-based index. 'none' will not use embeddings or search-based indexes."
         },
@@ -1078,18 +1055,12 @@
           "order": 6,
           "type": "string",
           "markdownDescription": "A custom instruction to be included at the start of all chat messages (e.g. \"Answer all my questions in Spanish.\")",
-          "examples": [
-            "Answer all my questions in Spanish."
-          ]
+          "examples": ["Answer all my questions in Spanish."]
         },
         "cody.chat.defaultLocation": {
           "order": 6,
           "type": "string",
-          "enum": [
-            "sticky",
-            "sidebar",
-            "editor"
-          ],
+          "enum": ["sticky", "sidebar", "editor"],
           "markdownDescription": "Controls where the Cody chat view opens when the user invokes the `Cody: New Chat` command, or the Alt+L and Alt+/ shortcuts.",
           "enumDescriptions": [
             "Opens in the last-activated view location, which is set whenever the user explicitly chooses to open chat in a given location",
@@ -1102,9 +1073,7 @@
           "order": 7,
           "type": "string",
           "markdownDescription": "A custom instruction to be included at the end of all instructions for edit commands (e.g. \"Write all unit tests with Jest instead of detected framework.\")",
-          "examples": [
-            "Write all unit tests with Jest instead of detected framework."
-          ]
+          "examples": ["Write all unit tests with Jest instead of detected framework."]
         },
         "cody.codeActions.enabled": {
           "order": 11,
@@ -1150,14 +1119,8 @@
         "cody.telemetry.level": {
           "order": 99,
           "type": "string",
-          "enum": [
-            "all",
-            "off"
-          ],
-          "enumDescriptions": [
-            "Sends usage data and errors.",
-            "Disables all extension telemetry."
-          ],
+          "enum": ["all", "off"],
+          "enumDescriptions": ["Sends usage data and errors.", "Disables all extension telemetry."],
           "markdownDescription": "Controls the telemetry about Cody usage and errors. See [Cody usage and privacy notice](https://about.sourcegraph.com/terms/cody-notice).",
           "default": "all"
         },
@@ -1186,11 +1149,7 @@
         "cody.autocomplete.advanced.model": {
           "type": "string",
           "default": null,
-          "enum": [
-            null,
-            "starcoder-16b",
-            "starcoder-7b"
-          ],
+          "enum": [null, "starcoder-16b", "starcoder-7b"],
           "markdownDescription": "Overwrite the  model used for code autocompletion inference. This is only supported with the `fireworks` provider"
         },
         "cody.autocomplete.completeSuggestWidgetSelection": {
@@ -1210,10 +1169,7 @@
         },
         "cody.experimental.foldingRanges": {
           "type": "string",
-          "enum": [
-            "lsp",
-            "indentation-based"
-          ],
+          "enum": ["lsp", "indentation-based"],
           "enumDescriptions": [
             "Use folding ranges that are enabled by default in VS Code, and are usually powered by LSP",
             "Use custom implementation of folding ranges that is indentation based. This is the implementation that is used by other Cody clients like the JetBrains plugin"
@@ -1224,13 +1180,7 @@
         "cody.autocomplete.experimental.graphContext": {
           "type": "string",
           "default": null,
-          "enum": [
-            null,
-            "bfg",
-            "bfg-mixed",
-            "tsc",
-            "tsc-mixed"
-          ],
+          "enum": [null, "bfg", "bfg-mixed", "tsc", "tsc-mixed"],
           "markdownDescription": "Use the code graph to retrieve context for autocomplete requests."
         },
         "cody.autocomplete.experimental.fireworksOptions": {
@@ -1405,9 +1355,7 @@
     "untrustedWorkspaces": {
       "supported": "limited",
       "description": "Cody only uses providers (configured in `openctx.providers`) from trusted workspaces because providers may execute arbitrary code.",
-      "restrictedConfigurations": [
-        "openctx.providers"
-      ]
+      "restrictedConfigurations": ["openctx.providers"]
     }
   },
   "dependencies": {

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -55,7 +55,14 @@
     "version-bump:patch": "RELEASE_TYPE=patch ts-node-transpile-only ./scripts/version-bump.ts",
     "version-bump:dry-run": "RELEASE_TYPE=prerelease ts-node-transpile-only ./scripts/version-bump.ts"
   },
-  "categories": ["AI", "Chat", "Programming Languages", "Machine Learning", "Snippets", "Education"],
+  "categories": [
+    "AI",
+    "Chat",
+    "Programming Languages",
+    "Machine Learning",
+    "Snippets",
+    "Education"
+  ],
   "keywords": [
     "cody",
     "codey",
@@ -119,7 +126,11 @@
   },
   "main": "./dist/extension.node.js",
   "browser": "./dist/extension.web.js",
-  "activationEvents": ["onLanguage", "onStartupFinished", "onWebviewPanel:cody.editorPanel"],
+  "activationEvents": [
+    "onLanguage",
+    "onStartupFinished",
+    "onWebviewPanel:cody.editorPanel"
+  ],
   "contributes": {
     "walkthroughs": [
       {
@@ -730,13 +741,17 @@
       },
       {
         "command": "cody.supercompletion.jumpTo",
-        "args": ["next"],
+        "args": [
+          "next"
+        ],
         "key": "shift+ctrl+down",
         "when": "cody.activated && !editorReadonly && cody.hasActionableSupercompletion"
       },
       {
         "command": "cody.supercompletion.jumpTo",
-        "args": ["previous"],
+        "args": [
+          "previous"
+        ],
         "key": "shift+ctrl+up",
         "when": "cody.activated && !editorReadonly && cody.hasActionableSupercompletion"
       }
@@ -998,12 +1013,20 @@
           "order": 2,
           "type": "string",
           "markdownDescription": "A Git repository URL to use instead of allowing Cody to infer the Git repository from the workspace.",
-          "examples": ["https://github.com/sourcegraph/cody", "ssh://git@github.com/sourcegraph/cody"]
+          "examples": [
+            "https://github.com/sourcegraph/cody",
+            "ssh://git@github.com/sourcegraph/cody"
+          ]
         },
         "cody.useContext": {
           "order": 99,
           "type": "string",
-          "enum": ["embeddings", "keyword", "blended", "none"],
+          "enum": [
+            "embeddings",
+            "keyword",
+            "blended",
+            "none"
+          ],
           "default": "blended",
           "markdownDescription": "Controls which context providers Cody uses for chat, commands and inline edits. Use 'blended' for best results. For debugging other context sources, 'embeddings' will use an embeddings-based index if available. 'keyword' will use a search-based index. 'none' will not use embeddings or search-based indexes."
         },
@@ -1055,12 +1078,18 @@
           "order": 6,
           "type": "string",
           "markdownDescription": "A custom instruction to be included at the start of all chat messages (e.g. \"Answer all my questions in Spanish.\")",
-          "examples": ["Answer all my questions in Spanish."]
+          "examples": [
+            "Answer all my questions in Spanish."
+          ]
         },
         "cody.chat.defaultLocation": {
           "order": 6,
           "type": "string",
-          "enum": ["sticky", "sidebar", "editor"],
+          "enum": [
+            "sticky",
+            "sidebar",
+            "editor"
+          ],
           "markdownDescription": "Controls where the Cody chat view opens when the user invokes the `Cody: New Chat` command, or the Alt+L and Alt+/ shortcuts.",
           "enumDescriptions": [
             "Opens in the last-activated view location, which is set whenever the user explicitly chooses to open chat in a given location",
@@ -1073,7 +1102,9 @@
           "order": 7,
           "type": "string",
           "markdownDescription": "A custom instruction to be included at the end of all instructions for edit commands (e.g. \"Write all unit tests with Jest instead of detected framework.\")",
-          "examples": ["Write all unit tests with Jest instead of detected framework."]
+          "examples": [
+            "Write all unit tests with Jest instead of detected framework."
+          ]
         },
         "cody.codeActions.enabled": {
           "order": 11,
@@ -1119,8 +1150,14 @@
         "cody.telemetry.level": {
           "order": 99,
           "type": "string",
-          "enum": ["all", "off"],
-          "enumDescriptions": ["Sends usage data and errors.", "Disables all extension telemetry."],
+          "enum": [
+            "all",
+            "off"
+          ],
+          "enumDescriptions": [
+            "Sends usage data and errors.",
+            "Disables all extension telemetry."
+          ],
           "markdownDescription": "Controls the telemetry about Cody usage and errors. See [Cody usage and privacy notice](https://about.sourcegraph.com/terms/cody-notice).",
           "default": "all"
         },
@@ -1149,7 +1186,11 @@
         "cody.autocomplete.advanced.model": {
           "type": "string",
           "default": null,
-          "enum": [null, "starcoder-16b", "starcoder-7b"],
+          "enum": [
+            null,
+            "starcoder-16b",
+            "starcoder-7b"
+          ],
           "markdownDescription": "Overwrite the  model used for code autocompletion inference. This is only supported with the `fireworks` provider"
         },
         "cody.autocomplete.completeSuggestWidgetSelection": {
@@ -1169,7 +1210,10 @@
         },
         "cody.experimental.foldingRanges": {
           "type": "string",
-          "enum": ["lsp", "indentation-based"],
+          "enum": [
+            "lsp",
+            "indentation-based"
+          ],
           "enumDescriptions": [
             "Use folding ranges that are enabled by default in VS Code, and are usually powered by LSP",
             "Use custom implementation of folding ranges that is indentation based. This is the implementation that is used by other Cody clients like the JetBrains plugin"
@@ -1180,7 +1224,13 @@
         "cody.autocomplete.experimental.graphContext": {
           "type": "string",
           "default": null,
-          "enum": [null, "bfg", "bfg-mixed", "tsc", "tsc-mixed"],
+          "enum": [
+            null,
+            "bfg",
+            "bfg-mixed",
+            "tsc",
+            "tsc-mixed"
+          ],
           "markdownDescription": "Use the code graph to retrieve context for autocomplete requests."
         },
         "cody.autocomplete.experimental.fireworksOptions": {
@@ -1355,7 +1405,9 @@
     "untrustedWorkspaces": {
       "supported": "limited",
       "description": "Cody only uses providers (configured in `openctx.providers`) from trusted workspaces because providers may execute arbitrary code.",
-      "restrictedConfigurations": ["openctx.providers"]
+      "restrictedConfigurations": [
+        "openctx.providers"
+      ]
     }
   },
   "dependencies": {
@@ -1417,6 +1469,7 @@
     "marked": "^4.0.16",
     "mkdirp": "^3.0.1",
     "os-browserify": "^0.3.0",
+    "postcss-scss": "^4.0.9",
     "react-markdown": "^9.0.1",
     "rehype-highlight": "^6.0.0",
     "rehype-sanitize": "^6.0.0",

--- a/vscode/src/chat/chat-view/ChatController.ts
+++ b/vscode/src/chat/chat-view/ChatController.ts
@@ -32,6 +32,7 @@ import {
     createMessageAPIForExtension,
     featureFlagProvider,
     getContextForChatMessage,
+    graphqlClient,
     hydrateAfterPostMessage,
     inputTextWithoutContextChipsFromPromptEditorState,
     isAbortErrorOrSocketHangUp,
@@ -1593,6 +1594,18 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
                                 startWith(undefined)
                             ),
                         ]).pipe(map(() => modelsService.instance!.getModels(ModelUsage.Chat))),
+                    highlights: parameters =>
+                        promiseFactoryToObservable(() =>
+                            graphqlClient.getHighlightedFileChunk(parameters)
+                        ).pipe(
+                            map(result => {
+                                if (isError(result)) {
+                                    return []
+                                }
+
+                                return result
+                            })
+                        ),
                     setChatModel: model => {
                         this.chatModel.updateModel(model)
 

--- a/vscode/tsconfig.json
+++ b/vscode/tsconfig.json
@@ -5,7 +5,7 @@
     "rootDir": ".",
     "outDir": "dist/tsc",
     "jsx": "react-jsx",
-    "lib": ["ESNext", "DOM", "DOM.Iterable"],
+    "lib": ["ESNext", "DOM", "DOM.Iterable", "es2021"],
     "types": ["@testing-library/jest-dom"],
     "paths": {
       "@/*": ["./webviews/*"]

--- a/vscode/webviews/AppWrapperForTest.tsx
+++ b/vscode/webviews/AppWrapperForTest.tsx
@@ -76,6 +76,7 @@ export const AppWrapperForTest: FunctionComponent<{ children: ReactNode }> = ({ 
                         prompts: { type: 'results', results: FIXTURE_PROMPTS },
                         commands: FIXTURE_COMMANDS,
                     }),
+                    highlights: () => Observable.of([]),
                     models: () => Observable.of(getDotComDefaultModels()),
                     setChatModel: () => EMPTY,
                     detectIntent: () => Observable.of(),

--- a/vscode/webviews/chat/Transcript.tsx
+++ b/vscode/webviews/chat/Transcript.tsx
@@ -329,6 +329,7 @@ const TranscriptInteraction: FC<TranscriptInteractionProps> = memo(props => {
                     model={assistantMessage?.model}
                     isForFirstMessage={humanMessage.index === 0}
                     defaultOpen={experimentalOneBoxEnabled && humanMessage.intent === 'search'}
+                    showSnippets={experimentalOneBoxEnabled}
                 />
             )}
             {assistantMessage && !isContextLoading && (

--- a/vscode/webviews/chat/cells/contextCell/ContextCell.module.css
+++ b/vscode/webviews/chat/cells/contextCell/ContextCell.module.css
@@ -8,24 +8,3 @@
     padding-left: 0.1rem;
     text-wrap: nowrap;
 }
-
-.context-item-link {
-    background: none;
-    border: none;
-    color: var(--vscode-textLink-foreground);
-    font-size: inherit;
-    padding: 0;
-    margin: 0;
-    text-align: left;
-    font-weight: normal;
-    display: flex;
-    align-items: center;
-    gap: 0.125rem;
-    overflow: hidden;
-}
-
-/* In light high contrast, --vscode-textLink-foreground provides little
-   contrast; instead inherit the --code-foreground color from the container. */
-body[data-vscode-theme-kind='vscode-high-contrast-light'] .context-item-link {
-    color: inherit;
-}

--- a/vscode/webviews/chat/cells/contextCell/ContextCell.tsx
+++ b/vscode/webviews/chat/cells/contextCell/ContextCell.tsx
@@ -31,6 +31,7 @@ export const ContextCell: FunctionComponent<{
     isForFirstMessage: boolean
     className?: string
     defaultOpen?: boolean
+    showSnippets?: boolean
 
     /** For use in storybooks only. */
     __storybook__initialOpen?: boolean
@@ -43,6 +44,7 @@ export const ContextCell: FunctionComponent<{
         className,
         defaultOpen,
         __storybook__initialOpen,
+        showSnippets = false,
     }) => {
         const [selectedAlternative, setSelectedAlternative] = useState<number | undefined>(undefined)
         const incrementSelectedAlternative = useCallback(
@@ -166,7 +168,11 @@ export const ContextCell: FunctionComponent<{
                                                 key={i}
                                                 data-testid="context-item"
                                             >
-                                                <FileContextItem item={item} />
+                                                <FileContextItem
+                                                    item={item}
+                                                    showSnippets={showSnippets}
+                                                    defaultOpen={defaultOpen}
+                                                />
                                                 {internalDebugContext &&
                                                     item.metadata &&
                                                     item.metadata.length > 0 && (

--- a/vscode/webviews/chat/cells/contextCell/ContextCell.tsx
+++ b/vscode/webviews/chat/cells/contextCell/ContextCell.tsx
@@ -1,12 +1,11 @@
 import type { ContextItem, Model } from '@sourcegraph/cody-shared'
 import { pluralize } from '@sourcegraph/cody-shared'
 import type { RankedContext } from '@sourcegraph/cody-shared/src/chat/transcript/messages'
-import { MENTION_CLASS_NAME } from '@sourcegraph/prompt-editor'
 import { clsx } from 'clsx'
 import isEqual from 'lodash/isEqual'
 import { BrainIcon, MessagesSquareIcon } from 'lucide-react'
 import { type FunctionComponent, memo, useCallback, useState } from 'react'
-import { FileLink } from '../../../components/FileLink'
+import { FileContextItem } from '../../../components/FileContextItem'
 import {
     Accordion,
     AccordionContent,
@@ -167,22 +166,7 @@ export const ContextCell: FunctionComponent<{
                                                 key={i}
                                                 data-testid="context-item"
                                             >
-                                                <FileLink
-                                                    uri={item.uri}
-                                                    repoName={item.repoName}
-                                                    revision={item.revision}
-                                                    source={item.source}
-                                                    range={item.range}
-                                                    title={item.title}
-                                                    isTooLarge={item.isTooLarge}
-                                                    isTooLargeReason={item.isTooLargeReason}
-                                                    isIgnored={item.isIgnored}
-                                                    className={clsx(
-                                                        styles.contextItem,
-                                                        MENTION_CLASS_NAME
-                                                    )}
-                                                    linkClassName={styles.contextItemLink}
-                                                />
+                                                <FileContextItem item={item} />
                                                 {internalDebugContext &&
                                                     item.metadata &&
                                                     item.metadata.length > 0 && (

--- a/vscode/webviews/components/FileContextItem.module.css
+++ b/vscode/webviews/components/FileContextItem.module.css
@@ -1,0 +1,42 @@
+.root {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+}
+
+.link-container {
+    display: inline-flex;
+    padding: 2px 4px 2px 2px;
+    min-width: 0;
+}
+
+.header {
+    display: flex;
+    gap: 0.25rem;
+    align-items: center;
+}
+
+.context-item-link {
+    background: none;
+    border: none;
+    color: var(--vscode-textLink-foreground);
+    font-size: inherit;
+    padding: 0;
+    margin: 0;
+    text-align: left;
+    font-weight: normal;
+    display: flex;
+    align-items: center;
+    gap: 0.125rem;
+    overflow: hidden;
+}
+
+/* In light high contrast, --vscode-textLink-foreground provides little
+   contrast; instead inherit the --code-foreground color from the container. */
+body[data-vscode-theme-kind='vscode-high-contrast-light'] .context-item-link {
+    color: inherit;
+}
+
+.code-block {
+    margin-bottom: 0.25rem;
+}

--- a/vscode/webviews/components/FileContextItem.tsx
+++ b/vscode/webviews/components/FileContextItem.tsx
@@ -12,14 +12,19 @@ import styles from './FileContextItem.module.css'
 
 interface FileContextItemProps {
     item: ContextItem
+    showSnippets: boolean
+    defaultOpen?: boolean
 }
 
-export const FileContextItem: FC<FileContextItemProps> = props => {
-    const { item } = props
-    const [isOpen, setOpen] = useState(false)
+export const FileContextItem: FC<FileContextItemProps> = ({
+    item,
+    showSnippets,
+    defaultOpen = false,
+}) => {
+    const [isOpen, setOpen] = useState(defaultOpen)
 
     // Fallback on link for any non file context items (like openctx items)
-    if (item.type !== 'file') {
+    if (item.type !== 'file' || !showSnippets) {
         return (
             <FileLink
                 uri={item.uri}
@@ -53,7 +58,6 @@ export const FileContextItem: FC<FileContextItemProps> = props => {
                     linkClassName={styles.contextItemLink}
                     className={clsx(styles.linkContainer, MENTION_CLASS_NAME)}
                 />
-
                 <Button variant="secondary" size="sm" onClick={() => setOpen(!isOpen)}>
                     {!isOpen ? (
                         <>

--- a/vscode/webviews/components/FileContextItem.tsx
+++ b/vscode/webviews/components/FileContextItem.tsx
@@ -1,0 +1,73 @@
+import type { ContextItem } from '@sourcegraph/cody-shared'
+import { MENTION_CLASS_NAME } from '@sourcegraph/prompt-editor'
+import { clsx } from 'clsx'
+import { ChevronRight, ChevronUp } from 'lucide-react'
+import { type FC, useState } from 'react'
+
+import { FileLink } from './FileLink'
+import { FileSnippet } from './FileSnippet'
+import { Button } from './shadcn/ui/button'
+
+import styles from './FileContextItem.module.css'
+
+interface FileContextItemProps {
+    item: ContextItem
+}
+
+export const FileContextItem: FC<FileContextItemProps> = props => {
+    const { item } = props
+    const [isOpen, setOpen] = useState(false)
+
+    // Fallback on link for any non file context items (like openctx items)
+    if (item.type !== 'file') {
+        return (
+            <FileLink
+                uri={item.uri}
+                repoName={item.repoName}
+                revision={item.revision}
+                source={item.source}
+                range={item.range}
+                title={item.title}
+                isTooLarge={item.isTooLarge}
+                isTooLargeReason={item.isTooLargeReason}
+                isIgnored={item.isIgnored}
+                linkClassName={styles.contextItemLink}
+                className={clsx(styles.linkContainer, MENTION_CLASS_NAME)}
+            />
+        )
+    }
+
+    return (
+        <div className={styles.root}>
+            <header className={styles.header}>
+                <FileLink
+                    uri={item.uri}
+                    repoName={item.repoName}
+                    revision={item.revision}
+                    source={item.source}
+                    range={item.range}
+                    title={item.title}
+                    isTooLarge={item.isTooLarge}
+                    isTooLargeReason={item.isTooLargeReason}
+                    isIgnored={item.isIgnored}
+                    linkClassName={styles.contextItemLink}
+                    className={clsx(styles.linkContainer, MENTION_CLASS_NAME)}
+                />
+
+                <Button variant="secondary" size="sm" onClick={() => setOpen(!isOpen)}>
+                    {!isOpen ? (
+                        <>
+                            Show <ChevronRight size={14} />
+                        </>
+                    ) : (
+                        <>
+                            Hide <ChevronUp size={14} />
+                        </>
+                    )}
+                </Button>
+            </header>
+
+            {isOpen && <FileSnippet item={item} className={styles.codeBlock} />}
+        </div>
+    )
+}

--- a/vscode/webviews/components/FileSnippet.tsx
+++ b/vscode/webviews/components/FileSnippet.tsx
@@ -1,0 +1,64 @@
+import type { ContextItem } from '@sourcegraph/cody-shared'
+import { useExtensionAPI } from '@sourcegraph/prompt-editor'
+import { type FC, useCallback, useMemo } from 'react'
+
+import type { Observable } from 'observable-fns'
+import { useConfig } from '../utils/useConfig'
+import { type FetchFileParameters, FileContentSearchResult } from './codeSnippet/CodeSnippet'
+import type { ContentMatch } from './codeSnippet/types'
+
+interface FileSnippetProps {
+    item: ContextItem
+    className?: string
+}
+
+export const FileSnippet: FC<FileSnippetProps> = props => {
+    const { item, className } = props
+
+    const highlights = useExtensionAPI().highlights
+    const {
+        config: { serverEndpoint },
+    } = useConfig()
+
+    const fetchHighlights = useCallback<(parameters: FetchFileParameters) => Observable<string[][]>>(
+        parameters => highlights(parameters),
+        [highlights]
+    )
+
+    const contentMatch = useMemo<ContentMatch>(() => {
+        const startLine = item.range?.start.line ?? 0
+        return {
+            type: 'content',
+            // Hack, file item always has file path as title
+            // TODO: Refactor content file item in order to have file path explicitly in object
+            path: item.title ?? '',
+            repository: item.repoName ?? '',
+            commit: item.revision,
+            chunkMatches: [
+                {
+                    content: item.content ?? '',
+                    contentStart: { line: Math.max(startLine - 1, 0), column: 0 },
+                    ranges: [],
+                },
+            ],
+        }
+    }, [item])
+
+    // Supports only file context (openctx items are not supported
+    // but possible could be presented by snippets as well)
+    if (item.type !== 'file') {
+        return null
+    }
+
+    return (
+        <FileContentSearchResult
+            serverEndpoint={serverEndpoint}
+            result={contentMatch}
+            showAllMatches={true}
+            defaultExpanded={false}
+            fetchHighlightedFileLineRanges={fetchHighlights}
+            className={className}
+            onSelect={() => {}}
+        />
+    )
+}

--- a/vscode/webviews/components/codeSnippet/CodeSnippet.module.css
+++ b/vscode/webviews/components/codeSnippet/CodeSnippet.module.css
@@ -1,0 +1,176 @@
+:root {
+    --border-color: #e6ebf2;
+    --border-color-2: #e6ebf2;
+    --result-header-bg: #f5f8fa;
+    --text-muted-highlighted: #566880;
+    --code-bg: white;
+    --primary-2: #a3d0ff;
+    --subtle-bg-2: #eff2f5;
+    --text-disabled: #798baf;
+    --text-muted: #5e6e8c;
+    --mark-bg: #f8e688;
+}
+
+.result-container {
+    contain: paint;
+    border: solid 1px gray;
+    border-radius: 4px;
+}
+
+.header {
+    padding: 0.5rem 0.75rem;
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+
+    position: sticky;
+    top: 0;
+
+    z-index: 1; // Show on top of search result contents
+
+    border-bottom: 1px solid var(--border-color-2);
+    background-color: var(--result-header-bg);
+
+    &-title {
+        flex: 1 1 auto;
+        display: flex;
+        flex-wrap: wrap;
+    }
+
+    :global(.match-highlight) {
+        color: var(--text-muted-highlighted);
+    }
+}
+
+.result {
+    background-color: var(--code-bg);
+    border-bottom: 1px solid var(--border-color-2);
+}
+
+.search-result-match {
+    text-decoration: none; /* don't use cascading link style */
+    display: flex;
+    align-items: flex-start;
+    overflow-x: auto;
+    overflow-y: hidden;
+    position: relative;
+}
+
+.horizontal-divider-between {
+    &:not(:last-child) {
+        border-bottom: 1px solid var(--border-color);
+    }
+}
+
+.focusable-block {
+    &:focus-visible {
+        box-shadow: inset 0 0 0 1px var(--primary-2);
+    }
+}
+
+.clickable {
+    cursor: pointer;
+    &:hover {
+        text-decoration: none;
+        background-color: var(--subtle-bg-2);
+    }
+}
+
+.copy-button {
+    visibility: hidden;
+    padding-top: 0;
+    padding-bottom: 0;
+    display: inline-flex;
+    align-items: center;
+
+    .copy-button-container:hover &,
+    .copy-button-container:focus-within & {
+        visibility: visible;
+    }
+}
+
+.divider-between {
+    > *:not(:last-child)::after {
+        content: ' ';
+        height: 1rem;
+        margin: 0 0.75rem;
+        border-right: 1px solid var(--border-color-2);
+        display: block;
+    }
+}
+
+.match-type {
+    white-space: nowrap;
+}
+
+.divider-vertical {
+    border-bottom: 1px solid var(--border-color-2);
+    width: 100%;
+    margin: 0.5rem 0;
+}
+
+.divider {
+    border-right: 1px solid var(--border-color-2);
+    height: 1rem;
+    margin: 0 0.5rem;
+}
+
+.gap-1 {
+    gap: 0.5rem;
+}
+
+.title-inner {
+    overflow-wrap: anywhere;
+}
+
+.icon {
+    margin-right: 0.25rem;
+}
+
+.title {
+    display: flex;
+    align-items: center;
+    flex-grow: 1;
+    min-width: 0;
+    flex-wrap: wrap;
+}
+
+.toggle-matches-button {
+    width: 100%;
+    text-align: left;
+    border: none;
+    padding: 0.25rem 0.5rem;
+    border-top: 1px solid var(--border-color);
+    background-color: var(--code-bg);
+    color: var(--text-disabled);
+
+    &:hover {
+        color: var(--text-muted);
+    }
+
+    &--expanded {
+        position: sticky;
+        bottom: 0;
+    }
+
+    &-text {
+        margin-left: 0.125rem;
+    }
+}
+
+:global(.sr-only) {
+    position: absolute;
+    width: 0.0625rem;
+    height: 0.0625rem;
+    padding: 0;
+    margin: -0.0625rem;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+}
+
+:global(.match-highlight) {
+    color: var(--text-muted-highlighted);
+    background-color: var(--mark-bg);
+}

--- a/vscode/webviews/components/codeSnippet/CodeSnippet.module.css
+++ b/vscode/webviews/components/codeSnippet/CodeSnippet.module.css
@@ -14,23 +14,23 @@
     contain: paint;
     border-radius: 4px;
     border: solid 1px var(--cody-chat-code-border-color);
-}
 
-:global(.match-highlight) {
-    color: var(--text-muted-highlighted);
-    background-color: var(--mark-bg);
-}
+    :global(.match-highlight) {
+        color: var(--text-muted-highlighted);
+        background-color: var(--mark-bg);
+    }
 
-:global(.sr-only) {
-    position: absolute;
-    width: 0.0625rem;
-    height: 0.0625rem;
-    padding: 0;
-    margin: -0.0625rem;
-    overflow: hidden;
-    clip: rect(0, 0, 0, 0);
-    white-space: nowrap;
-    border: 0;
+    :global(.sr-only) {
+        position: absolute;
+        width: 0.0625rem;
+        height: 0.0625rem;
+        padding: 0;
+        margin: -0.0625rem;
+        overflow: hidden;
+        clip: rect(0, 0, 0, 0);
+        white-space: nowrap;
+        border: 0;
+    }
 }
 
 .header {

--- a/vscode/webviews/components/codeSnippet/CodeSnippet.module.css
+++ b/vscode/webviews/components/codeSnippet/CodeSnippet.module.css
@@ -34,7 +34,7 @@
 }
 
 .header {
-    padding: 0.5rem 0.75rem;
+    padding: 0.45rem 0.5rem;
     display: flex;
     align-items: center;
     flex-wrap: wrap;

--- a/vscode/webviews/components/codeSnippet/CodeSnippet.module.css
+++ b/vscode/webviews/components/codeSnippet/CodeSnippet.module.css
@@ -26,7 +26,8 @@
     position: sticky;
     top: 0;
 
-    z-index: 1; // Show on top of search result contents
+    /* Show on top of search result contents */
+    z-index: 1;
 
     border-bottom: 1px solid var(--border-color-2);
     background-color: var(--result-header-bg);
@@ -36,10 +37,6 @@
         display: flex;
         flex-wrap: wrap;
     }
-
-    :global(.match-highlight) {
-        color: var(--text-muted-highlighted);
-    }
 }
 
 .result {
@@ -48,7 +45,8 @@
 }
 
 .search-result-match {
-    text-decoration: none; /* don't use cascading link style */
+    /* Don't use cascading link style */
+    text-decoration: none;
     display: flex;
     align-items: flex-start;
     overflow-x: auto;
@@ -76,19 +74,6 @@
     }
 }
 
-.copy-button {
-    visibility: hidden;
-    padding-top: 0;
-    padding-bottom: 0;
-    display: inline-flex;
-    align-items: center;
-
-    .copy-button-container:hover &,
-    .copy-button-container:focus-within & {
-        visibility: visible;
-    }
-}
-
 .divider-between {
     > *:not(:last-child)::after {
         content: ' ';
@@ -97,10 +82,6 @@
         border-right: 1px solid var(--border-color-2);
         display: block;
     }
-}
-
-.match-type {
-    white-space: nowrap;
 }
 
 .divider-vertical {
@@ -115,24 +96,16 @@
     margin: 0 0.5rem;
 }
 
-.gap-1 {
-    gap: 0.5rem;
-}
-
-.title-inner {
-    overflow-wrap: anywhere;
-}
-
-.icon {
-    margin-right: 0.25rem;
-}
-
 .title {
     display: flex;
     align-items: center;
     flex-grow: 1;
     min-width: 0;
     flex-wrap: wrap;
+}
+
+.title-inner {
+    overflow-wrap: anywhere;
 }
 
 .toggle-matches-button {

--- a/vscode/webviews/components/codeSnippet/CodeSnippet.module.css
+++ b/vscode/webviews/components/codeSnippet/CodeSnippet.module.css
@@ -1,20 +1,36 @@
 :root {
-    --border-color: #e6ebf2;
-    --border-color-2: #e6ebf2;
-    --result-header-bg: #f5f8fa;
-    --text-muted-highlighted: #566880;
-    --code-bg: white;
-    --primary-2: #a3d0ff;
-    --subtle-bg-2: #eff2f5;
-    --text-disabled: #798baf;
-    --text-muted: #5e6e8c;
+    --cody-chat-code-background: var(--vscode-textCodeBlock-background);
+    --cody-chat-code-header-background: var(--vscode-titleBar-inactiveBackground);
+    --cody-chat-code-subtle-background: var(--vscode-titleBar-inactiveBackground);
+    --cody-chat-code-border-color: var(--vscode-widget-border);
+    --cody-chat-code-text-muted: var(--vscode-input-placeholderForeground);
+    --cody-chat-code-focus-border: var(--vscode-focusBorder);
+
     --mark-bg: #f8e688;
+    --text-muted-highlighted: #566880;
 }
 
 .result-container {
     contain: paint;
-    border: solid 1px gray;
     border-radius: 4px;
+    border: solid 1px var(--cody-chat-code-border-color);
+}
+
+:global(.match-highlight) {
+    color: var(--text-muted-highlighted);
+    background-color: var(--mark-bg);
+}
+
+:global(.sr-only) {
+    position: absolute;
+    width: 0.0625rem;
+    height: 0.0625rem;
+    padding: 0;
+    margin: -0.0625rem;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
 }
 
 .header {
@@ -29,8 +45,8 @@
     /* Show on top of search result contents */
     z-index: 1;
 
-    border-bottom: 1px solid var(--border-color-2);
-    background-color: var(--result-header-bg);
+    border-bottom: 1px solid var(--cody-chat-code-border-color);
+    background-color: var(--vscode-titleBar-inactiveBackground);
 
     &-title {
         flex: 1 1 auto;
@@ -40,8 +56,7 @@
 }
 
 .result {
-    background-color: var(--code-bg);
-    border-bottom: 1px solid var(--border-color-2);
+    background-color: var(--cody-chat-code-background);
 }
 
 .search-result-match {
@@ -56,13 +71,13 @@
 
 .horizontal-divider-between {
     &:not(:last-child) {
-        border-bottom: 1px solid var(--border-color);
+        border-bottom: 1px solid var(--cody-chat-code-border-color);
     }
 }
 
 .focusable-block {
     &:focus-visible {
-        box-shadow: inset 0 0 0 1px var(--primary-2);
+        box-shadow: inset 0 0 0 1px var(--cody-chat-code-focus-border);
     }
 }
 
@@ -70,7 +85,7 @@
     cursor: pointer;
     &:hover {
         text-decoration: none;
-        background-color: var(--subtle-bg-2);
+        background-color: var(--cody-chat-code-subtle-background);
     }
 }
 
@@ -79,19 +94,19 @@
         content: ' ';
         height: 1rem;
         margin: 0 0.75rem;
-        border-right: 1px solid var(--border-color-2);
+        border-right: 1px solid var(--cody-chat-code-border-color);
         display: block;
     }
 }
 
 .divider-vertical {
-    border-bottom: 1px solid var(--border-color-2);
+    border-bottom: 1px solid var(--cody-chat-code-border-color);
     width: 100%;
     margin: 0.5rem 0;
 }
 
 .divider {
-    border-right: 1px solid var(--border-color-2);
+    border-right: 1px solid var(--cody-chat-code-border-color);
     height: 1rem;
     margin: 0 0.5rem;
 }
@@ -113,12 +128,12 @@
     text-align: left;
     border: none;
     padding: 0.25rem 0.5rem;
-    border-top: 1px solid var(--border-color);
-    background-color: var(--code-bg);
-    color: var(--text-disabled);
+    border-top: 1px solid var(--cody-chat-code-border-color);
+    background-color: var(--cody-chat-code-background);
+    color: var(--cody-chat-code-text-muted);
 
     &:hover {
-        color: var(--text-muted);
+        color: inherit;
     }
 
     &--expanded {
@@ -131,19 +146,3 @@
     }
 }
 
-:global(.sr-only) {
-    position: absolute;
-    width: 0.0625rem;
-    height: 0.0625rem;
-    padding: 0;
-    margin: -0.0625rem;
-    overflow: hidden;
-    clip: rect(0, 0, 0, 0);
-    white-space: nowrap;
-    border: 0;
-}
-
-:global(.match-highlight) {
-    color: var(--text-muted-highlighted);
-    background-color: var(--mark-bg);
-}

--- a/vscode/webviews/components/codeSnippet/CodeSnippet.story.tsx
+++ b/vscode/webviews/components/codeSnippet/CodeSnippet.story.tsx
@@ -5,229 +5,230 @@ import { FileContentSearchResult } from './CodeSnippet'
 const meta: Meta<typeof FileContentSearchResult> = {
     title: 'cody/FileContentSearchResult',
     component: FileContentSearchResult,
-    decorators: [
-        story => <div style={{ padding: 20 }}> {story()} </div>,
-        VSCodeStandaloneComponent,
-    ],
+    decorators: [story => <div style={{ padding: 20 }}> {story()} </div>, VSCodeStandaloneComponent],
     args: {
         allExpanded: false,
-        containerClassName: undefined,
         defaultExpanded: undefined,
         repoDisplayName: 'microsoft/vscode',
         showAllMatches: false,
         result: {
             chunkMatches: [
                 {
-                    "content": "\nclass SnippetBodyInsights {\n\n",
-                    "contentStart": {
-                        "offset": 1492,
-                        "line": 19,
-                        "column": 0
+                    content: '\nclass SnippetBodyInsights {\n\n',
+                    contentStart: {
+                        offset: 1492,
+                        line: 19,
+                        column: 0,
                     },
-                    "ranges": [
+                    ranges: [
                         {
-                            "start": {
-                                "offset": 1510,
-                                "line": 20,
-                                "column": 17
+                            start: {
+                                offset: 1510,
+                                line: 20,
+                                column: 17,
                             },
-                            "end": {
-                                "offset": 1517,
-                                "line": 20,
-                                "column": 24
-                            }
-                        }
-                    ]
+                            end: {
+                                offset: 1517,
+                                line: 20,
+                                column: 24,
+                            },
+                        },
+                    ],
                 },
                 {
-                    "content": "\n\tprivate readonly _bodyInsights: WindowIdleValue<SnippetBodyInsights>;\n\n",
-                    "contentStart": {
-                        "offset": 3909,
-                        "line": 101,
-                        "column": 0
+                    content:
+                        '\n\tprivate readonly _bodyInsights: WindowIdleValue<SnippetBodyInsights>;\n\n',
+                    contentStart: {
+                        offset: 3909,
+                        line: 101,
+                        column: 0,
                     },
-                    "ranges": [
+                    ranges: [
                         {
-                            "start": {
-                                "offset": 3933,
-                                "line": 102,
-                                "column": 23
+                            start: {
+                                offset: 3933,
+                                line: 102,
+                                column: 23,
                             },
-                            "end": {
-                                "offset": 3940,
-                                "line": 102,
-                                "column": 30
-                            }
+                            end: {
+                                offset: 3940,
+                                line: 102,
+                                column: 30,
+                            },
                         },
                         {
-                            "start": {
-                                "offset": 3970,
-                                "line": 102,
-                                "column": 60
+                            start: {
+                                offset: 3970,
+                                line: 102,
+                                column: 60,
                             },
-                            "end": {
-                                "offset": 3977,
-                                "line": 102,
-                                "column": 67
-                            }
-                        }
-                    ]
+                            end: {
+                                offset: 3977,
+                                line: 102,
+                                column: 67,
+                            },
+                        },
+                    ],
                 },
                 {
-                    "content": "\t\tthis.prefixLow = prefix.toLowerCase();\n\t\tthis._bodyInsights = new WindowIdleValue(getActiveWindow(), () => new SnippetBodyInsights(this.body));\n\t}\n",
-                    "contentStart": {
-                        "offset": 4357,
-                        "line": 118,
-                        "column": 0
+                    content:
+                        '\t\tthis.prefixLow = prefix.toLowerCase();\n\t\tthis._bodyInsights = new WindowIdleValue(getActiveWindow(), () => new SnippetBodyInsights(this.body));\n\t}\n',
+                    contentStart: {
+                        offset: 4357,
+                        line: 118,
+                        column: 0,
                     },
-                    "ranges": [
+                    ranges: [
                         {
-                            "start": {
-                                "offset": 4410,
-                                "line": 119,
-                                "column": 12
+                            start: {
+                                offset: 4410,
+                                line: 119,
+                                column: 12,
                             },
-                            "end": {
-                                "offset": 4417,
-                                "line": 119,
-                                "column": 19
-                            }
+                            end: {
+                                offset: 4417,
+                                line: 119,
+                                column: 19,
+                            },
                         },
                         {
-                            "start": {
-                                "offset": 4481,
-                                "line": 119,
-                                "column": 83
+                            start: {
+                                offset: 4481,
+                                line: 119,
+                                column: 83,
                             },
-                            "end": {
-                                "offset": 4488,
-                                "line": 119,
-                                "column": 90
-                            }
-                        }
-                    ]
+                            end: {
+                                offset: 4488,
+                                line: 119,
+                                column: 90,
+                            },
+                        },
+                    ],
                 },
                 {
-                    "content": "\tget codeSnippet(): string {\n\t\treturn this._bodyInsights.value.codeSnippet;\n\t}\n",
-                    "contentStart": {
-                        "offset": 4507,
-                        "line": 122,
-                        "column": 0
+                    content:
+                        '\tget codeSnippet(): string {\n\t\treturn this._bodyInsights.value.codeSnippet;\n\t}\n',
+                    contentStart: {
+                        offset: 4507,
+                        line: 122,
+                        column: 0,
                     },
-                    "ranges": [
+                    ranges: [
                         {
-                            "start": {
-                                "offset": 4555,
-                                "line": 123,
-                                "column": 19
+                            start: {
+                                offset: 4555,
+                                line: 123,
+                                column: 19,
                             },
-                            "end": {
-                                "offset": 4562,
-                                "line": 123,
-                                "column": 26
-                            }
-                        }
-                    ]
+                            end: {
+                                offset: 4562,
+                                line: 123,
+                                column: 26,
+                            },
+                        },
+                    ],
                 },
                 {
-                    "content": "\tget isBogous(): boolean {\n\t\treturn this._bodyInsights.value.isBogous;\n\t}\n",
-                    "contentStart": {
-                        "offset": 4587,
-                        "line": 126,
-                        "column": 0
+                    content:
+                        '\tget isBogous(): boolean {\n\t\treturn this._bodyInsights.value.isBogous;\n\t}\n',
+                    contentStart: {
+                        offset: 4587,
+                        line: 126,
+                        column: 0,
                     },
-                    "ranges": [
+                    ranges: [
                         {
-                            "start": {
-                                "offset": 4633,
-                                "line": 127,
-                                "column": 19
+                            start: {
+                                offset: 4633,
+                                line: 127,
+                                column: 19,
                             },
-                            "end": {
-                                "offset": 4640,
-                                "line": 127,
-                                "column": 26
-                            }
-                        }
-                    ]
+                            end: {
+                                offset: 4640,
+                                line: 127,
+                                column: 26,
+                            },
+                        },
+                    ],
                 },
                 {
-                    "content": "\tget isTrivial(): boolean {\n\t\treturn this._bodyInsights.value.isTrivial;\n\t}\n",
-                    "contentStart": {
-                        "offset": 4662,
-                        "line": 130,
-                        "column": 0
+                    content:
+                        '\tget isTrivial(): boolean {\n\t\treturn this._bodyInsights.value.isTrivial;\n\t}\n',
+                    contentStart: {
+                        offset: 4662,
+                        line: 130,
+                        column: 0,
                     },
-                    "ranges": [
+                    ranges: [
                         {
-                            "start": {
-                                "offset": 4709,
-                                "line": 131,
-                                "column": 19
+                            start: {
+                                offset: 4709,
+                                line: 131,
+                                column: 19,
                             },
-                            "end": {
-                                "offset": 4716,
-                                "line": 131,
-                                "column": 26
-                            }
-                        }
-                    ]
+                            end: {
+                                offset: 4716,
+                                line: 131,
+                                column: 26,
+                            },
+                        },
+                    ],
                 },
                 {
-                    "content": "\tget needsClipboard(): boolean {\n\t\treturn this._bodyInsights.value.usesClipboardVariable;\n\t}\n",
-                    "contentStart": {
-                        "offset": 4739,
-                        "line": 134,
-                        "column": 0
+                    content:
+                        '\tget needsClipboard(): boolean {\n\t\treturn this._bodyInsights.value.usesClipboardVariable;\n\t}\n',
+                    contentStart: {
+                        offset: 4739,
+                        line: 134,
+                        column: 0,
                     },
-                    "ranges": [
+                    ranges: [
                         {
-                            "start": {
-                                "offset": 4791,
-                                "line": 135,
-                                "column": 19
+                            start: {
+                                offset: 4791,
+                                line: 135,
+                                column: 19,
                             },
-                            "end": {
-                                "offset": 4798,
-                                "line": 135,
-                                "column": 26
-                            }
-                        }
-                    ]
+                            end: {
+                                offset: 4798,
+                                line: 135,
+                                column: 26,
+                            },
+                        },
+                    ],
                 },
                 {
-                    "content": "\tget usesSelection(): boolean {\n\t\treturn this._bodyInsights.value.usesSelectionVariable;\n\t}\n",
-                    "contentStart": {
-                        "offset": 4833,
-                        "line": 138,
-                        "column": 0
+                    content:
+                        '\tget usesSelection(): boolean {\n\t\treturn this._bodyInsights.value.usesSelectionVariable;\n\t}\n',
+                    contentStart: {
+                        offset: 4833,
+                        line: 138,
+                        column: 0,
                     },
-                    "ranges": [
+                    ranges: [
                         {
-                            "start": {
-                                "offset": 4884,
-                                "line": 139,
-                                "column": 19
+                            start: {
+                                offset: 4884,
+                                line: 139,
+                                column: 19,
                             },
-                            "end": {
-                                "offset": 4891,
-                                "line": 139,
-                                "column": 26
-                            }
-                        }
-                    ]
-                }
+                            end: {
+                                offset: 4891,
+                                line: 139,
+                                column: 26,
+                            },
+                        },
+                    ],
+                },
             ],
             branches: [''],
             commit: '90501335849147dda27da6b94372ac31de63f718',
-            hunks: null,
             language: 'TypeScript',
             path: 'src/vs/workbench/contrib/snippets/browser/snippetsFile.ts',
             repoLastFetched: '2024-09-10T03:19:51.107336Z',
             repoStars: 162299,
             repository: 'github.com/microsoft/vscode',
             type: 'content',
-            externalServiceType: ''
         },
         onSelect: () => {},
     },
@@ -241,50 +242,50 @@ export const PlainText: Story = {
     args: {},
 }
 
-export const Highlighted :Story = {
+export const Highlighted: Story = {
     args: {
         fetchHighlightedFileLineRanges: () =>
             Promise.resolve([
                 [
-                    "<tr><td class=\"line\" data-line=\"20\"></td><td class=\"code\"><span>\n</span></td></tr>",
-                    "<tr><td class=\"line\" data-line=\"21\"></td><td class=\"code\"><span class=\"hl-typed-Keyword\">class</span><span> </span><span class=\"hl-typed-IdentifierType\">SnippetBodyInsights</span><span> {</span></td></tr>",
-                    "<tr><td class=\"line\" data-line=\"22\"></td><td class=\"code\"><span>\n</span></td></tr>"
+                    '<tr><td class="line" data-line="20"></td><td class="code"><span>\n</span></td></tr>',
+                    '<tr><td class="line" data-line="21"></td><td class="code"><span class="hl-typed-Keyword">class</span><span> </span><span class="hl-typed-IdentifierType">SnippetBodyInsights</span><span> {</span></td></tr>',
+                    '<tr><td class="line" data-line="22"></td><td class="code"><span>\n</span></td></tr>',
                 ],
                 [
-                    "<tr><td class=\"line\" data-line=\"102\"></td><td class=\"code\"><span>\n</span></td></tr>",
-                    "<tr><td class=\"line\" data-line=\"103\"></td><td class=\"code\"><span>\t</span><span class=\"hl-typed-Keyword\">private</span><span> </span><span class=\"hl-typed-Keyword\">readonly</span><span> </span><span class=\"hl-typed-Identifier\">_bodyInsights</span><span>: </span><span class=\"hl-typed-IdentifierType\">WindowIdleValue</span><span>&lt;</span><span class=\"hl-typed-IdentifierType\">SnippetBodyInsights</span><span>&gt;;</span></td></tr>",
-                    "<tr><td class=\"line\" data-line=\"104\"></td><td class=\"code\"><span>\n</span></td></tr>"
+                    '<tr><td class="line" data-line="102"></td><td class="code"><span>\n</span></td></tr>',
+                    '<tr><td class="line" data-line="103"></td><td class="code"><span>\t</span><span class="hl-typed-Keyword">private</span><span> </span><span class="hl-typed-Keyword">readonly</span><span> </span><span class="hl-typed-Identifier">_bodyInsights</span><span>: </span><span class="hl-typed-IdentifierType">WindowIdleValue</span><span>&lt;</span><span class="hl-typed-IdentifierType">SnippetBodyInsights</span><span>&gt;;</span></td></tr>',
+                    '<tr><td class="line" data-line="104"></td><td class="code"><span>\n</span></td></tr>',
                 ],
                 [
-                    "<tr><td class=\"line\" data-line=\"119\"></td><td class=\"code\"><span>\t\t</span><span class=\"hl-typed-IdentifierBuiltin\">this</span><span>.</span><span class=\"hl-typed-Identifier\">prefixLow</span><span> = </span><span class=\"hl-typed-Identifier\">prefix</span><span>.</span><span class=\"hl-typed-IdentifierFunction\">toLowerCase</span><span>();</span></td></tr>",
-                    "<tr><td class=\"line\" data-line=\"120\"></td><td class=\"code\"><span>\t\t</span><span class=\"hl-typed-IdentifierBuiltin\">this</span><span>.</span><span class=\"hl-typed-Identifier\">_bodyInsights</span><span> = </span><span class=\"hl-typed-Keyword\">new</span><span> </span><span class=\"hl-typed-Identifier\">WindowIdleValue</span><span>(</span><span class=\"hl-typed-IdentifierFunction\">getActiveWindow</span><span>(), () =&gt; </span><span class=\"hl-typed-Keyword\">new</span><span> </span><span class=\"hl-typed-Identifier\">SnippetBodyInsights</span><span>(</span><span class=\"hl-typed-IdentifierBuiltin\">this</span><span>.</span><span class=\"hl-typed-Identifier\">body</span><span>));</span></td></tr>",
-                    "<tr><td class=\"line\" data-line=\"121\"></td><td class=\"code\"><span>\t}</span></td></tr>"
+                    '<tr><td class="line" data-line="119"></td><td class="code"><span>\t\t</span><span class="hl-typed-IdentifierBuiltin">this</span><span>.</span><span class="hl-typed-Identifier">prefixLow</span><span> = </span><span class="hl-typed-Identifier">prefix</span><span>.</span><span class="hl-typed-IdentifierFunction">toLowerCase</span><span>();</span></td></tr>',
+                    '<tr><td class="line" data-line="120"></td><td class="code"><span>\t\t</span><span class="hl-typed-IdentifierBuiltin">this</span><span>.</span><span class="hl-typed-Identifier">_bodyInsights</span><span> = </span><span class="hl-typed-Keyword">new</span><span> </span><span class="hl-typed-Identifier">WindowIdleValue</span><span>(</span><span class="hl-typed-IdentifierFunction">getActiveWindow</span><span>(), () =&gt; </span><span class="hl-typed-Keyword">new</span><span> </span><span class="hl-typed-Identifier">SnippetBodyInsights</span><span>(</span><span class="hl-typed-IdentifierBuiltin">this</span><span>.</span><span class="hl-typed-Identifier">body</span><span>));</span></td></tr>',
+                    '<tr><td class="line" data-line="121"></td><td class="code"><span>\t}</span></td></tr>',
                 ],
                 [
-                    "<tr><td class=\"line\" data-line=\"123\"></td><td class=\"code\"><span>\t</span><span class=\"hl-typed-Keyword\">get</span><span> </span><span class=\"hl-typed-IdentifierFunction\">codeSnippet</span><span>(): </span><span class=\"hl-typed-IdentifierBuiltinType\">string</span><span> {</span></td></tr>",
-                    "<tr><td class=\"line\" data-line=\"124\"></td><td class=\"code\"><span>\t\t</span><span class=\"hl-typed-Keyword\">return</span><span> </span><span class=\"hl-typed-IdentifierBuiltin\">this</span><span>.</span><span class=\"hl-typed-Identifier\">_bodyInsights</span><span>.</span><span class=\"hl-typed-Identifier\">value</span><span>.</span><span class=\"hl-typed-Identifier\">codeSnippet</span><span>;</span></td></tr>",
-                    "<tr><td class=\"line\" data-line=\"125\"></td><td class=\"code\"><span>\t}</span></td></tr>"
+                    '<tr><td class="line" data-line="123"></td><td class="code"><span>\t</span><span class="hl-typed-Keyword">get</span><span> </span><span class="hl-typed-IdentifierFunction">codeSnippet</span><span>(): </span><span class="hl-typed-IdentifierBuiltinType">string</span><span> {</span></td></tr>',
+                    '<tr><td class="line" data-line="124"></td><td class="code"><span>\t\t</span><span class="hl-typed-Keyword">return</span><span> </span><span class="hl-typed-IdentifierBuiltin">this</span><span>.</span><span class="hl-typed-Identifier">_bodyInsights</span><span>.</span><span class="hl-typed-Identifier">value</span><span>.</span><span class="hl-typed-Identifier">codeSnippet</span><span>;</span></td></tr>',
+                    '<tr><td class="line" data-line="125"></td><td class="code"><span>\t}</span></td></tr>',
                 ],
                 [
-                    "<tr><td class=\"line\" data-line=\"127\"></td><td class=\"code\"><span>\t</span><span class=\"hl-typed-Keyword\">get</span><span> </span><span class=\"hl-typed-IdentifierFunction\">isBogous</span><span>(): </span><span class=\"hl-typed-IdentifierBuiltinType\">boolean</span><span> {</span></td></tr>",
-                    "<tr><td class=\"line\" data-line=\"128\"></td><td class=\"code\"><span>\t\t</span><span class=\"hl-typed-Keyword\">return</span><span> </span><span class=\"hl-typed-IdentifierBuiltin\">this</span><span>.</span><span class=\"hl-typed-Identifier\">_bodyInsights</span><span>.</span><span class=\"hl-typed-Identifier\">value</span><span>.</span><span class=\"hl-typed-Identifier\">isBogous</span><span>;</span></td></tr>",
-                    "<tr><td class=\"line\" data-line=\"129\"></td><td class=\"code\"><span>\t}</span></td></tr>"
+                    '<tr><td class="line" data-line="127"></td><td class="code"><span>\t</span><span class="hl-typed-Keyword">get</span><span> </span><span class="hl-typed-IdentifierFunction">isBogous</span><span>(): </span><span class="hl-typed-IdentifierBuiltinType">boolean</span><span> {</span></td></tr>',
+                    '<tr><td class="line" data-line="128"></td><td class="code"><span>\t\t</span><span class="hl-typed-Keyword">return</span><span> </span><span class="hl-typed-IdentifierBuiltin">this</span><span>.</span><span class="hl-typed-Identifier">_bodyInsights</span><span>.</span><span class="hl-typed-Identifier">value</span><span>.</span><span class="hl-typed-Identifier">isBogous</span><span>;</span></td></tr>',
+                    '<tr><td class="line" data-line="129"></td><td class="code"><span>\t}</span></td></tr>',
                 ],
                 [
-                    "<tr><td class=\"line\" data-line=\"131\"></td><td class=\"code\"><span>\t</span><span class=\"hl-typed-Keyword\">get</span><span> </span><span class=\"hl-typed-IdentifierFunction\">isTrivial</span><span>(): </span><span class=\"hl-typed-IdentifierBuiltinType\">boolean</span><span> {</span></td></tr>",
-                    "<tr><td class=\"line\" data-line=\"132\"></td><td class=\"code\"><span>\t\t</span><span class=\"hl-typed-Keyword\">return</span><span> </span><span class=\"hl-typed-IdentifierBuiltin\">this</span><span>.</span><span class=\"hl-typed-Identifier\">_bodyInsights</span><span>.</span><span class=\"hl-typed-Identifier\">value</span><span>.</span><span class=\"hl-typed-Identifier\">isTrivial</span><span>;</span></td></tr>",
-                    "<tr><td class=\"line\" data-line=\"133\"></td><td class=\"code\"><span>\t}</span></td></tr>"
+                    '<tr><td class="line" data-line="131"></td><td class="code"><span>\t</span><span class="hl-typed-Keyword">get</span><span> </span><span class="hl-typed-IdentifierFunction">isTrivial</span><span>(): </span><span class="hl-typed-IdentifierBuiltinType">boolean</span><span> {</span></td></tr>',
+                    '<tr><td class="line" data-line="132"></td><td class="code"><span>\t\t</span><span class="hl-typed-Keyword">return</span><span> </span><span class="hl-typed-IdentifierBuiltin">this</span><span>.</span><span class="hl-typed-Identifier">_bodyInsights</span><span>.</span><span class="hl-typed-Identifier">value</span><span>.</span><span class="hl-typed-Identifier">isTrivial</span><span>;</span></td></tr>',
+                    '<tr><td class="line" data-line="133"></td><td class="code"><span>\t}</span></td></tr>',
                 ],
                 [
-                    "<tr><td class=\"line\" data-line=\"135\"></td><td class=\"code\"><span>\t</span><span class=\"hl-typed-Keyword\">get</span><span> </span><span class=\"hl-typed-IdentifierFunction\">needsClipboard</span><span>(): </span><span class=\"hl-typed-IdentifierBuiltinType\">boolean</span><span> {</span></td></tr>",
-                    "<tr><td class=\"line\" data-line=\"136\"></td><td class=\"code\"><span>\t\t</span><span class=\"hl-typed-Keyword\">return</span><span> </span><span class=\"hl-typed-IdentifierBuiltin\">this</span><span>.</span><span class=\"hl-typed-Identifier\">_bodyInsights</span><span>.</span><span class=\"hl-typed-Identifier\">value</span><span>.</span><span class=\"hl-typed-Identifier\">usesClipboardVariable</span><span>;</span></td></tr>",
-                    "<tr><td class=\"line\" data-line=\"137\"></td><td class=\"code\"><span>\t}</span></td></tr>"
+                    '<tr><td class="line" data-line="135"></td><td class="code"><span>\t</span><span class="hl-typed-Keyword">get</span><span> </span><span class="hl-typed-IdentifierFunction">needsClipboard</span><span>(): </span><span class="hl-typed-IdentifierBuiltinType">boolean</span><span> {</span></td></tr>',
+                    '<tr><td class="line" data-line="136"></td><td class="code"><span>\t\t</span><span class="hl-typed-Keyword">return</span><span> </span><span class="hl-typed-IdentifierBuiltin">this</span><span>.</span><span class="hl-typed-Identifier">_bodyInsights</span><span>.</span><span class="hl-typed-Identifier">value</span><span>.</span><span class="hl-typed-Identifier">usesClipboardVariable</span><span>;</span></td></tr>',
+                    '<tr><td class="line" data-line="137"></td><td class="code"><span>\t}</span></td></tr>',
                 ],
                 [
-                    "<tr><td class=\"line\" data-line=\"139\"></td><td class=\"code\"><span>\t</span><span class=\"hl-typed-Keyword\">get</span><span> </span><span class=\"hl-typed-IdentifierFunction\">usesSelection</span><span>(): </span><span class=\"hl-typed-IdentifierBuiltinType\">boolean</span><span> {</span></td></tr>",
-                    "<tr><td class=\"line\" data-line=\"140\"></td><td class=\"code\"><span>\t\t</span><span class=\"hl-typed-Keyword\">return</span><span> </span><span class=\"hl-typed-IdentifierBuiltin\">this</span><span>.</span><span class=\"hl-typed-Identifier\">_bodyInsights</span><span>.</span><span class=\"hl-typed-Identifier\">value</span><span>.</span><span class=\"hl-typed-Identifier\">usesSelectionVariable</span><span>;</span></td></tr>",
-                    "<tr><td class=\"line\" data-line=\"141\"></td><td class=\"code\"><span>\t}</span></td></tr>"
-                ]
-            ])
-    }
+                    '<tr><td class="line" data-line="139"></td><td class="code"><span>\t</span><span class="hl-typed-Keyword">get</span><span> </span><span class="hl-typed-IdentifierFunction">usesSelection</span><span>(): </span><span class="hl-typed-IdentifierBuiltinType">boolean</span><span> {</span></td></tr>',
+                    '<tr><td class="line" data-line="140"></td><td class="code"><span>\t\t</span><span class="hl-typed-Keyword">return</span><span> </span><span class="hl-typed-IdentifierBuiltin">this</span><span>.</span><span class="hl-typed-Identifier">_bodyInsights</span><span>.</span><span class="hl-typed-Identifier">value</span><span>.</span><span class="hl-typed-Identifier">usesSelectionVariable</span><span>;</span></td></tr>',
+                    '<tr><td class="line" data-line="141"></td><td class="code"><span>\t}</span></td></tr>',
+                ],
+            ]),
+    },
 }

--- a/vscode/webviews/components/codeSnippet/CodeSnippet.story.tsx
+++ b/vscode/webviews/components/codeSnippet/CodeSnippet.story.tsx
@@ -1,0 +1,290 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { VSCodeStandaloneComponent } from '../../storybook/VSCodeStoryDecorator'
+import { FileContentSearchResult } from './CodeSnippet'
+
+const meta: Meta<typeof FileContentSearchResult> = {
+    title: 'cody/FileContentSearchResult',
+    component: FileContentSearchResult,
+    decorators: [
+        story => <div style={{ padding: 20 }}> {story()} </div>,
+        VSCodeStandaloneComponent,
+    ],
+    args: {
+        allExpanded: false,
+        containerClassName: undefined,
+        defaultExpanded: undefined,
+        repoDisplayName: 'microsoft/vscode',
+        showAllMatches: false,
+        result: {
+            chunkMatches: [
+                {
+                    "content": "\nclass SnippetBodyInsights {\n\n",
+                    "contentStart": {
+                        "offset": 1492,
+                        "line": 19,
+                        "column": 0
+                    },
+                    "ranges": [
+                        {
+                            "start": {
+                                "offset": 1510,
+                                "line": 20,
+                                "column": 17
+                            },
+                            "end": {
+                                "offset": 1517,
+                                "line": 20,
+                                "column": 24
+                            }
+                        }
+                    ]
+                },
+                {
+                    "content": "\n\tprivate readonly _bodyInsights: WindowIdleValue<SnippetBodyInsights>;\n\n",
+                    "contentStart": {
+                        "offset": 3909,
+                        "line": 101,
+                        "column": 0
+                    },
+                    "ranges": [
+                        {
+                            "start": {
+                                "offset": 3933,
+                                "line": 102,
+                                "column": 23
+                            },
+                            "end": {
+                                "offset": 3940,
+                                "line": 102,
+                                "column": 30
+                            }
+                        },
+                        {
+                            "start": {
+                                "offset": 3970,
+                                "line": 102,
+                                "column": 60
+                            },
+                            "end": {
+                                "offset": 3977,
+                                "line": 102,
+                                "column": 67
+                            }
+                        }
+                    ]
+                },
+                {
+                    "content": "\t\tthis.prefixLow = prefix.toLowerCase();\n\t\tthis._bodyInsights = new WindowIdleValue(getActiveWindow(), () => new SnippetBodyInsights(this.body));\n\t}\n",
+                    "contentStart": {
+                        "offset": 4357,
+                        "line": 118,
+                        "column": 0
+                    },
+                    "ranges": [
+                        {
+                            "start": {
+                                "offset": 4410,
+                                "line": 119,
+                                "column": 12
+                            },
+                            "end": {
+                                "offset": 4417,
+                                "line": 119,
+                                "column": 19
+                            }
+                        },
+                        {
+                            "start": {
+                                "offset": 4481,
+                                "line": 119,
+                                "column": 83
+                            },
+                            "end": {
+                                "offset": 4488,
+                                "line": 119,
+                                "column": 90
+                            }
+                        }
+                    ]
+                },
+                {
+                    "content": "\tget codeSnippet(): string {\n\t\treturn this._bodyInsights.value.codeSnippet;\n\t}\n",
+                    "contentStart": {
+                        "offset": 4507,
+                        "line": 122,
+                        "column": 0
+                    },
+                    "ranges": [
+                        {
+                            "start": {
+                                "offset": 4555,
+                                "line": 123,
+                                "column": 19
+                            },
+                            "end": {
+                                "offset": 4562,
+                                "line": 123,
+                                "column": 26
+                            }
+                        }
+                    ]
+                },
+                {
+                    "content": "\tget isBogous(): boolean {\n\t\treturn this._bodyInsights.value.isBogous;\n\t}\n",
+                    "contentStart": {
+                        "offset": 4587,
+                        "line": 126,
+                        "column": 0
+                    },
+                    "ranges": [
+                        {
+                            "start": {
+                                "offset": 4633,
+                                "line": 127,
+                                "column": 19
+                            },
+                            "end": {
+                                "offset": 4640,
+                                "line": 127,
+                                "column": 26
+                            }
+                        }
+                    ]
+                },
+                {
+                    "content": "\tget isTrivial(): boolean {\n\t\treturn this._bodyInsights.value.isTrivial;\n\t}\n",
+                    "contentStart": {
+                        "offset": 4662,
+                        "line": 130,
+                        "column": 0
+                    },
+                    "ranges": [
+                        {
+                            "start": {
+                                "offset": 4709,
+                                "line": 131,
+                                "column": 19
+                            },
+                            "end": {
+                                "offset": 4716,
+                                "line": 131,
+                                "column": 26
+                            }
+                        }
+                    ]
+                },
+                {
+                    "content": "\tget needsClipboard(): boolean {\n\t\treturn this._bodyInsights.value.usesClipboardVariable;\n\t}\n",
+                    "contentStart": {
+                        "offset": 4739,
+                        "line": 134,
+                        "column": 0
+                    },
+                    "ranges": [
+                        {
+                            "start": {
+                                "offset": 4791,
+                                "line": 135,
+                                "column": 19
+                            },
+                            "end": {
+                                "offset": 4798,
+                                "line": 135,
+                                "column": 26
+                            }
+                        }
+                    ]
+                },
+                {
+                    "content": "\tget usesSelection(): boolean {\n\t\treturn this._bodyInsights.value.usesSelectionVariable;\n\t}\n",
+                    "contentStart": {
+                        "offset": 4833,
+                        "line": 138,
+                        "column": 0
+                    },
+                    "ranges": [
+                        {
+                            "start": {
+                                "offset": 4884,
+                                "line": 139,
+                                "column": 19
+                            },
+                            "end": {
+                                "offset": 4891,
+                                "line": 139,
+                                "column": 26
+                            }
+                        }
+                    ]
+                }
+            ],
+            branches: [''],
+            commit: '90501335849147dda27da6b94372ac31de63f718',
+            hunks: null,
+            language: 'TypeScript',
+            path: 'src/vs/workbench/contrib/snippets/browser/snippetsFile.ts',
+            repoLastFetched: '2024-09-10T03:19:51.107336Z',
+            repoStars: 162299,
+            repository: 'github.com/microsoft/vscode',
+            type: 'content',
+            externalServiceType: ''
+        },
+        onSelect: () => {},
+    },
+}
+
+export default meta
+
+type Story = StoryObj<typeof FileContentSearchResult>
+
+export const PlainText: Story = {
+    args: {},
+}
+
+export const Highlighted :Story = {
+    args: {
+        fetchHighlightedFileLineRanges: () =>
+            Promise.resolve([
+                [
+                    "<tr><td class=\"line\" data-line=\"20\"></td><td class=\"code\"><span>\n</span></td></tr>",
+                    "<tr><td class=\"line\" data-line=\"21\"></td><td class=\"code\"><span class=\"hl-typed-Keyword\">class</span><span> </span><span class=\"hl-typed-IdentifierType\">SnippetBodyInsights</span><span> {</span></td></tr>",
+                    "<tr><td class=\"line\" data-line=\"22\"></td><td class=\"code\"><span>\n</span></td></tr>"
+                ],
+                [
+                    "<tr><td class=\"line\" data-line=\"102\"></td><td class=\"code\"><span>\n</span></td></tr>",
+                    "<tr><td class=\"line\" data-line=\"103\"></td><td class=\"code\"><span>\t</span><span class=\"hl-typed-Keyword\">private</span><span> </span><span class=\"hl-typed-Keyword\">readonly</span><span> </span><span class=\"hl-typed-Identifier\">_bodyInsights</span><span>: </span><span class=\"hl-typed-IdentifierType\">WindowIdleValue</span><span>&lt;</span><span class=\"hl-typed-IdentifierType\">SnippetBodyInsights</span><span>&gt;;</span></td></tr>",
+                    "<tr><td class=\"line\" data-line=\"104\"></td><td class=\"code\"><span>\n</span></td></tr>"
+                ],
+                [
+                    "<tr><td class=\"line\" data-line=\"119\"></td><td class=\"code\"><span>\t\t</span><span class=\"hl-typed-IdentifierBuiltin\">this</span><span>.</span><span class=\"hl-typed-Identifier\">prefixLow</span><span> = </span><span class=\"hl-typed-Identifier\">prefix</span><span>.</span><span class=\"hl-typed-IdentifierFunction\">toLowerCase</span><span>();</span></td></tr>",
+                    "<tr><td class=\"line\" data-line=\"120\"></td><td class=\"code\"><span>\t\t</span><span class=\"hl-typed-IdentifierBuiltin\">this</span><span>.</span><span class=\"hl-typed-Identifier\">_bodyInsights</span><span> = </span><span class=\"hl-typed-Keyword\">new</span><span> </span><span class=\"hl-typed-Identifier\">WindowIdleValue</span><span>(</span><span class=\"hl-typed-IdentifierFunction\">getActiveWindow</span><span>(), () =&gt; </span><span class=\"hl-typed-Keyword\">new</span><span> </span><span class=\"hl-typed-Identifier\">SnippetBodyInsights</span><span>(</span><span class=\"hl-typed-IdentifierBuiltin\">this</span><span>.</span><span class=\"hl-typed-Identifier\">body</span><span>));</span></td></tr>",
+                    "<tr><td class=\"line\" data-line=\"121\"></td><td class=\"code\"><span>\t}</span></td></tr>"
+                ],
+                [
+                    "<tr><td class=\"line\" data-line=\"123\"></td><td class=\"code\"><span>\t</span><span class=\"hl-typed-Keyword\">get</span><span> </span><span class=\"hl-typed-IdentifierFunction\">codeSnippet</span><span>(): </span><span class=\"hl-typed-IdentifierBuiltinType\">string</span><span> {</span></td></tr>",
+                    "<tr><td class=\"line\" data-line=\"124\"></td><td class=\"code\"><span>\t\t</span><span class=\"hl-typed-Keyword\">return</span><span> </span><span class=\"hl-typed-IdentifierBuiltin\">this</span><span>.</span><span class=\"hl-typed-Identifier\">_bodyInsights</span><span>.</span><span class=\"hl-typed-Identifier\">value</span><span>.</span><span class=\"hl-typed-Identifier\">codeSnippet</span><span>;</span></td></tr>",
+                    "<tr><td class=\"line\" data-line=\"125\"></td><td class=\"code\"><span>\t}</span></td></tr>"
+                ],
+                [
+                    "<tr><td class=\"line\" data-line=\"127\"></td><td class=\"code\"><span>\t</span><span class=\"hl-typed-Keyword\">get</span><span> </span><span class=\"hl-typed-IdentifierFunction\">isBogous</span><span>(): </span><span class=\"hl-typed-IdentifierBuiltinType\">boolean</span><span> {</span></td></tr>",
+                    "<tr><td class=\"line\" data-line=\"128\"></td><td class=\"code\"><span>\t\t</span><span class=\"hl-typed-Keyword\">return</span><span> </span><span class=\"hl-typed-IdentifierBuiltin\">this</span><span>.</span><span class=\"hl-typed-Identifier\">_bodyInsights</span><span>.</span><span class=\"hl-typed-Identifier\">value</span><span>.</span><span class=\"hl-typed-Identifier\">isBogous</span><span>;</span></td></tr>",
+                    "<tr><td class=\"line\" data-line=\"129\"></td><td class=\"code\"><span>\t}</span></td></tr>"
+                ],
+                [
+                    "<tr><td class=\"line\" data-line=\"131\"></td><td class=\"code\"><span>\t</span><span class=\"hl-typed-Keyword\">get</span><span> </span><span class=\"hl-typed-IdentifierFunction\">isTrivial</span><span>(): </span><span class=\"hl-typed-IdentifierBuiltinType\">boolean</span><span> {</span></td></tr>",
+                    "<tr><td class=\"line\" data-line=\"132\"></td><td class=\"code\"><span>\t\t</span><span class=\"hl-typed-Keyword\">return</span><span> </span><span class=\"hl-typed-IdentifierBuiltin\">this</span><span>.</span><span class=\"hl-typed-Identifier\">_bodyInsights</span><span>.</span><span class=\"hl-typed-Identifier\">value</span><span>.</span><span class=\"hl-typed-Identifier\">isTrivial</span><span>;</span></td></tr>",
+                    "<tr><td class=\"line\" data-line=\"133\"></td><td class=\"code\"><span>\t}</span></td></tr>"
+                ],
+                [
+                    "<tr><td class=\"line\" data-line=\"135\"></td><td class=\"code\"><span>\t</span><span class=\"hl-typed-Keyword\">get</span><span> </span><span class=\"hl-typed-IdentifierFunction\">needsClipboard</span><span>(): </span><span class=\"hl-typed-IdentifierBuiltinType\">boolean</span><span> {</span></td></tr>",
+                    "<tr><td class=\"line\" data-line=\"136\"></td><td class=\"code\"><span>\t\t</span><span class=\"hl-typed-Keyword\">return</span><span> </span><span class=\"hl-typed-IdentifierBuiltin\">this</span><span>.</span><span class=\"hl-typed-Identifier\">_bodyInsights</span><span>.</span><span class=\"hl-typed-Identifier\">value</span><span>.</span><span class=\"hl-typed-Identifier\">usesClipboardVariable</span><span>;</span></td></tr>",
+                    "<tr><td class=\"line\" data-line=\"137\"></td><td class=\"code\"><span>\t}</span></td></tr>"
+                ],
+                [
+                    "<tr><td class=\"line\" data-line=\"139\"></td><td class=\"code\"><span>\t</span><span class=\"hl-typed-Keyword\">get</span><span> </span><span class=\"hl-typed-IdentifierFunction\">usesSelection</span><span>(): </span><span class=\"hl-typed-IdentifierBuiltinType\">boolean</span><span> {</span></td></tr>",
+                    "<tr><td class=\"line\" data-line=\"140\"></td><td class=\"code\"><span>\t\t</span><span class=\"hl-typed-Keyword\">return</span><span> </span><span class=\"hl-typed-IdentifierBuiltin\">this</span><span>.</span><span class=\"hl-typed-Identifier\">_bodyInsights</span><span>.</span><span class=\"hl-typed-Identifier\">value</span><span>.</span><span class=\"hl-typed-Identifier\">usesSelectionVariable</span><span>;</span></td></tr>",
+                    "<tr><td class=\"line\" data-line=\"141\"></td><td class=\"code\"><span>\t}</span></td></tr>"
+                ]
+            ])
+    }
+}

--- a/vscode/webviews/components/codeSnippet/CodeSnippet.story.tsx
+++ b/vscode/webviews/components/codeSnippet/CodeSnippet.story.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react'
+import { Observable } from 'observable-fns'
 import { VSCodeStandaloneComponent } from '../../storybook/VSCodeStoryDecorator'
 import { FileContentSearchResult } from './CodeSnippet'
 
@@ -16,19 +17,16 @@ const meta: Meta<typeof FileContentSearchResult> = {
                 {
                     content: '\nclass SnippetBodyInsights {\n\n',
                     contentStart: {
-                        offset: 1492,
                         line: 19,
                         column: 0,
                     },
                     ranges: [
                         {
                             start: {
-                                offset: 1510,
                                 line: 20,
                                 column: 17,
                             },
                             end: {
-                                offset: 1517,
                                 line: 20,
                                 column: 24,
                             },
@@ -39,31 +37,26 @@ const meta: Meta<typeof FileContentSearchResult> = {
                     content:
                         '\n\tprivate readonly _bodyInsights: WindowIdleValue<SnippetBodyInsights>;\n\n',
                     contentStart: {
-                        offset: 3909,
                         line: 101,
                         column: 0,
                     },
                     ranges: [
                         {
                             start: {
-                                offset: 3933,
                                 line: 102,
                                 column: 23,
                             },
                             end: {
-                                offset: 3940,
                                 line: 102,
                                 column: 30,
                             },
                         },
                         {
                             start: {
-                                offset: 3970,
                                 line: 102,
                                 column: 60,
                             },
                             end: {
-                                offset: 3977,
                                 line: 102,
                                 column: 67,
                             },
@@ -74,31 +67,26 @@ const meta: Meta<typeof FileContentSearchResult> = {
                     content:
                         '\t\tthis.prefixLow = prefix.toLowerCase();\n\t\tthis._bodyInsights = new WindowIdleValue(getActiveWindow(), () => new SnippetBodyInsights(this.body));\n\t}\n',
                     contentStart: {
-                        offset: 4357,
                         line: 118,
                         column: 0,
                     },
                     ranges: [
                         {
                             start: {
-                                offset: 4410,
                                 line: 119,
                                 column: 12,
                             },
                             end: {
-                                offset: 4417,
                                 line: 119,
                                 column: 19,
                             },
                         },
                         {
                             start: {
-                                offset: 4481,
                                 line: 119,
                                 column: 83,
                             },
                             end: {
-                                offset: 4488,
                                 line: 119,
                                 column: 90,
                             },
@@ -109,19 +97,16 @@ const meta: Meta<typeof FileContentSearchResult> = {
                     content:
                         '\tget codeSnippet(): string {\n\t\treturn this._bodyInsights.value.codeSnippet;\n\t}\n',
                     contentStart: {
-                        offset: 4507,
                         line: 122,
                         column: 0,
                     },
                     ranges: [
                         {
                             start: {
-                                offset: 4555,
                                 line: 123,
                                 column: 19,
                             },
                             end: {
-                                offset: 4562,
                                 line: 123,
                                 column: 26,
                             },
@@ -132,19 +117,16 @@ const meta: Meta<typeof FileContentSearchResult> = {
                     content:
                         '\tget isBogous(): boolean {\n\t\treturn this._bodyInsights.value.isBogous;\n\t}\n',
                     contentStart: {
-                        offset: 4587,
                         line: 126,
                         column: 0,
                     },
                     ranges: [
                         {
                             start: {
-                                offset: 4633,
                                 line: 127,
                                 column: 19,
                             },
                             end: {
-                                offset: 4640,
                                 line: 127,
                                 column: 26,
                             },
@@ -155,19 +137,16 @@ const meta: Meta<typeof FileContentSearchResult> = {
                     content:
                         '\tget isTrivial(): boolean {\n\t\treturn this._bodyInsights.value.isTrivial;\n\t}\n',
                     contentStart: {
-                        offset: 4662,
                         line: 130,
                         column: 0,
                     },
                     ranges: [
                         {
                             start: {
-                                offset: 4709,
                                 line: 131,
                                 column: 19,
                             },
                             end: {
-                                offset: 4716,
                                 line: 131,
                                 column: 26,
                             },
@@ -178,19 +157,16 @@ const meta: Meta<typeof FileContentSearchResult> = {
                     content:
                         '\tget needsClipboard(): boolean {\n\t\treturn this._bodyInsights.value.usesClipboardVariable;\n\t}\n',
                     contentStart: {
-                        offset: 4739,
                         line: 134,
                         column: 0,
                     },
                     ranges: [
                         {
                             start: {
-                                offset: 4791,
                                 line: 135,
                                 column: 19,
                             },
                             end: {
-                                offset: 4798,
                                 line: 135,
                                 column: 26,
                             },
@@ -201,19 +177,16 @@ const meta: Meta<typeof FileContentSearchResult> = {
                     content:
                         '\tget usesSelection(): boolean {\n\t\treturn this._bodyInsights.value.usesSelectionVariable;\n\t}\n',
                     contentStart: {
-                        offset: 4833,
                         line: 138,
                         column: 0,
                     },
                     ranges: [
                         {
                             start: {
-                                offset: 4884,
                                 line: 139,
                                 column: 19,
                             },
                             end: {
-                                offset: 4891,
                                 line: 139,
                                 column: 26,
                             },
@@ -245,7 +218,7 @@ export const PlainText: Story = {
 export const Highlighted: Story = {
     args: {
         fetchHighlightedFileLineRanges: () =>
-            Promise.resolve([
+            Observable.of([
                 [
                     '<tr><td class="line" data-line="20"></td><td class="code"><span>\n</span></td></tr>',
                     '<tr><td class="line" data-line="21"></td><td class="code"><span class="hl-typed-Keyword">class</span><span> </span><span class="hl-typed-IdentifierType">SnippetBodyInsights</span><span> {</span></td></tr>',

--- a/vscode/webviews/components/codeSnippet/CodeSnippet.tsx
+++ b/vscode/webviews/components/codeSnippet/CodeSnippet.tsx
@@ -1,0 +1,377 @@
+import {
+    type FC,
+    type ReactElement,
+    type ElementType,
+    type PropsWithChildren,
+    useState,
+    useCallback,
+    useEffect,
+    useMemo,
+    forwardRef,
+    useRef
+} from 'react'
+
+import { clsx } from 'clsx'
+
+import {
+    type SearchMatch,
+    type MatchGroup,
+    type ContentMatch,
+    type ChunkMatch,
+    type LineMatch,
+    HighlightLineRange,
+    HighlightResponseFormat
+} from './types'
+
+import { RepoFileLink } from './components/RepoLink'
+import { FileMatchChildren } from './components/FileMatchChildren';
+import { formatRepositoryStarCount, type ForwardReferenceExoticComponent, getFileMatchUrl, getRevision } from './utils'
+
+import styles from './CodeSnippet.module.css'
+
+console.log(styles)
+
+export interface FetchFileParameters {
+    repoName: string
+    commitID: string
+    filePath: string
+    disableTimeout?: boolean
+    ranges: HighlightLineRange[]
+    format?: HighlightResponseFormat
+}
+
+interface FileContentSearchResultProps {
+
+    /** The file match search result. */
+    result: ContentMatch
+
+    /** Whether or not to show all matches for this file, or only a subset. */
+    showAllMatches: boolean
+
+    /** Whether this file should be rendered as expanded by default. */
+    defaultExpanded: boolean
+
+    fetchHighlightedFileLineRanges?: (parameters: FetchFileParameters, force?: boolean) => Promise<string[][]>
+
+    /**
+     * Formatted repository name to be displayed in repository link. If not
+     * provided, the default format will be displayed.
+     */
+    repoDisplayName?: string
+
+    allExpanded?: boolean
+
+    /** CSS class name to be applied to the ResultContainer Component. */
+    containerClassName?: string
+
+    /** Called when the file's search result is selected. */
+    onSelect: () => void
+}
+
+export const FileContentSearchResult: FC<PropsWithChildren<FileContentSearchResultProps>> = props => {
+    const {
+        containerClassName,
+        result,
+        repoDisplayName,
+        defaultExpanded,
+        allExpanded,
+        showAllMatches,
+        fetchHighlightedFileLineRanges,
+        onSelect,
+    } = props
+
+    const unhighlightedGroups: MatchGroup[] = useMemo(() => matchesToMatchGroups(result), [result])
+
+    // Refs element
+    const rootRef = useRef<HTMLDivElement>(null)
+
+    // States
+    const [expanded, setExpanded] = useState(allExpanded || defaultExpanded)
+    const [hasBeenVisible, setHasBeenVisible] = useState(false)
+    const [expandedGroups, setExpandedGroups] = useState(unhighlightedGroups)
+
+    // Calculated state
+    const revisionDisplayName = getRevision(result.branches, result.commit)
+    const repoAtRevisionURL = getRepositoryUrl(result.repository, result.branches)
+    const collapsedGroups = truncateGroups(expandedGroups, 5, 1)
+    const expandedHighlightCount = countHighlightRanges(expandedGroups)
+    const collapsedHighlightCount = countHighlightRanges(collapsedGroups)
+    const hiddenMatchesCount = expandedHighlightCount - collapsedHighlightCount
+    const collapsible = !showAllMatches && expandedHighlightCount > collapsedHighlightCount
+
+    useEffect(() => setExpanded(allExpanded || defaultExpanded), [allExpanded, defaultExpanded])
+
+    useEffect(() => {
+        const hasHighlighting = unhighlightedGroups.some(group => group.highlightedHTMLRows)
+
+        if (hasHighlighting || !fetchHighlightedFileLineRanges) {
+            return
+        }
+
+        // This file contains some large lines, avoid stressing
+        // syntax-highlighter and the browser.
+        if (result.chunkMatches?.some(chunk => chunk.contentTruncated)) {
+            return
+        }
+
+        fetchHighlightedFileLineRanges(
+            {
+                repoName: result.repository,
+                commitID: result.commit || '',
+                filePath: result.path,
+                disableTimeout: false,
+                format: HighlightResponseFormat.HTML_HIGHLIGHT,
+                // Explicitly narrow the object otherwise we'll send a bunch of extra data in the request.
+                ranges: unhighlightedGroups.map(({ startLine, endLine }) => ({ startLine, endLine })),
+            },
+            false
+        )
+            .then(res => {
+                setExpandedGroups(
+                    unhighlightedGroups.map((group, i) => ({
+                        ...group,
+                        highlightedHTMLRows: res[i],
+                    }))
+                )
+            })
+    }, [result, fetchHighlightedFileLineRanges, unhighlightedGroups])
+
+    const toggle = useCallback((): void => {
+        if (collapsible) {
+            setExpanded(expanded => !expanded)
+        }
+
+        // Scroll back to top of result when collapsing
+        if (expanded) {
+            setTimeout(() => {
+                const reducedMotion = !window.matchMedia('(prefers-reduced-motion: no-preference)').matches
+                rootRef.current?.scrollIntoView({ block: 'nearest', behavior: reducedMotion ? 'auto' : 'smooth' })
+            }, 0)
+        }
+    }, [collapsible, expanded])
+
+    const title = (
+        <RepoFileLink
+            repoName={result.repository}
+            repoURL={repoAtRevisionURL}
+            filePath={result.path}
+            pathMatchRanges={result.pathMatches ?? []}
+            fileURL={getFileMatchUrl(result)}
+            repoDisplayName={
+                repoDisplayName
+                    ? `${repoDisplayName}${revisionDisplayName ? `@${revisionDisplayName}` : ''}`
+                    : undefined
+            }
+            className={styles.titleInner}
+        />
+    )
+
+    return (
+        <ResultContainer
+            ref={rootRef}
+            title={title}
+            resultType={result.type}
+            onResultClicked={onSelect}
+            repoName={result.repository}
+            repoStars={result.repoStars}
+            className={clsx(styles.copyButtonContainer, containerClassName)}
+            rankingDebug={result.debug}
+            repoLastFetched={result.repoLastFetched}
+        >
+            <div data-testid="file-search-result" data-expanded={expanded}>
+                <FileMatchChildren result={result} grouped={expanded ? expandedGroups : collapsedGroups} />
+                {collapsible && (
+                    <button
+                        type="button"
+                        className={clsx(
+                            styles.toggleMatchesButton,
+                            styles.focusableBlock,
+                            styles.clickable,
+                            {[styles.toggleMatchesButtonExpanded]: expanded}
+                        )}
+                        onClick={toggle}
+                    >
+                        <span className={styles.toggleMatchesButtonText}>
+                                {expanded
+                                    ? 'Show less'
+                                    : `Show ${hiddenMatchesCount} more ${pluralize(
+                                        'match',
+                                        hiddenMatchesCount,
+                                        'matches'
+                                    )}`}
+                            </span>
+                    </button>
+                )}
+            </div>
+        </ResultContainer>
+    )
+}
+
+export interface ResultContainerProps {
+    title: React.ReactNode
+    titleClassName?: string
+    resultClassName?: string
+    repoStars?: number
+    resultType?: SearchMatch['type']
+    repoName?: string
+    className?: string
+    rankingDebug?: string
+    actions?: ReactElement | boolean
+    onResultClicked?: () => void
+}
+
+const accessibleResultType: Record<SearchMatch['type'], string> = {
+    content: 'file content',
+}
+
+const ResultContainer: ForwardReferenceExoticComponent<
+    ElementType,
+    PropsWithChildren<ResultContainerProps>
+> = forwardRef(function ResultContainer(props, reference) {
+    const {
+        children,
+        title,
+        titleClassName,
+        resultClassName,
+        repoStars,
+        resultType,
+        repoName,
+        className,
+        rankingDebug,
+        actions,
+        as: Component = 'div',
+        onResultClicked,
+    } = props
+
+    const formattedRepositoryStarCount = formatRepositoryStarCount(repoStars)
+
+    const trackReferencePanelClick = (): void => onResultClicked?.()
+
+    return (
+        <Component
+            ref={reference}
+            className={clsx(className, styles.resultContainer)}
+            onClick={trackReferencePanelClick}
+        >
+            <article>
+                <header className={styles.header} data-result-header={true}>
+                    {/* Add a result type to be read out to screen readers only, so that screen reader users can
+                    easily scan the search results list (for example, by navigating by landmarks). */}
+                    <span className="sr-only">{resultType ? accessibleResultType[resultType] : 'search'} result,</span>
+                    <div
+                        className={clsx(styles.headerTitle, titleClassName)}
+                        data-testid="result-container-header"
+                    >
+                        {title}
+                    </div>
+
+                    {actions}
+                    {formattedRepositoryStarCount && (
+                        <span className="d-flex align-items-center">
+                            <span aria-hidden={true}>{formattedRepositoryStarCount}</span>
+                        </span>
+                    )}
+                </header>
+                {rankingDebug && <div>{rankingDebug}</div>}
+                {children && <div className={clsx(styles.result, resultClassName)}>{children}</div>}
+            </article>
+        </Component>
+    )
+})
+
+function getRepositoryUrl(repository: string, branches?: string[]): string {
+    const branch = branches?.[0]
+    const revision = branch ? `@${branch}` : ''
+    const label = repository + revision
+    return '/' + encodeURI(label)
+}
+
+function countHighlightRanges(groups: MatchGroup[]): number {
+    return groups.reduce((count, group) => count + group.matches.length, 0)
+}
+
+function pluralize(string: string, count: number | bigint, plural = string + 's'): string {
+    // @ts-ignore
+    return count === 1 || count === 1n ? string : plural
+}
+
+function matchesToMatchGroups(result: ContentMatch): MatchGroup[] {
+    return [
+        ...(result.lineMatches?.map(lineToMatchGroup) ?? []),
+        ...(result.chunkMatches?.map(chunkToMatchGroup) ?? []),
+    ]
+}
+
+function chunkToMatchGroup(chunk: ChunkMatch): MatchGroup {
+    const matches = chunk.ranges.map(range => ({
+        startLine: range.start.line,
+        startCharacter: range.start.column,
+        endLine: range.end.line,
+        endCharacter: range.end.column,
+    }))
+    const plaintextLines = chunk.content.replace(/\r?\n$/, '').split(/\r?\n/)
+    return {
+        plaintextLines,
+        highlightedHTMLRows: undefined, // populated lazily
+        matches,
+        startLine: chunk.contentStart.line,
+        endLine: chunk.contentStart.line + plaintextLines.length,
+    }
+}
+
+function lineToMatchGroup(line: LineMatch): MatchGroup {
+    const matches = line.offsetAndLengths.map(offsetAndLength => ({
+        startLine: line.lineNumber,
+        startCharacter: offsetAndLength[0],
+        endLine: line.lineNumber,
+        endCharacter: offsetAndLength[0] + offsetAndLength[1],
+    }))
+    return {
+        plaintextLines: [line.line],
+        highlightedHTMLRows: undefined, // populated lazily
+        matches,
+        startLine: line.lineNumber,
+        endLine: line.lineNumber + 1, // the matches support `endLine` == `startLine`, but MatchGroup requires `endLine` > `startLine`
+    }
+}
+
+function truncateGroups(groups: MatchGroup[], maxMatches: number, contextLines: number): MatchGroup[] {
+    const visibleGroups = []
+    let remainingMatches = maxMatches
+    for (const group of groups) {
+        if (remainingMatches === 0) {
+            break
+        } else if (group.matches.length > remainingMatches) {
+            visibleGroups.push(truncateGroup(group, remainingMatches, contextLines))
+            break
+        }
+        visibleGroups.push(group)
+        remainingMatches -= group.matches.length
+    }
+
+    return visibleGroups
+}
+
+function truncateGroup(group: MatchGroup, maxMatches: number, contextLines: number): MatchGroup {
+    const keepMatches = group.matches.slice(0, maxMatches)
+    const newStartLine = Math.max(
+        Math.min(...keepMatches.map(match => match.startLine)) - contextLines,
+        group.startLine
+    )
+    const newEndLine = Math.min(Math.max(...keepMatches.map(match => match.endLine)) + contextLines, group.endLine)
+    const matchesInKeepContext = group.matches
+        .slice(maxMatches)
+        .filter(match => match.startLine >= newStartLine && match.endLine <= newEndLine)
+    return {
+        ...group,
+        plaintextLines: group.plaintextLines.slice(newStartLine - group.startLine, newEndLine - group.startLine + 1),
+        highlightedHTMLRows: group.highlightedHTMLRows?.slice(
+            newStartLine - group.startLine,
+            newEndLine - group.startLine + 1
+        ),
+        matches: [...keepMatches, ...matchesInKeepContext],
+        startLine: newStartLine,
+        endLine: newEndLine,
+    }
+}
+

--- a/vscode/webviews/components/codeSnippet/components/Code.module.css
+++ b/vscode/webviews/components/codeSnippet/components/Code.module.css
@@ -1,21 +1,21 @@
 :root {
-    --code-font-family: sfmono-regular, consolas, menlo, dejavu sans mono, monospace;
     --code-font-size: #{(12/14)}em;
+    --code-font-family: sfmono-regular, consolas, menlo, dejavu sans mono, monospace;
 }
 
 .code {
-    font-family: var(--code-font-family);
-    font-size: var(--code-font-size);
-    line-height: 1rem;
     white-space: pre;
+    line-height: 1rem;
+    font-size: var(--code-font-size);
+    font-family: var(--code-font-family);
 }
 
-// Body / Small / Regular
 .small {
     font-size: 0.75rem;
     line-height: 1rem;
-    // Bootstrap applies `font-weight: 400;` to `small` element,
-    // but we want to control `font-weight` only with `strong` or `.font-weight-medium`.
+
+    /* Bootstrap applies `font-weight: 400;` to `small` element,
+       but we want to control `font-weight` only with `strong` or `.font-weight-medium`. */
     font-weight: inherit;
 }
 

--- a/vscode/webviews/components/codeSnippet/components/Code.module.css
+++ b/vscode/webviews/components/codeSnippet/components/Code.module.css
@@ -1,0 +1,21 @@
+:root {
+    --code-font-family: sfmono-regular, consolas, menlo, dejavu sans mono, monospace;
+    --code-font-size: #{(12/14)}em;
+}
+
+.code {
+    font-family: var(--code-font-family);
+    font-size: var(--code-font-size);
+    line-height: 1rem;
+    white-space: pre;
+}
+
+// Body / Small / Regular
+.small {
+    font-size: 0.75rem;
+    line-height: 1rem;
+    // Bootstrap applies `font-weight: 400;` to `small` element,
+    // but we want to control `font-weight` only with `strong` or `.font-weight-medium`.
+    font-weight: inherit;
+}
+

--- a/vscode/webviews/components/codeSnippet/components/Code.tsx
+++ b/vscode/webviews/components/codeSnippet/components/Code.tsx
@@ -1,4 +1,4 @@
-import { forwardRef } from 'react'
+import { type HTMLAttributes, forwardRef } from 'react'
 
 import { clsx } from 'clsx'
 import { upperFirst } from 'lodash'
@@ -10,13 +10,13 @@ import styles from './Code.module.css'
 export enum TYPOGRAPHY_WEIGHTS {
     regular = 'regular',
     medium = 'medium',
-    bold = 'bold'
+    bold = 'bold',
 }
 
 const getFontWeightStyle = (weight: TYPOGRAPHY_WEIGHTS | `${TYPOGRAPHY_WEIGHTS}`): string =>
     clsx(styles[`fontWeight${upperFirst(weight)}` as keyof typeof styles])
 
-interface CodeProps extends React.HTMLAttributes<HTMLElement> {
+interface CodeProps extends HTMLAttributes<HTMLElement> {
     size?: 'small' | 'base'
     weight?: TYPOGRAPHY_WEIGHTS | `${TYPOGRAPHY_WEIGHTS}`
 }

--- a/vscode/webviews/components/codeSnippet/components/Code.tsx
+++ b/vscode/webviews/components/codeSnippet/components/Code.tsx
@@ -1,0 +1,42 @@
+import { forwardRef } from 'react'
+
+import { clsx } from 'clsx'
+import { upperFirst } from 'lodash'
+
+import type { ForwardReferenceComponent } from '../utils'
+
+import styles from './Code.module.css'
+
+export enum TYPOGRAPHY_WEIGHTS {
+    regular = 'regular',
+    medium = 'medium',
+    bold = 'bold'
+}
+
+const getFontWeightStyle = (weight: TYPOGRAPHY_WEIGHTS | `${TYPOGRAPHY_WEIGHTS}`): string =>
+    clsx(styles[`fontWeight${upperFirst(weight)}` as keyof typeof styles])
+
+interface CodeProps extends React.HTMLAttributes<HTMLElement> {
+    size?: 'small' | 'base'
+    weight?: TYPOGRAPHY_WEIGHTS | `${TYPOGRAPHY_WEIGHTS}`
+}
+
+export const Code = forwardRef(function Code(
+    { children, as: Component = 'code', size, weight, className, ...props },
+    reference
+) {
+    return (
+        <Component
+            className={clsx(
+                styles.code,
+                size === 'small' && styles.small,
+                weight && getFontWeightStyle(weight),
+                className
+            )}
+            ref={reference}
+            {...props}
+        >
+            {children}
+        </Component>
+    )
+}) as ForwardReferenceComponent<'code', CodeProps>

--- a/vscode/webviews/components/codeSnippet/components/CodeExcerpt.module.css
+++ b/vscode/webviews/components/codeSnippet/components/CodeExcerpt.module.css
@@ -1,0 +1,35 @@
+.code-excerpt {
+    :global(.line),
+    :global(.code) {
+        /* stylelint-disable-next-line declaration-property-unit-allowed-list */
+        height: 18px;
+        vertical-align: middle;
+        padding: 0;
+    }
+
+    :global(.line) {
+        min-width: 1.5rem;
+        text-align: right;
+        user-select: none;
+
+        &::before {
+            /* draw line number with css so it cannot be copied to clipboard */
+            content: attr(data-line);
+            color: var(--text-muted);
+        }
+    }
+
+    :global(.code) {
+        white-space: pre;
+        padding-left: 1rem;
+    }
+
+    &-error {
+        width: 100%;
+    }
+
+    &-alert {
+        margin-bottom: 0;
+        color: #c92a2a;
+    }
+}

--- a/vscode/webviews/components/codeSnippet/components/CodeExcerpt.module.css
+++ b/vscode/webviews/components/codeSnippet/components/CodeExcerpt.module.css
@@ -15,7 +15,7 @@
         &::before {
             /* draw line number with css so it cannot be copied to clipboard */
             content: attr(data-line);
-            color: var(--text-muted);
+            color: var(--cody-chat-code-text-muted);
         }
     }
 
@@ -31,5 +31,9 @@
     &-alert {
         margin-bottom: 0;
         color: #c92a2a;
+    }
+
+    :global(.hl-text) {
+        color: #657b83;
     }
 }

--- a/vscode/webviews/components/codeSnippet/components/CodeExcerpt.tsx
+++ b/vscode/webviews/components/codeSnippet/components/CodeExcerpt.tsx
@@ -44,8 +44,7 @@ export interface HighlightRange {
  * A code excerpt that displays syntax highlighting and match range highlighting.
  */
 export const CodeExcerpt: FC<Props> = props => {
-    const { plaintextLines, highlightedLines, startLine, endLine, highlightRanges, className } =
-        props
+    const { plaintextLines, highlightedLines, startLine, endLine, highlightRanges, className } = props
 
     const [tableContainerElement, setTableContainerElement] = useState<HTMLElement | null>(null)
 

--- a/vscode/webviews/components/codeSnippet/components/CodeExcerpt.tsx
+++ b/vscode/webviews/components/codeSnippet/components/CodeExcerpt.tsx
@@ -1,9 +1,8 @@
-
-import { useLayoutEffect, useMemo, useState } from 'react'
+import { type FC, useLayoutEffect, useMemo, useState } from 'react'
 
 import { clsx } from 'clsx'
 
-import { highlightNodeMultiline } from '../utils'
+import { highlightNodeMultiline } from '../highlights'
 import { Code } from './Code'
 
 import styles from './CodeExcerpt.module.css'
@@ -17,10 +16,8 @@ interface Props {
     /** The 0-based (exclusive) line number that this code excerpt ends at */
     endLine: number
     className?: string
-
     plaintextLines: string[]
     highlightedLines?: string[]
-
     onCopy?: () => void
 }
 
@@ -46,41 +43,34 @@ export interface HighlightRange {
 /**
  * A code excerpt that displays syntax highlighting and match range highlighting.
  */
-export const CodeExcerpt: React.FunctionComponent<Props> = props => {
-    const {
-        plaintextLines,
-        highlightedLines,
-        startLine,
-        endLine,
-        highlightRanges,
-        className,
-        onCopy,
-    } = props
+export const CodeExcerpt: FC<Props> = props => {
+    const { plaintextLines, highlightedLines, startLine, endLine, highlightRanges, className, onCopy } =
+        props
+
+    const [tableContainerElement, setTableContainerElement] = useState<HTMLElement | null>(null)
 
     const table = useMemo(
         () =>
             highlightedLines ? (
+                // biome-ignore lint/security/noDangerouslySetInnerHtml:
                 <table dangerouslySetInnerHTML={{ __html: highlightedLines.join('') }} />
             ) : (
                 <table>
                     <tbody>
-                    {plaintextLines.map((line, i) => (
-                        // eslint-disable-next-line react/no-array-index-key
-                        <tr key={startLine + i}>
-                            <td className="line" data-line={startLine + i + 1} />
-                            <td className="code">
-                                <span className="hl-text hl-plain">{line}</span>
-                            </td>
-                        </tr>
-                    ))}
+                        {plaintextLines.map((line, i) => (
+                            // biome-ignore lint/suspicious/noArrayIndexKey:
+                            <tr key={startLine + i}>
+                                <td className="line" data-line={startLine + i + 1} />
+                                <td className="code">
+                                    <span className="hl-text hl-plain">{line}</span>
+                                </td>
+                            </tr>
+                        ))}
                     </tbody>
                 </table>
             ),
         [plaintextLines, highlightedLines, startLine]
     )
-
-
-    const [tableContainerElement, setTableContainerElement] = useState<HTMLElement | null>(null)
 
     // Highlight the search matches
     useLayoutEffect(() => {
@@ -110,10 +100,10 @@ export const CodeExcerpt: React.FunctionComponent<Props> = props => {
                 }
             }
         }
-    }, [highlightRanges, startLine, endLine, tableContainerElement, table])
+    }, [highlightRanges, startLine, tableContainerElement])
 
     return (
-        <Code data-testid="code-excerpt" onCopy={onCopy} className={clsx(styles.codeExcerpt, className)}>
+        <Code className={clsx(styles.codeExcerpt, className)}>
             <div ref={setTableContainerElement}>{table}</div>
         </Code>
     )

--- a/vscode/webviews/components/codeSnippet/components/CodeExcerpt.tsx
+++ b/vscode/webviews/components/codeSnippet/components/CodeExcerpt.tsx
@@ -1,0 +1,120 @@
+
+import { useLayoutEffect, useMemo, useState } from 'react'
+
+import { clsx } from 'clsx'
+
+import { highlightNodeMultiline } from '../utils'
+import { Code } from './Code'
+
+import styles from './CodeExcerpt.module.css'
+
+interface Props {
+    commitID: string
+    filePath: string
+    highlightRanges: HighlightRange[]
+    /** The 0-based (inclusive) line number that this code excerpt starts at */
+    startLine: number
+    /** The 0-based (exclusive) line number that this code excerpt ends at */
+    endLine: number
+    className?: string
+
+    plaintextLines: string[]
+    highlightedLines?: string[]
+
+    onCopy?: () => void
+}
+
+export interface HighlightRange {
+    /**
+     * The 0-based line number where this highlight range begins
+     */
+    startLine: number
+    /**
+     * The 0-based character offset from the beginning of startLine where this highlight range begins
+     */
+    startCharacter: number
+    /**
+     * The 0-based line number where this highlight range ends
+     */
+    endLine: number
+    /**
+     * The 0-based character offset from the beginning of endLine where this highlight range ends
+     */
+    endCharacter: number
+}
+
+/**
+ * A code excerpt that displays syntax highlighting and match range highlighting.
+ */
+export const CodeExcerpt: React.FunctionComponent<Props> = props => {
+    const {
+        plaintextLines,
+        highlightedLines,
+        startLine,
+        endLine,
+        highlightRanges,
+        className,
+        onCopy,
+    } = props
+
+    const table = useMemo(
+        () =>
+            highlightedLines ? (
+                <table dangerouslySetInnerHTML={{ __html: highlightedLines.join('') }} />
+            ) : (
+                <table>
+                    <tbody>
+                    {plaintextLines.map((line, i) => (
+                        // eslint-disable-next-line react/no-array-index-key
+                        <tr key={startLine + i}>
+                            <td className="line" data-line={startLine + i + 1} />
+                            <td className="code">
+                                <span className="hl-text hl-plain">{line}</span>
+                            </td>
+                        </tr>
+                    ))}
+                    </tbody>
+                </table>
+            ),
+        [plaintextLines, highlightedLines, startLine]
+    )
+
+
+    const [tableContainerElement, setTableContainerElement] = useState<HTMLElement | null>(null)
+
+    // Highlight the search matches
+    useLayoutEffect(() => {
+        if (tableContainerElement) {
+            const visibleRows = tableContainerElement.querySelectorAll<HTMLTableRowElement>('table tr')
+            for (const highlight of highlightRanges) {
+                // Select the HTML rows in the excerpt that correspond to the first and last line to be highlighted.
+                // highlight.startLine is the 0-indexed line number in the code file, and startLine is the 0-indexed
+                // line number of the first visible line in the excerpt. So, subtract startLine
+                // from highlight.startLine to get the correct 0-based index in visibleRows that holds the HTML row
+                // where highlighting should begin. Subtract startLine from highlight.endLine to get the correct 0-based
+                // index in visibleRows that holds the HTML row where highlighting should end.
+                const startRowIndex = highlight.startLine - startLine
+                const endRowIndex = highlight.endLine - startLine
+                const startRow = visibleRows[startRowIndex]
+                const endRow = visibleRows[endRowIndex]
+                if (startRow && endRow) {
+                    highlightNodeMultiline(
+                        visibleRows,
+                        startRow,
+                        endRow,
+                        startRowIndex,
+                        endRowIndex,
+                        highlight.startCharacter,
+                        highlight.endCharacter
+                    )
+                }
+            }
+        }
+    }, [highlightRanges, startLine, endLine, tableContainerElement, table])
+
+    return (
+        <Code data-testid="code-excerpt" onCopy={onCopy} className={clsx(styles.codeExcerpt, className)}>
+            <div ref={setTableContainerElement}>{table}</div>
+        </Code>
+    )
+}

--- a/vscode/webviews/components/codeSnippet/components/CodeExcerpt.tsx
+++ b/vscode/webviews/components/codeSnippet/components/CodeExcerpt.tsx
@@ -73,6 +73,7 @@ export const CodeExcerpt: FC<Props> = props => {
     )
 
     // Highlight the search matches
+    // biome-ignore lint/correctness/useExhaustiveDependencies:
     useLayoutEffect(() => {
         if (tableContainerElement) {
             const visibleRows = tableContainerElement.querySelectorAll<HTMLTableRowElement>('table tr')
@@ -100,7 +101,7 @@ export const CodeExcerpt: FC<Props> = props => {
                 }
             }
         }
-    }, [highlightRanges, startLine, tableContainerElement])
+    }, [highlightRanges, startLine, endLine, tableContainerElement, table])
 
     return (
         <Code className={clsx(styles.codeExcerpt, className)}>

--- a/vscode/webviews/components/codeSnippet/components/CodeExcerpt.tsx
+++ b/vscode/webviews/components/codeSnippet/components/CodeExcerpt.tsx
@@ -44,7 +44,7 @@ export interface HighlightRange {
  * A code excerpt that displays syntax highlighting and match range highlighting.
  */
 export const CodeExcerpt: FC<Props> = props => {
-    const { plaintextLines, highlightedLines, startLine, endLine, highlightRanges, className, onCopy } =
+    const { plaintextLines, highlightedLines, startLine, endLine, highlightRanges, className } =
         props
 
     const [tableContainerElement, setTableContainerElement] = useState<HTMLElement | null>(null)

--- a/vscode/webviews/components/codeSnippet/components/FileMatchChildren.module.css
+++ b/vscode/webviews/components/codeSnippet/components/FileMatchChildren.module.css
@@ -1,0 +1,13 @@
+.chunk {
+    position: relative;
+    overflow-x: auto;
+    background-color: var(--code-bg);
+
+    padding: 0.25rem 0.5rem;
+    &:first-child {
+        padding-top: 0.5rem;
+    }
+    &:last-child {
+        padding-bottom: 0.5rem;
+    }
+}

--- a/vscode/webviews/components/codeSnippet/components/FileMatchChildren.module.css
+++ b/vscode/webviews/components/codeSnippet/components/FileMatchChildren.module.css
@@ -1,12 +1,13 @@
 .chunk {
     position: relative;
     overflow-x: auto;
+    padding: 0.25rem 0.5rem;
     background-color: var(--code-bg);
 
-    padding: 0.25rem 0.5rem;
     &:first-child {
         padding-top: 0.5rem;
     }
+
     &:last-child {
         padding-bottom: 0.5rem;
     }

--- a/vscode/webviews/components/codeSnippet/components/FileMatchChildren.module.css
+++ b/vscode/webviews/components/codeSnippet/components/FileMatchChildren.module.css
@@ -2,7 +2,7 @@
     position: relative;
     overflow-x: auto;
     padding: 0.25rem 0.5rem;
-    background-color: var(--code-bg);
+    background-color: var(--cody-chat-code-background);
 
     &:first-child {
         padding-top: 0.5rem;

--- a/vscode/webviews/components/codeSnippet/components/FileMatchChildren.tsx
+++ b/vscode/webviews/components/codeSnippet/components/FileMatchChildren.tsx
@@ -1,0 +1,76 @@
+import { useCallback, type KeyboardEvent, type MouseEvent } from 'react'
+
+import { clsx } from 'clsx'
+
+import { SourcegraphURL } from '../url'
+import type { MatchGroup, ContentMatch } from '../types'
+import { getFileMatchUrl } from '../utils'
+
+import { CodeExcerpt } from './CodeExcerpt'
+
+import styles from './FileMatchChildren.module.css'
+import resultStyles from '../CodeSnippet.module.css'
+
+interface FileMatchProps {
+    result: ContentMatch
+    grouped: MatchGroup[]
+}
+
+export const FileMatchChildren: React.FunctionComponent<React.PropsWithChildren<FileMatchProps>> = props => {
+    const { result, grouped} = props
+
+    const createCodeExcerptLink = (group: MatchGroup): string => {
+        const match = group.matches[0]
+        return SourcegraphURL.from(getFileMatchUrl(result))
+            .setLineRange({
+                line: match.startLine + 1,
+                character: match.startCharacter + 1,
+                endLine: match.endLine + 1,
+                endCharacter: match.endCharacter + 1,
+            })
+            .toString()
+    }
+
+    // const navigate = useNavigate()
+    const navigateToFile = useCallback(
+        (event: KeyboardEvent<HTMLElement> | MouseEvent<HTMLElement>): void => {
+            // navigateToCodeExcerpt(event, props.openInNewTab ?? false, navigate)
+        },
+        []
+    )
+
+    return (
+        <div data-testid="file-match-children" data-selectable-search-results-group="true">
+            {grouped.length > 0 &&
+                grouped.map(group => (
+                    <div
+                        key={`linematch:${getFileMatchUrl(result)}${group.startLine}:${group.endLine}`}
+                        data-href={createCodeExcerptLink(group)}
+                        className={clsx(
+                            'test-file-match-children-item',
+                            styles.chunk,
+                            resultStyles.clickable,
+                            resultStyles.focusableBlock,
+                            resultStyles.horizontalDividerBetween
+                        )}
+                        onClick={navigateToFile}
+                        onKeyDown={navigateToFile}
+                        data-testid="file-match-children-item"
+                        tabIndex={0}
+                        role="link"
+                        data-selectable-search-result="true"
+                    >
+                        <CodeExcerpt
+                            commitID={result.commit || ''}
+                            filePath={result.path}
+                            startLine={group.startLine}
+                            endLine={group.endLine}
+                            highlightRanges={group.matches}
+                            plaintextLines={group.plaintextLines}
+                            highlightedLines={group.highlightedHTMLRows}
+                        />
+                    </div>
+                ))}
+        </div>
+    )
+}

--- a/vscode/webviews/components/codeSnippet/components/FileMatchChildren.tsx
+++ b/vscode/webviews/components/codeSnippet/components/FileMatchChildren.tsx
@@ -14,25 +14,32 @@ import styles from './FileMatchChildren.module.css'
 interface FileMatchProps {
     result: ContentMatch
     grouped: MatchGroup[]
+    serverEndpoint: string
 }
 
 export const FileMatchChildren: FC<PropsWithChildren<FileMatchProps>> = props => {
-    const { result, grouped } = props
+    const { result, grouped, serverEndpoint } = props
 
     const createCodeExcerptLink = (group: MatchGroup): string => {
+        const urlBuilder = SourcegraphURL.from(getFileMatchUrl(serverEndpoint, result))
+
         const match = group.matches[0]
-        return SourcegraphURL.from(getFileMatchUrl(result))
-            .setLineRange({
+
+        if (match) {
+            urlBuilder.setLineRange({
                 line: match.startLine + 1,
                 character: match.startCharacter + 1,
                 endLine: match.endLine + 1,
                 endCharacter: match.endCharacter + 1,
             })
-            .toString()
+        }
+
+        return urlBuilder.toString()
     }
 
     const navigateToFile = useCallback(
         (event: KeyboardEvent<HTMLElement> | MouseEvent<HTMLElement>): void => {
+            // TODO: implement navigation by blob
             // navigateToCodeExcerpt(event, props.openInNewTab ?? false, navigate)
         },
         []
@@ -43,7 +50,9 @@ export const FileMatchChildren: FC<PropsWithChildren<FileMatchProps>> = props =>
             {grouped.length > 0 &&
                 grouped.map(group => (
                     <div
-                        key={`linematch:${getFileMatchUrl(result)}${group.startLine}:${group.endLine}`}
+                        key={`linematch:${getFileMatchUrl(serverEndpoint, result)}${group.startLine}:${
+                            group.endLine
+                        }`}
                         role="link"
                         tabIndex={0}
                         data-href={createCodeExcerptLink(group)}

--- a/vscode/webviews/components/codeSnippet/components/FileMatchChildren.tsx
+++ b/vscode/webviews/components/codeSnippet/components/FileMatchChildren.tsx
@@ -1,23 +1,23 @@
-import { useCallback, type KeyboardEvent, type MouseEvent } from 'react'
+import { type FC, type KeyboardEvent, type MouseEvent, type PropsWithChildren, useCallback } from 'react'
 
 import { clsx } from 'clsx'
 
+import type { ContentMatch, MatchGroup } from '../types'
 import { SourcegraphURL } from '../url'
-import type { MatchGroup, ContentMatch } from '../types'
 import { getFileMatchUrl } from '../utils'
 
 import { CodeExcerpt } from './CodeExcerpt'
 
-import styles from './FileMatchChildren.module.css'
 import resultStyles from '../CodeSnippet.module.css'
+import styles from './FileMatchChildren.module.css'
 
 interface FileMatchProps {
     result: ContentMatch
     grouped: MatchGroup[]
 }
 
-export const FileMatchChildren: React.FunctionComponent<React.PropsWithChildren<FileMatchProps>> = props => {
-    const { result, grouped} = props
+export const FileMatchChildren: FC<PropsWithChildren<FileMatchProps>> = props => {
+    const { result, grouped } = props
 
     const createCodeExcerptLink = (group: MatchGroup): string => {
         const match = group.matches[0]
@@ -31,7 +31,6 @@ export const FileMatchChildren: React.FunctionComponent<React.PropsWithChildren<
             .toString()
     }
 
-    // const navigate = useNavigate()
     const navigateToFile = useCallback(
         (event: KeyboardEvent<HTMLElement> | MouseEvent<HTMLElement>): void => {
             // navigateToCodeExcerpt(event, props.openInNewTab ?? false, navigate)
@@ -40,11 +39,13 @@ export const FileMatchChildren: React.FunctionComponent<React.PropsWithChildren<
     )
 
     return (
-        <div data-testid="file-match-children" data-selectable-search-results-group="true">
+        <div data-testid="file-match-children">
             {grouped.length > 0 &&
                 grouped.map(group => (
                     <div
                         key={`linematch:${getFileMatchUrl(result)}${group.startLine}:${group.endLine}`}
+                        role="link"
+                        tabIndex={0}
                         data-href={createCodeExcerptLink(group)}
                         className={clsx(
                             'test-file-match-children-item',
@@ -55,10 +56,6 @@ export const FileMatchChildren: React.FunctionComponent<React.PropsWithChildren<
                         )}
                         onClick={navigateToFile}
                         onKeyDown={navigateToFile}
-                        data-testid="file-match-children-item"
-                        tabIndex={0}
-                        role="link"
-                        data-selectable-search-result="true"
                     >
                         <CodeExcerpt
                             commitID={result.commit || ''}

--- a/vscode/webviews/components/codeSnippet/components/RepoLink.tsx
+++ b/vscode/webviews/components/codeSnippet/components/RepoLink.tsx
@@ -1,7 +1,7 @@
-import * as React from 'react'
+import type * as React from 'react'
 import { useEffect, useRef } from 'react'
 
-import { highlightNode } from '../utils'
+import { highlightNode } from '../highlights'
 import type { Range } from '../types'
 
 interface Props {
@@ -44,14 +44,18 @@ export const RepoFileLink: React.FunctionComponent<React.PropsWithChildren<Props
                 )
             }
         }
-    }, [pathMatchRanges, fileName, containerElement])
+    }, [pathMatchRanges, fileName])
 
     return (
         <span className={className}>
             <span>
                 <a href={repoURL}>{repoDisplayName || displayRepoName(repoName)}</a>
                 <span aria-hidden={true}> ›</span>{' '}
-                <a href={fileURL} ref={containerElement} data-selectable-search-result={isKeyboardSelectable}>
+                <a
+                    href={fileURL}
+                    ref={containerElement}
+                    data-selectable-search-result={isKeyboardSelectable}
+                >
                     {fileBase ? `${fileBase}/` : null}
                     <strong>{fileName}</strong>
                 </a>

--- a/vscode/webviews/components/codeSnippet/components/RepoLink.tsx
+++ b/vscode/webviews/components/codeSnippet/components/RepoLink.tsx
@@ -49,11 +49,15 @@ export const RepoFileLink: React.FunctionComponent<React.PropsWithChildren<Props
     return (
         <span className={className}>
             <span>
-                <a href={repoURL}>{repoDisplayName || displayRepoName(repoName)}</a>
+                <a href={repoURL} target="_blank" rel="noreferrer">
+                    {repoDisplayName || displayRepoName(repoName)}
+                </a>
                 <span aria-hidden={true}> ›</span>{' '}
                 <a
                     href={fileURL}
                     ref={containerElement}
+                    target="_blank"
+                    rel="noreferrer"
                     data-selectable-search-result={isKeyboardSelectable}
                 >
                     {fileBase ? `${fileBase}/` : null}

--- a/vscode/webviews/components/codeSnippet/components/RepoLink.tsx
+++ b/vscode/webviews/components/codeSnippet/components/RepoLink.tsx
@@ -1,0 +1,80 @@
+import * as React from 'react'
+import { useEffect, useRef } from 'react'
+
+import { highlightNode } from '../utils'
+import type { Range } from '../types'
+
+interface Props {
+    repoName: string
+    repoURL: string
+    filePath: string
+    pathMatchRanges?: Range[]
+    fileURL: string
+    repoDisplayName?: string
+    className?: string
+    isKeyboardSelectable?: boolean
+}
+
+/**
+ * A link to a repository or a file within a repository, formatted as "repo" or "repo > file". Unless you
+ * absolutely need breadcrumb-like behavior, use this instead of FilePathBreadcrumb.
+ */
+export const RepoFileLink: React.FunctionComponent<React.PropsWithChildren<Props>> = props => {
+    const {
+        repoDisplayName,
+        repoName,
+        repoURL,
+        filePath,
+        pathMatchRanges,
+        fileURL,
+        className,
+        isKeyboardSelectable,
+    } = props
+
+    const [fileBase, fileName] = splitPath(filePath)
+    const containerElement = useRef<HTMLAnchorElement>(null)
+
+    useEffect((): void => {
+        if (containerElement.current && pathMatchRanges && fileName) {
+            for (const range of pathMatchRanges) {
+                highlightNode(
+                    containerElement.current as HTMLElement,
+                    range.start.column,
+                    range.end.column - range.start.column
+                )
+            }
+        }
+    }, [pathMatchRanges, fileName, containerElement])
+
+    return (
+        <span className={className}>
+            <span>
+                <a href={repoURL}>{repoDisplayName || displayRepoName(repoName)}</a>
+                <span aria-hidden={true}> ›</span>{' '}
+                <a href={fileURL} ref={containerElement} data-selectable-search-result={isKeyboardSelectable}>
+                    {fileBase ? `${fileBase}/` : null}
+                    <strong>{fileName}</strong>
+                </a>
+            </span>
+        </span>
+    )
+}
+
+/**
+ * Returns the friendly display form of the repository name (e.g., removing "github.com/").
+ */
+function displayRepoName(repoName: string): string {
+    let parts = repoName.split('/')
+    if (parts.length > 1 && parts[0].includes('.')) {
+        parts = parts.slice(1) // remove hostname from repo name (reduce visual noise)
+    }
+    return parts.join('/')
+}
+
+/**
+ * Splits the repository name into the dir and base components.
+ */
+function splitPath(path: string): [string, string] {
+    const components = path.split('/')
+    return [components.slice(0, -1).join('/'), components.at(-1)!]
+}

--- a/vscode/webviews/components/codeSnippet/errors.ts
+++ b/vscode/webviews/components/codeSnippet/errors.ts
@@ -1,4 +1,3 @@
-
 export interface ErrorLike {
     message: string
     name?: string
@@ -16,4 +15,7 @@ export function tryCatch<T>(function_: () => T): T | undefined {
 }
 
 export const isErrorLike = (value: unknown): value is ErrorLike =>
-    typeof value === 'object' && value !== null && ('stack' in value || 'message' in value) && !('__typename' in value)
+    typeof value === 'object' &&
+    value !== null &&
+    ('stack' in value || 'message' in value) &&
+    !('__typename' in value)

--- a/vscode/webviews/components/codeSnippet/errors.ts
+++ b/vscode/webviews/components/codeSnippet/errors.ts
@@ -1,0 +1,19 @@
+
+export interface ErrorLike {
+    message: string
+    name?: string
+}
+
+/**
+ * Run the passed function and return `undefined` if it throws an error.
+ */
+export function tryCatch<T>(function_: () => T): T | undefined {
+    try {
+        return function_()
+    } catch {
+        return undefined
+    }
+}
+
+export const isErrorLike = (value: unknown): value is ErrorLike =>
+    typeof value === 'object' && value !== null && ('stack' in value || 'message' in value) && !('__typename' in value)

--- a/vscode/webviews/components/codeSnippet/highlights.ts
+++ b/vscode/webviews/components/codeSnippet/highlights.ts
@@ -1,0 +1,222 @@
+/**
+ * Highlights match ranges within visibleRows, with support for highlighting match ranges that span multiple lines.
+ * @param visibleRows the visible rows of the HTML table containing the code excerpt
+ * @param startRow the row within the table where highlighting should begin
+ * @param endRow the row within the table where highlighting should end
+ * @param startRowIndex the index of startRow within visibleRows
+ * @param endRowIndex the index of endRow within visibleRows
+ * @param startCharacter the 0-based character offset from the beginning of startRow's text content where highlighting should begin
+ * @param endCharacter the 0-based character offset from the beginning of endRow's text content where highlighting should end
+ */
+export function highlightNodeMultiline(
+    visibleRows: NodeListOf<HTMLElement>,
+    startRow: HTMLElement,
+    endRow: HTMLElement,
+    startRowIndex: number,
+    endRowIndex: number,
+    startCharacter: number,
+    endCharacter: number
+): void {
+    // Take the lastChild of the row to select the code portion of the table row (each table row consists of the line number and code).
+    const startRowCode = startRow.querySelector('td:last-of-type') as HTMLTableCellElement
+    const endRowCode = endRow.querySelector('td:last-of-type') as HTMLTableCellElement
+
+    // Highlight a single-line match
+    if (endRowIndex === startRowIndex) {
+        highlightNode(startRowCode, startCharacter, endCharacter - startCharacter)
+        return
+    }
+
+    // Otherwise the match is a multiline match. Highlight from the start character through to the end character.
+    highlightNode(startRowCode, startCharacter, startRowCode.textContent!.length - startCharacter)
+    for (let currRowIndex = startRowIndex + 1; currRowIndex < endRowIndex; ++currRowIndex) {
+        if (visibleRows[currRowIndex]) {
+            const currRowCode = visibleRows[currRowIndex].lastChild as HTMLTableCellElement
+            highlightNode(currRowCode, 0, currRowCode.textContent!.length)
+        }
+    }
+    highlightNode(endRowCode, 0, endCharacter)
+}
+
+/**
+ * Highlights a node using recursive node walking.
+ * @param node the node to highlight
+ * @param start the current character position (starts at 0).
+ * @param length the number of characters to highlight.
+ */
+export function highlightNode(node: HTMLElement, start: number, length: number): void {
+    if (start < 0 || length <= 0 || start >= node.textContent!.length) {
+        return
+    }
+
+    // return if length is invalid/longer than remaining characters between start and end
+    if (length > node.textContent!.length - start) {
+        return
+    }
+    // We want to treat text nodes as walkable so they can be highlighted. Wrap these in a span and
+    // replace them in the DOM.
+    if (node.nodeType === Node.TEXT_NODE && node.textContent !== null) {
+        const span = document.createElement('span')
+        span.innerHTML = node.textContent
+        node.parentNode!.replaceChild(span, node)
+        node = span
+    }
+    node.classList.add('annotated-selection-match')
+    highlightNodeHelper(node, 0, start, length)
+}
+
+interface HighlightResult {
+    highlightingCompleted: boolean
+    charsConsumed: number
+    charsHighlighted: number
+}
+
+/**
+ * Highlights a node using recursive node walking.
+ * @param currentNode the current node being walked.
+ * @param currentOffset the current character position (starts at 0).
+ * @param start the offset character where highlting starts.
+ * @param length the number of characters to highlight.
+ */
+function highlightNodeHelper(
+    currentNode: HTMLElement,
+    currentOffset: number,
+    start: number,
+    length: number
+): HighlightResult {
+    if (length === 0) {
+        return { highlightingCompleted: true, charsConsumed: 0, charsHighlighted: 0 }
+    }
+
+    const origOffset = currentOffset
+    const numberChildNodes = currentNode.childNodes.length
+
+    let charsHighlighted = 0
+
+    for (let index = 0; index < numberChildNodes; ++index) {
+        if (currentOffset >= start + length) {
+            return { highlightingCompleted: true, charsConsumed: 0, charsHighlighted: 0 }
+        }
+        const isLastNode = index === currentNode.childNodes.length - 1
+        const child = currentNode.childNodes[index]
+
+        switch (child.nodeType) {
+            case Node.TEXT_NODE: {
+                const nodeText = child.textContent!
+
+                // Unpack the string to be sliced into an array of code points before doing the slice.
+                // This allows match range highlighting to continue to work when Unicode characters (such as emojis)
+                // are present in a matched line.
+                const unicodeAwareSlice = (text: string, start: number, end: number): string =>
+                    text.slice(start, end)
+
+                // Split the text node into a range before the highlight, a range overlapping with
+                // the highlight, and a range after the highlight. These ranges can be zero-length
+                const preHighlightedRange = unicodeAwareSlice(
+                    nodeText,
+                    0,
+                    Math.max(0, start - currentOffset)
+                )
+                const highlightedRange = unicodeAwareSlice(
+                    nodeText,
+                    Math.max(0, start - currentOffset),
+                    start - currentOffset + length
+                )
+                const postHighlightedRange = unicodeAwareSlice(
+                    nodeText,
+                    start - currentOffset + length,
+                    nodeText.length + 1
+                )
+
+                // Create new nodes for each of the ranges with length > 0
+                const newNodes: Node[] = []
+
+                if (preHighlightedRange) {
+                    newNodes.push(document.createTextNode(preHighlightedRange))
+                }
+
+                if (highlightedRange) {
+                    const highlight = document.createElement('span')
+                    /*
+                        a11y-ignore
+                        Rule: "color-contrast" (Elements must have sufficient color contrast)
+                        GitHub issue: https://github.com/sourcegraph/sourcegraph/issues/33343
+                    */
+                    highlight.className = 'match-highlight a11y-ignore'
+                    highlight.append(document.createTextNode(highlightedRange))
+                    newNodes.push(highlight)
+                }
+
+                if (postHighlightedRange) {
+                    newNodes.push(document.createTextNode(postHighlightedRange))
+                }
+
+                let newNode: Node
+                if (newNodes.length === 0) {
+                    newNode = document.createTextNode('')
+                } else if (newNodes.length === 1) {
+                    // If we only have one new node, no need to wrap it in a containing span
+                    newNode = newNodes[0]
+                } else {
+                    // If there are more than one new nodes, wrap them in a span
+                    const containerNode = document.createElement('span')
+                    containerNode.append(...newNodes)
+                    /*
+                        a11y-ignore
+                        Rule: "color-contrast" (Elements must have sufficient color contrast)
+                        GitHub issue: https://github.com/sourcegraph/sourcegraph/issues/33343
+                    */
+                    containerNode.className = 'a11y-ignore'
+                    newNode = containerNode
+                }
+
+                // Remove the original child and replace it with the new node
+                child.remove()
+                if (currentNode.childNodes.length === 0 || isLastNode) {
+                    if (currentNode.classList.contains('match-highlight')) {
+                        // Nothing to do; it's already highlighted.
+                        currentNode.append(child)
+                    } else {
+                        currentNode.append(newNode)
+                    }
+                } else {
+                    currentNode.insertBefore(
+                        newNode,
+                        currentNode.childNodes[index] || currentNode.firstChild
+                    )
+                }
+
+                // Count highlighted characters in terms of code points, not bytes
+                currentOffset += nodeText.length
+                charsHighlighted += highlightedRange.length
+                if (highlightedRange.length > 0 && postHighlightedRange.length > 0) {
+                    return {
+                        highlightingCompleted: true,
+                        charsConsumed: nodeText.length,
+                        charsHighlighted: highlightedRange.length,
+                    }
+                }
+
+                break
+            }
+
+            case Node.ELEMENT_NODE: {
+                const elementNode = child as HTMLElement
+                const result = highlightNodeHelper(
+                    elementNode,
+                    currentOffset,
+                    start + charsHighlighted,
+                    length - charsHighlighted
+                )
+                if (result.highlightingCompleted) {
+                    return result
+                }
+                currentOffset += result.charsConsumed
+                charsHighlighted += result.charsHighlighted
+                break
+            }
+        }
+    }
+
+    return { highlightingCompleted: false, charsConsumed: currentOffset - origOffset, charsHighlighted }
+}

--- a/vscode/webviews/components/codeSnippet/types.ts
+++ b/vscode/webviews/components/codeSnippet/types.ts
@@ -35,7 +35,6 @@ export interface ChunkMatch {
 }
 
 export interface Location {
-    offset: number
     line: number
     column: number
 }

--- a/vscode/webviews/components/codeSnippet/types.ts
+++ b/vscode/webviews/components/codeSnippet/types.ts
@@ -1,21 +1,18 @@
-
 export type SearchMatch = ContentMatch
 
 export interface ContentMatch {
     type: 'content'
     path: string
-    pathMatches?: Range[]
     repository: string
+    pathMatches?: Range[]
     repoStars?: number
     repoLastFetched?: string
     branches?: string[]
     commit?: string
     lineMatches?: LineMatch[]
     chunkMatches?: ChunkMatch[]
-    hunks?: DecoratedHunk[]
     language?: string
     debug?: string
-    externalServiceType: string
 }
 
 export interface LineMatch {
@@ -46,18 +43,6 @@ export interface Location {
 export interface Range {
     start: Location
     end: Location
-}
-
-export interface DecoratedHunk {
-    content: DecoratedContent
-    lineStart: number
-    lineCount: number
-    matches: Range[]
-}
-
-export interface DecoratedContent {
-    plaintext?: string
-    html?: string
 }
 
 /**
@@ -94,7 +79,7 @@ export enum HighlightResponseFormat {
     /** HTML formatted file content without syntax highlighting. */
     HTML_PLAINTEXT = 'HTML_PLAINTEXT',
     /** SCIP highlighting information as JSON. */
-    JSON_SCIP = 'JSON_SCIP'
+    JSON_SCIP = 'JSON_SCIP',
 }
 
 /** A specific highlighted line range to fetch. */
@@ -103,10 +88,10 @@ export interface HighlightLineRange {
      * The last line to fetch (0-indexed, inclusive). Values outside the bounds of the file will
      * automatically be clamped within the valid range.
      */
-    endLine: number;
+    endLine: number
     /**
      * The first line to fetch (0-indexed, inclusive). Values outside the bounds of the file will
      * automatically be clamped within the valid range.
      */
-    startLine: number;
+    startLine: number
 }

--- a/vscode/webviews/components/codeSnippet/types.ts
+++ b/vscode/webviews/components/codeSnippet/types.ts
@@ -1,0 +1,112 @@
+
+export type SearchMatch = ContentMatch
+
+export interface ContentMatch {
+    type: 'content'
+    path: string
+    pathMatches?: Range[]
+    repository: string
+    repoStars?: number
+    repoLastFetched?: string
+    branches?: string[]
+    commit?: string
+    lineMatches?: LineMatch[]
+    chunkMatches?: ChunkMatch[]
+    hunks?: DecoratedHunk[]
+    language?: string
+    debug?: string
+    externalServiceType: string
+}
+
+export interface LineMatch {
+    line: string
+    lineNumber: number
+    offsetAndLengths: number[][]
+}
+
+export interface ChunkMatch {
+    content: string
+    contentStart: Location
+    ranges: Range[]
+
+    /**
+     * Indicates that content has been truncated.
+     *
+     * This can only be true when maxLineLength search option is non-zero.
+     */
+    contentTruncated?: boolean
+}
+
+export interface Location {
+    offset: number
+    line: number
+    column: number
+}
+
+export interface Range {
+    start: Location
+    end: Location
+}
+
+export interface DecoratedHunk {
+    content: DecoratedContent
+    lineStart: number
+    lineCount: number
+    matches: Range[]
+}
+
+export interface DecoratedContent {
+    plaintext?: string
+    html?: string
+}
+
+/**
+ * Describes a single group of matches.
+ */
+export interface MatchGroup {
+    // The un-highlighted plain text for the lines in this group.
+    plaintextLines: string[]
+
+    // The highlighted HTML corresponding to plaintextLines.
+    // The strings each contain a HTML <tr> containing the highlighted code.
+    highlightedHTMLRows?: string[]
+
+    // The matches in this group to display.
+    matches: MatchGroupMatch[]
+
+    // The 0-based start line of the group (inclusive.)
+    startLine: number
+
+    // The 0-based end line of the group (inclusive.)
+    endLine: number
+}
+
+export interface MatchGroupMatch {
+    startLine: number
+    startCharacter: number
+    endLine: number
+    endCharacter: number
+}
+
+export enum HighlightResponseFormat {
+    /** HTML formatted file content with syntax highlighting. */
+    HTML_HIGHLIGHT = 'HTML_HIGHLIGHT',
+    /** HTML formatted file content without syntax highlighting. */
+    HTML_PLAINTEXT = 'HTML_PLAINTEXT',
+    /** SCIP highlighting information as JSON. */
+    JSON_SCIP = 'JSON_SCIP'
+}
+
+/** A specific highlighted line range to fetch. */
+export interface HighlightLineRange {
+    /**
+     * The last line to fetch (0-indexed, inclusive). Values outside the bounds of the file will
+     * automatically be clamped within the valid range.
+     */
+    endLine: number;
+    /**
+     * The first line to fetch (0-indexed, inclusive). Values outside the bounds of the file will
+     * automatically be clamped within the valid range.
+     */
+    startLine: number;
+}

--- a/vscode/webviews/components/codeSnippet/url.ts
+++ b/vscode/webviews/components/codeSnippet/url.ts
@@ -1,0 +1,483 @@
+/**
+ * Represents a line, a position, a line range, or a position range. It forbids
+ * just a character, or a range from a line to a position or vice versa (such as
+ * "L1-2:3" or "L1:2-3"), none of which would make much sense.
+ *
+ * 1-indexed.
+ *
+ * For backward compatibility, `character` and `endCharacter` are allowed to be 0,
+ * which is the same as not being set.
+ */
+export type LineOrPositionOrRange =
+    | { line?: undefined; character?: undefined; endLine?: undefined; endCharacter?: undefined }
+    | { line: number; character?: number; endLine?: undefined; endCharacter?: undefined }
+    | { line: number; character?: undefined; endLine?: number; endCharacter?: undefined }
+    | { line: number; character: number; endLine: number; endCharacter: number }
+
+/**
+ * Parses a string like that encodes a line or a position.
+ * Examples of valid input:
+ * L1          -  line:     line 1
+ * L1:2        -  position: line 1, character 2
+ *
+ * If the line is invalid (e.g. L0), the return value will be an empty object.
+ * If the character is invalid (e.g. L1:0), the return value will be a line.
+ *
+ * @param lineOrPosition a string like that encodes a line or a position
+ * @returns the parsed line or position, or an empty object if the input is invalid
+ */
+function parseLineOrPosition(
+    lineOrPosition: string
+): { line?: undefined; character?: undefined } | { line: number; character?: number } {
+    if (lineOrPosition.startsWith('L')) {
+        lineOrPosition = lineOrPosition.slice(1)
+    }
+    const parts = lineOrPosition.split(':', 2)
+    const line = parts.length >= 1 ? parseInt(parts[0], 10) : undefined
+    const character = parts.length === 2 ? parseInt(parts[1], 10) : undefined
+
+    if (line === undefined || isNaN(line) || line <= 0) {
+        return {}
+    }
+    if (character === undefined || isNaN(character) || character <= 0) {
+        return { line }
+    }
+    return { line, character }
+}
+
+/**
+ * Parses a string like that encodes a line, a position, a line range, or a position range.
+ *
+ * Examples of valid input:
+ * L1          -  line:           line 1
+ * L1:2        -  position:       line 1, character 2
+ * L1-2        -  line range:     line 1 to line 2
+ * L1:2-3:4    -  position range: line 1, character 2 to line 3, character 4
+ *
+ * Other combinations of lines or positions are not valid.
+ *
+ * If the range is empty, e.g. L1:2-1:2, the output return value will be simplified to a position, e.g. L1:2.
+ *
+ * @param range a string like that encodes a line, a position, a line range, or a position range
+ * @returns the parsed line, position, line range, or position range, or an empty object if the input is invalid
+ */
+function parseLineOrPositionOrRange(range: string): LineOrPositionOrRange {
+    if (!/^(L\d+(:\d+)?(-L?\d+(:\d+)?)?)?$/.test(range)) {
+        return {} // invalid
+    }
+
+    // Parse the line or position range, ensuring we don't get an inconsistent result
+    // (such as L1-2:3, a range from a line to a position).
+    let line: number | undefined // 17
+    let character: number | undefined // 19
+    let endLine: number | undefined // 21
+    let endCharacter: number | undefined // 23
+    if (range.startsWith('L')) {
+        const positionOrRangeString = range.slice(1)
+        const [startString, endString] = positionOrRangeString.split('-', 2)
+        if (startString) {
+            const parsed = parseLineOrPosition(startString)
+            line = parsed.line
+            character = parsed.character
+        }
+        if (endString) {
+            const parsed = parseLineOrPosition(endString)
+            endLine = parsed.line
+            endCharacter = parsed.character
+        }
+    }
+    if (line === undefined || (endLine !== undefined && typeof character !== typeof endCharacter)) {
+        return {}
+    }
+    if (character === undefined) {
+        return endLine === undefined ? { line } : { line, endLine }
+    }
+    if (endLine === undefined || endCharacter === undefined) {
+        return { line, character }
+    }
+    return simplifyRange({ line, character, endLine, endCharacter })
+}
+
+/**
+ * Simplifies a line or a position range. If the input represents an empty range,
+ * e.g. `{ line: 1, character: 2, endLine: 1, endCharacter: 2 }`, the output
+ * will be converted into a position, e.g. `{ line: 1, character: 2 }`.
+ * If the input is invalid, an empty object is returned.
+ *
+ * See {@link LineOrPositionOrRange}.
+ *
+ * @param range the line, position, line range, or position range to simplify
+ * @returns the simplified line, position, line range, or position range
+ */
+function simplifyRange(range: LineOrPositionOrRange): LineOrPositionOrRange {
+    if (range.line === undefined) {
+        return {}
+    }
+    // Treat character 0 or endCharacter 0 as 'not set'
+    if (range.character === 0 || range.endCharacter === 0) {
+        return { line: range.line, endLine: range.endLine }
+    }
+    if (range.line === range.endLine && range.character === range.endCharacter) {
+        return { line: range.line, character: range.character }
+    }
+    return range
+}
+
+/**
+ * Formats a line, a position, a line range, or a position range as a string. The output
+ * is suitable for use in a URL hash or search parameter and can be parsed with
+ * {@link parseLineOrPositionOrRange}.
+ * If the input represents an empty range, e.g. `{ line: 1, character: 2, endLine: 1, endCharacter: 2 }`,
+ * the output will be converted into a position, e.g. `L1:2`.
+ *
+ * See {@link LineOrPositionOrRange}.
+ *
+ * @param lpr the line, position, line range, or position range to format
+ * @returns the formatted line, position, line range, or position range
+ */
+function formatLineOrPositionOrRange(lpr: LineOrPositionOrRange): string {
+    lpr = simplifyRange(lpr)
+    if (lpr.line === undefined) {
+        return ''
+    }
+    if (lpr.character === undefined) {
+        return `L${lpr.line}${lpr.endLine ? `-${lpr.endLine}` : ''}`
+    }
+    return `L${lpr.line}:${lpr.character}${lpr.endLine ? `-${lpr.endLine}:${lpr.endCharacter}` : ''}`
+}
+
+/**
+ * Adds, updates or removes a line or position range in search parameters.
+ *
+ * @param inputParams the URL's search parameters
+ * @param lpr the line or position range to add or update
+ * @returns the updated search parameters
+ */
+function addOrUpdateLineRange(inputParams: URLSearchParams, lpr: LineOrPositionOrRange | null): URLSearchParams {
+    const params = new URLSearchParams(inputParams)
+    const range = lpr ? formatLineOrPositionOrRange(lpr) : ''
+
+    // Remove existing line range if it exists
+    const existingLineRangeKey = findLineKeyInSearchParameters(params)
+    if (existingLineRangeKey) {
+        params.delete(existingLineRangeKey)
+    }
+
+    return range !== '' ? new URLSearchParams([[range, ''], ...params]) : params
+}
+
+/**
+ * Tells if the given fragment component is a legacy blob hash component or not.
+ * Legacy fragments have the structure `#L<line>:<character>-<line>:<character>$<viewState>`.
+ *
+ * @param hash The URL fragment.
+ */
+export function isLegacyFragment(hash: string): boolean {
+    if (hash.startsWith('#')) {
+        hash = hash.slice(1)
+    }
+    return (
+        hash !== '' &&
+        !hash.includes('=') &&
+        (hash.includes('$info') ||
+            hash.includes('$def') ||
+            hash.includes('$references') ||
+            hash.includes('$impl') ||
+            hash.includes('$history'))
+    )
+}
+
+/**
+ * Parses the URL fragment (hash) portion, which consists of a line, position, or range in the file, plus an
+ * optional "viewState" parameter (that encodes other view state, such as for the panel).
+ *
+ * For example, in the URL fragment "#L17:19-21:23$foo:bar", the "viewState" is "foo:bar".
+ *
+ * NOTE: Prefer to use {@link SourcegraphURL} instead of this function.
+ *
+ * @template V The type that describes the view state (typically a union of string constants). There is no runtime check that the return value satisfies V.
+ */
+function parseHash<V extends string>(hash: string): LineOrPositionOrRange & { viewState?: V } {
+    if (hash.startsWith('#')) {
+        hash = hash.slice('#'.length)
+    }
+
+    if (!isLegacyFragment(hash)) {
+        // Modern hash parsing logic (e.g. for hashes like `"#L17:19-21:23&tab=foo:bar"`:
+        const searchParameters = new URLSearchParams(hash)
+        const existingLineRangeKey = findLineKeyInSearchParameters(searchParameters)
+        const lpr: LineOrPositionOrRange & { viewState?: V } = existingLineRangeKey
+            ? parseLineOrPositionOrRange(existingLineRangeKey)
+            : {}
+        if (searchParameters.get('tab')) {
+            lpr.viewState = searchParameters.get('tab') as V
+        }
+        return lpr
+    }
+
+    // Legacy hash parsing logic (e.g. for hashes like "#L17:19-21:23$foo:bar" where the "viewState" is "foo:bar"):
+    if (!/^(L\d+(:\d+)?(-\d+(:\d+)?)?)?(\$.*)?$/.test(hash)) {
+        // invalid or empty hash
+        return {}
+    }
+    const lineCharModalInfo = hash.split('$', 2) // e.g. "L17:19-21:23$references"
+    const lpr: LineOrPositionOrRange & { viewState?: V } = parseLineOrPositionOrRange(lineCharModalInfo[0])
+    if (lineCharModalInfo[1]) {
+        lpr.viewState = lineCharModalInfo[1] as V
+    }
+    return lpr
+}
+
+/**
+ * Finds an existing line range search parameter like "L1-2:3"
+ */
+function findLineKeyInSearchParameters(searchParameters: URLSearchParams): string | undefined {
+    for (const key of searchParameters.keys()) {
+        if (key.startsWith('L')) {
+            return key
+        }
+        break
+    }
+    return undefined
+}
+
+/**
+ * Stringifies the provided search parameters, replaces encoded `/` and `:` characters,
+ * and removes trailing `=`.
+ *
+ * E.g. L1%3A2 => L1:2
+ */
+function formatSearchParameters(searchParameters: string): string {
+    return searchParameters.replaceAll('%2F', '/').replaceAll('%3A', ':').replaceAll('=&', '&').replace(/=$/, '')
+}
+
+/**
+ * This class encapsulates the logic for creating and manipulating Soucegraph URLs.
+ * Not all methods are applicable to all types of URLs. If a method is not applicable
+ * to the URL, the operation will be a no-op.
+ *
+ * See the individual method documentation for details.
+ *
+ * Using this class to manipulate URLs is preferred over manual string manipulation
+ * because it ensures that the URL is prettified when converted to a string.
+ */
+export class SourcegraphURL {
+    private url: URL
+    private hasPathname: boolean
+    private hasOrigin: boolean
+
+    private constructor(url: string | URL) {
+        this.url = typeof url === 'string' ? new URL(url, 'http://0.0.0.0/') : new URL(url)
+        this.hasPathname = !(typeof url === 'string' && /^[#?]/.test(url))
+        this.hasOrigin = typeof url !== 'string' || /^https?:/.test(url)
+    }
+
+    /**
+     * Creates a new SourcegraphURL instance from a string, URL, URLSearchParams, or location object.
+     *
+     * When converting the URL back to a string, the string representation depends on the input as well
+     * as the changes that have been made to the URL.
+     *
+     * If the input contains an origin, the output will too.
+     * If the input contains a pathname, the output will too.
+     *
+     * This should make the output fairly predictable.
+     */
+    public static from(
+        url: string | URL | URLSearchParams | { pathname?: string; search?: string | URLSearchParams; hash?: string }
+    ): SourcegraphURL {
+        if (typeof url === 'string' || url instanceof URL) {
+            return new SourcegraphURL(url)
+        }
+        if (url instanceof URLSearchParams) {
+            return new SourcegraphURL(`?${formatSearchParameters(url.toString())}`)
+        }
+        return SourcegraphURL.fromLocation(url)
+    }
+
+    private static fromLocation(location: {
+        pathname?: string
+        search?: string | URLSearchParams
+        hash?: string
+    }): SourcegraphURL {
+        let { pathname = '', search = '', hash = '' } = location
+        if (search) {
+            if (typeof search === 'string') {
+                if (!search.startsWith('?')) {
+                    search = `?${search}`
+                }
+            } else {
+                search = `?${search.toString()}`
+            }
+        }
+        if (hash && !hash.startsWith('#')) {
+            hash = `#${hash}`
+        }
+        return new SourcegraphURL(`${pathname}${search}${hash}`)
+    }
+
+    // Mutation methods
+
+    /**
+     * Adds or updates a line or position range in a URL's search parameters.
+     *
+     * Example:
+     * ```
+     * const url = new SourcegraphURL('/foo?bar')
+     * url.addOrUpdateLineRange({ line: 24, character: 24 })
+     * url.toString() // => '/foo?L24:24&bar'
+     * ```
+     *
+     * @param href the URL to update
+     * @param lpr the line or position range to add or update
+     * @returns the updated URL
+     */
+    public setLineRange(lpr: LineOrPositionOrRange | null): this {
+        this.url.search = addOrUpdateLineRange(this.url.searchParams, lpr).toString()
+        return this
+    }
+
+    /**
+     * Sets the view state, using the modern hash format.
+     *
+     * Example:
+     * ```
+     * const url = new SourcegraphURL('/foo?bar')
+     * url.setViewState('references')
+     * url.toString() // => '/foo?bar#L1:2-3:4&tab=references'
+     * ```
+     *
+     * @template V The type that describes the view state (typically a union of string constants).
+     * @param viewState the view state to set
+     */
+    public setViewState<V extends string = string>(viewState: V | undefined): this {
+        // Try to preserve existing hash params
+        const hashParams = new URLSearchParams(this.url.hash.slice(1))
+        if (!viewState && !hashParams.has('tab')) {
+            // Nothing to do
+            return this
+        }
+        if (viewState) {
+            hashParams.set('tab', viewState)
+        } else {
+            hashParams.delete('tab')
+        }
+        this.url.hash = hashParams.toString()
+        return this
+    }
+
+    /**
+     * Adds a search parameter to the URL.
+     */
+    public setSearchParameter(key: string, value: string): this {
+        this.url.searchParams.set(key, value)
+        return this
+    }
+
+    /**
+     * Removes a search parameter from the URL.
+     */
+    public deleteSearchParameter(...keys: string[]): this {
+        for (const key of keys) {
+            this.url.searchParams.delete(key)
+        }
+        return this
+    }
+
+    // Accessors
+    //
+    /**
+     * Parses the encoded line range from the URL's search parameters or hash.
+     * A line range is often present in file URLs to indicate the selected lines or positions.
+     *
+     * If the URL contains a line range in both the search parameters and the hash,
+     * the search parameters take precedence.
+     *
+     * If the line range is "empty" (e.g. L1:2-1:2), the return value will be simplified
+     * to a position (e.g. L1:2).
+     *
+     * Examples of valid line or position ranges:
+     *
+     *   ?L1 => { line: 1 }
+     *   ?L1:2 => { line: 1, character: 2 }
+     *   ?L1-2 => { line: 1, endLine: 2 }
+     *   ?L1:2-3:4 => { line: 1, character: 2, endLine: 3, endCharacter: 4 }
+     *   ?L1:2-1:2 => { line: 1, character: 2 }
+     *   #L1 => { line: 1 }
+     *   #L1:2 => { line: 1, character: 2 }
+     *   #L1-2 => { line: 1, endLine: 2 }
+     *   #L1:2-3:4 => { line: 1, character: 2, endLine: 3, endCharacter: 4 }
+     *   #L1:2-1:2 => { line: 1, character: 2 }
+     *
+     * @returns the parsed line or position range, or an empty object if the input is invalid
+     */
+    public get lineRange(): LineOrPositionOrRange {
+        const existingLineRangeKey = findLineKeyInSearchParameters(this.url.searchParams)
+        if (existingLineRangeKey) {
+            return parseLineOrPositionOrRange(existingLineRangeKey)
+        }
+        return parseHash(this.url.hash)
+    }
+
+    /**
+     * Parses the view state from the URL.
+     *
+     * The view state is often present in file URLs to indicate the selected tab.
+     *
+     * The function supports both legacy and modern hash formats:
+     * - Legacy: `#L1:2-3:4$references`
+     * - Modern: `#L1:2-3:4&tab=references`
+     *
+     *  @returns the parsed view state, or undefined if the input is invalid
+     */
+    public get viewState(): string | undefined {
+        return parseHash(this.url.hash).viewState
+    }
+
+    /**
+     * The pathname of the URL.
+     */
+    public get pathname(): string {
+        return this.hasPathname ? this.url.pathname : ''
+    }
+
+    /**
+     * The search parameters of the URL.
+     */
+    public get searchParams(): URLSearchParams {
+        return this.url.searchParams
+    }
+
+    /**
+     * The search parameters of the URL as a string.
+     * Search parameters are prettied.
+     */
+    public get search(): string {
+        return formatSearchParameters(this.url.search)
+    }
+
+    /**
+     * The hash of the URL.
+     */
+    public get hash(): string {
+        return formatSearchParameters(this.url.hash)
+    }
+
+    /**
+     * Returns a string representation of the URL. The output
+     * depends on the original input and the changes that have been
+     * made to the URL.
+     * E.g. if the original input did not include a pathname, the output
+     * won't either.
+     *
+     * The stringified URL is prettified.
+     */
+    public toString(): string {
+        return (
+            (this.hasOrigin ? this.url.origin : '') +
+            (this.hasPathname ? this.url.pathname : '') +
+            this.search +
+            this.hash
+        )
+    }
+}

--- a/vscode/webviews/components/codeSnippet/utils.ts
+++ b/vscode/webviews/components/codeSnippet/utils.ts
@@ -51,10 +51,10 @@ export const formatRepositoryStarCount = (repoStars?: number): string | undefine
     return undefined
 }
 
-export function getFileMatchUrl(fileMatch: ContentMatch): string {
+export function getFileMatchUrl(base: string, fileMatch: ContentMatch): string {
     const revision = getRevision(fileMatch.branches, fileMatch.commit)
     const encodedFilePath = fileMatch.path.split('/').map(encodeURIComponent).join('/')
-    return `/${fileMatch.repository}${revision ? '@' + revision : ''}/-/blob/${encodedFilePath}`
+    return `${base}${fileMatch.repository}${revision ? '@' + revision : ''}/-/blob/${encodedFilePath}`
 }
 
 export function getRevision(branches?: string[], version?: string): string {

--- a/vscode/webviews/components/codeSnippet/utils.ts
+++ b/vscode/webviews/components/codeSnippet/utils.ts
@@ -1,0 +1,288 @@
+import type * as React from 'react'
+import { ContentMatch } from './types';
+
+type Merge<P1 = {}, P2 = {}> = Omit<P1, keyof P2> & P2
+
+export type ForwardReferenceExoticComponent<E, OwnProps> = React.ForwardRefExoticComponent<
+    Merge<E extends React.ElementType ? React.ComponentPropsWithRef<E> : never, OwnProps & { as?: E }>
+>
+
+type PropsWithChildren<P> = P &
+    ({ children?: React.ReactNode | undefined } | { children: (...args: any[]) => React.ReactNode })
+
+export interface ForwardReferenceComponent<
+    IntrinsicElementString,
+    OwnProps = {}
+    /**
+     * Extends original type to ensure built in React types play nice
+     * with polymorphic components still e.g. `React.ElementRef` etc.
+     */
+> extends ForwardReferenceExoticComponent<IntrinsicElementString, OwnProps> {
+    /**
+     * When `as` prop is passed, use this overload.
+     * Merges original own props (without DOM props) and the inferred props
+     * from `as` element with the own props taking precedence.
+     *
+     * We explicitly avoid `React.ElementType` and manually narrow the prop types
+     * so that events are typed when using JSX.IntrinsicElements.
+     */
+        <As = IntrinsicElementString>(
+        props: As extends ''
+            ? { as: keyof JSX.IntrinsicElements }
+            : As extends React.ComponentType<PropsWithChildren<infer P>>
+                ? Merge<P, OwnProps & { as: As }>
+                : As extends keyof JSX.IntrinsicElements
+                    ? Merge<JSX.IntrinsicElements[As], OwnProps & { as: As }>
+                    : never
+    ): React.ReactElement | null
+}
+
+export type ObservableStatus = 'initial' | 'next' | 'completed' | 'error'
+
+/**
+ * Converts the number of repo stars into a string, formatted nicely for large numbers
+ */
+export const formatRepositoryStarCount = (repoStars?: number): string | undefined => {
+    if (repoStars !== undefined) {
+        if (repoStars > 1000) {
+            return `${(repoStars / 1000).toFixed(1)}k`
+        }
+        return repoStars.toString()
+    }
+    return undefined
+}
+
+/**
+ * Highlights match ranges within visibleRows, with support for highlighting match ranges that span multiple lines.
+ * @param visibleRows the visible rows of the HTML table containing the code excerpt
+ * @param startRow the row within the table where highlighting should begin
+ * @param endRow the row within the table where highlighting should end
+ * @param startRowIndex the index of startRow within visibleRows
+ * @param endRowIndex the index of endRow within visibleRows
+ * @param startCharacter the 0-based character offset from the beginning of startRow's text content where highlighting should begin
+ * @param endCharacter the 0-based character offset from the beginning of endRow's text content where highlighting should end
+ */
+export function highlightNodeMultiline(
+    visibleRows: NodeListOf<HTMLElement>,
+    startRow: HTMLElement,
+    endRow: HTMLElement,
+    startRowIndex: number,
+    endRowIndex: number,
+    startCharacter: number,
+    endCharacter: number
+): void {
+    // Take the lastChild of the row to select the code portion of the table row (each table row consists of the line number and code).
+    const startRowCode = startRow.querySelector('td:last-of-type') as HTMLTableCellElement
+    const endRowCode = endRow.querySelector('td:last-of-type') as HTMLTableCellElement
+
+    // Highlight a single-line match
+    if (endRowIndex === startRowIndex) {
+        return highlightNode(startRowCode, startCharacter, endCharacter - startCharacter)
+    }
+
+    // Otherwise the match is a multiline match. Highlight from the start character through to the end character.
+    highlightNode(startRowCode, startCharacter, startRowCode.textContent!.length - startCharacter)
+    for (let currRowIndex = startRowIndex + 1; currRowIndex < endRowIndex; ++currRowIndex) {
+        if (visibleRows[currRowIndex]) {
+            const currRowCode = visibleRows[currRowIndex].lastChild as HTMLTableCellElement
+            highlightNode(currRowCode, 0, currRowCode.textContent!.length)
+        }
+    }
+    highlightNode(endRowCode, 0, endCharacter)
+}
+
+/**
+ * Highlights a node using recursive node walking.
+ * @param node the node to highlight
+ * @param start the current character position (starts at 0).
+ * @param length the number of characters to highlight.
+ */
+export function highlightNode(node: HTMLElement, start: number, length: number): void {
+    if (start < 0 || length <= 0 || start >= node.textContent!.length) {
+        return
+    }
+
+    // return if length is invalid/longer than remaining characters between start and end
+    if (length > node.textContent!.length - start) {
+        return
+    }
+    // We want to treat text nodes as walkable so they can be highlighted. Wrap these in a span and
+    // replace them in the DOM.
+    if (node.nodeType === Node.TEXT_NODE && node.textContent !== null) {
+        const span = document.createElement('span')
+        span.innerHTML = node.textContent
+        node.parentNode!.replaceChild(span, node)
+        node = span
+    }
+    node.classList.add('annotated-selection-match')
+    highlightNodeHelper(node, 0, start, length)
+}
+
+interface HighlightResult {
+    highlightingCompleted: boolean
+    charsConsumed: number
+    charsHighlighted: number
+}
+
+/**
+ * Highlights a node using recursive node walking.
+ * @param currentNode the current node being walked.
+ * @param currentOffset the current character position (starts at 0).
+ * @param start the offset character where highlting starts.
+ * @param length the number of characters to highlight.
+ */
+function highlightNodeHelper(
+    currentNode: HTMLElement,
+    currentOffset: number,
+    start: number,
+    length: number
+): HighlightResult {
+    if (length === 0) {
+        return { highlightingCompleted: true, charsConsumed: 0, charsHighlighted: 0 }
+    }
+
+    const origOffset = currentOffset
+    const numberChildNodes = currentNode.childNodes.length
+
+    let charsHighlighted = 0
+
+    for (let index = 0; index < numberChildNodes; ++index) {
+        if (currentOffset >= start + length) {
+            return { highlightingCompleted: true, charsConsumed: 0, charsHighlighted: 0 }
+        }
+        const isLastNode = index === currentNode.childNodes.length - 1
+        const child = currentNode.childNodes[index]
+
+        switch (child.nodeType) {
+            case Node.TEXT_NODE: {
+                const nodeText = child.textContent!
+
+                // Unpack the string to be sliced into an array of code points before doing the slice.
+                // This allows match range highlighting to continue to work when Unicode characters (such as emojis)
+                // are present in a matched line.
+                const unicodeAwareSlice = (text: string, start: number, end: number): string =>
+                    text.slice(start, end)
+
+                // Split the text node into a range before the highlight, a range overlapping with
+                // the highlight, and a range after the highlight. These ranges can be zero-length
+                const preHighlightedRange = unicodeAwareSlice(nodeText, 0, Math.max(0, start - currentOffset))
+                const highlightedRange = unicodeAwareSlice(
+                    nodeText,
+                    Math.max(0, start - currentOffset),
+                    start - currentOffset + length
+                )
+                const postHighlightedRange = unicodeAwareSlice(
+                    nodeText,
+                    start - currentOffset + length,
+                    nodeText.length + 1
+                )
+
+                // Create new nodes for each of the ranges with length > 0
+                const newNodes: Node[] = []
+
+                if (preHighlightedRange) {
+                    newNodes.push(document.createTextNode(preHighlightedRange))
+                }
+
+                if (highlightedRange) {
+                    const highlight = document.createElement('span')
+                    /*
+                        a11y-ignore
+                        Rule: "color-contrast" (Elements must have sufficient color contrast)
+                        GitHub issue: https://github.com/sourcegraph/sourcegraph/issues/33343
+                    */
+                    highlight.className = 'match-highlight a11y-ignore'
+                    highlight.append(document.createTextNode(highlightedRange))
+                    newNodes.push(highlight)
+                }
+
+                if (postHighlightedRange) {
+                    newNodes.push(document.createTextNode(postHighlightedRange))
+                }
+
+                let newNode: Node
+                if (newNodes.length === 0) {
+                    newNode = document.createTextNode('')
+                } else if (newNodes.length === 1) {
+                    // If we only have one new node, no need to wrap it in a containing span
+                    newNode = newNodes[0]
+                } else {
+                    // If there are more than one new nodes, wrap them in a span
+                    const containerNode = document.createElement('span')
+                    containerNode.append(...newNodes)
+                    /*
+                        a11y-ignore
+                        Rule: "color-contrast" (Elements must have sufficient color contrast)
+                        GitHub issue: https://github.com/sourcegraph/sourcegraph/issues/33343
+                    */
+                    containerNode.className = 'a11y-ignore'
+                    newNode = containerNode
+                }
+
+                // Remove the original child and replace it with the new node
+                child.remove()
+                if (currentNode.childNodes.length === 0 || isLastNode) {
+                    if (currentNode.classList.contains('match-highlight')) {
+                        // Nothing to do; it's already highlighted.
+                        currentNode.append(child)
+                    } else {
+                        currentNode.append(newNode)
+                    }
+                } else {
+                    currentNode.insertBefore(newNode, currentNode.childNodes[index] || currentNode.firstChild)
+                }
+
+                // Count highlighted characters in terms of code points, not bytes
+                currentOffset += nodeText.length
+                charsHighlighted += highlightedRange.length
+                if (highlightedRange.length > 0 && postHighlightedRange.length > 0) {
+                    return {
+                        highlightingCompleted: true,
+                        charsConsumed: nodeText.length,
+                        charsHighlighted: highlightedRange.length,
+                    }
+                }
+
+                break
+            }
+
+            case Node.ELEMENT_NODE: {
+                const elementNode = child as HTMLElement
+                const result = highlightNodeHelper(
+                    elementNode,
+                    currentOffset,
+                    start + charsHighlighted,
+                    length - charsHighlighted
+                )
+                if (result.highlightingCompleted) {
+                    return result
+                }
+                currentOffset += result.charsConsumed
+                charsHighlighted += result.charsHighlighted
+                break
+            }
+        }
+    }
+
+    return { highlightingCompleted: false, charsConsumed: currentOffset - origOffset, charsHighlighted }
+}
+
+export function getFileMatchUrl(fileMatch: ContentMatch): string {
+    const revision = getRevision(fileMatch.branches, fileMatch.commit)
+    const encodedFilePath = fileMatch.path.split('/').map(encodeURIComponent).join('/')
+    return `/${fileMatch.repository}${revision ? '@' + revision : ''}/-/blob/${encodedFilePath}`
+}
+
+export function getRevision(branches?: string[], version?: string): string {
+    let revision = ''
+    if (branches) {
+        const branch = branches[0]
+        if (branch !== '') {
+            revision = branch
+        }
+    } else if (version) {
+        revision = version
+    }
+
+    return revision
+}

--- a/vscode/webviews/components/codeSnippet/utils.ts
+++ b/vscode/webviews/components/codeSnippet/utils.ts
@@ -1,6 +1,7 @@
 import type * as React from 'react'
-import { ContentMatch } from './types';
+import type { ContentMatch } from './types'
 
+// biome-ignore lint/complexity/noBannedTypes:
 type Merge<P1 = {}, P2 = {}> = Omit<P1, keyof P2> & P2
 
 export type ForwardReferenceExoticComponent<E, OwnProps> = React.ForwardRefExoticComponent<
@@ -12,7 +13,7 @@ type PropsWithChildren<P> = P &
 
 export interface ForwardReferenceComponent<
     IntrinsicElementString,
-    OwnProps = {}
+    OwnProps = unknown,
     /**
      * Extends original type to ensure built in React types play nice
      * with polymorphic components still e.g. `React.ElementRef` etc.
@@ -26,18 +27,16 @@ export interface ForwardReferenceComponent<
      * We explicitly avoid `React.ElementType` and manually narrow the prop types
      * so that events are typed when using JSX.IntrinsicElements.
      */
-        <As = IntrinsicElementString>(
+    <As = IntrinsicElementString>(
         props: As extends ''
             ? { as: keyof JSX.IntrinsicElements }
             : As extends React.ComponentType<PropsWithChildren<infer P>>
-                ? Merge<P, OwnProps & { as: As }>
-                : As extends keyof JSX.IntrinsicElements
-                    ? Merge<JSX.IntrinsicElements[As], OwnProps & { as: As }>
-                    : never
+              ? Merge<P, OwnProps & { as: As }>
+              : As extends keyof JSX.IntrinsicElements
+                ? Merge<JSX.IntrinsicElements[As], OwnProps & { as: As }>
+                : never
     ): React.ReactElement | null
 }
-
-export type ObservableStatus = 'initial' | 'next' | 'completed' | 'error'
 
 /**
  * Converts the number of repo stars into a string, formatted nicely for large numbers
@@ -50,221 +49,6 @@ export const formatRepositoryStarCount = (repoStars?: number): string | undefine
         return repoStars.toString()
     }
     return undefined
-}
-
-/**
- * Highlights match ranges within visibleRows, with support for highlighting match ranges that span multiple lines.
- * @param visibleRows the visible rows of the HTML table containing the code excerpt
- * @param startRow the row within the table where highlighting should begin
- * @param endRow the row within the table where highlighting should end
- * @param startRowIndex the index of startRow within visibleRows
- * @param endRowIndex the index of endRow within visibleRows
- * @param startCharacter the 0-based character offset from the beginning of startRow's text content where highlighting should begin
- * @param endCharacter the 0-based character offset from the beginning of endRow's text content where highlighting should end
- */
-export function highlightNodeMultiline(
-    visibleRows: NodeListOf<HTMLElement>,
-    startRow: HTMLElement,
-    endRow: HTMLElement,
-    startRowIndex: number,
-    endRowIndex: number,
-    startCharacter: number,
-    endCharacter: number
-): void {
-    // Take the lastChild of the row to select the code portion of the table row (each table row consists of the line number and code).
-    const startRowCode = startRow.querySelector('td:last-of-type') as HTMLTableCellElement
-    const endRowCode = endRow.querySelector('td:last-of-type') as HTMLTableCellElement
-
-    // Highlight a single-line match
-    if (endRowIndex === startRowIndex) {
-        return highlightNode(startRowCode, startCharacter, endCharacter - startCharacter)
-    }
-
-    // Otherwise the match is a multiline match. Highlight from the start character through to the end character.
-    highlightNode(startRowCode, startCharacter, startRowCode.textContent!.length - startCharacter)
-    for (let currRowIndex = startRowIndex + 1; currRowIndex < endRowIndex; ++currRowIndex) {
-        if (visibleRows[currRowIndex]) {
-            const currRowCode = visibleRows[currRowIndex].lastChild as HTMLTableCellElement
-            highlightNode(currRowCode, 0, currRowCode.textContent!.length)
-        }
-    }
-    highlightNode(endRowCode, 0, endCharacter)
-}
-
-/**
- * Highlights a node using recursive node walking.
- * @param node the node to highlight
- * @param start the current character position (starts at 0).
- * @param length the number of characters to highlight.
- */
-export function highlightNode(node: HTMLElement, start: number, length: number): void {
-    if (start < 0 || length <= 0 || start >= node.textContent!.length) {
-        return
-    }
-
-    // return if length is invalid/longer than remaining characters between start and end
-    if (length > node.textContent!.length - start) {
-        return
-    }
-    // We want to treat text nodes as walkable so they can be highlighted. Wrap these in a span and
-    // replace them in the DOM.
-    if (node.nodeType === Node.TEXT_NODE && node.textContent !== null) {
-        const span = document.createElement('span')
-        span.innerHTML = node.textContent
-        node.parentNode!.replaceChild(span, node)
-        node = span
-    }
-    node.classList.add('annotated-selection-match')
-    highlightNodeHelper(node, 0, start, length)
-}
-
-interface HighlightResult {
-    highlightingCompleted: boolean
-    charsConsumed: number
-    charsHighlighted: number
-}
-
-/**
- * Highlights a node using recursive node walking.
- * @param currentNode the current node being walked.
- * @param currentOffset the current character position (starts at 0).
- * @param start the offset character where highlting starts.
- * @param length the number of characters to highlight.
- */
-function highlightNodeHelper(
-    currentNode: HTMLElement,
-    currentOffset: number,
-    start: number,
-    length: number
-): HighlightResult {
-    if (length === 0) {
-        return { highlightingCompleted: true, charsConsumed: 0, charsHighlighted: 0 }
-    }
-
-    const origOffset = currentOffset
-    const numberChildNodes = currentNode.childNodes.length
-
-    let charsHighlighted = 0
-
-    for (let index = 0; index < numberChildNodes; ++index) {
-        if (currentOffset >= start + length) {
-            return { highlightingCompleted: true, charsConsumed: 0, charsHighlighted: 0 }
-        }
-        const isLastNode = index === currentNode.childNodes.length - 1
-        const child = currentNode.childNodes[index]
-
-        switch (child.nodeType) {
-            case Node.TEXT_NODE: {
-                const nodeText = child.textContent!
-
-                // Unpack the string to be sliced into an array of code points before doing the slice.
-                // This allows match range highlighting to continue to work when Unicode characters (such as emojis)
-                // are present in a matched line.
-                const unicodeAwareSlice = (text: string, start: number, end: number): string =>
-                    text.slice(start, end)
-
-                // Split the text node into a range before the highlight, a range overlapping with
-                // the highlight, and a range after the highlight. These ranges can be zero-length
-                const preHighlightedRange = unicodeAwareSlice(nodeText, 0, Math.max(0, start - currentOffset))
-                const highlightedRange = unicodeAwareSlice(
-                    nodeText,
-                    Math.max(0, start - currentOffset),
-                    start - currentOffset + length
-                )
-                const postHighlightedRange = unicodeAwareSlice(
-                    nodeText,
-                    start - currentOffset + length,
-                    nodeText.length + 1
-                )
-
-                // Create new nodes for each of the ranges with length > 0
-                const newNodes: Node[] = []
-
-                if (preHighlightedRange) {
-                    newNodes.push(document.createTextNode(preHighlightedRange))
-                }
-
-                if (highlightedRange) {
-                    const highlight = document.createElement('span')
-                    /*
-                        a11y-ignore
-                        Rule: "color-contrast" (Elements must have sufficient color contrast)
-                        GitHub issue: https://github.com/sourcegraph/sourcegraph/issues/33343
-                    */
-                    highlight.className = 'match-highlight a11y-ignore'
-                    highlight.append(document.createTextNode(highlightedRange))
-                    newNodes.push(highlight)
-                }
-
-                if (postHighlightedRange) {
-                    newNodes.push(document.createTextNode(postHighlightedRange))
-                }
-
-                let newNode: Node
-                if (newNodes.length === 0) {
-                    newNode = document.createTextNode('')
-                } else if (newNodes.length === 1) {
-                    // If we only have one new node, no need to wrap it in a containing span
-                    newNode = newNodes[0]
-                } else {
-                    // If there are more than one new nodes, wrap them in a span
-                    const containerNode = document.createElement('span')
-                    containerNode.append(...newNodes)
-                    /*
-                        a11y-ignore
-                        Rule: "color-contrast" (Elements must have sufficient color contrast)
-                        GitHub issue: https://github.com/sourcegraph/sourcegraph/issues/33343
-                    */
-                    containerNode.className = 'a11y-ignore'
-                    newNode = containerNode
-                }
-
-                // Remove the original child and replace it with the new node
-                child.remove()
-                if (currentNode.childNodes.length === 0 || isLastNode) {
-                    if (currentNode.classList.contains('match-highlight')) {
-                        // Nothing to do; it's already highlighted.
-                        currentNode.append(child)
-                    } else {
-                        currentNode.append(newNode)
-                    }
-                } else {
-                    currentNode.insertBefore(newNode, currentNode.childNodes[index] || currentNode.firstChild)
-                }
-
-                // Count highlighted characters in terms of code points, not bytes
-                currentOffset += nodeText.length
-                charsHighlighted += highlightedRange.length
-                if (highlightedRange.length > 0 && postHighlightedRange.length > 0) {
-                    return {
-                        highlightingCompleted: true,
-                        charsConsumed: nodeText.length,
-                        charsHighlighted: highlightedRange.length,
-                    }
-                }
-
-                break
-            }
-
-            case Node.ELEMENT_NODE: {
-                const elementNode = child as HTMLElement
-                const result = highlightNodeHelper(
-                    elementNode,
-                    currentOffset,
-                    start + charsHighlighted,
-                    length - charsHighlighted
-                )
-                if (result.highlightingCompleted) {
-                    return result
-                }
-                currentOffset += result.charsConsumed
-                charsHighlighted += result.charsHighlighted
-                break
-            }
-        }
-    }
-
-    return { highlightingCompleted: false, charsConsumed: currentOffset - origOffset, charsHighlighted }
 }
 
 export function getFileMatchUrl(fileMatch: ContentMatch): string {
@@ -285,4 +69,9 @@ export function getRevision(branches?: string[], version?: string): string {
     }
 
     return revision
+}
+
+export function pluralize(string: string, count: number | bigint, plural = string + 's'): string {
+    // @ts-ignore
+    return count === 1 || count === 1n ? string : plural
 }

--- a/vscode/webviews/postcss.config.js
+++ b/vscode/webviews/postcss.config.js
@@ -1,4 +1,5 @@
 module.exports = {
+    syntax: 'postcss-scss',
     plugins: {
         'postcss-nested': {},
         tailwindcss: __dirname + '/tailwind.config.mjs',

--- a/vscode/webviews/utils/highlight.css
+++ b/vscode/webviews/utils/highlight.css
@@ -283,6 +283,10 @@
 	color: var(--hl-green-2);
 }
 
+.hl-typed-Keyword {
+    color: #569cd6;
+}
+
 .hl-typed-Comment {
 	color: var(--hl-dark-green);
 }


### PR DESCRIPTION
Part of [AI-205](https://linear.app/sourcegraph/issue/AI-205/show-code-snippets-for-context-files)

This PR 
- Adds a search file content code snippets block; it later will be used for search results within chat in one-box mode.
- Adds preview button to context item link which renders highlighted code snippet block (originally this PR was only about code snippet for one box, but I've found having code snippet preview for link very useful, links are usually very long and you don't remember which file it was, helped me to avoid opening a lot of tabs by checking just preview blocks)

<img width="1136" alt="Screenshot 2024-09-11 at 00 45 07" src="https://github.com/user-attachments/assets/6c21c8b1-183b-43e0-8c71-d6ee21beec1c">

## Todo
- [x] Add an unhighlighted text block 
- [x] Add highlights support 
- [x] Add demo 
- [x] Align colors for different vscode themes 

## Test plan
- CI is green
- Check storybook demo 
- Run VSCode (or Cody Web) check that you can see preview code blocks next to file context files 

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
