### PR TITLE
Revoke access token

### DIFF
--- a/lib/shared/src/sourcegraph-api/graphql/client.ts
+++ b/lib/shared/src/sourcegraph-api/graphql/client.ts
@@ -1228,11 +1228,11 @@ export class SourcegraphGraphQLAPIClient {
         return extractDataOrError(initialResponse, data => data)
     }
 
-    public async DeleteAccessToken(tokenID: string): Promise<unknown | Error> {
+    public async DeleteAccessToken(token: string): Promise<unknown | Error> {
         const initialResponse = await this.fetchSourcegraphAPI<APIResponse<unknown>>(
             DELETE_ACCESS_TOKEN_MUTATION,
             {
-                tokenID,
+                token,
             }
         )
         return extractDataOrError(initialResponse, data => data)

--- a/lib/shared/src/sourcegraph-api/graphql/client.ts
+++ b/lib/shared/src/sourcegraph-api/graphql/client.ts
@@ -32,6 +32,7 @@ import {
     CURRENT_USER_CODY_SUBSCRIPTION_QUERY,
     CURRENT_USER_ID_QUERY,
     CURRENT_USER_INFO_QUERY,
+    DELETE_ACCESS_TOKEN_MUTATION,
     EVALUATE_FEATURE_FLAG_QUERY,
     FILE_CONTENTS_QUERY,
     FILE_MATCH_SEARCH_QUERY,
@@ -1227,6 +1228,15 @@ export class SourcegraphGraphQLAPIClient {
         return extractDataOrError(initialResponse, data => data)
     }
 
+    public async DeleteAccessToken(tokenID: string): Promise<unknown | Error> {
+        const initialResponse = await this.fetchSourcegraphAPI<APIResponse<unknown>>(
+            DELETE_ACCESS_TOKEN_MUTATION,
+            {
+                tokenID,
+            }
+        )
+        return extractDataOrError(initialResponse, data => data)
+    }
     /**
      * logEvent is the legacy event-logging mechanism.
      * @deprecated use an implementation of implementation TelemetryRecorder

--- a/lib/shared/src/sourcegraph-api/graphql/queries.ts
+++ b/lib/shared/src/sourcegraph-api/graphql/queries.ts
@@ -366,6 +366,14 @@ mutation RecordTelemetryEvents($events: [TelemetryEventInput!]!) {
 }
 `
 
+export const DELETE_ACCESS_TOKEN_MUTATION = `
+mutation DeleteAccessToken($tokenID: ID!) {
+    deleteAccessToken(byID: $tokenID) {
+        alwaysNil
+    }
+}
+`
+
 export const CURRENT_SITE_IDENTIFICATION = `
 query SiteIdentification {
 	site {

--- a/lib/shared/src/sourcegraph-api/graphql/queries.ts
+++ b/lib/shared/src/sourcegraph-api/graphql/queries.ts
@@ -367,8 +367,8 @@ mutation RecordTelemetryEvents($events: [TelemetryEventInput!]!) {
 `
 
 export const DELETE_ACCESS_TOKEN_MUTATION = `
-mutation DeleteAccessToken($tokenID: ID!) {
-    deleteAccessToken(byID: $tokenID) {
+mutation DeleteAccessToken($token: String!) {
+    deleteAccessToken(byToken: $token) {
         alwaysNil
     }
 }

--- a/vscode/src/auth/auth.ts
+++ b/vscode/src/auth/auth.ts
@@ -358,10 +358,10 @@ export async function showSignOutMenu(): Promise<void> {
  * Log user out of the selected endpoint (remove token from secret).
  */
 async function signOut(endpoint: string): Promise<void> {
-    const theToken = await secretStorage.getToken(endpoint)
-    if (theToken) {
-        const response= await graphqlClient.DeleteAccessToken(theToken)
-        console.log("the response", response)
+    const token = await secretStorage.getToken(endpoint)
+    // Delete the access token from the Sourcegraph instance
+    if (token) {
+        await graphqlClient.DeleteAccessToken(token)
     }
     await secretStorage.deleteToken(endpoint)
     await localStorage.deleteEndpoint()

--- a/vscode/src/auth/auth.ts
+++ b/vscode/src/auth/auth.ts
@@ -6,6 +6,7 @@ import {
     DOTCOM_URL,
     currentAuthStatus,
     getCodyAuthReferralCode,
+    graphqlClient,
     isDotCom,
     telemetryRecorder,
 } from '@sourcegraph/cody-shared'
@@ -357,6 +358,11 @@ export async function showSignOutMenu(): Promise<void> {
  * Log user out of the selected endpoint (remove token from secret).
  */
 async function signOut(endpoint: string): Promise<void> {
+    const theToken = await secretStorage.getToken(endpoint)
+    if (theToken) {
+        const response= await graphqlClient.DeleteAccessToken(theToken)
+        console.log("the response", response)
+    }
     await secretStorage.deleteToken(endpoint)
     await localStorage.deleteEndpoint()
     await authProvider.auth({ endpoint, token: null })


### PR DESCRIPTION
Solves [Linear issue](https://linear.app/sourcegraph/issue/CODY-350/bug-revoke-the-access-token-when-a-user-signs-out-of-jetbrains-and)


## Test plan
Tested locally on both a local sourcegraph instance and with dotcom instance using Vscode cody.


## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
