### PR TITLE
centralize accessing the agentIDE and related values

### DIFF
--- a/agent/src/agent.ts
+++ b/agent/src/agent.ts
@@ -1490,9 +1490,6 @@ export class Agent extends MessageHandler implements ExtensionClient {
                 await authProvider.validateAndStoreCredentials(
                     {
                         configuration: {
-                            agentIDE: AgentWorkspaceConfiguration.clientNameToIDE(
-                                this.clientInfo?.name ?? ''
-                            ),
                             customHeaders: config.customHeaders,
                         },
                         auth: {

--- a/agent/src/cli/command-bench/llm-judge.ts
+++ b/agent/src/cli/command-bench/llm-judge.ts
@@ -1,4 +1,4 @@
-import type { PromptString } from '@sourcegraph/cody-shared'
+import { type PromptString, setClientCapabilitiesFromConfiguration } from '@sourcegraph/cody-shared'
 import { SourcegraphNodeCompletionsClient } from '../../../../vscode/src/completions/nodeClient'
 import { setStaticResolvedConfigurationWithAuthCredentials } from '../../../../vscode/src/configuration'
 import { localStorage } from '../../../../vscode/src/services/LocalStorageProvider'
@@ -18,6 +18,7 @@ export class LlmJudge {
             configuration: { customHeaders: undefined },
             auth: { accessToken: options.srcAccessToken, serverEndpoint: options.srcEndpoint },
         })
+        setClientCapabilitiesFromConfiguration({})
         this.client = new SourcegraphNodeCompletionsClient()
     }
 

--- a/lib/shared/src/auth/referral.ts
+++ b/lib/shared/src/auth/referral.ts
@@ -1,4 +1,5 @@
 import { CodyIDE } from '../configuration'
+import { clientCapabilities } from '../configuration/clientCapabilities'
 
 /**
  * Returns a known referral code to use based on the current VS Code environment.
@@ -6,7 +7,7 @@ import { CodyIDE } from '../configuration'
  * @link client/web/src/user/settings/accessTokens/UserSettingsCreateAccessTokenCallbackPage.tsx
  * Use "CODY" as the default referral code for fallback.
  */
-export function getCodyAuthReferralCode(ideName: CodyIDE, uriScheme?: string): string | undefined {
+export function getCodyAuthReferralCode(uriScheme: string): string | undefined {
     const referralCodes: Record<CodyIDE, string> = {
         [CodyIDE.JetBrains]: 'JETBRAINS',
         [CodyIDE.Neovim]: 'NEOVIM',
@@ -17,7 +18,7 @@ export function getCodyAuthReferralCode(ideName: CodyIDE, uriScheme?: string): s
         [CodyIDE.Web]: 'CODY',
     }
 
-    if (ideName === CodyIDE.VSCode) {
+    if (clientCapabilities().agentIDE === CodyIDE.VSCode) {
         switch (uriScheme) {
             case 'vscode-insiders':
                 return 'CODY_INSIDERS'
@@ -28,5 +29,5 @@ export function getCodyAuthReferralCode(ideName: CodyIDE, uriScheme?: string): s
         }
     }
 
-    return referralCodes[ideName] || undefined
+    return referralCodes[clientCapabilities().agentIDE] || undefined
 }

--- a/lib/shared/src/configuration.ts
+++ b/lib/shared/src/configuration.ts
@@ -1,3 +1,4 @@
+import type { ClientCapabilities } from './configuration/clientCapabilities'
 import type { ChatModelProviderConfig } from './models/sync'
 
 import type { PromptString } from './prompt/prompt-string'
@@ -18,7 +19,7 @@ interface RawClientConfiguration {
     debugFilter: RegExp | null
     debugVerbose: boolean
     telemetryLevel: 'all' | 'off' | 'agent'
-    telemetryClientName?: string
+
     serverEndpoint: string
     customHeaders?: Record<string, string>
     chatPreInstruction: PromptString
@@ -67,9 +68,35 @@ interface RawClientConfiguration {
      */
     hasNativeWebview: boolean
     isRunningInsideAgent?: boolean
+
+    /**
+     * @deprecated Do not use directly. Call {@link clientCapabilities} instead
+     * (`clientCapabilities().agentIDE`) and see the docstring on
+     * {@link ClientCapabilities.agentIDE}.
+     */
     agentIDE?: CodyIDE
-    agentIDEVersion?: string
-    agentExtensionVersion?: string
+
+    /**
+     * @deprecated Do not use directly. Call {@link clientCapabilities} instead
+     * (`clientCapabilities().agentIDEVersion`) and see the docstring on
+     * {@link ClientCapabilities.agentIDEVersion}.
+     */
+    agentIDEVersion?: ClientCapabilities['agentIDEVersion']
+
+    /**
+     * @deprecated Do not use directly. Call {@link clientCapabilities} instead
+     * (`clientCapabilities().agentExtensionVersion`) and see the docstring on
+     * {@link ClientCapabilities.agentExtensionVersion}.
+     */
+    agentExtensionVersion?: ClientCapabilities['agentExtensionVersion']
+
+    /**
+     * @deprecated Do not use directly. Call {@link clientCapabilities} instead
+     * (`clientCapabilities().agentIDEVersion`) and see the docstring on
+     * {@link ClientCapabilities.agentIDEVersion}.
+     */
+    telemetryClientName?: string
+
     agentHasPersistentStorage?: boolean
     autocompleteFirstCompletionTimeout: number
     autocompleteAdvancedModel: string | null

--- a/lib/shared/src/configuration/clientCapabilities.ts
+++ b/lib/shared/src/configuration/clientCapabilities.ts
@@ -1,0 +1,128 @@
+import { type ClientConfiguration, CodyIDE } from '../configuration'
+
+/**
+ * The capabilities of the client, such as the editor that Cody is being used with (directly for VS
+ * Code or via the agent for other editors) or the CLI.
+ */
+export interface ClientCapabilities {
+    /**
+     * The `agentIDE` value, which is the editor that Cody is being used with. If not set, it
+     * defaults to {@link CodyIDE.VSCode} to match the previous behavior.
+     *
+     * @deprecated Use one of the other {@link ClientCapabilities} fields instead to assert based on
+     * the client's actual capabilities at runtime and not your assumptions about their current
+     * capabilities, and to support future clients that are not in the {@link CodyIDE} enum. If you
+     * are truly interested in whether the editor is VS Code, such as to use the right link to
+     * documentation or describe the VS Code user interface, then it is OK to use this field.
+     */
+    agentIDE: CodyIDE
+
+    /**
+     * @deprecated For the same reason as {@link ClientCapabilities.agentIDE}.
+     */
+    isVSCode: boolean
+
+    /**
+     * @deprecated For the same reason as {@link ClientCapabilities.agentIDE}.
+     */
+    isCodyWeb: boolean
+
+    /**
+     * The `agentExtensionVersion` value, which is the version of Cody that is being used in the
+     * agent (if set).
+     *
+     * @deprecated Be careful when using this. It is NOT set if using VS Code, and you need to use
+     * the `/vscode/src/version.ts` module's `version` export. Soon this {@link ClientConfiguration}
+     * value will expose that.
+     */
+    agentExtensionVersion?: string
+
+    /**
+     * The `agentIDEVersion` value, which is the version of the client editor (if set).
+     */
+    agentIDEVersion?: string
+
+    /**
+     * The `telemetryClientName` value, which if set should be used instead of a synthesized client
+     * name when sending telemetry.
+     */
+    telemetryClientName?: string
+}
+
+/**
+ * Get the {@link ClientCapabilities} for the current client.
+ *
+ * This is the only place you should fetch these values. Previously, there were many ways that the
+ * logic for determining client capabilities was implemented, and you needed to remember that none
+ * of the values were set for VS Code and apply the right default. That was error-prone. The
+ * solution is this centralized accessor for the client capabilities.
+ *
+ * The return value does not change. However, it is only available after the configuration has been
+ * set, and this function throws if it's not available. This means that it can't be used at
+ * initialization time.
+ */
+export function clientCapabilities(): ClientCapabilities {
+    if (_mockValue) {
+        return _mockValue
+    }
+    if (!_configuration) {
+        throw new Error(
+            'clientCapabilities called before configuration was set with setClientCapabilitiesFromConfiguration'
+        )
+    }
+    return {
+        agentIDE: _configuration.agentIDE ?? CodyIDE.VSCode,
+        isVSCode: !_configuration.agentIDE || _configuration.agentIDE === CodyIDE.VSCode,
+        isCodyWeb: _configuration.agentIDE === CodyIDE.Web,
+        agentExtensionVersion: _configuration.agentExtensionVersion ?? _extensionVersion,
+        agentIDEVersion: _configuration.agentIDEVersion,
+        telemetryClientName: _configuration.telemetryClientName,
+    }
+}
+
+let _configuration:
+    | Pick<
+          ClientConfiguration,
+          'agentExtensionVersion' | 'agentIDE' | 'agentIDEVersion' | 'telemetryClientName'
+      >
+    | undefined
+
+/**
+ * Set the {@link ClientCapabilities} value from the {@link ResolvedConfiguration.configuration}.
+ */
+export function setClientCapabilitiesFromConfiguration(
+    configuration: NonNullable<typeof _configuration>
+): void {
+    _configuration = configuration
+}
+
+let _extensionVersion: string | undefined
+
+/**
+ * Set the extension version number, which is the version of Cody that is being used. This is the VS
+ * Code extension version if running in VS Code, or else the `vscode/package.json` version number.
+ * It must be set externally because this package is not able to determine the VS Code runtime
+ * extension version, which is the only way to handle pre-release versions properly.
+ */
+export function setExtensionVersion(version: string): void {
+    _extensionVersion = version
+}
+
+let _mockValue: ClientCapabilities | undefined
+
+/**
+ * Mock the {@link clientCapabilities} result.
+ *
+ * For use in tests only.
+ */
+export function mockClientCapabilities(value: ClientCapabilities | undefined): void {
+    _mockValue = value
+}
+
+export const CLIENT_CAPABILITIES_FIXTURE: ClientCapabilities = {
+    agentIDE: CodyIDE.VSCode,
+    isVSCode: true,
+    isCodyWeb: false,
+    agentExtensionVersion: '1.2.3',
+    agentIDEVersion: '4.5.6',
+}

--- a/lib/shared/src/index.ts
+++ b/lib/shared/src/index.ts
@@ -348,6 +348,7 @@ export {
 export * from './misc/observable'
 export * from './misc/observableOperation'
 export * from './configuration/resolver'
+export * from './configuration/clientCapabilities'
 export * from './singletons'
 export * from './auth/authStatus'
 export { fetchLocalOllamaModels } from './llm-providers/ollama/utils'

--- a/lib/shared/src/models/sync.test.ts
+++ b/lib/shared/src/models/sync.test.ts
@@ -2,6 +2,7 @@ import { Observable, Subject } from 'observable-fns'
 import { describe, expect, it, vi } from 'vitest'
 import { mockAuthStatus } from '../auth/authStatus'
 import { AUTH_STATUS_FIXTURE_AUTHED, type AuthStatus } from '../auth/types'
+import { CLIENT_CAPABILITIES_FIXTURE, mockClientCapabilities } from '../configuration/clientCapabilities'
 import type { ResolvedConfiguration } from '../configuration/resolver'
 import { featureFlagProvider } from '../experimentation/FeatureFlagProvider'
 import {
@@ -35,6 +36,8 @@ import { ModelUsage } from './types'
 vi.mock('graphqlClient')
 vi.mock('../services/LocalStorageProvider')
 vi.mock('../experimentation/FeatureFlagProvider')
+
+mockClientCapabilities(CLIENT_CAPABILITIES_FIXTURE)
 
 describe('maybeAdjustContextWindows', () => {
     it('works', () => {

--- a/lib/shared/src/models/sync.ts
+++ b/lib/shared/src/models/sync.ts
@@ -1,6 +1,7 @@
 import { Observable, interval, map } from 'observable-fns'
 import type { AuthStatus } from '../auth/types'
-import { type ClientConfiguration, CodyIDE } from '../configuration'
+import type { ClientConfiguration } from '../configuration'
+import { clientCapabilities } from '../configuration/clientCapabilities'
 import type { PickResolvedConfiguration } from '../configuration/resolver'
 import { FeatureFlag, featureFlagProvider } from '../experimentation/FeatureFlagProvider'
 import { fetchLocalOllamaModels } from '../llm-providers/ollama/utils'
@@ -56,13 +57,9 @@ export function syncModels({
             map(
                 config =>
                     ({
-                        agentIDE: config.configuration.agentIDE,
                         autocompleteExperimentalOllamaOptions:
                             config.configuration.autocompleteExperimentalOllamaOptions,
-                    }) satisfies Pick<
-                        ClientConfiguration,
-                        'agentIDE' | 'autocompleteExperimentalOllamaOptions'
-                    >
+                    }) satisfies Pick<ClientConfiguration, 'autocompleteExperimentalOllamaOptions'>
             ),
             distinctUntilChanged()
         ),
@@ -74,12 +71,11 @@ export function syncModels({
             )
         ),
     ]).pipe(
-        switchMap(([{ agentIDE }]) => {
-            const isCodyWeb = agentIDE === CodyIDE.Web
-            return isCodyWeb
+        switchMap(() =>
+            clientCapabilities().isCodyWeb
                 ? Observable.of([]) // disable Ollama local models for Cody Web
                 : promiseFactoryToObservable(signal => fetchLocalOllamaModels().catch(() => []))
-        }),
+        ),
         // Keep the old localModels results while we're fetching the new ones, to avoid UI jitter.
         shareReplay()
     )

--- a/lib/shared/src/models/utils.ts
+++ b/lib/shared/src/models/utils.ts
@@ -1,17 +1,17 @@
+import type { ClientConfiguration } from '../configuration'
+import { logDebug } from '../logger'
+import { ANSWER_TOKENS } from '../prompt/constants'
+import type { CodyLLMSiteConfiguration } from '../sourcegraph-api/graphql/client'
 import {
-    ANSWER_TOKENS,
     CHAT_INPUT_TOKEN_BUDGET,
     CHAT_OUTPUT_TOKEN_BUDGET,
-    type ClientConfiguration,
-    type CodyLLMSiteConfiguration,
     EXTENDED_CHAT_INPUT_TOKEN_BUDGET,
     EXTENDED_USER_CONTEXT_TOKEN_BUDGET,
-    type ModelContextWindow,
-    ModelTag,
-    logDebug,
-} from '..'
+} from '../token/constants'
 import type { Model } from './model'
 import type { ModelRef, ModelRefStr } from './modelsService'
+import { ModelTag } from './tags'
+import type { ModelContextWindow } from './types'
 
 export function getProviderName(name: string): string {
     const providerName = name.toLowerCase()

--- a/vscode/src/chat/context/chatContext.ts
+++ b/vscode/src/chat/context/chatContext.ts
@@ -1,6 +1,5 @@
 import type { Mention } from '@openctx/client'
 import {
-    CodyIDE,
     type ContextItem,
     type ContextItemOpenCtx,
     type ContextItemRepository,
@@ -10,6 +9,7 @@ import {
     type MentionQuery,
     REMOTE_REPOSITORY_PROVIDER_URI,
     SYMBOL_CONTEXT_MENTION_PROVIDER,
+    clientCapabilities,
     combineLatest,
     firstResultFromOperation,
     fromVSCodeEvent,
@@ -28,7 +28,6 @@ import { Observable, map } from 'observable-fns'
 import * as vscode from 'vscode'
 import { URI } from 'vscode-uri'
 import { getContextFileFromUri } from '../../commands/context/file-path'
-import { getConfiguration } from '../../configuration'
 import {
     getFileContextFiles,
     getOpenTabsContextFile,
@@ -79,8 +78,6 @@ export function getMentionMenuData(options: {
         },
     }
 
-    const isCodyWeb = getConfiguration().agentIDE === CodyIDE.Web
-
     try {
         const items = combineLatest([
             promiseFactoryToObservable(signal =>
@@ -88,7 +85,7 @@ export function getMentionMenuData(options: {
                     {
                         mentionQuery: options.query,
                         telemetryRecorder: scopedTelemetryRecorder,
-                        rangeFilter: !isCodyWeb,
+                        rangeFilter: !clientCapabilities().isCodyWeb,
                     },
                     signal
                 )

--- a/vscode/src/chat/initialContext.ts
+++ b/vscode/src/chat/initialContext.ts
@@ -1,12 +1,12 @@
 import {
     type AuthStatus,
-    CodyIDE,
     type ContextItem,
     ContextItemSource,
     type ContextItemTree,
     REMOTE_REPOSITORY_PROVIDER_URI,
     abortableOperation,
     authStatus,
+    clientCapabilities,
     combineLatest,
     contextFiltersProvider,
     debounceTime,
@@ -27,7 +27,6 @@ import { Observable, map } from 'observable-fns'
 import * as vscode from 'vscode'
 import { URI } from 'vscode-uri'
 import { getSelectionOrFileContext } from '../commands/context/selection'
-import { getConfiguration } from '../configuration'
 import { createRepositoryMention } from '../context/openctx/common/get-repository-mentions'
 import { remoteReposForAllWorkspaceFolders } from '../repository/remoteRepos'
 import { ChatBuilder } from './chat-view/ChatBuilder'
@@ -162,8 +161,7 @@ function getCorpusContextItemsForEditorState(): Observable<ContextItem[] | typeo
                 ({
                     authenticated: authStatus.authenticated,
                     endpoint: authStatus.endpoint,
-                    allowRemoteContext:
-                        getConfiguration().agentIDE === CodyIDE.Web || !isDotCom(authStatus),
+                    allowRemoteContext: clientCapabilities().isCodyWeb || !isDotCom(authStatus),
                 }) satisfies Pick<AuthStatus, 'authenticated' | 'endpoint'> & {
                     allowRemoteContext: boolean
                 }

--- a/vscode/src/chat/protocol.ts
+++ b/vscode/src/chat/protocol.ts
@@ -2,6 +2,7 @@ import type {
     AuthCredentials,
     AuthStatus,
     ChatMessage,
+    ClientCapabilities,
     ClientConfiguration,
     CodyIDE,
     ContextItem,
@@ -135,6 +136,7 @@ export type ExtensionMessage =
     | {
           type: 'config'
           config: ConfigurationSubsetForWebview & LocalEnv
+          clientCapabilities: ClientCapabilities
           authStatus: AuthStatus
           configFeatures: {
               chat: boolean
@@ -216,10 +218,7 @@ export interface ExtensionTranscriptMessage {
  * The subset of configuration that is visible to the webview.
  */
 export interface ConfigurationSubsetForWebview
-    extends Pick<
-            ClientConfiguration,
-            'experimentalNoodle' | 'agentIDE' | 'agentExtensionVersion' | 'internalDebugContext'
-        >,
+    extends Pick<ClientConfiguration, 'experimentalNoodle' | 'internalDebugContext'>,
         Pick<AuthCredentials, 'serverEndpoint'> {
     smartApply: boolean
     // Type/location of the current webview.

--- a/vscode/src/commands/services/provider.ts
+++ b/vscode/src/commands/services/provider.ts
@@ -1,8 +1,12 @@
-import { type CodyCommand, CodyIDE, type ContextItem, isFileURI } from '@sourcegraph/cody-shared'
+import {
+    type CodyCommand,
+    type ContextItem,
+    clientCapabilities,
+    isFileURI,
+} from '@sourcegraph/cody-shared'
 
 import * as vscode from 'vscode'
 import { CodyCommandMenuItems } from '..'
-import { getConfiguration } from '../../configuration'
 import { executeExplainHistoryCommand } from '../execute/explain-history'
 import { showCommandMenu } from '../menus'
 import type { CodyCommandArgs } from '../types'
@@ -33,15 +37,14 @@ export class CommandsProvider implements vscode.Disposable {
     protected customCommandsStore: CustomCommandsManager | undefined
 
     constructor() {
-        const agentIDE = getConfiguration().agentIDE
-        if (agentIDE !== CodyIDE.Web) {
+        if (!clientCapabilities().isCodyWeb) {
             for (const c of vscodeDefaultCommands) {
                 this.commands.set(c.key, c)
             }
         }
 
         // Only initialize custom commands store in VS Code.
-        if (!agentIDE || agentIDE === CodyIDE.VSCode) {
+        if (clientCapabilities().isVSCode) {
             this.customCommandsStoreInit()
         }
 

--- a/vscode/src/completions/get-inline-completions-tests/helpers.ts
+++ b/vscode/src/completions/get-inline-completions-tests/helpers.ts
@@ -8,6 +8,7 @@ import {
     AUTH_STATUS_FIXTURE_AUTHED_DOTCOM,
     type AuthenticatedAuthStatus,
     type AutocompleteProviderID,
+    CLIENT_CAPABILITIES_FIXTURE,
     ClientConfigSingleton,
     type CodeCompletionsClient,
     type CodyClientConfig,
@@ -16,6 +17,7 @@ import {
     CompletionStopReason,
     featureFlagProvider,
     mockAuthStatus,
+    mockClientCapabilities,
     mockResolvedConfig,
     setEditorWindowIsFocused,
     testFileUri,
@@ -406,6 +408,7 @@ export function initCompletionProviderConfig({
         auth: { serverEndpoint: 'https://example.com', ...configuration?.auth },
         clientState: { modelPreferences: {}, ...configuration?.clientState },
     })
+    mockClientCapabilities(CLIENT_CAPABILITIES_FIXTURE)
 }
 
 export function getMockedGenerateCompletionsOptions(): GenerateCompletionsOptions {

--- a/vscode/src/completions/inline-completion-item-provider-e2e.test.ts
+++ b/vscode/src/completions/inline-completion-item-provider-e2e.test.ts
@@ -1,9 +1,11 @@
 import {
+    CLIENT_CAPABILITIES_FIXTURE,
     type ClientConfiguration,
     type CodeCompletionsParams,
     contextFiltersProvider,
     currentAuthStatus,
     featureFlagProvider,
+    mockClientCapabilities,
     nextTick,
     telemetryRecorder,
 } from '@sourcegraph/cody-shared'
@@ -138,6 +140,7 @@ function getInlineCompletionProvider(
     args: Partial<ConstructorParameters<typeof InlineCompletionItemProvider>[0]> = {}
 ): InlineCompletionItemProvider {
     vi.spyOn(featureFlagProvider, 'evaluatedFeatureFlag').mockReturnValue(Observable.of(false))
+    mockClientCapabilities(CLIENT_CAPABILITIES_FIXTURE)
     return new InlineCompletionItemProvider({
         completeSuggestWidgetSelection: true,
         triggerDelay: 0,

--- a/vscode/src/context/openctx.test.ts
+++ b/vscode/src/context/openctx.test.ts
@@ -1,10 +1,12 @@
 import {
     type AuthStatus,
+    CLIENT_CAPABILITIES_FIXTURE,
     DOTCOM_URL,
     GIT_OPENCTX_PROVIDER_URI,
     WEB_PROVIDER_URI,
     featureFlagProvider,
     firstValueFrom,
+    mockClientCapabilities,
     mockResolvedConfig,
 } from '@sourcegraph/cody-shared'
 import { Observable } from 'observable-fns'
@@ -18,6 +20,7 @@ vi.mock('../../../lib/shared/src/experimentation')
 
 describe('getOpenCtxProviders', () => {
     beforeAll(() => {
+        mockClientCapabilities(CLIENT_CAPABILITIES_FIXTURE)
         mockResolvedConfig({
             configuration: { experimentalNoodle: false },
             auth: { serverEndpoint: 'https://example.com' },

--- a/vscode/src/context/openctx.ts
+++ b/vscode/src/context/openctx.ts
@@ -1,11 +1,11 @@
 import {
     type AuthStatus,
     type ClientConfiguration,
-    CodyIDE,
     FeatureFlag,
     GIT_OPENCTX_PROVIDER_URI,
     WEB_PROVIDER_URI,
     authStatus,
+    clientCapabilities,
     combineLatest,
     createDisposables,
     debounceTime,
@@ -45,8 +45,7 @@ export function exposeOpenCtxClient(
 
     return combineLatest([
         resolvedConfig.pipe(
-            map(({ configuration: { agentIDE, experimentalNoodle } }) => ({
-                agentIDE,
+            map(({ configuration: { experimentalNoodle } }) => ({
                 experimentalNoodle,
             })),
             distinctUntilChanged()
@@ -71,10 +70,8 @@ export function exposeOpenCtxClient(
             async () => createOpenCtxController ?? (await import('@openctx/vscode-lib')).createController
         ),
     ]).pipe(
-        createDisposables(([{ agentIDE, experimentalNoodle }, isValidSiteVersion, createController]) => {
+        createDisposables(([{ experimentalNoodle }, isValidSiteVersion, createController]) => {
             try {
-                const isCodyWeb = agentIDE === CodyIDE.Web
-
                 // Enable fetching of openctx configuration from Sourcegraph instance
                 const mergeConfiguration = experimentalNoodle
                     ? getMergeConfigurationFunction()
@@ -90,8 +87,8 @@ export function exposeOpenCtxClient(
                     extensionId: context.extension.id,
                     secrets: context.secrets,
                     outputChannel: openctxOutputChannel!,
-                    features: isCodyWeb ? {} : { annotations: true },
-                    providers: isCodyWeb
+                    features: clientCapabilities().isVSCode ? { annotations: true } : {},
+                    providers: clientCapabilities().isCodyWeb
                         ? Observable.of(getCodyWebOpenCtxProviders())
                         : getOpenCtxProviders(authStatus, isValidSiteVersion),
                     mergeConfiguration,

--- a/vscode/src/extension.node.ts
+++ b/vscode/src/extension.node.ts
@@ -18,7 +18,6 @@ import { initializeNetworkAgent, setCustomAgent } from './fetch.node'
 import { SymfRunner } from './local-context/symf'
 import { localStorage } from './services/LocalStorageProvider'
 import { OpenTelemetryService } from './services/open-telemetry/OpenTelemetryService.node'
-import { getExtensionDetails } from './services/telemetry-v2'
 import { serializeConfigSnapshot } from './uninstall/serializeConfig'
 
 /**
@@ -70,6 +69,5 @@ export async function deactivate(): Promise<void> {
     serializeConfigSnapshot({
         config,
         authStatus,
-        extensionDetails: getExtensionDetails(config.configuration),
     })
 }

--- a/vscode/src/local-context/rewrite-keyword-query.test.ts
+++ b/vscode/src/local-context/rewrite-keyword-query.test.ts
@@ -5,7 +5,13 @@ import { startPollyRecording } from '../testutils/polly'
 
 import { rewriteKeywordQuery } from './rewrite-keyword-query'
 
-import { type PromptString, mockResolvedConfig, ps } from '@sourcegraph/cody-shared'
+import {
+    CLIENT_CAPABILITIES_FIXTURE,
+    type PromptString,
+    mockClientCapabilities,
+    mockResolvedConfig,
+    ps,
+} from '@sourcegraph/cody-shared'
 import { SourcegraphNodeCompletionsClient } from '../completions/nodeClient'
 import { TESTING_CREDENTIALS } from '../testutils/testing-credentials'
 
@@ -29,6 +35,7 @@ describe('rewrite-query', () => {
                 serverEndpoint: TESTING_CREDENTIALS.dotcom.serverEndpoint,
             },
         })
+        mockClientCapabilities(CLIENT_CAPABILITIES_FIXTURE)
     })
 
     function check(query: PromptString, expectedHandler: (expandedTerm: string) => void): void {

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -3,7 +3,6 @@ import * as vscode from 'vscode'
 import {
     type ChatClient,
     ClientConfigSingleton,
-    CodyIDE,
     type ConfigurationInput,
     type DefaultCodyCommands,
     FeatureFlag,
@@ -13,6 +12,7 @@ import {
     type ResolvedConfiguration,
     authStatus,
     catchError,
+    clientCapabilities,
     combineLatest,
     contextFiltersProvider,
     createDisposables,
@@ -24,6 +24,7 @@ import {
     isDotCom,
     modelsService,
     resolvedConfig,
+    setClientCapabilitiesFromConfiguration,
     setClientNameVersion,
     setEditorWindowIsFocused,
     setLogger,
@@ -125,6 +126,8 @@ export async function start(
     setLogger({ logDebug, logError })
 
     const disposables: vscode.Disposable[] = []
+
+    setClientCapabilitiesFromConfiguration(getConfiguration())
 
     setResolvedConfigurationObservable(
         combineLatest([
@@ -239,7 +242,7 @@ const register = async (
     registerChatCommands(disposables)
     disposables.push(...registerSidebarCommands())
     registerOtherCommands(disposables)
-    if (!getConfiguration().agentIDE) {
+    if (clientCapabilities().isVSCode) {
         registerVSCodeOnlyFeatures(chatClient, disposables)
     }
     if (isExtensionModeDevOrTest) {
@@ -421,7 +424,7 @@ async function registerCodyCommands(
                 .pipe(
                     createDisposables(codyUnifiedPromptsFlag => {
                         const unifiedPromptsEnabled =
-                            codyUnifiedPromptsFlag && getConfiguration().agentIDE !== CodyIDE.Web
+                            codyUnifiedPromptsFlag && !clientCapabilities().isCodyWeb
                         vscode.commands.executeCommand(
                             'setContext',
                             'cody.menu.custom-commands.enable',

--- a/vscode/src/prompts/prompts.ts
+++ b/vscode/src/prompts/prompts.ts
@@ -1,8 +1,8 @@
 import {
     type CodyCommand,
-    CodyIDE,
     FeatureFlag,
     type PromptsResult,
+    clientCapabilities,
     featureFlagProvider,
     graphqlClient,
     isAbortError,
@@ -10,7 +10,6 @@ import {
 } from '@sourcegraph/cody-shared'
 import { FIXTURE_COMMANDS } from '../../webviews/components/promptList/fixtures'
 import { getCodyCommandList } from '../commands/CommandsController'
-import { getConfiguration } from '../configuration'
 
 /**
  * Observe results of querying the prompts from the Prompt Library, (deprecated) built-in commands,
@@ -45,7 +44,7 @@ export async function mergedPromptsAndLegacyCommands(
 
     // Ignore commands since with unified prompts vital commands will be replaced by out-of-box
     // commands, see main.ts register cody commands for unified prompts
-    if (isUnifiedPromptsEnabled && getConfiguration().agentIDE !== CodyIDE.Web) {
+    if (isUnifiedPromptsEnabled && !clientCapabilities().isCodyWeb) {
         return {
             query,
             commands: [],

--- a/vscode/src/repository/repo-name-resolver.test.ts
+++ b/vscode/src/repository/repo-name-resolver.test.ts
@@ -3,9 +3,11 @@ import { describe, expect, it, vi } from 'vitest'
 import {
     AUTH_STATUS_FIXTURE_AUTHED,
     AUTH_STATUS_FIXTURE_AUTHED_DOTCOM,
+    CLIENT_CAPABILITIES_FIXTURE,
     firstResultFromOperation,
     graphqlClient,
     mockAuthStatus,
+    mockClientCapabilities,
     mockResolvedConfig,
 } from '@sourcegraph/cody-shared'
 
@@ -20,6 +22,7 @@ describe('getRepoNamesContainingUri', () => {
         const repoNameResolver = new RepoNameResolver()
         mockAuthStatus(AUTH_STATUS_FIXTURE_AUTHED)
         mockResolvedConfig({ auth: {} })
+        mockClientCapabilities(CLIENT_CAPABILITIES_FIXTURE)
 
         vi.spyOn(remoteUrlsFromParentDirs, 'gitRemoteUrlsForUri').mockResolvedValue([
             'git@github.com:sourcegraph/cody.git',

--- a/vscode/src/services/AuthProvider.test.ts
+++ b/vscode/src/services/AuthProvider.test.ts
@@ -1,7 +1,9 @@
 import {
     type AuthStatus,
     type AuthenticatedAuthStatus,
+    CLIENT_CAPABILITIES_FIXTURE,
     type ResolvedConfiguration,
+    mockClientCapabilities,
     readValuesFrom,
 } from '@sourcegraph/cody-shared'
 import type { PartialDeep } from '@sourcegraph/cody-shared/src/utils'
@@ -18,6 +20,8 @@ function asyncValue<T>(value: T, delay?: number | undefined): Promise<T> {
         setTimeout(() => resolve(value), delay)
     })
 }
+
+mockClientCapabilities(CLIENT_CAPABILITIES_FIXTURE)
 
 describe('AuthProvider', () => {
     beforeAll(() => {

--- a/vscode/src/services/AuthProvider.ts
+++ b/vscode/src/services/AuthProvider.ts
@@ -3,12 +3,12 @@ import * as vscode from 'vscode'
 import {
     type AuthCredentials,
     type AuthStatus,
-    CodyIDE,
     NEVER,
     type ResolvedConfiguration,
     type Unsubscribable,
     abortableOperation,
     authStatus,
+    clientCapabilities,
     combineLatest,
     currentResolvedConfig,
     disposableSubscription,
@@ -69,7 +69,7 @@ class AuthProvider implements vscode.Disposable {
             ])
                 .pipe(
                     abortableOperation(async ([config], signal) => {
-                        if (config.configuration.agentIDE === CodyIDE.Web) {
+                        if (clientCapabilities().isCodyWeb) {
                             // Cody Web calls {@link AuthProvider.validateAndStoreCredentials}
                             // explicitly. This early exit prevents duplicate authentications during
                             // the initial load.
@@ -249,7 +249,6 @@ function toCredentialsOnlyNormalized(
 ): ResolvedConfigurationCredentialsOnly {
     return {
         configuration: {
-            agentIDE: config.configuration.agentIDE,
             customHeaders: config.configuration.customHeaders,
         },
         auth: { ...config.auth, serverEndpoint: normalizeServerEndpointURL(config.auth.serverEndpoint) },

--- a/vscode/src/services/AuthProviderSimplified.ts
+++ b/vscode/src/services/AuthProviderSimplified.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode'
 
-import { CodyIDE, DOTCOM_URL, getCodyAuthReferralCode } from '@sourcegraph/cody-shared'
+import { DOTCOM_URL, getCodyAuthReferralCode } from '@sourcegraph/cody-shared'
 
 import type { AuthMethod } from '../chat/protocol'
 
@@ -11,12 +11,8 @@ import { authProvider } from './AuthProvider'
 // for dotcom, and doesn't work on VScode web. See LoginSimplified.
 
 export class AuthProviderSimplified {
-    public async openExternalAuthUrl(
-        method: AuthMethod,
-        tokenReceiverUrl?: string,
-        agentIDE?: CodyIDE
-    ): Promise<boolean> {
-        if (!(await openExternalAuthUrl(method, tokenReceiverUrl, agentIDE))) {
+    public async openExternalAuthUrl(method: AuthMethod, tokenReceiverUrl?: string): Promise<boolean> {
+        if (!(await openExternalAuthUrl(method, tokenReceiverUrl))) {
             return false
         }
         authProvider.setAuthPendingToEndpoint(DOTCOM_URL.toString())
@@ -25,15 +21,11 @@ export class AuthProviderSimplified {
 }
 
 // Opens authentication URLs for simplified onboarding.
-function openExternalAuthUrl(
-    provider: AuthMethod,
-    tokenReceiverUrl?: string,
-    agentIDE = CodyIDE.VSCode
-): Thenable<boolean> {
+function openExternalAuthUrl(provider: AuthMethod, tokenReceiverUrl?: string): Thenable<boolean> {
     // Create the chain of redirects:
     // 1. Specific login page (GitHub, etc.) redirects to the new token page
     // 2. New token page redirects back to the extension with the new token
-    const referralCode = getCodyAuthReferralCode(agentIDE, vscode.env.uriScheme)
+    const referralCode = getCodyAuthReferralCode(vscode.env.uriScheme)
     const tokenReceiver = tokenReceiverUrl
         ? `&tokenReceiverUrl=${encodeURIComponent(tokenReceiverUrl)}`
         : ''

--- a/vscode/src/services/open-telemetry/utils.ts
+++ b/vscode/src/services/open-telemetry/utils.ts
@@ -1,26 +1,46 @@
 import type { Span } from '@opentelemetry/api'
-import { currentAuthStatus, featureFlagProvider } from '@sourcegraph/cody-shared'
+import {
+    type CodyIDE,
+    clientCapabilities,
+    currentAuthStatus,
+    featureFlagProvider,
+} from '@sourcegraph/cody-shared'
 import * as vscode from 'vscode'
-import { getConfiguration } from '../../configuration'
 import type { ExtensionApi } from '../../extension-api'
-import { getExtensionDetails } from '../telemetry-v2'
+import { getOSArch } from '../../os'
+import { version } from '../../version'
+
+const { platform, arch } = getOSArch()
 
 // Ensure to ad exposed experiments at the very end to make sure we include experiments that the
 // user is being exposed to while the span was generated
 export function recordExposedExperimentsToSpan(span: Span): void {
     span.setAttributes(featureFlagProvider.getExposedExperiments(currentAuthStatus().endpoint))
-    const extensionDetails = getExtensionDetails(getConfiguration(vscode.workspace.getConfiguration()))
-    span.setAttributes(extensionDetails as any)
+
+    // This object is the old ExtensionDetails type, maintained for backcompat.
+    interface ExtensionDetailsBackcompat {
+        ide: CodyIDE
+        arch?: string
+        platform: string
+        version: string
+    }
+    const cap = clientCapabilities()
+    span.setAttributes({
+        ide: cap.agentIDE,
+        arch,
+        platform: platform ?? 'browser',
+        version: cap.agentExtensionVersion || 'unknown',
+    } satisfies ExtensionDetailsBackcompat)
 
     const extensionApi: ExtensionApi | undefined =
         vscode.extensions.getExtension('sourcegraph.cody-ai')?.exports
-    if (extensionApi && extensionDetails.ide === 'VSCode') {
+    if (extensionApi && cap.isVSCode) {
         const vscodeChannel: 'release' | 'pre-release' | 'development' | 'test' | null =
             extensionApi.extensionMode === vscode.ExtensionMode.Development
                 ? 'development'
                 : extensionApi.extensionMode === vscode.ExtensionMode.Test
                   ? 'test'
-                  : inferVSCodeChannelFromVersion(extensionDetails.version)
+                  : inferVSCodeChannelFromVersion(cap.agentExtensionVersion ?? version)
         span.setAttribute('vscodeChannel', vscodeChannel)
     }
 }

--- a/vscode/src/uninstall/post-uninstall.ts
+++ b/vscode/src/uninstall/post-uninstall.ts
@@ -15,7 +15,7 @@ async function main() {
 
     const uninstaller = readConfig()
     if (uninstaller) {
-        const { config, extensionDetails, authStatus } = uninstaller
+        const { config, authStatus } = uninstaller
         if (config && authStatus) {
             try {
                 setStaticResolvedConfigurationValue(config)
@@ -26,11 +26,7 @@ async function main() {
             // Wait for `currentAuthStatusOrNotReadyYet` to have this value synchronously.
             await nextTick()
 
-            const provider = new TelemetryRecorderProvider(
-                extensionDetails,
-                config,
-                'connected-instance-only'
-            )
+            const provider = new TelemetryRecorderProvider(config, 'connected-instance-only')
             const recorder = provider.getRecorder()
             recorder.recordEvent('cody.extension', 'uninstalled', {
                 billingMetadata: {

--- a/vscode/src/uninstall/serializeConfig.ts
+++ b/vscode/src/uninstall/serializeConfig.ts
@@ -1,7 +1,7 @@
 import * as fs from 'node:fs'
 import * as os from 'node:os'
 import * as path from 'node:path'
-import type { AuthStatus, ExtensionDetails, ResolvedConfiguration } from '@sourcegraph/cody-shared'
+import type { AuthStatus, ResolvedConfiguration } from '@sourcegraph/cody-shared'
 
 import { Platform, getOSArch } from '../os'
 
@@ -42,7 +42,6 @@ function writeSnapshot(directory: string, filename: string, content: any) {
 interface UninstallerConfig {
     config?: ResolvedConfiguration
     authStatus: AuthStatus | undefined
-    extensionDetails: ExtensionDetails
 }
 
 /**

--- a/vscode/src/version.ts
+++ b/vscode/src/version.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode'
 
+import { setExtensionVersion } from '@sourcegraph/cody-shared'
 import { version as packageVersion } from '../package.json'
 
 // The runtime version (available from the host extension) will represent
@@ -8,3 +9,5 @@ import { version as packageVersion } from '../package.json'
 export const version =
     (vscode.extensions.getExtension('sourcegraph.cody-ai')?.packageJSON as { version: string })
         ?.version ?? packageVersion
+
+setExtensionVersion(version)

--- a/vscode/webviews/App.story.tsx
+++ b/vscode/webviews/App.story.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react'
 
-import { AUTH_STATUS_FIXTURE_AUTHED } from '@sourcegraph/cody-shared'
+import { AUTH_STATUS_FIXTURE_AUTHED, CLIENT_CAPABILITIES_FIXTURE } from '@sourcegraph/cody-shared'
 import { App } from './App'
 import { VSCodeWebview } from './storybook/VSCodeStoryDecorator'
 import { View } from './tabs'
@@ -29,6 +29,7 @@ const dummyVSCodeAPI: VSCodeWrapper = {
                 experimentalNoodle: false,
                 smartApply: false,
             },
+            clientCapabilities: CLIENT_CAPABILITIES_FIXTURE,
             authStatus: {
                 ...AUTH_STATUS_FIXTURE_AUTHED,
                 displayName: 'Tim Lucas',

--- a/vscode/webviews/App.tsx
+++ b/vscode/webviews/App.tsx
@@ -4,7 +4,6 @@ import styles from './App.module.css'
 
 import {
     type ChatMessage,
-    CodyIDE,
     type ContextItem,
     GuardrailsPost,
     PromptString,
@@ -177,7 +176,7 @@ export const App: React.FunctionComponent<{ vscodeAPI: VSCodeWrapper }> = ({ vsc
                         simplifiedLoginRedirect={loginRedirect}
                         uiKindIsWeb={config.config.uiKindIsWeb}
                         vscodeAPI={vscodeAPI}
-                        codyIDE={config.config.agentIDE ?? CodyIDE.VSCode}
+                        codyIDE={config.clientCapabilities.agentIDE}
                     />
                 </div>
             ) : (

--- a/vscode/webviews/AppWrapperForTest.tsx
+++ b/vscode/webviews/AppWrapperForTest.tsx
@@ -1,6 +1,7 @@
 import {
     AUTH_STATUS_FIXTURE_AUTHED,
     type AuthStatus,
+    CLIENT_CAPABILITIES_FIXTURE,
     type ClientConfiguration,
     type ContextItem,
     type ContextItemSymbol,
@@ -90,7 +91,6 @@ export const AppWrapperForTest: FunctionComponent<{ children: ReactNode }> = ({ 
                             auth: { accessToken: 'abc', serverEndpoint: 'https://example.com' },
                             configuration: {
                                 autocomplete: true,
-                                agentIDEVersion: '1.2.3',
                                 devModels: [{ model: 'my-model', provider: 'my-provider' }],
                             } satisfies Partial<ClientConfiguration> as ClientConfiguration,
                         } satisfies Partial<ResolvedConfiguration> as ResolvedConfiguration),
@@ -107,6 +107,7 @@ export const AppWrapperForTest: FunctionComponent<{ children: ReactNode }> = ({ 
                             authenticated: true,
                         } satisfies Partial<AuthStatus> as any,
                         config: {} as any,
+                        clientCapabilities: CLIENT_CAPABILITIES_FIXTURE,
                         configFeatures: {
                             chat: true,
                             serverSentModels: true,

--- a/vscode/webviews/Chat.tsx
+++ b/vscode/webviews/Chat.tsx
@@ -4,7 +4,6 @@ import { useCallback, useEffect, useMemo, useRef } from 'react'
 import type {
     AuthenticatedAuthStatus,
     ChatMessage,
-    CodyIDE,
     Guardrails,
     PromptString,
 } from '@sourcegraph/cody-shared'
@@ -224,9 +223,7 @@ export const Chat: React.FunctionComponent<React.PropsWithChildren<ChatboxProps>
                 guardrails={guardrails}
                 smartApplyEnabled={smartApplyEnabled}
             />
-            {transcript.length === 0 && showWelcomeMessage && (
-                <WelcomeMessage IDE={userInfo.ide} setView={setView} />
-            )}
+            {transcript.length === 0 && showWelcomeMessage && <WelcomeMessage setView={setView} />}
             {scrollableParent && (
                 <ScrollDown scrollableParent={scrollableParent} onClick={handleScrollDownClick} />
             )}
@@ -241,7 +238,6 @@ export interface UserAccountInfo {
         AuthenticatedAuthStatus,
         'username' | 'displayName' | 'avatarURL' | 'endpoint' | 'primaryEmail'
     >
-    ide: CodyIDE
 }
 
 export type ApiPostMessage = (message: any) => void

--- a/vscode/webviews/CodyPanel.story.tsx
+++ b/vscode/webviews/CodyPanel.story.tsx
@@ -1,4 +1,8 @@
-import { AUTH_STATUS_FIXTURE_AUTHED, AUTH_STATUS_FIXTURE_UNAUTHED } from '@sourcegraph/cody-shared'
+import {
+    AUTH_STATUS_FIXTURE_AUTHED,
+    AUTH_STATUS_FIXTURE_UNAUTHED,
+    CLIENT_CAPABILITIES_FIXTURE,
+} from '@sourcegraph/cody-shared'
 import type { Meta, StoryObj } from '@storybook/react'
 import { CodyPanel } from './CodyPanel'
 import { FIXTURE_TRANSCRIPT } from './chat/fixtures'
@@ -20,6 +24,7 @@ const meta: Meta<typeof CodyPanel> = {
         setView: () => {},
         configuration: {
             config: {} as any,
+            clientCapabilities: CLIENT_CAPABILITIES_FIXTURE,
             authStatus: AUTH_STATUS_FIXTURE_AUTHED,
         },
     },
@@ -32,6 +37,7 @@ export const NetworkError: StoryObj<typeof meta> = {
     args: {
         configuration: {
             config: {} as any,
+            clientCapabilities: CLIENT_CAPABILITIES_FIXTURE,
             authStatus: {
                 ...AUTH_STATUS_FIXTURE_UNAUTHED,
                 showNetworkError: true,

--- a/vscode/webviews/CodyPanel.tsx
+++ b/vscode/webviews/CodyPanel.tsx
@@ -1,4 +1,4 @@
-import { type AuthStatus, CodyIDE } from '@sourcegraph/cody-shared'
+import { type AuthStatus, type ClientCapabilities, CodyIDE } from '@sourcegraph/cody-shared'
 import type React from 'react'
 import { type ComponentProps, type FunctionComponent, useCallback, useRef } from 'react'
 import type { ConfigurationSubsetForWebview, LocalEnv } from '../src/chat/protocol'
@@ -16,7 +16,11 @@ export const CodyPanel: FunctionComponent<
     {
         view: View
         setView: (view: View) => void
-        configuration: { config: LocalEnv & ConfigurationSubsetForWebview; authStatus: AuthStatus }
+        configuration: {
+            config: LocalEnv & ConfigurationSubsetForWebview
+            clientCapabilities: ClientCapabilities
+            authStatus: AuthStatus
+        }
         errorMessages: string[]
         setErrorMessages: (errors: string[]) => void
         attributionEnabled: boolean
@@ -35,7 +39,7 @@ export const CodyPanel: FunctionComponent<
 > = ({
     view,
     setView,
-    configuration: { config, authStatus },
+    configuration: { config, clientCapabilities, authStatus },
     errorMessages,
     setErrorMessages,
     attributionEnabled,
@@ -75,11 +79,11 @@ export const CodyPanel: FunctionComponent<
             {!authStatus.authenticated && authStatus.showNetworkError && <ConnectivityStatusBanner />}
 
             {/* Hide tab bar in editor chat panels. */}
-            {(config.agentIDE === CodyIDE.Web || config.webviewType !== 'editor') && (
+            {(clientCapabilities.agentIDE === CodyIDE.Web || config.webviewType !== 'editor') && (
                 <TabsBar
                     currentView={view}
                     setView={setView}
-                    IDE={config.agentIDE || CodyIDE.VSCode}
+                    IDE={clientCapabilities.agentIDE}
                     onDownloadChatClick={onDownloadChatClick}
                 />
             )}
@@ -101,7 +105,7 @@ export const CodyPanel: FunctionComponent<
                 )}
                 {view === View.History && (
                     <HistoryTab
-                        IDE={config.agentIDE || CodyIDE.VSCode}
+                        IDE={clientCapabilities.agentIDE}
                         setView={setView}
                         webviewType={config.webviewType}
                         multipleWebviewsEnabled={config.multipleWebviewsEnabled}

--- a/vscode/webviews/chat/ChatMessageContent/ChatMessageContent.tsx
+++ b/vscode/webviews/chat/ChatMessageContent/ChatMessageContent.tsx
@@ -5,9 +5,9 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { clsx } from 'clsx'
 import type { FixupTaskID } from '../../../src/non-stop/FixupTask'
 import { CodyTaskState } from '../../../src/non-stop/state'
-import type { UserAccountInfo } from '../../Chat'
 import { type ClientActionListener, useClientActionListener } from '../../client/clientState'
 import { MarkdownFromCody } from '../../components/MarkdownFromCody'
+import { useConfig } from '../../utils/useConfig'
 import type { PriorHumanMessageInfo } from '../cells/messageCell/assistant/AssistantMessageCell'
 import styles from './ChatMessageContent.module.css'
 import { GuardrailsStatusController } from './GuardRailStatusController'
@@ -28,7 +28,6 @@ interface ChatMessageContentProps {
     displayMarkdown: string
     isMessageLoading: boolean
     humanMessage: PriorHumanMessageInfo | null
-    userInfo: UserAccountInfo
 
     copyButtonOnSubmit?: CodeBlockActionsProps['copyButtonOnSubmit']
     insertButtonOnSubmit?: CodeBlockActionsProps['insertButtonOnSubmit']
@@ -53,9 +52,9 @@ export const ChatMessageContent: React.FunctionComponent<ChatMessageContentProps
     className,
     smartApplyEnabled,
     smartApply,
-    userInfo,
 }) => {
     const rootRef = useRef<HTMLDivElement>(null)
+    const config = useConfig()
 
     const [smartApplyStates, setSmartApplyStates] = useState<Record<FixupTaskID, CodyTaskState>>({})
     const smartApplyInterceptor = useMemo<CodeBlockActionsProps['smartApply'] | undefined>(() => {
@@ -129,7 +128,7 @@ export const ChatMessageContent: React.FunctionComponent<ChatMessageContentProps
                     buttons = createButtonsExperimentalUI(
                         preText,
                         humanMessage,
-                        userInfo,
+                        config,
                         codeBlockName,
                         copyButtonOnSubmit,
                         insertButtonOnSubmit,

--- a/vscode/webviews/chat/ChatMessageContent/create-buttons.ts
+++ b/vscode/webviews/chat/ChatMessageContent/create-buttons.ts
@@ -1,3 +1,5 @@
+import type { FixupTaskID } from '../../../src/non-stop/FixupTask'
+import { CodyTaskState } from '../../../src/non-stop/state'
 import {
     CheckCodeBlockIcon,
     CloseIcon,
@@ -9,12 +11,8 @@ import {
     SyncSpinIcon,
     TickIcon,
 } from '../../icons/CodeBlockActionIcons'
-
-import { CodyIDE } from '@sourcegraph/cody-shared'
-import type { FixupTaskID } from '../../../src/non-stop/FixupTask'
-import { CodyTaskState } from '../../../src/non-stop/state'
-import type { UserAccountInfo } from '../../Chat'
 import { getVSCodeAPI } from '../../utils/VSCodeApi'
+import type { Config } from '../../utils/useConfig'
 import type { PriorHumanMessageInfo } from '../cells/messageCell/assistant/AssistantMessageCell'
 import type { CodeBlockActionsProps } from './ChatMessageContent'
 import styles from './ChatMessageContent.module.css'
@@ -81,7 +79,7 @@ export function createButtons(
 export function createButtonsExperimentalUI(
     preText: string,
     humanMessage: PriorHumanMessageInfo | null,
-    userInfo: UserAccountInfo,
+    config: Config,
     codeBlockName?: string, // The name of the code block, can be file name or 'command'.
     copyButtonOnSubmit?: CodeBlockActionsProps['copyButtonOnSubmit'],
     insertButtonOnSubmit?: CodeBlockActionsProps['insertButtonOnSubmit'],
@@ -94,8 +92,6 @@ export function createButtonsExperimentalUI(
     if (!copyButtonOnSubmit) {
         return container
     }
-
-    const isVSCode = userInfo.ide === CodyIDE.VSCode
 
     const buttons = document.createElement('div')
     buttons.className = styles.buttons
@@ -112,7 +108,7 @@ export function createButtonsExperimentalUI(
             // Execute button is only available in VS Code.
             const isExecutable = codeBlockName === 'command'
             const smartButton =
-                isExecutable && isVSCode
+                isExecutable && config.clientCapabilities.isVSCode
                     ? createExecuteButton(preText)
                     : createApplyButton(
                           preText,
@@ -126,7 +122,7 @@ export function createButtonsExperimentalUI(
             buttons.append(smartButton)
         }
 
-        if (isVSCode) {
+        if (config.clientCapabilities.isVSCode) {
             // VS Code provides additional support for rendering an OS-native dropdown, that has some
             // additional benefits. Mainly that it can "break out" of the webview.
             // TODO: A dropdown would be useful for other clients too, we should consider building

--- a/vscode/webviews/chat/cells/messageCell/assistant/AssistantMessageCell.tsx
+++ b/vscode/webviews/chat/cells/messageCell/assistant/AssistantMessageCell.tsx
@@ -112,7 +112,6 @@ export const AssistantMessageCell: FunctionComponent<{
                                 humanMessage={humanMessage}
                                 smartApplyEnabled={smartApplyEnabled}
                                 smartApply={smartApply}
-                                userInfo={userInfo}
                             />
                         ) : (
                             isLoading && (

--- a/vscode/webviews/chat/components/WelcomeMessage.test.tsx
+++ b/vscode/webviews/chat/components/WelcomeMessage.test.tsx
@@ -1,9 +1,10 @@
-import { CodyIDE } from '@sourcegraph/cody-shared'
+import { AUTH_STATUS_FIXTURE_AUTHED, type ClientCapabilities } from '@sourcegraph/cody-shared'
 import { fireEvent, render, screen } from '@testing-library/react'
 import { describe, expect, test, vi } from 'vitest'
 import { AppWrapperForTest } from '../../AppWrapperForTest'
 import { usePromptsQuery } from '../../components/promptList/usePromptsQuery'
 import { FIXTURE_PROMPTS } from '../../components/promptSelectField/fixtures'
+import * as useConfigModule from '../../utils/useConfig'
 import { WelcomeMessage } from './WelcomeMessage'
 
 vi.mock('../../components/promptList/usePromptsQuery')
@@ -25,7 +26,13 @@ describe('WelcomeMessage', () => {
         }
     }
     test('renders for CodyIDE.VSCode', () => {
-        render(<WelcomeMessage IDE={CodyIDE.VSCode} setView={() => {}} />, {
+        vi.spyOn(useConfigModule, 'useConfig').mockReturnValue({
+            clientCapabilities: {
+                isVSCode: true,
+            } satisfies Partial<ClientCapabilities> as ClientCapabilities,
+            authStatus: AUTH_STATUS_FIXTURE_AUTHED,
+        } satisfies Partial<useConfigModule.Config> as useConfigModule.Config)
+        render(<WelcomeMessage setView={() => {}} />, {
             wrapper: AppWrapperForTest,
         })
         openCollapsiblePanels()
@@ -41,7 +48,13 @@ describe('WelcomeMessage', () => {
     })
 
     test('renders for CodyIDE.JetBrains', () => {
-        render(<WelcomeMessage IDE={CodyIDE.JetBrains} setView={() => {}} />, {
+        vi.spyOn(useConfigModule, 'useConfig').mockReturnValue({
+            clientCapabilities: {
+                isVSCode: false,
+            } satisfies Partial<ClientCapabilities> as ClientCapabilities,
+            authStatus: AUTH_STATUS_FIXTURE_AUTHED,
+        } satisfies Partial<useConfigModule.Config> as useConfigModule.Config)
+        render(<WelcomeMessage setView={() => {}} />, {
             wrapper: AppWrapperForTest,
         })
         openCollapsiblePanels()

--- a/vscode/webviews/chat/components/WelcomeMessage.tsx
+++ b/vscode/webviews/chat/components/WelcomeMessage.tsx
@@ -1,4 +1,4 @@
-import { CodyIDE, FeatureFlag } from '@sourcegraph/cody-shared'
+import { FeatureFlag } from '@sourcegraph/cody-shared'
 import {
     AtSignIcon,
     type LucideProps,
@@ -14,6 +14,7 @@ import { Kbd } from '../../components/Kbd'
 import { PromptListSuitedForNonPopover } from '../../components/promptList/PromptList'
 import { onPromptSelectInPanel, onPromptSelectInPanelActionLabels } from '../../prompts/PromptsTab'
 import type { View } from '../../tabs'
+import { useConfig } from '../../utils/useConfig'
 import { useFeatureFlag } from '../../utils/useFeatureFlags'
 
 const MenuExample: FunctionComponent<{ children: React.ReactNode }> = ({ children }) => (
@@ -45,17 +46,18 @@ const FeatureRow: FunctionComponent<{
 const localStorageKey = 'chat.welcome-message-dismissed'
 
 interface WelcomeMessageProps {
-    IDE: CodyIDE
     setView: (view: View) => void
 }
 
-export const WelcomeMessage: FunctionComponent<WelcomeMessageProps> = ({ IDE, setView }) => {
+export const WelcomeMessage: FunctionComponent<WelcomeMessageProps> = ({ setView }) => {
     // Remove the old welcome message dismissal key that is no longer used.
     localStorage.removeItem(localStorageKey)
 
     const dispatchClientAction = useClientActionDispatcher()
 
     const isUnifiedPromptsAvailable = useFeatureFlag(FeatureFlag.CodyUnifiedPrompts)
+
+    const config = useConfig()
 
     return (
         <div className="tw-flex-1 tw-flex tw-flex-col tw-items-start tw-w-full tw-px-6 tw-gap-6 tw-transition-all">
@@ -85,7 +87,7 @@ export const WelcomeMessage: FunctionComponent<WelcomeMessageProps> = ({ IDE, se
                 <FeatureRow icon={AtSignIcon}>
                     Type <Kbd macOS="@" linuxAndWindows="@" /> to add context to your chat
                 </FeatureRow>
-                {IDE === CodyIDE.VSCode && (
+                {config.clientCapabilities.isVSCode && (
                     <>
                         <FeatureRow icon={TextIcon}>
                             To add code context from an editor, right click and use{' '}

--- a/vscode/webviews/chat/fixtures.ts
+++ b/vscode/webviews/chat/fixtures.ts
@@ -2,7 +2,6 @@ import { URI } from 'vscode-uri'
 
 import {
     type ChatMessage,
-    CodyIDE,
     ContextItemSource,
     FILE_MENTION_EDITOR_STATE_FIXTURE,
     ps,
@@ -192,5 +191,4 @@ export const FIXTURE_USER_ACCOUNT_INFO: UserAccountInfo = {
         avatarURL: 'https://avatars.githubusercontent.com/u/1976',
         endpoint: '',
     },
-    ide: CodyIDE.VSCode,
 }

--- a/vscode/webviews/components/MarkdownFromCody.test.tsx
+++ b/vscode/webviews/components/MarkdownFromCody.test.tsx
@@ -5,7 +5,7 @@ import { CodyIDE } from '@sourcegraph/cody-shared'
 import { MarkdownFromCody } from './MarkdownFromCody'
 
 vi.mock('../utils/useConfig', () => ({
-    useConfig: () => ({ config: { agentIDE: CodyIDE.VSCode } }),
+    useConfig: () => ({ clientCapabilities: { agentIDE: CodyIDE.VSCode } }),
 }))
 
 const complicatedMarkdown = [

--- a/vscode/webviews/components/MarkdownFromCody.tsx
+++ b/vscode/webviews/components/MarkdownFromCody.tsx
@@ -91,7 +91,7 @@ export const MarkdownFromCody: FunctionComponent<{ className?: string; children:
     className,
     children,
 }) => {
-    const clientType = useConfig().config.agentIDE ?? CodyIDE.VSCode
+    const clientType = useConfig().clientCapabilities.agentIDE
     const urlTransform = useMemo(() => URL_PROCESSORS[clientType], [clientType])
 
     return (

--- a/vscode/webviews/tabs/AccountTab.tsx
+++ b/vscode/webviews/tabs/AccountTab.tsx
@@ -6,7 +6,7 @@ import { MESSAGE_CELL_AVATAR_SIZE } from '../chat/cells/messageCell/BaseMessageC
 import { UserAvatar } from '../components/UserAvatar'
 import { Button } from '../components/shadcn/ui/button'
 import { getVSCodeAPI } from '../utils/VSCodeApi'
-import { useUserAccountInfo } from '../utils/useConfig'
+import { useConfig, useUserAccountInfo } from '../utils/useConfig'
 import { View } from './types'
 
 interface AccountAction {
@@ -19,12 +19,13 @@ interface AccountTabProps {
 
 // TODO: Implement the AccountTab component once the design is ready.
 export const AccountTab: React.FC<AccountTabProps> = ({ setView }) => {
+    const config = useConfig()
     const userInfo = useUserAccountInfo()
-    const { user, isCodyProUser, isDotComUser, ide } = userInfo
+    const { user, isCodyProUser, isDotComUser } = userInfo
     const { displayName, username, primaryEmail, endpoint } = user
 
     // We open the native system pop-up for VS Code.
-    if (ide === CodyIDE.VSCode) {
+    if (config.clientCapabilities.isVSCode) {
         return null
     }
 
@@ -68,7 +69,7 @@ export const AccountTab: React.FC<AccountTabProps> = ({ setView }) => {
             // automatically redirected to the Chat tab, rather than the accounts tab.
             // This is only for JB as the signout call is captured by the extension and not
             // passed through to the agent.
-            if (ide === CodyIDE.JetBrains) {
+            if (config.clientCapabilities.agentIDE === CodyIDE.JetBrains) {
                 setView(View.Chat)
             }
         },

--- a/vscode/webviews/utils/useConfig.tsx
+++ b/vscode/webviews/utils/useConfig.tsx
@@ -1,4 +1,4 @@
-import { CodyIDE, isCodyProUser } from '@sourcegraph/cody-shared'
+import { isCodyProUser } from '@sourcegraph/cody-shared'
 import {
     type ComponentProps,
     type FunctionComponent,
@@ -12,7 +12,7 @@ import type { UserAccountInfo } from '../Chat'
 export interface Config
     extends Pick<
         Extract<ExtensionMessage, { type: 'config' }>,
-        'config' | 'authStatus' | 'configFeatures' | 'isDotComUser'
+        'config' | 'clientCapabilities' | 'authStatus' | 'configFeatures' | 'isDotComUser'
     > {}
 
 const ConfigContext = createContext<Config | null>(null)
@@ -50,6 +50,5 @@ export function useUserAccountInfo(): UserAccountInfo {
         // with E2E tests where change the DOTCOM_URL via the env variable TESTING_DOTCOM_URL.
         isDotComUser: value.isDotComUser,
         user: value.authStatus,
-        ide: value.config.agentIDE ?? CodyIDE.VSCode,
     }
 }


### PR DESCRIPTION
Previously, we were doing 2 problematic things:

1. Determining extension/agent behavior based on the identity of the editor (`agentIDE`), instead of based on the client's reported capabilities. This is brittle and it is not clear *what* about (say) VS Code makes this code path work and this one not.
2. Taking the editor's identity from the agent (but falling back to VS Code implicitly), which meant that we were inconsistently doing `agentIDE ?? CodyIDE.VSCode` and similar for the extension version in many places. Of course, it's easy to make a mistake here.

This doesn't solve all of the problems, but it helps:

1. All places where we read the `agentIDE` are now centralized in a global `clientCapabilities()`. This will make future refactoring easier, solves a few problems (such as *explicitly* defaulting to `CodyIDE.VSCode`, which is not a great idea but at least codifies our current behavior with the type system), and makes it clear that this value can't change throughout the lifetime of the extension.
2. The gotchas when reading `agentIDE` and related values are documented, and the symbols are jsdoc'd with `@deprecated` to make them noticeable.

There is no intentional user-facing behavior change.

I found this code tricky when improving the sign-in page in https://github.com/sourcegraph/cody/pull/5746 because it was not clear why something was gated for VS Code. For example, the JetBrains UI in the storybook was configured to claim that it was running on the web, which made no sense but might be because it needed a UI more similar to what Cody Web used, and someone just reused that flag. We want to get away from that!

## Test plan

Agent tests and e2e tests are pretty good here. Also inspect telemetry and ensure that the right client name is being sent.