### PR TITLE
Chat: add vision support, upload images

### DIFF
--- a/lib/shared/src/chat/chat.ts
+++ b/lib/shared/src/chat/chat.ts
@@ -46,12 +46,13 @@ export class ChatClient {
 
         // We only want to send up the speaker and prompt text, regardless of whatever other fields
         // might be on the messages objects (`file`, `displayText`, `contextFiles`, etc.).
-        const messagesToSend = augmentedMessages.map(({ speaker, text }) => ({
+        const messagesToSend = augmentedMessages.map<Message>(({ speaker, text, content }) => ({
             text,
             speaker,
+            content,
         }))
 
-        const completionParams = {
+        const completionParams: CompletionParameters = {
             ...DEFAULT_CHAT_COMPLETION_PARAMETERS,
             ...params,
             messages: messagesToSend,
@@ -94,8 +95,8 @@ export function sanitizeMessages(messages: Message[]): Message[] {
         // the next one
         const nextMessage = sanitizedMessages[index + 1]
         if (
-            (nextMessage.speaker === 'assistant' && !nextMessage.text?.length) ||
-            (message.speaker === 'assistant' && !message.text?.length)
+            (nextMessage.speaker === 'assistant' && !nextMessage.text?.length && !nextMessage.content) ||
+            (message.speaker === 'assistant' && !message.text?.length && !message.content)
         ) {
             return false
         }

--- a/lib/shared/src/chat/transcript/messages.ts
+++ b/lib/shared/src/chat/transcript/messages.ts
@@ -15,6 +15,7 @@ export type RankedContext = {
 
 export interface ChatMessage extends Message {
     contextFiles?: ContextItem[]
+    base64Image?: string
 
     contextAlternatives?: RankedContext[]
 

--- a/lib/shared/src/sourcegraph-api/completions/types.ts
+++ b/lib/shared/src/sourcegraph-api/completions/types.ts
@@ -20,12 +20,13 @@ export interface Message {
     // Note: The unified API only supports one system message passed as the first message
     speaker: 'human' | 'assistant' | 'system'
     text?: PromptString
+    content?: string | MessagePart[]
+    base64Image?: string
 }
 
-export interface CompletionResponse {
-    completion: string
-    stopReason?: string
-}
+type MessagePart =
+    | { type: 'text'; text: string } // a normal text message
+    | { type: 'image_url'; image_url: { url: string } } // image message, per https://platform.openai.com/docs/guides/vision
 
 export interface CompletionParameters {
     fast?: boolean
@@ -37,6 +38,7 @@ export interface CompletionParameters {
     topP?: number
     model?: string
     stream?: boolean
+    base64Image?: string
 }
 
 export interface SerializedCompletionParameters extends Omit<CompletionParameters, 'messages'> {

--- a/vscode/src/chat/chat-view/ChatController.ts
+++ b/vscode/src/chat/chat-view/ChatController.ts
@@ -564,6 +564,11 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
                 })
                 break
             }
+
+            case 'chat/upload-file': {
+                this.chatModel.setImage(message.base64)
+                break
+            }
             case 'log': {
                 const logger = message.level === 'debug' ? logDebug : logError
                 logger(message.filterLabel, message.message)

--- a/vscode/src/chat/chat-view/ChatModel.ts
+++ b/vscode/src/chat/chat-view/ChatModel.ts
@@ -78,7 +78,7 @@ export class ChatModel {
         if (this.messages.at(-1)?.speaker === 'human') {
             throw new Error('Cannot add a user message after a user message')
         }
-        this.messages.push({ ...message, speaker: 'human' })
+        this.messages.push({ ...message, speaker: 'human', base64Image: this.getAndResetImage() })
     }
 
     public addBotMessage(message: Omit<Message, 'speaker'>): void {
@@ -205,6 +205,31 @@ export class ChatModel {
             }
         }
         return result
+    }
+
+    /**
+     * Store the base64-encoded image uploaded by user to a multi-modal model.
+     * Requires vision support in the model, added in the PR
+     * https://github.com/sourcegraph/sourcegraph/pull/546
+     */
+    private image: string | undefined = undefined
+
+    /**
+     * Sets the base64-encoded image for the chat model.
+     * @param base64Image - The base64-encoded image data to set.
+     */
+    public setImage(base64Image: string): void {
+        this.image = base64Image
+    }
+
+    /**
+     * Gets the base64-encoded image for the chat model and resets the internal image property to undefined.
+     * @returns The base64-encoded image, or undefined if no image has been set.
+     */
+    public getAndResetImage(): string | undefined {
+        const image = this.image
+        this.image = undefined
+        return image
     }
 }
 

--- a/vscode/src/chat/chat-view/prompt.ts
+++ b/vscode/src/chat/chat-view/prompt.ts
@@ -87,6 +87,9 @@ export class DefaultPrompter {
                     `Ignored ${messagesIgnored} chat messages due to context limit`
                 )
             }
+            for (const message of reverseTranscript) {
+                promptBuilder.tryAddImage(message.base64Image)
+            }
             // Counter for context items categorized by source
             const ignoredContext = { user: 0, corpus: 0, transcript: 0 }
 

--- a/vscode/src/chat/protocol.ts
+++ b/vscode/src/chat/protocol.ts
@@ -176,6 +176,7 @@ export type WebviewMessage =
     | { command: 'rpc/request'; message: RequestMessage }
     | { command: 'chatSession'; action: 'duplicate' | 'new'; sessionID?: string | undefined | null }
     | { command: 'log'; level: 'debug' | 'error'; filterLabel: string; message: string }
+    | { command: 'chat/upload-file'; base64: string }
 
 export interface SmartApplyResult {
     taskId: FixupTaskID

--- a/vscode/src/completions/nodeClient.ts
+++ b/vscode/src/completions/nodeClient.ts
@@ -22,6 +22,7 @@ import {
     getSerializedParams,
     getTraceparentHeaders,
     isError,
+    logDebug,
     logError,
     onAbort,
     parseEvents,
@@ -39,6 +40,10 @@ export class SourcegraphNodeCompletionsClient extends SourcegraphCompletionsClie
         signal?: AbortSignal
     ): Promise<void> {
         const { apiVersion } = requestParams
+        for (const message of params.messages) {
+            logDebug('apiVersion', JSON.stringify(apiVersion, null, 2))
+            logDebug('base64Image', JSON.stringify(message, null, 2))
+        }
 
         const url = new URL(await this.completionsEndpoint())
         if (apiVersion >= 1) {

--- a/vscode/src/prompt-builder/index.ts
+++ b/vscode/src/prompt-builder/index.ts
@@ -33,6 +33,7 @@ export class PromptBuilder {
      * A list of context items that are used to build context messages.
      */
     public contextItems: ContextItem[] = []
+    public images: string[] = []
 
     /**
      * Convenience constructor because loading the tokenizer is async due to its large size.
@@ -47,8 +48,26 @@ export class PromptBuilder {
         if (this.contextItems.length > 0) {
             this.buildContextMessages()
         }
-
+        this.buildImageMessages()
         return this.prefixMessages.concat([...this.reverseMessages].reverse())
+    }
+
+    private buildImageMessages(): void {
+        for (const image of this.images) {
+            const imageMessage: Message = {
+                speaker: 'human',
+                content: [
+                    {
+                        type: 'image_url',
+                        image_url: {
+                            // TODO: Handle PNG/JPEG, don't hardcode to JPEG
+                            url: `data:image/jpeg;base64,${image}`,
+                        },
+                    },
+                ],
+            }
+            this.reverseMessages.push(...[ASSISTANT_MESSAGE, imageMessage])
+        }
     }
 
     private buildContextMessages(): void {
@@ -106,6 +125,12 @@ export class PromptBuilder {
         }
         // All messages were added successfully.
         return undefined
+    }
+
+    public tryAddImage(base64Image: string | undefined): void {
+        if (base64Image) {
+            this.images.push(base64Image)
+        }
     }
 
     public async tryAddContext(

--- a/vscode/webviews/chat/cells/messageCell/human/editor/toolbar/Toolbar.tsx
+++ b/vscode/webviews/chat/cells/messageCell/human/editor/toolbar/Toolbar.tsx
@@ -9,6 +9,7 @@ import { PromptSelectField } from '../../../../../../components/promptSelectFiel
 import { useConfig } from '../../../../../../utils/useConfig'
 import { AddContextButton } from './AddContextButton'
 import { SubmitButton, type SubmitButtonState } from './SubmitButton'
+import { UploadImageButton } from './UploadImageButton'
 
 /**
  * The toolbar for the human message editor.
@@ -32,6 +33,9 @@ export const Toolbar: FunctionComponent<{
     hidden?: boolean
     className?: string
     experimentalOneBoxEnabled?: boolean
+
+    imageFile?: File
+    setImageFile: (file: File | undefined) => void
 }> = ({
     userInfo,
     isEditorFocused,
@@ -44,6 +48,8 @@ export const Toolbar: FunctionComponent<{
     hidden,
     className,
     experimentalOneBoxEnabled,
+    imageFile,
+    setImageFile,
 }) => {
     /**
      * If the user clicks in a gap or on the toolbar outside of any of its buttons, report back to
@@ -82,6 +88,13 @@ export const Toolbar: FunctionComponent<{
                         className="tw-opacity-60 focus-visible:tw-opacity-100 hover:tw-opacity-100 tw-mr-2"
                     />
                 )}
+                {
+                    <UploadImageButton
+                        className="tw-opacity-60"
+                        imageFile={imageFile}
+                        onClick={setImageFile}
+                    />
+                }
                 <PromptSelectFieldToolbarItem
                     focusEditor={focusEditor}
                     appendTextToEditor={appendTextToEditor}

--- a/vscode/webviews/chat/cells/messageCell/human/editor/toolbar/UploadImageButton.tsx
+++ b/vscode/webviews/chat/cells/messageCell/human/editor/toolbar/UploadImageButton.tsx
@@ -1,0 +1,68 @@
+import { ImageIcon, XIcon } from 'lucide-react'
+import { useRef } from 'react'
+import { Button } from '../../../../../../components/shadcn/ui/button'
+import { Tooltip, TooltipContent, TooltipTrigger } from '../../../../../../components/shadcn/ui/tooltip'
+
+interface UploadImageButtonProps {
+    className?: string
+    imageFile?: File
+    onClick: (file: File | undefined) => void
+}
+
+export const UploadImageButton = (props: UploadImageButtonProps) => {
+    const fileInputRef = useRef<HTMLInputElement>(null)
+
+    const handleButtonClick = () => {
+        fileInputRef.current?.click()
+    }
+
+    const handleFileChange = async (event: React.ChangeEvent<HTMLInputElement>) => {
+        const file = event.target.files?.[0]
+        props.onClick(file)
+    }
+
+    return (
+        <Tooltip>
+            <TooltipTrigger asChild>
+                <Button
+                    variant="ghost"
+                    size={props.imageFile ? 'sm' : 'icon'}
+                    aria-label="Upload an image"
+                    className={props.className}
+                >
+                    {props.imageFile ? (
+                        <>
+                            <span
+                                className="tw-max-w-[10em] tw-overflow-hidden tw-text-ellipsis"
+                                title={props.imageFile.name}
+                            >
+                                {props.imageFile.name}
+                            </span>
+                            <XIcon
+                                strokeWidth={1.25}
+                                className="tw-h-8 tw-w-8"
+                                onClick={() => props.onClick(undefined)}
+                            />
+                        </>
+                    ) : (
+                        <ImageIcon
+                            onClick={handleButtonClick}
+                            className="tw-w-8 tw-h-8"
+                            strokeWidth={1.25}
+                        />
+                    )}
+                </Button>
+            </TooltipTrigger>
+            <TooltipContent side="bottom">
+                {props.imageFile ? 'Remove attached image' : 'Upload an image'}
+            </TooltipContent>
+            <input
+                type="file"
+                accept="image/*"
+                ref={fileInputRef}
+                style={{ display: 'none' }}
+                onChange={handleFileChange}
+            />
+        </Tooltip>
+    )
+}

--- a/vscode/webviews/components/modelSelectField/ModelSelectField.module.css
+++ b/vscode/webviews/components/modelSelectField/ModelSelectField.module.css
@@ -32,6 +32,10 @@
     margin-left: auto;
 }
 
+.supports-image-upload-icon {
+    margin-left: auto;
+}
+
 .badge {
     margin-left: auto;
     line-height: 16px;
@@ -47,12 +51,17 @@
     opacity: 0.75;
 }
 
+.supports-image-upload-icon + .badge {
+    margin-left: 0;
+}
+
 button > .model-title-with-icon .model-name {
     font-weight: normal;
 }
 
 button > .model-title-with-icon .model-icon,
 button > .model-title-with-icon .model-provider,
-button > .model-title-with-icon .badge {
+button > .model-title-with-icon .badge,
+.supports-image-upload-icon {
     display: none;
 }


### PR DESCRIPTION
Demo https://www.loom.com/share/638240e061cd449ab4fd2ac30b6ec356

Previously, it was only possible to send text to Cody via Chat. This PR adds new support to additionally send Cody images. This can be helpful, for example, when you want to write a basic HTML structure based on a Figma design.

Based on the changes in https://github.com/sourcegraph/cody/pull/4694/files#diff-93ab3b057cf286b165b92ef5a20dd588f286bf3d93ee78e72d63c4696904a006
In this PR, the image goes to Sourcegraph backend and works with both Anthropic and OpenAI models. The other PR only worked with the local llava model via Ollama.

Accompanying backend PR https://github.com/sourcegraph/sourcegraph/pull/546


## Test plan
TBD
<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
