### PR TITLE
completion client: observe config

### DIFF
--- a/agent/src/cli/command-bench/llm-judge.ts
+++ b/agent/src/cli/command-bench/llm-judge.ts
@@ -1,5 +1,7 @@
 import type { PromptString } from '@sourcegraph/cody-shared'
 import { SourcegraphNodeCompletionsClient } from '../../../../vscode/src/completions/nodeClient'
+import { setStaticResolvedConfigurationWithAuthCredentials } from '../../../../vscode/src/configuration'
+import { localStorage } from '../../../../vscode/src/services/LocalStorageProvider'
 import type { CodyBenchOptions } from './command-bench'
 
 export interface LlmJudgeScore {
@@ -11,11 +13,12 @@ export interface LlmJudgeScore {
 export class LlmJudge {
     client: SourcegraphNodeCompletionsClient
     constructor(options: Pick<CodyBenchOptions, 'srcAccessToken' | 'srcEndpoint'>) {
-        this.client = new SourcegraphNodeCompletionsClient({
-            serverEndpoint: options.srcEndpoint,
-            accessToken: options.srcAccessToken,
-            customHeaders: {},
+        localStorage.setStorage('noop')
+        setStaticResolvedConfigurationWithAuthCredentials({
+            configuration: { customHeaders: undefined },
+            auth: { accessToken: options.srcAccessToken, serverEndpoint: options.srcEndpoint },
         })
+        this.client = new SourcegraphNodeCompletionsClient()
     }
 
     public async judge(prompt: PromptString): Promise<LlmJudgeScore> {

--- a/lib/shared/src/inferenceClient/misc.ts
+++ b/lib/shared/src/inferenceClient/misc.ts
@@ -1,4 +1,4 @@
-import type { CompletionLogger, CompletionsClientConfig } from '../sourcegraph-api/completions/client'
+import type { CompletionLogger } from '../sourcegraph-api/completions/client'
 import type {
     CompletionParameters,
     CompletionResponse,
@@ -58,6 +58,5 @@ export interface CodeCompletionsClient<
         params: T,
         abortController: AbortController,
         providerOptions?: ProviderSpecificOptions
-    ): CompletionResponseGenerator
-    onConfigurationChange(newConfig: CompletionsClientConfig): void
+    ): CompletionResponseGenerator | Promise<CompletionResponseGenerator>
 }

--- a/lib/shared/src/llm-providers/ollama/completions-client.ts
+++ b/lib/shared/src/llm-providers/ollama/completions-client.ts
@@ -88,7 +88,6 @@ export function createOllamaClient(
     return {
         complete,
         logger,
-        onConfigurationChange: () => undefined,
     }
 }
 

--- a/vscode/src/completions/get-inline-completions-tests/helpers.ts
+++ b/vscode/src/completions/get-inline-completions-tests/helpers.ts
@@ -163,7 +163,6 @@ export function params(
                 },
             }
         },
-        onConfigurationChange() {},
         logger: undefined,
     }
 

--- a/vscode/src/completions/providers/provider.ts
+++ b/vscode/src/completions/providers/provider.ts
@@ -170,7 +170,7 @@ export abstract class Provider {
         abortSignal: AbortSignal,
         snippets: AutocompleteContextSnippet[],
         tracer?: CompletionProviderTracer
-    ): AsyncGenerator<FetchCompletionResult[]>
+    ): AsyncGenerator<FetchCompletionResult[]> | Promise<AsyncGenerator<FetchCompletionResult[]>>
 }
 
 /**

--- a/vscode/src/completions/request-manager.test.ts
+++ b/vscode/src/completions/request-manager.test.ts
@@ -174,6 +174,7 @@ describe('RequestManager', () => {
         expect(provider1.didFinishNetworkRequest).toBe(false)
         expect(provider2.didFinishNetworkRequest).toBe(false)
 
+        await nextTick()
         provider2.yield(["'hello')"])
 
         expect((await promise2).completions[0].insertText).toBe("'hello')")
@@ -198,6 +199,7 @@ describe('RequestManager', () => {
         const provider2 = createProvider()
         const promise2 = createRequest(prefix2, provider2)
 
+        await nextTick()
         provider1.yield(["log('hello')"])
 
         const firstResult = await promise1
@@ -327,6 +329,7 @@ describe('RequestManager', () => {
             const provider2 = createProvider()
             const promise2 = createRequest(prefix2, provider2)
 
+            await nextTick()
             provider1.yield(["log('hello')"])
 
             expect((await promise1).completions[0].insertText).toBe("log('hello')")
@@ -344,6 +347,7 @@ describe('RequestManager', () => {
             const prefix1 = 'console.'
             const provider1 = createProvider()
             createRequest(prefix1, provider1)
+            await nextTick()
 
             const prefix2 = 'table.'
             const provider2 = createProvider()
@@ -356,6 +360,7 @@ describe('RequestManager', () => {
             const prefix1 = 'console.'
             const provider1 = createProvider()
             createRequest(prefix1, provider1)
+            await nextTick()
 
             const prefix2 = 'console.tabletop'
             const provider2 = createProvider()

--- a/vscode/src/completions/request-manager.ts
+++ b/vscode/src/completions/request-manager.ts
@@ -140,7 +140,7 @@ export class RequestManager {
 
         const generateCompletions = async (): Promise<void> => {
             try {
-                for await (const fetchCompletionResults of provider.generateCompletions(
+                for await (const fetchCompletionResults of await provider.generateCompletions(
                     providerOptions,
                     request.abortController.signal,
                     context,

--- a/vscode/src/configuration.ts
+++ b/vscode/src/configuration.ts
@@ -7,8 +7,10 @@ import {
     type ConfigurationUseContext,
     DOTCOM_URL,
     OLLAMA_DEFAULT_URL,
+    type PickResolvedConfiguration,
     PromptString,
     ps,
+    setStaticResolvedConfigurationValue,
 } from '@sourcegraph/cody-shared'
 
 import { URI } from 'vscode-uri'
@@ -237,4 +239,22 @@ function checkValidEnumValues(configName: string, value: string | null): void {
             )
         }
     }
+}
+
+/**
+ * Set the global {@link resolvedConfig} value with the given {@link AuthCredentials} and otherwise
+ * use global config and client state.
+ *
+ * Call this only when this value is guaranteed not to change during execution (such as in CLI
+ * programs).
+ */
+export function setStaticResolvedConfigurationWithAuthCredentials({
+    configuration,
+    auth,
+}: PickResolvedConfiguration<{ configuration: 'customHeaders'; auth: true }>): void {
+    setStaticResolvedConfigurationValue({
+        configuration: { ...getConfiguration(), customHeaders: configuration.customHeaders },
+        auth,
+        clientState: localStorage.getClientState(),
+    })
 }

