### PR TITLE
make graphqlClient observe global config/auth

### DIFF
--- a/agent/recordings/defaultClient_631904893/recording.har.yaml
+++ b/agent/recordings/defaultClient_631904893/recording.har.yaml
@@ -5,6 +5,211 @@ log:
     name: Polly.JS
     version: 6.0.6
   entries:
+    - _id: 4d7b84f278a68f81a65e407b527c4a0e
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 165
+        cookies: []
+        headers:
+          - _fromType: array
+            name: authorization
+            value: token
+              REDACTED_4a92106dd3be39a589d6e2d0a6e32b705744d4007d74518fdfd1dbf953176dc6
+          - _fromType: array
+            name: content-type
+            value: application/json; charset=utf-8
+          - _fromType: array
+            name: user-agent
+            value: defaultClient / v1
+          - _fromType: array
+            name: accept
+            value: "*/*"
+          - _fromType: array
+            name: content-length
+            value: "217"
+          - _fromType: array
+            name: accept-encoding
+            value: gzip,deflate
+          - name: host
+            value: sourcegraph.com
+        headersSize: 349
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json; charset=utf-8
+          params: []
+          textJSON:
+            query: |-
+              
+              query CodyConfigFeaturesResponse {
+                  site {
+                      codyConfigFeatures {
+                          chat
+                          autoComplete
+                          commands
+                          attribution
+                      }
+                  }
+              }
+            variables: {}
+        queryString:
+          - name: CodyConfigFeaturesResponse
+            value: null
+        url: https://sourcegraph.com/.api/graphql?CodyConfigFeaturesResponse
+      response:
+        bodySize: 22
+        content:
+          mimeType: text/plain; charset=utf-8
+          size: 22
+          text: |
+            Invalid access token.
+        cookies: []
+        headers:
+          - name: date
+            value: Fri, 23 Aug 2024 09:45:38 GMT
+          - name: content-type
+            value: text/plain; charset=utf-8
+          - name: content-length
+            value: "22"
+          - name: connection
+            value: keep-alive
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache, max-age=0
+          - name: vary
+            value: Cookie,Accept-Encoding,Authorization
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+        headersSize: 1263
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 401
+        statusText: Unauthorized
+      startedDateTime: 2024-08-23T09:45:38.644Z
+      time: 0
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 0
+    - _id: fed5129404cd476f4ecc5c751242f2f5
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 217
+        cookies: []
+        headers:
+          - _fromType: array
+            name: authorization
+            value: token
+              REDACTED_0ba08837494d00e3943c46999589eb29a210ba8063f084fff511c8e4d1503909
+          - _fromType: array
+            name: content-type
+            value: application/json; charset=utf-8
+          - _fromType: array
+            name: user-agent
+            value: rateLimitedClient / v1
+          - _fromType: array
+            name: accept
+            value: "*/*"
+          - _fromType: array
+            name: content-length
+            value: "217"
+          - _fromType: array
+            name: accept-encoding
+            value: gzip,deflate
+          - name: host
+            value: sourcegraph.com
+        headersSize: 336
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json; charset=utf-8
+          params: []
+          textJSON:
+            query: |-
+              
+              query CodyConfigFeaturesResponse {
+                  site {
+                      codyConfigFeatures {
+                          chat
+                          autoComplete
+                          commands
+                          attribution
+                      }
+                  }
+              }
+            variables: {}
+        queryString:
+          - name: CodyConfigFeaturesResponse
+            value: null
+        url: https://sourcegraph.com/.api/graphql?CodyConfigFeaturesResponse
+      response:
+        bodySize: 155
+        content:
+          encoding: base64
+          mimeType: application/json
+          size: 155
+          text: "[\"H4sIAAAAAAAAAzyLwQqA\",\"IBAF/2XPfYFXof/YdC0h3dDnIcR/Dws6DQwznTyDyXSq\
+            ETLp1N9Wc4j7KoxWpL72YJBBabIQN6jVdJ0yj885TYmzr38DlLg1RM1kAp9VxhjjAQA\
+            A//8DAIfOLkJuAAAA\"]"
+        cookies: []
+        headers:
+          - name: date
+            value: Wed, 03 Jul 2024 06:24:17 GMT
+          - name: content-type
+            value: application/json
+          - name: transfer-encoding
+            value: chunked
+          - name: connection
+            value: keep-alive
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache, max-age=0
+          - name: vary
+            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
+              X-Requested-With,Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+          - name: content-encoding
+            value: gzip
+        headersSize: 1333
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: 2024-07-03T06:24:16.670Z
+      time: 0
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 0
     - _id: 8ffa79cf5668b64b3fd5ad5674e1d846
       _order: 0
       cache: {}

