### PR TITLE
Fix auth redirection link

### DIFF
--- a/vscode/src/services/AuthProviderSimplified.ts
+++ b/vscode/src/services/AuthProviderSimplified.ts
@@ -39,7 +39,7 @@ function openExternalAuthUrl(
         : ''
 
     const newTokenUrl = `/user/settings/tokens/new/callback?requestFrom=${referralCode}${tokenReceiver}`
-    const site = new URL(newTokenUrl, DOTCOM_URL)
+    const site = DOTCOM_URL.toString() // Note, ends with the path /
     const genericLoginUrl = `${site}sign-in?returnTo=${newTokenUrl}`
     const gitHubLoginUrl = `${site}.auth/openidconnect/login?prompt_auth=github&pc=sams&redirect=${newTokenUrl}`
     const gitLabLoginUrl = `${site}.auth/openidconnect/login?prompt_auth=gitlab&pc=sams&redirect=${newTokenUrl}`


### PR DESCRIPTION
## Changes 

Before my change redirection URL looked like this:

https://sourcegraph.com/user/settings/tokens/new/callback?requestFrom=CODY_JETBRAINS&tokenReceiverUrl=http%3A%2F%2F127.0.0.1%3A60270%AUTH_TOKEN.auth/openidconnect/login?prompt_auth=github&pc=sams&redirect=/user/settings/tokens/new/callback?requestFrom=CODY_JETBRAINS&tokenReceiverUrl=http%3A%2F%2F127.0.0.1%3A60270%AUTH_TOKEN

Instead of:

https://sourcegraph.com/.auth/openidconnect/login?prompt_auth=github&pc=sams&redirect=/user/settings/tokens/new/callback?requestFrom=JETBRAINS&tokenReceiverUrl=http%3A%2F%2F127.0.0.1%3A59623%AUTH_TOKEN

## Test plan

1. Open JetBrains with `authentication` capability enabled and try to login using one of the providers like GitHub
2. You should be redirected to page asking for token creation authorisation [like this](https://sourcegraph.com/users/pkukielka/settings/tokens/new/callback?requestFrom=CODY),  NOT token [token page](https://sourcegraph.com/users/pkukielka/settings/tokens).
