### PR TITLE
remove unused chat/restore agent method

### DIFF
--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/agent/protocol_generated/CodyAgentServer.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/agent/protocol_generated/CodyAgentServer.kt
@@ -22,8 +22,6 @@ interface CodyAgentServer {
   fun chat_sidebar_new(params: Null?): CompletableFuture<Chat_Sidebar_NewResult>
   @JsonRequest("chat/delete")
   fun chat_delete(params: Chat_DeleteParams): CompletableFuture<List<ChatExportResult>>
-  @JsonRequest("chat/restore")
-  fun chat_restore(params: Chat_RestoreParams): CompletableFuture<String>
   @JsonRequest("chat/models")
   fun chat_models(params: Chat_ModelsParams): CompletableFuture<Chat_ModelsResult>
   @JsonRequest("chat/export")

--- a/agent/protocol.md
+++ b/agent/protocol.md
@@ -58,13 +58,7 @@ shutdown: [null, null]
 ```ts
 'chat/new': [null, string]
 ```
-<h2 id="chat_restore"><a href="#chat_restore" name="chat_restore"><code>chat/restore</code> (<img class="emoji" title=":arrow_right:" alt=":arrow_right:" src="https://github.githubassets.com/images/icons/emoji/unicode/27a1.png" height="20" width="20">)</a></h2>
-<p>Request sent from the client to client server.</p>
 
-
-```ts
-'chat/restore': [{ modelID: string; messages: AgentChatMessage[]; chatID: string; }, string]
-```
 <h2 id="chat_models"><a href="#chat_models" name="chat_models"><code>chat/models</code> (<img class="emoji" title=":arrow_right:" alt=":arrow_right:" src="https://github.githubassets.com/images/icons/emoji/unicode/27a1.png" height="20" width="20">)</a></h2>
 <p>Request sent from the client to client server.</p>
 

--- a/agent/src/__snapshots__/index.test.ts.snap
+++ b/agent/src/__snapshots__/index.test.ts.snap
@@ -1,7 +1,5 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`Agent > Chat > chat/restore (With null model) 1`] = `"I'm Cody, an advanced AI coding assistant developed by Sourcegraph. My model is specifically designed to excel at software development tasks, code analysis, and providing programming assistance. I'm equipped with extensive knowledge across various programming languages, frameworks, and development practices. While I don't have detailed information about my exact model specifications, I'm confident in my abilities to tackle a wide range of coding challenges and provide valuable insights. How can I leverage my capabilities to assist you with your coding needs today?"`;
-
 exports[`Agent > Chat > chat/submitMessage (long message) 1`] = `
 "Absolutely! I'd be happy to generate a simple "Hello World" function in Java for you. Here's a straightforward implementation:
 

--- a/agent/src/agent.ts
+++ b/agent/src/agent.ts
@@ -37,8 +37,6 @@ import {
     modelsService,
     setUserAgent,
 } from '@sourcegraph/cody-shared'
-
-import { ChatBuilder } from '../../vscode/src/chat/chat-view/ChatBuilder'
 import { chatHistory } from '../../vscode/src/chat/chat-view/ChatHistoryManager'
 import type { ExtensionMessage, WebviewMessage } from '../../vscode/src/chat/protocol'
 import { ProtocolTextDocumentWithUri } from '../../vscode/src/jsonrpc/TextDocumentWithUri'
@@ -1240,24 +1238,6 @@ export class Agent extends MessageHandler implements ExtensionClient {
 
             const chatId = this.webPanels.panels.get(panelId)?.chatID ?? ''
             return { panelId, chatId }
-        })
-
-        // TODO: JetBrains no longer uses this, consider deleting it.
-        this.registerAuthenticatedRequest('chat/restore', async ({ modelID, messages, chatID }) => {
-            const authStatus = currentAuthStatusAuthed()
-            modelID ??= (await firstResultFromOperation(modelsService.getDefaultChatModel())) ?? ''
-            const chatMessages = messages?.map(PromptString.unsafe_deserializeChatMessage) ?? []
-            const chatBuilder = new ChatBuilder(modelID, chatID, chatMessages)
-            const chat = chatBuilder.toSerializedChatTranscript()
-            if (chat) {
-                await chatHistory.saveChat(authStatus, chat)
-            }
-            return this.createChatPanel(
-                Promise.resolve({
-                    type: 'chat',
-                    session: await vscode.commands.executeCommand('cody.chat.panel.restore', [chatID]),
-                })
-            )
         })
 
         this.registerAuthenticatedRequest('chat/models', async ({ modelUsage }) => {

--- a/vscode/src/jsonrpc/agent-protocol.ts
+++ b/vscode/src/jsonrpc/agent-protocol.ts
@@ -8,7 +8,6 @@ import type {
     CurrentUserCodySubscription,
     Model,
     ModelUsage,
-    SerializedChatMessage,
     SerializedChatTranscript,
     event,
 } from '@sourcegraph/cody-shared'
@@ -63,21 +62,6 @@ export type ClientRequests = {
     // Deletes chat by its ID and returns newly updated chat history list
     // Primary is used only in cody web client
     'chat/delete': [{ chatId: string }, ChatExportResult[]]
-
-    // TODO: JetBrains no longer uses this, consider deleting it.
-    // Similar to `chat/new` except it starts a new chat session from an
-    // existing transcript. The chatID matches the `chatID` property of the
-    // `type: 'transcript'` ExtensionMessage that is sent via
-    // `webview/postMessage`. Returns a new *panel* ID, which can be used to
-    // send a chat message via `chat/submitMessage`.
-    'chat/restore': [
-        {
-            modelID?: string | undefined | null
-            messages: SerializedChatMessage[]
-            chatID: string
-        },
-        string,
-    ]
 
     'chat/models': [{ modelUsage: ModelUsage }, { models: ModelAvailabilityStatus[] }]
     'chat/export': [null | { fullHistory: boolean }, ChatExportResult[]]


### PR DESCRIPTION
This is [not used in JetBrains](https://sourcegraph.com/search?q=repo:sourcegraph/jetbrains+chat/restore&patternType=keyword&sm=0) and was marked for deletion 2 months ago.

## Test plan

CI & e2e