### PR TITLE
Autocomplete: use new `authStatus` helpers for provider creation

### DIFF
--- a/lib/shared/src/auth/authStatus.ts
+++ b/lib/shared/src/auth/authStatus.ts
@@ -1,7 +1,12 @@
 import { Observable } from 'observable-fns'
 import { distinctUntilChanged, fromLateSetSource, shareReplay, storeLastValue } from '../misc/observable'
+import { isDotCom } from '../sourcegraph-api/environments'
 import type { PartialDeep } from '../utils'
-import type { AuthStatus, AuthenticatedAuthStatus } from './types'
+import {
+    AUTH_STATUS_FIXTURE_AUTHED_DOTCOM,
+    type AuthStatus,
+    type AuthenticatedAuthStatus,
+} from './types'
 
 const _authStatus = fromLateSetSource<AuthStatus>()
 
@@ -66,11 +71,21 @@ export function currentAuthStatusOrNotReadyYet(): AuthStatus | undefined {
 }
 
 /**
+ * Uses {@link currentAuthStatusAuthed} to determine if a user is authenticated on DotCom.
+ */
+export function isDotComAuthed(): boolean {
+    return isDotCom(currentAuthStatusAuthed())
+}
+
+/**
  * Mock the {@link authStatus} and {@link currentAuthStatus} values.
+ * Uses {@link AUTH_STATUS_FIXTURE_AUTHED_DOTCOM} as an auth status by default.
  *
  * For use in tests only.
  */
