### PR TITLE
make ExternalServices and autocomplete more reactive

### DIFF
--- a/agent/recordings/cody-chat_103640681/recording.har.yaml
+++ b/agent/recordings/cody-chat_103640681/recording.har.yaml
@@ -88,7 +88,7 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: 709c04331ef053b321decb3b9eb8e0f0
+    - _id: 319763e777ba1797e749b0e6468a49a8
       _order: 0
       cache: {}
       request:
@@ -103,7 +103,7 @@ log:
             value: token
               REDACTED_964f5256e709a8c5c151a63d8696d5c7ac81604d179405864d88ff48a9232364
           - name: user-agent
-            value: jetbrains / 6.0.0-SNAPSHOT
+            value: cody-cli / 6.0.0-SNAPSHOT
           - name: connection
             value: keep-alive
           - name: host
@@ -206,7 +206,7 @@ log:
             value: token
               REDACTED_964f5256e709a8c5c151a63d8696d5c7ac81604d179405864d88ff48a9232364
           - name: user-agent
-            value: jetbrains / 6.0.0-SNAPSHOT
+            value: cody-cli / 6.0.0-SNAPSHOT
           - name: connection
             value: keep-alive
           - name: host

--- a/agent/recordings/defaultClient_631904893/recording.har.yaml
+++ b/agent/recordings/defaultClient_631904893/recording.har.yaml
@@ -105,6 +105,106 @@ log:
         send: 0
         ssl: -1
         wait: 0
+    - _id: 12581f1c735a04aeb88af7a54cd007b2
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 165
+        cookies: []
+        headers:
+          - _fromType: array
+            name: authorization
+            value: token
+              REDACTED_d5e0f0a37c9821e856b923fe14e67a605e3f6c0a517d5a4f46a4e35943ee0f6d
+          - _fromType: array
+            name: content-type
+            value: application/json; charset=utf-8
+          - _fromType: array
+            name: user-agent
+            value: defaultClient / v1
+          - _fromType: array
+            name: accept
+            value: "*/*"
+          - _fromType: array
+            name: content-length
+            value: "217"
+          - _fromType: array
+            name: accept-encoding
+            value: gzip,deflate
+          - name: host
+            value: sourcegraph.com
+        headersSize: 349
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json; charset=utf-8
+          params: []
+          textJSON:
+            query: |-
+              
+              query CodyConfigFeaturesResponse {
+                  site {
+                      codyConfigFeatures {
+                          chat
+                          autoComplete
+                          commands
+                          attribution
+                      }
+                  }
+              }
+            variables: {}
+        queryString:
+          - name: CodyConfigFeaturesResponse
+            value: null
+        url: https://sourcegraph.com/.api/graphql?CodyConfigFeaturesResponse
+      response:
+        bodySize: 22
+        content:
+          mimeType: text/plain; charset=utf-8
+          size: 22
+          text: |
+            Invalid access token.
+        cookies: []
+        headers:
+          - name: date
+            value: Fri, 23 Aug 2024 09:45:38 GMT
+          - name: content-type
+            value: text/plain; charset=utf-8
+          - name: content-length
+            value: "22"
+          - name: connection
+            value: keep-alive
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache, max-age=0
+          - name: vary
+            value: Cookie,Accept-Encoding,Authorization
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+        headersSize: 1263
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 401
+        statusText: Unauthorized
+      startedDateTime: 2024-08-23T09:45:38.644Z
+      time: 0
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 0
     - _id: fed5129404cd476f4ecc5c751242f2f5
       _order: 0
       cache: {}
@@ -221,6 +321,89 @@ log:
             name: authorization
             value: token
               REDACTED_d5e0f0a37c9821e856b923fe14e67a605e3f6c0a517d5a4f46a4e35943ee0f6d
+          - _fromType: array
+            name: content-type
+            value: application/json; charset=utf-8
+          - _fromType: array
+            name: user-agent
+            value: defaultClient / v1
+          - _fromType: array
+            name: accept
+            value: "*/*"
+          - _fromType: array
+            name: accept-encoding
+            value: gzip,deflate
+          - name: host
+            value: sourcegraph.com
+        headersSize: 289
+        httpVersion: HTTP/1.1
+        method: GET
+        queryString: []
+        url: https://sourcegraph.com/.api/client-config
+      response:
+        bodySize: 191
+        content:
+          encoding: base64
+          mimeType: text/plain; charset=utf-8
+          size: 191
+          text: "[\"H4sIAAAA\",\"AAAAA2zMsQoCMRCE4T5PsVztE9hJsLjOznrPrBjI7koyQeW4d7dRBEn9\
+            z3xrICKaLp5eR+OlSJr2hNpl9wk3xjBwh0fXexHI+NkbXKOrsqU2NoCal47s9utXLu0\
+            7aMoV0Q3yxDlb8sfQUU9S2uE0/ylhC28AAAD//wMAK/Ow9eAAAAA=\"]"
+        cookies: []
+        headers:
+          - name: date
+            value: Fri, 23 Aug 2024 09:45:38 GMT
+          - name: content-type
+            value: text/plain; charset=utf-8
+          - name: transfer-encoding
+            value: chunked
+          - name: connection
+            value: keep-alive
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache, max-age=0
+          - name: vary
+            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
+              X-Requested-With,Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+          - name: content-encoding
+            value: gzip
+        headersSize: 1342
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: 2024-08-23T09:45:38.482Z
+      time: 0
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 0
+    - _id: 2e7862e0c501fbdd157a5733d068fd52
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 0
+        cookies: []
+        headers:
+          - _fromType: array
+            name: authorization
+            value: token
+              REDACTED_0ba08837494d00e3943c46999589eb29a210ba8063f084fff511c8e4d1503909
           - _fromType: array
             name: content-type
             value: application/json; charset=utf-8

--- a/agent/src/AgentWorkspaceConfiguration.ts
+++ b/agent/src/AgentWorkspaceConfiguration.ts
@@ -112,8 +112,6 @@ export class AgentWorkspaceConfiguration implements vscode.WorkspaceConfiguratio
                 return this.clientInfo()?.capabilities?.webview === 'native' ?? false
             case 'editor.insertSpaces':
                 return true // TODO: override from IDE clients
-            case 'cody.accessToken':
-                return extensionConfig?.accessToken
             default:
                 // VS Code picks up default value in package.json, and only uses
                 // the `defaultValue` parameter if package.json provides no

