### PR TITLE
Enable extension-specific proxy settings

### DIFF
--- a/agent/recordings/unauthed_2245427793/recording.har.yaml
+++ b/agent/recordings/unauthed_2245427793/recording.har.yaml
@@ -41,7 +41,7 @@ log:
           params: []
           textJSON:
             query: |-
-              
+
               query CurrentSiteCodyLlmConfiguration {
                   site {
                       codyLLMConfiguration {
@@ -159,7 +159,7 @@ log:
           params: []
           textJSON:
             query: |-
-              
+
               query CurrentSiteCodyLlmConfiguration {
                   site {
                       codyLLMConfiguration {
@@ -265,7 +265,7 @@ log:
           params: []
           textJSON:
             query: |-
-              
+
               query CurrentSiteCodyLlmProvider {
                   site {
                       codyLLMConfiguration {
@@ -371,7 +371,7 @@ log:
           params: []
           textJSON:
             query: |-
-              
+
               query CurrentUser {
                   currentUser {
                       id
@@ -499,7 +499,7 @@ log:
           params: []
           textJSON:
             query: |-
-              
+
               query CurrentUserCodySubscription {
                   currentUser {
                       codySubscription {
@@ -615,7 +615,7 @@ log:
           params: []
           textJSON:
             query: |-
-              
+
               query SiteProductVersion {
                   site {
                       productVersion
@@ -722,7 +722,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Wed, 02 Oct 2024 01:38:28 GMT
+            value: Thu, 03 Oct 2024 17:13:11 GMT
           - name: content-type
             value: text/plain; charset=utf-8
           - name: transfer-encoding
@@ -753,7 +753,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-10-02T01:38:28.361Z
+      startedDateTime: 2024-10-03T17:13:10.854Z
       time: 0
       timings:
         blocked: -1
@@ -799,7 +799,7 @@ log:
           params: []
           textJSON:
             query: |-
-              
+
               query CurrentSiteCodyLlmConfiguration {
                   site {
                       codyLLMConfiguration {
@@ -907,7 +907,7 @@ log:
           params: []
           textJSON:
             query: |-
-              
+
               query CurrentSiteCodyLlmConfiguration {
                   site {
                       codyLLMConfiguration {
@@ -1009,7 +1009,7 @@ log:
           params: []
           textJSON:
             query: |-
-              
+
               query CurrentSiteCodyLlmProvider {
                   site {
                       codyLLMConfiguration {
@@ -1110,7 +1110,7 @@ log:
           params: []
           textJSON:
             query: |-
-              
+
               query CurrentUser {
                   currentUser {
                       id
@@ -1224,7 +1224,7 @@ log:
           params: []
           textJSON:
             query: |-
-              
+
               query SiteProductVersion {
                   site {
                       productVersion
@@ -1279,6 +1279,101 @@ log:
         status: 200
         statusText: OK
       startedDateTime: 2024-09-27T16:58:09.963Z
+      time: 0
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 0
+    - _id: b67fa467a48dcabba8c60bd47c398d1a
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 0
+        cookies: []
+        headers:
+          - _fromType: array
+            name: authorization
+            value: token
+              REDACTED_4229eb42e0efa2f15f3e6f8843764c7f92ab8051020cc4e90802f4fc0cc91bfa
+          - _fromType: array
+            name: user-agent
+            value: unauthed / v1
+          - _fromType: array
+            name: accept
+            value: "*/*"
+          - _fromType: array
+            name: accept-encoding
+            value: gzip,deflate
+          - name: host
+            value: sourcegraph.sourcegraph.com
+        headersSize: 281
+        httpVersion: HTTP/1.1
+        method: GET
+        queryString: []
+        url: https://sourcegraph.sourcegraph.com/.api/modelconfig/supported-models.json
+      response:
+        bodySize: 773
+        content:
+          encoding: base64
+          mimeType: text/plain; charset=utf-8
+          size: 773
+          text: "[\"H4sIAAAAAAAA/+yYX0/bPBTG7/sprNy+uDhpC+9yxzqxIY2BBmIXExeuc9pYTWLLdloqx\
+            HefkjRhaUyTIlQEo1dR/JzHf37H9Ynvewgh5GgWQkxvQGkuEsdHjtsnzkHRpmDBy9ek\
+            T/rkvwAWZaNUYsEDUNrx0e/8Vfa7r55yEQ+yWJqYUAnJ2Tq2ag64lhFd/aAxZLqTSlf\
+            JHg62W0+5gqVQc91ifVrpOlvPhJhF0OL7tRB1NhUSEspbTC8kJCdn3U1jro2iUYvr+V\
+            r1aJs/3a55xiKAaCvMXPETpjWkvu8Rb4DJESau77OIpgHgQX+EtUgSMC1jGud6NOiP0\
+            JVVn/dZqkt3XLpjj3hDcuSRzTBGJZ3wiBsO9SlVCgj4ZmdFZEit79c7odZw2+jVwEyo\
+            Vb5AjKWKstXmyLShJs3GlD1NmvllOKg8sRU02phIDNyZXzwJxNLxN/gU60XvzhKZmms\
+            xhyTrZjgihFjmE9O7i9TUlISQmu6hQwLukBNYyLRtm5b5gC4sWnsuZK5FHnjepxfOg8\
+            60hQlBPRe1VOKdkQ4pn6ddUX+zie2sc98C9oAcvxZsLQGC197Xx3uDXR2xvr9wfV8bq\
+            pgImum+wffKUDW26Wpon3Rrh0lTI5iIZQQG3hg8jwz/7wTPGx29JLsAQGqAOc6XHC88\
+            HHEDeEJ1W53zBUBeAczRjYe+cwPosyWmRpYyJtLE6EMtUsVgpqgMD4si43CHcXzkwUv\
+            kQVHLFkkwg5gnHLv9EbacPJv1bS5Gbn+ELpviGvDtvvv6c57QiCbs9dHu8TR+Au40oj\
+            rsjvfUJn8KsNX7nzp/98i3+GbMS60hJl5eas2kwcPWzXt5bRHVmVp93v7n09urqW2Um\
+            QhWOFtSLBUsOCwxIW6nywMk3DJme2ndpYf2dNhtA7fDXVJuIq4b1wHvH6/XGW/2Z7wz\
+            24b9B9utbHt/zdcJYErTyJyXN2WPwygW6Xn3Ys6UajPuFt/4ss4gw7ioftc3tTvU/L1\
+            ijg+9PwEAAP//fIckBg0WAAA=\"]"
+        cookies: []
+        headers:
+          - name: date
+            value: Thu, 03 Oct 2024 17:51:08 GMT
+          - name: content-type
+            value: text/plain; charset=utf-8
+          - name: content-length
+            value: "773"
+          - name: connection
+            value: keep-alive
+          - name: retry-after
+            value: "559"
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache, max-age=0
+          - name: content-encoding
+            value: gzip
+          - name: vary
+            value: Accept-Encoding, Authorization, Cookie, Authorization, X-Requested-With,
+              Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+        headersSize: 1358
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: 2024-10-03T17:51:07.644Z
       time: 0
       timings:
         blocked: -1

--- a/lib/shared/src/configuration.ts
+++ b/lib/shared/src/configuration.ts
@@ -23,8 +23,7 @@ export interface AuthCredentials {
 
 interface RawClientConfiguration {
     proxy?: string | null
-    proxyHost?: string | null
-    proxyPort?: number | null
+    proxyServer?: string | null
     proxyPath?: string | null
     proxyCACert?: string | null
     codebase?: string

--- a/lib/shared/src/configuration.ts
+++ b/lib/shared/src/configuration.ts
@@ -23,6 +23,10 @@ export interface AuthCredentials {
 
 interface RawClientConfiguration {
     proxy?: string | null
+    proxyHost?: string | null
+    proxyPort?: number | null
+    proxyPath?: string | null
+    proxyCACert?: string | null
     codebase?: string
     debugFilter: RegExp | null
     debugVerbose: boolean

--- a/lib/shared/src/fetch.ts
+++ b/lib/shared/src/fetch.ts
@@ -1,4 +1,4 @@
-import type { Agent } from 'node:http'
+import type { Agent, ClientRequest, RequestOptions } from 'node:http'
 
 /**
  * By hard-requiring isomorphic-fetch, we ensure that even in newer Node environments that include
@@ -21,7 +21,12 @@ import {
  *
  * Agent is a mutable ref so that we can override it from `fetch.node.ts`
  */
-export const agent: { current: ((url: URL) => Agent) | undefined } = { current: undefined }
+export const agent:
+    | { current: undefined; _forceCodyProxy?: undefined }
+    | {
+          current: (req?: Partial<ClientRequest>, opts?: Partial<RequestOptions>) => Agent
+          _forceCodyProxy?: boolean | undefined
+      } = { current: undefined }
 
 export function fetch(input: RequestInfo | URL, init?: RequestInit): Promise<BrowserOrNodeResponse> {
     if (customUserAgent) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -516,6 +516,9 @@ importers:
       '@vscode/webview-ui-toolkit':
         specifier: ^1.2.2
         version: 1.2.2(react@18.2.0)
+      agent-base:
+        specifier: ^7.1.1
+        version: 7.1.1
       async-mutex:
         specifier: ^0.4.0
         version: 0.4.0
@@ -3813,7 +3816,7 @@ packages:
   /@radix-ui/primitive@1.0.1:
     resolution: {integrity: sha512-yQ8oGX2GVsEYMWGxcovu1uGWPCxV5BFfeeYxqPmuAzUyLT9qmaMXSAhXpb0WrspIeqYzdJpkh2vHModJPgRIaw==}
     dependencies:
-      '@babel/runtime': 7.24.5
+      '@babel/runtime': 7.25.6
     dev: false
 
   /@radix-ui/primitive@1.1.0:
@@ -3942,7 +3945,7 @@ packages:
       '@types/react':
         optional: true
     dependencies:
-      '@babel/runtime': 7.24.5
+      '@babel/runtime': 7.25.6
       '@types/react': 18.2.79
       react: 18.2.0
     dev: false
@@ -3995,7 +3998,7 @@ packages:
       '@types/react':
         optional: true
     dependencies:
-      '@babel/runtime': 7.24.5
+      '@babel/runtime': 7.25.6
       '@types/react': 18.2.79
       react: 18.2.0
     dev: false
@@ -4132,7 +4135,7 @@ packages:
       '@types/react-dom':
         optional: true
     dependencies:
-      '@babel/runtime': 7.24.5
+      '@babel/runtime': 7.25.6
       '@radix-ui/primitive': 1.0.1
       '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.2.79)(react@18.2.0)
       '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.2.25)(@types/react@18.2.79)(react-dom@18.2.0)(react@18.2.0)
@@ -4167,7 +4170,7 @@ packages:
       '@types/react':
         optional: true
     dependencies:
-      '@babel/runtime': 7.24.5
+      '@babel/runtime': 7.25.6
       '@types/react': 18.2.79
       react: 18.2.0
     dev: false
@@ -4208,7 +4211,7 @@ packages:
       '@types/react-dom':
         optional: true
     dependencies:
-      '@babel/runtime': 7.24.5
+      '@babel/runtime': 7.25.6
       '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.2.79)(react@18.2.0)
       '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.2.25)(@types/react@18.2.79)(react-dom@18.2.0)(react@18.2.0)
       '@radix-ui/react-use-callback-ref': 1.0.1(@types/react@18.2.79)(react@18.2.0)
@@ -4267,7 +4270,7 @@ packages:
       '@types/react':
         optional: true
     dependencies:
-      '@babel/runtime': 7.24.5
+      '@babel/runtime': 7.25.6
       '@radix-ui/react-use-layout-effect': 1.0.1(@types/react@18.2.79)(react@18.2.0)
       '@types/react': 18.2.79
       react: 18.2.0
@@ -4355,7 +4358,7 @@ packages:
       '@types/react-dom':
         optional: true
     dependencies:
-      '@babel/runtime': 7.24.5
+      '@babel/runtime': 7.25.6
       '@floating-ui/react-dom': 2.0.9(react-dom@18.2.0)(react@18.2.0)
       '@radix-ui/react-arrow': 1.0.3(@types/react-dom@18.2.25)(@types/react@18.2.79)(react-dom@18.2.0)(react@18.2.0)
       '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.2.79)(react@18.2.0)
@@ -4406,7 +4409,7 @@ packages:
       '@types/react-dom':
         optional: true
     dependencies:
-      '@babel/runtime': 7.24.5
+      '@babel/runtime': 7.25.6
       '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.2.25)(@types/react@18.2.79)(react-dom@18.2.0)(react@18.2.0)
       '@types/react': 18.2.79
       '@types/react-dom': 18.2.25
@@ -4449,7 +4452,7 @@ packages:
       '@types/react-dom':
         optional: true
     dependencies:
-      '@babel/runtime': 7.24.5
+      '@babel/runtime': 7.25.6
       '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.2.79)(react@18.2.0)
       '@radix-ui/react-use-layout-effect': 1.0.1(@types/react@18.2.79)(react@18.2.0)
       '@types/react': 18.2.79
@@ -4492,7 +4495,7 @@ packages:
       '@types/react-dom':
         optional: true
     dependencies:
-      '@babel/runtime': 7.24.5
+      '@babel/runtime': 7.25.6
       '@radix-ui/react-slot': 1.0.2(@types/react@18.2.37)(react@18.2.0)
       '@types/react': 18.2.37
       '@types/react-dom': 18.2.15
@@ -4513,7 +4516,7 @@ packages:
       '@types/react-dom':
         optional: true
     dependencies:
-      '@babel/runtime': 7.24.5
+      '@babel/runtime': 7.25.6
       '@radix-ui/react-slot': 1.0.2(@types/react@18.2.79)(react@18.2.0)
       '@types/react': 18.2.79
       '@types/react-dom': 18.2.25
@@ -4750,7 +4753,7 @@ packages:
       '@types/react':
         optional: true
     dependencies:
-      '@babel/runtime': 7.24.5
+      '@babel/runtime': 7.25.6
       '@radix-ui/react-use-callback-ref': 1.0.1(@types/react@18.2.79)(react@18.2.0)
       '@types/react': 18.2.79
       react: 18.2.0
@@ -4884,7 +4887,7 @@ packages:
       '@types/react-dom':
         optional: true
     dependencies:
-      '@babel/runtime': 7.24.5
+      '@babel/runtime': 7.25.6
       '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.2.25)(@types/react@18.2.79)(react-dom@18.2.0)(react@18.2.0)
       '@types/react': 18.2.79
       '@types/react-dom': 18.2.25

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -597,6 +597,9 @@ importers:
       postcss-scss:
         specifier: ^4.0.9
         version: 4.0.9(postcss@8.4.38)
+      proxy-agent:
+        specifier: ^6.4.0
+        version: 6.4.0
       react-markdown:
         specifier: ^9.0.1
         version: 9.0.1(@types/react@18.2.79)(react@18.2.0)
@@ -6399,6 +6402,10 @@ packages:
     resolution: {integrity: sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==}
     engines: {node: '>= 10'}
 
+  /@tootallnate/quickjs-emscripten@0.23.0:
+    resolution: {integrity: sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==}
+    dev: false
+
   /@trysound/sax@0.2.0:
     resolution: {integrity: sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==}
     engines: {node: '>=10.13.0'}
@@ -7433,11 +7440,18 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: false
 
+  /ast-types@0.13.4:
+    resolution: {integrity: sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==}
+    engines: {node: '>=4'}
+    dependencies:
+      tslib: 2.7.0
+    dev: false
+
   /ast-types@0.16.1:
     resolution: {integrity: sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg==}
     engines: {node: '>=4'}
     dependencies:
-      tslib: 2.1.0
+      tslib: 2.7.0
     dev: true
 
   /astral-regex@2.0.0:
@@ -7621,6 +7635,11 @@ packages:
     engines: {node: '>= 0.8'}
     dependencies:
       safe-buffer: 5.1.2
+
+  /basic-ftp@5.0.5:
+    resolution: {integrity: sha512-4Bcg1P8xhUuqcii/S0Z9wiHIrQVPMermM1any+MX5GeGD7faD3/msQUDGLol9wOcz4/jbg/WJnGqoJF6LiBdtg==}
+    engines: {node: '>=10.0.0'}
+    dev: false
 
   /better-opn@3.0.2:
     resolution: {integrity: sha512-aVNobHnJqLiUelTaHat9DZ1qM2w0C0Eym4LPI/3JxOnSokGVdsl1T1kN7TFvsEAD8G47A6VKQ0TVHqbBnYMJlQ==}
@@ -8557,6 +8576,11 @@ packages:
     resolution: {integrity: sha512-wT5Y7mO8abrV16gnssKdmIhIbA9wSkeMzhh27jAguKrV82i24wER0vL5TGhUJ9dbJNDcigoRZ0IAHFEEEI4THQ==}
     dev: false
 
+  /data-uri-to-buffer@6.0.2:
+    resolution: {integrity: sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==}
+    engines: {node: '>= 14'}
+    dev: false
+
   /data-urls@4.0.0:
     resolution: {integrity: sha512-/mMTei/JXPqvFqQtfyTowxmJVwr2PVAeCcDxyFf6LhoOu/09TX2OX3kb2wzi4DMXcfj4OItwDOnhl5oziPnT6g==}
     engines: {node: '>=14'}
@@ -8784,6 +8808,15 @@ packages:
     resolution: {integrity: sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==}
     dev: true
 
+  /degenerator@5.0.1:
+    resolution: {integrity: sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==}
+    engines: {node: '>= 14'}
+    dependencies:
+      ast-types: 0.13.4
+      escodegen: 2.1.0
+      esprima: 4.0.1
+    dev: false
+
   /del@6.1.1:
     resolution: {integrity: sha512-ua8BhapfP0JUJKC/zV9yHHDW/rDoDxP4Zhn3AkA6/xT6gY7jYXJiaeyBZznYVujhZZET+UgcbZiQ7sN3WqcImg==}
     engines: {node: '>=10'}
@@ -8939,7 +8972,7 @@ packages:
     resolution: {integrity: sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==}
     dependencies:
       no-case: 3.0.4
-      tslib: 2.1.0
+      tslib: 2.7.0
     dev: true
 
   /dotenv-expand@10.0.0:
@@ -9229,7 +9262,6 @@ packages:
       esutils: 2.0.3
     optionalDependencies:
       source-map: 0.6.1
-    dev: true
 
   /eslint-visitor-keys@3.4.3:
     resolution: {integrity: sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==}
@@ -9249,7 +9281,6 @@ packages:
     resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
     engines: {node: '>=4'}
     hasBin: true
-    dev: true
 
   /estraverse@4.3.0:
     resolution: {integrity: sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==}
@@ -9259,7 +9290,6 @@ packages:
   /estraverse@5.3.0:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
     engines: {node: '>=4.0'}
-    dev: true
 
   /estree-util-is-identifier-name@3.0.0:
     resolution: {integrity: sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==}
@@ -9278,7 +9308,6 @@ packages:
   /esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
-    dev: true
 
   /etag@1.8.1:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
@@ -9776,7 +9805,6 @@ packages:
       graceful-fs: 4.2.11
       jsonfile: 6.1.0
       universalify: 2.0.1
-    dev: true
 
   /fs-minipass@2.1.0:
     resolution: {integrity: sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==}
@@ -9912,6 +9940,18 @@ packages:
     resolution: {integrity: sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==}
     engines: {node: '>=16'}
     dev: true
+
+  /get-uri@6.0.3:
+    resolution: {integrity: sha512-BzUrJBS9EcUb4cFol8r4W3v1cPsSyajLSthNkz5BxbpDcHN5tIrM10E2eNvfnvBn3DaT3DUgx0OpsBKkaOpanw==}
+    engines: {node: '>= 14'}
+    dependencies:
+      basic-ftp: 5.0.5
+      data-uri-to-buffer: 6.0.2
+      debug: 4.3.5
+      fs-extra: 11.2.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
 
   /get-value@2.0.6:
     resolution: {integrity: sha512-Ln0UQDlxH1BapMu3GPtf7CuYNwRZf2gwCuPqbyG6pB8WfmFpzqcy4xtAaAMUhnNqjMKTiCPZG2oMT3YSx8U2NA==}
@@ -10483,6 +10523,16 @@ packages:
       debug: 4.3.4(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
+
+  /https-proxy-agent@7.0.5:
+    resolution: {integrity: sha512-1e4Wqeblerz+tMKPIq2EMGiiWW1dIjZOksyHWSUm1rmuvw/how9hBHZ38lAGj5ID4Ik6EdkOw7NmWPy6LAwalw==}
+    engines: {node: '>= 14'}
+    dependencies:
+      agent-base: 7.1.1
+      debug: 4.3.5
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
 
   /human-signals@2.1.0:
     resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
@@ -11583,7 +11633,7 @@ packages:
   /lower-case@2.0.2:
     resolution: {integrity: sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==}
     dependencies:
-      tslib: 2.1.0
+      tslib: 2.7.0
     dev: true
 
   /lowlight@2.9.0:
@@ -12620,11 +12670,16 @@ packages:
     resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
     dev: true
 
+  /netmask@2.0.2:
+    resolution: {integrity: sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==}
+    engines: {node: '>= 0.4.0'}
+    dev: false
+
   /no-case@3.0.4:
     resolution: {integrity: sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==}
     dependencies:
       lower-case: 2.0.2
-      tslib: 2.1.0
+      tslib: 2.7.0
     dev: true
 
   /nocache@3.0.4:
@@ -13038,6 +13093,30 @@ packages:
     resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
     engines: {node: '>=6'}
     dev: true
+
+  /pac-proxy-agent@7.0.2:
+    resolution: {integrity: sha512-BFi3vZnO9X5Qt6NRz7ZOaPja3ic0PhlsmCRYLOpN11+mWBCR6XJDqW5RF3j8jm4WGGQZtBA+bTfxYzeKW73eHg==}
+    engines: {node: '>= 14'}
+    dependencies:
+      '@tootallnate/quickjs-emscripten': 0.23.0
+      agent-base: 7.1.1
+      debug: 4.3.5
+      get-uri: 6.0.3
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.5
+      pac-resolver: 7.0.1
+      socks-proxy-agent: 8.0.4
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /pac-resolver@7.0.1:
+    resolution: {integrity: sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==}
+    engines: {node: '>= 14'}
+    dependencies:
+      degenerator: 5.0.1
+      netmask: 2.0.2
+    dev: false
 
   /pako@0.2.9:
     resolution: {integrity: sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==}
@@ -13582,6 +13661,22 @@ packages:
       forwarded: 0.2.0
       ipaddr.js: 1.9.1
 
+  /proxy-agent@6.4.0:
+    resolution: {integrity: sha512-u0piLU+nCOHMgGjRbimiXmA9kM/L9EHh3zL81xCdp7m+Y2pHIsnmbdDoEDoAz5geaonNR6q6+yOPQs6n4T6sBQ==}
+    engines: {node: '>= 14'}
+    dependencies:
+      agent-base: 7.1.1
+      debug: 4.3.5
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.4
+      lru-cache: 7.18.3
+      pac-proxy-agent: 7.0.2
+      proxy-from-env: 1.1.0
+      socks-proxy-agent: 8.0.4
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
   /proxy-from-env@1.1.0:
     resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
 
@@ -13848,7 +13943,7 @@ packages:
       '@types/react': 18.2.37
       react: 18.2.0
       react-style-singleton: 2.2.1(@types/react@18.2.37)(react@18.2.0)
-      tslib: 2.1.0
+      tslib: 2.7.0
     dev: false
 
   /react-remove-scroll-bar@2.3.6(@types/react@18.2.79)(react@18.2.0):
@@ -13864,7 +13959,7 @@ packages:
       '@types/react': 18.2.79
       react: 18.2.0
       react-style-singleton: 2.2.1(@types/react@18.2.79)(react@18.2.0)
-      tslib: 2.1.0
+      tslib: 2.7.0
     dev: false
 
   /react-remove-scroll@2.5.5(@types/react@18.2.37)(react@18.2.0):
@@ -13919,7 +14014,7 @@ packages:
       get-nonce: 1.0.1
       invariant: 2.2.4
       react: 18.2.0
-      tslib: 2.1.0
+      tslib: 2.7.0
     dev: false
 
   /react-style-singleton@2.2.1(@types/react@18.2.79)(react@18.2.0):
@@ -13936,7 +14031,7 @@ packages:
       get-nonce: 1.0.1
       invariant: 2.2.4
       react: 18.2.0
-      tslib: 2.1.0
+      tslib: 2.7.0
     dev: false
 
   /react-visibility-sensor@5.1.1(react-dom@18.2.0)(react@18.2.0):
@@ -14057,7 +14152,7 @@ packages:
       esprima: 4.0.1
       source-map: 0.6.1
       tiny-invariant: 1.3.3
-      tslib: 2.1.0
+      tslib: 2.7.0
     dev: true
 
   /redent@3.0.0:
@@ -14679,7 +14774,7 @@ packages:
     resolution: {integrity: sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==}
     dependencies:
       dot-case: 3.0.4
-      tslib: 2.1.0
+      tslib: 2.7.0
     dev: true
 
   /snapdragon-node@2.1.1:
@@ -14736,6 +14831,17 @@ packages:
       - supports-color
     dev: false
 
+  /socks-proxy-agent@8.0.4:
+    resolution: {integrity: sha512-GNAq/eg8Udq2x0eNiFkr9gRg5bA7PXEWagQdeRX4cPSG+X/8V38v637gim9bjFptMk1QWsCTr0ttrJEiXbNnRw==}
+    engines: {node: '>= 14'}
+    dependencies:
+      agent-base: 7.1.1
+      debug: 4.3.5
+      socks: 2.8.3
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
   /socks@2.8.3:
     resolution: {integrity: sha512-l5x7VUUWbjVFbafGLxPWkYsHIhEvmF85tbIeFZWc8ZPtoMyybuEhL7Jye/ooC4/d48FgOjSJXgsF/AJPYCW8Zw==}
     engines: {node: '>= 10.0.0', npm: '>= 3.0.0'}
@@ -14785,7 +14891,6 @@ packages:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
     requiresBuild: true
-    dev: true
 
   /space-separated-tokens@2.0.2:
     resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
@@ -16022,7 +16127,7 @@ packages:
     dependencies:
       '@types/react': 18.2.37
       react: 18.2.0
-      tslib: 2.1.0
+      tslib: 2.7.0
     dev: false
 
   /use-callback-ref@1.3.2(@types/react@18.2.79)(react@18.2.0):
@@ -16037,7 +16142,7 @@ packages:
     dependencies:
       '@types/react': 18.2.79
       react: 18.2.0
-      tslib: 2.1.0
+      tslib: 2.7.0
     dev: false
 
   /use-sidecar@1.1.2(@types/react@18.2.37)(react@18.2.0):
@@ -16053,7 +16158,7 @@ packages:
       '@types/react': 18.2.37
       detect-node-es: 1.1.0
       react: 18.2.0
-      tslib: 2.1.0
+      tslib: 2.7.0
     dev: false
 
   /use-sidecar@1.1.2(@types/react@18.2.79)(react@18.2.0):
@@ -16069,7 +16174,7 @@ packages:
       '@types/react': 18.2.79
       detect-node-es: 1.1.0
       react: 18.2.0
-      tslib: 2.1.0
+      tslib: 2.7.0
     dev: false
 
   /use@3.1.1:

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -56,7 +56,14 @@
     "version-bump:patch": "RELEASE_TYPE=patch ts-node-transpile-only ./scripts/version-bump.ts",
     "version-bump:dry-run": "RELEASE_TYPE=prerelease ts-node-transpile-only ./scripts/version-bump.ts"
   },
-  "categories": ["AI", "Chat", "Programming Languages", "Machine Learning", "Snippets", "Education"],
+  "categories": [
+    "AI",
+    "Chat",
+    "Programming Languages",
+    "Machine Learning",
+    "Snippets",
+    "Education"
+  ],
   "keywords": [
     "cody",
     "codey",
@@ -120,7 +127,11 @@
   },
   "main": "./dist/extension.node.js",
   "browser": "./dist/extension.web.js",
-  "activationEvents": ["onLanguage", "onStartupFinished", "onWebviewPanel:cody.editorPanel"],
+  "activationEvents": [
+    "onLanguage",
+    "onStartupFinished",
+    "onWebviewPanel:cody.editorPanel"
+  ],
   "contributes": {
     "walkthroughs": [
       {
@@ -719,13 +730,17 @@
       },
       {
         "command": "cody.supercompletion.jumpTo",
-        "args": ["next"],
+        "args": [
+          "next"
+        ],
         "key": "shift+ctrl+down",
         "when": "cody.activated && !editorReadonly && cody.hasActionableSupercompletion"
       },
       {
         "command": "cody.supercompletion.jumpTo",
-        "args": ["previous"],
+        "args": [
+          "previous"
+        ],
         "key": "shift+ctrl+up",
         "when": "cody.activated && !editorReadonly && cody.hasActionableSupercompletion"
       }
@@ -979,7 +994,10 @@
           "order": 2,
           "type": "string",
           "markdownDescription": "A Git repository URL to use instead of allowing Cody to infer the Git repository from the workspace.",
-          "examples": ["https://github.com/sourcegraph/cody", "ssh://git@github.com/sourcegraph/cody"]
+          "examples": [
+            "https://github.com/sourcegraph/cody",
+            "ssh://git@github.com/sourcegraph/cody"
+          ]
         },
         "cody.customHeaders": {
           "order": 4,
@@ -1029,12 +1047,18 @@
           "order": 6,
           "type": "string",
           "markdownDescription": "A custom instruction to be included at the start of all chat messages (e.g. \"Answer all my questions in Spanish.\")",
-          "examples": ["Answer all my questions in Spanish."]
+          "examples": [
+            "Answer all my questions in Spanish."
+          ]
         },
         "cody.chat.defaultLocation": {
           "order": 6,
           "type": "string",
-          "enum": ["sticky", "sidebar", "editor"],
+          "enum": [
+            "sticky",
+            "sidebar",
+            "editor"
+          ],
           "markdownDescription": "Controls where the Cody chat view opens when the user invokes the `Cody: New Chat` command, or the Alt+L and Alt+/ shortcuts.",
           "enumDescriptions": [
             "Opens in the last-activated view location, which is set whenever the user explicitly chooses to open chat in a given location",
@@ -1047,7 +1071,9 @@
           "order": 7,
           "type": "string",
           "markdownDescription": "A custom instruction to be included at the end of all instructions for edit commands (e.g. \"Write all unit tests with Jest instead of detected framework.\")",
-          "examples": ["Write all unit tests with Jest instead of detected framework."]
+          "examples": [
+            "Write all unit tests with Jest instead of detected framework."
+          ]
         },
         "cody.codeActions.enabled": {
           "order": 11,
@@ -1093,15 +1119,24 @@
         "cody.telemetry.level": {
           "order": 99,
           "type": "string",
-          "enum": ["all", "off"],
-          "enumDescriptions": ["Sends usage data and errors.", "Disables all extension telemetry."],
+          "enum": [
+            "all",
+            "off"
+          ],
+          "enumDescriptions": [
+            "Sends usage data and errors.",
+            "Disables all extension telemetry."
+          ],
           "markdownDescription": "Controls the telemetry about Cody usage and errors. See [Cody usage and privacy notice](https://about.sourcegraph.com/terms/cody-notice).",
           "default": "all"
         },
         "cody.autocomplete.advanced.provider": {
           "type": "string",
           "default": "default",
-          "enum": ["default", "experimental-ollama"],
+          "enum": [
+            "default",
+            "experimental-ollama"
+          ],
           "enumDescriptions": [
             "Our recommended setup with the best balance of quality and latency. We continuously update this for optimal performance.",
             "Experimental support for Ollama users. Use `cody.autocomplete.experimental.ollamaOptions` to configure requests to Ollama server."
@@ -1125,7 +1160,10 @@
         },
         "cody.experimental.foldingRanges": {
           "type": "string",
-          "enum": ["lsp", "indentation-based"],
+          "enum": [
+            "lsp",
+            "indentation-based"
+          ],
           "enumDescriptions": [
             "Use folding ranges that are enabled by default in VS Code, and are usually powered by LSP",
             "Use custom implementation of folding ranges that is indentation based. This is the implementation that is used by other Cody clients like the JetBrains plugin"
@@ -1136,7 +1174,11 @@
         "cody.autocomplete.experimental.graphContext": {
           "type": "string",
           "default": null,
-          "enum": [null, "tsc", "tsc-mixed"],
+          "enum": [
+            null,
+            "tsc",
+            "tsc-mixed"
+          ],
           "markdownDescription": "Use the code graph to retrieve context for autocomplete requests."
         },
         "cody.autocomplete.experimental.fireworksOptions": {
@@ -1233,7 +1275,10 @@
           "default": false
         },
         "cody.proxy": {
-          "type": ["null", "object"],
+          "type": [
+            "null",
+            "object"
+          ],
           "description": "Configure the proxy to use when connecting to the Sourcegraph instance.",
           "default": null,
           "oneOf": [
@@ -1243,20 +1288,29 @@
                   "description": "Hostname/IP address and port of the server to use when proxying requests to the Sourcegraph instance. Do not include a protocol (like \"http://\")",
                   "type": "string",
                   "pattern": "^[^:]+:\\d+$",
-                  "examples": ["localhost:7080", "1.2.3.4:8080"]
+                  "examples": [
+                    "localhost:7080",
+                    "1.2.3.4:8080"
+                  ]
                 }
               },
-              "required": ["server"]
+              "required": [
+                "server"
+              ]
             },
             {
               "properties": {
                 "path": {
                   "description": "The full path to a file when proxying requests to the Sourcegraph instance via a UNIX domain socket.",
                   "type": "string",
-                  "examples": ["/home/user/mitm-proxy.sock"]
+                  "examples": [
+                    "/home/user/mitm-proxy.sock"
+                  ]
                 }
               },
-              "required": ["path"]
+              "required": [
+                "path"
+              ]
             }
           ],
           "properties": {
@@ -1350,7 +1404,9 @@
     "untrustedWorkspaces": {
       "supported": "limited",
       "description": "Cody only uses providers (configured in `openctx.providers`) from trusted workspaces because providers may execute arbitrary code.",
-      "restrictedConfigurations": ["openctx.providers"]
+      "restrictedConfigurations": [
+        "openctx.providers"
+      ]
     }
   },
   "dependencies": {
@@ -1386,6 +1442,7 @@
     "@types/react-dom": "18.2.25",
     "@vscode/codicons": "^0.0.35",
     "@vscode/webview-ui-toolkit": "^1.2.2",
+    "agent-base": "^7.1.1",
     "async-mutex": "^0.4.0",
     "axios": "^1.3.6",
     "class-variance-authority": "^0.7.0",

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -1231,6 +1231,30 @@
           "type": "boolean",
           "markdownDescription": "[INTERNAL ONLY] Enable all unstable experimental features.",
           "default": false
+        },
+        "sourcegraph.proxyProtocol": {
+          "description": "The protocol to use when proxying requests to the Sourcegraph instance.",
+          "type": "string",
+          "default": "",
+          "examples": ["http", "https"]
+        },
+        "sourcegraph.proxyHost": {
+          "description": "The host to use when proxying requests to the Sourcegraph instance. It shouldn't include a protocol (like \"http://\") or a port (like \":7080\"). When this is set, port must be set as well.",
+          "type": "string",
+          "default": "",
+          "examples": ["localhost", "1.2.3.4"]
+        },
+        "sourcegraph.proxyPort": {
+          "description": "The port to use when proxying requests to the Sourcegraph instance. When this is set, host must be set as well.",
+          "type": "number",
+          "default": 0,
+          "examples": [80, 443, 7080, 9090]
+        },
+        "sourcegraph.proxyPath": {
+          "description": "The full path to a file when proxying requests to the Sourcegraph instance via a UNIX domain socket.",
+          "type": "string",
+          "default": "",
+          "examples": ["/home/user/path/unix.socket"]
         }
       }
     },
@@ -1374,6 +1398,7 @@
     "mkdirp": "^3.0.1",
     "os-browserify": "^0.3.0",
     "postcss-scss": "^4.0.9",
+    "proxy-agent": "^6.4.0",
     "react-markdown": "^9.0.1",
     "react-visibility-sensor": "^5.1.1",
     "rehype-highlight": "^6.0.0",

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -1232,35 +1232,32 @@
           "markdownDescription": "[INTERNAL ONLY] Enable all unstable experimental features.",
           "default": false
         },
-        "cody.proxyProtocol": {
-          "description": "The protocol to use when proxying requests to the Sourcegraph instance.",
-          "type": "string",
-          "default": "",
-          "examples": ["http", "https"]
-        },
-        "cody.proxyHost": {
+        "cody.proxy.host": {
           "description": "The host to use when proxying requests to the Sourcegraph instance. It shouldn't include a protocol (like \"http://\") or a port (like \":7080\"). When this is set, port must be set as well.",
           "type": "string",
           "default": "",
           "examples": ["localhost", "1.2.3.4"]
         },
-        "cody.proxyPort": {
+        "cody.proxy.port": {
           "description": "The port to use when proxying requests to the Sourcegraph instance. When this is set, host must be set as well.",
           "type": "number",
           "default": 0,
           "examples": [80, 443, 7080, 9090]
         },
-        "cody.proxyPath": {
+        "cody.proxy.path": {
           "description": "The full path to a file when proxying requests to the Sourcegraph instance via a UNIX domain socket.",
           "type": "string",
           "default": "",
           "examples": ["/home/user/mitm-proxy.sock"]
         },
-        "cody.proxyCACert": {
-          "description": "The full path to a file that contains the PEM-encoded CA certificate the proxy uses. Does not need to contain the private key.",
+        "cody.proxy.cacert": {
+          "description": "Either the PEM-encoded CA certificate the proxy uses (replace newlines with `\n`), or the path to the file containing that certificate.",
           "type": "string",
           "default": "",
-          "examples": ["/home/user/.mitmproxy/mitmproxy-ca-cert.pem"]
+          "examples": [
+            "/home/user/.mitmproxy/mitmproxy-ca-cert.pem",
+            "-----BEGIN CERTIFICATE-----\n...\n-----END CERTIFICATE-----"
+          ]
         }
       }
     },

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -1239,18 +1239,14 @@
           "oneOf": [
             {
               "properties": {
-                "host": {
-                  "description": "The host to use when proxying requests to the Sourcegraph instance. It shouldn't include a protocol (like \"http://\") or a port (like \":7080\"). When this is set, port must be set as well.",
+                "server": {
+                  "description": "Hostname/IP address and port of the server to use when proxying requests to the Sourcegraph instance. Do not include a protocol (like \"http://\")",
                   "type": "string",
-                  "examples": ["localhost", "1.2.3.4"]
-                },
-                "port": {
-                  "description": "The port to use when proxying requests to the Sourcegraph instance. When this is set, host must be set as well.",
-                  "type": "number",
-                  "examples": [80, 443, 7080, 9090]
+                  "pattern": "^[^:]+:\\d+$",
+                  "examples": ["localhost:7080", "1.2.3.4:8080"]
                 }
               },
-              "required": ["host", "port"]
+              "required": ["server"]
             },
             {
               "properties": {

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -1232,32 +1232,48 @@
           "markdownDescription": "[INTERNAL ONLY] Enable all unstable experimental features.",
           "default": false
         },
-        "cody.proxy.host": {
-          "description": "The host to use when proxying requests to the Sourcegraph instance. It shouldn't include a protocol (like \"http://\") or a port (like \":7080\"). When this is set, port must be set as well.",
-          "type": "string",
-          "default": "",
-          "examples": ["localhost", "1.2.3.4"]
-        },
-        "cody.proxy.port": {
-          "description": "The port to use when proxying requests to the Sourcegraph instance. When this is set, host must be set as well.",
-          "type": "number",
-          "default": 0,
-          "examples": [80, 443, 7080, 9090]
-        },
-        "cody.proxy.path": {
-          "description": "The full path to a file when proxying requests to the Sourcegraph instance via a UNIX domain socket.",
-          "type": "string",
-          "default": "",
-          "examples": ["/home/user/mitm-proxy.sock"]
-        },
-        "cody.proxy.cacert": {
-          "description": "Either the PEM-encoded CA certificate the proxy uses (replace newlines with `\n`), or the path to the file containing that certificate.",
-          "type": "string",
-          "default": "",
-          "examples": [
-            "/home/user/.mitmproxy/mitmproxy-ca-cert.pem",
-            "-----BEGIN CERTIFICATE-----\n...\n-----END CERTIFICATE-----"
-          ]
+        "cody.proxy": {
+          "type": ["null", "object"],
+          "description": "Configure the proxy to use when connecting to the Sourcegraph instance.",
+          "default": null,
+          "oneOf": [
+            {
+              "properties": {
+                "host": {
+                  "description": "The host to use when proxying requests to the Sourcegraph instance. It shouldn't include a protocol (like \"http://\") or a port (like \":7080\"). When this is set, port must be set as well.",
+                  "type": "string",
+                  "examples": ["localhost", "1.2.3.4"]
+                },
+                "port": {
+                  "description": "The port to use when proxying requests to the Sourcegraph instance. When this is set, host must be set as well.",
+                  "type": "number",
+                  "examples": [80, 443, 7080, 9090]
+                }
+              },
+              "required": ["host", "port"]
+            },
+            {
+              "properties": {
+                "path": {
+                  "description": "The full path to a file when proxying requests to the Sourcegraph instance via a UNIX domain socket.",
+                  "type": "string",
+                  "examples": ["/home/user/mitm-proxy.sock"]
+                }
+              },
+              "required": ["path"]
+            }
+          ],
+          "properties": {
+            "cacert": {
+              "description": "Either the PEM-encoded CA certificate the proxy uses (replace newlines with `\n`), or the path to the file containing that certificate.",
+              "type": "string",
+              "default": "",
+              "examples": [
+                "/home/user/.mitmproxy/mitmproxy-ca-cert.pem",
+                "-----BEGIN CERTIFICATE-----\n...\n-----END CERTIFICATE-----"
+              ]
+            }
+          }
         }
       }
     },

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -1232,29 +1232,35 @@
           "markdownDescription": "[INTERNAL ONLY] Enable all unstable experimental features.",
           "default": false
         },
-        "sourcegraph.proxyProtocol": {
+        "cody.proxyProtocol": {
           "description": "The protocol to use when proxying requests to the Sourcegraph instance.",
           "type": "string",
           "default": "",
           "examples": ["http", "https"]
         },
-        "sourcegraph.proxyHost": {
+        "cody.proxyHost": {
           "description": "The host to use when proxying requests to the Sourcegraph instance. It shouldn't include a protocol (like \"http://\") or a port (like \":7080\"). When this is set, port must be set as well.",
           "type": "string",
           "default": "",
           "examples": ["localhost", "1.2.3.4"]
         },
-        "sourcegraph.proxyPort": {
+        "cody.proxyPort": {
           "description": "The port to use when proxying requests to the Sourcegraph instance. When this is set, host must be set as well.",
           "type": "number",
           "default": 0,
           "examples": [80, 443, 7080, 9090]
         },
-        "sourcegraph.proxyPath": {
+        "cody.proxyPath": {
           "description": "The full path to a file when proxying requests to the Sourcegraph instance via a UNIX domain socket.",
           "type": "string",
           "default": "",
-          "examples": ["/home/user/path/unix.socket"]
+          "examples": ["/home/user/mitm-proxy.sock"]
+        },
+        "cody.proxyCACert": {
+          "description": "The full path to a file that contains the PEM-encoded CA certificate the proxy uses. Does not need to contain the private key.",
+          "type": "string",
+          "default": "",
+          "examples": ["/home/user/.mitmproxy/mitmproxy-ca-cert.pem"]
         }
       }
     },

--- a/vscode/src/configuration-proxy.ts
+++ b/vscode/src/configuration-proxy.ts
@@ -1,8 +1,18 @@
 import * as fs from 'node:fs'
+import https from 'node:https'
 import * as os from 'node:os'
 import * as path from 'node:path'
+import { parse as parseUrl } from 'node:url'
+import { agent } from '@sourcegraph/cody-shared'
+import type { AuthCredentials, ClientConfiguration, ClientState } from '@sourcegraph/cody-shared'
+import { HttpProxyAgent } from 'http-proxy-agent'
+import { HttpsProxyAgent } from 'https-proxy-agent'
+import { ProxyAgent } from 'proxy-agent'
+import { SocksProxyAgent } from 'socks-proxy-agent'
 import * as vscode from 'vscode'
-
+import type * as vscode from 'vscode'
+// @ts-ignore
+import { registerLocalCertificates } from './certs'
 import { setCustomAgent } from './fetch.node'
 
 import {
@@ -17,8 +27,105 @@ import { CONFIG_KEY } from './configuration-keys'
 
 import { type Observable, map } from 'observable-fns'
 
+export async function intializeConfigurationProxy(
+    config: Observable<Pick<ClientConfiguration, 'proxy' | 'proxyServer' | 'proxyPath' | 'proxyCACert'>>
+) {
+    // 1. Attempt to load initial proxy settings / ca certs etc
+    //    1.1 set up config change listener to update agent = {current, _forceCodyProxy}
+    // 2. regardless of success resolve promise
+}
+
+function getGlobalProxyURI(protocol: string, env: typeof process.env): string | null {
+    if (protocol === 'http:') {
+        return env.HTTP_PROXY || env.http_proxy || null
+    }
+    if (protocol === 'https:') {
+        return env.HTTPS_PROXY || env.https_proxy || env.HTTP_PROXY || env.http_proxy || null
+    }
+    if (protocol.startsWith('socks')) {
+        return env.SOCKS_PROXY || env.socks_proxy || null
+    }
+    return null
+}
+
+function getAgentFactory({
+    proxy,
+    proxyServer,
+    proxyPath,
+    proxyCACert,
+}: ClientConfiguration): ({ protocol }: Pick<URL, 'protocol'>) => http.Agent {
+    return ({ protocol }) => {
+        if (proxyServer || proxyPath) {
+            const [proxyHost, proxyPort] = proxyServer ? proxyServer.split(':') : [undefined, undefined]
+
+            // Combine the CA certs from the global options with the one(s) defined in settings,
+            // otherwise the CA cert in the settings overrides all of the global agent options
+            // (or the other way around, depending on the order of the options).
+            const caCerts = (() => {
+                if (proxyCACert) {
+                    if (Array.isArray(https.globalAgent.options.ca)) {
+                        return [...https.globalAgent.options.ca, proxyCACert]
+                    }
+                    return [https.globalAgent.options.ca, proxyCACert]
+                }
+                return undefined
+            })()
+            const agent = new ProxyAgent({
+                protocol: protocol || 'https:',
+                ...(proxyServer ? { host: proxyHost, port: Number(proxyPort) } : null),
+                ...(proxyPath ? { socketPath: proxyPath } : null),
+                keepAlive: true,
+                keepAliveMsecs: 60000,
+                ...https.globalAgent.options,
+                // Being at the end, this will override https.globalAgent.options.ca
+                ...(caCerts ? { ca: caCerts } : null),
+            })
+            return agent
+        }
+
+        const proxyURL = proxy || getGlobalProxyURI(protocol, process.env)
+        if (proxyURL) {
+            if (proxyURL?.startsWith('socks')) {
+                if (!socksProxyAgent) {
+                    socksProxyAgent = new SocksProxyAgent(proxyURL, {
+                        keepAlive: true,
+                        keepAliveMsecs: 60000,
+                    })
+                }
+                return socksProxyAgent
+            }
+            const proxyEndpoint = parseUrl(proxyURL)
+
+            const opts = {
+                host: proxyEndpoint.hostname || '',
+                port:
+                    (proxyEndpoint.port ? +proxyEndpoint.port : 0) ||
+                    (proxyEndpoint.protocol === 'https' ? 443 : 80),
+                auth: proxyEndpoint.auth,
+                rejectUnauthorized: true,
+                keepAlive: true,
+                keepAliveMsecs: 60000,
+                ...https.globalAgent.options,
+            }
+            if (protocol === 'http:') {
+                if (!httpProxyAgent) {
+                    httpProxyAgent = new HttpProxyAgent(proxyURL, opts)
+                }
+                return httpProxyAgent
+            }
+
+            if (!httpsProxyAgent) {
+                httpsProxyAgent = new HttpsProxyAgent(proxyURL, opts)
+            }
+            return httpsProxyAgent
+        }
+        return protocol === 'http:' ? httpAgent : httpsAgent
+    }
+}
+
 // subscribe to proxy settings changes in order to validate them and refresh the agent if needed
 export const proxySettings: Observable<ClientConfiguration> = resolvedConfig.pipe(
+    // pluck(resolvedConfig, [CONFIG_KEY.proxy, CONFIG_KEY.proxyServer, CONFIG_KEY.proxyPath, CONFIG_KEY.proxyCACert]),
     map(validateProxySettings),
     distinctUntilChanged((prev, curr) => {
         return (
@@ -33,12 +140,12 @@ export const proxySettings: Observable<ClientConfiguration> = resolvedConfig.pip
 // set up the subscription here instead of in main.ts => start() because adding it to main.ts
 // introduced fetch.node.ts as a dependency, which pulled in transitive dependencies that are not
 // available for browser builds, which breaks the "_build:esbuild:web" target.
-// We handled a similar issue with the Search extension by using aliases in a build script,
-// but there's no build script here and `esbuild --alias` doesn't like `./` prefixes.
+// We handled a similar issue with the Search extension by using package resolution in a build script,
+// but there's no build script here and `esbuild --alias` doesn't like `./` prefixes, so it can't map
+// `./fetch.node` to a stub/shim module.
 proxySettings.subscribe(setCustomAgent)
 
 let cachedProxyPath: string | undefined
-
 let cachedProxyCACertPath: string | null | undefined
 let cachedProxyCACert: string | undefined
 

--- a/vscode/src/configuration-proxy.ts
+++ b/vscode/src/configuration-proxy.ts
@@ -3,6 +3,8 @@ import * as os from 'node:os'
 import * as path from 'node:path'
 import * as vscode from 'vscode'
 
+import { setCustomAgent } from './fetch.node'
+
 import {
     type ClientConfiguration,
     type ResolvedConfiguration,
@@ -27,6 +29,13 @@ export const proxySettings: Observable<ClientConfiguration> = resolvedConfig.pip
         )
     })
 )
+
+// set up the subscription here instead of in main.ts => start() because adding it to main.ts
+// introduced fetch.node.ts as a dependency, which pulled in transitive dependencies that are not
+// available for browser builds, which breaks the "_build:esbuild:web" target.
+// We handled a similar issue with the Search extension by using aliases in a build script,
+// but there's no build script here and `esbuild --alias` doesn't like `./` prefixes.
+proxySettings.subscribe(setCustomAgent)
 
 let cachedProxyPath: string | undefined
 

--- a/vscode/src/configuration-proxy.ts
+++ b/vscode/src/configuration-proxy.ts
@@ -1,0 +1,105 @@
+import * as fs from 'node:fs'
+import * as os from 'node:os'
+import * as path from 'node:path'
+import * as vscode from 'vscode'
+
+import {
+    type ClientConfiguration,
+    type ResolvedConfiguration,
+    distinctUntilChanged,
+    logError,
+    resolvedConfig,
+} from '@sourcegraph/cody-shared'
+
+import { CONFIG_KEY } from './configuration-keys'
+
+import { type Observable, map } from 'observable-fns'
+
+// subscribe to proxy settings changes in order to validate them and refresh the agent if needed
+export const proxySettings: Observable<ClientConfiguration> = resolvedConfig.pipe(
+    map(validateProxySettings),
+    distinctUntilChanged((prev, curr) => {
+        return (
+            prev.proxy === curr.proxy &&
+            prev.proxyServer === curr.proxyServer &&
+            prev.proxyPath === curr.proxyPath &&
+            prev.proxyCACert === curr.proxyCACert
+        )
+    })
+)
+
+let cachedProxyPath: string | undefined
+
+let cachedProxyCACertPath: string | null | undefined
+let cachedProxyCACert: string | undefined
+
+export function validateProxySettings(config: ResolvedConfiguration): ClientConfiguration {
+    const resolvedProxyPath = resolveHomedir(config.configuration.proxyPath)
+    const resolvedProxyCACert = resolveHomedir(config.configuration.proxyCACert)
+    if (resolvedProxyPath !== cachedProxyPath) {
+        cachedProxyPath = validateProxyPath(resolvedProxyPath)
+    }
+    if (resolvedProxyCACert !== cachedProxyCACertPath) {
+        cachedProxyCACert = readProxyCACert(resolvedProxyCACert)
+        cachedProxyCACertPath = config.configuration.proxyCACert
+    }
+
+    return {
+        ...config.configuration,
+        proxyPath: cachedProxyPath,
+        proxyCACert: cachedProxyCACert,
+    }
+}
+function validateProxyPath(filePath: string | null | undefined): string | undefined {
+    if (filePath) {
+        try {
+            if (!fs.statSync(filePath).isSocket()) {
+                throw new Error('Not a socket')
+            }
+            fs.accessSync(filePath, fs.constants.R_OK | fs.constants.W_OK)
+            return filePath
+        } catch (error) {
+            logError(
+                'vscode.configuration',
+                `Cannot verify ${CONFIG_KEY.proxy}.path: ${filePath}: ${error}`
+            )
+            void vscode.window.showErrorMessage(
+                `Cannot verify ${CONFIG_KEY.proxy}.path: ${filePath}:\n${error}`
+            )
+        }
+    }
+    return undefined
+}
+
+export function readProxyCACert(filePath: string | null | undefined): string | undefined {
+    if (filePath === cachedProxyCACertPath) {
+        return cachedProxyCACert
+    }
+    if (filePath) {
+        // support directly embedding a CA cert in the settings
+        if (filePath.startsWith('-----BEGIN CERTIFICATE-----')) {
+            return filePath
+        }
+        try {
+            return fs.readFileSync(filePath, { encoding: 'utf-8' })
+        } catch (error) {
+            logError(
+                'vscode.configuration',
+                `Cannot read ${CONFIG_KEY.proxy}.cacert: ${filePath}: ${error}`
+            )
+            void vscode.window.showErrorMessage(
+                `Error reading ${CONFIG_KEY.proxy}.cacert from ${filePath}:\n${error}`
+            )
+        }
+    }
+    return undefined
+}
+
+function resolveHomedir(filePath: string | null | undefined): string | undefined {
+    for (const homeDir of ['~/', '%USERPROFILE%\\']) {
+        if (filePath?.startsWith(homeDir)) {
+            return `${os.homedir()}${path.sep}${filePath.slice(homeDir.length)}`
+        }
+    }
+    return filePath ? filePath : undefined
+}

--- a/vscode/src/configuration.test.ts
+++ b/vscode/src/configuration.test.ts
@@ -111,6 +111,8 @@ describe('getConfiguration', () => {
                         return 123
                     case 'cody.dev.models':
                         return [{ model: 'm', provider: 'p' }] satisfies ChatModelProviderConfig[]
+                    case 'cody.proxy':
+                        return undefined
                     case 'cody.override.authToken':
                         return undefined
                     case 'cody.override.serverEndpoint':

--- a/vscode/src/configuration.ts
+++ b/vscode/src/configuration.ts
@@ -1,4 +1,3 @@
-import * as fs from 'node:fs'
 import * as os from 'node:os'
 import * as path from 'node:path'
 import * as vscode from 'vscode'
@@ -20,15 +19,6 @@ import { localStorage } from './services/LocalStorageProvider'
 interface ConfigGetter {
     get<T>(section: (typeof CONFIG_KEY)[ConfigKeys], defaultValue?: T): T
 }
-
-let lastProxyConfig: {
-    host?: string
-    port?: number
-    path?: string
-    cacert?: string
-} | null = null
-let cachedProxyPath: string | undefined
-let cachedProxyCACert: string | undefined
 
 /**
  * All configuration values, with some sanitization performed.
@@ -60,98 +50,28 @@ export function getConfiguration(
         debugRegex = /.*/
     }
 
-    function resolveHomedir(filePath?: string): string | undefined {
+    const vsCodeConfig = vscode.workspace.getConfiguration()
+
+    const proxyConfig = config.get<{
+        server?: string
+        path?: string
+        cacert?: string
+    } | null>(CONFIG_KEY.proxy, null)
+
+    function resolveHomedir(filePath: string | null | undefined): string | undefined {
         for (const homeDir of ['~/', '%USERPROFILE%\\']) {
             if (filePath?.startsWith(homeDir)) {
                 return `${os.homedir()}${path.sep}${filePath.slice(homeDir.length)}`
             }
         }
-        return filePath
+        return filePath ? filePath : undefined
     }
-
-    function readProxyPath(filePath: string | undefined): string | undefined {
-        if (filePath !== lastProxyConfig?.path) {
-            const path = resolveHomedir(filePath)
-            cachedProxyPath = undefined
-            if (path) {
-                try {
-                    if (!fs.statSync(path).isSocket()) {
-                        throw new Error('Not a socket')
-                    }
-                    fs.accessSync(path, fs.constants.R_OK | fs.constants.W_OK)
-                    cachedProxyPath = path
-                } catch (error) {
-                    // `logError` caused repeated calls of this code
-                    console.error(`Cannot verify ${CONFIG_KEY.proxy}.path: ${path}: ${error}`)
-                    void vscode.window.showErrorMessage(
-                        `Cannot verify ${CONFIG_KEY.proxy}.path: ${path}:\n${error}`
-                    )
-                }
-            }
-        }
-        return cachedProxyPath
-    }
-
-    function readProxyCACert(filePath: string | undefined): string | undefined {
-        if (filePath !== lastProxyConfig?.cacert) {
-            const path = resolveHomedir(filePath)
-            cachedProxyCACert = undefined
-            if (path) {
-                // support directly embedding a CA cert in the settings
-                if (path.startsWith('-----BEGIN CERTIFICATE-----')) {
-                    cachedProxyCACert = path
-                } else {
-                    try {
-                        cachedProxyCACert = fs.readFileSync(path, { encoding: 'utf-8' })
-                    } catch (error) {
-                        // `logError` caused repeated calls of this code
-                        console.error(`Cannot read ${CONFIG_KEY.proxy}.cacert: ${path}:\n${error}`)
-                        void vscode.window.showErrorMessage(
-                            `Error reading ${CONFIG_KEY.proxy}.cacert from ${path}:\n${error}`
-                        )
-                    }
-                }
-            }
-        }
-        return cachedProxyCACert
-    }
-
-    const vsCodeConfig = vscode.workspace.getConfiguration()
-
-    const proxyConfig = config.get<{
-        host?: string
-        port?: number
-        path?: string
-        cacert?: string
-    } | null>(CONFIG_KEY.proxy, null)
-
-    let proxyHost = proxyConfig?.host
-    let proxyPort = proxyConfig?.port
-
-    if (
-        (lastProxyConfig?.host !== proxyHost || lastProxyConfig?.port !== proxyPort) &&
-        ((proxyHost && !proxyPort) || (!proxyHost && proxyPort))
-    ) {
-        // `logError` caused repeated calls of this code
-        console.error(`${CONFIG_KEY.proxy}.host and ${CONFIG_KEY.proxy}.port must be set together`)
-        void vscode.window.showErrorMessage(
-            `${CONFIG_KEY.proxy}.host and ${CONFIG_KEY.proxy}.port must be set together`
-        )
-        proxyHost = undefined
-        proxyPort = undefined
-    }
-
-    const proxyPath = readProxyPath(proxyConfig?.path)
-    const proxyCACert = readProxyCACert(proxyConfig?.cacert)
-
-    lastProxyConfig = proxyConfig
 
     return {
         proxy: vsCodeConfig.get<string>('http.proxy'),
-        proxyHost: proxyHost,
-        proxyPort: proxyPort,
-        proxyPath: proxyPath,
-        proxyCACert: proxyCACert,
+        proxyServer: proxyConfig?.server,
+        proxyPath: resolveHomedir(proxyConfig?.path),
+        proxyCACert: resolveHomedir(proxyConfig?.cacert),
         codebase: sanitizeCodebase(config.get(CONFIG_KEY.codebase)),
         serverEndpoint: config.get<string>(CONFIG_KEY.serverEndpoint),
         customHeaders: config.get<Record<string, string>>(CONFIG_KEY.customHeaders),

--- a/vscode/src/configuration.ts
+++ b/vscode/src/configuration.ts
@@ -1,4 +1,6 @@
 import * as fs from 'node:fs'
+import * as os from 'node:os'
+import * as path from 'node:path'
 import * as vscode from 'vscode'
 
 import {
@@ -49,18 +51,17 @@ export function getConfiguration(
         debugRegex = /.*/
     }
 
-    function expandTilde(path?: string): string | undefined {
-        if (path?.startsWith('~/')) {
-            const homeDir = process.env.HOME || process.env.USERPROFILE
-            if (homeDir) {
-                return `${homeDir}/${path.slice(2)}`
+    function resolveHomedir(filePath?: string): string | undefined {
+        for (const homeDir of ['~/', '%USERPROFILE%\\']) {
+            if (filePath?.startsWith(homeDir)) {
+                return `${os.homedir()}${path.sep}${filePath.slice(homeDir.length)}`
             }
         }
-        return path
+        return filePath
     }
 
     function readProxyPath(): string | undefined {
-        const path = expandTilde(config.get<string>(CONFIG_KEY.proxyPath))
+        const path = resolveHomedir(config.get<string>(CONFIG_KEY.proxyPath))
         if (path) {
             try {
                 if (!fs.statSync(path).isSocket()) {
@@ -78,7 +79,7 @@ export function getConfiguration(
     }
 
     function readProxyCACert(): string | undefined {
-        const path = expandTilde(config.get<string>(CONFIG_KEY.proxyCacert))
+        const path = resolveHomedir(config.get<string>(CONFIG_KEY.proxyCacert))
         if (path) {
             // support directly embedding a CA cert in the settings
             if (path.startsWith('-----BEGIN CERTIFICATE-----')) {

--- a/vscode/src/configuration.ts
+++ b/vscode/src/configuration.ts
@@ -9,6 +9,7 @@ import {
     OLLAMA_DEFAULT_URL,
     type PickResolvedConfiguration,
     PromptString,
+    logError,
     ps,
     setStaticResolvedConfigurationValue,
 } from '@sourcegraph/cody-shared'
@@ -70,6 +71,10 @@ export function getConfiguration(
                 fs.accessSync(path, fs.constants.R_OK | fs.constants.W_OK)
                 return path
             } catch (error) {
+                logError(
+                    'vscode.configuration',
+                    `Cannot read ${CONFIG_KEY.proxyPath}: ${path}:\n${error}`
+                )
                 void vscode.window.showErrorMessage(
                     `Cannot verify ${CONFIG_KEY.proxyPath}: ${path}:\n${error}`
                 )
@@ -88,6 +93,10 @@ export function getConfiguration(
             try {
                 return fs.readFileSync(path, { encoding: 'utf-8' })
             } catch (error) {
+                logError(
+                    'vscode.configuration',
+                    `Cannot read ${CONFIG_KEY.proxyCacert}: ${path}:\n${error}`
+                )
                 void vscode.window.showErrorMessage(
                     `Error reading ${CONFIG_KEY.proxyCacert} from ${path}:\n${error}`
                 )

--- a/vscode/src/configuration.ts
+++ b/vscode/src/configuration.ts
@@ -79,19 +79,18 @@ export function getConfiguration(
 
     function readProxyCACert(): string | undefined {
         const path = expandTilde(config.get<string>(CONFIG_KEY.proxyCacert))
-        if (!path) {
-            return undefined
-        }
-        // support directly embedding a CA cert in the settings
-        if (path.startsWith('-----BEGIN CERTIFICATE-----')) {
-            return path
-        }
-        try {
-            return fs.readFileSync(path, { encoding: 'utf-8' })
-        } catch (error) {
-            void vscode.window.showErrorMessage(
-                `Error reading ${CONFIG_KEY.proxyCacert} from ${path}:\n${error}`
-            )
+        if (path) {
+            // support directly embedding a CA cert in the settings
+            if (path.startsWith('-----BEGIN CERTIFICATE-----')) {
+                return path
+            }
+            try {
+                return fs.readFileSync(path, { encoding: 'utf-8' })
+            } catch (error) {
+                void vscode.window.showErrorMessage(
+                    `Error reading ${CONFIG_KEY.proxyCacert} from ${path}:\n${error}`
+                )
+            }
         }
         return undefined
     }

--- a/vscode/src/configuration.ts
+++ b/vscode/src/configuration.ts
@@ -68,10 +68,9 @@ export function getConfiguration(
                 }
                 fs.accessSync(path, fs.constants.R_OK | fs.constants.W_OK)
                 return path
-            } catch (error: any) {
+            } catch (error) {
                 void vscode.window.showErrorMessage(
-                    `Cannot verify ${CONFIG_KEY.proxyPath}: ${path}`,
-                    error
+                    `Cannot verify ${CONFIG_KEY.proxyPath}: ${path}:\n${error}`
                 )
             }
         }
@@ -89,10 +88,9 @@ export function getConfiguration(
         }
         try {
             return fs.readFileSync(path, { encoding: 'utf-8' })
-        } catch (error: any) {
+        } catch (error) {
             void vscode.window.showErrorMessage(
-                `Error reading ${CONFIG_KEY.proxyCacert} from ${path}`,
-                error
+                `Error reading ${CONFIG_KEY.proxyCacert} from ${path}:\n${error}`
             )
         }
         return undefined

--- a/vscode/src/configuration.ts
+++ b/vscode/src/configuration.ts
@@ -1,3 +1,4 @@
+import * as fs from 'node:fs'
 import * as vscode from 'vscode'
 
 import {
@@ -48,10 +49,63 @@ export function getConfiguration(
         debugRegex = /.*/
     }
 
+    function expandTilde(path?: string): string | undefined {
+        if (path?.startsWith('~/')) {
+            const homeDir = process.env.HOME || process.env.USERPROFILE
+            if (homeDir) {
+                return `${homeDir}/${path.slice(2)}`
+            }
+        }
+        return path
+    }
+
+    function readProxyPath(): string | undefined {
+        const path = expandTilde(config.get<string>(CONFIG_KEY.proxyPath))
+        if (path) {
+            try {
+                if (!fs.statSync(path).isSocket()) {
+                    throw new Error('Not a socket')
+                }
+                fs.accessSync(path, fs.constants.R_OK | fs.constants.W_OK)
+                return path
+            } catch (error: any) {
+                void vscode.window.showErrorMessage(
+                    `Cannot verify ${CONFIG_KEY.proxyPath}: ${path}`,
+                    error
+                )
+            }
+        }
+        return undefined
+    }
+
+    function readProxyCACert(): string | undefined {
+        const path = expandTilde(config.get<string>(CONFIG_KEY.proxyCacert))
+        if (!path) {
+            return undefined
+        }
+        // support directly embedding a CA cert in the settings
+        if (path.startsWith('-----BEGIN CERTIFICATE-----')) {
+            return path
+        }
+        try {
+            return fs.readFileSync(path, { encoding: 'utf-8' })
+        } catch (error: any) {
+            void vscode.window.showErrorMessage(
+                `Error reading ${CONFIG_KEY.proxyCacert} from ${path}`,
+                error
+            )
+        }
+        return undefined
+    }
+
     const vsCodeConfig = vscode.workspace.getConfiguration()
 
     return {
         proxy: vsCodeConfig.get<string>('http.proxy'),
+        proxyHost: config.get<string>(CONFIG_KEY.proxyHost),
+        proxyPort: config.get<number>(CONFIG_KEY.proxyPort),
+        proxyPath: readProxyPath(),
+        proxyCACert: readProxyCACert(),
         codebase: sanitizeCodebase(config.get(CONFIG_KEY.codebase)),
         serverEndpoint: config.get<string>(CONFIG_KEY.serverEndpoint),
         customHeaders: config.get<Record<string, string>>(CONFIG_KEY.customHeaders),

--- a/vscode/src/configuration.ts
+++ b/vscode/src/configuration.ts
@@ -9,7 +9,6 @@ import {
     OLLAMA_DEFAULT_URL,
     type PickResolvedConfiguration,
     PromptString,
-    logError,
     ps,
     setStaticResolvedConfigurationValue,
 } from '@sourcegraph/cody-shared'
@@ -21,6 +20,15 @@ import { localStorage } from './services/LocalStorageProvider'
 interface ConfigGetter {
     get<T>(section: (typeof CONFIG_KEY)[ConfigKeys], defaultValue?: T): T
 }
+
+let lastProxyConfig: {
+    host?: string
+    port?: number
+    path?: string
+    cacert?: string
+} | null = null
+let cachedProxyPath: string | undefined
+let cachedProxyCACert: string | undefined
 
 /**
  * All configuration values, with some sanitization performed.
@@ -61,58 +69,89 @@ export function getConfiguration(
         return filePath
     }
 
-    function readProxyPath(): string | undefined {
-        const path = resolveHomedir(config.get<string>(CONFIG_KEY.proxyPath))
-        if (path) {
-            try {
-                if (!fs.statSync(path).isSocket()) {
-                    throw new Error('Not a socket')
+    function readProxyPath(filePath: string | undefined): string | undefined {
+        if (filePath !== lastProxyConfig?.path) {
+            const path = resolveHomedir(filePath)
+            cachedProxyPath = undefined
+            if (path) {
+                try {
+                    if (!fs.statSync(path).isSocket()) {
+                        throw new Error('Not a socket')
+                    }
+                    fs.accessSync(path, fs.constants.R_OK | fs.constants.W_OK)
+                    cachedProxyPath = path
+                } catch (error) {
+                    // `logError` caused repeated calls of this code
+                    console.error(`Cannot verify ${CONFIG_KEY.proxy}.path: ${path}: ${error}`)
+                    void vscode.window.showErrorMessage(
+                        `Cannot verify ${CONFIG_KEY.proxy}.path: ${path}:\n${error}`
+                    )
                 }
-                fs.accessSync(path, fs.constants.R_OK | fs.constants.W_OK)
-                return path
-            } catch (error) {
-                logError(
-                    'vscode.configuration',
-                    `Cannot read ${CONFIG_KEY.proxyPath}: ${path}:\n${error}`
-                )
-                void vscode.window.showErrorMessage(
-                    `Cannot verify ${CONFIG_KEY.proxyPath}: ${path}:\n${error}`
-                )
             }
         }
-        return undefined
+        return cachedProxyPath
     }
 
-    function readProxyCACert(): string | undefined {
-        const path = resolveHomedir(config.get<string>(CONFIG_KEY.proxyCacert))
-        if (path) {
-            // support directly embedding a CA cert in the settings
-            if (path.startsWith('-----BEGIN CERTIFICATE-----')) {
-                return path
-            }
-            try {
-                return fs.readFileSync(path, { encoding: 'utf-8' })
-            } catch (error) {
-                logError(
-                    'vscode.configuration',
-                    `Cannot read ${CONFIG_KEY.proxyCacert}: ${path}:\n${error}`
-                )
-                void vscode.window.showErrorMessage(
-                    `Error reading ${CONFIG_KEY.proxyCacert} from ${path}:\n${error}`
-                )
+    function readProxyCACert(filePath: string | undefined): string | undefined {
+        if (filePath !== lastProxyConfig?.cacert) {
+            const path = resolveHomedir(filePath)
+            cachedProxyCACert = undefined
+            if (path) {
+                // support directly embedding a CA cert in the settings
+                if (path.startsWith('-----BEGIN CERTIFICATE-----')) {
+                    cachedProxyCACert = path
+                } else {
+                    try {
+                        cachedProxyCACert = fs.readFileSync(path, { encoding: 'utf-8' })
+                    } catch (error) {
+                        // `logError` caused repeated calls of this code
+                        console.error(`Cannot read ${CONFIG_KEY.proxy}.cacert: ${path}:\n${error}`)
+                        void vscode.window.showErrorMessage(
+                            `Error reading ${CONFIG_KEY.proxy}.cacert from ${path}:\n${error}`
+                        )
+                    }
+                }
             }
         }
-        return undefined
+        return cachedProxyCACert
     }
 
     const vsCodeConfig = vscode.workspace.getConfiguration()
 
+    const proxyConfig = config.get<{
+        host?: string
+        port?: number
+        path?: string
+        cacert?: string
+    } | null>(CONFIG_KEY.proxy, null)
+
+    let proxyHost = proxyConfig?.host
+    let proxyPort = proxyConfig?.port
+
+    if (
+        (lastProxyConfig?.host !== proxyHost || lastProxyConfig?.port !== proxyPort) &&
+        ((proxyHost && !proxyPort) || (!proxyHost && proxyPort))
+    ) {
+        // `logError` caused repeated calls of this code
+        console.error(`${CONFIG_KEY.proxy}.host and ${CONFIG_KEY.proxy}.port must be set together`)
+        void vscode.window.showErrorMessage(
+            `${CONFIG_KEY.proxy}.host and ${CONFIG_KEY.proxy}.port must be set together`
+        )
+        proxyHost = undefined
+        proxyPort = undefined
+    }
+
+    const proxyPath = readProxyPath(proxyConfig?.path)
+    const proxyCACert = readProxyCACert(proxyConfig?.cacert)
+
+    lastProxyConfig = proxyConfig
+
     return {
         proxy: vsCodeConfig.get<string>('http.proxy'),
-        proxyHost: config.get<string>(CONFIG_KEY.proxyHost),
-        proxyPort: config.get<number>(CONFIG_KEY.proxyPort),
-        proxyPath: readProxyPath(),
-        proxyCACert: readProxyCACert(),
+        proxyHost: proxyHost,
+        proxyPort: proxyPort,
+        proxyPath: proxyPath,
+        proxyCACert: proxyCACert,
         codebase: sanitizeCodebase(config.get(CONFIG_KEY.codebase)),
         serverEndpoint: config.get<string>(CONFIG_KEY.serverEndpoint),
         customHeaders: config.get<Record<string, string>>(CONFIG_KEY.customHeaders),

--- a/vscode/src/extension.common.ts
+++ b/vscode/src/extension.common.ts
@@ -1,6 +1,10 @@
 import * as vscode from 'vscode'
 
-import type { CompletionLogger, SourcegraphCompletionsClient } from '@sourcegraph/cody-shared'
+import type {
+    ClientConfiguration,
+    CompletionLogger,
+    SourcegraphCompletionsClient,
+} from '@sourcegraph/cody-shared'
 import type { startTokenReceiver } from './auth/token-receiver'
 import { onActivationDevelopmentHelpers } from './dev/helpers'
 
@@ -22,6 +26,7 @@ type Constructor<T extends new (...args: any) => any> = T extends new (
     : never
 
 export interface PlatformContext {
+    intializeConfigurationProxy?: () => Promise<void>
     createOpenCtxController?: typeof createController
     createStorage?: () => Promise<vscode.Memento>
     createCommandsProvider?: Constructor<typeof CommandsProvider>

--- a/vscode/src/extension.node.ts
+++ b/vscode/src/extension.node.ts
@@ -29,6 +29,7 @@ export function activate(
     context: vscode.ExtensionContext,
     extensionClient?: ExtensionClient
 ): Promise<ExtensionApi> {
+    proxySettings.subscribe(setCustomAgent)
     initializeNetworkAgent(context)
 
     // When activated by VSCode, we are only passed the extension context.
@@ -44,6 +45,7 @@ export function activate(
         .get<boolean>('cody.experimental.telemetry.enabled', true)
 
     return activateCommon(context, {
+        intializeConfigurationProxy: () => {},
         createCompletionsClient: (...args) => new SourcegraphNodeCompletionsClient(...args),
         createCommandsProvider: () => new CommandsProvider(),
         createSymfRunner: isSymfEnabled ? (...args) => new SymfRunner(...args) : undefined,

--- a/vscode/src/extension.node.ts
+++ b/vscode/src/extension.node.ts
@@ -4,7 +4,6 @@ import { NodeSentryService } from './services/sentry/sentry.node'
 import {
     currentAuthStatus,
     currentResolvedConfig,
-    resolvedConfig,
     subscriptionDisposable,
 } from '@sourcegraph/cody-shared'
 import * as vscode from 'vscode'
@@ -19,6 +18,8 @@ import { SymfRunner } from './local-context/symf'
 import { localStorage } from './services/LocalStorageProvider'
 import { OpenTelemetryService } from './services/open-telemetry/OpenTelemetryService.node'
 import { serializeConfigSnapshot } from './uninstall/serializeConfig'
+
+import { proxySettings } from './configuration-proxy'
 
 /**
  * Activation entrypoint for the VS Code extension when running VS Code as a desktop app
@@ -52,9 +53,7 @@ export function activate(
             : undefined,
         startTokenReceiver: (...args) => startTokenReceiver(...args),
         otherInitialization: () => {
-            return subscriptionDisposable(
-                resolvedConfig.subscribe(config => setCustomAgent(config.configuration))
-            )
+            return subscriptionDisposable(proxySettings.subscribe(setCustomAgent))
         },
         extensionClient,
     })

--- a/vscode/src/fetch.node.ts
+++ b/vscode/src/fetch.node.ts
@@ -81,11 +81,10 @@ function getCustomAgent({
             // (or the other way around, depending on the order of the options).
             const caCerts = (() => {
                 if (proxyCACert) {
-                    return [proxyCACert]
-                    // if (Array.isArray(https.globalAgent.options.ca)) {
-                    //     return [...https.globalAgent.options.ca, proxyCACert]
-                    // }
-                    // return [https.globalAgent.options.ca, proxyCACert]
+                    if (Array.isArray(https.globalAgent.options.ca)) {
+                        return [...https.globalAgent.options.ca, proxyCACert]
+                    }
+                    return [https.globalAgent.options.ca, proxyCACert]
                 }
                 return undefined
             })()

--- a/vscode/src/fetch.node.ts
+++ b/vscode/src/fetch.node.ts
@@ -1,18 +1,23 @@
-import http from 'node:http'
-import https from 'node:https'
-import { parse as parseUrl } from 'node:url'
-import { agent } from '@sourcegraph/cody-shared'
-import type { AuthCredentials, ClientConfiguration, ClientState } from '@sourcegraph/cody-shared'
-import { HttpProxyAgent } from 'http-proxy-agent'
-import { HttpsProxyAgent } from 'https-proxy-agent'
-import { ProxyAgent } from 'proxy-agent'
-import { SocksProxyAgent } from 'socks-proxy-agent'
+import * as http from 'node:http'
+import * as https from 'node:https'
+// import http from 'node:http'
+// import https from 'node:https'
+// import { parse as parseUrl } from 'node:url'
+import { agent, logDebug, logError } from '@sourcegraph/cody-shared'
+// import type { AuthCredentials, ClientConfiguration, ClientState } from '@sourcegraph/cody-shared'
+// import { HttpProxyAgent } from 'http-proxy-agent'
+// import { HttpsProxyAgent } from 'https-proxy-agent'
+// import { ProxyAgent } from 'proxy-agent'
+// import { SocksProxyAgent } from 'socks-proxy-agent'
 import type * as vscode from 'vscode'
-// @ts-ignore
-import { registerLocalCertificates } from './certs'
-import { getConfiguration } from './configuration'
 
-import { validateProxySettings } from './configuration-proxy'
+import type { Agent } from 'agent-base'
+
+// @ts-ignore
+// import { registerLocalCertificates } from './certs'
+// import { getConfiguration } from './configuration'
+
+// import { validateProxySettings } from './configuration-proxy'
 
 // The path to the exported class can be found in the npm contents
 // https://www.npmjs.com/package/@vscode/proxy-agent?activeTab=code
@@ -23,117 +28,29 @@ const pacProxyAgent = 'PacProxyAgent'
 /**
  * We use keepAlive agents here to avoid excessive SSL/TLS handshakes for autocomplete requests.
  */
-let httpAgent: http.Agent
-let httpsAgent: https.Agent
-let socksProxyAgent: SocksProxyAgent
-let httpProxyAgent: HttpProxyAgent<string>
-let httpsProxyAgent: HttpsProxyAgent<string>
+// let httpAgent: http.Agent
+// let httpsAgent: https.Agent
+// let socksProxyAgent: SocksProxyAgent
+// let httpProxyAgent: HttpProxyAgent<string>
+// let httpsProxyAgent: HttpsProxyAgent<string>
 
-function getCustomAgent({
-    proxy,
-    proxyServer,
-    proxyPath,
-    proxyCACert,
-}: ClientConfiguration): ({ protocol }: Pick<URL, 'protocol'>) => http.Agent {
-    return ({ protocol }) => {
-        const proxyURL = proxy || getSystemProxyURI(protocol, process.env)
-        if (proxyURL) {
-            if (proxyURL?.startsWith('socks')) {
-                if (!socksProxyAgent) {
-                    socksProxyAgent = new SocksProxyAgent(proxyURL, {
-                        keepAlive: true,
-                        keepAliveMsecs: 60000,
-                    })
-                }
-                return socksProxyAgent
-            }
-            const proxyEndpoint = parseUrl(proxyURL)
-
-            const opts = {
-                host: proxyEndpoint.hostname || '',
-                port:
-                    (proxyEndpoint.port ? +proxyEndpoint.port : 0) ||
-                    (proxyEndpoint.protocol === 'https' ? 443 : 80),
-                auth: proxyEndpoint.auth,
-                rejectUnauthorized: true,
-                keepAlive: true,
-                keepAliveMsecs: 60000,
-                ...https.globalAgent.options,
-            }
-            if (protocol === 'http:') {
-                if (!httpProxyAgent) {
-                    httpProxyAgent = new HttpProxyAgent(proxyURL, opts)
-                }
-                return httpProxyAgent
-            }
-
-            if (!httpsProxyAgent) {
-                httpsProxyAgent = new HttpsProxyAgent(proxyURL, opts)
-            }
-            return httpsProxyAgent
-        }
-
-        if (proxyServer || proxyPath) {
-            const [proxyHost, proxyPort] = proxyServer ? proxyServer.split(':') : [undefined, undefined]
-
-            // Combine the CA certs from the global options with the one(s) defined in settings,
-            // otherwise the CA cert in the settings overrides all of the global agent options
-            // (or the other way around, depending on the order of the options).
-            const caCerts = (() => {
-                if (proxyCACert) {
-                    if (Array.isArray(https.globalAgent.options.ca)) {
-                        return [...https.globalAgent.options.ca, proxyCACert]
-                    }
-                    return [https.globalAgent.options.ca, proxyCACert]
-                }
-                return undefined
-            })()
-            const agent = new ProxyAgent({
-                protocol: protocol || 'https:',
-                ...(proxyServer ? { host: proxyHost, port: Number(proxyPort) } : null),
-                ...(proxyPath ? { socketPath: proxyPath } : null),
-                keepAlive: true,
-                keepAliveMsecs: 60000,
-                ...https.globalAgent.options,
-                // Being at the end, this will override https.globalAgent.options.ca
-                ...(caCerts ? { ca: caCerts } : null),
-            })
-            return agent
-        }
-
-        return protocol === 'http:' ? httpAgent : httpsAgent
-    }
-}
-
-export function setCustomAgent(
-    configuration: ClientConfiguration
-): ({ protocol }: Pick<URL, 'protocol'>) => http.Agent {
-    agent.current = getCustomAgent(configuration)
-    return agent.current as ({ protocol }: Pick<URL, 'protocol'>) => http.Agent
-}
-
-function getSystemProxyURI(protocol: string, env: typeof process.env): string | null {
-    if (protocol === 'http:') {
-        return env.HTTP_PROXY || env.http_proxy || null
-    }
-    if (protocol === 'https:') {
-        return env.HTTPS_PROXY || env.https_proxy || env.HTTP_PROXY || env.http_proxy || null
-    }
-    if (protocol.startsWith('socks')) {
-        return env.SOCKS_PROXY || env.socks_proxy || null
-    }
-    return null
-}
+// export function setCustomAgent(
+//     configuration: ClientConfiguration
+// ): ({ protocol }: Pick<URL, 'protocol'>) => http.Agent {
+//     agent.current = getCustomAgent(configuration)
+//     return agent.current as ({ protocol }: Pick<URL, 'protocol'>) => http.Agent
+// }
 
 export function initializeNetworkAgent(context: Pick<vscode.ExtensionContext, 'extensionUri'>): void {
     // This is to load certs for HTTPS requests
-    registerLocalCertificates(context)
+    /* TODO: Move to configuration proxy: registerLocalCertificates(context)
     httpAgent = new http.Agent({ keepAlive: true, keepAliveMsecs: 60000 })
     httpsAgent = new https.Agent({
         ...https.globalAgent.options,
         keepAlive: true,
         keepAliveMsecs: 60000,
     })
+
 
     const customAgent = setCustomAgent(
         validateProxySettings({
@@ -142,6 +59,7 @@ export function initializeNetworkAgent(context: Pick<vscode.ExtensionContext, 'e
             clientState: {} as ClientState,
         })
     )
+    */
 
     /**
      * This works around an issue in the default VS Code proxy agent code. When `http.proxySupport`
@@ -155,34 +73,152 @@ export function initializeNetworkAgent(context: Pick<vscode.ExtensionContext, 'e
      *
      * c.f. https://github.com/microsoft/vscode/issues/173861
      */
+
+    /**
+ *
+        const { secureEndpoint } = opts;
+
+		// Calculate the `url` parameter
+		const defaultPort = secureEndpoint ? 443 : 80;
+
+ * 		const urlOpts = {
+			...opts,
+			protocol: secureEndpoint ? 'https:' : 'http:',
+			pathname: path,
+			search,
+
+			// need to use `hostname` instead of `host` otherwise `port` is ignored
+			hostname: opts.host,
+			host: null,
+			href: null,
+
+			// set `port` to null when it is the protocol default port (80 / 443)
+			port: defaultPort === opts.port ? null : opts.port
+		};
+		const url = format(urlOpts);
+
+		debug('url: %o', url);
+		let result = await this.resolver(req, opts, url);
+
+ */
+
     try {
-        const PacProxyAgent =
-            (globalThis as any)?.[nodeModules]?.[proxyAgentPath]?.[pacProxyAgent] ?? customAgent
-        if (PacProxyAgent) {
-            const originalConnect = PacProxyAgent.prototype.connect
-            // Patches the implementation defined here:
-            // https://github.com/microsoft/vscode-proxy-agent/blob/d340b9d34684da494d6ebde3bcd18490a8bbd071/src/agent.ts#L53
-            PacProxyAgent.prototype.connect = function (
-                req: http.ClientRequest,
-                opts: { protocol: string }
-            ): any {
-                try {
-                    const connectionHeader = req.getHeader('connection')
-                    if (
-                        connectionHeader === 'keep-alive' ||
-                        (Array.isArray(connectionHeader) && connectionHeader.includes('keep-alive'))
-                    ) {
-                        this.opts.originalAgent = customAgent(opts)
-                        return originalConnect.call(this, req, opts)
-                    }
-                    return originalConnect.call(this, req, opts)
-                } catch {
-                    return originalConnect.call(this, req, opts)
-                }
+        const PacProxyAgent = (globalThis as any)?.[nodeModules]?.[proxyAgentPath]?.[
+            pacProxyAgent
+        ] /**?? customAgent**/
+        //TODO: Logging!
+        if (!PacProxyAgent) {
+            logDebug('fetch.node', 'TODO: Not patching stufffs.')
+            // WE don't handle this yet, we rely on the fact that Sourcegraph
+            // HTTP Client and Completions client explicitly set agent.current
+            // as their agent (which will be respected if PacProxy is not
+            // interfering)
+            return
+        } // this actually in "VSCode 'Extension Host'"
+        const originalConnect = PacProxyAgent.prototype.connect
+        PacProxyAgent.prototype.connect = async function (
+            req: http.ClientRequest,
+            opts: http.RequestOptions
+        ): Promise<any> {
+            const agentBuilder =
+                typeof opts.agent === 'function'
+                    ? (opts.agent as Exclude<typeof agent.current, undefined>)
+                    : null
+            const reqAgent = agentBuilder
+                ? agentBuilder(req, opts)
+                : (opts.agent as http.Agent | undefined)
+
+            if (!(agent._forceCodyProxy && reqAgent)) {
+                opts.agent = reqAgent
+                return originalConnect.apply(this, req, opts)
+            }
+
+            // this handles the case where the agent is not http.Agent but agent-base Agent
+            // which has extra utility functions.
+            try {
+                const connect = (reqAgent as any).connect ?? (() => reqAgent)
+                const socket = await connect()
+                req.emit('proxy', { socket })
+            } catch (err) {
+                logError('fetch.node', 'error while handling PacProxy request')
+                req.emit('proxy', { proxy, error: err })
             }
         }
-    } catch (error) {
-        // Ignore any errors in the patching logic
-        void error
+    } catch {}
+}
+// if(!agent._forceCodyProxy){
+//     // We've decided to, contrary to before, leave the original VSCode implmentation alone.
+//     // Especially w.r.t. keep-alive which for reasons TODO: XXX
+//     return
+// }
+
+// Overide PacProxyAgnent.connect()
+// let s: Duplex | http.Agent;
+// if (agent instanceof Agent) {
+//     s = await agent.connect(req, opts);
+// } else {
+//     s = agent;
+// }
+// req.emit('proxy', { proxy, socket: s });
+// return s;
+
+// const originalConnect = PacProxyAgent.prototype.connect
+// Patches the implementation defined here:
+// https://github.com/microsoft/vscode-proxy-agent/blob/d340b9d34684da494d6ebde3bcd18490a8bbd071/src/agent.ts#L53
+//             PacProxyAgent.prototype.connect = function (
+//                 req: http.ClientRequest,
+//                 opts: { protocol: string }
+//             ): any {
+//                 if (agent.current && agent._forceCodyProxy) {
+//                     const originalResolver = this.resolver
+//                     const originalAgent = this.opts.originalAgent
+//                     const reset = () => {
+//                         this.resolver = originalResolver
+//                         this.originalAgent = originalAgent
+//                     }
+
+//                     this.resolver = () => null
+//                     this.opts.originalAgent = agent.current
+//                     return originalConnect.call(this, req, opts).finally(reset.bind(this))
+//                 }
+//                 return originalConnect.call(this, req, opts)
+
+// try {
+//     const connectionHeader = req.getHeader('connection')
+//     if (
+//         connectionHeader === 'keep-alive' ||
+//         (Array.isArray(connectionHeader) && connectionHeader.includes('keep-alive'))
+//     ) {
+//         this.opts.originalAgent = customAgent(opts)
+//         return originalConnect.call(this, req, opts)
+//     }
+//     return originalConnect.call(this, req, opts)
+// } catch {
+//     return originalConnect.call(this, req, opts)
+// }
+
+// Yoinked from https://github.com/microsoft/vscode-proxy-agent/blob/main/src/index.ts
+function pacProxyIDFromURL(rawUrl: string | undefined) {
+    const url = (rawUrl || '').trim()
+
+    const [scheme, proxy] = url.split(/:\/\//, 1)
+    if (!proxy) {
+        return undefined
+    }
+
+    switch (scheme.toLowerCase()) {
+        case 'http':
+            return 'PROXY ' + proxy
+        case 'https':
+            return 'HTTPS ' + proxy
+        case 'socks':
+        case 'socks5':
+        case 'socks5h':
+            return 'SOCKS ' + proxy
+        case 'socks4':
+        case 'socks4a':
+            return 'SOCKS4 ' + proxy
+        default:
+            return undefined
     }
 }

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -105,10 +105,6 @@ import { SupercompletionProvider } from './supercompletions/supercompletion-prov
 import { parseAllVisibleDocuments, updateParseTreeOnEdit } from './tree-sitter/parse-tree-cache'
 import { version } from './version'
 
-import { proxySettings } from './configuration-proxy'
-
-import { setCustomAgent } from './fetch.node'
-
 /**
  * Start the extension, watching all relevant configuration and secrets for changes.
  */
@@ -161,8 +157,6 @@ export async function start(
             )
         )
     )
-
-    proxySettings.subscribe(setCustomAgent)
 
     setEditorWindowIsFocused(() => vscode.window.state.focused)
 

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -105,6 +105,10 @@ import { SupercompletionProvider } from './supercompletions/supercompletion-prov
 import { parseAllVisibleDocuments, updateParseTreeOnEdit } from './tree-sitter/parse-tree-cache'
 import { version } from './version'
 
+import { proxySettings } from './configuration-proxy'
+
+import { setCustomAgent } from './fetch.node'
+
 /**
  * Start the extension, watching all relevant configuration and secrets for changes.
  */
@@ -157,6 +161,9 @@ export async function start(
             )
         )
     )
+
+    proxySettings.subscribe(setCustomAgent)
+
     setEditorWindowIsFocused(() => vscode.window.state.focused)
 
     if (process.env.LOG_GLOBAL_STATE_EMISSIONS) {


### PR DESCRIPTION
Support extension-specific proxy settings (don't rely on `http(s)_proxy`).

Support using a unix domain socket as a proxy.

Add a CA cert setting to enable using proxies with self-signed or not-public certificates.

Closes CODY-3092

## Test plan

To test locally:

0. Install `socat` and `mitmproxy` (`brew install socat mitmproxy`)
1. Switch to this branch: `git switch peterguy/vscode-add-proxy-settings`
2. In one terminal, start up `socat` to listen on a UDS and send TCP connections to `mitm`
```
socat -d -d unix-listen:${HOME}/mitm-proxy.sock,fork tcp:localhost:8080
```
3. In another terminal, launch `mitmproxy`. I like to use `mitmweb` because it opens a web view of the traffic that is friendly.
```
mitmweb
```
4. Add the following to VSCode's `settings.json` (It's at `~/Library/Application Support/Code/User/settings.json` for me; you can also get to it by opening the Command Palette (Cmd-Shift-P), typing "settings" to filter, then selecting "Open User Settings (JSON)".
```
"http.proxySupport": "on",
"cody.proxy.path": "~/mitm-proxy.sock",
"cody.proxy.cacert": "~/.mitmproxy/mitmproxy-ca-cert.pem"
```
In addition to specifying proxy settings for the Cody extension, it also toggles VSCode's proxy support from `override` to `on`. If it's in the default `override` mode, it won't use the proxy agents we set up. I'd like to avoid this requirement, but until we figure out how to do that (probably with more "monkey patching", to quote @RXminuS 😄 ), we have to toggle the proxy support to either `on` or `fallback`.
5. Launch the Cody extension via the Run And Debug pane (Cmd-Shift-D), by clicking the green "play" icon at the top of the pane, when "Launch VSCode Extension (Desktop, recommended)" is selected (it's the default).
6. Note the outputs of `socat` and `mitmproxy` in the two terminals, and if you launched `mitmweb`, see the requests in the browser. If you are using `mitmweb` you can use the web interface to see the types of requests being made.
7. Execute a completion. I used Document Code as a simple triggerable one. If you launched `mitmweb` and are using a non-local LLM model (not Ollama), you should see calls to the completions endpoint in the mitm web page.
8. Optional: change the proxy settings to use `mitmproxy` directly. Remove the `proxyPath` setting and add `proxyHost` and `proxyPort`:
```
"cody.proxy.host": "localhost",
"cody.proxy.port": 8080
```
Then verify again that the extension is still operative. You should still see activity in the terminal that's running `mitmproxy` (or `mitmweb`), and the `mitmweb` web page should show more traffic, but there should be no activity in the `socat` terminal.