### PR TITLE
Custom Commands: initialize in VSCode only

### DIFF
--- a/vscode/src/commands/services/provider.ts
+++ b/vscode/src/commands/services/provider.ts
@@ -41,7 +41,7 @@ export class CommandsProvider implements vscode.Disposable {
         }
 
         // Only initialize custom commands store in VS Code.
-        if (agentIDE === CodyIDE.VSCode) {
+        if (!agentIDE || agentIDE === CodyIDE.VSCode) {
             this.customCommandsStoreInit()
         }
 

--- a/vscode/src/commands/services/provider.ts
+++ b/vscode/src/commands/services/provider.ts
@@ -30,15 +30,19 @@ const vscodeDefaultCommands: CodyCommand[] = CodyCommandMenuItems.filter(
 export class CommandsProvider implements vscode.Disposable {
     private disposables: vscode.Disposable[] = []
     protected readonly commands = new Map<string, CodyCommand>()
-    protected customCommandsStore = new CustomCommandsManager()
+    protected customCommandsStore: CustomCommandsManager | undefined
 
     constructor() {
-        this.disposables.push(this.customCommandsStore)
-
-        if (getConfiguration().agentIDE !== CodyIDE.Web) {
+        const agentIDE = getConfiguration().agentIDE
+        if (agentIDE !== CodyIDE.Web) {
             for (const c of vscodeDefaultCommands) {
                 this.commands.set(c.key, c)
             }
+        }
+
+        // Only initialize custom commands store in VS Code.
+        if (agentIDE === CodyIDE.VSCode) {
+            this.customCommandsStoreInit()
         }
 
         // Cody Command Menus
@@ -54,13 +58,17 @@ export class CommandsProvider implements vscode.Disposable {
                 executeExplainHistoryCommand(this, a)
             )
         )
+    }
 
+    public customCommandsStoreInit(): void {
+        this.customCommandsStore = new CustomCommandsManager()
+        this.disposables.push(this.customCommandsStore)
         this.customCommandsStore.init()
         void this.customCommandsStore.refresh()
     }
 
     private async menu(type: 'custom' | 'config' | 'default', args?: CodyCommandArgs): Promise<void> {
-        const customCommands = [...this.customCommandsStore.commands.values()]
+        const customCommands = [...(this.customCommandsStore?.commands.values() ?? [])]
         // Display the configuration menu if there is no custom command.
         if (type === 'custom' && !customCommands.length) {
             return showCommandMenu('config', customCommands, args)
@@ -72,14 +80,14 @@ export class CommandsProvider implements vscode.Disposable {
      * A list of all available commands.
      */
     public list(): CodyCommand[] {
-        return [...this.customCommandsStore.commands.values(), ...this.commands.values()]
+        return [...(this.customCommandsStore?.commands.values() ?? []), ...this.commands.values()]
     }
 
     /**
      * Find a command by its id
      */
     public get(id: string): CodyCommand | undefined {
-        return this.commands.get(id) ?? this.customCommandsStore.commands.get(id)
+        return this.commands.get(id) ?? this.customCommandsStore?.commands.get(id)
     }
 
     /**


### PR DESCRIPTION
CLOSE https://linear.app/sourcegraph/issue/CODY-3679/in-non-vs-code-editors-remove-manage-link-from-commands-section-hide

 
The custom commands store is only supported in the VS Code, so this change ensures it is only initialized in that case. This avoids unnecessary initialization and also ensure the custom commands will not show up in non-VS Code environment.

## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

1. Verify the custom commands store is not initialized in the web app
2. Verify the custom commands store is initialized in the VS Code extension

When agentIDE is undefined (because VS Code doesn't run agent) or agentIDE is not equal to VS Code:

<img width="661" alt="image" src="https://github.com/user-attachments/assets/f57e3e7a-3e6c-4c3a-9e07-3ba80e56fe8d">

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
