### PR TITLE
Add prompt-like standard commands

### DIFF
--- a/agent/recordings/cody-chat_103640681/recording.har.yaml
+++ b/agent/recordings/cody-chat_103640681/recording.har.yaml
@@ -1037,5 +1037,76 @@ log:
         send: 0
         ssl: -1
         wait: 0
+    - _id: 70d63cfe5382426cf94ed76a715e9af5
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 0
+        cookies: []
+        headers:
+          - _fromType: array
+            name: user-agent
+            value: cody-cli / 6.0.0-SNAPSHOT
+          - _fromType: array
+            name: accept
+            value: "*/*"
+          - _fromType: array
+            name: accept-encoding
+            value: gzip,deflate
+          - name: host
+            value: sourcegraph.sourcegraph.com
+        headersSize: 209
+        httpVersion: HTTP/1.1
+        method: GET
+        queryString: []
+        url: https://sourcegraph.sourcegraph.com/.api/modelconfig/supported-models.json
+      response:
+        bodySize: 38
+        content:
+          mimeType: text/plain; charset=utf-8
+          size: 38
+          text: |
+            Private mode requires authentication.
+        cookies: []
+        headers:
+          - name: date
+            value: Wed, 18 Sep 2024 05:01:12 GMT
+          - name: content-type
+            value: text/plain; charset=utf-8
+          - name: content-length
+            value: "38"
+          - name: connection
+            value: keep-alive
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache, max-age=0
+          - name: vary
+            value: Accept-Encoding, Authorization, Cookie, Authorization, X-Requested-With
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+        headersSize: 1218
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 401
+        statusText: Unauthorized
+      startedDateTime: 2024-09-18T05:01:12.456Z
+      time: 0
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 0
   pages: []
   version: "1.2"

--- a/agent/recordings/defaultClient_631904893/recording.har.yaml
+++ b/agent/recordings/defaultClient_631904893/recording.har.yaml
@@ -2656,194 +2656,6 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: f4a9ebf6662ce6de3f76ac0efdf9ca65
-      _order: 0
-      cache: {}
-      request:
-        bodySize: 3105
-        cookies: []
-        headers:
-          - name: content-type
-            value: application/json
-          - name: accept-encoding
-            value: gzip;q=0
-          - name: authorization
-            value: token
-              REDACTED_3dd704711f82a44ff6aba261b53b61a03fb8edba658774639148630d838c2d1d
-          - name: user-agent
-            value: defaultClient / v1
-          - name: traceparent
-            value: 00-a540472d2b0d95ab25c17b57c9386d8f-7b63c9f68a686ed2-01
-          - name: connection
-            value: keep-alive
-          - name: host
-            value: sourcegraph.com
-        headersSize: 401
-        httpVersion: HTTP/1.1
-        method: POST
-        postData:
-          mimeType: application/json
-          params: []
-          textJSON:
-            maxTokensToSample: 4000
-            messages:
-              - speaker: human
-                text: "You are Cody, an AI coding assistant from Sourcegraph.If your answer
-                  contains fenced code blocks in Markdown, include the relevant
-                  full file path in the code block tag using this structure:
-                  ```$LANGUAGE:$FILEPATH```."
-              - speaker: assistant
-                text: I am Cody, an AI coding assistant from Sourcegraph.
-              - speaker: human
-                text: >
-                  Codebase context from file path src/TestClass.ts: const foo =
-                  42
-
-
-                  export class TestClass {
-                      constructor(private shouldGreet: boolean) {}
-
-                      public functionName() {
-                          if (this.shouldGreet) {
-                              console.log(/* CURSOR */ 'Hello World!')
-                          }
-                      }
-                  }
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: >
-                  Codebase context from file path src/example.test.ts: import {
-                  expect } from 'vitest'
-
-                  import { it } from 'vitest'
-
-                  import { describe } from 'vitest'
-
-
-                  describe('test block', () => {
-                      it('does 1', () => {
-                          expect(true).toBe(true)
-                      })
-
-                      it('does 2', () => {
-                          expect(true).toBe(true)
-                      })
-
-                      it('does something else', () => {
-                          // This line will error due to incorrect usage of `performance.now`
-                          const startTime = performance.now(/* CURSOR */)
-                      })
-                  })
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: |-
-                  My selected code from codebase file src/animal.ts:1-6:
-                  ```
-
-                  export interface Animal {
-                      name: string
-                      makeAnimalSound(): string
-                      isMammal: boolean
-                  }
-                  ```
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: Review the shared code context and configurations to identify the test
-                  framework and libraries in use. Then, generate a suite of
-                  multiple unit tests for the functions in <selected> using the
-                  detected test framework and libraries. Be sure to import the
-                  function being tested. Follow the same patterns as any shared
-                  context. Only add packages, imports, dependencies, and
-                  assertions if they are used in the shared code. Pay attention
-                  to the file path of each shared context to see if test for
-                  <selected> already exists. If one exists, focus on generating
-                  new unit tests for uncovered cases. If none are detected,
-                  import common unit test libraries for {languageName}. Focus on
-                  validating key functionality with simple and complete
-                  assertions. Only include mocks if one is detected in the
-                  shared code. Before writing the tests, identify which test
-                  libraries and frameworks to import, e.g. 'No new imports
-                  needed - using existing libs' or 'Importing test framework
-                  that matches shared context usage' or 'Importing the defined
-                  framework', etc. Then briefly summarize test coverage and any
-                  limitations. At the end, enclose the full completed code for
-                  the new unit tests, including all necessary imports, in a
-                  single markdown codeblock. No fragments or TODO. The new tests
-                  should validate expected functionality and cover edge cases
-                  for <selected> with all required imports, including importing
-                  the function being tested. Do not repeat existing tests.
-            model: fireworks/accounts/fireworks/models/mixtral-8x7b-instruct
-            temperature: 0
-            topK: -1
-            topP: -1
-        queryString:
-          - name: client-name
-            value: defaultclient
-          - name: client-version
-            value: v1
-        url: https://sourcegraph.com/.api/completions/stream?client-name=defaultclient&client-version=v1
-      response:
-        bodySize: 49060
-        content:
-          mimeType: text/event-stream
-          size: 49060
-          text: >+
-            event: completion
-
-            data: {"completion":"Based on the provided code context, the test framework in use is `vitest`.\n\nThe selected code is an `Animal` interface, which does not have any implementations or functions to test. However, I'll assume that a function implementing the `Animal` interface exists somewhere. Here's an example of how you could write unit tests for such a function in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\nimport { expect, test } from 'vitest'\nimport { Animal } from './animal'\n\nconst myAnimal: Animal = {\n    name: 'Dog',\n    makeAnimalSound: () => 'Woof',\n    isMammal: true\n}\n\ntest('should test Animal interface implementation', () => {\n    expect(myAnimal.name).toBe('Dog')\n    expect(myAnimal.makeAnimalSound()).toBe('Woof')\n    expect(myAnimal.isMammal).toBe(true)\n})\n\ntest('should test makeAnimalSound implementation', () => {\n    const animal = {\n        name: 'Cat',\n        makeAnimalSound: () => 'Meow',\n        isMammal: true\n    }\n\n    expect(animal.makeAnimalSound()).toBe('Meow')\n})\n```\n\nHere's the explanation of the test coverage and limitations:\n\n* The tests cover the properties `name`, `makeAnimalSound`, and `isMammal` of the `Animal` interface.\n* The `makeAnimalSound` method is tested with a `Dog` sound and a `Cat` sound.\n* The tests do not cover any possible error conditions or edge cases, such as when the `name` property is null or the `makeAnimalSound` method throws an exception.\n\nNote that the above test code is written on the assumption that an implementation of the `Animal` interface exists. If this is not the case, please provide the implementation code for unit testing.","stopReason":"stop"}
-
-
-            event: done
-
-            data: {}
-
-        cookies: []
-        headers:
-          - name: date
-            value: Thu, 19 Sep 2024 04:39:30 GMT
-          - name: content-type
-            value: text/event-stream
-          - name: transfer-encoding
-            value: chunked
-          - name: connection
-            value: keep-alive
-          - name: retry-after
-            value: "569"
-          - name: access-control-allow-credentials
-            value: "true"
-          - name: access-control-allow-origin
-            value: ""
-          - name: cache-control
-            value: no-cache
-          - name: vary
-            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
-              X-Requested-With,Cookie
-          - name: x-content-type-options
-            value: nosniff
-          - name: x-frame-options
-            value: DENY
-          - name: x-xss-protection
-            value: 1; mode=block
-          - name: strict-transport-security
-            value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1406
-        httpVersion: HTTP/1.1
-        redirectURL: ""
-        status: 200
-        statusText: OK
-      startedDateTime: 2024-09-19T04:39:29.018Z
-      time: 0
-      timings:
-        blocked: -1
-        connect: -1
-        dns: -1
-        receive: 0
-        send: 0
-        ssl: -1
-        wait: 0
     - _id: 7b672f04297e865517703bd8c6c3817a
       _order: 0
       cache: {}
