### PR TITLE
Pass intent scores to telemetry

### DIFF
--- a/lib/shared/src/misc/rpc/webviewAPI.ts
+++ b/lib/shared/src/misc/rpc/webviewAPI.ts
@@ -50,7 +50,11 @@ export interface WebviewToExtensionAPI {
      */
     initialContext(): Observable<ContextItem[]>
 
-    detectIntent(text: string): Observable<ChatMessage['intent']>
+    detectIntent(
+        text: string
+    ): Observable<
+        { intent: ChatMessage['intent']; allScores: { intent: string; score: number }[] } | undefined
+    >
 
     /**
      * Observe the current resolved configuration (same as the global {@link resolvedConfig}

--- a/lib/shared/src/sourcegraph-api/graphql/client.ts
+++ b/lib/shared/src/sourcegraph-api/graphql/client.ts
@@ -41,6 +41,7 @@ import {
     GET_REMOTE_FILE_QUERY,
     GET_URL_CONTENT_QUERY,
     HIGHLIGHTED_FILE_QUERY,
+    LEGACY_CHAT_INTENT_QUERY,
     LEGACY_CONTEXT_SEARCH_QUERY,
     LOG_EVENT_MUTATION,
     LOG_EVENT_MUTATION_DEPRECATED,
@@ -338,6 +339,10 @@ interface ChatIntentResponse {
     chatIntent: {
         intent: string
         score: number
+        allScores?: {
+            intent: string
+            score: number
+        }[]
     }
 }
 
@@ -374,6 +379,10 @@ export interface Range {
 export interface ChatIntentResult {
     intent: string
     score: number
+    allScores?: {
+        intent: string
+        score: number
+    }[]
 }
 
 /**
@@ -935,8 +944,13 @@ export class SourcegraphGraphQLAPIClient {
 
     /** Experimental API */
     public async chatIntent(interactionID: string, query: string): Promise<ChatIntentResult | Error> {
+        const hasAllScoresField = await this.isValidSiteVersion({
+            minimumVersion: '5.9.0',
+            insider: true,
+        })
+
         const response = await this.fetchSourcegraphAPI<APIResponse<ChatIntentResponse>>(
-            CHAT_INTENT_QUERY,
+            hasAllScoresField ? CHAT_INTENT_QUERY : LEGACY_CHAT_INTENT_QUERY,
             {
                 query: query,
                 interactionId: interactionID,

--- a/lib/shared/src/sourcegraph-api/graphql/queries.ts
+++ b/lib/shared/src/sourcegraph-api/graphql/queries.ts
@@ -196,11 +196,23 @@ query Repositories($names: [String!]!, $first: Int!) {
   }
 `
 
+export const LEGACY_CHAT_INTENT_QUERY = `
+query ChatIntent($query: String!, $interactionId: String!) {
+    chatIntent(query: $query, interactionId: $interactionId) {
+        intent
+        score
+    }
+}`
+
 export const CHAT_INTENT_QUERY = `
 query ChatIntent($query: String!, $interactionId: String!) {
     chatIntent(query: $query, interactionId: $interactionId) {
         intent
         score
+        allScores {
+            intent
+            score
+        }
     }
 }`
 

--- a/vscode/src/chat/protocol.ts
+++ b/vscode/src/chat/protocol.ts
@@ -189,6 +189,7 @@ export interface WebviewSubmitMessage extends WebviewContextMessage {
     /** An opaque value representing the text editor's state. @see {ChatMessage.editorState} */
     editorState?: unknown | undefined | null
     intent?: ChatMessage['intent'] | undefined | null
+    intentScores?: { intent: string; score: number }[] | undefined | null
     manuallySelectedIntent?: boolean | undefined | null
 }
 
@@ -199,6 +200,7 @@ interface WebviewEditMessage extends WebviewContextMessage {
     /** An opaque value representing the text editor's state. @see {ChatMessage.editorState} */
     editorState?: unknown | undefined | null
     intent?: ChatMessage['intent'] | undefined | null
+    intentScores?: { intent: string; score: number }[] | undefined | null
     manuallySelectedIntent?: boolean | undefined | null
 }
 

--- a/vscode/webviews/chat/Transcript.tsx
+++ b/vscode/webviews/chat/Transcript.tsx
@@ -180,7 +180,11 @@ const TranscriptInteraction: FC<TranscriptInteractionProps> = memo(props => {
         smartApplyEnabled,
     } = props
 
-    const [intent, setIntent] = useState<ChatMessage['intent']>()
+    const [intentResults, setIntentResults] = useState<
+        | { intent: ChatMessage['intent']; allScores?: { intent: string; score: number }[] }
+        | undefined
+        | null
+    >()
 
     const humanEditorRef = useRef<PromptEditorRefAPI | null>(null)
 
@@ -189,22 +193,24 @@ const TranscriptInteraction: FC<TranscriptInteractionProps> = memo(props => {
             editHumanMessage({
                 messageIndexInTranscript: humanMessage.index,
                 editorValue,
-                intent: intentFromSubmit || intent,
+                intent: intentFromSubmit || intentResults?.intent,
+                intentScores: intentFromSubmit ? undefined : intentResults?.allScores,
                 manuallySelectedIntent: !!intentFromSubmit,
             })
         },
-        [humanMessage, intent]
+        [humanMessage, intentResults]
     )
 
     const onFollowupSubmit = useCallback(
         (editorValue: SerializedPromptEditorValue, intentFromSubmit?: ChatMessage['intent']): void => {
             submitHumanMessage({
                 editorValue,
-                intent: intentFromSubmit || intent,
+                intent: intentFromSubmit || intentResults?.intent,
+                intentScores: intentFromSubmit ? undefined : intentResults?.allScores,
                 manuallySelectedIntent: !!intentFromSubmit,
             })
         },
-        [intent]
+        [intentResults]
     )
 
     const extensionAPI = useExtensionAPI()
@@ -213,7 +219,7 @@ const TranscriptInteraction: FC<TranscriptInteractionProps> = memo(props => {
 
     const onChange = useMemo(() => {
         return debounce(async (editorValue: SerializedPromptEditorValue) => {
-            setIntent(undefined)
+            setIntentResults(undefined)
 
             if (!experimentalOneBoxEnabled) {
                 return
@@ -230,7 +236,7 @@ const TranscriptInteraction: FC<TranscriptInteractionProps> = memo(props => {
                         inputTextWithoutContextChipsFromPromptEditorState(editorValue.editorState)
                     )
                     .subscribe(value => {
-                        setIntent(value)
+                        setIntentResults(value)
                     })
             }
         }, 300)
@@ -284,7 +290,7 @@ const TranscriptInteraction: FC<TranscriptInteractionProps> = memo(props => {
         [reSubmitWithIntent]
     )
 
-    const resetIntent = useCallback(() => setIntent(undefined), [])
+    const resetIntent = useCallback(() => setIntentResults(undefined), [])
 
     return (
         <>
@@ -393,11 +399,13 @@ export function editHumanMessage({
     messageIndexInTranscript,
     editorValue,
     intent,
+    intentScores,
     manuallySelectedIntent,
 }: {
     messageIndexInTranscript: number
     editorValue: SerializedPromptEditorValue
     intent?: ChatMessage['intent']
+    intentScores?: { intent: string; score: number }[]
     manuallySelectedIntent?: boolean
 }): void {
     getVSCodeAPI().postMessage({
@@ -407,6 +415,7 @@ export function editHumanMessage({
         editorState: editorValue.editorState,
         contextItems: editorValue.contextItems.map(deserializeContextItem),
         intent,
+        intentScores,
         manuallySelectedIntent,
     })
     focusLastHumanMessageEditor()
@@ -415,10 +424,12 @@ export function editHumanMessage({
 function submitHumanMessage({
     editorValue,
     intent,
+    intentScores,
     manuallySelectedIntent,
 }: {
     editorValue: SerializedPromptEditorValue
     intent?: ChatMessage['intent']
+    intentScores?: { intent: string; score: number }[]
     manuallySelectedIntent?: boolean
 }): void {
     getVSCodeAPI().postMessage({
@@ -428,6 +439,7 @@ function submitHumanMessage({
         editorState: editorValue.editorState,
         contextItems: editorValue.contextItems.map(deserializeContextItem),
         intent,
+        intentScores,
         manuallySelectedIntent,
     })
     focusLastHumanMessageEditor()


### PR DESCRIPTION
closes: https://linear.app/sourcegraph/issue/SRCH-1028/log-telemetry-of-the-output-of-the-intent-detection-model-with-each

Passes intent scores to `chat-question:executed` event.

## Test plan

- execute chat and check if the intent scores are logged.
- execute chat with manually triggering search intent, that should not log the intent scores. 
- execute chat with manually triggering chat intent, that should not log the intent scores. 

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
