### PR TITLE
do not block on fetching the user's Cody Pro subscription status when authing

### DIFF
--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/agent/protocol_generated/AuthStatus.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/agent/protocol_generated/AuthStatus.kt
@@ -43,7 +43,6 @@ data class AuthenticatedAuthStatus(
   val primaryEmail: String? = null,
   val displayName: String? = null,
   val avatarURL: String? = null,
-  val userCanUpgrade: Boolean? = null,
   val pendingValidation: Boolean,
 ) : AuthStatus() {
 }

--- a/lib/shared/src/auth/types.ts
+++ b/lib/shared/src/auth/types.ts
@@ -1,5 +1,6 @@
 import { isDotCom } from '../sourcegraph-api/environments'
 import type { CodyLLMSiteConfiguration } from '../sourcegraph-api/graphql/client'
+import type { UserProductSubscription } from '../sourcegraph-api/userProductSubscription'
 
 /**
  * The authentication status, which includes representing the state when authentication failed or
@@ -32,14 +33,7 @@ export interface AuthenticatedAuthStatus {
     primaryEmail?: string
     displayName?: string
     avatarURL?: string
-    /**
-     * Whether the users account can be upgraded.
-     *
-     * This is `true` if the user is on dotCom and has not already upgraded. It
-     * is used to customize rate limit messages and show additional upgrade
-     * buttons in the UI.
-     */
-    userCanUpgrade?: boolean
+
     pendingValidation: boolean
 
     /**
@@ -84,12 +78,12 @@ export const AUTH_STATUS_FIXTURE_AUTHED_DOTCOM: AuthenticatedAuthStatus = {
     },
 }
 
-export function isCodyProUser(authStatus: AuthStatus): boolean {
-    return isDotCom(authStatus) && authStatus.authenticated && !authStatus.userCanUpgrade
+export function isCodyProUser(authStatus: AuthStatus, sub: UserProductSubscription | null): boolean {
+    return isDotCom(authStatus) && authStatus.authenticated && sub !== null && !sub.userCanUpgrade
 }
 
-export function isFreeUser(authStatus: AuthStatus): boolean {
-    return isDotCom(authStatus) && authStatus.authenticated && !!authStatus.userCanUpgrade
+export function isFreeUser(authStatus: AuthStatus, sub: UserProductSubscription | null): boolean {
+    return isDotCom(authStatus) && authStatus.authenticated && sub !== null && !!sub.userCanUpgrade
 }
 
 export function isEnterpriseUser(authStatus: AuthStatus): boolean {

--- a/lib/shared/src/chat/chat.ts
+++ b/lib/shared/src/chat/chat.ts
@@ -19,11 +19,7 @@ export class ChatClient {
         private completions: SourcegraphCompletionsClient,
         private getAuthStatus: () => Pick<
             AuthenticatedAuthStatus,
-            | 'authenticated'
-            | 'userCanUpgrade'
-            | 'endpoint'
-            | 'codyApiVersion'
-            | 'isFireworksTracingEnabled'
+            'authenticated' | 'endpoint' | 'codyApiVersion' | 'isFireworksTracingEnabled'
         >
     ) {}
 

--- a/lib/shared/src/index.ts
+++ b/lib/shared/src/index.ts
@@ -382,3 +382,9 @@ export * from './singletons'
 export * from './auth/authStatus'
 export { fetchLocalOllamaModels } from './llm-providers/ollama/utils'
 export * from './editor/editorState'
+export {
+    currentUserProductSubscription,
+    type UserProductSubscription,
+    cachedUserProductSubscription,
+    userProductSubscription,
+} from './sourcegraph-api/userProductSubscription'

--- a/lib/shared/src/misc/observable.ts
+++ b/lib/shared/src/misc/observable.ts
@@ -546,13 +546,16 @@ export function pluck<T>(...keyPath: any[]): (input: ObservableLike<T>) => Obser
 }
 
 export function pick<T, K extends keyof T>(
-    key: K
+    ...keys: K[]
 ): (input: ObservableLike<T>) => Observable<Pick<T, K>> {
-    return map(
-        value =>
-            ({
-                [key]: value[key],
-            }) as Pick<T, K>
+    return map(value =>
+        keys.reduce(
+            (acc, key) => {
+                acc[key] = value[key]
+                return acc
+            },
+            {} as Pick<T, K>
+        )
     )
 }
 

--- a/lib/shared/src/misc/rpc/webviewAPI.ts
+++ b/lib/shared/src/misc/rpc/webviewAPI.ts
@@ -1,5 +1,5 @@
 import { Observable } from 'observable-fns'
-import type { AuthStatus, ModelsData, ResolvedConfiguration } from '../..'
+import type { AuthStatus, ModelsData, ResolvedConfiguration, UserProductSubscription } from '../..'
 import type { ChatMessage, UserLocalHistory } from '../../chat/transcript/messages'
 import type { ContextItem } from '../../codebase-context/messages'
 import type { CodyCommand } from '../../commands/types'
@@ -76,6 +76,11 @@ export interface WebviewToExtensionAPI {
      * The current user's chat history.
      */
     userHistory(): Observable<UserLocalHistory | null>
