### PR TITLE
Add matched range matches to context files

### DIFF
--- a/lib/shared/src/codebase-context/messages.ts
+++ b/lib/shared/src/codebase-context/messages.ts
@@ -2,6 +2,7 @@ import type { URI } from 'vscode-uri'
 
 import type { RangeData } from '../common/range'
 import type { Message } from '../sourcegraph-api'
+import type { Range } from '../sourcegraph-api/graphql/client'
 
 export type ContextFileType = 'file' | 'symbol'
 
@@ -169,6 +170,8 @@ export interface ContextItemFile extends ContextItemCommon {
      * that we need to resolve this context item mention via remote search file
      */
     remoteRepositoryName?: string
+
+    ranges?: Range[]
 }
 
 /**

--- a/lib/shared/src/sourcegraph-api/graphql/queries.ts
+++ b/lib/shared/src/sourcegraph-api/graphql/queries.ts
@@ -270,6 +270,38 @@ query GetCodyContext($repos: [ID!]!, $query: String!, $codeResultsCount: Int!, $
     }
 }`
 
+export const CONTEXT_SEARCH_QUERY_WITH_RANGES = `
+query GetCodyContext($repos: [ID!]!, $query: String!, $codeResultsCount: Int!, $textResultsCount: Int!, $filePatterns: [String!]) {
+	getCodyContext(repos: $repos, query: $query, codeResultsCount: $codeResultsCount, textResultsCount: $textResultsCount, filePatterns: $filePatterns) {
+        ...on FileChunkContext {
+            blob {
+                path
+                repository {
+                  id
+                  name
+                }
+                commit {
+                  oid
+                }
+                url
+              }
+              startLine
+              endLine
+              chunkContent
+              matchedRanges {
+                start {
+                  line
+                  column: character
+                }
+                end {
+                  line
+                  column: character
+                }
+              }
+        }
+    }
+}`
+
 export const CONTEXT_FILTERS_QUERY = `
 query ContextFilters {
     site {

--- a/vscode/src/chat/chat-view/ContextRetriever.ts
+++ b/vscode/src/chat/chat-view/ContextRetriever.ts
@@ -347,9 +347,8 @@ export class ContextRetriever implements vscode.Disposable {
             return []
         }
 
-        const remoteResultPromise = graphqlClient.contextSearch({ repoIDs, query, signal })
+        const remoteResult = await graphqlClient.contextSearch({ repoIDs, query, signal })
 
-        const remoteResult = await remoteResultPromise
         if (isError(remoteResult)) {
             throw remoteResult
         }
@@ -385,7 +384,7 @@ export class ContextRetriever implements vscode.Disposable {
     }
 }
 
-function contextSearchResultToContextItem(result: ContextSearchResult): ContextItem | undefined {
+function contextSearchResultToContextItem(result: ContextSearchResult): ContextItemFile | undefined {
     if (result.startLine < 0 || result.endLine < 0) {
         logDebug(
             'ContextRetriever',
@@ -404,6 +403,7 @@ function contextSearchResultToContextItem(result: ContextSearchResult): ContextI
         repoName: result.repoName,
         title: result.path,
         revision: result.commit,
+        ranges: result.ranges,
     }
 }
 

--- a/vscode/webviews/components/FileSnippet.tsx
+++ b/vscode/webviews/components/FileSnippet.tsx
@@ -1,7 +1,7 @@
-import type { ContextItem } from '@sourcegraph/cody-shared'
 import { useExtensionAPI } from '@sourcegraph/prompt-editor'
 import { type FC, useCallback, useMemo } from 'react'
 
+import type { ContextItemFile } from '@sourcegraph/cody-shared'
 import type { Observable } from 'observable-fns'
 import { useTelemetryRecorder } from '../utils/telemetry'
 import { useConfig } from '../utils/useConfig'
@@ -10,7 +10,7 @@ import { type FetchFileParameters, FileContentSearchResult } from './codeSnippet
 import type { ContentMatch } from './codeSnippet/types'
 
 interface FileSnippetProps {
-    item: ContextItem
+    item: ContextItemFile
     className?: string
 }
 
@@ -40,7 +40,7 @@ export const FileSnippet: FC<FileSnippetProps> = props => {
                 {
                     content: item.content ?? '',
                     contentStart: { line: Math.max(startLine - 1, 0), column: 0 },
-                    ranges: [],
+                    ranges: item.ranges ?? [],
                 },
             ],
         }


### PR DESCRIPTION
Closes https://linear.app/sourcegraph/issue/SRCH-978/highlight-results-with-keyword-matches-in-cody-chat-queries

This PR simply adds highlights ranges to the code blocks with search context files. 

<img width="719" alt="Screenshot 2024-09-26 at 22 09 38" src="https://github.com/user-attachments/assets/ba258320-82f0-46f6-b288-fb44cbc2a02a">

## Test plan
- Check that in Search mode in one box you have matched range highlights 

