### PR TITLE
Add intent telemetry

### DIFF
--- a/vscode/src/chat/chat-view/ChatController.ts
+++ b/vscode/src/chat/chat-view/ChatController.ts
@@ -653,7 +653,7 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
         source?: EventSource
         command?: DefaultChatCommands
         intent?: ChatMessage['intent'] | undefined | null
-        manuallySelectedIntent?: boolean
+        manuallySelectedIntent?: boolean | undefined | null
     }): Promise<void> {
         return tracer.startActiveSpan('chat.submit', async (span): Promise<void> => {
             span.setAttribute('sampled', true)
@@ -1077,7 +1077,7 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
         contextFiles: ContextItem[]
         editorState: SerializedPromptEditorState | null
         intent?: ChatMessage['intent'] | undefined | null
-        manuallySelectedIntent?: boolean
+        manuallySelectedIntent?: boolean | undefined | null
     }): Promise<void> {
         const abortSignal = this.startNewSubmitOrEditOperation()
 

--- a/vscode/src/chat/chat-view/ChatController.ts
+++ b/vscode/src/chat/chat-view/ChatController.ts
@@ -299,6 +299,7 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
                     signal: this.startNewSubmitOrEditOperation(),
                     source: 'chat',
                     intent: message.intent,
+                    manuallySelectedIntent: message.manuallySelectedIntent,
                 })
                 break
             }
@@ -310,6 +311,7 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
                     contextFiles: message.contextItems ?? [],
                     editorState: message.editorState as SerializedPromptEditorState,
                     intent: message.intent,
+                    manuallySelectedIntent: message.manuallySelectedIntent,
                 })
                 break
             }
@@ -640,6 +642,7 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
         source,
         command,
         intent: detectedIntent,
