### PR TITLE
improve auth-related logging and abort/timeout handling

### DIFF
--- a/lib/shared/src/sourcegraph-api/errors.ts
+++ b/lib/shared/src/sourcegraph-api/errors.ts
@@ -102,6 +102,7 @@ export function isAbortError(error: unknown): error is AbortError {
         // custom abort error
         ((error instanceof AbortError && error.isAbortError) ||
             error.name === 'AbortError' ||
+            ('type' in error && error.type === 'aborted') ||
             // http module
             error.message === 'aborted' ||
             // fetch

--- a/lib/shared/src/sourcegraph-api/graphql/client.ts
+++ b/lib/shared/src/sourcegraph-api/graphql/client.ts
@@ -765,10 +765,13 @@ export class SourcegraphGraphQLAPIClient {
         )
     }
 
-    public async getCurrentUserCodySubscription(): Promise<CurrentUserCodySubscription | null | Error> {
+    public async getCurrentUserCodySubscription(
+        signal?: AbortSignal
+    ): Promise<CurrentUserCodySubscription | null | Error> {
         return this.fetchSourcegraphAPI<APIResponse<CurrentUserCodySubscriptionResponse>>(
             CURRENT_USER_CODY_SUBSCRIPTION_QUERY,
-            {}
+            {},
+            signal
         ).then(response =>
             extractDataOrError(response, data => data.currentUser?.codySubscription ?? null)
         )
@@ -1399,15 +1402,13 @@ export class SourcegraphGraphQLAPIClient {
     public async fetchSourcegraphAPI<T>(
         query: string,
         variables: Record<string, any> = {},
-        signalOrTimeout?: AbortSignal | number
+        signal?: AbortSignal
     ): Promise<T | Error> {
         if (!this.config) {
             throw new Error('SourcegraphGraphQLAPIClient config not set')
         }
         const config = await firstValueFrom(this.config)
-        if (signalOrTimeout instanceof AbortSignal) {
-            signalOrTimeout.throwIfAborted()
-        }
+        signal?.throwIfAborted()
 
         const headers = new Headers(config.configuration?.customHeaders as HeadersInit | undefined)
         headers.set('Content-Type', 'application/json; charset=utf-8')
@@ -1428,14 +1429,7 @@ export class SourcegraphGraphQLAPIClient {
             baseUrl: config.auth.serverEndpoint,
         })
 
-        const timeoutMs = typeof signalOrTimeout === 'number' ? signalOrTimeout : DEFAULT_TIMEOUT_MSEC
-        const timeoutSignal = AbortSignal.timeout(timeoutMs)
-
-        const abortController = dependentAbortController(
-            typeof signalOrTimeout !== 'number' ? signalOrTimeout : undefined
-        )
-        onAbort(timeoutSignal, () => abortController.abort())
-
+        const { abortController, timeoutSignal } = dependentAbortControllerWithTimeout(signal)
         return wrapInActiveSpan(`graphql.fetch${queryName ? `.${queryName}` : ''}`, () =>
             fetch(url, {
                 method: 'POST',
@@ -1445,17 +1439,7 @@ export class SourcegraphGraphQLAPIClient {
             })
                 .then(verifyResponseCode)
                 .then(response => response.json() as T)
-                .catch(error => {
-                    if (isAbortError(error)) {
-                        if (timeoutSignal.aborted) {
-                            return new Error(
-                                `ETIMEDOUT: Request timed out after ${timeoutMs}ms (${url})`
-                            )
-                        }
-                        return error
-                    }
-                    return new Error(`accessing Sourcegraph GraphQL API: ${error} (${url})`)
-                })
+                .catch(catchHTTPError(url, timeoutSignal))
         )
     }
     // make an anonymous request to the dotcom API
@@ -1529,14 +1513,9 @@ export class SourcegraphGraphQLAPIClient {
         addTraceparent(headers)
         addCustomUserAgent(headers)
 
-        // Timeout of 6 seconds.
-        const timeoutSignal = AbortSignal.timeout(DEFAULT_TIMEOUT_MSEC)
-
-        const abortController = dependentAbortController(signal)
-        onAbort(timeoutSignal, () => abortController.abort())
-
         const url = new URL(urlPath, config.auth.serverEndpoint).href
 
+        const { abortController, timeoutSignal } = dependentAbortControllerWithTimeout(signal)
         return wrapInActiveSpan(`httpapi.fetch${queryName ? `.${queryName}` : ''}`, () =>
             fetch(url, {
                 method: method,
@@ -1546,13 +1525,37 @@ export class SourcegraphGraphQLAPIClient {
             })
                 .then(verifyResponseCode)
                 .then(response => response.json() as T)
-                .catch(error => {
-                    if (isAbortError(error)) {
-                        return error
-                    }
-                    return new Error(`accessing Sourcegraph HTTP API: ${error} (${url})`)
-                })
+                .catch(catchHTTPError(url, timeoutSignal))
         )
+    }
+}
+
+/**
+ * Create an {@link AbortController} that aborts when the {@link signal} aborts or when the timeout
+ * elapses.
+ */
+function dependentAbortControllerWithTimeout(signal?: AbortSignal): {
+    abortController: AbortController
+    timeoutSignal: Pick<AbortSignal, 'aborted'>
+} {
+    const abortController = dependentAbortController(signal)
+    const timeoutSignal = AbortSignal.timeout(DEFAULT_TIMEOUT_MSEC)
+    onAbort(timeoutSignal, () => abortController.abort())
+    return { abortController, timeoutSignal }
+}
+
+function catchHTTPError(
+    url: string,
+    timeoutSignal: Pick<AbortSignal, 'aborted'>
+): (error: any) => Error {
+    return (error: any) => {
+        // Throw the plain AbortError for intentional aborts so we handle them with call
+        // flow, but treat timeout aborts as a network error (below) and include the
+        // URL.
+        if (isAbortError(error) && !timeoutSignal.aborted) {
+            return error
+        }
+        return new Error(`accessing Sourcegraph HTTP API: ${error} (${url})`)
     }
 }
 

--- a/vscode/src/completions/create-inline-completion-item-provider.ts
+++ b/vscode/src/completions/create-inline-completion-item-provider.ts
@@ -65,7 +65,9 @@ export function createInlineCompletionItemProvider({
     }
 
     if (!authStatus.authenticated) {
-        logDebug('AutocompleteProvider:notSignedIn', 'You are not signed in.')
+        if (!authStatus.pendingValidation) {
+            logDebug('AutocompleteProvider:notSignedIn', 'You are not signed in.')
+        }
 
         if (configuration.isRunningInsideAgent) {
             // Register an empty completion provider when running inside the

--- a/vscode/src/services/AuthProvider.ts
+++ b/vscode/src/services/AuthProvider.ts
@@ -13,6 +13,7 @@ import {
     currentResolvedConfig,
     disposableSubscription,
     distinctUntilChanged,
+    isAbortError,
     normalizeServerEndpointURL,
     pluck,
     resolvedConfig as resolvedConfig_,
@@ -92,7 +93,13 @@ class AuthProvider implements vscode.Disposable {
                             this.status.next(authStatus)
                             await this.handleAuthTelemetry(authStatus, signal)
                         } catch (error) {
-                            logError('AuthProvider', 'Unexpected error validating credentials', error)
+                            if (!isAbortError(error)) {
+                                logError(
+                                    'AuthProvider',
+                                    'Unexpected error validating credentials',
+                                    error
+                                )
+                            }
                         }
                     })
                 )

--- a/vscode/src/services/UpstreamHealthProvider.ts
+++ b/vscode/src/services/UpstreamHealthProvider.ts
@@ -136,12 +136,9 @@ class UpstreamHealthProvider implements vscode.Disposable {
                             : ''
                     }`,
                     {
-                        verbose: {
-                            Latency: upstreamResult.latency,
-                            url,
-                            status: upstreamResult.response.status,
-                            headers: headersToObject(upstreamResult.response.headers),
-                        },
+                        verbose: `url=${url} status=${
+                            upstreamResult.response.status
+                        } cf-ray=${upstreamResult.response.headers.get('cf-ray')}`,
                     }
                 )
             }
@@ -164,14 +161,6 @@ class UpstreamHealthProvider implements vscode.Disposable {
 }
 
 export const upstreamHealthProvider = new UpstreamHealthProvider()
-
-function headersToObject(headers: BrowserOrNodeResponse['headers']) {
-    const result: Record<string, string> = {}
-    for (const [key, value] of headers.entries()) {
-        result[key] = value
-    }
-    return result
-}
 
 async function measureLatencyToUri(
     headers: Headers,


### PR DESCRIPTION
- Improve logging
- Clean up usage of timeouts and aborts:
  - Re-throw AbortErrors so that they can be treated as control flow instead of returning them. Returning them might cause callers to treat it as a network error and store (eg) a "not authenticated" result instead of abandoning the operation entirely.
  - Factor out the common abort signal and timeout logic.

## Test plan

CI & e2e, manually reload under poor network conditions and ensure that timeouts and network errors are logged