### PR TITLE
Add browse library link to prompt popover

### DIFF
--- a/vscode/webviews/chat/components/WelcomeMessage.tsx
+++ b/vscode/webviews/chat/components/WelcomeMessage.tsx
@@ -71,7 +71,7 @@ export const WelcomeMessage: FunctionComponent<WelcomeMessageProps> = ({ setView
 
                 <div className="tw-flex tw-gap-8 tw-justify-center">
                     <Button
-                        variant="text"
+                        variant="ghost"
                         className="tw-justify-center tw-basis-0 tw-whitespace-nowrap"
                         onClick={() =>
                             document
@@ -83,7 +83,7 @@ export const WelcomeMessage: FunctionComponent<WelcomeMessageProps> = ({ setView
                     </Button>
 
                     <Button
-                        variant="text"
+                        variant="ghost"
                         className="tw-justify-center tw-basis-0 tw-whitespace-nowrap"
                         onClick={() => setView(View.Prompts)}
                     >

--- a/vscode/webviews/components/promptSelectField/PromptSelectField.tsx
+++ b/vscode/webviews/components/promptSelectField/PromptSelectField.tsx
@@ -1,6 +1,10 @@
 import type { Action } from '@sourcegraph/cody-shared'
+import { BookText } from 'lucide-react'
 import { useCallback } from 'react'
+import { Button } from '../../components/shadcn/ui/button'
+import { View } from '../../tabs'
 import { useTelemetryRecorder } from '../../utils/telemetry'
+import { useTabView } from '../../utils/useTabView'
 import { PromptList } from '../promptList/PromptList'
 import { ToolbarPopoverItem } from '../shadcn/ui/toolbar'
 import { cn } from '../shadcn/utils'
@@ -14,6 +18,7 @@ export const PromptSelectField: React.FunctionComponent<{
     __storybook__open?: boolean
 }> = ({ onSelect, onCloseByEscape, className, __storybook__open }) => {
     const telemetryRecorder = useTelemetryRecorder()
+    const { setView } = useTabView()
 
     const onOpenChange = useCallback(
         (open: boolean): void => {
@@ -42,18 +47,26 @@ export const PromptSelectField: React.FunctionComponent<{
             tooltip="Insert prompt from Prompt Library"
             aria-label="Insert prompt"
             popoverContent={close => (
-                <PromptList
-                    onSelect={item => {
-                        onSelect(item)
-                        close()
-                    }}
-                    showSearch={true}
-                    paddingLevels="middle"
-                    telemetryLocation="PromptSelectField"
-                    showOnlyPromptInsertableCommands={true}
-                    showPromptLibraryUnsupportedMessage={true}
-                    lastUsedSorting={true}
-                />
+                <div className="tw-flex tw-flex-col tw-gap-4">
+                    <PromptList
+                        onSelect={item => {
+                            onSelect(item)
+                            close()
+                        }}
+                        showSearch={true}
+                        paddingLevels="middle"
+                        telemetryLocation="PromptSelectField"
+                        showOnlyPromptInsertableCommands={true}
+                        showPromptLibraryUnsupportedMessage={true}
+                        lastUsedSorting={true}
+                    />
+
+                    <footer className="tw-px-2 tw-py-2 tw-border-t tw-border-border tw-bg-button-secondary-background">
+                        <Button variant="text" onClick={() => setView(View.Prompts)}>
+                            <BookText size={16} /> Browse library
+                        </Button>
+                    </footer>
+                </div>
             )}
             popoverRootProps={{ onOpenChange }}
             popoverContentProps={{

--- a/vscode/webviews/components/promptSelectField/PromptSelectField.tsx
+++ b/vscode/webviews/components/promptSelectField/PromptSelectField.tsx
@@ -61,7 +61,7 @@ export const PromptSelectField: React.FunctionComponent<{
                         lastUsedSorting={true}
                     />
 
-                    <footer className="tw-px-2 tw-py-2 tw-border-t tw-border-border tw-bg-button-secondary-background">
+                    <footer className="tw-px-2 tw-py-2 tw-border-t tw-border-border tw-bg-muted">
                         <Button variant="text" onClick={() => setView(View.Prompts)}>
                             <BookText size={16} /> Browse library
                         </Button>

--- a/vscode/webviews/components/shadcn/ui/command.tsx
+++ b/vscode/webviews/components/shadcn/ui/command.tsx
@@ -110,7 +110,7 @@ const CommandItem = React.forwardRef<
         <CommandPrimitive.Item
             ref={ref}
             className={cn(
-                'tw-relative tw-flex tw-cursor-pointer tw-select-none tw-items-center tw-rounded-sm tw-py-3 tw-px-2 tw-text-md tw-outline-none aria-selected:tw-bg-accent aria-selected:tw-text-accent-foreground hover:tw-bg-accent hover:tw-text-accent-foreground data-[disabled=true]:tw-pointer-events-none data-[disabled=true]:tw-opacity-50',
+                'tw-relative tw-flex tw-cursor-pointer tw-select-none tw-items-center tw-py-3 tw-px-2 tw-text-md tw-outline-none aria-selected:tw-bg-accent aria-selected:tw-text-accent-foreground hover:tw-bg-accent hover:tw-text-accent-foreground data-[disabled=true]:tw-pointer-events-none data-[disabled=true]:tw-opacity-50',
                 className
             )}
             title={tooltip}

--- a/vscode/webviews/utils/useTabView.ts
+++ b/vscode/webviews/utils/useTabView.ts
@@ -1,0 +1,16 @@
+import { createContext, useContext } from 'react'
+import { View } from '../tabs'
+
+interface TabViewContextData {
+    view: View
+    setView: (view: View) => void
+}
+
+export const TabViewContext = createContext<TabViewContextData>({
+    view: View.Chat,
+    setView: () => {},
+})
+
+export function useTabView(): TabViewContextData {
+    return useContext(TabViewContext)
+}


### PR DESCRIPTION
This adds 
- Ghost styling for welcome area buttons
- Link "Browser library" to prompt popover UI

<img width="424" alt="Screenshot 2024-10-02 at 14 33 48" src="https://github.com/user-attachments/assets/07ed8fad-c735-409e-8b33-47829c9f6585">

## Test plan
- Check that links work properly

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
