### PR TITLE
Agent: fix auth referral code mapping across client and server

### DIFF
--- a/lib/shared/src/auth/referral.ts
+++ b/lib/shared/src/auth/referral.ts
@@ -2,12 +2,15 @@ import { CodyIDE } from '../configuration'
 
 /**
  * Returns a known referral code to use based on the current VS Code environment.
+ * IMPORTANT: The code must be registered in the server-side referral code mapping:
+ * @link client/web/src/user/settings/accessTokens/UserSettingsCreateAccessTokenCallbackPage.tsx
+ * Use "CODY" as the default referral code for fallback.
  */
 export function getCodyAuthReferralCode(ideName: CodyIDE, uriScheme?: string): string | undefined {
     const referralCodes: Record<CodyIDE, string> = {
-        [CodyIDE.JetBrains]: 'CODY_JETBRAINS',
-        [CodyIDE.Neovim]: 'CODY_NEOVIM',
-        [CodyIDE.Emacs]: 'CODY_EMACS',
+        [CodyIDE.JetBrains]: 'JETBRAINS',
+        [CodyIDE.Neovim]: 'NEOVIM',
+        [CodyIDE.Emacs]: 'CODY',
         [CodyIDE.VisualStudio]: 'VISUAL_STUDIO',
         [CodyIDE.Eclipse]: 'ECLIPSE',
         [CodyIDE.VSCode]: 'CODY',


### PR DESCRIPTION
- Update the referral code mapping to use consistent codes across the client and server
- This ensures that the referral codes used in the client match the ones registered on the server side
- This fixes an issue where the referral codes were different on the server side for certain IDEs like JetBrains and Neovim
- EMACS is not registered on the server side so we will fall back to CODY for now

The referral code mapping has been updated, which may require changes on the server side to ensure the new codes are registered

Closes https://linear.app/sourcegraph/issue/CODY-3912/fix-redirection-url-and-referral-tokens-for-jetbrains-sign-in-panel


## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

Build JB with this branch to confirm the redirection works.

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->

Agent: fix auth referral code mapping across client and server