### PR TITLE
Autocomplete: add `google` provider tests

### DIFF
--- a/vscode/src/completions/model-helpers/__tests__/gemini.test.ts
+++ b/vscode/src/completions/model-helpers/__tests__/gemini.test.ts
@@ -1,0 +1,184 @@
+import { describe, expect, it } from 'vitest'
+
+import { isWindows } from '@sourcegraph/cody-shared'
+
+import { completionParams, contextSnippets } from './test-data'
+
+import { Gemini } from '../gemini'
+
+describe('Gemini ', () => {
+    describe.skipIf(isWindows())('getPrompt', () => {
+        it('returns the prompt with the correct intro snippets', () => {
+            const model = new Gemini()
+            const { docContext, document, provider } = completionParams
+
+            const result = model.getPrompt({
+                document,
+                docContext,
+                snippets: contextSnippets,
+                promptChars: provider.contextSizeHints.totalChars,
+            })
+
+            expect(result).toMatchInlineSnapshot(`
+              "You are a code completion AI, designed to autofill code enclosed in special markers based on its surrounding context.
+
+              -TYPE: file
+              -NAME: codebase/context1.ts
+              -CONTENT: function contextSnippetOne() {}
+              ---
+
+              -TYPE: file
+              -NAME: codebase/context2.ts
+              -CONTENT: const contextSnippet2 = {}
+              ---
+
+              -TYPE: symbol
+              -NAME: ContextParams
+              -CONTENT: interface ContextParams {}
+              ---
+
+
+              Code from codebase/test.ts file:
+              <|prefix|>console.log(prefix line: 1)
+              console.log(prefix line: 2)
+              console.log(prefix line: 3)
+              console.log(prefix line: 4)
+              console.log(prefix line: 5)
+              console.log(prefix line: 6)
+              console.log(prefix line: 7)
+              console.log(prefix line: 8)
+              console.log(prefix line: 9)
+              console.log(prefix line: 10)
+              console.log(prefix line: 11)
+              console.log(prefix line: 12)
+              console.log(prefix line: 13)
+              console.log(prefix line: 14)
+              console.log(prefix line: 15)
+              console.log(prefix line: 16)
+              console.log(prefix line: 17)
+              console.log(prefix line: 18)
+              console.log(prefix line: 19)
+              console.log(prefix line: 20)
+              console.log(prefix line: 21)
+              console.log(prefix line: 22)
+              console.log(prefix line: 23)
+              console.log(prefix line: 24)
+              console.log(prefix line: 25)
+              console.log(prefix line: 26)
+              console.log(prefix line: 27)
+              console.log(prefix line: 28)
+              console.log(prefix line: 29)
+              console.log(prefix line: 30)
+              console.log(prefix line: 31)
+              console.log(prefix line: 32)
+              console.log(prefix line: 33)
+              console.log(prefix line: 34)
+              console.log(prefix line: 35)
+              console.log(prefix line: 36)
+              console.log(prefix line: 37)
+              console.log(prefix line: 38)
+              console.log(prefix line: 39)
+              console.log(prefix line: 40)
+              console.log(prefix line: 41)
+              console.log(prefix line: 42)
+              console.log(prefix line: 43)
+              console.log(prefix line: 44)
+              console.log(prefix line: 45)
+              console.log(prefix line: 46)
+              console.log(prefix line: 47)
+              console.log(prefix line: 48)
+              console.log(prefix line: 49)
+              console.log(prefix line: 50)
+              console.log(prefix line: 51)
+              console.log(prefix line: 52)
+              console.log(prefix line: 53)
+              console.log(prefix line: 54)
+              console.log(prefix line: 55)
+              console.log(prefix line: 56)
+              console.log(prefix line: 57)
+              console.log(prefix line: 58)
+              console.log(prefix line: 59)
+              console.log(prefix line: 60)
+              console.log(prefix line: 61)
+              console.log(prefix line: 62)
+              console.log(prefix line: 63)
+              console.log(prefix line: 64)
+              console.log(prefix line: 65)
+              console.log(prefix line: 66)
+              console.log(prefix line: 67)
+              console.log(prefix line: 68)
+              console.log(prefix line: 69)
+              console.log(prefix line: 70)
+              console.log(prefix line: 71)
+              console.log(prefix line: 72)
+              console.log(prefix line: 73)
+              console.log(prefix line: 74)
+              console.log(prefix line: 75)
+              console.log(prefix line: 76)
+              console.log(prefix line: 77)
+              console.log(prefix line: 78)
+              console.log(prefix line: 79)
+              console.log(prefix line: 80)
+              console.log(prefix line: 81)
+              console.log(prefix line: 82)
+              console.log(prefix line: 83)
+              console.log(prefix line: 84)
+              console.log(prefix line: 85)
+              console.log(prefix line: 86)
+              console.log(prefix line: 87)
+              console.log(prefix line: 88)
+              console.log(prefix line: 89)
+              console.log(prefix line: 90)
+              console.log(prefix line: 91)
+              console.log(prefix line: 92)
+              console.log(prefix line: 93)
+              console.log(prefix line: 94)
+              console.log(prefix line: 95)
+              console.log(prefix line: 96)
+              console.log(prefix line: 97)
+              console.log(prefix line: 98)
+              console.log(prefix line: 99)
+              console.log(prefix line: 100)
+              function myFunction() {
+                  console.log(1)
+                  console.log(2)
+                  console.log(3)
+                  console.log(4)
+                  <|fim|>
+              }
+              console.log(suffix line: 1)
+              console.log(suffix line: 2)
+              console.log(suffix line: 3)
+              console.log(suffix line: 4)
+              console.log(suffix line: 5)
+              console.log(suffix line: 6)
+              console.log(suffix line: 7)
+              console.log(suffix line: 8)
+              console.log(suffix line: 9)
+              console.log(suffix line: 10)
+              console.log(suffix line: 11)
+              console.log(suffix line: 12)
+              console.log(suffix line: 13)
+              console.log(suffix line: 14)
+              console.log(suffix line: 15)
+              console.log(suffix line: 16)
+              console.log(suffix line: 17)
+              console.log(suffix line: 18)
+              console.log(suffix line: 19)
+              console.log(suffix line: 20)
+              console.log(suffix line: 21)
+              console.log(suffix line: 22)
+              console.log(suffix line: 23)
+              console.log(suffix line: 24)
+              console.log(suffix line: 25)<|suffix|>
+
+              Your mission is to generate completed code that I can replace the <|fim|> markers with, ensuring a seamless and syntactically correct result.
+
+              Do not repeat code from before and after <|fim|> in your output.
+              Maintain consistency with the indentation, spacing, and coding style used in the code.
+              Leave the output markers empty if no code is required to bridge the gap.
+              Your response should contains only the code required to connect the gap, and the code must be enclosed between <|fim|> WITHOUT backticks"
+            `)
+        })
+    })
+})

