### PR TITLE
make some services more reactive to config

### DIFF
--- a/agent/src/TestClient.ts
+++ b/agent/src/TestClient.ts
@@ -85,7 +85,6 @@ interface TestClientParams {
     readonly credentials: TestingCredentials
     bin?: string
     telemetryExporter?: 'testing' | 'graphql' // defaults to testing, which doesn't send telemetry
-    areFeatureFlagsEnabled?: boolean // do not evaluate feature flags by default
     logEventMode?: 'connected-instance-only' | 'all' | 'dotcom-only'
     onWindowRequest?: (params: ShowWindowMessageParams) => Promise<string>
     extraConfiguration?: Record<string, any>
@@ -165,7 +164,7 @@ export class TestClient extends MessageHandler {
                 SRC_ACCESS_TOKEN: params.credentials.token,
                 REDACTED_SRC_ACCESS_TOKEN: params.credentials.redactedToken,
                 CODY_TELEMETRY_EXPORTER: params.telemetryExporter ?? 'testing',
-                DISABLE_FEATURE_FLAGS: params.areFeatureFlagsEnabled ? undefined : 'true',
+                DISABLE_FEATURE_FLAGS: 'true',
                 DISABLE_UPSTREAM_HEALTH_PINGS: 'true',
                 CODY_LOG_EVENT_MODE: params.logEventMode,
                 ...process.env,

--- a/agent/src/cli/command-chat.test.ts
+++ b/agent/src/cli/command-chat.test.ts
@@ -30,7 +30,6 @@ describe('cody chat', () => {
         args: string[]
         expectedExitCode?: number
     }): Promise<ChatCommandResult> {
-        process.env.DISABLE_FEATURE_FLAGS = 'true'
         process.env.CODY_TELEMETRY_EXPORTER = 'testing'
         const args = [
             ...params.args,

--- a/lib/shared/src/cody-ignore/context-filters-provider.ts
+++ b/lib/shared/src/cody-ignore/context-filters-provider.ts
@@ -327,6 +327,5 @@ function parseContextFilterItem(item: CodyContextFilterItem): ParsedContextFilte
 
 /**
  * A singleton instance of the `ContextFiltersProvider` class.
- * `contextFiltersProvider.init` should be called and awaited on extension activation.
  */
 export const contextFiltersProvider = new ContextFiltersProvider()

--- a/lib/shared/src/experimentation/FeatureFlagProvider.test.ts
+++ b/lib/shared/src/experimentation/FeatureFlagProvider.test.ts
@@ -1,11 +1,12 @@
-import { beforeAll, describe, expect, it, vi, vitest } from 'vitest'
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi, vitest } from 'vitest'
 
 import { graphqlClient } from '../sourcegraph-api/graphql'
 
+import { mockAuthStatus } from '../auth/authStatus'
+import { AUTH_STATUS_FIXTURE_AUTHED } from '../auth/types'
 import { mockResolvedConfig } from '../configuration/resolver'
 import { readValuesFrom } from '../misc/observable'
-import { nextTick } from '../utils'
-import { FeatureFlag, FeatureFlagProvider } from './FeatureFlagProvider'
+import { FeatureFlag, FeatureFlagProviderImpl } from './FeatureFlagProvider'
 
 vi.mock('../sourcegraph-api/graphql/client')
 
@@ -15,110 +16,55 @@ describe('FeatureFlagProvider', () => {
         mockResolvedConfig({
             auth: { accessToken: null, serverEndpoint: 'https://example.com' },
         })
+        mockAuthStatus(AUTH_STATUS_FIXTURE_AUTHED)
     })
 
-    async function newFeatureFlagProvider(): Promise<FeatureFlagProvider> {
-        const provider = new FeatureFlagProvider()
-        await vi.runOnlyPendingTimersAsync() // wait for `this.cachedServerEndpoint` to be set asynchronously
-        return provider
-    }
-
-    it('evaluates the feature flag on dotcom', async () => {
-        vi.spyOn(graphqlClient, 'getEvaluatedFeatureFlags').mockResolvedValue({})
-        vi.spyOn(graphqlClient, 'evaluateFeatureFlag').mockResolvedValue(true)
-
-        const provider = new FeatureFlagProvider()
-
-        expect(await provider.evaluateFeatureFlag(FeatureFlag.TestFlagDoNotUse)).toBe(true)
+    let featureFlagProvider: FeatureFlagProviderImpl
+    beforeEach(() => {
+        featureFlagProvider = new FeatureFlagProviderImpl()
     })
 
-    it('loads all evaluated feature flag on `syncAuthStatus`', async () => {
+    let unsubscribeAfter: (() => void) | undefined = undefined
+    afterEach(() => {
+        vi.clearAllMocks()
+        unsubscribeAfter?.()
+        unsubscribeAfter = undefined
+    })
+
+    it('evaluates a single feature flag', async () => {
         const getEvaluatedFeatureFlagsMock = vi
             .spyOn(graphqlClient, 'getEvaluatedFeatureFlags')
-            .mockResolvedValue({
-                [FeatureFlag.TestFlagDoNotUse]: true,
-            })
-        const evaluateFeatureFlagMock = vi.spyOn(graphqlClient, 'evaluateFeatureFlag')
+            .mockResolvedValue({})
+        const evaluateFeatureFlagMock = vi
+            .spyOn(graphqlClient, 'evaluateFeatureFlag')
+            .mockResolvedValue(true)
 
-        const provider = await newFeatureFlagProvider()
-        await provider.refresh()
+        expect(await featureFlagProvider.evaluateFeatureFlag(FeatureFlag.TestFlagDoNotUse)).toBe(true)
+        expect(getEvaluatedFeatureFlagsMock).toHaveBeenCalledTimes(0)
+        expect(evaluateFeatureFlagMock).toHaveBeenCalledOnce()
+    })
 
-        expect(await provider.evaluateFeatureFlag(FeatureFlag.TestFlagDoNotUse)).toBe(true)
-        expect(getEvaluatedFeatureFlagsMock).toHaveBeenCalled()
-        expect(evaluateFeatureFlagMock).not.toHaveBeenCalled()
+    it('reports exposed experiments', async () => {
+        vi.spyOn(graphqlClient, 'getEvaluatedFeatureFlags').mockResolvedValue({
+            [FeatureFlag.TestFlagDoNotUse]: true,
+        })
+        vi.spyOn(graphqlClient, 'evaluateFeatureFlag').mockResolvedValue(true)
+        const { unsubscribe } = readValuesFrom(
+            featureFlagProvider.evaluatedFeatureFlag(FeatureFlag.TestFlagDoNotUse)
+        )
+        unsubscribeAfter = unsubscribe
+        await vi.runOnlyPendingTimersAsync()
+        expect(featureFlagProvider.getExposedExperiments('https://example.com')).toStrictEqual({
+            [FeatureFlag.TestFlagDoNotUse]: true,
+        })
+        expect(featureFlagProvider.getExposedExperiments('https://other.example.com')).toStrictEqual({})
     })
 
     it('should handle API errors', async () => {
         vi.spyOn(graphqlClient, 'getEvaluatedFeatureFlags').mockResolvedValue(new Error('API error'))
         vi.spyOn(graphqlClient, 'evaluateFeatureFlag').mockResolvedValue(new Error('API error'))
 
-        const provider = await newFeatureFlagProvider()
-
-        expect(await provider.evaluateFeatureFlag(FeatureFlag.TestFlagDoNotUse)).toBe(false)
-    })
-
-    it('should refresh flags', async () => {
-        const getEvaluatedFeatureFlagsMock = vi
-            .spyOn(graphqlClient, 'getEvaluatedFeatureFlags')
-            .mockResolvedValue({
-                [FeatureFlag.TestFlagDoNotUse]: true,
-            })
-        vi.spyOn(graphqlClient, 'evaluateFeatureFlag')
-
-        const provider = await newFeatureFlagProvider()
-
-        getEvaluatedFeatureFlagsMock.mockResolvedValue({
-            [FeatureFlag.TestFlagDoNotUse]: false,
-        })
-
-        await provider.refresh()
-
-        // Wait for the async reload
-        await nextTick()
-
-        expect(await provider.evaluateFeatureFlag(FeatureFlag.TestFlagDoNotUse)).toBe(false)
-    })
-
-    it('should refresh flags after one hour', async () => {
-        const originalNow = Date.now
-        try {
-            Date.now = () => 0
-            const getEvaluatedFeatureFlagsMock = vi
-                .spyOn(graphqlClient, 'getEvaluatedFeatureFlags')
-                .mockResolvedValue({
-                    [FeatureFlag.TestFlagDoNotUse]: true,
-                })
-            const evaluateFeatureFlagMock = vi.spyOn(graphqlClient, 'evaluateFeatureFlag')
-
-            const provider = await newFeatureFlagProvider()
-            await provider.refresh()
-
-            // Wait for the async initialization
-            await nextTick()
-
-            expect(await provider.evaluateFeatureFlag(FeatureFlag.TestFlagDoNotUse)).toBe(true)
-            expect(getEvaluatedFeatureFlagsMock).toHaveBeenCalled()
-            expect(evaluateFeatureFlagMock).not.toHaveBeenCalled()
-
-            getEvaluatedFeatureFlagsMock.mockResolvedValue({
-                [FeatureFlag.TestFlagDoNotUse]: false,
-            })
-
-            Date.now = () => 61 * 60 * 1000
-
-            // We have a stale-while-revalidate cache so this will return the previous value while it
-            // is reloading
-            expect(await provider.evaluateFeatureFlag(FeatureFlag.TestFlagDoNotUse)).toBe(true)
-            expect(getEvaluatedFeatureFlagsMock).toHaveBeenCalled()
-            expect(evaluateFeatureFlagMock).not.toHaveBeenCalled()
-
-            // Wait for the async reload
-            await nextTick()
-
-            expect(await provider.evaluateFeatureFlag(FeatureFlag.TestFlagDoNotUse)).toBe(false)
-        } finally {
-            Date.now = originalNow
-        }
+        expect(await featureFlagProvider.evaluateFeatureFlag(FeatureFlag.TestFlagDoNotUse)).toBe(false)
     })
 
     describe('evaluatedFeatureFlag', () => {
@@ -127,20 +73,19 @@ describe('FeatureFlagProvider', () => {
             updateMocks,
             expectFinalValues,
         }: {
-            expectInitialValues: (boolean | undefined)[]
+            expectInitialValues: boolean[]
             updateMocks?: () => void
-            expectFinalValues?: (boolean | undefined)[]
+            expectFinalValues?: boolean[]
         }): Promise<void> {
             vitest.useFakeTimers()
-            const provider = await newFeatureFlagProvider()
 
-            const flag$ = provider.evaluatedFeatureFlag(FeatureFlag.TestFlagDoNotUse)
-
-            const { values, done, unsubscribe } = readValuesFrom(flag$)
-            vitest.runAllTimers()
+            const { values, done, unsubscribe } = readValuesFrom(
+                featureFlagProvider.evaluatedFeatureFlag(FeatureFlag.TestFlagDoNotUse)
+            )
+            unsubscribeAfter = unsubscribe
 
             // Test the initial emissions.
-            await nextTick()
+            await vi.runOnlyPendingTimersAsync()
             expect(values).toEqual<typeof values>(expectInitialValues)
             values.length = 0
 
@@ -150,8 +95,8 @@ describe('FeatureFlagProvider', () => {
 
             // Test that the observable emits updated values when flags change.
             updateMocks()
-            provider.refresh()
-            await nextTick()
+            featureFlagProvider.refresh()
+            await vi.runOnlyPendingTimersAsync()
             expect(values).toEqual<typeof values>(expectFinalValues!)
             values.length = 0
 
@@ -161,7 +106,7 @@ describe('FeatureFlagProvider', () => {
             expect(values).toEqual<typeof values>([])
         }
 
-        it('should emit when a new flag is evaluated', async () => {
+        it('should emit when a new flag is evaluated', { timeout: 500 }, async () => {
             vi.spyOn(graphqlClient, 'getEvaluatedFeatureFlags').mockResolvedValue({})
             vi.spyOn(graphqlClient, 'evaluateFeatureFlag').mockResolvedValue(false)
             await testEvaluatedFeatureFlag({ expectInitialValues: [false] })
@@ -189,7 +134,6 @@ describe('FeatureFlagProvider', () => {
                 [FeatureFlag.TestFlagDoNotUse]: false,
             })
             vi.spyOn(graphqlClient, 'evaluateFeatureFlag').mockResolvedValue(false)
-
             await testEvaluatedFeatureFlag({
                 expectInitialValues: [false],
                 updateMocks: () => {
@@ -202,7 +146,7 @@ describe('FeatureFlagProvider', () => {
             })
         })
 
-        it('should emit undefined when a previously false flag is no longer in the exposed list', async () => {
+        it('should not emit false when a previously false flag is no longer in the exposed list', async () => {
             vi.spyOn(graphqlClient, 'getEvaluatedFeatureFlags').mockResolvedValue({
                 [FeatureFlag.TestFlagDoNotUse]: false,
             })
@@ -213,8 +157,66 @@ describe('FeatureFlagProvider', () => {
                     vi.spyOn(graphqlClient, 'getEvaluatedFeatureFlags').mockResolvedValue({})
                     vi.spyOn(graphqlClient, 'evaluateFeatureFlag').mockResolvedValue(null)
                 },
-                expectFinalValues: [undefined],
+                expectFinalValues: [],
             })
+        })
+
+        it('should refresh flags when the endpoint changes', async () => {
+            const getEvaluatedFeatureFlagsMock = vi
+                .spyOn(graphqlClient, 'getEvaluatedFeatureFlags')
+                .mockResolvedValue({
+                    [FeatureFlag.TestFlagDoNotUse]: true,
+                })
+            const evaluateFeatureFlagMock = vi
+                .spyOn(graphqlClient, 'evaluateFeatureFlag')
+                .mockResolvedValue(true)
+            mockAuthStatus({ ...AUTH_STATUS_FIXTURE_AUTHED, endpoint: 'https://example.com' })
+
+            expect(await featureFlagProvider.evaluateFeatureFlag(FeatureFlag.TestFlagDoNotUse)).toBe(
+                true
+            )
+
+            getEvaluatedFeatureFlagsMock.mockResolvedValue({
+                [FeatureFlag.TestFlagDoNotUse]: false,
+            })
+            evaluateFeatureFlagMock.mockResolvedValue(false)
+            mockAuthStatus({ ...AUTH_STATUS_FIXTURE_AUTHED, endpoint: 'https://other.example.com' })
+            await vi.runOnlyPendingTimersAsync()
+            expect(await featureFlagProvider.evaluateFeatureFlag(FeatureFlag.TestFlagDoNotUse)).toBe(
+                false
+            )
+        })
+
+        it('refresh()', async () => {
+            vi.clearAllMocks()
+            const getEvaluatedFeatureFlagsMock = vi
+                .spyOn(graphqlClient, 'getEvaluatedFeatureFlags')
+                .mockResolvedValue({
+                    [FeatureFlag.TestFlagDoNotUse]: true,
+                })
+            const evaluateFeatureFlagMock = vi
+                .spyOn(graphqlClient, 'evaluateFeatureFlag')
+                .mockResolvedValue(true)
+
+            const { values, unsubscribe } = readValuesFrom(
+                featureFlagProvider.evaluatedFeatureFlag(FeatureFlag.TestFlagDoNotUse)
+            )
+            unsubscribeAfter = unsubscribe
+
+            await vi.runOnlyPendingTimersAsync()
+            expect(values).toStrictEqual<typeof values>([true])
+            values.length = 0
+            expect(getEvaluatedFeatureFlagsMock).toHaveBeenCalledTimes(1)
+            expect(evaluateFeatureFlagMock).toHaveBeenCalledTimes(1)
+
+            getEvaluatedFeatureFlagsMock.mockResolvedValue({
+                [FeatureFlag.TestFlagDoNotUse]: false,
+            })
+            featureFlagProvider.refresh()
+            await vi.runOnlyPendingTimersAsync()
+            expect(values).toStrictEqual<typeof values>([false])
+            expect(getEvaluatedFeatureFlagsMock).toHaveBeenCalledTimes(2)
+            expect(evaluateFeatureFlagMock).toHaveBeenCalledTimes(1)
         })
     })
 })

--- a/lib/shared/src/index.ts
+++ b/lib/shared/src/index.ts
@@ -141,7 +141,7 @@ export { hydrateAfterPostMessage } from './editor/hydrateAfterPostMessage'
 export * from './editor/utils'
 export {
     FeatureFlag,
-    FeatureFlagProvider,
+    type FeatureFlagProvider,
     featureFlagProvider,
 } from './experimentation/FeatureFlagProvider'
 export { GuardrailsPost } from './guardrails'

--- a/lib/shared/src/misc/observable.ts
+++ b/lib/shared/src/misc/observable.ts
@@ -734,14 +734,16 @@ export function mergeMap<T, R>(
     }
 }
 
+export interface StoredLastValue<T> {
+    value: { last: undefined; isSet: false } | { last: T; isSet: true }
+    subscription: Unsubscribable
+}
+
 /**
  * Store the last value emitted by an {@link Observable} so that it can be accessed synchronously.
  * Callers must take care to not create a race condition when using this function.
  */
-export function storeLastValue<T>(observable: Observable<T>): {
-    value: { last: undefined; isSet: false } | { last: T; isSet: true }
-    subscription: Unsubscribable
-} {
+export function storeLastValue<T>(observable: Observable<T>): StoredLastValue<T> {
     const value: ReturnType<typeof storeLastValue>['value'] = { last: undefined, isSet: false }
     const subscription = observable.subscribe(v => {
         Object.assign(value, { last: v, isSet: true })

--- a/lib/shared/src/sourcegraph-api/graphql/client.ts
+++ b/lib/shared/src/sourcegraph-api/graphql/client.ts
@@ -1394,10 +1394,13 @@ export class SourcegraphGraphQLAPIClient {
         ).then(response => extractDataOrError(response, data => data.snippetAttribution))
     }
 
-    public async getEvaluatedFeatureFlags(): Promise<Record<string, boolean> | Error> {
+    public async getEvaluatedFeatureFlags(
+        signal?: AbortSignal
+    ): Promise<Record<string, boolean> | Error> {
         return this.fetchSourcegraphAPI<APIResponse<EvaluatedFeatureFlagsResponse>>(
             GET_FEATURE_FLAGS_QUERY,
-            {}
+            {},
+            signal
         ).then(response => {
             return extractDataOrError(response, data =>
                 data.evaluatedFeatureFlags.reduce((acc: Record<string, boolean>, { name, value }) => {
@@ -1408,12 +1411,16 @@ export class SourcegraphGraphQLAPIClient {
         })
     }
 
-    public async evaluateFeatureFlag(flagName: string): Promise<boolean | null | Error> {
+    public async evaluateFeatureFlag(
+        flagName: string,
+        signal?: AbortSignal
+    ): Promise<boolean | null | Error> {
         return this.fetchSourcegraphAPI<APIResponse<EvaluateFeatureFlagResponse>>(
             EVALUATE_FEATURE_FLAG_QUERY,
             {
                 flagName,
-            }
+            },
+            signal
         ).then(response => extractDataOrError(response, data => data.evaluateFeatureFlag))
     }
 

--- a/vscode/src/chat/clientStateBroadcaster.ts
+++ b/vscode/src/chat/clientStateBroadcaster.ts
@@ -7,6 +7,7 @@ import {
     authStatus,
     combineLatest,
     contextFiltersProvider,
+    currentResolvedConfig,
     displayLineRange,
     displayPathBasename,
     expandToLineRange,
@@ -134,6 +135,7 @@ export async function getCorpusContextItemsForEditorState(useRemote: boolean): P
     // remote search). There should be a single internal thing in Cody that lets you monitor the
     // user's current codebase.
     if (useRemote && workspaceReposMonitor) {
+        const { auth } = await currentResolvedConfig()
         const repoMetadata = await workspaceReposMonitor.getRepoMetadata()
         for (const repo of repoMetadata) {
             if (await contextFiltersProvider.isRepoNameIgnored(repo.repoName)) {
@@ -150,7 +152,8 @@ export async function getCorpusContextItemsForEditorState(useRemote: boolean): P
                             name: repo.repoName,
                             url: repo.repoName,
                         },
-                        REMOTE_REPOSITORY_PROVIDER_URI
+                        REMOTE_REPOSITORY_PROVIDER_URI,
+                        auth
                     )
                 ),
                 title: 'Current Repository',

--- a/vscode/src/completions/get-inline-completions-tests/helpers.ts
+++ b/vscode/src/completions/get-inline-completions-tests/helpers.ts
@@ -425,6 +425,7 @@ export function initCompletionProviderConfig({
 }: Partial<Pick<ParamsResult, 'configuration' | 'authStatus'>>): Promise<void> {
     graphqlClient.setConfig({} as unknown as GraphQLAPIClientConfig)
     vi.spyOn(featureFlagProvider, 'evaluateFeatureFlag').mockResolvedValue(false)
+    vi.spyOn(featureFlagProvider, 'evaluatedFeatureFlag').mockReturnValue(Observable.of(false))
     mockAuthStatus(authStatus)
     return completionProviderConfig.init((configuration ?? {}) as ClientConfiguration)
 }

--- a/vscode/src/completions/inline-completion-item-provider.test.ts
+++ b/vscode/src/completions/inline-completion-item-provider.test.ts
@@ -1,13 +1,11 @@
 import dedent from 'dedent'
-import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import * as vscode from 'vscode'
 
 import {
     AUTH_STATUS_FIXTURE_AUTHED,
-    type GraphQLAPIClientConfig,
     RateLimitError,
     contextFiltersProvider,
-    graphqlClient,
 } from '@sourcegraph/cody-shared'
 
 import { telemetryRecorder } from '@sourcegraph/cody-shared'
@@ -32,8 +30,6 @@ const DUMMY_CONTEXT: vscode.InlineCompletionContext = {
     selectedCompletionInfo: undefined,
     triggerKind: vscode.InlineCompletionTriggerKind.Automatic,
 }
-
-graphqlClient.setConfig({} as unknown as GraphQLAPIClientConfig)
 
 class MockableInlineCompletionItemProvider extends InlineCompletionItemProvider {
     constructor(
@@ -61,13 +57,10 @@ class MockableInlineCompletionItemProvider extends InlineCompletionItemProvider 
     public declare lastCandidate
 }
 
-describe('InlineCompletionItemProvider', () => {
-    beforeAll(async () => {
+describe('InlineCompletionItemProvider', async () => {
+    beforeEach(async () => {
         await initCompletionProviderConfig({})
         mockLocalStorage()
-    })
-
-    beforeEach(() => {
         vi.spyOn(contextFiltersProvider, 'isUriIgnored').mockResolvedValue(false)
         CompletionLogger.reset_testOnly()
     })

--- a/vscode/src/completions/providers/create-provider.test.ts
+++ b/vscode/src/completions/providers/create-provider.test.ts
@@ -2,24 +2,24 @@ import {
     AUTH_STATUS_FIXTURE_AUTHED_DOTCOM,
     type ClientConfiguration,
     type CodyLLMSiteConfiguration,
-    type GraphQLAPIClientConfig,
-    graphqlClient,
+    featureFlagProvider,
     mockAuthStatus,
     toFirstValueGetter,
 } from '@sourcegraph/cody-shared'
-import { beforeAll, describe, expect, it } from 'vitest'
+import { beforeAll, describe, expect, it, vi } from 'vitest'
 import { mockLocalStorage } from '../../services/LocalStorageProvider'
 import { getVSCodeConfigurationWithAccessToken } from '../../testutils/mocks'
 
+import { Observable } from 'observable-fns'
 import { createProvider } from './create-provider'
 
-graphqlClient.setConfig({} as unknown as GraphQLAPIClientConfig)
 const createProviderFirstValue = toFirstValueGetter(createProvider)
 
 describe('createProvider', () => {
     beforeAll(async () => {
         mockAuthStatus()
         mockLocalStorage()
+        vi.spyOn(featureFlagProvider, 'evaluatedFeatureFlag').mockReturnValue(Observable.of(false))
     })
 
     describe('local settings', () => {

--- a/vscode/src/context/openctx/remoteDirectorySearch.ts
+++ b/vscode/src/context/openctx/remoteDirectorySearch.ts
@@ -1,4 +1,4 @@
-import { REMOTE_DIRECTORY_PROVIDER_URI } from '@sourcegraph/cody-shared'
+import { REMOTE_DIRECTORY_PROVIDER_URI, currentResolvedConfig } from '@sourcegraph/cody-shared'
 
 import type { Item, Mention } from '@openctx/client'
 import { graphqlClient, isDefined, isError } from '@sourcegraph/cody-shared'
@@ -52,6 +52,9 @@ export async function getDirectoryMentions(
     const directoryRe = directoryPath ? escapeRegExp(directoryPath) : ''
     const query = `repo:${repoRe} file:${directoryRe}.*\/.* select:file.directory count:10`
 
+    const {
+        auth: { serverEndpoint },
+    } = await currentResolvedConfig()
     const dataOrError = await graphqlClient.searchFileMatches(query)
 
     if (isError(dataOrError) || dataOrError === null) {
@@ -64,7 +67,7 @@ export async function getDirectoryMentions(
                 return null
             }
 
-            const url = `${graphqlClient.endpoint.replace(/\/$/, '')}${result.file.url}`
+            const url = `${serverEndpoint.replace(/\/$/, '')}${result.file.url}`
 
             return {
                 uri: url,

--- a/vscode/src/context/openctx/remoteFileSearch.ts
+++ b/vscode/src/context/openctx/remoteFileSearch.ts
@@ -1,6 +1,7 @@
 import type { Item, Mention } from '@openctx/client'
 import {
     REMOTE_FILE_PROVIDER_URI,
+    currentResolvedConfig,
     displayPathBasename,
     graphqlClient,
     isDefined,
@@ -53,6 +54,7 @@ async function getFileMentions(repoName: string, filePath?: string): Promise<Men
     const fileRe = filePath ? escapeRegExp(filePath) : '^.*$'
     const query = `repo:${repoRe} file:${fileRe} type:file count:10`
 
+    const { auth } = await currentResolvedConfig()
     const dataOrError = await graphqlClient.searchFileMatches(query)
 
     if (isError(dataOrError) || dataOrError === null) {
@@ -65,7 +67,7 @@ async function getFileMentions(repoName: string, filePath?: string): Promise<Men
                 return null
             }
 
-            const url = `${graphqlClient.endpoint.replace(/\/$/, '')}${result.file.url}`
+            const url = `${auth.serverEndpoint.replace(/\/$/, '')}${result.file.url}`
 
             const basename = displayPathBasename(URI.parse(result.file.path))
 
@@ -84,6 +86,7 @@ async function getFileMentions(repoName: string, filePath?: string): Promise<Men
 }
 
 async function getFileItem(repoName: string, filePath: string, rev = 'HEAD'): Promise<Item[]> {
+    const { auth } = await currentResolvedConfig()
     const dataOrError = await graphqlClient.getFileContents(repoName, filePath, rev)
 
     if (isError(dataOrError)) {
@@ -95,7 +98,7 @@ async function getFileItem(repoName: string, filePath: string, rev = 'HEAD'): Pr
         return []
     }
 
-    const url = `${graphqlClient.endpoint.replace(/\/$/, '')}${file.url}`
+    const url = `${auth.serverEndpoint.replace(/\/$/, '')}${file.url}`
 
     return [
         {

--- a/vscode/src/context/openctx/remoteRepositorySearch.ts
+++ b/vscode/src/context/openctx/remoteRepositorySearch.ts
@@ -1,5 +1,10 @@
 import type { Item } from '@openctx/client'
-import { REMOTE_REPOSITORY_PROVIDER_URI, graphqlClient, isError } from '@sourcegraph/cody-shared'
+import {
+    REMOTE_REPOSITORY_PROVIDER_URI,
+    currentResolvedConfig,
+    graphqlClient,
+    isError,
+} from '@sourcegraph/cody-shared'
 
 import { getRepositoryMentions } from './common/get-repository-mentions'
 import type { OpenCtxProvider } from './types'
@@ -27,6 +32,7 @@ export function createRemoteRepositoryProvider(customTitle?: string): OpenCtxPro
                 return []
             }
 
+            const { auth } = await currentResolvedConfig()
             const dataOrError = await graphqlClient.contextSearch({
                 repoIDs: [mention?.data?.repoId as string],
                 query: message,
@@ -38,7 +44,7 @@ export function createRemoteRepositoryProvider(customTitle?: string): OpenCtxPro
             return dataOrError.map(
                 node =>
                     ({
-                        url: graphqlClient.endpoint + node.uri.toString(),
+                        url: auth.serverEndpoint + node.uri.toString(),
                         title: node.path,
                         ai: {
                             content: node.content,

--- a/vscode/src/editor/utils/editor-context.ts
+++ b/vscode/src/editor/utils/editor-context.ts
@@ -15,6 +15,7 @@ import {
     type SymbolKind,
     TokenCounterUtils,
     contextFiltersProvider,
+    currentResolvedConfig,
     displayPath,
     graphqlClient,
     isAbortError,
@@ -472,13 +473,14 @@ async function resolveFileOrSymbolContextItem(
             ? { startLine: contextItem.range.start.line, endLine: contextItem.range.end.line + 1 }
             : undefined
 
+        const { auth } = await currentResolvedConfig()
         const resultOrError = await graphqlClient.getFileContent(repository, path, ranges, signal)
 
         if (!isErrorLike(resultOrError)) {
             return {
                 ...contextItem,
                 title: path,
-                uri: URI.parse(`${graphqlClient.endpoint}${repository}/-/blob${path}`),
+                uri: URI.parse(`${auth.serverEndpoint}${repository}/-/blob${path}`),
                 content: resultOrError,
                 repoName: repository,
                 source: ContextItemSource.Unified,

--- a/vscode/src/extension.common.ts
+++ b/vscode/src/extension.common.ts
@@ -2,7 +2,6 @@ import * as vscode from 'vscode'
 
 import type {
     ClientConfiguration,
-    ClientConfigurationWithEndpoint,
     CompletionLogger,
     CompletionsClientConfig,
     SourcegraphCompletionsClient,
@@ -21,10 +20,7 @@ import type { ExtensionClient } from './extension-client'
 import type { LocalEmbeddingsConfig, LocalEmbeddingsController } from './local-context/local-embeddings'
 import type { SymfRunner } from './local-context/symf'
 import { start } from './main'
-import type {
-    OpenTelemetryService,
-    OpenTelemetryServiceConfig,
-} from './services/open-telemetry/OpenTelemetryService.node'
+import type { OpenTelemetryService } from './services/open-telemetry/OpenTelemetryService.node'
 import { type SentryService, captureException } from './services/sentry/sentry'
 
 type Constructor<T extends new (...args: any) => any> = T extends new (
@@ -46,10 +42,8 @@ export interface PlatformContext {
         config: CompletionsClientConfig,
         logger?: CompletionLogger
     ) => SourcegraphCompletionsClient
-    createSentryService?: (
-        config: Pick<ClientConfigurationWithEndpoint, 'serverEndpoint'>
-    ) => SentryService
-    createOpenTelemetryService?: (config: OpenTelemetryServiceConfig) => OpenTelemetryService
+    createSentryService?: () => SentryService
+    createOpenTelemetryService?: () => OpenTelemetryService
     startTokenReceiver?: typeof startTokenReceiver
     onConfigurationChange?: (configuration: ClientConfiguration) => void
     extensionClient: ExtensionClient

--- a/vscode/src/external-services.ts
+++ b/vscode/src/external-services.ts
@@ -59,8 +59,8 @@ export async function configureExternalServices(
     >
 ): Promise<ExternalServices> {
     const initialConfig = await firstValueFrom(resolvedConfigWithAccessToken)
-    const sentryService = platform.createSentryService?.(initialConfig)
-    const openTelemetryService = platform.createOpenTelemetryService?.(initialConfig)
+    platform.createSentryService?.()
+    platform.createOpenTelemetryService?.()
     const completionsClient = platform.createCompletionsClient(initialConfig, logger)
 
     const symfRunner = platform.createSymfRunner?.(context, completionsClient)
@@ -80,7 +80,7 @@ export async function configureExternalServices(
 
     const chatClient = new ChatClient(completionsClient, () => currentAuthStatusAuthed())
 
-    const guardrails = new SourcegraphGuardrailsClient(graphqlClient, initialConfig)
+    const guardrails = new SourcegraphGuardrailsClient()
 
     const contextAPIClient = new ContextAPIClient(graphqlClient)
 
@@ -92,10 +92,7 @@ export async function configureExternalServices(
         symfRunner,
         contextAPIClient,
         onConfigurationChange: newConfig => {
-            sentryService?.onConfigurationChange(newConfig)
-            openTelemetryService?.onConfigurationChange(newConfig)
             completionsClient.onConfigurationChange(newConfig)
-            guardrails.onConfigurationChange(newConfig)
             void localEmbeddings?.setAccessToken(newConfig.serverEndpoint, newConfig.accessToken)
         },
     }

--- a/vscode/src/local-context/symf.ts
+++ b/vscode/src/local-context/symf.ts
@@ -363,7 +363,7 @@ export class SymfRunner implements vscode.Disposable {
         }
 
         await rename(indexDir.fsPath, trashDir.fsPath)
-        void rm(trashDir.fsPath, { recursive: true, force: true }) // delete in background
+        rm(trashDir.fsPath, { recursive: true, force: true }).catch(() => {}) // delete in background
     }
 
     private async unsafeIndexExists(scopeDir: FileURI): Promise<boolean> {

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -7,14 +7,12 @@ import {
     type DefaultCodyCommands,
     type Guardrails,
     PromptString,
-    type ResolvedConfiguration,
     authStatus,
     combineLatest,
     contextFiltersProvider,
     currentAuthStatus,
     currentAuthStatusOrNotReadyYet,
     distinctUntilChanged,
-    featureFlagProvider,
     firstValueFrom,
     fromVSCodeEvent,
     graphqlClient,
@@ -153,13 +151,7 @@ export async function start(
         )
     )
 
-    disposables.push(
-        subscriptionDisposable(
-            resolvedConfig.subscribe({
-                next: config => configureEventsInfra(config, isExtensionModeDevOrTest),
-            })
-        )
-    )
+    disposables.push(createOrUpdateTelemetryRecorderProvider(isExtensionModeDevOrTest))
 
     disposables.push(
         subscriptionDisposable(
@@ -313,8 +305,6 @@ async function initializeSingletons(
                 next: config => {
                     void localStorage.setConfig(config)
                     graphqlClient.setConfig(config)
-                    void featureFlagProvider.refresh()
-                    upstreamHealthProvider.instance!.onConfigurationChange(config)
                     defaultCodeCompletionsClient.instance!.onConfigurationChange(config)
                 },
             })
@@ -793,14 +783,4 @@ function registerChat(
     }
 
     return { chatsController }
-}
-
-/**
- * Create or update events infrastructure, using the new telemetryRecorder.
- */
-async function configureEventsInfra(
-    config: ResolvedConfiguration,
-    isExtensionModeDevOrTest: boolean
-): Promise<void> {
-    await createOrUpdateTelemetryRecorderProvider(config, isExtensionModeDevOrTest)
 }

--- a/vscode/src/models/sync.test.ts
+++ b/vscode/src/models/sync.test.ts
@@ -11,6 +11,7 @@ import {
     RestClient,
     type ServerModel,
     type ServerModelConfiguration,
+    featureFlagProvider,
     getDotComDefaultModels,
     graphqlClient,
     mockAuthStatus,
@@ -31,6 +32,8 @@ describe('syncModels', () => {
     beforeEach(() => {
         setModelsSpy.mockClear()
         mockAuthStatus(AUTH_STATUS_FIXTURE_AUTHED)
+
+        vi.spyOn(featureFlagProvider, 'evaluateFeatureFlag').mockResolvedValue(false)
 
         // Mock the /.api/client-config for these tests so that modelsAPIEnabled == false
         vi.spyOn(ClientConfigSingleton.prototype, 'getConfig').mockResolvedValue({

--- a/vscode/src/notifications/setup-notification.ts
+++ b/vscode/src/notifications/setup-notification.ts
@@ -1,16 +1,14 @@
 import * as vscode from 'vscode'
 
-import type { ClientConfigurationWithAccessToken } from '@sourcegraph/cody-shared'
+import type { AuthCredentials } from '@sourcegraph/cody-shared'
 
 import { localStorage } from '../services/LocalStorageProvider'
 
 import { telemetryRecorder } from '@sourcegraph/cody-shared'
 import { showActionNotification } from '.'
 
-export const showSetupNotification = async (
-    config: ClientConfigurationWithAccessToken
-): Promise<void> => {
-    if (config.serverEndpoint && config.accessToken) {
+export const showSetupNotification = async (auth: AuthCredentials): Promise<void> => {
+    if (auth.serverEndpoint && auth.accessToken) {
         // User has already attempted to configure Cody.
         // Regardless of if they are authenticated or not, we don't want to prompt them.
         return

--- a/vscode/src/services/AuthProvider.ts
+++ b/vscode/src/services/AuthProvider.ts
@@ -227,6 +227,8 @@ export class AuthProvider implements vscode.Disposable {
 
     private async updateAuthStatus(authStatus: AuthStatus): Promise<void> {
         try {
+            this.status.next(authStatus)
+
             // We update the graphqlClient and ModelsService first
             // because many listeners rely on these
             graphqlClient.setConfig(await getFullConfig())
@@ -234,7 +236,6 @@ export class AuthProvider implements vscode.Disposable {
         } catch (error) {
             logDebug('AuthProvider', 'updateAuthStatus error', error)
         } finally {
-            this.status.next(authStatus)
             let eventValue: 'disconnected' | 'connected' | 'failed'
             if (authStatus.authenticated) {
                 eventValue = 'connected'

--- a/vscode/src/services/UpstreamHealthProvider.ts
+++ b/vscode/src/services/UpstreamHealthProvider.ts
@@ -1,12 +1,15 @@
 import {
     type BrowserOrNodeResponse,
-    type ClientConfigurationWithAccessToken,
     addCustomUserAgent,
     addTraceparent,
+    currentResolvedConfig,
+    distinctUntilChanged,
     isDotCom,
     logDebug,
+    resolvedConfig,
     setSingleton,
     singletonNotYetSet,
+    subscriptionDisposable,
     wrapInActiveSpan,
 } from '@sourcegraph/cody-shared'
 import { fetch } from '@sourcegraph/cody-shared'
@@ -23,20 +26,25 @@ const INITIAL_PING_DELAY_MS = 10 * 1000 // 10 seconds
  *
  * You can query it to get aggregates of the most recent pings.
  */
-class UpstreamHealthProvider implements vscode.Disposable {
+export class UpstreamHealthProvider implements vscode.Disposable {
     private lastUpstreamLatency?: number
     private lastGatewayLatency?: number
 
     private disposables: vscode.Disposable[] = []
 
-    private config: Pick<
-        ClientConfigurationWithAccessToken,
-        'serverEndpoint' | 'customHeaders' | 'accessToken'
-    > | null = null
     private nextTimeoutId: NodeJS.Timeout | null = null
 
     constructor() {
+        // Refresh when auth (endpoint or token) changes.
         this.disposables.push(
+            subscriptionDisposable(
+                resolvedConfig.pipe(distinctUntilChanged()).subscribe(() => {
+                    this.lastUpstreamLatency = undefined
+                    this.lastGatewayLatency = undefined
+
+                    this.enqueue(INITIAL_PING_DELAY_MS)
+                })
+            ),
             vscode.window.onDidChangeWindowState(state => {
                 if (state.focused && this.lastMeasurementSkippedBecauseNotFocused) {
                     this.lastMeasurementSkippedBecauseNotFocused = false
@@ -47,33 +55,11 @@ class UpstreamHealthProvider implements vscode.Disposable {
     }
 
     public getUpstreamLatency(): number | undefined {
-        if (!this.config) {
-            return undefined
-        }
         return this.lastUpstreamLatency
     }
 
     public getGatewayLatency(): number | undefined {
-        if (!this.config) {
-            return undefined
-        }
         return this.lastGatewayLatency
-    }
-
-    public onConfigurationChange(
-        newConfig: Pick<
-            ClientConfigurationWithAccessToken,
-            'serverEndpoint' | 'customHeaders' | 'accessToken'
-        >
-    ) {
-        this.config = newConfig
-        this.lastUpstreamLatency = undefined
-        this.lastGatewayLatency = undefined
-
-        // Enqueue the initial ping after a config change in 10 seconds. This
-        // avoids running the test while the extension is still initializing and
-        // competing with many other network requests.
-        this.enqueue(INITIAL_PING_DELAY_MS)
     }
 
     private enqueue(delay: number): void {
@@ -90,41 +76,38 @@ class UpstreamHealthProvider implements vscode.Disposable {
             clearTimeout(this.nextTimeoutId)
         }
 
+        if (!vscode.window.state.focused) {
+            // Skip if the window is not focused, and try again when the window becomes focused
+            // again. Some users have OS firewalls that make periodic background network access
+            // annoying for users, and this eliminates that annoyance. See
+            // https://linear.app/sourcegraph/issue/CODY-3745/codys-background-periodic-network-access-causes-2fa.
+            this.lastMeasurementSkippedBecauseNotFocused = true
+            return
+        }
+
         try {
             if (process.env.DISABLE_UPSTREAM_HEALTH_PINGS === 'true') {
                 return
             }
 
-            if (!vscode.window.state.focused) {
-                // Skip if the window is not focused, and try again when the window becomes focused
-                // again. Some users have OS firewalls that make periodic background network access
-                // annoying for users, and this eliminates that annoyance. See
-                // https://linear.app/sourcegraph/issue/CODY-3745/codys-background-periodic-network-access-causes-2fa.
-                this.lastMeasurementSkippedBecauseNotFocused = true
-                return
-            }
-
-            if (!this.config) {
-                throw new Error('UpstreamHealthProvider not initialized')
-            }
-
-            const sharedHeaders = new Headers(this.config.customHeaders as HeadersInit)
+            const { auth, configuration } = await currentResolvedConfig()
+            const sharedHeaders = new Headers(configuration.customHeaders as HeadersInit | undefined)
             sharedHeaders.set('Content-Type', 'application/json; charset=utf-8')
             addTraceparent(sharedHeaders)
             addCustomUserAgent(sharedHeaders)
 
             const upstreamHeaders = new Headers(sharedHeaders)
-            if (this.config.accessToken) {
-                upstreamHeaders.set('Authorization', `token ${this.config.accessToken}`)
+            if (auth.accessToken) {
+                upstreamHeaders.set('Authorization', `token ${auth.accessToken}`)
             }
-            const url = new URL('/healthz', this.config.serverEndpoint)
+            const url = new URL('/healthz', auth.serverEndpoint)
             const upstreamResult = await wrapInActiveSpan('upstream-latency.upstream', span => {
                 span.setAttribute('sampled', true)
                 return measureLatencyToUri(upstreamHeaders, url.toString())
             })
 
             // We don't want to congest the network so we run the test serially
-            if (isDotCom(this.config.serverEndpoint)) {
+            if (isDotCom(auth.serverEndpoint)) {
                 const gatewayHeaders = new Headers(sharedHeaders)
                 const uri = 'https://cody-gateway.sourcegraph.com/-/__version'
                 const gatewayResult = await wrapInActiveSpan('upstream-latency.gateway', span => {

--- a/vscode/src/services/open-telemetry/utils.ts
+++ b/vscode/src/services/open-telemetry/utils.ts
@@ -1,5 +1,5 @@
 import type { Span } from '@opentelemetry/api'
-import { featureFlagProvider } from '@sourcegraph/cody-shared'
+import { currentAuthStatus, featureFlagProvider } from '@sourcegraph/cody-shared'
 import * as vscode from 'vscode'
 import { getConfiguration } from '../../configuration'
 import type { ExtensionApi } from '../../extension-api'
@@ -8,7 +8,7 @@ import { getExtensionDetails } from '../telemetry-v2'
 // Ensure to ad exposed experiments at the very end to make sure we include experiments that the
 // user is being exposed to while the span was generated
 export function recordExposedExperimentsToSpan(span: Span): void {
-    span.setAttributes(featureFlagProvider.getExposedExperiments())
+    span.setAttributes(featureFlagProvider.getExposedExperiments(currentAuthStatus().endpoint))
     const extensionDetails = getExtensionDetails(getConfiguration(vscode.workspace.getConfiguration()))
     span.setAttributes(extensionDetails as any)
 

--- a/vscode/src/test-support.ts
+++ b/vscode/src/test-support.ts
@@ -1,4 +1,9 @@
-import { type ChatMessage, ps } from '@sourcegraph/cody-shared'
+import {
+    type AuthStatus,
+    type ChatMessage,
+    currentAuthStatusOrNotReadyYet,
+    ps,
+} from '@sourcegraph/cody-shared'
 import type { ChatController } from './chat/chat-view/ChatController'
 
 // A one-slot channel which lets readers block on a value being
@@ -40,5 +45,9 @@ export class TestSupport {
 
     public async chatMessages(): Promise<readonly ChatMessage[]> {
         return (await this.chatPanelProvider.get()).getViewTranscript()
+    }
+
+    public authStatus(): AuthStatus | undefined {
+        return currentAuthStatusOrNotReadyYet()
     }
 }

--- a/vscode/src/testutils/mocks.ts
+++ b/vscode/src/testutils/mocks.ts
@@ -12,8 +12,6 @@ import type {
 import {
     type ClientConfiguration,
     type ClientConfigurationWithAccessToken,
-    type FeatureFlag,
-    FeatureFlagProvider,
     OLLAMA_DEFAULT_URL,
     ps,
 } from '@sourcegraph/cody-shared'
@@ -872,22 +870,6 @@ export const vsCodeMocks = {
     TextDocumentChangeReason,
     ProgressLocation,
 } as const
-
-export class MockFeatureFlagProvider extends FeatureFlagProvider {
-    constructor(private readonly enabledFlags: Set<FeatureFlag>) {
-        super()
-    }
-
-    public evaluateFeatureFlag(flag: FeatureFlag): Promise<boolean> {
-        return Promise.resolve(this.enabledFlags.has(flag))
-    }
-
-    public refresh(): Promise<void> {
-        return Promise.resolve()
-    }
-}
-
-export const emptyMockFeatureFlagProvider = new MockFeatureFlagProvider(new Set<FeatureFlag>())
 
 export const DEFAULT_VSCODE_SETTINGS = {
     proxy: undefined,


### PR DESCRIPTION
Partial application of https://github.com/sourcegraph/cody/pull/5221 to some services: FeatureFlagProvider, ClientStateBroadcaster, UpstreamHealthProvider, OpenTelemetryService, SentryService, etc.

The idea is to make services listen to config instead of checking it once and not updating themselves when config changes, which is bad because users need to reload the editor sometimes when they change config.

## Test plan

CI