### PR TITLE
Update Prompts UI (enhanced with client last used action sorting)

### DIFF
--- a/lib/shared/src/misc/rpc/webviewAPI.ts
+++ b/lib/shared/src/misc/rpc/webviewAPI.ts
@@ -114,27 +114,42 @@ export interface MentionMenuData {
     error?: string
 }
 
+export interface PromptAction extends Prompt {
+    actionType: 'prompt'
+}
+
+export interface CommandAction extends CodyCommand {
+    actionType: 'command'
+}
+
+export type Action = PromptAction | CommandAction
+
 export interface PromptsResult {
-    /**
-     * `undefined` means the Sourcegraph endpoint is an older Sourcegraph version that doesn't
-     * support the Prompt Library.
-     */
-    prompts:
-        | { type: 'results'; results: Prompt[] }
-        | { type: 'error'; error: string }
-        | { type: 'unsupported' }
+    // /**
+    //  * `undefined` means the Sourcegraph endpoint is an older Sourcegraph version that doesn't
+    //  * support the Prompt Library.
+    //  */
+    // prompts:
+    //     | { type: 'results'; results: Prompt[] }
+    //     | { type: 'error'; error: string }
+    //     | { type: 'unsupported' }
+    //
+    // /**
+    //  * Provides previously built-in commands which became prompt-like actions (explain code,
+    //  * generate unit tests, document symbol, etc.) Currently, is used behind feature flag.
+    //  */
+    // standardPrompts?: CodyCommand[]
+    //
+    // /**
+    //  * `undefined` means that commands should not be shown at all (not even as an empty
+    //  * list). Builtin and custom commands are deprecated in favor of the Prompt Library.
+    //  */
+    // commands: CodyCommand[]
 
-    /**
-     * Provides previously built-in commands which became prompt-like actions (explain code,
-     * generate unit tests, document symbol, etc.) Currently, is used behind feature flag.
-     */
-    standardPrompts?: CodyCommand[]
+    isPromptsSupported: boolean
 
-    /**
-     * `undefined` means that commands should not be shown at all (not even as an empty
-     * list). Builtin and custom commands are deprecated in favor of the Prompt Library.
-     */
-    commands: CodyCommand[]
+    /** List of all available actions (prompts and/or commands) */
+    actions: Action[]
 
     /** The original query used to fetch this result. */
     query: string

--- a/lib/shared/src/misc/rpc/webviewAPI.ts
+++ b/lib/shared/src/misc/rpc/webviewAPI.ts
@@ -125,28 +125,8 @@ export interface CommandAction extends CodyCommand {
 export type Action = PromptAction | CommandAction
 
 export interface PromptsResult {
-    // /**
-    //  * `undefined` means the Sourcegraph endpoint is an older Sourcegraph version that doesn't
-    //  * support the Prompt Library.
-    //  */
-    // prompts:
-    //     | { type: 'results'; results: Prompt[] }
-    //     | { type: 'error'; error: string }
-    //     | { type: 'unsupported' }
-    //
-    // /**
-    //  * Provides previously built-in commands which became prompt-like actions (explain code,
-    //  * generate unit tests, document symbol, etc.) Currently, is used behind feature flag.
-    //  */
-    // standardPrompts?: CodyCommand[]
-    //
-    // /**
-    //  * `undefined` means that commands should not be shown at all (not even as an empty
-    //  * list). Builtin and custom commands are deprecated in favor of the Prompt Library.
-    //  */
-    // commands: CodyCommand[]
 
-    isPromptsSupported: boolean
+    arePromptsSupported: boolean
 
     /** List of all available actions (prompts and/or commands) */
     actions: Action[]

--- a/lib/shared/src/misc/rpc/webviewAPI.ts
+++ b/lib/shared/src/misc/rpc/webviewAPI.ts
@@ -125,7 +125,6 @@ export interface CommandAction extends CodyCommand {
 export type Action = PromptAction | CommandAction
 
 export interface PromptsResult {
-
     arePromptsSupported: boolean
 
     /** List of all available actions (prompts and/or commands) */

--- a/lib/shared/src/sourcegraph-api/graphql/client.ts
+++ b/lib/shared/src/sourcegraph-api/graphql/client.ts
@@ -415,6 +415,12 @@ export interface Prompt {
         text: string
     }
     url: string
+    createdBy: {
+        id: string
+        username: string
+        displayName: string
+        avatarURL: string
+    }
 }
 
 interface ContextFiltersResponse {

--- a/lib/shared/src/sourcegraph-api/graphql/queries.ts
+++ b/lib/shared/src/sourcegraph-api/graphql/queries.ts
@@ -303,7 +303,7 @@ query ContextFilters {
 
 export const PROMPTS_QUERY = `
 query ViewerPrompts($query: String!) {
-    prompts(query: $query, first: 100, viewerIsAffiliated: true, orderBy: PROMPT_NAME_WITH_OWNER) {
+    prompts(query: $query, first: 100, includeDrafts: false, viewerIsAffiliated: true, orderBy: PROMPT_UPDATED_AT) {
         nodes {
             id
             name

--- a/lib/shared/src/sourcegraph-api/graphql/queries.ts
+++ b/lib/shared/src/sourcegraph-api/graphql/queries.ts
@@ -317,6 +317,12 @@ query ViewerPrompts($query: String!) {
                 text
             }
             url
+            createdBy {
+                id
+                username
+                displayName
+                avatarURL
+            }
         }
         totalCount
         pageInfo {

--- a/vscode/src/prompts/prompts.ts
+++ b/vscode/src/prompts/prompts.ts
@@ -55,7 +55,7 @@ const STANDARD_PROMPTS_LIKE_COMMAND: CommandAction[] = [
 ]
 
 /**
- * Observe results of querying the prompts from the Prompt Library, (deprecated) built-in commands,
+ * Merges results  of querying the prompts from the Prompt Library, (deprecated) built-in commands,
  * and (deprecated) custom commands. Commands are deprecated in favor of prompts in the Prompt
  * Library.
  */
@@ -79,7 +79,7 @@ export async function mergedPromptsAndLegacyCommands(
                   ...c,
                   actionType: 'command',
               }))
-        : // Ignore any commands for Cody Web since none commands are supported there
+        : // Ignore any commands for Cody Web since no commands are supported
           []
 
     const matchingCommands = allCommands.filter(
@@ -90,12 +90,12 @@ export async function mergedPromptsAndLegacyCommands(
     )
 
     const actions =
-        customPrompts !== 'unsupported' ? [...customPrompts, ...matchingCommands] : matchingCommands
+        customPrompts === 'unsupported' ? matchingCommands : [...customPrompts, ...matchingCommands]
 
     return {
         query,
         actions,
-        isPromptsSupported: customPrompts !== 'unsupported',
+        arePromptsSupported: customPrompts !== 'unsupported',
     }
 }
 

--- a/vscode/src/prompts/prompts.ts
+++ b/vscode/src/prompts/prompts.ts
@@ -1,6 +1,7 @@
 import {
-    type CodyCommand,
+    type CommandAction,
     FeatureFlag,
+    type PromptAction,
     type PromptsResult,
     clientCapabilities,
     featureFlagProvider,
@@ -11,6 +12,48 @@ import {
 import { FIXTURE_COMMANDS } from '../../webviews/components/promptList/fixtures'
 import { getCodyCommandList } from '../commands/CommandsController'
 
+/** For testing only. */
+const USE_CUSTOM_COMMANDS_FIXTURE = false
+
+const STANDARD_PROMPTS_LIKE_COMMAND: CommandAction[] = [
+    {
+        key: 'doc',
+        type: 'default',
+        mode: 'ask',
+        description: 'Document Code',
+        slashCommand: 'cody.command.prompt-document-code',
+        prompt: '',
+        actionType: 'command',
+    },
+    {
+        key: 'explain',
+        type: 'default',
+        mode: 'ask',
+        description: 'Explain Code',
+        slashCommand: 'cody.command.explain-code',
+        prompt: '',
+        actionType: 'command',
+    },
+    {
+        key: 'test',
+        type: 'default',
+        mode: 'ask',
+        description: 'Generate Unit Tests',
+        slashCommand: 'cody.command.unit-tests',
+        prompt: '',
+        actionType: 'command',
+    },
+    {
+        key: 'smell',
+        type: 'default',
+        mode: 'ask',
+        description: 'Find Code Smells',
+        slashCommand: 'cody.command.smell-code',
+        prompt: '',
+        actionType: 'command',
+    },
+]
+
 /**
  * Observe results of querying the prompts from the Prompt Library, (deprecated) built-in commands,
  * and (deprecated) custom commands. Commands are deprecated in favor of prompts in the Prompt
@@ -18,78 +61,26 @@ import { getCodyCommandList } from '../commands/CommandsController'
  */
 export async function mergedPromptsAndLegacyCommands(
     query: string,
-    signal?: AbortSignal
+    signal: AbortSignal
 ): Promise<PromptsResult> {
-    let promptsValue: PromptsResult['prompts']
-    try {
-        const prompts = await graphqlClient.queryPrompts(query, signal)
-        promptsValue = { type: 'results', results: prompts }
-    } catch (error) {
-        if (isAbortError(error)) {
-            throw error
-        }
-        const errorMessage = isErrorLike(error) ? error.message : String(error)
-        if (errorMessage.startsWith(`Cannot query field "prompts"`)) {
-            // Server does not yet support Prompt Library.
-            promptsValue = { type: 'unsupported' }
-        } else {
-            promptsValue = { type: 'error', error: errorMessage }
-        }
-    }
-
     const queryLower = query.toLowerCase()
-    const isUnifiedPromptsEnabled = await featureFlagProvider.evaluateFeatureFlagEphemerally(
-        FeatureFlag.CodyUnifiedPrompts
-    )
+    const [customPrompts, isUnifiedPromptsEnabled] = await Promise.all([
+        fetchCustomPrompts(queryLower, signal),
+        featureFlagProvider.evaluateFeatureFlagEphemerally(FeatureFlag.CodyUnifiedPrompts),
+    ])
 
-    // Ignore commands since with unified prompts vital commands will be replaced by out-of-box
-    // commands, see main.ts register cody commands for unified prompts
-    if (isUnifiedPromptsEnabled && !clientCapabilities().isCodyWeb) {
-        return {
-            query,
-            commands: [],
-            prompts: promptsValue,
-            standardPrompts: [
-                {
-                    key: 'doc',
-                    description: 'Document Code',
-                    prompt: '',
-                    slashCommand: 'cody.command.prompt-document-code',
-                    mode: 'ask',
-                    type: 'default',
-                },
-                {
-                    key: 'explain',
-                    description: 'Explain Code',
-                    prompt: '',
-                    slashCommand: 'cody.command.explain-code',
-                    mode: 'ask',
-                    type: 'default',
-                },
-                {
-                    key: 'test',
-                    description: 'Generate Unit Tests',
-                    prompt: '',
-                    slashCommand: 'cody.command.unit-tests',
-                    mode: 'ask',
-                    type: 'default',
-                },
-                {
-                    key: 'smell',
-                    description: 'Find Code Smells',
-                    slashCommand: 'cody.command.smell-code',
-                    prompt: '',
-                    mode: 'ask',
-                    type: 'default',
-                },
-            ] satisfies CodyCommand[],
-        }
-    }
-
-    const allCommands = [
-        ...getCodyCommandList(),
-        ...(USE_CUSTOM_COMMANDS_FIXTURE ? FIXTURE_COMMANDS : []),
-    ].filter(command => (isUnifiedPromptsEnabled ? { ...command, mode: 'ask' } : command))
+    const codyCommands = getCodyCommandList()
+    const allCommands: CommandAction[] = !clientCapabilities().isCodyWeb
+        ? // Ignore commands since with unified prompts vital commands will be replaced by out-of-box
+          // prompts, see main.ts register cody commands for unified prompts
+          isUnifiedPromptsEnabled
+            ? STANDARD_PROMPTS_LIKE_COMMAND
+            : [...codyCommands, ...(USE_CUSTOM_COMMANDS_FIXTURE ? FIXTURE_COMMANDS : [])].map(c => ({
+                  ...c,
+                  actionType: 'command',
+              }))
+        : // Ignore any commands for Cody Web since none commands are supported there
+          []
 
     const matchingCommands = allCommands.filter(
         c =>
@@ -98,20 +89,51 @@ export async function mergedPromptsAndLegacyCommands(
             matchesQuery(queryLower, c.prompt)
     )
 
+    const actions =
+        customPrompts !== 'unsupported' ? [...customPrompts, ...matchingCommands] : matchingCommands
+
+    const editCommandIndex = actions.findIndex(
+        action => action.actionType === 'command' && action.key === 'edit'
+    )
+
+    // Bring Edit command on top of the command list
+    if (editCommandIndex !== -1) {
+        actions.unshift(actions.splice(editCommandIndex, 1)[0])
+    }
+
     return {
-        prompts: promptsValue,
-        commands: matchingCommands,
         query,
+        actions,
+        isPromptsSupported: customPrompts !== 'unsupported',
     }
 }
-
-/** For testing only. */
-const USE_CUSTOM_COMMANDS_FIXTURE = false
 
 function matchesQuery(query: string, text: string): boolean {
     try {
         return text.toLowerCase().includes(query)
     } catch {
         return false
+    }
+}
+
+async function fetchCustomPrompts(
+    query: string,
+    signal: AbortSignal
+): Promise<PromptAction[] | 'unsupported'> {
+    try {
+        const prompts = await graphqlClient.queryPrompts(query, signal)
+        return prompts.map(prompt => ({ ...prompt, actionType: 'prompt' }))
+    } catch (error) {
+        if (isAbortError(error)) {
+            throw error
+        }
+
+        const errorMessage = isErrorLike(error) ? error.message : String(error)
+        if (errorMessage.startsWith(`Cannot query field "prompts"`)) {
+            // Server does not yet support Prompt Library.
+            return 'unsupported'
+        }
+
+        return []
     }
 }

--- a/vscode/src/prompts/prompts.ts
+++ b/vscode/src/prompts/prompts.ts
@@ -92,15 +92,6 @@ export async function mergedPromptsAndLegacyCommands(
     const actions =
         customPrompts !== 'unsupported' ? [...customPrompts, ...matchingCommands] : matchingCommands
 
-    const editCommandIndex = actions.findIndex(
-        action => action.actionType === 'command' && action.key === 'edit'
-    )
-
-    // Bring Edit command on top of the command list
-    if (editCommandIndex !== -1) {
-        actions.unshift(actions.splice(editCommandIndex, 1)[0])
-    }
-
     return {
         query,
         actions,

--- a/vscode/src/prompts/prompts.ts
+++ b/vscode/src/prompts/prompts.ts
@@ -17,6 +17,15 @@ const USE_CUSTOM_COMMANDS_FIXTURE = false
 
 const STANDARD_PROMPTS_LIKE_COMMAND: CommandAction[] = [
     {
+        key: 'edit',
+        type: 'default',
+        mode: 'ask',
+        description: 'Edit Code',
+        prompt: 'Start a code edit',
+        slashCommand: 'cody.command.edit-code',
+        actionType: 'command',
+    },
+    {
         key: 'doc',
         type: 'default',
         mode: 'ask',

--- a/vscode/test/e2e/chat-atFile.test.ts
+++ b/vscode/test/e2e/chat-atFile.test.ts
@@ -7,6 +7,7 @@ import {
     expectContextCellCounts,
     focusChatInputAtEnd,
     getContextCell,
+    mentionMenu,
     openContextCell,
     openFileInEditorTab,
     openMentionsForProvider,
@@ -45,7 +46,7 @@ test.extend<ExpectedV2Events>({
     await chatInput.dblclick()
     await chatInput.focus()
     await page.keyboard.type('@')
-    await expect(chatPanelFrame.getByRole('option', { selected: true })).toHaveText('Files')
+    await expect(mentionMenu(chatPanelFrame).getByRole('option', { selected: true })).toHaveText('Files')
     await page.keyboard.press('Backspace')
 
     // No results

--- a/vscode/test/e2e/common.ts
+++ b/vscode/test/e2e/common.ts
@@ -158,6 +158,10 @@ export async function openMentionsForProvider(
     await frame.getByRole('option', { name: provider }).click()
 }
 
+export function mentionMenu(chatFrame: FrameLocator): Locator {
+    return chatFrame.locator('[cmdk-root][data-testid="mention-menu"]')
+}
+
 export function mentionMenuItems(chatFrame: FrameLocator): Locator {
     return chatFrame.locator('[cmdk-root][data-testid="mention-menu"] [role="option"]')
 }

--- a/vscode/webviews/AppWrapperForTest.tsx
+++ b/vscode/webviews/AppWrapperForTest.tsx
@@ -80,7 +80,7 @@ export const AppWrapperForTest: FunctionComponent<{ children: ReactNode }> = ({ 
                         }),
                     evaluatedFeatureFlag: _flag => Observable.of(true),
                     prompts: makePromptsAPIWithData({
-                        prompts: { type: 'results', results: FIXTURE_PROMPTS },
+                        prompts: FIXTURE_PROMPTS,
                         commands: FIXTURE_COMMANDS,
                     }),
                     highlights: () => Observable.of([]),

--- a/vscode/webviews/Chat.story.tsx
+++ b/vscode/webviews/Chat.story.tsx
@@ -45,7 +45,8 @@ export const EmptyWithPromptLibraryUnsupported: StoryObj<typeof meta> = {
             value={{
                 ...MOCK_API,
                 prompts: makePromptsAPIWithData({
-                    prompts: { type: 'unsupported' },
+                    isPromptsSupported: false,
+                    prompts: [],
                     commands: FIXTURE_COMMANDS,
                 }),
                 evaluatedFeatureFlag: _flag => Observable.of(true),
@@ -63,7 +64,7 @@ export const EmptyWithNoPrompts: StoryObj<typeof meta> = {
             value={{
                 ...MOCK_API,
                 prompts: makePromptsAPIWithData({
-                    prompts: { type: 'results', results: [] },
+                    prompts: [],
                     commands: FIXTURE_COMMANDS,
                 }),
                 evaluatedFeatureFlag: _flag => Observable.of(true),

--- a/vscode/webviews/Chat.story.tsx
+++ b/vscode/webviews/Chat.story.tsx
@@ -45,7 +45,7 @@ export const EmptyWithPromptLibraryUnsupported: StoryObj<typeof meta> = {
             value={{
                 ...MOCK_API,
                 prompts: makePromptsAPIWithData({
-                    isPromptsSupported: false,
+                    arePromptsSupported: false,
                     prompts: [],
                     commands: FIXTURE_COMMANDS,
                 }),

--- a/vscode/webviews/chat/cells/messageCell/human/editor/HumanMessageEditor.module.css
+++ b/vscode/webviews/chat/cells/messageCell/human/editor/HumanMessageEditor.module.css
@@ -22,7 +22,6 @@
 
 .toolbar {
     padding: calc(0.75*var(--prompt-editor-padding-y)) var(--prompt-editor-padding-x);
-    margin-left: -2px;
     overflow: hidden;
 }
 

--- a/vscode/webviews/chat/cells/messageCell/human/editor/toolbar/Toolbar.tsx
+++ b/vscode/webviews/chat/cells/messageCell/human/editor/toolbar/Toolbar.tsx
@@ -1,13 +1,11 @@
-import type { ChatMessage, Model } from '@sourcegraph/cody-shared'
+import type { Action, ChatMessage, Model } from '@sourcegraph/cody-shared'
 import { useExtensionAPI, useObservable } from '@sourcegraph/prompt-editor'
 import clsx from 'clsx'
 import { type FunctionComponent, useCallback, useMemo } from 'react'
 import type { UserAccountInfo } from '../../../../../../Chat'
-import { useClientActionDispatcher } from '../../../../../../client/clientState'
 import { ModelSelectField } from '../../../../../../components/modelSelectField/ModelSelectField'
-import type { PromptOrDeprecatedCommand } from '../../../../../../components/promptList/PromptList'
 import { PromptSelectField } from '../../../../../../components/promptSelectField/PromptSelectField'
-import { onPromptSelectInPanel } from '../../../../../../prompts/PromptsTab'
+import { useActionSelect } from '../../../../../../prompts/PromptsTab'
 import { useConfig } from '../../../../../../utils/useConfig'
 import { AddContextButton } from './AddContextButton'
 import { SubmitButton, type SubmitButtonState } from './SubmitButton'
@@ -102,14 +100,14 @@ const PromptSelectFieldToolbarItem: FunctionComponent<{
     focusEditor?: () => void
     className?: string
 }> = ({ focusEditor, className }) => {
-    const dispatchClientAction = useClientActionDispatcher()
+    const runAction = useActionSelect()
 
     const onSelect = useCallback(
-        (item: PromptOrDeprecatedCommand) => {
-            onPromptSelectInPanel(item, () => {}, dispatchClientAction)
+        (item: Action) => {
+            runAction(item, () => {})
             focusEditor?.()
         },
-        [focusEditor, dispatchClientAction]
+        [focusEditor, runAction]
     )
 
     return <PromptSelectField onSelect={onSelect} onCloseByEscape={focusEditor} className={className} />

--- a/vscode/webviews/chat/components/WelcomeMessage.test.tsx
+++ b/vscode/webviews/chat/components/WelcomeMessage.test.tsx
@@ -11,8 +11,8 @@ vi.mock('../../components/promptList/usePromptsQuery')
 vi.mocked(usePromptsQuery).mockReturnValue({
     value: {
         query: '',
-        commands: [],
-        prompts: { type: 'results', results: [FIXTURE_PROMPTS[0]] },
+        isPromptsSupported: true,
+        actions: [{ ...FIXTURE_PROMPTS[0], actionType: 'prompt' }],
     },
     done: false,
     error: null,

--- a/vscode/webviews/chat/components/WelcomeMessage.test.tsx
+++ b/vscode/webviews/chat/components/WelcomeMessage.test.tsx
@@ -11,7 +11,7 @@ vi.mock('../../components/promptList/usePromptsQuery')
 vi.mocked(usePromptsQuery).mockReturnValue({
     value: {
         query: '',
-        isPromptsSupported: true,
+        arePromptsSupported: true,
         actions: [{ ...FIXTURE_PROMPTS[0], actionType: 'prompt' }],
     },
     done: false,

--- a/vscode/webviews/chat/components/WelcomeMessage.tsx
+++ b/vscode/webviews/chat/components/WelcomeMessage.tsx
@@ -69,13 +69,27 @@ export const WelcomeMessage: FunctionComponent<WelcomeMessageProps> = ({ setView
                     onSelect={item => runAction(item, setView)}
                 />
 
-                <Button
-                    variant="text"
-                    className="tw-justify-center"
-                    onClick={() => setView(View.Prompts)}
-                >
-                    All Prompts
-                </Button>
+                <div className="tw-flex tw-gap-8">
+                    <Button
+                        variant="text"
+                        className="tw-justify-center"
+                        onClick={() =>
+                            document
+                                .querySelector<HTMLButtonElement>("button[aria-label='Insert prompt']")
+                                ?.click()
+                        }
+                    >
+                        Recently used
+                    </Button>
+
+                    <Button
+                        variant="text"
+                        className="tw-justify-center"
+                        onClick={() => setView(View.Prompts)}
+                    >
+                        All Prompts
+                    </Button>
+                </div>
             </div>
 
             <CollapsiblePanel

--- a/vscode/webviews/chat/components/WelcomeMessage.tsx
+++ b/vscode/webviews/chat/components/WelcomeMessage.tsx
@@ -75,7 +75,7 @@ export const WelcomeMessage: FunctionComponent<WelcomeMessageProps> = ({ setView
                     className="tw-justify-center"
                     onClick={() => setView(View.Prompts)}
                 >
-                    Prompt Library
+                    All Prompts
                 </Button>
             </div>
 

--- a/vscode/webviews/chat/components/WelcomeMessage.tsx
+++ b/vscode/webviews/chat/components/WelcomeMessage.tsx
@@ -65,6 +65,8 @@ export const WelcomeMessage: FunctionComponent<WelcomeMessageProps> = ({ setView
                     showCommandOrigins={true}
                     showPromptLibraryUnsupportedMessage={false}
                     showOnlyPromptInsertableCommands={false}
+                    lastUsedSorting={true}
+                    includeEditCommandOnTop={true}
                     onSelect={item => runAction(item, setView)}
                 />
 

--- a/vscode/webviews/chat/components/WelcomeMessage.tsx
+++ b/vscode/webviews/chat/components/WelcomeMessage.tsx
@@ -65,7 +65,6 @@ export const WelcomeMessage: FunctionComponent<WelcomeMessageProps> = ({ setView
                     showCommandOrigins={true}
                     showPromptLibraryUnsupportedMessage={false}
                     showOnlyPromptInsertableCommands={false}
-                    lastUsedSorting={true}
                     includeEditCommandOnTop={true}
                     onSelect={item => runAction(item, setView)}
                 />

--- a/vscode/webviews/chat/components/WelcomeMessage.tsx
+++ b/vscode/webviews/chat/components/WelcomeMessage.tsx
@@ -1,4 +1,3 @@
-import { FeatureFlag } from '@sourcegraph/cody-shared'
 import {
     AtSignIcon,
     type LucideProps,
@@ -8,14 +7,13 @@ import {
 } from 'lucide-react'
 import type { FunctionComponent } from 'react'
 import type React from 'react'
-import { useClientActionDispatcher } from '../../client/clientState'
 import { CollapsiblePanel } from '../../components/CollapsiblePanel'
 import { Kbd } from '../../components/Kbd'
-import { PromptListSuitedForNonPopover } from '../../components/promptList/PromptList'
-import { onPromptSelectInPanel, onPromptSelectInPanelActionLabels } from '../../prompts/PromptsTab'
-import type { View } from '../../tabs'
+import { PromptList } from '../../components/promptList/PromptList'
+import { Button } from '../../components/shadcn/ui/button'
+import { useActionSelect } from '../../prompts/PromptsTab'
+import { View } from '../../tabs'
 import { useConfig } from '../../utils/useConfig'
-import { useFeatureFlag } from '../../utils/useFeatureFlags'
 
 const MenuExample: FunctionComponent<{ children: React.ReactNode }> = ({ children }) => (
     <span className="tw-p-1 tw-rounded tw-text-keybinding-foreground tw-border tw-border-keybinding-border tw-bg-keybinding-background tw-whitespace-nowrap">
@@ -53,31 +51,32 @@ export const WelcomeMessage: FunctionComponent<WelcomeMessageProps> = ({ setView
     // Remove the old welcome message dismissal key that is no longer used.
     localStorage.removeItem(localStorageKey)
 
-    const dispatchClientAction = useClientActionDispatcher()
-
-    const isUnifiedPromptsAvailable = useFeatureFlag(FeatureFlag.CodyUnifiedPrompts)
-
     const config = useConfig()
+    const runAction = useActionSelect()
 
     return (
         <div className="tw-flex-1 tw-flex tw-flex-col tw-items-start tw-w-full tw-px-6 tw-gap-6 tw-transition-all">
-            <CollapsiblePanel
-                storageKey="prompts"
-                title={isUnifiedPromptsAvailable ? 'Prompts' : 'Prompts & Commands'}
-                className="tw-mb-6"
-                contentClassName="!tw-p-0 tw-overflow-clip"
-                initialOpen={true}
-            >
-                <PromptListSuitedForNonPopover
-                    onSelect={item => onPromptSelectInPanel(item, setView, dispatchClientAction)}
-                    onSelectActionLabels={onPromptSelectInPanelActionLabels}
+            <div className="tw-flex tw-flex-col tw-gap-4 tw-w-full">
+                <PromptList
+                    showSearch={false}
+                    showFirstNItems={4}
+                    appearanceMode="chips-list"
                     telemetryLocation="PromptsTab"
                     showCommandOrigins={true}
                     showPromptLibraryUnsupportedMessage={false}
                     showOnlyPromptInsertableCommands={false}
-                    className="tw-rounded-none"
+                    onSelect={item => runAction(item, setView)}
                 />
-            </CollapsiblePanel>
+
+                <Button
+                    variant="text"
+                    className="tw-justify-center"
+                    onClick={() => setView(View.Prompts)}
+                >
+                    Prompt Library
+                </Button>
+            </div>
+
             <CollapsiblePanel
                 storageKey="chat-help"
                 title="Chat Help"

--- a/vscode/webviews/components/StateDebugOverlay.tsx
+++ b/vscode/webviews/components/StateDebugOverlay.tsx
@@ -7,15 +7,9 @@ import type {
 } from '@sourcegraph/cody-shared'
 import { useExtensionAPI, useInitialContextForChat, useObservable } from '@sourcegraph/prompt-editor'
 import clsx from 'clsx'
-import React, {
-    type Dispatch,
-    type FunctionComponent,
-    type SetStateAction,
-    useCallback,
-    useMemo,
-    useState,
-} from 'react'
+import React, { type FunctionComponent, useMemo } from 'react'
 import { getVSCodeAPI } from '../utils/VSCodeApi'
+import { useLocalStorage } from './hooks'
 import { Button } from './shadcn/ui/button'
 import { TabContainer, TabRoot } from './shadcn/ui/tabs'
 
@@ -197,25 +191,4 @@ const DebugActions: FunctionComponent<{ className?: string }> = ({ className }) 
             </li>
         </ul>
     )
-}
-
-function useLocalStorage<T>(
-    key: string,
-    defaultValue?: T
-): [T | undefined, Dispatch<SetStateAction<T>>] {
-    const [value, setValue] = useState<T>(() => {
-        const json = localStorage.getItem(key)
-        return json ? JSON.parse(json) : defaultValue
-    })
-    const persistValue = useCallback(
-        (value: T | Dispatch<T>) => {
-            setValue(current => {
-                const newValue = typeof value === 'function' ? (value as (prev: T) => T)(current) : value
-                localStorage.setItem(key, JSON.stringify(newValue))
-                return newValue
-            })
-        },
-        [key]
-    )
-    return [value, persistValue]
 }

--- a/vscode/webviews/components/hooks.ts
+++ b/vscode/webviews/components/hooks.ts
@@ -1,0 +1,22 @@
+import { type Dispatch, type SetStateAction, useCallback, useState } from 'react'
+
+export function useLocalStorage<T>(
+    key: string,
+    defaultValue?: T
+): [T | undefined, Dispatch<SetStateAction<T>>] {
+    const [value, setValue] = useState<T>(() => {
+        const json = localStorage.getItem(key)
+        return json ? JSON.parse(json) : defaultValue
+    })
+    const persistValue = useCallback(
+        (value: T | Dispatch<T>) => {
+            setValue(current => {
+                const newValue = typeof value === 'function' ? (value as (prev: T) => T)(current) : value
+                localStorage.setItem(key, JSON.stringify(newValue))
+                return newValue
+            })
+        },
+        [key]
+    )
+    return [value, persistValue]
+}

--- a/vscode/webviews/components/promptList/ActionItem.module.css
+++ b/vscode/webviews/components/promptList/ActionItem.module.css
@@ -30,8 +30,8 @@
 
     &--avatar {
         flex-shrink: 0;
-        width: 30px;
-        height: 30px;
+        width: 26px;
+        height: 26px;
         display: flex;
         align-items: center;
         justify-content: center;

--- a/vscode/webviews/components/promptList/ActionItem.module.css
+++ b/vscode/webviews/components/promptList/ActionItem.module.css
@@ -1,0 +1,66 @@
+
+.item {
+    display: flex;
+    padding: 0.5rem;
+    gap: 0.5rem;
+
+    &--indicator {
+        display: none !important;
+        margin-left: auto;
+        align-self: flex-start;
+    }
+
+    &[data-selected="true"]  {
+        .item--indicator {
+            display: block !important;
+            color: inherit;
+        }
+
+        .prompt--avatar, .prompt--description, .prompt--icon {
+            color: inherit;
+        }
+    }
+}
+
+.prompt {
+    display: flex;
+    gap: 0.5rem;
+    align-items: center;
+    min-width: 0;
+
+    &--avatar {
+        flex-shrink: 0;
+        width: 30px;
+        height: 30px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+    }
+
+    &--icon {
+        color: var(--vscode-input-placeholderForeground);
+    }
+
+    &--content {
+        min-width: 0;
+        display: flex;
+        flex-direction: column;
+    }
+
+    &--title {
+        min-width: 0;
+        display: flex;
+        gap: 0.25rem;
+    }
+
+    &--name {
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+    }
+
+    &--description {
+        color: var(--vscode-input-placeholderForeground);
+    }
+}
+

--- a/vscode/webviews/components/promptList/ActionItem.module.css
+++ b/vscode/webviews/components/promptList/ActionItem.module.css
@@ -30,8 +30,8 @@
 
     &--avatar {
         flex-shrink: 0;
-        width: 26px;
-        height: 26px;
+        width: 22px;
+        height: 22px;
         display: flex;
         align-items: center;
         justify-content: center;
@@ -57,6 +57,7 @@
         white-space: nowrap;
         overflow: hidden;
         text-overflow: ellipsis;
+        font-weight: 500;
     }
 
     &--description {

--- a/vscode/webviews/components/promptList/ActionItem.module.css
+++ b/vscode/webviews/components/promptList/ActionItem.module.css
@@ -61,6 +61,9 @@
 
     &--description {
         color: var(--vscode-input-placeholderForeground);
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
     }
 }
 

--- a/vscode/webviews/components/promptList/ActionItem.tsx
+++ b/vscode/webviews/components/promptList/ActionItem.tsx
@@ -1,0 +1,136 @@
+import { clsx } from 'clsx'
+import type { FC } from 'react'
+
+import {
+    type Action,
+    type CommandAction,
+    CustomCommandType,
+    type PromptAction,
+} from '@sourcegraph/cody-shared'
+
+import { UserAvatar } from '../../components/UserAvatar'
+import { Badge } from '../../components/shadcn/ui/badge'
+import { CommandItem } from '../../components/shadcn/ui/command'
+import { commandRowValue } from './utils'
+
+import { BookOpen, FileQuestion, Hammer, PencilLine, PencilRuler } from 'lucide-react'
+import styles from './ActionItem.module.css'
+
+interface ActionItemProps {
+    action: Action
+    className?: string
+    onSelect: (actionCommand: string) => void
+}
+
+export const ActionItem: FC<ActionItemProps> = props => {
+    const { action, className, onSelect } = props
+
+    return (
+        <CommandItem
+            value={commandRowValue(action)}
+            className={clsx(className, styles.item)}
+            onSelect={onSelect}
+        >
+            {action.actionType === 'prompt' ? (
+                <ActionPrompt prompt={action} />
+            ) : (
+                <ActionCommand command={action} />
+            )}
+        </CommandItem>
+    )
+}
+
+interface ActionPromptProps {
+    prompt: PromptAction
+}
+
+const ActionPrompt: FC<ActionPromptProps> = props => {
+    const { prompt } = props
+
+    return (
+        <div className={styles.prompt}>
+            <UserAvatar
+                size={30}
+                user={{ ...prompt.createdBy, endpoint: '' }}
+                className={styles.promptAvatar}
+            />
+
+            <div className={styles.promptContent}>
+                <div className={styles.promptTitle}>
+                    <strong className={styles.promptName}>{prompt.name}</strong>
+                    {prompt.draft && (
+                        <Badge variant="secondary" className="tw-text-xxs tw-mt-0.5">
+                            Draft
+                        </Badge>
+                    )}
+                </div>
+
+                <span className={styles.promptDescription}>
+                    {prompt.description ?? 'No description provided'}
+                </span>
+            </div>
+        </div>
+    )
+}
+
+const COMMAND_ICONS: Record<
+    string,
+    React.ComponentType<{
+        size?: string | number
+        strokeWidth?: string | number
+        className?: string
+    }>
+> = {
+    edit: PencilLine,
+    explain: FileQuestion,
+    doc: BookOpen,
+    test: Hammer,
+}
+
+const COMMAND_DESCRIPTIONS: Record<string, string> = {
+    edit: 'Run on a file or selection to modify code',
+    explain: 'Understand the open project or file better',
+    doc: 'Add comments to file or selection',
+    test: 'Create tests for the open file or selected function',
+    smell: 'Analyze selected code and find suspicious logic',
+}
+
+interface ActionCommandProps {
+    command: CommandAction
+}
+
+const ActionCommand: FC<ActionCommandProps> = props => {
+    const { command } = props
+    const Icon = COMMAND_ICONS[command.key] ?? PencilRuler
+
+    const description =
+        command.type !== 'default' ? command.description : COMMAND_DESCRIPTIONS[command.key]
+
+    return (
+        <div className={styles.prompt}>
+            <div className={styles.promptAvatar}>
+                <Icon size={24} strokeWidth={1.5} className={styles.promptIcon} />
+            </div>
+
+            <div className={styles.promptContent}>
+                <div className={styles.promptTitle}>
+                    <strong className={styles.promptName}>
+                        {command.type === 'default' ? command.description : command.key}
+                    </strong>
+
+                    {command.type !== 'default' && (
+                        <Badge variant="secondary" className="tw-text-xxs tw-mt-0.5">
+                            {command.type === CustomCommandType.User
+                                ? 'Local User Settings'
+                                : 'Workspace Settings'}
+                        </Badge>
+                    )}
+                </div>
+
+                <span className={styles.promptDescription}>
+                    {description ?? 'No description provided'}
+                </span>
+            </div>
+        </div>
+    )
+}

--- a/vscode/webviews/components/promptList/ActionItem.tsx
+++ b/vscode/webviews/components/promptList/ActionItem.tsx
@@ -50,7 +50,7 @@ const ActionPrompt: FC<ActionPromptProps> = props => {
     return (
         <div className={styles.prompt}>
             <UserAvatar
-                size={30}
+                size={26}
                 user={{ ...prompt.createdBy, endpoint: '' }}
                 className={styles.promptAvatar}
             />
@@ -109,7 +109,7 @@ const ActionCommand: FC<ActionCommandProps> = props => {
     return (
         <div className={styles.prompt}>
             <div className={styles.promptAvatar}>
-                <Icon size={24} strokeWidth={1.5} className={styles.promptIcon} />
+                <Icon size={20} strokeWidth={1.5} className={styles.promptIcon} />
             </div>
 
             <div className={styles.promptContent}>

--- a/vscode/webviews/components/promptList/ActionItem.tsx
+++ b/vscode/webviews/components/promptList/ActionItem.tsx
@@ -119,7 +119,10 @@ const ActionCommand: FC<ActionCommandProps> = props => {
                     </strong>
 
                     {command.type !== 'default' && (
-                        <Badge variant="secondary" className="tw-text-xxs tw-mt-0.5">
+                        <Badge
+                            variant="secondary"
+                            className="tw-text-xxs tw-mt-0.5 tw-whitespace-nowrap"
+                        >
                             {command.type === CustomCommandType.User
                                 ? 'Local User Settings'
                                 : 'Workspace Settings'}

--- a/vscode/webviews/components/promptList/ActionItem.tsx
+++ b/vscode/webviews/components/promptList/ActionItem.tsx
@@ -13,7 +13,7 @@ import { Badge } from '../../components/shadcn/ui/badge'
 import { CommandItem } from '../../components/shadcn/ui/command'
 import { commandRowValue } from './utils'
 
-import { BookOpen, FileQuestion, Hammer, PencilLine, PencilRuler } from 'lucide-react'
+import { BookOpen, FileQuestion, Hammer, PencilLine, PencilRuler, TextSearch } from 'lucide-react'
 import styles from './ActionItem.module.css'
 
 interface ActionItemProps {
@@ -50,7 +50,7 @@ const ActionPrompt: FC<ActionPromptProps> = props => {
     return (
         <div className={styles.prompt}>
             <UserAvatar
-                size={26}
+                size={22}
                 user={{ ...prompt.createdBy, endpoint: '' }}
                 className={styles.promptAvatar}
             />
@@ -66,7 +66,7 @@ const ActionPrompt: FC<ActionPromptProps> = props => {
                 </div>
 
                 <span className={styles.promptDescription}>
-                    {prompt.description ?? 'No description provided'}
+                    {prompt.description ?? '(No description provided)'}
                 </span>
             </div>
         </div>
@@ -85,6 +85,7 @@ const COMMAND_ICONS: Record<
     explain: FileQuestion,
     doc: BookOpen,
     test: Hammer,
+    smell: TextSearch,
 }
 
 const COMMAND_DESCRIPTIONS: Record<string, string> = {
@@ -109,7 +110,7 @@ const ActionCommand: FC<ActionCommandProps> = props => {
     return (
         <div className={styles.prompt}>
             <div className={styles.promptAvatar}>
-                <Icon size={20} strokeWidth={1.5} className={styles.promptIcon} />
+                <Icon size={16} strokeWidth={1.5} className={styles.promptIcon} />
             </div>
 
             <div className={styles.promptContent}>
@@ -131,7 +132,7 @@ const ActionCommand: FC<ActionCommandProps> = props => {
                 </div>
 
                 <span className={styles.promptDescription}>
-                    {description ?? 'No description provided'}
+                    {description ?? '(No description provided)'}
                 </span>
             </div>
         </div>

--- a/vscode/webviews/components/promptList/PromptList.module.css
+++ b/vscode/webviews/components/promptList/PromptList.module.css
@@ -1,0 +1,40 @@
+
+.list {
+    outline: none;
+    background-color: transparent !important;
+    max-height: unset !important;
+
+    &--input {
+        margin: 0.5rem;
+        padding: 0.5rem;
+        border-radius: 3px;
+        background-color: var(--vscode-input-background);
+        color: var(--vscode-input-foreground);
+
+        &:focus {
+            //border-color: var(--vscode-focusBorder);
+            box-shadow: 0 0 0 0.125rem var(--vscode-focusBorder)
+        }
+    }
+
+    &-chips {
+       [cmdk-list-sizer] {
+           display: flex;
+           flex-direction: column;
+           gap: 0.5rem
+       }
+
+        .list--item {
+            border-radius: 3px;
+            border: 1px solid var(--vscode-dropdown-border, transparent);
+
+            &[aria-selected="true"] {
+                border-color: var(--vscode-list-activeSelectionBackground);
+            }
+
+            &:not([aria-selected="true"]) {
+                background-color: var(--vscode-dropdown-background);
+            }
+        }
+    }
+}

--- a/vscode/webviews/components/promptList/PromptList.module.css
+++ b/vscode/webviews/components/promptList/PromptList.module.css
@@ -1,7 +1,7 @@
 
 .list {
     outline: none;
-    background-color: transparent !important;
+    background-color: transparent;
     max-height: unset !important;
 
     &--input {
@@ -12,7 +12,6 @@
         color: var(--vscode-input-foreground);
 
         &:focus {
-            //border-color: var(--vscode-focusBorder);
             box-shadow: 0 0 0 0.125rem var(--vscode-focusBorder)
         }
     }

--- a/vscode/webviews/components/promptList/PromptList.story.tsx
+++ b/vscode/webviews/components/promptList/PromptList.story.tsx
@@ -48,7 +48,7 @@ export const WithOnlyCommands: Story = {
             value={{
                 ...MOCK_API,
                 prompts: makePromptsAPIWithData({
-                    isPromptsSupported: false,
+                    arePromptsSupported: false,
                     prompts: [],
                     commands: FIXTURE_COMMANDS,
                 }),

--- a/vscode/webviews/components/promptList/PromptList.story.tsx
+++ b/vscode/webviews/components/promptList/PromptList.story.tsx
@@ -1,5 +1,6 @@
 import { ExtensionAPIProviderForTestsOnly, MOCK_API } from '@sourcegraph/prompt-editor'
 import type { Meta, StoryObj } from '@storybook/react'
+import { Observable } from 'observable-fns'
 import { VSCodeStandaloneComponent } from '../../storybook/VSCodeStoryDecorator'
 import { FIXTURE_PROMPTS } from '../promptSelectField/fixtures'
 import { PromptList } from './PromptList'
@@ -10,11 +11,7 @@ const meta: Meta<typeof PromptList> = {
     title: 'cody/PromptList',
     component: PromptList,
     decorators: [
-        story => (
-            <div className="tw-border tw-border-border" style={{ maxWidth: '700px', margin: '2rem' }}>
-                {story()}
-            </div>
-        ),
+        story => <div style={{ maxWidth: '700px', margin: '2rem' }}>{story()}</div>,
         VSCodeStandaloneComponent,
     ],
     args: {
@@ -35,7 +32,7 @@ export const WithPromptsAndCommands: Story = {
             value={{
                 ...MOCK_API,
                 prompts: makePromptsAPIWithData({
-                    prompts: { type: 'results', results: FIXTURE_PROMPTS },
+                    prompts: FIXTURE_PROMPTS,
                     commands: FIXTURE_COMMANDS,
                 }),
             }}
@@ -51,7 +48,8 @@ export const WithOnlyCommands: Story = {
             value={{
                 ...MOCK_API,
                 prompts: makePromptsAPIWithData({
-                    prompts: { type: 'unsupported' },
+                    isPromptsSupported: false,
+                    prompts: [],
                     commands: FIXTURE_COMMANDS,
                 }),
             }}
@@ -66,9 +64,10 @@ export const ErrorMessage: Story = {
         <ExtensionAPIProviderForTestsOnly
             value={{
                 ...MOCK_API,
-                prompts: () => {
-                    throw new Error('my error')
-                },
+                prompts: () =>
+                    new Observable(() => {
+                        throw new Error('my error')
+                    }),
             }}
         >
             <PromptList {...args} />

--- a/vscode/webviews/components/promptList/PromptList.tsx
+++ b/vscode/webviews/components/promptList/PromptList.tsx
@@ -31,6 +31,8 @@ interface PromptListProps {
     className?: string
     paddingLevels?: 'none' | 'middle' | 'big'
     appearanceMode?: 'flat-list' | 'chips-list'
+    lastUsedSorting?: boolean
+    includeEditCommandOnTop?: boolean
     onSelect: (item: Action) => void
 }
 
@@ -52,6 +54,8 @@ export const PromptList: FC<PromptListProps> = props => {
         className,
         paddingLevels = 'none',
         appearanceMode = 'flat-list',
+        lastUsedSorting,
+        includeEditCommandOnTop,
         onSelect: parentOnSelect,
     } = props
 
@@ -129,7 +133,17 @@ export const PromptList: FC<PromptListProps> = props => {
         ? result?.actions.filter(action => action.actionType === 'prompt' || action.mode === 'ask') ?? []
         : result?.actions ?? []
 
-    const sortedActions = getSortedActions(allActions, lastUsedActions)
+    const sortedActions = lastUsedSorting ? getSortedActions(allActions, lastUsedActions) : allActions
+
+    const editCommandIndex = sortedActions.findIndex(
+        action => action.actionType === 'command' && action.key === 'edit'
+    )
+
+    // Bring Edit command on top of the command list
+    if (includeEditCommandOnTop && editCommandIndex !== -1) {
+        sortedActions.unshift(sortedActions.splice(editCommandIndex, 1)[0])
+    }
+
     const actions = showFirstNItems ? sortedActions.slice(0, showFirstNItems) : sortedActions
 
     const inputPaddingClass =

--- a/vscode/webviews/components/promptList/PromptList.tsx
+++ b/vscode/webviews/components/promptList/PromptList.tsx
@@ -1,29 +1,38 @@
-import { type CodyCommand, CustomCommandType, type Prompt } from '@sourcegraph/cody-shared'
 import clsx from 'clsx'
-import { PlusIcon } from 'lucide-react'
-import { type ComponentProps, type FunctionComponent, useCallback, useState } from 'react'
+import { type FC, useCallback, useState } from 'react'
+
+import type { Action } from '@sourcegraph/cody-shared'
+
 import { useTelemetryRecorder } from '../../utils/telemetry'
 import { useConfig } from '../../utils/useConfig'
 import { useDebounce } from '../../utils/useDebounce'
-import { Badge } from '../shadcn/ui/badge'
-import { Button } from '../shadcn/ui/button'
 import {
     Command,
-    CommandGroup,
     CommandInput,
-    CommandItem,
     CommandList,
     CommandLoading,
     CommandSeparator,
 } from '../shadcn/ui/command'
-import { Tooltip, TooltipContent, TooltipTrigger } from '../shadcn/ui/tooltip'
+import { ActionItem } from './ActionItem'
 import { usePromptsQuery } from './usePromptsQuery'
+import { commandRowValue } from './utils'
 
-export type PromptOrDeprecatedCommand =
-    | { type: 'prompt'; value: Prompt }
-    | { type: 'command'; value: CodyCommand }
+import { useLocalStorage } from '../../components/hooks'
+import styles from './PromptList.module.css'
 
-type SelectActionLabel = 'insert' | 'run'
+interface PromptListProps {
+    showSearch: boolean
+    showFirstNItems?: number
+    telemetryLocation: 'PromptSelectField' | 'PromptsTab'
+    showOnlyPromptInsertableCommands?: boolean
+    showInitialSelectedItem?: boolean
+    showCommandOrigins?: boolean
+    showPromptLibraryUnsupportedMessage?: boolean
+    className?: string
+    paddingLevels?: 'none' | 'middle' | 'big'
+    appearanceMode?: 'flat-list' | 'chips-list'
+    onSelect: (item: Action) => void
+}
 
 /**
  * A list of prompts from the Prompt Library. For backcompat, it also displays built-in commands and
@@ -32,30 +41,24 @@ type SelectActionLabel = 'insert' | 'run'
  * It is used in the {@link PromptSelectField} in a popover and in {@link PromptsTab} as a list (not
  * in a popover).
  */
-export const PromptList: React.FunctionComponent<{
-    onSelect: (item: PromptOrDeprecatedCommand) => void
-    onSelectActionLabels?: { prompt: SelectActionLabel; command: SelectActionLabel }
-    showSearch?: boolean
-    showOnlyPromptInsertableCommands?: boolean
-    showInitialSelectedItem?: boolean
-    showPromptLibraryUnsupportedMessage?: boolean
-    showCommandOrigins?: boolean
-    className?: string
-    commandListClassName?: string
-    telemetryLocation: 'PromptSelectField' | 'PromptsTab'
-}> = ({
-    onSelect: parentOnSelect,
-    onSelectActionLabels,
-    showSearch = true,
-    showOnlyPromptInsertableCommands,
-    showInitialSelectedItem = true,
-    showPromptLibraryUnsupportedMessage = true,
-    showCommandOrigins = false,
-    className,
-    commandListClassName,
-    telemetryLocation,
-}) => {
+export const PromptList: FC<PromptListProps> = props => {
+    const {
+        showSearch,
+        showFirstNItems,
+        telemetryLocation,
+        showOnlyPromptInsertableCommands,
+        showInitialSelectedItem = true,
+        showPromptLibraryUnsupportedMessage = true,
+        className,
+        paddingLevels = 'none',
+        appearanceMode = 'flat-list',
+        onSelect: parentOnSelect,
+    } = props
+
+    const endpointURL = new URL(useConfig().authStatus.endpoint)
     const telemetryRecorder = useTelemetryRecorder()
+    const [lastUsedActions = {}] = useLocalStorage<Record<string, number>>('last-used-actions', {})
+
     const telemetryPublicMetadata: Record<string, number> = {
         [`in${telemetryLocation}`]: 1,
     }
@@ -66,68 +69,50 @@ export const PromptList: React.FunctionComponent<{
 
     const onSelect = useCallback(
         (rowValue: string): void => {
-            const prompt =
-                result?.prompts.type === 'results'
-                    ? result.prompts.results.find(
-                          p => commandRowValue({ type: 'prompt', value: p }) === rowValue
-                      )
-                    : undefined
+            const action = result?.actions.find(p => commandRowValue(p) === rowValue)
 
-            const standardPromptCommand =
-                prompt === undefined
-                    ? result?.standardPrompts?.find(
-                          c => commandRowValue({ type: 'command', value: c }) === rowValue
-                      )
-                    : undefined
-
-            const codyCommand =
-                standardPromptCommand ??
-                result?.commands?.find(c => commandRowValue({ type: 'command', value: c }) === rowValue)
-
-            const entry: PromptOrDeprecatedCommand | undefined = prompt
-                ? { type: 'prompt', value: prompt }
-                : codyCommand
-                  ? { type: 'command', value: codyCommand }
-                  : undefined
-            if (!entry) {
+            if (!action || !result) {
                 return
             }
+
+            const isPrompt = action.actionType === 'prompt'
+            const isCommand = action.actionType === 'command'
+            const isBuiltInCommand = isCommand && action.type === 'default'
+
             telemetryRecorder.recordEvent('cody.promptList', 'select', {
                 metadata: {
-                    isPrompt: prompt ? 1 : 0,
-                    isCommand: codyCommand ? 1 : 0,
-                    isCommandBuiltin: codyCommand?.type === 'default' ? 1 : 0,
-                    isCommandCustom: codyCommand?.type !== 'default' ? 1 : 0,
+                    isPrompt: isPrompt ? 1 : 0,
+                    isCommand: isCommand ? 1 : 0,
+                    isCommandBuiltin: isBuiltInCommand ? 1 : 0,
+                    isCommandCustom: !isBuiltInCommand ? 1 : 0,
                     ...telemetryPublicMetadata,
                 },
                 privateMetadata: {
-                    nameWithOwner: prompt ? prompt.nameWithOwner : undefined,
+                    nameWithOwner: isPrompt ? action.nameWithOwner : undefined,
                 },
             })
-            if (result) {
-                telemetryRecorder.recordEvent('cody.promptList', 'query', {
-                    metadata: {
-                        queryLength: debouncedQuery.length,
-                        resultCount:
-                            (result.prompts.type === 'results' ? result.prompts.results.length : 0) +
-                            (result.commands?.length ?? 0),
-                        resultCountPromptsOnly:
-                            result.prompts.type === 'results' ? result.prompts.results.length : 0,
-                        resultCountCommandsOnly: result.commands?.length ?? 0,
-                        supportsPrompts: result.prompts.type !== 'unsupported' ? 1 : 0,
-                        hasUsePromptsQueryError: error ? 1 : 0,
-                        hasPromptsResultError: result.prompts.type === 'error' ? 1 : 0,
-                        ...telemetryPublicMetadata,
-                    },
-                    privateMetadata: {
-                        query: debouncedQuery,
-                        usePromptsQueryErrorMessage: error?.message,
-                        promptsResultErrorMessage:
-                            result.prompts.type === 'error' ? result.prompts.error : undefined,
-                    },
-                })
-            }
-            parentOnSelect(entry)
+
+            const prompts = result.actions.filter(action => action.actionType === 'prompt')
+            const commands = result.actions.filter(action => action.actionType === 'command')
+
+            telemetryRecorder.recordEvent('cody.promptList', 'query', {
+                metadata: {
+                    queryLength: debouncedQuery.length,
+                    resultCount: result.actions.length,
+                    resultCountPromptsOnly: prompts.length,
+                    resultCountCommandsOnly: commands.length,
+                    hasUsePromptsQueryError: error ? 1 : 0,
+                    supportsPrompts: 1,
+                    hasPromptsResultError: 0,
+                    ...telemetryPublicMetadata,
+                },
+                privateMetadata: {
+                    query: debouncedQuery,
+                    usePromptsQueryErrorMessage: error?.message,
+                },
+            })
+
+            parentOnSelect(action)
         },
         [
             result,
@@ -139,166 +124,83 @@ export const PromptList: React.FunctionComponent<{
         ]
     )
 
-    const endpointURL = new URL(useConfig().authStatus.endpoint)
-
     // Don't show builtin commands to insert in the prompt editor.
-    const filteredCommands = showOnlyPromptInsertableCommands
-        ? result?.commands.filter(c => c.type !== 'default')
-        : result?.commands
+    const allActions = showOnlyPromptInsertableCommands
+        ? result?.actions.filter(action => action.actionType === 'prompt' || action.mode === 'ask') ?? []
+        : result?.actions ?? []
+
+    const sortedActions = getSortedActions(allActions, lastUsedActions)
+    const actions = showFirstNItems ? sortedActions.slice(0, showFirstNItems) : sortedActions
+
+    const inputPaddingClass =
+        paddingLevels !== 'none' ? (paddingLevels === 'middle' ? '!tw-p-2' : '!tw-px-4 !tw-py-4') : ''
+
+    const itemPaddingClass =
+        paddingLevels !== 'none' ? (paddingLevels === 'middle' ? '!tw-px-6' : '!tw-px-8') : ''
 
     return (
         <Command
             loop={true}
             tabIndex={0}
-            className={clsx('focus:tw-outline-none', className)}
             shouldFilter={false}
             defaultValue={showInitialSelectedItem ? undefined : 'xxx-no-item'}
+            className={clsx(styles.list, { [styles.listChips]: appearanceMode === 'chips-list' })}
         >
-            <CommandList
-                className={clsx(
-                    '[&_[cmdk-group]]:tw-pt-0 [&_[cmdk-group-heading]]:tw-flex [&_[cmdk-group-heading]]:tw-gap-2 [&_[cmdk-group-heading]]:tw-items-center [&_[cmdk-group-heading]]:!tw-min-h-[30px] [&_[cmdk-group-heading]]:tw--mx-2 [&_[cmdk-group-heading]]:tw-px-4 [&_[cmdk-group-heading]]:tw-mb-2 [&_[cmdk-group-heading]]:tw-bg-muted [&_[cmdk-group]]:!tw-border-0',
-                    commandListClassName
-                )}
-            >
+            <CommandList className={className}>
                 {showSearch && (
-                    <CommandInput
-                        value={query}
-                        onValueChange={setQuery}
-                        placeholder="Search..."
-                        autoFocus={true}
-                    />
+                    <div className={inputPaddingClass}>
+                        <CommandInput
+                            value={query}
+                            onValueChange={setQuery}
+                            placeholder="Search..."
+                            autoFocus={true}
+                            className={styles.listInput}
+                        />
+                    </div>
                 )}
-                {result && result.prompts.type !== 'unsupported' && (
-                    <CommandGroup
-                        heading={
+
+                {!result && !error && (
+                    <CommandLoading className={itemPaddingClass}>Loading...</CommandLoading>
+                )}
+                {result && actions.filter(action => action.actionType === 'prompt').length === 0 && (
+                    <CommandLoading className={itemPaddingClass}>
+                        {result?.query === '' ? (
                             <>
-                                <span>Prompt Library</span>
-                                <div className="tw-flex-grow" />
-                                <Button variant="ghost" size="sm" asChild>
-                                    <a
-                                        href={new URL('/prompts', endpointURL).toString()}
-                                        target="_blank"
-                                        rel="noreferrer"
-                                        className="!tw-text-[unset]"
-                                    >
-                                        Manage
-                                    </a>
-                                </Button>
-                                <Button
-                                    variant="ghost"
-                                    size="sm"
-                                    className="tw-flex tw-items-center tw-gap-0.5"
-                                    asChild
+                                Your Prompt Library is empty.{' '}
+                                <a
+                                    href={new URL('/prompts/new', endpointURL).toString()}
+                                    target="_blank"
+                                    rel="noreferrer"
                                 >
-                                    <a
-                                        href={new URL('/prompts/new', endpointURL).toString()}
-                                        target="_blank"
-                                        rel="noreferrer"
-                                        className="!tw-text-[unset]"
-                                    >
-                                        <PlusIcon size={12} strokeWidth={1.25} />
-                                        New
-                                    </a>
-                                </Button>
+                                    Add a prompt
+                                </a>{' '}
+                                to reuse and share it.
                             </>
-                        }
-                    >
-                        {result.prompts.type === 'results' ? (
-                            <>
-                                {result.prompts.results.length === 0 && (
-                                    <CommandLoading>
-                                        {result.query === '' ? (
-                                            <>
-                                                Your Prompt Library is empty.{' '}
-                                                <a
-                                                    href={new URL(
-                                                        '/prompts/new',
-                                                        endpointURL
-                                                    ).toString()}
-                                                    target="_blank"
-                                                    rel="noreferrer"
-                                                >
-                                                    Add a prompt
-                                                </a>{' '}
-                                                to reuse and share it.
-                                            </>
-                                        ) : (
-                                            <>No prompts found</>
-                                        )}
-                                    </CommandLoading>
-                                )}
-                                {result.prompts.results.map(prompt => (
-                                    <PromptCommandItem
-                                        key={prompt.id}
-                                        prompt={prompt}
-                                        onSelect={onSelect}
-                                        selectActionLabel={onSelectActionLabels?.prompt}
-                                    />
-                                ))}
-                            </>
-                        ) : null}
-                        {result.prompts.type === 'error' && (
-                            <CommandLoading>Error: {result.prompts.error}</CommandLoading>
+                        ) : (
+                            <>No prompts found</>
                         )}
-                    </CommandGroup>
+                    </CommandLoading>
                 )}
-                {!showOnlyPromptInsertableCommands &&
-                    result?.standardPrompts &&
-                    result.standardPrompts.length > 0 && (
-                        <CommandGroup heading={<span>Standard Prompts</span>}>
-                            {result.standardPrompts.map(command => (
-                                <CodyCommandItem
-                                    key={command.key}
-                                    command={command}
-                                    onSelect={onSelect}
-                                    selectActionLabel={onSelectActionLabels?.prompt}
-                                    showCommandOrigins={false}
-                                />
-                            ))}
-                        </CommandGroup>
-                    )}
-                {result && filteredCommands && filteredCommands.length > 0 && (
-                    <CommandGroup
-                        heading={
-                            <>
-                                <span>Commands</span>
-                                <div className="tw-flex-grow" />
-                                {hasCustomCommands(filteredCommands) && (
-                                    <Button variant="ghost" size="sm" asChild>
-                                        <a
-                                            className="!tw-text-[unset]"
-                                            href="command:cody.menu.commands-settings"
-                                        >
-                                            Manage
-                                        </a>
-                                    </Button>
-                                )}
-                            </>
-                        }
-                    >
-                        {filteredCommands.map(command => (
-                            <CodyCommandItem
-                                key={command.key}
-                                command={command}
-                                onSelect={onSelect}
-                                selectActionLabel={onSelectActionLabels?.command}
-                                showCommandOrigins={showCommandOrigins}
-                            />
-                        ))}
-                    </CommandGroup>
+
+                {actions.map(action => (
+                    <ActionItem
+                        key={commandRowValue(action)}
+                        action={action}
+                        onSelect={onSelect}
+                        className={clsx(itemPaddingClass, styles.listItem)}
+                    />
+                ))}
+
+                {showPromptLibraryUnsupportedMessage && result && !result.isPromptsSupported && (
+                    <>
+                        <CommandSeparator alwaysRender={true} />
+                        <CommandLoading className="tw-px-4">
+                            Prompt Library is not yet available on {endpointURL.hostname}. Ask your site
+                            admin to upgrade to Sourcegraph 5.6 or later.
+                        </CommandLoading>
+                    </>
                 )}
-                {showPromptLibraryUnsupportedMessage &&
-                    result &&
-                    result.prompts.type === 'unsupported' && (
-                        <>
-                            <CommandSeparator alwaysRender={true} />
-                            <CommandLoading className="tw-px-4">
-                                Prompt Library is not yet available on {endpointURL.hostname}. Ask your
-                                site admin to upgrade to Sourcegraph 5.6 or later.
-                            </CommandLoading>
-                        </>
-                    )}
-                {!result && !error && <CommandLoading className="tw-px-4">Loading...</CommandLoading>}
+
                 {error && (
                     <CommandLoading className="tw-px-4">
                         Error: {error.message || 'unknown'}
@@ -309,123 +211,13 @@ export const PromptList: React.FunctionComponent<{
     )
 }
 
-function hasCustomCommands(commands: CodyCommand[]): boolean {
-    return commands.some(
-        command =>
-            command.type === CustomCommandType.Workspace || command.type === CustomCommandType.User
-    )
+function getSortedActions(actions: Action[], lastUsedActions: Record<string, number>): Action[] {
+    return [...actions].sort((action1, action2) => {
+        const action1Key = action1.actionType === 'prompt' ? action1.id : action1.key
+        const action2Key = action2.actionType === 'prompt' ? action2.id : action2.key
+        const action1Count = lastUsedActions[action1Key] ?? 0
+        const action2Count = lastUsedActions[action2Key] ?? 0
+
+        return action2Count - action1Count
+    })
 }
-
-function commandRowValue(row: PromptOrDeprecatedCommand): string {
-    return row.type === 'prompt' ? `prompt-${row.value.id}` : `command-${row.value.key}`
-}
-
-const PromptCommandItem: FunctionComponent<{
-    prompt: Prompt
-    onSelect: (value: string) => void
-    selectActionLabel: SelectActionLabel | undefined
-}> = ({ prompt, onSelect, selectActionLabel }) => (
-    <CommandItem
-        value={commandRowValue({ type: 'prompt', value: prompt })}
-        onSelect={onSelect}
-        className="!tw-items-start tw-group/[cmdk-item]"
-    >
-        <div>
-            <div className="tw-flex tw-gap-3 tw-w-full tw-items-start">
-                <span>
-                    <span className="tw-text-muted-foreground">{prompt.owner.namespaceName} / </span>
-                    <strong>{prompt.name}</strong>
-                </span>
-                {prompt.draft && (
-                    <Badge variant="secondary" className="tw-text-xxs tw-mt-0.5">
-                        Draft
-                    </Badge>
-                )}
-            </div>
-            {prompt.description && (
-                <span className="tw-text-xs tw-text-muted-foreground tw-text-nowrap tw-overflow-hidden tw-text-ellipsis tw-w-full">
-                    {prompt.description}
-                </span>
-            )}
-        </div>
-        <div className="tw-flex-grow" />
-        {selectActionLabel && <CommandItemAction label={selectActionLabel} />}
-    </CommandItem>
-)
-
-const CodyCommandItem: FunctionComponent<{
-    command: CodyCommand
-    onSelect: (value: string) => void
-    selectActionLabel: SelectActionLabel | undefined
-    showCommandOrigins: boolean
-}> = ({ command, onSelect, selectActionLabel, showCommandOrigins }) => (
-    <CommandItem
-        value={commandRowValue({ type: 'command', value: command })}
-        onSelect={onSelect}
-        className="!tw-items-start tw-group/[cmdk-item]"
-    >
-        <div>
-            <div className="tw-flex tw-flex-wrap tw-gap-3 tw-w-full tw-items-start">
-                <strong className="tw-whitespace-nowrap">
-                    {command.type === 'default' ? command.description : command.key}
-                </strong>
-                {showCommandOrigins && command.type !== 'default' && (
-                    <Badge variant="secondary" className="tw-text-xxs tw-mt-0.5 tw-whitespace-nowrap">
-                        {command.type === CustomCommandType.User
-                            ? 'Local User Settings'
-                            : 'Workspace Settings'}
-                    </Badge>
-                )}
-            </div>
-            {command.type !== 'default' && command.description && (
-                <span className="tw-text-xs tw-text-muted-foreground tw-text-nowrap tw-overflow-hidden tw-text-ellipsis tw-w-full">
-                    {command.description}
-                </span>
-            )}
-        </div>
-        <div className="tw-flex-grow" />
-        {selectActionLabel && <CommandItemAction label={selectActionLabel} />}
-    </CommandItem>
-)
-
-/** Indicator for what will occur when a CommandItem is selected. */
-const CommandItemAction: FunctionComponent<{ label: SelectActionLabel; className?: string }> = ({
-    label,
-    className,
-}) => (
-    <Tooltip>
-        <TooltipTrigger asChild>
-            <Button
-                type="button"
-                variant="default"
-                size="xs"
-                className={clsx(
-                    'tw-tracking-tight tw-text-accent-foreground tw-opacity-30 tw-bg-transparent hover:tw-bg-transparent tw-invisible group-[[aria-selected="true"]]/[cmdk-item]:tw-visible group-hover/[cmdk-item]:tw-visible',
-                    className
-                )}
-            >
-                {label === 'insert' ? 'Insert' : 'Run'}
-            </Button>
-        </TooltipTrigger>
-        <TooltipContent>
-            {label === 'insert'
-                ? 'Append prompt text to chat message'
-                : 'Run command on current selection in editor'}
-        </TooltipContent>
-    </Tooltip>
-)
-
-/**
- * A variant of {@link PromptList} that is visually more suited for a non-popover.
- */
-export const PromptListSuitedForNonPopover: FunctionComponent<
-    Omit<ComponentProps<typeof PromptList>, 'showSearch' | 'showInitialSelectedItem'>
-> = ({ className, commandListClassName, ...props }) => (
-    <PromptList
-        {...props}
-        showSearch={false}
-        showInitialSelectedItem={false}
-        className={clsx('tw-w-full !tw-max-w-[unset] !tw-bg-[unset]', className)}
-        commandListClassName={clsx('!tw-max-h-[unset]', commandListClassName)}
-    />
-)

--- a/vscode/webviews/components/promptList/PromptList.tsx
+++ b/vscode/webviews/components/promptList/PromptList.tsx
@@ -147,7 +147,7 @@ export const PromptList: FC<PromptListProps> = props => {
     const actions = showFirstNItems ? sortedActions.slice(0, showFirstNItems) : sortedActions
 
     const inputPaddingClass =
-        paddingLevels !== 'none' ? (paddingLevels === 'middle' ? '!tw-p-2' : '!tw-px-4 !tw-py-4') : ''
+        paddingLevels !== 'none' ? (paddingLevels === 'middle' ? '!tw-p-2' : '!tw-p-4') : ''
 
     const itemPaddingClass =
         paddingLevels !== 'none' ? (paddingLevels === 'middle' ? '!tw-px-6' : '!tw-px-8') : ''
@@ -205,7 +205,7 @@ export const PromptList: FC<PromptListProps> = props => {
                     />
                 ))}
 
-                {showPromptLibraryUnsupportedMessage && result && !result.isPromptsSupported && (
+                {showPromptLibraryUnsupportedMessage && result && !result.arePromptsSupported && (
                     <>
                         <CommandSeparator alwaysRender={true} />
                         <CommandLoading className="tw-px-4">

--- a/vscode/webviews/components/promptList/PromptList.tsx
+++ b/vscode/webviews/components/promptList/PromptList.tsx
@@ -162,7 +162,7 @@ export const PromptList: FC<PromptListProps> = props => {
                 {!result && !error && (
                     <CommandLoading className={itemPaddingClass}>Loading...</CommandLoading>
                 )}
-                {result && actions.filter(action => action.actionType === 'prompt').length === 0 && (
+                {result && allActions.filter(action => action.actionType === 'prompt').length === 0 && (
                     <CommandLoading className={itemPaddingClass}>
                         {result?.query === '' ? (
                             <>

--- a/vscode/webviews/components/promptList/fixtures.ts
+++ b/vscode/webviews/components/promptList/fixtures.ts
@@ -1,6 +1,8 @@
 import {
+    type Action,
     type CodyCommand,
     CustomCommandType,
+    type Prompt,
     type PromptsResult,
     type WebviewToExtensionAPI,
     promiseFactoryToObservable,
@@ -59,11 +61,14 @@ export const FIXTURE_COMMANDS: CodyCommand[] = [
 /**
  * For testing only.
  */
-export function makePromptsAPIWithData(
-    data: Omit<PromptsResult, 'query'>
-): WebviewToExtensionAPI['prompts'] {
+export function makePromptsAPIWithData(data: {
+    isPromptsSupported?: boolean
+    prompts: Prompt[]
+    commands?: CodyCommand[]
+}): WebviewToExtensionAPI['prompts'] {
     return query =>
         promiseFactoryToObservable<PromptsResult>(async () => {
+            const { isPromptsSupported = true, prompts, commands = [] } = data
             await new Promise<void>(resolve => setTimeout(resolve, 500))
 
             const queryLower = query.toLowerCase()
@@ -72,15 +77,17 @@ export function makePromptsAPIWithData(
             }
 
             return {
-                prompts:
-                    data.prompts.type === 'results'
-                        ? {
-                              type: 'results',
-                              results: data.prompts.results.filter(prompt => matchQuery(prompt.name)),
-                          }
-                        : data.prompts,
-                commands: data.commands?.filter(c => matchQuery(c.key)),
                 query,
+                isPromptsSupported: isPromptsSupported,
+                actions: [
+                    ...prompts
+                        .filter(prompt => matchQuery(prompt.name))
+                        .map<Action>(prompt => ({ ...prompt, actionType: 'prompt' })),
+
+                    ...commands
+                        .filter(c => matchQuery(c.key))
+                        .map<Action>(prompt => ({ ...prompt, actionType: 'command' })),
+                ],
             } satisfies PromptsResult
         })
 }

--- a/vscode/webviews/components/promptList/fixtures.ts
+++ b/vscode/webviews/components/promptList/fixtures.ts
@@ -62,13 +62,13 @@ export const FIXTURE_COMMANDS: CodyCommand[] = [
  * For testing only.
  */
 export function makePromptsAPIWithData(data: {
-    isPromptsSupported?: boolean
+    arePromptsSupported?: boolean
     prompts: Prompt[]
     commands?: CodyCommand[]
 }): WebviewToExtensionAPI['prompts'] {
     return query =>
         promiseFactoryToObservable<PromptsResult>(async () => {
-            const { isPromptsSupported = true, prompts, commands = [] } = data
+            const { arePromptsSupported = true, prompts, commands = [] } = data
             await new Promise<void>(resolve => setTimeout(resolve, 500))
 
             const queryLower = query.toLowerCase()
@@ -78,7 +78,7 @@ export function makePromptsAPIWithData(data: {
 
             return {
                 query,
-                isPromptsSupported: isPromptsSupported,
+                arePromptsSupported,
                 actions: [
                     ...prompts
                         .filter(prompt => matchQuery(prompt.name))

--- a/vscode/webviews/components/promptList/utils.ts
+++ b/vscode/webviews/components/promptList/utils.ts
@@ -1,0 +1,5 @@
+import type { Action } from '@sourcegraph/cody-shared'
+
+export function commandRowValue(row: Action): string {
+    return row.actionType === 'prompt' ? `prompt-${row.id}` : `command-${row.key}`
+}

--- a/vscode/webviews/components/promptSelectField/PromptSelectField.tsx
+++ b/vscode/webviews/components/promptSelectField/PromptSelectField.tsx
@@ -52,6 +52,7 @@ export const PromptSelectField: React.FunctionComponent<{
                     telemetryLocation="PromptSelectField"
                     showOnlyPromptInsertableCommands={true}
                     showPromptLibraryUnsupportedMessage={true}
+                    lastUsedSorting={true}
                 />
             )}
             popoverRootProps={{ onOpenChange }}

--- a/vscode/webviews/components/promptSelectField/PromptSelectField.tsx
+++ b/vscode/webviews/components/promptSelectField/PromptSelectField.tsx
@@ -1,11 +1,12 @@
+import type { Action } from '@sourcegraph/cody-shared'
 import { useCallback } from 'react'
 import { useTelemetryRecorder } from '../../utils/telemetry'
-import { PromptList, type PromptOrDeprecatedCommand } from '../promptList/PromptList'
+import { PromptList } from '../promptList/PromptList'
 import { ToolbarPopoverItem } from '../shadcn/ui/toolbar'
 import { cn } from '../shadcn/utils'
 
 export const PromptSelectField: React.FunctionComponent<{
-    onSelect: (item: PromptOrDeprecatedCommand) => void
+    onSelect: (item: Action) => void
     onCloseByEscape?: () => void
     className?: string
 
@@ -46,16 +47,17 @@ export const PromptSelectField: React.FunctionComponent<{
                         onSelect(item)
                         close()
                     }}
-                    onSelectActionLabels={{ prompt: 'insert', command: 'insert' }}
                     showSearch={true}
+                    paddingLevels="middle"
+                    telemetryLocation="PromptSelectField"
                     showOnlyPromptInsertableCommands={true}
                     showPromptLibraryUnsupportedMessage={true}
-                    telemetryLocation="PromptSelectField"
                 />
             )}
             popoverRootProps={{ onOpenChange }}
             popoverContentProps={{
-                className: 'tw-min-w-[325px] tw-w-[75vw] tw-max-w-[550px] !tw-p-0',
+                className:
+                    'tw-min-w-[325px] tw-w-[75vw] tw-max-w-[550px] !tw-p-0 tw-max-h-[500px] tw-overflow-auto',
                 onKeyDown: onKeyDown,
                 onCloseAutoFocus: event => {
                     // Prevent the popover trigger from stealing focus after the user selects an

--- a/vscode/webviews/components/promptSelectField/fixtures.ts
+++ b/vscode/webviews/components/promptSelectField/fixtures.ts
@@ -10,6 +10,12 @@ export const FIXTURE_PROMPTS: Prompt[] = [
         draft: false,
         definition: { text: 'Generate unit tests for vitest' },
         url: 'https://example.com',
+        createdBy: {
+            id: '001',
+            username: 'kevin.chen',
+            avatarURL: 'https://avatars.githubusercontent.com/u/3654603?v=4',
+            displayName: 'Kevin Chen',
+        },
     },
     {
         id: '2',
@@ -20,6 +26,12 @@ export const FIXTURE_PROMPTS: Prompt[] = [
         draft: true,
         definition: { text: 'Review the following OpenCtx provider code' },
         url: 'https://example.com',
+        createdBy: {
+            id: '001',
+            username: 'kevin.chen',
+            avatarURL: '',
+            displayName: 'Kevin Chen',
+        },
     },
     {
         id: '3',
@@ -29,6 +41,12 @@ export const FIXTURE_PROMPTS: Prompt[] = [
         draft: false,
         definition: { text: 'Generate a JUnit integration test' },
         url: 'https://example.com',
+        createdBy: {
+            id: '001',
+            username: 'kevin.chen',
+            avatarURL: 'https://avatars.githubusercontent.com/u/3654603?v=4',
+            displayName: 'Kevin Chen',
+        },
     },
     {
         id: '4',
@@ -38,6 +56,12 @@ export const FIXTURE_PROMPTS: Prompt[] = [
         draft: false,
         definition: { text: 'Fix common issues in this Bazel BUILD file' },
         url: 'https://example.com',
+        createdBy: {
+            id: '001',
+            username: 'kevin.chen',
+            avatarURL: 'https://avatars.githubusercontent.com/u/3654603?v=4',
+            displayName: 'Kevin Chen',
+        },
     },
     {
         id: '5',
@@ -49,5 +73,11 @@ export const FIXTURE_PROMPTS: Prompt[] = [
         draft: false,
         definition: { text: 'Convert from a React class component to a function component' },
         url: 'https://example.com',
+        createdBy: {
+            id: '001',
+            username: 'kevin.chen',
+            avatarURL: 'https://avatars.githubusercontent.com/u/3654603?v=4',
+            displayName: 'Kevin Chen',
+        },
     },
 ]

--- a/vscode/webviews/components/shadcn/ui/command.tsx
+++ b/vscode/webviews/components/shadcn/ui/command.tsx
@@ -22,11 +22,11 @@ const CommandInput = React.forwardRef<
     React.ElementRef<typeof CommandPrimitive.Input>,
     React.ComponentPropsWithoutRef<typeof CommandPrimitive.Input>
 >(({ className, ...props }, ref) => (
-    <div className="tw-flex tw-items-center tw-border-b tw-border-b-border" cmdk-input-wrapper="">
+    <div className="tw-flex tw-items-center" cmdk-input-wrapper="">
         <CommandPrimitive.Input
             ref={ref}
             className={cn(
-                'tw-flex tw-w-full tw-border-solid tw-border tw-border-transparent tw-bg-transparent tw-pt-4 tw-pb-3 tw-px-3 tw-text-md tw-leading-none placeholder:tw-text-muted-foreground disabled:tw-cursor-not-allowed disabled:tw-opacity-50 focus:tw-outline-none',
+                'tw-flex tw-w-full tw-border-solid tw-border tw-border-transparent tw-text-md tw-leading-none placeholder:tw-text-muted-foreground disabled:tw-cursor-not-allowed disabled:tw-opacity-50 focus:tw-outline-none',
                 className
             )}
             inputMode="search"
@@ -43,7 +43,7 @@ const CommandList = React.forwardRef<
 >(({ className, ...props }, ref) => (
     <CommandPrimitive.List
         ref={ref}
-        className={cn('tw-max-h-[500px] tw-overflow-y-auto tw-overflow-x-hidden', className)}
+        className={cn('tw-overflow-y-auto tw-overflow-x-hidden', className)}
         {...props}
     />
 ))

--- a/vscode/webviews/components/shadcn/ui/popover.module.css
+++ b/vscode/webviews/components/shadcn/ui/popover.module.css
@@ -1,0 +1,5 @@
+
+.popover {
+    box-shadow: 0 193px 54px 0 rgba(0, 0, 0, 0), 0 123px 49px 0 rgba(0, 0, 0, 0.01),
+    0 69px 42px 0 rgba(0, 0, 0, 0.04), 0 31px 31px 0 rgba(0, 0, 0, 0.07), 0 8px 17px 0 rgba(0, 0, 0, 0.08);
+}

--- a/vscode/webviews/components/shadcn/ui/popover.tsx
+++ b/vscode/webviews/components/shadcn/ui/popover.tsx
@@ -2,6 +2,7 @@ import * as PopoverPrimitive from '@radix-ui/react-popover'
 import * as React from 'react'
 
 import { cn } from '../utils'
+import styles from './popover.module.css'
 
 const Popover = PopoverPrimitive.Root
 
@@ -23,8 +24,9 @@ const PopoverContent = React.forwardRef<
                         align={align}
                         sideOffset={sideOffset}
                         className={cn(
-                            'tw-z-50 tw-w-72 tw-rounded-md tw-border tw-border-ring tw-bg-popover tw-p-4 tw-text-popover-foreground tw-shadow-md tw-outline-none',
-                            className
+                            'tw-z-50 tw-w-72 tw-rounded-md tw-border tw-border-border tw-bg-popover tw-p-4 tw-text-popover-foreground tw-outline-none',
+                            className,
+                            styles.popover
                         )}
                         {...props}
                     />

--- a/vscode/webviews/prompts/PromptsTab.story.tsx
+++ b/vscode/webviews/prompts/PromptsTab.story.tsx
@@ -42,7 +42,7 @@ export const WithOnlyCommands: Story = {
             value={{
                 ...MOCK_API,
                 prompts: makePromptsAPIWithData({
-                    isPromptsSupported: false,
+                    arePromptsSupported: false,
                     prompts: [],
                     commands: FIXTURE_COMMANDS,
                 }),

--- a/vscode/webviews/prompts/PromptsTab.story.tsx
+++ b/vscode/webviews/prompts/PromptsTab.story.tsx
@@ -26,7 +26,7 @@ export const WithPromptsAndCommands: Story = {
             value={{
                 ...MOCK_API,
                 prompts: makePromptsAPIWithData({
-                    prompts: { type: 'results', results: FIXTURE_PROMPTS },
+                    prompts: FIXTURE_PROMPTS,
                     commands: FIXTURE_COMMANDS,
                 }),
             }}
@@ -42,7 +42,8 @@ export const WithOnlyCommands: Story = {
             value={{
                 ...MOCK_API,
                 prompts: makePromptsAPIWithData({
-                    prompts: { type: 'unsupported' },
+                    isPromptsSupported: false,
+                    prompts: [],
                     commands: FIXTURE_COMMANDS,
                 }),
             }}

--- a/vscode/webviews/prompts/PromptsTab.tsx
+++ b/vscode/webviews/prompts/PromptsTab.tsx
@@ -1,73 +1,76 @@
-import type { ComponentProps } from 'react'
+import type { Action } from '@sourcegraph/cody-shared'
 import { useClientActionDispatcher } from '../client/clientState'
-import {
-    type PromptList,
-    PromptListSuitedForNonPopover,
-    type PromptOrDeprecatedCommand,
-} from '../components/promptList/PromptList'
+import { useLocalStorage } from '../components/hooks'
+import { PromptList } from '../components/promptList/PromptList'
 import { View } from '../tabs/types'
 import { getVSCodeAPI } from '../utils/VSCodeApi'
 
 export const PromptsTab: React.FC<{
     setView: (view: View) => void
 }> = ({ setView }) => {
-    const dispatchClientAction = useClientActionDispatcher()
+    const runAction = useActionSelect()
+
     return (
-        <div className="tw-overflow-auto tw-p-8">
-            <PromptListSuitedForNonPopover
-                onSelect={item => onPromptSelectInPanel(item, setView, dispatchClientAction)}
-                onSelectActionLabels={onPromptSelectInPanelActionLabels}
+        <div className="tw-overflow-auto">
+            <PromptList
+                showSearch={true}
                 showCommandOrigins={true}
+                paddingLevels="big"
+                telemetryLocation="PromptsTab"
                 showPromptLibraryUnsupportedMessage={true}
                 showOnlyPromptInsertableCommands={false}
-                telemetryLocation="PromptsTab"
-                className="tw-border tw-border-border"
+                onSelect={item => runAction(item, setView)}
             />
         </div>
     )
 }
 
-export function onPromptSelectInPanel(
-    item: PromptOrDeprecatedCommand,
-    setView: (view: View) => void,
-    dispatchClientAction: ReturnType<typeof useClientActionDispatcher>
-): void {
-    switch (item.type) {
-        case 'prompt': {
-            setView(View.Chat)
-            dispatchClientAction(
-                { appendTextToLastPromptEditor: item.value.definition.text },
-                // Buffer because PromptEditor is not guaranteed to be mounted after the `setView`
-                // call above, and it needs to be mounted to receive the action.
-                { buffer: true }
-            )
-            break
+export function useActionSelect() {
+    const dispatchClientAction = useClientActionDispatcher()
+    const [lastUsedActions = {}, persistValue] = useLocalStorage<Record<string, number>>(
+        'last-used-actions',
+        {}
+    )
+
+    return (action: Action, setView: (view: View) => void) => {
+        try {
+            const actionKey = action.actionType === 'prompt' ? action.id : action.key
+            const lastUsedActionCount = lastUsedActions[actionKey] ?? 0
+            persistValue({ ...lastUsedActions, [actionKey]: lastUsedActionCount + 1 })
+        } catch {
+            console.error('Failed to persist last used action count')
         }
-        case 'command': {
-            if (item.value.slashCommand) {
-                getVSCodeAPI().postMessage({
-                    command: 'command',
-                    id: item.value.slashCommand,
-                })
-            } else {
-                getVSCodeAPI().postMessage({
-                    command: 'command',
-                    id: 'cody.action.command',
-                    arg: item.value.key,
-                })
-            }
-            if (item.value.mode === 'ask' && item.value.type === 'default') {
-                // Chat response will show up in the same panel, so make the chat view visible.
+
+        switch (action.actionType) {
+            case 'prompt': {
                 setView(View.Chat)
+                dispatchClientAction(
+                    { appendTextToLastPromptEditor: action.definition.text },
+                    // Buffer because PromptEditor is not guaranteed to be mounted after the `setView`
+                    // call above, and it needs to be mounted to receive the action.
+                    { buffer: true }
+                )
+                break
             }
-            break
+            case 'command': {
+                if (action.slashCommand) {
+                    getVSCodeAPI().postMessage({
+                        command: 'command',
+                        id: action.slashCommand,
+                    })
+                } else {
+                    getVSCodeAPI().postMessage({
+                        command: 'command',
+                        id: 'cody.action.command',
+                        arg: action.key,
+                    })
+                }
+                if (action.mode === 'ask' && action.type === 'default') {
+                    // Chat response will show up in the same panel, so make the chat view visible.
+                    setView(View.Chat)
+                }
+                break
+            }
         }
     }
-}
-
-export const onPromptSelectInPanelActionLabels: NonNullable<
-    ComponentProps<typeof PromptList>['onSelectActionLabels']
-> = {
-    command: 'run',
-    prompt: 'insert',
 }


### PR DESCRIPTION
Part of https://linear.app/sourcegraph/issue/SRCH-1103/update-prompts-ui-welcome-screen

This PR does a few things (TL;DR I suggest checking the [loom](https://www.loom.com/share/3922d57405fc4db2b328a317c211231e?sid=28e903cd-aa63-4c7c-93cb-262b1de6ef7d))
 
- Improve prompts and commands list UI (you can find the latest designs for it [here](https://www.figma.com/design/f078wFMKsIOaEwj7Iwj5xy/Unified-Cody?node-id=4845-20933&node-type=symbol&t=Ao2Y68OYj5lFV3rA-0))
- Adds smart last-used prompts/commands sorting

<img width="1136" alt="Screenshot 2024-10-02 at 02 52 01" src="https://github.com/user-attachments/assets/2d4f2991-6086-4e1b-8b49-10b85c5c35e0">

So this PR is another attempt to bring commands and prompts closer and smooth transition from commands to prompts, so in this PR
- There is no separation between commands and prompts it is basically one list
- on the welcome screen we show only the last 4 used actions (action here means prompts or commands)
- By default, we show out-of-the-box actions 
- If we have custom commands or custom prompts we shift the list to show the last created prompts or commands
- If you used some prompts or commands it will show up on top of the list on the welcome screen 

This is a crucial improvement for customers with a possible high count of prompts because it helps with discoverability and we don't bombard the welcome screen with a big set of items in the suggestion list

## Future follow-ups
- In designs, we have a Search Prompt button below the action list on the welcome screen, for simplicity now it's just a link to the prompt tab but in future, we should open in place modal UI with a search prompt UI 
The last used action is currently implemented with local storage, later we should track usage on the backend  

## Test plan
- Check that you can see only 4 items max on the welcome screen 
- Check that you can find prompts that you have on prompts tab or prompts toolbar 
- Check that last used prompts/commands can be found on the welcome screen right after you used them 

