### PR TITLE
prettier rendering of context items

### DIFF
--- a/vscode/test/e2e/command-custom.test.ts
+++ b/vscode/test/e2e/command-custom.test.ts
@@ -189,11 +189,11 @@ test.extend<ExpectedV2Events>({
     await expectContextCellCounts(contextCell, { files: 2 })
     await openContextCell(contextCell)
     await expect(
-        chatPanel.getByRole('button', { name: withPlatformSlashes('lib/batches/env/var.go') })
+        chatPanel.getByRole('button', { name: withPlatformSlashes('var.go:1 lib/batches/env') })
     ).toBeVisible()
     // Click on the file link should open the 'var.go file in the editor
     await contextCell
-        .getByRole('button', { name: withPlatformSlashes('lib/batches/env/var.go') })
+        .getByRole('button', { name: withPlatformSlashes('var.go:1 lib/batches/env') })
         .click()
     await expect(page.getByRole('tab', { name: 'var.go' })).toBeVisible()
 
@@ -209,7 +209,7 @@ test.extend<ExpectedV2Events>({
     await openContextCell(contextCell)
     await expect(contextCell.getByRole('button', { name: 'index.html' })).toBeVisible()
     await expect(
-        contextCell.getByRole('button', { name: withPlatformSlashes('lib/batches/env/var.go') })
+        contextCell.getByRole('button', { name: withPlatformSlashes('var.go lib/batches/env') })
     ).toBeVisible()
 })
 
@@ -305,6 +305,6 @@ testGitWorkspace('use terminal output as context', async ({ page, sidebar }) => 
     await expectContextCellCounts(contextCell, { files: 2 })
     await openContextCell(contextCell)
     await expect(
-        contextCell.getByRole('button', { name: withPlatformSlashes('/git diff') })
+        contextCell.getByRole('button', { name: withPlatformSlashes('git diff') })
     ).toBeVisible()
 })

--- a/vscode/webviews/chat/cells/contextCell/ContextCell.story.tsx
+++ b/vscode/webviews/chat/cells/contextCell/ContextCell.story.tsx
@@ -72,6 +72,21 @@ export const Default: Story = {
                 source: ContextItemSource.User,
             },
             {
+                type: 'file',
+                uri: URI.file('README.md'),
+                range: { start: { line: 1, character: 2 }, end: { line: 5, character: 0 } },
+            },
+            {
+                type: 'file',
+                uri: URI.file('C:\\windows\\style\\path\\file.go'),
+                range: { start: { line: 1, character: 2 }, end: { line: 5, character: 0 } },
+            },
+            {
+                type: 'file',
+                uri: URI.file('\\\\remote\\server\\README.md'),
+                range: { start: { line: 1, character: 2 }, end: { line: 5, character: 0 } },
+            },
+            {
                 type: 'symbol',
                 uri: URI.file('/util/urlParser.php'),
                 kind: 'function',

--- a/vscode/webviews/chat/fixtures.ts
+++ b/vscode/webviews/chat/fixtures.ts
@@ -111,6 +111,30 @@ export const FIXTURE_TRANSCRIPT: Record<
                     uri: URI.file('README.md'),
                     range: { start: { line: 1, character: 0 }, end: { line: 8, character: 0 } },
                 },
+                {
+                    source: ContextItemSource.Unified,
+                    type: 'file',
+                    remoteRepositoryName: 'myRepo',
+                    repoName: 'myRepo',
+                    title: 'README.md',
+                    revision: 'main',
+                    uri: URI.parse(
+                        'https://sourcegraph.sourcegraph.com/github.com/sourcegraph/cody/-/blob/vscode/e2e/issues/CODY-2392.test.ts?L21-43'
+                    ),
+                    range: { start: { line: 1, character: 0 }, end: { line: 8, character: 0 } },
+                },
+                {
+                    source: ContextItemSource.Unified,
+                    type: 'file',
+                    remoteRepositoryName: 'myRepo',
+                    repoName: 'myRepo',
+                    title: 'fooDir/file-c-1.py',
+                    revision: 'main',
+                    uri: URI.parse(
+                        'https://sourcegraph.sourcegraph.com/github.com/sourcegraph/cody/-/blob/vscode/e2e/issues/CODY-2392.test.ts?L21-43'
+                    ),
+                    range: { start: { line: 1, character: 0 }, end: { line: 8, character: 0 } },
+                },
             ],
         },
         {

--- a/vscode/webviews/components/FileLink.module.css
+++ b/vscode/webviews/components/FileLink.module.css
@@ -7,3 +7,17 @@
 .excluded {
     text-decoration: line-through !important;
 }
+
+.repoShortName {
+    color: var(--vscode-disabledForeground);
+    font-size: smaller;
+}
+
+.dirname {
+    color: var(--vscode-disabledForeground);
+    font-size: smaller;
+}
+
+.range {
+    color: var(--vscode-disabledForeground);
+}

--- a/vscode/webviews/components/FileLink.module.css
+++ b/vscode/webviews/components/FileLink.module.css
@@ -2,10 +2,17 @@
     white-space: nowrap;
     text-overflow: ellipsis;
     overflow: hidden;
+
+    /* Makes ellipsis show in default text color, we show the basename in link color below */
+    color: var(--vscode-disabledForeground);
 }
 
 .excluded {
     text-decoration: line-through !important;
+}
+
+.basename {
+    color: var(--vscode-textLink-foreground);
 }
 
 .repoShortName {

--- a/vscode/webviews/components/FileLink.test.tsx
+++ b/vscode/webviews/components/FileLink.test.tsx
@@ -1,0 +1,62 @@
+import { render as render_ } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { AppWrapperForTest } from '../AppWrapperForTest'
+import { PrettyPrintedContextItem } from './FileLink'
+function render(element: JSX.Element): ReturnType<typeof render_> {
+    return render_(element, { wrapper: AppWrapperForTest })
+}
+
+describe('PrettyPrintedContextItem', () => {
+    it.each([
+        { path: 'src/index.js', range: '10', expectedInnerText: 'index.js:10 src' },
+        { path: 'README.md', range: '1-10', expectedInnerText: 'README.md:1-10' },
+        {
+            path: 'C:\\windows\\style\\path\\file.go',
+            range: '1-5',
+            expectedInnerText: 'file.go:1-5 C:\\windows\\style\\path',
+        },
+        {
+            path: '\\\\remote\\server\\README.md',
+            range: '1-5',
+            expectedInnerText: 'README.md:1-5 \\\\remote\\server',
+        },
+        {
+            repo: 'myRepo',
+            path: 'foo/bar/baz.py',
+            range: '1-10',
+            expectedInnerText: 'baz.py:1-10 myRepo/foo/bar',
+        },
+        {
+            repo: 'myRepo',
+            path: '/foo/bar/baz.py',
+            range: '1-10',
+            expectedInnerText: 'baz.py:1-10 myRepo/foo/bar',
+        },
+        {
+            repo: 'myRepo',
+            path: 'README.md',
+            range: '1-10',
+            expectedInnerText: 'README.md:1-10 myRepo',
+        },
+        {
+            repo: 'myRepo',
+            path: 'subdir/README.md',
+            range: '1-10',
+            expectedInnerText: 'README.md:1-10 myRepo/subdir',
+        },
+        {
+            repo: 'myRepo',
+            path: '\\\\subdir\\README.md',
+            range: '1-10',
+            expectedInnerText: 'README.md:1-10 myRepo\\\\subdir',
+        },
+    ])(
+        'renders correctly with path $path, range $range, repo $repo',
+        ({ repo, path, range, expectedInnerText }) => {
+            const { baseElement } = render(
+                <PrettyPrintedContextItem path={path} range={range} repoShortName={repo} />
+            )
+            expect(baseElement.innerText.trim()).toEqual(expectedInnerText.trim())
+        }
+    )
+})

--- a/vscode/webviews/components/FileLink.tsx
+++ b/vscode/webviews/components/FileLink.tsx
@@ -165,9 +165,6 @@ const PrettyPrintedContextItem: React.FunctionComponent<{
     if (!path.includes('/')) {
         sep = '\\'
     }
-    if (!path.includes(sep)) {
-        return <>{path}</>
-    }
 
     const basename = path.split(sep).pop()
     const dirname = path.split(sep).slice(0, -1).join(sep)

--- a/vscode/webviews/components/FileLink.tsx
+++ b/vscode/webviews/components/FileLink.tsx
@@ -156,7 +156,7 @@ export const FileLink: React.FunctionComponent<
     )
 }
 
