### PR TITLE
DeepCody: Enhance error handling for disallowed shell commands

### DIFF
--- a/vscode/src/commands/context/shell.ts
+++ b/vscode/src/commands/context/shell.ts
@@ -36,7 +36,7 @@ export async function getContextFileFromShell(command: string): Promise<ContextI
         const filteredCommand = command.replaceAll(/(\s~\/)/g, ` ${homeDir}${path.sep}`)
 
         try {
-            if (filter(commandsNotAllowed, cmd => filteredCommand.startsWith(cmd)).length > 0) {
+            if (commandsNotAllowed.some(cmd => filteredCommand.startsWith(cmd)) {
                 void vscode.window.showErrorMessage('Cody cannot execute this command')
                 throw new Error('Cody cannot execute this command')
             }

--- a/vscode/src/commands/context/shell.ts
+++ b/vscode/src/commands/context/shell.ts
@@ -36,11 +36,8 @@ export async function getContextFileFromShell(command: string): Promise<ContextI
         const filteredCommand = command.replaceAll(/(\s~\/)/g, ` ${homeDir}${path.sep}`)
 
         try {
-
             if (filter(commandsNotAllowed, cmd => filteredCommand.startsWith(cmd)).length > 0) {
-                void vscode.window.showErrorMessage(
-                    `Cody cannot execute this command`
-                )
+                void vscode.window.showErrorMessage('Cody cannot execute this command')
                 throw new Error('Cody cannot execute this command')
             }
 

--- a/vscode/src/commands/context/shell.ts
+++ b/vscode/src/commands/context/shell.ts
@@ -36,7 +36,7 @@ export async function getContextFileFromShell(command: string): Promise<ContextI
         const filteredCommand = command.replaceAll(/(\s~\/)/g, ` ${homeDir}${path.sep}`)
 
         try {
-            if (commandsNotAllowed.some(cmd => filteredCommand.startsWith(cmd)) {
+            if (commandsNotAllowed.some(cmd => filteredCommand.startsWith(cmd))) {
                 void vscode.window.showErrorMessage('Cody cannot execute this command')
                 throw new Error('Cody cannot execute this command')
             }

--- a/vscode/src/commands/context/shell.ts
+++ b/vscode/src/commands/context/shell.ts
@@ -35,11 +35,15 @@ export async function getContextFileFromShell(command: string): Promise<ContextI
         const cwd = vscode.workspace.workspaceFolders?.[0]?.uri?.fsPath
         const filteredCommand = command.replaceAll(/(\s~\/)/g, ` ${homeDir}${path.sep}`)
 
-        if (filter(commandsNotAllowed, cmd => filteredCommand.startsWith(cmd)).length > 0) {
-            throw new Error('Cody cannot execute this command')
-        }
-
         try {
+
+            if (filter(commandsNotAllowed, cmd => filteredCommand.startsWith(cmd)).length > 0) {
+                void vscode.window.showErrorMessage(
+                    `Cody cannot execute this command`
+                )
+                throw new Error('Cody cannot execute this command')
+            }
+
             const { stdout, stderr } = await execAsync(filteredCommand, { cwd, encoding: 'utf8' })
             const output = JSON.stringify(stdout || stderr).trim()
             if (!output || output === '""') {

--- a/vscode/src/commands/context/shell.ts
+++ b/vscode/src/commands/context/shell.ts
@@ -8,7 +8,6 @@ import {
     TokenCounterUtils,
     wrapInActiveSpan,
 } from '@sourcegraph/cody-shared'
-import { filter } from 'lodash'
 import * as vscode from 'vscode'
 import { logError } from '../../log'
 


### PR DESCRIPTION
If DeepCody tries to execute a disallowed shell command, it will remain in the `thinking' state.

This PR fixes and improves the error handling mechanism for disallowed shell commands in the `getContextFileFromShell` function.

Changes:
- Relocated the disallowed command check inside the try block for better error management
- Implemented a user-facing error message using `vscode.window.showErrorMessage`
- Retained the existing error throw for maintaining consistency with error handling patterns

## Test plan
- Verified that disallowed commands trigger the new error message and DeepCody does not hang.
- Ensured that allowed commands continue to function as expected
- Checked that the error throw still occurs for proper error propagation

## Changelog
