### PR TITLE
Revert "use the current document to track range for persistence"

### DIFF
--- a/vscode/src/completions/inline-completion-item-provider.ts
+++ b/vscode/src/completions/inline-completion-item-provider.ts
@@ -861,6 +861,8 @@ export class InlineCompletionItemProvider
                     suggestionEvent.markAsRead({
                         document: invokedDocument,
                         position: invokedPosition,
+                        completePrefix: completion.requestParams.docContext.completePrefix,
+                        completeSuffix: completion.requestParams.docContext.completeSuffix,
                     })
                 }
             }, this.COMPLETION_VISIBLE_DELAY_MS)

--- a/vscode/src/completions/logger.test.ts
+++ b/vscode/src/completions/logger.test.ts
@@ -79,6 +79,8 @@ describe('logger', () => {
         suggestionEvent?.markAsRead({
             document,
             position,
+            completePrefix: defaultRequestParams.docContext.completePrefix,
+            completeSuffix: defaultRequestParams.docContext.completeSuffix,
         })
         CompletionLogger.accepted(id, document, item, range(0, 0, 0, 0), false)
 
@@ -117,6 +119,8 @@ describe('logger', () => {
         firstSuggestionEvent?.markAsRead({
             document,
             position,
+            completePrefix: defaultRequestParams.docContext.completePrefix,
+            completeSuffix: defaultRequestParams.docContext.completeSuffix,
         })
 
         const loggerItem = CompletionLogger.getCompletionEvent(id1)
@@ -138,6 +142,8 @@ describe('logger', () => {
         secondSuggestionEvent?.markAsRead({
             document,
             position,
+            completePrefix: defaultRequestParams.docContext.completePrefix,
+            completeSuffix: defaultRequestParams.docContext.completeSuffix,
         })
         CompletionLogger.accepted(id2, document, item, range(0, 0, 0, 0), false)
 
@@ -166,6 +172,8 @@ describe('logger', () => {
         thirdSuggestionEvent?.markAsRead({
             document,
             position,
+            completePrefix: defaultRequestParams.docContext.completePrefix,
+            completeSuffix: defaultRequestParams.docContext.completeSuffix,
         })
 
         const loggerItem3 = CompletionLogger.getCompletionEvent(id3)


### PR DESCRIPTION
Reverts sourcegraph/cody#5812