### PR TITLE
fix explicitly selected model on new chat is not reset on account switch

### DIFF
--- a/vscode/src/chat/chat-view/ChatBuilder.ts
+++ b/vscode/src/chat/chat-view/ChatBuilder.ts
@@ -94,7 +94,7 @@ export class ChatBuilder {
          * one, or else `undefined` to use the default chat model on the current endpoint at the
          * time the chat is sent.
          */
-        public selectedModel: ChatModel | undefined,
+        public selectedModel?: ChatModel | undefined,
 
         public readonly sessionID: string = new Date(Date.now()).toUTCString(),
         private messages: ChatMessage[] = [],

--- a/vscode/src/chat/chat-view/ChatsController.ts
+++ b/vscode/src/chat/chat-view/ChatsController.ts
@@ -438,7 +438,7 @@ export class ChatsController implements vscode.Disposable {
     ): Promise<ChatController> {
         const chatController = this.createChatController()
         if (chatID) {
-            await chatController.restoreSession(chatID)
+            chatController.restoreSession(chatID)
         }
 
         if (panel) {


### PR DESCRIPTION
If you are on endpoint E1 and choose a model M1 in a new chat that is NOT sent, and then switch accounts to endpoint E2, the model selector will show your default model for E2 but your unsent chat will, when sent, use the model M1, which is likely not valid on E2. Now, we reset the new chat when your endpoint changes, which eliminates this problem.

Fixes https://linear.app/sourcegraph/issue/CODY-3898/explicitly-selected-model-in-new-chat-is-not-overwritten-on-account.

## Test plan

As described above.