### PR TITLE
Rename onebox telemetry metadata fields

### DIFF
--- a/vscode/webviews/chat/Transcript.tsx
+++ b/vscode/webviews/chat/Transcript.tsx
@@ -274,9 +274,9 @@ const TranscriptInteraction: FC<TranscriptInteractionProps> = memo(props => {
                         recordsPrivateMetadataTranscript: 1,
                     },
                     privateMetadata: {
-                        initial_intent: humanMessage.intent,
-                        user_selected_intent: intent,
-                        query: editorState.text,
+                        initialIntent: humanMessage.intent,
+                        userSpecifiedIntent: intent,
+                        promptText: editorState.text,
                     },
                 })
             }

--- a/vscode/webviews/components/FileLink.tsx
+++ b/vscode/webviews/components/FileLink.tsx
@@ -120,8 +120,8 @@ export const FileLink: React.FunctionComponent<
         const external = uri.scheme === 'http' || uri.scheme === 'https'
         telemetryRecorder.recordEvent('onebox.searchResult', 'clicked', {
             metadata: {
-                is_local: external ? 0 : 1,
-                is_remote: external ? 1 : 0,
+                isLocal: external ? 0 : 1,
+                isRemote: external ? 1 : 0,
             },
             privateMetadata: {
                 filename: displayPath(uri),


### PR DESCRIPTION
This PR renames a bunch of OneBox telemetry events metadata fields and make them camelcase.

~~This PR also removes the check `isDotCom` from the `promptText` private metadata field passed with the `chat-question:executed` event. None of the private metadata fields are sent to SG through the telemetery pipeline, so that data is still private, similar to the other present privateMetadata field. The only change is that the `promptText` will be recorded in the event_logs on that sourcegraph instance.~~

We need to remove the check so that we can selectively collect that field for the S2 instance, configured by a env var here: https://github.com/sourcegraph/cloud/pull/15143


## Test plan

Make sure all the updated events are still recorded correctly. 

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
