### PR TITLE
reset repo name->ID mapping when switching accounts

### DIFF
--- a/vscode/src/repository/repo-metadata-from-git-api.ts
+++ b/vscode/src/repository/repo-metadata-from-git-api.ts
@@ -28,6 +28,8 @@ class WorkspaceReposMonitor implements vscode.Disposable {
         this.disposables.push(
             subscriptionDisposable(
                 combineLatest([authStatus, this.workspaceRepoMapper.changes]).subscribe(() => {
+                    this.repoMetadata.clear()
+                    this.workspaceRepoMapper.clear()
                     for (const folderURI of this.getFolderURIs()) {
                         this.addWorkspaceFolder(folderURI)
                     }


### PR DESCRIPTION
Previously, the repo name->ID mapping was not cleared when switching accounts. This meant that if you were on one instance and switched to another, and if you had a chat that was open but had not sent any messages on it, then after switching accounts, the chat would return an error `Error retrieving context, no search context was used: Error: could not find repo with id ...`. The repo ID was the ID from the prior instance before the account switch. Now, it properly clears the mapping when you switch accounts.

This code is due for some improvements, but this fixes the immediate issue.

Fixes https://linear.app/sourcegraph/issue/CODY-3838/error-retrieving-context-could-not-find-repo-id-error-when-chatting.

## Test plan

As described above. Confirm there is no error.