### PR TITLE
Fix auth flashes

### DIFF
--- a/lib/shared/src/auth/types.ts
+++ b/lib/shared/src/auth/types.ts
@@ -5,7 +5,7 @@ import type { CodyLLMSiteConfiguration } from '../sourcegraph-api/graphql/client
  * The authentication status, which includes representing the state when authentication failed or
  * has not yet been attempted.
  */
-export type AuthStatus = UnauthenticatedAuthStatus | AuthenticatedAuthStatus
+export type AuthStatus = UnauthenticatedAuthStatus | AuthenticatedAuthStatus | AuthenticatingAuthStatus
 
 /**
  * The authentication status for a user who has successfully authenticated.
@@ -51,6 +51,10 @@ export interface UnauthenticatedAuthStatus {
     authenticated: false
     showNetworkError?: boolean
     showInvalidAccessTokenError?: boolean
+}
+
+export interface AuthenticatingAuthStatus extends UnauthenticatedAuthStatus {
+    verifying: true
 }
 
 export const AUTH_STATUS_FIXTURE_AUTHED: AuthenticatedAuthStatus = {

--- a/lib/shared/src/auth/types.ts
+++ b/lib/shared/src/auth/types.ts
@@ -5,7 +5,7 @@ import type { CodyLLMSiteConfiguration } from '../sourcegraph-api/graphql/client
  * The authentication status, which includes representing the state when authentication failed or
  * has not yet been attempted.
  */
-export type AuthStatus = UnauthenticatedAuthStatus | AuthenticatedAuthStatus | AuthenticatingAuthStatus
+export type AuthStatus = UnauthenticatedAuthStatus | AuthenticatedAuthStatus
 
 /**
  * The authentication status for a user who has successfully authenticated.
@@ -40,6 +40,7 @@ export interface AuthenticatedAuthStatus {
      * buttons in the UI.
      */
     userCanUpgrade?: boolean
