### PR TITLE
Autocomplete: use prefetched flag in the jaccard-similarity retriever

### DIFF
--- a/vscode/src/completions/context/retrievers/jaccard-similarity/jaccard-similarity-retriever.ts
+++ b/vscode/src/completions/context/retrievers/jaccard-similarity/jaccard-similarity-retriever.ts
@@ -126,11 +126,12 @@ export class JaccardSimilarityRetriever extends CachedRetriever implements Conte
 
         const curLang = currentDocument.languageId
 
-        const enableExtendedLanguagePool = Boolean(
-            await featureFlagProvider.evaluateFeatureFlag(
-                FeatureFlag.CodyAutocompleteContextExtendLanguagePool
-            )
-        )
+        let enableExtendedLanguagePool = false
+        featureFlagProvider
+            .evaluatedFeatureFlag(FeatureFlag.CodyAutocompleteContextExtendLanguagePool)
+            .subscribe(resolvedFlag => {
+                enableExtendedLanguagePool = resolvedFlag
+            })
 
         function addDocument(document: vscode.TextDocument): void {
             // Only add files and VSCode user settings.


### PR DESCRIPTION
Closes https://linear.app/sourcegraph/issue/CODY-3760/cody-prerelease-%E2%96%88-jaccardsimilarityretriever-cannot-add-dependency

## Test plan

1. Local VS Code build
2. Open multiple files in the editor
3. Generate a completion in one of them
4. Observe that `jaccardsimilarityretriever-cannot-add-dependency` is not logged in the Cody output channel