--- a/vscode/src/extension.common.ts
+++ b/vscode/src/extension.common.ts
@@ -3,7 +3,6 @@ import * as vscode from 'vscode'
 import type {
     ClientConfiguration,
     CompletionLogger,
-    CompletionsClientConfig,
     SourcegraphCompletionsClient,
 } from '@sourcegraph/cody-shared'
 import type { startTokenReceiver } from './auth/token-receiver'
@@ -38,10 +37,7 @@ export interface PlatformContext {
     ) => Promise<LocalEmbeddingsController>
     createSymfRunner?: Constructor<typeof SymfRunner>
     createBfgRetriever?: () => BfgRetriever
-    createCompletionsClient: (
-        config: CompletionsClientConfig,
-        logger?: CompletionLogger
-    ) => SourcegraphCompletionsClient
+    createCompletionsClient: (logger?: CompletionLogger) => SourcegraphCompletionsClient
     createSentryService?: () => SentryService
     createOpenTelemetryService?: () => OpenTelemetryService
     startTokenReceiver?: typeof startTokenReceiver

--- a/vscode/src/external-services.ts
+++ b/vscode/src/external-services.ts
@@ -61,7 +61,7 @@ export async function configureExternalServices(
     const initialConfig = await firstValueFrom(resolvedConfigWithAccessToken)
     platform.createSentryService?.()
     platform.createOpenTelemetryService?.()
-    const completionsClient = platform.createCompletionsClient(initialConfig, logger)
+    const completionsClient = platform.createCompletionsClient(logger)
 
     const symfRunner = platform.createSymfRunner?.(context, completionsClient)
 
@@ -92,7 +92,6 @@ export async function configureExternalServices(
         symfRunner,
         contextAPIClient,
         onConfigurationChange: newConfig => {
-            completionsClient.onConfigurationChange(newConfig)
             void localEmbeddings?.setAccessToken(newConfig.serverEndpoint, newConfig.accessToken)
         },
     }

--- a/vscode/src/local-context/rewrite-keyword-query.test.ts
+++ b/vscode/src/local-context/rewrite-keyword-query.test.ts
@@ -5,16 +5,12 @@ import { startPollyRecording } from '../testutils/polly'
 
 import { rewriteKeywordQuery } from './rewrite-keyword-query'
 
-import { type PromptString, ps } from '@sourcegraph/cody-shared'
+import { type PromptString, mockResolvedConfig, ps } from '@sourcegraph/cody-shared'
 import { SourcegraphNodeCompletionsClient } from '../completions/nodeClient'
 import { TESTING_CREDENTIALS } from '../testutils/testing-credentials'
 
 describe('rewrite-query', () => {
-    const client = new SourcegraphNodeCompletionsClient({
-        accessToken: TESTING_CREDENTIALS.dotcom.token ?? TESTING_CREDENTIALS.dotcom.redactedToken,
-        serverEndpoint: TESTING_CREDENTIALS.dotcom.serverEndpoint,
-        customHeaders: {},
-    })
+    const client = new SourcegraphNodeCompletionsClient()
 
     let polly: Polly
     beforeAll(() => {
@@ -23,6 +19,15 @@ describe('rewrite-query', () => {
             // Run the command below to update recordings:
             // source agent/scripts/export-cody-http-recording-tokens.sh
             // CODY_RECORDING_MODE=record pnpm -C vscode test:unit
+        })
+
+        mockResolvedConfig({
+            configuration: { customHeaders: {} },
+            auth: {
+                accessToken:
+                    TESTING_CREDENTIALS.dotcom.token ?? TESTING_CREDENTIALS.dotcom.redactedToken,
+                serverEndpoint: TESTING_CREDENTIALS.dotcom.serverEndpoint,
+            },
         })
     })
 

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -60,7 +60,6 @@ import type { CodyCommandArgs } from './commands/types'
 import { newCodyCommandArgs } from './commands/utils/get-commands'
 import { createInlineCompletionItemProvider } from './completions/create-inline-completion-item-provider'
 import { createInlineCompletionItemFromMultipleProviders } from './completions/create-multi-model-inline-completion-provider'
-import { defaultCodeCompletionsClient } from './completions/default-client'
 import { getConfiguration, getFullConfig } from './configuration'
 import { exposeOpenCtxClient } from './context/openctx'
 import { EditManager } from './edit/manager'
@@ -305,7 +304,6 @@ async function initializeSingletons(
             resolvedConfigWithAccessToken.subscribe({
                 next: config => {
                     graphqlClient.setConfig(config)
-                    defaultCodeCompletionsClient.instance!.onConfigurationChange(config)
                 },
             })
         ),

--- a/vscode/src/services/LocalStorageProvider.ts
+++ b/vscode/src/services/LocalStorageProvider.ts
@@ -52,8 +52,8 @@ class LocalStorage {
         return this._storage
     }
 
-    public setStorage(storage: Memento): void {
-        this._storage = storage
+    public setStorage(storage: Memento | 'noop'): void {
+        this._storage = storage === 'noop' ? noopLocalStorage : storage
     }
 
     public getClientState(): ClientState {


### PR DESCRIPTION
Makes it so that our completions HTTP clients observe the config using the standard global `resolvedConfig` observable instead of through an ad-hoc way of reading it. (Actually, in practice, since it is not a long-lived instance, it just reads it on-the-fly at request time, but the idea is to standardize this, and that's what is achieved here.)

## Test plan

e2e