--- a/agent/src/cli/command-auth/AuthenticatedAccount.ts
+++ b/agent/src/cli/command-auth/AuthenticatedAccount.ts
@@ -37,9 +37,10 @@ export class AuthenticatedAccount {
         options: AuthenticationOptions,
         source: AuthenticationSource
     ): Promise<AuthenticatedAccount | Error> {
-        const graphqlClient = new SourcegraphGraphQLAPIClient({
-            accessToken: options.accessToken,
-            serverEndpoint: options.endpoint,
+        const graphqlClient = SourcegraphGraphQLAPIClient.withStaticConfig({
+            configuration: { telemetryLevel: 'agent' },
+            auth: { accessToken: options.accessToken, serverEndpoint: options.endpoint },
+            clientState: { anonymousUserID: null },
         })
         const userInfo = await graphqlClient.getCurrentUserInfo()
         if (isError(userInfo)) {

--- a/agent/src/cli/command-auth/command-login.ts
+++ b/agent/src/cli/command-auth/command-login.ts
@@ -121,10 +121,10 @@ async function loginAction(
         isCliLogin && options.endpoint && options.accessToken
             ? options.accessToken
             : await captureAccessTokenViaBrowserRedirect(serverEndpoint, spinner)
-    const client = new SourcegraphGraphQLAPIClient({
-        accessToken: token,
-        serverEndpoint: serverEndpoint,
-        customHeaders: {},
+    const client = SourcegraphGraphQLAPIClient.withStaticConfig({
+        configuration: { telemetryLevel: 'agent' },
+        auth: { accessToken: token, serverEndpoint: serverEndpoint },
+        clientState: { anonymousUserID: null },
     })
     const userInfo = await client.getCurrentUserInfo()
     if (isError(userInfo)) {
@@ -254,10 +254,10 @@ async function promptUserAboutLoginMethod(spinner: Ora, options: LoginOptions): 
         return 'web-login'
     }
     try {
-        const client = new SourcegraphGraphQLAPIClient({
-            accessToken: options.accessToken,
-            serverEndpoint: options.endpoint,
-            customHeaders: {},
+        const client = SourcegraphGraphQLAPIClient.withStaticConfig({
+            configuration: { telemetryLevel: 'agent' },
+            auth: { accessToken: options.accessToken, serverEndpoint: options.endpoint },
+            clientState: { anonymousUserID: null },
         })
         const userInfo = await client.getCurrentUserInfo()
         const isValidAccessToken = userInfo && !isError(userInfo)

--- a/agent/src/cli/command-bench/command-bench.ts
+++ b/agent/src/cli/command-bench/command-bench.ts
@@ -10,13 +10,9 @@ import { newAgentClient } from '../../agent'
 import { exec } from 'node:child_process'
 import fs from 'node:fs'
 import { promisify } from 'node:util'
-import {
-    type ConfigurationUseContext,
-    graphqlClient,
-    isDefined,
-    modelsService,
-} from '@sourcegraph/cody-shared'
+import { type ConfigurationUseContext, isDefined, modelsService } from '@sourcegraph/cody-shared'
 import { sleep } from '../../../../vscode/src/completions/utils'
+import { setStaticResolvedConfigurationWithAuthCredentials } from '../../../../vscode/src/configuration'
 import { startPollyRecording } from '../../../../vscode/src/testutils/polly'
 import { dotcomCredentials } from '../../../../vscode/src/testutils/testing-credentials'
 import { allClientCapabilitiesEnabled } from '../../allClientCapabilitiesEnabled'
@@ -325,10 +321,12 @@ export const benchCommand = new commander.Command('bench')
         )
 
         // Required to use `PromptString`.
-        graphqlClient.setConfig({
-            accessToken: options.srcAccessToken,
-            serverEndpoint: options.srcEndpoint,
-            customHeaders: {},
+        setStaticResolvedConfigurationWithAuthCredentials({
+            configuration: { customHeaders: {} },
+            auth: {
+                accessToken: options.srcAccessToken,
+                serverEndpoint: options.srcEndpoint,
+            },
         })
 
         const recordingDirectory = path.join(path.dirname(options.evaluationConfig), 'recordings')

--- a/agent/src/cli/command-context/command-context.ts
+++ b/agent/src/cli/command-context/command-context.ts
@@ -4,6 +4,7 @@ import * as commander from 'commander'
 import { parse } from 'csv-parse/sync'
 import { createObjectCsvWriter } from 'csv-writer'
 import { isError } from 'lodash'
+import { setStaticResolvedConfigurationWithAuthCredentials } from '../../../../vscode/src/configuration'
 import { dotcomCredentials } from '../../../../vscode/src/testutils/testing-credentials'
 
 interface CodyContextOptions {
@@ -58,10 +59,12 @@ export const contextCommand = new commander.Command('context')
             process.exit(1)
         }
 
-        graphqlClient.setConfig({
-            accessToken: options.srcAccessToken,
-            serverEndpoint: options.srcEndpoint,
-            customHeaders: {},
+        setStaticResolvedConfigurationWithAuthCredentials({
+            configuration: { customHeaders: {} },
+            auth: {
+                accessToken: options.srcAccessToken,
+                serverEndpoint: options.srcEndpoint,
+            },
         })
 
         const examples = await readExamplesFromCSV(options.inputFile)

--- a/agent/src/index.test.ts
+++ b/agent/src/index.test.ts
@@ -73,7 +73,7 @@ describe('Agent', () => {
             serverEndpoint: client.info.extensionConfiguration?.serverEndpoint ?? DOTCOM_URL.toString(),
             customHeaders: {},
         })
-        expect(valid?.authenticated).toBeTruthy()
+        expect(valid?.authenticated).toBe(true)
 
         for (const name of [
             'src/animal.ts',

--- a/agent/src/local-e2e/helpers.ts
+++ b/agent/src/local-e2e/helpers.ts
@@ -94,10 +94,10 @@ export class LocalSGInstance {
 
         // We'll need our own client to request the site-config (as a site-admin)
         // for checking the LLM configuration section.
-        this.gqlclient = new SourcegraphGraphQLAPIClient({
-            accessToken: this.params.accessToken,
-            serverEndpoint: this.params.serverEndpoint,
-            customHeaders: headers,
+        this.gqlclient = SourcegraphGraphQLAPIClient.withStaticConfig({
+            configuration: { customHeaders: headers, telemetryLevel: 'agent' },
+            auth: { accessToken: this.params.accessToken, serverEndpoint: this.params.serverEndpoint },
+            clientState: { anonymousUserID: 'anonymousUserID' },
         })
     }
 

--- a/lib/shared/src/index.ts
+++ b/lib/shared/src/index.ts
@@ -234,7 +234,6 @@ export {
     INCLUDE_EVERYTHING_CONTEXT_FILTERS,
     EXCLUDE_EVERYTHING_CONTEXT_FILTERS,
     type BrowserOrNodeResponse,
-    type GraphQLAPIClientConfig,
     type LogEventMode,
     type ContextFilters,
     type CodyContextFilterItem,

--- a/lib/shared/src/sourcegraph-api/graphql/client.ts
+++ b/lib/shared/src/sourcegraph-api/graphql/client.ts
@@ -5,11 +5,13 @@ import { fetch } from '../../fetch'
 import type { TelemetryEventInput } from '@sourcegraph/telemetry'
 
 import { escapeRegExp } from 'lodash'
+import { Observable } from 'observable-fns'
 import semver from 'semver'
 import type { AuthStatus } from '../../auth/types'
 import { dependentAbortController, onAbort } from '../../common/abortController'
-import type { ClientConfiguration, ClientConfigurationWithAccessToken } from '../../configuration'
+import { type PickResolvedConfiguration, resolvedConfig } from '../../configuration/resolver'
 import { logDebug, logError } from '../../logger'
+import { firstValueFrom } from '../../misc/observable'
 import { addTraceparent, wrapInActiveSpan } from '../../tracing'
 import { isError } from '../../utils'
 import { DOTCOM_URL, isDotCom } from '../environments'
@@ -587,11 +589,11 @@ export interface HighlightLineRange {
     startLine: number
 }
 
-export type GraphQLAPIClientConfig = Pick<
-    ClientConfigurationWithAccessToken,
-    'serverEndpoint' | 'accessToken' | 'customHeaders'
-> &
-    Pick<Partial<ClientConfiguration>, 'telemetryLevel'>
+type GraphQLAPIClientConfig = PickResolvedConfiguration<{
+    auth: true
+    configuration: 'telemetryLevel' | 'customHeaders'
+    clientState: 'anonymousUserID'
+}>
 
 export let customUserAgent: string | undefined
 export function addCustomUserAgent(headers: Headers): void {
@@ -607,45 +609,23 @@ const QUERY_TO_NAME_REGEXP = /^\s*(?:query|mutation)\s+(\w+)/m
 
 export class SourcegraphGraphQLAPIClient {
     private dotcomUrl = DOTCOM_URL
-    private anonymousUserID: string | undefined
-
-    /**
-     * Should be set on extension activation via `localStorage.onConfigurationChange(config)`
-     * Done to avoid passing the graphql client around as a parameter and instead
-     * access it as a singleton via the module import.
-     */
-    private _config: GraphQLAPIClientConfig | null = null
-
-    private get config(): GraphQLAPIClientConfig {
-        if (!this._config) {
-            throw new Error('GraphQLAPIClientConfig is not set')
-        }
-
-        return this._config
-    }
 
     private isAgentTesting = process.env.CODY_SHIM_TESTING === 'true'
 
-    constructor(config: GraphQLAPIClientConfig | null = null) {
-        this._config = config
-    }
-
-    public setConfig(newConfig: GraphQLAPIClientConfig): void {
-        this._config = newConfig
+    public static withGlobalConfig(): SourcegraphGraphQLAPIClient {
+        return new SourcegraphGraphQLAPIClient(resolvedConfig)
     }
 
     /**
-     * If set, anonymousUID is transmitted as 'X-Sourcegraph-Actor-Anonymous-UID'
-     * which is automatically picked up by Sourcegraph backends 5.2+
+     * Create a GraphQL client with the given configuration. Only use this for testing and API
+     * client usage outside of the normal extension lifecycle where it is not possible or desirable
+     * to use the currently active configuration.
      */
-    public setAnonymousUserID(anonymousUID: string): void {
-        this.anonymousUserID = anonymousUID
+    public static withStaticConfig(config: GraphQLAPIClientConfig): SourcegraphGraphQLAPIClient {
+        return new SourcegraphGraphQLAPIClient(Observable.of(config))
     }
 
-    // Gets the server endpoint for this client.
-    public get endpoint(): string {
-        return this.config.serverEndpoint
-    }
+    private constructor(private readonly config: Observable<GraphQLAPIClientConfig>) {}
 
     public async getSiteVersion(signal?: AbortSignal): Promise<string | Error> {
         return this.fetchSourcegraphAPI<APIResponse<SiteVersionResponse>>(
@@ -770,10 +750,11 @@ export class SourcegraphGraphQLAPIClient {
         )
     }
 
-    public async getSiteHasIsCodyEnabledField(): Promise<boolean | Error> {
+    public async getSiteHasIsCodyEnabledField(signal?: AbortSignal): Promise<boolean | Error> {
         return this.fetchSourcegraphAPI<APIResponse<SiteGraphqlFieldsResponse>>(
             CURRENT_SITE_GRAPHQL_FIELDS_QUERY,
-            {}
+            {},
+            signal
         ).then(response =>
             extractDataOrError(
                 response,
@@ -782,10 +763,11 @@ export class SourcegraphGraphQLAPIClient {
         )
     }
 
-    public async getSiteHasCodyEnabled(): Promise<boolean | Error> {
+    public async getSiteHasCodyEnabled(signal?: AbortSignal): Promise<boolean | Error> {
         return this.fetchSourcegraphAPI<APIResponse<SiteHasCodyEnabledResponse>>(
             CURRENT_SITE_HAS_CODY_ENABLED_QUERY,
-            {}
+            {},
+            signal
         ).then(response => extractDataOrError(response, data => data.site?.isCodyEnabled ?? false))
     }
 
@@ -816,10 +798,11 @@ export class SourcegraphGraphQLAPIClient {
         )
     }
 
-    public async getCurrentUserInfo(): Promise<CurrentUserInfo | null | Error> {
+    public async getCurrentUserInfo(signal?: AbortSignal): Promise<CurrentUserInfo | null | Error> {
         return this.fetchSourcegraphAPI<APIResponse<CurrentUserInfoResponse>>(
             CURRENT_USER_INFO_QUERY,
-            {}
+            {},
+            signal
         ).then(response =>
             extractDataOrError(response, data => (data.currentUser ? { ...data.currentUser } : null))
         )
@@ -828,10 +811,11 @@ export class SourcegraphGraphQLAPIClient {
     /**
      * Fetches the Site Admin enabled/disable Cody config features for the current instance.
      */
-    public async getCodyConfigFeatures(): Promise<CodyConfigFeatures | Error> {
+    public async getCodyConfigFeatures(signal?: AbortSignal): Promise<CodyConfigFeatures | Error> {
         const response = await this.fetchSourcegraphAPI<APIResponse<CodyConfigFeaturesResponse>>(
             CURRENT_SITE_CODY_CONFIG_FEATURES,
-            {}
+            {},
+            signal
         )
         return extractDataOrError(
             response,
@@ -839,16 +823,22 @@ export class SourcegraphGraphQLAPIClient {
         )
     }
 
-    public async getCodyLLMConfiguration(): Promise<undefined | CodyLLMSiteConfiguration | Error> {
+    public async getCodyLLMConfiguration(
+        signal?: AbortSignal
+    ): Promise<undefined | CodyLLMSiteConfiguration | Error> {
         // fetch Cody LLM provider separately for backward compatibility
         const [configResponse, providerResponse, smartContextWindow] = await Promise.all([
             this.fetchSourcegraphAPI<APIResponse<CodyLLMSiteConfigurationResponse>>(
-                CURRENT_SITE_CODY_LLM_CONFIGURATION
+                CURRENT_SITE_CODY_LLM_CONFIGURATION,
+                undefined,
+                signal
             ),
             this.fetchSourcegraphAPI<APIResponse<CodyLLMSiteConfigurationProviderResponse>>(
-                CURRENT_SITE_CODY_LLM_PROVIDER
+                CURRENT_SITE_CODY_LLM_PROVIDER,
+                undefined,
+                signal
             ),
-            this.getCodyLLMConfigurationSmartContext(),
+            this.getCodyLLMConfigurationSmartContext(signal),
         ])
 
         const config = extractDataOrError(
@@ -871,11 +861,12 @@ export class SourcegraphGraphQLAPIClient {
         return { ...config, provider, smartContextWindow }
     }
 
-    async getCodyLLMConfigurationSmartContext(): Promise<boolean> {
+    async getCodyLLMConfigurationSmartContext(signal?: AbortSignal): Promise<boolean> {
         return (
             this.fetchSourcegraphAPI<APIResponse<CodyEnterpriseConfigSmartContextResponse>>(
                 CURRENT_SITE_CODY_LLM_CONFIGURATION_SMART_CONTEXT,
-                {}
+                {},
+                signal
             )
                 .then(response => {
                     const smartContextResponse = extractDataOrError(
@@ -1063,6 +1054,7 @@ export class SourcegraphGraphQLAPIClient {
         filePatterns?: string[]
     }): Promise<ContextSearchResult[] | null | Error> {
         const isValidVersion = await this.isValidSiteVersion({ minimumVersion: '5.7.0' })
+        const config = await firstValueFrom(this.config!)
 
         return this.fetchSourcegraphAPI<APIResponse<ContextSearchResponse>>(
             isValidVersion ? CONTEXT_SEARCH_QUERY : LEGACY_CONTEXT_SEARCH_QUERY,
@@ -1081,9 +1073,9 @@ export class SourcegraphGraphQLAPIClient {
                     repoName: item.blob.repository.name,
                     path: item.blob.path,
                     uri: URI.parse(
-                        `${this.endpoint}${item.blob.repository.name}/-/blob/${item.blob.path}?L${
-                            item.startLine + 1
-                        }-${item.endLine}`
+                        `${config.auth.serverEndpoint}${item.blob.repository.name}/-/blob/${
+                            item.blob.path
+                        }?L${item.startLine + 1}-${item.endLine}`
                     ),
                     startLine: item.startLine,
                     endLine: item.endLine,
@@ -1181,12 +1173,12 @@ export class SourcegraphGraphQLAPIClient {
      * If the field exists, it calls `getSiteHasCodyEnabled()` to check its value.
      * If the field does not exist, Cody is assumed to be enabled for versions between 5.0.0 - 5.1.0.
      */
-    public async isCodyEnabled(): Promise<{
+    public async isCodyEnabled(signal?: AbortSignal): Promise<{
         enabled: boolean
         version: string
     }> {
         // Check site version.
-        const siteVersion = await this.getSiteVersion()
+        const siteVersion = await this.getSiteVersion(signal)
         if (isError(siteVersion)) {
             return { enabled: false, version: 'unknown' }
         }
@@ -1201,10 +1193,10 @@ export class SourcegraphGraphQLAPIClient {
         }
         // Beta version is betwewen 5.0.0 - 5.1.0 and does not have isCodyEnabled field
         const betaVersion = semver.gte(siteVersion, '5.0.0') && semver.lt(siteVersion, '5.1.0')
-        const hasIsCodyEnabledField = await this.getSiteHasIsCodyEnabledField()
+        const hasIsCodyEnabledField = await this.getSiteHasIsCodyEnabledField(signal)
         // The isCodyEnabled field does not exist before version 5.1.0
         if (!betaVersion && !isError(hasIsCodyEnabledField) && hasIsCodyEnabledField) {
-            const siteHasCodyEnabled = await this.getSiteHasCodyEnabled()
+            const siteHasCodyEnabled = await this.getSiteHasCodyEnabled(signal)
             return {
                 enabled: !isError(siteHasCodyEnabled) && siteHasCodyEnabled,
                 version: siteVersion,
@@ -1247,14 +1239,15 @@ export class SourcegraphGraphQLAPIClient {
         if (this.isAgentTesting) {
             return {}
         }
-        if (this.config?.telemetryLevel === 'off') {
+        const config = await firstValueFrom(this.config!)
+        if (config.configuration?.telemetryLevel === 'off') {
             return {}
         }
         /**
          * If connected to dotcom, just log events to the instance, as it means
          * the same thing.
          */
-        if (isDotCom(this.config.serverEndpoint)) {
+        if (isDotCom(config.auth.serverEndpoint)) {
             return this.sendEventLogRequestToAPI(event)
         }
 
@@ -1438,13 +1431,18 @@ export class SourcegraphGraphQLAPIClient {
         variables: Record<string, any> = {},
         signalOrTimeout?: AbortSignal | number
     ): Promise<T | Error> {
-        const headers = new Headers(this.config.customHeaders as HeadersInit)
-        headers.set('Content-Type', 'application/json; charset=utf-8')
-        if (this.config.accessToken) {
-            headers.set('Authorization', `token ${this.config.accessToken}`)
+        if (!this.config) {
+            throw new Error('SourcegraphGraphQLAPIClient config not set')
         }
-        if (this.anonymousUserID && !process.env.CODY_WEB_DONT_SET_SOME_HEADERS) {
-            headers.set('X-Sourcegraph-Actor-Anonymous-UID', this.anonymousUserID)
+        const config = await firstValueFrom(this.config)
+
+        const headers = new Headers(config.configuration?.customHeaders as HeadersInit | undefined)
+        headers.set('Content-Type', 'application/json; charset=utf-8')
+        if (config.auth.accessToken) {
+            headers.set('Authorization', `token ${config.auth.accessToken}`)
+        }
+        if (config.clientState.anonymousUserID && !process.env.CODY_WEB_DONT_SET_SOME_HEADERS) {
+            headers.set('X-Sourcegraph-Actor-Anonymous-UID', config.clientState.anonymousUserID)
         }
 
         addTraceparent(headers)
@@ -1454,7 +1452,7 @@ export class SourcegraphGraphQLAPIClient {
 
         const url = buildGraphQLUrl({
             request: query,
-            baseUrl: this.config.serverEndpoint,
+            baseUrl: config.auth.serverEndpoint,
         })
 
         // Default timeout of 6 seconds.
@@ -1534,35 +1532,44 @@ export class SourcegraphGraphQLAPIClient {
     }
 
     // Performs an authenticated request to our non-GraphQL HTTP / REST API.
-    public fetchHTTP<T>(
+    public async fetchHTTP<T>(
         queryName: string,
         method: string,
         urlPath: string,
-        body?: string
+        body?: string,
+        signal?: AbortSignal
     ): Promise<T | Error> {
-        const headers = new Headers(this.config.customHeaders as HeadersInit)
-        headers.set('Content-Type', 'application/json; charset=utf-8')
-        if (this.config.accessToken) {
-            headers.set('Authorization', `token ${this.config.accessToken}`)
+        if (!this.config) {
+            throw new Error('SourcegraphGraphQLAPIClient config not set')
         }
-        if (this.anonymousUserID && !process.env.CODY_WEB_DONT_SET_SOME_HEADERS) {
-            headers.set('X-Sourcegraph-Actor-Anonymous-UID', this.anonymousUserID)
+        const config = await firstValueFrom(this.config)
+
+        const headers = new Headers(config.configuration?.customHeaders as HeadersInit | undefined)
+        headers.set('Content-Type', 'application/json; charset=utf-8')
+        if (config.auth.accessToken) {
+            headers.set('Authorization', `token ${config.auth.accessToken}`)
+        }
+        if (config.clientState.anonymousUserID && !process.env.CODY_WEB_DONT_SET_SOME_HEADERS) {
+            headers.set('X-Sourcegraph-Actor-Anonymous-UID', config.clientState.anonymousUserID)
         }
 
         addTraceparent(headers)
         addCustomUserAgent(headers)
 
         // Timeout of 6 seconds.
-        const signal = AbortSignal.timeout(6000)
+        const timeoutSignal = AbortSignal.timeout(6000)
 
-        const url = new URL(urlPath, this.config.serverEndpoint).href
+        const abortController = dependentAbortController(signal)
+        onAbort(timeoutSignal, () => abortController.abort())
+
+        const url = new URL(urlPath, config.auth.serverEndpoint).href
 
         return wrapInActiveSpan(`httpapi.fetch${queryName ? `.${queryName}` : ''}`, () =>
             fetch(url, {
                 method: method,
                 body: body,
                 headers,
-                signal,
+                signal: abortController.signal,
             })
                 .then(verifyResponseCode)
                 .then(response => response.json() as T)
@@ -1578,9 +1585,8 @@ export class SourcegraphGraphQLAPIClient {
 
 /**
  * Singleton instance of the graphql client.
- * Should be configured on the extension activation via `graphqlClient.onConfigurationChange(config)`.
  */
-export const graphqlClient = new SourcegraphGraphQLAPIClient()
+export const graphqlClient = SourcegraphGraphQLAPIClient.withGlobalConfig()
 
 /**
  * ClientConfigSingleton is a class that manages the retrieval
@@ -1612,24 +1618,24 @@ export class ClientConfigSingleton {
         return ClientConfigSingleton.instance
     }
 
-    public async setAuthStatus(authStatus: AuthStatus): Promise<void> {
-        this.isSignedIn = authStatus.authenticated
+    public async setAuthStatus(authStatus: AuthStatus, signal?: AbortSignal): Promise<void> {
+        this.isSignedIn = !!authStatus.authenticated
         if (this.isSignedIn) {
-            await this.refreshConfig()
+            await this.refreshConfig(signal)
         } else {
             this.cachedClientConfig = undefined
             this.cachedAt = 0
         }
     }
 
-    public async getConfig(): Promise<CodyClientConfig | undefined> {
+    public async getConfig(signal?: AbortSignal): Promise<CodyClientConfig | undefined> {
         try {
             switch (this.shouldFetch()) {
                 case 'sync':
-                    return this.refreshConfig()
+                    return this.refreshConfig(signal)
                 // biome-ignore lint/suspicious/noFallthroughSwitchClause: This is intentional
                 case 'async':
-                    this.refreshConfig()
+                    this.refreshConfig(signal)
                 case false:
                     return this.cachedClientConfig
             }
@@ -1666,13 +1672,14 @@ export class ClientConfigSingleton {
     }
 
     // Refreshes the config features by fetching them from the server and caching the result
-    private async refreshConfig(): Promise<CodyClientConfig> {
+    private async refreshConfig(signal?: AbortSignal): Promise<CodyClientConfig> {
         logDebug('ClientConfigSingleton', 'refreshing configuration')
 
         // Determine based on the site version if /.api/client-config is available.
         return graphqlClient
-            .getSiteVersion()
+            .getSiteVersion(signal)
             .then(siteVersion => {
+                signal?.throwIfAborted()
                 if (isError(siteVersion)) {
                     logError(
                         'ClientConfigSingleton',
@@ -1695,14 +1702,22 @@ export class ClientConfigSingleton {
                 return true
             })
             .then(supportsClientConfig => {
+                signal?.throwIfAborted()
+
                 // If /.api/client-config is not available, fallback to the myriad of GraphQL
                 // requests that we previously used to determine the client configuration
                 if (!supportsClientConfig) {
-                    return this.fetchClientConfigLegacy()
+                    return this.fetchClientConfigLegacy(signal)
                 }
 
                 return graphqlClient
-                    .fetchHTTP<CodyClientConfig>('client-config', 'GET', '/.api/client-config')
+                    .fetchHTTP<CodyClientConfig>(
+                        'client-config',
+                        'GET',
+                        '/.api/client-config',
+                        undefined,
+                        signal
+                    )
                     .then(clientConfig => {
                         if (isError(clientConfig)) {
                             logError('ClientConfigSingleton', 'refresh client config', clientConfig)
@@ -1727,13 +1742,15 @@ export class ClientConfigSingleton {
             })
     }
 
-    private async fetchClientConfigLegacy(): Promise<CodyClientConfig> {
+    private async fetchClientConfigLegacy(signal?: AbortSignal): Promise<CodyClientConfig> {
         // Note: all of these promises are written carefully to not throw errors internally, but
         // rather to return sane defaults, and so we do not catch() here.
-        const smartContextWindow = await graphqlClient.getCodyLLMConfigurationSmartContext()
-        const features = await this.fetchConfigFeaturesLegacy(this.featuresLegacy)
+        const smartContextWindow = await graphqlClient.getCodyLLMConfigurationSmartContext(signal)
+        signal?.throwIfAborted()
+        const features = await this.fetchConfigFeaturesLegacy(this.featuresLegacy, signal)
+        signal?.throwIfAborted()
 
-        return graphqlClient.isCodyEnabled().then(isCodyEnabled => ({
+        return {
             chatEnabled: features.chat,
             autoCompleteEnabled: features.autoComplete,
             customCommandsEnabled: features.commands,
@@ -1742,14 +1759,15 @@ export class ClientConfigSingleton {
 
             // Things that did not exist before logically default to disabled.
             modelsAPIEnabled: false,
-        }))
+        }
     }
 
     // Fetches the config features from the server and handles errors, using the old/legacy GraphQL API.
     private async fetchConfigFeaturesLegacy(
-        defaultErrorValue: CodyConfigFeatures
+        defaultErrorValue: CodyConfigFeatures,
+        signal?: AbortSignal
     ): Promise<CodyConfigFeatures> {
-        const features = await graphqlClient.getCodyConfigFeatures()
+        const features = await graphqlClient.getCodyConfigFeatures(signal)
         if (features instanceof Error) {
             // An error here most likely indicates the Sourcegraph instance is so old that it doesn't
             // even support this legacy GraphQL API.

--- a/vscode/src/completions/context/context-mixer.test.ts
+++ b/vscode/src/completions/context/context-mixer.test.ts
@@ -1,8 +1,6 @@
 import {
     type AutocompleteContextSnippet,
-    type GraphQLAPIClientConfig,
     contextFiltersProvider,
-    graphqlClient,
     testFileUri,
     uriBasename,
 } from '@sourcegraph/cody-shared'
@@ -15,8 +13,6 @@ import { ContextMixer } from './context-mixer'
 import type { ContextStrategyFactory } from './context-strategy'
 
 import type * as vscode from 'vscode'
-
-graphqlClient.setConfig({} as unknown as GraphQLAPIClientConfig)
 
 function createMockStrategy(resultSets: AutocompleteContextSnippet[][]): ContextStrategyFactory {
     const retrievers = []

--- a/vscode/src/completions/get-inline-completions-tests/helpers.ts
+++ b/vscode/src/completions/get-inline-completions-tests/helpers.ts
@@ -12,10 +12,8 @@ import {
     type CompletionParameters,
     type CompletionResponse,
     CompletionStopReason,
-    type GraphQLAPIClientConfig,
     type ResolvedConfiguration,
     featureFlagProvider,
-    graphqlClient,
     mockAuthStatus,
     mockResolvedConfig,
     testFileUri,
@@ -424,7 +422,6 @@ export function initCompletionProviderConfig({
     configuration,
     authStatus,
 }: Partial<Pick<ParamsResult, 'configuration' | 'authStatus'>>): void {
-    graphqlClient.setConfig({} as unknown as GraphQLAPIClientConfig)
     vi.spyOn(featureFlagProvider, 'evaluateFeatureFlag').mockResolvedValue(false)
     vi.spyOn(featureFlagProvider, 'evaluatedFeatureFlag').mockReturnValue(Observable.of(false))
     mockAuthStatus(authStatus ?? AUTH_STATUS_FIXTURE_AUTHED)

--- a/vscode/src/completions/inline-completion-item-provider-e2e.test.ts
+++ b/vscode/src/completions/inline-completion-item-provider-e2e.test.ts
@@ -1,11 +1,9 @@
 import {
     AUTH_STATUS_FIXTURE_AUTHED,
     type ClientConfiguration,
-    type GraphQLAPIClientConfig,
     type ResolvedConfiguration,
     contextFiltersProvider,
     featureFlagProvider,
-    graphqlClient,
     nextTick,
     telemetryRecorder,
 } from '@sourcegraph/cody-shared'
@@ -45,8 +43,6 @@ const DUMMY_CONTEXT: vscode.InlineCompletionContext = {
     selectedCompletionInfo: undefined,
     triggerKind: vsCodeMocks.InlineCompletionTriggerKind.Automatic,
 }
-
-graphqlClient.setConfig({} as unknown as GraphQLAPIClientConfig)
 
 const getAnalyticEventCalls = (mockInstance: MockInstance) => {
     return mockInstance.mock.calls.map(args => {

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -301,13 +301,6 @@ async function initializeSingletons(
     commandControllerInit(platform.createCommandsProvider?.(), platform.extensionClient.capabilities)
     disposables.push(
         subscriptionDisposable(
-            resolvedConfigWithAccessToken.subscribe({
-                next: config => {
-                    graphqlClient.setConfig(config)
-                },
-            })
-        ),
-        subscriptionDisposable(
             resolvedConfig.subscribe({
                 next: config => {
                     void localStorage.setConfig(config)

--- a/vscode/src/models/sync.test.ts
+++ b/vscode/src/models/sync.test.ts
@@ -4,7 +4,6 @@ import {
     type AuthenticatedAuthStatus,
     ClientConfigSingleton,
     DOTCOM_URL,
-    type GraphQLAPIClientConfig,
     Model,
     ModelTag,
     ModelUsage,
@@ -13,8 +12,8 @@ import {
     type ServerModelConfiguration,
     featureFlagProvider,
     getDotComDefaultModels,
-    graphqlClient,
     mockAuthStatus,
+    mockResolvedConfig,
     modelsService,
 } from '@sourcegraph/cody-shared'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -59,10 +58,7 @@ describe('syncModels', () => {
     })
 
     it('sets dotcom default models if on dotcom', async () => {
-        // @ts-ignore
-        graphqlClient._config = {
-            serverEndpoint: DOTCOM_URL.toString(),
-        } as Partial<GraphQLAPIClientConfig> as GraphQLAPIClientConfig
+        mockResolvedConfig({ auth: { serverEndpoint: DOTCOM_URL.toString() } })
         localStorage.set('mock', '1')
         await syncModels({ ...AUTH_STATUS_FIXTURE_AUTHED, endpoint: DOTCOM_URL.toString() })
         expect(setModelsSpy).toHaveBeenCalledWith(getDotComDefaultModels())

--- a/vscode/src/models/sync.ts
+++ b/vscode/src/models/sync.ts
@@ -48,7 +48,8 @@ export async function syncModels(authStatus: AuthStatus, signal?: AbortSignal): 
 
     // Fetch the LLM models and configuration server-side. See:
     // https://linear.app/sourcegraph/project/server-side-cody-model-selection-cca47c48da6d
-    const clientConfig = await ClientConfigSingleton.getInstance().getConfig()
+    const clientConfig = await ClientConfigSingleton.getInstance().getConfig(signal)
+    signal?.throwIfAborted()
 
     if (clientConfig?.modelsAPIEnabled) {
         logDebug('ModelsService', 'new models API enabled')


### PR DESCRIPTION
Previously, it relied on having its config updated in `vscode/src/main.ts`. Now, it observes the global `resolvedConfig` just as everything else does now.


## Test plan

e2e