### PR TITLE
do not block on getting the site version or is-cody-enabled during auth

### DIFF
--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/agent/protocol_generated/AuthStatus.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/agent/protocol_generated/AuthStatus.kt
@@ -37,8 +37,6 @@ data class AuthenticatedAuthStatus(
   val isFireworksTracingEnabled: Boolean? = null,
   val hasVerifiedEmail: Boolean? = null,
   val requiresVerifiedEmail: Boolean? = null,
-  val siteVersion: String,
-  val codyApiVersion: Long,
   val configOverwrites: CodyLLMSiteConfiguration? = null,
   val primaryEmail: String? = null,
   val displayName: String? = null,

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/agent/protocol_generated/ServerInfo.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/agent/protocol_generated/ServerInfo.kt
@@ -4,7 +4,6 @@ package com.sourcegraph.cody.agent.protocol_generated;
 data class ServerInfo(
   val name: String,
   val authenticated: Boolean? = null,
-  val codyVersion: String? = null,
   val authStatus: AuthStatus? = null,
 )
 

--- a/agent/src/agent.ts
+++ b/agent/src/agent.ts
@@ -477,7 +477,6 @@ export class Agent extends MessageHandler implements ExtensionClient {
                 return {
                     name: 'cody-agent',
                     authenticated: authStatus?.authenticated ?? false,
-                    codyVersion: authStatus?.authenticated ? authStatus.siteVersion : undefined,
                     authStatus,
                 }
             } catch (error) {

--- a/lib/shared/package.json
+++ b/lib/shared/package.json
@@ -44,7 +44,7 @@
     "@types/isomorphic-fetch": "^0.0.39",
     "@types/lodash": "^4.14.195",
     "@types/node-fetch": "^2.6.4",
-    "@types/semver": "^7.5.0",
+    "@types/semver": "^7.5.8",
     "@types/vscode": "^1.80.0",
     "type-fest": "^4.26.1"
   }

--- a/lib/shared/src/auth/types.ts
+++ b/lib/shared/src/auth/types.ts
@@ -26,8 +26,6 @@ export interface AuthenticatedAuthStatus {
 
     hasVerifiedEmail?: boolean
     requiresVerifiedEmail?: boolean
-    siteVersion: string
-    codyApiVersion: number
     configOverwrites?: CodyLLMSiteConfiguration
 
     primaryEmail?: string
@@ -58,8 +56,6 @@ export const AUTH_STATUS_FIXTURE_AUTHED: AuthenticatedAuthStatus = {
     endpoint: 'https://example.com',
     authenticated: true,
     username: 'alice',
-    codyApiVersion: 1,
-    siteVersion: '9999',
     pendingValidation: false,
 }
 

--- a/lib/shared/src/chat/chat.ts
+++ b/lib/shared/src/chat/chat.ts
@@ -1,10 +1,12 @@
-import type { AuthenticatedAuthStatus } from '../auth/types'
+import { authStatus } from '../auth/authStatus'
+import { firstValueFrom } from '../misc/observable'
 import type { Message } from '../sourcegraph-api'
 import type { SourcegraphCompletionsClient } from '../sourcegraph-api/completions/client'
 import type {
     CompletionGeneratorValue,
     CompletionParameters,
 } from '../sourcegraph-api/completions/types'
+import { currentSiteVersion } from '../sourcegraph-api/siteVersion'
 
 type ChatParameters = Omit<CompletionParameters, 'messages'>
 
@@ -15,28 +17,31 @@ const DEFAULT_CHAT_COMPLETION_PARAMETERS: Omit<ChatParameters, 'maxTokensToSampl
 }
 
 export class ChatClient {
-    constructor(
-        private completions: SourcegraphCompletionsClient,
-        private getAuthStatus: () => Pick<
-            AuthenticatedAuthStatus,
-            'authenticated' | 'endpoint' | 'codyApiVersion' | 'isFireworksTracingEnabled'
-        >
-    ) {}
+    constructor(private completions: SourcegraphCompletionsClient) {}
 
-    public chat(
+    public async chat(
         messages: Message[],
         params: Partial<ChatParameters> & Pick<ChatParameters, 'maxTokensToSample'>,
         abortSignal?: AbortSignal
-    ): AsyncGenerator<CompletionGeneratorValue> {
-        const authStatus = this.getAuthStatus()
-
+    ): Promise<AsyncGenerator<CompletionGeneratorValue>> {
         // Replace internal models used for wrapper models with the actual model ID.
         params.model = params.model?.replace(
             'sourcegraph::2023-06-01::deep-cody',
             'anthropic::2023-06-01::claude-3.5-sonnet'
         )
 
-        const useApiV1 = authStatus.codyApiVersion >= 1 && params.model?.includes('claude-3')
+        const [versions, authStatus_] = await Promise.all([
+            currentSiteVersion(),
+            await firstValueFrom(authStatus),
+        ])
+        if (!versions) {
+            throw new Error('unable to determine Cody API version')
+        }
+        if (!authStatus_.authenticated) {
+            throw new Error('not authenticated')
+        }
+
+        const useApiV1 = versions.codyAPIVersion >= 1 && params.model?.includes('claude-3')
         const isLastMessageFromHuman = messages.length > 0 && messages.at(-1)!.speaker === 'human'
 
         const isFireworks = params?.model?.startsWith('fireworks/')
@@ -62,13 +67,14 @@ export class ChatClient {
 
         // Enabled Fireworks tracing for Sourcegraph teammates.
         // https://readme.fireworks.ai/docs/enabling-tracing
+
         const customHeaders: Record<string, string> =
-            isFireworks && authStatus.isFireworksTracingEnabled ? { 'X-Fireworks-Genie': 'true' } : {}
+            isFireworks && authStatus_.isFireworksTracingEnabled ? { 'X-Fireworks-Genie': 'true' } : {}
 
         return this.completions.stream(
             completionParams,
             {
-                apiVersion: useApiV1 ? authStatus.codyApiVersion : 0,
+                apiVersion: useApiV1 ? versions.codyAPIVersion : 0,
                 customHeaders,
             },
             abortSignal

--- a/lib/shared/src/cody-ignore/context-filters-provider.test.ts
+++ b/lib/shared/src/cody-ignore/context-filters-provider.test.ts
@@ -29,7 +29,7 @@ describe('ContextFiltersProvider', () => {
         provider = new ContextFiltersProvider()
         vi.useFakeTimers()
 
-        vi.spyOn(graphqlClient, 'isCodyEnabled').mockResolvedValue({ enabled: true, version: '6.0.0' })
+        vi.spyOn(graphqlClient, 'getSiteVersion').mockResolvedValue('6.0.0')
     })
 
     afterEach(() => {
@@ -298,10 +298,7 @@ describe('ContextFiltersProvider', () => {
         }
 
         it('should handle the case when version is older than the supported version', async () => {
-            vi.spyOn(graphqlClient, 'isCodyEnabled').mockResolvedValue({
-                enabled: true,
-                version: '5.3.2',
-            })
+            vi.spyOn(graphqlClient, 'getSiteVersion').mockResolvedValue('5.3.2')
             await initProviderWithContextFilters({
                 include: [{ repoNamePattern: '^github\\.com/sourcegraph/cody' }],
                 exclude: [{ repoNamePattern: '^github\\.com/sourcegraph/sourcegraph' }],

--- a/lib/shared/src/index.ts
+++ b/lib/shared/src/index.ts
@@ -379,3 +379,4 @@ export {
     cachedUserProductSubscription,
     userProductSubscription,
 } from './sourcegraph-api/userProductSubscription'
+export { siteVersion, currentSiteVersion } from './sourcegraph-api/siteVersion'

--- a/lib/shared/src/sourcegraph-api/siteVersion.test.ts
+++ b/lib/shared/src/sourcegraph-api/siteVersion.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from 'vitest'
+import { inferCodyApiVersion } from './siteVersion'
+
+describe('inferCodyApiVersion', () => {
+    test('returns API version 0 for a legacy instance', () => {
+        expect(inferCodyApiVersion('5.2.0', false)).toBe(0)
+    })
+
+    test('returns API version 1 for older versions', () => {
+        expect(inferCodyApiVersion('5.4.0', false)).toBe(1)
+        expect(inferCodyApiVersion('5.5.0', false)).toBe(1)
+        expect(inferCodyApiVersion('5.6.0', false)).toBe(1)
+        expect(inferCodyApiVersion('5.7.0', false)).toBe(1)
+    })
+
+    test('returns API version 2 for newer versions', () => {
+        expect(inferCodyApiVersion('5.8.0', false)).toBe(2)
+        expect(inferCodyApiVersion('5.9.0', false)).toBe(2)
+        expect(inferCodyApiVersion('5.10.1', false)).toBe(2)
+    })
+
+    test('returns API version 2 for dotcom', () => {
+        expect(inferCodyApiVersion('1.2.3', true)).toBe(2)
+    })
+})

--- a/lib/shared/src/sourcegraph-api/siteVersion.ts
+++ b/lib/shared/src/sourcegraph-api/siteVersion.ts
@@ -1,0 +1,127 @@
+import { Observable, map } from 'observable-fns'
+import semver from 'semver'
+import { authStatus } from '../auth/authStatus'
+import { logError } from '../logger'
+import {
+    distinctUntilChanged,
+    pick,
+    promiseFactoryToObservable,
+    storeLastValue,
+} from '../misc/observable'
+import {
+    firstResultFromOperation,
+    pendingOperation,
+    switchMapReplayOperation,
+} from '../misc/observableOperation'
+import { isError } from '../utils'
+import { isDotCom } from './environments'
+import { graphqlClient } from './graphql'
+
+export interface SiteAndCodyAPIVersions {
+    siteVersion: string
+    codyAPIVersion: CodyApiVersion
+}
+
+/**
+ * Observe the site version and Cody API version of the currently authenticated endpoint.
+ */
+export const siteVersion: Observable<SiteAndCodyAPIVersions | null | typeof pendingOperation> =
+    authStatus.pipe(
+        pick('authenticated', 'endpoint', 'pendingValidation'),
+        distinctUntilChanged(),
+        switchMapReplayOperation(
+            (
+                authStatus
+            ): Observable<SiteAndCodyAPIVersions | Error | null | typeof pendingOperation> => {
+                if (authStatus.pendingValidation) {
+                    return Observable.of(pendingOperation)
+                }
+
+                if (!authStatus.authenticated) {
+                    return Observable.of(null)
+                }
+
+                return promiseFactoryToObservable(signal => graphqlClient.getSiteVersion(signal)).pipe(
+                    map((siteVersion): SiteAndCodyAPIVersions | null | typeof pendingOperation => {
+                        if (isError(siteVersion)) {
+                            logError(
+                                'siteVersion',
+                                `Failed to get site version from ${authStatus.endpoint}: ${siteVersion}`
+                            )
+                            return null
+                        }
+                        return {
+                            siteVersion,
+                            codyAPIVersion: inferCodyApiVersion(siteVersion, isDotCom(authStatus)),
+                        }
+                    })
+                )
+            }
+        ),
+        map(result => (isError(result) ? null : result)) // the operation catches its own errors, so errors will never get here
+    )
+
+const siteVersionStorage = storeLastValue(siteVersion)
+
+/**
+ * Get the current site version. If authentication is pending, it awaits successful authentication.
+ */
+export function currentSiteVersion(): Promise<SiteAndCodyAPIVersions | null> {
+    return firstResultFromOperation(siteVersionStorage.observable)
+}
+
+type CodyApiVersion = 0 | 1 | 2
+
+/** @internal Exported for testing only. */
+export function inferCodyApiVersion(version: string, isDotCom: boolean): CodyApiVersion {
+    const parsedVersion = semver.valid(version)
+    const isLocalBuild = parsedVersion === '0.0.0'
+
+    if (isDotCom || isLocalBuild) {
+        // The most recent version is api-version=2, which was merged on 2024-09-11
+        // https://github.com/sourcegraph/sourcegraph/pull/470
+        return 2
+    }
+
+    // On Cloud deployments from main, the version identifier will use a format
+    // like "2024-09-11_5.7-4992e874aee2", which does not parse as SemVer.  We
+    // make a best effort go parse the date from the version identifier
+    // allowing us to selectively enable new API versions on instances like SG02
+    // (that deploy frequently) without crashing on other Cloud deployments that
+    // release less frequently.
+    const isCloudBuildFromMain = parsedVersion === null
+    if (isCloudBuildFromMain) {
+        const date = parseDateFromPreReleaseVersion(version)
+        if (date && date >= new Date('2024-09-11')) {
+            return 2
+        }
+        // It's safe to bump this up to api-version=2 after the 5.8 release
+        return 1
+    }
+
+    // 5.8.0+ is the first version to support api-version=2.
+    if (semver.gte(parsedVersion, '5.8.0')) {
+        return 2
+    }
+
+    // 5.4.0+ is the first version to support api-version=1.
+    if (semver.gte(parsedVersion, '5.4.0')) {
+        return 1
+    }
+
+    return 0 // zero refers to the legacy, unversioned, Cody API
+}
+
+// Pre-release versions have a format like this "2024-09-11_5.7-4992e874aee2".
+// This function return undefined for stable Enterprise releases like "5.7.0".
+function parseDateFromPreReleaseVersion(version: string): Date | undefined {
+    try {
+        const dateString = version.split('_').at(1)
+        if (!dateString) {
+            return undefined
+        }
+        return new Date(dateString)
+    } catch {
+        return undefined
+    }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -409,7 +409,7 @@ importers:
         specifier: ^2.6.4
         version: 2.6.4
       '@types/semver':
-        specifier: ^7.5.0
+        specifier: ^7.5.8
         version: 7.5.8
       '@types/vscode':
         specifier: ^1.80.0
@@ -3810,7 +3810,7 @@ packages:
   /@radix-ui/primitive@1.0.1:
     resolution: {integrity: sha512-yQ8oGX2GVsEYMWGxcovu1uGWPCxV5BFfeeYxqPmuAzUyLT9qmaMXSAhXpb0WrspIeqYzdJpkh2vHModJPgRIaw==}
     dependencies:
-      '@babel/runtime': 7.24.5
+      '@babel/runtime': 7.25.6
     dev: false
 
   /@radix-ui/primitive@1.1.0:
@@ -3939,7 +3939,7 @@ packages:
       '@types/react':
         optional: true
     dependencies:
-      '@babel/runtime': 7.24.5
+      '@babel/runtime': 7.25.6
       '@types/react': 18.2.79
       react: 18.2.0
     dev: false
@@ -3992,7 +3992,7 @@ packages:
       '@types/react':
         optional: true
     dependencies:
-      '@babel/runtime': 7.24.5
+      '@babel/runtime': 7.25.6
       '@types/react': 18.2.79
       react: 18.2.0
     dev: false
@@ -4129,7 +4129,7 @@ packages:
       '@types/react-dom':
         optional: true
     dependencies:
-      '@babel/runtime': 7.24.5
+      '@babel/runtime': 7.25.6
       '@radix-ui/primitive': 1.0.1
       '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.2.79)(react@18.2.0)
       '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.2.25)(@types/react@18.2.79)(react-dom@18.2.0)(react@18.2.0)
@@ -4164,7 +4164,7 @@ packages:
       '@types/react':
         optional: true
     dependencies:
-      '@babel/runtime': 7.24.5
+      '@babel/runtime': 7.25.6
       '@types/react': 18.2.79
       react: 18.2.0
     dev: false
@@ -4205,7 +4205,7 @@ packages:
       '@types/react-dom':
         optional: true
     dependencies:
-      '@babel/runtime': 7.24.5
+      '@babel/runtime': 7.25.6
       '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.2.79)(react@18.2.0)
       '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.2.25)(@types/react@18.2.79)(react-dom@18.2.0)(react@18.2.0)
       '@radix-ui/react-use-callback-ref': 1.0.1(@types/react@18.2.79)(react@18.2.0)
@@ -4264,7 +4264,7 @@ packages:
       '@types/react':
         optional: true
     dependencies:
-      '@babel/runtime': 7.24.5
+      '@babel/runtime': 7.25.6
       '@radix-ui/react-use-layout-effect': 1.0.1(@types/react@18.2.79)(react@18.2.0)
       '@types/react': 18.2.79
       react: 18.2.0
@@ -4352,7 +4352,7 @@ packages:
       '@types/react-dom':
         optional: true
     dependencies:
-      '@babel/runtime': 7.24.5
+      '@babel/runtime': 7.25.6
       '@floating-ui/react-dom': 2.0.9(react-dom@18.2.0)(react@18.2.0)
       '@radix-ui/react-arrow': 1.0.3(@types/react-dom@18.2.25)(@types/react@18.2.79)(react-dom@18.2.0)(react@18.2.0)
       '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.2.79)(react@18.2.0)
@@ -4403,7 +4403,7 @@ packages:
       '@types/react-dom':
         optional: true
     dependencies:
-      '@babel/runtime': 7.24.5
+      '@babel/runtime': 7.25.6
       '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.2.25)(@types/react@18.2.79)(react-dom@18.2.0)(react@18.2.0)
       '@types/react': 18.2.79
       '@types/react-dom': 18.2.25
@@ -4446,7 +4446,7 @@ packages:
       '@types/react-dom':
         optional: true
     dependencies:
-      '@babel/runtime': 7.24.5
+      '@babel/runtime': 7.25.6
       '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.2.79)(react@18.2.0)
       '@radix-ui/react-use-layout-effect': 1.0.1(@types/react@18.2.79)(react@18.2.0)
       '@types/react': 18.2.79
@@ -4489,7 +4489,7 @@ packages:
       '@types/react-dom':
         optional: true
     dependencies:
-      '@babel/runtime': 7.24.5
+      '@babel/runtime': 7.25.6
       '@radix-ui/react-slot': 1.0.2(@types/react@18.2.37)(react@18.2.0)
       '@types/react': 18.2.37
       '@types/react-dom': 18.2.15
@@ -4510,7 +4510,7 @@ packages:
       '@types/react-dom':
         optional: true
     dependencies:
-      '@babel/runtime': 7.24.5
+      '@babel/runtime': 7.25.6
       '@radix-ui/react-slot': 1.0.2(@types/react@18.2.79)(react@18.2.0)
       '@types/react': 18.2.79
       '@types/react-dom': 18.2.25
@@ -4575,7 +4575,7 @@ packages:
       '@types/react':
         optional: true
     dependencies:
-      '@babel/runtime': 7.24.5
+      '@babel/runtime': 7.25.6
       '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.2.37)(react@18.2.0)
       '@types/react': 18.2.37
       react: 18.2.0
@@ -4590,7 +4590,7 @@ packages:
       '@types/react':
         optional: true
     dependencies:
-      '@babel/runtime': 7.24.5
+      '@babel/runtime': 7.25.6
       '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.2.79)(react@18.2.0)
       '@types/react': 18.2.79
       react: 18.2.0
@@ -4747,7 +4747,7 @@ packages:
       '@types/react':
         optional: true
     dependencies:
-      '@babel/runtime': 7.24.5
+      '@babel/runtime': 7.25.6
       '@radix-ui/react-use-callback-ref': 1.0.1(@types/react@18.2.79)(react@18.2.0)
       '@types/react': 18.2.79
       react: 18.2.0
@@ -4881,7 +4881,7 @@ packages:
       '@types/react-dom':
         optional: true
     dependencies:
-      '@babel/runtime': 7.24.5
+      '@babel/runtime': 7.25.6
       '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.2.25)(@types/react@18.2.79)(react-dom@18.2.0)(react@18.2.0)
       '@types/react': 18.2.79
       '@types/react-dom': 18.2.25
@@ -4917,24 +4917,8 @@ packages:
     dev: true
     optional: true
 
-  /@rollup/rollup-android-arm-eabi@4.24.0:
-    resolution: {integrity: sha512-Q6HJd7Y6xdB48x8ZNVDOqsbh2uByBhgK8PiQgPhwkIw/HC/YX5Ghq2mQY5sRMZWHb3VsFkWooUVOZHKr7DmDIA==}
-    cpu: [arm]
-    os: [android]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /@rollup/rollup-android-arm64@4.20.0:
     resolution: {integrity: sha512-u00Ro/nok7oGzVuh/FMYfNoGqxU5CPWz1mxV85S2w9LxHR8OoMQBuSk+3BKVIDYgkpeOET5yXkx90OYFc+ytpQ==}
-    cpu: [arm64]
-    os: [android]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@rollup/rollup-android-arm64@4.24.0:
-    resolution: {integrity: sha512-ijLnS1qFId8xhKjT81uBHuuJp2lU4x2yxa4ctFPtG+MqEE6+C5f/+X/bStmxapgmwLwiL3ih122xv8kVARNAZA==}
     cpu: [arm64]
     os: [android]
     requiresBuild: true
@@ -4949,24 +4933,8 @@ packages:
     dev: true
     optional: true
 
-  /@rollup/rollup-darwin-arm64@4.24.0:
-    resolution: {integrity: sha512-bIv+X9xeSs1XCk6DVvkO+S/z8/2AMt/2lMqdQbMrmVpgFvXlmde9mLcbQpztXm1tajC3raFDqegsH18HQPMYtA==}
-    cpu: [arm64]
-    os: [darwin]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /@rollup/rollup-darwin-x64@4.20.0:
     resolution: {integrity: sha512-xbrMDdlev53vNXexEa6l0LffojxhqDTBeL+VUxuuIXys4x6xyvbKq5XqTXBCEUA8ty8iEJblHvFaWRJTk/icAQ==}
-    cpu: [x64]
-    os: [darwin]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@rollup/rollup-darwin-x64@4.24.0:
-    resolution: {integrity: sha512-X6/nOwoFN7RT2svEQWUsW/5C/fYMBe4fnLK9DQk4SX4mgVBiTA9h64kjUYPvGQ0F/9xwJ5U5UfTbl6BEjaQdBQ==}
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
@@ -4981,24 +4949,8 @@ packages:
     dev: true
     optional: true
 
-  /@rollup/rollup-linux-arm-gnueabihf@4.24.0:
-    resolution: {integrity: sha512-0KXvIJQMOImLCVCz9uvvdPgfyWo93aHHp8ui3FrtOP57svqrF/roSSR5pjqL2hcMp0ljeGlU4q9o/rQaAQ3AYA==}
-    cpu: [arm]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /@rollup/rollup-linux-arm-musleabihf@4.20.0:
     resolution: {integrity: sha512-1asSTl4HKuIHIB1GcdFHNNZhxAYEdqML/MW4QmPS4G0ivbEcBr1JKlFLKsIRqjSwOBkdItn3/ZDlyvZ/N6KPlw==}
-    cpu: [arm]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@rollup/rollup-linux-arm-musleabihf@4.24.0:
-    resolution: {integrity: sha512-it2BW6kKFVh8xk/BnHfakEeoLPv8STIISekpoF+nBgWM4d55CZKc7T4Dx1pEbTnYm/xEKMgy1MNtYuoA8RFIWw==}
     cpu: [arm]
     os: [linux]
     requiresBuild: true
@@ -5013,24 +4965,8 @@ packages:
     dev: true
     optional: true
 
-  /@rollup/rollup-linux-arm64-gnu@4.24.0:
-    resolution: {integrity: sha512-i0xTLXjqap2eRfulFVlSnM5dEbTVque/3Pi4g2y7cxrs7+a9De42z4XxKLYJ7+OhE3IgxvfQM7vQc43bwTgPwA==}
-    cpu: [arm64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /@rollup/rollup-linux-arm64-musl@4.20.0:
     resolution: {integrity: sha512-+it+mBSyMslVQa8wSPvBx53fYuZK/oLTu5RJoXogjk6x7Q7sz1GNRsXWjn6SwyJm8E/oMjNVwPhmNdIjwP135Q==}
-    cpu: [arm64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@rollup/rollup-linux-arm64-musl@4.24.0:
-    resolution: {integrity: sha512-9E6MKUJhDuDh604Qco5yP/3qn3y7SLXYuiC0Rpr89aMScS2UAmK1wHP2b7KAa1nSjWJc/f/Lc0Wl1L47qjiyQw==}
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
@@ -5045,24 +4981,8 @@ packages:
     dev: true
     optional: true
 
-  /@rollup/rollup-linux-powerpc64le-gnu@4.24.0:
-    resolution: {integrity: sha512-2XFFPJ2XMEiF5Zi2EBf4h73oR1V/lycirxZxHZNc93SqDN/IWhYYSYj8I9381ikUFXZrz2v7r2tOVk2NBwxrWw==}
-    cpu: [ppc64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /@rollup/rollup-linux-riscv64-gnu@4.20.0:
     resolution: {integrity: sha512-qmuxFpfmi/2SUkAw95TtNq/w/I7Gpjurx609OOOV7U4vhvUhBcftcmXwl3rqAek+ADBwSjIC4IVNLiszoj3dPA==}
-    cpu: [riscv64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@rollup/rollup-linux-riscv64-gnu@4.24.0:
-    resolution: {integrity: sha512-M3Dg4hlwuntUCdzU7KjYqbbd+BLq3JMAOhCKdBE3TcMGMZbKkDdJ5ivNdehOssMCIokNHFOsv7DO4rlEOfyKpg==}
     cpu: [riscv64]
     os: [linux]
     requiresBuild: true
@@ -5077,24 +4997,8 @@ packages:
     dev: true
     optional: true
 
-  /@rollup/rollup-linux-s390x-gnu@4.24.0:
-    resolution: {integrity: sha512-mjBaoo4ocxJppTorZVKWFpy1bfFj9FeCMJqzlMQGjpNPY9JwQi7OuS1axzNIk0nMX6jSgy6ZURDZ2w0QW6D56g==}
-    cpu: [s390x]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /@rollup/rollup-linux-x64-gnu@4.20.0:
     resolution: {integrity: sha512-y+eoL2I3iphUg9tN9GB6ku1FA8kOfmF4oUEWhztDJ4KXJy1agk/9+pejOuZkNFhRwHAOxMsBPLbXPd6mJiCwew==}
-    cpu: [x64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@rollup/rollup-linux-x64-gnu@4.24.0:
-    resolution: {integrity: sha512-ZXFk7M72R0YYFN5q13niV0B7G8/5dcQ9JDp8keJSfr3GoZeXEoMHP/HlvqROA3OMbMdfr19IjCeNAnPUG93b6A==}
     cpu: [x64]
     os: [linux]
     requiresBuild: true
@@ -5109,24 +5013,8 @@ packages:
     dev: true
     optional: true
 
-  /@rollup/rollup-linux-x64-musl@4.24.0:
-    resolution: {integrity: sha512-w1i+L7kAXZNdYl+vFvzSZy8Y1arS7vMgIy8wusXJzRrPyof5LAb02KGr1PD2EkRcl73kHulIID0M501lN+vobQ==}
-    cpu: [x64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /@rollup/rollup-win32-arm64-msvc@4.20.0:
     resolution: {integrity: sha512-psegMvP+Ik/Bg7QRJbv8w8PAytPA7Uo8fpFjXyCRHWm6Nt42L+JtoqH8eDQ5hRP7/XW2UiIriy1Z46jf0Oa1kA==}
-    cpu: [arm64]
-    os: [win32]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@rollup/rollup-win32-arm64-msvc@4.24.0:
-    resolution: {integrity: sha512-VXBrnPWgBpVDCVY6XF3LEW0pOU51KbaHhccHw6AS6vBWIC60eqsH19DAeeObl+g8nKAz04QFdl/Cefta0xQtUQ==}
     cpu: [arm64]
     os: [win32]
     requiresBuild: true
@@ -5141,24 +5029,8 @@ packages:
     dev: true
     optional: true
 
-  /@rollup/rollup-win32-ia32-msvc@4.24.0:
-    resolution: {integrity: sha512-xrNcGDU0OxVcPTH/8n/ShH4UevZxKIO6HJFK0e15XItZP2UcaiLFd5kiX7hJnqCbSztUF8Qot+JWBC/QXRPYWQ==}
-    cpu: [ia32]
-    os: [win32]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /@rollup/rollup-win32-x64-msvc@4.20.0:
     resolution: {integrity: sha512-aJ1EJSuTdGnM6qbVC4B5DSmozPTqIag9fSzXRNNo+humQLG89XpPgdt16Ia56ORD7s+H8Pmyx44uczDQ0yDzpg==}
-    cpu: [x64]
-    os: [win32]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@rollup/rollup-win32-x64-msvc@4.24.0:
-    resolution: {integrity: sha512-fbMkAF7fufku0N2dE5TBXcNlg0pt0cJue4xBRE2Qc5Vqikxr4VCgKj/ht6SMdFcOacVA9rqF70APJ8RN/4vMJw==}
     cpu: [x64]
     os: [win32]
     requiresBuild: true
@@ -6541,10 +6413,6 @@ packages:
 
   /@types/estree@1.0.5:
     resolution: {integrity: sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==}
-
-  /@types/estree@1.0.6:
-    resolution: {integrity: sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==}
-    dev: true
 
   /@types/express-serve-static-core@4.19.0:
     resolution: {integrity: sha512-bGyep3JqPCRry1wq+O5n7oiBgGWmeIJXPjXXCo8EK0u8duZGSYar7cGqd3ML2JUsLGeB7fmc06KYo9fLGWqPvQ==}
@@ -14391,32 +14259,6 @@ packages:
       fsevents: 2.3.3
     dev: true
 
-  /rollup@4.24.0:
-    resolution: {integrity: sha512-DOmrlGSXNk1DM0ljiQA+i+o0rSLhtii1je5wgk60j49d1jHT5YYttBv1iWOnYSTG+fZZESUOSNiAl89SIet+Cg==}
-    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
-    hasBin: true
-    dependencies:
-      '@types/estree': 1.0.6
-    optionalDependencies:
-      '@rollup/rollup-android-arm-eabi': 4.24.0
-      '@rollup/rollup-android-arm64': 4.24.0
-      '@rollup/rollup-darwin-arm64': 4.24.0
-      '@rollup/rollup-darwin-x64': 4.24.0
-      '@rollup/rollup-linux-arm-gnueabihf': 4.24.0
-      '@rollup/rollup-linux-arm-musleabihf': 4.24.0
-      '@rollup/rollup-linux-arm64-gnu': 4.24.0
-      '@rollup/rollup-linux-arm64-musl': 4.24.0
-      '@rollup/rollup-linux-powerpc64le-gnu': 4.24.0
-      '@rollup/rollup-linux-riscv64-gnu': 4.24.0
-      '@rollup/rollup-linux-s390x-gnu': 4.24.0
-      '@rollup/rollup-linux-x64-gnu': 4.24.0
-      '@rollup/rollup-linux-x64-musl': 4.24.0
-      '@rollup/rollup-win32-arm64-msvc': 4.24.0
-      '@rollup/rollup-win32-ia32-msvc': 4.24.0
-      '@rollup/rollup-win32-x64-msvc': 4.24.0
-      fsevents: 2.3.3
-    dev: true
-
   /route-recognizer@0.3.4:
     resolution: {integrity: sha512-2+MhsfPhvauN1O8KaXpXAOfR/fwe8dnUXVM+xw7yt40lJRfPVQxV6yryZm0cgRvAj5fMF/mdRZbL2ptwbs5i2g==}
 
@@ -16270,7 +16112,7 @@ packages:
       '@types/node': 20.12.7
       esbuild: 0.21.5
       postcss: 8.4.47
-      rollup: 4.24.0
+      rollup: 4.20.0
     optionalDependencies:
       fsevents: 2.3.3
     dev: true

--- a/vscode/src/chat/agentic/DeepCody.ts
+++ b/vscode/src/chat/agentic/DeepCody.ts
@@ -115,7 +115,7 @@ export class DeepCodyAgent {
         const agentAbortController = new AbortController()
 
         try {
-            const stream = this.chatClient.chat(
+            const stream = await this.chatClient.chat(
                 promptData.prompt,
                 { model: DeepCodyAgent.ModelRef, maxTokensToSample: 2000 },
                 agentAbortController.signal

--- a/vscode/src/chat/chat-view/ChatController.test.ts
+++ b/vscode/src/chat/chat-view/ChatController.test.ts
@@ -6,6 +6,7 @@ import {
     type Guardrails,
     PromptString,
     errorToChatError,
+    graphqlClient,
     mockAuthStatus,
     mockClientCapabilities,
     mockResolvedConfig,
@@ -54,6 +55,8 @@ describe('ChatController', () => {
         'publicRepoMetadataIfAllWorkspaceReposArePublic',
         'get'
     ).mockReturnValue(Observable.of({ isPublic: false, repoMetadata: undefined }))
+
+    vi.spyOn(graphqlClient, 'getSiteVersion').mockResolvedValue('1.2.3')
 
     const mockNowDate = new Date(123456)
 

--- a/vscode/src/chat/chat-view/ChatController.ts
+++ b/vscode/src/chat/chat-view/ChatController.ts
@@ -2,6 +2,7 @@ import {
     type ChatModel,
     cenv,
     clientCapabilities,
+    currentSiteVersion,
     distinctUntilChanged,
     firstResultFromOperation,
     pendingOperation,
@@ -771,11 +772,15 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
                     )
 
                     try {
+                        const versions = await currentSiteVersion()
+                        if (!versions) {
+                            throw new Error('unable to determine site version')
+                        }
                         const { prompt, context } = await this.buildPrompt(
                             prompter,
                             signal,
                             requestID,
-                            authStatus.codyApiVersion,
+                            versions.codyAPIVersion,
                             contextAlternatives
                         )
 
@@ -1303,7 +1308,7 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
                 params.stream = false
             }
 
-            const stream = this.chatClient.chat(prompt, params, abortSignal)
+            const stream = await this.chatClient.chat(prompt, params, abortSignal)
             for await (const message of stream) {
                 switch (message.type) {
                     case 'change': {

--- a/vscode/src/chat/utils.test.ts
+++ b/vscode/src/chat/utils.test.ts
@@ -26,7 +26,6 @@ describe('validateAuthStatus', () => {
                 primaryEmail: 'alice@example.com',
                 hasVerifiedEmail: true,
                 username: 'alice',
-                siteVersion: '999',
                 organizations: { nodes: [{ id: 'x', name: 'foo' }] },
             })
         ).toStrictEqual<AuthStatus>({
@@ -35,8 +34,6 @@ describe('validateAuthStatus', () => {
             username: 'alice',
             hasVerifiedEmail: true,
             requiresVerifiedEmail: true,
-            codyApiVersion: 2,
-            siteVersion: '999',
             isFireworksTracingEnabled: false,
             pendingValidation: false,
             primaryEmail: 'alice@example.com',
@@ -50,18 +47,15 @@ describe('validateAuthStatus', () => {
                 authenticated: true,
                 endpoint: 'https://example.com',
                 username: 'alice',
-                siteVersion: '999',
             })
         ).toStrictEqual<AuthStatus>({
             authenticated: true,
             hasVerifiedEmail: false,
             endpoint: 'https://example.com',
-            codyApiVersion: 1,
             isFireworksTracingEnabled: false,
             primaryEmail: undefined,
             requiresVerifiedEmail: false,
             pendingValidation: false,
-            siteVersion: '999',
             username: 'alice',
             organizations: undefined,
         })
@@ -78,29 +72,6 @@ describe('validateAuthStatus', () => {
             endpoint: 'https://example.com',
             pendingValidation: false,
             showInvalidAccessTokenError: true,
-        })
-    })
-
-    it('returns API version 0 for a legacy instance', () => {
-        expect(
-            newAuthStatus({
-                authenticated: true,
-                endpoint: 'https://example.com',
-                siteVersion: '5.2.0',
-                username: 'alice',
-            })
-        ).toStrictEqual<AuthStatus>({
-            authenticated: true,
-            endpoint: 'https://example.com',
-            siteVersion: '5.2.0',
-            hasVerifiedEmail: false,
-            codyApiVersion: 0,
-            username: 'alice',
-            requiresVerifiedEmail: false,
-            isFireworksTracingEnabled: false,
-            pendingValidation: false,
-            primaryEmail: undefined,
-            organizations: undefined,
         })
     })
 })

--- a/vscode/src/commands/scm/source-control.ts
+++ b/vscode/src/commands/scm/source-control.ts
@@ -174,7 +174,7 @@ export class CodySourceControl implements vscode.Disposable {
                 throw new Error()
             })
 
-            const stream = this.chatClient.chat(
+            const stream = await this.chatClient.chat(
                 prompt,
                 { model, maxTokensToSample: contextWindow.output },
                 abortController?.signal

--- a/vscode/src/edit/manager.ts
+++ b/vscode/src/edit/manager.ts
@@ -4,7 +4,7 @@ import {
     type ChatClient,
     ClientConfigSingleton,
     PromptString,
-    currentAuthStatusAuthed,
+    currentSiteVersion,
     firstResultFromOperation,
     modelsService,
     ps,
@@ -311,7 +311,11 @@ export class EditManager implements vscode.Disposable {
         // queries to ask the LLM to generate a selection, and then ultimately apply the edit.
         const replacementCode = PromptString.unsafe_fromLLMResponse(configuration.replacement)
 
-        const authStatus = currentAuthStatusAuthed()
+        const versions = await currentSiteVersion()
+        if (!versions) {
+            throw new Error('unable to determine site version')
+        }
+
         const selection = await getSmartApplySelection(
             configuration.id,
             configuration.instruction,
@@ -319,7 +323,7 @@ export class EditManager implements vscode.Disposable {
             configuration.document,
             model,
             this.options.chat,
-            authStatus.codyApiVersion
+            versions.codyAPIVersion
         )
 
         // We finished prompting the LLM for the selection, we can now remove the "progress" decoration

--- a/vscode/src/edit/prompt/smart-apply.ts
+++ b/vscode/src/edit/prompt/smart-apply.ts
@@ -131,7 +131,7 @@ async function promptModelForOriginalCode(
         model,
         codyApiVersion
     )
-    const stream = client.chat(
+    const stream = await client.chat(
         messages,
         {
             model,

--- a/vscode/src/external-services.ts
+++ b/vscode/src/external-services.ts
@@ -5,7 +5,6 @@ import {
     type Guardrails,
     type SourcegraphCompletionsClient,
     SourcegraphGuardrailsClient,
-    currentAuthStatusAuthed,
     graphqlClient,
 } from '@sourcegraph/cody-shared'
 import { ChatIntentAPIClient } from './chat/context/chatIntentAPIClient'
@@ -45,7 +44,7 @@ export async function configureExternalServices(
     const symfRunner = platform.createSymfRunner?.(context, completionsClient)
     if (symfRunner) disposables.push(symfRunner)
 
-    const chatClient = new ChatClient(completionsClient, () => currentAuthStatusAuthed())
+    const chatClient = new ChatClient(completionsClient)
 
     const guardrails = new SourcegraphGuardrailsClient()
 

--- a/vscode/src/jsonrpc/agent-protocol.ts
+++ b/vscode/src/jsonrpc/agent-protocol.ts
@@ -621,7 +621,6 @@ export interface WebviewNativeConfig {
 export interface ServerInfo {
     name: string
     authenticated?: boolean | undefined | null
-    codyVersion?: string | undefined | null
     authStatus?: AuthStatus | undefined | null
 }
 

--- a/vscode/src/supercompletions/get-supercompletion.ts
+++ b/vscode/src/supercompletions/get-supercompletion.ts
@@ -69,7 +69,7 @@ async function* generateRawChanges(
     messages: Message[],
     abortSignal: AbortSignal
 ): AsyncGenerator<RawChange> {
-    const stream = chat.chat(
+    const stream = await chat.chat(
         messages,
         { model: MODEL, temperature: 0.1, maxTokensToSample: 1000 },
         abortSignal

--- a/vscode/webviews/App.story.tsx
+++ b/vscode/webviews/App.story.tsx
@@ -37,7 +37,6 @@ const dummyVSCodeAPI: VSCodeWrapper = {
                 authenticated: true,
                 hasVerifiedEmail: true,
                 requiresVerifiedEmail: false,
-                siteVersion: '5.1.0',
                 endpoint: 'https://example.com',
             },
             userProductSubscription: null,


### PR DESCRIPTION
The site version and Cody API version is now exposed in the `siteVersion` global observable, which returns the site version and Cody API version for the currently authenticated endpoint (and caches the value).

If the Sourcegraph instance does not have Cody enabled, this means that the error message will come later, not at sign-in. With one box, the lines are getting blurrier anyway, and the logic for determining if Cody was enabled was complex and often treated network errors as "Cody is disabled". It is not worth it to invest time in making this more robust because few users will encounter this, and those who do will just get an error that Cody is disabled when they actually try to perform any operation.

This means that initial auth takes 1-3 less HTTP requests.

## Test plan

CI & e2e