### PR TITLE
do not block on CodyLLMSiteConfiguration (configOverwrites) fetch in initial auth

### DIFF
--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/agent/protocol_generated/AuthStatus.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/agent/protocol_generated/AuthStatus.kt
@@ -37,7 +37,6 @@ data class AuthenticatedAuthStatus(
   val isFireworksTracingEnabled: Boolean? = null,
   val hasVerifiedEmail: Boolean? = null,
   val requiresVerifiedEmail: Boolean? = null,
-  val configOverwrites: CodyLLMSiteConfiguration? = null,
   val primaryEmail: String? = null,
   val displayName: String? = null,
   val avatarURL: String? = null,

--- a/lib/shared/src/auth/types.ts
+++ b/lib/shared/src/auth/types.ts
@@ -1,5 +1,4 @@
 import { isDotCom } from '../sourcegraph-api/environments'
-import type { CodyLLMSiteConfiguration } from '../sourcegraph-api/graphql/client'
 import type { UserProductSubscription } from '../sourcegraph-api/userProductSubscription'
 
 /**
@@ -26,7 +25,6 @@ export interface AuthenticatedAuthStatus {
 
     hasVerifiedEmail?: boolean
     requiresVerifiedEmail?: boolean
-    configOverwrites?: CodyLLMSiteConfiguration
 
     primaryEmail?: string
     displayName?: string
@@ -68,10 +66,6 @@ export const AUTH_STATUS_FIXTURE_UNAUTHED: AuthStatus & { authenticated: false }
 export const AUTH_STATUS_FIXTURE_AUTHED_DOTCOM: AuthenticatedAuthStatus = {
     ...AUTH_STATUS_FIXTURE_AUTHED,
     endpoint: 'https://sourcegraph.com',
-    configOverwrites: {
-        provider: 'sourcegraph',
-        completionModel: 'fireworks/starcoder-hybrid',
-    },
 }
 
 export function isCodyProUser(authStatus: AuthStatus, sub: UserProductSubscription | null): boolean {

--- a/lib/shared/src/index.ts
+++ b/lib/shared/src/index.ts
@@ -380,3 +380,4 @@ export {
     userProductSubscription,
 } from './sourcegraph-api/userProductSubscription'
 export { siteVersion, currentSiteVersion } from './sourcegraph-api/siteVersion'
+export { configOverwrites } from './models/configOverwrites'

--- a/lib/shared/src/models/configOverwrites.ts
+++ b/lib/shared/src/models/configOverwrites.ts
@@ -1,0 +1,52 @@
+import { Observable, map } from 'observable-fns'
+import { authStatus } from '../auth/authStatus'
+import { logError } from '../logger'
+import { distinctUntilChanged, pick, promiseFactoryToObservable } from '../misc/observable'
+import { pendingOperation, switchMapReplayOperation } from '../misc/observableOperation'
+import { type CodyLLMSiteConfiguration, graphqlClient } from '../sourcegraph-api/graphql/client'
+import { isError } from '../utils'
+
+/**
+ * Observe the model-related config overwrites on the server for the currently authenticated user.
+ */
+export const configOverwrites: Observable<CodyLLMSiteConfiguration | null | typeof pendingOperation> =
+    authStatus.pipe(
+        pick('authenticated', 'endpoint', 'pendingValidation'),
+        distinctUntilChanged(),
+        switchMapReplayOperation(
+            (
+                authStatus
+            ): Observable<CodyLLMSiteConfiguration | Error | null | typeof pendingOperation> => {
+                if (authStatus.pendingValidation) {
+                    return Observable.of(pendingOperation)
+                }
+
+                if (!authStatus.authenticated) {
+                    return Observable.of(null)
+                }
+
+                return promiseFactoryToObservable(signal =>
+                    graphqlClient.getCodyLLMConfiguration(signal)
+                ).pipe(
+                    map((result): CodyLLMSiteConfiguration | null | typeof pendingOperation => {
+                        if (isError(result)) {
+                            logError(
+                                'configOverwrites',
+                                `Failed to get Cody LLM configuration from ${authStatus.endpoint}: ${result}`
+                            )
+                            return null
+                        }
+                        return result ?? null
+                    })
+                )
+            }
+        ),
+        map(result => (isError(result) ? null : result)) // the operation catches its own errors, so errors will never get here
+    )
+
+// Subscribe so that other subscribers get the replayed value. There are no other permanent
+// subscribers to this value.
+//
+// TODO(sqs): This fixes an issue where switching accounts (`rtx exec node@18.17.1 -- pnpm run test
+// agent/src/auth.test.ts -t 'switches'`) took ~2.7s on Node 18.
+configOverwrites.subscribe({})

--- a/lib/shared/src/models/modelsService.ts
+++ b/lib/shared/src/models/modelsService.ts
@@ -25,6 +25,7 @@ import {
     userProductSubscription,
 } from '../sourcegraph-api/userProductSubscription'
 import { CHAT_INPUT_TOKEN_BUDGET, CHAT_OUTPUT_TOKEN_BUDGET } from '../token/constants'
+import { configOverwrites } from './configOverwrites'
 import { type Model, type ServerModel, modelTier } from './model'
 import { syncModels } from './sync'
 import { ModelTag } from './tags'
@@ -291,6 +292,7 @@ export class ModelsService {
             distinctUntilChanged()
         ),
         authStatus,
+        configOverwrites,
         clientConfig: ClientConfigSingleton.getInstance().changes,
     })
 

