### PR TITLE
Autocomplete: use prefetched flag in the jaccard-similarity retriever [2]

### DIFF
--- a/vscode/src/completions/context/retrievers/jaccard-similarity/history.ts
+++ b/vscode/src/completions/context/retrievers/jaccard-similarity/history.ts
@@ -1,4 +1,4 @@
-import { FeatureFlag, featureFlagProvider } from '@sourcegraph/cody-shared'
+import { FeatureFlag, featureFlagProvider, subscriptionDisposable } from '@sourcegraph/cody-shared'
 import * as vscode from 'vscode'
 import { type ShouldUseContextParams, shouldBeUsedAsContext } from '../../utils'
 
@@ -8,7 +8,7 @@ interface HistoryItem {
 
 export interface DocumentHistory {
     addItem(newItem: HistoryItem): void
-    lastN(n: number, languageId?: string, ignoreUris?: vscode.Uri[]): Promise<HistoryItem[]>
+    lastN(n: number, languageId?: string, ignoreUris?: vscode.Uri[]): HistoryItem[]
 }
 
 export class VSCodeDocumentHistory implements DocumentHistory, vscode.Disposable {
@@ -18,6 +18,7 @@ export class VSCodeDocumentHistory implements DocumentHistory, vscode.Disposable
     private history: HistoryItem[]
 
     private subscriptions: vscode.Disposable[] = []
+    public enableExtendedLanguagePool = false
 
     constructor(
         register: () => vscode.Disposable | null = () =>
@@ -37,6 +38,16 @@ export class VSCodeDocumentHistory implements DocumentHistory, vscode.Disposable
                 this.subscriptions.push(disposable)
             }
         }
+
+        this.subscriptions.push(
+            subscriptionDisposable(
+                featureFlagProvider
+                    .evaluatedFeatureFlag(FeatureFlag.CodyAutocompleteContextExtendLanguagePool)
+                    .subscribe(resolvedFlag => {
+                        this.enableExtendedLanguagePool = Boolean(resolvedFlag)
+                    })
+            )
+        )
     }
 
     public dispose(): void {
@@ -62,17 +73,7 @@ export class VSCodeDocumentHistory implements DocumentHistory, vscode.Disposable
     /**
      * Returns the last n items of history in reverse chronological order (latest item at the front)
      */
-    public async lastN(
-        n: number,
-        baseLanguageId: string,
-        ignoreUris?: vscode.Uri[]
-    ): Promise<HistoryItem[]> {
-        const enableExtendedLanguagePool = Boolean(
-            await featureFlagProvider.evaluateFeatureFlag(
-                FeatureFlag.CodyAutocompleteContextExtendLanguagePool
-            )
-        )
-
+    public lastN(n: number, baseLanguageId: string, ignoreUris?: vscode.Uri[]): HistoryItem[] {
         const ret: HistoryItem[] = []
         const ignoreSet = new Set(ignoreUris || [])
         for (let i = this.history.length - 1; i >= 0; i--) {
@@ -84,7 +85,7 @@ export class VSCodeDocumentHistory implements DocumentHistory, vscode.Disposable
                 continue
             }
             const params: ShouldUseContextParams = {
-                enableExtendedLanguagePool,
+                enableExtendedLanguagePool: this.enableExtendedLanguagePool,
                 baseLanguageId: baseLanguageId,
                 languageId: item.document.languageId,
             }

--- a/vscode/src/completions/context/retrievers/jaccard-similarity/jaccard-similarity-retriever.ts
+++ b/vscode/src/completions/context/retrievers/jaccard-similarity/jaccard-similarity-retriever.ts
@@ -5,7 +5,7 @@ import { getContextRange } from '../../../doc-context-getters'
 import type { ContextRetriever, ContextRetrieverOptions } from '../../../types'
 import { type DocumentHistory, VSCodeDocumentHistory } from './history'
 
-import { FeatureFlag, featureFlagProvider, isDefined } from '@sourcegraph/cody-shared'
+import { isDefined } from '@sourcegraph/cody-shared'
 import { lastNLines } from '../../../text-processing'
 import { RetrieverIdentifier, type ShouldUseContextParams, shouldBeUsedAsContext } from '../../utils'
 import { type CachedRerieverOptions, CachedRetriever } from '../cached-retriever'
@@ -125,13 +125,8 @@ export class JaccardSimilarityRetriever extends CachedRetriever implements Conte
         const files: FileContents[] = []
 
         const curLang = currentDocument.languageId
-
-        let enableExtendedLanguagePool = false
-        featureFlagProvider
-            .evaluatedFeatureFlag(FeatureFlag.CodyAutocompleteContextExtendLanguagePool)
-            .subscribe(resolvedFlag => {
-                enableExtendedLanguagePool = resolvedFlag
-            })
+        const { enableExtendedLanguagePool } = this.history
+        console.log({ enableExtendedLanguagePool })
 
         function addDocument(document: vscode.TextDocument): void {
             // Only add files and VSCode user settings.
@@ -230,7 +225,7 @@ export class JaccardSimilarityRetriever extends CachedRetriever implements Conte
             addDocument(document)
         }
 
-        const lastN = await history.lastN(10, curLang, [currentDocument.uri, ...files.map(f => f.uri)])
+        const lastN = history.lastN(10, curLang, [currentDocument.uri, ...files.map(f => f.uri)])
         await Promise.all(
             lastN.map(async item => {
                 try {

--- a/vscode/src/completions/context/retrievers/jaccard-similarity/jaccard-similarity-retriever.ts
+++ b/vscode/src/completions/context/retrievers/jaccard-similarity/jaccard-similarity-retriever.ts
@@ -126,7 +126,6 @@ export class JaccardSimilarityRetriever extends CachedRetriever implements Conte
 
         const curLang = currentDocument.languageId
         const { enableExtendedLanguagePool } = this.history
-        console.log({ enableExtendedLanguagePool })
 
         function addDocument(document: vscode.TextDocument): void {
             // Only add files and VSCode user settings.


### PR DESCRIPTION
- Properly fixes https://linear.app/sourcegraph/issue/CODY-3760/cody-prerelease-%E2%96%88-jaccardsimilarityretriever-cannot-add-dependency
- Follow up based on [this comment](https://github.com/sourcegraph/cody/pull/5602#discussion_r1762312541). 

## Test plan

Enabled [the feature flag](https://sourcegraph.com/site-admin/feature-flags/configuration/cody-autocomplete-context-extend-language-pool) for my user on DotCom and verified that it's `true` at the runtime.