### PR TITLE
StateDebugOverlay debug helper for seeing state values in the webview

### DIFF
--- a/lib/shared/src/configuration.ts
+++ b/lib/shared/src/configuration.ts
@@ -52,6 +52,7 @@ interface RawClientConfiguration {
      */
     internalUnstable: boolean
     internalDebugContext?: boolean
+    internalDebugState?: boolean
 
     /**
      * Experimental autocomplete

--- a/lib/shared/src/misc/rpc/webviewAPI.ts
+++ b/lib/shared/src/misc/rpc/webviewAPI.ts
@@ -1,4 +1,5 @@
 import type { Observable } from 'observable-fns'
+import type { AuthStatus, ResolvedConfiguration } from '../..'
 import type { ChatMessage } from '../../chat/transcript/messages'
 import type { ContextItem } from '../../codebase-context/messages'
 import type { CodyCommand } from '../../commands/types'
@@ -40,6 +41,22 @@ export interface WebviewToExtensionAPI {
     setChatModel(model: Model['id']): Observable<void>
 
     detectIntent(text: string): Observable<ChatMessage['intent']>
+
+    /**
+     * Observe the current resolved configuration (same as the global {@link resolvedConfig}
+     * observable).
+     */
+    resolvedConfig(): Observable<ResolvedConfiguration>
+
+    /**
+     * Observe the current auth status (same as the global {@link authStatus} observable).
+     */
+    authStatus(): Observable<AuthStatus>
+
+    /**
+     * Observe the current transcript.
+     */
+    transcript(): Observable<readonly ChatMessage[]>
 }
 
 export function createExtensionAPI(
@@ -53,6 +70,9 @@ export function createExtensionAPI(
         highlights: proxyExtensionAPI(messageAPI, 'highlights'),
         setChatModel: proxyExtensionAPI(messageAPI, 'setChatModel'),
         detectIntent: proxyExtensionAPI(messageAPI, 'detectIntent'),
+        resolvedConfig: proxyExtensionAPI(messageAPI, 'resolvedConfig'),
+        authStatus: proxyExtensionAPI(messageAPI, 'authStatus'),
+        transcript: proxyExtensionAPI(messageAPI, 'transcript'),
     }
 }
 

--- a/vscode/src/chat/chat-view/ChatController.ts
+++ b/vscode/src/chat/chat-view/ChatController.ts
@@ -1,4 +1,10 @@
-import { type ChatModel, firstResultFromOperation, pendingOperation, ps } from '@sourcegraph/cody-shared'
+import {
+    type ChatModel,
+    firstResultFromOperation,
+    pendingOperation,
+    ps,
+    resolvedConfig,
+} from '@sourcegraph/cody-shared'
 import * as uuid from 'uuid'
 import * as vscode from 'vscode'
 
@@ -1746,6 +1752,10 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
                         promiseFactoryToObservable<ChatMessage['intent']>(() =>
                             this.detectChatIntent({ text })
                         ),
+                    resolvedConfig: () => resolvedConfig,
+                    authStatus: () => authStatus,
+                    transcript: () =>
+                        this.chatBuilder.changes.pipe(map(chat => chat.getDehydratedMessages())),
                 }
             )
         )

