### PR TITLE
Add a way to update agent recordings on Windows

### DIFF
--- a/agent/README.md
+++ b/agent/README.md
@@ -132,6 +132,15 @@ pnpm update-agent-recordings                  # run tests to update recordings
 pnpm run test agent/src/index.test.ts         # validate that tests are passing successfully in replay mode
 ```
 
+On Windows, install `gcloud` and the Sourcegraph client `src`, then:
+
+```powershell
+gcloud auth login  # log in to Sourcegraph
+Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass  # allow running scripts
+& .\agent\scripts\export-cody-http-recording-tokens.ps1
+pnpm update-agent-recordings-windows
+```
+
 Please post in #wg-cody-agent if you have problems getting the agent tests to
 pass after recording. Worst case, feel free to disable the agent tests by
 uncommenting the block of code in `index.test.ts`. See comment in the code for

--- a/agent/scripts/export-cody-http-recording-tokens.ps1
+++ b/agent/scripts/export-cody-http-recording-tokens.ps1
@@ -1,0 +1,8 @@
+# This is a PowerShell version of export-cody-http-recording-tokens.sh
+
+$Env:SRC_DOTCOM_PRO_ACCESS_TOKEN = & gcloud secrets versions access latest --secret CODY_PRO_ACCESS_TOKEN --project cody-agent-tokens --quiet
+$Env:SRC_ENTERPRISE_ACCESS_TOKEN = & gcloud secrets versions access latest --secret CODY_ENTERPRISE_ACCESS_TOKEN --project cody-agent-tokens --quiet
+$Env:SRC_S2_ACCESS_TOKEN = & gcloud secrets versions access latest --secret CODY_S2_ACCESS_TOKEN --project cody-agent-tokens --quiet
+$Env:SRC_DOTCOM_PRO_RATE_LIMIT_ACCESS_TOKEN = & gcloud secrets versions access latest --secret CODY_PRO_RATE_LIMITED_ACCESS_TOKEN --project cody-agent-tokens --quiet
+$Env:SRC_ACCESS_TOKEN_FREE_USER_WITH_RATE_LIMIT = & gcloud secrets versions access latest --secret CODY_FREE_RATE_LIMITED_ACCESS_TOKEN --project cody-agent-tokens --quiet
+$Env:SRC_ENDPOINT='https://sourcegraph.com'

--- a/agent/scripts/export-cody-http-recording-tokens.sh
+++ b/agent/scripts/export-cody-http-recording-tokens.sh
@@ -7,6 +7,8 @@
 #   pnpm update-agent-recordings
 #   pnpm update-rewrite-recordings
 #
+# If you change this script, please also update export-cody-http-recording-tokens.ps1
+#
 # Tips to update these secrets:
 #  - Use 1Password to find account passwords
 #  - Use no expiration dates when creating access tokens

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "test:local-e2e": "RUN_LOCAL_E2E_TESTS=true pnpm test agent/src/local-e2e/template.test.ts",
     "generate-agent-kotlin-bindings": "./agent/scripts/generate-agent-kotlin-bindings.sh",
     "update-agent-recordings": "pnpm build && CODY_KEEP_UNUSED_RECORDINGS=false CODY_RECORD_IF_MISSING=true vitest agent/src",
+    "update-agent-recordings-windows": "PowerShell -ExecutionPolicy Bypass -Command \"pnpm build; if ($?) { $Env:CODY_KEEP_UNUSED_RECORDINGS='false'; $Env:CODY_RECORD_IF_MISSING='true'; vitest agent/src }\"",
     "update-rewrite-recordings": "rm -rf recordings && CODY_RECORD_IF_MISSING=true vitest vscode/src/local-context/rewrite-keyword-query.test.ts",
     "openctx:link": "cd ../openctx && pnpm -C lib/client link --global && pnpm -C lib/schema link --global && pnpm -C lib/protocol link --global && pnpm -C client/vscode-lib link --global && cd ../cody && pnpm link --global @openctx/client && pnpm link --global @openctx/schema &&  pnpm link --global @openctx/protocol && cd vscode && pnpm link --global @openctx/vscode-lib",
     "openctx:unlink": "pnpm unlink --global @openctx/client && pnpm unlink --global @openctx/schema &&  pnpm unlink --global @openctx/protocol && cd vscode && pnpm unlink --global @openctx/vscode-lib",


### PR DESCRIPTION
## Test plan

Follow the steps in `agent/README.md`:

1. Install gcloud, src
2. Run the `agent/scripts/export-cody-http-recording-tokens.ps1`
3. `pnpm update-agent-recordings-windows`

This should produce new agent records, for example see #5688 