### PR TITLE
reduce background network access

### DIFF
--- a/vscode/src/testutils/mocks.ts
+++ b/vscode/src/testutils/mocks.ts
@@ -803,6 +803,8 @@ export const vsCodeMocks = {
         },
         onDidChangeActiveTextEditor() {},
         onDidChangeTextEditorSelection() {},
+        onDidChangeWindowState() {},
+        state: { focused: false },
         createTextEditorDecorationType: () => ({
             key: 'foo',
             dispose: () => {},


### PR DESCRIPTION
Skip the UpstreamHealthProviderCheck if the window is not focused, and try again when the window becomes focused again. Some users have OS firewalls that make periodic background network access annoying for users. See https://linear.app/sourcegraph/issue/CODY-3745/codys-background-periodic-network-access-causes-2fa.

This check is used to gather latency information to properly measure actual latency for autocomplete. As long as the user has VS Code focused for slightly more than 10 seconds, it will still gather the necessary latency information for these calculations.

Fixes https://linear.app/sourcegraph/issue/CODY-3745/codys-background-periodic-network-access-causes-2fa



## Test plan

Open VS Code and check logs for the UpstreamHealthProvider call. Ensure that it does not trigger when the window is not focused, and then it triggers within 10 seconds of being focused after that.

## Changelog

Suppressed Cody's background process for monitoring latency to the Sourcegraph endpoint, which was used to calculate autocomplete latency for performance tracking purposes. For users with OS firewalls that notify on background network access, this will reduce notification annoyance.