--- a/vscode/src/auth/auth.ts
+++ b/vscode/src/auth/auth.ts
@@ -417,10 +417,7 @@ export async function validateCredentials(
         clientState: config.clientState,
     })
 
-    const [codyLLMConfiguration, userInfo] = await Promise.all([
-        client.getCodyLLMConfiguration(signal),
-        client.getCurrentUserInfo(signal),
-    ])
+    const userInfo = await client.getCurrentUserInfo(signal)
     signal?.throwIfAborted()
 
     if (isError(userInfo) && isNetworkLikeError(userInfo)) {
@@ -451,12 +448,9 @@ export async function validateCredentials(
     }
 
     logDebug('auth', `Authentication succeeed to endpoint ${config.auth.serverEndpoint}`)
-    const configOverwrites = isError(codyLLMConfiguration) ? undefined : codyLLMConfiguration
-
     return newAuthStatus({
         ...userInfo,
         endpoint: config.auth.serverEndpoint,
-        configOverwrites,
         authenticated: true,
         hasVerifiedEmail: false,
     })

--- a/vscode/src/chat/utils.ts
+++ b/vscode/src/chat/utils.ts
@@ -5,12 +5,7 @@ type NewAuthStatusOptions = { endpoint: string } & (
     | { authenticated: false; showNetworkError?: boolean; showInvalidAccessTokenError?: boolean }
     | (Pick<
           AuthenticatedAuthStatus,
-          | 'authenticated'
-          | 'username'
-          | 'configOverwrites'
-          | 'hasVerifiedEmail'
-          | 'displayName'
-          | 'avatarURL'
+          'authenticated' | 'username' | 'hasVerifiedEmail' | 'displayName' | 'avatarURL'
       > & {
           organizations?: CurrentUserInfo['organizations']
           primaryEmail?:

--- a/vscode/src/completions/create-inline-completion-item-provider.ts
+++ b/vscode/src/completions/create-inline-completion-item-provider.ts
@@ -6,6 +6,7 @@ import {
     NEVER,
     type PickResolvedConfiguration,
     type UnauthenticatedAuthStatus,
+    configOverwrites,
     createDisposables,
     promiseFactoryToObservable,
     skipPendingOperation,
@@ -22,9 +23,7 @@ import { registerAutocompleteTraceView } from './tracer/traceView'
 
 interface InlineCompletionItemProviderArgs {
     config: PickResolvedConfiguration<{ configuration: true }>
-    authStatus:
-        | UnauthenticatedAuthStatus
-        | Pick<AuthenticatedAuthStatus, 'authenticated' | 'endpoint' | 'configOverwrites'>
+    authStatus: UnauthenticatedAuthStatus | Pick<AuthenticatedAuthStatus, 'authenticated' | 'endpoint'>
     platform: Pick<PlatformContext, 'extensionClient'>
     statusBar: CodyStatusBar
 }
@@ -61,7 +60,7 @@ export function createInlineCompletionItemProvider({
         return await getInlineCompletionItemProviderFilters(configuration.autocompleteLanguages)
     }).pipe(
         switchMap(documentFilters =>
-            createProvider({ config: { configuration }, authStatus }).pipe(
+            createProvider({ config: { configuration }, authStatus, configOverwrites }).pipe(
                 skipPendingOperation(),
                 createDisposables(providerOrError => {
                     if (providerOrError instanceof Error) {

--- a/vscode/src/completions/get-inline-completions-tests/helpers.ts
+++ b/vscode/src/completions/get-inline-completions-tests/helpers.ts
@@ -12,6 +12,7 @@ import {
     ClientConfigSingleton,
     type CodeCompletionsClient,
     type CodyClientConfig,
+    type CodyLLMSiteConfiguration,
     type CompletionParameters,
     type CompletionResponse,
     CompletionStopReason,
@@ -65,6 +66,7 @@ export type Params = Partial<Omit<InlineCompletionsParams, 'document' | 'positio
     ) => Generator<CompletionResponse> | AsyncGenerator<CompletionResponse>
     configuration?: Parameters<typeof mockResolvedConfig>[0]
     authStatus?: AuthenticatedAuthStatus
+    configOverwrites?: CodyLLMSiteConfiguration | null
     documentUri?: URI
 }
 
@@ -96,6 +98,7 @@ export function params(
         takeSuggestWidgetSelectionIntoAccount,
         configuration: config,
         documentUri = testFileUri('test.ts'),
+        configOverwrites = null,
         ...restParams
     }: Params = {}
 ): ParamsResult {
@@ -166,6 +169,7 @@ export function params(
             (config?.configuration?.autocompleteAdvancedModel as AutocompleteProviderID) || 'anthropic',
         source: 'local-editor-settings',
         authStatus,
+        configOverwrites,
     })
 
     provider.client = client
@@ -420,8 +424,12 @@ export function initCompletionProviderConfig({
     mockClientCapabilities(CLIENT_CAPABILITIES_FIXTURE)
 }
 
-export function getMockedGenerateCompletionsOptions(): GenerateCompletionsOptions {
-    const { position, document, docContext, triggerKind } = params('const value = █', [])
+export function getMockedGenerateCompletionsOptions({
+    configOverwrites,
+}: Pick<Params, 'configOverwrites'> = {}): GenerateCompletionsOptions {
+    const { position, document, docContext, triggerKind } = params('const value = █', [], {
+        configOverwrites,
+    })
     return {
         position,
         document,

--- a/vscode/src/completions/inline-completion-item-provider-e2e.test.ts
+++ b/vscode/src/completions/inline-completion-item-provider-e2e.test.ts
@@ -149,6 +149,7 @@ function getInlineCompletionProvider(
             authStatus: currentAuthStatus(),
             provider: 'default',
             source: 'local-editor-settings',
+            configOverwrites: null,
         }),
         firstCompletionTimeout:
             args?.firstCompletionTimeout ?? DEFAULT_VSCODE_SETTINGS.autocompleteFirstCompletionTimeout,
@@ -174,6 +175,7 @@ function createNetworkProvider(params: RequestParams): MockRequestProvider {
             id: 'mock-provider',
             legacyModel: 'test-model',
             source: 'local-editor-settings',
+            configOverwrites: null,
         },
         providerOptions
     )

--- a/vscode/src/completions/inline-completion-item-provider.test.ts
+++ b/vscode/src/completions/inline-completion-item-provider.test.ts
@@ -48,6 +48,7 @@ class MockableInlineCompletionItemProvider extends InlineCompletionItemProvider 
                 provider: 'anthropic',
                 source: 'local-editor-settings',
                 authStatus: currentAuthStatusAuthed(),
+                configOverwrites: null,
             }),
             firstCompletionTimeout:
                 superArgs?.firstCompletionTimeout ??

--- a/vscode/src/completions/providers/anthropic.test.ts
+++ b/vscode/src/completions/providers/anthropic.test.ts
@@ -141,11 +141,7 @@ describe('anthropic autocomplete provider', () => {
 
         expect(provider.id).toBe(providerId)
         expect(provider.legacyModel).toBe(legacyModel)
-        expect(getRequestParamsWithoutMessages(provider)).toStrictEqual({
-            ...requestParams,
-            // The model ID is ignored by BYOK clients
-            model: undefined,
-        })
+        expect(getRequestParamsWithoutMessages(provider)).toStrictEqual(requestParams)
     })
 
     it('[dotcom] site-config-cody-llm-configuration special case for google hosted models', async () => {
@@ -169,11 +165,7 @@ describe('anthropic autocomplete provider', () => {
 
         expect(provider.id).toBe(providerId)
         expect(provider.legacyModel).toBe(legacyModel)
-        expect(getRequestParamsWithoutMessages(provider)).toStrictEqual({
-            ...requestParams,
-            // The model ID is ignored by BYOK clients
-            model: undefined,
-        })
+        expect(getRequestParamsWithoutMessages(provider)).toStrictEqual(requestParams)
     })
 
     it('throws if the wrong "completionModel" separator is used', async () => {
@@ -252,7 +244,14 @@ describe('anthropic/aws-bedrock autocomplete provider', () => {
             isDotCom: true,
         })
 
-        assertProviderValues(provider, claudeInstantAssertion)
+        assertProviderValues(provider, {
+            ...claudeInstantAssertion,
+            requestParams: {
+                ...claudeInstantAssertion.requestParams,
+                // The model ID is ignored by BYOK clients
+                model: undefined,
+            },
+        })
     })
 
     it('[enterprise] site-config-cody-llm-configuration', async () => {

--- a/vscode/src/completions/providers/anthropic.ts
+++ b/vscode/src/completions/providers/anthropic.ts
@@ -67,10 +67,16 @@ function getClientModel(
     return model || BYOK_MODEL_ID_FOR_LOGS
 }
 
-export function createProvider({ legacyModel, source, authStatus }: ProviderFactoryParams): Provider {
+export function createProvider({
+    legacyModel,
+    source,
+    authStatus,
+    configOverwrites,
+}: ProviderFactoryParams): Provider {
     return new AnthropicProvider({
         id: 'anthropic',
         legacyModel: getClientModel(legacyModel, authStatus),
         source,
+        configOverwrites,
     })
 }

--- a/vscode/src/completions/providers/expopenaicompatible.ts
+++ b/vscode/src/completions/providers/expopenaicompatible.ts
@@ -87,7 +87,11 @@ function getClientModel(model?: string): OpenAICompatibleModel {
     throw new Error(`Unknown model: \`${model}\``)
 }
 
-export function createProvider({ legacyModel, source }: ProviderFactoryParams): Provider {
+export function createProvider({
+    legacyModel,
+    source,
+    configOverwrites,
+}: ProviderFactoryParams): Provider {
     const clientModel = getClientModel(legacyModel)
 
     return new ExpOpenAICompatibleProvider({
@@ -95,5 +99,6 @@ export function createProvider({ legacyModel, source }: ProviderFactoryParams): 
         legacyModel: clientModel,
         maxContextTokens: getMaxContextTokens(clientModel),
         source,
+        configOverwrites,
     })
 }

--- a/vscode/src/completions/providers/fireworks.ts
+++ b/vscode/src/completions/providers/fireworks.ts
@@ -182,7 +182,12 @@ function getClientModel(
     throw new Error(`Unknown model: '${model}'`)
 }
 
-export function createProvider({ legacyModel, source, authStatus }: ProviderFactoryParams): Provider {
+export function createProvider({
+    legacyModel,
+    source,
+    authStatus,
+    configOverwrites,
+}: ProviderFactoryParams): Provider {
     const clientModel = getClientModel(legacyModel, authStatus)
 
     return new FireworksProvider({
@@ -190,5 +195,6 @@ export function createProvider({ legacyModel, source, authStatus }: ProviderFact
         legacyModel: clientModel,
         maxContextTokens: getMaxContextTokens(clientModel),
         source,
+        configOverwrites,
     })
 }

--- a/vscode/src/completions/providers/google.ts
+++ b/vscode/src/completions/providers/google.ts
@@ -25,7 +25,11 @@ class GoogleGeminiProvider extends Provider {
 
 const SUPPORTED_GEMINI_MODELS = ['gemini-1.5-flash', 'gemini-pro', 'gemini-1.0-pro'] as const
 
-export function createProvider({ legacyModel, source }: ProviderFactoryParams): Provider {
+export function createProvider({
+    legacyModel,
+    source,
+    configOverwrites,
+}: ProviderFactoryParams): Provider {
     const clientModel = legacyModel ?? 'gemini-1.5-flash'
 
     if (!SUPPORTED_GEMINI_MODELS.some(m => clientModel.includes(m))) {
@@ -36,5 +40,6 @@ export function createProvider({ legacyModel, source }: ProviderFactoryParams): 
         id: 'google',
         legacyModel: clientModel,
         source,
+        configOverwrites,
     })
 }

--- a/vscode/src/completions/providers/openaicompatible.ts
+++ b/vscode/src/completions/providers/openaicompatible.ts
@@ -24,7 +24,7 @@ class OpenAICompatibleProvider extends Provider {
     }
 }
 
-export function createProvider({ model, source }: ProviderFactoryParams): Provider {
+export function createProvider({ model, source, configOverwrites }: ProviderFactoryParams): Provider {
     if (model) {
         logDebug('OpenAICompatible', 'autocomplete provider using model', JSON.stringify(model))
 
@@ -41,6 +41,7 @@ export function createProvider({ model, source }: ProviderFactoryParams): Provid
             model,
             maxContextTokens,
             source,
+            configOverwrites,
         })
     }
 

--- a/vscode/src/completions/providers/shared/create-provider.test.ts
+++ b/vscode/src/completions/providers/shared/create-provider.test.ts
@@ -62,6 +62,7 @@ describe('createProvider', () => {
                     },
                 },
                 authStatus: AUTH_STATUS_FIXTURE_AUTHED,
+                configOverwrites: Observable.of<CodyLLMSiteConfiguration | null>(null),
             })
 
             await expect(createCall).rejects.toThrowErrorMatchingInlineSnapshot(
@@ -78,6 +79,7 @@ describe('createProvider', () => {
                     },
                 },
                 authStatus: AUTH_STATUS_FIXTURE_AUTHED,
+                configOverwrites: Observable.of<CodyLLMSiteConfiguration | null>(null),
             })
             expect(provider.id).toBe('unstable-openai')
             expect(provider.legacyModel).toBe(
@@ -114,10 +116,8 @@ describe('createProvider', () => {
                             autocompleteAdvancedModel: null,
                         },
                     },
-                    authStatus: {
-                        ...AUTH_STATUS_FIXTURE_AUTHED_DOTCOM,
-                        configOverwrites,
-                    },
+                    authStatus: AUTH_STATUS_FIXTURE_AUTHED_DOTCOM,
+                    configOverwrites: Observable.of<CodyLLMSiteConfiguration | null>(configOverwrites),
                 })
 
                 await expect(createCall).rejects.toThrow()

--- a/vscode/src/completions/providers/shared/create-provider.ts
+++ b/vscode/src/completions/providers/shared/create-provider.ts
@@ -4,12 +4,15 @@ import {
     AUTOCOMPLETE_PROVIDER_ID,
     type AuthenticatedAuthStatus,
     type AutocompleteProviderID,
+    type CodyLLMSiteConfiguration,
     type Model,
     ModelUsage,
     type PickResolvedConfiguration,
     isDotComAuthed,
+    isError,
     modelsService,
     pendingOperation,
+    switchMap,
     switchMapReplayOperation,
     toLegacyModel,
 } from '@sourcegraph/cody-shared'
@@ -29,85 +32,97 @@ import type { Provider, ProviderFactory } from './provider'
 export function createProvider({
     config: { configuration },
     authStatus,
+    configOverwrites,
 }: {
     config: PickResolvedConfiguration<{
         configuration: 'autocompleteAdvancedModel' | 'autocompleteAdvancedProvider'
     }>
-    authStatus: Pick<AuthenticatedAuthStatus, 'endpoint' | 'configOverwrites'>
+    authStatus: Pick<AuthenticatedAuthStatus, 'endpoint'>
+    configOverwrites: Observable<CodyLLMSiteConfiguration | null | typeof pendingOperation>
 }): Observable<Provider | typeof pendingOperation | Error> {
-    // Resolve the provider config from the VS Code config.
-    if (
-        configuration.autocompleteAdvancedProvider &&
-        configuration.autocompleteAdvancedProvider !== 'default'
-    ) {
-        return Observable.of(
-            createProviderHelper({
-                legacyModel: configuration.autocompleteAdvancedModel || undefined,
-                provider: configuration.autocompleteAdvancedProvider,
-                source: 'local-editor-settings',
-                authStatus,
-            })
-        )
-    }
+    return configOverwrites.pipe(
+        switchMap(configOverwrites => {
+            if (configOverwrites === pendingOperation) {
+                return Observable.of(pendingOperation)
+            }
 
-    return getDotComExperimentModel({ authStatus }).pipe(
-        switchMapReplayOperation(dotComExperiment => {
-            // Check if a user participates in autocomplete experiments.
-            if (dotComExperiment) {
+            // Resolve the provider config from the VS Code config.
+            if (
+                configuration.autocompleteAdvancedProvider &&
+                configuration.autocompleteAdvancedProvider !== 'default'
+            ) {
                 return Observable.of(
                     createProviderHelper({
-                        legacyModel: dotComExperiment.model,
-                        provider: dotComExperiment.provider,
-                        source: 'dotcom-feature-flags',
+                        legacyModel: configuration.autocompleteAdvancedModel || undefined,
+                        provider: configuration.autocompleteAdvancedProvider,
+                        source: 'local-editor-settings',
                         authStatus,
+                        configOverwrites,
                     })
                 )
             }
 
-            return modelsService.getDefaultModel(ModelUsage.Autocomplete).pipe(
-                map(model => {
-                    if (model === pendingOperation) {
-                        return pendingOperation
+            return getDotComExperimentModel({ authStatus }).pipe(
+                switchMapReplayOperation(dotComExperiment => {
+                    // Check if a user participates in autocomplete experiments.
+                    if (dotComExperiment) {
+                        return Observable.of(
+                            createProviderHelper({
+                                legacyModel: dotComExperiment.model,
+                                provider: dotComExperiment.provider,
+                                source: 'dotcom-feature-flags',
+                                authStatus,
+                                configOverwrites,
+                            })
+                        )
                     }
 
-                    // Check if server-side model configuration is available.
-                    if (model) {
-                        const provider = model.clientSideConfig?.openAICompatible
-                            ? 'openaicompatible'
-                            : model.provider
+                    return modelsService.getDefaultModel(ModelUsage.Autocomplete).pipe(
+                        map(model => {
+                            if (model === pendingOperation) {
+                                return pendingOperation
+                            }
 
-                        return createProviderHelper({
-                            legacyModel: model.id,
-                            model,
-                            provider,
-                            source: 'server-side-model-config',
-                            authStatus,
+                            // Check if server-side model configuration is available.
+                            if (model) {
+                                const provider = model.clientSideConfig?.openAICompatible
+                                    ? 'openaicompatible'
+                                    : model.provider
+
+                                return createProviderHelper({
+                                    legacyModel: model.id,
+                                    model,
+                                    provider,
+                                    source: 'server-side-model-config',
+                                    authStatus,
+                                    configOverwrites,
+                                })
+                            }
+
+                            // Fallback to site-config Cody LLM configuration.
+                            if (configOverwrites?.provider) {
+                                const parsedProviderAndModel = parseProviderAndModel({
+                                    provider: configOverwrites.provider,
+                                    legacyModel: configOverwrites.completionModel,
+                                })
+
+                                if (parsedProviderAndModel instanceof Error) {
+                                    return parsedProviderAndModel
+                                }
+
+                                return createProviderHelper({
+                                    legacyModel: parsedProviderAndModel.legacyModel,
+                                    provider: parsedProviderAndModel.provider,
+                                    source: 'site-config-cody-llm-configuration',
+                                    authStatus,
+                                    configOverwrites,
+                                })
+                            }
+
+                            return new Error(
+                                'Failed to create autocomplete provider. Please configure the `completionModel` using site configuration.'
+                            )
                         })
-                    }
-
-                    // Fallback to site-config Cody LLM configuration.
-                    const { configOverwrites } = authStatus
-
-                    if (configOverwrites?.provider) {
-                        const parsedProviderAndModel = parseProviderAndModel({
-                            provider: configOverwrites.provider,
-                            legacyModel: configOverwrites.completionModel,
-                        })
-
-                        if (parsedProviderAndModel instanceof Error) {
-                            return parsedProviderAndModel
-                        }
-
-                        return createProviderHelper({
-                            legacyModel: parsedProviderAndModel.legacyModel,
-                            provider: parsedProviderAndModel.provider,
-                            source: 'site-config-cody-llm-configuration',
-                            authStatus,
-                        })
-                    }
-
-                    return new Error(
-                        'Failed to create autocomplete provider. Please configure the `completionModel` using site configuration.'
                     )
                 })
             )
@@ -122,25 +137,31 @@ interface CreateProviderHelperParams {
     model?: Model
     source: AutocompleteProviderConfigSource
 
-    authStatus: Pick<AuthenticatedAuthStatus, 'endpoint' | 'configOverwrites'>
+    authStatus: Pick<AuthenticatedAuthStatus, 'endpoint'>
+    configOverwrites: CodyLLMSiteConfiguration | null
 }
 
 function createProviderHelper(params: CreateProviderHelperParams): Provider | Error {
-    const { legacyModel, model, provider, source, authStatus } = params
+    const { legacyModel, model, provider, source, authStatus, configOverwrites } = params
 
     const providerCreator = getProviderCreator({
         provider: provider as AutocompleteProviderID,
-        authStatus,
+        configOverwrites,
     })
 
     if (providerCreator) {
-        return providerCreator({
-            model,
-            legacyModel: legacyModel ? toLegacyModel(legacyModel) : legacyModel,
-            provider: provider as AutocompleteProviderID,
-            source,
-            authStatus,
-        })
+        try {
+            return providerCreator({
+                model,
+                legacyModel: legacyModel ? toLegacyModel(legacyModel) : legacyModel,
+                provider: provider as AutocompleteProviderID,
+                source,
+                authStatus,
+                configOverwrites,
+            })
+        } catch (error) {
+            return isError(error) ? error : new Error(`${error}`)
+        }
     }
 
     const sourceDependentMessage =
@@ -157,11 +178,11 @@ function createProviderHelper(params: CreateProviderHelperParams): Provider | Er
 
 interface GetProviderCreatorParams {
     provider: AutocompleteProviderID
-    authStatus: Pick<AuthenticatedAuthStatus, 'configOverwrites'>
+    configOverwrites: CodyLLMSiteConfiguration | null
 }
 
 function getProviderCreator(params: GetProviderCreatorParams): ProviderFactory | null {
-    const { provider, authStatus } = params
+    const { provider, configOverwrites } = params
 
     if (
         provider === AUTOCOMPLETE_PROVIDER_ID.default ||
@@ -185,8 +206,6 @@ function getProviderCreator(params: GetProviderCreatorParams): ProviderFactory |
     if (provider === AUTOCOMPLETE_PROVIDER_ID['experimental-openaicompatible']) {
         return createExperimentalOpenAICompatibleProvider
     }
-
-    const { configOverwrites } = authStatus
 
     if (
         provider === AUTOCOMPLETE_PROVIDER_ID.anthropic ||

--- a/vscode/src/completions/providers/unstable-openai.ts
+++ b/vscode/src/completions/providers/unstable-openai.ts
@@ -30,10 +30,15 @@ class UnstableOpenAIProvider extends Provider {
     }
 }
 
-export function createProvider({ legacyModel, source }: ProviderFactoryParams): Provider {
+export function createProvider({
+    legacyModel,
+    source,
+    configOverwrites,
+}: ProviderFactoryParams): Provider {
     return new UnstableOpenAIProvider({
         id: 'unstable-openai',
         legacyModel: legacyModel || BYOK_MODEL_ID_FOR_LOGS,
         source,
+        configOverwrites,
     })
 }

--- a/vscode/src/completions/request-manager.test.ts
+++ b/vscode/src/completions/request-manager.test.ts
@@ -88,6 +88,7 @@ function createProvider() {
         id: 'mock-provider',
         legacyModel: 'test-model',
         source: 'local-editor-settings',
+        configOverwrites: null,
     })
 }
 


### PR DESCRIPTION
   To authenticate a user and start showing the UI, we actually don't need to
   fetch the CodyLLMSiteConfiguration (`configOverwrites`). This reduces the
   number of HTTP requests (albeit they were parallelized somewhat) needed
   before the user can be authenticated and start seeing the Cody UI.

   This uncovered some possible "bugs" in the `anthropic.test.ts` autocomplete
   tests, where they were asserting that the `model` would be set but it
   actually would not be in real life. In `Provider.maybeFilterOutModel` it
   sees that `this.configOverwrites?.provider === 'sourcegraph'` in the test,
   but that should not be true in real life because it’s being passed an
   `authStatus` that is non-dotcom. The reason the test is bad is because that
   method gets the auth status from `currentAuthStatus()`, which is dotcom in
   testing only because of a prior test's mock value.

- do not block on fetching the user's Cody Pro subscription status when authing

## Test plan

CI & e2e. Sign in and ensure that operation that need the site version (such as autocomplete) still function without an error.

## Changelog

- Made authentication faster and less prone to network instability by reducing the number of HTTP requests needed for authentication.