### PR TITLE
Chat: show loading state during codebase context retrieval

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -16,6 +16,7 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 - Chat: Fixed feedback buttons not working in chat. [pull/5509](https://github.com/sourcegraph/cody/pull/5509)
 - Command: Removed duplicated default commands from the Cody Commands menu that were incorrectly listed as custom commands.
 - Enterprise: Smart context window is now correctly set for all Claude Sonnet models configured on the server side. [pull/5677](https://github.com/sourcegraph/cody/pull/5677)
+- Chat: Display the correct loading state during codebase context retrieval instead of 0 item by default.
 
 ### Changed
 

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -16,7 +16,7 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 - Chat: Fixed feedback buttons not working in chat. [pull/5509](https://github.com/sourcegraph/cody/pull/5509)
 - Command: Removed duplicated default commands from the Cody Commands menu that were incorrectly listed as custom commands.
 - Enterprise: Smart context window is now correctly set for all Claude Sonnet models configured on the server side. [pull/5677](https://github.com/sourcegraph/cody/pull/5677)
-- Chat: Display the correct loading state during codebase context retrieval instead of 0 item by default.
+- Chat: Display the correct loading state during codebase context retrieval instead of 0 item by default. [pull/5761](https://github.com/sourcegraph/cody/pull/5761)
 
 ### Changed
 

--- a/vscode/webviews/chat/Transcript.tsx
+++ b/vscode/webviews/chat/Transcript.tsx
@@ -357,6 +357,7 @@ const TranscriptInteraction: FC<TranscriptInteractionProps> = memo(props => {
                     isForFirstMessage={humanMessage.index === 0}
                     showSnippets={experimentalOneBoxEnabled && humanMessage.intent === 'search'}
                     defaultOpen={experimentalOneBoxEnabled && humanMessage.intent === 'search'}
+                    isContextLoading={isContextLoading}
                 />
             )}
             {(!experimentalOneBoxEnabled || humanMessage.intent !== 'search') &&

--- a/vscode/webviews/chat/cells/contextCell/ContextCell.tsx
+++ b/vscode/webviews/chat/cells/contextCell/ContextCell.tsx
@@ -27,6 +27,7 @@ import styles from './ContextCell.module.css'
 export const ContextCell: FunctionComponent<{
     contextItems: ContextItem[] | undefined
     contextAlternatives?: RankedContext[]
+    isContextLoading: boolean
     model?: Model['id']
     isForFirstMessage: boolean
     className?: string
@@ -45,6 +46,7 @@ export const ContextCell: FunctionComponent<{
         defaultOpen,
         __storybook__initialOpen,
         showSnippets = false,
+        isContextLoading,
     }) => {
         const [selectedAlternative, setSelectedAlternative] = useState<number | undefined>(undefined)
         const incrementSelectedAlternative = useCallback(
@@ -131,7 +133,10 @@ export const ContextCell: FunctionComponent<{
                                         <span className="tw-flex tw-items-baseline">
                                             Context
                                             <span className="tw-opacity-60 tw-text-sm tw-ml-2">
-                                                &mdash; {itemCountLabel}
+                                                &mdash;{' '}
+                                                {isContextLoading
+                                                    ? 'Retrieving codebase files…'
+                                                    : itemCountLabel}
                                             </span>
                                         </span>
                                     </AccordionTrigger>


### PR DESCRIPTION
CLOSE https://linear.app/sourcegraph/issue/CODY-3886/context-says-0-items-while-its-loading

Displays "Retrieving codebase files..." instead of "0 items" when codebase context is loading  in the chat interface.

## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

Submit a chat question with current repository added with @-mention to confirm we are now showing 'Retrieving codebase files…' instead of '0 item' during the context retrieval step: 

![image](https://github.com/user-attachments/assets/675252eb-aa13-4cc2-b648-50f2bb4aede3)

https://github.com/user-attachments/assets/eca567b7-fbf6-4ae5-9ad3-c828ea7d5bb3

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->

Chat: Display the correct loading state during codebase context retrieval instead of 0 item by default.