### PR TITLE
Add new footer design to welcome screen

### DIFF
--- a/vscode/webviews/Chat.tsx
+++ b/vscode/webviews/Chat.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useMemo, useRef } from 'react'
 import type {
     AuthenticatedAuthStatus,
     ChatMessage,
+    CodyIDE,
     Guardrails,
     PromptString,
 } from '@sourcegraph/cody-shared'
@@ -245,6 +246,7 @@ export interface UserAccountInfo {
         AuthenticatedAuthStatus,
         'username' | 'displayName' | 'avatarURL' | 'endpoint' | 'primaryEmail'
     >
+    IDE: CodyIDE
 }
 
 export type ApiPostMessage = (message: any) => void

--- a/vscode/webviews/Chat.tsx
+++ b/vscode/webviews/Chat.tsx
@@ -227,7 +227,7 @@ export const Chat: React.FunctionComponent<React.PropsWithChildren<ChatboxProps>
             {transcript.length === 0 && showWelcomeMessage && (
                 <>
                     <WelcomeMessage setView={setView} />
-                    <WelcomeFooter />
+                    <WelcomeFooter IDE={userInfo.IDE} />
                 </>
             )}
 

--- a/vscode/webviews/Chat.tsx
+++ b/vscode/webviews/Chat.tsx
@@ -13,6 +13,7 @@ import type { VSCodeWrapper } from './utils/VSCodeApi'
 import { truncateTextStart } from '@sourcegraph/cody-shared/src/prompt/truncation'
 import { CHAT_INPUT_TOKEN_BUDGET } from '@sourcegraph/cody-shared/src/token/constants'
 import styles from './Chat.module.css'
+import WelcomeFooter from './chat/components/WelcomeFooter'
 import { WelcomeMessage } from './chat/components/WelcomeMessage'
 import { ScrollDown } from './components/ScrollDown'
 import type { View } from './tabs'
@@ -223,7 +224,13 @@ export const Chat: React.FunctionComponent<React.PropsWithChildren<ChatboxProps>
                 guardrails={guardrails}
                 smartApplyEnabled={smartApplyEnabled}
             />
-            {transcript.length === 0 && showWelcomeMessage && <WelcomeMessage setView={setView} />}
+            {transcript.length === 0 && showWelcomeMessage && (
+                <>
+                    <WelcomeMessage setView={setView} />
+                    <WelcomeFooter />
+                </>
+            )}
+
             {scrollableParent && (
                 <ScrollDown scrollableParent={scrollableParent} onClick={handleScrollDownClick} />
             )}

