### PR TITLE
treat ChatBuilder (nee ChatModel) as having minimal state

### DIFF
--- a/agent/src/agent.ts
+++ b/agent/src/agent.ts
@@ -37,8 +37,8 @@ import {
     setUserAgent,
 } from '@sourcegraph/cody-shared'
 
+import { ChatBuilder } from '../../vscode/src/chat/chat-view/ChatBuilder'
 import { chatHistory } from '../../vscode/src/chat/chat-view/ChatHistoryManager'
-import { ChatModel } from '../../vscode/src/chat/chat-view/ChatModel'
 import type { ExtensionMessage, WebviewMessage } from '../../vscode/src/chat/protocol'
 import { ProtocolTextDocumentWithUri } from '../../vscode/src/jsonrpc/TextDocumentWithUri'
 import type * as agent_protocol from '../../vscode/src/jsonrpc/agent-protocol'
@@ -1243,8 +1243,8 @@ export class Agent extends MessageHandler implements ExtensionClient {
             const authStatus = currentAuthStatusAuthed()
             modelID ??= (await firstResultFromOperation(modelsService.getDefaultChatModel())) ?? ''
             const chatMessages = messages?.map(PromptString.unsafe_deserializeChatMessage) ?? []
-            const chatModel = new ChatModel(modelID, chatID, chatMessages)
-            await chatHistory.saveChat(authStatus, chatModel.toSerializedChatTranscript())
+            const chatBuilder = new ChatBuilder(modelID, chatID, chatMessages)
+            await chatHistory.saveChat(authStatus, chatBuilder.toSerializedChatTranscript())
             return this.createChatPanel(
                 Promise.resolve({
                     type: 'chat',

--- a/lib/shared/src/chat/preamble.ts
+++ b/lib/shared/src/chat/preamble.ts
@@ -1,3 +1,4 @@
+import type { ChatModel, EditModel } from '../models/types'
 import { type PromptString, ps } from '../prompt/prompt-string'
 import type { Message } from '../sourcegraph-api'
 
@@ -13,7 +14,7 @@ const SMART_APPLY_PREAMBLE = ps`If your answer contains fenced code blocks in Ma
 const CHAT_PREAMBLE = DEFAULT_PREAMBLE.concat(SMART_APPLY_PREAMBLE)
 
 export function getSimplePreamble(
-    model: string | undefined,
+    model: ChatModel | EditModel | undefined,
     apiVersion: number,
     type: 'Chat' | 'Default',
     preInstruction?: PromptString

--- a/lib/shared/src/cody-ignore/context-filters-provider.ts
+++ b/lib/shared/src/cody-ignore/context-filters-provider.ts
@@ -122,11 +122,14 @@ export class ContextFiltersProvider implements vscode.Disposable {
         }
     }
 
-    public get changes(): Observable<ContextFilters> {
-        return fromVSCodeEvent(listener => {
-            const dispose = this.onContextFiltersChanged(listener)
-            return { dispose }
-        })
+    public get changes(): Observable<ContextFilters | null> {
+        return fromVSCodeEvent(
+            listener => {
+                const dispose = this.onContextFiltersChanged(listener)
+                return { dispose }
+            },
+            () => this.lastContextFiltersResponse
+        )
     }
 
     private setContextFilters(contextFilters: ContextFilters): void {

--- a/lib/shared/src/models/modelsService.ts
+++ b/lib/shared/src/models/modelsService.ts
@@ -448,12 +448,24 @@ export class ModelsService {
     /**
      * Finds the model provider with the given model ID and returns its Context Window.
      */
-    public getContextWindowByID(modelID: string): ModelContextWindow {
+    public getContextWindowByID(modelID: string, models = this.models): ModelContextWindow {
         // TODO(sqs)#observe: remove synchronous access here, return an Observable<ModelContextWindow> instead
-        const model = this.models.find(m => m.id === modelID)
+        const model = models.find(m => m.id === modelID)
         return model
             ? model.contextWindow
             : { input: CHAT_INPUT_TOKEN_BUDGET, output: CHAT_OUTPUT_TOKEN_BUDGET }
+    }
+
+    public observeContextWindowByID(
+        modelID: string
+    ): Observable<ModelContextWindow | typeof pendingOperation> {
+        return this.modelsChanges.pipe(
+            map(data =>
+                data === pendingOperation
+                    ? pendingOperation
+                    : this.getContextWindowByID(modelID, data.primaryModels.concat(data.localModels))
+            )
+        )
     }
 
     public getModelByID(modelID: string): Model | undefined {

--- a/lib/shared/src/prompt/prompt-mixin.ts
+++ b/lib/shared/src/prompt/prompt-mixin.ts
@@ -1,4 +1,5 @@
 import type { ChatMessage } from '../chat/transcript/messages'
+import type { ChatModel } from '../models/types'
 import { PromptString, ps } from './prompt-string'
 
 /**
@@ -22,7 +23,7 @@ export class PromptMixin {
      * Prepends all mixins to `humanMessage`. Modifies and returns `humanMessage`.
      * Add hedging prevention prompt to specific models who need this.
      */
-    public static mixInto(humanMessage: ChatMessage, modelID: string): ChatMessage {
+    public static mixInto(humanMessage: ChatMessage, modelID: ChatModel | undefined): ChatMessage {
         // Default Mixin is added at the end so that it cannot be overriden by other mixins.
         let mixins = PromptString.join(
             [...PromptMixin.mixins, PromptMixin.contextMixin].map(mixin => mixin.prompt),
@@ -30,7 +31,7 @@ export class PromptMixin {
         )
 
         // Add prompt that prevents Claude 3.5 Sonnet from apologizing constantly.
-        if (modelID.includes('3-5-sonnet') || modelID.includes('3.5-sonnet')) {
+        if (modelID?.includes('3-5-sonnet') || modelID?.includes('3.5-sonnet')) {
             mixins = mixins.concat(HEDGES_PREVENTION)
         }
 

--- a/vscode/src/chat/chat-view/prompt.ts
+++ b/vscode/src/chat/chat-view/prompt.ts
@@ -5,13 +5,14 @@ import {
     type Message,
     PromptMixin,
     PromptString,
+    firstResultFromOperation,
     getSimplePreamble,
     isDefined,
     wrapInActiveSpan,
 } from '@sourcegraph/cody-shared'
 import { logDebug } from '../../log'
 import { PromptBuilder } from '../../prompt-builder'
-import type { ChatModel } from './ChatModel'
+import { ChatBuilder } from './ChatBuilder'
 
 export interface PromptInfo {
     prompt: Message[]
@@ -41,9 +42,10 @@ export class DefaultPrompter {
     //
     // Returns the reverse prompt and the new context that was used in the prompt for the current message.
     // If user-context added at the last message is ignored, returns the items in the newContextIgnored array.
-    public async makePrompt(chat: ChatModel, codyApiVersion: number): Promise<PromptInfo> {
+    public async makePrompt(chat: ChatBuilder, codyApiVersion: number): Promise<PromptInfo> {
         return wrapInActiveSpan('chat.prompter', async () => {
-            const promptBuilder = await PromptBuilder.create(chat.contextWindow)
+            const contextWindow = await firstResultFromOperation(ChatBuilder.contextWindowForChat(chat))
+            const promptBuilder = await PromptBuilder.create(contextWindow)
             const preInstruction: PromptString | undefined = PromptString.fromConfig(
                 vscode.workspace.getConfiguration('cody.chat'),
                 'preInstruction',
@@ -51,14 +53,10 @@ export class DefaultPrompter {
             )
 
             // Add preamble messages
-            const preambleMessages = getSimplePreamble(
-                chat.modelID,
-                codyApiVersion,
-                'Chat',
-                preInstruction
-            )
+            const chatModel = await firstResultFromOperation(ChatBuilder.resolvedModelForChat(chat))
+            const preambleMessages = getSimplePreamble(chatModel, codyApiVersion, 'Chat', preInstruction)
             if (!promptBuilder.tryAddToPrefix(preambleMessages)) {
-                throw new Error(`Preamble length exceeded context window ${chat.contextWindow.input}`)
+                throw new Error(`Preamble length exceeded context window ${contextWindow.input}`)
             }
 
             // Add existing chat transcript messages
@@ -77,7 +75,7 @@ export class DefaultPrompter {
                 !this.isCommand &&
                 Boolean(this.explicitContext.length || historyItems.length || this.corpusContext.length)
             ) {
-                reverseTranscript[0] = PromptMixin.mixInto(reverseTranscript[0], chat.modelID)
+                reverseTranscript[0] = PromptMixin.mixInto(reverseTranscript[0], chatModel)
             }
 
             const messagesIgnored = promptBuilder.tryAddMessages(reverseTranscript)

--- a/vscode/src/services/HistoryChat.ts
+++ b/vscode/src/services/HistoryChat.ts
@@ -4,7 +4,7 @@ import { chatHistory } from '../chat/chat-view/ChatHistoryManager'
 import { getChatPanelTitle } from '../chat/chat-view/chat-helpers'
 
 import { type AuthStatus, type ChatMessage, PromptString } from '@sourcegraph/cody-shared'
-import { prepareChatMessage } from '../chat/chat-view/ChatModel'
+import { prepareChatMessage } from '../chat/chat-view/ChatBuilder'
 import { getRelativeChatPeriod } from '../common/time-date'
 
 interface CodySidebarTreeItem {


### PR DESCRIPTION
Previously, the ChatModel was a source of truth and a cache. It cached the model that would be used for the next assistant message, and ChatController had to update that whenever the default chat model changed. Now, ChatBuilder (renamed from ChatModel to be less confusing) only stores the chat model *if* the user explicitly selected one; otherwise, its `model` is `undefined` and it is resolved to the default chat model as late as possible, when the chat is actually submitted. The actual chat model used is then stored in the message transcript.
    
This is better because ChatController does not need to worry about stale state being present in the ChatBuilder, except if the user's explicitly chosen model is no longer available on the endpoint, which is an error case that needs to be handled interactively (and isn't an error case that is just present because of our internal logic).    

Closes https://linear.app/sourcegraph/issue/CODY-3845/fix-chatcontroller-chipmunk-state.

Fixes https://linear.app/sourcegraph/issue/CODY-3835/chat-model-used-can-be-inconsistent-with-what-is-shown.

## Test plan

1. Sign into s2 and send a chat message with Claude 3 Haiku. Confirm it is sent using that model.
2. Switch accounts to dotcom and send a message with Gemini 1.5 Flash. Confirm it is sent using that model.
3. Switch back to s2 and confirm that the chat model selector defaults to Claude 3 Haiku. Without using the chat model selector, send another chat message and ensure it is sent using Claude 3 Haiku and not Gemini 1.5 Flash.

(Note: You can choose any models here as long as they are different on s2 and dotcom so you can see that it's properly resetting to the default.)