### PR TITLE
Autocomplete: add `anthropic` provider tests

### DIFF
--- a/lib/shared/src/index.ts
+++ b/lib/shared/src/index.ts
@@ -10,6 +10,7 @@ export {
     type PerSitePreferences,
     type SitePreferences,
     type ModelRefStr,
+    type LegacyModelRefStr,
     type ModelRef,
     type ModelsData,
     TestLocalStorageForModelPreferences,

--- a/lib/shared/src/inferenceClient/misc.ts
+++ b/lib/shared/src/inferenceClient/misc.ts
@@ -1,3 +1,4 @@
+import type { LegacyModelRefStr, ModelRefStr } from '../models/modelsService'
 import type { CompletionLogger } from '../sourcegraph-api/completions/client'
 import type {
     CompletionParameters,
@@ -23,7 +24,11 @@ export enum CompletionStopReason {
     RequestFinished = 'cody-request-finished',
 }
 
-export type CodeCompletionsParams = Omit<CompletionParameters, 'fast'> & { timeoutMs: number }
+export type CodeCompletionsParams = Omit<CompletionParameters, 'fast'> & {
+    timeoutMs: number
+    // TODO: apply the same type to the underlying `CompletionParameters`
+    model?: LegacyModelRefStr | ModelRefStr
+}
 export type SerializedCodeCompletionsParams = Omit<SerializedCompletionParameters, 'fast'>
 
 export type CompletionResponseWithMetaData = {

--- a/lib/shared/src/models/model.ts
+++ b/lib/shared/src/models/model.ts
@@ -18,8 +18,8 @@ import { getModelInfo } from './utils'
  */
 export interface Model {
     /**
-     * The model id that includes the provider name & the model name,
-     * e.g. "anthropic/claude-3-sonnet-20240229"
+     * The model name _without_ the provider ID.
+     * e.g. "claude-3-sonnet-20240229"
      *
      * TODO(PRIME-282): Replace this with a `ModelRefStr` instance and introduce a separate
      * "modelId" that is distinct from the "modelName". (e.g. "claude-3-sonnet" vs. "claude-3-sonnet-20240229")
@@ -97,12 +97,12 @@ export function createModel({
     }
 
     return {
-        id: id,
+        id,
         modelRef,
-        usage: usage,
-        contextWindow: contextWindow,
-        clientSideConfig: clientSideConfig,
-        tags: tags,
+        usage,
+        contextWindow,
+        clientSideConfig,
+        tags,
         provider: modelRef.providerId,
         title: title ?? modelRef.modelId,
     }

--- a/lib/shared/src/models/modelsService.ts
+++ b/lib/shared/src/models/modelsService.ts
@@ -31,6 +31,7 @@ type ApiVersionId = string
 type ProviderId = string
 
 export type ModelRefStr = `${ProviderId}::${ApiVersionId}::${ModelId}`
+export type LegacyModelRefStr = `${ProviderId}/${ModelId}`
 export interface ModelRef {
     providerId: ProviderId
     apiVersionId: ApiVersionId

--- a/vscode/src/completions/get-inline-completions-tests/analytics.test.ts
+++ b/vscode/src/completions/get-inline-completions-tests/analytics.test.ts
@@ -51,6 +51,11 @@ describe('[getInlineCompletions] completion event', () => {
                     },
                 ],
                 {
+                    configuration: {
+                        configuration: {
+                            autocompleteAdvancedProvider: 'fireworks',
+                        },
+                    },
                     authStatus: additionalParams.isDotComUser
                         ? AUTH_STATUS_FIXTURE_AUTHED_DOTCOM
                         : AUTH_STATUS_FIXTURE_AUTHED,
@@ -142,8 +147,8 @@ describe('[getInlineCompletions] completion event', () => {
                   "languageId": "typescript",
                   "multiline": true,
                   "multilineMode": "block",
-                  "providerIdentifier": "anthropic",
-                  "providerModel": "",
+                  "providerIdentifier": "fireworks",
+                  "providerModel": "starcoder-hybrid",
                   "resolvedModel": "sourcegraph/gateway-model",
                   "responseHeaders": {
                     "fireworks-speculation-matched-tokens": "100",
@@ -214,8 +219,8 @@ describe('[getInlineCompletions] completion event', () => {
                   "languageId": "typescript",
                   "multiline": false,
                   "multilineMode": null,
-                  "providerIdentifier": "anthropic",
-                  "providerModel": "",
+                  "providerIdentifier": "fireworks",
+                  "providerModel": "starcoder-hybrid",
                   "resolvedModel": "sourcegraph/gateway-model",
                   "responseHeaders": {
                     "fireworks-speculation-matched-tokens": "100",

--- a/vscode/src/completions/get-inline-completions-tests/helpers.ts
+++ b/vscode/src/completions/get-inline-completions-tests/helpers.ts
@@ -144,8 +144,7 @@ export function params(
 
     // TODO: add support for `createProvider` from `vscode/src/completions/providers/shared/create-provider.ts`
     const createProvider =
-        config?.configuration?.autocompleteAdvancedProvider === 'fireworks' &&
-        config?.configuration?.autocompleteAdvancedModel
+        config?.configuration?.autocompleteAdvancedProvider === 'fireworks'
             ? createFireworksProvider
             : createAnthropicProvider
 

--- a/vscode/src/completions/model-helpers/__tests__/claude.test.ts
+++ b/vscode/src/completions/model-helpers/__tests__/claude.test.ts
@@ -2,14 +2,13 @@ import { describe, expect, it } from 'vitest'
 
 import { isWindows } from '@sourcegraph/cody-shared'
 
+import { Claude } from '../claude'
 import { completionParams, contextSnippets } from './test-data'
 
-import { Mistral } from '../mistral'
-
-describe('Mistral', () => {
+describe('Claude ', () => {
     describe.skipIf(isWindows())('getMessages', () => {
         it('returns the prompt with the correct intro snippets', () => {
-            const model = new Mistral()
+            const model = new Claude()
             const { docContext, document, provider } = completionParams
 
             const result = model.getMessages({
@@ -23,17 +22,40 @@ describe('Mistral', () => {
               [
                 {
                   "speaker": "human",
-                  "text": "<s>[INST] Below is the code from file path codebase/test.ts. Review the code outside the XML tags to detect the functionality, formats, style, patterns, and logics in use. Then, use what you detect and reuse methods/libraries to complete and enclose completed code only inside XML tags precisely without duplicating existing implementations. Here is the code:
+                  "text": "Codebase context from file path 'codebase/context1.ts': <CODE5711>function contextSnippetOne() {}</CODE5711>",
+                },
+                {
+                  "speaker": "assistant",
+                  "text": "I will refer to this code to complete your next request.",
+                },
+                {
+                  "speaker": "human",
+                  "text": "Codebase context from file path 'codebase/context2.ts': <CODE5711>const contextSnippet2 = {}</CODE5711>",
+                },
+                {
+                  "speaker": "assistant",
+                  "text": "I will refer to this code to complete your next request.",
+                },
+                {
+                  "speaker": "human",
+                  "text": "Additional documentation for \`ContextParams\`: <CODE5711>interface ContextParams {}</CODE5711>",
+                },
+                {
+                  "speaker": "assistant",
+                  "text": "I will refer to this code to complete your next request.",
+                },
+                {
+                  "speaker": "human",
+                  "text": "You are a code completion AI designed to take the surrounding code and shared context into account in order to predict and suggest high-quality code to complete the code enclosed in <CODE5711> tags. You only respond with code that works and fits seamlessly with surrounding code if any or use best practice and nothing else.",
+                },
+                {
+                  "speaker": "assistant",
+                  "text": "I am a code completion AI with exceptional context-awareness designed to auto-complete nested code blocks with high-quality code that seamlessly integrates with surrounding code.",
+                },
+                {
+                  "speaker": "human",
+                  "text": "Below is the code from file path codebase/test.ts. Review the code outside the XML tags to detect the functionality, formats, style, patterns, and logics in use. Then, use what you detect and reuse methods/libraries to complete and enclose completed code only inside XML tags precisely without duplicating existing implementations. Here is the code: 
               \`\`\`
-              // Here is a reference snippet of code from codebase/context1.ts:
-              // function contextSnippetOne() {}
-
-              // Here is a reference snippet of code from codebase/context2.ts:
-              // const contextSnippet2 = {}
-
-              // Additional documentation for \`ContextParams\`:
-              // interface ContextParams {}
-
               console.log(prefix line: 1)
               console.log(prefix line: 2)
               console.log(prefix line: 3)
@@ -164,8 +186,11 @@ describe('Mistral', () => {
               console.log(suffix line: 23)
               console.log(suffix line: 24)
               console.log(suffix line: 25)
-              \`\`\`[/INST]
-               <CODE5711>console.log(3)
+              \`\`\`",
+                },
+                {
+                  "speaker": "assistant",
+                  "text": "<CODE5711>console.log(3)
                   console.log(4)
               ",
                 },

--- a/vscode/src/completions/model-helpers/__tests__/codegemma.test.ts
+++ b/vscode/src/completions/model-helpers/__tests__/codegemma.test.ts
@@ -7,12 +7,12 @@ import { completionParams, contextSnippets } from './test-data'
 import { CodeGemma } from '../codegemma'
 
 describe('CodeGemma', () => {
-    describe.skipIf(isWindows())('getPrompt', () => {
+    describe.skipIf(isWindows())('getMessages', () => {
         it('returns the prompt with the correct intro snippets', () => {
             const model = new CodeGemma()
             const { docContext, document, provider } = completionParams
 
-            const result = model.getPrompt({
+            const result = model.getMessages({
                 document,
                 docContext,
                 snippets: contextSnippets,
@@ -20,7 +20,10 @@ describe('CodeGemma', () => {
             })
 
             expect(result).toMatchInlineSnapshot(`
-              "// Here is a reference snippet of code from codebase/context1.ts:
+              [
+                {
+                  "speaker": "human",
+                  "text": "// Here is a reference snippet of code from codebase/context1.ts:
               // function contextSnippetOne() {}
 
               // Here is a reference snippet of code from codebase/context2.ts:
@@ -160,7 +163,9 @@ describe('CodeGemma', () => {
               console.log(suffix line: 22)
               console.log(suffix line: 23)
               console.log(suffix line: 24)
-              console.log(suffix line: 25)<|fim_middle|>"
+              console.log(suffix line: 25)<|fim_middle|>",
+                },
+              ]
             `)
         })
     })

--- a/vscode/src/completions/model-helpers/__tests__/codellama.test.ts
+++ b/vscode/src/completions/model-helpers/__tests__/codellama.test.ts
@@ -7,12 +7,12 @@ import { completionParams, contextSnippets } from './test-data'
 import { CodeLlama } from '../codellama'
 
 describe('CodeLlama', () => {
-    describe.skipIf(isWindows())('getPrompt', () => {
+    describe.skipIf(isWindows())('getMessages', () => {
         it('returns the prompt with the correct intro snippets', () => {
             const model = new CodeLlama()
             const { docContext, document, provider } = completionParams
 
-            const result = model.getPrompt({
+            const result = model.getMessages({
                 document,
                 docContext,
                 snippets: contextSnippets,
@@ -20,7 +20,10 @@ describe('CodeLlama', () => {
             })
 
             expect(result).toMatchInlineSnapshot(`
-              "<PRE> // Path: codebase/test.ts
+              [
+                {
+                  "speaker": "human",
+                  "text": "<PRE> // Path: codebase/test.ts
 
               // Here is a reference snippet of code from codebase/context1.ts:
               // function contextSnippetOne() {}
@@ -162,7 +165,9 @@ describe('CodeLlama', () => {
               console.log(suffix line: 22)
               console.log(suffix line: 23)
               console.log(suffix line: 24)
-              console.log(suffix line: 25) <MID>"
+              console.log(suffix line: 25) <MID>",
+                },
+              ]
             `)
         })
     })

--- a/vscode/src/completions/model-helpers/__tests__/deepseek.test.ts
+++ b/vscode/src/completions/model-helpers/__tests__/deepseek.test.ts
@@ -7,12 +7,12 @@ import { completionParams, contextSnippets } from './test-data'
 import { DeepseekCoder } from '../deepseek'
 
 describe('DeepseekCoder ', () => {
-    describe.skipIf(isWindows())('getPrompt', () => {
+    describe.skipIf(isWindows())('getMessages', () => {
         it('returns the prompt with the correct intro snippets', () => {
             const model = new DeepseekCoder()
             const { docContext, document, provider } = completionParams
 
-            const result = model.getPrompt({
+            const result = model.getMessages({
                 document,
                 docContext,
                 snippets: contextSnippets,
@@ -20,7 +20,10 @@ describe('DeepseekCoder ', () => {
             })
 
             expect(result).toMatchInlineSnapshot(`
-              "#codebase/context1.ts
+              [
+                {
+                  "speaker": "human",
+                  "text": "#codebase/context1.ts
               function contextSnippetOne() {}
 
               #codebase/context2.ts
@@ -161,7 +164,9 @@ describe('DeepseekCoder ', () => {
               console.log(suffix line: 22)
               console.log(suffix line: 23)
               console.log(suffix line: 24)
-              console.log(suffix line: 25)<｜fim▁end｜>"
+              console.log(suffix line: 25)<｜fim▁end｜>",
+                },
+              ]
             `)
         })
     })

--- a/vscode/src/completions/model-helpers/__tests__/default.test.ts
+++ b/vscode/src/completions/model-helpers/__tests__/default.test.ts
@@ -7,12 +7,12 @@ import { completionParams, contextSnippets } from './test-data'
 import { DefaultModel } from '../default'
 
 describe('DefaultModel', () => {
-    describe.skipIf(isWindows())('getPrompt', () => {
+    describe.skipIf(isWindows())('getMessages', () => {
         it('returns the prompt with the correct intro snippets', () => {
             const model = new DefaultModel()
             const { docContext, document, provider } = completionParams
 
-            const result = model.getPrompt({
+            const result = model.getMessages({
                 document,
                 docContext,
                 snippets: contextSnippets,
@@ -20,7 +20,10 @@ describe('DefaultModel', () => {
             })
 
             expect(result).toMatchInlineSnapshot(`
-              "// Here is a reference snippet of code from codebase/context1.ts:
+              [
+                {
+                  "speaker": "human",
+                  "text": "// Here is a reference snippet of code from codebase/context1.ts:
               // function contextSnippetOne() {}
 
               // Here is a reference snippet of code from codebase/context2.ts:
@@ -134,7 +137,9 @@ describe('DefaultModel', () => {
                   console.log(2)
                   console.log(3)
                   console.log(4)
-                  "
+                  ",
+                },
+              ]
             `)
         })
     })

--- a/vscode/src/completions/model-helpers/__tests__/gemini.test.ts
+++ b/vscode/src/completions/model-helpers/__tests__/gemini.test.ts
@@ -7,12 +7,12 @@ import { completionParams, contextSnippets } from './test-data'
 import { Gemini } from '../gemini'
 
 describe('Gemini ', () => {
-    describe.skipIf(isWindows())('getPrompt', () => {
+    describe.skipIf(isWindows())('getMessages', () => {
         it('returns the prompt with the correct intro snippets', () => {
             const model = new Gemini()
             const { docContext, document, provider } = completionParams
 
-            const result = model.getPrompt({
+            const result = model.getMessages({
                 document,
                 docContext,
                 snippets: contextSnippets,
@@ -20,7 +20,10 @@ describe('Gemini ', () => {
             })
 
             expect(result).toMatchInlineSnapshot(`
-              "You are a code completion AI, designed to autofill code enclosed in special markers based on its surrounding context.
+              [
+                {
+                  "speaker": "human",
+                  "text": "You are a code completion AI, designed to autofill code enclosed in special markers based on its surrounding context.
 
               -TYPE: file
               -NAME: codebase/context1.ts
@@ -177,7 +180,13 @@ describe('Gemini ', () => {
               Do not repeat code from before and after <|fim|> in your output.
               Maintain consistency with the indentation, spacing, and coding style used in the code.
               Leave the output markers empty if no code is required to bridge the gap.
-              Your response should contains only the code required to connect the gap, and the code must be enclosed between <|fim|> WITHOUT backticks"
+              Your response should contains only the code required to connect the gap, and the code must be enclosed between <|fim|> WITHOUT backticks",
+                },
+                {
+                  "speaker": "assistant",
+                  "text": "<|fim|>",
+                },
+              ]
             `)
         })
     })

--- a/vscode/src/completions/model-helpers/__tests__/starcoder.test.ts
+++ b/vscode/src/completions/model-helpers/__tests__/starcoder.test.ts
@@ -7,12 +7,12 @@ import { completionParams, contextSnippets } from './test-data'
 import { StarCoder } from '../starcoder'
 
 describe('StarCoder', () => {
-    describe.skipIf(isWindows())('getPrompt', () => {
+    describe.skipIf(isWindows())('getMessages', () => {
         it('returns the prompt with the correct intro snippets', () => {
             const model = new StarCoder()
             const { docContext, document, provider } = completionParams
 
-            const result = model.getPrompt({
+            const result = model.getMessages({
                 document,
                 docContext,
                 snippets: contextSnippets,
@@ -20,7 +20,10 @@ describe('StarCoder', () => {
             })
 
             expect(result).toMatchInlineSnapshot(`
-              "<filename>codebase/test.ts<fim_prefix>// Here is a reference snippet of code from codebase/context1.ts:
+              [
+                {
+                  "speaker": "human",
+                  "text": "<filename>codebase/test.ts<fim_prefix>// Here is a reference snippet of code from codebase/context1.ts:
               // function contextSnippetOne() {}
 
               // Here is a reference snippet of code from codebase/context2.ts:
@@ -160,7 +163,9 @@ describe('StarCoder', () => {
               console.log(suffix line: 22)
               console.log(suffix line: 23)
               console.log(suffix line: 24)
-              console.log(suffix line: 25)<fim_middle>"
+              console.log(suffix line: 25)<fim_middle>",
+                },
+              ]
             `)
         })
 
@@ -168,7 +173,7 @@ describe('StarCoder', () => {
             const model = new StarCoder()
             const { docContext, document, provider } = completionParams
 
-            const result = model.getPrompt({
+            const result = model.getMessages({
                 document,
                 docContext,
                 snippets: contextSnippets,
@@ -177,7 +182,10 @@ describe('StarCoder', () => {
             })
 
             expect(result).toMatchInlineSnapshot(`
-              "// Path: codebase/test.ts
+              [
+                {
+                  "speaker": "human",
+                  "text": "// Path: codebase/test.ts
 
               // Here is a reference snippet of code from codebase/context1.ts:
               // function contextSnippetOne() {}
@@ -293,7 +301,9 @@ describe('StarCoder', () => {
                   console.log(2)
                   console.log(3)
                   console.log(4)
-                  "
+                  ",
+                },
+              ]
             `)
         })
     })

--- a/vscode/src/completions/model-helpers/claude.ts
+++ b/vscode/src/completions/model-helpers/claude.ts
@@ -1,0 +1,168 @@
+import * as anthropic from '@anthropic-ai/sdk'
+
+import {
+    type AutocompleteContextSnippet,
+    type AutocompleteSymbolContextSnippet,
+    type DocumentContext,
+    type Message,
+    PromptString,
+    ps,
+} from '@sourcegraph/cody-shared'
+
+import {
+    CLOSING_CODE_TAG,
+    OPENING_CODE_TAG,
+    extractFromCodeBlock,
+    fixBadCompletionStart,
+    getHeadAndTail,
+    trimLeadingWhitespaceUntilNewline,
+} from '../text-processing'
+import { messagesToText } from '../utils'
+import { DefaultModel, type GetOllamaPromptParams, type GetPromptParams } from './default'
+
+export const GEMINI_MARKERS = {
+    Prefix: ps`<|prefix|>`,
+    Suffix: ps`<|suffix|>`,
+    Response: ps`<|fim|>`,
+}
+
+interface GetIntroMessagesParams {
+    fileName: PromptString
+    /**
+     * code before the cursor, without the code extracted for the infillBlock
+     */
+    infillPrefix: PromptString
+    /**
+     * code after the cursor
+     */
+    infillSuffix: PromptString
+    /**
+     * Infill block represents the code we want the model to complete
+     */
+    infillBlock: PromptString
+}
+
+export class Claude extends DefaultModel {
+    public stopSequences = [anthropic.HUMAN_PROMPT, CLOSING_CODE_TAG.toString()]
+
+    getOllamaPrompt(promptContext: GetOllamaPromptParams): PromptString {
+        throw new Error('OpenAI is not supported by the Ollama provider yet!')
+    }
+
+    private emptyPromptLength(options: GetIntroMessagesParams): number {
+        const messages = this.getIntroMessages(options)
+        const promptNoSnippets = messagesToText(messages)
+        return promptNoSnippets.length - 10 // extra 10 chars of buffer cuz who knows
+    }
+
+    private getIntroMessages(params: GetIntroMessagesParams): Message[] {
+        const { fileName, infillPrefix, infillSuffix, infillBlock } = params
+
+        return [
+            {
+                speaker: 'human',
+                text: ps`You are a code completion AI designed to take the surrounding code and shared context into account in order to predict and suggest high-quality code to complete the code enclosed in ${OPENING_CODE_TAG} tags. You only respond with code that works and fits seamlessly with surrounding code if any or use best practice and nothing else.`,
+            },
+            {
+                speaker: 'assistant',
+                text: ps`I am a code completion AI with exceptional context-awareness designed to auto-complete nested code blocks with high-quality code that seamlessly integrates with surrounding code.`,
+            },
+            {
+                speaker: 'human',
+                text: ps`Below is the code from file path ${fileName}. Review the code outside the XML tags to detect the functionality, formats, style, patterns, and logics in use. Then, use what you detect and reuse methods/libraries to complete and enclose completed code only inside XML tags precisely without duplicating existing implementations. Here is the code: \n\`\`\`\n${infillPrefix}${OPENING_CODE_TAG}${CLOSING_CODE_TAG}${infillSuffix}\n\`\`\``,
+            },
+            {
+                speaker: 'assistant',
+                text: ps`${OPENING_CODE_TAG}${infillBlock}`,
+            },
+        ]
+    }
+
+    public getMessages(params: GetPromptParams): Message[] {
+        const { snippets, docContext, document, promptChars } = params
+        const { prefix, suffix } = PromptString.fromAutocompleteDocumentContext(docContext, document.uri)
+
+        const prefixLines = prefix.split('\n')
+        if (prefixLines.length === 0) {
+            throw new Error('no prefix lines')
+        }
+
+        const { head, tail } = getHeadAndTail(prefix)
+
+        // Infill block represents the code we want the model to complete
+        const infillBlock = tail.trimmed.toString().endsWith('{\n')
+            ? tail.trimmed.trimEnd()
+            : tail.trimmed
+
+        const contextSnippetMessages: Message[] = []
+
+        const introParams = {
+            fileName: PromptString.fromDisplayPath(document.uri),
+            infillPrefix: head.raw ?? ps``,
+            infillSuffix: suffix,
+            infillBlock,
+        }
+
+        let remainingChars = promptChars - this.emptyPromptLength(introParams)
+        const introMessages = this.getIntroMessages(introParams)
+
+        for (const snippet of snippets) {
+            const snippetMessages: Message[] = [
+                {
+                    speaker: 'human',
+                    text:
+                        'symbol' in snippet
+                            ? this.symbolSnippetToPromptString(snippet)
+                            : this.fileSnippetToPromptString(snippet),
+                },
+                {
+                    speaker: 'assistant',
+                    text: ps`I will refer to this code to complete your next request.`,
+                },
+            ]
+
+            const numSnippetChars = messagesToText(snippetMessages).length + 1
+            if (numSnippetChars > remainingChars) {
+                break
+            }
+            contextSnippetMessages.push(...snippetMessages)
+            remainingChars -= numSnippetChars
+        }
+
+        return [...contextSnippetMessages, ...introMessages]
+    }
+
+    protected fileSnippetToPromptString(snippet: AutocompleteContextSnippet): PromptString {
+        const { uri } = snippet
+        const { content } = PromptString.fromAutocompleteContextSnippet(snippet)
+
+        const uriPromptString = PromptString.fromDisplayPath(uri)
+        return ps`Codebase context from file path '${uriPromptString}': ${OPENING_CODE_TAG}${content}${CLOSING_CODE_TAG}`
+    }
+
+    protected symbolSnippetToPromptString(snippet: AutocompleteSymbolContextSnippet): PromptString {
+        const { content, symbol } = PromptString.fromAutocompleteContextSnippet(snippet)
+
+        return ps`Additional documentation for \`${symbol!}\`: ${OPENING_CODE_TAG}${content}${CLOSING_CODE_TAG}`
+    }
+
+    public postProcess(content: string, docContext: DocumentContext): string {
+        let completion = extractFromCodeBlock(content)
+
+        const trimmedPrefixContainNewline = docContext.prefix
+            .slice(docContext.prefix.trimEnd().length)
+            .includes('\n')
+        if (trimmedPrefixContainNewline) {
+            // The prefix already contains a `\n` that Claude was not aware of, so we remove any
+            // leading `\n` followed by whitespace that Claude might add.
+            completion = completion.replace(/^\s*\n\s*/, '')
+        } else {
+            completion = trimLeadingWhitespaceUntilNewline(completion)
+        }
+
+        // Remove bad symbols from the start of the completion string.
+        completion = fixBadCompletionStart(completion)
+
+        return completion
+    }
+}

--- a/vscode/src/completions/model-helpers/claude.ts
+++ b/vscode/src/completions/model-helpers/claude.ts
@@ -46,7 +46,7 @@ export class Claude extends DefaultModel {
     public stopSequences = [anthropic.HUMAN_PROMPT, CLOSING_CODE_TAG.toString()]
 
     getOllamaPrompt(promptContext: GetOllamaPromptParams): PromptString {
-        throw new Error('OpenAI is not supported by the Ollama provider yet!')
+        throw new Error('Claude is not supported by the Ollama provider yet!')
     }
 
     private emptyPromptLength(options: GetIntroMessagesParams): number {

--- a/vscode/src/completions/model-helpers/default.ts
+++ b/vscode/src/completions/model-helpers/default.ts
@@ -6,6 +6,7 @@ import {
     type CodeCompletionsParams,
     type DocumentContext,
     type GitContext,
+    type Message,
     type OllamaGenerateParameters,
     PromptString,
     ps,
@@ -31,7 +32,7 @@ export interface FormatIntroSnippetsParams {
     languageConfig: LanguageConfig | null
 }
 
-interface GetPromptParams {
+export interface GetPromptParams {
     snippets: AutocompleteContextSnippet[]
     docContext: DocumentContext
     document: vscode.TextDocument
@@ -102,7 +103,11 @@ export class DefaultModel {
         return ps`${PromptString.join(commentedOutSnippets, ps`\n\n`)}\n\n`
     }
 
-    public getPrompt(params: GetPromptParams): PromptString {
+    public getMessages(params: GetPromptParams): Message[] {
+        return [{ speaker: 'human', text: this.getPrompt(params) }]
+    }
+
+    protected getPrompt(params: GetPromptParams): PromptString {
         const { snippets, docContext, document, promptChars, gitContext, isInfill = true } = params
         const { prefix, suffix } = PromptString.fromAutocompleteDocumentContext(docContext, document.uri)
 

--- a/vscode/src/completions/model-helpers/gemini.ts
+++ b/vscode/src/completions/model-helpers/gemini.ts
@@ -26,7 +26,7 @@ export class Gemini extends DefaultModel {
     public stopSequences = [`${GEMINI_MARKERS.Response}`]
 
     getOllamaPrompt(promptContext: GetOllamaPromptParams): PromptString {
-        throw new Error('OpenAI is not supported by the Ollama provider yet!')
+        throw new Error('Gemini is not supported by the Ollama provider yet!')
     }
 
     public getMessages(params: GetPromptParams): Message[] {

--- a/vscode/src/completions/model-helpers/gemini.ts
+++ b/vscode/src/completions/model-helpers/gemini.ts
@@ -2,6 +2,7 @@ import {
     type AutocompleteContextSnippet,
     type AutocompleteSymbolContextSnippet,
     type DocumentContext,
+    type Message,
     PromptString,
     ps,
 } from '@sourcegraph/cody-shared'
@@ -12,9 +13,10 @@ import {
     type FormatIntroSnippetsParams,
     type FormatPromptParams,
     type GetOllamaPromptParams,
+    type GetPromptParams,
 } from './default'
 
-export const GEMINI_MARKERS = {
+const GEMINI_MARKERS = {
     Prefix: ps`<|prefix|>`,
     Suffix: ps`<|suffix|>`,
     Response: ps`<|fim|>`,
@@ -25,6 +27,13 @@ export class Gemini extends DefaultModel {
 
     getOllamaPrompt(promptContext: GetOllamaPromptParams): PromptString {
         throw new Error('OpenAI is not supported by the Ollama provider yet!')
+    }
+
+    public getMessages(params: GetPromptParams): Message[] {
+        return [
+            { speaker: 'human', text: this.getPrompt(params) },
+            { speaker: 'assistant', text: ps`${GEMINI_MARKERS.Response}` },
+        ]
     }
 
     protected fileSnippetToPromptString(snippet: AutocompleteContextSnippet): PromptString {

--- a/vscode/src/completions/model-helpers/index.ts
+++ b/vscode/src/completions/model-helpers/index.ts
@@ -1,3 +1,4 @@
+import { Claude } from './claude'
 import { CodeGemma } from './codegemma'
 import { CodeLlama } from './codellama'
 import { DeepseekCoder } from './deepseek'
@@ -35,6 +36,10 @@ export function getModelHelpers(model: string): DefaultModel {
 
     if (model.includes('gemini')) {
         return new Gemini()
+    }
+
+    if (model.includes('claude')) {
+        return new Claude()
     }
 
     return new DefaultModel()

--- a/vscode/src/completions/model-helpers/openai.ts
+++ b/vscode/src/completions/model-helpers/openai.ts
@@ -16,6 +16,8 @@ import {
 } from './default'
 
 export class OpenAI extends DefaultModel {
+    public stopSequences = [CLOSING_CODE_TAG.toString()]
+
     private instructions =
         ps`You are a code completion AI designed to take the surrounding code and shared context into account in order to predict and suggest high-quality code to complete the code enclosed in ${OPENING_CODE_TAG} tags.  You only respond with code that works and fits seamlessly with surrounding code. Do not include anything else beyond the code.`
 

--- a/vscode/src/completions/providers/anthropic.test.ts
+++ b/vscode/src/completions/providers/anthropic.test.ts
@@ -1,7 +1,7 @@
 import { Observable } from 'observable-fns'
-import { afterEach, beforeEach, describe, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { featureFlagProvider, modelsService } from '@sourcegraph/cody-shared'
+import { featureFlagProvider } from '@sourcegraph/cody-shared'
 
 import { mockLocalStorage } from '../../services/LocalStorageProvider'
 
@@ -10,6 +10,7 @@ import {
     getAutocompleteProviderFromLocalSettings,
     getAutocompleteProviderFromServerSideModelConfig,
     getAutocompleteProviderFromSiteConfigCodyLLMConfiguration,
+    getRequestParamsWithoutMessages,
     testAutocompleteProvider,
 } from './shared/helpers'
 
@@ -19,20 +20,15 @@ describe('anthropic autocomplete provider', () => {
         vi.spyOn(featureFlagProvider, 'evaluatedFeatureFlag').mockReturnValue(Observable.of(false))
     })
 
-    afterEach(() => {
-        modelsService.reset()
-    })
-
-    const sonnetAssertion = {
+    const claudeInstantAssertion = {
         providerId: 'anthropic',
-        legacyModel: 'claude-3-sonnet',
+        legacyModel: 'claude-instant-1.2',
         requestParams: {
             maxTokensToSample: 256,
-            temperature: 0,
+            temperature: 0.5,
             timeoutMs: 7000,
             topK: 0,
-            topP: 0.95,
-            model: 'claude-3-sonnet',
+            model: 'anthropic/claude-instant-1.2',
         },
     } satisfies AutocompleteProviderValuesToAssert
 
@@ -41,42 +37,187 @@ describe('anthropic autocomplete provider', () => {
         legacyModel: 'claude-3-haiku-20240307',
         requestParams: {
             maxTokensToSample: 256,
-            temperature: 0,
+            temperature: 0.5,
             timeoutMs: 7000,
             topK: 0,
-            topP: 0.95,
-            model: 'claude-3-haiku-20240307',
+            model: 'anthropic/claude-3-haiku-20240307',
         },
     } satisfies AutocompleteProviderValuesToAssert
 
-    // testAutocompleteProvider('local-editor-settings', sonnetAssertion, isDotCom =>
-    //     getAutocompleteProviderFromLocalSettings({
-    //         providerId: 'anthropic',
-    //         legacyModel: 'claude-3-sonnet',
-    //         isDotCom,
-    //     })
-    // )
-
-    // testAutocompleteProvider('server-side-model-config', sonnetAssertion, isDotCom =>
-    //     getAutocompleteProviderFromServerSideModelConfig({
-    //         modelRef: 'anthropic::2023-06-01::claude-3-sonnet',
-    //         isDotCom,
-    //     })
-    // )
-
-    // testAutocompleteProvider('site-config-cody-llm-configuration', sonnetAssertion, isDotCom =>
-    //     getAutocompleteProviderFromSiteConfigCodyLLMConfiguration({
-    //         providerId: 'anthropic',
-    //         legacyModel: 'claude-3-sonnet',
-    //         isDotCom,
-    //     })
-    // )
-
-    testAutocompleteProvider('site-config-cody-llm-configuration', haikuAssertion, isDotCom =>
-        getAutocompleteProviderFromSiteConfigCodyLLMConfiguration({
+    it('[dotcom] local-editor-settings without model', async () => {
+        const provider = await getAutocompleteProviderFromLocalSettings({
             providerId: 'anthropic',
-            legacyModel: 'anthropic/claude-3-haiku-20240307',
+            legacyModel: null,
+            isDotCom: true,
+        })
+
+        expect(provider.id).toBe('anthropic')
+        expect(provider.legacyModel).toBe('claude-instant-1.2')
+        expect(getRequestParamsWithoutMessages(provider)).toStrictEqual(
+            claudeInstantAssertion.requestParams
+        )
+    })
+
+    it('[dotcom] local-editor-settings with model', async () => {
+        const provider = await getAutocompleteProviderFromLocalSettings({
+            providerId: 'anthropic',
+            legacyModel: 'claude-3-haiku-20240307',
+            isDotCom: true,
+        })
+
+        expect(provider.id).toBe('anthropic')
+        // The local editor settings model is ignored for now by the Anthropic provider.
+        expect(provider.legacyModel).toBe('claude-instant-1.2')
+        expect(getRequestParamsWithoutMessages(provider)).toStrictEqual(
+            claudeInstantAssertion.requestParams
+        )
+    })
+
+    it('[dotcom] server-side-model-config', async () => {
+        const provider = await getAutocompleteProviderFromServerSideModelConfig({
+            modelRef: 'anthropic::2023-06-01::claude-3-haiku-20240307',
+            isDotCom: true,
+        })
+
+        // Still uses claude instant on dotcom.
+        const { providerId, legacyModel, requestParams } = claudeInstantAssertion
+
+        expect(provider.id).toBe(providerId)
+        expect(provider.legacyModel).toBe(legacyModel)
+        expect(getRequestParamsWithoutMessages(provider)).toStrictEqual(requestParams)
+    })
+
+    it('[enterprise] server-side-model-config', async () => {
+        const provider = await getAutocompleteProviderFromServerSideModelConfig({
+            modelRef: 'anthropic::2023-06-01::claude-3-haiku-20240307',
+            isDotCom: false,
+        })
+
+        const { providerId, legacyModel, requestParams } = haikuAssertion
+
+        expect(provider.id).toBe(providerId)
+        expect(provider.legacyModel).toBe(legacyModel)
+        expect(getRequestParamsWithoutMessages(provider)).toStrictEqual(requestParams)
+    })
+
+    testAutocompleteProvider('site-config-cody-llm-configuration', claudeInstantAssertion, isDotCom =>
+        getAutocompleteProviderFromSiteConfigCodyLLMConfiguration({
+            completionModel: 'anthropic/claude-instant-1.2',
+            provider: 'sourcegraph',
             isDotCom,
         })
     )
+
+    it('throws if the wrong "completionModel" separator is used', async () => {
+        const createCall = getAutocompleteProviderFromSiteConfigCodyLLMConfiguration({
+            completionModel: 'anthropic.claude-instant-1.2',
+            provider: 'sourcegraph',
+            isDotCom: false,
+        })
+
+        await expect(createCall).rejects.toThrowErrorMatchingInlineSnapshot(
+            `[Error: Failed to parse the model name 'anthropic.claude-instant-1.2' for 'sourcegraph' completions provider.]`
+        )
+    })
+
+    it('throws if completionModel does not have a model name', async () => {
+        const createCall = getAutocompleteProviderFromSiteConfigCodyLLMConfiguration({
+            completionModel: 'anthropic/',
+            provider: 'sourcegraph',
+            isDotCom: false,
+        })
+
+        await expect(createCall).rejects.toThrowErrorMatchingInlineSnapshot(
+            `[Error: Failed to parse the model name 'anthropic/' for 'sourcegraph' completions provider.]`
+        )
+    })
+
+    it('throws if completionModel does not have a provider ID', async () => {
+        const createCall = getAutocompleteProviderFromSiteConfigCodyLLMConfiguration({
+            completionModel: '/claude-instant-1.2',
+            provider: 'sourcegraph',
+            isDotCom: false,
+        })
+
+        await expect(createCall).rejects.toThrowErrorMatchingInlineSnapshot(
+            `[Error: Failed to parse the model name '/claude-instant-1.2' for 'sourcegraph' completions provider.]`
+        )
+    })
+})
+
+describe('anthropic/aws-bedrock autocomplete provider', () => {
+    beforeEach(async () => {
+        mockLocalStorage()
+        vi.spyOn(featureFlagProvider, 'evaluatedFeatureFlag').mockReturnValue(Observable.of(false))
+    })
+
+    const claudeInstantAssertion = {
+        providerId: 'anthropic',
+        legacyModel: 'claude-instant-1.2',
+        requestParams: {
+            maxTokensToSample: 256,
+            temperature: 0.5,
+            timeoutMs: 7000,
+            topK: 0,
+            model: 'anthropic/claude-instant-1.2',
+        },
+    } satisfies AutocompleteProviderValuesToAssert
+
+    it('[dotcom] local-editor-settings without model', async () => {
+        const provider = await getAutocompleteProviderFromLocalSettings({
+            providerId: 'aws-bedrock',
+            legacyModel: null,
+            isDotCom: true,
+        })
+
+        expect(provider.id).toBe('anthropic')
+        expect(provider.legacyModel).toBe('claude-instant-1.2')
+        expect(getRequestParamsWithoutMessages(provider)).toStrictEqual(
+            claudeInstantAssertion.requestParams
+        )
+    })
+
+    testAutocompleteProvider('site-config-cody-llm-configuration', claudeInstantAssertion, isDotCom =>
+        getAutocompleteProviderFromSiteConfigCodyLLMConfiguration({
+            completionModel: 'anthropic.claude-instant-1.2',
+            provider: 'aws-bedrock',
+            isDotCom,
+        })
+    )
+
+    it('throws if the wrong "completionModel" separator is used', async () => {
+        const createCall = getAutocompleteProviderFromSiteConfigCodyLLMConfiguration({
+            completionModel: 'anthropic/claude-instant-1.2',
+            provider: 'aws-bedrock',
+            isDotCom: false,
+        })
+
+        await expect(createCall).rejects.toThrowErrorMatchingInlineSnapshot(
+            `[Error: Failed to create "anthropic/claude-instant-1" autocomplete provider derived from "site-config-cody-llm-configuration". Please report the issue using the "Cody Debug: Report Issue" VS Code command.]`
+        )
+    })
+
+    it('throws if completionModel does not have a model name', async () => {
+        const createCall = getAutocompleteProviderFromSiteConfigCodyLLMConfiguration({
+            completionModel: 'anthropic.',
+            provider: 'aws-bedrock',
+            isDotCom: false,
+        })
+
+        await expect(createCall).rejects.toThrowErrorMatchingInlineSnapshot(
+            `[Error: Failed to parse the model name 'anthropic.' for 'aws-bedrock' completions provider.]`
+        )
+    })
+
+    it('throws if completionModel does not have a provider ID', async () => {
+        const createCall = getAutocompleteProviderFromSiteConfigCodyLLMConfiguration({
+            completionModel: 'hello-world',
+            provider: 'aws-bedrock',
+            isDotCom: false,
+        })
+
+        await expect(createCall).rejects.toThrowErrorMatchingInlineSnapshot(
+            `[Error: Failed to parse the model name 'hello-world' for 'aws-bedrock' completions provider.]`
+        )
+    })
 })

--- a/vscode/src/completions/providers/anthropic.test.ts
+++ b/vscode/src/completions/providers/anthropic.test.ts
@@ -1,0 +1,82 @@
+import { Observable } from 'observable-fns'
+import { afterEach, beforeEach, describe, vi } from 'vitest'
+
+import { featureFlagProvider, modelsService } from '@sourcegraph/cody-shared'
+
+import { mockLocalStorage } from '../../services/LocalStorageProvider'
+
+import {
+    type AutocompleteProviderValuesToAssert,
+    getAutocompleteProviderFromLocalSettings,
+    getAutocompleteProviderFromServerSideModelConfig,
+    getAutocompleteProviderFromSiteConfigCodyLLMConfiguration,
+    testAutocompleteProvider,
+} from './shared/helpers'
+
+describe('anthropic autocomplete provider', () => {
+    beforeEach(async () => {
+        mockLocalStorage()
+        vi.spyOn(featureFlagProvider, 'evaluatedFeatureFlag').mockReturnValue(Observable.of(false))
+    })
+
+    afterEach(() => {
+        modelsService.reset()
+    })
+
+    const sonnetAssertion = {
+        providerId: 'anthropic',
+        legacyModel: 'claude-3-sonnet',
+        requestParams: {
+            maxTokensToSample: 256,
+            temperature: 0,
+            timeoutMs: 7000,
+            topK: 0,
+            topP: 0.95,
+            model: 'claude-3-sonnet',
+        },
+    } satisfies AutocompleteProviderValuesToAssert
+
+    const haikuAssertion = {
+        providerId: 'anthropic',
+        legacyModel: 'claude-3-haiku-20240307',
+        requestParams: {
+            maxTokensToSample: 256,
+            temperature: 0,
+            timeoutMs: 7000,
+            topK: 0,
+            topP: 0.95,
+            model: 'claude-3-haiku-20240307',
+        },
+    } satisfies AutocompleteProviderValuesToAssert
+
+    // testAutocompleteProvider('local-editor-settings', sonnetAssertion, isDotCom =>
+    //     getAutocompleteProviderFromLocalSettings({
+    //         providerId: 'anthropic',
+    //         legacyModel: 'claude-3-sonnet',
+    //         isDotCom,
+    //     })
+    // )
+
+    // testAutocompleteProvider('server-side-model-config', sonnetAssertion, isDotCom =>
+    //     getAutocompleteProviderFromServerSideModelConfig({
+    //         modelRef: 'anthropic::2023-06-01::claude-3-sonnet',
+    //         isDotCom,
+    //     })
+    // )
+
+    // testAutocompleteProvider('site-config-cody-llm-configuration', sonnetAssertion, isDotCom =>
+    //     getAutocompleteProviderFromSiteConfigCodyLLMConfiguration({
+    //         providerId: 'anthropic',
+    //         legacyModel: 'claude-3-sonnet',
+    //         isDotCom,
+    //     })
+    // )
+
+    testAutocompleteProvider('site-config-cody-llm-configuration', haikuAssertion, isDotCom =>
+        getAutocompleteProviderFromSiteConfigCodyLLMConfiguration({
+            providerId: 'anthropic',
+            legacyModel: 'anthropic/claude-3-haiku-20240307',
+            isDotCom,
+        })
+    )
+})

--- a/vscode/src/completions/providers/anthropic.ts
+++ b/vscode/src/completions/providers/anthropic.ts
@@ -23,8 +23,6 @@ import {
 let isOutdatedSourcegraphInstanceWithoutAnthropicAllowlist = false
 
 class AnthropicProvider extends Provider {
-    public stopSequences = [anthropic.HUMAN_PROMPT, CLOSING_CODE_TAG.toString(), '\n\n', '\n\r\n']
-
     public getRequestParams(options: GenerateCompletionsOptions): CodeCompletionsParams {
         const { snippets, docContext, document } = options
 

--- a/vscode/src/completions/providers/anthropic.ts
+++ b/vscode/src/completions/providers/anthropic.ts
@@ -3,29 +3,11 @@ import * as anthropic from '@anthropic-ai/sdk'
 import {
     type AuthenticatedAuthStatus,
     type CodeCompletionsParams,
-    type DocumentContext,
-    type Message,
-    PromptString,
     isDotCom,
-    ps,
 } from '@sourcegraph/cody-shared'
 
-import {
-    CLOSING_CODE_TAG,
-    OPENING_CODE_TAG,
-    type PrefixComponents,
-    extractFromCodeBlock,
-    fixBadCompletionStart,
-    getHeadAndTail,
-    trimLeadingWhitespaceUntilNewline,
-} from '../text-processing'
-import {
-    forkSignal,
-    generatorWithErrorObserver,
-    generatorWithTimeout,
-    messagesToText,
-    zipGenerators,
-} from '../utils'
+import { CLOSING_CODE_TAG } from '../text-processing'
+import { forkSignal, generatorWithErrorObserver, generatorWithTimeout, zipGenerators } from '../utils'
 
 import {
     type FetchCompletionResult,
@@ -43,105 +25,15 @@ let isOutdatedSourcegraphInstanceWithoutAnthropicAllowlist = false
 class AnthropicProvider extends Provider {
     public stopSequences = [anthropic.HUMAN_PROMPT, CLOSING_CODE_TAG.toString(), '\n\n', '\n\r\n']
 
-    public emptyPromptLength(options: GenerateCompletionsOptions): number {
-        const { messages } = this.createPromptPrefix(options)
-        const promptNoSnippets = messagesToText(messages)
-        return promptNoSnippets.length - 10 // extra 10 chars of buffer cuz who knows
-    }
-
-    private createPromptPrefix(options: GenerateCompletionsOptions): {
-        messages: Message[]
-        prefix: PrefixComponents
-    } {
-        const { prefix, suffix } = PromptString.fromAutocompleteDocumentContext(
-            options.docContext,
-            options.document.uri
-        )
-
-        const prefixLines = prefix.split('\n')
-        if (prefixLines.length === 0) {
-            throw new Error('no prefix lines')
-        }
-
-        const { head, tail, overlap } = getHeadAndTail(prefix)
-
-        // Infill block represents the code we want the model to complete
-        const infillBlock = tail.trimmed.toString().endsWith('{\n')
-            ? tail.trimmed.trimEnd()
-            : tail.trimmed
-        // code before the cursor, without the code extracted for the infillBlock
-        const infillPrefix = head.raw
-        // code after the cursor
-        const infillSuffix = suffix
-        const relativeFilePath = PromptString.fromDisplayPath(options.document.uri)
-
-        const prefixMessagesWithInfill: Message[] = [
-            {
-                speaker: 'human',
-                text: ps`You are a code completion AI designed to take the surrounding code and shared context into account in order to predict and suggest high-quality code to complete the code enclosed in ${OPENING_CODE_TAG} tags. You only respond with code that works and fits seamlessly with surrounding code if any or use best practice and nothing else.`,
-            },
-            {
-                speaker: 'assistant',
-                text: ps`I am a code completion AI with exceptional context-awareness designed to auto-complete nested code blocks with high-quality code that seamlessly integrates with surrounding code.`,
-            },
-            {
-                speaker: 'human',
-                text: ps`Below is the code from file path ${relativeFilePath}. Review the code outside the XML tags to detect the functionality, formats, style, patterns, and logics in use. Then, use what you detect and reuse methods/libraries to complete and enclose completed code only inside XML tags precisely without duplicating existing implementations. Here is the code: \n\`\`\`\n${
-                    infillPrefix ? infillPrefix : ''
-                }${OPENING_CODE_TAG}${CLOSING_CODE_TAG}${infillSuffix}\n\`\`\``,
-            },
-            {
-                speaker: 'assistant',
-                text: ps`${OPENING_CODE_TAG}${infillBlock}`,
-            },
-        ]
-
-        return { messages: prefixMessagesWithInfill, prefix: { head, tail, overlap } }
-    }
-
-    // Creates the resulting prompt and adds as many snippets from the reference
-    // list as possible.
-    protected createPrompt(options: GenerateCompletionsOptions): {
-        messages: Message[]
-        prefix: PrefixComponents
-    } {
-        const { snippets } = options
-        const { messages: prefixMessages, prefix } = this.createPromptPrefix(options)
-
-        const referenceSnippetMessages: Message[] = []
-
-        let remainingChars = this.promptChars - this.emptyPromptLength(options)
-
-        for (const snippet of snippets) {
-            const contextPrompts = PromptString.fromAutocompleteContextSnippet(snippet)
-
-            const snippetMessages: Message[] = [
-                {
-                    speaker: 'human',
-                    text: contextPrompts.symbol
-                        ? ps`Additional documentation for \`${contextPrompts.symbol}\`: ${OPENING_CODE_TAG}${contextPrompts.content}${CLOSING_CODE_TAG}`
-                        : ps`Codebase context from file path '${PromptString.fromDisplayPath(
-                              snippet.uri
-                          )}': ${OPENING_CODE_TAG}${contextPrompts.content}${CLOSING_CODE_TAG}`,
-                },
-                {
-                    speaker: 'assistant',
-                    text: ps`I will refer to this code to complete your next request.`,
-                },
-            ]
-            const numSnippetChars = messagesToText(snippetMessages).length + 1
-            if (numSnippetChars > remainingChars) {
-                break
-            }
-            referenceSnippetMessages.push(...snippetMessages)
-            remainingChars -= numSnippetChars
-        }
-
-        return { messages: [...referenceSnippetMessages, ...prefixMessages], prefix }
-    }
-
     public getRequestParams(options: GenerateCompletionsOptions): CodeCompletionsParams {
-        const { messages } = this.createPrompt(options)
+        const { snippets, docContext, document } = options
+
+        const messages = this.modelHelper.getMessages({
+            snippets,
+            docContext,
+            document,
+            promptChars: this.promptChars,
+        })
 
         return {
             ...this.defaultRequestParams,
@@ -169,8 +61,8 @@ class AnthropicProvider extends Provider {
         tracer?: CompletionProviderTracer
     ): Promise<AsyncGenerator<FetchCompletionResult[]>> {
         const { docContext, numberOfCompletionsToGenerate } = options
-        const requestParams = this.getRequestParams(options)
 
+        const requestParams = this.getRequestParams(options)
         tracer?.params(requestParams)
 
         const completionsGenerators = Array.from({ length: numberOfCompletionsToGenerate }).map(
@@ -209,36 +101,15 @@ class AnthropicProvider extends Provider {
                 return fetchAndProcessDynamicMultilineCompletions({
                     completionResponseGenerator,
                     abortController,
-                    providerSpecificPostProcess: this.postProcess(docContext),
                     generateOptions: options,
+                    providerSpecificPostProcess: content =>
+                        this.modelHelper.postProcess(content, docContext),
                 })
             }
         )
 
         return zipGenerators(await Promise.all(completionsGenerators))
     }
-
-    private postProcess =
-        (docContext: DocumentContext) =>
-        (rawResponse: string): string => {
-            let completion = extractFromCodeBlock(rawResponse)
-
-            const trimmedPrefixContainNewline = docContext.prefix
-                .slice(docContext.prefix.trimEnd().length)
-                .includes('\n')
-            if (trimmedPrefixContainNewline) {
-                // The prefix already contains a `\n` that Claude was not aware of, so we remove any
-                // leading `\n` followed by whitespace that Claude might add.
-                completion = completion.replace(/^\s*\n\s*/, '')
-            } else {
-                completion = trimLeadingWhitespaceUntilNewline(completion)
-            }
-
-            // Remove bad symbols from the start of the completion string.
-            completion = fixBadCompletionStart(completion)
-
-            return completion
-        }
 }
 
 function getClientModel(

--- a/vscode/src/completions/providers/expopenaicompatible.test.ts
+++ b/vscode/src/completions/providers/expopenaicompatible.test.ts
@@ -27,7 +27,7 @@ describe('experimental-openaicompatible autocomplete provider', () => {
             temperature: 0.2,
             timeoutMs: 7000,
             topK: 0,
-            model: '',
+            model: undefined,
         },
     } satisfies AutocompleteProviderValuesToAssert
 
@@ -68,16 +68,16 @@ describe('experimental-openaicompatible autocomplete provider', () => {
 
     testAutocompleteProvider('site-config-cody-llm-configuration', starChatAssertion, isDotCom =>
         getAutocompleteProviderFromSiteConfigCodyLLMConfiguration({
-            providerId: 'experimental-openaicompatible',
-            legacyModel: 'starchat-16b-beta',
+            provider: 'sourcegraph',
+            completionModel: 'experimental-openaicompatible/starchat-16b-beta',
             isDotCom,
         })
     )
 
     testAutocompleteProvider('site-config-cody-llm-configuration', starCoderHybridAssertion, isDotCom =>
         getAutocompleteProviderFromSiteConfigCodyLLMConfiguration({
-            providerId: 'experimental-openaicompatible',
-            legacyModel: 'starcoder-hybrid',
+            provider: 'sourcegraph',
+            completionModel: 'experimental-openaicompatible/starcoder-hybrid',
             isDotCom,
         })
     )

--- a/vscode/src/completions/providers/expopenaicompatible.ts
+++ b/vscode/src/completions/providers/expopenaicompatible.ts
@@ -28,7 +28,7 @@ const MODEL_MAP = {
     'llama-code-13b': 'openaicompatible/llama-code-13b',
     'llama-code-13b-instruct': 'openaicompatible/llama-code-13b-instruct',
     'mistral-7b-instruct-4k': 'openaicompatible/mistral-7b-instruct-4k',
-}
+} as const
 
 type OpenAICompatibleModel =
     | keyof typeof MODEL_MAP
@@ -75,7 +75,7 @@ class ExpOpenAICompatibleProvider extends Provider {
             this.legacyModel === 'starcoder-hybrid'
                 ? MODEL_MAP[multiline ? 'starcoder-16b' : 'starcoder-7b']
                 : this.legacyModel.startsWith('starchat')
-                  ? '' // starchat is not a supported backend model yet, use the default server-chosen model.
+                  ? undefined // starchat is not a supported backend model yet, use the default server-chosen model.
                   : MODEL_MAP[this.legacyModel as keyof typeof MODEL_MAP]
 
         return {

--- a/vscode/src/completions/providers/expopenaicompatible.ts
+++ b/vscode/src/completions/providers/expopenaicompatible.ts
@@ -62,7 +62,7 @@ class ExpOpenAICompatibleProvider extends Provider {
     public getRequestParams(options: GenerateCompletionsOptions): CodeCompletionsParams {
         const { multiline, docContext, document, snippets } = options
 
-        const prompt = this.modelHelper.getPrompt({
+        const messages = this.modelHelper.getMessages({
             snippets,
             docContext,
             document,
@@ -80,7 +80,7 @@ class ExpOpenAICompatibleProvider extends Provider {
 
         return {
             ...this.defaultRequestParams,
-            messages: [{ speaker: 'human', text: prompt }],
+            messages,
             model,
         }
     }

--- a/vscode/src/completions/providers/fireworks.ts
+++ b/vscode/src/completions/providers/fireworks.ts
@@ -108,7 +108,7 @@ class FireworksProvider extends Provider {
                 ? MODEL_MAP[useMultilineModel ? 'starcoder-16b' : 'starcoder-7b']
                 : MODEL_MAP[this.legacyModel as keyof typeof MODEL_MAP]
 
-        const prompt = this.modelHelper.getPrompt({
+        const messages = this.modelHelper.getMessages({
             snippets,
             docContext,
             document,
@@ -117,7 +117,7 @@ class FireworksProvider extends Provider {
 
         return this.modelHelper.getRequestParams({
             ...this.defaultRequestParams,
-            messages: [{ speaker: 'human', text: prompt }],
+            messages,
             model,
         })
     }

--- a/vscode/src/completions/providers/fireworks.ts
+++ b/vscode/src/completions/providers/fireworks.ts
@@ -48,8 +48,8 @@ const MODEL_MAP = {
     // Fireworks model identifiers
     'llama-code-13b': 'fireworks/accounts/fireworks/models/llama-v2-13b-code',
 
-    [FIREWORKS_DEEPSEEK_7B_LANG_SPECIFIC_V0]: 'finetuned-fim-lang-specific-model-ds2-v0',
-    [FIREWORKS_DEEPSEEK_7B_LANG_SPECIFIC_V1]: 'finetuned-fim-lang-specific-model-ds2-v1',
+    [FIREWORKS_DEEPSEEK_7B_LANG_SPECIFIC_V0]: 'fireworks/finetuned-fim-lang-specific-model-ds2-v0',
+    [FIREWORKS_DEEPSEEK_7B_LANG_SPECIFIC_V1]: 'fireworks/finetuned-fim-lang-specific-model-ds2-v1',
     [FIREWORKS_DEEPSEEK_7B_LANG_ALL]: 'accounts/sourcegraph/models/finetuned-fim-lang-all-model-ds2-v0',
     [DEEPSEEK_CODER_V2_LITE_BASE]: 'fireworks/deepseek-coder-v2-lite-base',
     [DEEPSEEK_CODER_V2_LITE_BASE_WINDOW_4096]: 'accounts/sourcegraph/models/deepseek-coder-v2-lite-base',
@@ -58,7 +58,7 @@ const MODEL_MAP = {
         'accounts/sourcegraph/models/deepseek-coder-v2-lite-base',
     [DEEPSEEK_CODER_V2_LITE_BASE_WINDOW_32768]:
         'accounts/sourcegraph/models/deepseek-coder-v2-lite-base',
-}
+} as const
 
 type FireworksModel =
     | keyof typeof MODEL_MAP
@@ -103,7 +103,7 @@ class FireworksProvider extends Provider {
         const { multiline, docContext, document, triggerKind, snippets } = options
         const useMultilineModel = multiline || triggerKind !== TriggerKind.Automatic
 
-        const model: string =
+        const model =
             this.legacyModel === 'starcoder-hybrid'
                 ? MODEL_MAP[useMultilineModel ? 'starcoder-16b' : 'starcoder-7b']
                 : MODEL_MAP[this.legacyModel as keyof typeof MODEL_MAP]

--- a/vscode/src/completions/providers/google.test.ts
+++ b/vscode/src/completions/providers/google.test.ts
@@ -28,7 +28,7 @@ describe('google autocomplete provider', () => {
             timeoutMs: 7000,
             topK: 0,
             topP: 0.95,
-            model: 'gemini-1.5-flash-latest',
+            model: 'google/gemini-1.5-flash-latest',
         },
     } satisfies AutocompleteProviderValuesToAssert
 
@@ -49,8 +49,8 @@ describe('google autocomplete provider', () => {
 
     testAutocompleteProvider('site-config-cody-llm-configuration', starChatAssertion, isDotCom =>
         getAutocompleteProviderFromSiteConfigCodyLLMConfiguration({
-            providerId: 'google',
-            legacyModel: 'gemini-1.5-flash-latest',
+            provider: 'sourcegraph',
+            completionModel: 'google/gemini-1.5-flash-latest',
             isDotCom,
         })
     )

--- a/vscode/src/completions/providers/google.ts
+++ b/vscode/src/completions/providers/google.ts
@@ -28,7 +28,7 @@ class GoogleGeminiProvider extends Provider {
             ...this.defaultRequestParams,
             topP: 0.95,
             temperature: 0,
-            model: this.legacyModel,
+            model: `${this.id}/${this.legacyModel}`,
             messages,
         }
     }
@@ -70,7 +70,7 @@ class GoogleGeminiProvider extends Provider {
 const SUPPORTED_GEMINI_MODELS = ['gemini-1.5-flash', 'gemini-pro', 'gemini-1.0-pro'] as const
 
 export function createProvider({ legacyModel, source }: ProviderFactoryParams): Provider {
-    const clientModel = legacyModel ?? 'google/gemini-1.5-flash'
+    const clientModel = legacyModel ?? 'gemini-1.5-flash'
 
     if (!SUPPORTED_GEMINI_MODELS.some(m => clientModel.includes(m))) {
         throw new Error(`Model ${legacyModel} is not supported by GeminiProvider`)

--- a/vscode/src/completions/providers/google.ts
+++ b/vscode/src/completions/providers/google.ts
@@ -1,6 +1,5 @@
-import { type CodeCompletionsParams, ps } from '@sourcegraph/cody-shared'
+import type { CodeCompletionsParams } from '@sourcegraph/cody-shared'
 
-import { GEMINI_MARKERS } from '../model-helpers/gemini'
 import { forkSignal, generatorWithTimeout, zipGenerators } from '../utils'
 
 import {
@@ -18,7 +17,7 @@ class GoogleGeminiProvider extends Provider {
     public getRequestParams(options: GenerateCompletionsOptions): CodeCompletionsParams {
         const { snippets, docContext, document } = options
 
-        const prompt = this.modelHelper.getPrompt({
+        const messages = this.modelHelper.getMessages({
             snippets,
             docContext,
             document,
@@ -30,10 +29,7 @@ class GoogleGeminiProvider extends Provider {
             topP: 0.95,
             temperature: 0,
             model: this.legacyModel,
-            messages: [
-                { speaker: 'human', text: prompt },
-                { speaker: 'assistant', text: ps`${GEMINI_MARKERS.Response}` },
-            ],
+            messages,
         }
     }
 

--- a/vscode/src/completions/providers/openaicompatible.test.ts
+++ b/vscode/src/completions/providers/openaicompatible.test.ts
@@ -19,7 +19,18 @@ describe('openaicompatible autocomplete provider', () => {
         vi.spyOn(featureFlagProvider, 'evaluatedFeatureFlag').mockReturnValue(Observable.of(false))
     })
 
-    const valuesToAssert = {
+    const anthropicParams = {
+        providerId: 'anthropic',
+        legacyModel: 'claude-instant-1.2',
+        requestParams: {
+            maxTokensToSample: 256,
+            temperature: 0.5,
+            timeoutMs: 7000,
+            topK: 0,
+        },
+    } satisfies AutocompleteProviderValuesToAssert
+
+    const openaicompatibleParams = {
         providerId: 'openaicompatible',
         legacyModel: 'llama-3.1-70b-versatile',
         requestParams: {
@@ -51,8 +62,11 @@ describe('openaicompatible autocomplete provider', () => {
 
         // Switches to the first available model, because `llama-3.1-70b-versatile` is
         // the enterprise tier model and cannot be used on DotCom.
-        expect(provider.id).toBe('anthropic')
-        expect(provider.legacyModel).toBe('anthropic/claude-instant-1.2')
+        const { providerId, legacyModel, requestParams } = anthropicParams
+
+        expect(provider.id).toBe(providerId)
+        expect(provider.legacyModel).toBe(legacyModel)
+        expect(getRequestParamsWithoutMessages(provider)).toMatchObject(requestParams)
     })
 
     it('[enterprise] server-side-model-config', async () => {
@@ -60,7 +74,7 @@ describe('openaicompatible autocomplete provider', () => {
             modelRef: 'groq::v1::llama-3.1-70b-versatile',
             isDotCom: false,
         })
-        const { providerId, legacyModel, requestParams } = valuesToAssert
+        const { providerId, legacyModel, requestParams } = openaicompatibleParams
 
         expect(provider.id).toBe(providerId)
         expect(provider.legacyModel).toBe(legacyModel)
@@ -69,8 +83,8 @@ describe('openaicompatible autocomplete provider', () => {
 
     it('throws if used with site-config-cody-llm-configuration', async () => {
         const createCall = getAutocompleteProviderFromSiteConfigCodyLLMConfiguration({
-            providerId: 'openaicompatible',
-            legacyModel: 'gpt-4o',
+            provider: 'sourcegraph',
+            completionModel: 'openaicompatible/gpt-4o',
             isDotCom: true,
         })
 

--- a/vscode/src/completions/providers/openaicompatible.ts
+++ b/vscode/src/completions/providers/openaicompatible.ts
@@ -30,7 +30,6 @@ class OpenAICompatibleProvider extends Provider {
         return {
             ...this.defaultRequestParams,
             messages,
-            model: this.legacyModel,
         }
     }
 

--- a/vscode/src/completions/providers/openaicompatible.ts
+++ b/vscode/src/completions/providers/openaicompatible.ts
@@ -18,7 +18,7 @@ class OpenAICompatibleProvider extends Provider {
     public getRequestParams(options: GenerateCompletionsOptions): CodeCompletionsParams {
         const { docContext, document, snippets } = options
 
-        const prompt = this.modelHelper.getPrompt({
+        const messages = this.modelHelper.getMessages({
             snippets,
             docContext,
             document,
@@ -29,7 +29,7 @@ class OpenAICompatibleProvider extends Provider {
 
         return {
             ...this.defaultRequestParams,
-            messages: [{ speaker: 'human', text: prompt }],
+            messages,
             model: this.legacyModel,
         }
     }

--- a/vscode/src/completions/providers/shared/__mocks__/create-provider-mocks.ts
+++ b/vscode/src/completions/providers/shared/__mocks__/create-provider-mocks.ts
@@ -104,7 +104,7 @@ const serverSentModelsMock = {
             },
         },
         {
-            modelRef: 'anthropic::2023-06-01::claude-3-haiku',
+            modelRef: 'anthropic::2023-06-01::claude-3-haiku-20240307',
             displayName: 'Claude 3 Haiku',
             modelName: 'claude-3-haiku-20240307',
             capabilities: ['autocomplete', 'chat'],

--- a/vscode/src/completions/providers/shared/create-provider.test.ts
+++ b/vscode/src/completions/providers/shared/create-provider.test.ts
@@ -110,20 +110,6 @@ describe('createProvider', () => {
             expect(provider.legacyModel).toBe('deepseek-coder-v2-lite-base')
         })
 
-        it('returns "anthropic" provider config if specified in VSCode settings', async () => {
-            const provider = await createProviderForTest({
-                config: {
-                    configuration: {
-                        autocompleteAdvancedProvider: 'anthropic',
-                        autocompleteAdvancedModel: null,
-                    },
-                },
-                authStatus: AUTH_STATUS_FIXTURE_AUTHED_DOTCOM,
-            })
-            expect(provider.id).toBe('anthropic')
-            expect(provider.legacyModel).toBe('anthropic/claude-instant-1.2')
-        })
-
         it('provider specified in VSCode settings takes precedence over the one defined in the site config', async () => {
             const provider = await createProviderForTest({
                 config: {
@@ -154,51 +140,9 @@ describe('createProvider', () => {
             {
                 configOverwrites: {
                     provider: 'sourcegraph',
-                    completionModel: 'anthropic/claude-instant-1.2',
-                },
-                expected: { provider: 'anthropic', legacyModel: 'anthropic/claude-instant-1.2' },
-            },
-            {
-                configOverwrites: { provider: 'sourcegraph', completionModel: 'anthropic/' },
-                expected: null,
-            },
-            {
-                configOverwrites: {
-                    provider: 'sourcegraph',
-                    completionModel: '/claude-instant-1.2',
-                },
-                expected: null,
-            },
-            {
-                configOverwrites: {
-                    provider: 'sourcegraph',
                     completionModel: 'fireworks/starcoder',
                 },
                 expected: { provider: 'fireworks', legacyModel: 'starcoder' },
-            },
-
-            // aws-bedrock
-            {
-                configOverwrites: { provider: 'aws-bedrock', completionModel: 'hello-world' },
-                expected: null,
-            },
-            {
-                configOverwrites: {
-                    provider: 'aws-bedrock',
-                    completionModel: 'anthropic.claude-instant-1.2',
-                },
-                expected: { provider: 'anthropic', legacyModel: 'anthropic/claude-instant-1.2' },
-            },
-            {
-                configOverwrites: { provider: 'aws-bedrock', completionModel: 'anthropic.' },
-                expected: null,
-            },
-            {
-                configOverwrites: {
-                    provider: 'aws-bedrock',
-                    completionModel: 'anthropic/claude-instant-1.2',
-                },
-                expected: null,
             },
 
             // open-ai

--- a/vscode/src/completions/providers/shared/create-provider.ts
+++ b/vscode/src/completions/providers/shared/create-provider.ts
@@ -98,7 +98,8 @@ export function createProvider({
                         }
 
                         return createProviderHelper({
-                            ...parsedProviderAndModel,
+                            legacyModel: parsedProviderAndModel.legacyModel,
+                            provider: parsedProviderAndModel.provider,
                             source: 'site-config-cody-llm-configuration',
                             authStatus,
                         })

--- a/vscode/src/completions/providers/shared/helpers.ts
+++ b/vscode/src/completions/providers/shared/helpers.ts
@@ -103,10 +103,14 @@ export async function getAutocompleteProviderFromServerSideModelConfig({
  * Creates autocomplete provider from the mocked site-config Cody LLM configuration.
  */
 export function getAutocompleteProviderFromSiteConfigCodyLLMConfiguration({
-    providerId,
-    legacyModel,
+    completionModel,
+    provider,
     isDotCom,
-}: { providerId: AutocompleteProviderID; legacyModel: string; isDotCom: boolean }): Promise<Provider> {
+}: {
+    completionModel: string
+    provider: AutocompleteProviderID | 'sourcegraph'
+    isDotCom: boolean
+}): Promise<Provider> {
     const authStatus = isDotCom ? AUTH_STATUS_FIXTURE_AUTHED_DOTCOM : AUTH_STATUS_FIXTURE_AUTHED
 
     vi.spyOn(modelsService, 'modelsChanges', 'get').mockReturnValue(
@@ -127,8 +131,8 @@ export function getAutocompleteProviderFromSiteConfigCodyLLMConfiguration({
         authStatus: {
             ...authStatus,
             configOverwrites: {
-                provider: providerId,
-                completionModel: legacyModel,
+                provider,
+                completionModel,
             },
         },
     })

--- a/vscode/src/completions/providers/shared/parse-provider-and-model.ts
+++ b/vscode/src/completions/providers/shared/parse-provider-and-model.ts
@@ -29,7 +29,7 @@ export function parseProviderAndModel({
         return { provider, legacyModel }
     }
 
-    if (legacyModel) {
+    if (legacyModel.includes(delimiter)) {
         const index = legacyModel.indexOf(delimiter)
         const parsedProvider = legacyModel.slice(0, index)
         const parsedModel = legacyModel.slice(index + 1)
@@ -39,6 +39,6 @@ export function parseProviderAndModel({
     }
 
     return new Error(
-        `Failed to parse the model name ${legacyModel} for '${provider}' completions provider.`
+        `Failed to parse the model name '${legacyModel}' for '${provider}' completions provider.`
     )
 }

--- a/vscode/src/completions/providers/shared/provider.ts
+++ b/vscode/src/completions/providers/shared/provider.ts
@@ -162,7 +162,7 @@ export abstract class Provider {
     } as const satisfies Omit<CodeCompletionsParams, 'messages'>
 
     /**
-     * Returns the passed model ID only if we're using Cody Gateway and
+     * Returns the passed model ID only if we're using Cody Gateway (not BYOK) and
      * the model ID is resolved on the client.
      */
     protected maybeFilterOutModel(
@@ -173,6 +173,9 @@ export abstract class Provider {
         }
 
         const { configOverwrites } = currentAuthStatusAuthed()
+
+        // The model ID is ignored by BYOK clients (configOverwrites?.provider !== 'sourcegraph')
+        // so we can remove it from the request params we send to the backend.
         return configOverwrites?.provider === 'sourcegraph' ? model : undefined
     }
 

--- a/vscode/src/completions/providers/unstable-openai.test.ts
+++ b/vscode/src/completions/providers/unstable-openai.test.ts
@@ -48,8 +48,8 @@ describe('unstable-openai autocomplete provider', () => {
 
     testAutocompleteProvider('site-config-cody-llm-configuration', valuesToAssert, isDotCom =>
         getAutocompleteProviderFromSiteConfigCodyLLMConfiguration({
-            providerId: 'unstable-openai',
-            legacyModel: 'gpt-4o',
+            provider: 'sourcegraph',
+            completionModel: 'unstable-openai/gpt-4o',
             isDotCom,
         })
     )

--- a/vscode/src/completions/providers/unstable-openai.ts
+++ b/vscode/src/completions/providers/unstable-openai.ts
@@ -1,7 +1,6 @@
 import type { CodeCompletionsParams } from '@sourcegraph/cody-shared'
 
 import { OpenAI } from '../model-helpers/openai'
-import { CLOSING_CODE_TAG, MULTILINE_STOP_SEQUENCE } from '../text-processing'
 import { forkSignal, generatorWithTimeout, zipGenerators } from '../utils'
 
 import {
@@ -17,7 +16,6 @@ import {
 } from './shared/provider'
 
 class UnstableOpenAIProvider extends Provider {
-    public stopSequences = [CLOSING_CODE_TAG.toString(), MULTILINE_STOP_SEQUENCE]
     protected modelHelper = new OpenAI()
 
     public getRequestParams(generateOptions: GenerateCompletionsOptions): CodeCompletionsParams {

--- a/vscode/src/completions/providers/unstable-openai.ts
+++ b/vscode/src/completions/providers/unstable-openai.ts
@@ -23,7 +23,7 @@ class UnstableOpenAIProvider extends Provider {
     public getRequestParams(generateOptions: GenerateCompletionsOptions): CodeCompletionsParams {
         const { document, docContext, snippets } = generateOptions
 
-        const prompt = this.modelHelper.getPrompt({
+        const messages = this.modelHelper.getMessages({
             snippets,
             docContext,
             document,
@@ -32,7 +32,7 @@ class UnstableOpenAIProvider extends Provider {
 
         return {
             ...this.defaultRequestParams,
-            messages: [{ speaker: 'human', text: prompt }],
+            messages,
             topP: 0.5,
         }
     }


### PR DESCRIPTION
The problem: currently, we [assert](https://github.com/sourcegraph/cody/blob/d10b88f3bcaad1c140352088a15f641f4697c80f/vscode/src/completions/providers/shared/create-provider.test.ts#L218-L219) the model ID assigned to the provider instance, but often, it's not used at all to make requests, which means this assertion is irrelevant to the actual functionality where we bump into bugs.

- This PR adds tests for autocomplete request parameters in all supported instance configurations: dotcom/enterprise X local-settings/server-side-model-config/site-config for the `anthropic` provider.
- Moves Claude-specific code to a model helper.
- Changes the model helper interface to provider messages instead of only the prompt string.
- Enforces the consistent `requestParams.model` format — `providerId/modelName` and consistent `provider.legacyModel` format — `modelName`.
- Follow up for https://github.com/sourcegraph/cody/pull/5604.
- No functional changes.
- Part of https://linear.app/sourcegraph/issue/CODY-3409/self-hosted-models-openaicompatible-autocomplete-provider-supports
- Part of https://linear.app/sourcegraph/issue/CODY-3778/add-autocomplete-provider-tests-to-assert-request-parameters

## Note

The only remaining provider with few tests is Fireworks. I'm working on adding request params tests for it rn. But if you open different autocomplete providers now, you'll see they are 90% identical. I hope we can merge most of them soon and rely primarily on model helpers. Then, it will be much easier to work towards the future, where models are defined in the site-config, and the client has only one autocomplete provider that can handle all the cases. Also, unifying the `requestParms.model` format also brings us closer to migrating to server-side model config usage.

## Test plan

1. CI and new unit tests
2. For manual testing, add "cody.autocomplete.advanced.provider": "anthropic" to your local settings and see if autocomplete works on DotCom.
3. For enterprise testing, use one of the instances with the configured Anthropic model (sg02 with Haiku), set the Anthropic model as the default `codeCompletion` in the site-config under `modelConfiguration.defaultModels`, and generate completions.

Beware that s2, sg02, and sg04 have server-side model config disabled [currently](https://sourcegraph.slack.com/archives/C05AGQYD528/p1727322294844429).
