### PR TITLE
Remove Client served models

### DIFF
--- a/agent/src/edit.test.ts
+++ b/agent/src/edit.test.ts
@@ -1,5 +1,5 @@
 import path from 'node:path'
-import { getDotComDefaultModels, modelsService } from '@sourcegraph/cody-shared'
+import { getMockedDotComClientModels, modelsService } from '@sourcegraph/cody-shared'
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
 import { TESTING_CREDENTIALS } from '../../vscode/src/testutils/testing-credentials'
 import { TestClient } from './TestClient'
@@ -16,7 +16,7 @@ describe('Edit', () => {
     })
 
     beforeAll(async () => {
-        vi.spyOn(modelsService, 'models', 'get').mockReturnValue(getDotComDefaultModels())
+        vi.spyOn(modelsService, 'models', 'get').mockReturnValue(getMockedDotComClientModels())
         await workspace.beforeAll()
         await client.beforeAll()
         await client.request('command/execute', { command: 'cody.search.index-update' })
@@ -55,7 +55,7 @@ describe('Edit', () => {
         await client.openFile(uri)
         const task = await client.request('editCommands/code', {
             instruction: 'Add types to these props. Introduce new interfaces as necessary',
-            model: modelsService.getModelByIDSubstringOrError('anthropic/claude-3-5-sonnet-20240620').id,
+            model: 'anthropic/claude-3-5-sonnet-20240620',
         })
         await client.acceptEditTask(uri, task)
         expect(client.documentText(uri)).toMatchInlineSnapshot(
@@ -107,7 +107,7 @@ describe('Edit', () => {
         const task = await client.request('editCommands/code', {
             instruction:
                 'Create and export a Heading component that uses these props. Do not use default exports',
-            model: modelsService.getModelByIDSubstringOrError('anthropic/claude-3-5-sonnet-20240620').id,
+            model: 'anthropic/claude-3-5-sonnet-20240620',
         })
         await client.acceptEditTask(uri, task)
         expect(client.documentText(uri)).toMatchInlineSnapshot(
@@ -136,7 +136,7 @@ describe('Edit', () => {
         await client.openFile(uri, { removeCursor: true })
         const task = await client.request('editCommands/code', {
             instruction: 'Convert this to use a switch statement',
-            model: modelsService.getModelByIDSubstringOrError('anthropic/claude-3-opus').id,
+            model: 'anthropic/claude-3-opus-20240229',
         })
         await client.acceptEditTask(uri, task)
         expect(client.documentText(uri)).toMatchInlineSnapshot(

--- a/lib/shared/src/index.ts
+++ b/lib/shared/src/index.ts
@@ -32,7 +32,7 @@ export {
     ModelUsage,
     type ModelContextWindow,
 } from './models/types'
-export { getDotComDefaultModels } from './models/dotcom'
+export { getMockedDotComClientModels, getMockedDotComServerModels } from './models/dotcom'
 export { ModelTag } from './models/tags'
 export {
     getProviderName,

--- a/lib/shared/src/models/dotcom.ts
+++ b/lib/shared/src/models/dotcom.ts
@@ -1,142 +1,178 @@
-import {
-    CHAT_INPUT_TOKEN_BUDGET,
-    CHAT_OUTPUT_TOKEN_BUDGET,
-    EXTENDED_CHAT_INPUT_TOKEN_BUDGET,
-    EXTENDED_USER_CONTEXT_TOKEN_BUDGET,
-} from '../token/constants'
-import type { Model } from './model'
-import { ModelTag } from './tags'
+import { type Model, type ServerModel, createModelFromServerModel } from './model'
+import type { ServerModelConfiguration } from './modelsService'
+import type { ModelTag } from './tags'
 
-import { type ModelContextWindow, ModelUsage } from './types'
+/**
+ * Copy of the DotCom model configuration API response from Sep 26 2024.
+ */
+const MOCKED_SERVER_MODELS_CONFIG = {
+    schemaVersion: '1.0',
+    revision: '0.0.0+dev',
+    providers: [
+        {
+            id: 'anthropic',
+            displayName: 'Anthropic',
+        },
+        {
+            id: 'fireworks',
+            displayName: 'Fireworks',
+        },
+        {
+            id: 'google',
+            displayName: 'Google',
+        },
+        {
+            id: 'openai',
+            displayName: 'OpenAI',
+        },
+        {
+            id: 'mistral',
+            displayName: 'Mistral',
+        },
+    ],
+    models: [
+        {
+            modelRef: 'anthropic::2023-06-01::claude-3.5-sonnet',
+            displayName: 'Claude 3.5 Sonnet',
+            modelName: 'claude-3-5-sonnet-20240620',
+            capabilities: ['edit', 'chat'],
+            category: 'balanced' as ModelTag.Balanced,
+            status: 'stable',
+            tier: 'free' as ModelTag.Free,
+            contextWindow: {
+                maxInputTokens: 45000,
+                maxOutputTokens: 4000,
+            },
+        },
+        {
+            modelRef: 'anthropic::2023-06-01::claude-3-opus',
+            displayName: 'Claude 3 Opus',
+            modelName: 'claude-3-opus-20240229',
+            capabilities: ['edit', 'chat'],
+            category: 'other',
+            status: 'stable',
+            tier: 'pro' as ModelTag.Pro,
+            contextWindow: {
+                maxInputTokens: 45000,
+                maxOutputTokens: 4000,
+            },
+        },
+        {
+            modelRef: 'anthropic::2023-06-01::claude-3-haiku',
+            displayName: 'Claude 3 Haiku',
+            modelName: 'claude-3-haiku-20240307',
+            capabilities: ['edit', 'chat'],
+            category: 'speed' as ModelTag.Speed,
+            status: 'stable',
+            tier: 'free' as ModelTag.Free,
+            contextWindow: {
+                maxInputTokens: 7000,
+                maxOutputTokens: 4000,
+            },
+        },
+        {
+            modelRef: 'fireworks::v1::starcoder',
+            displayName: 'StarCoder',
+            modelName: 'starcoder',
+            capabilities: ['autocomplete'],
+            category: 'speed' as ModelTag.Speed,
+            status: 'stable',
+            tier: 'pro' as ModelTag.Pro,
+            contextWindow: {
+                maxInputTokens: 2048,
+                maxOutputTokens: 256,
+            },
+        },
+        {
+            modelRef: 'fireworks::v1::deepseek-coder-v2-lite-base',
+            displayName: 'DeepSeek V2 Lite Base',
+            modelName: 'accounts/sourcegraph/models/deepseek-coder-v2-lite-base',
+            capabilities: ['autocomplete'],
+            category: 'speed' as ModelTag.Speed,
+            status: 'stable',
+            tier: 'pro' as ModelTag.Pro,
+            contextWindow: {
+                maxInputTokens: 2048,
+                maxOutputTokens: 256,
+            },
+        },
+        {
+            modelRef: 'google::v1::gemini-1.5-pro',
+            displayName: 'Gemini 1.5 Pro',
+            modelName: 'gemini-1.5-pro',
+            capabilities: ['edit', 'chat'],
+            category: 'balanced' as ModelTag.Balanced,
+            status: 'stable',
+            tier: 'free' as ModelTag.Free,
+            contextWindow: {
+                maxInputTokens: 45000,
+                maxOutputTokens: 4000,
+            },
+        },
+        {
+            modelRef: 'google::v1::gemini-1.5-flash',
+            displayName: 'Gemini 1.5 Flash',
+            modelName: 'gemini-1.5-flash',
+            capabilities: ['edit', 'chat'],
+            category: 'speed' as ModelTag.Speed,
+            status: 'stable',
+            tier: 'free' as ModelTag.Free,
+            contextWindow: {
+                maxInputTokens: 45000,
+                maxOutputTokens: 4000,
+            },
+        },
+        {
+            modelRef: 'openai::2024-02-01::gpt-4o',
+            displayName: 'GPT-4o',
+            modelName: 'gpt-4o',
+            capabilities: ['edit', 'chat'],
+            category: 'balanced' as ModelTag.Balanced,
+            status: 'stable',
+            tier: 'pro' as ModelTag.Pro,
+            contextWindow: {
+                maxInputTokens: 45000,
+                maxOutputTokens: 4000,
+            },
+        },
+        {
+            modelRef: 'openai::2024-02-01::cody-chat-preview-001',
+            displayName: 'OpenAI o1-preview',
+            modelName: 'cody-chat-preview-001',
+            capabilities: ['chat'],
+            category: 'accuracy',
+            status: 'waitlist' as ModelTag.Waitlist,
+            tier: 'pro' as ModelTag.Pro,
+            contextWindow: {
+                maxInputTokens: 45000,
+                maxOutputTokens: 4000,
+            },
+        },
+        {
+            modelRef: 'openai::2024-02-01::cody-chat-preview-002',
+            displayName: 'OpenAI o1-mini',
+            modelName: 'cody-chat-preview-002',
+            capabilities: ['chat'],
+            category: 'accuracy',
+            status: 'waitlist' as ModelTag.Waitlist,
+            tier: 'pro' as ModelTag.Pro,
+            contextWindow: {
+                maxInputTokens: 45000,
+                maxOutputTokens: 4000,
+            },
+        },
+    ],
+    defaultModels: {
+        chat: 'anthropic::2023-06-01::claude-3.5-sonnet',
+        fastChat: 'anthropic::2023-06-01::claude-3-haiku',
+        codeCompletion: 'fireworks::v1::deepseek-coder-v2-lite-base',
+    },
+} as const satisfies ServerModelConfiguration
 
-const basicContextWindow: ModelContextWindow = {
-    input: CHAT_INPUT_TOKEN_BUDGET,
-    output: CHAT_OUTPUT_TOKEN_BUDGET,
+export function getMockedDotComClientModels(): Model[] {
+    return MOCKED_SERVER_MODELS_CONFIG.models.map(createModelFromServerModel)
 }
 
-/**
- * Has a higher context window with a separate limit for user-context.
- */
-const expandedContextWindow: ModelContextWindow = {
-    input: EXTENDED_CHAT_INPUT_TOKEN_BUDGET,
-    output: CHAT_OUTPUT_TOKEN_BUDGET,
-    context: { user: EXTENDED_USER_CONTEXT_TOKEN_BUDGET },
-}
-
-/**
- * Returns an array of Models representing the default models for DotCom.
- * The order listed here is the order shown to users. Put the default LLM first.
- *
- * NOTE: The models MUST first be added to the custom chat models list in Cody Gateway.
- * @link https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/internal/completions/httpapi/chat.go?L48-51
- *
- * @returns An array of `Models` objects.
- * @deprecated This will be replaced with server-sent models
- */
-export const DEFAULT_DOT_COM_MODELS = [
-    // --------------------------------
-    // Powerful models
-    // --------------------------------
-    {
-        title: 'Claude 3.5 Sonnet',
-        id: 'anthropic/claude-3-5-sonnet-20240620',
-        provider: 'Anthropic',
-        usage: [ModelUsage.Chat, ModelUsage.Edit],
-        contextWindow: expandedContextWindow,
-        tags: [ModelTag.Gateway, ModelTag.Power, ModelTag.Recommended, ModelTag.Free],
-    },
-    {
-        title: 'Claude 3 Opus',
-        id: 'anthropic/claude-3-opus-20240229',
-        provider: 'Anthropic',
-        usage: [ModelUsage.Chat, ModelUsage.Edit],
-        contextWindow: expandedContextWindow,
-        tags: [ModelTag.Gateway, ModelTag.Pro, ModelTag.Power],
-    },
-    {
-        title: 'GPT-4o',
-        id: 'openai/gpt-4o',
-        provider: 'OpenAI',
-        usage: [ModelUsage.Chat, ModelUsage.Edit],
-        contextWindow: expandedContextWindow,
-        tags: [ModelTag.Gateway, ModelTag.Power, ModelTag.Pro],
-    },
-    {
-        title: 'Gemini 1.5 Pro',
-        id: 'google/gemini-1.5-pro',
-        provider: 'Google',
-        usage: [ModelUsage.Chat, ModelUsage.Edit],
-        contextWindow: expandedContextWindow,
-        tags: [ModelTag.Gateway, ModelTag.Power],
-    },
-
-    // --------------------------------
-    // Preview / Early Access
-    // --------------------------------
-    {
-        title: 'OpenAI o1-preview',
-        id: 'openai/cody-chat-preview-001',
-        provider: 'OpenAI',
-        usage: [ModelUsage.Chat, ModelUsage.Edit],
-        contextWindow: basicContextWindow,
-        tags: [
-            ModelTag.Gateway,
-            ModelTag.Power,
-            ModelTag.Pro,
-            ModelTag.Waitlist,
-            ModelTag.StreamDisabled,
-        ],
-    },
-    {
-        title: 'OpenAI o1-mini',
-        id: 'openai/cody-chat-preview-002',
-        provider: 'OpenAI',
-        usage: [ModelUsage.Chat, ModelUsage.Edit],
-        contextWindow: expandedContextWindow,
-        tags: [
-            ModelTag.Gateway,
-            ModelTag.Power,
-            ModelTag.Pro,
-            ModelTag.Waitlist,
-            ModelTag.StreamDisabled,
-        ],
-    },
-
-    // --------------------------------
-    // Faster models
-    // --------------------------------
-    {
-        title: 'Gemini 1.5 Flash',
-        id: 'google/gemini-1.5-flash',
-        provider: 'Google',
-        usage: [ModelUsage.Chat, ModelUsage.Edit],
-        contextWindow: expandedContextWindow,
-        tags: [ModelTag.Gateway, ModelTag.Speed],
-    },
-    {
-        title: 'Claude 3 Haiku',
-        id: 'anthropic/claude-3-haiku-20240307',
-        provider: 'Anthropic',
-        usage: [ModelUsage.Chat, ModelUsage.Edit],
-        contextWindow: basicContextWindow,
-        tags: [ModelTag.Gateway, ModelTag.Speed],
-    },
-    {
-        title: 'Mixtral 8x7B',
-        id: 'fireworks/accounts/fireworks/models/mixtral-8x7b-instruct',
-        provider: 'Mistral',
-        usage: [ModelUsage.Chat],
-        contextWindow: basicContextWindow,
-        tags: [ModelTag.Gateway, ModelTag.Speed],
-    },
-] as const satisfies Model[]
-
-/**
- * Returns an array of Models representing the default models for DotCom.
- *
- * @returns An array of `Models` objects.
- * @deprecated This will be replaced with server-sent models
- */
-export function getDotComDefaultModels(): Model[] {
-    return DEFAULT_DOT_COM_MODELS
+export function getMockedDotComServerModels(): ServerModel[] {
+    return MOCKED_SERVER_MODELS_CONFIG.models
 }

--- a/lib/shared/src/models/modelsService.test.ts
+++ b/lib/shared/src/models/modelsService.test.ts
@@ -5,7 +5,7 @@ import { AUTH_STATUS_FIXTURE_AUTHED, type AuthenticatedAuthStatus } from '../aut
 import { firstValueFrom } from '../misc/observable'
 import { DOTCOM_URL } from '../sourcegraph-api/environments'
 import { CHAT_INPUT_TOKEN_BUDGET, CHAT_OUTPUT_TOKEN_BUDGET } from '../token/constants'
-import { getDotComDefaultModels } from './dotcom'
+import { getMockedDotComClientModels } from './dotcom'
 import type { Model } from './model'
 import { createModel } from './model'
 import { type ModelsData, ModelsService, TestLocalStorageForModelPreferences } from './modelsService'
@@ -60,7 +60,7 @@ describe('modelsService', () => {
         })
 
         it('returns max token limit for known DotCom chat model ', () => {
-            const models = getDotComDefaultModels()
+            const models = getMockedDotComClientModels()
             const modelsService = modelsServiceWithModels(models)
             expect(models[0].id).toBeDefined()
             const cw = modelsService.getContextWindowByID(models[0].id)
@@ -68,13 +68,13 @@ describe('modelsService', () => {
         })
 
         it('returns max token limit for known DotCom chat model with higher context window (claude 3)', () => {
-            const models = getDotComDefaultModels()
+            const models = getMockedDotComClientModels()
             const modelsService = modelsServiceWithModels(models)
-            const claude3SonnetModelID = 'anthropic/claude-3-5-sonnet-20240620'
-            const claude3SonnetModel = modelsService.getModelByID(claude3SonnetModelID)
+            const claude3SonnetSubString = 'claude-3.5-sonnet'
+            const claude3SonnetModel = modelsService.getModelByIDSubstringOrError(claude3SonnetSubString)
             expect(claude3SonnetModel?.contextWindow?.context?.user).greaterThan(0)
             expect(claude3SonnetModel).toBeDefined()
-            const cw = modelsService.getContextWindowByID(claude3SonnetModelID)
+            const cw = modelsService.getContextWindowByID(claude3SonnetModel.id)
             expect(cw).toEqual(claude3SonnetModel?.contextWindow)
         })
 
@@ -103,7 +103,7 @@ describe('modelsService', () => {
         })
 
         it('returns max token limit for known chat model', () => {
-            const models = getDotComDefaultModels()
+            const models = getMockedDotComClientModels()
             const modelsService = modelsServiceWithModels(models)
             const knownModel = models[0]
             const { output } = modelsService.getContextWindowByID(knownModel.id)

--- a/lib/shared/src/models/types.ts
+++ b/lib/shared/src/models/types.ts
@@ -1,4 +1,4 @@
-import type { DEFAULT_DOT_COM_MODELS } from './dotcom'
+import type { getMockedDotComClientModels } from './dotcom'
 
 export enum ModelUsage {
     Chat = 'chat',
@@ -13,7 +13,7 @@ type HasUsage<T, I> = T extends { usage: readonly ModelUsage[] }
         : never
     : never
 
-type Models = typeof DEFAULT_DOT_COM_MODELS
+type Models = typeof getMockedDotComClientModels
 
 /**
  * Available models for Edit.

--- a/vscode/src/commands/scm/source-control.ts
+++ b/vscode/src/commands/scm/source-control.ts
@@ -8,7 +8,6 @@ import {
     type ModelContextWindow,
     ModelUsage,
     Typewriter,
-    getDotComDefaultModels,
     getSimplePreamble,
     modelsService,
     pluralize,
@@ -26,7 +25,7 @@ export class CodySourceControl implements vscode.Disposable {
     private disposables: vscode.Disposable[] = []
     private gitAPI: API | undefined
     private abortController: AbortController | undefined
-    private model: Model | undefined = getDotComDefaultModels().at(0)
+    private model: Model | undefined
 
     private commitTemplate?: string
 

--- a/vscode/webviews/AppWrapperForTest.tsx
+++ b/vscode/webviews/AppWrapperForTest.tsx
@@ -9,7 +9,7 @@ import {
     type ResolvedConfiguration,
     SYMBOL_CONTEXT_MENTION_PROVIDER,
     type SymbolKind,
-    getDotComDefaultModels,
+    getMockedDotComClientModels,
     promiseFactoryToObservable,
 } from '@sourcegraph/cody-shared'
 import { ClientStateContextProvider, ExtensionAPIProviderForTestsOnly } from '@sourcegraph/prompt-editor'
@@ -81,7 +81,7 @@ export const AppWrapperForTest: FunctionComponent<{ children: ReactNode }> = ({ 
                         commands: FIXTURE_COMMANDS,
                     }),
                     highlights: () => Observable.of([]),
-                    models: () => Observable.of(getDotComDefaultModels()),
+                    models: () => Observable.of(getMockedDotComClientModels()),
                     setChatModel: () => EMPTY,
                     detectIntent: () => Observable.of(),
                     resolvedConfig: () =>

--- a/vscode/webviews/components/modelSelectField/ModelSelectField.story.tsx
+++ b/vscode/webviews/components/modelSelectField/ModelSelectField.story.tsx
@@ -2,12 +2,12 @@ import type { Meta, StoryObj } from '@storybook/react'
 
 import { VSCodeStandaloneComponent } from '../../storybook/VSCodeStoryDecorator'
 
-import { type Model, ModelTag, ModelUsage, getDotComDefaultModels } from '@sourcegraph/cody-shared'
+import { type Model, ModelTag, ModelUsage, getMockedDotComClientModels } from '@sourcegraph/cody-shared'
 import { useArgs } from '@storybook/preview-api'
 import { ModelSelectField } from './ModelSelectField'
 
 const MODELS: Model[] = [
-    ...getDotComDefaultModels(),
+    ...getMockedDotComClientModels(),
     {
         title: 'Llama 3 q4_K f16',
         provider: 'Ollama',


### PR DESCRIPTION
Remove all the current usage of the client-side dotcom models from the codebase.
Replace with a copy of the server-side model config from DotCom as mock that can be use for testing.

## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

green CI

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
