### PR TITLE
Autocomplete: clean up settings

### DIFF
--- a/lib/shared/src/configuration.ts
+++ b/lib/shared/src/configuration.ts
@@ -46,15 +46,7 @@ interface RawClientConfiguration {
      */
     autocomplete: boolean
     autocompleteLanguages: Record<string, boolean>
-    autocompleteAdvancedProvider:
-        | 'anthropic'
-        | 'fireworks'
-        | 'unstable-gemini'
-        | 'unstable-openai'
-        | 'experimental-openaicompatible'
-        | 'experimental-ollama'
-        | null
-    autocompleteAdvancedModel: string | null
+    autocompleteAdvancedProvider: AutocompleteProviderID | string
     autocompleteCompleteSuggestWidgetSelection?: boolean
     autocompleteFormatOnAccept?: boolean
     autocompleteDisableInsideComments: boolean
@@ -94,6 +86,7 @@ interface RawClientConfiguration {
     agentExtensionVersion?: string
     agentHasPersistentStorage?: boolean
     autocompleteFirstCompletionTimeout: number
+    autocompleteAdvancedModel: string | null
 
     testingModelConfig: EmbeddingsModelConfig | undefined
 }
@@ -118,6 +111,111 @@ export type ClientConfigurationWithEndpoint = Omit<ClientConfigurationWithAccess
 export interface ClientConfigurationWithAccessToken
     extends ReadonlyDeep<RawClientConfiguration>,
         AuthCredentials {}
+
+export type AutocompleteProviderID = keyof typeof AUTOCOMPLETE_PROVIDER_ID
+
+export const AUTOCOMPLETE_PROVIDER_ID = {
+    /**
+     * Default identifier that maps to the recommended autocomplete provider on DotCom.
+     */
+    default: 'default',
+
+    /**
+     * Cody talking to Fireworks official API.
+     * https://docs.fireworks.ai/api-reference/introduction
+     */
+    fireworks: 'fireworks',
+
+    /**
+     * Cody talking to openai compatible API.
+     * We plan to use this provider instead of all the existing openai-related providers.
+     */
+    openaicompatible: 'openaicompatible',
+
+    /**
+     * Cody talking to OpenAI's official public API.
+     * https://platform.openai.com/docs/api-reference/introduction
+     */
+    openai: 'openai',
+
+    /**
+     * Cody talking to OpenAI's official public API.
+     * https://platform.openai.com/docs/api-reference/introduction
+     *
+     * @deprecated use `openai` instead
+     */
+    'unstable-openai': 'unstable-openai',
+
+    /**
+     * Cody talking to OpenAI through Microsoft Azure's API (they re-sell the OpenAI API, but slightly modified).
+     *
+     * @deprecated use `openai` instead
+     */
+    'azure-openai': 'azure-openai',
+
+    /**
+     * Cody talking to customer's custom proxy service.
+     *
+     * TODO(slimsag): self-hosted models: deprecate and remove this
+     * once customers are upgraded to non-experimental version.
+     *
+     * @deprecated use `openaicompatible` instead
+     */
+    'experimental-openaicompatible': 'experimental-openaicompatible',
+
+    /**
+     * This refers to either Anthropic models re-sold by AWS,
+     * or to other models hosted by AWS' Bedrock inference API service
+     */
+    'aws-bedrock': 'aws-bedrock',
+
+    /**
+     * Cody talking to Anthropic's official public API.
+     * https://docs.anthropic.com/en/api/getting-started
+     */
+    anthropic: 'anthropic',
+
+    /**
+     * Cody talking to Google's APIs for models created by Google, which include:
+     * - their public Gemini API
+     * - their GCP Gemini API
+     * - GCP Vertex API
+     * - Anthropic-reselling APIs
+     */
+    google: 'google',
+
+    /**
+     * Cody talking to Google's APIs for models created by Google, which include:
+     * - their public Gemini API
+     * - their GCP Gemini API
+     * - GCP Vertex API
+     */
+    gemini: 'gemini',
+
+    /**
+     * Cody talking to Google's APIs for models created by Google, which include:
+     * - their public Gemini API
+     * - their GCP Gemini API
+     * - GCP Vertex API
+     *
+     * @deprecated use `gemini` instead.
+     */
+    'unstable-gemini': 'unstable-gemini',
+
+    /**
+     * Cody talking to Ollama's official public API.
+     * https://ollama.ai/docs/api
+     */
+    'experimental-ollama': 'experimental-ollama',
+
+    /**
+     * Cody talking to Ollama's official public API.
+     * https://ollama.ai/docs/api
+     *
+     * @deprecated use `experimental-ollama` instead.
+     */
+    'unstable-ollama': 'unstable-ollama',
+} as const
 
 export interface OllamaOptions {
     /**

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -12,13 +12,14 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 
 ### Fixed
 
-Chat: Fixed feedback buttons not working in chat. [pull/5509](https://github.com/sourcegraph/cody/pull/5509)
-Command: Removed duplicated default commands from the Cody Commands menu that were incorrectly listed as custom commands.
+- Chat: Fixed feedback buttons not working in chat. [pull/5509](https://github.com/sourcegraph/cody/pull/5509)
+- Command: Removed duplicated default commands from the Cody Commands menu that were incorrectly listed as custom commands.
 
 ### Changed
 
-Enterprise: Remote Repository items in the mention menu now display only the org/repo part of the title, omitting the code host name to prevent repository names from being truncated in the UI. [pull/5518](https://github.com/sourcegraph/cody/pull/5518)
-Cody Ignore: This internal experimental feature is now deprecated and the use of `.cody/ignore` file is no longer supported. [pull/5537](https://github.com/sourcegraph/cody/pull/5537)
+- Enterprise: Remote Repository items in the mention menu now display only the org/repo part of the title, omitting the code host name to prevent repository names from being truncated in the UI. [pull/5518](https://github.com/sourcegraph/cody/pull/5518)
+- Cody Ignore: This internal experimental feature is now deprecated and the use of `.cody/ignore` file is no longer supported. [pull/5537](https://github.com/sourcegraph/cody/pull/5537)
+- Autocomplete: removed the `cody.autocomplete.advanced.model` setting and updated supported values for `cody.autocomplete.advanced.provider`.
 
 ## 1.34.2
 

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -1115,31 +1115,13 @@
         },
         "cody.autocomplete.advanced.provider": {
           "type": "string",
-          "default": null,
-          "enum": [
-            null,
-            "anthropic",
-            "fireworks",
-            "unstable-gemini",
-            "unstable-openai",
-            "experimental-ollama",
-            "experimental-openaicompatible"
+          "default": "default",
+          "enum": ["default", "experimental-ollama"],
+          "enumDescriptions": [
+            "Our recommended setup with the best balance of quality and latency. We continuously update this for optimal performance.",
+            "Experimental support for Ollama users. Use `cody.autocomplete.experimental.ollamaOptions` to configure requests to Ollama server."
           ],
-          "markdownDescription": "The provider used for code autocomplete. Most providers other than `anthropic` require the `cody.autocomplete.advanced.serverEndpoint` and `cody.autocomplete.advanced.accessToken` settings to also be set. Check the Cody output channel for error messages if autocomplete is not working as expected."
-        },
-        "cody.autocomplete.advanced.serverEndpoint": {
-          "type": "string",
-          "markdownDescription": "The server endpoint used for code autocomplete. This is only supported with a provider other than `anthropic`."
-        },
-        "cody.autocomplete.advanced.accessToken": {
-          "type": "string",
-          "markdownDescription": "The access token used for code autocomplete. This is only supported with a provider other than `anthropic`."
-        },
-        "cody.autocomplete.advanced.model": {
-          "type": "string",
-          "default": null,
-          "enum": [null, "starcoder-16b", "starcoder-7b"],
-          "markdownDescription": "Overwrite the  model used for code autocompletion inference. This is only supported with the `fireworks` provider"
+          "markdownDescription": "The provider for code autocomplete. Users should rely on the `default` provider for the best experience. The underlying model can be found in the Cody output channel logs."
         },
         "cody.autocomplete.completeSuggestWidgetSelection": {
           "type": "boolean",

--- a/vscode/src/completions/create-multi-model-inline-completion-provider.ts
+++ b/vscode/src/completions/create-multi-model-inline-completion-provider.ts
@@ -134,7 +134,7 @@ export async function createInlineCompletionItemFromMultipleProviders({
         }
 
         // Use the experimental config to get the context provider
-        const provider = createProviderHelper({
+        const providerOrError = createProviderHelper({
             legacyModel: currentProviderConfig.model,
             provider: currentProviderConfig.provider,
             config: newConfig,
@@ -145,9 +145,9 @@ export async function createInlineCompletionItemFromMultipleProviders({
             .getConfiguration()
             .get<number>('cody.autocomplete.triggerDelay')
 
-        if (provider) {
+        if (!(providerOrError instanceof Error)) {
             const completionsProvider = new InlineCompletionItemProvider({
-                provider,
+                provider: providerOrError,
                 config: newConfig,
                 triggerDelay: triggerDelay ?? 0,
                 firstCompletionTimeout: config.configuration.autocompleteFirstCompletionTimeout,

--- a/vscode/src/completions/get-inline-completions-tests/helpers.ts
+++ b/vscode/src/completions/get-inline-completions-tests/helpers.ts
@@ -6,6 +6,7 @@ import type { URI } from 'vscode-uri'
 import {
     AUTH_STATUS_FIXTURE_AUTHED,
     AUTH_STATUS_FIXTURE_AUTHED_DOTCOM,
+    type AutocompleteProviderID,
     type ClientConfiguration,
     type ClientState,
     type CodeCompletionsClient,
@@ -46,7 +47,6 @@ import {
     SINGLE_LINE_STOP_SEQUENCES,
     createProvider as createAnthropicProvider,
 } from '../providers/anthropic'
-import type { AutocompleteProviderID } from '../providers/create-provider'
 import { createProvider as createFireworksProvider } from '../providers/fireworks'
 import { pressEnterAndGetIndentString } from '../providers/hot-streak'
 import { RequestManager } from '../request-manager'

--- a/vscode/src/completions/providers/provider.ts
+++ b/vscode/src/completions/providers/provider.ts
@@ -3,6 +3,7 @@ import type { Position, TextDocument } from 'vscode'
 import {
     type AuthenticatedAuthStatus,
     type AutocompleteContextSnippet,
+    type AutocompleteProviderID,
     type CodeCompletionsClient,
     type CompletionParameters,
     type DocumentContext,
@@ -18,7 +19,7 @@ import type { InlineCompletionItemWithAnalytics } from '../text-processing/proce
 
 import { defaultCodeCompletionsClient } from '../default-client'
 import { type DefaultModel, getModelHelpers } from '../model-helpers'
-import type { AutocompleteProviderConfigSource, AutocompleteProviderID } from './create-provider'
+import type { AutocompleteProviderConfigSource } from './create-provider'
 import type { FetchCompletionResult } from './fetch-and-process-completions'
 import { MAX_RESPONSE_TOKENS } from './get-completion-params'
 

--- a/vscode/src/configuration-keys.ts
+++ b/vscode/src/configuration-keys.ts
@@ -28,15 +28,6 @@ function getConfigFromPackageJson(): ConfigurationKeysMap {
     }, {} as ConfigurationKeysMap)
 }
 
-export function getConfigEnumValues(key: string): string[] {
-    const configKeys = properties[key as keyof typeof properties]
-    let enumValues: string[] = []
-    if ('enum' in configKeys) {
-        enumValues = configKeys.enum as string[]
-    }
-    return enumValues
-}
-
 // Use template literal type for string manipulation. See examples here:
 // https://www.typescriptlang.org/docs/handbook/2/template-literal-types.html
 type RemoveCodyPrefixAndCamelCase<T extends string> = T extends `cody.${infer A}`

--- a/vscode/src/configuration.test.ts
+++ b/vscode/src/configuration.test.ts
@@ -56,7 +56,7 @@ describe('getConfiguration', () => {
                     case 'cody.edit.preInstruction':
                         return 'My name is not Jeff.'
                     case 'cody.autocomplete.advanced.provider':
-                        return 'unstable-openai'
+                        return 'default'
                     case 'cody.autocomplete.advanced.model':
                         return 'starcoder-16b'
                     case 'cody.autocomplete.advanced.timeout.multiline':
@@ -144,7 +144,7 @@ describe('getConfiguration', () => {
             debugFilter: /.*/,
             telemetryLevel: 'off',
             agentHasPersistentStorage: false,
-            autocompleteAdvancedProvider: 'unstable-openai',
+            autocompleteAdvancedProvider: 'default',
             autocompleteAdvancedModel: 'starcoder-16b',
             autocompleteCompleteSuggestWidgetSelection: false,
             autocompleteFormatOnAccept: true,

--- a/vscode/src/testutils/mocks.ts
+++ b/vscode/src/testutils/mocks.ts
@@ -900,7 +900,7 @@ export const DEFAULT_VSCODE_SETTINGS = {
     telemetryLevel: 'all',
     internalUnstable: false,
     internalDebugContext: false,
-    autocompleteAdvancedProvider: null,
+    autocompleteAdvancedProvider: 'default',
     autocompleteAdvancedModel: null,
     autocompleteCompleteSuggestWidgetSelection: true,
     autocompleteFormatOnAccept: true,


### PR DESCRIPTION
TLDR: clean up autocomplete settings and improve visibility/debuggability of autocomplete provider creation errors.

- Changed the exposed values for `cody.autocomplete.advanced.provider` to:
    - `default` — our recommended setup.
    - `experimental-ollama` — for Ollama users.
- Added proper descriptions to `cody.autocomplete.advanced.provider` and its options.
    - <img width="694" alt="Screenshot 2024-09-16 at 12 02 23" src="https://github.com/user-attachments/assets/65eeac9f-5e76-4d59-82d5-123a85962fd3">
- Hidden `cody.autocomplete.advanced.model`. It's kept for internal testing purposes only.
- Removed unused `cody.autocomplete.advanced.serverEndpoint` and `cody.autocomplete.advanced.accessToken`.
- Replaced provider value validation based on enums specified in package.json with the runtime error surfaced to the user at the end of the autocomplete provider creation calls. The same error is logged to the output channel for debugging purposes. The error is different depending on the provider ID source and instance type:
    - <img width="461" alt="Screenshot 2024-09-16 at 11 56 54" src="https://github.com/user-attachments/assets/b3158bf6-d798-4f64-9942-47085d6dc205">
    - <img width="459" alt="Screenshot 2024-09-16 at 11 56 28" src="https://github.com/user-attachments/assets/d0636480-6917-42dd-9cd6-d1616cb70c37">
    - <img width="458" alt="Screenshot 2024-09-16 at 11 54 17" src="https://github.com/user-attachments/assets/c70a1282-4a5a-46e6-a72b-5ec60c224b03">
- Closes https://linear.app/sourcegraph/issue/CODY-3744/revise-autocomplete-provider-settings-based-on-user-feedback
- [Slack thread](https://sourcegraph.slack.com/archives/C04MSD3DP5L/p1725858507331409?thread_ts=1725637232.112709&cid=C04MSD3DP5L) with related discussion.

## Test plan

1. Search for the `cody.autocomplete.advanced.provider` setting in VS Code settings UI and ensure it matches changes from this PR description (updated description and options).
2. Add "cody.autocomplete.advanced.provider": "random-value" to your settings.json file and observe the error autocomplete error message in the standard VS Code error tooltip.
3. CI with updated unit tests.

## Changelog

- Autocomplete: removed the `cody.autocomplete.advanced.model` setting and updated supported values for `cody.autocomplete.advanced.provider`.
