### PR TITLE
remove unused, needless transcript-errors/isTranscriptError

### DIFF
--- a/vscode/src/chat/chat-view/ChatController.ts
+++ b/vscode/src/chat/chat-view/ChatController.ts
@@ -1176,10 +1176,6 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
         if (type === 'transcript') {
             this.chatBuilder.addErrorAsBotMessage(error, ChatBuilder.NO_MODEL)
             this.postViewTranscript()
-            void this.postMessage({
-                type: 'transcript-errors',
-                isTranscriptError: true,
-            })
             return
         }
 

--- a/vscode/src/chat/protocol.ts
+++ b/vscode/src/chat/protocol.ts
@@ -154,7 +154,6 @@ export type ExtensionMessage =
     | ({ type: 'transcript' } & ExtensionTranscriptMessage)
     | { type: 'view'; view: View }
     | { type: 'errors'; errors: string }
-    | { type: 'transcript-errors'; isTranscriptError: boolean }
     | {
           type: 'clientAction'
           addContextItemsToLastHumanInput?: ContextItem[] | null | undefined

--- a/vscode/webviews/App.tsx
+++ b/vscode/webviews/App.tsx
@@ -37,7 +37,6 @@ export const App: React.FunctionComponent<{ vscodeAPI: VSCodeWrapper }> = ({ vsc
     const [userHistory, setUserHistory] = useState<SerializedChatTranscript[]>()
 
     const [errorMessages, setErrorMessages] = useState<string[]>([])
-    const [isTranscriptError, setIsTranscriptError] = useState<boolean>(false)
 
     const dispatchClientAction = useClientActionDispatcher()
 
@@ -70,7 +69,6 @@ export const App: React.FunctionComponent<{ vscodeAPI: VSCodeWrapper }> = ({ vsc
                             const msgLength = deserializedMessages.length - 1
                             setTranscript(deserializedMessages.slice(0, msgLength))
                             setMessageInProgress(deserializedMessages[msgLength])
-                            setIsTranscriptError(false)
                         } else {
                             setTranscript(deserializedMessages)
                             setMessageInProgress(null)
@@ -97,9 +95,6 @@ export const App: React.FunctionComponent<{ vscodeAPI: VSCodeWrapper }> = ({ vsc
                         break
                     case 'view':
                         setView(message.view)
-                        break
-                    case 'transcript-errors':
-                        setIsTranscriptError(message.isTranscriptError)
                         break
                     case 'attribution':
                         if (message.attribution) {
@@ -202,7 +197,6 @@ export const App: React.FunctionComponent<{ vscodeAPI: VSCodeWrapper }> = ({ vsc
                     messageInProgress={messageInProgress}
                     transcript={transcript}
                     vscodeAPI={vscodeAPI}
-                    isTranscriptError={isTranscriptError}
                     guardrails={guardrails}
                     userHistory={userHistory ?? []}
                     smartApplyEnabled={config.config.smartApply}

--- a/vscode/webviews/Chat.story.tsx
+++ b/vscode/webviews/Chat.story.tsx
@@ -26,7 +26,6 @@ const meta: Meta<typeof Chat> = {
             postMessage: () => {},
             onMessage: () => () => {},
         },
-        isTranscriptError: false,
         setView: () => {},
     } satisfies React.ComponentProps<typeof Chat>,
 

--- a/vscode/webviews/Chat.tsx
+++ b/vscode/webviews/Chat.tsx
@@ -25,7 +25,6 @@ interface ChatboxProps {
     messageInProgress: ChatMessage | null
     transcript: ChatMessage[]
     vscodeAPI: Pick<VSCodeWrapper, 'postMessage' | 'onMessage'>
-    isTranscriptError: boolean
     guardrails?: Guardrails
     scrollableParent?: HTMLElement | null
     showWelcomeMessage?: boolean
@@ -38,7 +37,6 @@ export const Chat: React.FunctionComponent<React.PropsWithChildren<ChatboxProps>
     messageInProgress,
     transcript,
     vscodeAPI,
-    isTranscriptError,
     chatEnabled = true,
     guardrails,
     scrollableParent,
@@ -220,7 +218,6 @@ export const Chat: React.FunctionComponent<React.PropsWithChildren<ChatboxProps>
                 copyButtonOnSubmit={copyButtonOnSubmit}
                 insertButtonOnSubmit={insertButtonOnSubmit}
                 smartApply={smartApply}
-                isTranscriptError={isTranscriptError}
                 userInfo={userInfo}
                 chatEnabled={chatEnabled}
                 postMessage={postMessage}

--- a/vscode/webviews/CodyPanel.story.tsx
+++ b/vscode/webviews/CodyPanel.story.tsx
@@ -16,7 +16,6 @@ const meta: Meta<typeof CodyPanel> = {
             postMessage: () => {},
             onMessage: () => () => {},
         },
-        isTranscriptError: false,
         view: View.Chat,
         setView: () => {},
         configuration: {

--- a/vscode/webviews/CodyPanel.tsx
+++ b/vscode/webviews/CodyPanel.tsx
@@ -26,7 +26,6 @@ export const CodyPanel: FunctionComponent<
         | 'messageInProgress'
         | 'transcript'
         | 'vscodeAPI'
-        | 'isTranscriptError'
         | 'guardrails'
         | 'showWelcomeMessage'
         | 'showIDESnippetActions'
@@ -44,7 +43,6 @@ export const CodyPanel: FunctionComponent<
     messageInProgress,
     transcript,
     vscodeAPI,
-    isTranscriptError,
     guardrails,
     showIDESnippetActions,
     showWelcomeMessage,
@@ -93,7 +91,6 @@ export const CodyPanel: FunctionComponent<
                         messageInProgress={messageInProgress}
                         transcript={transcript}
                         vscodeAPI={vscodeAPI}
-                        isTranscriptError={isTranscriptError}
                         guardrails={attributionEnabled ? guardrails : undefined}
                         showIDESnippetActions={showIDESnippetActions}
                         showWelcomeMessage={showWelcomeMessage}

--- a/vscode/webviews/chat/Transcript.story.tsx
+++ b/vscode/webviews/chat/Transcript.story.tsx
@@ -125,7 +125,6 @@ export const WithError: StoryObj<typeof meta> = {
             { speaker: 'human', text: ps`What color is the sky?'`, contextFiles: [] },
             { speaker: 'assistant', error: errorToChatError(new Error('some error')) },
         ]),
-        isTranscriptError: true,
     },
 }
 
@@ -141,7 +140,6 @@ export const WithRateLimitError: StoryObj<typeof meta> = {
                 ),
             },
         ]),
-        isTranscriptError: true,
     },
 }
 
@@ -152,7 +150,6 @@ export const abortedBeforeResponse: StoryObj<typeof meta> = {
             { speaker: 'human', text: ps`What color is the sky?'`, contextFiles: [] },
             { speaker: 'assistant', error: errorToChatError(new Error('aborted')) },
         ]),
-        isTranscriptError: true,
     },
 }
 
