### PR TITLE
fix(chat): support non-streaming chat completion requests

### DIFF
--- a/lib/shared/src/sourcegraph-api/completions/browserClient.ts
+++ b/lib/shared/src/sourcegraph-api/completions/browserClient.ts
@@ -8,7 +8,7 @@ import { addClientInfoParams } from '../client-name-version'
 import { CompletionsResponseBuilder } from './CompletionsResponseBuilder'
 import { type CompletionRequestParameters, SourcegraphCompletionsClient } from './client'
 import { parseCompletionJSON } from './parse'
-import type { CompletionCallbacks, CompletionParameters, Event } from './types'
+import type { CompletionCallbacks, CompletionParameters, CompletionResponse, Event } from './types'
 import { getSerializedParams } from './utils'
 
 declare const WorkerGlobalScope: never
@@ -150,16 +150,16 @@ export class SourcegraphBrowserCompletionsClient extends SourcegraphCompletionsC
                         : errorMessage
                 )
             }
-            const data = await response.json()
+            const data = (await response.json()) as CompletionResponse
             if (data?.completion) {
                 cb.onChange(data.completion)
                 cb.onComplete()
             } else {
                 throw new Error('Unexpected response format')
             }
-        } catch (error: any) {
-            cb.onError(error.message)
+        } catch (error) {
             console.error(error)
+            cb.onError(error instanceof Error ? error : new Error(`${error}`))
         }
     }
 }

--- a/lib/shared/src/sourcegraph-api/completions/client.ts
+++ b/lib/shared/src/sourcegraph-api/completions/client.ts
@@ -9,6 +9,7 @@ import type {
     CompletionParameters,
     CompletionResponse,
     Event,
+    SerializedCompletionParameters,
 } from './types'
 
 export interface CompletionLogger {

--- a/lib/shared/src/sourcegraph-api/completions/client.ts
+++ b/lib/shared/src/sourcegraph-api/completions/client.ts
@@ -93,7 +93,7 @@ export abstract class SourcegraphCompletionsClient {
     protected async prepareRequest(
         params: CompletionParameters,
         requestParams: CompletionRequestParameters
-    ): Promise<{ url: URL; serializedParams: any }> {
+    ): Promise<{ url: URL; serializedParams: SerializedCompletionParameters }> {
         const { apiVersion } = requestParams
         const serializedParams = await getSerializedParams(params)
         const url = new URL(this.completionsEndpoint)

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -8,6 +8,7 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 
 - The [new OpenAI models (OpenAI O1 & OpenAI O1-mini)](https://sourcegraph.com/blog/openai-o1-for-cody) are now available to selected Cody Pro users for early access. [pull/5508](https://github.com/sourcegraph/cody/pull/5508)
 - Cody Pro users can join the waitlist for the new models by clicking the "Join Waitlist" button. [pull/5508](https://github.com/sourcegraph/cody/pull/5508)
+- Chat: Support non-streaming requests.
 
 ### Fixed
 

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -8,7 +8,7 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 
 - The [new OpenAI models (OpenAI O1 & OpenAI O1-mini)](https://sourcegraph.com/blog/openai-o1-for-cody) are now available to selected Cody Pro users for early access. [pull/5508](https://github.com/sourcegraph/cody/pull/5508)
 - Cody Pro users can join the waitlist for the new models by clicking the "Join Waitlist" button. [pull/5508](https://github.com/sourcegraph/cody/pull/5508)
-- Chat: Support non-streaming requests.
+- Chat: Support non-streaming requests. [pull/5565](https://github.com/sourcegraph/cody/pull/5565)
 
 ### Fixed
 

--- a/vscode/src/completions/nodeClient.ts
+++ b/vscode/src/completions/nodeClient.ts
@@ -10,6 +10,7 @@ import {
     type CompletionCallbacks,
     type CompletionParameters,
     type CompletionRequestParameters,
+    type CompletionResponse,
     NetworkError,
     RateLimitError,
     SourcegraphCompletionsClient,
@@ -320,7 +321,7 @@ export class SourcegraphNodeCompletionsClient extends SourcegraphCompletionsClie
                         getActiveTraceAndSpanId()?.traceId
                     )
                 }
-                const json = await response.json()
+                const json = (await response.json()) as CompletionResponse
                 if (typeof json?.completion === 'string') {
                     cb.onChange(json.completion)
                     cb.onComplete()


### PR DESCRIPTION
Follow up on https://github.com/sourcegraph/cody/pull/5508
CLOSE https://linear.app/sourcegraph/issue/CODY-3741/oai-o1-hits-parsing-error

This change adds support for non-streaming requests, particularly for new OpenAI models that do not support streaming. It also fixes a "Parse Error: JS exception" issue that occurred when handling non-streaming responses in the streaming client.

- Remove HACK for handling non-streaming requests in the stream method in nodeClient.ts that's resulting in parsing error
- Implement a new `_fetchWithCallbacks` method in the `SourcegraphCompletionsClient` class to handle non-streaming requests
- Update the `SourcegraphNodeCompletionsClient` and `SourcegraphBrowserCompletionsClient` classes to use the new `_fetchWithCallbacks` method when `params.stream` is `false`
- This change ensures that non-streaming requests, such as those for the new OpenAI models that do not support streaming, are handled correctly and avoid issues like "Parse Error: JS exception" that can occur when the response is not parsed correctly in the streaming client

The `SourcegraphCompletionsClient` class now has a new abstract method `_fetchWithCallbacks` that must be implemented by subclasses

## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

Verify that chat requests using non-streaming models (e.g., OpenAI O1, OpenAI O1-mini) work correctly without any parsing errors. Example: ask Cody about cody repo with "cody what are the latest updates in this repo?"

### After

First try

![image](https://github.com/user-attachments/assets/24fbd1b0-185d-4b07-90be-385fdd5da975)

Second try

![image](https://github.com/user-attachments/assets/becdc7f6-18bb-4fec-8fcc-8263072680f8)

### Before

First try

![image](https://github.com/user-attachments/assets/8975cb5a-b605-4e0a-ac2c-dab053124920)

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->

feat(chat): support non-streaming requests