### PR TITLE
use the current document to track range for persistence

### DIFF
--- a/vscode/src/completions/inline-completion-item-provider.ts
+++ b/vscode/src/completions/inline-completion-item-provider.ts
@@ -861,8 +861,6 @@ export class InlineCompletionItemProvider
                     suggestionEvent.markAsRead({
                         document: invokedDocument,
                         position: invokedPosition,
-                        completePrefix: completion.requestParams.docContext.completePrefix,
-                        completeSuffix: completion.requestParams.docContext.completeSuffix,
                     })
                 }
             }, this.COMPLETION_VISIBLE_DELAY_MS)

--- a/vscode/src/completions/logger.test.ts
+++ b/vscode/src/completions/logger.test.ts
@@ -79,8 +79,6 @@ describe('logger', () => {
         suggestionEvent?.markAsRead({
             document,
             position,
-            completePrefix: defaultRequestParams.docContext.completePrefix,
-            completeSuffix: defaultRequestParams.docContext.completeSuffix,
         })
         CompletionLogger.accepted(id, document, item, range(0, 0, 0, 0), false)
 
@@ -119,8 +117,6 @@ describe('logger', () => {
         firstSuggestionEvent?.markAsRead({
             document,
             position,
-            completePrefix: defaultRequestParams.docContext.completePrefix,
-            completeSuffix: defaultRequestParams.docContext.completeSuffix,
         })
 
         const loggerItem = CompletionLogger.getCompletionEvent(id1)
@@ -142,8 +138,6 @@ describe('logger', () => {
         secondSuggestionEvent?.markAsRead({
             document,
             position,
-            completePrefix: defaultRequestParams.docContext.completePrefix,
-            completeSuffix: defaultRequestParams.docContext.completeSuffix,
         })
         CompletionLogger.accepted(id2, document, item, range(0, 0, 0, 0), false)
 
@@ -172,8 +166,6 @@ describe('logger', () => {
         thirdSuggestionEvent?.markAsRead({
             document,
             position,
-            completePrefix: defaultRequestParams.docContext.completePrefix,
-            completeSuffix: defaultRequestParams.docContext.completeSuffix,
         })
 
         const loggerItem3 = CompletionLogger.getCompletionEvent(id3)

--- a/vscode/src/completions/logger.ts
+++ b/vscode/src/completions/logger.ts
@@ -776,9 +776,7 @@ function getInlineContextItemContext(
 function suggestionDocumentDiffTracker(
     interactionId: CompletionAnalyticsID,
     document: vscode.TextDocument,
-    position: vscode.Position,
-    completePrefix: string,
-    completeSuffix: string
+    position: vscode.Position
 ): void {
     // If user is not in the same document, we don't track the diff.
     if (document.uri.scheme !== 'file') {
@@ -795,12 +793,12 @@ function suggestionDocumentDiffTracker(
         Math.min(document.getText().length, document.offsetAt(position) + offsetBytes)
     )
     const trackingRange = new vscode.Range(startPosition, endPosition)
-    const documentText = completePrefix.slice(-offsetBytes) + completeSuffix.slice(0, offsetBytes)
+    const documentText = document.getText(trackingRange)
 
     const persistenceTimeoutList = [
-        15 * 1000, // 15 seconds
-        30 * 1000, // 30 seconds
+        20 * 1000, // 20 seconds
         60 * 1000, // 60 seconds
+        120 * 1000, // 120 seconds
     ]
     persistenceTracker.track({
         id: interactionId,
@@ -820,8 +818,6 @@ function suggestionDocumentDiffTracker(
 type SuggestionMarkReadParam = {
     document: vscode.TextDocument
     position: vscode.Position
-    completePrefix: string
-    completeSuffix: string
 }
 
 // Suggested completions will not be logged immediately. Instead, we log them when we either hide
@@ -879,13 +875,7 @@ export function prepareSuggestionEvent({
                     isDotCom(authStatus.endpoint || '') &&
                     event.params.inlineCompletionItemContext?.isRepoPublic
                 ) {
-                    suggestionDocumentDiffTracker(
-                        event.params.id,
-                        param.document,
-                        param.position,
-                        param.completePrefix,
-                        param.completeSuffix
-                    )
+                    suggestionDocumentDiffTracker(event.params.id, param.document, param.position)
                 }
             },
         }


### PR DESCRIPTION
Use the current document for tracking the insertText. Using the pre-calculated text was making the offline diffs inaccurate, as introduced in the [PR](https://github.com/sourcegraph/cody/pull/5767/files).

## Test plan
CI checks