### PR TITLE
Unified prompts: Return inline documentation command

### DIFF
--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -444,7 +444,11 @@ async function registerCodyCommands(
                                       executeSmellCommand(a)
                                   ),
                                   vscode.commands.registerCommand('cody.command.document-code', a =>
-                                      executeDocChatCommand(a)
+                                      executeDocCommand(a)
+                                  ),
+                                  vscode.commands.registerCommand(
+                                      'cody.command.prompt-document-code',
+                                      a => executeDocChatCommand(a)
                                   ),
                               ]
                             : [

--- a/vscode/src/prompts/prompts.ts
+++ b/vscode/src/prompts/prompts.ts
@@ -54,7 +54,7 @@ export async function mergedPromptsAndLegacyCommands(
                     key: 'doc',
                     description: 'Document Code',
                     prompt: '',
-                    slashCommand: 'cody.command.document-code',
+                    slashCommand: 'cody.command.prompt-document-code',
                     mode: 'ask',
                     type: 'default',
                 },


### PR DESCRIPTION
This PR returns inline documentation code command functionality, We deleted it for unified prompts experience but found that our smart apply can't replace our inline commands fully at the moment (it's still too slow in most of the cases). 

So this PR brings back the inline documentation command, but note that documentation code button on the welcome screen still works as a prompt (this is intended) cc @aramaraju 

## Test plan
- Check that with the unified-prompts feature flag (currently enabled on s2) 
- You can trigger the inline documentation command by shortcut opt+D and by right-clicking the context menu sub-option.
- Check that documentation code standard prompt on the welcome screen works 

