### PR TITLE
Hitesh/vscode 1.34.3 release

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -10,6 +10,11 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 
 ### Changed
 
+## 1.34.3
+
+### Fixed
+- Autocomplete Logging: Fix the diff for recent edits by replacing psDedent with ps to preserve the indentation. [pull/5574](https://github.com/sourcegraph/cody/pull/5574)
+
 
 ## 1.34.2
 

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -3,7 +3,7 @@
   "name": "cody-ai",
   "private": true,
   "displayName": "Cody: AI Coding Assistant with Autocomplete & Chat",
-  "version": "1.34.2",
+  "version": "1.34.3",
   "publisher": "sourcegraph",
   "license": "Apache-2.0",
   "icon": "resources/cody.png",

--- a/vscode/src/completions/context/retrievers/recent-edits/recent-edits-retriever.ts
+++ b/vscode/src/completions/context/retrievers/recent-edits/recent-edits-retriever.ts
@@ -1,8 +1,6 @@
 import { PromptString, contextFiltersProvider } from '@sourcegraph/cody-shared'
-import { ps, psDedent } from '@sourcegraph/cody-shared'
 import type { AutocompleteContextSnippet } from '@sourcegraph/cody-shared'
 import * as vscode from 'vscode'
-import { getLanguageConfig } from '../../../../tree-sitter/language'
 import type { ContextRetriever, ContextRetrieverOptions } from '../../../types'
 import { RetrieverIdentifier, type ShouldUseContextParams, shouldBeUsedAsContext } from '../../utils'
 
@@ -47,11 +45,7 @@ export class RecentEditsRetriever implements vscode.Disposable, ContextRetriever
 
         const autocompleteContextSnippets = []
         for (const diff of diffs) {
-            const content = this.getCommentedPromptForCompletions(
-                diff.languageId,
-                diff.uri,
-                diff.diff
-            ).toString()
+            const content = diff.diff.toString()
             const autocompleteSnippet = {
                 uri: diff.uri,
                 identifier: RetrieverIdentifier.RecentEditsRetriever,
@@ -87,18 +81,6 @@ export class RecentEditsRetriever implements vscode.Disposable, ContextRetriever
         const results = await Promise.all(diffPromises)
         diffs.push(...results.filter((result): result is DiffAcrossDocuments => result !== null))
         return diffs
-    }
-
-    public getCommentedPromptForCompletions(
-        languageId: string,
-        filename: vscode.Uri,
-        diff: PromptString
-    ): PromptString {
-        const filePath = PromptString.fromDisplayPath(filename)
-        const languageConfig = getLanguageConfig(languageId)
-        const commentStart = languageConfig ? languageConfig.commentStart : ps`// `
-        const prompt = psDedent`${commentStart} Here is git diff of the recent change made to the file ${filePath} which is used to provide context for the completion:\n${diff}`
-        return prompt
     }
 
     public filterCandidateDiffs(


### PR DESCRIPTION
## Cherry-pick
Autocomplete Logging: Fix the diff for recent edits by replacing psDedent with ps to preserve the indentation. [pull/5574](https://github.com/sourcegraph/cody/pull/5574)

## Test plan
version and changelog change