--- a/vscode/webviews/chat/components/WelcomeFooter.module.css
+++ b/vscode/webviews/chat/components/WelcomeFooter.module.css
@@ -1,8 +1,4 @@
 .welcome-footer {
-    position: fixed;
-    bottom: 0;
-    left: 0;
-    right: 0;
     padding: 1rem 1.0rem;
     display: flex;
     flex-flow: column nowrap;
@@ -24,13 +20,12 @@
 .links {
     display: flex;
     flex-shrink: none;
-    flex-flow: row nowrap;
+    flex-direction: row;
     padding: 1.0rem 1.5rem;
     gap: 0.5rem;
     flex-shrink: 0;
     justify-content: space-around;
     align-items: center;
-    min-width: 325px;
 }
 
 .item {

--- a/vscode/webviews/chat/components/WelcomeFooter.module.css
+++ b/vscode/webviews/chat/components/WelcomeFooter.module.css
@@ -1,0 +1,43 @@
+.welcome-footer {
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    padding: 1rem 1.0rem;
+    display: flex;
+    flex-flow: column nowrap;
+    justify-content: space-between;
+    align-items: center;
+    max-width: 100%;
+    color: var(--vscode-input-placeholderForeground)
+}
+
+.tips {
+    display: flex;
+    flex-flow: column nowrap;
+    flex-shrink: 0;
+    gap: 0.5rem;
+    padding: 1.0rem;
+    border-bottom: 0.25px solid var(--vscode-dropdown-border);
+}
+
+.links {
+    display: flex;
+    flex-shrink: none;
+    flex-flow: row nowrap;
+    padding: 1.0rem 1.5rem;
+    gap: 0.5rem;
+    flex-shrink: 0;
+    justify-content: space-around;
+    align-items: center;
+    min-width: 325px;
+}
+
+.item {
+    display: flex;
+    flex-flow: row nowrap;
+    flex-shrink: 0;
+    gap: 0.5rem;
+    align-items: center;
+}
+

--- a/vscode/webviews/chat/components/WelcomeFooter.module.css
+++ b/vscode/webviews/chat/components/WelcomeFooter.module.css
@@ -1,5 +1,5 @@
 .welcome-footer {
-    padding: 1rem 1.0rem;
+    padding: 1rem 1rem;
     display: flex;
     flex-flow: column nowrap;
     justify-content: space-between;
@@ -36,3 +36,8 @@
     align-items: center;
 }
 
+.link {
+    color: inherit;
+    text-decoration: none;
+
+}

--- a/vscode/webviews/chat/components/WelcomeFooter.tsx
+++ b/vscode/webviews/chat/components/WelcomeFooter.tsx
@@ -50,7 +50,7 @@ const chatLinks: ChatViewLink[] = [
     },
 ]
 
-export default function WelcomeFooter() {
+export default function WelcomeFooter({ IDE }: { IDE: CodyIDE }) {
     function tips() {
         return chatTips.map((tip, key) => {
             const Icon = tip.icon
@@ -79,7 +79,7 @@ export default function WelcomeFooter() {
 
     return (
         <div className={styles.welcomeFooter}>
-            {CodyIDE.VSCode && <div className={styles.tips}>{tips()}</div>}
+            {IDE === CodyIDE.VSCode && <div className={styles.tips}>{tips()}</div>}
             <div className={styles.links}>{links()}</div>
         </div>
     )

--- a/vscode/webviews/chat/components/WelcomeFooter.tsx
+++ b/vscode/webviews/chat/components/WelcomeFooter.tsx
@@ -1,3 +1,4 @@
+import { CodyIDE } from '@sourcegraph/cody-shared'
 import styles from './WelcomeFooter.module.css'
 
 import {
@@ -78,7 +79,7 @@ export default function WelcomeFooter() {
 
     return (
         <div className={styles.welcomeFooter}>
-            <div className={styles.tips}>{tips()}</div>
+            {CodyIDE.VSCode && <div className={styles.tips}>{tips()}</div>}
             <div className={styles.links}>{links()}</div>
         </div>
     )

--- a/vscode/webviews/chat/components/WelcomeFooter.tsx
+++ b/vscode/webviews/chat/components/WelcomeFooter.tsx
@@ -14,6 +14,7 @@ import type { ForwardRefExoticComponent } from 'react'
 interface ChatViewTip {
     message: string
     icon: ForwardRefExoticComponent<Omit<LucideProps, 'ref'>>
+    vsCodeOnly: boolean
 }
 
 interface ChatViewLink {
@@ -26,14 +27,17 @@ const chatTips: ChatViewTip[] = [
     {
         message: 'Type @ to add context to your chat',
         icon: AtSignIcon,
+        vsCodeOnly: true,
     },
     {
         message: 'Start a new chat using ⌥ / or the New Chat button',
         icon: MessageSquarePlus,
+        vsCodeOnly: false,
     },
     {
         message: 'To add code context from an editor, right click and use Add to Cody Chat',
         icon: TextSelect,
+        vsCodeOnly: true,
     },
 ]
 
@@ -54,6 +58,9 @@ export default function WelcomeFooter({ IDE }: { IDE: CodyIDE }) {
     function tips() {
         return chatTips.map((tip, key) => {
             const Icon = tip.icon
+            if (tip.vsCodeOnly && IDE !== CodyIDE.VSCode) {
+                return null
+            }
             return (
                 <div key={`tip-${key + 1}`} className={styles.item}>
                     <Icon className="tw-w-8 tw-h-8 tw-shrink-0" strokeWidth={1.25} />
@@ -79,7 +86,7 @@ export default function WelcomeFooter({ IDE }: { IDE: CodyIDE }) {
 
     return (
         <div className={styles.welcomeFooter}>
-            {IDE === CodyIDE.VSCode && <div className={styles.tips}>{tips()}</div>}
+            <div className={styles.tips}>{tips()}</div>
             <div className={styles.links}>{links()}</div>
         </div>
     )

--- a/vscode/webviews/chat/components/WelcomeFooter.tsx
+++ b/vscode/webviews/chat/components/WelcomeFooter.tsx
@@ -69,7 +69,7 @@ export default function WelcomeFooter() {
             return (
                 <div className={styles.item} key={`link-${key + 1}`}>
                     <Icon className="tw-w-8 tw-h-8" strokeWidth={1.25} />
-                    <a href={link.url} rel="noreferrer" target="_blank">
+                    <a href={link.url} className={styles.link} rel="noreferrer" target="_blank">
                         {link.text}
                     </a>
                 </div>

--- a/vscode/webviews/chat/components/WelcomeFooter.tsx
+++ b/vscode/webviews/chat/components/WelcomeFooter.tsx
@@ -1,0 +1,85 @@
+import styles from './WelcomeFooter.module.css'
+
+import {
+    AtSignIcon,
+    BookOpenText,
+    type LucideProps,
+    MessageCircleQuestion,
+    MessageSquarePlus,
+    TextSelect,
+} from 'lucide-react'
+import type { ForwardRefExoticComponent } from 'react'
+
+interface ChatViewTip {
+    message: string
+    icon: ForwardRefExoticComponent<Omit<LucideProps, 'ref'>>
+}
+
+interface ChatViewLink {
+    icon: ForwardRefExoticComponent<Omit<LucideProps, 'ref'>>
+    text: string
+    url: string
+}
+
+const chatTips: ChatViewTip[] = [
+    {
+        message: 'Type @ to add context to your chat',
+        icon: AtSignIcon,
+    },
+    {
+        message: 'Start a new chat using ⌥ / or the New Chat button',
+        icon: MessageSquarePlus,
+    },
+    {
+        message: 'To add code context from an editor, right click and use Add to Cody Chat',
+        icon: TextSelect,
+    },
+]
+
+const chatLinks: ChatViewLink[] = [
+    {
+        icon: BookOpenText,
+        text: 'Documentation',
+        url: 'https://sourcegraph.com/docs/cody',
+    },
+    {
+        icon: MessageCircleQuestion,
+        text: 'Help and Support',
+        url: 'https://community.sourcegraph.com/',
+    },
+]
+
+export default function WelcomeFooter() {
+    function tips() {
+        return chatTips.map((tip, key) => {
+            const Icon = tip.icon
+            return (
+                <div key={`tip-${key + 1}`} className={styles.item}>
+                    <Icon className="tw-w-8 tw-h-8 tw-shrink-0" strokeWidth={1.25} />
+                    <div className="tw-text-muted-foreground">{tip.message}</div>
+                </div>
+            )
+        })
+    }
+
+    function links() {
+        return chatLinks.map((link, key) => {
+            const Icon = link.icon
+            return (
+                <div className={styles.item} key={`link-${key + 1}`}>
+                    <Icon className="tw-w-8 tw-h-8" strokeWidth={1.25} />
+                    <a href={link.url} rel="noreferrer" target="_blank">
+                        {link.text}
+                    </a>
+                </div>
+            )
+        })
+    }
+
+    return (
+        <div className={styles.welcomeFooter}>
+            <div className={styles.tips}>{tips()}</div>
+            <div className={styles.links}>{links()}</div>
+        </div>
+    )
+}

--- a/vscode/webviews/chat/components/WelcomeMessage.test.tsx
+++ b/vscode/webviews/chat/components/WelcomeMessage.test.tsx
@@ -39,11 +39,6 @@ describe('WelcomeMessage', () => {
 
         // Check common elements
         expect(screen.getByText(FIXTURE_PROMPTS[0].name)).toBeInTheDocument()
-
-        // Check elements specific to CodyIDE.VSCode
-        expect(screen.getByText(/To add code context from an editor/)).toBeInTheDocument()
-        expect(screen.getByText(/Start a new chat using/)).toBeInTheDocument()
-        expect(screen.getByText(/Customize chat settings/)).toBeInTheDocument()
     })
 
     test('renders for CodyIDE.JetBrains', () => {
@@ -59,12 +54,6 @@ describe('WelcomeMessage', () => {
         openCollapsiblePanels()
 
         // Check common elements
-        expect(screen.getByText(/Chat Help/)).toBeInTheDocument()
         expect(screen.getByText(FIXTURE_PROMPTS[0].name)).toBeInTheDocument()
-
-        // Check elements specific to CodyIDE.JetBrains
-        expect(screen.queryByText(/To add code context from an editor/)).not.toBeInTheDocument()
-        expect(screen.queryByText(/Start a new chat using/)).not.toBeInTheDocument()
-        expect(screen.queryByText(/Customize chat settings/)).not.toBeInTheDocument()
     })
 })

--- a/vscode/webviews/chat/components/WelcomeMessage.test.tsx
+++ b/vscode/webviews/chat/components/WelcomeMessage.test.tsx
@@ -38,7 +38,6 @@ describe('WelcomeMessage', () => {
         openCollapsiblePanels()
 
         // Check common elements
-        expect(screen.getByText(/Chat Help/)).toBeInTheDocument()
         expect(screen.getByText(FIXTURE_PROMPTS[0].name)).toBeInTheDocument()
 
         // Check elements specific to CodyIDE.VSCode

--- a/vscode/webviews/chat/components/WelcomeMessage.tsx
+++ b/vscode/webviews/chat/components/WelcomeMessage.tsx
@@ -1,14 +1,6 @@
-import {
-    AtSignIcon,
-    type LucideProps,
-    MessageSquarePlusIcon,
-    SettingsIcon,
-    TextIcon,
-} from 'lucide-react'
+import type { LucideProps } from 'lucide-react'
 import type { FunctionComponent } from 'react'
 import type React from 'react'
-import { CollapsiblePanel } from '../../components/CollapsiblePanel'
-import { Kbd } from '../../components/Kbd'
 import { PromptList } from '../../components/promptList/PromptList'
 import { Button } from '../../components/shadcn/ui/button'
 import { useActionSelect } from '../../prompts/PromptsTab'
@@ -91,33 +83,6 @@ export const WelcomeMessage: FunctionComponent<WelcomeMessageProps> = ({ setView
                     </Button>
                 </div>
             </div>
-
-            <CollapsiblePanel
-                storageKey="chat-help"
-                title="Chat Help"
-                className="tw-mb-6 tw-mt-2"
-                initialOpen={true}
-            >
-                <FeatureRow icon={AtSignIcon}>
-                    Type <Kbd macOS="@" linuxAndWindows="@" /> to add context to your chat
-                </FeatureRow>
-                {config.clientCapabilities.isVSCode && (
-                    <>
-                        <FeatureRow icon={TextIcon}>
-                            To add code context from an editor, right click and use{' '}
-                            <MenuExample>Cody &gt; Add File/Selection to Cody Chat</MenuExample>
-                        </FeatureRow>
-                        <FeatureRow icon={MessageSquarePlusIcon}>
-                            Start a new chat using <Kbd macOS="opt+L" linuxAndWindows="alt+L" />
-                        </FeatureRow>
-                        <FeatureRow icon={SettingsIcon}>
-                            Customize chat settings with the <FeatureRowInlineIcon Icon={SettingsIcon} />{' '}
-                            button, or see the{' '}
-                            <a href="https://sourcegraph.com/docs/cody">documentation</a>
-                        </FeatureRow>
-                    </>
-                )}
-            </CollapsiblePanel>
         </div>
     )
 }

--- a/vscode/webviews/chat/components/WelcomeMessage.tsx
+++ b/vscode/webviews/chat/components/WelcomeMessage.tsx
@@ -1,37 +1,8 @@
-import type { LucideProps } from 'lucide-react'
 import type { FunctionComponent } from 'react'
-import type React from 'react'
 import { PromptList } from '../../components/promptList/PromptList'
 import { Button } from '../../components/shadcn/ui/button'
 import { useActionSelect } from '../../prompts/PromptsTab'
 import { View } from '../../tabs'
-import { useConfig } from '../../utils/useConfig'
-
-const MenuExample: FunctionComponent<{ children: React.ReactNode }> = ({ children }) => (
-    <span className="tw-p-1 tw-rounded tw-text-keybinding-foreground tw-border tw-border-keybinding-border tw-bg-keybinding-background tw-whitespace-nowrap">
-        {children}
-    </span>
-)
-
-type FeatureRowIcon = React.ForwardRefExoticComponent<
-    Omit<LucideProps, 'ref'> & React.RefAttributes<SVGSVGElement>
->
-
-const FeatureRowInlineIcon: FunctionComponent<{
-    Icon: FeatureRowIcon
-}> = ({ Icon }) => (
-    <Icon size={16} strokeWidth={1.25} className="tw-flex-none tw-inline-flex tw-mt-1 tw-opacity-80" />
-)
-
-const FeatureRow: FunctionComponent<{
-    icon: FeatureRowIcon
-    children: React.ReactNode
-}> = ({ icon, children }) => (
-    <div className="tw-py-2 tw-px-4 tw-inline-flex tw-gap-3 tw-text-foreground tw-items-start">
-        <FeatureRowInlineIcon Icon={icon} />
-        <div className="tw-grow">{children}</div>
-    </div>
-)
 
 const localStorageKey = 'chat.welcome-message-dismissed'
 
@@ -43,7 +14,6 @@ export const WelcomeMessage: FunctionComponent<WelcomeMessageProps> = ({ setView
     // Remove the old welcome message dismissal key that is no longer used.
     localStorage.removeItem(localStorageKey)
 
-    const config = useConfig()
     const runAction = useActionSelect()
 
     return (

--- a/vscode/webviews/chat/components/WelcomeMessage.tsx
+++ b/vscode/webviews/chat/components/WelcomeMessage.tsx
@@ -3,6 +3,7 @@ import { PromptList } from '../../components/promptList/PromptList'
 import { Button } from '../../components/shadcn/ui/button'
 import { useActionSelect } from '../../prompts/PromptsTab'
 import { View } from '../../tabs'
+import { useUserAccountInfo } from '@/utils/useConfig'
 
 const localStorageKey = 'chat.welcome-message-dismissed'
 

--- a/vscode/webviews/chat/components/WelcomeMessage.tsx
+++ b/vscode/webviews/chat/components/WelcomeMessage.tsx
@@ -3,7 +3,6 @@ import { PromptList } from '../../components/promptList/PromptList'
 import { Button } from '../../components/shadcn/ui/button'
 import { useActionSelect } from '../../prompts/PromptsTab'
 import { View } from '../../tabs'
-import { useUserAccountInfo } from '@/utils/useConfig'
 
 const localStorageKey = 'chat.welcome-message-dismissed'
 

--- a/vscode/webviews/chat/fixtures.ts
+++ b/vscode/webviews/chat/fixtures.ts
@@ -2,6 +2,7 @@ import { URI } from 'vscode-uri'
 
 import {
     type ChatMessage,
+    CodyIDE,
     ContextItemSource,
     FILE_MENTION_EDITOR_STATE_FIXTURE,
     ps,
@@ -191,4 +192,5 @@ export const FIXTURE_USER_ACCOUNT_INFO: UserAccountInfo = {
         avatarURL: 'https://avatars.githubusercontent.com/u/1976',
         endpoint: '',
     },
+    IDE: CodyIDE.VSCode,
 }

--- a/vscode/webviews/utils/useConfig.tsx
+++ b/vscode/webviews/utils/useConfig.tsx
@@ -50,5 +50,6 @@ export function useUserAccountInfo(): UserAccountInfo {
         // with E2E tests where change the DOTCOM_URL via the env variable TESTING_DOTCOM_URL.
         isDotComUser: value.isDotComUser,
         user: value.authStatus,
+        IDE: value.clientCapabilities.agentIDE,
     }
 }


### PR DESCRIPTION
This PR introduces a redesigned footer for Cody Chat in the VS Code extension.
![Screenshot 2024-10-02 at 10 03 13 AM](https://github.com/user-attachments/assets/0ca19d3f-bb6e-463a-a8cc-9bcc45ebacda)

NOTE: I added the `IDE` property back to UserAccountInfo in order to get this out for the release, but we should ultimately resolve this issue another way with a useIDE() hook, or something like it. 

## Test plan
<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
- Manual testing
- Passing CI
- Update unit tests to reflect UI changes. Confirmed they are passing.