### PR TITLE
deflake "chat input focus" e2e test

### DIFF
--- a/vscode/test/e2e/chat-input.test.ts
+++ b/vscode/test/e2e/chat-input.test.ts
@@ -58,7 +58,10 @@ test.extend<ExpectedV2Events>({
     await page.getByText("fizzbuzz.push('Buzz')").click()
 
     // Submit a new chat question from the command menu.
-    await page.getByLabel(/Commands \(/).click()
+    await page
+        .locator('[id="workbench\\.parts\\.editor"]')
+        .getByLabel(/Commands \(/)
+        .click()
     await page.waitForTimeout(100)
 
     // HACK: The 'delay' command is used to make sure the response is streamed 400ms after


### PR DESCRIPTION
It often complains that there are 3 matching elements. Any of them would work, but now the e2e test more specifically mentions the one we intend to select.

See https://github.com/sourcegraph/cody/actions/runs/10984735543/job/30495688350?pr=5221#step:10:155 for an example of a flake.

## Test plan

CI