### PR TITLE
pass chat history to webview using webviewAPI, not old postMessage protocol

### DIFF
--- a/agent/src/agent.ts
+++ b/agent/src/agent.ts
@@ -1232,7 +1232,10 @@ export class Agent extends MessageHandler implements ExtensionClient {
             modelID ??= (await firstResultFromOperation(modelsService.getDefaultChatModel())) ?? ''
             const chatMessages = messages?.map(PromptString.unsafe_deserializeChatMessage) ?? []
             const chatBuilder = new ChatBuilder(modelID, chatID, chatMessages)
-            await chatHistory.saveChat(authStatus, chatBuilder.toSerializedChatTranscript())
+            const chat = chatBuilder.toSerializedChatTranscript()
+            if (chat) {
+                await chatHistory.saveChat(authStatus, chat)
+            }
             return this.createChatPanel(
                 Promise.resolve({
                     type: 'chat',

--- a/lib/shared/src/misc/rpc/webviewAPI.ts
+++ b/lib/shared/src/misc/rpc/webviewAPI.ts
@@ -1,6 +1,6 @@
 import { Observable } from 'observable-fns'
 import type { AuthStatus, ResolvedConfiguration } from '../..'
-import type { ChatMessage } from '../../chat/transcript/messages'
+import type { ChatMessage, UserLocalHistory } from '../../chat/transcript/messages'
 import type { ContextItem } from '../../codebase-context/messages'
 import type { CodyCommand } from '../../commands/types'
 import type { FeatureFlag } from '../../experimentation/FeatureFlagProvider'
@@ -62,6 +62,11 @@ export interface WebviewToExtensionAPI {
      * Observe the current transcript.
      */
     transcript(): Observable<readonly ChatMessage[]>
+
+    /**
+     * The current user's chat history.
+     */
+    userHistory(): Observable<UserLocalHistory | null>
 }
 
 export function createExtensionAPI(
@@ -84,6 +89,7 @@ export function createExtensionAPI(
         resolvedConfig: proxyExtensionAPI(messageAPI, 'resolvedConfig'),
         authStatus: proxyExtensionAPI(messageAPI, 'authStatus'),
         transcript: proxyExtensionAPI(messageAPI, 'transcript'),
+        userHistory: proxyExtensionAPI(messageAPI, 'userHistory'),
     }
 }
 

--- a/vscode/src/chat/chat-view/ChatController.ts
+++ b/vscode/src/chat/chat-view/ChatController.ts
@@ -253,14 +253,6 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
                     })
             )
         )
