### PR TITLE
expose ModelsService.changes and listen to that in ChatController

### DIFF
--- a/lib/shared/src/models/index.test.ts
+++ b/lib/shared/src/models/index.test.ts
@@ -1,4 +1,5 @@
-import { beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { mockAuthStatus } from '../auth/authStatus'
 import { AUTH_STATUS_FIXTURE_AUTHED, type AuthenticatedAuthStatus } from '../auth/types'
 import {
     Model,
@@ -38,6 +39,9 @@ describe('Model Provider', () => {
     let modelsService = new ModelsService()
     beforeEach(() => {
         modelsService = new ModelsService()
+    })
+    afterEach(() => {
+        modelsService.dispose()
     })
 
     describe('getContextWindowByID', () => {
@@ -135,7 +139,7 @@ describe('Model Provider', () => {
         })
 
         beforeEach(() => {
-            modelsService.setAuthStatus(codyProAuthStatus)
+            mockAuthStatus(codyProAuthStatus)
             modelsService.setModels([model1chat, model2chat, model3all, model4edit])
         })
 
@@ -254,7 +258,7 @@ describe('Model Provider', () => {
         beforeEach(async () => {
             storage = new TestStorage()
             modelsService.setStorage(storage)
-            modelsService.setAuthStatus(enterpriseAuthStatus)
+            mockAuthStatus(enterpriseAuthStatus)
             await modelsService.setServerSentModels(SERVER_MODELS)
         })
 
@@ -348,37 +352,37 @@ describe('Model Provider', () => {
         })
 
         it('returns false for unknown model', () => {
-            modelsService.setAuthStatus(codyProAuthStatus)
+            mockAuthStatus(codyProAuthStatus)
             expect(modelsService.isModelAvailable('unknown-model')).toBe(false)
         })
 
         it('allows enterprise user to use any model', () => {
-            modelsService.setAuthStatus(enterpriseAuthStatus)
+            mockAuthStatus(enterpriseAuthStatus)
             expect(modelsService.isModelAvailable(enterpriseModel)).toBe(true)
             expect(modelsService.isModelAvailable(proModel)).toBe(true)
             expect(modelsService.isModelAvailable(freeModel)).toBe(true)
         })
 
         it('allows Cody Pro user to use Pro and Free models', () => {
-            modelsService.setAuthStatus(codyProAuthStatus)
+            mockAuthStatus(codyProAuthStatus)
             expect(modelsService.isModelAvailable(enterpriseModel)).toBe(false)
             expect(modelsService.isModelAvailable(proModel)).toBe(true)
             expect(modelsService.isModelAvailable(freeModel)).toBe(true)
         })
 
         it('allows free user to use only Free models', () => {
-            modelsService.setAuthStatus(freeUserAuthStatus)
+            mockAuthStatus(freeUserAuthStatus)
             expect(modelsService.isModelAvailable(enterpriseModel)).toBe(false)
             expect(modelsService.isModelAvailable(proModel)).toBe(false)
             expect(modelsService.isModelAvailable(freeModel)).toBe(true)
         })
 
         it('handles model passed as string', () => {
-            modelsService.setAuthStatus(freeUserAuthStatus)
+            mockAuthStatus(freeUserAuthStatus)
             expect(modelsService.isModelAvailable(freeModel.id)).toBe(true)
             expect(modelsService.isModelAvailable(proModel.id)).toBe(false)
 
-            modelsService.setAuthStatus(codyProAuthStatus)
+            mockAuthStatus(codyProAuthStatus)
             expect(modelsService.isModelAvailable(proModel.id)).toBe(true)
         })
     })

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -254,7 +254,6 @@ const register = async (
         subscriptionDisposable(
             authStatus.subscribe({
                 next: authStatus => {
-                    sourceControl.setAuthStatus(authStatus)
                     statusBar.setAuthStatus(authStatus)
                 },
             })
@@ -315,7 +314,6 @@ async function initializeSingletons(
                     void localStorage.setConfig(config)
                     graphqlClient.setConfig(config)
                     void featureFlagProvider.refresh()
-                    void modelsService.instance!.onConfigChange(config)
                     upstreamHealthProvider.instance!.onConfigurationChange(config)
                     defaultCodeCompletionsClient.instance!.onConfigurationChange(config)
                 },

--- a/vscode/src/models/sync.test.ts
+++ b/vscode/src/models/sync.test.ts
@@ -13,6 +13,7 @@ import {
     type ServerModelConfiguration,
     getDotComDefaultModels,
     graphqlClient,
+    mockAuthStatus,
     modelsService,
 } from '@sourcegraph/cody-shared'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -29,6 +30,7 @@ describe('syncModels', () => {
 
     beforeEach(() => {
         setModelsSpy.mockClear()
+        mockAuthStatus(AUTH_STATUS_FIXTURE_AUTHED)
 
         // Mock the /.api/client-config for these tests so that modelsAPIEnabled == false
         vi.spyOn(ClientConfigSingleton.prototype, 'getConfig').mockResolvedValue({

--- a/vscode/src/models/sync.ts
+++ b/vscode/src/models/sync.ts
@@ -13,7 +13,11 @@ import {
     modelsService,
     telemetryRecorder,
 } from '@sourcegraph/cody-shared'
-import type { ServerModel, ServerModelConfiguration } from '@sourcegraph/cody-shared/src/models'
+import {
+    ModelsService,
+    type ServerModel,
+    type ServerModelConfiguration,
+} from '@sourcegraph/cody-shared/src/models'
 import { ModelTag } from '@sourcegraph/cody-shared/src/models/tags'
 import * as vscode from 'vscode'
 import { getConfiguration } from '../configuration'
@@ -31,7 +35,6 @@ import { getEnterpriseContextWindow } from './utils'
  */
 export async function syncModels(authStatus: AuthStatus): Promise<void> {
     // Offline mode only support Ollama models, which would be synced seperately.
-    modelsService.instance!.setAuthStatus(authStatus)
     if (authStatus.authenticated && authStatus.isOfflineMode) {
         modelsService.instance!.setModels([])
         return
@@ -52,7 +55,7 @@ export async function syncModels(authStatus: AuthStatus): Promise<void> {
         const serverSideModels = await fetchServerSideModels(authStatus.endpoint || '')
         // If the request failed, fall back to using the default models
         if (serverSideModels) {
-            modelsService.instance!.setServerSentModels({
+            await modelsService.instance!.setServerSentModels({
                 ...serverSideModels,
                 models: maybeAdjustContextWindows(serverSideModels.models),
             })
@@ -120,6 +123,8 @@ export async function syncModels(authStatus: AuthStatus): Promise<void> {
         modelsService.instance!.setModels([])
     }
 }
+
+ModelsService.syncModels = syncModels
 
 export async function joinModelWaitlist(authStatus: AuthStatus): Promise<void> {
     localStorage.set(localStorage.keys.waitlist_o1, true)

--- a/vscode/src/services/AuthProvider.ts
+++ b/vscode/src/services/AuthProvider.ts
@@ -20,7 +20,6 @@ import { formatURL } from '../auth/auth'
 import { newAuthStatus } from '../chat/utils'
 import { getFullConfig } from '../configuration'
 import { logDebug } from '../log'
-import { syncModels } from '../models/sync'
 import { maybeStartInteractiveTutorial } from '../tutorial/helpers'
 import { localStorage } from './LocalStorageProvider'
 import { secretStorage } from './SecretStorageProvider'
@@ -232,7 +231,6 @@ export class AuthProvider implements vscode.Disposable {
             // because many listeners rely on these
             graphqlClient.setConfig(await getFullConfig())
             await ClientConfigSingleton.getInstance().setAuthStatus(authStatus)
-            await syncModels(authStatus)
         } catch (error) {
             logDebug('AuthProvider', 'updateAuthStatus error', error)
         } finally {


### PR DESCRIPTION
Previously, the ChatController listened for auth changes and assumed that model changes would have been already applied. This required a specific ordering of operations in the AuthProvider, which was a brittle way of ensuring this behavior (and the `chat model selector` e2e test broke when that behavior was slightly changed). Now, the ModelsService exposes a `changes` observable and the ChatController listens to that to follow changes to models, which makes sense.

## Test plan

e2e tests cover this well.