### PR TITLE
Onebox: don't reference "vscode" for generic setting

### DIFF
--- a/vscode/src/chat/chat-view/ChatController.ts
+++ b/vscode/src/chat/chat-view/ChatController.ts
@@ -869,7 +869,7 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
         this.chatModel.setLastMessageContext(context, contextAlternatives)
         this.chatModel.addBotMessage({
             text: PromptString.unsafe_fromLLMResponse(
-                'You have set `"cody.internal.onebox": true` in your vscode settings.'
+                'You have set `"cody.internal.onebox": true` in your settings.'
             ),
         })
 


### PR DESCRIPTION
Previously, we displayed a user-facing message that referred to "vscode settings" when the setting is available to all IDEs, not only VS Code. This PR removes the unnecessary mention of VS Code in the message.

Reported in https://sourcegraph.slack.com/archives/C05MW2TMYAV/p1726608135321689


## Test plan
n/a
<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