-
-        // Observe any changes in chat history and send client notifications to
-        // the consumer
-        this.disposables.push(
-            chatHistory.onHistoryChanged(chatHistory => {
-                this.postMessage({ type: 'history', localHistory: chatHistory })
-            })
-        )
     }
 
     /**
@@ -1466,15 +1458,9 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
         const authStatus = currentAuthStatus()
         if (authStatus.authenticated) {
             // Only try to save if authenticated because otherwise we wouldn't be showing a chat.
-            const allHistory = await chatHistory.saveChat(
-                authStatus,
-                this.chatBuilder.toSerializedChatTranscript()
-            )
-            if (allHistory) {
-                void this.postMessage({
-                    type: 'history',
-                    localHistory: allHistory,
-                })
+            const chat = this.chatBuilder.toSerializedChatTranscript()
+            if (chat) {
+                await chatHistory.saveChat(authStatus, chat)
             }
         }
     }
@@ -1674,6 +1660,7 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
                     authStatus: () => authStatus,
                     transcript: () =>
                         this.chatBuilder.changes.pipe(map(chat => chat.getDehydratedMessages())),
+                    userHistory: () => chatHistory.changes,
                 }
             )
         )

--- a/vscode/src/chat/chat-view/ChatHistoryManager.ts
+++ b/vscode/src/chat/chat-view/ChatHistoryManager.ts
@@ -1,12 +1,16 @@
-import type {
-    AccountKeyedChatHistory,
-    AuthStatus,
-    AuthenticatedAuthStatus,
-    SerializedChatTranscript,
-    UserLocalHistory,
+import {
+    type AccountKeyedChatHistory,
+    type AuthStatus,
+    type AuthenticatedAuthStatus,
+    type SerializedChatTranscript,
+    type UnauthenticatedAuthStatus,
+    type UserLocalHistory,
+    authStatus,
+    combineLatest,
+    distinctUntilChanged,
+    startWith,
 } from '@sourcegraph/cody-shared'
-
-import debounce from 'lodash/debounce'
+import { type Observable, Subject, map } from 'observable-fns'
 import * as vscode from 'vscode'
 import { localStorage } from '../../services/LocalStorageProvider'
 
@@ -24,7 +28,9 @@ class ChatHistoryManager implements vscode.Disposable {
         }
     }
 
-    public getLocalHistory(authStatus: AuthenticatedAuthStatus): UserLocalHistory | null {
+    public getLocalHistory(
+        authStatus: Pick<AuthenticatedAuthStatus, 'endpoint' | 'username'>
+    ): UserLocalHistory | null {
         return localStorage.getChatHistory(authStatus)
     }
 
@@ -38,16 +44,12 @@ class ChatHistoryManager implements vscode.Disposable {
 
     public async saveChat(
         authStatus: AuthenticatedAuthStatus,
-        chat: SerializedChatTranscript | undefined
-    ): Promise<UserLocalHistory> {
+        chat: SerializedChatTranscript
+    ): Promise<void> {
         const history = localStorage.getChatHistory(authStatus)
-        if (chat === undefined) {
-            return history
-        }
         history.chat[chat.id] = chat
         await localStorage.setChatHistory(authStatus, history)
-        this.notifyChatHistoryChanged(authStatus)
-        return history
+        this.changeNotifications.next()
     }
 
     public async importChatHistory(
@@ -56,29 +58,44 @@ class ChatHistoryManager implements vscode.Disposable {
         authStatus: AuthStatus
     ): Promise<void> {
         await localStorage.importChatHistory(history, merge)
-        this.notifyChatHistoryChanged(authStatus)
+        this.changeNotifications.next()
     }
 
     public async deleteChat(authStatus: AuthenticatedAuthStatus, chatID: string): Promise<void> {
         await localStorage.deleteChatHistory(authStatus, chatID)
-        this.notifyChatHistoryChanged(authStatus)
+        this.changeNotifications.next()
     }
 
     // Remove chat history and input history
     public async clear(authStatus: AuthenticatedAuthStatus): Promise<void> {
         await localStorage.removeChatHistory(authStatus)
-        this.notifyChatHistoryChanged(authStatus)
+        this.changeNotifications.next()
     }
 
-    public onHistoryChanged(listener: (chatHistory: UserLocalHistory | null) => any): vscode.Disposable {
-        return this.historyChanged.event(listener)
-    }
-
-    private notifyChatHistoryChanged = debounce(
-        authStatus => this.historyChanged.fire(this.getLocalHistory(authStatus)),
-        100,
-        { leading: true, trailing: true }
-    )
+    private changeNotifications = new Subject<void>()
+    public changes: Observable<UserLocalHistory | null> = combineLatest([
+        authStatus.pipe(
+            // Only need to rere-fetch the chat history when the endpoint or username changes for
+            // authed users (i.e., when they switch to a different account), not when anything else
+            // in the authStatus might change.
+            map(
+                (
+                    authStatus
+                ):
+                    | UnauthenticatedAuthStatus
+                    | Pick<AuthenticatedAuthStatus, 'authenticated' | 'endpoint' | 'username'> =>
+                    authStatus.authenticated
+                        ? {
+                              authenticated: authStatus.authenticated,
+                              endpoint: authStatus.endpoint,
+                              username: authStatus.username,
+                          }
+                        : authStatus
+            ),
+            distinctUntilChanged()
+        ),
+        this.changeNotifications.pipe(startWith(undefined)),
+    ]).pipe(map(([authStatus]) => (authStatus.authenticated ? this.getLocalHistory(authStatus) : null)))
 }
 
 export const chatHistory = new ChatHistoryManager()

--- a/vscode/src/chat/protocol.ts
+++ b/vscode/src/chat/protocol.ts
@@ -11,7 +11,6 @@ import type {
     RequestMessage,
     ResponseMessage,
     SerializedChatMessage,
-    UserLocalHistory,
 } from '@sourcegraph/cody-shared'
 
 import type { BillingCategory, BillingProduct } from '@sourcegraph/cody-shared/src/telemetry-v2'
@@ -146,7 +145,6 @@ export type ExtensionMessage =
           isDotComUser: boolean
           workspaceFolderUris: string[]
       }
-    | { type: 'history'; localHistory?: UserLocalHistory | undefined | null }
     | {
           /** Used by JetBrains and not VS Code. */
           type: 'ui/theme'