--- a/vscode/src/completions/model-helpers/default.ts
+++ b/vscode/src/completions/model-helpers/default.ts
@@ -124,7 +124,7 @@ export class DefaultModel {
                 const snippet = snippets[snippetsToInclude - 1]
 
                 if ('symbol' in snippet) {
-                    introSnippets.push(symbolSnippetToPromptString(snippet))
+                    introSnippets.push(this.symbolSnippetToPromptString(snippet))
                 } else {
                     introSnippets.push(this.fileSnippetToPromptString(snippet))
                 }
@@ -167,12 +167,13 @@ export class DefaultModel {
         return ps`Here is a reference snippet of code from ${uriPromptString}:\n${content}`
     }
 
+    protected symbolSnippetToPromptString(snippet: AutocompleteSymbolContextSnippet): PromptString {
+        const { content, symbol } = PromptString.fromAutocompleteContextSnippet(snippet)
+
+        return ps`Additional documentation for \`${symbol!}\`:\n${content}`
+    }
+
     protected formatPrompt(param: FormatPromptParams): PromptString {
         return ps`${param.intro}${param.prefix}`
     }
-}
-
-function symbolSnippetToPromptString(snippet: AutocompleteSymbolContextSnippet): PromptString {
-    const { content, symbol } = PromptString.fromAutocompleteContextSnippet(snippet)
-    return ps`Additional documentation for \`${symbol!}\`:\n${content}`
 }

