### PR TITLE
feat(chat): improve messaging for non-streaming models

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -6,7 +6,7 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 
 ### Added
 
-- The [new OpenAI models (OpenAI O1 & OpenAI O1-mini)](https://sourcegraph.com/blog/openai-o1-for-cody) are now available to selected Cody Pro users for early access. [pull/5508](https://github.com/sourcegraph/cody/pull/5508)
+- The [new OpenAI models (OpenAI o1-preview & OpenAI o1-mini)](https://sourcegraph.com/blog/openai-o1-for-cody) are now available to selected Cody Pro users for early access. [pull/5508](https://github.com/sourcegraph/cody/pull/5508)
 - Cody Pro users can join the waitlist for the new models by clicking the "Join Waitlist" button. [pull/5508](https://github.com/sourcegraph/cody/pull/5508)
 - Chat: Support non-streaming requests. [pull/5565](https://github.com/sourcegraph/cody/pull/5565)
 

--- a/vscode/webviews/chat/cells/messageCell/assistant/AssistantMessageCell.tsx
+++ b/vscode/webviews/chat/cells/messageCell/assistant/AssistantMessageCell.tsx
@@ -119,7 +119,8 @@ export const AssistantMessageCell: FunctionComponent<{
                                 <div>
                                     {hasLongerResponseTime && (
                                         <p className="tw-m-4 tw-mt-0 tw-text-muted-foreground">
-                                            This model may take longer to response.
+                                            This model may take longer to respond because it takes time
+                                            to "think". Recommended for complex reasoning & coding tasks.
                                         </p>
                                     )}
                                     <LoadingDots />


### PR DESCRIPTION
- Update the `AssistantMessageCell` component to provide more informative messaging when a non-streaming model is used
- The new message explains that non-streaming models may take longer to respond, but are recommended for complex reasoning and coding tasks

This may be slightly too heavy-handed, but I think it's important to show why it takes longer since not everyone will be familiar with the models.

<img width="821" alt="image" src="https://github.com/user-attachments/assets/6d92b68c-8793-4b84-8518-8e772cc54b23">

## Test plan

Test manually.