### PR TITLE
Fix prompts button layout on welcome screen

### DIFF
--- a/vscode/webviews/chat/components/WelcomeMessage.tsx
+++ b/vscode/webviews/chat/components/WelcomeMessage.tsx
@@ -69,10 +69,10 @@ export const WelcomeMessage: FunctionComponent<WelcomeMessageProps> = ({ setView
                     onSelect={item => runAction(item, setView)}
                 />
 
-                <div className="tw-flex tw-gap-8">
+                <div className="tw-flex tw-gap-8 tw-justify-center">
                     <Button
                         variant="text"
-                        className="tw-justify-center"
+                        className="tw-justify-center tw-basis-0 tw-whitespace-nowrap"
                         onClick={() =>
                             document
                                 .querySelector<HTMLButtonElement>("button[aria-label='Insert prompt']")
@@ -84,7 +84,7 @@ export const WelcomeMessage: FunctionComponent<WelcomeMessageProps> = ({ setView
 
                     <Button
                         variant="text"
-                        className="tw-justify-center"
+                        className="tw-justify-center tw-basis-0 tw-whitespace-nowrap"
                         onClick={() => setView(View.Prompts)}
                     >
                         All Prompts


### PR DESCRIPTION

Don't stretch "Recently used" and "All prompts" buttons on full width of the block

<img width="442" alt="Screenshot 2024-10-02 at 11 54 52" src="https://github.com/user-attachments/assets/11b9a271-fd2a-4217-b3f9-82ebfe2e9c0f">

## Test plan
- Check that buttons don't grow and placed on the center of the prompts suggestion layout

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
