### PR TITLE
shipment of direct routing and prompt caching to PLG users

### DIFF
--- a/lib/shared/src/experimentation/FeatureFlagProvider.ts
+++ b/lib/shared/src/experimentation/FeatureFlagProvider.ts
@@ -31,6 +31,8 @@ export enum FeatureFlag {
     CodyAutocompleteFIMFineTunedModelHybrid = 'cody-autocomplete-fim-fine-tuned-model-hybrid',
     // Enable the deepseek-v2 as the default model via Fireworks
     CodyAutocompleteDeepseekV2LiteBase = 'cody-autocomplete-deepseek-v2-lite-base',
+    // Enable the deepseek-v2 with direct routing as the default model via Fireworks
+    CodyAutocompleteDeepseekV2LiteBaseDirectRoute = 'cody-autocomplete-deepseek-v2-lite-base-direct-route',
 
     // Enable various feature flags to experiment with FIM trained fine-tuned models via Fireworks
     CodyAutocompleteFIMModelExperimentBaseFeatureFlag = 'cody-autocomplete-fim-model-experiment-flag-v2',

--- a/lib/shared/src/experimentation/FeatureFlagProvider.ts
+++ b/lib/shared/src/experimentation/FeatureFlagProvider.ts
@@ -31,8 +31,6 @@ export enum FeatureFlag {
     CodyAutocompleteFIMFineTunedModelHybrid = 'cody-autocomplete-fim-fine-tuned-model-hybrid',
     // Enable the deepseek-v2 as the default model via Fireworks
     CodyAutocompleteDeepseekV2LiteBase = 'cody-autocomplete-deepseek-v2-lite-base',
-    // Enable the deepseek-v2 with direct routing as the default model via Fireworks
-    CodyAutocompleteDeepseekV2LiteBaseDirectRoute = 'cody-autocomplete-deepseek-v2-lite-base-direct-route',
 
     // Enable various feature flags to experiment with FIM trained fine-tuned models via Fireworks
     CodyAutocompleteFIMModelExperimentBaseFeatureFlag = 'cody-autocomplete-fim-model-experiment-flag-v2',

--- a/vscode/src/completions/providers/fireworks.ts
+++ b/vscode/src/completions/providers/fireworks.ts
@@ -255,7 +255,7 @@ function getClientModel(
     authStatus: Pick<AuthenticatedAuthStatus, 'endpoint'>
 ): FireworksModel {
     if (model === undefined || model === '') {
-        return isDotCom(authStatus) ? DEEPSEEK_CODER_V2_LITE_BASE : 'starcoder-hybrid'
+        return isDotCom(authStatus) ? DEEPSEEK_CODER_V2_LITE_BASE_DIRECT_ROUTE : 'starcoder-hybrid'
     }
 
     if (model === 'starcoder-hybrid' || Object.prototype.hasOwnProperty.call(MODEL_MAP, model)) {

--- a/vscode/src/completions/providers/fireworks.ts
+++ b/vscode/src/completions/providers/fireworks.ts
@@ -30,7 +30,6 @@ export const FIREWORKS_DEEPSEEK_7B_LANG_SPECIFIC_V0 = 'deepseek-finetuned-lang-s
 export const FIREWORKS_DEEPSEEK_7B_LANG_SPECIFIC_V1 = 'deepseek-finetuned-lang-specific-v1'
 export const FIREWORKS_DEEPSEEK_7B_LANG_ALL = 'deepseek-finetuned-lang-all-v0'
 
-export const DEEPSEEK_CODER_V2_LITE_BASE_DIRECT_ROUTE = 'deepseek-coder-v2-lite-base-direct-route'
 export const DEEPSEEK_CODER_V2_LITE_BASE = 'deepseek-coder-v2-lite-base'
 
 // Context window experiments with DeepSeek Model
@@ -54,8 +53,6 @@ const MODEL_MAP = {
     [FIREWORKS_DEEPSEEK_7B_LANG_SPECIFIC_V1]: 'finetuned-fim-lang-specific-model-ds2-v1',
     [FIREWORKS_DEEPSEEK_7B_LANG_ALL]: 'accounts/sourcegraph/models/finetuned-fim-lang-all-model-ds2-v0',
     [DEEPSEEK_CODER_V2_LITE_BASE]: 'fireworks/deepseek-coder-v2-lite-base',
-    [DEEPSEEK_CODER_V2_LITE_BASE_DIRECT_ROUTE]:
-        'accounts/sourcegraph/models/deepseek-coder-v2-lite-base',
     [DEEPSEEK_CODER_V2_LITE_BASE_WINDOW_4096]: 'accounts/sourcegraph/models/deepseek-coder-v2-lite-base',
     [DEEPSEEK_CODER_V2_LITE_BASE_WINDOW_8192]: 'accounts/sourcegraph/models/deepseek-coder-v2-lite-base',
     [DEEPSEEK_CODER_V2_LITE_BASE_WINDOW_16384]:
@@ -86,8 +83,7 @@ function getMaxContextTokens(model: FireworksModel): number {
         case FIREWORKS_DEEPSEEK_7B_LANG_SPECIFIC_V0:
         case FIREWORKS_DEEPSEEK_7B_LANG_SPECIFIC_V1:
         case FIREWORKS_DEEPSEEK_7B_LANG_ALL:
-        case DEEPSEEK_CODER_V2_LITE_BASE:
-        case DEEPSEEK_CODER_V2_LITE_BASE_DIRECT_ROUTE: {
+        case DEEPSEEK_CODER_V2_LITE_BASE: {
             return 2048
         }
         case DEEPSEEK_CODER_V2_LITE_BASE_WINDOW_4096:
@@ -181,21 +177,7 @@ class FireworksProvider extends Provider {
             customHeaders['X-Fireworks-Genie'] = 'true'
         }
 
-        if (this.checkIfDirectRouteShouldBeEnabled()) {
-            customHeaders['X-Sourcegraph-Use-Direct-Route'] = 'true'
-        }
-
         return customHeaders
-    }
-
-    private checkIfDirectRouteShouldBeEnabled(): boolean {
-        return [
-            DEEPSEEK_CODER_V2_LITE_BASE_DIRECT_ROUTE,
-            DEEPSEEK_CODER_V2_LITE_BASE_WINDOW_4096,
-            FIREWORKS_DEEPSEEK_7B_LANG_ALL,
-            FIREWORKS_DEEPSEEK_7B_LANG_SPECIFIC_V0,
-            FIREWORKS_DEEPSEEK_7B_LANG_SPECIFIC_V1,
-        ].includes(this.legacyModel)
     }
 
     private async createClient(
@@ -255,7 +237,7 @@ function getClientModel(
     authStatus: Pick<AuthenticatedAuthStatus, 'endpoint'>
 ): FireworksModel {
     if (model === undefined || model === '') {
-        return isDotCom(authStatus) ? DEEPSEEK_CODER_V2_LITE_BASE_DIRECT_ROUTE : 'starcoder-hybrid'
+        return isDotCom(authStatus) ? DEEPSEEK_CODER_V2_LITE_BASE : 'starcoder-hybrid'
     }
 
     if (model === 'starcoder-hybrid' || Object.prototype.hasOwnProperty.call(MODEL_MAP, model)) {

--- a/vscode/src/completions/providers/shared/get-experiment-model.ts
+++ b/vscode/src/completions/providers/shared/get-experiment-model.ts
@@ -41,8 +41,9 @@ export function getDotComExperimentModel({
             FeatureFlag.CodyAutocompleteFIMModelExperimentBaseFeatureFlag
         ),
         featureFlagProvider.evaluatedFeatureFlag(FeatureFlag.CodyAutocompleteDeepseekV2LiteBase),
+        featureFlagProvider.evaluatedFeatureFlag(FeatureFlag.CodyAutocompleteDeepseekV2LiteBaseDirectRoute),
     ]).pipe(
-        mergeMap(([starCoderHybrid, claude3, fimModelExperimentFlag, deepseekV2LiteBase]) => {
+        mergeMap(([starCoderHybrid, claude3, fimModelExperimentFlag, deepseekV2LiteBase, deepseekV2LiteBaseDirectRoute]) => {
             // We run fine tuning experiment for VSC client only.
             // We disable for all agent clients like the JetBrains plugin.
             const isFinetuningExperimentDisabled = vscode.workspace
@@ -52,6 +53,13 @@ export function getDotComExperimentModel({
             if (!isFinetuningExperimentDisabled && fimModelExperimentFlag) {
                 // The traffic in this feature flag is interpreted as a traffic allocated to the fine-tuned experiment.
                 return resolveFIMModelExperimentFromFeatureFlags()
+            }
+
+            if (deepseekV2LiteBaseDirectRoute) {
+                return Observable.of({
+                    provider: 'fireworks',
+                    model: DEEPSEEK_CODER_V2_LITE_BASE_DIRECT_ROUTE,
+                })
             }
 
             if (deepseekV2LiteBase) {

--- a/vscode/src/completions/providers/shared/get-experiment-model.ts
+++ b/vscode/src/completions/providers/shared/get-experiment-model.ts
@@ -12,7 +12,6 @@ import { Observable, map } from 'observable-fns'
 import * as vscode from 'vscode'
 import {
     DEEPSEEK_CODER_V2_LITE_BASE,
-    DEEPSEEK_CODER_V2_LITE_BASE_DIRECT_ROUTE,
     DEEPSEEK_CODER_V2_LITE_BASE_WINDOW_4096,
     FIREWORKS_DEEPSEEK_7B_LANG_ALL,
     FIREWORKS_DEEPSEEK_7B_LANG_SPECIFIC_V0,
@@ -41,9 +40,8 @@ export function getDotComExperimentModel({
             FeatureFlag.CodyAutocompleteFIMModelExperimentBaseFeatureFlag
         ),
         featureFlagProvider.evaluatedFeatureFlag(FeatureFlag.CodyAutocompleteDeepseekV2LiteBase),
-        featureFlagProvider.evaluatedFeatureFlag(FeatureFlag.CodyAutocompleteDeepseekV2LiteBaseDirectRoute),
     ]).pipe(
-        mergeMap(([starCoderHybrid, claude3, fimModelExperimentFlag, deepseekV2LiteBase, deepseekV2LiteBaseDirectRoute]) => {
+        mergeMap(([starCoderHybrid, claude3, fimModelExperimentFlag, deepseekV2LiteBase]) => {
             // We run fine tuning experiment for VSC client only.
             // We disable for all agent clients like the JetBrains plugin.
             const isFinetuningExperimentDisabled = vscode.workspace
@@ -53,13 +51,6 @@ export function getDotComExperimentModel({
             if (!isFinetuningExperimentDisabled && fimModelExperimentFlag) {
                 // The traffic in this feature flag is interpreted as a traffic allocated to the fine-tuned experiment.
                 return resolveFIMModelExperimentFromFeatureFlags()
-            }
-
-            if (deepseekV2LiteBaseDirectRoute) {
-                return Observable.of({
-                    provider: 'fireworks',
-                    model: DEEPSEEK_CODER_V2_LITE_BASE_DIRECT_ROUTE,
-                })
             }
 
             if (deepseekV2LiteBase) {
@@ -114,7 +105,7 @@ function resolveFIMModelExperimentFromFeatureFlags(): ReturnType<typeof getDotCo
                 fimModelCurrentBest,
             ]) => {
                 if (fimModelVariant1) {
-                    return { provider: 'fireworks', model: DEEPSEEK_CODER_V2_LITE_BASE_DIRECT_ROUTE }
+                    return { provider: 'fireworks', model: DEEPSEEK_CODER_V2_LITE_BASE }
                 }
                 if (fimModelVariant2) {
                     return { provider: 'fireworks', model: FIREWORKS_DEEPSEEK_7B_LANG_SPECIFIC_V0 }


### PR DESCRIPTION
## Context 
Shipment of direct routing and prompt caching to all users.
Online Results: https://sourcegraph.slack.com/archives/C0729T2PBV2/p1725574821564519 

## Related PR
1. https://github.com/sourcegraph/sourcegraph/pull/571

## Test plan
1. Manually overriding in the feature flag and checking completions results.