+        manuallySelectedIntent,
     }: {
         requestID: string
         inputText: PromptString
@@ -650,6 +653,7 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
         source?: EventSource
         command?: DefaultChatCommands
         intent?: ChatMessage['intent'] | undefined | null
+        manuallySelectedIntent?: boolean
     }): Promise<void> {
         return tracer.startActiveSpan('chat.submit', async (span): Promise<void> => {
             span.setAttribute('sampled', true)
@@ -719,6 +723,17 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
                     ['repository', 'tree'].includes(contextItem.type)
                 )
 
+                // We are checking the feature flag here to log non-undefined intent only if the feature flag is on
+                let intent: ChatMessage['intent'] | undefined = this.featureCodyExperimentalOneBox
+                    ? detectedIntent
+                    : undefined
+
+                const userSpecifiedIntent = this.featureCodyExperimentalOneBox
+                    ? manuallySelectedIntent && detectedIntent
+                        ? detectedIntent
+                        : 'auto'
+                    : undefined
+
                 if (this.featureCodyExperimentalOneBox && repositoryMentioned) {
                     const inputTextWithoutContextChips = editorState
                         ? PromptString.unsafe_fromUserQuery(
@@ -726,7 +741,7 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
                           )
                         : inputText
 
-                    const intent = detectedIntent
+                    intent = detectedIntent
                         ? detectedIntent
                         : await this.detectChatIntent({
                               requestID,
@@ -741,6 +756,15 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
                               .catch(() => undefined)
                     signal.throwIfAborted()
                     if (intent === 'search') {
+                        void this.sendChatExecutedTelemetry({
+                            span,
+                            firstTokenSpan,
+                            inputText,
+                            sharedProperties,
+                            userSpecifiedIntent,
+                            detectedIntent: intent,
+                        })
+
                         return await this.handleSearchIntent({
                             context: corpusContext,
                             signal,
@@ -767,13 +791,15 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
                         contextAlternatives
                     )
 
-                    void this.sendChatExecutedTelemetry(
+                    void this.sendChatExecutedTelemetry({
                         span,
                         firstTokenSpan,
                         inputText,
                         sharedProperties,
-                        context
-                    )
+                        context,
+                        detectedIntent: intent,
+                        userSpecifiedIntent,
+                    })
 
                     signal.throwIfAborted()
                     this.streamAssistantResponse(requestID, prompt, model, span, firstTokenSpan, signal)
@@ -834,29 +860,42 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
         this.postViewTranscript()
     }
 
-    private async sendChatExecutedTelemetry(
-        span: Span,
-        firstTokenSpan: Span,
-        inputText: PromptString,
-        sharedProperties: any,
-        context: PromptInfo['context']
-    ): Promise<void> {
+    private async sendChatExecutedTelemetry({
+        span,
+        firstTokenSpan,
+        inputText,
+        sharedProperties,
+        context,
+        detectedIntent,
+        userSpecifiedIntent,
+    }: {
+        span: Span
+        firstTokenSpan: Span
+        inputText: PromptString
+        sharedProperties: any
+        context?: PromptInfo['context']
+        detectedIntent?: ChatMessage['intent']
+        userSpecifiedIntent?: ChatMessage['intent'] | 'auto'
+    }): Promise<void> {
         const authStatus = currentAuthStatus()
 
         // Create a summary of how many code snippets of each context source are being
         // included in the prompt
         const contextSummary: { [key: string]: number } = {}
-        for (const { source } of context.used) {
-            if (!source) {
-                continue
-            }
-            if (contextSummary[source]) {
-                contextSummary[source] += 1
-            } else {
-                contextSummary[source] = 1
+        if (context) {
+            for (const { source } of context.used) {
+                if (!source) {
+                    continue
+                }
+                if (contextSummary[source]) {
+                    contextSummary[source] += 1
+                } else {
+                    contextSummary[source] = 1
+                }
             }
         }
-        const privateContextSummary = await this.buildPrivateContextSummary(context)
+
+        const privateContextSummary = context && (await this.buildPrivateContextSummary(context))
 
         const properties = {
             ...sharedProperties,
@@ -873,6 +912,8 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
                 recordsPrivateMetadataTranscript: isDotCom(authStatus) ? 1 : 0,
             },
             privateMetadata: {
+                detectedIntent,
+                userSpecifiedIntent,
                 properties,
                 privateContextSummary: privateContextSummary,
                 // 🚨 SECURITY: chat transcripts are to be included only for DotCom users AND for V2 telemetry
@@ -1028,6 +1069,7 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
         contextFiles,
         editorState,
         intent,
+        manuallySelectedIntent,
     }: {
         requestID: string
         text: PromptString
@@ -1035,6 +1077,7 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
         contextFiles: ContextItem[]
         editorState: SerializedPromptEditorState | null
         intent?: ChatMessage['intent'] | undefined | null
+        manuallySelectedIntent?: boolean
     }): Promise<void> {
         const abortSignal = this.startNewSubmitOrEditOperation()
 
@@ -1060,6 +1103,7 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
                 signal: abortSignal,
                 source: 'chat',
                 intent,
+                manuallySelectedIntent,
             })
         } catch {
             this.postError(new Error('Failed to edit prompt'), 'transcript')

--- a/vscode/src/chat/protocol.ts
+++ b/vscode/src/chat/protocol.ts
@@ -243,7 +243,7 @@ export interface WebviewSubmitMessage extends WebviewContextMessage {
     /** An opaque value representing the text editor's state. @see {ChatMessage.editorState} */
     editorState?: unknown | undefined | null
     intent?: ChatMessage['intent'] | undefined | null
-    manuallySelectedIntent?: boolean
+    manuallySelectedIntent?: boolean | undefined | null
 }
 
 interface WebviewEditMessage extends WebviewContextMessage {
@@ -253,7 +253,7 @@ interface WebviewEditMessage extends WebviewContextMessage {
     /** An opaque value representing the text editor's state. @see {ChatMessage.editorState} */
     editorState?: unknown | undefined | null
     intent?: ChatMessage['intent'] | undefined | null
-    manuallySelectedIntent?: boolean
+    manuallySelectedIntent?: boolean | undefined | null
 }
 
 interface WebviewContextMessage {

--- a/vscode/src/chat/protocol.ts
+++ b/vscode/src/chat/protocol.ts
@@ -243,6 +243,7 @@ export interface WebviewSubmitMessage extends WebviewContextMessage {
     /** An opaque value representing the text editor's state. @see {ChatMessage.editorState} */
     editorState?: unknown | undefined | null
     intent?: ChatMessage['intent'] | undefined | null
+    manuallySelectedIntent?: boolean
 }
 
 interface WebviewEditMessage extends WebviewContextMessage {
@@ -252,6 +253,7 @@ interface WebviewEditMessage extends WebviewContextMessage {
     /** An opaque value representing the text editor's state. @see {ChatMessage.editorState} */
     editorState?: unknown | undefined | null
     intent?: ChatMessage['intent'] | undefined | null
+    manuallySelectedIntent?: boolean
 }
 
 interface WebviewContextMessage {

--- a/vscode/webviews/chat/Transcript.tsx
+++ b/vscode/webviews/chat/Transcript.tsx
@@ -268,6 +268,9 @@ const TranscriptInteraction: FC<TranscriptInteractionProps> = memo(props => {
             if (editorState) {
                 onEditSubmit(editorState, intent)
                 telemetryRecorder.recordEvent('onebox.intentCorrection', 'clicked', {
+                    metadata: {
+                        recordsPrivateMetadataTranscript: 1,
+                    },
                     privateMetadata: {
                         initial_intent: humanMessage.intent,
                         user_selected_intent: intent,

--- a/vscode/webviews/chat/cells/contextCell/ContextCell.tsx
+++ b/vscode/webviews/chat/cells/contextCell/ContextCell.tsx
@@ -99,10 +99,9 @@ export const ContextCell: FunctionComponent<{
         const logValueChange = useCallback(
             (value: string | undefined) => {
                 if (oneboxEnabled) {
-                    telemetryRecorder.recordEvent(
-                        'onebox.contextDrawer',
-                        value ? 'expanded' : 'collapsed'
-                    )
+                    telemetryRecorder.recordEvent('onebox.contextDrawer', 'clicked', {
+                        [value ? 'expanded' : 'collapsed']: 1,
+                    })
                 }
             },
             [telemetryRecorder, oneboxEnabled]

--- a/vscode/webviews/chat/cells/messageCell/assistant/AssistantMessageCell.tsx
+++ b/vscode/webviews/chat/cells/messageCell/assistant/AssistantMessageCell.tsx
@@ -216,7 +216,11 @@ export function makeHumanMessageInfo(
                             withInitialContext.repositories) ||
                         (item.type === 'file' && withInitialContext.files)
                 )
-                editHumanMessage(assistantMessage.index - 1, newEditorValue)
+                editHumanMessage({
+                    messageIndexInTranscript: assistantMessage.index - 1,
+                    editorValue: newEditorValue,
+                    intent: humanMessage.intent,
+                })
             }
         },
         hasExplicitMentions: Boolean(contextItems.some(item => item.source === ContextItemSource.User)),

--- a/vscode/webviews/components/FileLink.tsx
+++ b/vscode/webviews/components/FileLink.tsx
@@ -9,9 +9,11 @@ import {
     webviewOpenURIForContextItem,
 } from '@sourcegraph/cody-shared'
 
-import { useMemo } from 'react'
+import { useCallback, useMemo } from 'react'
 import type { URI } from 'vscode-uri'
 import { getVSCodeAPI } from '../utils/VSCodeApi'
+import { useTelemetryRecorder } from '../utils/telemetry'
+import { useExperimentalOneBox } from '../utils/useExperimentalOneBox'
 import styles from './FileLink.module.css'
 import { Button } from './shadcn/ui/button'
 
@@ -104,8 +106,30 @@ export const FileLink: React.FunctionComponent<
     const iconTitle =
         source && hoverSourceLabels[source] ? `Included ${hoverSourceLabels[source]}` : undefined
 
+    const telemetryRecorder = useTelemetryRecorder()
+    const oneboxEnabled = useExperimentalOneBox()
+    const logClick = useCallback(() => {
+        if (!oneboxEnabled) {
+            return
+        }
+        const external = uri.scheme === 'http' || uri.scheme === 'https'
+        telemetryRecorder.recordEvent('onebox.searchResult', 'clicked', {
+            metadata: {
+                is_local: external ? 0 : 1,
+                is_remote: external ? 1 : 0,
+            },
+            privateMetadata: {
+                filename: displayPath(uri),
+            },
+        })
+    }, [telemetryRecorder, oneboxEnabled, uri])
+
     return (
-        <div className={clsx('tw-inline-flex tw-items-center tw-max-w-full', className)}>
+        <div
+            className={clsx('tw-inline-flex tw-items-center tw-max-w-full', className)}
+            onClick={logClick}
+            onKeyDown={logClick}
+        >
             {(isIgnored || isTooLarge) && (
                 <i className="codicon codicon-warning" title={linkDetails.tooltip} />
             )}

--- a/vscode/webviews/components/FileSnippet.tsx
+++ b/vscode/webviews/components/FileSnippet.tsx
@@ -3,7 +3,9 @@ import { useExtensionAPI } from '@sourcegraph/prompt-editor'
 import { type FC, useCallback, useMemo } from 'react'
 
 import type { Observable } from 'observable-fns'
+import { useTelemetryRecorder } from '../utils/telemetry'
 import { useConfig } from '../utils/useConfig'
+import { useExperimentalOneBox } from '../utils/useExperimentalOneBox'
 import { type FetchFileParameters, FileContentSearchResult } from './codeSnippet/CodeSnippet'
 import type { ContentMatch } from './codeSnippet/types'
 
@@ -44,6 +46,16 @@ export const FileSnippet: FC<FileSnippetProps> = props => {
         }
     }, [item])
 
+    const telemetryRecorder = useTelemetryRecorder()
+    const oneboxEnabled = useExperimentalOneBox()
+    const logSelection = useCallback(() => {
+        if (oneboxEnabled) {
+            telemetryRecorder.recordEvent('onebox.searchResult', 'clicked', {
+                privateMetadata: { filename: contentMatch.path },
+            })
+        }
+    }, [telemetryRecorder, oneboxEnabled, contentMatch.path])
+
     // Supports only file context (openctx items are not supported
     // but possible could be presented by snippets as well)
     if (item.type !== 'file') {
@@ -58,7 +70,7 @@ export const FileSnippet: FC<FileSnippetProps> = props => {
             defaultExpanded={false}
             fetchHighlightedFileLineRanges={fetchHighlights}
             className={className}
-            onSelect={() => {}}
+            onSelect={logSelection}
         />
     )
 }


### PR DESCRIPTION
closes: https://linear.app/sourcegraph/issue/AI-298/log-telemetry-for-one-box-clicks

Add telemetry events for onebox as per the linear issue requirements. 

## Test plan
Check if the telemetry events are triggered for the following
- expand and collapse context files accordion for both search and chat intents
- click on search results and context files 
- switch intent from response.

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
