### PR TITLE
disable fetching Ollama models during vitest unit testing to avoid nondeterminism

### DIFF
--- a/lib/shared/src/llm-providers/ollama/utils.ts
+++ b/lib/shared/src/llm-providers/ollama/utils.ts
@@ -8,6 +8,13 @@ import { CHAT_OUTPUT_TOKEN_BUDGET } from '../../token/constants'
  * Fetches available Ollama models from the Ollama server.
  */
 export async function fetchLocalOllamaModels(): Promise<Model[]> {
+    if (process.env.VITEST) {
+        // We currently never intend to fetch local Ollama models during tests, but it's easy to
+        // accidentally invoke this and introduce test nondeterminism or local vs. remote
+        // divergence.
+        return []
+    }
+    // TODO(sqs)#observe: make ollama models observable
     return (await ollama.list()).models?.map(m =>
         createModel({
             id: `ollama/${m.name}`,


### PR DESCRIPTION
This will make our tests more reliable when run locally.

It is possible that this could make it harder to spot issues in unit tests and agent tests where Ollama being available causes issues. If we see such an issue, then we should build in a case to prevent that problem. As is, CI and many/most devs aren't running Ollama, so we have at best uneven protection, and at worst the flakiness causes wasted dev time and possibly bad workarounds.

## Test plan

CI