### PR TITLE
Fix styling of avatar component when no avatarURL is present

### DIFF
--- a/vscode/webviews/components/UserAvatar.module.css
+++ b/vscode/webviews/components/UserAvatar.module.css
@@ -6,7 +6,7 @@
     color: var(--vscode-inputOption-activeForeground);
     align-items: center;
     justify-content: center;
-    height: fit-content;
+    height: 100%;
 }
 
 .sourcegraph-gradient-border {


### PR DESCRIPTION
This is a stop-gap commit that fixes the users profile picture so that it doesn't break the UI. The previous behavior can be viewed [in this issue](https://linear.app/sourcegraph/issue/SRCH-1139/fix-chat-ui-issues-caused-by-profile-pictures-in-cody).

Ultimately, we should follow up with another PR with a more elegant solution, but this fixes the immediate problem. 

## Test plan
- Pass a broken avatar link into the UserAvatar component and make sure it doesn't break the UI.
- Passing CI
<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

## Changelog
<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
- Fixes a bug where avatar's were stretching to fit the content of the alt text instead of remaining a static size. 
