### PR TITLE
remove ChatSubmitType user-newchat

### DIFF
--- a/agent/src/TestClient.ts
+++ b/agent/src/TestClient.ts
@@ -805,7 +805,7 @@ export class TestClient extends MessageHandler {
                 message: {
                     command: 'submit',
                     text,
-                    submitType: 'user',
+                    submitType: 'user-newchat',
                     contextItems: params?.contextFiles,
                 },
             })

--- a/agent/src/TestClient.ts
+++ b/agent/src/TestClient.ts
@@ -805,7 +805,6 @@ export class TestClient extends MessageHandler {
                 message: {
                     command: 'submit',
                     text,
-                    submitType: 'user-newchat',
                     contextItems: params?.contextFiles,
                 },
             })

--- a/agent/src/agent.ts
+++ b/agent/src/agent.ts
@@ -55,6 +55,8 @@ import * as uuid from 'uuid'
 import type { MessageConnection } from 'vscode-jsonrpc'
 import type { CommandResult } from '../../vscode/src/CommandResult'
 import { formatURL } from '../../vscode/src/auth/auth'
+import { executeExplainCommand, executeSmellCommand } from '../../vscode/src/commands/execute'
+import type { CodyCommandArgs } from '../../vscode/src/commands/types'
 import { loadTscRetriever } from '../../vscode/src/completions/context/retrievers/tsc/load-tsc-retriever'
 import { supportedTscLanguages } from '../../vscode/src/completions/context/retrievers/tsc/supportedTscLanguages'
 import type { CompletionItemID } from '../../vscode/src/completions/logger'
@@ -1099,12 +1101,10 @@ export class Agent extends MessageHandler implements ExtensionClient {
         })
 
         // The arguments to pass to the command to make sure edit commands would also run in chat mode
-        const commandArgs = [{ source: 'editor' }]
+        const commandArgs: Partial<CodyCommandArgs> = { source: 'editor' }
 
         this.registerAuthenticatedRequest('commands/explain', () => {
-            return this.createChatPanel(
-                vscode.commands.executeCommand('cody.command.explain-code', commandArgs)
-            )
+            return this.createChatPanel(executeExplainCommand(commandArgs))
         })
 
         this.registerAuthenticatedRequest('editTask/accept', async ({ id }) => {
@@ -1196,9 +1196,7 @@ export class Agent extends MessageHandler implements ExtensionClient {
         })
 
         this.registerAuthenticatedRequest('commands/smell', () => {
-            return this.createChatPanel(
-                vscode.commands.executeCommand('cody.command.smell-code', commandArgs)
-            )
+            return this.createChatPanel(executeSmellCommand(commandArgs))
         })
 
         this.registerAuthenticatedRequest('commands/custom', ({ key }) => {

--- a/agent/src/cli/command-bench/strategy-chat.ts
+++ b/agent/src/cli/command-bench/strategy-chat.ts
@@ -51,7 +51,7 @@ export async function evaluateChatStrategy(
             id,
             message: {
                 command: 'submit',
-                submitType: 'user',
+                submitType: 'user-newchat',
                 text: task.question,
                 contextItems,
             },

--- a/agent/src/cli/command-bench/strategy-chat.ts
+++ b/agent/src/cli/command-bench/strategy-chat.ts
@@ -51,7 +51,6 @@ export async function evaluateChatStrategy(
             id,
             message: {
                 command: 'submit',
-                submitType: 'user-newchat',
                 text: task.question,
                 contextItems,
             },

--- a/agent/src/cli/command-chat.ts
+++ b/agent/src/cli/command-chat.ts
@@ -279,7 +279,7 @@ export async function chatAction(options: ChatOptions): Promise<number> {
             id,
             message: {
                 command: 'submit',
-                submitType: 'user',
+                submitType: 'user-newchat',
                 text: messageText,
                 contextItems,
             },

--- a/agent/src/cli/command-chat.ts
+++ b/agent/src/cli/command-chat.ts
@@ -279,7 +279,6 @@ export async function chatAction(options: ChatOptions): Promise<number> {
             id,
             message: {
                 command: 'submit',
-                submitType: 'user-newchat',
                 text: messageText,
                 contextItems,
             },

--- a/agent/src/index.test.ts
+++ b/agent/src/index.test.ts
@@ -262,7 +262,6 @@ describe('Agent', () => {
                     message: {
                         command: 'submit',
                         text: 'My name is Lars Monsen.',
-                        submitType: 'user-newchat',
                     },
                 })
             )
@@ -284,7 +283,6 @@ describe('Agent', () => {
                     message: {
                         command: 'submit',
                         text: 'What is my name?',
-                        submitType: 'user-newchat',
                     },
                 })
             )
@@ -315,7 +313,6 @@ describe('Agent', () => {
                     message: {
                         command: 'submit',
                         text: 'What model are you?',
-                        submitType: 'user-newchat',
                     },
                 })
             )
@@ -332,7 +329,6 @@ describe('Agent', () => {
                     message: {
                         command: 'submit',
                         text: 'What model are you?',
-                        submitType: 'user-newchat',
                     },
                 })
             )

--- a/agent/src/index.test.ts
+++ b/agent/src/index.test.ts
@@ -262,7 +262,7 @@ describe('Agent', () => {
                     message: {
                         command: 'submit',
                         text: 'My name is Lars Monsen.',
-                        submitType: 'user',
+                        submitType: 'user-newchat',
                     },
                 })
             )
@@ -284,7 +284,7 @@ describe('Agent', () => {
                     message: {
                         command: 'submit',
                         text: 'What is my name?',
-                        submitType: 'user',
+                        submitType: 'user-newchat',
                     },
                 })
             )
@@ -315,7 +315,7 @@ describe('Agent', () => {
                     message: {
                         command: 'submit',
                         text: 'What model are you?',
-                        submitType: 'user',
+                        submitType: 'user-newchat',
                     },
                 })
             )