@@ -2991,81 +2803,159 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: dd62d6d2b28587b02a552ca5b80a73b1
+    - _id: fb988001a14492fcfd2b59a73fcf5089
       _order: 0
       cache: {}
       request:
-        bodySize: 217
+        bodySize: 3240
         cookies: []
         headers:
-          - _fromType: array
-            name: authorization
+          - name: content-type
+            value: application/json
+          - name: accept-encoding
+            value: gzip;q=0
+          - name: authorization
             value: token
               REDACTED_3dd704711f82a44ff6aba261b53b61a03fb8edba658774639148630d838c2d1d
-          - _fromType: array
-            name: content-type
-            value: application/json; charset=utf-8
-          - _fromType: array
-            name: user-agent
+          - name: user-agent
             value: defaultClient / v1
-          - _fromType: array
-            name: accept
-            value: "*/*"
-          - _fromType: array
-            name: content-length
-            value: "217"
-          - _fromType: array
-            name: accept-encoding
-            value: gzip,deflate
+          - name: traceparent
+            value: 00-6c6f39871e71569ef734f30a978bd8fd-81d2b0b58158e147-01
+          - name: connection
+            value: keep-alive
           - name: host
             value: sourcegraph.com
-        headersSize: 378
+        headersSize: 401
         httpVersion: HTTP/1.1
         method: POST
         postData:
-          mimeType: application/json; charset=utf-8
+          mimeType: application/json
           params: []
           textJSON:
