### PR TITLE
do not show phantom OpenCtx editor status bar item

### DIFF
--- a/vscode/src/context/openctx.ts
+++ b/vscode/src/context/openctx.ts
@@ -90,7 +90,7 @@ export function exposeOpenCtxClient(
                     extensionId: context.extension.id,
                     secrets: context.secrets,
                     outputChannel: openctxOutputChannel!,
-                    features: isCodyWeb ? {} : { annotations: true, statusBar: true },
+                    features: isCodyWeb ? {} : { annotations: true },
                     providers: isCodyWeb
                         ? Observable.of(getCodyWebOpenCtxProviders())
                         : getOpenCtxProviders(authStatus, isValidSiteVersion),


### PR DESCRIPTION
Fixes https://linear.app/sourcegraph/issue/CODY-3885/openctx-status-bar-item-shows-in-cody-extension.

## Test plan

Run and ensure there is no empty OpenCtx status bar item.