### PR TITLE
Small improvements to cody bench context

### DIFF
--- a/agent/src/cli/command-bench/strategy-chat-context.ts
+++ b/agent/src/cli/command-bench/strategy-chat-context.ts
@@ -97,7 +97,11 @@ async function runContextCommand(examples: Example[], outputFile: string): Promi
     await writeExamplesToCSV(outputFile, exampleOutputs)
 }
 
-function contextOverlaps(parentStr: string, childStr: string, threshold = 0.2): boolean {
+function contextOverlaps(
+    parentStr: string,
+    childStr: string,
+    threshold = { lines: 3, fraction: 0.2 }
+): boolean {
     const parent = contextItemFromString(parentStr)
     const child = contextItemFromString(childStr)
     if (!parent || !child) {
@@ -123,7 +127,7 @@ function contextOverlaps(parentStr: string, childStr: string, threshold = 0.2): 
     const overlapLength = overlapEnd - overlapStart + 1
     const parentLength = parent.endLine - parent.startLine + 1
 
-    return overlapLength / parentLength >= threshold
+    return overlapLength / parentLength >= threshold.fraction || overlapLength >= threshold.lines
 }
 
 function computeRecall(

--- a/agent/src/cli/command-bench/strategy-chat-context.ts
+++ b/agent/src/cli/command-bench/strategy-chat-context.ts
@@ -53,7 +53,7 @@ async function runContextCommand(examples: Example[], outputFile: string): Promi
         const repoNames = targetRepoRevs.map(repoRev => repoRev.repoName)
         const repoIDNames = await graphqlClient.getRepoIds(repoNames, repoNames.length + 10)
         if (isError(repoIDNames)) {
-            throw repoIDNames
+            throw new Error(`getRepoIds failed for [${repoNames.join(',')}]: ${repoIDNames}`)
         }
         if (repoIDNames.length !== repoNames.length) {
             throw new Error(
@@ -69,10 +69,10 @@ async function runContextCommand(examples: Example[], outputFile: string): Promi
             filePatterns: [],
         })
         if (isError(resultsResp)) {
-            throw resultsResp
+            throw new Error(`contextSearch failed for [${repoNames.join(',')}]: ${resultsResp}`)
         }
         if (resultsResp === null) {
-            throw new Error('!!! null results')
+            throw new Error(`contextSearch failed for [${repoNames.join(',')}]: null results`)
         }
         const results = resultsResp ?? []
         const actualContext: EvalContextItem[] = results.map(result => ({


### PR DESCRIPTION
Adjust the overlap threshold at which we count something as a "hit". The ground truth now includes some pretty large blocks of context, so we use a min of a percentage threshold and a constant line overlap.

Make error messages more descriptive when `cody internal bench` fails.

## Test plan

N/A (benchmarks only)
