### PR TITLE
Autocomplete: fix `authStatus` mocks in provider tests

### DIFF
--- a/vscode/src/completions/get-inline-completions-tests/helpers.ts
+++ b/vscode/src/completions/get-inline-completions-tests/helpers.ts
@@ -15,6 +15,7 @@ import {
     type CompletionParameters,
     type CompletionResponse,
     CompletionStopReason,
+    currentAuthStatusOrNotReadyYet,
     featureFlagProvider,
     mockAuthStatus,
     mockClientCapabilities,
@@ -95,10 +96,18 @@ export function params(
         takeSuggestWidgetSelectionIntoAccount,
         configuration: config,
         documentUri = testFileUri('test.ts'),
-        authStatus = AUTH_STATUS_FIXTURE_AUTHED_DOTCOM,
         ...restParams
     }: Params = {}
 ): ParamsResult {
+    const currentAuthStatus = currentAuthStatusOrNotReadyYet()
+
+    const authStatus =
+        // If authStatus is not explicitly provided, check the current value, which
+        // might be mocked prior to calling this function.
+        restParams.authStatus || currentAuthStatus?.authenticated
+            ? (currentAuthStatus! as AuthenticatedAuthStatus)
+            : AUTH_STATUS_FIXTURE_AUTHED_DOTCOM
+
     mockAuthStatus(authStatus)
 
     let requestCounter = 0

--- a/vscode/src/completions/providers/anthropic.test.ts
+++ b/vscode/src/completions/providers/anthropic.test.ts
@@ -7,11 +7,11 @@ import { mockLocalStorage } from '../../services/LocalStorageProvider'
 
 import {
     type AutocompleteProviderValuesToAssert,
+    assertProviderValues,
     getAutocompleteProviderFromLocalSettings,
     getAutocompleteProviderFromServerSideModelConfig,
     getAutocompleteProviderFromSiteConfigCodyLLMConfiguration,
     getRequestParamsWithoutMessages,
-    testAutocompleteProvider,
 } from './shared/helpers'
 
 describe('anthropic autocomplete provider', () => {
@@ -77,6 +77,7 @@ describe('anthropic autocomplete provider', () => {
         const provider = await getAutocompleteProviderFromServerSideModelConfig({
             modelRef: 'anthropic::2023-06-01::claude-3-haiku-20240307',
             isDotCom: true,
+            isBYOK: false,
         })
 
         // Still uses claude instant on dotcom.
@@ -87,10 +88,11 @@ describe('anthropic autocomplete provider', () => {
         expect(getRequestParamsWithoutMessages(provider)).toStrictEqual(requestParams)
     })
 
-    it('[enterprise] server-side-model-config', async () => {
+    it('[enterprise] CLOUD server-side-model-config', async () => {
         const provider = await getAutocompleteProviderFromServerSideModelConfig({
             modelRef: 'anthropic::2023-06-01::claude-3-haiku-20240307',
             isDotCom: false,
+            isBYOK: false,
         })
 
         const { providerId, legacyModel, requestParams } = haikuAssertion
@@ -100,24 +102,79 @@ describe('anthropic autocomplete provider', () => {
         expect(getRequestParamsWithoutMessages(provider)).toStrictEqual(requestParams)
     })
 
-    testAutocompleteProvider('site-config-cody-llm-configuration', claudeInstantAssertion, isDotCom =>
-        getAutocompleteProviderFromSiteConfigCodyLLMConfiguration({
+    it('[enterprise] BYOK server-side-model-config', async () => {
+        const provider = await getAutocompleteProviderFromServerSideModelConfig({
+            modelRef: 'anthropic::2023-06-01::claude-3-haiku-20240307',
+            isDotCom: false,
+            isBYOK: true,
+        })
+
+        const { providerId, legacyModel, requestParams } = haikuAssertion
+
+        expect(provider.id).toBe(providerId)
+        expect(provider.legacyModel).toBe(legacyModel)
+        expect(getRequestParamsWithoutMessages(provider)).toStrictEqual({
+            ...requestParams,
+            // The model ID is ignored by BYOK clients
+            model: undefined,
+        })
+    })
+
+    it('[dotcom] site-config-cody-llm-configuration', async () => {
+        const provider = await getAutocompleteProviderFromSiteConfigCodyLLMConfiguration({
             completionModel: 'anthropic/claude-instant-1.2',
             provider: 'sourcegraph',
-            isDotCom,
+            isDotCom: true,
         })
-    )
 
-    testAutocompleteProvider(
-        'site-config-cody-llm-configuration special case for google hosted models',
-        claudeInstantAssertion,
-        isDotCom =>
-            getAutocompleteProviderFromSiteConfigCodyLLMConfiguration({
-                completionModel: 'google/claude-instant-1.2',
-                provider: 'sourcegraph',
-                isDotCom,
-            })
-    )
+        assertProviderValues(provider, claudeInstantAssertion)
+    })
+
+    it('[enterprise] site-config-cody-llm-configuration', async instanceType => {
+        const provider = await getAutocompleteProviderFromSiteConfigCodyLLMConfiguration({
+            completionModel: 'anthropic/claude-instant-1.2',
+            provider: 'sourcegraph',
+            isDotCom: false,
+        })
+
+        const { providerId, legacyModel, requestParams } = claudeInstantAssertion
+
+        expect(provider.id).toBe(providerId)
+        expect(provider.legacyModel).toBe(legacyModel)
+        expect(getRequestParamsWithoutMessages(provider)).toStrictEqual({
+            ...requestParams,
+            // The model ID is ignored by BYOK clients
+            model: undefined,
+        })
+    })
+
+    it('[dotcom] site-config-cody-llm-configuration special case for google hosted models', async () => {
+        const provider = await getAutocompleteProviderFromSiteConfigCodyLLMConfiguration({
+            completionModel: 'google/claude-instant-1.2',
+            provider: 'sourcegraph',
+            isDotCom: true,
+        })
+
+        assertProviderValues(provider, claudeInstantAssertion)
+    })
+
+    it('[enterprise] site-config-cody-llm-configuration special case for google hosted models', async instanceType => {
+        const provider = await getAutocompleteProviderFromSiteConfigCodyLLMConfiguration({
+            completionModel: 'google/claude-instant-1.2',
+            provider: 'sourcegraph',
+            isDotCom: false,
+        })
+
+        const { providerId, legacyModel, requestParams } = claudeInstantAssertion
+
+        expect(provider.id).toBe(providerId)
+        expect(provider.legacyModel).toBe(legacyModel)
+        expect(getRequestParamsWithoutMessages(provider)).toStrictEqual({
+            ...requestParams,
+            // The model ID is ignored by BYOK clients
+            model: undefined,
+        })
+    })
 
     it('throws if the wrong "completionModel" separator is used', async () => {
         const createCall = getAutocompleteProviderFromSiteConfigCodyLLMConfiguration({
@@ -188,13 +245,33 @@ describe('anthropic/aws-bedrock autocomplete provider', () => {
         )
     })
 
-    testAutocompleteProvider('site-config-cody-llm-configuration', claudeInstantAssertion, isDotCom =>
-        getAutocompleteProviderFromSiteConfigCodyLLMConfiguration({
+    it('[dotcom] site-config-cody-llm-configuration', async () => {
+        const provider = await getAutocompleteProviderFromSiteConfigCodyLLMConfiguration({
             completionModel: 'anthropic.claude-instant-1.2',
             provider: 'aws-bedrock',
-            isDotCom,
+            isDotCom: true,
         })
-    )
+
+        assertProviderValues(provider, claudeInstantAssertion)
+    })
+
+    it('[enterprise] site-config-cody-llm-configuration', async () => {
+        const provider = await getAutocompleteProviderFromSiteConfigCodyLLMConfiguration({
+            completionModel: 'anthropic.claude-instant-1.2',
+            provider: 'aws-bedrock',
+            isDotCom: false,
+        })
+
+        const { providerId, legacyModel, requestParams } = claudeInstantAssertion
+
+        expect(provider.id).toBe(providerId)
+        expect(provider.legacyModel).toBe(legacyModel)
+        expect(getRequestParamsWithoutMessages(provider)).toStrictEqual({
+            ...requestParams,
+            // The model ID is ignored by BYOK clients
+            model: undefined,
+        })
+    })
 
     it('throws if the wrong "completionModel" separator is used', async () => {
         const createCall = getAutocompleteProviderFromSiteConfigCodyLLMConfiguration({
@@ -204,7 +281,7 @@ describe('anthropic/aws-bedrock autocomplete provider', () => {
         })
 
         await expect(createCall).rejects.toThrowErrorMatchingInlineSnapshot(
-            `[Error: Failed to create "anthropic/claude-instant-1" autocomplete provider derived from "site-config-cody-llm-configuration". Please report the issue using the "Cody Debug: Report Issue" VS Code command.]`
+            `[Error: Failed to create "anthropic/claude-instant-1" autocomplete provider derived from "site-config-cody-llm-configuration". Please check your site configuration for autocomplete: https://sourcegraph.com/docs/cody/capabilities/autocomplete.]`
         )
     })
 

--- a/vscode/src/completions/providers/expopenaicompatible.test.ts
+++ b/vscode/src/completions/providers/expopenaicompatible.test.ts
@@ -63,6 +63,7 @@ describe('experimental-openaicompatible autocomplete provider', () => {
         getAutocompleteProviderFromServerSideModelConfig({
             modelRef: 'experimental-openaicompatible::2024-02-01::starchat-16b-beta',
             isDotCom,
+            isBYOK: !isDotCom,
         })
     )
 

--- a/vscode/src/completions/providers/fireworks.test.ts
+++ b/vscode/src/completions/providers/fireworks.test.ts
@@ -90,6 +90,7 @@ describe('fireworks autocomplete provider', () => {
         getAutocompleteProviderFromServerSideModelConfig({
             modelRef: 'fireworks::v1::deepseek-coder-v2-lite-base',
             isDotCom,
+            isBYOK: !isDotCom,
         })
     )
 

--- a/vscode/src/completions/providers/google.test.ts
+++ b/vscode/src/completions/providers/google.test.ts
@@ -44,6 +44,7 @@ describe('google autocomplete provider', () => {
         getAutocompleteProviderFromServerSideModelConfig({
             modelRef: 'google::v1::gemini-1.5-flash-latest',
             isDotCom,
+            isBYOK: !isDotCom,
         })
     )
 

--- a/vscode/src/completions/providers/openaicompatible.test.ts
+++ b/vscode/src/completions/providers/openaicompatible.test.ts
@@ -58,6 +58,7 @@ describe('openaicompatible autocomplete provider', () => {
         const provider = await getAutocompleteProviderFromServerSideModelConfig({
             modelRef: 'groq::v1::llama-3.1-70b-versatile',
             isDotCom: true,
+            isBYOK: false,
         })
 
         // Switches to the first available model, because `llama-3.1-70b-versatile` is
@@ -73,6 +74,7 @@ describe('openaicompatible autocomplete provider', () => {
         const provider = await getAutocompleteProviderFromServerSideModelConfig({
             modelRef: 'groq::v1::llama-3.1-70b-versatile',
             isDotCom: false,
+            isBYOK: true,
         })
         const { providerId, legacyModel, requestParams } = openaicompatibleParams
 

--- a/vscode/src/completions/providers/unstable-openai.test.ts
+++ b/vscode/src/completions/providers/unstable-openai.test.ts
@@ -46,6 +46,7 @@ describe('unstable-openai autocomplete provider', () => {
             getAutocompleteProviderFromServerSideModelConfig({
                 modelRef: 'unstable-openai::2024-02-01::gpt-4o',
                 isDotCom,
+                isBYOK: !isDotCom,
             })
         )
 
@@ -100,6 +101,7 @@ describe('unstable-openai autocomplete provider', () => {
             getAutocompleteProviderFromServerSideModelConfig({
                 modelRef: 'azure-openai::v1::gpt-4o-mini-test',
                 isDotCom,
+                isBYOK: !isDotCom,
             })
         )
 


### PR DESCRIPTION
- No functional changes.
- @sqs spotted an issue with the incorrect assertion in the `anthropic` provider tests. The problem was caused by inconsistent `authStatus` mocks. This happened because `params` from `vscode/src/completions/get-inline-completions-tests/helpers.ts` independently changed mock values to the DotCom auth status. This PR fixes it by making `params` check if the mock already exists.Inconsistent `authStatus` mocks caused the problem

## Test plan

CI and `pnpm vitest vscode/src/completions/providers/*.test.ts`