### PR TITLE
bump openctx for quieter provider errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "vitest": "^2.0.5"
   },
   "dependencies": {
-    "@openctx/client": "^0.0.28",
+    "@openctx/client": "^0.0.29",
     "@sourcegraph/telemetry": "^0.18.0",
     "ignore": "^5.3.1",
     "observable-fns": "^0.6.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,8 +18,8 @@ importers:
   .:
     dependencies:
       '@openctx/client':
-        specifier: ^0.0.28
-        version: 0.0.28
+        specifier: ^0.0.29
+        version: 0.0.29
       '@sourcegraph/telemetry':
         specifier: ^0.18.0
         version: 0.18.0
@@ -424,8 +424,8 @@ importers:
         specifier: ^0.0.9
         version: 0.0.9
       '@openctx/vscode-lib':
-        specifier: ^0.0.24
-        version: 0.0.24
+        specifier: ^0.0.25
+        version: 0.0.25
       '@opentelemetry/api':
         specifier: ^1.7.0
         version: 1.7.0
@@ -827,8 +827,8 @@ importers:
   web:
     devDependencies:
       '@openctx/vscode-lib':
-        specifier: ^0.0.24
-        version: 0.0.24
+        specifier: ^0.0.25
+        version: 0.0.25
       '@sourcegraph/cody':
         specifier: workspace:*
         version: link:../agent
@@ -3363,8 +3363,8 @@ packages:
       which: 4.0.0
     dev: true
 
-  /@openctx/client@0.0.28:
-    resolution: {integrity: sha512-XXaWo/Oa9XZYzhVzSntVV+LRhp/arZc3fnu2JZfVTsZeHgKXhXzKEynWxRaK6eZGI7SNnZMjc0UZUCmMAii28A==}
+  /@openctx/client@0.0.29:
+    resolution: {integrity: sha512-KTY6pPjVQ89ZLNU/DxngzNrvH08y/sk9HRYgAhohPmjjD5tEJp+t60/7QI1bjLVu0RT9ZLF3kI8Jb4OIPXJv5Q==}
     dependencies:
       '@openctx/protocol': 0.0.19
       '@openctx/provider': 0.0.18
@@ -3424,10 +3424,10 @@ packages:
       sanitize-html: 2.13.0
       xss: 1.0.15
 
-  /@openctx/vscode-lib@0.0.24:
-    resolution: {integrity: sha512-CN/Flz+hDsPAnyKWiHdQLz8yUwKHTVyMgupe16s/JZdVCEb0YbWlIJrXe2CM8Ve+wVQfuyM0TEb/Wj8mi5Ligg==}
+  /@openctx/vscode-lib@0.0.25:
+    resolution: {integrity: sha512-DrhUBdiYXh+3JkuqkASept1vAD6GPvS4S+3X2725rDImtpdvrmTpWI2YYJtj6Fa33UpHxe7sch13DitV56Qe1Q==}
     dependencies:
-      '@openctx/client': 0.0.28
+      '@openctx/client': 0.0.29
       '@openctx/ui-common': 0.0.14
       observable-fns: 0.6.1
 
@@ -8388,6 +8388,18 @@ packages:
         optional: true
     dependencies:
       ms: 2.1.3
+    dev: true
+
+  /debug@4.3.4:
+    resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+    dependencies:
+      ms: 2.1.2
     dev: true
 
   /debug@4.3.4(supports-color@8.1.1):
@@ -14832,7 +14844,7 @@ packages:
       cosmiconfig: 8.3.6(typescript@5.5.4)
       css-functions-list: 3.2.2
       css-tree: 2.3.1
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       fast-glob: 3.3.2
       fastest-levenshtein: 1.0.16
       file-entry-cache: 7.0.2

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -1321,7 +1321,7 @@
   "dependencies": {
     "@anthropic-ai/sdk": "^0.20.8",
     "@openctx/provider-linear-issues": "^0.0.9",
-    "@openctx/vscode-lib": "^0.0.24",
+    "@openctx/vscode-lib": "^0.0.25",
     "@opentelemetry/api": "^1.7.0",
     "@opentelemetry/core": "^1.18.1",
     "@opentelemetry/exporter-trace-otlp-http": "^0.45.1",

--- a/web/package.json
+++ b/web/package.json
@@ -19,7 +19,7 @@
     "build-ts": "tsc --build"
   },
   "devDependencies": {
-    "@openctx/vscode-lib": "^0.0.24",
+    "@openctx/vscode-lib": "^0.0.25",
     "@sourcegraph/cody": "workspace:*",
     "@sourcegraph/cody-shared": "workspace:*",
     "@sourcegraph/prompt-editor": "workspace:*",


### PR DESCRIPTION
Incorporates https://github.com/sourcegraph/openctx/pull/207 and https://github.com/sourcegraph/openctx/pull/206.

Fixes https://linear.app/sourcegraph/issue/CODY-3799/quieter-openctx-provider-ui-notifs-in-vs-code-and-better-error-logging.

## Test plan

Open VS Code with an OpenCtx provider that throws an error. Ensure that no VS Code error notification is shown in the UI, and that it's logged to the `OpenCtx` output channel with the provider URI mentioned.