### PR TITLE
Refactor onebox experimental flag

### DIFF
--- a/lib/shared/src/misc/rpc/webviewAPI.ts
+++ b/lib/shared/src/misc/rpc/webviewAPI.ts
@@ -2,7 +2,7 @@ import type { Observable } from 'observable-fns'
 import type { ChatMessage } from '../../chat/transcript/messages'
 import type { ContextItem } from '../../codebase-context/messages'
 import type { CodyCommand } from '../../commands/types'
-import type { FeatureFlag } from '../../experimentation/FeatureFlagProvider'
+import { FeatureFlag } from '../../experimentation/FeatureFlagProvider'
 import type { ContextMentionProviderMetadata } from '../../mentions/api'
 import type { MentionQuery } from '../../mentions/query'
 import type { Model } from '../../models/model'
@@ -93,5 +93,7 @@ export interface PromptsResult {
  * explicitly requested feature flags are evaluated immediately. If you don't add one here, its old
  * value will be cached on the server and returned until it is explicitly evaluated.
  */
-const FEATURE_FLAGS_USED_IN_WEBVIEW = [] as const satisfies FeatureFlag[]
+const FEATURE_FLAGS_USED_IN_WEBVIEW = [
+    FeatureFlag.CodyExperimentalOneBox,
+] as const satisfies FeatureFlag[]
 export type FeatureFlagUsedInWebview = (typeof FEATURE_FLAGS_USED_IN_WEBVIEW)[number]

--- a/vscode/src/chat/protocol.ts
+++ b/vscode/src/chat/protocol.ts
@@ -279,7 +279,6 @@ export interface ConfigurationSubsetForWebview
         >,
         Pick<AuthCredentials, 'serverEndpoint'> {
     smartApply: boolean
-    experimentalOneBox: boolean
     // Type/location of the current webview.
     webviewType?: WebviewType | undefined | null
     // Whether support running multiple webviews (e.g. sidebar w/ multiple editor panels).

--- a/vscode/webviews/App.story.tsx
+++ b/vscode/webviews/App.story.tsx
@@ -27,7 +27,6 @@ const dummyVSCodeAPI: VSCodeWrapper = {
                 uiKindIsWeb: false,
                 experimentalNoodle: false,
                 smartApply: false,
-                experimentalOneBox: false,
             },
             authStatus: {
                 ...AUTH_STATUS_FIXTURE_AUTHED,

--- a/vscode/webviews/App.tsx
+++ b/vscode/webviews/App.tsx
@@ -223,7 +223,6 @@ export const App: React.FunctionComponent<{ vscodeAPI: VSCodeWrapper }> = ({ vsc
                     guardrails={guardrails}
                     userHistory={userHistory ?? []}
                     smartApplyEnabled={config.config.smartApply}
-                    experimentalOneBoxEnabled={config.config.experimentalOneBox}
                 />
             )}
         </ComposedWrappers>

--- a/vscode/webviews/Chat.tsx
+++ b/vscode/webviews/Chat.tsx
@@ -32,7 +32,6 @@ interface ChatboxProps {
     showIDESnippetActions?: boolean
     setView: (view: View) => void
     smartApplyEnabled?: boolean
-    experimentalOneBoxEnabled?: boolean
 }
 
 export const Chat: React.FunctionComponent<React.PropsWithChildren<ChatboxProps>> = ({
@@ -47,7 +46,6 @@ export const Chat: React.FunctionComponent<React.PropsWithChildren<ChatboxProps>
     showIDESnippetActions = true,
     setView,
     smartApplyEnabled,
-    experimentalOneBoxEnabled,
 }) => {
     const telemetryRecorder = useTelemetryRecorder()
 
@@ -233,7 +231,6 @@ export const Chat: React.FunctionComponent<React.PropsWithChildren<ChatboxProps>
                 postMessage={postMessage}
                 guardrails={guardrails}
                 smartApplyEnabled={smartApplyEnabled}
-                experimentalOneBoxEnabled={experimentalOneBoxEnabled}
             />
             {transcript.length === 0 && showWelcomeMessage && (
                 <WelcomeMessage IDE={userInfo.ide} setView={setView} />

--- a/vscode/webviews/CodyPanel.tsx
+++ b/vscode/webviews/CodyPanel.tsx
@@ -29,7 +29,6 @@ export const CodyPanel: FunctionComponent<
         | 'showWelcomeMessage'
         | 'showIDESnippetActions'
         | 'smartApplyEnabled'
-        | 'experimentalOneBoxEnabled'
     > &
         Pick<ComponentProps<typeof HistoryTab>, 'userHistory'>
 > = ({
@@ -49,7 +48,6 @@ export const CodyPanel: FunctionComponent<
     showWelcomeMessage,
     userHistory,
     smartApplyEnabled,
-    experimentalOneBoxEnabled,
 }) => {
     const tabContainerRef = useRef<HTMLDivElement>(null)
 
@@ -96,7 +94,6 @@ export const CodyPanel: FunctionComponent<
                         showWelcomeMessage={showWelcomeMessage}
                         scrollableParent={tabContainerRef.current}
                         smartApplyEnabled={smartApplyEnabled}
-                        experimentalOneBoxEnabled={experimentalOneBoxEnabled}
                         setView={setView}
                     />
                 )}

--- a/vscode/webviews/chat/Transcript.tsx
+++ b/vscode/webviews/chat/Transcript.tsx
@@ -16,6 +16,7 @@ import type { UserAccountInfo } from '../Chat'
 import type { ApiPostMessage } from '../Chat'
 import { Button } from '../components/shadcn/ui/button'
 import { getVSCodeAPI } from '../utils/VSCodeApi'
+import { useExperimentalOneBox } from '../utils/useExperimentalOneBox'
 import type { CodeBlockActionsProps } from './ChatMessageContent/ChatMessageContent'
 import { ContextCell } from './cells/contextCell/ContextCell'
 import {
@@ -41,7 +42,6 @@ interface TranscriptProps {
     insertButtonOnSubmit?: CodeBlockActionsProps['insertButtonOnSubmit']
     smartApply?: CodeBlockActionsProps['smartApply']
     smartApplyEnabled?: boolean
-    experimentalOneBoxEnabled?: boolean
 }
 
 export const Transcript: FC<TranscriptProps> = props => {
@@ -58,7 +58,6 @@ export const Transcript: FC<TranscriptProps> = props => {
         insertButtonOnSubmit,
         smartApply,
         smartApplyEnabled,
-        experimentalOneBoxEnabled,
     } = props
 
     const interactions = useMemo(
@@ -95,7 +94,6 @@ export const Transcript: FC<TranscriptProps> = props => {
                     )}
                     smartApply={smartApply}
                     smartApplyEnabled={smartApplyEnabled}
-                    experimentalOneBoxEnabled={experimentalOneBoxEnabled}
                 />
             ))}
         </div>
@@ -183,7 +181,6 @@ const TranscriptInteraction: FC<TranscriptInteractionProps> = memo(props => {
         copyButtonOnSubmit,
         smartApply,
         smartApplyEnabled,
-        experimentalOneBoxEnabled,
     } = props
 
     const [intent, setIntent] = useState<ChatMessage['intent']>()
@@ -205,6 +202,8 @@ const TranscriptInteraction: FC<TranscriptInteractionProps> = memo(props => {
     )
 
     const extensionAPI = useExtensionAPI()
+
+    const experimentalOneBoxEnabled = useExperimentalOneBox()
 
     const onChange = useMemo(() => {
         return debounce(async (editorValue: SerializedPromptEditorValue) => {
@@ -287,7 +286,6 @@ const TranscriptInteraction: FC<TranscriptInteractionProps> = memo(props => {
                 isEditorInitiallyFocused={isLastInteraction}
                 editorRef={humanEditorRef}
                 className={!isFirstInteraction && isLastInteraction ? 'tw-mt-auto' : ''}
-                experimentalOneBoxEnabled={experimentalOneBoxEnabled}
                 onEditorFocusChange={resetIntent}
             />
             {experimentalOneBoxEnabled && humanMessage.intent && (

--- a/vscode/webviews/chat/cells/messageCell/human/HumanMessageCell.tsx
+++ b/vscode/webviews/chat/cells/messageCell/human/HumanMessageCell.tsx
@@ -47,8 +47,6 @@ export const HumanMessageCell: FunctionComponent<{
 
     /** For use in storybooks only. */
     __storybook__focus?: boolean
-
-    experimentalOneBoxEnabled?: boolean
 }> = memo(
     ({
         message,
@@ -66,7 +64,6 @@ export const HumanMessageCell: FunctionComponent<{
         className,
         editorRef,
         __storybook__focus,
-        experimentalOneBoxEnabled,
         onEditorFocusChange,
     }) => {
         const messageJSON = JSON.stringify(message)
@@ -103,7 +100,6 @@ export const HumanMessageCell: FunctionComponent<{
                         isEditorInitiallyFocused={isEditorInitiallyFocused}
                         editorRef={editorRef}
                         __storybook__focus={__storybook__focus}
-                        experimentalOneBoxEnabled={experimentalOneBoxEnabled}
                         onEditorFocusChange={onEditorFocusChange}
                     />
                 }

--- a/vscode/webviews/chat/cells/messageCell/human/editor/HumanMessageEditor.tsx
+++ b/vscode/webviews/chat/cells/messageCell/human/editor/HumanMessageEditor.tsx
@@ -66,8 +66,6 @@ export const HumanMessageEditor: FunctionComponent<{
 
     /** For use in storybooks only. */
     __storybook__focus?: boolean
-
-    experimentalOneBoxEnabled?: boolean
 }> = ({
     userInfo,
     initialEditorState,
@@ -85,7 +83,6 @@ export const HumanMessageEditor: FunctionComponent<{
     className,
     editorRef: parentEditorRef,
     __storybook__focus,
-    experimentalOneBoxEnabled,
     onEditorFocusChange: parentOnEditorFocusChange,
 }) => {
     const telemetryRecorder = useTelemetryRecorder()
@@ -379,7 +376,6 @@ export const HumanMessageEditor: FunctionComponent<{
                     appendTextToEditor={appendTextToEditor}
                     hidden={!focused && isSent}
                     className={styles.toolbar}
-                    experimentalOneBoxEnabled={experimentalOneBoxEnabled}
                 />
             )}
         </div>

--- a/vscode/webviews/chat/cells/messageCell/human/editor/toolbar/SubmitButton.tsx
+++ b/vscode/webviews/chat/cells/messageCell/human/editor/toolbar/SubmitButton.tsx
@@ -7,6 +7,7 @@ import { Button } from '../../../../../../components/shadcn/ui/button'
 import { Command, CommandItem, CommandList } from '../../../../../../components/shadcn/ui/command'
 import { ToolbarPopoverItem } from '../../../../../../components/shadcn/ui/toolbar'
 import { Tooltip, TooltipContent, TooltipTrigger } from '../../../../../../components/shadcn/ui/tooltip'
+import { useExperimentalOneBox } from '../../../../../../utils/useExperimentalOneBox'
 import { CodyIcon } from '../../../../../components/CodyIcon'
 
 export type SubmitButtonState = 'submittable' | 'emptyEditorValue' | 'waitingResponseComplete'
@@ -16,8 +17,9 @@ export const SubmitButton: FunctionComponent<{
     isEditorFocused?: boolean
     state?: SubmitButtonState
     className?: string
-    experimentalOneBoxEnabled?: boolean
-}> = ({ onClick, state = 'submittable', className, experimentalOneBoxEnabled }) => {
+}> = ({ onClick, state = 'submittable', className }) => {
+    const experimentalOneBoxEnabled = useExperimentalOneBox()
+
     if (state === 'waitingResponseComplete') {
         return (
             <Tooltip>

--- a/vscode/webviews/chat/cells/messageCell/human/editor/toolbar/Toolbar.tsx
+++ b/vscode/webviews/chat/cells/messageCell/human/editor/toolbar/Toolbar.tsx
@@ -31,7 +31,6 @@ export const Toolbar: FunctionComponent<{
 
     hidden?: boolean
     className?: string
-    experimentalOneBoxEnabled?: boolean
 }> = ({
     userInfo,
     isEditorFocused,
@@ -43,7 +42,6 @@ export const Toolbar: FunctionComponent<{
     appendTextToEditor,
     hidden,
     className,
-    experimentalOneBoxEnabled,
 }) => {
     /**
      * If the user clicks in a gap or on the toolbar outside of any of its buttons, report back to
@@ -98,7 +96,6 @@ export const Toolbar: FunctionComponent<{
                     onClick={onSubmitClick}
                     isEditorFocused={isEditorFocused}
                     state={submitState}
-                    experimentalOneBoxEnabled={experimentalOneBoxEnabled}
                 />
             </div>
         </menu>

--- a/vscode/webviews/utils/useExperimentalOneBox.tsx
+++ b/vscode/webviews/utils/useExperimentalOneBox.tsx
@@ -1,0 +1,7 @@
+import { useConfig } from './useConfig'
+
+export const useExperimentalOneBox = (): boolean => {
+    const config = useConfig()
+
+    return config.config.experimentalOneBox
+}

--- a/vscode/webviews/utils/useExperimentalOneBox.tsx
+++ b/vscode/webviews/utils/useExperimentalOneBox.tsx
@@ -1,7 +1,6 @@
-import { useConfig } from './useConfig'
+import { FeatureFlag } from '@sourcegraph/cody-shared'
+import { useFeatureFlag } from './useFeatureFlags'
 
-export const useExperimentalOneBox = (): boolean => {
-    const config = useConfig()
-
-    return config.config.experimentalOneBox
+export const useExperimentalOneBox = (): boolean | undefined => {
+    return useFeatureFlag(FeatureFlag.CodyExperimentalOneBox)
 }

--- a/web/lib/components/CodyWebChat.tsx
+++ b/web/lib/components/CodyWebChat.tsx
@@ -269,7 +269,6 @@ const CodyWebPanel: FC<CodyWebPanelProps> = props => {
                                 transcript={transcript}
                                 vscodeAPI={vscodeAPI}
                                 isTranscriptError={isTranscriptError}
-                                experimentalOneBoxEnabled={config.config.experimentalOneBox}
                             />
                         </ComposedWrappers>
                     </ChatMentionContext.Provider>


### PR DESCRIPTION
Refactor onebox experimental flag drill down to rather use `useConfig`.

## Test plan
- Connect to s2, the chat submit button should have a dropdown and on submit, intent detection box should be visible.
- Connect to dotcom, the chat submit button should have no dropdown and the intent detection box should not be visible.

## Changelog
None.

