### PR TITLE
Fix switching accounts auth problem

### DIFF
--- a/vscode/src/chat/chat-view/ChatController.ts
+++ b/vscode/src/chat/chat-view/ChatController.ts
@@ -38,7 +38,6 @@ import {
     currentAuthStatusAuthed,
     currentResolvedConfig,
     featureFlagProvider,
-    firstValueFrom,
     getContextForChatMessage,
     graphqlClient,
     hydrateAfterPostMessage,
@@ -566,11 +565,7 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
     }
 
     private async sendConfig(): Promise<void> {
-        const currentAuthStatus = await firstValueFrom(authStatus)
-        if (!currentAuthStatus) {
-            return
-        }
-
+        const authStatus = currentAuthStatus()
         const configForWebview = await this.getConfigForWebview()
         const workspaceFolderUris =
             vscode.workspace.workspaceFolders?.map(folder => folder.uri.toString()) ?? []
@@ -592,7 +587,7 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
         await this.postMessage({
             type: 'config',
             config: configForWebview,
-            authStatus: currentAuthStatus,
+            authStatus: authStatus,
             workspaceFolderUris,
             configFeatures: {
                 // If clientConfig is undefined means we were unable to fetch the client configuration -
@@ -603,7 +598,7 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
                 attribution: clientConfig?.attributionEnabled ?? false,
                 serverSentModels: clientConfig?.modelsAPIEnabled ?? false,
             },
-            isDotComUser: isDotCom(currentAuthStatus),
+            isDotComUser: isDotCom(authStatus),
         })
         logDebug('ChatController', 'updateViewConfig', {
             verbose: configForWebview,


### PR DESCRIPTION
Currently there is a problem that you can't switch account with new auth logic (after we make auth state reactive), my guess this is because we fire config event too late and in this method we wait for the last event which never will be emited because by the time we run send config we already missed this. 

This PR just tries to take the last auth value, I'm not sure that maybe I should use `currentAuthStatusOrNotReadyYet` instead, but I think it should be not possible to run into config event without non init auth status observable. 

## Test plan
- Try to switch accounts 
- Try to log out completely and sign in in multiple accounts 

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
