### PR TITLE
Edit: display authentication and network errors with code lenses

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -397,13 +397,6 @@
         "enablement": "cody.activated"
       },
       {
-        "command": "cody.show-rate-limit-modal",
-        "category": "Cody",
-        "title": "Show Rate Limit Modal",
-        "group": "Cody",
-        "enablement": "cody.activated"
-      },
-      {
         "command": "cody.menu.commands",
         "category": "Cody Menu",
         "title": "Cody Commands",
@@ -795,10 +788,6 @@
         },
         {
           "command": "cody.show-page",
-          "when": "false"
-        },
-        {
-          "command": "cody.show-rate-limit-modal",
           "when": "false"
         },
         {

--- a/vscode/src/non-stop/codelenses/items.ts
+++ b/vscode/src/non-stop/codelenses/items.ts
@@ -106,8 +106,6 @@ export function getLensesForTask(task: FixupTask): vscode.CodeLens[] {
 // List of lenses
 function getErrorLens(codeLensRange: vscode.Range, task: FixupTask): vscode.CodeLens {
     const lens = new vscode.CodeLens(codeLensRange)
-    console.log(task.error, 'task.error')
-    console.log(task.error, task.error?.message, 'task.error')
     if (task.error?.message.includes('network error')) {
         lens.command = {
             title: '$(warning) Network Disconnected',

--- a/vscode/src/non-stop/codelenses/items.ts
+++ b/vscode/src/non-stop/codelenses/items.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode'
 
-import { isRateLimitError } from '@sourcegraph/cody-shared'
+import { isAuthError, isRateLimitError } from '@sourcegraph/cody-shared'
 
 import { isRunningInsideAgent } from '../../jsonrpc/isRunningInsideAgent'
 import type { FixupTask } from '../FixupTask'
@@ -106,6 +106,13 @@ export function getLensesForTask(task: FixupTask): vscode.CodeLens[] {
 // List of lenses
 function getErrorLens(codeLensRange: vscode.Range, task: FixupTask): vscode.CodeLens {
     const lens = new vscode.CodeLens(codeLensRange)
+    if (isAuthError(task.error)) {
+        lens.command = {
+            title: '$(warning) Authentication Failed',
+            command: 'cody.chat.signIn',
+        }
+        return lens
+    }
     if (isRateLimitError(task.error)) {
         if (task.error.upgradeIsAvailable) {
             lens.command = {

--- a/vscode/src/non-stop/codelenses/items.ts
+++ b/vscode/src/non-stop/codelenses/items.ts
@@ -106,14 +106,19 @@ export function getLensesForTask(task: FixupTask): vscode.CodeLens[] {
 // List of lenses
 function getErrorLens(codeLensRange: vscode.Range, task: FixupTask): vscode.CodeLens {
     const lens = new vscode.CodeLens(codeLensRange)
-    if (isAuthError(task.error)) {
+    console.log(task.error, 'task.error')
+    console.log(task.error, task.error?.message, 'task.error')
+    if (task.error?.message.includes('network error')) {
+        lens.command = {
+            title: '$(warning) Network Disconnected',
+            command: 'cody.chat.signIn',
+        }
+    } else if (isAuthError(task.error)) {
         lens.command = {
             title: '$(warning) Authentication Failed',
             command: 'cody.chat.signIn',
         }
-        return lens
-    }
-    if (isRateLimitError(task.error)) {
+    } else if (isRateLimitError(task.error)) {
         if (task.error.upgradeIsAvailable) {
             lens.command = {
                 title: '⚡️ Upgrade to Cody Pro',


### PR DESCRIPTION
Close https://linear.app/sourcegraph/issue/CODY-251/bug-no-visual-indication-in-editor-when-a-users-access-token-is-no

The original issue in the linked issue has been issue, but Dom mentioned the code lenses right now are just displaying "Applying Edit Fails" on authentication error. This PR adds an if statement to display "Authentication Failed" when an authentication error occurs or "Network Disconnected" when a network error occurs during Edits.

This change adds handling for authentication errors in the codelenses, displaying a "Authentication Failed" message and providing a command to sign in.

Additionally, the "Show Rate Limit Modal" command has been removed from the package.json as this is a utils command that should not be registered for users to use.

## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

I'm not sure how to replicate an auth error, but to test the Network error, you can start Cody from this branch in the debugger, and then turn off your Wi-Fi connection before running the Document Command:

![image](https://github.com/user-attachments/assets/b5b86f84-b866-4c2c-a589-40ff18e091e8)

### Before

You will see a codelens with "Applying Edit Failed" without any details into the error:

![image](https://github.com/user-attachments/assets/09453885-ba3e-4bd0-81d5-54fb476e00be)


## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->

Edit: display authentication and network errors with code lenses