### PR TITLE
Fix typo around longer response time with non-streaming models

### DIFF
--- a/vscode/webviews/chat/cells/messageCell/assistant/AssistantMessageCell.tsx
+++ b/vscode/webviews/chat/cells/messageCell/assistant/AssistantMessageCell.tsx
@@ -119,7 +119,7 @@ export const AssistantMessageCell: FunctionComponent<{
                                 <div>
                                     {hasLongerResponseTime && (
                                         <p className="tw-m-4 tw-mt-0 tw-text-muted-foreground">
-                                            This model may take longer to response.
+                                            This model may take longer to respond.
                                         </p>
                                     )}
                                     <LoadingDots />


### PR DESCRIPTION
## Test plan

Verify when using o1 models that it shows "This model may take longer to respond." 