### PR TITLE
Reduce padding of container around search input.

### DIFF
--- a/vscode/webviews/components/promptList/PromptList.tsx
+++ b/vscode/webviews/components/promptList/PromptList.tsx
@@ -147,10 +147,10 @@ export const PromptList: FC<PromptListProps> = props => {
     const actions = showFirstNItems ? sortedActions.slice(0, showFirstNItems) : sortedActions
 
     const inputPaddingClass =
-        paddingLevels !== 'none' ? (paddingLevels === 'middle' ? '!tw-p-2' : '!tw-p-4') : ''
+        paddingLevels !== 'none' ? (paddingLevels === 'middle' ? '!tw-p-0' : '!tw-p-0') : ''
 
     const itemPaddingClass =
-        paddingLevels !== 'none' ? (paddingLevels === 'middle' ? '!tw-px-6' : '!tw-px-8') : ''
+        paddingLevels !== 'none' ? (paddingLevels === 'middle' ? '!tw-px-6' : '!tw-px-6') : ''
 
     return (
         <Command


### PR DESCRIPTION
Reduces the padding of the container outside the prompt search to make it slightly more dense.

<img width="402" alt="CleanShot 2024-10-02 at 16 46 06@2x" src="https://github.com/user-attachments/assets/27ac1538-11cd-422c-90aa-2236f8828f46">


## Test Plan

Tested manually.