### PR TITLE
Remove mentions for intent detection query

### DIFF
--- a/vscode/src/chat/chat-view/ChatController.ts
+++ b/vscode/src/chat/chat-view/ChatController.ts
@@ -734,9 +734,18 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
                 )
 
                 if ((await oneBoxEnabled) && repositoryMentioned) {
+                    const inputTextWithoutContextChips = editorState
+                        ? PromptString.unsafe_fromUserQuery(
+                              inputTextWithoutContextChipsFromPromptEditorState(editorState)
+                          )
+                        : inputText
+
                     const intent = detectedIntent
                         ? detectedIntent
-                        : await this.detectChatIntent({ requestID, text: inputText.toString() })
+                        : await this.detectChatIntent({
+                              requestID,
+                              text: inputTextWithoutContextChips.toString(),
+                          })
                               .then(async intent => {
                                   signal.throwIfAborted()
                                   this.chatModel.setLastMessageIntent(intent)

--- a/vscode/webviews/chat/Transcript.tsx
+++ b/vscode/webviews/chat/Transcript.tsx
@@ -3,6 +3,7 @@ import {
     type Guardrails,
     type SerializedPromptEditorValue,
     deserializeContextItem,
+    inputTextWithoutContextChipsFromPromptEditorState,
     isAbortErrorOrSocketHangUp,
 } from '@sourcegraph/cody-shared'
 import { type PromptEditorRefAPI, useExtensionAPI } from '@sourcegraph/prompt-editor'
@@ -219,9 +220,13 @@ const TranscriptInteraction: FC<TranscriptInteractionProps> = memo(props => {
                     ['repository', 'tree'].includes(contextItem.type)
                 )
             ) {
-                extensionAPI.detectIntent(editorValue.text).subscribe(value => {
-                    setIntent(value)
-                })
+                extensionAPI
+                    .detectIntent(
+                        inputTextWithoutContextChipsFromPromptEditorState(editorValue.editorState)
+                    )
+                    .subscribe(value => {
+                        setIntent(value)
+                    })
             }
         }, 300)
     }, [experimentalOneBoxEnabled, extensionAPI])


### PR DESCRIPTION
context: https://sourcegraph.slack.com/archives/C07EQBRSF35/p1726126230126479

Removed the mention chips text from queries sent for intent detection for improvement accuracy. 

## Test plan

- check if the intent is returned correctly....
## Changelog

- Removed the mentioned chips from the query sent for intent detection.