### PR TITLE
feat(eclipse): Add support for linux (CODY-3536)

### DIFF
--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/agent/protocol_generated/ClientCapabilities.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/agent/protocol_generated/ClientCapabilities.kt
@@ -22,7 +22,7 @@ data class ClientCapabilities(
   val globalState: GlobalStateEnum? = null, // Oneof: stateless, server-managed, client-managed
   val secrets: SecretsEnum? = null, // Oneof: stateless, client-managed
   val webview: WebviewEnum? = null, // Oneof: agentic, native
-  val webviewNativeConfig: WebviewNativeConfigParams? = null,
+  val webviewNativeConfig: WebviewNativeConfig? = null,
 ) {
 
   enum class AuthenticationEnum {

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/agent/protocol_generated/CodyAgentClient.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/agent/protocol_generated/CodyAgentClient.kt
@@ -25,9 +25,9 @@ interface CodyAgentClient {
   @JsonRequest("secrets/get")
   fun secrets_get(params: Secrets_GetParams): CompletableFuture<String?>
   @JsonRequest("secrets/store")
-  fun secrets_store(params: Secrets_StoreParams): CompletableFuture<String?>
+  fun secrets_store(params: Secrets_StoreParams): CompletableFuture<Null?>
   @JsonRequest("secrets/delete")
-  fun secrets_delete(params: Secrets_DeleteParams): CompletableFuture<String?>
+  fun secrets_delete(params: Secrets_DeleteParams): CompletableFuture<Null?>
   @JsonRequest("env/openExternal")
   fun env_openExternal(params: Env_OpenExternalParams): CompletableFuture<Boolean>
 

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/agent/protocol_generated/WebviewNativeConfig.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/agent/protocol_generated/WebviewNativeConfig.kt
@@ -3,11 +3,11 @@ package com.sourcegraph.cody.agent.protocol_generated;
 
 import com.google.gson.annotations.SerializedName;
 
-data class WebviewNativeConfigParams(
+data class WebviewNativeConfig(
   val view: ViewEnum, // Oneof: multiple, single
   val cspSource: String,
-  val webviewBundleServingPrefix: String,
-  val rootDir: String? = null,
+  val webviewBundleServingPrefix: String? = null,
+  val skipResourceRelativization: Boolean? = null,
   val injectScript: String? = null,
   val injectStyle: String? = null,
 ) {

--- a/agent/src/NativeWebview.ts
+++ b/agent/src/NativeWebview.ts
@@ -1,10 +1,8 @@
 import * as uuid from 'uuid'
 import * as vscode from 'vscode'
 import type { Agent } from './agent'
-import type { DefiniteWebviewOptions } from './protocol-alias'
+import type { DefiniteWebviewOptions, WebviewNativeConfig } from './protocol-alias'
 import * as vscode_shim from './vscode-shim'
-
-type NativeWebviewConfig = { cspSource: string; webviewBundleServingPrefix: string }
 
 type NativeWebviewHandle = string
 
@@ -12,7 +10,7 @@ type NativeWebviewHandle = string
  * A delegate for adapting the VSCode Webview, WebviewPanel and WebviewView API
  * to a client which has a native webview implementation.
  */
-interface WebviewProtocolDelegate {
+interface WebviewProtocolDelegate extends WebviewNativeConfig {
     // CSP, resource-related
     readonly webviewBundleLocalPrefix: vscode.Uri
     readonly webviewBundleServingPrefix: string
@@ -88,15 +86,14 @@ export function resolveWebviewView(
 export function registerNativeWebviewHandlers(
     agent: Agent,
     webviewBundleLocalPrefix: vscode.Uri,
-    config: NativeWebviewConfig
+    config: WebviewNativeConfig
 ): void {
     webviewProtocolDelegate = {
+        ...config,
         // TODO: When we want to serve resources outside dist/, make Agent
         // include 'dist' in its bundle paths, and simply set this to
         // extensionUri.
         webviewBundleLocalPrefix,
-        webviewBundleServingPrefix: config.webviewBundleServingPrefix,
-        cspSource: config.cspSource,
         createWebviewPanel: (handle, viewType, title, showOptions, options) => {
             agent.notify('webview/createWebviewPanel', {
                 handle,

--- a/agent/src/NativeWebview.ts
+++ b/agent/src/NativeWebview.ts
@@ -13,8 +13,6 @@ type NativeWebviewHandle = string
 interface WebviewProtocolDelegate extends WebviewNativeConfig {
     // CSP, resource-related
     readonly webviewBundleLocalPrefix: vscode.Uri
-    readonly webviewBundleServingPrefix: string
-    readonly cspSource: string
 
     // WebviewPanel
     createWebviewPanel(

--- a/agent/src/agent.ts
+++ b/agent/src/agent.ts
@@ -452,9 +452,7 @@ export class Agent extends MessageHandler implements ExtensionClient {
                     }
                     registerNativeWebviewHandlers(
                         this,
-                        nativeWebviewConfig.rootDir
-                            ? vscode.Uri.parse(nativeWebviewConfig.rootDir, true)
-                            : vscode.Uri.file(codyPaths().config + '/dist'),
+                        vscode.Uri.file(codyPaths().config + '/dist'),
                         nativeWebviewConfig
                     )
                 } else {

--- a/agent/src/cli/scip-codegen/Codegen.ts
+++ b/agent/src/cli/scip-codegen/Codegen.ts
@@ -375,11 +375,7 @@ export class Codegen extends BaseCodegen {
                                     break
                             }
                         })
-                        if (this.language === TargetLanguage.Java) {
-                            p.line('};')
-                        } else {
-                            p.line('}')
-                        }
+                        p.line('}')
                     })
                     switch (this.language) {
                         case TargetLanguage.CSharp:
@@ -392,6 +388,9 @@ export class Codegen extends BaseCodegen {
                                     'JsonSerializer.Serialize(writer, value, value.GetType(), options);'
                                 )
                             })
+                            break
+                        case TargetLanguage.Java:
+                            p.line('};')
                             break
                         default:
                             p.line('}')

--- a/agent/src/cli/scip-codegen/Formatter.ts
+++ b/agent/src/cli/scip-codegen/Formatter.ts
@@ -146,6 +146,12 @@ export class Formatter {
             const nonNullableTypes = parameterOrResultType.union_type.types.filter(
                 tpe => !this.isNullable(tpe)
             )
+            if (nonNullableTypes.length === 0) {
+                if (this.language === TargetLanguage.Kotlin) {
+                    return 'Null'
+                }
+                return 'Void'
+            }
             if (nonNullableTypes.length === 1) {
                 return this.nonNullableJsonrpcTypeName(jsonrpcMethod, nonNullableTypes[0], kind)
             }

--- a/vscode/src/chat/chat-view/ChatController.test.ts
+++ b/vscode/src/chat/chat-view/ChatController.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest'
+import * as vscode from 'vscode'
+import { manipulateWebviewHTML } from './ChatController'
+
+describe('manipulateWebviewHTML', () => {
+    const options = {
+        cspSource: 'self',
+    }
+    it('replaces relative paths with resource paths', () => {
+        const html = '<img src="./image.png">'
+        const result = manipulateWebviewHTML(html, {
+            ...options,
+            resources: vscode.Uri.parse('https://example.com/resources'),
+        })
+        expect(result).toBe('<img src="https://example.com/resources/image.png">')
+    })
+
+    it('injects script and removes CSP when injectScript is provided', () => {
+        const html =
+            '<!-- START CSP --><meta http-equiv="Content-Security-Policy" content="default-src \'none\';"><!-- END CSP --><script>/*injectedScript*/</script>'
+        const result = manipulateWebviewHTML(html, {
+            ...options,
+            injectScript: 'console.log("Injected script")',
+        })
+        expect(result).not.toContain('Content-Security-Policy')
+        expect(result).toContain('console.log("Injected script")')
+    })
+
+    it('injects style and removes CSP when injectStyle is provided', () => {
+        const html =
+            '<!-- START CSP --><meta http-equiv="Content-Security-Policy" content="default-src \'none\';"><!-- END CSP --><style>/*injectedStyle*/</style>'
+        const result = manipulateWebviewHTML(html, {
+            ...options,
+            injectStyle: 'body { background: red; }',
+        })
+        expect(result).not.toContain('Content-Security-Policy')
+        expect(result).toContain('body { background: red; }')
+    })
+
+    it('updates CSP source when no injection is provided', () => {
+        const html =
+            '<meta http-equiv="Content-Security-Policy" content="default-src \'self\' {cspSource};">'
+        const result = manipulateWebviewHTML(html, {
+            ...options,
+            cspSource: 'https://example.com',
+        })
+        expect(result).toBe(
+            '<meta http-equiv="Content-Security-Policy" content="default-src https://example.com https://example.com;">'
+        )
+    })
+
+    it('handles multiple replacements correctly', () => {
+        const html =
+            '<!-- START CSP --><meta http-equiv="Content-Security-Policy" content="default-src \'self\';"><!-- END CSP --><img src="./image1.png"><img src="./image2.png"><script>/*injectedScript*/</script><style>/*injectedStyle*/</style>'
+        const result = manipulateWebviewHTML(html, {
+            ...options,
+            resources: vscode.Uri.parse('https://example.com/resources'),
+            injectScript: 'console.log("Test")',
+            injectStyle: 'body { color: blue; }',
+        })
+        expect(result).not.toContain('Content-Security-Policy')
+        expect(result).toContain('https://example.com/resources/image1.png')
+        expect(result).toContain('https://example.com/resources/image2.png')
+        expect(result).toContain('console.log("Test")')
+        expect(result).toContain('body { color: blue; }')
+    })
+})

--- a/vscode/src/chat/chat-view/ChatController.ts
+++ b/vscode/src/chat/chat-view/ChatController.ts
@@ -1833,32 +1833,48 @@ async function addWebviewViewHTML(
     }
     const config = extensionClient.capabilities?.webviewNativeConfig
     const webviewPath = vscode.Uri.joinPath(extensionUri, 'dist', 'webviews')
-    // Create Webview using vscode/index.html
     const root = vscode.Uri.joinPath(webviewPath, 'index.html')
     const bytes = await vscode.workspace.fs.readFile(root)
     let html = new TextDecoder('utf-8').decode(bytes)
 
-    // Update URIs to load styles and scripts into webview (eg. path that starts with ./)
-    if (!config?.skipResourceRelativization) {
-        const resources = view.webview.asWebviewUri(webviewPath)
-        html = html.replaceAll('./', `${resources.toString()}/`)
+    html = manipulateWebviewHTML(html, {
+        cspSource: view.webview.cspSource,
+        resources: config?.skipResourceRelativization
+            ? undefined
+            : view.webview.asWebviewUri(webviewPath),
+        injectScript: config?.injectScript ?? undefined,
+        injectStyle: config?.injectStyle ?? undefined,
+    })
+
+    view.webview.html = html
+}
+
+interface TransformHTMLOptions {
+    cspSource: string
+    resources?: vscode.Uri
+    injectScript?: string
+    injectStyle?: string
+}
+
+// Exported for testing purposes
+export function manipulateWebviewHTML(html: string, options: TransformHTMLOptions): string {
+    if (options.resources) {
+        html = html.replaceAll('./', `${options.resources}/`)
     }
 
     // If a script or style is injected, replace the placeholder with the script or style
     // and drop the content-security-policy meta tag which prevents inline scripts and styles
-    if (config?.injectScript || config?.injectStyle) {
+    if (options.injectScript || options.injectStyle) {
         html = html
             .replace(/<!-- START CSP -->.*<!-- END CSP -->/s, '')
-            .replaceAll('/*injectedScript*/', config?.injectScript ?? '')
-            .replaceAll('/*injectedStyle*/', config?.injectStyle ?? '')
+            .replaceAll('/*injectedScript*/', options.injectScript ?? '')
+            .replaceAll('/*injectedStyle*/', options.injectStyle ?? '')
     } else {
         // Update URIs for content security policy to only allow specific scripts to be run
-        html = html
-            .replaceAll("'self'", view.webview.cspSource)
-            .replaceAll('{cspSource}', view.webview.cspSource)
+        html = html.replaceAll("'self'", options.cspSource).replaceAll('{cspSource}', options.cspSource)
     }
 
-    view.webview.html = html
+    return html
 }
 
 // This is the manual ordering of the different retrieved and explicit context sources

--- a/vscode/src/chat/chat-view/ChatController.ts
+++ b/vscode/src/chat/chat-view/ChatController.ts
@@ -1835,9 +1835,9 @@ async function addWebviewViewHTML(
     const webviewPath = vscode.Uri.joinPath(extensionUri, 'dist', 'webviews')
     const root = vscode.Uri.joinPath(webviewPath, 'index.html')
     const bytes = await vscode.workspace.fs.readFile(root)
-    let html = new TextDecoder('utf-8').decode(bytes)
+    const html = new TextDecoder('utf-8').decode(bytes)
 
-    html = manipulateWebviewHTML(html, {
+    view.webview.html = manipulateWebviewHTML(html, {
         cspSource: view.webview.cspSource,
         resources: config?.skipResourceRelativization
             ? undefined
@@ -1845,8 +1845,6 @@ async function addWebviewViewHTML(
         injectScript: config?.injectScript ?? undefined,
         injectStyle: config?.injectStyle ?? undefined,
     })
-
-    view.webview.html = html
 }
 
 interface TransformHTMLOptions {

--- a/vscode/src/jsonrpc/agent-protocol.ts
+++ b/vscode/src/jsonrpc/agent-protocol.ts
@@ -608,21 +608,19 @@ export interface ClientCapabilities {
     // Defaults to 'agentic'.
     webview?: 'agentic' | 'native' | undefined | null
     // If webview === 'native', describes how the client has configured webview resources.
+    webviewNativeConfig?: WebviewNativeConfig | undefined | null
+}
+
+export interface WebviewNativeConfig {
+    // Set the view to 'single' when client only support single chat view, e.g. sidebar chat.
+    view: 'multiple' | 'single'
     // cspSource is passed to the extension as the Webview cspSource property.
+    cspSource: string
     // webviewBundleServingPrefix is prepended to resource paths under 'dist' in
     // asWebviewUri (note, multiple prefixes are not yet implemented.)
-    // Set the view to 'single' when client only support single chat view, e.g. sidebar chat.
-    webviewNativeConfig?:
-        | {
-              view: 'multiple' | 'single'
-              cspSource: string
-              webviewBundleServingPrefix: string
-              rootDir?: string | undefined | null
-              injectScript?: string | undefined | null
-              injectStyle?: string | undefined | null
-          }
-        | undefined
-        | null
+    webviewBundleServingPrefix: string
+    injectScript?: string | undefined | null
+    injectStyle?: string | undefined | null
 }
 
 export interface ServerInfo {

--- a/vscode/src/jsonrpc/agent-protocol.ts
+++ b/vscode/src/jsonrpc/agent-protocol.ts
@@ -618,7 +618,10 @@ export interface WebviewNativeConfig {
     cspSource: string
     // webviewBundleServingPrefix is prepended to resource paths under 'dist' in
     // asWebviewUri (note, multiple prefixes are not yet implemented.)
-    webviewBundleServingPrefix: string
+    webviewBundleServingPrefix?: string | undefined | null
+    // when true, resource paths are not relativized, and the client must
+    // handle serving the resources relative to the webview.
+    skipResourceRelativization?: boolean | undefined | null
     injectScript?: string | undefined | null
     injectStyle?: string | undefined | null
 }


### PR DESCRIPTION
Adds support for linux for Cody Eclipse. Replacement for https://github.com/sourcegraph/cody/pull/5354.

There is a bug in the logic for processing the webview index.html file that was allowing the eclipse plugin to work accidentally, because the MacOS and Windows integrated browsers were effectively  ignoring the content security policy. 

This patches that logic and allows a setting for injecting scripts and removing the CSP (required for inline-scripts) and allows skipping converting all embedded links into file:// paths (the eclipse browser cannot handle custom protocols).

Also fixes two bugs around Java code generation.

## Test plan
Unit tests added.
