### PR TITLE
Autocomplete: add openai model helper for the `unstable-openai` provider

### DIFF
--- a/vscode/src/completions/model-helpers/default.ts
+++ b/vscode/src/completions/model-helpers/default.ts
@@ -151,7 +151,7 @@ export class DefaultModel {
         return currentPrompt
     }
 
-    public postProcess(content: string): string {
+    public postProcess(content: string, docContext: DocumentContext): string {
         return content.replace(' <EOT>', '')
     }
 

--- a/vscode/src/completions/model-helpers/mistral.ts
+++ b/vscode/src/completions/model-helpers/mistral.ts
@@ -1,4 +1,5 @@
 import { type PromptString, ps } from '@sourcegraph/cody-shared'
+
 import { CLOSING_CODE_TAG, OPENING_CODE_TAG, getHeadAndTail } from '../text-processing'
 import { DefaultModel, type FormatPromptParams, type GetOllamaPromptParams } from './default'
 

--- a/vscode/src/completions/model-helpers/openai.ts
+++ b/vscode/src/completions/model-helpers/openai.ts
@@ -1,0 +1,37 @@
+import { type PromptString, ps } from '@sourcegraph/cody-shared'
+
+import { CLOSING_CODE_TAG, OPENING_CODE_TAG, getHeadAndTail } from '../text-processing'
+import {
+    DefaultModel,
+    type FormatPromptParams,
+    type GetDefaultIntroSnippetsParams,
+    type GetOllamaPromptParams,
+} from './default'
+
+export class OpenAI extends DefaultModel {
+    private instructions =
+        ps`You are a code completion AI designed to take the surrounding code and shared context into account in order to predict and suggest high-quality code to complete the code enclosed in ${OPENING_CODE_TAG} tags.  You only respond with code that works and fits seamlessly with surrounding code. Do not include anything else beyond the code.`
+
+    getOllamaPrompt(promptContext: GetOllamaPromptParams): PromptString {
+        throw new Error('OpenAI is not supported by the Ollama provider yet!')
+    }
+
+    protected getDefaultIntroSnippets(params: GetDefaultIntroSnippetsParams): PromptString[] {
+        return [this.instructions]
+    }
+
+    formatPrompt(params: FormatPromptParams): PromptString {
+        const { intro, prefix, suffix, fileName } = params
+
+        const { head, tail } = getHeadAndTail(prefix)
+        const infillBlock = tail.trimmed.toString().endsWith('{\n')
+            ? tail.trimmed.trimEnd()
+            : tail.trimmed
+
+        const infillPrefix = head.raw || ''
+
+        return ps`Below is the code from file path ${fileName}. Review the code outside the XML tags to detect the functionality, formats, style, patterns, and logics in use. Then, use what you detect and reuse methods/libraries to complete and enclose completed code only inside XML tags precisely without duplicating existing implementations. Here is the code:\n\`\`\`\n${intro}${infillPrefix}${OPENING_CODE_TAG}${CLOSING_CODE_TAG}${suffix}\n\`\`\`
+
+${OPENING_CODE_TAG}${infillBlock}`
+    }
+}

--- a/vscode/src/completions/model-helpers/openai.ts
+++ b/vscode/src/completions/model-helpers/openai.ts
@@ -1,6 +1,13 @@
-import { type PromptString, ps } from '@sourcegraph/cody-shared'
+import { type DocumentContext, type PromptString, ps } from '@sourcegraph/cody-shared'
 
-import { CLOSING_CODE_TAG, OPENING_CODE_TAG, getHeadAndTail } from '../text-processing'
+import {
+    CLOSING_CODE_TAG,
+    OPENING_CODE_TAG,
+    extractFromCodeBlock,
+    fixBadCompletionStart,
+    getHeadAndTail,
+    trimLeadingWhitespaceUntilNewline,
+} from '../text-processing'
 import {
     DefaultModel,
     type FormatPromptParams,
@@ -33,5 +40,25 @@ export class OpenAI extends DefaultModel {
         return ps`Below is the code from file path ${fileName}. Review the code outside the XML tags to detect the functionality, formats, style, patterns, and logics in use. Then, use what you detect and reuse methods/libraries to complete and enclose completed code only inside XML tags precisely without duplicating existing implementations. Here is the code:\n\`\`\`\n${intro}${infillPrefix}${OPENING_CODE_TAG}${CLOSING_CODE_TAG}${suffix}\n\`\`\`
 
 ${OPENING_CODE_TAG}${infillBlock}`
+    }
+
+    public postProcess(content: string, docContext: DocumentContext): string {
+        let completion = extractFromCodeBlock(content)
+
+        const trimmedPrefixContainNewline = docContext.prefix
+            .slice(docContext.prefix.trimEnd().length)
+            .includes('\n')
+        if (trimmedPrefixContainNewline) {
+            // The prefix already contains a `\n` that LLM was not aware of, so we remove any
+            // leading `\n` followed by whitespace that might be add.
+            completion = completion.replace(/^\s*\n\s*/, '')
+        } else {
+            completion = trimLeadingWhitespaceUntilNewline(completion)
+        }
+
+        // Remove bad symbols from the start of the completion string.
+        completion = fixBadCompletionStart(completion)
+
+        return completion
     }
 }

--- a/vscode/src/completions/providers/unstable-openai.ts
+++ b/vscode/src/completions/providers/unstable-openai.ts
@@ -1,18 +1,15 @@
-import {
-    type AutocompleteContextSnippet,
-    type CodeCompletionsParams,
-    type DocumentContext,
-    PromptString,
-    ps,
+import type {
+    AutocompleteContextSnippet,
+    CodeCompletionsParams,
+    DocumentContext,
 } from '@sourcegraph/cody-shared'
 
+import { OpenAI } from '../model-helpers/openai'
 import {
     CLOSING_CODE_TAG,
     MULTILINE_STOP_SEQUENCE,
-    OPENING_CODE_TAG,
     extractFromCodeBlock,
     fixBadCompletionStart,
-    getHeadAndTail,
     trimLeadingWhitespaceUntilNewline,
 } from '../text-processing'
 import { forkSignal, generatorWithTimeout, zipGenerators } from '../utils'
@@ -30,79 +27,7 @@ import {
 
 class UnstableOpenAIProvider extends Provider {
     public stopSequences = [CLOSING_CODE_TAG.toString(), MULTILINE_STOP_SEQUENCE]
-
-    private instructions =
-        ps`You are a code completion AI designed to take the surrounding code and shared context into account in order to predict and suggest high-quality code to complete the code enclosed in ${OPENING_CODE_TAG} tags.  You only respond with code that works and fits seamlessly with surrounding code. Do not include anything else beyond the code.`
-
-    public emptyPromptLength(options: GenerateCompletionsOptions): number {
-        const promptNoSnippets = [this.instructions, this.createPromptPrefix(options)].join('\n\n')
-        return promptNoSnippets.length - 10 // extra 10 chars of buffer cuz who knows
-    }
-
-    private createPromptPrefix(options: GenerateCompletionsOptions): PromptString {
-        const { prefix, suffix } = PromptString.fromAutocompleteDocumentContext(
-            options.docContext,
-            options.document.uri
-        )
-
-        const prefixLines = prefix.toString().split('\n')
-        if (prefixLines.length === 0) {
-            throw new Error('no prefix lines')
-        }
-
-        const { head, tail } = getHeadAndTail(prefix)
-
-        // Infill block represents the code we want the model to complete
-        const infillBlock = tail.trimmed.toString().endsWith('{\n')
-            ? tail.trimmed.trimEnd()
-            : tail.trimmed
-        // code before the cursor, without the code extracted for the infillBlock
-        const infillPrefix = head.raw
-        // code after the cursor
-        const infillSuffix = suffix
-        const relativeFilePath = PromptString.fromDisplayPath(options.document.uri)
-
-        return ps`Below is the code from file path ${relativeFilePath}. Review the code outside the XML tags to detect the functionality, formats, style, patterns, and logics in use. Then, use what you detect and reuse methods/libraries to complete and enclose completed code only inside XML tags precisely without duplicating existing implementations. Here is the code:\n\`\`\`\n${
-            infillPrefix ? infillPrefix : ''
-        }${OPENING_CODE_TAG}${CLOSING_CODE_TAG}${infillSuffix}\n\`\`\`
-
-${OPENING_CODE_TAG}${infillBlock}`
-    }
-
-    // Creates the resulting prompt and adds as many snippets from the reference
-    // list as possible.
-    protected createPrompt(
-        options: GenerateCompletionsOptions,
-        snippets: AutocompleteContextSnippet[]
-    ): PromptString {
-        const prefix = this.createPromptPrefix(options)
-
-        const referenceSnippetMessages: PromptString[] = []
-        let remainingChars = this.promptChars - this.emptyPromptLength(options)
-
-        for (const snippet of snippets) {
-            const contextPrompts = PromptString.fromAutocompleteContextSnippet(snippet)
-
-            const snippetMessages: PromptString[] = [
-                contextPrompts.symbol?.toString() !== ''
-                    ? ps`Additional documentation for \`${
-                          contextPrompts.symbol ?? ps``
-                      }\`: ${OPENING_CODE_TAG}${contextPrompts.content}${CLOSING_CODE_TAG}`
-                    : ps`Codebase context from file path '${PromptString.fromDisplayPath(
-                          snippet.uri
-                      )}': ${OPENING_CODE_TAG}${contextPrompts.content}${CLOSING_CODE_TAG}`,
-            ]
-            const numSnippetChars = snippetMessages.join('\n\n').length + 1
-            if (numSnippetChars > remainingChars) {
-                break
-            }
-            referenceSnippetMessages.push(...snippetMessages)
-            remainingChars -= numSnippetChars
-        }
-
-        const messages = [this.instructions, ...referenceSnippetMessages, prefix]
-        return PromptString.join(messages, ps`\n\n`)
-    }
+    protected modelHelper = new OpenAI()
 
     public async generateCompletions(
         options: GenerateCompletionsOptions,
@@ -110,34 +35,41 @@ ${OPENING_CODE_TAG}${infillBlock}`
         snippets: AutocompleteContextSnippet[],
         tracer?: CompletionProviderTracer
     ): Promise<AsyncGenerator<FetchCompletionResult[]>> {
-        const { docContext } = options
+        const { document, docContext } = options
+
+        const prompt = this.modelHelper.getPrompt({
+            snippets,
+            docContext,
+            document,
+            promptChars: this.promptChars,
+        })
 
         const requestParams: CodeCompletionsParams = {
             ...this.defaultRequestParams,
-            messages: [{ speaker: 'human', text: this.createPrompt(options, snippets) }],
+            messages: [{ speaker: 'human', text: prompt }],
             topP: 0.5,
         }
 
         tracer?.params(requestParams)
 
-        const completionsGenerators = Array.from({
-            length: options.numberOfCompletionsToGenerate,
-        }).map(async () => {
-            const abortController = forkSignal(abortSignal)
+        const completionsGenerators = Array.from({ length: options.numberOfCompletionsToGenerate }).map(
+            async () => {
+                const abortController = forkSignal(abortSignal)
 
-            const completionResponseGenerator = generatorWithTimeout(
-                await this.client.complete(requestParams, abortController),
-                requestParams.timeoutMs,
-                abortController
-            )
+                const completionResponseGenerator = generatorWithTimeout(
+                    await this.client.complete(requestParams, abortController),
+                    requestParams.timeoutMs,
+                    abortController
+                )
 
-            return fetchAndProcessDynamicMultilineCompletions({
-                completionResponseGenerator,
-                abortController,
-                providerSpecificPostProcess: this.postProcess(docContext),
-                generateOptions: options,
-            })
-        })
+                return fetchAndProcessDynamicMultilineCompletions({
+                    completionResponseGenerator,
+                    abortController,
+                    providerSpecificPostProcess: this.postProcess(docContext),
+                    generateOptions: options,
+                })
+            }
+        )
 
         return zipGenerators(await Promise.all(completionsGenerators))
     }


### PR DESCRIPTION
- Use model helpers with the `unstable-openai` provider to reduce code duplication.
- No functional changes.
- Part of https://linear.app/sourcegraph/issue/CODY-3409/self-hosted-models-openaicompatible-autocomplete-provider-supports

## Test plan

CI and manually tested the `unstable-openai` provider with the sg02 backend.