@@ -167,7 +164,6 @@ export const abortedWithPartialResponse: StoryObj<typeof meta> = {
             },
             { speaker: 'assistant', text: ps`Bl`, error: errorToChatError(new Error('aborted')) },
         ]),
-        isTranscriptError: true,
     },
 }
 
@@ -185,7 +181,6 @@ export const TextWrapping: StoryObj<typeof meta> = {
                 text: ps`The sky is blueblueblueblueblueblueblueblueblueblueblueblueblueblueblueblueblueblueblueblueblueblueblueblueblueblueblueblueblueblue.\n\n\`\`\`\nconst color = 'blueblueblueblueblueblueblueblueblueblueblueblueblueblueblueblueblueblueblueblueblueblueblueblueblue'\n\`\`\`\n\nMore info:\n\n- Color of sky: blueblueblueblueblueblueblueblueblueblueblueblueblueblueblueblueblueblueblueblueblueblue`,
             },
         ]),
-        isTranscriptError: true,
     },
 }
 

--- a/vscode/webviews/chat/Transcript.tsx
+++ b/vscode/webviews/chat/Transcript.tsx
@@ -36,7 +36,6 @@ interface TranscriptProps {
 
     guardrails?: Guardrails
     postMessage?: ApiPostMessage
-    isTranscriptError?: boolean
 
     feedbackButtonsOnSubmit: (text: string) => void
     copyButtonOnSubmit: CodeBlockActionsProps['copyButtonOnSubmit']
@@ -53,7 +52,6 @@ export const Transcript: FC<TranscriptProps> = props => {
         messageInProgress,
         guardrails,
         postMessage,
-        isTranscriptError,
         feedbackButtonsOnSubmit,
         copyButtonOnSubmit,
         insertButtonOnSubmit,
@@ -81,7 +79,6 @@ export const Transcript: FC<TranscriptProps> = props => {
                     interaction={interaction}
                     guardrails={guardrails}
                     postMessage={postMessage}
-                    isTranscriptError={isTranscriptError}
                     feedbackButtonsOnSubmit={feedbackButtonsOnSubmit}
                     copyButtonOnSubmit={copyButtonOnSubmit}
                     insertButtonOnSubmit={insertButtonOnSubmit}
@@ -172,7 +169,6 @@ const TranscriptInteraction: FC<TranscriptInteractionProps> = memo(props => {
         isLastInteraction,
         isLastSentInteraction,
         priorAssistantMessageIsLoading,
-        isTranscriptError,
         userInfo,
         chatEnabled,
         feedbackButtonsOnSubmit,
@@ -374,7 +370,6 @@ const TranscriptInteraction: FC<TranscriptInteractionProps> = memo(props => {
                         isLoading={assistantMessage.isLoading}
                         showFeedbackButtons={
                             !assistantMessage.isLoading &&
-                            !isTranscriptError &&
                             !assistantMessage.error &&
                             isLastSentInteraction
                         }

--- a/web/lib/components/CodyWebChat.tsx
+++ b/web/lib/components/CodyWebChat.tsx
@@ -110,7 +110,6 @@ const CodyWebPanel: FC<CodyWebPanelProps> = props => {
 
     const dispatchClientAction = useClientActionDispatcher()
     const [errorMessages, setErrorMessages] = useState<string[]>([])
-    const [isTranscriptError, setIsTranscriptError] = useState<boolean>(false)
     const [messageInProgress, setMessageInProgress] = useState<ChatMessage | null>(null)
     const [transcript, setTranscript] = useState<ChatMessage[]>([])
     const [config, setConfig] = useState<Config | null>(null)
@@ -128,7 +127,6 @@ const CodyWebPanel: FC<CodyWebPanelProps> = props => {
                         const msgLength = deserializedMessages.length - 1
                         setTranscript(deserializedMessages.slice(0, msgLength))
                         setMessageInProgress(deserializedMessages[msgLength])
-                        setIsTranscriptError(false)
                     } else {
                         setTranscript(deserializedMessages)
                         setMessageInProgress(null)
@@ -140,9 +138,6 @@ const CodyWebPanel: FC<CodyWebPanelProps> = props => {
                     break
                 case 'view':
                     setView(message.view)
-                    break
-                case 'transcript-errors':
-                    setIsTranscriptError(message.isTranscriptError)
                     break
                 case 'config':
                     message.config.webviewType = 'sidebar'
@@ -265,7 +260,6 @@ const CodyWebPanel: FC<CodyWebPanelProps> = props => {
                                 messageInProgress={messageInProgress}
                                 transcript={transcript}
                                 vscodeAPI={vscodeAPI}
-                                isTranscriptError={isTranscriptError}
                             />
                         </ComposedWrappers>
                     </ChatMentionContext.Provider>


### PR DESCRIPTION
This was only used to control whether to show feedback buttons after a message, and any message with isTranscriptError would also have an assistant reply with an error as well, so this did not do anything.

## Test plan

CI