### PR TITLE
Prepare one box UI for Cody Web usage

### DIFF
--- a/vscode/webviews/chat/Transcript.tsx
+++ b/vscode/webviews/chat/Transcript.tsx
@@ -289,7 +289,7 @@ const TranscriptInteraction: FC<TranscriptInteractionProps> = memo(props => {
                 <InfoMessage>
                     {humanMessage.intent === 'search' ? (
                         <div className="tw-flex tw-justify-between tw-gap-4">
-                            <p>Intent detection selected a code search response.</p>
+                            <span>Intent detection selected a code search response.</span>
                             <div>
                                 <Button
                                     size="sm"
@@ -304,7 +304,7 @@ const TranscriptInteraction: FC<TranscriptInteractionProps> = memo(props => {
                         </div>
                     ) : (
                         <div className="tw-flex tw-justify-between tw-gap-4">
-                            <p>Intent detection selected an LLM response.</p>
+                            <span>Intent detection selected an LLM response.</span>
                             <div>
                                 <Button
                                     size="sm"

--- a/vscode/webviews/chat/Transcript.tsx
+++ b/vscode/webviews/chat/Transcript.tsx
@@ -328,8 +328,8 @@ const TranscriptInteraction: FC<TranscriptInteractionProps> = memo(props => {
                     contextAlternatives={humanMessage.contextAlternatives}
                     model={assistantMessage?.model}
                     isForFirstMessage={humanMessage.index === 0}
+                    showSnippets={experimentalOneBoxEnabled && humanMessage.intent === 'search'}
                     defaultOpen={experimentalOneBoxEnabled && humanMessage.intent === 'search'}
-                    showSnippets={experimentalOneBoxEnabled}
                 />
             )}
             {assistantMessage && !isContextLoading && (

--- a/vscode/webviews/chat/cells/Cell.tsx
+++ b/vscode/webviews/chat/cells/Cell.tsx
@@ -37,7 +37,7 @@ export const Cell = forwardRef<HTMLDivElement, PropsWithChildren<CellProps>>((pr
             <header className="tw-flex tw-gap-4 tw-items-center [&_>_*]:tw-flex-shrink-0">
                 {header}
             </header>
-            <div className={clsx('tw-flex-1 tw-overflow-hidden', contentClassName)}>{children}</div>
+            <div className={clsx('tw-flex-1', contentClassName)}>{children}</div>
         </div>
     )
 })

--- a/vscode/webviews/chat/cells/contextCell/ContextCell.tsx
+++ b/vscode/webviews/chat/cells/contextCell/ContextCell.tsx
@@ -135,7 +135,7 @@ export const ContextCell: FunctionComponent<{
                             </AccordionTrigger>
                         }
                         containerClassName={className}
-                        contentClassName="tw-flex tw-flex-col tw-gap-4 tw-overflow-hidden tw-max-w-full"
+                        contentClassName="tw-flex tw-flex-col tw-gap-4 tw-max-w-full"
                         data-testid="context"
                     >
                         {contextItems === undefined ? (

--- a/vscode/webviews/chat/cells/contextCell/ContextCell.tsx
+++ b/vscode/webviews/chat/cells/contextCell/ContextCell.tsx
@@ -171,7 +171,6 @@ export const ContextCell: FunctionComponent<{
                                                 <FileContextItem
                                                     item={item}
                                                     showSnippets={showSnippets}
-                                                    defaultOpen={defaultOpen}
                                                 />
                                                 {internalDebugContext &&
                                                     item.metadata &&

--- a/vscode/webviews/components/FileContextItem.tsx
+++ b/vscode/webviews/components/FileContextItem.tsx
@@ -1,28 +1,19 @@
 import type { ContextItem } from '@sourcegraph/cody-shared'
 import { MENTION_CLASS_NAME } from '@sourcegraph/prompt-editor'
 import { clsx } from 'clsx'
-import { ChevronRight, ChevronUp } from 'lucide-react'
-import { type FC, useState } from 'react'
+import type { FC } from 'react'
 
 import { FileLink } from './FileLink'
 import { FileSnippet } from './FileSnippet'
-import { Button } from './shadcn/ui/button'
 
 import styles from './FileContextItem.module.css'
 
 interface FileContextItemProps {
     item: ContextItem
     showSnippets: boolean
-    defaultOpen?: boolean
 }
 
-export const FileContextItem: FC<FileContextItemProps> = ({
-    item,
-    showSnippets,
-    defaultOpen = false,
-}) => {
-    const [isOpen, setOpen] = useState(defaultOpen)
-
+export const FileContextItem: FC<FileContextItemProps> = ({ item, showSnippets }) => {
     // Fallback on link for any non file context items (like openctx items)
     if (item.type !== 'file' || !showSnippets) {
         return (
@@ -42,36 +33,5 @@ export const FileContextItem: FC<FileContextItemProps> = ({
         )
     }
 
-    return (
-        <div className={styles.root}>
-            <header className={styles.header}>
-                <FileLink
-                    uri={item.uri}
-                    repoName={item.repoName}
-                    revision={item.revision}
-                    source={item.source}
-                    range={item.range}
-                    title={item.title}
-                    isTooLarge={item.isTooLarge}
-                    isTooLargeReason={item.isTooLargeReason}
-                    isIgnored={item.isIgnored}
-                    linkClassName={styles.contextItemLink}
-                    className={clsx(styles.linkContainer, MENTION_CLASS_NAME)}
-                />
-                <Button variant="secondary" size="sm" onClick={() => setOpen(!isOpen)}>
-                    {!isOpen ? (
-                        <>
-                            Show <ChevronRight size={14} />
-                        </>
-                    ) : (
-                        <>
-                            Hide <ChevronUp size={14} />
-                        </>
-                    )}
-                </Button>
-            </header>
-
-            {isOpen && <FileSnippet item={item} className={styles.codeBlock} />}
-        </div>
-    )
+    return <FileSnippet item={item} className={styles.codeBlock} />
 }

--- a/vscode/webviews/components/codeSnippet/CodeSnippet.module.css
+++ b/vscode/webviews/components/codeSnippet/CodeSnippet.module.css
@@ -46,7 +46,7 @@
     z-index: 1;
 
     border-bottom: 1px solid var(--cody-chat-code-border-color);
-    background-color: var(--vscode-titleBar-inactiveBackground);
+    background-color: var(--cody-chat-code-header-background);
 
     &-title {
         flex: 1 1 auto;

--- a/vscode/webviews/components/codeSnippet/components/CodeExcerpt.tsx
+++ b/vscode/webviews/components/codeSnippet/components/CodeExcerpt.tsx
@@ -103,7 +103,7 @@ export const CodeExcerpt: FC<Props> = props => {
     }, [highlightRanges, startLine, endLine, tableContainerElement, table])
 
     return (
-        <Code className={clsx(styles.codeExcerpt, className)}>
+        <Code className={clsx(styles.codeExcerpt, className)} data-code-excerpt={true}>
             <div ref={setTableContainerElement}>{table}</div>
         </Code>
     )

--- a/vscode/webviews/components/shadcn/ui/accordion.tsx
+++ b/vscode/webviews/components/shadcn/ui/accordion.tsx
@@ -40,7 +40,7 @@ const AccordionContent = React.forwardRef<
 >(({ className, children, ...props }, ref) => (
     <AccordionPrimitive.Content
         ref={ref}
-        className="tw-overflow-hidden tw-transition-all data-[state=closed]:tw-animate-accordion-up data-[state=open]:tw-animate-accordion-down"
+        className="tw-transition-all data-[state=closed]:tw-animate-accordion-up data-[state=open]:tw-animate-accordion-down"
         {...props}
     >
         <div className={className}>{children}</div>

--- a/web/CHANGELOG.md
+++ b/web/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.8.0
+- Add support for Cody one-box search results
+
 ## 0.7.7 
 - Revert "prompts and commands" new UI 
 

--- a/web/demo/App.module.css
+++ b/web/demo/App.module.css
@@ -1,3 +1,5 @@
+@import url('../../vscode/.storybook/static/vscode-themes/dark-modern.css');
+
 html,
 :host {
     tab-size: 4;

--- a/web/lib/components/CodyWebChat.tsx
+++ b/web/lib/components/CodyWebChat.tsx
@@ -269,6 +269,7 @@ const CodyWebPanel: FC<CodyWebPanelProps> = props => {
                                 transcript={transcript}
                                 vscodeAPI={vscodeAPI}
                                 isTranscriptError={isTranscriptError}
+                                experimentalOneBoxEnabled={config.config.experimentalOneBox}
                             />
                         </ComposedWrappers>
                     </ChatMentionContext.Provider>

--- a/web/lib/global-styles/styles.css
+++ b/web/lib/global-styles/styles.css
@@ -5,8 +5,6 @@ not include this in the cody web package since highlights styles is already
 imported in Sourcegraph shell.
 */
 /*@import url('../../../vscode/webviews/utils/highlight.css');*/
-
-@import url('../../../vscode/.storybook/static/vscode-themes/dark-modern.css');
 @import url('../../node_modules/@vscode/codicons/dist/codicon.css');
 @import url('./reset.css');
 

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sourcegraph/cody-web",
-  "version": "0.7.7",
+  "version": "0.8.0",
   "description": "Cody standalone web app",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
This PR 
- Fixes styles problem with Cody Web (the whole time vs code dark theme was included in the main lib bundle, which shouldn't be used anywhere outside of storybook demos)
- Prepare one box UI (render code block only for search intent results and only for one box UI)

## Test plan
- Check Cody Web UI (with one box functionality)
- Check that vscode one box doesn't get any regressions

