### PR TITLE
Autocomplete: reuse `generateCompletions` across providers

### DIFF
--- a/lib/shared/src/index.ts
+++ b/lib/shared/src/index.ts
@@ -23,6 +23,7 @@ export {
     createModelFromServerModel,
     modelTier,
     parseModelRef,
+    toLegacyModel,
 } from './models/model'
 export {
     type EditModel,

--- a/vscode/src/completions/inline-completion-item-provider-e2e.test.ts
+++ b/vscode/src/completions/inline-completion-item-provider-e2e.test.ts
@@ -103,10 +103,17 @@ class MockRequestProvider extends Provider {
         return {} as any as CodeCompletionsParams
     }
 
-    public async *generateCompletions(
-        options: GenerateCompletionsOptions,
+    public async generateCompletions(
+        generateOptions: GenerateCompletionsOptions,
         abortSignal: AbortSignal
-    ): AsyncGenerator<FetchCompletionResult[]> {
+    ): Promise<AsyncGenerator<FetchCompletionResult[]>> {
+        return this.responseGenerator(generateOptions, abortSignal)
+    }
+
+    public async *responseGenerator(
+        generateOptions: GenerateCompletionsOptions,
+        abortSignal: AbortSignal
+    ) {
         abortSignal.addEventListener('abort', () => {
             this.didAbort = true
         })

--- a/vscode/src/completions/providers/expopenaicompatible.ts
+++ b/vscode/src/completions/providers/expopenaicompatible.ts
@@ -3,17 +3,7 @@
 
 import type { CodeCompletionsParams } from '@sourcegraph/cody-shared'
 
-import { forkSignal, generatorWithTimeout, zipGenerators } from '../utils'
-import {
-    type FetchCompletionResult,
-    fetchAndProcessDynamicMultilineCompletions,
-} from './shared/fetch-and-process-completions'
-import {
-    type CompletionProviderTracer,
-    type GenerateCompletionsOptions,
-    Provider,
-    type ProviderFactoryParams,
-} from './shared/provider'
+import { type GenerateCompletionsOptions, Provider, type ProviderFactoryParams } from './shared/provider'
 
 // Model identifiers (we are the source/definition for these in case of the openaicompatible provider.)
 const MODEL_MAP = {
@@ -82,54 +72,6 @@ class ExpOpenAICompatibleProvider extends Provider {
             messages,
             model,
         }
-    }
-
-    public async generateCompletions(
-        generateOptions: GenerateCompletionsOptions,
-        abortSignal: AbortSignal,
-        tracer?: CompletionProviderTracer
-    ): Promise<AsyncGenerator<FetchCompletionResult[]>> {
-        const { numberOfCompletionsToGenerate, docContext } = generateOptions
-
-        const requestParams = this.getRequestParams(generateOptions)
-        tracer?.params(requestParams)
-
-        const completionsGenerators = Array.from({ length: numberOfCompletionsToGenerate }).map(
-            async () => {
-                const abortController = forkSignal(abortSignal)
-
-                const completionResponseGenerator = generatorWithTimeout(
-                    await this.client.complete(requestParams, abortController),
-                    requestParams.timeoutMs,
-                    abortController
-                )
-
-                return fetchAndProcessDynamicMultilineCompletions({
-                    completionResponseGenerator,
-                    abortController,
-                    generateOptions,
-                    providerSpecificPostProcess: content =>
-                        this.modelHelper.postProcess(content, docContext),
-                })
-            }
-        )
-
-        /**
-         * This implementation waits for all generators to yield values
-         * before passing them to the consumer (request-manager). While this may appear
-         * as a performance bottleneck, it's necessary for the current design.
-         *
-         * The consumer operates on promises, allowing only a single resolve call
-         * from `requestManager.request`. Therefore, we must wait for the initial
-         * batch of completions before returning them collectively, ensuring all
-         * are included as suggested completions.
-         *
-         * To circumvent this performance issue, a method for adding completions to
-         * the existing suggestion list is needed. Presently, this feature is not
-         * available, and the switch to async generators maintains the same behavior
-         * as with promises.
-         */
-        return zipGenerators(await Promise.all(completionsGenerators))
     }
 }
 

--- a/vscode/src/completions/providers/openaicompatible.ts
+++ b/vscode/src/completions/providers/openaicompatible.ts
@@ -1,18 +1,8 @@
 import { type CodeCompletionsParams, charsToTokens, logError } from '@sourcegraph/cody-shared'
 
-import { forkSignal, generatorWithTimeout, zipGenerators } from '../utils'
-
 import { logDebug } from '../../log'
-import {
-    type FetchCompletionResult,
-    fetchAndProcessDynamicMultilineCompletions,
-} from './shared/fetch-and-process-completions'
-import {
-    type CompletionProviderTracer,
-    type GenerateCompletionsOptions,
-    Provider,
-    type ProviderFactoryParams,
-} from './shared/provider'
+
+import { type GenerateCompletionsOptions, Provider, type ProviderFactoryParams } from './shared/provider'
 
 class OpenAICompatibleProvider extends Provider {
     public getRequestParams(options: GenerateCompletionsOptions): CodeCompletionsParams {
@@ -31,54 +21,6 @@ class OpenAICompatibleProvider extends Provider {
             ...this.defaultRequestParams,
             messages,
         }
-    }
-
-    public async generateCompletions(
-        generateOptions: GenerateCompletionsOptions,
-        abortSignal: AbortSignal,
-        tracer?: CompletionProviderTracer
-    ): Promise<AsyncGenerator<FetchCompletionResult[]>> {
-        const { docContext, numberOfCompletionsToGenerate } = generateOptions
-
-        const requestParams = this.getRequestParams(generateOptions)
-        tracer?.params(requestParams)
-
-        const completionsGenerators = Array.from({ length: numberOfCompletionsToGenerate }).map(
-            async () => {
-                const abortController = forkSignal(abortSignal)
-
-                const completionResponseGenerator = generatorWithTimeout(
-                    await this.client.complete(requestParams, abortController),
-                    requestParams.timeoutMs,
-                    abortController
-                )
-
-                return fetchAndProcessDynamicMultilineCompletions({
-                    completionResponseGenerator,
-                    abortController,
-                    generateOptions,
-                    providerSpecificPostProcess: content =>
-                        this.modelHelper.postProcess(content, docContext),
-                })
-            }
-        )
-
-        /**
-         * This implementation waits for all generators to yield values
-         * before passing them to the consumer (request-manager). While this may appear
-         * as a performance bottleneck, it's necessary for the current design.
-         *
-         * The consumer operates on promises, allowing only a single resolve call
-         * from `requestManager.request`. Therefore, we must wait for the initial
-         * batch of completions before returning them collectively, ensuring all
-         * are included as suggested completions.
-         *
-         * To circumvent this performance issue, a method for adding completions to
-         * the existing suggestion list is needed. Presently, this feature is not
-         * available, and the switch to async generators maintains the same behavior
-         * as with promises.
-         */
-        return zipGenerators(await Promise.all(completionsGenerators))
     }
 }
 

--- a/vscode/src/completions/providers/shared/create-provider.ts
+++ b/vscode/src/completions/providers/shared/create-provider.ts
@@ -11,6 +11,7 @@ import {
     modelsService,
     pendingOperation,
     switchMapReplayOperation,
+    toLegacyModel,
 } from '@sourcegraph/cody-shared'
 
 import { createProvider as createAnthropicProvider } from '../anthropic'
@@ -21,7 +22,6 @@ import { createProvider as createGeminiProviderConfig } from '../google'
 import { createProvider as createOpenAICompatibleProviderConfig } from '../openaicompatible'
 import { createProvider as createUnstableOpenAIProviderConfig } from '../unstable-openai'
 
-import { toLegacyModel } from '@sourcegraph/cody-shared/src/models/model'
 import { getDotComExperimentModel } from './get-experiment-model'
 import { parseProviderAndModel } from './parse-provider-and-model'
 import type { Provider, ProviderFactory } from './provider'

--- a/vscode/src/completions/providers/shared/provider.ts
+++ b/vscode/src/completions/providers/shared/provider.ts
@@ -7,11 +7,13 @@ import {
     type CodeCompletionsClient,
     type CodeCompletionsParams,
     type CompletionParameters,
+    type CompletionResponseGenerator,
     type DocumentContext,
     type GitContext,
     type LegacyModelRefStr,
     type Model,
     currentAuthStatusAuthed,
+    toLegacyModel,
     tokensToChars,
 } from '@sourcegraph/cody-shared'
 
@@ -20,10 +22,13 @@ import type { TriggerKind } from '../../get-inline-completions'
 import type * as CompletionLogger from '../../logger'
 import { type DefaultModel, getModelHelpers } from '../../model-helpers'
 import type { InlineCompletionItemWithAnalytics } from '../../text-processing/process-inline-completions'
+import { forkSignal, generatorWithErrorObserver, generatorWithTimeout, zipGenerators } from '../../utils'
 
-import { toLegacyModel } from '@sourcegraph/cody-shared/src/models/model'
 import type { AutocompleteProviderConfigSource } from './create-provider'
-import type { FetchCompletionResult } from './fetch-and-process-completions'
+import {
+    type FetchCompletionResult,
+    fetchAndProcessDynamicMultilineCompletions,
+} from './fetch-and-process-completions'
 
 export const MAX_RESPONSE_TOKENS = 256
 
@@ -144,41 +149,21 @@ export abstract class Provider {
     public contextSizeHints: ProviderContextSizeHints
     public client: CodeCompletionsClient = defaultCodeCompletionsClient.instance!
     public configSource: AutocompleteProviderConfigSource
+    public mayUseOnDeviceInference: boolean
 
     protected maxContextTokens: number
-
     protected promptChars: number
     protected modelHelper: DefaultModel
 
-    public mayUseOnDeviceInference: boolean
-
-    public stopSequences: string[] = ['\n\n', '\n\r\n']
-
     protected defaultRequestParams = {
         timeoutMs: 7_000,
-        stopSequences: this.stopSequences,
+        stopSequences: ['\n\n', '\n\r\n'],
         maxTokensToSample: MAX_RESPONSE_TOKENS,
         temperature: 0.2,
         topK: 0,
     } as const satisfies Omit<CodeCompletionsParams, 'messages'>
 
-    /**
-     * Returns the passed model ID only if we're using Cody Gateway (not BYOK) and
-     * the model ID is resolved on the client.
-     */
-    protected maybeFilterOutModel(
-        model?: typeof BYOK_MODEL_ID_FOR_LOGS | LegacyModelRefStr
-    ): LegacyModelRefStr | undefined {
-        if (!model || model === BYOK_MODEL_ID_FOR_LOGS) {
-            return undefined
-        }
-
-        const { configOverwrites } = currentAuthStatusAuthed()
-
-        // The model ID is ignored by BYOK clients (configOverwrites?.provider !== 'sourcegraph')
-        // so we can remove it from the request params we send to the backend.
-        return configOverwrites?.provider === 'sourcegraph' ? model : undefined
-    }
+    private isModernSourcegraphInstanceWithoutModelAllowlist = true
 
     constructor(public readonly options: Readonly<ProviderOptions>) {
         const {
@@ -211,11 +196,110 @@ export abstract class Provider {
 
     public abstract getRequestParams(options: GenerateCompletionsOptions): object
 
-    public abstract generateCompletions(
-        options: GenerateCompletionsOptions,
+    /**
+     * Returns the passed model ID only if we're using Cody Gateway (not BYOK) and
+     * the model ID is resolved on the client.
+     */
+    protected maybeFilterOutModel(
+        model?: typeof BYOK_MODEL_ID_FOR_LOGS | LegacyModelRefStr
+    ): LegacyModelRefStr | undefined {
+        if (
+            model === BYOK_MODEL_ID_FOR_LOGS ||
+            !model ||
+            !this.isModernSourcegraphInstanceWithoutModelAllowlist
+        ) {
+            return undefined
+        }
+
+        const { configOverwrites } = currentAuthStatusAuthed()
+
+        // The model ID is ignored by BYOK clients (configOverwrites?.provider !== 'sourcegraph')
+        // so we can remove it from the request params we send to the backend.
+        return configOverwrites?.provider === 'sourcegraph' ? model : undefined
+    }
+
+    protected getCompletionResponseGenerator(
+        generateOptions: GenerateCompletionsOptions,
+        requestParams: CodeCompletionsParams,
+        abortController: AbortController
+    ): Promise<CompletionResponseGenerator> {
+        return Promise.resolve(this.client.complete(requestParams, abortController))
+    }
+
+    public async generateCompletions(
+        generateOptions: GenerateCompletionsOptions,
         abortSignal: AbortSignal,
         tracer?: CompletionProviderTracer
-    ): AsyncGenerator<FetchCompletionResult[]> | Promise<AsyncGenerator<FetchCompletionResult[]>>
+    ): Promise<AsyncGenerator<FetchCompletionResult[]>> {
+        const { docContext, numberOfCompletionsToGenerate } = generateOptions
+
+        const requestParams = this.getRequestParams(generateOptions) as CodeCompletionsParams
+        tracer?.params(requestParams)
+
+        const completionsGenerators = Array.from({ length: numberOfCompletionsToGenerate }).map(
+            async () => {
+                const abortController = forkSignal(abortSignal)
+
+                const completionResponseGenerator = generatorWithErrorObserver(
+                    generatorWithTimeout(
+                        await this.getCompletionResponseGenerator(
+                            generateOptions,
+                            requestParams,
+                            abortController
+                        ),
+                        requestParams.timeoutMs,
+                        abortController
+                    ),
+                    error => {
+                        if (error instanceof Error) {
+                            // If an "unsupported code completion model" error is thrown,
+                            // it's most likely because we started adding the `model` identifier to
+                            // requests to ensure the clients does not crash when the default site
+                            // config value changes.
+                            //
+                            // Older instances do not allow for the `model` to be set, even to
+                            // identifiers it supports and thus the error.
+                            //
+                            // If it happens once, we disable the behavior where the client includes a
+                            // `model` parameter.
+                            if (
+                                error.message.includes('Unsupported code completion model') ||
+                                error.message.includes('Unsupported chat model') ||
+                                error.message.includes('Unsupported custom model')
+                            ) {
+                                this.isModernSourcegraphInstanceWithoutModelAllowlist = false
+                            }
+                        }
+                    }
+                )
+
+                return fetchAndProcessDynamicMultilineCompletions({
+                    completionResponseGenerator,
+                    abortController,
+                    generateOptions,
+                    providerSpecificPostProcess: content =>
+                        this.modelHelper.postProcess(content, docContext),
+                })
+            }
+        )
+
+        /**
+         * This implementation waits for all generators to yield values
+         * before passing them to the consumer (request-manager). While this may appear
+         * as a performance bottleneck, it's necessary for the current design.
+         *
+         * The consumer operates on promises, allowing only a single resolve call
+         * from `requestManager.request`. Therefore, we must wait for the initial
+         * batch of completions before returning them collectively, ensuring all
+         * are included as suggested completions.
+         *
+         * To circumvent this performance issue, a method for adding completions to
+         * the existing suggestion list is needed. Presently, this feature is not
+         * available, and the switch to async generators maintains the same behavior
+         * as with promises.
+         */
+        return zipGenerators(await Promise.all(completionsGenerators))
+    }
 }
 
 /**

--- a/vscode/src/completions/request-manager.test.ts
+++ b/vscode/src/completions/request-manager.test.ts
@@ -49,10 +49,17 @@ class MockProvider extends Provider {
         return {} as any as CodeCompletionsParams
     }
 
-    public async *generateCompletions(
+    public async generateCompletions(
+        options: GenerateCompletionsOptions,
+        abortSignal: AbortSignal
+    ): Promise<AsyncGenerator<FetchCompletionResult[]>> {
+        return this.responseGenerator(options, abortSignal)
+    }
+
+    public async *responseGenerator(
         generateOptions: GenerateCompletionsOptions,
         abortSignal: AbortSignal
-    ): AsyncGenerator<FetchCompletionResult[]> {
+    ) {
         this.generateOptions = generateOptions
 
         abortSignal.addEventListener('abort', () => {


### PR DESCRIPTION
- Reusing the `generateCompletions` method across all autocomplete providers, which became identical after the recent refactorings.
- No functional changes.
- Part of https://linear.app/sourcegraph/issue/CODY-3409/self-hosted-models-openaicompatible-autocomplete-provider-supports
- Part of https://linear.app/sourcegraph/issue/CODY-3778/add-autocomplete-provider-tests-to-assert-request-parameters

## Test plan

CI