### PR TITLE
Enterprise: expand smart context window for all Claude Sonnet models

### DIFF
--- a/lib/shared/src/models/utils.ts
+++ b/lib/shared/src/models/utils.ts
@@ -134,7 +134,7 @@ function applyLocalTokenLimitOverwrite(
  * @returns True if the chat model supports extended context windows, false otherwise.
  */
 const modelWithExpandedWindowSubStrings = [
-    'claude-3-opus',
+    'opus',
     'sonnet', // Covers claude 3 sonnet & 3.5 sonnet
     'gemini-1.5',
     'gpt-4o',

--- a/lib/shared/src/models/utils.ts
+++ b/lib/shared/src/models/utils.ts
@@ -135,8 +135,7 @@ function applyLocalTokenLimitOverwrite(
  */
 const modelWithExpandedWindowSubStrings = [
     'claude-3-opus',
-    'claude-3-sonnet',
-    'claude-3-5-sonnet',
+    'sonnet', // Covers claude 3 sonnet & 3.5 sonnet
     'gemini-1.5',
     'gpt-4o',
     'gpt-4-turbo',

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -14,7 +14,7 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 
 - Chat: Fixed feedback buttons not working in chat. [pull/5509](https://github.com/sourcegraph/cody/pull/5509)
 - Command: Removed duplicated default commands from the Cody Commands menu that were incorrectly listed as custom commands.
-- Enterprise: Smart context window is now correctly set for all Claude Sonnet models configured on the server side.
+- Enterprise: Smart context window is now correctly set for all Claude Sonnet models configured on the server side. [pull/5677](https://github.com/sourcegraph/cody/pull/5677)
 
 ### Changed
 

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -14,6 +14,7 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 
 - Chat: Fixed feedback buttons not working in chat. [pull/5509](https://github.com/sourcegraph/cody/pull/5509)
 - Command: Removed duplicated default commands from the Cody Commands menu that were incorrectly listed as custom commands.
+- Enterprise: Smart context window is now correctly set for all Claude Sonnet models configured on the server side.
 
 ### Changed
 
@@ -24,8 +25,8 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 ## 1.34.3
 
 ### Fixed
-- Autocomplete Logging: Fix the diff for recent edits by replacing psDedent with ps to preserve the indentation. [pull/5574](https://github.com/sourcegraph/cody/pull/5574)
 
+- Autocomplete Logging: Fix the diff for recent edits by replacing psDedent with ps to preserve the indentation. [pull/5574](https://github.com/sourcegraph/cody/pull/5574)
 
 ## 1.34.2
 


### PR DESCRIPTION
Protential fix for https://linear.app/sourcegraph/issue/SRCH-1086

The changes expand the smart context window to cover additional Claude Sonnet models, including 'claude-3-sonnet' and 'claude-3-5-sonnet', in addition to the existing 'claude-3-opus' model. This ensures the smart context window is correctly set for all Claude Sonnet models configured on the server side, which is using the 3.5-sonnet instead of 3-5-sonnet substring.

This fixes an issue where server-side configurations using the claude-3.5-sonnet are assigned a basic context window (7k token limit) instead of the expanded context window, which has a 45k token limit.

![image](https://github.com/user-attachments/assets/040f23a0-a428-4778-91cc-cd984cbe2c1f)


## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

Try connecting to S2 and add a file with more than 7k token using @-mention to confirm you don't run into the context window limit.

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->

Enterprise: Smart context window is now correctly set for all Claude Sonnet models configured on the server side. [pull/5677](https://github.com/sourcegraph/cody/pull/5677)