### PR TITLE
fix Cody Web issue with @-mention menu appearing behind tabs bar

### DIFF
--- a/vscode/webviews/tabs/TabsBar.module.css
+++ b/vscode/webviews/tabs/TabsBar.module.css
@@ -1,5 +1,5 @@
 :root {
-    --vscode-overlay-background: rgba(0, 0, 0, 0.5);
+    --vscode-overlay-background: rgb(0 0 0 / 50%);
     --vscode-modal-background: var(--vscode-sideBar-background);
 }
 
@@ -10,9 +10,7 @@
 .tabs-root {
     container-type: inline-size;
     container-name: tabs-container;
-
     isolation: isolate;
-    z-index: 1;
 }
 
 .tabs-container {
@@ -92,10 +90,9 @@
         left: 50%;
         transform: translate(-50%, -50%);
         padding: 25px;
-
         border-radius: 6px;
         background-color: var(--vscode-modal-background);
-        box-shadow: hsl(206 22% 7% / 35%) 0 10px 38px -10px, hsl(206 22% 7% / 20%) 0 10px 20px -15px;
+        box-shadow: hsl(206deg 22% 7% / 35%) 0 10px 38px -10px, hsl(206deg 22% 7% / 20%) 0 10px 20px -15px;
 
         &:focus {
             outline: none;


### PR DESCRIPTION
The removal of `z-index: 1` is what was needed, and I don't see why other elements would be on top of this tab bar or its popovers.

The other diffs are from stylelint.

![atmention-zindex-issue](https://github.com/user-attachments/assets/ce40e367-453d-4453-9ad0-9a71adfa95f0)


## Test plan

Test that @-mentions are not clipped by the tabs bar in `pnpm -C web dev`.