+    pendingValidation: boolean
 }
 
 /**
@@ -51,10 +52,7 @@ export interface UnauthenticatedAuthStatus {
     authenticated: false
     showNetworkError?: boolean
     showInvalidAccessTokenError?: boolean
-}
-
-export interface AuthenticatingAuthStatus extends UnauthenticatedAuthStatus {
-    verifying: true
+    pendingValidation: boolean
 }
 
 export const AUTH_STATUS_FIXTURE_AUTHED: AuthenticatedAuthStatus = {
@@ -63,11 +61,13 @@ export const AUTH_STATUS_FIXTURE_AUTHED: AuthenticatedAuthStatus = {
     username: 'alice',
     codyApiVersion: 1,
     siteVersion: '9999',
+    pendingValidation: false,
 }
 
 export const AUTH_STATUS_FIXTURE_UNAUTHED: AuthStatus & { authenticated: false } = {
     endpoint: 'https://example.com',
     authenticated: false,
+    pendingValidation: false,
 }
 
 export const AUTH_STATUS_FIXTURE_AUTHED_DOTCOM: AuthenticatedAuthStatus = {

--- a/vscode/src/auth/auth.ts
+++ b/vscode/src/auth/auth.ts
@@ -392,7 +392,7 @@ export async function validateCredentials(
     // An access token is needed except for Cody Web, which uses cookies.
     const isCodyWeb = config.configuration.agentIDE === CodyIDE.Web
     if (!config.auth.accessToken && !isCodyWeb) {
-        return { authenticated: false, endpoint: config.auth.serverEndpoint }
+        return { authenticated: false, endpoint: config.auth.serverEndpoint, pendingValidation: false }
     }
 
     // Check if credentials are valid and if Cody is enabled for the credentials and endpoint.
@@ -417,20 +417,26 @@ export async function validateCredentials(
         JSON.stringify({ siteHasCodyEnabled, siteVersion, codyLLMConfiguration, userInfo })
     )
     if (isError(userInfo) && isNetworkLikeError(userInfo)) {
-        return { authenticated: false, showNetworkError: true, endpoint: config.auth.serverEndpoint }
+        return {
+            authenticated: false,
+            showNetworkError: true,
+            endpoint: config.auth.serverEndpoint,
+            pendingValidation: false,
+        }
     }
     if (!userInfo || isError(userInfo)) {
         return {
             authenticated: false,
             endpoint: config.auth.serverEndpoint,
             showInvalidAccessTokenError: true,
+            pendingValidation: false,
         }
     }
     if (!siteHasCodyEnabled) {
         vscode.window.showErrorMessage(
             `Cody is not enabled on this Sourcegraph instance (${config.auth.serverEndpoint}). Ask a site administrator to enable it.`
         )
-        return { authenticated: false, endpoint: config.auth.serverEndpoint }
+        return { authenticated: false, endpoint: config.auth.serverEndpoint, pendingValidation: false }
     }
 
     const configOverwrites = isError(codyLLMConfiguration) ? undefined : codyLLMConfiguration

--- a/vscode/src/chat/chat-view/ChatController.ts
+++ b/vscode/src/chat/chat-view/ChatController.ts
@@ -594,6 +594,12 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
 
     private async sendConfig(): Promise<void> {
         const authStatus = currentAuthStatus()
+
+        // Don't emit config if we're verifying auth status to avoid UI auth flashes on the client
+        if ('verifying' in authStatus) {
+            return
+        }
+
         const configForWebview = await this.getConfigForWebview()
         const workspaceFolderUris =
             vscode.workspace.workspaceFolders?.map(folder => folder.uri.toString()) ?? []

--- a/vscode/src/chat/chat-view/ChatController.ts
+++ b/vscode/src/chat/chat-view/ChatController.ts
@@ -596,7 +596,7 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
         const authStatus = currentAuthStatus()
 
         // Don't emit config if we're verifying auth status to avoid UI auth flashes on the client
-        if ('verifying' in authStatus) {
+        if (authStatus.pendingValidation) {
             return
         }
 

--- a/vscode/src/chat/utils.test.ts
+++ b/vscode/src/chat/utils.test.ts
@@ -14,6 +14,7 @@ describe('validateAuthStatus', () => {
             endpoint: DOTCOM_URL.toString(),
             authenticated: false,
             showInvalidAccessTokenError: true,
+            pendingValidation: false,
         })
     })
 
@@ -36,6 +37,7 @@ describe('validateAuthStatus', () => {
             codyApiVersion: 2,
             siteVersion: '999',
             isFireworksTracingEnabled: false,
+            pendingValidation: false,
             primaryEmail: 'alice@example.com',
         })
     })
@@ -56,6 +58,7 @@ describe('validateAuthStatus', () => {
             isFireworksTracingEnabled: false,
             primaryEmail: undefined,
             requiresVerifiedEmail: false,
+            pendingValidation: false,
             siteVersion: '999',
             username: 'alice',
         })
@@ -70,6 +73,7 @@ describe('validateAuthStatus', () => {
         ).toStrictEqual<AuthStatus>({
             authenticated: false,
             endpoint: 'https://example.com',
+            pendingValidation: false,
             showInvalidAccessTokenError: true,
         })
     })
@@ -91,6 +95,7 @@ describe('validateAuthStatus', () => {
             username: 'alice',
             requiresVerifiedEmail: false,
             isFireworksTracingEnabled: false,
+            pendingValidation: false,
             primaryEmail: undefined,
         })
     })

--- a/vscode/src/chat/utils.ts
+++ b/vscode/src/chat/utils.ts
@@ -29,7 +29,12 @@ type NewAuthStatusOptions = { endpoint: string } & (
 
 export function newAuthStatus(options: NewAuthStatusOptions): AuthStatus {
     if (!options.authenticated) {
-        return { authenticated: false, endpoint: options.endpoint, showInvalidAccessTokenError: true }
+        return {
+            authenticated: false,
+            endpoint: options.endpoint,
+            showInvalidAccessTokenError: true,
+            pendingValidation: false,
+        }
     }
 
     const { endpoint, siteVersion, userOrganizations } = options
@@ -47,6 +52,7 @@ export function newAuthStatus(options: NewAuthStatusOptions): AuthStatus {
         requiresVerifiedEmail,
         hasVerifiedEmail,
         codyApiVersion,
+        pendingValidation: false,
         isFireworksTracingEnabled:
             isDotCom_ && !!userOrganizations?.nodes.find(org => org.name === 'sourcegraph'),
     }

--- a/vscode/src/services/AuthProvider.test.ts
+++ b/vscode/src/services/AuthProvider.test.ts
@@ -87,7 +87,7 @@ describe('AuthProvider', () => {
         // Initial emission.
         await vi.advanceTimersByTimeAsync(1)
         expect(values).toStrictEqual<typeof values>([
-            { authenticated: false, endpoint: 'https://example.com/' },
+            { authenticated: false, endpoint: 'https://example.com/', pendingValidation: true },
         ])
         clearValues()
         expect(validateCredentialsMock).toHaveBeenCalledTimes(1)
@@ -109,7 +109,7 @@ describe('AuthProvider', () => {
         } satisfies PartialDeep<ResolvedConfiguration> as ResolvedConfiguration)
         await vi.advanceTimersByTimeAsync(1)
         expect(values).toStrictEqual<typeof values>([
-            { authenticated: false, endpoint: 'https://other.example.com/' },
+            { authenticated: false, endpoint: 'https://other.example.com/', pendingValidation: true },
         ])
         clearValues()
         expect(validateCredentialsMock).toHaveBeenCalledTimes(2)
@@ -155,7 +155,7 @@ describe('AuthProvider', () => {
         // Initial emission.
         await vi.advanceTimersByTimeAsync(10)
         expect(values).toStrictEqual<typeof values>([
-            { authenticated: false, endpoint: 'https://example.com/' },
+            { authenticated: false, endpoint: 'https://example.com/', pendingValidation: true },
             authedAuthStatusAlice,
         ])
         clearValues()
@@ -208,7 +208,7 @@ describe('AuthProvider', () => {
         // Initial authentication.
         await vi.advanceTimersByTimeAsync(11)
         expect(values).toStrictEqual<typeof values>([
-            { authenticated: false, endpoint: 'https://example.com/' },
+            { authenticated: false, endpoint: 'https://example.com/', pendingValidation: true },
             authedAuthStatus,
         ])
         clearValues()
@@ -219,8 +219,9 @@ describe('AuthProvider', () => {
         authProvider.refresh()
         await vi.advanceTimersByTimeAsync(1)
         expect(values).toStrictEqual<typeof values>([
-            { authenticated: false, endpoint: 'https://example.com/' },
+            { authenticated: false, endpoint: 'https://example.com/', pendingValidation: true },
         ])
+
         clearValues()
 
         await vi.advanceTimersByTimeAsync(10)

--- a/vscode/src/services/AuthProvider.ts
+++ b/vscode/src/services/AuthProvider.ts
@@ -82,6 +82,7 @@ class AuthProvider implements vscode.Disposable {
                         // authentication status.
                         this.status.next({
                             authenticated: false,
+                            verifying: true,
                             endpoint: config.auth.serverEndpoint,
                         })
 

--- a/vscode/src/services/AuthProvider.ts
+++ b/vscode/src/services/AuthProvider.ts
@@ -82,7 +82,7 @@ class AuthProvider implements vscode.Disposable {
                         // authentication status.
                         this.status.next({
                             authenticated: false,
-                            verifying: true,
+                            pendingValidation: true,
                             endpoint: config.auth.serverEndpoint,
                         })
 
@@ -183,7 +183,7 @@ class AuthProvider implements vscode.Disposable {
 
     public setAuthPendingToEndpoint(endpoint: string): void {
         // TODO(sqs)#observe: store this pending endpoint in clientState instead of authStatus
-        this.status.next({ authenticated: false, endpoint })
+        this.status.next({ authenticated: false, endpoint, pendingValidation: true })
     }
 
     // Logs a telemetry event if the user has never authenticated to Sourcegraph.


### PR DESCRIPTION
This PR is on top of another fix for auth https://github.com/sourcegraph/cody/pull/5709

So, currently, you can see the log-out UI state when we're verifying the auth state. This PR tries to fix it on the extension side (so, in theory, we should fix this problem for all consumers). 

The fix is simple but I'm not sure we shouldn't send the configuration if we're verifying the auth state, maybe this prevent rendering logic should be on the client side and we just need to expose verify status information

## Test plan
- Try to run the VSCode extension and check you don't see log out screen if you're already signed in

