### PR TITLE
deflake Cody Context Filters test

### DIFF
--- a/lib/shared/src/cody-ignore/context-filters-provider.test.ts
+++ b/lib/shared/src/cody-ignore/context-filters-provider.test.ts
@@ -3,6 +3,8 @@ import { RE2JS as RE2 } from 're2js'
 import { type Mock, afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { URI } from 'vscode-uri'
 
+import { mockAuthStatus } from '../auth/authStatus'
+import { AUTH_STATUS_FIXTURE_AUTHED, AUTH_STATUS_FIXTURE_AUTHED_DOTCOM } from '../auth/types'
 import { isDefined } from '../common'
 import { mockResolvedConfig } from '../configuration/resolver'
 import { DOTCOM_URL } from '../sourcegraph-api/environments'
@@ -20,6 +22,7 @@ describe('ContextFiltersProvider', () => {
 
     beforeEach(() => {
         mockResolvedConfig({ configuration: {}, auth: { serverEndpoint: 'https://example.com' } })
+        mockAuthStatus(AUTH_STATUS_FIXTURE_AUTHED)
         getRepoNamesFromWorkspaceUri = vi.fn()
         ContextFiltersProvider.repoNameResolver = { getRepoNamesFromWorkspaceUri }
 
@@ -383,8 +386,8 @@ describe('ContextFiltersProvider', () => {
                     configuration: {},
                     auth: { serverEndpoint: DOTCOM_URL.toString() },
                 })
+                mockAuthStatus(AUTH_STATUS_FIXTURE_AUTHED_DOTCOM)
                 provider = new ContextFiltersProvider()
-                ;(provider as any).isDotCom = true
                 await vi.runOnlyPendingTimersAsync()
                 await provider.isRepoNameIgnored('anything')
 


### PR DESCRIPTION
There were a few problems:

- If the overridePolicy was not set at the start, it would trigger a background fetch. This would overwrite the filters value at some random point during testing, causing flakiness.
- We can use currentAuthStatus() instead of having a live subscription to determine if we're on dotcom. That is simpler.

## Test plan

CI