### PR TITLE
Bump Cody Web version 0.9.0

### DIFF
--- a/web/CHANGELOG.md
+++ b/web/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.9.0
+- Big refactoring change around authorization (see [#5221](https://github.com/sourcegraph/cody/pull/5221))
+
 ## 0.8.3 
 - Fixes critical problem with auth flow on clear index db storage [#5621](https://github.com/sourcegraph/cody/pull/5621)
 

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sourcegraph/cody-web",
-  "version": "0.8.3",
+  "version": "0.9.0",
   "description": "Cody standalone web app",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
This is just a Cody Web bump PR in order to publish new version of cody chat with fixes from https://github.com/sourcegraph/cody/pull/5221

## Test plan
- CI is green

