### PR TITLE
Do not show an LLM response when we trigger a code search

### DIFF
--- a/vscode/webviews/chat/Transcript.tsx
+++ b/vscode/webviews/chat/Transcript.tsx
@@ -335,29 +335,31 @@ const TranscriptInteraction: FC<TranscriptInteractionProps> = memo(props => {
                     defaultOpen={experimentalOneBoxEnabled && humanMessage.intent === 'search'}
                 />
             )}
-            {assistantMessage && !isContextLoading && (
-                <AssistantMessageCell
-                    key={assistantMessage.index}
-                    userInfo={userInfo}
-                    chatEnabled={chatEnabled}
-                    message={assistantMessage}
-                    feedbackButtonsOnSubmit={feedbackButtonsOnSubmit}
-                    copyButtonOnSubmit={copyButtonOnSubmit}
-                    insertButtonOnSubmit={insertButtonOnSubmit}
-                    postMessage={postMessage}
-                    guardrails={guardrails}
-                    humanMessage={humanMessageInfo}
-                    isLoading={assistantMessage.isLoading}
-                    showFeedbackButtons={
-                        !assistantMessage.isLoading &&
-                        !isTranscriptError &&
-                        !assistantMessage.error &&
-                        isLastSentInteraction
-                    }
-                    smartApply={smartApply}
-                    smartApplyEnabled={smartApplyEnabled}
-                />
-            )}
+            {(!experimentalOneBoxEnabled || humanMessage.intent !== 'search') &&
+                assistantMessage &&
+                !isContextLoading && (
+                    <AssistantMessageCell
+                        key={assistantMessage.index}
+                        userInfo={userInfo}
+                        chatEnabled={chatEnabled}
+                        message={assistantMessage}
+                        feedbackButtonsOnSubmit={feedbackButtonsOnSubmit}
+                        copyButtonOnSubmit={copyButtonOnSubmit}
+                        insertButtonOnSubmit={insertButtonOnSubmit}
+                        postMessage={postMessage}
+                        guardrails={guardrails}
+                        humanMessage={humanMessageInfo}
+                        isLoading={assistantMessage.isLoading}
+                        showFeedbackButtons={
+                            !assistantMessage.isLoading &&
+                            !isTranscriptError &&
+                            !assistantMessage.error &&
+                            isLastSentInteraction
+                        }
+                        smartApply={smartApply}
+                        smartApplyEnabled={smartApplyEnabled}
+                    />
+                )}
         </>
     )
 }, isEqual)


### PR DESCRIPTION
closes: https://linear.app/sourcegraph/issue/SRCH-1080/dont-show-an-llm-response-when-we-trigger-a-code-search

Hides the hard coded LLM response for search intent.

## Test plan
- connect to s2 and enter a code search query. 
- no LLM response text should be visible.

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