--- a/vscode/src/completions/model-helpers/gemini.ts
+++ b/vscode/src/completions/model-helpers/gemini.ts
@@ -1,0 +1,94 @@
+import {
+    type AutocompleteContextSnippet,
+    type AutocompleteSymbolContextSnippet,
+    type DocumentContext,
+    PromptString,
+    ps,
+} from '@sourcegraph/cody-shared'
+
+import { fixBadCompletionStart } from '../text-processing'
+import {
+    DefaultModel,
+    type FormatIntroSnippetsParams,
+    type FormatPromptParams,
+    type GetOllamaPromptParams,
+} from './default'
+
+export const GEMINI_MARKERS = {
+    Prefix: ps`<|prefix|>`,
+    Suffix: ps`<|suffix|>`,
+    Response: ps`<|fim|>`,
+}
+
+export class Gemini extends DefaultModel {
+    public stopSequences = [`${GEMINI_MARKERS.Response}`]
+
+    getOllamaPrompt(promptContext: GetOllamaPromptParams): PromptString {
+        throw new Error('OpenAI is not supported by the Ollama provider yet!')
+    }
+
+    protected fileSnippetToPromptString(snippet: AutocompleteContextSnippet): PromptString {
+        const { content, symbol } = PromptString.fromAutocompleteContextSnippet(snippet)
+
+        return this.formatContextSnippet(
+            ps`file`,
+            symbol ? symbol : PromptString.fromDisplayPath(snippet.uri),
+            content
+        )
+    }
+
+    protected symbolSnippetToPromptString(snippet: AutocompleteSymbolContextSnippet): PromptString {
+        const { content, symbol } = PromptString.fromAutocompleteContextSnippet(snippet)
+
+        return this.formatContextSnippet(
+            ps`symbol`,
+            symbol ? symbol : PromptString.fromDisplayPath(snippet.uri),
+            content
+        )
+    }
+
+    private formatContextSnippet(type: PromptString, name: PromptString, content: PromptString) {
+        return ps`\n-TYPE: ${type}\n-NAME: ${name}\n-CONTENT: ${content.trimEnd()}\n---\n`
+    }
+
+    protected formatIntroSnippets({ intro }: FormatIntroSnippetsParams): PromptString {
+        return PromptString.join(intro, ps``)
+    }
+
+    protected formatPrompt(params: FormatPromptParams): PromptString {
+        const { intro, prefix, suffix, fileName } = params
+
+        // See official docs on prompting for Gemini models:
+        // https://ai.google.dev/gemini-api/docs/prompting-intro
+        const fimPrompt = ps`${GEMINI_MARKERS.Prefix}${prefix}${GEMINI_MARKERS.Response}${suffix}${GEMINI_MARKERS.Suffix}`
+
+        const humanText = ps`You are a code completion AI, designed to autofill code enclosed in special markers based on its surrounding context.
+${intro}
+
+Code from ${fileName} file:
+${fimPrompt}
+
+Your mission is to generate completed code that I can replace the ${GEMINI_MARKERS.Response} markers with, ensuring a seamless and syntactically correct result.
+
+Do not repeat code from before and after ${GEMINI_MARKERS.Response} in your output.
+Maintain consistency with the indentation, spacing, and coding style used in the code.
+Leave the output markers empty if no code is required to bridge the gap.
+Your response should contains only the code required to connect the gap, and the code must be enclosed between ${GEMINI_MARKERS.Response} WITHOUT backticks`
+
+        return humanText
+    }
+
+    public postProcess(content: string, docContext: DocumentContext): string {
+        let completion = content
+
+        // Because the response should be enclosed with RESPONSE_CODE for consistency.
+        completion = completion
+            .replaceAll(`${GEMINI_MARKERS.Response}`, '')
+            .replaceAll(`${GEMINI_MARKERS.Suffix}`, '')
+
+        // Remove bad symbols from the start of the completion string.
+        completion = fixBadCompletionStart(completion)
+
+        return completion
+    }
+}

--- a/vscode/src/completions/model-helpers/index.ts
+++ b/vscode/src/completions/model-helpers/index.ts
@@ -2,6 +2,7 @@ import { CodeGemma } from './codegemma'
 import { CodeLlama } from './codellama'
 import { DeepseekCoder } from './deepseek'
 import { DefaultModel } from './default'
+import { Gemini } from './gemini'
 import { Mistral } from './mistral'
 import { StarCoder } from './starcoder'
 
