### PR TITLE
Chat: add support to send terminal text to Cody chat

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -537,7 +537,7 @@
         "group": "Chat",
         "title": "Add Selection to Cody Chat",
         "icon": "$(mention)",
-        "enablement": "cody.activated && editorHasSelection"
+        "enablement": "cody.activated"
       },
       {
         "command": "cody.mention.file",
@@ -957,6 +957,11 @@
           "command": "cody.command.explain-output",
           "group": "0_cody",
           "when": "cody.activated"
+        },
+        {
+          "command": "cody.mention.selection",
+          "group": "0_cody",
+          "when": "cody.activated && terminalTabsSingularSelection"
         }
       ],
       "scm/title": [

--- a/vscode/src/chat/chat-view/ChatController.ts
+++ b/vscode/src/chat/chat-view/ChatController.ts
@@ -990,6 +990,13 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
         }
     }
 
+    public async handleTextToUserInput(text: string): Promise<void> {
+        void this.postMessage({
+            type: 'clientAction',
+            appendTextToLastPromptEditor: text,
+        })
+    }
+
     public async handleSmartApplyResult(result: SmartApplyResult): Promise<void> {
         void this.postMessage({
             type: 'clientAction',


### PR DESCRIPTION
CLOSE https://linear.app/sourcegraph/issue/CODY-3703/add-terminal-output-as-chat-context

The `cody.mention.selection` command now handles `selection` argument that enables users to send selected text from terminal to Cody chat.

- Update  `cody.mention.selection` command to send terminal text to Cody chat
- Update mention selection command to handle text selection
- Update package.json to enable terminal text mention command

Note: Keybinding doesn't seem to work when terminal is focused?

## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

Select some text in your terminal and right click > `Add Selection to Cody Chat`:

https://github.com/user-attachments/assets/89c7f12a-398a-46df-8daa-32d4184a3c39

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->

Chat: add support to send selected text from terminal to Cody chat