### PR TITLE
Telemetry: Record installation events for all non-Web clients

### DIFF
--- a/vscode/src/services/telemetry-v2.ts
+++ b/vscode/src/services/telemetry-v2.ts
@@ -84,9 +84,11 @@ export function createOrUpdateTelemetryRecorderProvider(
              * On first initialization, also record some initial events.
              * Skip any init events for Cody Web use case.
              */
-            const newAnonymousUser = localStorage.checkIfCreatedAnonymousUserID()
+            // Makes sure anonymousUserID is set before recording events.
+            const anonymousUserID = localStorage.anonymousUserID()
+            const newAnonymousUserCreated = localStorage.checkIfCreatedAnonymousUserID()
             if (initialize && !clientCapabilities().isCodyWeb) {
-                if (newAnonymousUser) {
+                if (anonymousUserID && newAnonymousUserCreated) {
                     /**
                      * New user
                      */

--- a/vscode/test/e2e/helpers.ts
+++ b/vscode/test/e2e/helpers.ts
@@ -100,8 +100,8 @@ export const test = base
         expectedV2Events: async ({ preAuthenticate }, use) =>
             await use(
                 preAuthenticate
-                    ? ['cody.extention.installed', 'cody.auth:connected']
-                    : ['cody.extention.installed', 'cody.auth:connected']
+                    ? ['cody.extention:installed', 'cody.auth:connected']
+                    : ['cody.extention:installed', 'cody.auth:connected']
             ),
     })
     .extend<TestDirectories>({

--- a/vscode/test/e2e/helpers.ts
+++ b/vscode/test/e2e/helpers.ts
@@ -100,16 +100,8 @@ export const test = base
         expectedV2Events: async ({ preAuthenticate }, use) =>
             await use(
                 preAuthenticate
-                    ? [
-                          // ToDo: Uncomment once this bug is resolved: https://github.com/sourcegraph/cody/issues/3825
-                          // 'cody.extention.installed'
-                          'cody.auth:connected',
-                      ]
-                    : [
-                          // ToDo: Uncomment once this bug is resolved: https://github.com/sourcegraph/cody/issues/3825
-                          // 'cody.extention.installed',
-                          'cody.auth:connected',
-                      ]
+                    ? ['cody.extention.installed', 'cody.auth:connected']
+                    : ['cody.extention.installed', 'cody.auth:connected']
             ),
     })
     .extend<TestDirectories>({

--- a/vscode/test/e2e/helpers.ts
+++ b/vscode/test/e2e/helpers.ts
@@ -100,8 +100,8 @@ export const test = base
         expectedV2Events: async ({ preAuthenticate }, use) =>
             await use(
                 preAuthenticate
-                    ? ['cody.extention:installed', 'cody.auth:connected']
-                    : ['cody.extention:installed', 'cody.auth:connected']
+                    ? ['cody.extension:installed', 'cody.auth:connected']
+                    : ['cody.extension:installed', 'cody.auth:connected']
             ),
     })
     .extend<TestDirectories>({


### PR DESCRIPTION
CLOSE https://linear.app/sourcegraph/issue/CODY-49/bug-v2-telemetry-for-cody-installations-not-being-fired

I think this might have already been fixed when we update the `clientCapabilities().isCodyWeb` check to returns false when agentIDE is not set to CodyIDE.Web. Before that change, `clientCapabilities().isCodyWeb` would always returns true for all IDEs.

We can confirm by enabling E2E tests for logging the `installed` event and installing Cody in a new machine.

## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

1. Green CI to confirm the `cody.extension:installed` events are now being logged.
2. In a new machine, confirm the `cody.extension:installed` events is logged:

![image](https://github.com/user-attachments/assets/bcd44eb5-28b0-4a49-a367-b9478df7f9e8)

```
█ telemetry-v2: recordEvent: cody.extension/installed  {
  "parameters": {
    "version": 0,
    "billingMetadata": {
      "product": "cody",
      "category": "billable"
    }
  },
  "timestamp": "2024-10-01T16:35:14.262Z"
}
```

NOTE: The installed event does not fire for users who uninstalled then re-install Cody.

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
