### PR TITLE
watch feature flags instead of calling evaluateFeatureFlag (which is non-reactive)

### DIFF
--- a/agent/src/agent.ts
+++ b/agent/src/agent.ts
@@ -1387,7 +1387,7 @@ export class Agent extends MessageHandler implements ExtensionClient {
         })
 
         this.registerAuthenticatedRequest('featureFlags/getFeatureFlag', async ({ flagName }) => {
-            return featureFlagProvider.evaluateFeatureFlag(
+            return featureFlagProvider.evaluateFeatureFlagEphemerally(
                 FeatureFlag[flagName as keyof typeof FeatureFlag]
             )
         })

--- a/lib/shared/src/experimentation/FeatureFlagProvider.test.ts
+++ b/lib/shared/src/experimentation/FeatureFlagProvider.test.ts
@@ -1,4 +1,14 @@
-import { afterEach, beforeAll, beforeEach, describe, expect, it, vi, vitest } from 'vitest'
+import {
+    type TaskContext,
+    afterEach,
+    beforeAll,
+    beforeEach,
+    describe,
+    expect,
+    it,
+    vi,
+    vitest,
+} from 'vitest'
 
 import { graphqlClient } from '../sourcegraph-api/graphql'
 
@@ -23,12 +33,9 @@ describe('FeatureFlagProvider', () => {
     beforeEach(() => {
         featureFlagProvider = new FeatureFlagProviderImpl()
     })
-
-    let unsubscribeAfter: (() => void) | undefined = undefined
     afterEach(() => {
         vi.clearAllMocks()
-        unsubscribeAfter?.()
-        unsubscribeAfter = undefined
+        featureFlagProvider.dispose()
     })
 
     it('evaluates a single feature flag', async () => {
@@ -39,12 +46,22 @@ describe('FeatureFlagProvider', () => {
             .spyOn(graphqlClient, 'evaluateFeatureFlag')
             .mockResolvedValue(true)
 
-        expect(await featureFlagProvider.evaluateFeatureFlag(FeatureFlag.TestFlagDoNotUse)).toBe(true)
+        expect(
+            await featureFlagProvider.evaluateFeatureFlagEphemerally(FeatureFlag.TestFlagDoNotUse)
+        ).toBe(true)
         expect(getEvaluatedFeatureFlagsMock).toHaveBeenCalledTimes(0)
-        expect(evaluateFeatureFlagMock).toHaveBeenCalledOnce()
+        expect(evaluateFeatureFlagMock).toHaveBeenCalledTimes(1)
+        evaluateFeatureFlagMock.mockClear()
+
+        // The result is cached.
+        expect(
+            await featureFlagProvider.evaluateFeatureFlagEphemerally(FeatureFlag.TestFlagDoNotUse)
+        ).toBe(true)
+        expect(getEvaluatedFeatureFlagsMock).toHaveBeenCalledTimes(0)
+        expect(evaluateFeatureFlagMock).toHaveBeenCalledTimes(0)
     })
 
-    it('reports exposed experiments', async () => {
+    it('reports exposed experiments', async task => {
         vi.spyOn(graphqlClient, 'getEvaluatedFeatureFlags').mockResolvedValue({
             [FeatureFlag.TestFlagDoNotUse]: true,
         })
@@ -52,7 +69,7 @@ describe('FeatureFlagProvider', () => {
         const { unsubscribe } = readValuesFrom(
             featureFlagProvider.evaluatedFeatureFlag(FeatureFlag.TestFlagDoNotUse)
         )
-        unsubscribeAfter = unsubscribe
+        task.onTestFinished(() => unsubscribe())
         await vi.runOnlyPendingTimersAsync()
         expect(featureFlagProvider.getExposedExperiments('https://example.com')).toStrictEqual({
             [FeatureFlag.TestFlagDoNotUse]: true,
@@ -64,7 +81,9 @@ describe('FeatureFlagProvider', () => {
         vi.spyOn(graphqlClient, 'getEvaluatedFeatureFlags').mockResolvedValue(new Error('API error'))
         vi.spyOn(graphqlClient, 'evaluateFeatureFlag').mockResolvedValue(new Error('API error'))
 
-        expect(await featureFlagProvider.evaluateFeatureFlag(FeatureFlag.TestFlagDoNotUse)).toBe(false)
+        expect(
+            await featureFlagProvider.evaluateFeatureFlagEphemerally(FeatureFlag.TestFlagDoNotUse)
+        ).toBe(false)
     })
 
     describe('evaluatedFeatureFlag', () => {
@@ -72,17 +91,19 @@ describe('FeatureFlagProvider', () => {
             expectInitialValues,
             updateMocks,
             expectFinalValues,
+            task,
         }: {
             expectInitialValues: boolean[]
             updateMocks?: () => void
             expectFinalValues?: boolean[]
+            task: TaskContext
         }): Promise<void> {
             vitest.useFakeTimers()
 
             const { values, clearValues, done, unsubscribe } = readValuesFrom(
                 featureFlagProvider.evaluatedFeatureFlag(FeatureFlag.TestFlagDoNotUse)
             )
-            unsubscribeAfter = unsubscribe
+            task.onTestFinished(() => unsubscribe())
 
             // Test the initial emissions.
             await vi.runOnlyPendingTimersAsync()
@@ -106,13 +127,13 @@ describe('FeatureFlagProvider', () => {
             expect(values).toEqual<typeof values>([])
         }
 
-        it('should emit when a new flag is evaluated', { timeout: 500 }, async () => {
+        it('should emit when a new flag is evaluated', { timeout: 500 }, async task => {
             vi.spyOn(graphqlClient, 'getEvaluatedFeatureFlags').mockResolvedValue({})
             vi.spyOn(graphqlClient, 'evaluateFeatureFlag').mockResolvedValue(false)
-            await testEvaluatedFeatureFlag({ expectInitialValues: [false] })
+            await testEvaluatedFeatureFlag({ expectInitialValues: [false], task })
         })
 
-        it('should emit when value changes from true to false', async () => {
+        it('should emit when value changes from true to false', async task => {
             vi.spyOn(graphqlClient, 'getEvaluatedFeatureFlags').mockResolvedValue({
                 [FeatureFlag.TestFlagDoNotUse]: true,
             })
@@ -126,10 +147,11 @@ describe('FeatureFlagProvider', () => {
                     vi.spyOn(graphqlClient, 'evaluateFeatureFlag').mockResolvedValue(false)
                 },
                 expectFinalValues: [false],
+                task,
             })
         })
 
-        it('should emit when value changes from false to true', async () => {
+        it('should emit when value changes from false to true', async task => {
             vi.spyOn(graphqlClient, 'getEvaluatedFeatureFlags').mockResolvedValue({
                 [FeatureFlag.TestFlagDoNotUse]: false,
             })
@@ -143,10 +165,11 @@ describe('FeatureFlagProvider', () => {
                     vi.spyOn(graphqlClient, 'evaluateFeatureFlag').mockResolvedValue(true)
                 },
                 expectFinalValues: [true],
+                task,
             })
         })
 
-        it('should not emit false when a previously false flag is no longer in the exposed list', async () => {
+        it('should not emit false when a previously false flag is no longer in the exposed list', async task => {
             vi.spyOn(graphqlClient, 'getEvaluatedFeatureFlags').mockResolvedValue({
                 [FeatureFlag.TestFlagDoNotUse]: false,
             })
@@ -158,6 +181,7 @@ describe('FeatureFlagProvider', () => {
                     vi.spyOn(graphqlClient, 'evaluateFeatureFlag').mockResolvedValue(null)
                 },
                 expectFinalValues: [],
+                task,
             })
         })
 
@@ -172,9 +196,9 @@ describe('FeatureFlagProvider', () => {
                 .mockResolvedValue(true)
             mockAuthStatus({ ...AUTH_STATUS_FIXTURE_AUTHED, endpoint: 'https://example.com' })
 
-            expect(await featureFlagProvider.evaluateFeatureFlag(FeatureFlag.TestFlagDoNotUse)).toBe(
-                true
-            )
+            expect(
+                await featureFlagProvider.evaluateFeatureFlagEphemerally(FeatureFlag.TestFlagDoNotUse)
+            ).toBe(true)
 
             getEvaluatedFeatureFlagsMock.mockResolvedValue({
                 [FeatureFlag.TestFlagDoNotUse]: false,
@@ -182,12 +206,12 @@ describe('FeatureFlagProvider', () => {
             evaluateFeatureFlagMock.mockResolvedValue(false)
             mockAuthStatus({ ...AUTH_STATUS_FIXTURE_AUTHED, endpoint: 'https://other.example.com' })
             await vi.runOnlyPendingTimersAsync()
-            expect(await featureFlagProvider.evaluateFeatureFlag(FeatureFlag.TestFlagDoNotUse)).toBe(
-                false
-            )
+            expect(
+                await featureFlagProvider.evaluateFeatureFlagEphemerally(FeatureFlag.TestFlagDoNotUse)
+            ).toBe(false)
         })
 
-        it('refresh()', async () => {
+        it('refresh()', async task => {
             vi.clearAllMocks()
             const getEvaluatedFeatureFlagsMock = vi
                 .spyOn(graphqlClient, 'getEvaluatedFeatureFlags')
@@ -201,7 +225,7 @@ describe('FeatureFlagProvider', () => {
             const { values, clearValues, unsubscribe } = readValuesFrom(
                 featureFlagProvider.evaluatedFeatureFlag(FeatureFlag.TestFlagDoNotUse)
             )
-            unsubscribeAfter = unsubscribe
+            task.onTestFinished(() => unsubscribe())
 
             await vi.runOnlyPendingTimersAsync()
             expect(values).toStrictEqual<typeof values>([true])

--- a/lib/shared/src/misc/observable.ts
+++ b/lib/shared/src/misc/observable.ts
@@ -975,6 +975,7 @@ export function switchMap<T, R>(
 
 export interface StoredLastValue<T> {
     value: { last: undefined; isSet: false } | { last: T; isSet: true }
+    observable: Observable<T>
     subscription: Unsubscribable
 }
 
@@ -987,7 +988,7 @@ export function storeLastValue<T>(observable: Observable<T>): StoredLastValue<T>
     const subscription = observable.subscribe(v => {
         Object.assign(value, { last: v, isSet: true })
     })
-    return { value, subscription }
+    return { value, observable, subscription }
 }
 
 export function debounceTime<T>(duration: number): (source: ObservableLike<T>) => Observable<T> {

--- a/lib/shared/src/misc/rpc/webviewAPI.ts
+++ b/lib/shared/src/misc/rpc/webviewAPI.ts
@@ -2,7 +2,7 @@ import type { Observable } from 'observable-fns'
 import type { ChatMessage } from '../../chat/transcript/messages'
 import type { ContextItem } from '../../codebase-context/messages'
 import type { CodyCommand } from '../../commands/types'
-import { FeatureFlag } from '../../experimentation/FeatureFlagProvider'
+import type { FeatureFlag } from '../../experimentation/FeatureFlagProvider'
 import type { ContextMentionProviderMetadata } from '../../mentions/api'
 import type { MentionQuery } from '../../mentions/query'
 import type { Model } from '../../models/model'
@@ -16,10 +16,9 @@ export interface WebviewToExtensionAPI {
     mentionMenuData(query: MentionQuery): Observable<MentionMenuData>
 
     /**
-     * Get the evaluated value of a feature flag. All feature flags used by the webview must be in
-     * {@link FEATURE_FLAGS_USED_IN_WEBVIEW}.
+     * Get the evaluated value of a feature flag.
      */
-    evaluatedFeatureFlag(flag: FeatureFlagUsedInWebview): Observable<boolean | undefined>
+    evaluatedFeatureFlag(flag: FeatureFlag): Observable<boolean | undefined>
 
     /**
      * Observe the results of querying prompts in the Prompt Library. For backcompat, it also
@@ -93,13 +92,3 @@ export interface PromptsResult {
     /** The original query used to fetch this result. */
     query: string
 }
-
-/**
- * You must add a feature flag here if you need to use it from the frontend. This is because only
- * explicitly requested feature flags are evaluated immediately. If you don't add one here, its old
- * value will be cached on the server and returned until it is explicitly evaluated.
- */
-const FEATURE_FLAGS_USED_IN_WEBVIEW = [
-    FeatureFlag.CodyExperimentalOneBox,
-] as const satisfies FeatureFlag[]
-export type FeatureFlagUsedInWebview = (typeof FEATURE_FLAGS_USED_IN_WEBVIEW)[number]

--- a/vscode/src/chat/chat-view/ChatController.ts
+++ b/vscode/src/chat/chat-view/ChatController.ts
@@ -564,9 +564,6 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
         const sidebarViewOnly = this.extensionClient.capabilities?.webviewNativeConfig?.view === 'single'
         const isEditorViewType = this.webviewPanelOrView?.viewType === 'cody.editorPanel'
         const webviewType = isEditorViewType && !sidebarViewOnly ? 'editor' : 'sidebar'
-        const unifiedPromptsAvailable = await featureFlagProvider.evaluateFeatureFlag(
-            FeatureFlag.CodyUnifiedPrompts
-        )
 
         return {
             agentIDE: configuration.agentIDE ?? CodyIDE.VSCode,
@@ -577,7 +574,6 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
             serverEndpoint: auth.serverEndpoint,
             experimentalNoodle: configuration.experimentalNoodle,
             smartApply: this.isSmartApplyEnabled(),
-            unifiedPromptsAvailable,
             webviewType,
             multipleWebviewsEnabled: !sidebarViewOnly,
             internalDebugContext: configuration.internalDebugContext,

--- a/vscode/src/chat/protocol.ts
+++ b/vscode/src/chat/protocol.ts
@@ -276,7 +276,6 @@ export interface ConfigurationSubsetForWebview
         >,
         Pick<AuthCredentials, 'serverEndpoint'> {
     smartApply: boolean
-    unifiedPromptsAvailable: boolean
     // Type/location of the current webview.
     webviewType?: WebviewType | undefined | null
     // Whether support running multiple webviews (e.g. sidebar w/ multiple editor panels).

--- a/vscode/src/completions/completion-provider-config.ts
+++ b/vscode/src/completions/completion-provider-config.ts
@@ -1,5 +1,6 @@
 import {
     FeatureFlag,
+    type Unsubscribable,
     combineLatest,
     distinctUntilChanged,
     featureFlagProvider,
@@ -11,10 +12,18 @@ import { isRunningInsideAgent } from '../jsonrpc/isRunningInsideAgent'
 import type { ContextStrategy } from './context/context-strategy'
 
 class CompletionProviderConfig {
-    /** Pre-fetch the feature flags we need so they are cached and immediately available when the
-     * user performs their first autocomplete, and so that our performance metrics are not
-     * skewed by the 1st autocomplete's feature flag evaluation time. */
+    private prefetchSubscription: Unsubscribable | undefined
+
+    /**
+     * Pre-fetch the feature flags we need so they are cached and immediately available when the
+     * user performs their first autocomplete, and so that our performance metrics are not skewed by
+     * the 1st autocomplete's feature flag evaluation time.
+     */
     public async prefetch(): Promise<void> {
+        if (this.prefetchSubscription) {
+            // Only one prefetch subscription is needed.
+            return
+        }
         const featureFlagsUsed: FeatureFlag[] = [
             FeatureFlag.CodyAutocompleteContextExperimentBaseFeatureFlag,
             FeatureFlag.CodyAutocompleteContextExperimentVariant1,
@@ -27,8 +36,15 @@ class CompletionProviderConfig {
             FeatureFlag.CodyAutocompletePreloadingExperimentVariant2,
             FeatureFlag.CodyAutocompletePreloadingExperimentVariant3,
             FeatureFlag.CodyAutocompleteDisableLowPerfLangDelay,
+            FeatureFlag.CodyAutocompleteTracing,
         ]
-        await Promise.all(featureFlagsUsed.map(flag => featureFlagProvider.evaluateFeatureFlag(flag)))
+        this.prefetchSubscription = combineLatest(
+            featureFlagsUsed.map(flag => featureFlagProvider.evaluatedFeatureFlag(flag))
+        ).subscribe({})
+    }
+
+    public dispose(): void {
+        this.prefetchSubscription?.unsubscribe()
     }
 
     public get contextStrategy(): Observable<ContextStrategy> {

--- a/vscode/src/completions/default-client.ts
+++ b/vscode/src/completions/default-client.ts
@@ -55,7 +55,7 @@ class DefaultCodeCompletionsClient implements CodeCompletionsClient {
         return tracer.startActiveSpan(
             `POST ${url}`,
             async function* (span): CompletionResponseGenerator {
-                const tracingFlagEnabled = await featureFlagProvider.evaluateFeatureFlag(
+                const tracingFlagEnabled = await featureFlagProvider.evaluateFeatureFlagEphemerally(
                     FeatureFlag.CodyAutocompleteTracing
                 )
 

--- a/vscode/src/completions/get-inline-completions-tests/helpers.ts
+++ b/vscode/src/completions/get-inline-completions-tests/helpers.ts
@@ -393,7 +393,7 @@ export function initCompletionProviderConfig({
     configuration,
     authStatus,
 }: Partial<Pick<ParamsResult, 'configuration' | 'authStatus'>>): void {
-    vi.spyOn(featureFlagProvider, 'evaluateFeatureFlag').mockResolvedValue(false)
+    vi.spyOn(featureFlagProvider, 'evaluateFeatureFlagEphemerally').mockResolvedValue(false)
     vi.spyOn(featureFlagProvider, 'evaluatedFeatureFlag').mockReturnValue(Observable.of(false))
     vi.spyOn(ClientConfigSingleton.getInstance(), 'getConfig').mockResolvedValue({
         autoCompleteEnabled: true,

--- a/vscode/src/completions/inline-completion-item-provider.ts
+++ b/vscode/src/completions/inline-completion-item-provider.ts
@@ -455,7 +455,7 @@ export class InlineCompletionItemProvider
             }
 
             const latencyFeatureFlags: LatencyFeatureFlags = {
-                user: await featureFlagProvider.evaluateFeatureFlag(
+                user: await featureFlagProvider.evaluateFeatureFlagEphemerally(
                     FeatureFlag.CodyAutocompleteUserLatency
                 ),
             }

--- a/vscode/src/notifications/cody-pro-expiration.test.ts
+++ b/vscode/src/notifications/cody-pro-expiration.test.ts
@@ -45,8 +45,8 @@ describe('Cody Pro expiration notifications', () => {
         enabledFeatureFlags.clear()
         enabledFeatureFlags.add(FeatureFlag.UseSscForCodySubscription)
         enabledFeatureFlags.add(FeatureFlag.CodyProTrialEnded)
-        vi.spyOn(featureFlagProvider, 'evaluateFeatureFlag').mockImplementation((flag: FeatureFlag) =>
-            Promise.resolve(enabledFeatureFlags.has(flag))
+        vi.spyOn(featureFlagProvider, 'evaluateFeatureFlagEphemerally').mockImplementation(
+            (flag: FeatureFlag) => Promise.resolve(enabledFeatureFlags.has(flag))
         )
         vi.spyOn(graphqlClient, 'getCurrentUserCodySubscription').mockImplementation(async () => ({
             status: codyStatus,

--- a/vscode/src/notifications/cody-pro-expiration.ts
+++ b/vscode/src/notifications/cody-pro-expiration.ts
@@ -93,7 +93,7 @@ export class CodyProExpirationNotifications implements vscode.Disposable {
         const authStatus_ = currentAuthStatusOrNotReadyYet()
         if (!authStatus_?.authenticated || !isDotCom(authStatus_)) return
 
-        const useSscForCodySubscription = await featureFlagProvider.evaluateFeatureFlag(
+        const useSscForCodySubscription = await featureFlagProvider.evaluateFeatureFlagEphemerally(
             FeatureFlag.UseSscForCodySubscription
         )
         if (this.shouldSuppressNotifications()) return // Status may have changed during await
@@ -122,7 +122,7 @@ export class CodyProExpirationNotifications implements vscode.Disposable {
     }
 
     private async showNotification(): Promise<void> {
-        const codyProTrialEnded = await featureFlagProvider.evaluateFeatureFlag(
+        const codyProTrialEnded = await featureFlagProvider.evaluateFeatureFlagEphemerally(
             FeatureFlag.CodyProTrialEnded
         )
         if (this.shouldSuppressNotifications()) return // Status may have changed during await

--- a/vscode/src/prompts/prompts.ts
+++ b/vscode/src/prompts/prompts.ts
@@ -39,7 +39,7 @@ export async function mergedPromptsAndLegacyCommands(
     }
 
     const queryLower = query.toLowerCase()
-    const isUnifiedPromptsEnabled = await featureFlagProvider.evaluateFeatureFlag(
+    const isUnifiedPromptsEnabled = await featureFlagProvider.evaluateFeatureFlagEphemerally(
         FeatureFlag.CodyUnifiedPrompts
     )
 

--- a/vscode/src/tutorial/helpers.ts
+++ b/vscode/src/tutorial/helpers.ts
@@ -33,7 +33,9 @@ export const maybeStartInteractiveTutorial = async () => {
         },
     })
     await featureFlagProvider.refresh()
-    const enabled = await featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyInteractiveTutorial)
+    const enabled = await featureFlagProvider.evaluateFeatureFlagEphemerally(
+        FeatureFlag.CodyInteractiveTutorial
+    )
     logFirstEnrollmentEvent(FeatureFlag.CodyInteractiveTutorial, enabled)
     if (!enabled) {
         return

--- a/vscode/webviews/App.story.tsx
+++ b/vscode/webviews/App.story.tsx
@@ -27,7 +27,6 @@ const dummyVSCodeAPI: VSCodeWrapper = {
                 uiKindIsWeb: false,
                 experimentalNoodle: false,
                 smartApply: false,
-                unifiedPromptsAvailable: false,
             },
             authStatus: {
                 ...AUTH_STATUS_FIXTURE_AUTHED,

--- a/vscode/webviews/Chat.tsx
+++ b/vscode/webviews/Chat.tsx
@@ -32,7 +32,6 @@ interface ChatboxProps {
     showIDESnippetActions?: boolean
     setView: (view: View) => void
     smartApplyEnabled?: boolean
-    isUnifiedPromptsAvailable?: boolean
 }
 
 export const Chat: React.FunctionComponent<React.PropsWithChildren<ChatboxProps>> = ({
@@ -47,7 +46,6 @@ export const Chat: React.FunctionComponent<React.PropsWithChildren<ChatboxProps>
     showIDESnippetActions = true,
     setView,
     smartApplyEnabled,
-    isUnifiedPromptsAvailable,
 }) => {
     const telemetryRecorder = useTelemetryRecorder()
 
@@ -235,11 +233,7 @@ export const Chat: React.FunctionComponent<React.PropsWithChildren<ChatboxProps>
                 smartApplyEnabled={smartApplyEnabled}
             />
             {transcript.length === 0 && showWelcomeMessage && (
-                <WelcomeMessage
-                    IDE={userInfo.ide}
-                    setView={setView}
-                    isUnifiedPromptsAvailable={isUnifiedPromptsAvailable}
-                />
+                <WelcomeMessage IDE={userInfo.ide} setView={setView} />
             )}
             {scrollableParent && (
                 <ScrollDown scrollableParent={scrollableParent} onClick={handleScrollDownClick} />

--- a/vscode/webviews/CodyPanel.tsx
+++ b/vscode/webviews/CodyPanel.tsx
@@ -80,7 +80,6 @@ export const CodyPanel: FunctionComponent<
                     currentView={view}
                     setView={setView}
                     IDE={config.agentIDE || CodyIDE.VSCode}
-                    isUnifiedPromptsAvailable={config.unifiedPromptsAvailable}
                     onDownloadChatClick={onDownloadChatClick}
                 />
             )}
@@ -98,7 +97,6 @@ export const CodyPanel: FunctionComponent<
                         showWelcomeMessage={showWelcomeMessage}
                         scrollableParent={tabContainerRef.current}
                         smartApplyEnabled={smartApplyEnabled}
-                        isUnifiedPromptsAvailable={config.unifiedPromptsAvailable}
                         setView={setView}
                     />
                 )}

--- a/vscode/webviews/chat/components/WelcomeMessage.tsx
+++ b/vscode/webviews/chat/components/WelcomeMessage.tsx
@@ -1,4 +1,4 @@
-import { CodyIDE } from '@sourcegraph/cody-shared'
+import { CodyIDE, FeatureFlag } from '@sourcegraph/cody-shared'
 import {
     AtSignIcon,
     type LucideProps,
@@ -14,6 +14,7 @@ import { Kbd } from '../../components/Kbd'
 import { PromptListSuitedForNonPopover } from '../../components/promptList/PromptList'
 import { onPromptSelectInPanel, onPromptSelectInPanelActionLabels } from '../../prompts/PromptsTab'
 import type { View } from '../../tabs'
+import { useFeatureFlag } from '../../utils/useFeatureFlags'
 
 const MenuExample: FunctionComponent<{ children: React.ReactNode }> = ({ children }) => (
     <span className="tw-p-1 tw-rounded tw-text-keybinding-foreground tw-border tw-border-keybinding-border tw-bg-keybinding-background tw-whitespace-nowrap">
@@ -45,19 +46,16 @@ const localStorageKey = 'chat.welcome-message-dismissed'
 
 interface WelcomeMessageProps {
     IDE: CodyIDE
-    isUnifiedPromptsAvailable?: boolean
     setView: (view: View) => void
 }
 
-export const WelcomeMessage: FunctionComponent<WelcomeMessageProps> = ({
-    IDE,
-    isUnifiedPromptsAvailable,
-    setView,
-}) => {
+export const WelcomeMessage: FunctionComponent<WelcomeMessageProps> = ({ IDE, setView }) => {
     // Remove the old welcome message dismissal key that is no longer used.
     localStorage.removeItem(localStorageKey)
 
     const dispatchClientAction = useClientActionDispatcher()
+
+    const isUnifiedPromptsAvailable = useFeatureFlag(FeatureFlag.CodyUnifiedPrompts)
 
     return (
         <div className="tw-flex-1 tw-flex tw-flex-col tw-items-start tw-w-full tw-px-6 tw-gap-6 tw-transition-all">

--- a/vscode/webviews/tabs/TabsBar.tsx
+++ b/vscode/webviews/tabs/TabsBar.tsx
@@ -16,20 +16,20 @@ import {
 import { getVSCodeAPI } from '../utils/VSCodeApi'
 import { View } from './types'
 
-import { CodyIDE, isDefined } from '@sourcegraph/cody-shared'
+import { CodyIDE, FeatureFlag, isDefined } from '@sourcegraph/cody-shared'
 import { type FC, Fragment, forwardRef, useCallback, useMemo, useState } from 'react'
 import { Kbd } from '../components/Kbd'
 import { Tooltip, TooltipContent, TooltipTrigger } from '../components/shadcn/ui/tooltip'
 import { useConfig } from '../utils/useConfig'
 
 import { Button } from '../components/shadcn/ui/button'
+import { useFeatureFlag } from '../utils/useFeatureFlags'
 import styles from './TabsBar.module.css'
 import { getCreateNewChatCommand } from './utils'
 
 interface TabsBarProps {
     IDE: CodyIDE
     currentView: View
-    isUnifiedPromptsAvailable: boolean
     setView: (view: View) => void
     onDownloadChatClick?: () => void
 }
@@ -63,14 +63,8 @@ interface TabConfig {
     subActions?: TabSubAction[]
 }
 
-export const TabsBar: React.FC<TabsBarProps> = ({
-    currentView,
-    isUnifiedPromptsAvailable,
-    setView,
-    IDE,
-    onDownloadChatClick,
-}) => {
-    const tabItems = useTabs({ IDE, isUnifiedPromptsAvailable, onDownloadChatClick })
+export const TabsBar: React.FC<TabsBarProps> = ({ currentView, setView, IDE, onDownloadChatClick }) => {
+    const tabItems = useTabs({ IDE, onDownloadChatClick })
     const {
         config: { webviewType, multipleWebviewsEnabled },
     } = useConfig()
@@ -317,13 +311,12 @@ TabButton.displayName = 'TabButton'
  * Returns list of tabs and its sub-action buttons, used later as configuration for
  * tabs rendering in chat header.
  */
-function useTabs(
-    input: Pick<TabsBarProps, 'IDE' | 'isUnifiedPromptsAvailable' | 'onDownloadChatClick'>
-): TabConfig[] {
-    const { isUnifiedPromptsAvailable, IDE, onDownloadChatClick } = input
+function useTabs(input: Pick<TabsBarProps, 'IDE' | 'onDownloadChatClick'>): TabConfig[] {
+    const { IDE, onDownloadChatClick } = input
     const {
         config: { multipleWebviewsEnabled },
     } = useConfig()
+    const isUnifiedPromptsAvailable = useFeatureFlag(FeatureFlag.CodyUnifiedPrompts)
 
     return useMemo<TabConfig[]>(
         () =>

--- a/vscode/webviews/utils/useFeatureFlags.tsx
+++ b/vscode/webviews/utils/useFeatureFlags.tsx
@@ -1,4 +1,4 @@
-import type { FeatureFlagUsedInWebview } from '@sourcegraph/cody-shared'
+import type { FeatureFlag } from '@sourcegraph/cody-shared'
 import { useExtensionAPI, useObservable } from '@sourcegraph/prompt-editor'
 import { useMemo } from 'react'
 
@@ -8,7 +8,7 @@ import { useMemo } from 'react'
  * @returns `true` or `false` if the flag is exposed by the server endpoint, has been fetched, and
  * is not stale. Otherwise `undefined` (which callers should usually treat as `false`).
  */
-export function useFeatureFlag(flag: FeatureFlagUsedInWebview): boolean | undefined {
+export function useFeatureFlag(flag: FeatureFlag): boolean | undefined {
     const evaluatedFeatureFlag = useExtensionAPI().evaluatedFeatureFlag
     return useObservable(useMemo(() => evaluatedFeatureFlag(flag), [evaluatedFeatureFlag, flag])).value
 }


### PR DESCRIPTION
- Updates some places in code to watch feature flags instead of evaluating them once. This makes our application immediately reactive to changes in feature flag values, which means users can get the desired functionality without needing to restart their editor.
- Renames the `evaluateFeatureFlag` method to `evaluateFeatureFlagEphemerally`, deprecates it, documents when it may be safely used, and makes it cache the result.

This also reduces the latency of autocomplete after #5221 was merged because it makes `evaluateFeatureFlag` calls not hit the network each time (and each autocomplete calls that 1-2 times).
    
Fixes https://linear.app/sourcegraph/issue/CODY-3846/remove-most-uses-of-evaluatefeatureflag-method.

## Test plan

CI. Check that the unified prompts feature flag works correctly.