@@ -30,6 +31,10 @@ export function getModelHelpers(model: string): DefaultModel {
 
     if (model.includes('codegemma')) {
         return new CodeGemma()
+    }
+
+    if (model.includes('gemini')) {
+        return new Gemini()
     }
 
     return new DefaultModel()

--- a/vscode/src/completions/providers/google.test.ts
+++ b/vscode/src/completions/providers/google.test.ts
@@ -1,0 +1,61 @@
+import { Observable } from 'observable-fns'
+import { afterEach, beforeEach, describe, vi } from 'vitest'
+
+import { featureFlagProvider, modelsService } from '@sourcegraph/cody-shared'
+
+import { mockLocalStorage } from '../../services/LocalStorageProvider'
+
+import {
+    type AutocompleteProviderValuesToAssert,
+    getAutocompleteProviderFromLocalSettings,
+    getAutocompleteProviderFromServerSideModelConfig,
+    getAutocompleteProviderFromSiteConfigCodyLLMConfiguration,
+    testAutocompleteProvider,
+} from './shared/helpers'
+
+describe('google autocomplete provider', () => {
+    beforeEach(async () => {
+        mockLocalStorage()
+        vi.spyOn(featureFlagProvider, 'evaluatedFeatureFlag').mockReturnValue(Observable.of(false))
+    })
+
+    afterEach(() => {
+        modelsService.reset()
+    })
+
+    const starChatAssertion = {
+        providerId: 'google',
+        legacyModel: 'gemini-1.5-flash-latest',
+        requestParams: {
+            maxTokensToSample: 256,
+            temperature: 0,
+            timeoutMs: 7000,
+            topK: 0,
+            topP: 0.95,
+            model: 'gemini-1.5-flash-latest',
+        },
+    } satisfies AutocompleteProviderValuesToAssert
+
+    testAutocompleteProvider('local-editor-settings', starChatAssertion, isDotCom =>
+        getAutocompleteProviderFromLocalSettings({
+            providerId: 'google',
+            legacyModel: 'gemini-1.5-flash-latest',
+            isDotCom,
+        })
+    )
+
+    testAutocompleteProvider('server-side-model-config', starChatAssertion, isDotCom =>
+        getAutocompleteProviderFromServerSideModelConfig({
+            modelRef: 'google::v1::gemini-1.5-flash-latest',
+            isDotCom,
+        })
+    )
+
+    testAutocompleteProvider('site-config-cody-llm-configuration', starChatAssertion, isDotCom =>
+        getAutocompleteProviderFromSiteConfigCodyLLMConfiguration({
+            providerId: 'google',
+            legacyModel: 'gemini-1.5-flash-latest',
+            isDotCom,
+        })
+    )
+})

--- a/vscode/src/completions/providers/google.ts
+++ b/vscode/src/completions/providers/google.ts
@@ -1,13 +1,7 @@
-import {
-    type AutocompleteContextSnippet,
-    type CodeCompletionsParams,
-    type Message,
-    PromptString,
-    ps,
-} from '@sourcegraph/cody-shared'
+import { type CodeCompletionsParams, ps } from '@sourcegraph/cody-shared'
 
-import { type PrefixComponents, fixBadCompletionStart, getHeadAndTail } from '../text-processing'
-import { forkSignal, generatorWithTimeout, messagesToText, zipGenerators } from '../utils'
+import { GEMINI_MARKERS } from '../model-helpers/gemini'
+import { forkSignal, generatorWithTimeout, zipGenerators } from '../utils'
 
 import {
     type FetchCompletionResult,
@@ -20,97 +14,26 @@ import {
     type ProviderFactoryParams,
 } from './shared/provider'
 
-const MARKERS = {
-    Prefix: ps`<|prefix|>`,
-    Suffix: ps`<|suffix|>`,
-    Response: ps`<|fim|>`,
-}
-
 class GoogleGeminiProvider extends Provider {
-    public stopSequences = [`${MARKERS.Response}`]
-
-    public emptyPromptLength(options: GenerateCompletionsOptions): number {
-        const { messages } = this.createPrompt(options, [])
-        const promptNoSnippets = messagesToText(messages)
-        return promptNoSnippets.length - 10
-    }
-
-    protected createPrompt(
-        options: GenerateCompletionsOptions,
-        snippets: AutocompleteContextSnippet[]
-    ): {
-        messages: Message[]
-        prefix: PrefixComponents
-    } {
-        const { prefix, suffix } = PromptString.fromAutocompleteDocumentContext(
-            options.docContext,
-            options.document.uri
-        )
-
-        const { head, tail, overlap } = getHeadAndTail(prefix)
-
-        const relativeFilePath = PromptString.fromDisplayPath(options.document.uri)
-
-        let groupedSnippets = ps``
-
-        for (const snippet of snippets) {
-            const { uri } = snippet
-            const { content, symbol } = PromptString.fromAutocompleteContextSnippet(snippet)
-            const contextPrompt = this.createContext(
-                symbol ? ps`symbol` : ps`file`,
-                symbol ? symbol : PromptString.fromDisplayPath(uri),
-                content
-            )
-
-            if (
-                contextPrompt.length + 1 > this.promptChars - this.emptyPromptLength(options) ||
-                !contextPrompt.length
-            ) {
-                break
-            }
-
-            groupedSnippets = groupedSnippets.concat(contextPrompt)
-        }
-
-        if (groupedSnippets.length) {
-            groupedSnippets = ps`Context:\n${groupedSnippets}\n`
-        }
-
-        // See official docs on prompting for Gemini models:
-        // https://ai.google.dev/gemini-api/docs/prompting-intro
-        const fimPrompt = ps`${MARKERS.Prefix}${prefix}${MARKERS.Response}${suffix}${MARKERS.Suffix}`
-
-        const humanText = ps`You are a code completion AI, designed to autofill code enclosed in special markers based on its surrounding context.
-${groupedSnippets}
-
-Code from ${relativeFilePath} file:
-${fimPrompt}
-
-Your mission is to generate completed code that I can replace the ${MARKERS.Response} markers with, ensuring a seamless and syntactically correct result.
-
-Do not repeat code from before and after ${MARKERS.Response} in your output.
-Maintain consistency with the indentation, spacing, and coding style used in the code.
-Leave the output markers empty if no code is required to bridge the gap.
-Your response should contains only the code required to connect the gap, and the code must be enclosed between ${MARKERS.Response} WITHOUT backticks`
-
-        const messages: Message[] = [
-            { speaker: 'human', text: humanText },
-            { speaker: 'assistant', text: ps`${MARKERS.Response}` },
-        ]
-
-        return { messages, prefix: { head, tail, overlap } }
-    }
-
     public getRequestParams(options: GenerateCompletionsOptions): CodeCompletionsParams {
-        const { snippets } = options
-        const { messages } = this.createPrompt(options, snippets)
+        const { snippets, docContext, document } = options
+
+        const prompt = this.modelHelper.getPrompt({
+            snippets,
+            docContext,
+            document,
+            promptChars: this.promptChars,
+        })
 
         return {
             ...this.defaultRequestParams,
-            messages,
             topP: 0.95,
             temperature: 0,
             model: this.legacyModel,
+            messages: [
+                { speaker: 'human', text: prompt },
+                { speaker: 'assistant', text: ps`${GEMINI_MARKERS.Response}` },
+            ],
         }
     }
 
@@ -119,7 +42,7 @@ Your response should contains only the code required to connect the gap, and the
         abortSignal: AbortSignal,
         tracer?: CompletionProviderTracer
     ): Promise<AsyncGenerator<FetchCompletionResult[]>> {
-        const { numberOfCompletionsToGenerate } = generateOptions
+        const { numberOfCompletionsToGenerate, docContext } = generateOptions
 
         const requestParams = this.getRequestParams(generateOptions)
         tracer?.params(requestParams)
@@ -138,28 +61,13 @@ Your response should contains only the code required to connect the gap, and the
                     completionResponseGenerator,
                     abortController,
                     generateOptions,
-                    providerSpecificPostProcess: this.postProcess,
+                    providerSpecificPostProcess: content =>
+                        this.modelHelper.postProcess(content, docContext),
                 })
             }
         )
 
         return zipGenerators(await Promise.all(completionsGenerators))