--- a/vscode/src/configuration.test.ts
+++ b/vscode/src/configuration.test.ts
@@ -91,6 +91,8 @@ describe('getConfiguration', () => {
                         return false
                     case 'cody.internal.debug.context':
                         return false
+                    case 'cody.internal.debug.state':
+                        return false
                     case 'cody.experimental.supercompletions':
                         return false
                     case 'cody.experimental.noodle':
@@ -141,6 +143,7 @@ describe('getConfiguration', () => {
             hasNativeWebview: true,
             internalUnstable: false,
             internalDebugContext: false,
+            internalDebugState: false,
             debugVerbose: true,
             debugFilter: /.*/,
             telemetryLevel: 'off',

--- a/vscode/src/configuration.ts
+++ b/vscode/src/configuration.ts
@@ -87,6 +87,7 @@ export function getConfiguration(
 
         internalUnstable: getHiddenSetting('internal.unstable', isTesting),
         internalDebugContext: getHiddenSetting('internal.debug.context', false),
+        internalDebugState: getHiddenSetting('internal.debug.state', false),
 
         autocompleteAdvancedModel: getHiddenSetting('autocomplete.advanced.model', null),
         autocompleteExperimentalGraphContext: getHiddenSetting<

--- a/vscode/src/testutils/mocks.ts
+++ b/vscode/src/testutils/mocks.ts
@@ -900,6 +900,7 @@ export const DEFAULT_VSCODE_SETTINGS = {
     telemetryLevel: 'all',
     internalUnstable: false,
     internalDebugContext: false,
+    internalDebugState: false,
     autocompleteAdvancedProvider: 'default',
     autocompleteAdvancedModel: null,
     autocompleteCompleteSuggestWidgetSelection: true,

--- a/vscode/webviews/AppWrapperForTest.tsx
+++ b/vscode/webviews/AppWrapperForTest.tsx
@@ -1,9 +1,12 @@
 import {
+    AUTH_STATUS_FIXTURE_AUTHED,
     type AuthStatus,
+    type ClientConfiguration,
     type ContextItem,
     type ContextItemSymbol,
     EMPTY,
     FILE_CONTEXT_MENTION_PROVIDER,
+    type ResolvedConfiguration,
     SYMBOL_CONTEXT_MENTION_PROVIDER,
     type SymbolKind,
     getDotComDefaultModels,
@@ -14,6 +17,7 @@ import { Observable } from 'observable-fns'
 import { type ComponentProps, type FunctionComponent, type ReactNode, useMemo } from 'react'
 import { URI } from 'vscode-uri'
 import { COMMON_WRAPPERS } from './AppWrapper'
+import { FIXTURE_TRANSCRIPT } from './chat/fixtures'
 import { FIXTURE_COMMANDS, makePromptsAPIWithData } from './components/promptList/fixtures'
 import { FIXTURE_PROMPTS } from './components/promptSelectField/fixtures'
 import { ComposedWrappers, type Wrapper } from './utils/composeWrappers'
@@ -80,6 +84,17 @@ export const AppWrapperForTest: FunctionComponent<{ children: ReactNode }> = ({ 
                     models: () => Observable.of(getDotComDefaultModels()),
                     setChatModel: () => EMPTY,
                     detectIntent: () => Observable.of(),
+                    resolvedConfig: () =>
+                        Observable.of({
+                            auth: { accessToken: 'abc', serverEndpoint: 'https://example.com' },
+                            configuration: {
+                                autocomplete: true,
+                                agentIDEVersion: '1.2.3',
+                                devModels: [{ model: 'my-model', provider: 'my-provider' }],
+                            } satisfies Partial<ClientConfiguration> as ClientConfiguration,
+                        } satisfies Partial<ResolvedConfiguration> as ResolvedConfiguration),
+                    authStatus: () => Observable.of(AUTH_STATUS_FIXTURE_AUTHED),
+                    transcript: () => Observable.of(FIXTURE_TRANSCRIPT.explainCode),
                 },
             } satisfies Wrapper<ComponentProps<typeof ExtensionAPIProviderForTestsOnly>['value']>,
             {

--- a/vscode/webviews/CodyPanel.tsx
+++ b/vscode/webviews/CodyPanel.tsx
@@ -5,6 +5,7 @@ import type { ConfigurationSubsetForWebview, LocalEnv } from '../src/chat/protoc
 import styles from './App.module.css'
 import { Chat } from './Chat'
 import { ConnectivityStatusBanner } from './components/ConnectivityStatusBanner'
+import { StateDebugOverlay } from './components/StateDebugOverlay'
 import { TabContainer, TabRoot } from './components/shadcn/ui/tabs'
 import { AccountTab, HistoryTab, PromptsTab, SettingsTab, TabsBar, View } from './tabs'
 
@@ -72,6 +73,7 @@ export const CodyPanel: FunctionComponent<
             orientation="vertical"
             className={styles.outerContainer}
         >
+            <StateDebugOverlay />
             {!authStatus.authenticated && authStatus.showNetworkError && <ConnectivityStatusBanner />}
 
             {/* Hide tab bar in editor chat panels. */}

--- a/vscode/webviews/components/StateDebugOverlay.tsx
+++ b/vscode/webviews/components/StateDebugOverlay.tsx
@@ -1,0 +1,84 @@
+import type { AuthStatus, ChatMessage, Model, ResolvedConfiguration } from '@sourcegraph/cody-shared'
+import { useExtensionAPI, useObservable } from '@sourcegraph/prompt-editor'
+import { type FunctionComponent, useMemo } from 'react'
+import { CollapsiblePanel } from './CollapsiblePanel'
+
+/**
+ * A component that displays the current state (configuration, auth status, models, etc.) at the top
+ * of the {@link CodyPanel}.
+ *
+ * To enable, set the `cody.internal.debug.state` user setting to `true`.
+ */
+export const StateDebugOverlay: FunctionComponent<Record<string, never>> = () => {
+    // First, only observe the resolvedConfig so that if this overlay is disabled, we don't incur the overhead of all the other observable subscriptions.
+    const resolvedConfig = useResolvedConfig()
+    return (
+        resolvedConfig?.configuration.internalDebugState && (
+            <StateDebugOverlayInner resolvedConfig={resolvedConfig} />
+        )
+    )
+}
+
+const StateDebugOverlayInner: FunctionComponent<{ resolvedConfig: ResolvedConfiguration }> = ({
+    resolvedConfig,
+}) => {
+    const authStatus = useAuthStatus()
+    const models = useChatModels()
+    const transcript = useTranscript()
+    return (
+        resolvedConfig?.configuration.internalDebugState && (
+            <div className="tw-p-3 tw-bg-background tw-max-h-[70vh] tw-overflow-auto tw-flex-shrink-0">
+                <h2
+                    className="tw-mt-1 tw-mb-3 tw-uppercase tw-font-bold tw-text-sm tw-text-muted-foreground"
+                    title="To hide, set the cody.internal.debug.state user setting to false."
+                >
+                    State Debug
+                </h2>
+                {(
+                    [
+                        { title: 'resolvedConfig', value: resolvedConfig },
+                        {
+                            title: `authStatus ${
+                                authStatus ? `(${authStatus.endpoint})` : '(undefined)'
+                            }`,
+                            value: authStatus,
+                        },
+                        { title: 'models', value: models },
+                        { title: 'transcript', value: transcript },
+                    ] satisfies { title: string; value: unknown }[]
+                ).map(({ title, value }) => (
+                    <CollapsiblePanel
+                        key={title}
+                        title={title}
+                        storageKey={`StateDebugOverlay-${title}`}
+                        className="tw-text-sm"
+                    >
+                        <pre className="tw-max-h-[40vh] tw-overflow-auto tw-text-xs">
+                            {JSON.stringify(value, null, 2)}
+                        </pre>
+                    </CollapsiblePanel>
+                ))}
+            </div>
+        )
+    )
+}
+
+function useResolvedConfig(): ResolvedConfiguration | undefined {
+    const resolvedConfig = useExtensionAPI().resolvedConfig
+    return useObservable(useMemo(() => resolvedConfig(), [resolvedConfig])).value
+}
+
+function useAuthStatus(): AuthStatus | undefined {
+    const authStatus = useExtensionAPI().authStatus
+    return useObservable(useMemo(() => authStatus(), [authStatus])).value
+}
+
+function useChatModels(): Model[] | undefined {
+    const models = useExtensionAPI().models
+    return useObservable(useMemo(() => models(), [models])).value
+}
+
+function useTranscript(): readonly ChatMessage[] | undefined {
+    const transcript = useExtensionAPI().transcript
+    return useObservable(useMemo(() => transcript(), [transcript])).value
+}


### PR DESCRIPTION
Adds a component that displays the current state (configuration, auth status, models, etc.) at the top of the CodyPanel to help when debugging. To enable, set the `cody.internal.debug.state` user setting to `true`.

<img width="660" alt="image" src="https://github.com/user-attachments/assets/01fd4490-a3a4-41df-a489-adea99b0bd10">


## Test plan

n/a