### PR TITLE
fix(commands): remove duplicated commands from Cody Commands menu

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -9,6 +9,7 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 ### Fixed
 
 Chat: Fixed feedback buttons not working in chat. [pull/5509](https://github.com/sourcegraph/cody/pull/5509)
+Command: Removed duplicated default commands from the Cody Commands menu that were incorrectly listed as custom commands.
 
 ### Changed
 

--- a/vscode/src/commands/menus/index.ts
+++ b/vscode/src/commands/menus/index.ts
@@ -5,7 +5,7 @@ import { CommandMenuOption, CustomCommandConfigMenuItems } from './items/menu'
 
 import { CustomCommandType } from '@sourcegraph/cody-shared'
 import { telemetryRecorder } from '@sourcegraph/cody-shared'
-import { CodyCommandMenuItems } from '..'
+import { CodyCommandMenuItems as defaultCommands } from '..'
 import { executeEdit } from '../../edit/execute'
 import { executeChat } from '../execute/ask'
 import { openCustomCommandDocsLink } from '../services/custom-commands'
@@ -16,7 +16,7 @@ import type { CommandMenuItem } from './types'
 
 export async function showCommandMenu(
     type: 'default' | 'custom' | 'config',
-    allCommands: CodyCommand[],
+    customCommands: CodyCommand[],
     args?: CodyCommandArgs
 ): Promise<void> {
     const items: CommandMenuItem[] = []
@@ -43,20 +43,14 @@ export async function showCommandMenu(
         // Add Default Commands
         if (type !== 'custom') {
             items.push(CommandMenuSeperator.commands)
-            for (const item of CodyCommandMenuItems) {
-                // Skip the 'Custom Commands' option
-                if (item.key === 'custom') {
-                    continue
-                }
-
+            for (const item of defaultCommands) {
                 if (
                     item.requires?.setting &&
                     !vscode.workspace.getConfiguration().get(item.requires?.setting)
                 ) {
-                    // Skip items that are missing the correct setting
+                    // Skip items that are missing the correct setting / feature flag.
                     continue
                 }
-
                 const key = item.key
                 const label = `$(${item.icon}) ${item.description}`
                 const command = item.command.command
@@ -68,9 +62,9 @@ export async function showCommandMenu(
         }
 
         // Add Custom Commands
-        if (allCommands?.length) {
+        if (customCommands?.length) {
             items.push(CommandMenuSeperator.custom)
-            for (const customCommand of allCommands) {
+            for (const customCommand of customCommands) {
                 const label = `$(tools) ${customCommand.key}`
                 const description = customCommand.description ?? customCommand.prompt
                 const command = customCommand.key
@@ -101,11 +95,11 @@ export async function showCommandMenu(
         quickPick.onDidTriggerButton(async item => {
             // On gear icon click
             if (item.tooltip?.startsWith('Configure')) {
-                await showCommandMenu('config', allCommands)
+                await showCommandMenu('config', customCommands)
                 return
             }
             // On back button click
-            await showCommandMenu('default', allCommands)
+            await showCommandMenu('default', customCommands)
             quickPick.hide()
         })
 

--- a/vscode/src/commands/services/provider.ts
+++ b/vscode/src/commands/services/provider.ts
@@ -1,10 +1,4 @@
-import {
-    type CodyCommand,
-    CodyIDE,
-    type ContextItem,
-    CustomCommandType,
-    isFileURI,
-} from '@sourcegraph/cody-shared'
+import { type CodyCommand, CodyIDE, type ContextItem, isFileURI } from '@sourcegraph/cody-shared'
 
 import * as vscode from 'vscode'
 import { CodyCommandMenuItems } from '..'
@@ -66,19 +60,17 @@ export class CommandsProvider implements vscode.Disposable {
     }
 
     private async menu(type: 'custom' | 'config' | 'default', args?: CodyCommandArgs): Promise<void> {
-        const commandArray = this.list().filter(
-            c =>
-                type !== 'custom' ||
-                c.type === CustomCommandType.User ||
-                c.type === CustomCommandType.Workspace
-        )
-        if (type === 'custom' && !commandArray.length) {
-            return showCommandMenu('config', commandArray, args)
+        const customCommands = [...this.customCommandsStore.commands.values()]
+        // Display the configuration menu if there is no custom command.
+        if (type === 'custom' && !customCommands.length) {
+            return showCommandMenu('config', customCommands, args)
         }
-
-        await showCommandMenu(type, commandArray, args)
+        await showCommandMenu(type, customCommands, args)
     }
 
+    /**
+     * A list of all available commands.
+     */
     public list(): CodyCommand[] {
         return [...this.customCommandsStore.commands.values(), ...this.commands.values()]
     }

--- a/vscode/test/e2e/command-custom.test.ts
+++ b/vscode/test/e2e/command-custom.test.ts
@@ -14,6 +14,7 @@ import {
     type ExpectedV2Events,
     test as baseTest,
     executeCommandInPalette,
+    openCodyCommandsQuickPick,
     openCustomCommandMenu,
     withPlatformSlashes,
 } from './helpers'
@@ -54,8 +55,15 @@ test.extend<ExpectedV2Events>({
 
     // Bring the cody sidebar to the foreground
     await page.getByRole('tab', { name: 'Cody', exact: true }).locator('a').click()
+
+    // Verify the default commands are not showing up as custom commands in the menu.
+    // Meaning it should only shouw up once in the command menu.
+    await openCodyCommandsQuickPick(page)
+    await expect(page.getByText('Explain Code', { exact: true })).toBeVisible()
+
     // Click the Custom Commands button in the Sidebar to open the Custom Commands menu
     await openCustomCommandMenu(page)
+    await expect(page.getByText('Explain Code', { exact: true })).not.toBeVisible()
 
     const commandName = 'ATestCommand'
     const prompt = 'The test command has been created'
@@ -110,7 +118,7 @@ test.extend<ExpectedV2Events>({
 
     // The new command should show up
     await openCustomCommandMenu(page)
-    expect(await page.getByText(commandName)).toBeVisible({ timeout: 1000 })
+    await expect(page.getByText(commandName)).toBeVisible({ timeout: 1000 })
 })
 
 // NOTE: If no custom commands are showing up in the command menu, it might

--- a/vscode/test/e2e/helpers.ts
+++ b/vscode/test/e2e/helpers.ts
@@ -512,8 +512,13 @@ export function getMetaKeyByOS(): 'Meta' | 'Control' {
     return isPlatform('darwin') ? 'Meta' : 'Control'
 }
 
+export const openCodyCommandsQuickPick = async (page: Page): Promise<void> => {
+    await executeCommandInPalette(page, 'Cody Menu: Cody Commands')
+    await expect(page.getByText('Cody Commands')).toBeVisible()
+}
+
 export const openCustomCommandMenu = async (page: Page): Promise<void> => {
-    await executeCommandInPalette(page, 'Custom Commands')
+    await executeCommandInPalette(page, 'Cody Menu: Custom Commands')
 }
 
 export const testWithGitRemote = test.extend<WorkspaceDirectory>({


### PR DESCRIPTION
CLOSE https://linear.app/sourcegraph/issue/CODY-3698/remove-duplicate-command-buttons-in-ui-to-avoid-confusion

This PR fixes an issue where duplicated default commands are listed as custom commands in the Cody Commands QuickPick menu.

Root cause: All commands (including default ones) were being sent to the quick pick menu during the build step used to append to the menu.

Fix: Send only custom commands to the menu, preventing default commands from being listed as custom.

- Update showCommandMenu function to use only custom commands
- Modify CommandsProvider to pass only custom commands for menu display
- Update E2E tests to verify default commands are not shown as custom
- Refactor command menu opening functions for consistency
- Update CHANGELOG.md to reflect the fix

This change ensures that default Cody commands are not incorrectly listed as custom commands in the Cody Commands menu, improving the user experience and reducing confusion.

## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

Green CI with the updated E2E test.

Manual Test:

1. Click on the Cody icon in your editor to bring up the Cody Commands menu
2. Verify the default commands are only showing up once

#### After

![image](https://github.com/user-attachments/assets/193795eb-53c3-46b5-bb50-11cd30003016)

#### Before:

Default commands are showing up twice, once at the top and once at the bottom of the menu:

![image](https://github.com/user-attachments/assets/3d13dec7-97a1-459d-b621-3332b99e930e)


## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
