### PR TITLE
Simplify artificial delay logic and remove user-based latency

### DIFF
--- a/lib/shared/src/experimentation/FeatureFlagProvider.ts
+++ b/lib/shared/src/experimentation/FeatureFlagProvider.ts
@@ -45,8 +45,6 @@ export enum FeatureFlag {
     CodyAutocompleteDisableLowPerfLangDelay = 'cody-autocomplete-disable-low-perf-lang-delay',
     // Enables Claude 3 if the user is in our holdout group
     CodyAutocompleteClaude3 = 'cody-autocomplete-claude-3',
-    // Enable latency adjustments based on accept/reject streaks
-    CodyAutocompleteUserLatency = 'cody-autocomplete-user-latency',
 
     CodyAutocompletePreloadingExperimentBaseFeatureFlag = 'cody-autocomplete-preloading-experiment-flag',
     CodyAutocompletePreloadingExperimentVariant1 = 'cody-autocomplete-preloading-experiment-variant-1',

--- a/vscode/src/completions/artificial-delay.test.ts
+++ b/vscode/src/completions/artificial-delay.test.ts
@@ -1,293 +1,45 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-
-import { getArtificialDelay, lowPerformanceLanguageIds, resetArtificialDelay } from './artificial-delay'
-const featureFlags = {
-    user: true,
-}
+import { describe, expect, it } from 'vitest'
+import { getArtificialDelay, lowPerformanceConfig } from './artificial-delay'
 
 describe('getArtificialDelay', () => {
-    beforeEach(() => {
-        vi.useFakeTimers()
+    const testCases = [
+        { languageId: 'css', completionIntent: undefined, isLowPerf: true },
+        { languageId: 'css', completionIntent: 'comment', isLowPerf: true },
+        { languageId: 'go', completionIntent: 'comment', isLowPerf: true },
+        { languageId: 'go', completionIntent: undefined, isLowPerf: false },
+    ]
+
+    it('correctly identifies low performance configurations', () => {
+        for (const { languageId, completionIntent, isLowPerf } of testCases) {
+            const isLowPerfLang = lowPerformanceConfig.languageIds.has(languageId)
+            const isLowPerfIntent = completionIntent
+                ? lowPerformanceConfig.completionIntents.has(completionIntent as string)
+                : false
+            expect(isLowPerfLang || isLowPerfIntent).toBe(isLowPerf)
+        }
     })
 
-    afterEach(() => {
-        vi.restoreAllMocks()
-        resetArtificialDelay()
-    })
-
-    it('returns no artificial delay when codyAutocompleteDisableLowPerfLangDelay is true for a low performance language', () => {
-        const uri = 'file://foo/bar/test.css'
-        // css is a low performance language
-        const languageId = 'css'
-        expect(lowPerformanceLanguageIds.has(languageId)).toBe(true)
-        const params = {
-            featureFlags,
-            uri,
-            languageId,
-            codyAutocompleteDisableLowPerfLangDelay: true,
+    it.each(testCases)(
+        'returns correct delay based on configuration when codyAutocompleteDisableLowPerfLangDelay is false',
+        ({ languageId, completionIntent, isLowPerf }) => {
+            const params = {
+                languageId,
+                completionIntent: completionIntent as 'comment' | undefined,
+                codyAutocompleteDisableLowPerfLangDelay: false,
+            }
+            expect(getArtificialDelay(params)).toBe(isLowPerf ? 1000 : 0)
         }
+    )
 
-        // expect no artificial delay when codyAutocompleteDisableLowPerfLangDelay is true
-        expect(getArtificialDelay(params)).toBe(0)
-    })
-
-    it('returns gradually increasing latency up to max for CSS when suggestions are rejected', () => {
-        const uri = 'file://foo/bar/test.css'
-
-        // css is a low performance language
-        const languageId = 'css'
-        expect(lowPerformanceLanguageIds.has(languageId)).toBe(true)
-        const codyAutocompleteDisableLowPerfLangDelay = false
-        const params = {
-            featureFlags,
-            uri,
-            languageId,
-            codyAutocompleteDisableLowPerfLangDelay,
+    it.each(testCases)(
+        'returns no delay when codyAutocompleteDisableLowPerfLangDelay is true',
+        ({ languageId, completionIntent }) => {
+            const params = {
+                languageId,
+                completionIntent: completionIntent as 'comment' | undefined,
+                codyAutocompleteDisableLowPerfLangDelay: true,
+            }
+            expect(getArtificialDelay(params)).toBe(0)
         }
-        // start with default high latency for low performance lang with default user latency added
-        expect(getArtificialDelay(params)).toBe(1000)
-        expect(getArtificialDelay(params)).toBe(1000)
-        expect(getArtificialDelay(params)).toBe(1000)
-        expect(getArtificialDelay(params)).toBe(1000)
-        expect(getArtificialDelay(params)).toBe(1000)
-        // start at default, but gradually increasing latency after 5 rejected suggestions
-        expect(getArtificialDelay(params)).toBe(1050)
-        expect(getArtificialDelay(params)).toBe(1100)
-        expect(getArtificialDelay(params)).toBe(1150)
-        expect(getArtificialDelay(params)).toBe(1200)
-        expect(getArtificialDelay(params)).toBe(1250)
-        expect(getArtificialDelay(params)).toBe(1300)
-        expect(getArtificialDelay(params)).toBe(1350)
-        expect(getArtificialDelay(params)).toBe(1400)
-        // max latency at 1400
-        expect(getArtificialDelay(params)).toBe(1400)
-        // after the suggestion was accepted, user latency resets to 0, using baseline only
-        resetArtificialDelay()
-        expect(getArtificialDelay(params)).toBe(1000)
-        resetArtificialDelay()
-        expect(getArtificialDelay(params)).toBe(1000)
-        expect(getArtificialDelay(params)).toBe(1000)
-        expect(getArtificialDelay(params)).toBe(1000)
-        expect(getArtificialDelay(params)).toBe(1000)
-        expect(getArtificialDelay(params)).toBe(1000)
-        // gradually increasing latency after 5 rejected suggestions
-        expect(getArtificialDelay(params)).toBe(1050)
-        expect(getArtificialDelay(params)).toBe(1100)
-        expect(getArtificialDelay(params)).toBe(1150)
-        expect(getArtificialDelay(params)).toBe(1200)
-        expect(getArtificialDelay(params)).toBe(1250)
-        expect(getArtificialDelay(params)).toBe(1300)
-        expect(getArtificialDelay(params)).toBe(1350)
-        expect(getArtificialDelay(params)).toBe(1400)
-        // Latency will not reset before 5 minutes
-        vi.advanceTimersByTime(3 * 60 * 1000)
-        expect(getArtificialDelay(params)).toBe(1400)
-        // Latency will be reset after 5 minutes
-        vi.advanceTimersByTime(5 * 60 * 1000)
-        expect(getArtificialDelay(params)).toBe(1000)
-        // reset latency on accepted suggestion
-        resetArtificialDelay()
-        expect(getArtificialDelay(params)).toBe(1000)
-    })
-
-    it('returns increasing latency after rejecting suggestions', () => {
-        const uri = 'file://foo/bar/test.ts'
-
-        // Confirm typescript is not a low performance language
-        const languageId = 'typescript'
-        const codyAutocompleteDisableLowPerfLangDelay = false
-        expect(lowPerformanceLanguageIds.has(languageId)).toBe(codyAutocompleteDisableLowPerfLangDelay)
-        const params = {
-            featureFlags,
-            uri,
-            languageId,
-            codyAutocompleteDisableLowPerfLangDelay,
-        }
-
-        // start at default, but gradually increasing latency after 5 rejected suggestions
-        expect(
-            getArtificialDelay({
-                ...params,
-                completionIntent: 'arguments',
-            })
-        ).toBe(0)
-        expect(
-            getArtificialDelay({
-                ...params,
-                completionIntent: 'function.body',
-            })
-        ).toBe(0)
-        // baseline latency increased to 1000 due to comment node type
-        expect(
-            getArtificialDelay({
-                ...params,
-                completionIntent: 'comment',
-            })
-        ).toBe(1000)
-        expect(getArtificialDelay(params)).toBe(0)
-        expect(getArtificialDelay(params)).toBe(0)
-        // gradually increasing latency after 5 rejected suggestions
-        expect(getArtificialDelay(params)).toBe(50)
-        expect(getArtificialDelay(params)).toBe(100)
-        expect(getArtificialDelay(params)).toBe(150)
-        expect(getArtificialDelay(params)).toBe(200)
-        // after the suggestion was accepted, user latency resets to 0, using baseline only
-        resetArtificialDelay()
-        expect(getArtificialDelay(params)).toBe(0)
-    })
-
-    it('returns default latency for CSS after accepting suggestion and resets after 5 minutes', () => {
-        const uri = 'file://foo/bar/test.css'
-
-        // css is a low performance language
-        const languageId = 'css'
-        expect(lowPerformanceLanguageIds.has(languageId)).toBe(true)
-        const codyAutocompleteDisableLowPerfLangDelay = false
-        const params = {
-            featureFlags,
-            uri,
-            languageId,
-            codyAutocompleteDisableLowPerfLangDelay,
-        }
-        // start with default baseline latency for low performance lang
-        expect(getArtificialDelay(params)).toBe(1000)
-        // reset to starting point on every accepted suggestion
-        resetArtificialDelay()
-        expect(getArtificialDelay(params)).toBe(1000)
-        resetArtificialDelay()
-        expect(getArtificialDelay(params)).toBe(1000)
-        expect(getArtificialDelay(params)).toBe(1000)
-        // Latency will not reset before 5 minutes
-        vi.advanceTimersByTime(3 * 60 * 1000)
-        expect(getArtificialDelay(params)).toBe(1000)
-        expect(getArtificialDelay(params)).toBe(1000)
-        expect(getArtificialDelay(params)).toBe(1000)
-        expect(getArtificialDelay(params)).toBe(1050)
-        // Latency will be reset after 5 minutes
-        vi.advanceTimersByTime(5 * 60 * 1000)
-        expect(getArtificialDelay(params)).toBe(1000)
-    })
-
-    it('returns increasing latency up to max after rejecting multiple suggestions, resets after file change and accept', () => {
-        const uri = 'file://foo/bar/test.ts'
-        const languageId = 'typescript'
-        const codyAutocompleteDisableLowPerfLangDelay = false
-        expect(lowPerformanceLanguageIds.has(languageId)).toBe(codyAutocompleteDisableLowPerfLangDelay)
-        const params = {
-            featureFlags,
-            uri,
-            languageId,
-            codyAutocompleteDisableLowPerfLangDelay,
-        }
-        // reject the first 5 suggestions, and confirm latency remains unchanged
-        expect(getArtificialDelay(params)).toBe(0)
-        expect(getArtificialDelay(params)).toBe(0)
-        expect(getArtificialDelay(params)).toBe(0)
-        expect(getArtificialDelay(params)).toBe(0)
-        expect(getArtificialDelay(params)).toBe(0)
-        // latency should start increasing after 5 rejections, but max at 1400
-        expect(getArtificialDelay(params)).toBe(50)
-        // line is a comment, so latency should be increased where:
-        // base is 1000 due to line is a comment, and user latency is 400 as this is the 7th rejection
-        expect(getArtificialDelay({ ...params, completionIntent: 'comment' })).toBe(1100)
-        for (let i = 150; i <= 1400; i += 50) {
-            expect(getArtificialDelay(params)).toBe(i)
-        }
-        // max at 1400 after multiple rejection
-        expect(getArtificialDelay(params)).toBe(1400)
-
-        // reset latency on file change to default
-        const newUri = 'foo/test.ts'
-        // latency should start increasing again after 5 rejections
-        expect(getArtificialDelay({ ...params, uri: newUri })).toBe(0)
-        expect(getArtificialDelay({ ...params, uri: newUri })).toBe(0)
-        // line is a comment, so latency should be increased
-        expect(getArtificialDelay({ ...params, uri: newUri, completionIntent: 'comment' })).toBe(1000)
-        expect(getArtificialDelay({ ...params, uri: newUri })).toBe(0)
-        expect(getArtificialDelay({ ...params, uri: newUri })).toBe(0)
-        // Latency will not reset before 5 minutes
-        vi.advanceTimersByTime(3 * 60 * 1000)
-        expect(getArtificialDelay({ ...params, uri: newUri })).toBe(50)
-        // reset latency on accepted suggestion
-        resetArtificialDelay()
-        expect(getArtificialDelay({ ...params, uri: newUri })).toBe(0)
-    })
-
-    it('returns default latency for low performance language only when only language flag is enabled', () => {
-        const uri = 'file://foo/bar/test.css'
-        const codyAutocompleteDisableLowPerfLangDelay = false
-
-        const featureFlagsLangOnly = {
-            user: false,
-        }
-
-        // css is a low performance language
-        const lowPerformLanguageId = 'css'
-        expect(lowPerformanceLanguageIds.has(lowPerformLanguageId)).toBe(true)
-
-        // go is not a low performance language
-        const languageId = 'go'
-        const goUri = 'foo/bar/test.go'
-        expect(lowPerformanceLanguageIds.has(languageId)).toBe(codyAutocompleteDisableLowPerfLangDelay)
-
-        const params = {
-            featureFlags: featureFlagsLangOnly,
-            uri,
-            languageId,
-            codyAutocompleteDisableLowPerfLangDelay,
-        }
-        // latency should only change based on language id when only the language flag is enabled
-        expect(getArtificialDelay({ ...params, languageId: lowPerformLanguageId })).toBe(1000)
-        expect(getArtificialDelay({ ...params, languageId: lowPerformLanguageId })).toBe(1000)
-        expect(getArtificialDelay({ ...params, languageId: lowPerformLanguageId })).toBe(1000)
-        expect(getArtificialDelay({ ...params, languageId: lowPerformLanguageId })).toBe(1000)
-        expect(getArtificialDelay({ ...params, languageId: lowPerformLanguageId })).toBe(1000)
-        expect(getArtificialDelay({ ...params, languageId: lowPerformLanguageId })).toBe(1000)
-        // latency back to 0 when language is no longer low-performance
-        expect(getArtificialDelay({ ...params, uri: goUri, languageId })).toBe(0)
-    })
-
-    it('returns latency based on language only when user flag is disabled', () => {
-        const uri = 'file://foo/bar/test.css'
-
-        // css is a low performance language
-        const languageId = 'css'
-        const codyAutocompleteDisableLowPerfLangDelay = false
-        expect(lowPerformanceLanguageIds.has(languageId)).toBe(true)
-
-        const featureFlagsNoUser = {
-            user: false,
-        }
-
-        const params = {
-            featureFlags: featureFlagsNoUser,
-            uri,
-            languageId,
-            codyAutocompleteDisableLowPerfLangDelay,
-        }
-
-        // latency starts with language latency
-        expect(getArtificialDelay(params)).toBe(1000)
-        expect(getArtificialDelay(params)).toBe(1000)
-        expect(getArtificialDelay(params)).toBe(1000)
-        expect(getArtificialDelay(params)).toBe(1000)
-        expect(getArtificialDelay(params)).toBe(1000)
-        // latency should remains unchanged after 5 rejections
-        expect(getArtificialDelay(params)).toBe(1000)
-        expect(getArtificialDelay(params)).toBe(1000)
-        expect(getArtificialDelay(params)).toBe(1000)
-
-        // switch to a non-low-performance language - go is not a low performance language
-        const goLanguageId = 'go'
-        const goUri = 'foo/bar/test.go'
-        expect(lowPerformanceLanguageIds.has(goLanguageId)).toBe(codyAutocompleteDisableLowPerfLangDelay)
-        // reset to provider latency because language latency is ignored for non-low-performance languages
-        const goParams = {
-            featureFlags: featureFlagsNoUser,
-            uri: goUri,
-            languageId: goLanguageId,
-            codyAutocompleteDisableLowPerfLangDelay,
-        }
-        expect(getArtificialDelay(goParams)).toBe(0)
-    })
+    )
 })

--- a/vscode/src/completions/artificial-delay.ts
+++ b/vscode/src/completions/artificial-delay.ts
@@ -1,116 +1,49 @@
 import { logDebug } from '../log'
 import type { CompletionIntent } from '../tree-sitter/queries'
-export interface LatencyFeatureFlags {
-    user?: boolean
-}
 
-const defaultLatencies = {
-    user: 50,
-    lowPerformance: 1000,
-    max: 1400,
-}
-
-// Languages with lower performance get additional latency to avoid spamming users with unhelpful
-// suggestions
-export const lowPerformanceLanguageIds = new Set([
-    'css',
-    'html',
-    'scss',
-    'vue',
-    'dart',
-    'json',
-    'yaml',
-    'postcss',
-    'markdown',
-    'plaintext',
-    'xml',
-    'twig',
-    'jsonc',
-    'handlebars',
-])
-
-const lowPerformanceCompletionIntents = new Set(['comment', 'import.source'])
-
-let userMetrics = {
-    sessionTimestamp: 0,
-    currentLatency: 0,
-    suggested: 0,
-    uri: '',
+export const lowPerformanceConfig = {
+    languageIds: new Set([
+        'css',
+        'html',
+        'scss',
+        'vue',
+        'dart',
+        'json',
+        'yaml',
+        'postcss',
+        'markdown',
+        'plaintext',
+        'xml',
+        'twig',
+        'jsonc',
+        'handlebars',
+    ]),
+    completionIntents: new Set(['comment', 'import.source']),
 }
 
 /**
- * Calculates the artificial delay to be added to code completion suggestions based on various factors.
- *
- * The delay is calculated based on the following:
- * - A baseline delay for low-performance languages or completion intents
- * - The user's current latency, which increases linearly up to a maximum after 5 rejected suggestions
- * - The session timestamp, which is reset every 5 minutes or on file change
- *
- * The function returns the total delay to be added, which is capped at a maximum value.
+ * Calculates the artificial delay to apply to code completions based on the language ID and completion intent.
+ * The function adds a baseline latency for low-performance languages or low-performance completion intents,
+ * unless the user has enabled the flag that stops this behavior.
  */
-export function getArtificialDelay(params: {
-    featureFlags: LatencyFeatureFlags
-    uri: string
+export function getArtificialDelay({
+    languageId,
+    codyAutocompleteDisableLowPerfLangDelay,
+    completionIntent,
+}: {
     languageId: string
     codyAutocompleteDisableLowPerfLangDelay: boolean
     completionIntent?: CompletionIntent
 }): number {
-    const { featureFlags, uri, languageId, codyAutocompleteDisableLowPerfLangDelay, completionIntent } =
-        params
+    const isLowPerformance =
+        lowPerformanceConfig.languageIds.has(languageId) ||
+        (completionIntent ? lowPerformanceConfig.completionIntents.has(completionIntent) : false)
 
-    let baseline = 0
+    const latency = !codyAutocompleteDisableLowPerfLangDelay && isLowPerformance ? 1000 : 0
 
-    const isLowPerformanceLanguageId = lowPerformanceLanguageIds.has(languageId)
-    const isLowPerformanceCompletionIntent =
-        completionIntent && lowPerformanceCompletionIntents.has(completionIntent)
-    // Add a baseline latency for low performance languages
-    if (isLowPerformanceLanguageId || isLowPerformanceCompletionIntent) {
-        // if user has disabled low performace language delay, then don't add latency
-        if (!codyAutocompleteDisableLowPerfLangDelay) {
-            baseline = defaultLatencies.lowPerformance
-        }
+    if (latency > 0) {
+        logDebug('AutocompleteProvider:getLatency', `Delay added: ${latency}`)
     }
 
-    const timestamp = Date.now()
-    if (!userMetrics.sessionTimestamp) {
-        userMetrics.sessionTimestamp = timestamp
-    }
-
-    const elapsed = timestamp - userMetrics.sessionTimestamp
-    // reset metrics and timer after 5 minutes or file change
-    if (elapsed >= 5 * 60 * 1000 || userMetrics.uri !== uri) {
-        resetArtificialDelay(timestamp)
-    }
-
-    userMetrics.suggested++
-    userMetrics.uri = uri
-
-    const total = Math.max(
-        baseline,
-        Math.min(baseline + userMetrics.currentLatency, defaultLatencies.max)
-    )
-
-    // Increase latency linearly up to max after 5 rejected suggestions
-    if (userMetrics.suggested >= 5 && userMetrics.currentLatency < defaultLatencies.max) {
-        userMetrics.currentLatency += featureFlags.user ? defaultLatencies.user : 0
-    }
-
-    if (total > 0) {
-        logDebug('AutocompleteProvider:getLatency', `Delay added: ${total}`)
-    }
-
-    return total
-}
-
-// reset user latency and counter:
-// - on acceptance
-// - every 5 minutes
-// - on file change
-export function resetArtificialDelay(timestamp = 0): void {
-    userMetrics = {
-        sessionTimestamp: timestamp,
-        currentLatency: 0,
-        suggested: 0,
-        uri: '',
-    }
+    return latency
 }

--- a/vscode/src/completions/inline-completion-item-provider.ts
+++ b/vscode/src/completions/inline-completion-item-provider.ts
@@ -22,7 +22,7 @@ import { type CodyIgnoreType, showCodyIgnoreNotification } from '../cody-ignore/
 import { autocompleteStageCounterLogger } from '../services/autocomplete-stage-counter-logger'
 import { recordExposedExperimentsToSpan } from '../services/open-telemetry/utils'
 import { isInTutorial } from '../tutorial/helpers'
-import { type LatencyFeatureFlags, getArtificialDelay, resetArtificialDelay } from './artificial-delay'
+import { getArtificialDelay } from './artificial-delay'
 import { completionProviderConfig } from './completion-provider-config'
 import { ContextMixer } from './context/context-mixer'
 import { DefaultContextStrategyFactory } from './context/context-strategy'
@@ -452,14 +452,7 @@ export class InlineCompletionItemProvider
                 return null
             }
 
-            const latencyFeatureFlags: LatencyFeatureFlags = {
-                user: await featureFlagProvider.evaluateFeatureFlagEphemerally(
-                    FeatureFlag.CodyAutocompleteUserLatency
-                ),
-            }
             const artificialDelay = getArtificialDelay({
-                featureFlags: latencyFeatureFlags,
-                uri: document.uri.toString(),
                 languageId: document.languageId,
                 codyAutocompleteDisableLowPerfLangDelay: this.disableLowPerfLangDelay,
                 completionIntent,
@@ -693,8 +686,6 @@ export class InlineCompletionItemProvider
         if (this.config.formatOnAccept && !this.config.isRunningInsideAgent) {
             await formatCompletion(completion as AutocompleteItem)
         }
-
-        resetArtificialDelay()
 
         // When a completion is accepted, the lastCandidate should be cleared. This makes sure the
         // log id is never reused if the completion is accepted.


### PR DESCRIPTION
Solves [Linear Issue](https://linear.app/sourcegraph/issue/CODY-3759/remove-codyautocompleteuserlatency-feature-flag)

## History: 
When working on the Removal of Artificial Latency [behind a feature flag](https://github.com/sourcegraph/cody/pull/5480)  Valery said FeatureFlag.CodyAutocompleteUserLatency feature flag and all the related logic is not used anymore and plan on conducting [no further experiments with it](https://github.com/sourcegraph/cody/pull/5480#discussion_r1762175835). So I removed that and a lot of related logic that made this function and its tests very intricate. 


### This PR does 
- Remove user-based latency adjustments and related feature flag
- Simplify getArtificialDelay function to only consider language and completion intent
- Update lowPerformanceConfig to include both language IDs and completion intents
- Remove resetArtificialDelay function and related calls(This function would reset User based latency for when completions were rejected. This stuff is not relevant after the removal of the feature flag)
- Update tests to reflect new simplified logic
- Remove unused LatencyFeatureFlags interface and related parameters



## Test plan
Added new tests and made the logic very clean and self explainatory.

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
