### PR TITLE
user visible error when context retrieval or computation fails

### DIFF
--- a/vscode/src/chat/chat-view/ChatController.ts
+++ b/vscode/src/chat/chat-view/ChatController.ts
@@ -946,6 +946,26 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
         span: Span,
         signal?: AbortSignal
     ): Promise<RankedContext[]> {
+        try {
+            return await this._computeContext({ text, mentions }, requestID, editorState, span, signal)
+        } catch (e) {
+            this.postError(new Error(`Unexpected error computing context, no context was used: ${e}`))
+            return [
+                {
+                    strategy: 'none',
+                    items: [],
+                },
+            ]
+        }
+    }
+
+    private async _computeContext(
+        { text, mentions }: HumanInput,
+        requestID: string,
+        editorState: SerializedPromptEditorState | null,
+        span: Span,
+        signal?: AbortSignal
+    ): Promise<RankedContext[]> {
         // Remove context chips (repo, @-mentions) from the input text for context retrieval.
         const inputTextWithoutContextChips = editorState
             ? PromptString.unsafe_fromUserQuery(
@@ -959,13 +979,16 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
             span,
             signal
         )
-        const priorityContextPromise = retrievedContextPromise.then(p =>
-            getPriorityContext(text, this.editor, p)
-        )
+        const priorityContextPromise = retrievedContextPromise
+            .then(p => getPriorityContext(text, this.editor, p))
+            .catch(() => getPriorityContext(text, this.editor, []))
         const openCtxContextPromise = getContextForChatMessage(text.toString(), signal)
         const [priorityContext, retrievedContext, openCtxContext] = await Promise.all([
             priorityContextPromise,
-            retrievedContextPromise,
+            retrievedContextPromise.catch(e => {
+                this.postError(new Error(`Error retrieving context, no search context was used: ${e}`))
+                return []
+            }),
             openCtxContextPromise,
         ])
 

--- a/vscode/src/chat/chat-view/ContextRetriever.ts
+++ b/vscode/src/chat/chat-view/ContextRetriever.ts
@@ -175,13 +175,8 @@ export class ContextRetriever implements vscode.Disposable {
         span: Span,
         signal?: AbortSignal
     ): Promise<ContextItem[]> {
-        try {
-            const roots = await codebaseRootsFromMentions(mentions, signal)
-            return await this._retrieveContext(roots, inputTextWithoutContextChips, span, signal)
-        } catch (error) {
-            logError('ContextRetriever', 'Unhandled error retrieving context', error)
-            return []
-        }
+        const roots = await codebaseRootsFromMentions(mentions, signal)
+        return await this._retrieveContext(roots, inputTextWithoutContextChips, span, signal)
     }
 
     private async _retrieveContext(

--- a/vscode/webviews/App.module.css
+++ b/vscode/webviews/App.module.css
@@ -28,7 +28,7 @@
 .close-btn {
     position: absolute;
     top: 0.65rem;
-    right: 0.25rem;
+    right: 0.65rem;
     background: none;
     border: none;
     color: var(--vscode-input-foreground);


### PR DESCRIPTION
When context retrieval or computation throws an error preventing context from being fetched, don't just silently use no context, display a user-visible message conveying the error and explaining why the response does not incorporate context.

![image](https://github.com/user-attachments/assets/9d97d724-8a14-474c-99a9-6f4210afcdc1)


## Test plan

Throw an unexpected error in `ChatController._computeContext` or `ContextRetriever.retrieveContext`, and verify the error shows.
