### PR TITLE
Improve chat context eval runner

### DIFF
--- a/agent/src/cli/command-bench/command-bench.ts
+++ b/agent/src/cli/command-bench/command-bench.ts
@@ -14,6 +14,7 @@ import { isDefined, modelsService } from '@sourcegraph/cody-shared'
 import { sleep } from '../../../../vscode/src/completions/utils'
 import { setStaticResolvedConfigurationWithAuthCredentials } from '../../../../vscode/src/configuration'
 import { localStorage } from '../../../../vscode/src/services/LocalStorageProvider'
+import { createOrUpdateTelemetryRecorderProvider } from '../../../../vscode/src/services/telemetry-v2'
 import { startPollyRecording } from '../../../../vscode/src/testutils/polly'
 import { dotcomCredentials } from '../../../../vscode/src/testutils/testing-credentials'
 import { allClientCapabilitiesEnabled } from '../../allClientCapabilitiesEnabled'
@@ -351,6 +352,8 @@ export const benchCommand = new commander.Command('bench')
 
 async function evaluateWorkspace(options: CodyBenchOptions, recordingDirectory: string): Promise<void> {
     console.log(`starting evaluation: fixture=${options.fixture.name} workspace=${options.workspace}`)
+
+    createOrUpdateTelemetryRecorderProvider(true)
 
     const workspaceRootUri = vscode.Uri.from({ scheme: 'file', path: options.workspace })
 

--- a/agent/src/cli/command-bench/strategy-chat-context-types.ts
+++ b/agent/src/cli/command-bench/strategy-chat-context-types.ts
@@ -12,10 +12,11 @@ export interface ClientOptions {
 
 export interface EvalOutput {
     evaluatedAt: string
+    codyClientVersion: string
     clientOptions: ClientOptions
     siteUserMetadata: {
         url: string
-        version: string
+        sourcegraphVersion: string
         username: string
         userId: string
         evaluatedFeatureFlags: Record<string, boolean>

--- a/agent/src/cli/command-bench/strategy-chat-context-types.ts
+++ b/agent/src/cli/command-bench/strategy-chat-context-types.ts
@@ -4,6 +4,24 @@ import { parse } from 'csv-parse/sync'
 import { createObjectCsvWriter } from 'csv-writer'
 import { mkdirp } from 'fs-extra'
 import isError from 'lodash/isError'
+import { stringify as yamlStringify } from 'yaml'
+
+export interface ClientOptions {
+    rewrite: boolean
+}
+
+export interface EvalOutput {
+    evaluatedAt: string
+    clientOptions: ClientOptions
+    siteUserMetadata: {
+        url: string
+        version: string
+        username: string
+        userId: string
+        evaluatedFeatureFlags: Record<string, boolean>
+    }
+    examples: ExampleOutput[]
+}
 
 export interface EvalContextItem {
     repoName: string
@@ -157,6 +175,21 @@ export async function readExamplesFromCSV(filePath: string): Promise<{
         examples,
         ignoredRecords,
     }
+}
+
+/**
+ * Note: this mutates evalOutput to remove the content field from actualContext context items.
+ */
+export async function writeYAMLMetadata(outputFile: string, evalOutput: EvalOutput): Promise<void> {
+    await mkdirp(path.dirname(outputFile))
+
+    for (const example of evalOutput.examples) {
+        for (const contextItem of example.actualContext) {
+            contextItem.content = undefined
+        }
+    }
+
+    await fs.writeFile(outputFile, yamlStringify(evalOutput))
 }
 
 export async function writeExamplesToCSV(outputFile: string, examples: ExampleOutput[]): Promise<void> {

--- a/agent/src/cli/command-bench/strategy-chat-context.ts
+++ b/agent/src/cli/command-bench/strategy-chat-context.ts
@@ -1,10 +1,5 @@
 import path from 'node:path'
-import {
-    PromptString,
-    SourcegraphCompletionsClient,
-    graphqlClient,
-    isError,
-} from '@sourcegraph/cody-shared'
+import { PromptString, graphqlClient, isError } from '@sourcegraph/cody-shared'
 import { SourcegraphNodeCompletionsClient } from '../../../../vscode/src/completions/nodeClient'
 import { rewriteKeywordQuery } from '../../../../vscode/src/local-context/rewrite-keyword-query'
 import { version } from '../../../package.json'

--- a/agent/src/cli/command-bench/strategy-chat-context.ts
+++ b/agent/src/cli/command-bench/strategy-chat-context.ts
@@ -7,6 +7,7 @@ import {
 } from '@sourcegraph/cody-shared'
 import { SourcegraphNodeCompletionsClient } from '../../../../vscode/src/completions/nodeClient'
 import { rewriteKeywordQuery } from '../../../../vscode/src/local-context/rewrite-keyword-query'
+import { version } from '../../../package.json'
 import type { RpcMessageHandler } from '../../jsonrpc-alias'
 import type { CodyBenchOptions } from './command-bench'
 import {
@@ -74,13 +75,15 @@ export async function evaluateChatContextStrategy(
     }
 
     const outputs = await runContextCommand({ rewrite: clientOptions.rewrite }, examples)
+    const codyClientVersion = process.env.CODY_COMMIT ?? version
     await writeExamplesToCSV(outputCSVFile, outputs)
     await writeYAMLMetadata(outputYAMLFile, {
         evaluatedAt: currentTimestamp,
         clientOptions,
+        codyClientVersion,
         siteUserMetadata: {
             url: options.srcEndpoint,
-            version: siteVersion,
+            sourcegraphVersion: siteVersion,
             username: userInfo?.username ?? '[none]',
             userId: userInfo?.id ?? '[none]',
             evaluatedFeatureFlags,


### PR DESCRIPTION
Previously, `cody internal bench` when running the `chat-context` strategy would emit an `output.csv` file. This was fine for a standalone eval run, but there was no way to easily compare results across different eval runs.

Update the `chat-context` strategy to do the following:
* Emit an output CSV whose name incorporates the following:
  * The input file name
  * The product version of the Sourcegraph instance run against
* Emits an output YAML file with the following metadata:
  * timestamp
  * Sourcegraph instance URL
  * Sourcegraph username and id of the access token used
  * evaluated feature flags returned for that user on that instance

Outputs from multiple runs will be displayed in the next version of cody-leaderboard-private.

## Test plan

Run

```
pnpm -C agent agent:skip-root-build internal bench --evaluation-config path/to/cody-leaderboard-private/chat-context-bench-v2.json --src-endpoint https://sourcegraph.sourcegraph.com --src-access-token $ACCESS_TOKEN
```