-const PrettyPrintedContextItem: React.FunctionComponent<{
+export const PrettyPrintedContextItem: React.FunctionComponent<{
     path: string
     range?: string
     repoShortName?: string
@@ -175,7 +175,7 @@ const PrettyPrintedContextItem: React.FunctionComponent<{
             {repoShortName && (
                 <span className={styles.repoShortName}>
                     {repoShortName}
-                    {sep}
+                    {dirname.length === 0 || dirname.startsWith(sep) ? '' : sep}
                 </span>
             )}
             <span className={styles.dirname}>{dirname}</span>

--- a/vscode/webviews/components/FileLink.tsx
+++ b/vscode/webviews/components/FileLink.tsx
@@ -166,11 +166,11 @@ export const PrettyPrintedContextItem: React.FunctionComponent<{
         sep = '\\'
     }
 
-    const basename = path.split(sep).pop()
+    const basename = path.split(sep).pop() || ''
     const dirname = path.split(sep).slice(0, -1).join(sep)
     return (
         <>
-            <span>{basename}</span>
+            <span className={styles.basename}>{basename}</span>
             <span className={styles.range}>{range ? `:${range}` : ''}</span>{' '}
             {repoShortName && (
                 <span className={styles.repoShortName}>


### PR DESCRIPTION
Improve the rendering of context items in Cody
* Render the basename first
* Followed by line numbers in gray text
* Repo and dirname after in gray text and smaller font

<table>
<tr>
<th>Before</th>
<th>After</th>
</tr>
<tr>
<td>
<img src="https://github.com/user-attachments/assets/5d799e72-6fa9-4dfd-b7be-88ca797efbd5"/>
</td>
<td>
<img src="https://github.com/user-attachments/assets/be913792-7ca5-45d6-8b9d-4b0905316f3b"/>
</td>
</tr>

<tr>

<td>
<img src="https://github.com/user-attachments/assets/6c27ded3-df9a-4a3a-957b-e7df4e613b44"/>
</td>

<td>
<img src="https://github.com/user-attachments/assets/4fb8cdad-0bf1-46ba-9f48-3d72ec0afe13"/>
</td>

</tr>

</table>








## Test plan

Test locally and on web.