--- a/vscode/src/services/LocalStorageProvider.ts
+++ b/vscode/src/services/LocalStorageProvider.ts
@@ -152,14 +152,16 @@ class LocalStorage implements LocalStorageForModelPreferences {
         await this.set(this.CODY_ENDPOINT_HISTORY, [...historySet], fire)
     }
 
-    public getChatHistory(authStatus: AuthenticatedAuthStatus): UserLocalHistory {
+    public getChatHistory(
+        authStatus: Pick<AuthenticatedAuthStatus, 'endpoint' | 'username'>
+    ): UserLocalHistory {
         const history = this.storage.get<AccountKeyedChatHistory | null>(this.KEY_LOCAL_HISTORY, null)
         const accountKey = getKeyForAuthStatus(authStatus)
         return history?.[accountKey] ?? { chat: {} }
     }
 
     public async setChatHistory(
-        authStatus: AuthenticatedAuthStatus,
+        authStatus: Pick<AuthenticatedAuthStatus, 'endpoint' | 'username'>,
         history: UserLocalHistory
     ): Promise<void> {
         try {
@@ -324,7 +326,9 @@ class LocalStorage implements LocalStorageForModelPreferences {
  */
 export const localStorage = new LocalStorage()
 
-function getKeyForAuthStatus(authStatus: AuthenticatedAuthStatus): ChatHistoryKey {
+function getKeyForAuthStatus(
+    authStatus: Pick<AuthenticatedAuthStatus, 'endpoint' | 'username'>
+): ChatHistoryKey {
     return `${authStatus.endpoint}-${authStatus.username}`
 }
 

--- a/vscode/webviews/App.story.tsx
+++ b/vscode/webviews/App.story.tsx
@@ -44,23 +44,6 @@ const dummyVSCodeAPI: VSCodeWrapper = {
             workspaceFolderUris: [],
             isDotComUser: true,
         })
-        cb({
-            type: 'history',
-            localHistory: {
-                chat: {
-                    a: {
-                        id: 'a',
-                        lastInteractionTimestamp: '2024-03-29',
-                        interactions: [
-                            {
-                                humanMessage: { speaker: 'human', text: 'Hello, world!' },
-                                assistantMessage: { speaker: 'assistant', text: 'Hi!' },
-                            },
-                        ],
-                    },
-                },
-            },
-        })
         if (firstTime) {
             cb({ type: 'view', view: View.Chat })
             firstTime = false

--- a/vscode/webviews/App.tsx
+++ b/vscode/webviews/App.tsx
@@ -7,7 +7,6 @@ import {
     type ContextItem,
     GuardrailsPost,
     PromptString,
-    type SerializedChatTranscript,
     type TelemetryRecorder,
 } from '@sourcegraph/cody-shared'
 import type { AuthMethod } from '../src/chat/protocol'
@@ -31,8 +30,6 @@ export const App: React.FunctionComponent<{ vscodeAPI: VSCodeWrapper }> = ({ vsc
     const [messageInProgress, setMessageInProgress] = useState<ChatMessage | null>(null)
 
     const [transcript, setTranscript] = useState<ChatMessage[]>([])
-
-    const [userHistory, setUserHistory] = useState<SerializedChatTranscript[]>()
 
     const [errorMessages, setErrorMessages] = useState<string[]>([])
 
@@ -81,9 +78,6 @@ export const App: React.FunctionComponent<{ vscodeAPI: VSCodeWrapper }> = ({ vsc
                         if (view && view !== View.Chat && !message.authStatus?.authenticated) {
                             setView(View.Chat)
                         }
-                        break
-                    case 'history':
-                        setUserHistory(Object.values(message.localHistory?.chat ?? {}))
                         break
                     case 'clientAction':
                         dispatchClientAction(message)
@@ -192,7 +186,6 @@ export const App: React.FunctionComponent<{ vscodeAPI: VSCodeWrapper }> = ({ vsc
                     transcript={transcript}
                     vscodeAPI={vscodeAPI}
                     guardrails={guardrails}
-                    userHistory={userHistory ?? []}
                     smartApplyEnabled={config.config.smartApply}
                 />
             )}

--- a/vscode/webviews/AppWrapperForTest.tsx
+++ b/vscode/webviews/AppWrapperForTest.tsx
@@ -10,6 +10,7 @@ import {
     type ResolvedConfiguration,
     SYMBOL_CONTEXT_MENTION_PROVIDER,
     type SymbolKind,
+    type UserLocalHistory,
     getMockedDotComClientModels,
     promiseFactoryToObservable,
 } from '@sourcegraph/cody-shared'
@@ -96,6 +97,21 @@ export const AppWrapperForTest: FunctionComponent<{ children: ReactNode }> = ({ 
                         } satisfies Partial<ResolvedConfiguration> as ResolvedConfiguration),
                     authStatus: () => Observable.of(AUTH_STATUS_FIXTURE_AUTHED),
                     transcript: () => Observable.of(FIXTURE_TRANSCRIPT.explainCode),
+                    userHistory: () =>
+                        Observable.of<UserLocalHistory | null>({
+                            chat: {
+                                a: {
+                                    id: 'a',
+                                    lastInteractionTimestamp: '2024-03-29',
+                                    interactions: [
+                                        {
+                                            humanMessage: { speaker: 'human', text: 'Hello, world!' },
+                                            assistantMessage: { speaker: 'assistant', text: 'Hi!' },
+                                        },
+                                    ],
+                                },
+                            },
+                        }),
                 },
             } satisfies Wrapper<ComponentProps<typeof ExtensionAPIProviderForTestsOnly>['value']>,
             {

--- a/vscode/webviews/CodyPanel.tsx
+++ b/vscode/webviews/CodyPanel.tsx
@@ -1,6 +1,6 @@
 import { type AuthStatus, type ClientCapabilities, CodyIDE } from '@sourcegraph/cody-shared'
 import type React from 'react'
-import { type ComponentProps, type FunctionComponent, useCallback, useRef } from 'react'
+import { type ComponentProps, type FunctionComponent, useRef } from 'react'
 import type { ConfigurationSubsetForWebview, LocalEnv } from '../src/chat/protocol'
 import styles from './App.module.css'
 import { Chat } from './Chat'
@@ -34,8 +34,7 @@ export const CodyPanel: FunctionComponent<
         | 'showWelcomeMessage'
         | 'showIDESnippetActions'
         | 'smartApplyEnabled'
-    > &
-        Pick<ComponentProps<typeof HistoryTab>, 'userHistory'>
+    >
 > = ({
     view,
     setView,
@@ -50,23 +49,9 @@ export const CodyPanel: FunctionComponent<
     guardrails,
     showIDESnippetActions,
     showWelcomeMessage,
-    userHistory,
     smartApplyEnabled,
 }) => {
     const tabContainerRef = useRef<HTMLDivElement>(null)
-
-    // Use native browser download dialog to download chat history as a JSON file.
-    const onDownloadChatClick = useCallback(() => {
-        const json = JSON.stringify(userHistory, null, 2)
-        const blob = new Blob([json], { type: 'application/json' })
-        const url = URL.createObjectURL(blob)
-        const timestamp = new Date().toISOString().replace(/[:.]/g, '-').slice(0, -5) // Format: YYYY-MM-DDTHH-mm
-        const a = document.createElement('a') // a temporary anchor element
-        a.href = url
-        a.download = `cody-chat-history-${timestamp}.json`
-        a.target = '_blank'
-        a.click()
-    }, [userHistory])
 
     return (
         <TabRoot
@@ -80,12 +65,7 @@ export const CodyPanel: FunctionComponent<
 
             {/* Hide tab bar in editor chat panels. */}
             {(clientCapabilities.agentIDE === CodyIDE.Web || config.webviewType !== 'editor') && (
-                <TabsBar
-                    currentView={view}
-                    setView={setView}
-                    IDE={clientCapabilities.agentIDE}
-                    onDownloadChatClick={onDownloadChatClick}
-                />
+                <TabsBar currentView={view} setView={setView} IDE={clientCapabilities.agentIDE} />
             )}
             {errorMessages && <ErrorBanner errors={errorMessages} setErrors={setErrorMessages} />}
             <TabContainer value={view} ref={tabContainerRef}>
@@ -109,7 +89,6 @@ export const CodyPanel: FunctionComponent<
                         setView={setView}
                         webviewType={config.webviewType}
                         multipleWebviewsEnabled={config.multipleWebviewsEnabled}
-                        userHistory={userHistory}
                     />
                 )}
                 {view === View.Prompts && <PromptsTab setView={setView} />}

--- a/vscode/webviews/chat/downloadChatHistory.ts
+++ b/vscode/webviews/chat/downloadChatHistory.ts
@@ -1,0 +1,29 @@
+import {
+    type SerializedChatTranscript,
+    type WebviewToExtensionAPI,
+    firstResultFromOperation,
+} from '@sourcegraph/cody-shared'
+
+/**
+ * Use native browser download dialog to download chat history as a JSON file.
+ */
+export async function downloadChatHistory(
+    extensionAPI: Pick<WebviewToExtensionAPI, 'userHistory'>
+): Promise<void> {
+    const userHistory = await firstResultFromOperation(extensionAPI.userHistory())
+    const chatHistory: SerializedChatTranscript[] | null = userHistory
+        ? Object.values(userHistory.chat)
+        : null
+    if (!chatHistory) {
+        return
+    }
+    const json = JSON.stringify(chatHistory, null, 2)
+    const blob = new Blob([json], { type: 'application/json' })
+    const url = URL.createObjectURL(blob)
+    const timestamp = new Date().toISOString().replace(/[:.]/g, '-').slice(0, -5) // Format: YYYY-MM-DDTHH-mm
+    const a = document.createElement('a') // a temporary anchor element
+    a.href = url
+    a.download = `cody-chat-history-${timestamp}.json`
+    a.target = '_blank'
+    a.click()
+}

--- a/vscode/webviews/tabs/HistoryTab.story.tsx
+++ b/vscode/webviews/tabs/HistoryTab.story.tsx
@@ -1,34 +1,34 @@
 import { CodyIDE } from '@sourcegraph/cody-shared'
 import type { Meta, StoryObj } from '@storybook/react'
 import { VSCodeStandaloneComponent } from '../storybook/VSCodeStoryDecorator'
-import { HistoryTab } from './HistoryTab'
+import { HistoryTabWithData } from './HistoryTab'
 
-const meta: Meta<typeof HistoryTab> = {
+const meta: Meta<typeof HistoryTabWithData> = {
     title: 'cody/HistoryTab',
-    component: HistoryTab,
+    component: HistoryTabWithData,
     decorators: [VSCodeStandaloneComponent],
     render: args => (
         <div style={{ position: 'relative', padding: '1rem' }}>
-            <HistoryTab {...args} />
+            <HistoryTabWithData {...args} />
         </div>
     ),
 }
 
 export default meta
 
-type Story = StoryObj<typeof HistoryTab>
+type Story = StoryObj<typeof HistoryTabWithData>
 
 export const Empty: Story = {
     args: {
         IDE: CodyIDE.VSCode,
         setView: () => {},
-        userHistory: [],
+        chats: [],
     },
 }
 
 export const SingleDay: Story = {
     args: {
-        userHistory: [
+        chats: [
             {
                 id: '1',
                 interactions: [
@@ -45,7 +45,7 @@ export const SingleDay: Story = {
 
 export const MultiDay: Story = {
     args: {
-        userHistory: [
+        chats: [
             {
                 id: '1',
                 interactions: [

--- a/vscode/webviews/tabs/HistoryTab.test.tsx
+++ b/vscode/webviews/tabs/HistoryTab.test.tsx
@@ -1,0 +1,22 @@
+import { CodyIDE } from '@sourcegraph/cody-shared'
+import { render, screen } from '@testing-library/react'
+import { describe, expect, test, vi } from 'vitest'
+import { AppWrapperForTest } from '../AppWrapperForTest'
+import { HistoryTabWithData } from './HistoryTab'
+
+describe('HistoryTabWithData', () => {
+    test('renders empty state when there are no non-empty chats', () => {
+        const mockSetView = vi.fn()
+        const emptyChats = [
+            { id: '1', interactions: [], lastInteractionTimestamp: new Date().toISOString() },
+            { id: '2', interactions: [], lastInteractionTimestamp: new Date().toISOString() },
+        ]
+
+        render(<HistoryTabWithData IDE={CodyIDE.VSCode} setView={mockSetView} chats={emptyChats} />, {
+            wrapper: AppWrapperForTest,
+        })
+
+        expect(screen.getByText('You have no chat history')).toBeInTheDocument()
+        expect(screen.getByText('Start a new chat')).toBeInTheDocument()
+    })
+})

--- a/vscode/webviews/tabs/HistoryTab.tsx
+++ b/vscode/webviews/tabs/HistoryTab.tsx
@@ -1,9 +1,11 @@
-import type { CodyIDE, SerializedChatTranscript } from '@sourcegraph/cody-shared'
+import type { CodyIDE, SerializedChatTranscript, UserLocalHistory } from '@sourcegraph/cody-shared'
+import { useExtensionAPI, useObservable } from '@sourcegraph/prompt-editor'
 import { HistoryIcon, MessageSquarePlusIcon, MessageSquareTextIcon, TrashIcon } from 'lucide-react'
 import type React from 'react'
 import { useCallback, useMemo } from 'react'
 import type { WebviewType } from '../../src/chat/protocol'
 import { getRelativeChatPeriod } from '../../src/common/time-date'
+import { LoadingDots } from '../chat/components/LoadingDots'
 import { CollapsiblePanel } from '../components/CollapsiblePanel'
 import { Button } from '../components/shadcn/ui/button'
 import { getVSCodeAPI } from '../utils/VSCodeApi'
@@ -13,34 +15,53 @@ import { getCreateNewChatCommand } from './utils'
 interface HistoryTabProps {
     IDE: CodyIDE
     setView: (view: View) => void
-    userHistory: SerializedChatTranscript[]
     webviewType?: WebviewType | undefined | null
     multipleWebviewsEnabled?: boolean | undefined | null
 }
 
-export const HistoryTab: React.FC<HistoryTabProps> = ({
-    userHistory,
-    IDE,
-    webviewType,
-    multipleWebviewsEnabled,
-    setView,
-}) => {
+export const HistoryTab: React.FC<HistoryTabProps> = props => {
+    const userHistory = useUserHistory()
+    const chats = useMemo(
+        () => (userHistory ? Object.values(userHistory.chat) : userHistory),
+        [userHistory]
+    )
+
+    return (
+        <div className="tw-px-8 tw-pt-6 tw-pb-12">
+            {chats === undefined ? (
+                <LoadingDots />
+            ) : chats === null ? (
+                <p>History is not available.</p>
+            ) : (
+                <HistoryTabWithData {...props} chats={chats} />
+            )}
+        </div>
+    )
+}
+
+export const HistoryTabWithData: React.FC<
+    HistoryTabProps & { chats: UserLocalHistory['chat'][string][] }
+> = ({ IDE, webviewType, multipleWebviewsEnabled, setView, chats }) => {
+    const nonEmptyChats = useMemo(() => chats.filter(chat => chat.interactions.length > 0), [chats])
+
     const chatByPeriod = useMemo(
         () =>
-            userHistory
-                .filter(chat => chat.interactions.length)
-                .reverse()
-                .reduce((acc, chat) => {
-                    const period = getRelativeChatPeriod(new Date(chat.lastInteractionTimestamp))
-                    acc.set(period, [...(acc.get(period) || []), chat])
-                    return acc
-                }, new Map<string, SerializedChatTranscript[]>()),
-        [userHistory]
+            Array.from(
+                nonEmptyChats
+                    .filter(chat => chat.interactions.length)
+                    .reverse()
+                    .reduce((acc, chat) => {
+                        const period = getRelativeChatPeriod(new Date(chat.lastInteractionTimestamp))
+                        acc.set(period, [...(acc.get(period) || []), chat])
+                        return acc
+                    }, new Map<string, SerializedChatTranscript[]>())
+            ),
+        [nonEmptyChats]
     )
 
     const onDeleteButtonClick = useCallback(
         (id: string) => {
-            if (userHistory.find(chat => chat.id === id)) {
+            if (chats.find(chat => chat.id === id)) {
                 getVSCodeAPI().postMessage({
                     command: 'command',
                     id: 'cody.chat.history.clear',
@@ -48,7 +69,7 @@ export const HistoryTab: React.FC<HistoryTabProps> = ({
                 })
             }
         },
-        [userHistory]
+        [chats]
     )
 
     const handleStartNewChat = () => {
@@ -59,11 +80,9 @@ export const HistoryTab: React.FC<HistoryTabProps> = ({
         setView(View.Chat)
     }
 
-    const chats = Array.from(chatByPeriod)
-
     return (
-        <div className="tw-px-8 tw-pt-6 tw-pb-12 tw-flex tw-flex-col tw-gap-10">
-            {chats.map(([period, chats]) => (
+        <div className="tw-flex tw-flex-col tw-gap-10">
+            {chatByPeriod.map(([period, chats]) => (
                 <CollapsiblePanel
                     id={`history-${period}`.replaceAll(' ', '-').toLowerCase()}
                     key={period}
@@ -113,7 +132,7 @@ export const HistoryTab: React.FC<HistoryTabProps> = ({
                 </CollapsiblePanel>
             ))}
 
-            {chats.length === 0 && (
+            {nonEmptyChats.length === 0 && (
                 <div className="tw-flex tw-flex-col tw-items-center tw-mt-6">
                     <HistoryIcon
                         size={20}
@@ -144,4 +163,9 @@ export const HistoryTab: React.FC<HistoryTabProps> = ({
             )}
         </div>
     )
+}
+
+function useUserHistory(): UserLocalHistory | null | undefined {
+    const userHistory = useExtensionAPI().userHistory
+    return useObservable(useMemo(() => userHistory(), [userHistory])).value
 }

--- a/web/lib/components/CodyWebChat.tsx
+++ b/web/lib/components/CodyWebChat.tsx
@@ -10,7 +10,6 @@ import {
     ContextItemSource,
     PromptString,
     REMOTE_DIRECTORY_PROVIDER_URI,
-    type SerializedChatTranscript,
     isErrorLike,
     setDisplayPathEnvInfo,
 } from '@sourcegraph/cody-shared'
@@ -112,7 +111,6 @@ const CodyWebPanel: FC<CodyWebPanelProps> = props => {
     const [transcript, setTranscript] = useState<ChatMessage[]>([])
     const [config, setConfig] = useState<Config | null>(null)
     const [view, setView] = useState<View | undefined>()
-    const [userHistory, setUserHistory] = useState<SerializedChatTranscript[]>()
 
     useLayoutEffect(() => {
         vscodeAPI.onMessage(message => {
@@ -144,9 +142,6 @@ const CodyWebPanel: FC<CodyWebPanelProps> = props => {
                     break
                 case 'clientAction':
                     dispatchClientAction(message)
-                    break
-                case 'history':
-                    setUserHistory(Object.values(message.localHistory?.chat ?? {}))
                     break
             }
         })
@@ -234,7 +229,7 @@ const CodyWebPanel: FC<CodyWebPanelProps> = props => {
         }
     }, [initialContextData])
 
-    const isLoading = !config || !view || !userHistory
+    const isLoading = !config || !view
 
     return (
         <div className={className} data-cody-web-chat={true}>
@@ -248,7 +243,6 @@ const CodyWebPanel: FC<CodyWebPanelProps> = props => {
                             setErrorMessages={setErrorMessages}
                             attributionEnabled={false}
                             configuration={config}
-                            userHistory={userHistory}
                             chatEnabled={true}
                             showWelcomeMessage={true}
                             showIDESnippetActions={false}


### PR DESCRIPTION
Previously, chat history was synced to the webview using the old postMessage protocol. Now, the ChatHistoryManager exposes an observable and that is read directly (using the standard webviewAPI) by the webview. This is a code refactor with no user-facing behavior change.

## Test plan

In Cody Web and in VS Code, try downloading chat history. Ensure the JSON file is downloaded and is a JSON array of chat history.