### PR TITLE
Send info if model is available together with the model

### DIFF
--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/agent/protocol_generated/ModelAvailabilityStatus.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/agent/protocol_generated/ModelAvailabilityStatus.kt
@@ -1,7 +1,8 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
 package com.sourcegraph.cody.agent.protocol_generated;
 
-data class Chat_ModelsResult(
-  val models: List<ModelAvailabilityStatus>,
+data class ModelAvailabilityStatus(
+  val model: Model,
+  val isModelAvailable: Boolean,
 )
 

--- a/agent/src/agent.ts
+++ b/agent/src/agent.ts
@@ -1264,7 +1264,7 @@ export class Agent extends MessageHandler implements ExtensionClient {
 
         this.registerAuthenticatedRequest('chat/models', async ({ modelUsage }) => {
             return {
-                models: await firstResultFromOperation(modelsService.getModels(modelUsage)),
+                models: await modelsService.getModelsAvailabilityStatus(modelUsage),
             }
         })
 

--- a/agent/src/auth.test.ts
+++ b/agent/src/auth.test.ts
@@ -137,7 +137,7 @@ describe(
             // Listing models should work.
             const { models } = await client.request('chat/models', { modelUsage: ModelUsage.Chat })
             expect(models.length).toBeGreaterThanOrEqual(2)
-            expect(models.map(({model}) => model.id)).toContain('openai::2024-02-01::gpt-4o') // arbitrary model that we expect to be included
+            expect(models.map(({ model }) => model.id)).toContain('openai::2024-02-01::gpt-4o') // arbitrary model that we expect to be included
         })
 
         it('switches to a different account', async ({ task }) => {
@@ -177,7 +177,9 @@ describe(
 
             // Enterprise models should not contain models with the waitlist tag.
             const enterpriseModels = await client.request('chat/models', { modelUsage: ModelUsage.Chat })
-            expect(enterpriseModels.models?.some(({model}) => model.tags.includes(ModelTag.Waitlist))).toBeFalsy()
+            expect(
+                enterpriseModels.models?.some(({ model }) => model.tags.includes(ModelTag.Waitlist))
+            ).toBeFalsy()
 
             // The chat that we started before switching accounts should not be usable from the new
             // account.
@@ -198,7 +200,7 @@ describe(
             // Listing models should work.
             const { models } = await client.request('chat/models', { modelUsage: ModelUsage.Chat })
             expect(models.length).toBeGreaterThanOrEqual(2)
-            expect(models.map(({model}) => toModelRefStr(model.modelRef!))).toContain(
+            expect(models.map(({ model }) => toModelRefStr(model.modelRef!))).toContain(
                 'openai::2024-02-01::gpt-4o' // arbitrary model that we expect to be included
             )
         })

--- a/agent/src/auth.test.ts
+++ b/agent/src/auth.test.ts
@@ -137,7 +137,7 @@ describe(
             // Listing models should work.
             const { models } = await client.request('chat/models', { modelUsage: ModelUsage.Chat })
             expect(models.length).toBeGreaterThanOrEqual(2)
-            expect(models.map(model => model.id)).toContain('openai::2024-02-01::gpt-4o') // arbitrary model that we expect to be included
+            expect(models.map(({model}) => model.id)).toContain('openai::2024-02-01::gpt-4o') // arbitrary model that we expect to be included
         })
 
         it('switches to a different account', async ({ task }) => {
@@ -177,7 +177,7 @@ describe(
 
             // Enterprise models should not contain models with the waitlist tag.
             const enterpriseModels = await client.request('chat/models', { modelUsage: ModelUsage.Chat })
-            expect(enterpriseModels.models?.some(m => m.tags.includes(ModelTag.Waitlist))).toBeFalsy()
+            expect(enterpriseModels.models?.some(({model}) => model.tags.includes(ModelTag.Waitlist))).toBeFalsy()
 
             // The chat that we started before switching accounts should not be usable from the new
             // account.
@@ -198,7 +198,7 @@ describe(
             // Listing models should work.
             const { models } = await client.request('chat/models', { modelUsage: ModelUsage.Chat })
             expect(models.length).toBeGreaterThanOrEqual(2)
-            expect(models.map(model => toModelRefStr(model.modelRef!))).toContain(
+            expect(models.map(({model}) => toModelRefStr(model.modelRef!))).toContain(
                 'openai::2024-02-01::gpt-4o' // arbitrary model that we expect to be included
             )
         })

--- a/agent/src/cli/command-chat.ts
+++ b/agent/src/cli/command-chat.ts
@@ -186,7 +186,7 @@ export async function chatAction(options: ChatOptions): Promise<number> {
             const lastMessage = message.message.messages.at(-1)
             if (lastMessage?.model && !spinner.text.startsWith('Model')) {
                 const modelName =
-                    models.find(model => model.id === lastMessage.model)?.title ?? lastMessage.model
+                    models.find(({model}) => model.id === lastMessage.model)?.model.title ?? lastMessage.model
                 spinner.text = modelName
                 spinner.spinner = spinners.dots
             }

--- a/agent/src/cli/command-chat.ts
+++ b/agent/src/cli/command-chat.ts
@@ -186,7 +186,8 @@ export async function chatAction(options: ChatOptions): Promise<number> {
             const lastMessage = message.message.messages.at(-1)
             if (lastMessage?.model && !spinner.text.startsWith('Model')) {
                 const modelName =
-                    models.find(({model}) => model.id === lastMessage.model)?.model.title ?? lastMessage.model
+                    models.find(({ model }) => model.id === lastMessage.model)?.model.title ??
+                    lastMessage.model
                 spinner.text = modelName
                 spinner.spinner = spinners.dots
             }

--- a/agent/src/index.test.ts
+++ b/agent/src/index.test.ts
@@ -148,7 +148,9 @@ describe('Agent', () => {
         })
         expect(invalid?.authenticated).toBeFalsy()
         const invalidModels = await client.request('chat/models', { modelUsage: ModelUsage.Chat })
-        const remoteInvalidModels = invalidModels.models.filter(({model}) => model.provider !== 'Ollama')
+        const remoteInvalidModels = invalidModels.models.filter(
+            ({ model }) => model.provider !== 'Ollama'
+        )
         expect(remoteInvalidModels).toStrictEqual([])
 
         const valid = await client.request('extensionConfiguration/change', {

--- a/agent/src/index.test.ts
+++ b/agent/src/index.test.ts
@@ -136,7 +136,7 @@ describe('Agent', () => {
         // change.
         const initModelName = 'anthropic::2023-06-01::claude-3.5-sonnet'
         const { models } = await client.request('chat/models', { modelUsage: ModelUsage.Chat })
-        expect(models[0].id).toStrictEqual(initModelName)
+        expect(models[0].model.id).toStrictEqual(initModelName)
 
         const invalid = await client.request('extensionConfiguration/change', {
             ...client.info.extensionConfiguration,
@@ -148,7 +148,7 @@ describe('Agent', () => {
         })
         expect(invalid?.authenticated).toBeFalsy()
         const invalidModels = await client.request('chat/models', { modelUsage: ModelUsage.Chat })
-        const remoteInvalidModels = invalidModels.models.filter(model => model.provider !== 'Ollama')
+        const remoteInvalidModels = invalidModels.models.filter(({model}) => model.provider !== 'Ollama')
         expect(remoteInvalidModels).toStrictEqual([])
 
         const valid = await client.request('extensionConfiguration/change', {
@@ -166,7 +166,7 @@ describe('Agent', () => {
             modelUsage: ModelUsage.Chat,
         })
         expect(reauthenticatedModels.models).not.toStrictEqual([])
-        expect(reauthenticatedModels.models[0].id).toStrictEqual(initModelName)
+        expect(reauthenticatedModels.models[0].model.id).toStrictEqual(initModelName)
 
         // Please don't update the recordings to use a different account without consulting #team-cody-core.
         // When changing an account, you also need to update the REDACTED_ hash above.
@@ -272,7 +272,7 @@ describe('Agent', () => {
             } = await client.request('chat/models', { modelUsage: ModelUsage.Chat })
 
             const id2 = await client.request('chat/restore', {
-                modelID: model.id,
+                modelID: model.model.id,
                 messages: reply1.messages,
                 chatID: new Date().toISOString(), // Create new Chat ID with a different timestamp
             })

--- a/lib/shared/src/models/modelsService.ts
+++ b/lib/shared/src/models/modelsService.ts
@@ -207,6 +207,11 @@ export interface LocalStorageForModelPreferences {
     setModelPreferences(preferences: PerSitePreferences): Promise<void>
 }
 
+export interface ModelAvailabilityStatus {
+    model: Model
+    isModelAvailable: boolean
+}
+
 /**
  * ModelsService is the component responsible for keeping track of which models
  * are supported on the backend, which ones are available based on the user's
@@ -320,6 +325,16 @@ export class ModelsService {
             }),
             distinctUntilChanged(),
             shareReplay()
+        )
+    }
+
+    public async getModelsAvailabilityStatus(type: ModelUsage): Promise<ModelAvailabilityStatus[]> {
+        const models = await firstResultFromOperation(modelsService.getModels(type))
+        return Promise.all(
+            models.map(async model => {
+                const isModelAvailable = await firstResultFromOperation(this.isModelAvailable(model))
+                return { model, isModelAvailable }
+            })
         )
     }
 

--- a/vscode/src/jsonrpc/agent-protocol.ts
+++ b/vscode/src/jsonrpc/agent-protocol.ts
@@ -20,6 +20,7 @@ import type {
 } from '@sourcegraph/telemetry'
 import type * as vscode from 'vscode'
 
+import type { ModelAvailabilityStatus } from '@sourcegraph/cody-shared/dist/models/modelsService'
 import type { ExtensionMessage, WebviewMessage } from '../chat/protocol'
 import type { CompletionBookkeepingEvent, CompletionItemID } from '../completions/logger'
 import type { FixupTaskID } from '../non-stop/FixupTask'
@@ -78,7 +79,7 @@ export type ClientRequests = {
         string,
     ]
 
-    'chat/models': [{ modelUsage: ModelUsage }, { models: Model[] }]
+    'chat/models': [{ modelUsage: ModelUsage }, { models: ModelAvailabilityStatus[] }]
     'chat/export': [null | { fullHistory: boolean }, ChatExportResult[]]
 
     // history is Map of {endpoint}-{username} to chat transcripts by date


### PR DESCRIPTION
## Changes

This change will allow clients to know if model is useable for them with  of manually fetching account tier and computing model availability.
This makes client code simpler, ensures the same conditions are used by both Cody and clients, and is less error prone.

## Test plan

This is only used in JetBrains currently.

Testplan on the JetBrains side:
https://github.com/sourcegraph/jetbrains/pull/2386