### PR TITLE
fix storybook build (`pnpm -C web dev`)

### DIFF
--- a/lib/shared/src/index.ts
+++ b/lib/shared/src/index.ts
@@ -1,14 +1,6 @@
 // Add anything else here that needs to be used outside of this library.
 
 export {
-    modelsService,
-    mockModelsService,
-    ModelsService,
-    ModelCategory,
-    ModelTier,
-    type ServerModelConfiguration,
-} from './models/modelsService'
-export {
     type Model,
     type ServerModel,
     createModel,
@@ -16,6 +8,12 @@ export {
     modelTier,
     parseModelRef,
 } from './models/model'
+export {
+    modelsService,
+    mockModelsService,
+    ModelsService,
+    type ServerModelConfiguration,
+} from './models/modelsService'
 export {
     type EditModel,
     type EditProvider,
@@ -234,7 +232,7 @@ export {
     SourcegraphGraphQLAPIClient,
     graphqlClient,
 } from './sourcegraph-api/graphql'
-export { ClientConfigSingleton, CodyClientConfig } from './sourcegraph-api/clientConfig'
+export { ClientConfigSingleton } from './sourcegraph-api/clientConfig'
 export {
     addCustomUserAgent,
     customUserAgent,

--- a/lib/shared/src/index.ts
+++ b/lib/shared/src/index.ts
@@ -4,8 +4,8 @@ export {
     modelsService,
     mockModelsService,
     ModelsService,
-    ModelCategory,
-    ModelTier,
+    type ModelCategory,
+    type ModelTier,
     type ServerModelConfiguration,
 } from './models/modelsService'
 export {
@@ -234,7 +234,7 @@ export {
     SourcegraphGraphQLAPIClient,
     graphqlClient,
 } from './sourcegraph-api/graphql'
-export { ClientConfigSingleton, CodyClientConfig } from './sourcegraph-api/clientConfig'
+export { ClientConfigSingleton, type CodyClientConfig } from './sourcegraph-api/clientConfig'
 export {
     addCustomUserAgent,
     customUserAgent,

--- a/lib/shared/src/index.ts
+++ b/lib/shared/src/index.ts
@@ -1,6 +1,14 @@
 // Add anything else here that needs to be used outside of this library.
 
 export {
+    modelsService,
+    mockModelsService,
+    ModelsService,
+    ModelCategory,
+    ModelTier,
+    type ServerModelConfiguration,
+} from './models/modelsService'
+export {
     type Model,
     type ServerModel,
     createModel,
@@ -8,12 +16,6 @@ export {
     modelTier,
     parseModelRef,
 } from './models/model'
-export {
-    modelsService,
-    mockModelsService,
-    ModelsService,
-    type ServerModelConfiguration,
-} from './models/modelsService'
 export {
     type EditModel,
     type EditProvider,
@@ -232,7 +234,7 @@ export {
     SourcegraphGraphQLAPIClient,
     graphqlClient,
 } from './sourcegraph-api/graphql'
-export { ClientConfigSingleton } from './sourcegraph-api/clientConfig'
+export { ClientConfigSingleton, CodyClientConfig } from './sourcegraph-api/clientConfig'
 export {
     addCustomUserAgent,
     customUserAgent,


### PR DESCRIPTION
For reasons I don't fully understand, these imports were causing the storybook build (`pnpm -C web dev`) to fail. It looks like the re-exported symbols in question (`modelsService`, `CodyClientConfig`) were stripped but then later expected from within Storybook, which caused errors like this:

```
Uncaught SyntaxError: The requested module '/@fs/home/beyang/src/github.com/sourcegraph/cody/lib/shared/src/models/modelsService.ts' does not provide an export named 'ModelCategory' (at index.ts:7:5)
```

## Test plan

Dev-only