--- a/agent/src/TestClient.ts
+++ b/agent/src/TestClient.ts
@@ -983,7 +983,12 @@ ${patch}`
             version: 'v1',
             workspaceRootUri: this.params.workspaceRootUri.toString(),
             workspaceRootPath: this.params.workspaceRootUri.fsPath,
-            capabilities: allClientCapabilitiesEnabled,
+            capabilities: {
+                ...allClientCapabilitiesEnabled,
+                // The test client doesn't implement secrets/didChange, so we need to use the
+                // stateless secrets store.
+                secrets: 'stateless',
+            },
             extensionConfiguration: {
                 anonymousUserID: `${this.name}abcde1234`,
                 accessToken: this.params.credentials.token ?? this.params.credentials.redactedToken,

--- a/agent/src/local-e2e/helpers.ts
+++ b/agent/src/local-e2e/helpers.ts
@@ -97,7 +97,7 @@ export class LocalSGInstance {
         this.gqlclient = SourcegraphGraphQLAPIClient.withStaticConfig({
             configuration: { customHeaders: headers, telemetryLevel: 'agent' },
             auth: { accessToken: this.params.accessToken, serverEndpoint: this.params.serverEndpoint },
-            clientState: { anonymousUserID: 'anonymousUserID' },
+            clientState: { anonymousUserID: null },
         })
     }
 

--- a/lib/shared/src/auth/authStatus.ts
+++ b/lib/shared/src/auth/authStatus.ts
@@ -71,10 +71,11 @@ export function currentAuthStatusOrNotReadyYet(): AuthStatus | undefined {
 }
 
 /**
- * Uses {@link currentAuthStatusAuthed} to determine if a user is authenticated on DotCom.
+ * Whether a user is authenticated on DotCom.
  */
 export function isDotComAuthed(): boolean {
-    return isDotCom(currentAuthStatusAuthed())
+    const authStatus = currentAuthStatusOrNotReadyYet()
+    return Boolean(authStatus?.authenticated && isDotCom(authStatus))
 }
 
 /**

--- a/lib/shared/src/configuration.ts
+++ b/lib/shared/src/configuration.ts
@@ -105,12 +105,6 @@ export enum CodyIDE {
     Eclipse = 'Eclipse',
 }
 
-export type ClientConfigurationWithEndpoint = Omit<ClientConfigurationWithAccessToken, 'accessToken'>
-
-export interface ClientConfigurationWithAccessToken
-    extends ReadonlyDeep<RawClientConfiguration>,
-        AuthCredentials {}
-
 export type AutocompleteProviderID = keyof typeof AUTOCOMPLETE_PROVIDER_ID
 
 export const AUTOCOMPLETE_PROVIDER_ID = {

--- a/lib/shared/src/index.ts
+++ b/lib/shared/src/index.ts
@@ -199,7 +199,6 @@ export { SourcegraphBrowserCompletionsClient } from './sourcegraph-api/completio
 export { SourcegraphCompletionsClient } from './sourcegraph-api/completions/client'
 export type {
     CompletionLogger,
-    CompletionsClientConfig,
     CompletionRequestParameters,
 } from './sourcegraph-api/completions/client'
 export * from './sourcegraph-api/completions/types'

--- a/lib/shared/src/inferenceClient/misc.ts
+++ b/lib/shared/src/inferenceClient/misc.ts
@@ -46,6 +46,10 @@ export type CompletionResponseGenerator = AsyncGenerator<
 >
 
 export interface CodeCompletionProviderOptions {
+    /**
+     * Custom headers to send with the HTTP request, in addition to the globally configured headers
+     * on {@link ClientConfiguration.customHeaders}.
+     */
     customHeaders?: Record<string, string>
 }
 

--- a/lib/shared/src/misc/observable.ts
+++ b/lib/shared/src/misc/observable.ts
@@ -940,3 +940,12 @@ export function lifecycle<T>({
             }
         })
 }
+
+export function abortableOperation<T, R>(
+    operation: (input: T, signal: AbortSignal) => Promise<R>
+): (source: ObservableLike<T>) => Observable<R> {
+    return (source: ObservableLike<T>): Observable<R> =>
+        Observable.from(source).pipe(
+            mergeMap(input => promiseFactoryToObservable(signal => operation(input, signal)))
+        )
+}

--- a/lib/shared/src/models/index.test.ts
+++ b/lib/shared/src/models/index.test.ts
@@ -33,11 +33,10 @@ describe('Model Provider', () => {
     const enterpriseAuthStatus: AuthenticatedAuthStatus = {
         ...AUTH_STATUS_FIXTURE_AUTHED,
         endpoint: 'https://sourcegraph.example.com',
-        authenticated: true,
     }
 
     // Reset service
-    let modelsService = new ModelsService()
+    let modelsService: ModelsService
     beforeEach(() => {
         modelsService = new ModelsService()
     })

--- a/lib/shared/src/models/index.ts
+++ b/lib/shared/src/models/index.ts
@@ -1,5 +1,5 @@
 import { type Observable, Subject } from 'observable-fns'
-import { authStatus, currentAuthStatus } from '../auth/authStatus'
+import { authStatus, currentAuthStatus, currentAuthStatusOrNotReadyYet } from '../auth/authStatus'
 import { mockAuthStatus } from '../auth/authStatus'
 import { type AuthStatus, isCodyProUser, isEnterpriseUser } from '../auth/types'
 import { AUTH_STATUS_FIXTURE_AUTHED_DOTCOM } from '../auth/types'
@@ -422,8 +422,8 @@ export class ModelsService {
             defaults: {},
             selected: {},
         }
-        const endpoint = currentAuthStatus().endpoint
-        if (!endpoint) {
+        const authStatus = currentAuthStatusOrNotReadyYet()
+        if (!authStatus) {
             if (!process.env.VITEST) {
                 logError('ModelsService::preferences', 'No auth status set')
             }
@@ -435,14 +435,14 @@ export class ModelsService {
             this._preferences = (serialized ? JSON.parse(serialized) : {}) as PerSitePreferences
         }
 
-        const current = this._preferences[endpoint]
+        const current = this._preferences[authStatus.endpoint]
         if (current) {
             // cache hit!
             return current
         }
 
         // Else the endpoint cache is missing, so initialize it
-        this._preferences[endpoint] = empty
+        this._preferences[authStatus.endpoint] = empty
         return empty
     }
 

--- a/lib/shared/src/sourcegraph-api/completions/client.ts
+++ b/lib/shared/src/sourcegraph-api/completions/client.ts
@@ -1,5 +1,5 @@
 import type { Span } from '@opentelemetry/api'
-import { type ClientConfigurationWithAccessToken, addClientInfoParams, getSerializedParams } from '../..'
+import { addClientInfoParams, getSerializedParams } from '../..'
 import { currentResolvedConfig } from '../../configuration/resolver'
 import { useCustomChatClient } from '../../llm-providers'
 import { recordErrorToSpan } from '../../tracing'
@@ -31,11 +31,6 @@ export interface CompletionRequestParameters {
     apiVersion: number
     customHeaders?: Record<string, string>
 }
-
-export type CompletionsClientConfig = Pick<
-    ClientConfigurationWithAccessToken,
-    'serverEndpoint' | 'accessToken' | 'customHeaders'
->
 
 /**
  * Access the chat based LLM APIs via a Sourcegraph server instance.

--- a/vscode/src/chat/chat-view/ChatController.ts
+++ b/vscode/src/chat/chat-view/ChatController.ts
@@ -33,6 +33,7 @@ import {
     createMessageAPIForExtension,
     currentAuthStatus,
     currentAuthStatusAuthed,
+    currentAuthStatusOrNotReadyYet,
     featureFlagProvider,
     getContextForChatMessage,
     graphqlClient,
@@ -613,7 +614,11 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
     }
 
     private async sendConfig(): Promise<void> {
-        const authStatus = currentAuthStatus()
+        const authStatus = currentAuthStatusOrNotReadyYet()
+        if (!authStatus) {
+            return
+        }
+
         const configForWebview = await this.getConfigForWebview()
         const workspaceFolderUris =
             vscode.workspace.workspaceFolders?.map(folder => folder.uri.toString()) ?? []

--- a/vscode/src/chat/chat-view/ChatsController.ts
+++ b/vscode/src/chat/chat-view/ChatsController.ts
@@ -14,7 +14,6 @@ import {
     subscriptionDisposable,
     telemetryRecorder,
 } from '@sourcegraph/cody-shared'
-import type { LocalEmbeddingsController } from '../../local-context/local-embeddings'
 import type { SymfRunner } from '../../local-context/symf'
 import { logDebug, logError } from '../../log'
 import type { MessageProviderOptions } from '../MessageProvider'
@@ -69,7 +68,6 @@ export class ChatsController implements vscode.Disposable {
         private options: Options,
         private chatClient: ChatClient,
 
-        private readonly localEmbeddings: LocalEmbeddingsController | null,
         private readonly symf: SymfRunner | null,
 
         private readonly contextRetriever: ContextRetriever,
@@ -480,7 +478,7 @@ export class ChatsController implements vscode.Disposable {
         return new ChatController({
             ...this.options,
             chatClient: this.chatClient,
-            retrievers: new AuthDependentRetrievers(this.localEmbeddings, this.symf),
+            retrievers: new AuthDependentRetrievers(this.symf),
             guardrails: this.guardrails,
             startTokenReceiver: this.options.startTokenReceiver,
             contextAPIClient: this.contextAPIClient,

--- a/vscode/src/chat/chat-view/ContextRetriever.ts
+++ b/vscode/src/chat/chat-view/ContextRetriever.ts
@@ -12,6 +12,7 @@ import {
     type FileURI,
     type PromptString,
     type SourcegraphCompletionsClient,
+    type StoredLastValue,
     graphqlClient,
     isFileURI,
 } from '@sourcegraph/cody-shared'
@@ -161,7 +162,9 @@ export class ContextRetriever implements vscode.Disposable {
     constructor(
         private editor: VSCodeEditor,
         private symf: SymfRunner | undefined,
-        private localEmbeddings: LocalEmbeddingsController | undefined,
+        private localEmbeddings:
+            | StoredLastValue<LocalEmbeddingsController | undefined>['value']
+            | undefined,
         private llms: SourcegraphCompletionsClient
     ) {}
 
@@ -397,7 +400,7 @@ export class ContextRetriever implements vscode.Disposable {
             ).then(r => r.flat())
         }
 
-        const localEmbeddings = this.localEmbeddings
+        const localEmbeddings = this.localEmbeddings?.last
         let localEmbeddingsResults: Promise<ContextItem[]> = Promise.resolve([])
         if (localEmbeddings && contextStrategy !== 'keyword' && localRootURIs.length > 0) {
             // TODO(beyang): retire this

--- a/vscode/src/chat/protocol.ts
+++ b/vscode/src/chat/protocol.ts
@@ -1,9 +1,10 @@
 import type { URI } from 'vscode-uri'
 
 import type {
+    AuthCredentials,
     AuthStatus,
     ChatMessage,
-    ClientConfigurationWithEndpoint,
+    ClientConfiguration,
     ClientStateForWebview,
     CodyIDE,
     ContextItem,
@@ -273,13 +274,10 @@ export interface ExtensionTranscriptMessage {
  */
 export interface ConfigurationSubsetForWebview
     extends Pick<
-        ClientConfigurationWithEndpoint,
-        | 'experimentalNoodle'
-        | 'serverEndpoint'
-        | 'agentIDE'
-        | 'agentExtensionVersion'
-        | 'internalDebugContext'
-    > {
+            ClientConfiguration,
+            'experimentalNoodle' | 'agentIDE' | 'agentExtensionVersion' | 'internalDebugContext'
+        >,
+        Pick<AuthCredentials, 'serverEndpoint'> {
     smartApply: boolean
     experimentalOneBox: boolean
     // Type/location of the current webview.

--- a/vscode/src/completions/fast-path-client.ts
+++ b/vscode/src/completions/fast-path-client.ts
@@ -10,6 +10,7 @@ import {
     addTraceparent,
     contextFiltersProvider,
     createSSEIterator,
+    currentAuthStatusAuthed,
     currentResolvedConfig,
     getActiveTraceAndSpanId,
     isAbortError,
@@ -27,7 +28,7 @@ import { logDebug } from '../log'
 import { createRateLimitErrorFromResponse } from './default-client'
 import type { GenerateCompletionsOptions } from './providers/shared/provider'
 
-interface FastPathParams extends Pick<GenerateCompletionsOptions, 'authStatus'> {
+interface FastPathParams {
     isLocalInstance: boolean
     fireworksConfig: ExperimentalFireworksConfig | undefined
     logger: CompletionLogger | undefined
@@ -55,7 +56,6 @@ export function createFastPathClient(
         fireworksConfig,
         logger,
         providerOptions,
-        authStatus,
         fastPathAccessToken,
         fireworksCustomHeaders,
     }: FastPathParams
@@ -118,7 +118,7 @@ export function createFastPathClient(
         // identical to the SG instance response but does not contain information on whether a user
         // is eligible to upgrade to the pro plan. We get this from the authState instead.
         if (response.status === 429) {
-            const upgradeIsAvailable = !!authStatus.userCanUpgrade
+            const upgradeIsAvailable = !!currentAuthStatusAuthed().userCanUpgrade
 
             throw recordErrorToSpan(
                 span,

--- a/vscode/src/completions/fast-path-client.ts
+++ b/vscode/src/completions/fast-path-client.ts
@@ -33,7 +33,11 @@ interface FastPathParams extends Pick<GenerateCompletionsOptions, 'authStatus'> 
     logger: CompletionLogger | undefined
     providerOptions: GenerateCompletionsOptions
     fastPathAccessToken: string | undefined
-    customHeaders: Record<string, string>
+
+    /**
+     * Custom headers for the HTTP request to Fireworks.
+     */
+    fireworksCustomHeaders: Record<string, string>
 }
 
 // When using the fast path, the Cody client talks directly to Cody Gateway. Since CG only
@@ -53,7 +57,7 @@ export function createFastPathClient(
         providerOptions,
         authStatus,
         fastPathAccessToken,
-        customHeaders,
+        fireworksCustomHeaders,
     }: FastPathParams
 ): CompletionResponseGenerator {
     const gatewayUrl = isLocalInstance ? 'http://localhost:9992' : 'https://cody-gateway.sourcegraph.com'
@@ -88,7 +92,7 @@ export function createFastPathClient(
             languageId: providerOptions.document.languageId,
             user: (await currentResolvedConfig()).clientState.anonymousUserID,
         }
-        const headers = new Headers(customHeaders)
+        const headers = new Headers(fireworksCustomHeaders)
         // Force HTTP connection reuse to reduce latency.
         // c.f. https://github.com/microsoft/vscode/issues/173861
         headers.set('Connection', 'keep-alive')

--- a/vscode/src/completions/get-inline-completions-tests/models.test.ts
+++ b/vscode/src/completions/get-inline-completions-tests/models.test.ts
@@ -18,7 +18,6 @@ describe('[getInlineCompletions] models', () => {
                         autocompleteAdvancedProvider: 'fireworks',
                         autocompleteAdvancedModel: 'starcoder-hybrid',
                     },
-                    auth: { accessToken: 'asdf' },
                 },
             })
         }

--- a/vscode/src/completions/get-inline-completions.ts
+++ b/vscode/src/completions/get-inline-completions.ts
@@ -4,8 +4,6 @@ import type { URI } from 'vscode-uri'
 import {
     type AutocompleteContextSnippet,
     type DocumentContext,
-    type ResolvedConfiguration,
-    currentAuthStatus,
     getActiveTraceAndSpanId,
     isAbortError,
     isDotComAuthed,
@@ -48,7 +46,6 @@ export interface InlineCompletionsParams {
     completionIntent?: CompletionIntent
     lastAcceptedCompletionItem?: Pick<AutocompleteItem, 'requestParams' | 'analyticsItem'>
     provider: Provider
-    configuration: ResolvedConfiguration
 
     // Shared
     requestManager: RequestManager
@@ -243,7 +240,6 @@ async function doGetInlineCompletions(
         completionIntent,
         lastAcceptedCompletionItem,
         stageRecorder,
-        configuration: config,
         numberOfCompletionsToGenerate,
     } = params
 
@@ -487,8 +483,6 @@ async function doGetInlineCompletions(
         firstCompletionTimeout,
         completionLogId: logId,
         gitContext,
-        authStatus: currentAuthStatus(),
-        config,
         numberOfCompletionsToGenerate: numberOfCompletionsToGenerate ?? n,
         multiline: !!docContext.multilineTrigger,
     }

--- a/vscode/src/completions/inline-completion-item-provider-config-singleton.ts
+++ b/vscode/src/completions/inline-completion-item-provider-config-singleton.ts
@@ -1,4 +1,3 @@
-import type { ResolvedConfiguration } from '@sourcegraph/cody-shared'
 import type { CodyStatusBar } from '../services/StatusBar'
 import type { BfgRetriever } from './context/retrievers/bfg/bfg-retriever'
 import type { Provider } from './providers/shared/provider'
@@ -10,9 +9,6 @@ export interface CodyCompletionItemProviderConfig {
     statusBar: CodyStatusBar
     tracer?: ProvideInlineCompletionItemsTracer | null
     isRunningInsideAgent?: boolean
-    config: ResolvedConfiguration
-
-    isDotComUser?: boolean
 
     createBfgRetriever?: () => BfgRetriever
 
@@ -28,8 +24,7 @@ export interface CodyCompletionItemProviderConfig {
 export type InlineCompletionItemProviderConfig = Omit<
     CodyCompletionItemProviderConfig,
     'createBfgRetriever'
-> &
-    Required<Pick<CodyCompletionItemProviderConfig, 'isDotComUser'>>
+>
 
 /**
  * A singleton that manages the configuration for the inline completion item provider.

--- a/vscode/src/completions/inline-completion-item-provider-e2e.test.ts
+++ b/vscode/src/completions/inline-completion-item-provider-e2e.test.ts
@@ -1,8 +1,7 @@
 import {
-    AUTH_STATUS_FIXTURE_AUTHED,
     type ClientConfiguration,
-    type ResolvedConfiguration,
     contextFiltersProvider,
+    currentAuthStatus,
     featureFlagProvider,
     nextTick,
     telemetryRecorder,
@@ -132,9 +131,10 @@ function getInlineCompletionProvider(
         triggerDelay: 0,
         statusBar: { addError: () => {}, hasError: () => {}, startLoading: () => {} } as any,
         provider: createProvider({
-            config: args.config ?? ({ configuration: {} } as ResolvedConfiguration),
-        } as any),
-        config: args.config ?? ({ configuration: {} } as ResolvedConfiguration),
+            authStatus: currentAuthStatus(),
+            provider: 'default',
+            source: 'local-editor-settings',
+        }),
         firstCompletionTimeout:
             args?.firstCompletionTimeout ?? DEFAULT_VSCODE_SETTINGS.autocompleteFirstCompletionTimeout,
         ...args,
@@ -151,8 +151,6 @@ function createNetworkProvider(params: RequestParams): MockRequestProvider {
         firstCompletionTimeout: 1500,
         triggerKind: TriggerKind.Automatic,
         completionLogId: 'mock-log-id' as CompletionLogger.CompletionLogID,
-        authStatus: AUTH_STATUS_FIXTURE_AUTHED,
-        config: { configuration: {} } as ResolvedConfiguration,
     }
 
     return new MockRequestProvider(
@@ -406,7 +404,7 @@ describe('InlineCompletionItemProvider preloading', () => {
 
     it('triggers preload request on cursor movement if cursor is at the end of a line', async () => {
         const autocompleteParams = params('console.log(█', [], {
-            configuration: { configuration: autocompleteConfig },
+            configuration: { configuration: autocompleteConfig, auth: {} },
         })
 
         const { document, position } = autocompleteParams
@@ -440,7 +438,7 @@ describe('InlineCompletionItemProvider preloading', () => {
 
     it('does not trigger preload request if current line has non-empty suffix', async () => {
         const autocompleteParams = params('console.log(█);', [], {
-            configuration: { configuration: autocompleteConfig },
+            configuration: { configuration: autocompleteConfig, auth: {} },
         })
 
         const { document, position } = autocompleteParams

--- a/vscode/src/completions/inline-completion-item-provider.test.ts
+++ b/vscode/src/completions/inline-completion-item-provider.test.ts
@@ -6,6 +6,8 @@ import {
     AUTH_STATUS_FIXTURE_AUTHED,
     RateLimitError,
     contextFiltersProvider,
+    currentAuthStatusAuthed,
+    mockAuthStatus,
 } from '@sourcegraph/cody-shared'
 
 import { telemetryRecorder } from '@sourcegraph/cody-shared'
@@ -43,9 +45,10 @@ class MockableInlineCompletionItemProvider extends InlineCompletionItemProvider 
             // we can just make them `null`.
             statusBar: null as any,
             provider: createProvider({
-                authStatus: AUTH_STATUS_FIXTURE_AUTHED,
-            } as any),
-            config: {} as any,
+                provider: 'anthropic',
+                source: 'local-editor-settings',
+                authStatus: currentAuthStatusAuthed(),
+            }),
             firstCompletionTimeout:
                 superArgs?.firstCompletionTimeout ??
                 DEFAULT_VSCODE_SETTINGS.autocompleteFirstCompletionTimeout,
@@ -57,8 +60,9 @@ class MockableInlineCompletionItemProvider extends InlineCompletionItemProvider 
     public declare lastCandidate
 }
 
-describe('InlineCompletionItemProvider', async () => {
+describe('InlineCompletionItemProvider', () => {
     beforeEach(() => {
+        mockAuthStatus(AUTH_STATUS_FIXTURE_AUTHED)
         initCompletionProviderConfig({})
         mockLocalStorage()
         vi.spyOn(contextFiltersProvider, 'isUriIgnored').mockResolvedValue(false)

--- a/vscode/src/completions/inline-completion-item-provider.ts
+++ b/vscode/src/completions/inline-completion-item-provider.ts
@@ -6,9 +6,11 @@ import {
     type DocumentContext,
     FeatureFlag,
     RateLimitError,
+    authStatus,
     contextFiltersProvider,
     createDisposables,
     featureFlagProvider,
+    isDotCom,
     subscriptionDisposable,
     telemetryRecorder,
     wrapInActiveSpan,
@@ -120,6 +122,9 @@ export class InlineCompletionItemProvider
      */
     private shouldSample = false
 
+    /** Value derived from the {@link authStatus}, available synchronously. */
+    private isDotComUser = false
+
     private get config(): InlineCompletionItemProviderConfig {
         return InlineCompletionItemProviderConfigSingleton.configuration
     }
@@ -143,7 +148,6 @@ export class InlineCompletionItemProvider
             disableInsideComments,
             tracer,
             isRunningInsideAgent: config.isRunningInsideAgent ?? false,
-            isDotComUser: config.isDotComUser ?? false,
         })
 
         autocompleteStageCounterLogger.setProviderModel(config.provider.legacyModel)
@@ -155,6 +159,14 @@ export class InlineCompletionItemProvider
                     .subscribe(shouldSample => {
                         this.shouldSample = Boolean(shouldSample)
                     })
+            )
+        )
+
+        this.disposables.push(
+            subscriptionDisposable(
+                authStatus.subscribe(({ endpoint }) => {
+                    this.isDotComUser = isDotCom(endpoint)
+                })
             )
         )
 
@@ -178,6 +190,8 @@ export class InlineCompletionItemProvider
         }
 
         this.requestManager = new RequestManager()
+
+        void completionProviderConfig.prefetch()
 
         const strategyFactory = new DefaultContextStrategyFactory(
             completionProviderConfig.contextStrategy,
@@ -456,7 +470,6 @@ export class InlineCompletionItemProvider
                     triggerKind,
                     selectedCompletionInfo: context.selectedCompletionInfo,
                     docContext,
-                    configuration: this.config.config,
                     provider: this.config.provider,
                     contextMixer: this.contextMixer,
                     smartThrottleService: this.smartThrottleService,
@@ -690,7 +703,7 @@ export class InlineCompletionItemProvider
             completion.requestParams.document,
             completion.analyticsItem,
             completion.trackedRange,
-            this.config.isDotComUser
+            this.isDotComUser
         )
     }
 
@@ -865,7 +878,7 @@ export class InlineCompletionItemProvider
             completion.logId,
             completion.analyticsItem,
             acceptedLength,
-            this.config.isDotComUser
+            this.isDotComUser
         )
     }
 
@@ -914,7 +927,7 @@ export class InlineCompletionItemProvider
                 return
             }
 
-            const isEnterpriseUser = this.config.isDotComUser !== true
+            const isEnterpriseUser = this.isDotComUser !== true
             const canUpgrade = error.upgradeIsAvailable
             const tier = isEnterpriseUser ? 'enterprise' : canUpgrade ? 'free' : 'pro'
 

--- a/vscode/src/completions/providers/anthropic.ts
+++ b/vscode/src/completions/providers/anthropic.ts
@@ -1,13 +1,13 @@
 import * as anthropic from '@anthropic-ai/sdk'
 
 import {
+    type AuthenticatedAuthStatus,
     type AutocompleteContextSnippet,
     type CodeCompletionsParams,
     type DocumentContext,
     type Message,
     PromptString,
-    currentAuthStatusAuthed,
-    isDotComAuthed,
+    isDotCom,
     ps,
 } from '@sourcegraph/cody-shared'
 
@@ -241,9 +241,12 @@ class AnthropicProvider extends Provider {
         }
 }
 
-function getClientModel(provider: string): string {
+function getClientModel(
+    provider: string,
+    authStatus: Pick<AuthenticatedAuthStatus, 'endpoint' | 'configOverwrites'>
+): string {
     // Always use the default PLG model on DotCom
-    if (isDotComAuthed()) {
+    if (isDotCom(authStatus)) {
         return DEFAULT_PLG_ANTHROPIC_MODEL
     }
 
@@ -252,7 +255,7 @@ function getClientModel(provider: string): string {
         return ''
     }
 
-    const { configOverwrites } = currentAuthStatusAuthed()
+    const { configOverwrites } = authStatus
 
     // Only pass through the upstream-defined model if we're using Cody Gateway
     if (configOverwrites?.provider === 'sourcegraph') {
@@ -262,10 +265,10 @@ function getClientModel(provider: string): string {
     return ''
 }
 
-export function createProvider({ provider, source }: ProviderFactoryParams): Provider {
+export function createProvider({ provider, source, authStatus }: ProviderFactoryParams): Provider {
     return new AnthropicProvider({
         id: 'anthropic',
-        legacyModel: getClientModel(provider),
+        legacyModel: getClientModel(provider, authStatus),
         source,
     })
 }

--- a/vscode/src/completions/providers/fireworks.ts
+++ b/vscode/src/completions/providers/fireworks.ts
@@ -1,16 +1,19 @@
 import {
+    type AuthenticatedAuthStatus,
     type AutocompleteContextSnippet,
     type CodeCompletionsParams,
     type CompletionResponseGenerator,
+    currentAuthStatusAuthed,
+    currentResolvedConfig,
     dotcomTokenToGatewayToken,
+    isDotCom,
     isDotComAuthed,
     tokensToChars,
 } from '@sourcegraph/cody-shared'
-import { forkSignal, generatorWithTimeout, zipGenerators } from '../utils'
-
 import { defaultCodeCompletionsClient } from '../default-client'
 import { createFastPathClient } from '../fast-path-client'
 import { TriggerKind } from '../get-inline-completions'
+import { forkSignal, generatorWithTimeout, zipGenerators } from '../utils'
 import {
     type FetchCompletionResult,
     fetchAndProcessDynamicMultilineCompletions,
@@ -200,7 +203,8 @@ class FireworksProvider extends Provider {
         requestParams: CodeCompletionsParams,
         abortController: AbortController
     ): Promise<CompletionResponseGenerator> {
-        const { authStatus, config } = options
+        const authStatus = currentAuthStatusAuthed()
+        const config = await currentResolvedConfig()
 
         const isLocalInstance = Boolean(
             authStatus.endpoint?.includes('sourcegraph.test') ||
@@ -236,7 +240,6 @@ class FireworksProvider extends Provider {
                 logger: defaultCodeCompletionsClient.instance!.logger,
                 providerOptions: options,
                 fastPathAccessToken,
-                authStatus: authStatus,
                 fireworksCustomHeaders: this.getCustomHeaders(authStatus.isFireworksTracingEnabled),
             })
         }
@@ -247,9 +250,12 @@ class FireworksProvider extends Provider {
     }
 }
 
-function getClientModel(model?: string): FireworksModel {
+function getClientModel(
+    model: string | undefined,
+    authStatus: Pick<AuthenticatedAuthStatus, 'endpoint'>
+): FireworksModel {
     if (model === undefined || model === '') {
-        return isDotComAuthed() ? DEEPSEEK_CODER_V2_LITE_BASE : 'starcoder-hybrid'
+        return isDotCom(authStatus) ? DEEPSEEK_CODER_V2_LITE_BASE : 'starcoder-hybrid'
     }
 
     if (model === 'starcoder-hybrid' || Object.prototype.hasOwnProperty.call(MODEL_MAP, model)) {
@@ -259,8 +265,8 @@ function getClientModel(model?: string): FireworksModel {
     throw new Error(`Unknown model: \`${model}\``)
 }
 
