### PR TITLE
default vitest unit test timeout of 500ms

### DIFF
--- a/.config/viteShared.ts
+++ b/.config/viteShared.ts
@@ -22,6 +22,7 @@ const defaultProjectConfig: UserWorkspaceConfig = {
         fakeTimers: {
             toFake: [...configDefaults.fakeTimers.toFake, 'performance'],
         },
+        testTimeout: 500,
     },
 }
 

--- a/agent/src/document-code.test.ts
+++ b/agent/src/document-code.test.ts
@@ -4,7 +4,7 @@ import { TESTING_CREDENTIALS } from '../../vscode/src/testutils/testing-credenti
 import { TestClient } from './TestClient'
 import { TestWorkspace } from './TestWorkspace'
 
-describe('Document Code', () => {
+describe('Document Code', { timeout: 5000 }, () => {
     const workspace = new TestWorkspace(path.join(__dirname, '__tests__', 'document-code'))
     const client = TestClient.create({
         workspaceRootUri: workspace.rootUri,

--- a/agent/src/edit.test.ts
+++ b/agent/src/edit.test.ts
@@ -7,7 +7,7 @@ import { TestWorkspace } from './TestWorkspace'
 import { explainPollyError } from './explainPollyError'
 import { trimEndOfLine } from './trimEndOfLine'
 
-describe('Edit', () => {
+describe('Edit', { timeout: 5000 }, () => {
     const workspace = new TestWorkspace(path.join(__dirname, '__tests__', 'edit-code'))
     const client = TestClient.create({
         workspaceRootUri: workspace.rootUri,

--- a/vscode/src/completions/context/retrievers/lsp-light/lsp-light-retriever.integration.test.ts
+++ b/vscode/src/completions/context/retrievers/lsp-light/lsp-light-retriever.integration.test.ts
@@ -39,7 +39,7 @@ const disposable = {
 // To run these tests only with clean debug output:
 // pnpm vitest vscode/src/completions/context/retrievers/lsp-light/lsp-light-retriever.integration.test.ts --disableConsoleIntercept --hideSkippedTests --reporter=basic
 // TODO: fix windows tests. Probably caused by the issues files paths.
-describe.skipIf(isWindows())('LspLightRetriever', () => {
+describe.skipIf(isWindows())('LspLightRetriever', { timeout: 5000 }, () => {
     let connection: rpc.MessageConnection
     let mainFileUri: vscode.Uri
     let mainDocument: vscode.TextDocument

--- a/vscode/src/tree-sitter/grammars.test.ts
+++ b/vscode/src/tree-sitter/grammars.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest'
 import { SupportedLanguage } from './grammars'
 import { initTreeSitterParser } from './test-helpers'
 
-describe('tree-sitter grammars', () => {
+describe('tree-sitter grammars', { timeout: 5000 }, () => {
     const testCases: {
         language: SupportedLanguage
         code: string

--- a/vscode/src/tree-sitter/query-tests/documentable-nodes.test.ts
+++ b/vscode/src/tree-sitter/query-tests/documentable-nodes.test.ts
@@ -7,7 +7,7 @@ import { SupportedLanguage } from '../grammars'
 import type { QueryWrappers } from '../query-sdk'
 import { type Captures, annotateAndMatchSnapshot } from './annotate-and-match-snapshot'
 
-describe('getDocumentableNode', () => {
+describe('getDocumentableNode', { timeout: 5000 }, () => {
     const queryWrapper =
         (query: QueryWrappers['getDocumentableNode']): Captures =>
         (node, start, end) => {


### PR DESCRIPTION
Almost all tests finish in 500ms. If a test is taking longer, it's probably hanging indefinitely, and killing it at 500ms gives faster feedback.

## Test plan

n/a