### PR TITLE
make authProvider a simple singleton, expose currentAuthStatus() sync

### DIFF
--- a/lib/shared/src/auth/types.ts
+++ b/lib/shared/src/auth/types.ts
@@ -1,6 +1,5 @@
 import { isDotCom } from '../sourcegraph-api/environments'
 import type { CodyLLMSiteConfiguration } from '../sourcegraph-api/graphql/client'
-import type { ReadonlyDeep } from '../utils'
 
 /**
  * The authentication status, which includes representing the state when authentication failed or
@@ -54,10 +53,6 @@ export interface UnauthenticatedAuthStatus {
     authenticated: false
     showNetworkError?: boolean
     showInvalidAccessTokenError?: boolean
-}
-
-export interface AuthStatusProvider {
-    status: ReadonlyDeep<AuthStatus>
 }
 
 export const AUTH_STATUS_FIXTURE_AUTHED: AuthenticatedAuthStatus = {

--- a/vscode/src/auth/account-menu.ts
+++ b/vscode/src/auth/account-menu.ts
@@ -5,7 +5,7 @@ import { authProvider } from '../services/AuthProvider'
 import { showSignInMenu, showSignOutMenu } from './auth'
 
 export async function showAccountMenu(): Promise<void> {
-    const authStatus = authProvider.instance!.statusAuthed
+    const authStatus = authProvider.statusAuthed
     const selected = await openAccountMenuFirstStep(authStatus)
     if (selected === undefined) {
         return

--- a/vscode/src/auth/account-menu.ts
+++ b/vscode/src/auth/account-menu.ts
@@ -1,11 +1,14 @@
-import { type AuthenticatedAuthStatus, isDotCom } from '@sourcegraph/cody-shared'
+import {
+    type AuthenticatedAuthStatus,
+    currentAuthStatusAuthed,
+    isDotCom,
+} from '@sourcegraph/cody-shared'
 import * as vscode from 'vscode'
 import { ACCOUNT_USAGE_URL } from '../chat/protocol'
-import { authProvider } from '../services/AuthProvider'
 import { showSignInMenu, showSignOutMenu } from './auth'
 
 export async function showAccountMenu(): Promise<void> {
-    const authStatus = authProvider.statusAuthed
+    const authStatus = currentAuthStatusAuthed()
     const selected = await openAccountMenuFirstStep(authStatus)
     if (selected === undefined) {
         return

--- a/vscode/src/auth/auth.ts
+++ b/vscode/src/auth/auth.ts
@@ -4,6 +4,7 @@ import {
     type AuthStatus,
     CodyIDE,
     DOTCOM_URL,
+    currentAuthStatus,
     getCodyAuthReferralCode,
     isDotCom,
     telemetryRecorder,
@@ -23,7 +24,7 @@ export async function showSignInMenu(
     uri?: string,
     agentIDE: CodyIDE = CodyIDE.VSCode
 ): Promise<void> {
-    const authStatus = authProvider.status
+    const authStatus = currentAuthStatus()
     const mode = authStatus.authenticated ? 'switch' : 'signin'
     logDebug('AuthProvider:signinMenu', mode)
     telemetryRecorder.recordEvent('cody.auth.login', 'clicked')
@@ -291,7 +292,7 @@ export async function tokenCallbackHandler(
 
     const params = new URLSearchParams(uri.query)
     const token = params.get('code') || params.get('token')
-    const endpoint = authProvider.status.endpoint
+    const endpoint = currentAuthStatus().endpoint
     if (!token || !endpoint) {
         return
     }
@@ -344,7 +345,7 @@ export async function showSignOutMenu(): Promise<void> {
             category: 'billable',
         },
     })
-    const { endpoint } = authProvider.status
+    const { endpoint } = currentAuthStatus()
 
     if (endpoint) {
         await signOut(endpoint)

--- a/vscode/src/chat/chat-view/ChatsController.ts
+++ b/vscode/src/chat/chat-view/ChatsController.ts
@@ -350,7 +350,7 @@ export class ChatsController implements vscode.Disposable {
                 category: 'billable',
             },
         })
-        const authStatus = authProvider.instance!.status
+        const authStatus = authProvider.status
         if (authStatus.authenticated) {
             try {
                 const historyJson = chatHistory.getLocalHistory(authStatus)
@@ -380,7 +380,7 @@ export class ChatsController implements vscode.Disposable {
         // The chat ID for client to pass in to clear all chats without showing window pop-up for confirmation.
         const ClearWithoutConfirmID = 'clear-all-no-confirm'
         const isClearAll = !chatID || chatID === ClearWithoutConfirmID
-        const authStatus = authProvider.instance!.statusAuthed
+        const authStatus = authProvider.statusAuthed
 
         if (isClearAll) {
             if (chatID !== ClearWithoutConfirmID) {

--- a/vscode/src/chat/chat-view/ChatsController.ts
+++ b/vscode/src/chat/chat-view/ChatsController.ts
@@ -9,6 +9,8 @@ import {
     DEFAULT_EVENT_SOURCE,
     type Guardrails,
     authStatus,
+    currentAuthStatus,
+    currentAuthStatusAuthed,
     editorStateFromPromptString,
     subscriptionDisposable,
     telemetryRecorder,
@@ -23,7 +25,6 @@ import type { startTokenReceiver } from '../../auth/token-receiver'
 import type { ExecuteChatArguments } from '../../commands/execute/ask'
 import { getConfiguration } from '../../configuration'
 import type { ExtensionClient } from '../../extension-client'
-import { authProvider } from '../../services/AuthProvider'
 import { type ChatLocation, localStorage } from '../../services/LocalStorageProvider'
 import {
     handleCodeFromInsertAtCursor,
@@ -350,7 +351,7 @@ export class ChatsController implements vscode.Disposable {
                 category: 'billable',
             },
         })
-        const authStatus = authProvider.status
+        const authStatus = currentAuthStatus()
         if (authStatus.authenticated) {
             try {
                 const historyJson = chatHistory.getLocalHistory(authStatus)
@@ -380,7 +381,7 @@ export class ChatsController implements vscode.Disposable {
         // The chat ID for client to pass in to clear all chats without showing window pop-up for confirmation.
         const ClearWithoutConfirmID = 'clear-all-no-confirm'
         const isClearAll = !chatID || chatID === ClearWithoutConfirmID
-        const authStatus = authProvider.statusAuthed
+        const authStatus = currentAuthStatusAuthed()
 
         if (isClearAll) {
             if (chatID !== ClearWithoutConfirmID) {

--- a/vscode/src/commands/GhostHintDecorator.ts
+++ b/vscode/src/commands/GhostHintDecorator.ts
@@ -2,6 +2,7 @@ import {
     type AuthStatus,
     authStatus,
     contextFiltersProvider,
+    currentAuthStatus,
     getEditorInsertSpaces,
     getEditorTabSize,
     isMacOS,
@@ -11,7 +12,6 @@ import { telemetryRecorder } from '@sourcegraph/cody-shared'
 import { type DebouncedFunc, throttle } from 'lodash'
 import * as vscode from 'vscode'
 import type { SyntaxNode } from 'web-tree-sitter'
-import { authProvider } from '../services/AuthProvider'
 import { execQueryWrapper } from '../tree-sitter/query-sdk'
 
 const EDIT_SHORTCUT_LABEL = isMacOS() ? 'Opt+K' : 'Alt+K'
@@ -199,7 +199,7 @@ export class GhostHintDecorator implements vscode.Disposable {
         )
 
         // Set initial state, based on the configuration and authentication status
-        const initialAuth = authProvider.status
+        const initialAuth = currentAuthStatus()
         this.updateEnablement(initialAuth)
 
         // Listen to authentication changes
@@ -211,7 +211,7 @@ export class GhostHintDecorator implements vscode.Disposable {
         this.permanentDisposables.push(
             vscode.workspace.onDidChangeConfiguration(e => {
                 if (e.affectsConfiguration('cody')) {
-                    this.updateEnablement(authProvider.status)
+                    this.updateEnablement(currentAuthStatus())
                 }
             }),
             vscode.workspace.onDidChangeTextDocument(event => {

--- a/vscode/src/commands/GhostHintDecorator.ts
+++ b/vscode/src/commands/GhostHintDecorator.ts
@@ -199,7 +199,7 @@ export class GhostHintDecorator implements vscode.Disposable {
         )
 
         // Set initial state, based on the configuration and authentication status
-        const initialAuth = authProvider.instance!.status
+        const initialAuth = authProvider.status
         this.updateEnablement(initialAuth)
 
         // Listen to authentication changes
@@ -211,7 +211,7 @@ export class GhostHintDecorator implements vscode.Disposable {
         this.permanentDisposables.push(
             vscode.workspace.onDidChangeConfiguration(e => {
                 if (e.affectsConfiguration('cody')) {
-                    this.updateEnablement(authProvider.instance!.status)
+                    this.updateEnablement(authProvider.status)
                 }
             }),
             vscode.workspace.onDidChangeTextDocument(event => {

--- a/vscode/src/completions/create-inline-completion-item-provider.ts
+++ b/vscode/src/completions/create-inline-completion-item-provider.ts
@@ -47,7 +47,7 @@ export function createInlineCompletionItemProvider({
     statusBar,
     createBfgRetriever,
 }: InlineCompletionItemProviderArgs): Observable<void> {
-    const authStatus = authProvider.instance!.status
+    const authStatus = authProvider.status
     if (!authStatus.authenticated) {
         logDebug('CodyCompletionProvider:notSignedIn', 'You are not signed in.')
 
@@ -74,7 +74,7 @@ export function createInlineCompletionItemProvider({
             createProvider(config, authStatus).pipe(
                 createDisposables(provider => {
                     if (provider) {
-                        const authStatus = authProvider.instance!.statusAuthed
+                        const authStatus = authProvider.statusAuthed
                         const triggerDelay =
                             vscode.workspace
                                 .getConfiguration()

--- a/vscode/src/completions/create-inline-completion-item-provider.ts
+++ b/vscode/src/completions/create-inline-completion-item-provider.ts
@@ -2,6 +2,8 @@ import {
     type ClientConfigurationWithAccessToken,
     NEVER,
     createDisposables,
+    currentAuthStatus,
+    currentAuthStatusAuthed,
     isDotCom,
     mergeMap,
     promiseFactoryToObservable,
@@ -10,7 +12,6 @@ import {
 import * as vscode from 'vscode'
 
 import { logDebug } from '../log'
-import { authProvider } from '../services/AuthProvider'
 import type { CodyStatusBar } from '../services/StatusBar'
 
 import { type Observable, map } from 'observable-fns'
@@ -47,7 +48,7 @@ export function createInlineCompletionItemProvider({
     statusBar,
     createBfgRetriever,
 }: InlineCompletionItemProviderArgs): Observable<void> {
-    const authStatus = authProvider.status
+    const authStatus = currentAuthStatus()
     if (!authStatus.authenticated) {
         logDebug('CodyCompletionProvider:notSignedIn', 'You are not signed in.')
 
@@ -74,7 +75,7 @@ export function createInlineCompletionItemProvider({
             createProvider(config, authStatus).pipe(
                 createDisposables(provider => {
                     if (provider) {
-                        const authStatus = authProvider.statusAuthed
+                        const authStatus = currentAuthStatusAuthed()
                         const triggerDelay =
                             vscode.workspace
                                 .getConfiguration()

--- a/vscode/src/completions/create-multi-model-inline-completion-provider.ts
+++ b/vscode/src/completions/create-multi-model-inline-completion-provider.ts
@@ -1,8 +1,7 @@
-import { type MultimodelSingleModelConfig, isDotCom } from '@sourcegraph/cody-shared'
+import { type MultimodelSingleModelConfig, currentAuthStatus, isDotCom } from '@sourcegraph/cody-shared'
 import { cloneDeep } from 'lodash'
 import * as vscode from 'vscode'
 import { logDebug } from '../log'
-import { authProvider } from '../services/AuthProvider'
 import { completionProviderConfig } from './completion-provider-config'
 import type { InlineCompletionItemProviderArgs } from './create-inline-completion-item-provider'
 import { InlineCompletionItemProvider } from './inline-completion-item-provider'
@@ -78,7 +77,7 @@ export async function createInlineCompletionItemFromMultipleProviders({
     // Creates multiple providers to get completions from.
     // The primary purpose of this method is to get the completions generated from multiple providers,
     // which helps judge the quality of code completions
-    const authStatus = authProvider.status
+    const authStatus = currentAuthStatus()
     if (
         !authStatus.authenticated ||
         config.autocompleteExperimentalMultiModelCompletions === undefined

--- a/vscode/src/completions/create-multi-model-inline-completion-provider.ts
+++ b/vscode/src/completions/create-multi-model-inline-completion-provider.ts
@@ -78,7 +78,7 @@ export async function createInlineCompletionItemFromMultipleProviders({
     // Creates multiple providers to get completions from.
     // The primary purpose of this method is to get the completions generated from multiple providers,
     // which helps judge the quality of code completions
-    const authStatus = authProvider.instance!.status
+    const authStatus = authProvider.status
     if (
         !authStatus.authenticated ||
         config.autocompleteExperimentalMultiModelCompletions === undefined

--- a/vscode/src/completions/logger.ts
+++ b/vscode/src/completions/logger.ts
@@ -849,7 +849,7 @@ export function prepareSuggestionEvent({
                 completionIdsMarkedAsSuggested.set(completionId, true)
                 event.suggestionAnalyticsLoggedAt = performance.now()
 
-                const authStatus = authProvider.instance?.statusAuthed
+                const authStatus = authProvider.statusAuthed
                 // 🚨 SECURITY: Track the diff in the document after suggestion is shown for DotCom users and public repos.
                 if (
                     event.params.id &&

--- a/vscode/src/completions/logger.ts
+++ b/vscode/src/completions/logger.ts
@@ -6,11 +6,11 @@ import {
     type AutocompleteContextSnippet,
     type BillingCategory,
     type BillingProduct,
+    currentAuthStatusAuthed,
     isDotCom,
     isNetworkError,
     telemetryRecorder,
 } from '@sourcegraph/cody-shared'
-import { authProvider } from '../services/AuthProvider'
 
 import type { KnownString, TelemetryEventParameters } from '@sourcegraph/telemetry'
 
@@ -849,7 +849,7 @@ export function prepareSuggestionEvent({
                 completionIdsMarkedAsSuggested.set(completionId, true)
                 event.suggestionAnalyticsLoggedAt = performance.now()
 
-                const authStatus = authProvider.statusAuthed
+                const authStatus = currentAuthStatusAuthed()
                 // 🚨 SECURITY: Track the diff in the document after suggestion is shown for DotCom users and public repos.
                 if (
                     event.params.id &&

--- a/vscode/src/edit/input/get-input.ts
+++ b/vscode/src/edit/input/get-input.ts
@@ -95,7 +95,7 @@ export const getInput = async (
               ? EXPANDED_RANGE_ITEM
               : SELECTION_RANGE_ITEM
 
-    const authStatus = authProvider.instance!.statusAuthed
+    const authStatus = authProvider.statusAuthed
     const isCodyPro = !authStatus.userCanUpgrade
     const modelOptions = modelsService.instance!.getModels(ModelUsage.Edit)
     const modelItems = getModelOptionItems(modelOptions, isCodyPro)

--- a/vscode/src/edit/input/get-input.ts
+++ b/vscode/src/edit/input/get-input.ts
@@ -8,6 +8,7 @@ import {
     ModelUsage,
     PromptString,
     SYMBOL_CONTEXT_MENTION_PROVIDER,
+    currentAuthStatusAuthed,
     displayLineRange,
     modelsService,
     parseMentionQuery,
@@ -21,7 +22,6 @@ import { ACCOUNT_UPGRADE_URL } from '../../chat/protocol'
 import { executeDocCommand, executeTestEditCommand } from '../../commands/execute'
 import { getEditor } from '../../editor/active-editor'
 import { type TextChange, updateRangeMultipleChanges } from '../../non-stop/tracked-range'
-import { authProvider } from '../../services/AuthProvider'
 import type { EditIntent, EditMode } from '../types'
 import { isGenerateIntent } from '../utils/edit-intent'
 import { CURSOR_RANGE_ITEM, EXPANDED_RANGE_ITEM, SELECTION_RANGE_ITEM } from './get-items/constants'
@@ -95,7 +95,7 @@ export const getInput = async (
               ? EXPANDED_RANGE_ITEM
               : SELECTION_RANGE_ITEM
 
-    const authStatus = authProvider.statusAuthed
+    const authStatus = currentAuthStatusAuthed()
     const isCodyPro = !authStatus.userCanUpgrade
     const modelOptions = modelsService.instance!.getModels(ModelUsage.Edit)
     const modelItems = getModelOptionItems(modelOptions, isCodyPro)

--- a/vscode/src/edit/manager.ts
+++ b/vscode/src/edit/manager.ts
@@ -4,6 +4,7 @@ import {
     type ChatClient,
     ClientConfigSingleton,
     PromptString,
+    currentAuthStatusAuthed,
     modelsService,
     ps,
     telemetryRecorder,
@@ -19,7 +20,6 @@ import { DEFAULT_EVENT_SOURCE } from '@sourcegraph/cody-shared'
 import { isUriIgnoredByContextFilterWithNotification } from '../cody-ignore/context-filter'
 import type { ExtensionClient } from '../extension-client'
 import { ACTIVE_TASK_STATES } from '../non-stop/codelenses/constants'
-import { authProvider } from '../services/AuthProvider'
 import { splitSafeMetadata } from '../services/telemetry-v2'
 import type { ExecuteEditArguments } from './execute'
 import { SMART_APPLY_FILE_DECORATION, getSmartApplySelection } from './prompt/smart-apply'
@@ -308,7 +308,7 @@ export class EditManager implements vscode.Disposable {
         // queries to ask the LLM to generate a selection, and then ultimately apply the edit.
         const replacementCode = PromptString.unsafe_fromLLMResponse(configuration.replacement)
 
-        const authStatus = authProvider.statusAuthed
+        const authStatus = currentAuthStatusAuthed()
         const selection = await getSmartApplySelection(
             configuration.id,
             configuration.instruction,

--- a/vscode/src/edit/manager.ts
+++ b/vscode/src/edit/manager.ts
@@ -308,7 +308,7 @@ export class EditManager implements vscode.Disposable {
         // queries to ask the LLM to generate a selection, and then ultimately apply the edit.
         const replacementCode = PromptString.unsafe_fromLLMResponse(configuration.replacement)
 
-        const authStatus = authProvider.instance!.statusAuthed
+        const authStatus = authProvider.statusAuthed
         const selection = await getSmartApplySelection(
             configuration.id,
             configuration.instruction,

--- a/vscode/src/edit/provider.ts
+++ b/vscode/src/edit/provider.ts
@@ -54,7 +54,7 @@ export class EditProvider {
             this.config.controller.startTask(this.config.task)
             const model = this.config.task.model
             const contextWindow = modelsService.instance!.getContextWindowByID(model)
-            const authStatus = authProvider.instance!.statusAuthed
+            const authStatus = authProvider.statusAuthed
             const {
                 messages,
                 stopSequences,
@@ -217,7 +217,7 @@ export class EditProvider {
                 ...countCode(response),
             }
             const { metadata, privateMetadata } = splitSafeMetadata(legacyMetadata)
-            const endpoint = authProvider.instance!.status.endpoint
+            const endpoint = authProvider.status.endpoint
             telemetryRecorder.recordEvent('cody.fixup.response', 'hasCode', {
                 metadata,
                 privateMetadata: {

--- a/vscode/src/edit/provider.ts
+++ b/vscode/src/edit/provider.ts
@@ -3,6 +3,8 @@ import { Utils } from 'vscode-uri'
 import {
     BotResponseMultiplexer,
     Typewriter,
+    currentAuthStatus,
+    currentAuthStatusAuthed,
     isAbortError,
     isDotCom,
     isNetworkLikeError,
@@ -16,7 +18,6 @@ import {
 import { logError } from '../log'
 import type { FixupController } from '../non-stop/FixupController'
 import type { FixupTask } from '../non-stop/FixupTask'
-import { authProvider } from '../services/AuthProvider'
 
 import {
     DEFAULT_EVENT_SOURCE,
@@ -54,7 +55,7 @@ export class EditProvider {
             this.config.controller.startTask(this.config.task)
             const model = this.config.task.model
             const contextWindow = modelsService.instance!.getContextWindowByID(model)
-            const authStatus = authProvider.statusAuthed
+            const authStatus = currentAuthStatusAuthed()
             const {
                 messages,
                 stopSequences,
@@ -217,7 +218,7 @@ export class EditProvider {
                 ...countCode(response),
             }
             const { metadata, privateMetadata } = splitSafeMetadata(legacyMetadata)
-            const endpoint = authProvider.status.endpoint
+            const endpoint = currentAuthStatus().endpoint
             telemetryRecorder.recordEvent('cody.fixup.response', 'hasCode', {
                 metadata,
                 privateMetadata: {

--- a/vscode/src/extension.node.ts
+++ b/vscode/src/extension.node.ts
@@ -79,7 +79,7 @@ export function activate(
 // The vscode API is not available in the post-uninstall script.
 export async function deactivate(): Promise<void> {
     const config = localStorage.getConfig() ?? (await getFullConfig())
-    const authStatus = authProvider.instance?.status
+    const authStatus = authProvider.status
     const anonymousUserID = localStorage.anonymousUserID()
     serializeConfigSnapshot({
         config,

--- a/vscode/src/extension.node.ts
+++ b/vscode/src/extension.node.ts
@@ -1,6 +1,7 @@
 // Sentry should be imported first
 import { NodeSentryService } from './services/sentry/sentry.node'
 
+import { currentAuthStatus } from '@sourcegraph/cody-shared'
 import * as vscode from 'vscode'
 import { startTokenReceiver } from './auth/token-receiver'
 import { CommandsProvider } from './commands/services/provider'
@@ -18,7 +19,6 @@ import {
     createLocalEmbeddingsController,
 } from './local-context/local-embeddings'
 import { SymfRunner } from './local-context/symf'
-import { authProvider } from './services/AuthProvider'
 import { localStorage } from './services/LocalStorageProvider'
 import { OpenTelemetryService } from './services/open-telemetry/OpenTelemetryService.node'
 import { getExtensionDetails } from './services/telemetry-v2'
@@ -79,7 +79,7 @@ export function activate(
 // The vscode API is not available in the post-uninstall script.
 export async function deactivate(): Promise<void> {
     const config = localStorage.getConfig() ?? (await getFullConfig())
-    const authStatus = authProvider.status
+    const authStatus = currentAuthStatus()
     const anonymousUserID = localStorage.anonymousUserID()
     serializeConfigSnapshot({
         config,

--- a/vscode/src/external-services.ts
+++ b/vscode/src/external-services.ts
@@ -73,11 +73,11 @@ export async function configureExternalServices(
 
     // Disable local embeddings for enterprise users.
     const localEmbeddings =
-        authProvider.instance!.status.authenticated && isDotCom(authProvider.instance!.status)
+        authProvider.status.authenticated && isDotCom(authProvider.status)
             ? await platform.createLocalEmbeddingsController?.(initialConfig)
             : undefined
 
-    const chatClient = new ChatClient(completionsClient, () => authProvider.instance!.statusAuthed)
+    const chatClient = new ChatClient(completionsClient, () => authProvider.statusAuthed)
 
     const guardrails = new SourcegraphGuardrailsClient(graphqlClient, initialConfig)
 

--- a/vscode/src/external-services.ts
+++ b/vscode/src/external-services.ts
@@ -7,6 +7,8 @@ import {
     type GuardrailsClientConfig,
     type SourcegraphCompletionsClient,
     SourcegraphGuardrailsClient,
+    currentAuthStatus,
+    currentAuthStatusAuthed,
     firstValueFrom,
     graphqlClient,
     isDotCom,
@@ -19,7 +21,6 @@ import type { PlatformContext } from './extension.common'
 import type { LocalEmbeddingsConfig, LocalEmbeddingsController } from './local-context/local-embeddings'
 import type { SymfRunner } from './local-context/symf'
 import { logDebug, logger } from './log'
-import { authProvider } from './services/AuthProvider'
 
 interface ExternalServices {
     chatClient: ChatClient
@@ -73,11 +74,11 @@ export async function configureExternalServices(
 
     // Disable local embeddings for enterprise users.
     const localEmbeddings =
-        authProvider.status.authenticated && isDotCom(authProvider.status)
+        currentAuthStatus().authenticated && isDotCom(currentAuthStatus())
             ? await platform.createLocalEmbeddingsController?.(initialConfig)
             : undefined
 
-    const chatClient = new ChatClient(completionsClient, () => authProvider.statusAuthed)
+    const chatClient = new ChatClient(completionsClient, () => currentAuthStatusAuthed())
 
     const guardrails = new SourcegraphGuardrailsClient(graphqlClient, initialConfig)
 

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -11,6 +11,8 @@ import {
     authStatus,
     combineLatest,
     contextFiltersProvider,
+    currentAuthStatus,
+    currentAuthStatusOrNotReadyYet,
     distinctUntilChanged,
     featureFlagProvider,
     firstValueFrom,
@@ -477,7 +479,7 @@ function registerChatCommands(disposables: vscode.Disposable[]): void {
             vscode.commands.executeCommand('workbench.action.moveEditorToNewWindow')
         }),
         vscode.commands.registerCommand('cody.chat.history.panel', async () => {
-            await displayHistoryQuickPick(authProvider.status)
+            await displayHistoryQuickPick(currentAuthStatus())
         }),
         vscode.commands.registerCommand('cody.settings.extension.chat', () =>
             vscode.commands.executeCommand('workbench.action.openSettings', {
@@ -498,7 +500,7 @@ function registerAuthCommands(disposables: vscode.Disposable[]): void {
         vscode.commands.registerCommand('cody.auth.support', () => showFeedbackSupportQuickPick()),
         vscode.commands.registerCommand(
             'cody.auth.status',
-            () => authProvider.statusOrNotReadyYet ?? null
+            () => currentAuthStatusOrNotReadyYet() ?? null
         ), // Used by the agent
         vscode.commands.registerCommand(
             'cody.agent.auth.authenticate',
@@ -536,7 +538,7 @@ function registerUpgradeHandlers(disposables: vscode.Disposable[]): void {
 
         // Check if user has just moved back from a browser window to upgrade cody pro
         vscode.window.onDidChangeWindowState(async ws => {
-            const authStatus = authProvider.status
+            const authStatus = currentAuthStatus()
             if (ws.focused && isDotCom(authStatus) && authStatus.authenticated) {
                 const res = await graphqlClient.getCurrentUserCodyProEnabled()
                 if (res instanceof Error) {

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -23,7 +23,6 @@ import {
     setClientNameVersion,
     setLogger,
     setResolvedConfigurationObservable,
-    setSingleton,
     startWith,
     subscriptionDisposable,
     telemetryRecorder,
@@ -79,7 +78,7 @@ import { CodyProExpirationNotifications } from './notifications/cody-pro-expirat
 import { showSetupNotification } from './notifications/setup-notification'
 import { initVSCodeGitApi } from './repository/git-extension-api'
 import { initWorkspaceReposMonitor } from './repository/repo-metadata-from-git-api'
-import { AuthProvider, authProvider } from './services/AuthProvider'
+import { authProvider } from './services/AuthProvider'
 import { CharactersLogger } from './services/CharactersLogger'
 import { showFeedbackSupportQuickPick } from './services/FeedbackOptions'
 import { displayHistoryQuickPick } from './services/HistoryChat'
@@ -294,14 +293,13 @@ async function initializeSingletons(
     isExtensionModeDevOrTest: boolean,
     disposables: vscode.Disposable[]
 ): Promise<void> {
-    setSingleton(authProvider, new AuthProvider(await firstValueFrom(resolvedConfigWithAccessToken)))
     // The split between AuthProvider construction and initialization is
     // awkward, but exists so we can initialize the telemetry recorder
     // first, as it is used in AuthProvider before AuthProvider initialization
     // is complete. It is also important that AuthProvider inintialization
     // completes before initializeSingletons is called, because many of
     // those assume an initialized AuthProvider
-    await authProvider.instance!.init()
+    await authProvider.init()
 
     // Allow the VS Code app's instance of ModelsService to use local storage to persist
     // user's model choices
@@ -479,7 +477,7 @@ function registerChatCommands(disposables: vscode.Disposable[]): void {
             vscode.commands.executeCommand('workbench.action.moveEditorToNewWindow')
         }),
         vscode.commands.registerCommand('cody.chat.history.panel', async () => {
-            await displayHistoryQuickPick(authProvider.instance!.status)
+            await displayHistoryQuickPick(authProvider.status)
         }),
         vscode.commands.registerCommand('cody.settings.extension.chat', () =>
             vscode.commands.executeCommand('workbench.action.openSettings', {
@@ -500,7 +498,7 @@ function registerAuthCommands(disposables: vscode.Disposable[]): void {
         vscode.commands.registerCommand('cody.auth.support', () => showFeedbackSupportQuickPick()),
         vscode.commands.registerCommand(
             'cody.auth.status',
-            () => authProvider.instance?.statusOrNotReadyYet ?? null
+            () => authProvider.statusOrNotReadyYet ?? null
         ), // Used by the agent
         vscode.commands.registerCommand(
             'cody.agent.auth.authenticate',
@@ -511,7 +509,9 @@ function registerAuthCommands(disposables: vscode.Disposable[]): void {
                 if (typeof accessToken !== 'string') {
                     throw new TypeError('accessToken is required')
                 }
-                return await authProvider.instance!.auth({
+                await localStorage.saveEndpoint(serverEndpoint)
+                await secretStorage.storeToken(serverEndpoint, accessToken)
+                return await authProvider.auth({
                     endpoint: serverEndpoint,
                     token: accessToken,
                     customHeaders,
@@ -536,7 +536,7 @@ function registerUpgradeHandlers(disposables: vscode.Disposable[]): void {
 
         // Check if user has just moved back from a browser window to upgrade cody pro
         vscode.window.onDidChangeWindowState(async ws => {
-            const authStatus = authProvider.instance!.status
+            const authStatus = authProvider.status
             if (ws.focused && isDotCom(authStatus) && authStatus.authenticated) {
                 const res = await graphqlClient.getCurrentUserCodyProEnabled()
                 if (res instanceof Error) {
@@ -546,7 +546,7 @@ function registerUpgradeHandlers(disposables: vscode.Disposable[]): void {
                 // Re-auth if user's cody pro status has changed
                 const isCurrentCodyProUser = !authStatus.userCanUpgrade
                 if (res && res.codyProEnabled !== isCurrentCodyProUser) {
-                    authProvider.instance!.reloadAuthStatus()
+                    authProvider.reloadAuthStatus()
                 }
             }
         }),
@@ -584,7 +584,7 @@ async function registerTestCommands(
         }),
         // Access token - this is only used in configuration tests
         vscode.commands.registerCommand('cody.test.token', async (endpoint, token) =>
-            authProvider.instance!.auth({ endpoint, token })
+            authProvider.auth({ endpoint, token })
         )
     )
 }

--- a/vscode/src/minion/MinionController.ts
+++ b/vscode/src/minion/MinionController.ts
@@ -391,7 +391,7 @@ export class MinionController extends ReactPanelController<
     }
 
     private async handleSetSession(id: string): Promise<void> {
-        const storedSessionState = await this.storage.load(authProvider.instance!.status, id)
+        const storedSessionState = await this.storage.load(authProvider.status, id)
         if (!storedSessionState) {
             throw new Error(`session not found with id: ${id}`)
         }
@@ -409,7 +409,7 @@ export class MinionController extends ReactPanelController<
     }
 
     private async handleClearHistory(): Promise<void> {
-        await this.storage.clear(authProvider.instance!.status)
+        await this.storage.clear(authProvider.status)
         if (this.sessionState) {
             await this.save()
         }
@@ -498,7 +498,7 @@ export class MinionController extends ReactPanelController<
         if (!this.sessionState) {
             throw new Error('no session to save')
         }
-        await this.storage.save(authProvider.instance!.status, {
+        await this.storage.save(authProvider.status, {
             session: this.sessionState.session,
         })
     }
@@ -562,7 +562,7 @@ export class MinionController extends ReactPanelController<
     private async postUpdateSessionIds(): Promise<void> {
         this.postMessage({
             type: 'update-session-ids',
-            sessionIds: await this.storage.listIds(authProvider.instance!.status),
+            sessionIds: await this.storage.listIds(authProvider.status),
             currentSessionId: this.sessionState?.session.id,
         })
     }

--- a/vscode/src/minion/MinionController.ts
+++ b/vscode/src/minion/MinionController.ts
@@ -1,5 +1,5 @@
 import type Anthropic from '@anthropic-ai/sdk'
-import { hydrateAfterPostMessage } from '@sourcegraph/cody-shared'
+import { currentAuthStatus, hydrateAfterPostMessage } from '@sourcegraph/cody-shared'
 import * as vscode from 'vscode'
 import type {
     MinionExtensionMessage,
@@ -7,7 +7,6 @@ import type {
 } from '../../webviews/minion/webview_protocol'
 import { InitDoer } from '../chat/chat-view/InitDoer'
 import type { SymfRunner } from '../local-context/symf'
-import { authProvider } from '../services/AuthProvider'
 import { MinionStorage } from './MinionStorage'
 import { PlanController } from './PlanController'
 import type { Event, MinionSession, MinionTranscriptBlock, MinionTranscriptItem } from './action'
@@ -391,7 +390,7 @@ export class MinionController extends ReactPanelController<
     }
 
     private async handleSetSession(id: string): Promise<void> {
-        const storedSessionState = await this.storage.load(authProvider.status, id)
+        const storedSessionState = await this.storage.load(currentAuthStatus(), id)
         if (!storedSessionState) {
             throw new Error(`session not found with id: ${id}`)
         }
@@ -409,7 +408,7 @@ export class MinionController extends ReactPanelController<
     }
 
     private async handleClearHistory(): Promise<void> {
-        await this.storage.clear(authProvider.status)
+        await this.storage.clear(currentAuthStatus())
         if (this.sessionState) {
             await this.save()
         }
@@ -498,7 +497,7 @@ export class MinionController extends ReactPanelController<
         if (!this.sessionState) {
             throw new Error('no session to save')
         }
-        await this.storage.save(authProvider.status, {
+        await this.storage.save(currentAuthStatus(), {
             session: this.sessionState.session,
         })
     }
@@ -562,7 +561,7 @@ export class MinionController extends ReactPanelController<
     private async postUpdateSessionIds(): Promise<void> {
         this.postMessage({
             type: 'update-session-ids',
-            sessionIds: await this.storage.listIds(authProvider.status),
+            sessionIds: await this.storage.listIds(currentAuthStatus()),
             currentSessionId: this.sessionState?.session.id,
         })
     }

--- a/vscode/src/non-stop/FixupController.ts
+++ b/vscode/src/non-stop/FixupController.ts
@@ -5,6 +5,7 @@ import {
     type EditModel,
     type EventSource,
     type PromptString,
+    currentAuthStatus,
     displayPathBasename,
     telemetryRecorder,
 } from '@sourcegraph/cody-shared'
@@ -32,7 +33,6 @@ import { isStreamedIntent } from '../edit/utils/edit-intent'
 import { getOverridenModelForIntent } from '../edit/utils/edit-models'
 import type { ExtensionClient } from '../extension-client'
 import { isRunningInsideAgent } from '../jsonrpc/isRunningInsideAgent'
-import { authProvider } from '../services/AuthProvider'
 import { FixupDocumentEditObserver } from './FixupDocumentEditObserver'
 import type { FixupFile } from './FixupFile'
 import { FixupFileObserver } from './FixupFileObserver'
@@ -497,7 +497,7 @@ export class FixupController
         telemetryMetadata?: FixupTelemetryMetadata,
         taskId?: FixupTaskID
     ): Promise<FixupTask> {
-        const authStatus = authProvider.status
+        const authStatus = currentAuthStatus()
         const overridenModel = getOverridenModelForIntent(intent, model, authStatus)
         const fixupFile = this.files.forUri(document.uri)
         const task = new FixupTask(

--- a/vscode/src/non-stop/FixupController.ts
+++ b/vscode/src/non-stop/FixupController.ts
@@ -497,7 +497,7 @@ export class FixupController
         telemetryMetadata?: FixupTelemetryMetadata,
         taskId?: FixupTaskID
     ): Promise<FixupTask> {
-        const authStatus = authProvider.instance!.status
+        const authStatus = authProvider.status
         const overridenModel = getOverridenModelForIntent(intent, model, authStatus)
         const fixupFile = this.files.forUri(document.uri)
         const task = new FixupTask(

--- a/vscode/src/notifications/cody-pro-expiration.test.ts
+++ b/vscode/src/notifications/cody-pro-expiration.test.ts
@@ -12,10 +12,11 @@ import {
     featureFlagProvider,
     graphqlClient,
 } from '@sourcegraph/cody-shared'
-import { type AuthProvider, authProvider } from '../services/AuthProvider'
+import { authProvider } from '../services/AuthProvider'
 import { CodyProExpirationNotifications } from './cody-pro-expiration'
 
 vi.mock('../../../lib/shared/src/experimentation/FeatureFlagProvider')
+vi.mock('../services/AuthProvider')
 
 describe('Cody Pro expiration notifications', () => {
     let notifier: CodyProExpirationNotifications
@@ -67,18 +68,13 @@ describe('Cody Pro expiration notifications', () => {
                 },
             }
         })
-        authProvider.instance = {
-            get status() {
-                return authStatus_
-            },
-        } as AuthProvider
         authStatus_ = { ...AUTH_STATUS_FIXTURE_AUTHED, endpoint: DOTCOM_URL.toString() }
+        vi.spyOn(authProvider, 'status', 'get').mockReturnValue(authStatus_)
         localStorageData = {}
     })
 
     afterEach(() => {
         vi.restoreAllMocks()
-        authProvider.instance = null
         notifier?.dispose()
     })
 

--- a/vscode/src/notifications/cody-pro-expiration.test.ts
+++ b/vscode/src/notifications/cody-pro-expiration.test.ts
@@ -11,8 +11,8 @@ import {
     authStatus,
     featureFlagProvider,
     graphqlClient,
+    mockAuthStatus,
 } from '@sourcegraph/cody-shared'
-import { authProvider } from '../services/AuthProvider'
 import { CodyProExpirationNotifications } from './cody-pro-expiration'
 
 vi.mock('../../../lib/shared/src/experimentation/FeatureFlagProvider')
@@ -69,7 +69,7 @@ describe('Cody Pro expiration notifications', () => {
             }
         })
         authStatus_ = { ...AUTH_STATUS_FIXTURE_AUTHED, endpoint: DOTCOM_URL.toString() }
-        vi.spyOn(authProvider, 'status', 'get').mockReturnValue(authStatus_)
+        mockAuthStatus(authStatus_)
         localStorageData = {}
     })
 
@@ -161,12 +161,14 @@ describe('Cody Pro expiration notifications', () => {
 
     it('does not show if not authenticated', async () => {
         authStatus_.authenticated = false
+        mockAuthStatus(authStatus_)
         await createNotifier().triggerExpirationCheck()
         expectNoNotification()
     })
 
     it('does not show if not DotCom', async () => {
         authStatus_.endpoint = 'https://example.com' // non-dotcom
+        mockAuthStatus(authStatus_)
         await createNotifier().triggerExpirationCheck()
         expectNoNotification()
     })
@@ -208,11 +210,13 @@ describe('Cody Pro expiration notifications', () => {
     it('shows later if auth status changes', async () => {
         // Not shown initially because not logged in
         authStatus_.authenticated = false
+        mockAuthStatus(authStatus_)
         await createNotifier().triggerExpirationCheck()
         expectNoNotification()
 
         // Simulate login status change.
         authStatus_.authenticated = true
+        mockAuthStatus(authStatus_)
         authChangeListener()
 
         // Allow time async operations (checking feature flags) to run as part of the check

--- a/vscode/src/notifications/cody-pro-expiration.ts
+++ b/vscode/src/notifications/cody-pro-expiration.ts
@@ -90,7 +90,7 @@ export class CodyProExpirationNotifications implements vscode.Disposable {
         }
 
         // Not logged in or not DotCom, don't show.
-        const authStatus_ = authProvider.instance!.status
+        const authStatus_ = authProvider.status
         if (!authStatus_.authenticated || !isDotCom(authStatus_)) return
 
         const useSscForCodySubscription = await featureFlagProvider.evaluateFeatureFlag(

--- a/vscode/src/notifications/cody-pro-expiration.ts
+++ b/vscode/src/notifications/cody-pro-expiration.ts
@@ -3,12 +3,12 @@ import {
     type SourcegraphGraphQLAPIClient,
     type Unsubscribable,
     authStatus,
+    currentAuthStatus,
     featureFlagProvider,
     isDotCom,
 } from '@sourcegraph/cody-shared'
 import type * as vscode from 'vscode'
 import { URI } from 'vscode-uri'
-import { authProvider } from '../services/AuthProvider'
 import { localStorage } from '../services/LocalStorageProvider'
 
 export class CodyProExpirationNotifications implements vscode.Disposable {
@@ -90,7 +90,7 @@ export class CodyProExpirationNotifications implements vscode.Disposable {
         }
 
         // Not logged in or not DotCom, don't show.
-        const authStatus_ = authProvider.status
+        const authStatus_ = currentAuthStatus()
         if (!authStatus_.authenticated || !isDotCom(authStatus_)) return
 
         const useSscForCodySubscription = await featureFlagProvider.evaluateFeatureFlag(

--- a/vscode/src/repository/repo-name-resolver.test.ts
+++ b/vscode/src/repository/repo-name-resolver.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, it, vi } from 'vitest'
 
-import { AUTH_STATUS_FIXTURE_AUTHED, DOTCOM_URL, graphqlClient } from '@sourcegraph/cody-shared'
-
-import { authProvider } from '../services/AuthProvider'
+import {
+    AUTH_STATUS_FIXTURE_AUTHED,
+    DOTCOM_URL,
+    graphqlClient,
+    mockAuthStatus,
+} from '@sourcegraph/cody-shared'
 
 import * as gitExtensionAPI from './git-extension-api'
 import { RepoNameResolver } from './repo-name-resolver'
@@ -13,7 +16,7 @@ vi.mock('../services/AuthProvider')
 describe('getRepoNamesFromWorkspaceUri', () => {
     it('resolves the repo name using graphql for enterprise accounts', async () => {
         const repoNameResolver = new RepoNameResolver()
-        vi.spyOn(authProvider, 'status', 'get').mockReturnValue({
+        mockAuthStatus({
             ...AUTH_STATUS_FIXTURE_AUTHED,
             authenticated: true,
             endpoint: 'https://example.com',
@@ -48,7 +51,7 @@ describe('getRepoNamesFromWorkspaceUri', () => {
 
     it('resolves the repo name using local conversion function for PLG accounts', async () => {
         const repoNameResolver = new RepoNameResolver()
-        vi.spyOn(authProvider, 'status', 'get').mockReturnValue({
+        mockAuthStatus({
             ...AUTH_STATUS_FIXTURE_AUTHED,
             authenticated: true,
             endpoint: DOTCOM_URL.toString(),

--- a/vscode/src/repository/repo-name-resolver.test.ts
+++ b/vscode/src/repository/repo-name-resolver.test.ts
@@ -1,26 +1,23 @@
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 import { AUTH_STATUS_FIXTURE_AUTHED, DOTCOM_URL, graphqlClient } from '@sourcegraph/cody-shared'
 
-import { type AuthProvider, authProvider } from '../services/AuthProvider'
+import { authProvider } from '../services/AuthProvider'
 
 import * as gitExtensionAPI from './git-extension-api'
 import { RepoNameResolver } from './repo-name-resolver'
 import { mockFsCalls } from './test-helpers'
 
+vi.mock('../services/AuthProvider')
+
 describe('getRepoNamesFromWorkspaceUri', () => {
-    afterEach(() => {
-        authProvider.instance = null
-    })
     it('resolves the repo name using graphql for enterprise accounts', async () => {
         const repoNameResolver = new RepoNameResolver()
-        authProvider.instance = {
-            status: {
-                ...AUTH_STATUS_FIXTURE_AUTHED,
-                authenticated: true,
-                endpoint: 'https://example.com',
-            },
-        } as Pick<AuthProvider, 'status'> as unknown as AuthProvider
+        vi.spyOn(authProvider, 'status', 'get').mockReturnValue({
+            ...AUTH_STATUS_FIXTURE_AUTHED,
+            authenticated: true,
+            endpoint: 'https://example.com',
+        })
 
         vi.spyOn(gitExtensionAPI, 'gitRemoteUrlsFromGitExtension').mockReturnValue([
             'git@github.com:sourcegraph/cody.git',
@@ -51,13 +48,11 @@ describe('getRepoNamesFromWorkspaceUri', () => {
 
     it('resolves the repo name using local conversion function for PLG accounts', async () => {
         const repoNameResolver = new RepoNameResolver()
-        authProvider.instance = {
-            status: {
-                ...AUTH_STATUS_FIXTURE_AUTHED,
-                authenticated: true,
-                endpoint: DOTCOM_URL.toString(),
-            },
-        } as Pick<AuthProvider, 'status'> as unknown as AuthProvider
+        vi.spyOn(authProvider, 'status', 'get').mockReturnValue({
+            ...AUTH_STATUS_FIXTURE_AUTHED,
+            authenticated: true,
+            endpoint: DOTCOM_URL.toString(),
+        })
 
         vi.spyOn(gitExtensionAPI, 'gitRemoteUrlsFromGitExtension').mockReturnValue([
             'git@github.com:sourcegraph/cody.git',

--- a/vscode/src/repository/repo-name-resolver.ts
+++ b/vscode/src/repository/repo-name-resolver.ts
@@ -94,14 +94,14 @@ export class RepoNameResolver {
     }
 
     private async getRepoNamesFromRemoteUrls(remoteUrls: string[]): Promise<string[]> {
-        if (!authProvider.instance) {
+        if (!authProvider) {
             throw new Error('RepoNameResolver not initialized')
         }
 
         const uniqueRemoteUrls = Array.from(new Set(remoteUrls))
 
         // Use local conversion function for non-enterprise accounts.
-        if (isDotCom(authProvider.instance.status)) {
+        if (isDotCom(authProvider.status)) {
             return uniqueRemoteUrls.map(convertGitCloneURLToCodebaseName).filter(isDefined)
         }
 

--- a/vscode/src/repository/repo-name-resolver.ts
+++ b/vscode/src/repository/repo-name-resolver.ts
@@ -6,6 +6,7 @@ import {
     type Unsubscribable,
     authStatus,
     convertGitCloneURLToCodebaseName,
+    currentAuthStatus,
     graphqlClient,
     isDefined,
     isDotCom,
@@ -101,7 +102,7 @@ export class RepoNameResolver {
         const uniqueRemoteUrls = Array.from(new Set(remoteUrls))
 
         // Use local conversion function for non-enterprise accounts.
-        if (isDotCom(authProvider.status)) {
+        if (isDotCom(currentAuthStatus())) {
             return uniqueRemoteUrls.map(convertGitCloneURLToCodebaseName).filter(isDefined)
         }
 

--- a/vscode/src/services/AuthProviderSimplified.ts
+++ b/vscode/src/services/AuthProviderSimplified.ts
@@ -19,7 +19,7 @@ export class AuthProviderSimplified {
         if (!(await openExternalAuthUrl(method, tokenReceiverUrl, agentIDE))) {
             return false
         }
-        authProvider.instance!.setAuthPendingToEndpoint(DOTCOM_URL.toString())
+        authProvider.setAuthPendingToEndpoint(DOTCOM_URL.toString())
         return true
     }
 }

--- a/vscode/src/services/telemetry-v2.ts
+++ b/vscode/src/services/telemetry-v2.ts
@@ -16,8 +16,6 @@ import { TimestampTelemetryProcessor } from '@sourcegraph/telemetry/dist/process
 import { logDebug } from '../log'
 import { getOSArch } from '../os'
 import { version } from '../version'
-
-import { authProvider } from './AuthProvider'
 import { localStorage } from './LocalStorageProvider'
 
 const { platform, arch } = getOSArch()
@@ -85,7 +83,6 @@ export async function createOrUpdateTelemetryRecorderProvider(
             new MockServerTelemetryRecorderProvider(
                 extensionDetails,
                 config.configuration,
-                authProvider.instance!,
                 anonymousUserID
             )
         )
@@ -97,7 +94,6 @@ export async function createOrUpdateTelemetryRecorderProvider(
             new TelemetryRecorderProvider(
                 extensionDetails,
                 { ...config.configuration, ...config.auth },
-                authProvider.instance!,
                 anonymousUserID,
                 legacyBackcompatLogEventMode
             )


### PR DESCRIPTION
No more `authProvider.instance!`.

Also move `AuthProvider.status` to `currentAuthStatus()` funcs.
    
Refactor helpers:
    
```
fastmod -e ts -F 'authProvider.statusAuthed' 'currentAuthStatusAuthed()'
fastmod -e ts -F 'authProvider.status' 'currentAuthStatus()'
```


## Test plan

CI