### PR TITLE
higher default timeout than 6s

### DIFF
--- a/lib/shared/src/sourcegraph-api/graphql/client.ts
+++ b/lib/shared/src/sourcegraph-api/graphql/client.ts
@@ -581,6 +581,8 @@ export function setUserAgent(newUseragent: string): void {
 
 const QUERY_TO_NAME_REGEXP = /^\s*(?:query|mutation)\s+(\w+)/m
 
+const DEFAULT_TIMEOUT_MSEC = 20000
+
 export class SourcegraphGraphQLAPIClient {
     private dotcomUrl = DOTCOM_URL
 
@@ -1426,8 +1428,7 @@ export class SourcegraphGraphQLAPIClient {
             baseUrl: config.auth.serverEndpoint,
         })
 
-        // Default timeout of 6 seconds.
-        const timeoutMs = typeof signalOrTimeout === 'number' ? signalOrTimeout : 6000
+        const timeoutMs = typeof signalOrTimeout === 'number' ? signalOrTimeout : DEFAULT_TIMEOUT_MSEC
         const timeoutSignal = AbortSignal.timeout(timeoutMs)
 
         const abortController = dependentAbortController(
@@ -1529,7 +1530,7 @@ export class SourcegraphGraphQLAPIClient {
         addCustomUserAgent(headers)
 
         // Timeout of 6 seconds.
-        const timeoutSignal = AbortSignal.timeout(6000)
+        const timeoutSignal = AbortSignal.timeout(DEFAULT_TIMEOUT_MSEC)
 
         const abortController = dependentAbortController(signal)
         onAbort(timeoutSignal, () => abortController.abort())


### PR DESCRIPTION
The 6000ms timeout may be too short for some users on high-latency network connections. I have experienced this as a problem once or twice recently when on airplane (satellite) wifi. This may also help with https://github.com/sourcegraph/cody/issues/5783, but I am not certain of that since this timeout has been in place for a while and the reports of that issue are new.

Why 20s and not higher/lower? This makes it so the user does get feedback about network problems without waiting 60s (default) or longer. Why not lower (like 15s)? Arbitrary decision.

## Test plan

n/a