@@ -332,7 +332,7 @@ describe('Agent', () => {
                     message: {
                         command: 'submit',
                         text: 'What model are you?',
-                        submitType: 'user',
+                        submitType: 'user-newchat',
                     },
                 })
             )

--- a/vscode/src/chat/chat-view/ChatController.ts
+++ b/vscode/src/chat/chat-view/ChatController.ts
@@ -115,7 +115,6 @@ import type { ChatIntentAPIClient } from '../context/chatIntentAPIClient'
 import { observeInitialContext } from '../initialContext'
 import {
     CODY_BLOG_URL_o1_WAITLIST,
-    type ChatSubmitType,
     type ConfigurationSubsetForWebview,
     type ExtensionMessage,
     type LocalEnv,
@@ -272,7 +271,6 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
                 await this.handleUserMessageSubmission({
                     requestID: uuid.v4(),
                     inputText: PromptString.unsafe_fromUserQuery(message.text),
-                    submitType: message.submitType,
                     mentions: message.contextItems ?? [],
                     editorState: message.editorState as SerializedPromptEditorState,
                     signal: this.startNewSubmitOrEditOperation(),
@@ -592,7 +590,7 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
     public async handleUserMessageSubmission({
         requestID,
         inputText,
-        submitType,
+        isEdit,
         mentions,
         editorState,
         signal,
@@ -604,7 +602,7 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
     }: {
         requestID: string
         inputText: PromptString
-        submitType: ChatSubmitType
+        isEdit?: boolean
         mentions: ContextItem[]
         editorState: SerializedPromptEditorState | null
         signal: AbortSignal
@@ -661,7 +659,7 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
                     return this.clearAndRestartSession()
                 }
 
-                if (submitType === 'user-newchat' && !this.chatBuilder.isEmpty()) {
+                if (!isEdit && !this.chatBuilder.isEmpty()) {
                     span.addEvent('clearAndRestartSession')
                     await this.clearAndRestartSession()
                     signal.throwIfAborted()
@@ -992,7 +990,7 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
             return await this.handleUserMessageSubmission({
                 requestID,
                 inputText: text,
-                submitType: 'user',
+                isEdit: true,
                 mentions: contextFiles,
                 editorState,
                 signal: abortSignal,

--- a/vscode/src/chat/chat-view/ChatController.ts
+++ b/vscode/src/chat/chat-view/ChatController.ts
@@ -590,7 +590,6 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
     public async handleUserMessageSubmission({
         requestID,
         inputText,
-        isEdit,
         mentions,
         editorState,
         signal,
@@ -602,7 +601,6 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
     }: {
         requestID: string
         inputText: PromptString
-        isEdit?: boolean
         mentions: ContextItem[]
         editorState: SerializedPromptEditorState | null
         signal: AbortSignal
@@ -657,12 +655,6 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
                     span.addEvent('clearAndRestartSession')
                     span.end()
                     return this.clearAndRestartSession()
-                }
-
-                if (!isEdit && !this.chatBuilder.isEmpty()) {
-                    span.addEvent('clearAndRestartSession')
-                    await this.clearAndRestartSession()
-                    signal.throwIfAborted()
                 }
 
                 this.chatBuilder.addHumanMessage({
@@ -990,7 +982,6 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
             return await this.handleUserMessageSubmission({
                 requestID,
                 inputText: text,
-                isEdit: true,
                 mentions: contextFiles,
                 editorState,
                 signal: abortSignal,

--- a/vscode/src/chat/chat-view/ChatsController.ts
+++ b/vscode/src/chat/chat-view/ChatsController.ts
@@ -322,7 +322,6 @@ export class ChatsController implements vscode.Disposable {
         await provider.handleUserMessageSubmission({
             requestID: uuid.v4(),
             inputText: text,
-            submitType,
             mentions: contextItems ?? [],
             editorState,
             signal: abortSignal,

--- a/vscode/src/chat/chat-view/ChatsController.ts
+++ b/vscode/src/chat/chat-view/ChatsController.ts
@@ -305,18 +305,18 @@ export class ChatsController implements vscode.Disposable {
      */
     private async submitChat({
         text,
-        submitType,
         contextItems,
         source = DEFAULT_EVENT_SOURCE,
         command,
     }: ExecuteChatArguments): Promise<ChatSession | undefined> {
         let provider: ChatController
         // If the sidebar panel is visible and empty, use it instead of creating a new panel
-        if (submitType === 'user-newchat' && this.panel.isVisible() && this.panel.isEmpty()) {
+        if (this.panel.isVisible() && this.panel.isEmpty()) {
             provider = this.panel
         } else {
             provider = await this.getOrCreateEditorChatController()
         }
+        await provider.clearAndRestartSession()
         const abortSignal = provider.startNewSubmitOrEditOperation()
         const editorState = editorStateFromPromptString(text)
         await provider.handleUserMessageSubmission({

--- a/vscode/src/chat/protocol.ts
+++ b/vscode/src/chat/protocol.ts
@@ -175,16 +175,8 @@ interface ExtensionAttributionMessage {
     error?: string | undefined | null
 }
 
-/**
- * ChatSubmitType represents the type of chat submission.
- * - 'user': The user starts a new chat panel.
- * - 'user-newchat': The user reuses the current chat panel.
- */
-export type ChatSubmitType = 'user' | 'user-newchat'
-
 export interface WebviewSubmitMessage extends WebviewContextMessage {
     text: string
-    submitType: Extract<ChatSubmitType, 'user-newchat'>
 
     /** An opaque value representing the text editor's state. @see {ChatMessage.editorState} */
     editorState?: unknown | undefined | null

--- a/vscode/src/chat/protocol.ts
+++ b/vscode/src/chat/protocol.ts
@@ -184,7 +184,7 @@ export type ChatSubmitType = 'user' | 'user-newchat'
 
 export interface WebviewSubmitMessage extends WebviewContextMessage {
     text: string
-    submitType: ChatSubmitType
+    submitType: Extract<ChatSubmitType, 'user-newchat'>
 
     /** An opaque value representing the text editor's state. @see {ChatMessage.editorState} */
     editorState?: unknown | undefined | null

--- a/vscode/src/code-actions/explain.ts
+++ b/vscode/src/code-actions/explain.ts
@@ -33,7 +33,6 @@ export class ExplainCodeAction implements vscode.CodeActionProvider {
                 {
                     text: instruction,
                     source: 'code-action:explain',
-                    submitType: 'user-newchat',
                 } satisfies ExecuteChatArguments,
             ],
             title: 'Ask Cody to Explain',

--- a/vscode/src/commands/execute/ask.ts
+++ b/vscode/src/commands/execute/ask.ts
@@ -6,16 +6,14 @@ import {
 } from '@sourcegraph/cody-shared'
 import * as vscode from 'vscode'
 import type { ChatSession } from '../../chat/chat-view/ChatController'
-import type { ChatSubmitType, WebviewSubmitMessage } from '../../chat/protocol'
+import type { WebviewSubmitMessage } from '../../chat/protocol'
 import { isUriIgnoredByContextFilterWithNotification } from '../../cody-ignore/context-filter'
 import { getEditor } from '../../editor/active-editor'
 
-export interface ExecuteChatArguments
-    extends Omit<WebviewSubmitMessage, 'text' | 'editorState' | 'submitType'> {
+export interface ExecuteChatArguments extends Omit<WebviewSubmitMessage, 'text' | 'editorState'> {
     source?: EventSource
     command?: DefaultChatCommands
     text: PromptString
-    submitType: Extract<ChatSubmitType, 'user-newchat'>
 }
 
 /**

--- a/vscode/src/commands/execute/ask.ts
+++ b/vscode/src/commands/execute/ask.ts
@@ -6,14 +6,16 @@ import {
 } from '@sourcegraph/cody-shared'
 import * as vscode from 'vscode'
 import type { ChatSession } from '../../chat/chat-view/ChatController'
-import type { WebviewSubmitMessage } from '../../chat/protocol'
+import type { ChatSubmitType, WebviewSubmitMessage } from '../../chat/protocol'
 import { isUriIgnoredByContextFilterWithNotification } from '../../cody-ignore/context-filter'
 import { getEditor } from '../../editor/active-editor'
 
-export interface ExecuteChatArguments extends Omit<WebviewSubmitMessage, 'text' | 'editorState'> {
+export interface ExecuteChatArguments
+    extends Omit<WebviewSubmitMessage, 'text' | 'editorState' | 'submitType'> {
     source?: EventSource
     command?: DefaultChatCommands
     text: PromptString
+    submitType: Extract<ChatSubmitType, 'user-newchat'>
 }
 
 /**

--- a/vscode/src/commands/execute/doc.ts
+++ b/vscode/src/commands/execute/doc.ts
@@ -157,7 +157,6 @@ async function docChatCommand(
 
     return {
         text: prompt,
-        submitType: 'user-newchat',
         contextItems,
         source: args?.source,
         command: DefaultChatCommands.Doc,

--- a/vscode/src/commands/execute/explain-history.ts
+++ b/vscode/src/commands/execute/explain-history.ts
@@ -61,7 +61,6 @@ async function explainHistoryCommand(
 
     return {
         text: prompt,
-        submitType: 'user-newchat',
         contextItems,
         source: args?.source,
     }

--- a/vscode/src/commands/execute/explain.ts
+++ b/vscode/src/commands/execute/explain.ts
@@ -50,7 +50,6 @@ export async function explainCommand(
 
     return {
         text: prompt,
-        submitType: 'user-newchat',
         contextItems,
         source: args?.source,
         command: DefaultChatCommands.Explain,

--- a/vscode/src/commands/execute/smell.ts
+++ b/vscode/src/commands/execute/smell.ts
@@ -50,7 +50,6 @@ async function smellCommand(
 
     return {
         text: prompt,
-        submitType: 'user-newchat',
         contextItems,
         source: args?.source,
         command: DefaultChatCommands.Smell,

--- a/vscode/src/commands/execute/terminal.ts
+++ b/vscode/src/commands/execute/terminal.ts
@@ -55,7 +55,6 @@ export async function executeExplainOutput(
             type: 'chat',
             session: await executeChat({
                 text: prompt,
-                submitType: 'user-newchat',
                 contextItems: [],
                 source,
             }),

--- a/vscode/src/commands/execute/test-chat.ts
+++ b/vscode/src/commands/execute/test-chat.ts
@@ -65,7 +65,6 @@ async function unitTestCommand(
         text: prompt,
         contextItems,
         source: args?.source,
-        submitType: 'user-newchat',
         command: DefaultChatCommands.Test,
     }
 }

--- a/vscode/src/commands/menus/index.ts
+++ b/vscode/src/commands/menus/index.ts
@@ -163,7 +163,6 @@ export async function showCommandMenu(
                     } else {
                         void executeChat({
                             text: value.trim(),
-                            submitType: 'user-newchat',
                             source,
                         })
                     }

--- a/vscode/src/commands/services/runner.ts
+++ b/vscode/src/commands/services/runner.ts
@@ -123,7 +123,7 @@ export class CommandRunner implements vscode.Disposable {
             type: 'chat',
             session: await executeChat({
                 text: prompt,
-                submitType: 'user',
+                submitType: 'user-newchat',
                 contextItems,
                 source: 'custom-commands',
                 command: DefaultChatCommands.Custom,

--- a/vscode/src/commands/services/runner.ts
+++ b/vscode/src/commands/services/runner.ts
@@ -123,7 +123,6 @@ export class CommandRunner implements vscode.Disposable {
             type: 'chat',
             session: await executeChat({
                 text: prompt,
-                submitType: 'user-newchat',
                 contextItems,
                 source: 'custom-commands',
                 command: DefaultChatCommands.Custom,

--- a/vscode/test/integration/single-root/chat.test.ts
+++ b/vscode/test/integration/single-root/chat.test.ts
@@ -35,7 +35,6 @@ suite('Chat', function () {
         await chatView.handleUserMessageSubmission({
             requestID: 'test',
             inputText: getPs()`hello from the human`,
-            submitType: 'user',
             mentions: [],
             editorState: null,
             signal: new AbortController().signal,
@@ -55,7 +54,6 @@ suite('Chat', function () {
         await chatView.handleUserMessageSubmission({
             requestID: 'test',
             inputText: getPs()`hello from the human`,
-            submitType: 'user',
             mentions: [],
             editorState: null,
             signal: new AbortController().signal,

--- a/vscode/webviews/chat/Transcript.tsx
+++ b/vscode/webviews/chat/Transcript.tsx
@@ -436,7 +436,6 @@ function submitHumanMessage({
 }): void {
     getVSCodeAPI().postMessage({
         command: 'submit',
-        submitType: 'user-newchat',
         text: editorValue.text,
         editorState: editorValue.editorState,
         contextItems: editorValue.contextItems.map(deserializeContextItem),

--- a/vscode/webviews/chat/Transcript.tsx
+++ b/vscode/webviews/chat/Transcript.tsx
@@ -436,7 +436,7 @@ function submitHumanMessage({
 }): void {
     getVSCodeAPI().postMessage({
         command: 'submit',
-        submitType: 'user',
+        submitType: 'user-newchat',
         text: editorValue.text,
         editorState: editorValue.editorState,
         contextItems: editorValue.contextItems.map(deserializeContextItem),


### PR DESCRIPTION
This controlled whether a chat would reuse the same window or create a new one. Replies and edits reuse the same chat window, but everything else (except for custom commands, optionally) starts a new chat.

The only user-facing behavior change is for custom commands (described below).

The `user` `ChatSubmitType` was used in 2 places:

- For edits in ChatController (not needed, can refactor more simply internally)
- For custom commands

Since custom commands are being removed and the "reuse existing chat window" of custom commands is not important to preserve even for now, we can simplify the code by removing this mode and `submitType` throughout.

## Test plan

CI & e2e