### PR TITLE
Update Remote Directory label

### DIFF
--- a/lib/prompt-editor/src/mentions/mentionMenu/MentionMenu.tsx
+++ b/lib/prompt-editor/src/mentions/mentionMenu/MentionMenu.tsx
@@ -369,7 +369,7 @@ function getItemsHeading(
             <div className="tw-flex tw-flex-gap-2 tw-items-center tw-justify-between">
                 <div>
                     {mentionQuery.text.includes(':')
-                        ? 'Directory - Select a directory*'
+                        ? 'Directory - Select or search for a directory*'
                         : 'Directory - Select a repository*'}
                 </div>
                 <div


### PR DESCRIPTION
I found the label/prompt to select a remote directory confusing when using @-mention remote directories. It was not clear to me that it was possible to continue typing to search for matching directories within the repo.

## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

Open Cody
Select Remote Directories
Check for updated label once repo selected


## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->

Update Remote Directory label.

