### PR TITLE
use local cache instead of localStorage to get repo status

### DIFF
--- a/lib/shared/src/experimentation/FeatureFlagProvider.ts
+++ b/lib/shared/src/experimentation/FeatureFlagProvider.ts
@@ -35,7 +35,7 @@ export enum FeatureFlag {
     CodyAutocompleteDeepseekV2LiteBase = 'cody-autocomplete-deepseek-v2-lite-base',
 
     // Data collection variants used for completions and next edit completions
-    CodyAutocompleteDataCollectionFlag = 'cody-autocomplete-data-collection-flag',
+    CodyAutocompleteDataCollectionFlag = 'cody-autocomplete-logs-collection-flag',
 
     // Enable various feature flags to experiment with FIM trained fine-tuned models via Fireworks
     CodyAutocompleteFIMModelExperimentBaseFeatureFlag = 'cody-autocomplete-fim-model-experiment-flag',

--- a/vscode/src/completions/inline-completion-item-provider.ts
+++ b/vscode/src/completions/inline-completion-item-provider.ts
@@ -843,7 +843,7 @@ export class InlineCompletionItemProvider
                 takeSuggestWidgetSelectionIntoAccount,
                 undefined
             )
-            completion.requestParams.docContext.position
+
             if (isStillVisible) {
                 suggestionEvent.markAsRead({
                     document: invokedDocument,

--- a/vscode/src/completions/providers/fireworks.ts
+++ b/vscode/src/completions/providers/fireworks.ts
@@ -22,6 +22,9 @@ import {
 export const DEEPSEEK_CODER_V2_LITE_BASE = 'deepseek-coder-v2-lite-base'
 // Context window experiments with DeepSeek Model
 export const DEEPSEEK_CODER_V2_LITE_BASE_WINDOW_4096 = 'deepseek-coder-v2-lite-base-context-4096'
+export const DEEPSEEK_CODER_V2_LITE_BASE_WINDOW_8192 = 'deepseek-coder-v2-lite-base-context-8192'
+export const DEEPSEEK_CODER_V2_LITE_BASE_WINDOW_16384 = 'deepseek-coder-v2-lite-base-context-16384'
+
 export const CODE_QWEN_7B_V2P5 = 'code-qwen-7b-v2p5'
 
 // Model identifiers can be found in https://docs.fireworks.ai/explore/ and in our internal
@@ -36,6 +39,8 @@ const MODEL_MAP = {
     'llama-code-13b': 'fireworks/accounts/fireworks/models/llama-v2-13b-code',
     [DEEPSEEK_CODER_V2_LITE_BASE]: 'fireworks/deepseek-coder-v2-lite-base',
     [DEEPSEEK_CODER_V2_LITE_BASE_WINDOW_4096]: 'accounts/fireworks/models/deepseek-coder-v2-lite-base',
+    [DEEPSEEK_CODER_V2_LITE_BASE_WINDOW_8192]: 'accounts/fireworks/models/deepseek-coder-v2-lite-base',
+    [DEEPSEEK_CODER_V2_LITE_BASE_WINDOW_16384]: 'accounts/fireworks/models/deepseek-coder-v2-lite-base',
     [CODE_QWEN_7B_V2P5]: 'accounts/fireworks/models/qwen-v2p5-7b',
 } as const
 
@@ -64,6 +69,10 @@ function getMaxContextTokens(model: FireworksModel): number {
         }
         case DEEPSEEK_CODER_V2_LITE_BASE_WINDOW_4096:
             return 4096
+        case DEEPSEEK_CODER_V2_LITE_BASE_WINDOW_8192:
+            return 8192
+        case DEEPSEEK_CODER_V2_LITE_BASE_WINDOW_16384:
+            return 16384
         default:
             return 1200
     }

--- a/vscode/src/completions/providers/shared/get-experiment-model.ts
+++ b/vscode/src/completions/providers/shared/get-experiment-model.ts
@@ -14,6 +14,8 @@ import {
     CODE_QWEN_7B_V2P5,
     DEEPSEEK_CODER_V2_LITE_BASE,
     DEEPSEEK_CODER_V2_LITE_BASE_WINDOW_4096,
+    DEEPSEEK_CODER_V2_LITE_BASE_WINDOW_8192,
+    DEEPSEEK_CODER_V2_LITE_BASE_WINDOW_16384,
 } from '../fireworks'
 
 interface ProviderConfigFromFeatureFlags {
@@ -86,22 +88,38 @@ function resolveFIMModelExperimentFromFeatureFlags(): ReturnType<typeof getDotCo
     return combineLatest(
         featureFlagProvider.evaluatedFeatureFlag(FeatureFlag.CodyAutocompleteFIMModelExperimentControl),
         featureFlagProvider.evaluatedFeatureFlag(FeatureFlag.CodyAutocompleteFIMModelExperimentVariant1),
-        featureFlagProvider.evaluatedFeatureFlag(FeatureFlag.CodyAutocompleteFIMModelExperimentVariant2)
+        featureFlagProvider.evaluatedFeatureFlag(FeatureFlag.CodyAutocompleteFIMModelExperimentVariant2),
+        featureFlagProvider.evaluatedFeatureFlag(FeatureFlag.CodyAutocompleteFIMModelExperimentVariant3),
+        featureFlagProvider.evaluatedFeatureFlag(FeatureFlag.CodyAutocompleteFIMModelExperimentVariant4)
     ).pipe(
-        map(([fimModelControl, fimModelVariant1, fimModelVariant2]) => {
-            if (fimModelVariant1) {
-                return { provider: 'fireworks', model: DEEPSEEK_CODER_V2_LITE_BASE_WINDOW_4096 }
-            }
-            if (fimModelVariant2) {
-                return { provider: 'fireworks', model: CODE_QWEN_7B_V2P5 }
-            }
-            if (fimModelControl) {
-                // Current production model
+        map(
+            ([
+                fimModelControl,
+                fimModelVariant1,
+                fimModelVariant2,
+                fimModelVariant3,
+                fimModelVariant4,
+            ]) => {
+                if (fimModelVariant1) {
+                    return { provider: 'fireworks', model: DEEPSEEK_CODER_V2_LITE_BASE_WINDOW_4096 }
+                }
+                if (fimModelVariant2) {
+                    return { provider: 'fireworks', model: CODE_QWEN_7B_V2P5 }
+                }
+                if (fimModelVariant3) {
+                    return { provider: 'fireworks', model: DEEPSEEK_CODER_V2_LITE_BASE_WINDOW_8192 }
+                }
+                if (fimModelVariant4) {
+                    return { provider: 'fireworks', model: DEEPSEEK_CODER_V2_LITE_BASE_WINDOW_16384 }
+                }
+                if (fimModelControl) {
+                    // Current production model
+                    return { provider: 'fireworks', model: DEEPSEEK_CODER_V2_LITE_BASE }
+                }
+                // Extra free traffic - redirect to the current production model which could be different than control
                 return { provider: 'fireworks', model: DEEPSEEK_CODER_V2_LITE_BASE }
             }
-            // Extra free traffic - redirect to the current production model which could be different than control
-            return { provider: 'fireworks', model: DEEPSEEK_CODER_V2_LITE_BASE }
-        }),
+        ),
         distinctUntilChanged()
     )
 }

--- a/vscode/src/repository/githubRepoMetadata.ts
+++ b/vscode/src/repository/githubRepoMetadata.ts
@@ -10,7 +10,6 @@ import {
 } from '@sourcegraph/cody-shared'
 import { Observable, map } from 'observable-fns'
 import { logDebug } from '../log'
-import { localStorage } from '../services/LocalStorageProvider'
 import { remoteReposForAllWorkspaceFolders } from './remoteRepos'
 
 interface GitHubDotComRepoMetaData {
@@ -22,6 +21,7 @@ interface GitHubDotComRepoMetaData {
 export class GitHubDotComRepoMetadata {
     // This class is used to get the metadata from the gitApi.
     private static instance: GitHubDotComRepoMetadata | null = null
+    private cache = new Map<string /* repoName */, GitHubDotComRepoMetaData | undefined>()
 
     private constructor() {}
 
@@ -37,14 +37,7 @@ export class GitHubDotComRepoMetadata {
         if (!normalizedRepoName) {
             return undefined
         }
-        const repoVisibility = localStorage.getGitHubRepoVisibility(normalizedRepoName)
-        if (!repoVisibility) {
-            return undefined
-        }
-        return {
-            repoName: normalizedRepoName,
-            isPublic: repoVisibility,
-        }
+        return this.cache.get(normalizedRepoName)
     }
 
     public async getRepoMetadataUsingRepoName(
@@ -57,7 +50,7 @@ export class GitHubDotComRepoMetadata {
         }
         const repoMetaData = await this.ghMetadataFromGit(repoBaseName, signal)
         if (repoMetaData) {
-            await localStorage.setGitHubRepoVisibility(repoBaseName, repoMetaData.isPublic)
+            this.cache.set(repoMetaData.repoName, repoMetaData)
         }
         return repoMetaData
     }

--- a/vscode/src/services/LocalStorageProvider.ts
+++ b/vscode/src/services/LocalStorageProvider.ts
@@ -32,7 +32,6 @@ class LocalStorage implements LocalStorageForModelPreferences {
     protected readonly CODY_ENDPOINT_HISTORY = 'SOURCEGRAPH_CODY_ENDPOINT_HISTORY'
     protected readonly CODY_ENROLLMENT_HISTORY = 'SOURCEGRAPH_CODY_ENROLLMENTS'
     protected readonly LAST_USED_CHAT_MODALITY = 'cody-last-used-chat-modality'
-    protected readonly GIT_REPO_VISIBILITY_KEY = 'cody-git-repo-visibility'
     public readonly ANONYMOUS_USER_ID_KEY = 'sourcegraphAnonymousUid'
     public readonly LAST_USED_ENDPOINT = 'SOURCEGRAPH_CODY_ENDPOINT'
     public readonly LAST_USED_USERNAME = 'SOURCEGRAPH_CODY_USERNAME'
@@ -226,34 +225,6 @@ class LocalStorage implements LocalStorageForModelPreferences {
     public getMinionHistory(authStatus: AuthStatus): string | null {
         // TODO(beyang): SECURITY - use authStatus
         return this.get<string | null>(this.KEY_LOCAL_MINION_HISTORY)
-    }
-
-    public async setGitHubRepoVisibility(repoName: string, visibility: boolean): Promise<void> {
-        const visibilityKey = `${this.GIT_REPO_VISIBILITY_KEY}_${repoName}`
-        const visibilityValue = {
-            visibility: visibility,
-            timestamp: Date.now(),
-        }
-        await this.set(visibilityKey, visibilityValue)
-    }
-
-    public getGitHubRepoVisibility(repoName: string): boolean | null {
-        const visibilityKey = `${this.GIT_REPO_VISIBILITY_KEY}_${repoName}`
-        const visibilityValue = this.get<{ visibility: boolean; timestamp: number } | null>(
-            visibilityKey
-        )
-
-        if (visibilityValue) {
-            const currentTime = Date.now()
-            const timeDifference = currentTime - visibilityValue.timestamp
-            // If the visibility value is older than 24 hours, delete it.
-            if (timeDifference > 24 * 60 * 60 * 1000) {
-                this.delete(visibilityKey)
-                return null
-            }
-            return visibilityValue.visibility
-        }
-        return null
     }
 
     public async removeChatHistory(authStatus: AuthenticatedAuthStatus): Promise<void> {


### PR DESCRIPTION
## Context
Fixes https://github.com/sourcegraph/cody/issues/5787 and https://github.com/sourcegraph/cody/issues/5780
1. The PR removes the caching introduced in the vscode `localStorage` in the [PR](https://github.com/sourcegraph/cody/pull/5767/files#diff-795b77ed195550f3e764295bad38afdec49b0f2ad96476c63c945df119b561f7R40) to get the repo status, and uses local cache to store the results. 
2. get request from `localStorage` was being triggered for every logging request [here](https://github.com/sourcegraph/cody/blob/main/vscode/src/completions/logger.ts#L741) causing the slowness in vscode workspace.

## Test plan
Do this test before and after the PR commits.
1. Open multiple workspace in vscode in the debug mode.
2. Follow the steps listed by @arafatkatze [here](https://github.com/sourcegraph/cody/issues/5787#issuecomment-2391278595) to get the cpu profiling data.
4. Type something really fast. We should be able to see the lags introduced when typing.
5. In addition, use https://www.speedscope.app/ to visualize the profiling data gathered.
6. Profiling data before/after this PR

<img width="1512" alt="image" src="https://github.com/user-attachments/assets/1056adbf-d57e-4470-b553-06fab83470a1">

Logs Link:
1. [after_pr_change.cpuprofile.txt](https://github.com/user-attachments/files/17250317/after_pr_change.cpuprofile.txt)
2. [before_pr_change.cpuprofile.txt](https://github.com/user-attachments/files/17250318/before_pr_change.cpuprofile.txt)


## Changelog
- Fixes the vscode slowness issue when completions is turned on.