-            query: |-
-              
-              query CodyConfigFeaturesResponse {
-                  site {
-                      codyConfigFeatures {
-                          chat
-                          autoComplete
-                          commands
-                          attribution
+            maxTokensToSample: 4000
+            messages:
+              - speaker: human
+                text: "You are Cody, an AI coding assistant from Sourcegraph.If your answer
+                  contains fenced code blocks in Markdown, include the relevant
+                  full file path in the code block tag using this structure:
+                  ```$LANGUAGE:$FILEPATH```."
+              - speaker: assistant
+                text: I am Cody, an AI coding assistant from Sourcegraph.
+              - speaker: human
+                text: >
+                  Codebase context from file path src/TestClass.ts: const foo =
+                  42
+
+
+                  export class TestClass {
+                      constructor(private shouldGreet: boolean) {}
+
+                      public functionName() {
+                          if (this.shouldGreet) {
+                              console.log(/* CURSOR */ 'Hello World!')
+                          }
                       }
                   }
-              }
-            variables: {}
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: >
+                  Codebase context from file path src/example.test.ts: import {
+                  expect } from 'vitest'
+
+                  import { it } from 'vitest'
+
+                  import { describe } from 'vitest'
+
+
+                  describe('test block', () => {
+                      it('does 1', () => {
+                          expect(true).toBe(true)
+                      })
+
+                      it('does 2', () => {
+                          expect(true).toBe(true)
+                      })
+
+                      it('does something else', () => {
+                          // This line will error due to incorrect usage of `performance.now`
+                          const startTime = performance.now(/* CURSOR */)
+                      })
+                  })
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: |-
+                  My selected code from codebase file src/animal.ts:1-6:
+                  ```
+
+                  export interface Animal {
+                      name: string
+                      makeAnimalSound(): string
+                      isMammal: boolean
+                  }
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: Review @src/example.test.ts:1-18 ( @src/TestClass.ts:1-11 ) context and
+                  configurations to identify the test framework and libraries in
+                  use. Then, generate a suite of multiple unit tests for the
+                  functions in @src/animal.ts:1-6 using the detected test
+                  framework and libraries. Be sure to import the function being
+                  tested. Follow the same patterns as any shared context. Only
+                  add packages, imports, dependencies, and assertions if they
+                  are used in @src/example.test.ts:1-18 ( @src/TestClass.ts:1-11
+                  ). Pay attention to the file path of each shared context to
+                  see if test for @src/animal.ts:1-6 already exists. If one
+                  exists, focus on generating new unit tests for uncovered
+                  cases. If none are detected, import common unit test libraries
+                  for {languageName}. Focus on validating key functionality with
+                  simple and complete assertions. Only include mocks if one is
+                  detected in @src/example.test.ts:1-18 ( @src/TestClass.ts:1-11
+                  ). Before writing the tests, identify which test libraries and
+                  frameworks to import, e.g. 'No new imports needed - using
+                  existing libs' or 'Importing test framework that matches
+                  shared context usage' or 'Importing the defined framework',
+                  etc. Then briefly summarize test coverage and any limitations.
+                  At the end, enclose the full completed code for the new unit
+                  tests, including all necessary imports, in a single markdown
+                  codeblock. No fragments or TODO. The new tests should validate
+                  expected functionality and cover edge cases for
+                  @src/animal.ts:1-6 with all required imports, including
+                  importing the function being tested. Do not repeat existing
+                  tests.
+            model: fireworks/accounts/fireworks/models/mixtral-8x7b-instruct
+            temperature: 0
+            topK: -1
+            topP: -1
         queryString:
-          - name: CodyConfigFeaturesResponse
-            value: null
-        url: https://sourcegraph.com/.api/graphql?CodyConfigFeaturesResponse
+          - name: client-name
+            value: defaultclient
+          - name: client-version
+            value: v1
+        url: https://sourcegraph.com/.api/completions/stream?client-name=defaultclient&client-version=v1
       response:
-        bodySize: 152
+        bodySize: 240064
         content:
-          encoding: base64
-          mimeType: application/json
-          size: 152
-          text: "[\"H4sIAAAAAAAAAzyLwQqAIBAF/2XPfYFXof/YdC0h3dDnIcR/Dws6DQwznTyDyXSqETLp1\
-            N9Wc4j7KoxWpL72YJBBabIQN6jVdJ0yj885TYmzr38DlLg1RM1kAp9VxhjjAQAA//8D\
-            AIfOLkJuAAAA\"]"
-          textDecoded:
-            data:
-              site:
-                codyConfigFeatures:
-                  attribution: false
-                  autoComplete: true
-                  chat: true
-                  commands: true
+          mimeType: text/event-stream
+          size: 240064
+          text: >+
+            event: completion
+
+            data: {"completion":"Based on the context provided in `@src/example.test.ts` and `@src/TestClass.ts`, the test framework in use is `vitest`. Here is a suite of multiple unit tests for the functions in `@src/animal.ts` using the detected test framework.\n\nTest coverage:\n\n* The `Animal` interface has been tested to ensure that all its properties have been properly defined and initialized.\n* The `makeAnimalSound()` function has been tested for different animal sounds.\n* The tests cover positive and negative cases, and edge cases for the `isMammal` property.\n\nLimitations:\n\n* This is a basic test suite, and additional tests should be added to cover more complex functionality if necessary.\n* It assumes that the implementation of `isMammal` property is correct and consistent.\n\nHere's the completed code for the new unit tests:\n```typescript\n// @src/animal.test.ts\nimport { describe, expect, test } from 'vitest'\nimport { Animal } from './animal'\n\ndescribe('Animal', () => {\n  test('should correctly define name property', () => {\n    const animal: Animal = {\n      name: 'Dog',\n      makeAnimalSound: () => 'Woof woof!',\n      isMammal: true,\n    }\n\n    expect(animal).toHaveProperty('name', 'Dog')\n    expect(animal.name).toBe('Dog')\n  })\n\n  test('should correctly define makeAnimalSound() function', () => {\n    const animal: Animal = {\n      name: 'Dog',\n      makeAnimalSound: () => 'Woof woof!',\n      isMammal: true,\n    }\n\n    expect(animal.makeAnimalSound()).toBe('Woof woof!')\n  })\n\n  test('should correctly define isMammal property', () => {\n    const animal: Animal = {\n      name: 'Dog',\n      makeAnimalSound: () => 'Woof woof!',\n      isMammal: true,\n    }\n\n    expect(animal).toHaveProperty('isMammal', true)\n    expect(animal.isMammal).toBe(true)\n  })\n\n  test('should return false for non-mammals', () => {\n    const animal: Animal = {\n      name: 'Snake',\n      makeAnimalSound: () => 'Hiss',\n      isMammal: false,\n    }\n\n    expect(animal).toHaveProperty('isMammal', false)\n    expect(animal.isMammal).toBe(false)\n  })\n\n  test('should handle undefined or null isMammal property', () => {\n    const animal: Animal = {\n      name: 'Unknown',\n      makeAnimalSound: () => '',\n      isMammal: undefined,\n    }\n\n    const animal2: Animal = {\n      name: 'Unknown',\n      makeAnimalSound: () => '',\n      isMammal: null,\n    }\n\n    expect(animal).toHaveProperty('isMammal', false)\n    expect(animal.isMammal).toBeFalsy()\n\n    expect(animal2).toHaveProperty('isMammal', false)\n    expect(animal2.isMammal).toBeFalsy()\n  })\n})\n```\nThis code includes imports for testing libraries, uses the `vitest` functions `describe()` and `test()` to organize the tests, and uses `expect()` to make assertions about the `Animal` interface and its properties. The tests include both positive and negative cases, edge cases, and coverage of the required functionality.","stopReason":"stop"}
+
+
+            event: done
+
+            data: {}
+
         cookies: []
         headers:
           - name: date
-            value: Thu, 19 Sep 2024 04:38:49 GMT
+            value: Fri, 20 Sep 2024 01:30:14 GMT
           - name: content-type
-            value: application/json
+            value: text/event-stream
           - name: transfer-encoding
             value: chunked
           - name: connection
@@ -3075,7 +2965,7 @@ log:
           - name: access-control-allow-origin
             value: ""
           - name: cache-control
-            value: no-cache, max-age=0
+            value: no-cache
           - name: vary
             value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
               X-Requested-With,Cookie
@@ -3087,116 +2977,12 @@ log:
             value: 1; mode=block
           - name: strict-transport-security
             value: max-age=31536000; includeSubDomains; preload
-          - name: content-encoding
-            value: gzip
-        headersSize: 1473
+        headersSize: 1299
         httpVersion: HTTP/1.1
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-09-19T04:38:49.205Z
-      time: 0
-      timings:
-        blocked: -1
-        connect: -1
-        dns: -1
-        receive: 0
-        send: 0
-        ssl: -1
-        wait: 0
-    - _id: fed5129404cd476f4ecc5c751242f2f5
-      _order: 0
-      cache: {}
-      request:
-        bodySize: 217
-        cookies: []
-        headers:
-          - _fromType: array
-            name: authorization
-            value: token
-              REDACTED_0ba08837494d00e3943c46999589eb29a210ba8063f084fff511c8e4d1503909
-          - _fromType: array
-            name: content-type
-            value: application/json; charset=utf-8
-          - _fromType: array
-            name: user-agent
-            value: defaultClient / v1
-          - _fromType: array
-            name: accept
-            value: "*/*"
-          - _fromType: array
-            name: content-length
-            value: "217"
-          - _fromType: array
-            name: accept-encoding
-            value: gzip,deflate
-          - name: host
-            value: sourcegraph.com
-        headersSize: 390
-        httpVersion: HTTP/1.1
-        method: POST
-        postData:
-          mimeType: application/json; charset=utf-8
-          params: []
-          textJSON:
-            query: |-
-              
-              query CodyConfigFeaturesResponse {
-                  site {
-                      codyConfigFeatures {
-                          chat
-                          autoComplete
-                          commands
-                          attribution
-                      }
-                  }
-              }
-            variables: {}
-        queryString:
-          - name: CodyConfigFeaturesResponse
-            value: null
-        url: https://sourcegraph.com/.api/graphql?CodyConfigFeaturesResponse
-      response:
-        bodySize: 22
-        content:
-          mimeType: text/plain; charset=utf-8
-          size: 22
-          text: |
-            Invalid access token.
-        cookies: []
-        headers:
-          - name: date
-            value: Thu, 19 Sep 2024 04:40:05 GMT
-          - name: content-type
-            value: text/plain; charset=utf-8
-          - name: content-length
-            value: "22"
-          - name: connection
-            value: keep-alive
-          - name: retry-after
-            value: "533"
-          - name: access-control-allow-credentials
-            value: "true"
-          - name: access-control-allow-origin
-            value: ""
-          - name: cache-control
-            value: no-cache, max-age=0
-          - name: vary
-            value: Cookie,Accept-Encoding,Authorization
-          - name: x-content-type-options
-            value: nosniff
-          - name: x-frame-options
-            value: DENY
-          - name: x-xss-protection
-            value: 1; mode=block
-          - name: strict-transport-security
-            value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1510
-        httpVersion: HTTP/1.1
-        redirectURL: ""
-        status: 401
-        statusText: Unauthorized
-      startedDateTime: 2024-09-19T04:40:04.838Z
+      startedDateTime: 2024-09-20T01:30:12.366Z
       time: 0
       timings:
         blocked: -1

--- a/agent/src/__snapshots__/index.test.ts.snap
+++ b/agent/src/__snapshots__/index.test.ts.snap
@@ -137,75 +137,89 @@ Overall, the code has a good structure and generally follows sound design princi
 `;
 
 exports[`Agent > Commands > commands/test 1`] = `
-"Based on the provided code context, the codebase is written in TypeScript and uses the Vitest test framework. I will generate a set of unit tests for the \`Animal\` interface in \`src/animal.ts\`.
+"Based on the context provided in \`@src/example.test.ts\` and \`@src/TestClass.ts\`, the test framework in use is \`vitest\`. Here is a suite of multiple unit tests for the functions in \`@src/animal.ts\` using the detected test framework.
 
-Importing the necessary modules:
-\`\`\`typescript
-import { expect, describe, it } from 'vitest'
-import { Animal } from './animal'
-\`\`\`
-Unit tests for \`src/animal.ts\`:
-\`\`\`typescript
-describe('Animal', () => {
-  let animal: Animal
-
-  // Define a base animal with required properties
-  beforeEach(() => {
-    animal = {
-      name: 'Cat',
-      makeAnimalSound: () => 'Meow',
-      isMammal: true,
-    }
-  })
-
-  it('should have a name property of string type', () => {
-    expect(animal.name).toBeTypeOf('string')
-  })
-
-Here is a suite of unit tests for the functions in \`@src/animal.ts:1-6\` using vitest:
-\`\`\`typescript
-import { expect } from 'vitest'
-import { TestClass } from './TestClass'
-import { Animal, isMammal, makeAnimalSound } from './animal'
-
-describe('Animal tests', () => {
-  const testAnimal: Animal = {
-    name: 'Test Animal',
-    makeAnimalSound: () => 'Test Sound',
-    isMammal: true,
-  }
-
-  it('Should have a name property', () => {
-    expect(testAnimal).toHaveProperty('name')
-  })
-
-  it('Should have a makeAnimalSound function', () => {
-    expect(testAnimal).toHaveProperty('makeAnimalSound')
-    expect(typeof testAnimal.makeAnimalSound).toBe('function')
-  })
-
-  it('Should have an isMammal property', () => {
-    expect(testAnimal).toHaveProperty('isMammal')
-    expect(typeof testAnimal.isMammal).toBe('boolean')
-  })
-
-  it('makeAnimalSound should return a string', () => {
-    expect(makeAnimalSound(testAnimal)).toBe('Test Sound')
-  })
-
-  it('isMammal should return true if the animal is a mammal', () => {
-    expect(isMammal(testAnimal)).toBe(true)
-  })
-})
-\`\`\`
 Test coverage:
 
-* Validates that the \`Animal\` interface has the expected properties.
-* Validates that the \`makeAnimalSound\` function returns a string.
-* Validates that the \`isMammal\` function returns the expected boolean value.
+* The \`Animal\` interface has been tested to ensure that all its properties have been properly defined and initialized.
+* The \`makeAnimalSound()\` function has been tested for different animal sounds.
+* The tests cover positive and negative cases, and edge cases for the \`isMammal\` property.
 
 Limitations:
 
-* This test suite assumes that the \`makeAnimalSound\` function and \`isMammal\` function are properly implemented in the source code.
-* Additional tests could be added to check for proper error handling, boundary cases, etc."
+* This is a basic test suite, and additional tests should be added to cover more complex functionality if necessary.
+* It assumes that the implementation of \`isMammal\` property is correct and consistent.
+
+Here's the completed code for the new unit tests:
+\`\`\`typescript
+// @src/animal.test.ts
+import { describe, expect, test } from 'vitest'
+import { Animal } from './animal'
+
+describe('Animal', () => {
+  test('should correctly define name property', () => {
+    const animal: Animal = {
+      name: 'Dog',
+      makeAnimalSound: () => 'Woof woof!',
+      isMammal: true,
+    }
+
+    expect(animal).toHaveProperty('name', 'Dog')
+    expect(animal.name).toBe('Dog')
+  })
+
+  test('should correctly define makeAnimalSound() function', () => {
+    const animal: Animal = {
+      name: 'Dog',
+      makeAnimalSound: () => 'Woof woof!',
+      isMammal: true,
+    }
+
+    expect(animal.makeAnimalSound()).toBe('Woof woof!')
+  })
+
+  test('should correctly define isMammal property', () => {
+    const animal: Animal = {
+      name: 'Dog',
+      makeAnimalSound: () => 'Woof woof!',
+      isMammal: true,
+    }
+
+    expect(animal).toHaveProperty('isMammal', true)
+    expect(animal.isMammal).toBe(true)
+  })
+
+  test('should return false for non-mammals', () => {
+    const animal: Animal = {
+      name: 'Snake',
+      makeAnimalSound: () => 'Hiss',
+      isMammal: false,
+    }
+
+    expect(animal).toHaveProperty('isMammal', false)
+    expect(animal.isMammal).toBe(false)
+  })
+
+  test('should handle undefined or null isMammal property', () => {
+    const animal: Animal = {
+      name: 'Unknown',
+      makeAnimalSound: () => '',
+      isMammal: undefined,
+    }
+
+    const animal2: Animal = {
+      name: 'Unknown',
+      makeAnimalSound: () => '',
+      isMammal: null,
+    }
+
+    expect(animal).toHaveProperty('isMammal', false)
+    expect(animal.isMammal).toBeFalsy()
+
+    expect(animal2).toHaveProperty('isMammal', false)
+    expect(animal2.isMammal).toBeFalsy()
+  })
+})
+\`\`\`
+This code includes imports for testing libraries, uses the \`vitest\` functions \`describe()\` and \`test()\` to organize the tests, and uses \`expect()\` to make assertions about the \`Animal\` interface and its properties. The tests include both positive and negative cases, edge cases, and coverage of the required functionality."
 `;

--- a/agent/src/__snapshots__/index.test.ts.snap
+++ b/agent/src/__snapshots__/index.test.ts.snap
@@ -137,43 +137,75 @@ Overall, the code has a good structure and generally follows sound design princi
 `;
 
 exports[`Agent > Commands > commands/test 1`] = `
-"Based on the provided code context, the test framework in use is \`vitest\`.
+"Based on the provided code context, the codebase is written in TypeScript and uses the Vitest test framework. I will generate a set of unit tests for the \`Animal\` interface in \`src/animal.ts\`.
 
-The selected code is an \`Animal\` interface, which does not have any implementations or functions to test. However, I'll assume that a function implementing the \`Animal\` interface exists somewhere. Here's an example of how you could write unit tests for such a function in \`src/animal.test.ts\`:
-
+Importing the necessary modules:
 \`\`\`typescript
-// src/animal.test.ts
-import { expect, test } from 'vitest'
+import { expect, describe, it } from 'vitest'
 import { Animal } from './animal'
+\`\`\`
+Unit tests for \`src/animal.ts\`:
+\`\`\`typescript
+describe('Animal', () => {
+  let animal: Animal
 
-const myAnimal: Animal = {
-    name: 'Dog',
-    makeAnimalSound: () => 'Woof',
-    isMammal: true
-}
-
-test('should test Animal interface implementation', () => {
-    expect(myAnimal.name).toBe('Dog')
-    expect(myAnimal.makeAnimalSound()).toBe('Woof')
-    expect(myAnimal.isMammal).toBe(true)
-})
-
-test('should test makeAnimalSound implementation', () => {
-    const animal = {
-        name: 'Cat',
-        makeAnimalSound: () => 'Meow',
-        isMammal: true
+  // Define a base animal with required properties
+  beforeEach(() => {
+    animal = {
+      name: 'Cat',
+      makeAnimalSound: () => 'Meow',
+      isMammal: true,
     }
+  })
 
-    expect(animal.makeAnimalSound()).toBe('Meow')
+  it('should have a name property of string type', () => {
+    expect(animal.name).toBeTypeOf('string')
+  })
+
+Here is a suite of unit tests for the functions in \`@src/animal.ts:1-6\` using vitest:
+\`\`\`typescript
+import { expect } from 'vitest'
+import { TestClass } from './TestClass'
+import { Animal, isMammal, makeAnimalSound } from './animal'
+
+describe('Animal tests', () => {
+  const testAnimal: Animal = {
+    name: 'Test Animal',
+    makeAnimalSound: () => 'Test Sound',
+    isMammal: true,
+  }
+
+  it('Should have a name property', () => {
+    expect(testAnimal).toHaveProperty('name')
+  })
+
+  it('Should have a makeAnimalSound function', () => {
+    expect(testAnimal).toHaveProperty('makeAnimalSound')
+    expect(typeof testAnimal.makeAnimalSound).toBe('function')
+  })
+
+  it('Should have an isMammal property', () => {
+    expect(testAnimal).toHaveProperty('isMammal')
+    expect(typeof testAnimal.isMammal).toBe('boolean')
+  })
+
+  it('makeAnimalSound should return a string', () => {
+    expect(makeAnimalSound(testAnimal)).toBe('Test Sound')
+  })
+
+  it('isMammal should return true if the animal is a mammal', () => {
+    expect(isMammal(testAnimal)).toBe(true)
+  })
 })
 \`\`\`
+Test coverage:
 
-Here's the explanation of the test coverage and limitations:
+* Validates that the \`Animal\` interface has the expected properties.
+* Validates that the \`makeAnimalSound\` function returns a string.
+* Validates that the \`isMammal\` function returns the expected boolean value.
 
-* The tests cover the properties \`name\`, \`makeAnimalSound\`, and \`isMammal\` of the \`Animal\` interface.
-* The \`makeAnimalSound\` method is tested with a \`Dog\` sound and a \`Cat\` sound.
-* The tests do not cover any possible error conditions or edge cases, such as when the \`name\` property is null or the \`makeAnimalSound\` method throws an exception.
+Limitations:
 
-Note that the above test code is written on the assumption that an implementation of the \`Animal\` interface exists. If this is not the case, please provide the implementation code for unit testing."
+* This test suite assumes that the \`makeAnimalSound\` function and \`isMammal\` function are properly implemented in the source code.
+* Additional tests could be added to check for proper error handling, boundary cases, etc."
 `;

--- a/lib/shared/src/commands/types.ts
+++ b/lib/shared/src/commands/types.ts
@@ -3,6 +3,7 @@ export type DefaultCodyCommands = DefaultChatCommands | DefaultEditCommands
 
 // Default Cody Commands that runs as a Chat request
 export enum DefaultChatCommands {
+    Doc = 'doc', // Generate documentation in Chat
     Explain = 'explain', // Explain code
     Unit = 'unit', // Generate unit tests in Chat
     Smell = 'smell', // Generate code smell report in Chat

--- a/lib/shared/src/experimentation/FeatureFlagProvider.ts
+++ b/lib/shared/src/experimentation/FeatureFlagProvider.ts
@@ -88,6 +88,12 @@ export enum FeatureFlag {
 
     /** Whether user has access to early-acess models. */
     CodyEarlyAccess = 'cody-early-access',
+
+    /**
+     * Enables experimental unified prompts (show no commands and include
+     * some standard out of box prompts like documentation and explain code prompts
+     */
+    CodyUnifiedPrompts = 'cody-unified-prompts',
 }
 
 const ONE_HOUR = 60 * 60 * 1000

--- a/lib/shared/src/experimentation/FeatureFlagProvider.ts
+++ b/lib/shared/src/experimentation/FeatureFlagProvider.ts
@@ -91,7 +91,7 @@ export enum FeatureFlag {
 
     /**
      * Enables experimental unified prompts (show no commands and include
-     * some standard out of box prompts like documentation and explain code prompts
+     * some standard out-of-the-box prompts like documentation and explain code prompts)
      */
     CodyUnifiedPrompts = 'cody-unified-prompts',
 }

--- a/lib/shared/src/misc/rpc/webviewAPI.ts
+++ b/lib/shared/src/misc/rpc/webviewAPI.ts
@@ -79,6 +79,12 @@ export interface PromptsResult {
         | { type: 'unsupported' }
 
     /**
+     * Provides previously built-in commands which became prompt-like actions (explain code,
+     * generate unit tests, document symbol, etc.) Currently, is used behind feature flag.
+     */
+    standardPrompts?: CodyCommand[]
+
+    /**
      * `undefined` means that commands should not be shown at all (not even as an empty
      * list). Builtin and custom commands are deprecated in favor of the Prompt Library.
      */

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -851,7 +851,7 @@
         },
         {
           "command": "cody.menu.custom-commands",
-          "when": "cody.activated",
+          "when": "cody.activated && cody.menu.custom-commands.enable",
           "group": "custom-commands"
         },
         {

--- a/vscode/src/chat/chat-view/ChatController.ts
+++ b/vscode/src/chat/chat-view/ChatController.ts
@@ -586,7 +586,6 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
         const sidebarViewOnly = this.extensionClient.capabilities?.webviewNativeConfig?.view === 'single'
         const isEditorViewType = this.webviewPanelOrView?.viewType === 'cody.editorPanel'
         const webviewType = isEditorViewType && !sidebarViewOnly ? 'editor' : 'sidebar'
-        const experimentalOneBox = this.isOneBoxEnabled()
         const unifiedPromptsAvailable = await featureFlagProvider.evaluateFeatureFlag(
             FeatureFlag.CodyUnifiedPrompts
         )
@@ -600,7 +599,6 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
             serverEndpoint: auth.serverEndpoint,
             experimentalNoodle: configuration.experimentalNoodle,
             smartApply: this.isSmartApplyEnabled(),
-            experimentalOneBox,
             unifiedPromptsAvailable,
             webviewType,
             multipleWebviewsEnabled: !sidebarViewOnly,

--- a/vscode/src/chat/chat-view/ChatController.ts
+++ b/vscode/src/chat/chat-view/ChatController.ts
@@ -586,6 +586,10 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
         const sidebarViewOnly = this.extensionClient.capabilities?.webviewNativeConfig?.view === 'single'
         const isEditorViewType = this.webviewPanelOrView?.viewType === 'cody.editorPanel'
         const webviewType = isEditorViewType && !sidebarViewOnly ? 'editor' : 'sidebar'
+        const experimentalOneBox = this.isOneBoxEnabled()
+        const unifiedPromptsAvailable = await featureFlagProvider.evaluateFeatureFlag(
+            FeatureFlag.CodyUnifiedPrompts
+        )
 
         return {
             agentIDE: configuration.agentIDE ?? CodyIDE.VSCode,
@@ -596,6 +600,8 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
             serverEndpoint: auth.serverEndpoint,
             experimentalNoodle: configuration.experimentalNoodle,
             smartApply: this.isSmartApplyEnabled(),
+            experimentalOneBox,
+            unifiedPromptsAvailable,
             webviewType,
             multipleWebviewsEnabled: !sidebarViewOnly,
             internalDebugContext: configuration.internalDebugContext,

--- a/vscode/src/chat/chat-view/ChatsController.ts
+++ b/vscode/src/chat/chat-view/ChatsController.ts
@@ -317,7 +317,7 @@ export class ChatsController implements vscode.Disposable {
     }: ExecuteChatArguments): Promise<ChatSession | undefined> {
         let provider: ChatController
         // If the sidebar panel is visible and empty, use it instead of creating a new panel
-        if (submitType === 'user-newchat' && this.panel.isVisible() && this.panel.isEmpty()) {
+        if (submitType === 'user-newchat' && this.panel.isVisible()) {
             provider = this.panel
         } else {
             provider = await this.getOrCreateEditorChatController()

--- a/vscode/src/chat/chat-view/ChatsController.ts
+++ b/vscode/src/chat/chat-view/ChatsController.ts
@@ -317,7 +317,7 @@ export class ChatsController implements vscode.Disposable {
     }: ExecuteChatArguments): Promise<ChatSession | undefined> {
         let provider: ChatController
         // If the sidebar panel is visible and empty, use it instead of creating a new panel
-        if (submitType === 'user-newchat' && this.panel.isVisible()) {
+        if (submitType === 'user-newchat' && this.panel.isVisible() && this.panel.isEmpty()) {
             provider = this.panel
         } else {
             provider = await this.getOrCreateEditorChatController()

--- a/vscode/src/chat/protocol.ts
+++ b/vscode/src/chat/protocol.ts
@@ -279,6 +279,8 @@ export interface ConfigurationSubsetForWebview
         >,
         Pick<AuthCredentials, 'serverEndpoint'> {
     smartApply: boolean
+    experimentalOneBox: boolean
+    unifiedPromptsAvailable: boolean
     // Type/location of the current webview.
     webviewType?: WebviewType | undefined | null
     // Whether support running multiple webviews (e.g. sidebar w/ multiple editor panels).

--- a/vscode/src/chat/protocol.ts
+++ b/vscode/src/chat/protocol.ts
@@ -279,7 +279,6 @@ export interface ConfigurationSubsetForWebview
         >,
         Pick<AuthCredentials, 'serverEndpoint'> {
     smartApply: boolean
-    experimentalOneBox: boolean
     unifiedPromptsAvailable: boolean
     // Type/location of the current webview.
     webviewType?: WebviewType | undefined | null

--- a/vscode/src/commands/CommandsController.ts
+++ b/vscode/src/commands/CommandsController.ts
@@ -131,6 +131,7 @@ function convertDefaultCommandsToPromptString(input: DefaultCodyCommands | Promp
             return ps`unit`
         case DefaultEditCommands.Test:
             return ps`test`
+        case DefaultChatCommands.Doc:
         case DefaultEditCommands.Doc:
             return ps`doc`
         case DefaultEditCommands.Edit:

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -257,7 +257,7 @@ const register = async (
     registerAutocomplete(platform, statusBar, disposables)
     const tutorialSetup = tryRegisterTutorial(context, disposables)
 
-    registerCodyCommands(statusBar, sourceControl, chatClient, disposables)
+    await registerCodyCommands(statusBar, sourceControl, chatClient, disposables)
     registerAuthCommands(disposables)
     registerChatCommands(disposables)
     disposables.push(...registerSidebarCommands())

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -449,8 +449,7 @@ async function registerCodyCommands(
             vscode.commands.registerCommand('cody.command.explain-code', a => executeExplainCommand(a)),
             vscode.commands.registerCommand('cody.command.smell-code', a => executeSmellCommand(a)),
             vscode.commands.registerCommand('cody.command.document-code', a => executeDocChatCommand(a)),
-            vscode.commands.registerCommand('cody.command.unit-tests', a => executeTestChatCommand(a)),
-            sourceControl // Generate Commit Message command
+            vscode.commands.registerCommand('cody.command.unit-tests', a => executeTestChatCommand(a))
         )
 
         return

--- a/vscode/src/prompts/prompts.ts
+++ b/vscode/src/prompts/prompts.ts
@@ -1,6 +1,16 @@
-import { type PromptsResult, graphqlClient, isAbortError, isErrorLike } from '@sourcegraph/cody-shared'
+import {
+    type CodyCommand,
+    CodyIDE,
+    FeatureFlag,
+    type PromptsResult,
+    featureFlagProvider,
+    graphqlClient,
+    isAbortError,
+    isErrorLike,
+} from '@sourcegraph/cody-shared'
 import { FIXTURE_COMMANDS } from '../../webviews/components/promptList/fixtures'
 import { getCodyCommandList } from '../commands/CommandsController'
+import { getConfiguration } from '../configuration'
 
 /**
  * Observe results of querying the prompts from the Prompt Library, (deprecated) built-in commands,
@@ -29,20 +39,64 @@ export async function mergedPromptsAndLegacyCommands(
     }
 
     const queryLower = query.toLowerCase()
-    function matchesQuery(text: string): boolean {
-        try {
-            return text.toLowerCase().includes(queryLower)
-        } catch {
-            return false
+    const isUnifiedPromptsEnabled = await featureFlagProvider.evaluateFeatureFlag(
+        FeatureFlag.CodyUnifiedPrompts
+    )
+
+    // Ignore commands since with unified prompts vital commands will be replaced by out-of-box
+    // commands, see main.ts register cody commands for unified prompts
+    if (isUnifiedPromptsEnabled && getConfiguration().agentIDE !== CodyIDE.Web) {
+        return {
+            query,
+            commands: [],
+            prompts: promptsValue,
+            standardPrompts: [
+                {
+                    key: 'doc',
+                    description: 'Document Code',
+                    prompt: '',
+                    slashCommand: 'cody.command.document-code',
+                    mode: 'ask',
+                    type: 'default',
+                },
+                {
+                    key: 'explain',
+                    description: 'Explain Code',
+                    prompt: '',
+                    slashCommand: 'cody.command.explain-code',
+                    mode: 'ask',
+                    type: 'default',
+                },
+                {
+                    key: 'test',
+                    description: 'Generate Unit Tests',
+                    prompt: '',
+                    slashCommand: 'cody.command.unit-tests',
+                    mode: 'ask',
+                    type: 'default',
+                },
+                {
+                    key: 'smell',
+                    description: 'Find Code Smells',
+                    slashCommand: 'cody.command.smell-code',
+                    prompt: '',
+                    mode: 'ask',
+                    type: 'default',
+                },
+            ] satisfies CodyCommand[],
         }
     }
 
     const allCommands = [
         ...getCodyCommandList(),
         ...(USE_CUSTOM_COMMANDS_FIXTURE ? FIXTURE_COMMANDS : []),
-    ]
+    ].filter(command => (isUnifiedPromptsEnabled ? { ...command, mode: 'ask' } : command))
+
     const matchingCommands = allCommands.filter(
-        c => matchesQuery(c.key) || matchesQuery(c.description ?? '') || matchesQuery(c.prompt)
+        c =>
+            matchesQuery(queryLower, c.key) ||
+            matchesQuery(queryLower, c.description ?? '') ||
+            matchesQuery(queryLower, c.prompt)
     )
 
     return {
@@ -54,3 +108,11 @@ export async function mergedPromptsAndLegacyCommands(
 
 /** For testing only. */
 const USE_CUSTOM_COMMANDS_FIXTURE = false
+
+function matchesQuery(query: string, text: string): boolean {
+    try {
+        return text.toLowerCase().includes(query)
+    } catch {
+        return false
+    }
+}

--- a/vscode/webviews/App.story.tsx
+++ b/vscode/webviews/App.story.tsx
@@ -27,7 +27,6 @@ const dummyVSCodeAPI: VSCodeWrapper = {
                 uiKindIsWeb: false,
                 experimentalNoodle: false,
                 smartApply: false,
-                experimentalOneBox: false,
                 unifiedPromptsAvailable: false,
             },
             authStatus: {

--- a/vscode/webviews/App.story.tsx
+++ b/vscode/webviews/App.story.tsx
@@ -27,6 +27,8 @@ const dummyVSCodeAPI: VSCodeWrapper = {
                 uiKindIsWeb: false,
                 experimentalNoodle: false,
                 smartApply: false,
+                experimentalOneBox: false,
+                unifiedPromptsAvailable: false,
             },
             authStatus: {
                 ...AUTH_STATUS_FIXTURE_AUTHED,

--- a/vscode/webviews/Chat.tsx
+++ b/vscode/webviews/Chat.tsx
@@ -32,6 +32,8 @@ interface ChatboxProps {
     showIDESnippetActions?: boolean
     setView: (view: View) => void
     smartApplyEnabled?: boolean
+    experimentalOneBoxEnabled?: boolean
+    isUnifiedPromptsAvailable?: boolean
 }
 
 export const Chat: React.FunctionComponent<React.PropsWithChildren<ChatboxProps>> = ({
@@ -46,6 +48,8 @@ export const Chat: React.FunctionComponent<React.PropsWithChildren<ChatboxProps>
     showIDESnippetActions = true,
     setView,
     smartApplyEnabled,
+    experimentalOneBoxEnabled,
+    isUnifiedPromptsAvailable,
 }) => {
     const telemetryRecorder = useTelemetryRecorder()
 
@@ -233,7 +237,11 @@ export const Chat: React.FunctionComponent<React.PropsWithChildren<ChatboxProps>
                 smartApplyEnabled={smartApplyEnabled}
             />
             {transcript.length === 0 && showWelcomeMessage && (
-                <WelcomeMessage IDE={userInfo.ide} setView={setView} />
+                <WelcomeMessage
+                    IDE={userInfo.ide}
+                    setView={setView}
+                    isUnifiedPromptsAvailable={isUnifiedPromptsAvailable}
+                />
             )}
             {scrollableParent && (
                 <ScrollDown scrollableParent={scrollableParent} onClick={handleScrollDownClick} />

--- a/vscode/webviews/Chat.tsx
+++ b/vscode/webviews/Chat.tsx
@@ -32,7 +32,6 @@ interface ChatboxProps {
     showIDESnippetActions?: boolean
     setView: (view: View) => void
     smartApplyEnabled?: boolean
-    experimentalOneBoxEnabled?: boolean
     isUnifiedPromptsAvailable?: boolean
 }
 
@@ -48,7 +47,6 @@ export const Chat: React.FunctionComponent<React.PropsWithChildren<ChatboxProps>
     showIDESnippetActions = true,
     setView,
     smartApplyEnabled,
-    experimentalOneBoxEnabled,
     isUnifiedPromptsAvailable,
 }) => {
     const telemetryRecorder = useTelemetryRecorder()

--- a/vscode/webviews/CodyPanel.tsx
+++ b/vscode/webviews/CodyPanel.tsx
@@ -95,7 +95,6 @@ export const CodyPanel: FunctionComponent<
                         showWelcomeMessage={showWelcomeMessage}
                         scrollableParent={tabContainerRef.current}
                         smartApplyEnabled={smartApplyEnabled}
-                        experimentalOneBoxEnabled={experimentalOneBoxEnabled}
                         isUnifiedPromptsAvailable={config.unifiedPromptsAvailable}
                         setView={setView}
                     />

--- a/vscode/webviews/CodyPanel.tsx
+++ b/vscode/webviews/CodyPanel.tsx
@@ -77,6 +77,7 @@ export const CodyPanel: FunctionComponent<
                     currentView={view}
                     setView={setView}
                     IDE={config.agentIDE || CodyIDE.VSCode}
+                    isUnifiedPromptsAvailable={config.unifiedPromptsAvailable}
                     onDownloadChatClick={onDownloadChatClick}
                 />
             )}
@@ -94,6 +95,8 @@ export const CodyPanel: FunctionComponent<
                         showWelcomeMessage={showWelcomeMessage}
                         scrollableParent={tabContainerRef.current}
                         smartApplyEnabled={smartApplyEnabled}
+                        experimentalOneBoxEnabled={experimentalOneBoxEnabled}
+                        isUnifiedPromptsAvailable={config.unifiedPromptsAvailable}
                         setView={setView}
                     />
                 )}

--- a/vscode/webviews/chat/cells/contextCell/ContextCell.tsx
+++ b/vscode/webviews/chat/cells/contextCell/ContextCell.tsx
@@ -109,7 +109,7 @@ export const ContextCell: FunctionComponent<{
         return contextItemsToDisplay === undefined || contextItemsToDisplay.length !== 0 ? (
             <Accordion
                 type="single"
-                collapsible
+                collapsible={!showSnippets}
                 defaultValue={((__storybook__initialOpen || defaultOpen) && 'item-1') || undefined}
                 asChild={true}
             >
@@ -142,7 +142,7 @@ export const ContextCell: FunctionComponent<{
                             <LoadingDots />
                         ) : (
                             <>
-                                <AccordionContent>
+                                <AccordionContent overflow={showSnippets}>
                                     {internalDebugContext && contextAlternatives && (
                                         <div>
                                             <button onClick={prevSelectedAlternative} type="button">

--- a/vscode/webviews/chat/cells/messageCell/human/editor/HumanMessageEditor.tsx
+++ b/vscode/webviews/chat/cells/messageCell/human/editor/HumanMessageEditor.tsx
@@ -228,13 +228,6 @@ export const HumanMessageEditor: FunctionComponent<{
         [onGapClick]
     )
 
-    const appendTextToEditor = useCallback((text: string): void => {
-        if (!editorRef.current) {
-            throw new Error('No editorRef')
-        }
-        editorRef.current.appendText(text)
-    }, [])
-
     const onMentionClick = useCallback((): void => {
         if (!editorRef.current) {
             throw new Error('No editorRef')
@@ -373,7 +366,6 @@ export const HumanMessageEditor: FunctionComponent<{
                     submitState={submitState}
                     onGapClick={onGapClick}
                     focusEditor={focusEditor}
-                    appendTextToEditor={appendTextToEditor}
                     hidden={!focused && isSent}
                     className={styles.toolbar}
                 />

--- a/vscode/webviews/chat/cells/messageCell/human/editor/toolbar/Toolbar.tsx
+++ b/vscode/webviews/chat/cells/messageCell/human/editor/toolbar/Toolbar.tsx
@@ -3,9 +3,11 @@ import { useExtensionAPI, useObservable } from '@sourcegraph/prompt-editor'
 import clsx from 'clsx'
 import { type FunctionComponent, useCallback, useMemo } from 'react'
 import type { UserAccountInfo } from '../../../../../../Chat'
+import { useClientActionDispatcher } from '../../../../../../client/clientState'
 import { ModelSelectField } from '../../../../../../components/modelSelectField/ModelSelectField'
 import type { PromptOrDeprecatedCommand } from '../../../../../../components/promptList/PromptList'
 import { PromptSelectField } from '../../../../../../components/promptSelectField/PromptSelectField'
+import { onPromptSelectInPanel } from '../../../../../../prompts/PromptsTab'
 import { useConfig } from '../../../../../../utils/useConfig'
 import { AddContextButton } from './AddContextButton'
 import { SubmitButton, type SubmitButtonState } from './SubmitButton'
@@ -27,7 +29,6 @@ export const Toolbar: FunctionComponent<{
     onGapClick?: () => void
 
     focusEditor?: () => void
-    appendTextToEditor: (text: string) => void
 
     hidden?: boolean
     className?: string
@@ -39,7 +40,6 @@ export const Toolbar: FunctionComponent<{
     submitState,
     onGapClick,
     focusEditor,
-    appendTextToEditor,
     hidden,
     className,
 }) => {
@@ -80,11 +80,7 @@ export const Toolbar: FunctionComponent<{
                         className="tw-opacity-60 focus-visible:tw-opacity-100 hover:tw-opacity-100 tw-mr-2"
                     />
                 )}
-                <PromptSelectFieldToolbarItem
-                    focusEditor={focusEditor}
-                    appendTextToEditor={appendTextToEditor}
-                    className="tw-ml-1 tw-mr-1"
-                />
+                <PromptSelectFieldToolbarItem focusEditor={focusEditor} className="tw-ml-1 tw-mr-1" />
                 <ModelSelectFieldToolbarItem
                     userInfo={userInfo}
                     focusEditor={focusEditor}
@@ -104,15 +100,16 @@ export const Toolbar: FunctionComponent<{
 
 const PromptSelectFieldToolbarItem: FunctionComponent<{
     focusEditor?: () => void
-    appendTextToEditor: (text: string) => void
     className?: string
-}> = ({ focusEditor, appendTextToEditor, className }) => {
+}> = ({ focusEditor, className }) => {
+    const dispatchClientAction = useClientActionDispatcher()
+
     const onSelect = useCallback(
         (item: PromptOrDeprecatedCommand) => {
-            appendTextToEditor(item.type === 'prompt' ? item.value.definition.text : item.value.prompt)
+            onPromptSelectInPanel(item, () => {}, dispatchClientAction)
             focusEditor?.()
         },
-        [appendTextToEditor, focusEditor]
+        [focusEditor, dispatchClientAction]
     )
 
     return <PromptSelectField onSelect={onSelect} onCloseByEscape={focusEditor} className={className} />

--- a/vscode/webviews/chat/components/WelcomeMessage.tsx
+++ b/vscode/webviews/chat/components/WelcomeMessage.tsx
@@ -56,7 +56,7 @@ export const WelcomeMessage: FunctionComponent<{ IDE: CodyIDE; setView: (view: V
         <div className="tw-flex-1 tw-flex tw-flex-col tw-items-start tw-w-full tw-px-6 tw-gap-6 tw-transition-all">
             <CollapsiblePanel
                 storageKey="prompts"
-                title="Prompts & Commands"
+                title="Prompts"
                 className="tw-mb-6"
                 contentClassName="!tw-p-0 tw-overflow-clip"
                 initialOpen={true}

--- a/vscode/webviews/chat/components/WelcomeMessage.tsx
+++ b/vscode/webviews/chat/components/WelcomeMessage.tsx
@@ -43,8 +43,15 @@ const FeatureRow: FunctionComponent<{
 
 const localStorageKey = 'chat.welcome-message-dismissed'
 
-export const WelcomeMessage: FunctionComponent<{ IDE: CodyIDE; setView: (view: View) => void }> = ({
+interface WelcomeMessageProps {
+    IDE: CodyIDE
+    isUnifiedPromptsAvailable?: boolean
+    setView: (view: View) => void
+}
+
+export const WelcomeMessage: FunctionComponent<WelcomeMessageProps> = ({
     IDE,
+    isUnifiedPromptsAvailable,
     setView,
 }) => {
     // Remove the old welcome message dismissal key that is no longer used.
@@ -56,7 +63,7 @@ export const WelcomeMessage: FunctionComponent<{ IDE: CodyIDE; setView: (view: V
         <div className="tw-flex-1 tw-flex tw-flex-col tw-items-start tw-w-full tw-px-6 tw-gap-6 tw-transition-all">
             <CollapsiblePanel
                 storageKey="prompts"
-                title="Prompts"
+                title={isUnifiedPromptsAvailable ? 'Prompts' : 'Prompts & Commands'}
                 className="tw-mb-6"
                 contentClassName="!tw-p-0 tw-overflow-clip"
                 initialOpen={true}

--- a/vscode/webviews/components/promptList/PromptList.tsx
+++ b/vscode/webviews/components/promptList/PromptList.tsx
@@ -72,12 +72,18 @@ export const PromptList: React.FunctionComponent<{
                           p => commandRowValue({ type: 'prompt', value: p }) === rowValue
                       )
                     : undefined
-            const codyCommand =
+
+            const standardPromptCommand =
                 prompt === undefined
-                    ? result?.commands?.find(
+                    ? result?.standardPrompts?.find(
                           c => commandRowValue({ type: 'command', value: c }) === rowValue
                       )
                     : undefined
+
+            const codyCommand =
+                standardPromptCommand ??
+                result?.commands?.find(c => commandRowValue({ type: 'command', value: c }) === rowValue)
+
             const entry: PromptOrDeprecatedCommand | undefined = prompt
                 ? { type: 'prompt', value: prompt }
                 : codyCommand
@@ -234,6 +240,19 @@ export const PromptList: React.FunctionComponent<{
                         {result.prompts.type === 'error' && (
                             <CommandLoading>Error: {result.prompts.error}</CommandLoading>
                         )}
+                    </CommandGroup>
+                )}
+                {!showOnlyPromptInsertableCommands && result?.standardPrompts && result.standardPrompts.length > 0 && (
+                    <CommandGroup heading={<span>Standard Prompts</span>}>
+                        {result.standardPrompts.map(command => (
+                            <CodyCommandItem
+                                key={command.key}
+                                command={command}
+                                onSelect={onSelect}
+                                selectActionLabel={onSelectActionLabels?.prompt}
+                                showCommandOrigins={false}
+                            />
+                        ))}
                     </CommandGroup>
                 )}
                 {result && filteredCommands && filteredCommands.length > 0 && (

--- a/vscode/webviews/components/promptList/PromptList.tsx
+++ b/vscode/webviews/components/promptList/PromptList.tsx
@@ -242,19 +242,21 @@ export const PromptList: React.FunctionComponent<{
                         )}
                     </CommandGroup>
                 )}
-                {!showOnlyPromptInsertableCommands && result?.standardPrompts && result.standardPrompts.length > 0 && (
-                    <CommandGroup heading={<span>Standard Prompts</span>}>
-                        {result.standardPrompts.map(command => (
-                            <CodyCommandItem
-                                key={command.key}
-                                command={command}
-                                onSelect={onSelect}
-                                selectActionLabel={onSelectActionLabels?.prompt}
-                                showCommandOrigins={false}
-                            />
-                        ))}
-                    </CommandGroup>
-                )}
+                {!showOnlyPromptInsertableCommands &&
+                    result?.standardPrompts &&
+                    result.standardPrompts.length > 0 && (
+                        <CommandGroup heading={<span>Standard Prompts</span>}>
+                            {result.standardPrompts.map(command => (
+                                <CodyCommandItem
+                                    key={command.key}
+                                    command={command}
+                                    onSelect={onSelect}
+                                    selectActionLabel={onSelectActionLabels?.prompt}
+                                    showCommandOrigins={false}
+                                />
+                            ))}
+                        </CommandGroup>
+                    )}
                 {result && filteredCommands && filteredCommands.length > 0 && (
                     <CommandGroup
                         heading={

--- a/vscode/webviews/components/shadcn/ui/accordion.tsx
+++ b/vscode/webviews/components/shadcn/ui/accordion.tsx
@@ -2,6 +2,7 @@ import * as AccordionPrimitive from '@radix-ui/react-accordion'
 import { ChevronRight } from 'lucide-react'
 import * as React from 'react'
 
+import { clsx } from 'clsx'
 import { cn } from '../utils'
 
 const Accordion = AccordionPrimitive.Root
@@ -34,13 +35,21 @@ const AccordionTrigger = React.forwardRef<
 ))
 AccordionTrigger.displayName = AccordionPrimitive.Trigger.displayName
 
+interface AccordionContentProps
+    extends React.ComponentPropsWithoutRef<typeof AccordionPrimitive.Content> {
+    overflow?: boolean
+}
+
 const AccordionContent = React.forwardRef<
     React.ElementRef<typeof AccordionPrimitive.Content>,
-    React.ComponentPropsWithoutRef<typeof AccordionPrimitive.Content>
->(({ className, children, ...props }, ref) => (
+    AccordionContentProps
+>(({ className, overflow, children, ...props }, ref) => (
     <AccordionPrimitive.Content
         ref={ref}
-        className="tw-transition-all data-[state=closed]:tw-animate-accordion-up data-[state=open]:tw-animate-accordion-down"
+        className={clsx(
+            'tw-transition-all data-[state=closed]:tw-animate-accordion-up data-[state=open]:tw-animate-accordion-down',
+            { 'tw-overflow-hidden': !overflow }
+        )}
         {...props}
     >
         <div className={className}>{children}</div>

--- a/vscode/webviews/prompts/PromptsTab.tsx
+++ b/vscode/webviews/prompts/PromptsTab.tsx
@@ -44,11 +44,18 @@ export function onPromptSelectInPanel(
             break
         }
         case 'command': {
-            getVSCodeAPI().postMessage({
-                command: 'command',
-                id: 'cody.action.command',
-                arg: item.value.key,
-            })
+            if (item.value.slashCommand) {
+                getVSCodeAPI().postMessage({
+                    command: 'command',
+                    id: item.value.slashCommand,
+                })
+            } else {
+                getVSCodeAPI().postMessage({
+                    command: 'command',
+                    id: 'cody.action.command',
+                    arg: item.value.key,
+                })
+            }
             if (item.value.mode === 'ask' && item.value.type === 'default') {
                 // Chat response will show up in the same panel, so make the chat view visible.
                 setView(View.Chat)

--- a/vscode/webviews/tabs/TabsBar.tsx
+++ b/vscode/webviews/tabs/TabsBar.tsx
@@ -29,6 +29,7 @@ import { getCreateNewChatCommand } from './utils'
 interface TabsBarProps {
     IDE: CodyIDE
     currentView: View
+    isUnifiedPromptsAvailable: boolean
     setView: (view: View) => void
     onDownloadChatClick?: () => void
 }
@@ -62,8 +63,14 @@ interface TabConfig {
     subActions?: TabSubAction[]
 }
 
-export const TabsBar: React.FC<TabsBarProps> = ({ currentView, setView, IDE, onDownloadChatClick }) => {
-    const tabItems = useTabs({ IDE, onDownloadChatClick })
+export const TabsBar: React.FC<TabsBarProps> = ({
+    currentView,
+    isUnifiedPromptsAvailable,
+    setView,
+    IDE,
+    onDownloadChatClick,
+}) => {
+    const tabItems = useTabs({ IDE, isUnifiedPromptsAvailable, onDownloadChatClick })
     const {
         config: { webviewType, multipleWebviewsEnabled },
     } = useConfig()
@@ -310,8 +317,10 @@ TabButton.displayName = 'TabButton'
  * Returns list of tabs and its sub-action buttons, used later as configuration for
  * tabs rendering in chat header.
  */
-function useTabs(input: Pick<TabsBarProps, 'IDE' | 'onDownloadChatClick'>): TabConfig[] {
-    const { IDE, onDownloadChatClick } = input
+function useTabs(
+    input: Pick<TabsBarProps, 'IDE' | 'isUnifiedPromptsAvailable' | 'onDownloadChatClick'>
+): TabConfig[] {
+    const { isUnifiedPromptsAvailable, IDE, onDownloadChatClick } = input
     const {
         config: { multipleWebviewsEnabled },
     } = useConfig()
@@ -365,7 +374,10 @@ function useTabs(input: Pick<TabsBarProps, 'IDE' | 'onDownloadChatClick'>): TabC
                     },
                     {
                         view: View.Prompts,
-                        title: IDE === CodyIDE.Web ? 'Prompts' : 'Prompts & Commands',
+                        title:
+                            IDE === CodyIDE.Web || isUnifiedPromptsAvailable
+                                ? 'Prompts'
+                                : 'Prompts & Commands',
                         Icon: BookTextIcon,
                         changesView: true,
                     },
@@ -388,6 +400,6 @@ function useTabs(input: Pick<TabsBarProps, 'IDE' | 'onDownloadChatClick'>): TabC
                         : null,
                 ] as (TabConfig | null)[]
             ).filter(isDefined),
-        [IDE, onDownloadChatClick, multipleWebviewsEnabled]
+        [IDE, onDownloadChatClick, multipleWebviewsEnabled, isUnifiedPromptsAvailable]
     )
 }


### PR DESCRIPTION
Main Linear issue [SRCH-1052](https://linear.app/sourcegraph/issue/SRCH-1052/get-rid-of-out-of-the-box-commands-for-walmart-parent-task)
Closes [SRCH-1064](https://linear.app/sourcegraph/issue/SRCH-1064/automatically-create-ootb-prompts-for-plg-new-enterprise-prospects)
Closes [SRCH-1049](https://linear.app/sourcegraph/issue/SRCH-1049/kill-all-out-of-the-box-commands-put-behind-a-feature-flag-for-walmart)
Closes [SRCH-1050](https://linear.app/sourcegraph/issue/SRCH-1050/create-prompts-that-replace-todays-commands-and-automatically-load)

So this PR does a few things with prompts and commands (I recorded a loom with changes walkthrough [here](https://www.loom.com/share/fb8c8e18d34847eca248d9e0f729d59f))

- First of all, all changes in this PR are behind the feature flag `cody-unified-prompts` (I enabled it on s2 so the change will be available to you if you're connected to s2, if not, go to your instance, go to feature flags in site admin and create boolean feature flag `cody-unified-prompts`)

- If you enable this feature flag, you will see that standard commands become prompts and work as prompts now
   - Explain code just fills out the text box in the search 
   - Documentation code still works with selection but it also now works through chat 
   - Find smell and unit test generation as well as work through chat now

- Despite [SRCH-1049](https://linear.app/sourcegraph/issue/SRCH-1049/kill-all-out-of-the-box-commands-put-behind-a-feature-flag-for-walmart) You still can see these prompts in the context menu, originally we wanted to completely delete them for Walmart but since these commands now work as prompts we can keep them in sub-menus
   - But now out of box commands were renamed in Standard Prompts
   - The custom commands menu is hidden now if the feature flag is on 
   
- Keyboard shortcuts for commands-prompts like "Documentation" still work but it opens a new chat and fills out the textbox with a prompt about documentation 

## Tech note
Even though I called them "standard prompts," they still work on command rails from a tech point of view. However, having them as standard prompts requires a bit more work. It's a bit unclear how to properly get the current selection and current file (and in general context) to generate a proper text message. I think we will just use the same thing as we do with standard mentions but will try to find a less manual approach

## Test plan 
@chenkc805 @aramaraju detailed instruction if you want to check it locally https://www.loom.com/share/fb8c8e18d34847eca248d9e0f729d59f
 
- Open VSCode on this PR branch 
- Click the "Run and Debug" tabs in the left navigation panel 
- Click "Start debugging", this will open yet another VSCode instance with built local Cody extension 
- After this make sure that you're connected to S2, 
- All standard prompts like code documentation, or explain code,..etc should work as prompts 

