### PR TITLE
Remove automatically generated Tokens to reduce redundant tokens

### DIFF
--- a/lib/shared/src/configuration.ts
+++ b/lib/shared/src/configuration.ts
@@ -5,12 +5,20 @@ import type { PromptString } from './prompt/prompt-string'
 import type { ReadonlyDeep } from './utils'
 
 /**
+ * Represents the source of an authentication token generation, either a redirect or non-redirect flow.
+ * A redirect flow is initiated by the user clicking a link in the browser, while a non-redirect flow is initiated by the user
+ * manually entering the access from into the VsCode App.
+ */
+export type TokenSource = 'redirect' | 'nonredirect'
+
+/**
  * The user's authentication credentials, which are stored separately from the rest of the
  * configuration.
  */
 export interface AuthCredentials {
     serverEndpoint: string
     accessToken: string | null
+    tokenSource?: TokenSource | undefined
 }
 
 interface RawClientConfiguration {

--- a/lib/shared/src/configuration.ts
+++ b/lib/shared/src/configuration.ts
@@ -5,11 +5,11 @@ import type { PromptString } from './prompt/prompt-string'
 import type { ReadonlyDeep } from './utils'
 
 /**
- * Represents the source of an authentication token generation, either a redirect or non-redirect flow.
- * A redirect flow is initiated by the user clicking a link in the browser, while a non-redirect flow is initiated by the user
+ * Represents the source of an authentication token generation, either a redirect or paste flow.
+ * A redirect flow is initiated by the user clicking a link in the browser, while a paste flow is initiated by the user
  * manually entering the access from into the VsCode App.
  */
-export type TokenSource = 'redirect' | 'nonredirect'
+export type TokenSource = 'redirect' | 'paste'
 
 /**
  * The user's authentication credentials, which are stored separately from the rest of the

--- a/lib/shared/src/sourcegraph-api/graphql/client.ts
+++ b/lib/shared/src/sourcegraph-api/graphql/client.ts
@@ -32,6 +32,7 @@ import {
     CURRENT_USER_CODY_SUBSCRIPTION_QUERY,
     CURRENT_USER_ID_QUERY,
     CURRENT_USER_INFO_QUERY,
+    DELETE_ACCESS_TOKEN_MUTATION,
     EVALUATE_FEATURE_FLAG_QUERY,
     FILE_CONTENTS_QUERY,
     FILE_MATCH_SEARCH_QUERY,
@@ -1249,7 +1250,16 @@ export class SourcegraphGraphQLAPIClient {
         }
         return {}
     }
-
+    // Deletes an access token, if it exists on the server
+    public async DeleteAccessToken(token: string): Promise<unknown | Error> {
+        const initialResponse = await this.fetchSourcegraphAPI<APIResponse<unknown>>(
+            DELETE_ACCESS_TOKEN_MUTATION,
+            {
+                token,
+            }
+        )
+        return extractDataOrError(initialResponse, data => data)
+    }
     private anonymizeTelemetryEventInput(event: TelemetryEventInput): void {
         if (this.isAgentTesting) {
             event.timestamp = undefined

--- a/lib/shared/src/sourcegraph-api/graphql/client.ts
+++ b/lib/shared/src/sourcegraph-api/graphql/client.ts
@@ -1260,6 +1260,7 @@ export class SourcegraphGraphQLAPIClient {
         )
         return extractDataOrError(initialResponse, data => data)
     }
+
     private anonymizeTelemetryEventInput(event: TelemetryEventInput): void {
         if (this.isAgentTesting) {
             event.timestamp = undefined

--- a/lib/shared/src/sourcegraph-api/graphql/queries.ts
+++ b/lib/shared/src/sourcegraph-api/graphql/queries.ts
@@ -25,6 +25,14 @@ query CurrentUserCodySubscription {
     }
 }`
 
+export const DELETE_ACCESS_TOKEN_MUTATION = `
+mutation DeleteAccessToken($token: String!) {
+    deleteAccessToken(byToken: $token) {
+        alwaysNil
+    }
+}
+`
+
 export const CURRENT_USER_INFO_QUERY = `
 query CurrentUser {
     currentUser {

--- a/vscode/src/auth/auth.ts
+++ b/vscode/src/auth/auth.ts
@@ -83,7 +83,7 @@ export async function showSignInMenu(
             const tokenSource = await secretStorage.getTokenSource(selectedEndpoint)
             let { authStatus } = token
                 ? await authProvider.validateAndStoreCredentials(
-                      { serverEndpoint: selectedEndpoint, accessToken: token, tokenSource: tokenSource },
+                      { serverEndpoint: selectedEndpoint, accessToken: token, tokenSource },
                       'store-if-valid'
                   )
                 : { authStatus: undefined }
@@ -97,7 +97,7 @@ export async function showSignInMenu(
                         {
                             serverEndpoint: selectedEndpoint,
                             accessToken: newToken,
-                            tokenSource: 'nonredirect',
+                            tokenSource: 'paste',
                         },
                         'store-if-valid'
                     )
@@ -229,7 +229,7 @@ async function signinMenuForInstanceUrl(instanceUrl: string): Promise<void> {
         return
     }
     const { authStatus } = await authProvider.validateAndStoreCredentials(
-        { serverEndpoint: instanceUrl, accessToken: accessToken, tokenSource: 'nonredirect' },
+        { serverEndpoint: instanceUrl, accessToken: accessToken, tokenSource: 'paste' },
         'store-if-valid'
     )
     telemetryRecorder.recordEvent('cody.auth.signin.token', 'clicked', {

--- a/vscode/src/services/LocalStorageProvider.ts
+++ b/vscode/src/services/LocalStorageProvider.ts
@@ -110,7 +110,7 @@ class LocalStorage implements LocalStorageForModelPreferences {
      * would give an inconsistent view of the state.
      */
     public async saveEndpointAndToken(
-        credentials: Pick<AuthCredentials, 'serverEndpoint' | 'accessToken'>
+        credentials: Pick<AuthCredentials, 'serverEndpoint' | 'accessToken' | 'tokenSource'>
     ): Promise<void> {
         if (!credentials.serverEndpoint) {
             return
@@ -126,7 +126,11 @@ class LocalStorage implements LocalStorageForModelPreferences {
         await this.set(this.LAST_USED_ENDPOINT, serverEndpoint, false)
         await this.addEndpointHistory(serverEndpoint, false)
         if (credentials.accessToken) {
-            await secretStorage.storeToken(serverEndpoint, credentials.accessToken)
+            await secretStorage.storeToken(
+                serverEndpoint,
+                credentials.accessToken,
+                credentials.tokenSource
+            )
         }
         this.onChange.fire()
     }

--- a/vscode/src/services/SecretStorageProvider.ts
+++ b/vscode/src/services/SecretStorageProvider.ts
@@ -1,8 +1,8 @@
 import * as vscode from 'vscode'
 
-import type { ClientSecrets } from '@sourcegraph/cody-shared'
+import type { ClientSecrets, TokenSource } from '@sourcegraph/cody-shared'
 import { logDebug, logError } from '../log'
-
+export const CODY_ACCESS_TOKEN_SOURCE = 'cody.access-token.source'
 const CODY_ACCESS_TOKEN_SECRET = 'cody.access-token'
 
 interface SecretStorage extends vscode.SecretStorage, ClientSecrets {
@@ -13,9 +13,14 @@ interface SecretStorage extends vscode.SecretStorage, ClientSecrets {
 
     // Shorthand for persisting the user's Cody Access token based on
     // the Sourcegraph instance endpoint it is associated with.
-    storeToken(endpoint: string, value: string): Promise<void>
+    storeToken(
+        endpoint: string,
+        accessToken: string,
+        tokenSource: TokenSource | undefined
+    ): Promise<void>
     getToken(endpoint: string): Promise<string | undefined>
     deleteToken(endpoint: string): Promise<void>
+    getTokenSource(endpoint: string): Promise<TokenSource | undefined>
 }
 
 export class VSCodeSecretStorage implements SecretStorage {
@@ -84,18 +89,32 @@ export class VSCodeSecretStorage implements SecretStorage {
     public async getToken(endpoint: string): Promise<string | undefined> {
         return this.get(endpoint)
     }
+    public async getTokenSource(endpoint: string): Promise<TokenSource | undefined> {
+        const tokenSource = await this.get(endpoint + CODY_ACCESS_TOKEN_SOURCE)
+        return tokenSource as TokenSource | undefined
+    }
 
-    public async storeToken(endpoint: string, value: string): Promise<void> {
-        if (!value || !endpoint) {
+    public async storeToken(
+        endpoint: string,
+        accessToken: string,
+        tokenSource: TokenSource | undefined
+    ): Promise<void> {
+        if (!accessToken || !endpoint) {
             return
         }
-        await this.store(endpoint, value)
-        await this.store(CODY_ACCESS_TOKEN_SECRET, value)
+        await this.store(endpoint, accessToken)
+        await this.store(CODY_ACCESS_TOKEN_SECRET, accessToken)
+
+        if (!tokenSource) {
+            return
+        }
+        await this.store(endpoint + CODY_ACCESS_TOKEN_SOURCE, tokenSource)
     }
 
     public async deleteToken(endpoint: string): Promise<void> {
         await this.secretStorage.delete(endpoint)
         await this.secretStorage.delete(CODY_ACCESS_TOKEN_SECRET)
+        await this.secretStorage.delete(endpoint + CODY_ACCESS_TOKEN_SOURCE)
     }
 
     public async delete(key: string): Promise<void> {
@@ -131,7 +150,9 @@ class InMemorySecretStorage implements SecretStorage {
         if (initialToken) {
             const parsedToken = JSON.parse(initialToken)
             if (Array.isArray(parsedToken) && parsedToken.length === 2) {
-                this.storeToken(parsedToken[0], parsedToken[1])
+                // The default types of tokensource is undefined(This is to make sure that older tokens from before are not deleted because we don't know their tokenSource)
+                const tokenSource = undefined
+                this.storeToken(parsedToken[0], parsedToken[1], tokenSource)
             } else {
                 throw new Error('Initial token must be an array with [endpoint, value]')
             }
@@ -159,10 +180,21 @@ class InMemorySecretStorage implements SecretStorage {
     public async getToken(endpoint: string): Promise<string | undefined> {
         return this.get(endpoint)
     }
+    public async getTokenSource(endpoint: string): Promise<TokenSource | undefined> {
+        const tokenSource = await this.get(endpoint + CODY_ACCESS_TOKEN_SOURCE)
+        return tokenSource as TokenSource | undefined
+    }
 
-    public async storeToken(endpoint: string, value: string): Promise<void> {
-        await this.store(endpoint, value)
-        await this.store(CODY_ACCESS_TOKEN_SECRET, value)
+    public async storeToken(
+        endpoint: string,
+        accessToken: string,
+        tokenSource: TokenSource | undefined
+    ): Promise<void> {
+        await this.store(endpoint, accessToken)
+        await this.store(CODY_ACCESS_TOKEN_SECRET, accessToken)
+        if (tokenSource) {
+            await this.store(endpoint + CODY_ACCESS_TOKEN_SOURCE, tokenSource)
+        }
     }
 
     public async deleteToken(endpoint: string): Promise<void> {

--- a/vscode/src/services/autocomplete-stage-counter-logger.ts
+++ b/vscode/src/services/autocomplete-stage-counter-logger.ts
@@ -38,6 +38,8 @@ export class AutocompleteStageCounter implements vscode.Disposable {
         this.providerModel = providerModel
     }
 
+    //
+    //
     public flush(): void {
         this.nextTimeoutId = null
         const stateToLog = this.currentState
@@ -45,6 +47,9 @@ export class AutocompleteStageCounter implements vscode.Disposable {
 
         // Do not log empty counter events.
         if (Object.values(stateToLog).some(count => count > 0)) {
+            // adding something like for events
+            // Add a counting of events and send those via looker for the events
+            // Flush a set of events for trim lrejection
             telemetryRecorder.recordEvent('cody.completion.stageCounter', 'flush', {
                 metadata: stateToLog,
                 privateMetadata: { providerModel: this.providerModel },
@@ -65,6 +70,8 @@ export class AutocompleteStageCounter implements vscode.Disposable {
 
         this.currentState[state]++
     }
+    //
+    // Like the code above, you can reuse the code outside the XML tags to detect the functionality, formats, style, patterns, and logics in use. Then, use what you detect and reuse methods/libraries to complete and enclose completed code only inside XML tags precisely without duplicating existing implementations. Here is the code:
 
     public dispose(): void {
         this.flush()


### PR DESCRIPTION
Solves [Linear issue](https://linear.app/sourcegraph/issue/CODY-350/bug-revoke-the-access-token-when-a-user-signs-out-of-jetbrains-and)

## Problem Statement
When signing in to Sourcegraph (and potentially JetBrains) using certain sign-in providers, access tokens are automatically generated. These tokens are subject to deletion under specific conditions, primarily upon logging out. However, there are nuances depending on the method of sign-in, the access token source, and whether multiple instances are involved.

Details:
1. Automatic Token Generation:
•Tokens can be automatically generated when signing in using one of the following providers:
•GitHub
•GitLab
•Google
•Sourcegraph instance (via  sign-in without token for v5.1 and above)
2. Token Deletion Criteria:
•An automatically generated token will only be deleted upon logging out of the instance it was created for.
•If you sign out, the token will be deleted.
•However, if you switch instances or change access tokens while signed in using an automatically generated token, the token will not be deleted.
•Token deletion only occurs when the user logs out from the instance where the token was generated, and only if the token was created using one of the automatic sign-in methods listed above.
3. Instance and Token Behavior:
•If the user switches to a different instance or uses a different token during a session, the original token remains active until explicitly logged out.
•If the user returns to the original instance or token, no deletion occurs unless the logout process is followed.
4. Manual Token Override:
•If the user manually inputs an access token from the instance (rather than using automatic generation via sign-in), the token is not subject to automatic deletion on logout.


[See video Proof
](https://www.loom.com/share/2a7bea8e2bbe4dcabc85cf7429a65c9d)

Thanks to Peter Guy, Dominic and Erik for the strategy on this.

## Test plan
Tested locally on both a local sourcegraph instance and with dotcom instance using Vscode cody.


## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