-    }
-
-    private postProcess = (rawResponse: string): string => {
-        let completion = rawResponse
-
-        // Because the response should be enclosed with RESPONSE_CODE for consistency.
-        completion = completion.replaceAll(`${MARKERS.Response}`, '').replaceAll(`${MARKERS.Suffix}`, '')
-
-        // Remove bad symbols from the start of the completion string.
-        completion = fixBadCompletionStart(completion)
-
-        return completion
-    }
-
-    private createContext(type: PromptString, name: PromptString, content: PromptString) {
-        return ps`\n-TYPE: ${type}\n-NAME: ${name}\n-CONTENT: ${content.trimEnd()}\n---\n`
     }
 }
 


### PR DESCRIPTION
The problem: currently, we [assert](https://github.com/sourcegraph/cody/blob/d10b88f3bcaad1c140352088a15f641f4697c80f/vscode/src/completions/providers/shared/create-provider.test.ts#L218-L219) the model ID assigned to the provider instance, but often, it's not used at all to make requests, which means this assertion is irrelevant to the actual functionality where we bump into bugs.

- This PR adds tests for autocomplete request parameters in all supported instance configurations: dotcom/enterprise X local-settings/server-side-model-config/site-config for the `google` provider.
- Removes model-specific code by leveraging model helpers we already use in other providers.
- Follow up for https://github.com/sourcegraph/cody/pull/5604.
- No functional changes.
- Part of https://linear.app/sourcegraph/issue/CODY-3409/self-hosted-models-openaicompatible-autocomplete-provider-supports
- Part of https://linear.app/sourcegraph/issue/CODY-3778/add-autocomplete-provider-tests-to-assert-request-parameters

## Test plan

CI and new unit tests
