### PR TITLE
E2E: fix flanky mention-repo test

### DIFF
--- a/vscode/test/e2e/mention-repository.test.ts
+++ b/vscode/test/e2e/mention-repository.test.ts
@@ -12,7 +12,8 @@ import {
 import { mockEnterpriseRepoMapping, testWithGitRemote } from './helpers'
 
 testWithGitRemote('@-mention repository', async ({ page, sidebar, server }) => {
-    mockEnterpriseRepoMapping(server, 'codehost.example/user/myrepo')
+    const userRepo = 'codehost.example/user/myrepo'
+    mockEnterpriseRepoMapping(server, userRepo)
 
     await sidebarSignin(page, sidebar)
     const [chatFrame, lastChatInput] = await createEmptyChatPanel(page)
@@ -40,11 +41,10 @@ testWithGitRemote('@-mention repository', async ({ page, sidebar, server }) => {
         } satisfies RepoSuggestionsSearchResponse,
     })
 
+    // Wait for the current user repo to be loaded before opening the mention menu.
+    await expect(chatInputMentions(lastChatInput)).toHaveText([userRepo])
     await openMentionsForProvider(chatFrame, lastChatInput, 'Remote Repositories')
     await expect(mentionMenuItems(chatFrame)).toHaveText(['a/b', 'c/d'])
     await selectMentionMenuItem(chatFrame, 'c/d')
-    await expect(chatInputMentions(lastChatInput)).toHaveText([
-        'codehost.example/user/myrepo',
-        'codehost.example/c/d',
-    ])
+    await expect(chatInputMentions(lastChatInput)).toHaveText([userRepo, 'codehost.example/c/d'])
 })


### PR DESCRIPTION
Attempted to fix the mentioned repository e2e test that is failing on main.

It's reproducible by running `pnpm test:e2e mention-repository` locally

![image](https://github.com/user-attachments/assets/01ceb1bd-dfec-4ffa-9769-d65a9f2158cb)

This shows the user repo is not showing up in the chat input, and based on the replay, it looks like this is because the mentioned menu is opened before the initial context is ready and added.

Adding a check to make sure the initial user repo is showing up in the chat input box before we open the mention menu fixes the issue for me locally.

## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

Run the `pnpm test:e2e mention-repository` command from the root of the repo to confirm the e2e test is now passing locally:

![image](https://github.com/user-attachments/assets/597ec05a-5685-444c-9a60-0cb14cb677bb)


## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
