### PR TITLE
switch to chat tab when clicking New Chat from another tab

### DIFF
--- a/vscode/webviews/tabs/TabsBar.tsx
+++ b/vscode/webviews/tabs/TabsBar.tsx
@@ -47,6 +47,7 @@ interface TabSubAction {
     command: string
     arg?: string | undefined | null
     callback?: () => void
+    changesView?: View
     confirmation?: {
         title: string
         description: string
@@ -83,7 +84,7 @@ export const TabsBar: React.FC<TabsBarProps> = ({ currentView, setView, IDE, onD
     )
 
     const handleSubActionClick = useCallback(
-        (action: Pick<TabSubAction, 'callback' | 'command' | 'arg'>) => {
+        (action: Pick<TabSubAction, 'callback' | 'command' | 'arg' | 'changesView'>) => {
             if (action.callback) {
                 action.callback()
             } else {
@@ -93,8 +94,11 @@ export const TabsBar: React.FC<TabsBarProps> = ({ currentView, setView, IDE, onD
                     arg: action.arg,
                 })
             }
+            if (action.changesView) {
+                setView(action.changesView)
+            }
         },
-        []
+        [setView]
     )
 
     return (
@@ -129,8 +133,10 @@ export const TabsBar: React.FC<TabsBarProps> = ({ currentView, setView, IDE, onD
                                     )}
                                 </>
                             }
+                            view={View.Chat}
                             onClick={() =>
                                 handleSubActionClick({
+                                    changesView: View.Chat,
                                     command: getCreateNewChatCommand({
                                         IDE,
                                         webviewType,


### PR DESCRIPTION
Fixes https://linear.app/sourcegraph/issue/CODY-3837/new-chat-button-does-not-focus-chat-sidebar-panel-if-clicked-on.

## Test plan

Open the chat view and go to the history tab. Press New Chat. Confirm it opens up the chat tab. Try clicking New Chat from the chat tab to ensure it doesn't do anything weird.

## Changelog

Fixes an issue where the "New Chat" button would not take you to the chat tab with your new chat.