### PR TITLE
Chat Telemetry: Restores `prompt` and `response` text recording

### DIFF
--- a/lib/shared/src/prompt/truncation.ts
+++ b/lib/shared/src/prompt/truncation.ts
@@ -3,16 +3,15 @@ import { getTokenCounterUtils } from '../token/counter'
 
 import type { PromptString } from './prompt-string'
 
-import { Tiktoken } from 'js-tiktoken/lite'
-import ranks from 'js-tiktoken/ranks/cl100k_base'
-
-export function truncatePromptString(text: PromptString, maxTokens: number): PromptString {
-    const encoder = new Tiktoken(ranks)
-    const encoded = encoder.encode(text.toString())
-
+export async function truncatePromptString(
+    text: PromptString,
+    maxTokens: number
+): Promise<PromptString> {
+    const tokenCounterUtils = await getTokenCounterUtils()
+    const encoded = tokenCounterUtils.encode(text.toString())
     return encoded.length <= maxTokens
         ? text
-        : text.slice(0, encoder.decode(encoded.slice(0, maxTokens))?.length).trim()
+        : text.slice(0, tokenCounterUtils.decode(encoded.slice(0, maxTokens))?.length).trim()
 }
 
 /**

--- a/lib/shared/src/prompt/truncation.ts
+++ b/lib/shared/src/prompt/truncation.ts
@@ -3,15 +3,16 @@ import { getTokenCounterUtils } from '../token/counter'
 
 import type { PromptString } from './prompt-string'
 
-export async function truncatePromptString(
-    text: PromptString,
-    maxTokens: number
-): Promise<PromptString> {
-    const tokenCounterUtils = await getTokenCounterUtils()
-    const encoded = tokenCounterUtils.encode(text.toString())
+import { Tiktoken } from 'js-tiktoken/lite'
+import ranks from 'js-tiktoken/ranks/cl100k_base'
+
+export function truncatePromptString(text: PromptString, maxTokens: number): PromptString {
+    const encoder = new Tiktoken(ranks)
+    const encoded = encoder.encode(text.toString())
+
     return encoded.length <= maxTokens
         ? text
-        : text.slice(0, tokenCounterUtils.decode(encoded.slice(0, maxTokens))?.length).trim()
+        : text.slice(0, encoder.decode(encoded.slice(0, maxTokens))?.length).trim()
 }
 
 /**

--- a/vscode/src/chat/chat-view/ChatController.ts
+++ b/vscode/src/chat/chat-view/ChatController.ts
@@ -878,8 +878,7 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
                 // V2 telemetry exports privateMetadata only for DotCom users
                 // the condition below is an additional safeguard measure
                 promptText:
-                    isDotCom(authStatus) &&
-                    (await truncatePromptString(inputText, CHAT_INPUT_TOKEN_BUDGET)),
+                    isDotCom(authStatus) && truncatePromptString(inputText, CHAT_INPUT_TOKEN_BUDGET),
             },
             billingMetadata: {
                 product: 'cody',
@@ -1378,7 +1377,7 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
     /**
      * Finalizes adding a bot message to the chat model and triggers an update to the view.
      */
-    private async addBotMessage(requestID: string, rawResponse: PromptString): Promise<void> {
+    private addBotMessage(requestID: string, rawResponse: PromptString): void {
         const messageText = reformatBotMessageForChat(rawResponse)
         this.chatModel.addBotMessage({ text: messageText })
         void this.saveSession()
@@ -1403,8 +1402,7 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
                 // V2 telemetry exports privateMetadata only for DotCom users
                 // the condition below is an aditional safegaurd measure
                 responseText:
-                    isDotCom(authStatus) &&
-                    (await truncatePromptString(messageText, CHAT_OUTPUT_TOKEN_BUDGET)),
+                    isDotCom(authStatus) && truncatePromptString(messageText, CHAT_OUTPUT_TOKEN_BUDGET),
                 chatModel: this.chatModel.modelID,
             },
             billingMetadata: {

--- a/vscode/src/chat/chat-view/ChatController.ts
+++ b/vscode/src/chat/chat-view/ChatController.ts
@@ -878,7 +878,8 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
                 // V2 telemetry exports privateMetadata only for DotCom users
                 // the condition below is an additional safeguard measure
                 promptText:
-                    isDotCom(authStatus) && truncatePromptString(inputText, CHAT_INPUT_TOKEN_BUDGET),
+                    isDotCom(authStatus) &&
+                    (await truncatePromptString(inputText, CHAT_INPUT_TOKEN_BUDGET)),
             },
             billingMetadata: {
                 product: 'cody',
@@ -1377,7 +1378,7 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
     /**
      * Finalizes adding a bot message to the chat model and triggers an update to the view.
      */
-    private addBotMessage(requestID: string, rawResponse: PromptString): void {
+    private async addBotMessage(requestID: string, rawResponse: PromptString): Promise<void> {
         const messageText = reformatBotMessageForChat(rawResponse)
         this.chatModel.addBotMessage({ text: messageText })
         void this.saveSession()
@@ -1402,7 +1403,8 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
                 // V2 telemetry exports privateMetadata only for DotCom users
                 // the condition below is an aditional safegaurd measure
                 responseText:
-                    isDotCom(authStatus) && truncatePromptString(messageText, CHAT_OUTPUT_TOKEN_BUDGET),
+                    isDotCom(authStatus) &&
+                    (await truncatePromptString(messageText, CHAT_OUTPUT_TOKEN_BUDGET)),
                 chatModel: this.chatModel.modelID,
             },
             billingMetadata: {

--- a/vscode/src/chat/chat-view/ChatController.ts
+++ b/vscode/src/chat/chat-view/ChatController.ts
@@ -878,7 +878,8 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
                 // V2 telemetry exports privateMetadata only for DotCom users
                 // the condition below is an additional safeguard measure
                 promptText:
-                    isDotCom(authStatus) && truncatePromptString(inputText, CHAT_INPUT_TOKEN_BUDGET),
+                    isDotCom(authStatus) &&
+                    (await truncatePromptString(inputText, CHAT_INPUT_TOKEN_BUDGET)),
             },
             billingMetadata: {
                 product: 'cody',
@@ -1377,7 +1378,7 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
     /**
      * Finalizes adding a bot message to the chat model and triggers an update to the view.
      */
-    private addBotMessage(requestID: string, rawResponse: PromptString): void {
+    private async addBotMessage(requestID: string, rawResponse: PromptString): Promise<void> {
         const messageText = reformatBotMessageForChat(rawResponse)
         this.chatModel.addBotMessage({ text: messageText })
         void this.saveSession()
@@ -1402,7 +1403,8 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
                 // V2 telemetry exports privateMetadata only for DotCom users
                 // the condition below is an aditional safegaurd measure
                 responseText:
-                    isDotCom(authStatus) && truncatePromptString(messageText, CHAT_OUTPUT_TOKEN_BUDGET),
+                    isDotCom(authStatus) &&
+                    (await truncatePromptString(messageText, CHAT_OUTPUT_TOKEN_BUDGET)),
                 chatModel: this.chatModel.modelID,
             },
             billingMetadata: {
@@ -1738,7 +1740,8 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
                 // V2 telemetry exports privateMetadata only for DotCom users
                 // the condition below is an additional safeguard measure
                 promptText:
-                    isDotCom(authStatus) && truncatePromptString(inputText, CHAT_INPUT_TOKEN_BUDGET),
+                    isDotCom(authStatus) &&
+                    (await truncatePromptString(inputText, CHAT_INPUT_TOKEN_BUDGET)),
                 gitMetadata,
             },
             billingMetadata: {


### PR DESCRIPTION
Previously, chat telemetry events were not capturing `promptText` and `responseText` due to the asynchronous nature of the `truncatePromptString` function, which was modified in a recent pull request(https://github.com/sourcegraph/cody/pull/5231). 

Now, we have added the proper `await` calls when using `truncatePromptString`, re-enabling the collection of this data for chat telemetry events.

Key changes:
1. Added `await` to `ChatController` where `truncatePromptString` is being used
2. Made `addBotMessage` an async func

## Test plan
Tested locally and verified `promptText` and `responseText` are being recorded again.

https://github.com/user-attachments/assets/b3952819-0945-4162-baf7-d98704aec21d


<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