+
+    /**
+     * The current user's product subscription information (Cody Free/Pro).
+     */
+    userProductSubscription(): Observable<UserProductSubscription | null>
 }
 
 export function createExtensionAPI(
@@ -100,6 +105,7 @@ export function createExtensionAPI(
         authStatus: proxyExtensionAPI(messageAPI, 'authStatus'),
         transcript: proxyExtensionAPI(messageAPI, 'transcript'),
         userHistory: proxyExtensionAPI(messageAPI, 'userHistory'),
+        userProductSubscription: proxyExtensionAPI(messageAPI, 'userProductSubscription'),
     }
 }
 

--- a/lib/shared/src/models/sync.test.ts
+++ b/lib/shared/src/models/sync.test.ts
@@ -13,6 +13,7 @@ import {
 } from '../misc/observable'
 import { pendingOperation, skipPendingOperation } from '../misc/observableOperation'
 import type { CodyClientConfig } from '../sourcegraph-api/clientConfig'
+import * as userProductSubscriptionModule from '../sourcegraph-api/userProductSubscription'
 import type { PartialDeep } from '../utils'
 import {
     type Model,
@@ -218,6 +219,9 @@ describe('server sent models', async () => {
     })
 
     it("sets server models and default models if they're not already set", async () => {
+        vi.spyOn(userProductSubscriptionModule, 'userProductSubscription', 'get').mockReturnValue(
+            Observable.of({ userCanUpgrade: true })
+        )
         // expect all defaults to be set
         expect(await firstValueFrom(modelsService.getDefaultChatModel())).toBe(opus.id)
         expect(await firstValueFrom(modelsService.getDefaultEditModel())).toBe(opus.id)

--- a/lib/shared/src/sourcegraph-api/userProductSubscription.ts
+++ b/lib/shared/src/sourcegraph-api/userProductSubscription.ts
@@ -1,0 +1,97 @@
+import { Observable, map } from 'observable-fns'
+import { authStatus } from '../auth/authStatus'
+import { logError } from '../logger'
+import {
+    debounceTime,
+    distinctUntilChanged,
+    pick,
+    promiseFactoryToObservable,
+    storeLastValue,
+} from '../misc/observable'
+import {
+    firstResultFromOperation,
+    pendingOperation,
+    switchMapReplayOperation,
+} from '../misc/observableOperation'
+import { isError } from '../utils'
+import { isDotCom } from './environments'
+import { graphqlClient } from './graphql'
+
+export interface UserProductSubscription {
+    // TODO(sqs): this is the only field related to the user's subscription we were using previously
+    // in AuthStatus, so start with just it and we can add more.
+
+    /**
+     * Whether the user is on Cody Free (i.e., can upgrade to Cody Pro). This is `false` for
+     * enterprise users because they already have a higher degree of access than Cody Free/Pro.
+     *
+     * It's used to customize rate limit messages and show upgrade buttons in the UI.
+     */
+    userCanUpgrade: boolean
+}
+
+/**
+ * Observe the currently authenticated user's Cody subscription status (for Sourcegraph.com Cody
+ * Free/Pro users only).
+ */
+export const userProductSubscription: Observable<
+    UserProductSubscription | null | typeof pendingOperation
+> = authStatus.pipe(
+    pick('authenticated', 'endpoint', 'pendingValidation'),
+    distinctUntilChanged(),
+    debounceTime(0),
+    switchMapReplayOperation(
+        (authStatus): Observable<UserProductSubscription | Error | null | typeof pendingOperation> => {
+            if (authStatus.pendingValidation) {
+                return Observable.of(pendingOperation)
+            }
+
+            if (!authStatus.authenticated) {
+                return Observable.of(null)
+            }
+
+            if (!isDotCom(authStatus)) {
+                return Observable.of(null)
+            }
+
+            return promiseFactoryToObservable(signal =>
+                graphqlClient.getCurrentUserCodySubscription(signal)
+            ).pipe(
+                map((sub): UserProductSubscription | null | typeof pendingOperation => {
+                    if (isError(sub)) {
+                        logError(
+                            'userProductSubscription',
+                            `Failed to get the Cody product subscription info from ${authStatus.endpoint}: ${sub}`
+                        )
+                        return null
+                    }
+                    const isActiveProUser =
+                        sub !== null && 'plan' in sub && sub.plan === 'PRO' && sub.status !== 'PENDING'
+                    return {
+                        userCanUpgrade: !isActiveProUser,
+                    }
+                })
+            )
+        }
+    ),
+    map(result => (isError(result) ? null : result)) // the operation catches its own errors, so errors will never get here
+)
+
+const userProductSubscriptionStorage = storeLastValue(userProductSubscription)
+
+/**
+ * Get the current user's product subscription info. If authentication is pending, it awaits
+ * successful authentication.
+ */
+export function currentUserProductSubscription(): Promise<UserProductSubscription | null> {
+    return firstResultFromOperation(userProductSubscriptionStorage.observable)
+}
+
+/**
+ * Get the current user's last-known product subscription info. Using this introduce a race
+ * condition if auth is pending.
+ */
+export function cachedUserProductSubscription(): UserProductSubscription | null {
+    const value = userProductSubscriptionStorage.value.last
+    return value === pendingOperation || !value ? null : value
+}

--- a/lib/shared/src/telemetry-v2/TelemetryRecorderProvider.ts
+++ b/lib/shared/src/telemetry-v2/TelemetryRecorderProvider.ts
@@ -19,6 +19,10 @@ import { currentAuthStatusOrNotReadyYet } from '../auth/authStatus'
 import type { AuthStatus } from '../auth/types'
 import { clientCapabilities } from '../configuration/clientCapabilities'
 import type { PickResolvedConfiguration } from '../configuration/resolver'
+import {
+    type UserProductSubscription,
+    cachedUserProductSubscription,
+} from '../sourcegraph-api/userProductSubscription'
 import { getTier } from './cody-tier'
 
 export interface ExtensionDetails {
@@ -184,13 +188,15 @@ class ConfigurationMetadataProcessor implements TelemetryProcessor {
         // The tier is not known yet when the user is not authed, and
         // `this.authStatusProvider.status` will throw, so omit it.
         let authStatus: AuthStatus | undefined
+        let sub: UserProductSubscription | null = null
         try {
             authStatus = currentAuthStatusOrNotReadyYet()
+            sub = cachedUserProductSubscription()
         } catch {}
         if (authStatus) {
             event.parameters.metadata.push({
                 key: 'tier',
-                value: getTier(authStatus),
+                value: getTier(authStatus, sub),
             })
         }
     }

--- a/lib/shared/src/telemetry-v2/cody-tier.ts
+++ b/lib/shared/src/telemetry-v2/cody-tier.ts
@@ -1,5 +1,6 @@
 import type { AuthStatus } from '../auth/types'
 import { isDotCom } from '../sourcegraph-api/environments'
+import type { UserProductSubscription } from '../sourcegraph-api/userProductSubscription'
 
 enum CodyTier {
     Free = 0,
@@ -7,12 +8,15 @@ enum CodyTier {
     Enterprise = 2,
 }
 
-export function getTier(authStatus: AuthStatus): CodyTier | undefined {
+export function getTier(
+    authStatus: AuthStatus,
+    sub: UserProductSubscription | null
+): CodyTier | undefined {
     return !authStatus.authenticated
         ? undefined
         : !isDotCom(authStatus)
           ? CodyTier.Enterprise
-          : authStatus.userCanUpgrade
+          : !sub || sub.userCanUpgrade
             ? CodyTier.Free
             : CodyTier.Pro
 }

--- a/vscode/src/auth/account-menu.ts
+++ b/vscode/src/auth/account-menu.ts
@@ -1,6 +1,8 @@
 import {
     type AuthenticatedAuthStatus,
+    type UserProductSubscription,
     currentAuthStatusAuthed,
+    currentUserProductSubscription,
     isDotCom,
 } from '@sourcegraph/cody-shared'
 import * as vscode from 'vscode'
@@ -9,7 +11,8 @@ import { showSignInMenu, showSignOutMenu } from './auth'
 
 export async function showAccountMenu(): Promise<void> {
     const authStatus = currentAuthStatusAuthed()
-    const selected = await openAccountMenuFirstStep(authStatus)
+    const sub = await currentUserProductSubscription()
+    const selected = await openAccountMenuFirstStep(authStatus, sub)
     if (selected === undefined) {
         return
     }
@@ -39,14 +42,15 @@ enum AccountMenuOptions {
 }
 
 async function openAccountMenuFirstStep(
-    authStatus: AuthenticatedAuthStatus
+    authStatus: AuthenticatedAuthStatus,
+    sub: UserProductSubscription | null
 ): Promise<AccountMenuOptions | undefined> {
     const isDotComInstance = isDotCom(authStatus.endpoint)
 
     const displayName = authStatus.displayName || authStatus.username
     const email = authStatus.primaryEmail || 'No Email'
     const username = authStatus.username || authStatus.displayName
-    const planDetail = `Plan: ${authStatus.userCanUpgrade ? 'Cody Free' : 'Cody Pro'}`
+    const planDetail = sub ? `Plan: ${sub.userCanUpgrade ? 'Cody Free' : 'Cody Pro'}` : ''
     const enterpriseDetail = `Enterprise Instance:\n${authStatus.endpoint}`
 
     const options = isDotComInstance ? [AccountMenuOptions.Manage] : []

--- a/vscode/src/auth/auth.ts
+++ b/vscode/src/auth/auth.ts
@@ -463,42 +463,14 @@ export async function validateCredentials(
     }
 
     logDebug('auth', `Authentication succeeed to endpoint ${config.auth.serverEndpoint}`)
-
     const configOverwrites = isError(codyLLMConfiguration) ? undefined : codyLLMConfiguration
 
-    if (!isDotCom(config.auth.serverEndpoint)) {
-        return newAuthStatus({
-            ...userInfo,
-            endpoint: config.auth.serverEndpoint,
-            siteVersion,
-            configOverwrites,
-            authenticated: true,
-            hasVerifiedEmail: false,
-            userCanUpgrade: false,
-        })
-    }
-
-    logDebug('auth', `Checking Cody subscription status for user ${userInfo.username}`)
-    const proStatus = await client.getCurrentUserCodySubscription(signal)
-    signal?.throwIfAborted()
-    if (isError(proStatus)) {
-        logDebug('auth', 'Error checking Cody subscription status', proStatus.message)
-    }
-    const isActiveProUser =
-        proStatus !== null &&
-        'plan' in proStatus &&
-        proStatus.plan === 'PRO' &&
-        proStatus.status !== 'PENDING'
-    logDebug(
-        'auth',
-        `Checked Cody subscription status for user ${userInfo.username}: isActiveProUser=${isActiveProUser}`
-    )
     return newAuthStatus({
         ...userInfo,
-        authenticated: true,
         endpoint: config.auth.serverEndpoint,
         siteVersion,
         configOverwrites,
-        userCanUpgrade: !isActiveProUser,
+        authenticated: true,
+        hasVerifiedEmail: false,
     })
 }

--- a/vscode/src/chat/agentic/DeepCody.test.ts
+++ b/vscode/src/chat/agentic/DeepCody.test.ts
@@ -26,13 +26,11 @@ describe('DeepCody', () => {
         ...AUTH_STATUS_FIXTURE_AUTHED,
         endpoint: DOTCOM_URL.toString(),
         authenticated: true,
-        userCanUpgrade: false,
     }
     const enterpriseAuthStatus: AuthenticatedAuthStatus = {
         ...AUTH_STATUS_FIXTURE_AUTHED,
         endpoint: 'https://example.sourcegraph.com',
         authenticated: true,
-        userCanUpgrade: false,
     }
 
     let mockChatBuilder: ChatBuilder

--- a/vscode/src/chat/chat-view/ChatController.ts
+++ b/vscode/src/chat/chat-view/ChatController.ts
@@ -45,6 +45,7 @@ import {
     currentAuthStatus,
     currentAuthStatusAuthed,
     currentResolvedConfig,
+    currentUserProductSubscription,
     featureFlagProvider,
     getContextForChatMessage,
     graphqlClient,
@@ -70,6 +71,7 @@ import {
     telemetryRecorder,
     tracer,
     truncatePromptString,
+    userProductSubscription,
 } from '@sourcegraph/cody-shared'
 
 import type { Span } from '@opentelemetry/api'
@@ -550,6 +552,7 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
             config: configForWebview,
             clientCapabilities: clientCapabilities(),
             authStatus: authStatus,
+            userProductSubscription: await currentUserProductSubscription(),
             workspaceFolderUris,
             configFeatures: {
                 // If clientConfig is undefined means we were unable to fetch the client configuration -
@@ -1614,6 +1617,10 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
                     transcript: () =>
                         this.chatBuilder.changes.pipe(map(chat => chat.getDehydratedMessages())),
                     userHistory: () => chatHistory.changes,
+                    userProductSubscription: () =>
+                        userProductSubscription.pipe(
+                            map(value => (value === pendingOperation ? null : value))
+                        ),
                 }
             )
         )

--- a/vscode/src/chat/protocol.ts
+++ b/vscode/src/chat/protocol.ts
@@ -11,6 +11,7 @@ import type {
     RequestMessage,
     ResponseMessage,
     SerializedChatMessage,
+    UserProductSubscription,
 } from '@sourcegraph/cody-shared'
 
 import type { BillingCategory, BillingProduct } from '@sourcegraph/cody-shared/src/telemetry-v2'
@@ -137,6 +138,7 @@ export type ExtensionMessage =
           config: ConfigurationSubsetForWebview & LocalEnv
           clientCapabilities: ClientCapabilities
           authStatus: AuthStatus
+          userProductSubscription?: UserProductSubscription | null | undefined
           configFeatures: {
               chat: boolean
               attribution: boolean

--- a/vscode/src/chat/utils.ts
+++ b/vscode/src/chat/utils.ts
@@ -15,7 +15,6 @@ type NewAuthStatusOptions = { endpoint: string } & (
           | 'hasVerifiedEmail'
           | 'displayName'
           | 'avatarURL'
-          | 'userCanUpgrade'
       > & {
           organizations?: CurrentUserInfo['organizations']
           primaryEmail?:

--- a/vscode/src/completions/fast-path-client.ts
+++ b/vscode/src/completions/fast-path-client.ts
@@ -10,8 +10,8 @@ import {
     addTraceparent,
     contextFiltersProvider,
     createSSEIterator,
-    currentAuthStatusAuthed,
     currentResolvedConfig,
+    currentUserProductSubscription,
     getActiveTraceAndSpanId,
     isAbortError,
     isNodeResponse,
@@ -118,7 +118,8 @@ export function createFastPathClient(
         // identical to the SG instance response but does not contain information on whether a user
         // is eligible to upgrade to the pro plan. We get this from the authState instead.
         if (response.status === 429) {
-            const upgradeIsAvailable = !!currentAuthStatusAuthed().userCanUpgrade
+            const sub = await currentUserProductSubscription()
+            const upgradeIsAvailable = sub !== null && !!sub.userCanUpgrade
 
             throw recordErrorToSpan(
                 span,

--- a/vscode/src/completions/providers/shared/create-provider.test.ts
+++ b/vscode/src/completions/providers/shared/create-provider.test.ts
@@ -6,6 +6,7 @@ import {
     AUTH_STATUS_FIXTURE_AUTHED_DOTCOM,
     type CodyLLMSiteConfiguration,
     type ModelsData,
+    type UserProductSubscription,
     featureFlagProvider,
     firstValueFrom,
     mockAuthStatus,
@@ -15,10 +16,14 @@ import {
 
 import { mockLocalStorage } from '../../../services/LocalStorageProvider'
 
+import * as userProductSubscriptionModule from '../../../../../lib/shared/src/sourcegraph-api/userProductSubscription'
 import { createProvider } from './create-provider'
 import type { Provider } from './provider'
 
 async function createProviderForTest(...args: Parameters<typeof createProvider>): Promise<Provider> {
+    vi.spyOn(userProductSubscriptionModule, 'userProductSubscription', 'get').mockReturnValue(
+        Observable.of<UserProductSubscription | null>({ userCanUpgrade: false })
+    )
     const providerOrError = await firstValueFrom(createProvider(...args).pipe(skipPendingOperation()))
 
     if (providerOrError instanceof Error) {

--- a/vscode/src/edit/input/get-input.ts
+++ b/vscode/src/edit/input/get-input.ts
@@ -8,7 +8,7 @@ import {
     ModelUsage,
     PromptString,
     SYMBOL_CONTEXT_MENTION_PROVIDER,
-    currentAuthStatusAuthed,
+    currentUserProductSubscription,
     displayLineRange,
     firstResultFromOperation,
     modelsService,
@@ -96,8 +96,8 @@ export const getInput = async (
               ? EXPANDED_RANGE_ITEM
               : SELECTION_RANGE_ITEM
 
-    const authStatus = currentAuthStatusAuthed()
-    const isCodyPro = !authStatus.userCanUpgrade
+    const sub = await currentUserProductSubscription()
+    const isCodyPro = Boolean(sub && !sub.userCanUpgrade)
     const modelOptions = await firstResultFromOperation(modelsService.getModels(ModelUsage.Edit))
     const modelItems = getModelOptionItems(modelOptions, isCodyPro)
     const showModelSelector = modelOptions.length > 1

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -17,6 +17,7 @@ import {
     contextFiltersProvider,
     createDisposables,
     currentAuthStatus,
+    currentUserProductSubscription,
     distinctUntilChanged,
     featureFlagProvider,
     fromVSCodeEvent,
@@ -574,6 +575,7 @@ function registerUpgradeHandlers(disposables: vscode.Disposable[]): void {
         // Check if user has just moved back from a browser window to upgrade cody pro
         vscode.window.onDidChangeWindowState(async ws => {
             const authStatus = currentAuthStatus()
+            const sub = await currentUserProductSubscription()
             if (ws.focused && isDotCom(authStatus) && authStatus.authenticated) {
                 const res = await graphqlClient.getCurrentUserCodyProEnabled()
                 if (res instanceof Error) {
@@ -581,7 +583,7 @@ function registerUpgradeHandlers(disposables: vscode.Disposable[]): void {
                     return
                 }
                 // Re-auth if user's cody pro status has changed
-                const isCurrentCodyProUser = !authStatus.userCanUpgrade
+                const isCurrentCodyProUser = sub && !sub.userCanUpgrade
                 if (res && res.codyProEnabled !== isCurrentCodyProUser) {
                     authProvider.refresh()
                 }

--- a/vscode/webviews/App.story.tsx
+++ b/vscode/webviews/App.story.tsx
@@ -40,6 +40,7 @@ const dummyVSCodeAPI: VSCodeWrapper = {
                 siteVersion: '5.1.0',
                 endpoint: 'https://example.com',
             },
+            userProductSubscription: null,
             configFeatures: { attribution: true, chat: true, serverSentModels: true },
             workspaceFolderUris: [],
             isDotComUser: true,

--- a/vscode/webviews/AppWrapperForTest.tsx
+++ b/vscode/webviews/AppWrapperForTest.tsx
@@ -119,6 +119,7 @@ export const AppWrapperForTest: FunctionComponent<{ children: ReactNode }> = ({ 
                                 },
                             },
                         }),
+                    userProductSubscription: () => Observable.of(null),
                 },
             } satisfies Wrapper<ComponentProps<typeof ExtensionAPIProviderForTestsOnly>['value']>,
             {
@@ -129,6 +130,7 @@ export const AppWrapperForTest: FunctionComponent<{ children: ReactNode }> = ({ 
                             endpoint: 'https://sourcegraph.example.com',
                             authenticated: true,
                         } satisfies Partial<AuthStatus> as any,
+                        userProductSubscription: null,
                         config: {} as any,
                         clientCapabilities: CLIENT_CAPABILITIES_FIXTURE,
                         configFeatures: {

--- a/vscode/webviews/utils/useConfig.tsx
+++ b/vscode/webviews/utils/useConfig.tsx
@@ -12,7 +12,12 @@ import type { UserAccountInfo } from '../Chat'
 export interface Config
     extends Pick<
         Extract<ExtensionMessage, { type: 'config' }>,
-        'config' | 'clientCapabilities' | 'authStatus' | 'configFeatures' | 'isDotComUser'
+        | 'config'
+        | 'clientCapabilities'
+        | 'authStatus'
+        | 'configFeatures'
+        | 'isDotComUser'
+        | 'userProductSubscription'
     > {}
 
 const ConfigContext = createContext<Config | null>(null)
@@ -45,7 +50,7 @@ export function useUserAccountInfo(): UserAccountInfo {
         )
     }
     return {
-        isCodyProUser: isCodyProUser(value.authStatus),
+        isCodyProUser: isCodyProUser(value.authStatus, value.userProductSubscription ?? null),
         // Receive this value from the extension backend to make it work
         // with E2E tests where change the DOTCOM_URL via the env variable TESTING_DOTCOM_URL.
         isDotComUser: value.isDotComUser,


### PR DESCRIPTION
This moves the user's product subscription status to a separate global observable, which saves one roundtrip and at least ~300ms from the time it takes to sign in when using Sourcegraph.com.

## Test plan

CI & e2e