### PR TITLE
`Cody: Refresh Settings (Debug)` helper action

### DIFF
--- a/lib/shared/src/misc/observable.ts
+++ b/lib/shared/src/misc/observable.ts
@@ -29,6 +29,13 @@ export function subscriptionDisposable(sub: Unsubscribable): { dispose(): void }
 }
 
 /**
+ * Make a VS Code Disposable from an {@link Unsubscribable}.
+ */
+export function disposableSubscription(disposable: { dispose(): void }): Unsubscribable {
+    return { unsubscribe: () => disposable.dispose() }
+}
+
+/**
  * @internal For testing only.
  */
 export function observableOfSequence<T>(...values: T[]): Observable<T> {

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -368,6 +368,12 @@
         "title": "Switch Account…"
       },
       {
+        "command": "cody.auth.refresh",
+        "category": "Cody",
+        "title": "Refresh Settings (Debug)",
+        "enablement": "config.cody.internal.unstable"
+      },
+      {
         "command": "cody.settings.extension",
         "category": "Cody",
         "title": "Extension Settings",

--- a/vscode/src/services/AuthProvider.ts
+++ b/vscode/src/services/AuthProvider.ts
@@ -11,6 +11,7 @@ import {
     authStatus,
     combineLatest,
     currentResolvedConfig,
+    disposableSubscription,
     distinctUntilChanged,
     normalizeServerEndpointURL,
     pluck,
@@ -108,6 +109,12 @@ class AuthProvider implements vscode.Disposable {
 
         // Report auth changes.
         this.subscriptions.push(startAuthTelemetryReporter())
+
+        this.subscriptions.push(
+            disposableSubscription(
+                vscode.commands.registerCommand('cody.auth.refresh', () => this.refresh())
+            )
+        )
     }
 
     private async handleAuthTelemetry(authStatus: AuthStatus, signal?: AbortSignal): Promise<void> {


### PR DESCRIPTION
This VS Code action in the command palette only shows up when you have `cody.internal.unstable` set to `true` in your VS Code user settings. It causes Cody to re-authenticate to your current endpoint, which is useful for testing signin/account-switching behavior.

## Test plan

Use it and ensure it reloads auth by seeing it flash to unauthed and then authed again.