### PR TITLE
never minify agent

### DIFF
--- a/agent/package.json
+++ b/agent/package.json
@@ -16,7 +16,6 @@
     "build:for-tests": "pnpm run -s build:root && pnpm run -s build:agent",
     "build:webviews": "pnpm -C ../vscode run -s _build:webviews --mode production --outDir ../../agent/dist/webviews",
     "build": "pnpm run -s build:root && pnpm run -s build:webviews && pnpm run -s build:agent",
-    "build-minify": "pnpm run build --minify",
     "agent": "pnpm run build:for-tests && node --enable-source-maps dist/index.js",
     "agent:skip-root-build": "pnpm run build:agent && node --enable-source-maps dist/index.js",
     "agent:debug": "pnpm run build && CODY_AGENT_TRACE_PATH=/tmp/agent.json CODY_AGENT_DEBUG_REMOTE=true node --enable-source-maps ./dist/index.js api jsonrpc-stdio",

--- a/agent/src/esbuild.mjs
+++ b/agent/src/esbuild.mjs
@@ -11,9 +11,7 @@ main().catch(err => {
 
 async function main() {
     await verifyShim()
-
-    const minify = process.argv.includes('--minify')
-    await buildAgent(minify)
+    await buildAgent()
 }
 
 async function verifyShim() {
@@ -44,10 +42,9 @@ async function verifyShim() {
 
 /**
  * Builds the Cody agent using esbuild.
- * @param {boolean} minify - Whether to minify the output or not.
  * @returns {Promise<void>} - A promise that resolves when the build process is complete.
  */
-async function buildAgent(minify) {
+async function buildAgent() {
     /** @type {import('esbuild').BuildOptions} */
     const esbuildOptions = {
         entryPoints: ['./src/index.ts'],
@@ -57,7 +54,6 @@ async function buildAgent(minify) {
         sourcemap: true,
         logLevel: 'error',
         external: ['typescript'],
-        minify: minify,
 
         alias: {
             vscode: path.resolve(process.cwd(), 'src', 'vscode-shim.ts'),


### PR DESCRIPTION
The benefits (smaller bundle size) are not worth the additional debugging pain, esp. since this build was only ever used for desktop releases and not web.

## Test plan

n/a