### PR TITLE
Cody Web: Fix code snippets leaking styles

### DIFF
--- a/vscode/webviews/chat/Transcript.tsx
+++ b/vscode/webviews/chat/Transcript.tsx
@@ -293,7 +293,7 @@ const TranscriptInteraction: FC<TranscriptInteractionProps> = memo(props => {
             {experimentalOneBoxEnabled && humanMessage.intent && (
                 <InfoMessage>
                     {humanMessage.intent === 'search' ? (
-                        <div className="tw-flex tw-justify-between tw-gap-4">
+                        <div className="tw-flex tw-justify-between tw-gap-4 tw-items-center">
                             <span>Intent detection selected a code search response.</span>
                             <div>
                                 <Button
@@ -308,7 +308,7 @@ const TranscriptInteraction: FC<TranscriptInteractionProps> = memo(props => {
                             </div>
                         </div>
                     ) : (
-                        <div className="tw-flex tw-justify-between tw-gap-4">
+                        <div className="tw-flex tw-justify-between tw-gap-4 tw-items-center">
                             <span>Intent detection selected an LLM response.</span>
                             <div>
                                 <Button

--- a/vscode/webviews/components/codeSnippet/CodeSnippet.module.css
+++ b/vscode/webviews/components/codeSnippet/CodeSnippet.module.css
@@ -5,9 +5,8 @@
     --cody-chat-code-border-color: var(--vscode-widget-border);
     --cody-chat-code-text-muted: var(--vscode-input-placeholderForeground);
     --cody-chat-code-focus-border: var(--vscode-focusBorder);
-
-    --mark-bg: #f8e688;
-    --text-muted-highlighted: #566880;
+    --cody-chat-code-mark-background: #f8e688;
+    --cody-chat-code-text-highlighted: #566880;
 }
 
 .result-container {
@@ -16,8 +15,8 @@
     border: solid 1px var(--cody-chat-code-border-color);
 
     :global(.match-highlight) {
-        color: var(--text-muted-highlighted);
-        background-color: var(--mark-bg);
+        color: var(--cody-chat-code-text-highlighted);
+        background-color: var(--cody-chat-code-mark-background);
     }
 
     :global(.sr-only) {

--- a/web/CHANGELOG.md
+++ b/web/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.8.1
+- Fix leaking highlighted code matches styles 
+
 ## 0.8.0
 - Add support for Cody one-box search results
 

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sourcegraph/cody-web",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Cody standalone web app",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
Part of https://linear.app/sourcegraph/issue/SRCH-1061/cody-web-leaks-styles-for-highlighted-code-matches

This simply renames color variables to avoid namespaces overlapping with the Sourcegraph Web App. 

## Test plan
- This doesn't change anything about existing Cody Chat styles, so no regression

