### PR TITLE
Chat: update chat history export button

### DIFF
--- a/vscode/webviews/CodyPanel.tsx
+++ b/vscode/webviews/CodyPanel.tsx
@@ -56,9 +56,11 @@ export const CodyPanel: FunctionComponent<
         const json = JSON.stringify(userHistory, null, 2)
         const blob = new Blob([json], { type: 'application/json' })
         const url = URL.createObjectURL(blob)
-        const a = document.createElement('a')
+        const timestamp = new Date().toISOString().replace(/[:.]/g, '-').slice(0, -5) // Format: YYYY-MM-DDTHH-mm
+        const a = document.createElement('a') // a temporary anchor element
         a.href = url
-        a.download = 'cody-chat-history.json'
+        a.download = `cody-chat-history-${timestamp}.json`
+        a.target = '_blank'
         a.click()
     }, [userHistory])
 

--- a/vscode/webviews/index.html
+++ b/vscode/webviews/index.html
@@ -9,7 +9,7 @@
         <!-- This content security policy also implicitly disables inline scripts and styles. -->
         <meta
             http-equiv="Content-Security-Policy"
-            content="default-src 'none'; img-src 'self' https: data:; script-src 'self'; style-src 'self'; font-src data: 'self';"
+            content="default-src 'none'; img-src 'self' https: data:; script-src 'self'; style-src 'self'; font-src data: 'self'; connect-src 'self'; object-src 'self'; frame-src 'self'; media-src blob:;"
         />
         <!-- DO NOT REMOVE: THIS FILE IS THE ENTRY FILE FOR CODY WEBVIEW -->
         <!-- END CSP -->


### PR DESCRIPTION
This fixes an issue where clicking on the "Export" chat history button in Eclipse would open the chat history as json in the current webview, instead of showing up as a download dialogue.

- Open the blob link in a new window instead of current window
- Add timestamp to the downloaded file name to make it unique
- Update Content Security Policy to allow more connections for the webview

## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

Run this branch in Eclipse to confirm the Chat History export button works. Here is a demo when running this branch from the latest eclipse main branch:

https://github.com/user-attachments/assets/4ef85c4d-0cb5-4130-9d57-c4e5c78183db

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
