### PR TITLE
Cody Web 0.8.2 release

### DIFF
--- a/web/CHANGELOG.md
+++ b/web/CHANGELOG.md
@@ -1,5 +1,8 @@
+## 0.8.2
+- Adds wait-list for OpenAI-o1 & OpenAI-o1 mini [#5508](https://github.com/sourcegraph/cody/pull/5508)
+
 ## 0.8.1
-- Fix leaking highlighted code matches styles 
+- Fix leaking highlighted code matches styles
 
 ## 0.8.0
 - Add support for Cody one-box search results

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sourcegraph/cody-web",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Cody standalone web app",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
Simply update version in `package.json` and `changelog` to bump recent changes about new GPT models for cody web in Sourcegraph web app 

## Test plan
- No test plan

