### PR TITLE
Edit: use consistent model provider icon mapping

### DIFF
--- a/vscode/src/edit/input/get-items/model.ts
+++ b/vscode/src/edit/input/get-items/model.ts
@@ -8,27 +8,21 @@ import {
 import type { GetItemsResult } from '../quick-pick'
 import type { EditModelItem } from './types'
 
-const getModelProviderIcon = (provider: string): string => {
-    switch (provider) {
-        case 'anthropic':
-            return '$(anthropic-logo)'
-        case 'openAI':
-            return '$(openai-logo)'
-        case 'mistral':
-            return '$(mistral-logo)'
-        case 'ollama':
-            return '$(ollama-logo)'
-        case 'google':
-            return '$(gemini-logo)'
-        default:
-            return '$(cody-logo)'
-    }
+const MODEL_PROVIDER_ICONS: Record<string, string> = {
+    anthropic: '$(anthropic-logo)',
+    openai: '$(openai-logo)',
+    mistral: '$(mistral-logo)',
+    ollama: '$(ollama-logo)',
+    google: '$(gemini-logo)',
 }
+
+const getModelProviderIcon = (provider: string): string =>
+    MODEL_PROVIDER_ICONS[provider.toLowerCase()] || '$(cody-logo)'
 
 export const getModelOptionItems = (modelOptions: Model[], isCodyPro: boolean): EditModelItem[] => {
     const allOptions = modelOptions
         .map(modelOption => {
-            const icon = getModelProviderIcon(modelOption.provider.toLowerCase())
+            const icon = getModelProviderIcon(modelOption.provider)
             const title = modelOption.title || modelOption.id
             return {
                 label: `${QUICK_PICK_ITEM_EMPTY_INDENT_PREFIX} ${icon} ${title}`,


### PR DESCRIPTION
- Refactor `getModelProviderIcon` function to use a constant mapping object `MODEL_PROVIDER_ICONS` instead of a switch statement
- This makes the icon mapping more explicit and easier to maintain
- This also fixes an issue where OpenAI models are not using the correct logo because the capitalized "AI" in the previous switch map

## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

Check the Edit model dropdown list to confirm openAI models are showing the correct logo:

![image](https://github.com/user-attachments/assets/2e98390b-3973-45e4-b929-ed6761bc1cf1)

### Currently on main

OpenAI model (GPT-4o) is showing up with Cody logo instead of OpenAI logo.

![image](https://github.com/user-attachments/assets/0c64f4df-4510-4195-bc89-04dd54811c53)

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
