### PR TITLE
Chat: prevent Claude 3.5 Sonnet model from apologizing constantly

### DIFF
--- a/lib/shared/src/prompt/prompt-mixin.ts
+++ b/lib/shared/src/prompt/prompt-mixin.ts
@@ -29,7 +29,8 @@ export class PromptMixin {
             ps`\n\n`
         )
 
-        if (modelID.includes('claude-3-5-sonnet')) {
+        // Add prompt that prevents Claude 3.5 Sonnet from apologizing constantly.
+        if (modelID.includes('3-5-sonnet') || modelID.includes('3.5-sonnet')) {
             mixins = mixins.concat(HEDGES_PREVENTION)
         }
 


### PR DESCRIPTION
This change adds a prompt that prevents the Claude 3.5 Sonnet model from constantly apologizing. Currently we are adding this prompt to model ID that matches claude-3-5-sonnet; However, the server side config on S2 is using claude-3.5-sonnet as the model ID, causing this check to fail.

The prompt now applies to model when the model ID contains '3.5-sonnet' or '3-5-sonnet'.

## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

Connect to S2 and open the Output channel to confirm the chat Model id is showing up as `sourcegraph/claude-3.5-sonnet`:

```
█ CodyLLMConfiguration: {"chatModel":"sourcegraph/claude-3.5-sonnet"}
```

Ask Cody a question and confirm the heading prompt is attached to your question when checking the transcript in the Output channel.

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
