### PR TITLE
Chat: rename the 'OpenAI o1' model to 'OpenAI o1-preview

### DIFF
--- a/agent/recordings/defaultClient_631904893/recording.har.yaml
+++ b/agent/recordings/defaultClient_631904893/recording.har.yaml
@@ -1141,114 +1141,6 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: 6b6c4b45cd9d690f4cfcf661370d6665
-      _order: 0
-      cache: {}
-      request:
-        bodySize: 513
-        cookies: []
-        headers:
-          - name: content-type
-            value: application/json
-          - name: accept-encoding
-            value: gzip;q=0
-          - name: authorization
-            value: token
-              REDACTED_d5e0f0a37c9821e856b923fe14e67a605e3f6c0a517d5a4f46a4e35943ee0f6d
-          - name: user-agent
-            value: defaultClient / v1
-          - name: traceparent
-            value: 00-45e4e1da01f2127c77de706758f3e65d-51588ce492518030-01
-          - name: connection
-            value: keep-alive
-          - name: host
-            value: sourcegraph.com
-        headersSize: 401
-        httpVersion: HTTP/1.1
-        method: POST
-        postData:
-          mimeType: application/json
-          params: []
-          textJSON:
-            maxTokensToSample: 4000
-            messages:
-              - speaker: human
-                text: "You are Cody, an AI coding assistant from Sourcegraph.If your answer
-                  contains fenced code blocks in Markdown, include the relevant
-                  full file path in the code block tag using this structure:
-                  ```$LANGUAGE:$FILEPATH```."
-              - speaker: assistant
-                text: I am Cody, an AI coding assistant from Sourcegraph.
-              - speaker: human
-                text: what color is the sky?
-              - speaker: assistant
-            model: openai/gpt-3.5-turbo
-            temperature: 0
-            topK: -1
-            topP: -1
-        queryString:
-          - name: client-name
-            value: defaultclient
-          - name: client-version
-            value: v1
-        url: https://sourcegraph.com/.api/completions/stream?client-name=defaultclient&client-version=v1
-      response:
-        bodySize: 12890
-        content:
-          mimeType: text/event-stream
-          size: 12890
-          text: >+
-            event: completion
-
-            data: {"completion":"The sky is typically blue during the day due to the scattering of sunlight by the Earth's atmosphere. However, at sunrise and sunset, the sky can appear in shades of orange, pink, and red due to the longer path that sunlight has to travel through the atmosphere during these times.\n\n```plaintext```","stopReason":"stop"}
-
-
-            event: done
-
-            data: {}
-
-        cookies: []
-        headers:
-          - name: date
-            value: Fri, 23 Aug 2024 09:46:02 GMT
-          - name: content-type
-            value: text/event-stream
-          - name: transfer-encoding
-            value: chunked
-          - name: connection
-            value: keep-alive
-          - name: access-control-allow-credentials
-            value: "true"
-          - name: access-control-allow-origin
-            value: ""
-          - name: cache-control
-            value: no-cache
-          - name: vary
-            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
-              X-Requested-With,Cookie
-          - name: x-content-type-options
-            value: nosniff
-          - name: x-frame-options
-            value: DENY
-          - name: x-xss-protection
-            value: 1; mode=block
-          - name: strict-transport-security
-            value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1299
-        httpVersion: HTTP/1.1
-        redirectURL: ""
-        status: 200
-        statusText: OK
-      startedDateTime: 2024-08-23T09:46:01.811Z
-      time: 0
-      timings:
-        blocked: -1
-        connect: -1
-        dns: -1
-        receive: 0
-        send: 0
-        ssl: -1
-        wait: 0
     - _id: 54576e5e77faaa1011ca7e70953762e8
       _order: 0
       cache: {}
@@ -2944,6 +2836,113 @@ log:
         status: 200
         statusText: OK
       startedDateTime: 2024-08-23T09:46:27.703Z