-export function mockAuthStatus(value: PartialDeep<AuthStatus>): void {
+export function mockAuthStatus(
+    value: PartialDeep<AuthStatus> = AUTH_STATUS_FIXTURE_AUTHED_DOTCOM
+): void {
     _authStatus.setSource(Observable.of(value as AuthStatus), false)
     Object.assign(syncValue, { last: value, isSet: true })
     syncValueSubscription.unsubscribe()

--- a/lib/shared/src/auth/types.ts
+++ b/lib/shared/src/auth/types.ts
@@ -71,6 +71,10 @@ export const AUTH_STATUS_FIXTURE_UNAUTHED: AuthStatus & { authenticated: false }
 export const AUTH_STATUS_FIXTURE_AUTHED_DOTCOM: AuthenticatedAuthStatus = {
     ...AUTH_STATUS_FIXTURE_AUTHED,
     endpoint: 'https://sourcegraph.com',
+    configOverwrites: {
+        provider: 'sourcegraph',
+        completionModel: 'fireworks/starcoder-hybrid',
+    },
 }
 
 export const AUTH_STATUS_FIXTURE_OFFLINE: Omit<AuthenticatedAuthStatus, 'isOfflineMode'> & {

--- a/lib/shared/src/misc/observable.ts
+++ b/lib/shared/src/misc/observable.ts
@@ -82,6 +82,14 @@ export async function firstValueFrom<T>(observable: Observable<T>): Promise<T> {
     })
 }
 
+/**
+ * Converts the observable factory to an async function that returns the first value emitted by the
+ * created observable.
+ */
+export function toFirstValueGetter<T, U extends unknown[]>(fn: (...args: U) => Observable<T>) {
+    return (...args: U): Promise<T> => firstValueFrom(fn(...args))
+}
+
 export async function waitUntilComplete(observable: Observable<unknown>): Promise<void> {
     return new Promise<void>((resolve, reject) => {
         observable.subscribe({

--- a/vscode/src/completions/create-inline-completion-item-provider.ts
+++ b/vscode/src/completions/create-inline-completion-item-provider.ts
@@ -72,7 +72,7 @@ export function createInlineCompletionItemProvider({
         return await getInlineCompletionItemProviderFilters(config.autocompleteLanguages)
     }).pipe(
         mergeMap(documentFilters =>
-            createProvider(config, authStatus).pipe(
+            createProvider(config).pipe(
                 createDisposables(provider => {
                     if (provider) {
                         const authStatus = currentAuthStatusAuthed()
@@ -92,7 +92,7 @@ export function createInlineCompletionItemProvider({
                             disableInsideComments: config.autocompleteDisableInsideComments,
                             isRunningInsideAgent: config.isRunningInsideAgent,
                             createBfgRetriever,
-                            isDotComUser: isDotCom(authStatus.endpoint || ''),
+                            isDotComUser: isDotCom(authStatus),
                         })
 
                         return [

--- a/vscode/src/completions/create-multi-model-inline-completion-provider.ts
+++ b/vscode/src/completions/create-multi-model-inline-completion-provider.ts
@@ -133,7 +133,6 @@ export async function createInlineCompletionItemFromMultipleProviders({
         // Use the experimental config to get the context provider
         completionProviderConfig.setConfig(newConfig)
         const provider = createProviderHelper({
-            authStatus,
             legacyModel: currentProviderConfig.model,
             provider: currentProviderConfig.provider,
             config: newConfig,
@@ -142,6 +141,7 @@ export async function createInlineCompletionItemFromMultipleProviders({
         const triggerDelay = vscode.workspace
             .getConfiguration()
             .get<number>('cody.autocomplete.triggerDelay')
+
         if (provider) {
             const completionsProvider = new InlineCompletionItemProvider({
                 provider,
@@ -154,7 +154,7 @@ export async function createInlineCompletionItemFromMultipleProviders({
                 disableInsideComments: config.autocompleteDisableInsideComments,
                 isRunningInsideAgent: config.isRunningInsideAgent,
                 createBfgRetriever,
-                isDotComUser: isDotCom(authStatus.endpoint || ''),
+                isDotComUser: isDotCom(authStatus),
                 noInlineAccept: true,
             })
             allCompletionsProviders.push({

--- a/vscode/src/completions/get-inline-completions-tests/analytics.test.ts
+++ b/vscode/src/completions/get-inline-completions-tests/analytics.test.ts
@@ -7,7 +7,7 @@ import * as CompletionLogger from '../logger'
 import type { CompletionBookkeepingEvent } from '../logger'
 import { initTreeSitterParser } from '../test-helpers'
 
-import { DOTCOM_URL } from '@sourcegraph/cody-shared'
+import { AUTH_STATUS_FIXTURE_AUTHED, AUTH_STATUS_FIXTURE_AUTHED_DOTCOM } from '@sourcegraph/cody-shared'
 import { Response } from 'node-fetch'
 import { getInlineCompletions, params } from './helpers'
 
@@ -51,12 +51,9 @@ describe('[getInlineCompletions] completion event', () => {
                     },
                 ],
                 {
-                    authStatus: {
-                        authenticated: true,
-                        endpoint: additionalParams.isDotComUser
-                            ? DOTCOM_URL.toString()
-                            : 'https://example.com',
-                    },
+                    authStatus: additionalParams.isDotComUser
+                        ? AUTH_STATUS_FIXTURE_AUTHED_DOTCOM
+                        : AUTH_STATUS_FIXTURE_AUTHED,
                 }
             )
         )
@@ -146,7 +143,7 @@ describe('[getInlineCompletions] completion event', () => {
                   "multiline": true,
                   "multilineMode": "block",
                   "providerIdentifier": "anthropic",
-                  "providerModel": "anthropic/claude-instant-1.2",
+                  "providerModel": "",
                   "resolvedModel": "sourcegraph/gateway-model",
                   "responseHeaders": {
                     "fireworks-speculation-matched-tokens": "100",
@@ -218,7 +215,7 @@ describe('[getInlineCompletions] completion event', () => {
                   "multiline": false,
                   "multilineMode": null,
                   "providerIdentifier": "anthropic",
-                  "providerModel": "anthropic/claude-instant-1.2",
+                  "providerModel": "",
                   "resolvedModel": "sourcegraph/gateway-model",
                   "responseHeaders": {
                     "fireworks-speculation-matched-tokens": "100",

--- a/vscode/src/completions/get-inline-completions-tests/helpers.ts
+++ b/vscode/src/completions/get-inline-completions-tests/helpers.ts
@@ -4,7 +4,6 @@ import { expect, vi } from 'vitest'
 import type { URI } from 'vscode-uri'
 
 import {
-    AUTH_STATUS_FIXTURE_AUTHED,
     AUTH_STATUS_FIXTURE_AUTHED_DOTCOM,
     type AuthenticatedAuthStatus,
     type ClientConfiguration,
@@ -79,7 +78,7 @@ type Params = Partial<
         params: CompletionParameters
     ) => Generator<CompletionResponse> | AsyncGenerator<CompletionResponse>
     configuration?: Partial<ClientConfiguration>
-    authStatus?: Partial<AuthenticatedAuthStatus>
+    authStatus?: AuthenticatedAuthStatus
     documentUri?: URI
 }
 
@@ -91,7 +90,7 @@ export interface ParamsResult extends Omit<InlineCompletionsParams, 'configurati
      */
     completionResponseGeneratorPromise: Promise<unknown>
     configuration?: Partial<ClientConfigurationWithAccessToken>
-    authStatus: Partial<AuthenticatedAuthStatus>
+    authStatus: AuthenticatedAuthStatus
 }
 
 /**
@@ -113,8 +112,11 @@ export function params(
         takeSuggestWidgetSelectionIntoAccount,
         configuration,
         documentUri = testFileUri('test.ts'),
+        authStatus = AUTH_STATUS_FIXTURE_AUTHED_DOTCOM,
         ...restParams
     } = params
+
+    mockAuthStatus(authStatus)
 
     let requestCounter = 0
     let resolveCompletionResponseGenerator: (value?: unknown) => void
@@ -170,7 +172,6 @@ export function params(
 
     const configWithAccessToken = getVSCodeConfigurationWithAccessToken(configuration)
     const provider = createProvider({
-        authStatus: AUTH_STATUS_FIXTURE_AUTHED_DOTCOM,
         legacyModel: configuration?.autocompleteAdvancedModel!,
         config: configWithAccessToken,
         anonymousUserID: 'anonymousUserID',
@@ -204,7 +205,7 @@ export function params(
     }
 
     return {
-        authStatus: AUTH_STATUS_FIXTURE_AUTHED_DOTCOM,
+        authStatus,
         configuration,
         document,
         position,
@@ -424,7 +425,7 @@ export function initCompletionProviderConfig({
 }: Partial<Pick<ParamsResult, 'configuration' | 'authStatus'>>): Promise<void> {
     graphqlClient.setConfig({} as unknown as GraphQLAPIClientConfig)
     vi.spyOn(featureFlagProvider, 'evaluateFeatureFlag').mockResolvedValue(false)
-    mockAuthStatus(authStatus ?? AUTH_STATUS_FIXTURE_AUTHED)
+    mockAuthStatus(authStatus)
     return completionProviderConfig.init((configuration ?? {}) as ClientConfiguration)
 }
 

--- a/vscode/src/completions/get-inline-completions.ts
+++ b/vscode/src/completions/get-inline-completions.ts
@@ -8,7 +8,7 @@ import {
     currentAuthStatus,
     getActiveTraceAndSpanId,
     isAbortError,
-    isDotCom,
+    isDotComAuthed,
     wrapInActiveSpan,
 } from '@sourcegraph/cody-shared'
 
@@ -249,9 +249,8 @@ async function doGetInlineCompletions(
 
     tracer?.({ params: { document, position, triggerKind, selectedCompletionInfo } })
 
-    const authStatus = await currentAuthStatus()
+    const isDotComUser = isDotComAuthed()
 
-    const isDotComUser = isDotCom(authStatus.endpoint)
     const gitIdentifiersForFile =
         isDotComUser === true ? gitMetadataForCurrentEditor.getGitIdentifiersForFile() : undefined
     if (gitIdentifiersForFile?.gitUrl) {
@@ -488,7 +487,7 @@ async function doGetInlineCompletions(
         firstCompletionTimeout,
         completionLogId: logId,
         gitContext,
-        authStatus,
+        authStatus: currentAuthStatus(),
         config,
         numberOfCompletionsToGenerate: numberOfCompletionsToGenerate ?? n,
         multiline: !!docContext.multilineTrigger,

--- a/vscode/src/completions/inline-completion-item-provider-e2e.test.ts
+++ b/vscode/src/completions/inline-completion-item-provider-e2e.test.ts
@@ -9,7 +9,7 @@ import {
 } from '@sourcegraph/cody-shared'
 import { type MockInstance, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 import type * as vscode from 'vscode'
-import { localStorage } from '../services/LocalStorageProvider'
+import { mockLocalStorage } from '../services/LocalStorageProvider'
 import { DEFAULT_VSCODE_SETTINGS, vsCodeMocks } from '../testutils/mocks'
 import { getCurrentDocContext } from './get-current-doc-context'
 import { TriggerKind } from './get-inline-completions'
@@ -197,10 +197,7 @@ describe.skip('InlineCompletionItemProvider E2E', () => {
     describe('smart throttle in-flight requests', () => {
         beforeAll(async () => {
             await initCompletionProviderConfig({ configuration: {} })
-            localStorage.setStorage({
-                get: () => null,
-                update: () => {},
-            } as any as vscode.Memento)
+            mockLocalStorage()
         })
 
         beforeEach(() => {
@@ -399,11 +396,7 @@ describe('InlineCompletionItemProvider preloading', () => {
         vi.useFakeTimers()
 
         await initCompletionProviderConfig({ configuration: autocompleteConfig })
-
-        localStorage.setStorage({
-            get: () => null,
-            update: () => {},
-        } as any as vscode.Memento)
+        mockLocalStorage()
     })
 
     it('triggers preload request on cursor movement if cursor is at the end of a line', async () => {

--- a/vscode/src/completions/inline-completion-item-provider.test.ts
+++ b/vscode/src/completions/inline-completion-item-provider.test.ts
@@ -11,7 +11,7 @@ import {
 } from '@sourcegraph/cody-shared'
 
 import { telemetryRecorder } from '@sourcegraph/cody-shared'
-import { localStorage } from '../services/LocalStorageProvider'
+import { mockLocalStorage } from '../services/LocalStorageProvider'
 import { DEFAULT_VSCODE_SETTINGS } from '../testutils/mocks'
 import { withPosixPaths } from '../testutils/textDocument'
 import { SupportedLanguage } from '../tree-sitter/grammars'
@@ -64,13 +64,9 @@ class MockableInlineCompletionItemProvider extends InlineCompletionItemProvider 
 describe('InlineCompletionItemProvider', () => {
     beforeAll(async () => {
         await initCompletionProviderConfig({})
-
-        // Dummy noop implementation of localStorage.
-        localStorage.setStorage({
-            get: () => null,
-            update: () => {},
-        } as any as vscode.Memento)
+        mockLocalStorage()
     })
+
     beforeEach(() => {
         vi.spyOn(contextFiltersProvider, 'isUriIgnored').mockResolvedValue(false)
         CompletionLogger.reset_testOnly()

--- a/vscode/src/completions/providers/create-provider.test.ts
+++ b/vscode/src/completions/providers/create-provider.test.ts
@@ -1,162 +1,125 @@
 import {
-    AUTH_STATUS_FIXTURE_AUTHED,
-    type AuthenticatedAuthStatus,
+    AUTH_STATUS_FIXTURE_AUTHED_DOTCOM,
     type ClientConfiguration,
-    type ClientConfigurationWithAccessToken,
     type CodyLLMSiteConfiguration,
-    DOTCOM_URL,
     type GraphQLAPIClientConfig,
-    type ObservableValue,
-    firstValueFrom,
     graphqlClient,
+    mockAuthStatus,
+    toFirstValueGetter,
 } from '@sourcegraph/cody-shared'
 import { beforeAll, describe, expect, it } from 'vitest'
-import type * as vscode from 'vscode'
-import { localStorage } from '../../services/LocalStorageProvider'
-import { DEFAULT_VSCODE_SETTINGS } from '../../testutils/mocks'
+import { mockLocalStorage } from '../../services/LocalStorageProvider'
+import { getVSCodeConfigurationWithAccessToken } from '../../testutils/mocks'
 
 import { createProvider } from './create-provider'
 
-const getVSCodeConfigurationWithAccessToken = (
-    config: Partial<ClientConfiguration> = {}
-): ClientConfigurationWithAccessToken => ({
-    ...DEFAULT_VSCODE_SETTINGS,
-    ...config,
-    serverEndpoint: 'https://example.com',
-    accessToken: 'foobar',
-})
-
-const dummyAuthStatus: AuthenticatedAuthStatus = {
-    ...AUTH_STATUS_FIXTURE_AUTHED,
-    endpoint: DOTCOM_URL.toString(),
-    configOverwrites: {
-        provider: 'sourcegraph',
-        completionModel: 'fireworks/starcoder-hybrid',
-    },
-}
-
 graphqlClient.setConfig({} as unknown as GraphQLAPIClientConfig)
+const createProviderFirstValue = toFirstValueGetter(createProvider)
 
 describe('createProvider', () => {
     beforeAll(async () => {
-        localStorage.setStorage({
-            get: () => null,
-            update: () => Promise.resolve(undefined),
-        } as any as vscode.Memento)
+        mockAuthStatus()
+        mockLocalStorage()
     })
 
-    function createProviderForTest(
-        ...args: Parameters<typeof createProvider>
-    ): Promise<ObservableValue<ReturnType<typeof createProvider>>> {
-        return firstValueFrom(createProvider(...args))
-    }
-
-    describe('if completions provider fields are defined in VSCode settings', () => {
-        it('returns null if completions provider is not supported', async () => {
-            const provider = await createProviderForTest(
+    describe('local settings', () => {
+        it('returns `null` if completions provider is not supported', async () => {
+            const provider = await createProviderFirstValue(
                 getVSCodeConfigurationWithAccessToken({
                     autocompleteAdvancedProvider:
                         'nasa-ai' as ClientConfiguration['autocompleteAdvancedProvider'],
-                }),
-                AUTH_STATUS_FIXTURE_AUTHED
+                })
             )
+
             expect(provider).toBeNull()
         })
-    })
 
-    describe('if completions provider field is not defined in VSCode settings', () => {
-        it('returns `null` if completions provider is not configured', async () => {
-            const provider = await createProviderForTest(
+        it('uses configOverwrites if completions provider is not configured', async () => {
+            const provider = await createProviderFirstValue(
                 getVSCodeConfigurationWithAccessToken({
                     autocompleteAdvancedProvider:
                         null as ClientConfiguration['autocompleteAdvancedProvider'],
-                }),
-                AUTH_STATUS_FIXTURE_AUTHED
+                })
             )
-            expect(provider).toBeNull()
+
+            expect(provider?.id).toBe('fireworks')
+            expect(provider?.legacyModel).toBe('starcoder-hybrid')
         })
 
         it('returns "fireworks" provider config and corresponding model if specified', async () => {
-            const provider = await createProviderForTest(
+            const provider = await createProviderFirstValue(
                 getVSCodeConfigurationWithAccessToken({
                     autocompleteAdvancedProvider: 'fireworks',
                     autocompleteAdvancedModel: 'starcoder-7b',
-                }),
-                dummyAuthStatus
+                })
             )
             expect(provider?.id).toBe('fireworks')
             expect(provider?.legacyModel).toBe('starcoder-7b')
         })
 
         it('returns "fireworks" provider config if specified in settings and default model', async () => {
-            const provider = await createProviderForTest(
-                getVSCodeConfigurationWithAccessToken({ autocompleteAdvancedProvider: 'fireworks' }),
-                dummyAuthStatus
+            const provider = await createProviderFirstValue(
+                getVSCodeConfigurationWithAccessToken({ autocompleteAdvancedProvider: 'fireworks' })
             )
             expect(provider?.id).toBe('fireworks')
             expect(provider?.legacyModel).toBe('deepseek-coder-v2-lite-base')
         })
 
         it('returns "experimental-openaicompatible" provider config and corresponding model if specified', async () => {
-            const provider = await createProviderForTest(
+            const provider = await createProviderFirstValue(
                 getVSCodeConfigurationWithAccessToken({
                     autocompleteAdvancedProvider: 'experimental-openaicompatible',
                     autocompleteAdvancedModel: 'starchat-16b-beta',
-                }),
-                dummyAuthStatus
+                })
             )
             expect(provider?.id).toBe('experimental-openaicompatible')
             expect(provider?.legacyModel).toBe('starchat-16b-beta')
         })
 
         it('returns "experimental-openaicompatible" provider config if specified in settings and default model', async () => {
-            const provider = await createProviderForTest(
+            const provider = await createProviderFirstValue(
                 getVSCodeConfigurationWithAccessToken({
                     autocompleteAdvancedProvider: 'experimental-openaicompatible',
-                }),
-                dummyAuthStatus
+                })
             )
             expect(provider?.id).toBe('experimental-openaicompatible')
-            // TODO(slimsag): make this default to starchat2 once added
-            // specifically just when using `experimental-openaicompatible`
             expect(provider?.legacyModel).toBe('starcoder-hybrid')
         })
 
         it('returns "unstable-openai" provider config if specified in VSCode settings; model is ignored', async () => {
-            const provider = await createProviderForTest(
+            const provider = await createProviderFirstValue(
                 getVSCodeConfigurationWithAccessToken({
                     autocompleteAdvancedProvider: 'unstable-openai',
                     autocompleteAdvancedModel: 'hello-world',
-                }),
-                dummyAuthStatus
+                })
             )
             expect(provider?.id).toBe('unstable-openai')
             expect(provider?.legacyModel).toBe('gpt-35-turbo')
         })
 
         it('returns "anthropic" provider config if specified in VSCode settings', async () => {
-            const provider = await createProviderForTest(
+            const provider = await createProviderFirstValue(
                 getVSCodeConfigurationWithAccessToken({
                     autocompleteAdvancedProvider: 'anthropic',
-                }),
-                dummyAuthStatus
+                })
             )
             expect(provider?.id).toBe('anthropic')
             expect(provider?.legacyModel).toBe('anthropic/claude-instant-1.2')
         })
 
         it('provider specified in VSCode settings takes precedence over the one defined in the site config', async () => {
-            const provider = await createProviderForTest(
+            mockAuthStatus({
+                ...AUTH_STATUS_FIXTURE_AUTHED_DOTCOM,
+                configOverwrites: {
+                    provider: 'fireworks',
+                    completionModel: 'starcoder-hybrid',
+                },
+            })
+
+            const provider = await createProviderFirstValue(
                 getVSCodeConfigurationWithAccessToken({
                     autocompleteAdvancedProvider: 'unstable-openai',
-                }),
-                {
-                    ...dummyAuthStatus,
-                    configOverwrites: {
-                        provider: 'azure-open-ai',
-                        completionModel: 'gpt-35-turbo-test',
-                    },
-                }
+                })
             )
             expect(provider?.id).toBe('unstable-openai')
             expect(provider?.legacyModel).toBe('gpt-35-turbo')
@@ -274,13 +237,15 @@ describe('createProvider', () => {
                 it(`returns ${JSON.stringify(expected)} when cody LLM config is ${JSON.stringify(
                     configOverwrites
                 )}`, async () => {
-                    const provider = await createProviderForTest(
-                        getVSCodeConfigurationWithAccessToken(),
-                        {
-                            ...dummyAuthStatus,
-                            configOverwrites,
-                        }
+                    mockAuthStatus({
+                        ...AUTH_STATUS_FIXTURE_AUTHED_DOTCOM,
+                        configOverwrites,
+                    })
+
+                    const provider = await createProviderFirstValue(
+                        getVSCodeConfigurationWithAccessToken()
                     )
+
                     if (expected === null) {
                         expect(provider).toBeNull()
                     } else {

--- a/vscode/src/completions/providers/create-provider.ts
+++ b/vscode/src/completions/providers/create-provider.ts
@@ -1,8 +1,7 @@
 import {
-    type AuthenticatedAuthStatus,
     type ClientConfigurationWithAccessToken,
     type Model,
-    isDotCom,
+    currentAuthStatusAuthed,
 } from '@sourcegraph/cody-shared'
 
 import { Observable, map } from 'observable-fns'
@@ -19,15 +18,11 @@ import { createProvider as createOpenAICompatibleProviderConfig } from './openai
 import type { Provider, ProviderFactory } from './provider'
 import { createProvider as createUnstableOpenAIProviderConfig } from './unstable-openai'
 
-export function createProvider(
-    config: ClientConfigurationWithAccessToken,
-    authStatus: AuthenticatedAuthStatus
-): Observable<Provider | null> {
+export function createProvider(config: ClientConfigurationWithAccessToken): Observable<Provider | null> {
     // Resolve the provider config from the VS Code config.
     if (config.autocompleteAdvancedProvider) {
         return Observable.of(
             createProviderHelper({
-                authStatus,
                 legacyModel: config.autocompleteAdvancedModel || undefined,
                 provider: config.autocompleteAdvancedProvider,
                 config,
@@ -35,20 +30,19 @@ export function createProvider(
         )
     }
 
-    return getExperimentModel(isDotCom(authStatus)).pipe(
+    return getExperimentModel().pipe(
         map(configFromFeatureFlags => {
             // Check if a user participates in autocomplete model experiments, and use the
             // experiment model if available.
             if (configFromFeatureFlags) {
                 return createProviderHelper({
-                    authStatus,
                     legacyModel: configFromFeatureFlags.model,
                     provider: configFromFeatureFlags.provider,
                     config,
                 })
             }
 
-            const modelInfoOrError = getModelInfo(authStatus)
+            const modelInfoOrError = getModelInfo()
 
             if (modelInfoOrError instanceof Error) {
                 logError('createProvider', modelInfoOrError.message)
@@ -58,7 +52,6 @@ export function createProvider(
             const { provider, legacyModel, model } = modelInfoOrError
 
             return createProviderHelper({
-                authStatus,
                 legacyModel,
                 model,
                 provider,
@@ -69,7 +62,6 @@ export function createProvider(
 }
 
 interface CreateConfigHelperParams {
-    authStatus: AuthenticatedAuthStatus
     legacyModel: string | undefined
     provider: string
     config: ClientConfigurationWithAccessToken
@@ -77,19 +69,17 @@ interface CreateConfigHelperParams {
 }
 
 export function createProviderHelper(params: CreateConfigHelperParams): Provider | null {
-    const { authStatus, legacyModel, model, provider, config } = params
+    const { legacyModel, model, provider, config } = params
     const anonymousUserID = localStorage.anonymousUserID()
 
     const providerCreator = getProviderCreator({
         provider: provider as AutocompleteProviderID,
-        authStatus,
     })
 
     if (providerCreator) {
         return providerCreator({
             model,
             legacyModel: legacyModel,
-            authStatus,
             config,
             anonymousUserID,
             provider,
@@ -101,11 +91,10 @@ export function createProviderHelper(params: CreateConfigHelperParams): Provider
 
 interface GetProviderCreatorParams {
     provider: AutocompleteProviderID
-    authStatus: AuthenticatedAuthStatus
 }
 
 function getProviderCreator(params: GetProviderCreatorParams): ProviderFactory | null {
-    const { provider, authStatus } = params
+    const { provider } = params
 
     if (provider === AUTOCOMPLETE_PROVIDER_ID.fireworks) {
         return createFireworksProvider
@@ -127,12 +116,14 @@ function getProviderCreator(params: GetProviderCreatorParams): ProviderFactory |
         return createExperimentalOpenAICompatibleProvider
     }
 
+    const { configOverwrites } = currentAuthStatusAuthed()
+
     if (
         provider === AUTOCOMPLETE_PROVIDER_ID.anthropic ||
         provider === AUTOCOMPLETE_PROVIDER_ID['aws-bedrock'] ||
         // An exception where we have to check the completion model string in addition to the provider ID.
         (provider === AUTOCOMPLETE_PROVIDER_ID.google &&
-            authStatus.configOverwrites?.completionModel?.includes('claude'))
+            configOverwrites?.completionModel?.includes('claude'))
     ) {
         return createAnthropicProvider
     }

--- a/vscode/src/completions/providers/fireworks.ts
+++ b/vscode/src/completions/providers/fireworks.ts
@@ -3,7 +3,7 @@ import {
     type CodeCompletionsParams,
     type CompletionResponseGenerator,
     dotcomTokenToGatewayToken,
-    isDotCom,
+    isDotComAuthed,
     tokensToChars,
 } from '@sourcegraph/cody-shared'
 import { forkSignal, generatorWithTimeout, zipGenerators } from '../utils'
@@ -225,7 +225,7 @@ class FireworksProvider extends Provider {
         let fastPathAccessToken =
             config.accessToken &&
             // Require the upstream to be dotcom
-            (isDotCom(authStatus) || isLocalInstance) &&
+            (isDotComAuthed() || isLocalInstance) &&
             process.env.CODY_DISABLE_FASTPATH !== 'true' && // Used for testing
             // The fast path client only supports Node.js style response streams
             isNode
@@ -261,9 +261,9 @@ class FireworksProvider extends Provider {
     }
 }
 
-function getClientModel(isDotCom: boolean, model?: string): FireworksModel {
+function getClientModel(model?: string): FireworksModel {
     if (model === undefined || model === '') {
-        return isDotCom ? DEEPSEEK_CODER_V2_LITE_BASE : 'starcoder-hybrid'
+        return isDotComAuthed() ? DEEPSEEK_CODER_V2_LITE_BASE : 'starcoder-hybrid'
     }
 
     if (model === 'starcoder-hybrid' || Object.prototype.hasOwnProperty.call(MODEL_MAP, model)) {
@@ -274,9 +274,9 @@ function getClientModel(isDotCom: boolean, model?: string): FireworksModel {
 }
 
 export function createProvider(params: ProviderFactoryParams): Provider {
-    const { legacyModel, authStatus, anonymousUserID } = params
+    const { legacyModel, anonymousUserID } = params
 
-    const clientModel = getClientModel(isDotCom(authStatus), legacyModel)
+    const clientModel = getClientModel(legacyModel)
 
     return new FireworksProvider({
         id: 'fireworks',

--- a/vscode/src/completions/providers/get-model-info.ts
+++ b/vscode/src/completions/providers/get-model-info.ts
@@ -1,9 +1,4 @@
-import {
-    type AuthenticatedAuthStatus,
-    type Model,
-    ModelUsage,
-    modelsService,
-} from '@sourcegraph/cody-shared'
+import { type Model, ModelUsage, currentAuthStatusAuthed, modelsService } from '@sourcegraph/cody-shared'
 
 interface ModelInfo {
     provider: string
@@ -11,7 +6,7 @@ interface ModelInfo {
     model?: Model
 }
 
-export function getModelInfo(authStatus: AuthenticatedAuthStatus): ModelInfo | Error {
+export function getModelInfo(): ModelInfo | Error {
     const model = modelsService.instance!.getDefaultModel(ModelUsage.Autocomplete)
 
     if (model) {
@@ -22,10 +17,12 @@ export function getModelInfo(authStatus: AuthenticatedAuthStatus): ModelInfo | E
         return { provider, legacyModel: model.id, model }
     }
 
-    if (authStatus.configOverwrites?.provider) {
+    const { configOverwrites } = currentAuthStatusAuthed()
+
+    if (configOverwrites?.provider) {
         return parseProviderAndModel({
-            provider: authStatus.configOverwrites.provider,
-            legacyModel: authStatus.configOverwrites.completionModel,
+            provider: configOverwrites.provider,
+            legacyModel: configOverwrites.completionModel,
         })
     }
 

--- a/vscode/src/completions/providers/provider.ts
+++ b/vscode/src/completions/providers/provider.ts
@@ -89,8 +89,6 @@ export type ProviderFactoryParams = {
     model?: Model
     legacyModel?: string
     config: ClientConfigurationWithAccessToken
-    // TODO: eliminate by using a singleton instead.
-    authStatus: AuthenticatedAuthStatus
     anonymousUserID: string
     mayUseOnDeviceInference?: boolean
     provider: string

--- a/vscode/src/notifications/cody-pro-expiration.test.ts
+++ b/vscode/src/notifications/cody-pro-expiration.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi, vitest } from 'vitest'
-import { localStorage } from '../services/LocalStorageProvider'
+import { mockLocalStorage } from '../services/LocalStorageProvider'
 
 import {
     AUTH_STATUS_FIXTURE_AUTHED,
@@ -33,7 +33,7 @@ describe('Cody Pro expiration notifications', () => {
 
     // Set up local storage backed by an object.
     let localStorageData: { [key: string]: unknown } = {}
-    localStorage.setStorage({
+    mockLocalStorage({
         get: (key: string) => localStorageData[key],
         update: (key: string, value: unknown) => {
             localStorageData[key] = value

--- a/vscode/src/repository/repo-name-resolver.test.ts
+++ b/vscode/src/repository/repo-name-resolver.test.ts
@@ -1,11 +1,6 @@
 import { describe, expect, it, vi } from 'vitest'
 
-import {
-    AUTH_STATUS_FIXTURE_AUTHED,
-    DOTCOM_URL,
-    graphqlClient,
-    mockAuthStatus,
-} from '@sourcegraph/cody-shared'
+import { AUTH_STATUS_FIXTURE_AUTHED, graphqlClient, mockAuthStatus } from '@sourcegraph/cody-shared'
 
 import * as gitExtensionAPI from './git-extension-api'
 import { RepoNameResolver } from './repo-name-resolver'
@@ -16,11 +11,7 @@ vi.mock('../services/AuthProvider')
 describe('getRepoNamesFromWorkspaceUri', () => {
     it('resolves the repo name using graphql for enterprise accounts', async () => {
         const repoNameResolver = new RepoNameResolver()
-        mockAuthStatus({
-            ...AUTH_STATUS_FIXTURE_AUTHED,
-            authenticated: true,
-            endpoint: 'https://example.com',
-        })
+        mockAuthStatus(AUTH_STATUS_FIXTURE_AUTHED)
 
         vi.spyOn(gitExtensionAPI, 'gitRemoteUrlsFromGitExtension').mockReturnValue([
             'git@github.com:sourcegraph/cody.git',
@@ -51,11 +42,7 @@ describe('getRepoNamesFromWorkspaceUri', () => {
 
     it('resolves the repo name using local conversion function for PLG accounts', async () => {
         const repoNameResolver = new RepoNameResolver()
-        mockAuthStatus({
-            ...AUTH_STATUS_FIXTURE_AUTHED,
-            authenticated: true,
-            endpoint: DOTCOM_URL.toString(),
-        })
+        mockAuthStatus()
 
         vi.spyOn(gitExtensionAPI, 'gitRemoteUrlsFromGitExtension').mockReturnValue([
             'git@github.com:sourcegraph/cody.git',

--- a/vscode/src/services/LocalStorageProvider.ts
+++ b/vscode/src/services/LocalStorageProvider.ts
@@ -290,3 +290,12 @@ export const localStorage = new LocalStorage()
 function getKeyForAuthStatus(authStatus: AuthenticatedAuthStatus): ChatHistoryKey {
     return `${authStatus.endpoint}-${authStatus.username}`
 }
+
+const noopLocalStorage = {
+    get: () => null,
+    update: () => Promise.resolve(undefined),
+} as any as Memento
+
+export function mockLocalStorage(storage: Memento = noopLocalStorage) {
+    localStorage.setStorage(storage)
+}

--- a/vscode/src/testutils/mocks.ts
+++ b/vscode/src/testutils/mocks.ts
@@ -11,6 +11,7 @@ import type {
 
 import {
     type ClientConfiguration,
+    type ClientConfigurationWithAccessToken,
     type FeatureFlag,
     FeatureFlagProvider,
     OLLAMA_DEFAULT_URL,
@@ -929,3 +930,14 @@ export const DEFAULT_VSCODE_SETTINGS = {
     testingModelConfig: undefined,
     experimentalGuardrailsTimeoutSeconds: undefined,
 } satisfies ClientConfiguration
+
+export function getVSCodeConfigurationWithAccessToken(
+    config: Partial<ClientConfiguration> = {}
+): ClientConfigurationWithAccessToken {
+    return {
+        ...DEFAULT_VSCODE_SETTINGS,
+        serverEndpoint: 'https://sourcegraph.com',
+        accessToken: 'test_access_token',
+        ...config,
+    }
+}


### PR DESCRIPTION
- Replaces the `authStatus` propagation in the autocomplete provider creation logic with new global getters, which are reactively updated.
- No functional changes.

## Test plan

CI