-export function createProvider({ legacyModel, source }: ProviderFactoryParams): Provider {
-    const clientModel = getClientModel(legacyModel)
+export function createProvider({ legacyModel, source, authStatus }: ProviderFactoryParams): Provider {
+    const clientModel = getClientModel(legacyModel, authStatus)
 
     return new FireworksProvider({
         id: 'fireworks',

--- a/vscode/src/completions/providers/fireworks.ts
+++ b/vscode/src/completions/providers/fireworks.ts
@@ -169,7 +169,7 @@ class FireworksProvider extends Provider {
         return zipGenerators(await Promise.all(completionsGenerators))
     }
 
-    private getCustomHeaders = (isFireworksTracingEnabled?: boolean): Record<string, string> => {
+    private getCustomHeaders(isFireworksTracingEnabled?: boolean): Record<string, string> {
         // Enabled Fireworks tracing for Sourcegraph teammates.
         // https://readme.fireworks.ai/docs/enabling-tracing
         const customHeaders: Record<string, string> = {}
@@ -236,8 +236,8 @@ class FireworksProvider extends Provider {
                 logger: defaultCodeCompletionsClient.instance!.logger,
                 providerOptions: options,
                 fastPathAccessToken,
-                customHeaders: this.getCustomHeaders(authStatus.isFireworksTracingEnabled),
                 authStatus: authStatus,
+                fireworksCustomHeaders: this.getCustomHeaders(authStatus.isFireworksTracingEnabled),
             })
         }
 

--- a/vscode/src/completions/providers/shared/get-experiment-model.ts
+++ b/vscode/src/completions/providers/shared/get-experiment-model.ts
@@ -1,9 +1,10 @@
 import {
+    type AuthenticatedAuthStatus,
     FeatureFlag,
     combineLatest,
     distinctUntilChanged,
     featureFlagProvider,
-    isDotComAuthed,
+    isDotCom,
     mergeMap,
 } from '@sourcegraph/cody-shared'
 
@@ -23,9 +24,13 @@ interface ProviderConfigFromFeatureFlags {
     model?: string
 }
 
-export function getDotComExperimentModel(): Observable<ProviderConfigFromFeatureFlags | null> {
-    // We run model experiments only on DotCom.
-    if (!isDotComAuthed()) {
+export function getDotComExperimentModel({
+    authStatus,
+}: {
+    authStatus: Pick<AuthenticatedAuthStatus, 'endpoint'>
+}): Observable<ProviderConfigFromFeatureFlags | null> {
+    if (!isDotCom(authStatus)) {
+        // We run model experiments only on DotCom.
         return Observable.of(null)
     }
 
@@ -50,11 +55,17 @@ export function getDotComExperimentModel(): Observable<ProviderConfigFromFeature
             }
 
             if (deepseekV2LiteBase) {
-                return Observable.of({ provider: 'fireworks', model: DEEPSEEK_CODER_V2_LITE_BASE })
+                return Observable.of({
+                    provider: 'fireworks',
+                    model: DEEPSEEK_CODER_V2_LITE_BASE,
+                })
             }
 
             if (starCoderHybrid) {
-                return Observable.of({ provider: 'fireworks', model: 'starcoder-hybrid' })
+                return Observable.of({
+                    provider: 'fireworks',
+                    model: 'starcoder-hybrid',
+                })
             }
 
             if (claude3) {

--- a/vscode/src/completions/providers/shared/provider.ts
+++ b/vscode/src/completions/providers/shared/provider.ts
@@ -10,7 +10,6 @@ import {
     type DocumentContext,
     type GitContext,
     type Model,
-    type ResolvedConfiguration,
     tokensToChars,
 } from '@sourcegraph/cody-shared'
 
@@ -57,14 +56,6 @@ export interface GenerateCompletionsOptions {
      */
     gitContext?: GitContext
     maxContextTokens?: number
-
-    authStatus: Pick<
-        AuthenticatedAuthStatus,
-        'userCanUpgrade' | 'endpoint' | 'isFireworksTracingEnabled'
-    >
-
-    // TODO: eliminate by using config watcher
-    config: ResolvedConfiguration
 }
 
 const DEFAULT_MAX_CONTEXT_TOKENS = 2048
@@ -108,8 +99,9 @@ export type ProviderFactoryParams = {
      */
     source: AutocompleteProviderConfigSource
 
-    config: ResolvedConfiguration
     mayUseOnDeviceInference?: boolean
+
+    authStatus: Pick<AuthenticatedAuthStatus, 'endpoint' | 'configOverwrites'>
 }
 
 export type ProviderFactory = (params: ProviderFactoryParams) => Provider

--- a/vscode/src/completions/utils.ts
+++ b/vscode/src/completions/utils.ts
@@ -67,10 +67,13 @@ export async function* generatorWithErrorObserver<T>(
 }
 
 export async function* generatorWithTimeout<T>(
-    generator: AsyncGenerator<T>,
+    generatorInput: AsyncGenerator<T> | Promise<AsyncGenerator<T>>,
     timeoutMs: number,
     abortController: AbortController
 ): AsyncGenerator<T> {
+    const generator = await (generatorInput instanceof Promise
+        ? generatorInput
+        : Promise.resolve(generatorInput))
     try {
         if (timeoutMs === 0) {
             return

--- a/vscode/src/configuration.ts
+++ b/vscode/src/configuration.ts
@@ -2,10 +2,8 @@ import * as vscode from 'vscode'
 
 import {
     type ClientConfiguration,
-    type ClientConfigurationWithAccessToken,
     type CodyIDE,
     type ConfigurationUseContext,
-    DOTCOM_URL,
     OLLAMA_DEFAULT_URL,
     type PickResolvedConfiguration,
     PromptString,
@@ -16,7 +14,6 @@ import {
 import { URI } from 'vscode-uri'
 import { CONFIG_KEY, type ConfigKeys } from './configuration-keys'
 import { localStorage } from './services/LocalStorageProvider'
-import { getAccessToken } from './services/SecretStorageProvider'
 
 interface ConfigGetter {
     get<T>(section: (typeof CONFIG_KEY)[ConfigKeys], defaultValue?: T): T
@@ -170,24 +167,6 @@ function sanitizeCodebase(codebase: string | undefined): string {
     const protocolRegexp = /^(https?):\/\//
     const trailingSlashRegexp = /\/$/
     return codebase.replace(protocolRegexp, '').trim().replace(trailingSlashRegexp, '')
-}
-
-export function getConfigWithEndpoint(): Omit<ClientConfigurationWithAccessToken, 'accessToken'> {
-    const config = getConfiguration()
-    const isTesting = process.env.CODY_TESTING === 'true'
-    const serverEndpoint =
-        localStorage?.getEndpoint() || (isTesting ? 'http://localhost:49300/' : DOTCOM_URL.href)
-    return { ...config, serverEndpoint }
-}
-
-export const getFullConfig = async (): Promise<ClientConfigurationWithAccessToken> => {
-    return {
-        ...getConfigWithEndpoint(),
-        accessToken:
-            vscode.workspace.getConfiguration().get<string>('cody.accessToken') ||
-            (await getAccessToken()) ||
-            null,
-    }
 }
 
 /**

--- a/vscode/src/context/openctx.ts
+++ b/vscode/src/context/openctx.ts
@@ -50,18 +50,19 @@ export function exposeOpenCtxClient(
             })),
             distinctUntilChanged()
         ),
-        resolvedConfig.pipe(
-            pluck('auth'),
+        authStatus.pipe(
             distinctUntilChanged(),
-            mergeMap(() =>
-                promiseFactoryToObservable(signal =>
-                    graphqlClient.isValidSiteVersion(
-                        {
-                            minimumVersion: '5.7.0',
-                        },
-                        signal
-                    )
-                )
+            mergeMap(auth =>
+                auth.authenticated
+                    ? promiseFactoryToObservable(signal =>
+                          graphqlClient.isValidSiteVersion(
+                              {
+                                  minimumVersion: '5.7.0',
+                              },
+                              signal
+                          )
+                      )
+                    : Observable.of(false)
             )
         ),
         promiseFactoryToObservable(

--- a/vscode/src/dev/helpers.ts
+++ b/vscode/src/dev/helpers.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode'
 
+import { authStatus, resolvedConfig, subscriptionDisposable } from '@sourcegraph/cody-shared'
 import { outputChannel } from '../log'
 
 /**
@@ -21,4 +22,48 @@ export function onActivationDevelopmentHelpers(): void {
     if (settings.get('openOutputConsole')) {
         outputChannel.show()
     }
+}
+
+/**
+ * A development helper that logs emissions from the global {@link resolvedConfig} and
+ * {@link authStatus} observables.
+ */
+export function logGlobalStateEmissions(): vscode.Disposable {
+    const disposables: vscode.Disposable[] = []
+
+    let configChanges = 0
+    let lastConfigTime = performance.now()
+    disposables.push(
+        subscriptionDisposable(
+            resolvedConfig.subscribe(config => {
+                const now = performance.now()
+                console.debug(
+                    `%cCONFIG ${++configChanges} %c[+${Math.round(now - lastConfigTime)}ms]`,
+                    'color: green',
+                    'color: gray',
+                    config
+                )
+                lastConfigTime = now
+            })
+        )
+    )
+
+    let authStatusChanges = 0
+    let lastAuthTime = performance.now()
+    disposables.push(
+        subscriptionDisposable(
+            authStatus.subscribe(authStatus => {
+                const now = performance.now()
+                console.debug(
+                    `%cAUTH ${++authStatusChanges} %c[+${Math.round(now - lastAuthTime)}ms]`,
+                    'color: green',
+                    'color: gray',
+                    authStatus
+                )
+                lastAuthTime = now
+            })
+        )
+    )
+
+    return vscode.Disposable.from(...disposables)
 }

--- a/vscode/src/extension.common.ts
+++ b/vscode/src/extension.common.ts
@@ -4,6 +4,7 @@ import type {
     ClientConfiguration,
     CompletionLogger,
     SourcegraphCompletionsClient,
+    StoredLastValue,
 } from '@sourcegraph/cody-shared'
 import type { startTokenReceiver } from './auth/token-receiver'
 
@@ -16,7 +17,7 @@ import type { createController } from '@openctx/vscode-lib'
 import type { CommandsProvider } from './commands/services/provider'
 import { ExtensionApi } from './extension-api'
 import type { ExtensionClient } from './extension-client'
-import type { LocalEmbeddingsConfig, LocalEmbeddingsController } from './local-context/local-embeddings'
+import type { LocalEmbeddingsController } from './local-context/local-embeddings'
 import type { SymfRunner } from './local-context/symf'
 import { start } from './main'
 import type { OpenTelemetryService } from './services/open-telemetry/OpenTelemetryService.node'
@@ -32,9 +33,7 @@ export interface PlatformContext {
     createOpenCtxController?: typeof createController
     createStorage?: () => Promise<vscode.Memento>
     createCommandsProvider?: Constructor<typeof CommandsProvider>
-    createLocalEmbeddingsController?: (
-        config: LocalEmbeddingsConfig
-    ) => Promise<LocalEmbeddingsController>
+    createLocalEmbeddingsController?: () => StoredLastValue<LocalEmbeddingsController | undefined>
     createSymfRunner?: Constructor<typeof SymfRunner>
     createBfgRetriever?: () => BfgRetriever
     createCompletionsClient: (logger?: CompletionLogger) => SourcegraphCompletionsClient

--- a/vscode/src/extension.common.ts
+++ b/vscode/src/extension.common.ts
@@ -1,7 +1,6 @@
 import * as vscode from 'vscode'
 
 import type {
-    ClientConfiguration,
     CompletionLogger,
     SourcegraphCompletionsClient,
     StoredLastValue,
@@ -40,7 +39,7 @@ export interface PlatformContext {
     createSentryService?: () => SentryService
     createOpenTelemetryService?: () => OpenTelemetryService
     startTokenReceiver?: typeof startTokenReceiver
-    onConfigurationChange?: (configuration: ClientConfiguration) => void
+    otherInitialization?: () => vscode.Disposable
     extensionClient: ExtensionClient
 }
 

--- a/vscode/src/extension.node.ts
+++ b/vscode/src/extension.node.ts
@@ -1,7 +1,12 @@
 // Sentry should be imported first
 import { NodeSentryService } from './services/sentry/sentry.node'
 
-import { currentAuthStatus, currentResolvedConfig } from '@sourcegraph/cody-shared'
+import {
+    currentAuthStatus,
+    currentResolvedConfig,
+    resolvedConfig,
+    subscriptionDisposable,
+} from '@sourcegraph/cody-shared'
 import * as vscode from 'vscode'
 import { startTokenReceiver } from './auth/token-receiver'
 import { CommandsProvider } from './commands/services/provider'
@@ -51,7 +56,11 @@ export function activate(
             ? (...args) => new OpenTelemetryService(...args)
             : undefined,
         startTokenReceiver: (...args) => startTokenReceiver(...args),
-        onConfigurationChange: setCustomAgent,
+        otherInitialization: () => {
+            return subscriptionDisposable(
+                resolvedConfig.subscribe(config => setCustomAgent(config.configuration))
+            )
+        },
         extensionClient,
     })
 }

--- a/vscode/src/local-context/local-embeddings.ts
+++ b/vscode/src/local-context/local-embeddings.ts
@@ -3,7 +3,6 @@ import * as vscode from 'vscode'
 import { URI } from 'vscode-uri'
 
 import {
-    type ClientConfigurationWithAccessToken,
     type EmbeddingsModelConfig,
     type EmbeddingsSearchResult,
     FeatureFlag,
@@ -11,40 +10,61 @@ import {
     type LocalEmbeddingsFetcher,
     type LocalEmbeddingsProvider,
     type PromptString,
+    type StoredLastValue,
+    type Unsubscribable,
+    combineLatest,
+    createDisposables,
+    currentResolvedConfig,
+    distinctUntilChanged,
     featureFlagProvider,
     isDefined,
     isDotCom,
     isFileURI,
+    pluck,
     recordErrorToSpan,
+    resolvedConfig,
+    storeLastValue,
     telemetryRecorder,
     wrapInActiveSpan,
 } from '@sourcegraph/cody-shared'
-
+import { map } from 'observable-fns'
 import type { IndexHealthResultFound, IndexRequest } from '../jsonrpc/embeddings-protocol'
+import { isRunningInsideAgent } from '../jsonrpc/isRunningInsideAgent'
 import type { MessageHandler } from '../jsonrpc/jsonrpc'
 import { logDebug } from '../log'
 import { vscodeGitAPI } from '../repository/git-extension-api'
 import { captureException } from '../services/sentry/sentry'
 import { CodyEngineService } from './cody-engine'
 
-export async function createLocalEmbeddingsController(
-    context: vscode.ExtensionContext,
-    config: LocalEmbeddingsConfig
-): Promise<LocalEmbeddingsController> {
-    const modelConfig =
-        config.testingModelConfig ||
-        (await featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyEmbeddingsGenerateMetadata))
-            ? sourcegraphMetadataModelConfig
-            : sourcegraphModelConfig
+export function createLocalEmbeddingsController(
+    context: vscode.ExtensionContext
+): StoredLastValue<LocalEmbeddingsController | undefined> {
+    return storeLastValue(
+        combineLatest([
+            resolvedConfig,
+            featureFlagProvider.evaluatedFeatureFlag(FeatureFlag.CodyEmbeddingsGenerateMetadata),
+        ]).pipe(
+            map(([config, ffCodyEmbeddingsGenerateMetadata]) => {
+                // NOTE: local embeddings are only going to be supported in VSC for now.
+                // Until we revisit this decision, we disable local embeddings in the agent.
+                let isLocalEmbeddingsEnabled = !isRunningInsideAgent()
+                isLocalEmbeddingsEnabled = vscode.workspace
+                    .getConfiguration()
+                    .get<boolean>('cody.experimental.localEmbeddings.enabled', isLocalEmbeddingsEnabled)
 
-    return new LocalEmbeddingsController(context, config, modelConfig)
-}
+                if (!isLocalEmbeddingsEnabled) {
+                    return undefined
+                }
 
-export type LocalEmbeddingsConfig = Pick<
-    ClientConfigurationWithAccessToken,
-    'serverEndpoint' | 'accessToken'
-> & {
-    testingModelConfig: EmbeddingsModelConfig | undefined
+                const modelConfig =
+                    config.configuration.testingModelConfig || ffCodyEmbeddingsGenerateMetadata
+                        ? sourcegraphMetadataModelConfig
+                        : sourcegraphModelConfig
+                return new LocalEmbeddingsController(context, modelConfig)
+            }),
+            createDisposables(localEmbeddingsController => localEmbeddingsController)
+        )
+    )
 }
 
 const CODY_GATEWAY_PROD_ENDPOINT = 'https://cody-gateway.sourcegraph.com/v1/embeddings'
@@ -100,10 +120,6 @@ export class LocalEmbeddingsController implements LocalEmbeddingsFetcher, vscode
     private service: Promise<MessageHandler> | undefined
     // True if the service has finished starting and been initialized.
     private serviceStarted = false
-    // The access token for Cody Gateway.
-    private accessToken: string | undefined
-    // Whether the account is a consumer account.
-    private endpointIsDotcom = false
     // The last index we loaded, or attempted to load, if any.
     private lastRepo: { dir: FileURI; repoName: string | false } | undefined
     // The last health report, if any.
@@ -120,21 +136,36 @@ export class LocalEmbeddingsController implements LocalEmbeddingsFetcher, vscode
     // The status bar item local embeddings is displaying, if any.
     private statusBar: vscode.StatusBarItem | undefined
 
+    private configSubscription: Unsubscribable
+
     constructor(
         private readonly context: vscode.ExtensionContext,
-        config: LocalEmbeddingsConfig,
         private readonly modelConfig: EmbeddingsModelConfig
     ) {
         logDebug('LocalEmbeddingsController', 'constructor')
         this.disposables.push(
             vscode.commands.registerCommand('cody.embeddings.resolveIssue', () =>
                 this.resolveIssueCommand()
-            )
+            ),
+            vscode.commands.registerCommand('cody.embeddings.index', () => this.index())
         )
 
-        // Pick up the initial access token, and whether the account is dotcom.
-        this.accessToken = config.accessToken || undefined
-        this.endpointIsDotcom = isDotCom(config.serverEndpoint)
+        // Keep token updated.
+        this.configSubscription = resolvedConfig
+            .pipe(pluck('auth'), distinctUntilChanged())
+            .subscribe(async auth => {
+                if (isDotCom(auth.serverEndpoint)) {
+                    // TODO: Add a "drop token" for sign out
+                    if (this.serviceStarted) {
+                        await (await this.getService()).request(
+                            'embeddings/set-token',
+                            auth.accessToken ?? ''
+                        )
+                    }
+                }
+            })
+
+        void this.start()
     }
 
     public dispose(): void {
@@ -142,6 +173,7 @@ export class LocalEmbeddingsController implements LocalEmbeddingsFetcher, vscode
             disposable.dispose()
         }
         this.statusBar?.dispose()
+        this.configSubscription.unsubscribe()
     }
 
     // Hint that local embeddings should start cody-engine, if necessary.
@@ -167,29 +199,17 @@ export class LocalEmbeddingsController implements LocalEmbeddingsFetcher, vscode
         })
     }
 
-    public async setAccessToken(serverEndpoint: string, token: string | null): Promise<void> {
-        const endpointIsDotcom = isDotCom(serverEndpoint)
-        logDebug(
-            'LocalEmbeddingsController',
-            'setAccessToken',
-            endpointIsDotcom ? 'is dotcom' : 'not dotcom'
-        )
-        this.endpointIsDotcom = endpointIsDotcom
-        if (token === this.accessToken) {
-            return Promise.resolve()
-        }
-        this.accessToken = token || undefined
-        // TODO: Add a "drop token" for sign out
-        if (token && this.serviceStarted) {
-            await (await this.getService()).request('embeddings/set-token', token)
-        }
-    }
-
-    private getService(): Promise<MessageHandler> {
+    private async getService(): Promise<MessageHandler> {
         if (!this.service) {
             const instance = CodyEngineService.getInstance(this.context)
             this.service = instance.getService(this.setupLocalEmbeddingsService)
         }
+
+        const { auth } = await currentResolvedConfig()
+        if (!isDotCom(auth.serverEndpoint)) {
+            throw new Error('local embeddings are only available on Sourcegraph.com')
+        }
+
         return this.service
     }
 
@@ -230,17 +250,18 @@ export class LocalEmbeddingsController implements LocalEmbeddingsFetcher, vscode
             codyGatewayEndpoint: this.modelConfig.endpoint,
             indexPath: this.modelConfig.indexPath.fsPath,
         })
+
+        const { auth } = await currentResolvedConfig()
         logDebug('LocalEmbeddingsController', 'spawnAndBindService', 'initialized', {
             verbose: {
                 initResult,
-                tokenAvailable: !!this.accessToken,
+                tokenAvailable: Boolean(auth.accessToken),
             },
         })
 
-        if (this.accessToken) {
-            // Set the initial access token
-            await service.request('embeddings/set-token', this.accessToken)
-        }
+        // Set the initial access token
+        await service.request('embeddings/set-token', auth.accessToken ?? '')
+
         this.serviceStarted = true
     }
 
@@ -272,7 +293,9 @@ export class LocalEmbeddingsController implements LocalEmbeddingsFetcher, vscode
     // Interactions with cody-engine
 
     public async index(): Promise<void> {
-        if (!(this.endpointIsDotcom && this.lastRepo?.dir && !this.lastRepo?.repoName)) {
+        const { auth } = await currentResolvedConfig()
+        const endpointIsDotCom = isDotCom(auth.serverEndpoint)
+        if (!(endpointIsDotCom && this.lastRepo?.dir && !this.lastRepo?.repoName)) {
             // TODO: Support index updates.
             logDebug('LocalEmbeddingsController', 'index', 'no repository to index/already indexed')
             return
@@ -286,7 +309,9 @@ export class LocalEmbeddingsController implements LocalEmbeddingsFetcher, vscode
     }
 
     public async indexRetry(): Promise<void> {
-        if (!(this.endpointIsDotcom && this.lastRepo?.dir)) {
+        const { auth } = await currentResolvedConfig()
+        const endpointIsDotCom = isDotCom(auth.serverEndpoint)
+        if (!(endpointIsDotCom && this.lastRepo?.dir)) {
             logDebug('LocalEmbeddingsController', 'indexRetry', 'no repository to retry')
             return
         }
@@ -586,7 +611,9 @@ export class LocalEmbeddingsController implements LocalEmbeddingsFetcher, vscode
 
     /** {@link LocalEmbeddingsFetcher.getContext} */
     public async getContext(query: PromptString, numResults: number): Promise<EmbeddingsSearchResult[]> {
-        if (!this.endpointIsDotcom) {
+        const { auth } = await currentResolvedConfig()
+        const endpointIsDotCom = isDotCom(auth.serverEndpoint)
+        if (!endpointIsDotCom) {
             return []
         }
         return wrapInActiveSpan('LocalEmbeddingsController.query', async span => {

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -191,11 +191,16 @@ const register = async (
     registerChatListeners(disposables)
 
     // Initialize external services
-    const { chatClient, completionsClient, guardrails, localEmbeddings, symfRunner, contextAPIClient } =
-        await configureExternalServices(context, platform)
-    if (symfRunner) {
-        disposables.push(symfRunner)
-    }
+    const {
+        chatClient,
+        completionsClient,
+        guardrails,
+        localEmbeddings,
+        symfRunner,
+        contextAPIClient,
+        dispose: disposeExternalServices,
+    } = await configureExternalServices(context, platform)
+    disposables.push({ dispose: disposeExternalServices })
 
     const editor = new VSCodeEditor()
     const contextRetriever = new ContextRetriever(

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -60,6 +60,7 @@ import { newCodyCommandArgs } from './commands/utils/get-commands'
 import { createInlineCompletionItemProvider } from './completions/create-inline-completion-item-provider'
 import { getConfiguration, getFullConfig } from './configuration'
 import { exposeOpenCtxClient } from './context/openctx'
+import { logGlobalStateEmissions } from './dev/helpers'
 import { EditManager } from './edit/manager'
 import { manageDisplayPathEnvInfoForExtension } from './editor/displayPathEnvInfo'
 import { VSCodeEditor } from './editor/vscode-editor'
@@ -144,6 +145,10 @@ export async function start(
             )
         )
     )
+
+    if (process.env.LOG_GLOBAL_STATE_EMISSIONS) {
+        disposables.push(logGlobalStateEmissions())
+    }
 
     disposables.push(createOrUpdateTelemetryRecorderProvider(isExtensionModeDevOrTest))
     disposables.push(await register(context, platform, isExtensionModeDevOrTest))

--- a/vscode/src/notifications/cody-pro-expiration.ts
+++ b/vscode/src/notifications/cody-pro-expiration.ts
@@ -3,7 +3,7 @@ import {
     type SourcegraphGraphQLAPIClient,
     type Unsubscribable,
     authStatus,
-    currentAuthStatus,
+    currentAuthStatusOrNotReadyYet,
     featureFlagProvider,
     isDotCom,
 } from '@sourcegraph/cody-shared'
@@ -90,8 +90,8 @@ export class CodyProExpirationNotifications implements vscode.Disposable {
         }
 
         // Not logged in or not DotCom, don't show.
-        const authStatus_ = currentAuthStatus()
-        if (!authStatus_.authenticated || !isDotCom(authStatus_)) return
+        const authStatus_ = currentAuthStatusOrNotReadyYet()
+        if (!authStatus_?.authenticated || !isDotCom(authStatus_)) return
 
         const useSscForCodySubscription = await featureFlagProvider.evaluateFeatureFlag(
             FeatureFlag.UseSscForCodySubscription

--- a/vscode/src/services/AuthProvider.ts
+++ b/vscode/src/services/AuthProvider.ts
@@ -2,7 +2,6 @@ import * as vscode from 'vscode'
 
 import {
     type AuthStatus,
-    ClientConfigSingleton,
     CodyIDE,
     type PickResolvedConfiguration,
     SourcegraphGraphQLAPIClient,
@@ -234,7 +233,6 @@ class AuthProvider implements vscode.Disposable {
     private async updateAuthStatus(authStatus: AuthStatus, signal?: AbortSignal): Promise<void> {
         try {
             this.status.next(authStatus)
-            await ClientConfigSingleton.getInstance().setAuthStatus(authStatus, signal)
         } catch (error) {
             if (!isAbortError(error)) {
                 logDebug('AuthProvider', 'updateAuthStatus error', error)

--- a/vscode/src/services/SecretStorageProvider.ts
+++ b/vscode/src/services/SecretStorageProvider.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode'
 
+import type { ClientSecrets } from '@sourcegraph/cody-shared'
 import { logDebug, logError } from '../log'
 
 const CODY_ACCESS_TOKEN_SECRET = 'cody.access-token'
@@ -19,7 +20,7 @@ export async function getAccessToken(): Promise<string | null> {
     }
 }
 
-interface SecretStorage extends vscode.SecretStorage {
+interface SecretStorage extends vscode.SecretStorage, ClientSecrets {
     get(key: string): Promise<string | undefined>
     store(key: string, value: string): Promise<void>
     delete(key: string): Promise<void>


### PR DESCRIPTION
This is another PR on the way to making it so a user never needs to reload their VS Code editor again to pick up new config or auth state changes.

See individual commits:

- autocomplete providers observe config
- remove ClientConfiguration types with access token and endpoint
- logGlobalStateEmissions helper
- register misc services reactively
- create external services reactively
- make local embeddings observe config and auth state
- document and rename to make fireworks custom headers clearer

## Test plan

e2e tests