+      time: 0
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 0
+    - _id: dcf68d0adcbf3da025d782b6300b0461
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 492
+        cookies: []
+        headers:
+          - name: content-type
+            value: application/json
+          - name: accept-encoding
+            value: gzip;q=0
+          - name: authorization
+            value: token
+              REDACTED_d5e0f0a37c9821e856b923fe14e67a605e3f6c0a517d5a4f46a4e35943ee0f6d
+          - name: user-agent
+            value: defaultClient / v1
+          - name: traceparent
+            value: 00-f21e1d1363902b6d0f9bd13c233aca9e-45284a9e6e2de455-01
+          - name: connection
+            value: keep-alive
+          - name: host
+            value: sourcegraph.com
+        headersSize: 401
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json
+          params: []
+          textJSON:
+            maxTokensToSample: 4000
+            messages:
+              - speaker: human
+                text: "You are Cody, an AI coding assistant from Sourcegraph.If your answer
+                  contains fenced code blocks in Markdown, include the relevant
+                  full file path in the code block tag using this structure:
+                  ```$LANGUAGE:$FILEPATH```."
+              - speaker: assistant
+                text: I am Cody, an AI coding assistant from Sourcegraph.
+              - speaker: human
+                text: what color is the sky?
+            model: google/gemini-1.5-flash
+            temperature: 0
+            topK: -1
+            topP: -1
+        queryString:
+          - name: client-name
+            value: defaultclient
+          - name: client-version
+            value: v1
+        url: https://sourcegraph.com/.api/completions/stream?client-name=defaultclient&client-version=v1
+      response:
+        bodySize: 1331
+        content:
+          mimeType: text/event-stream
+          size: 1331
+          text: >+
+            event: completion
+
+            data: {"completion":"The sky appears blue due to a phenomenon called **Rayleigh scattering**.  Sunlight is made up of all the colors of the rainbow, but blue light is scattered more easily by the tiny particles in the atmosphere than other colors.  \n\nSo, while the sky is technically colorless, the blue light that is scattered reaches our eyes most prominently, making the sky appear blue. \n","stopReason":"STOP"}
+
+
+            event: done
+
+            data: {}
+
+        cookies: []
+        headers:
+          - name: date
+            value: Fri, 13 Sep 2024 00:13:01 GMT
+          - name: content-type
+            value: text/event-stream
+          - name: transfer-encoding
+            value: chunked
+          - name: connection
+            value: keep-alive
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache
+          - name: vary
+            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
+              X-Requested-With,Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+        headersSize: 1299
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: 2024-09-13T00:12:59.896Z
       time: 0
       timings:
         blocked: -1

--- a/agent/src/index.test.ts
+++ b/agent/src/index.test.ts
@@ -542,8 +542,9 @@ describe('Agent', () => {
             ]
             const id = await client.request('chat/new', null)
             {
-                await client.request('chat/setModel', { id, model: 'openai/gpt-3.5-turbo' })
+                await client.request('chat/setModel', { id, model: 'google/gemini-1.5-flash' })
                 const lastMessage = await client.sendMessage(id, 'what color is the sky?')
+                console.log(lastMessage, 'lastMessage')
                 expect(lastMessage?.text?.toLocaleLowerCase().includes('blue')).toBeTruthy()
             }
         }, 30_000)

--- a/lib/shared/src/models/dotcom.ts
+++ b/lib/shared/src/models/dotcom.ts
@@ -74,7 +74,7 @@ export const DEFAULT_DOT_COM_MODELS = [
     // Preview / Early Access
     // --------------------------------
     {
-        title: 'OpenAI o1',
+        title: 'OpenAI o1-preview',
         id: 'openai/cody-chat-preview-001',
         provider: 'OpenAI',
         usage: [ModelUsage.Chat, ModelUsage.Edit],

--- a/vscode/src/chat/chat-view/ChatModel.ts
+++ b/vscode/src/chat/chat-view/ChatModel.ts
@@ -30,8 +30,11 @@ export class ChatModel {
     }
 
     public updateModel(newModelID: string) {
-        this.modelID = newModelID
-        this.contextWindow = modelsService.instance!.getContextWindowByID(this.modelID)
+        // Only update the model if it is available to the user.
+        if (modelsService.instance!.isModelAvailable(newModelID)) {
+            this.modelID = newModelID
+            this.contextWindow = modelsService.instance!.getContextWindowByID(this.modelID)
+        }
     }
 
     public isEmpty(): boolean {


### PR DESCRIPTION

fix: update model selection to only allow available models
- Only update the model ID if the new model is available to the user
- Rename the 'OpenAI o1' model to 'OpenAI o1-preview' to better indicate it is a preview model


## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

Switch to OpenAI o1-preview model to confirm it opens the waitlist blog
Then switch to another model to confirm you can submit chat without issue

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->

Rename the 'OpenAI o1' model to 'OpenAI o1-preview'