### PR TITLE
Autocomplete: context filters autocomplete agent tests

### DIFF
--- a/agent/recordings/enterpriseMainBranchClient_759014996/recording.har.yaml
+++ b/agent/recordings/enterpriseMainBranchClient_759014996/recording.har.yaml
@@ -36,52 +36,491 @@ log:
         queryString: []
         url: https://sourcegraph.sourcegraph.com/.api/client-config
       response:
-        bodySize: 219
+        bodySize: 230
         content:
           encoding: base64
           mimeType: text/plain; charset=utf-8
-          size: 219
-          text:
-            "[\"H4sIAAAAAAAAA2zOsQrDMAwE0D1fYTJ36pgthA7ZAoF2VmpBDZYUrDNNKf33Lhk9v7vjv\
-            l0IIfRPi5+b0pY59kNAqXw54UVo\",\"AlXYZLJnBreb1WEymQhp9PYGUNJWkUyb7kI\
-            Fkyn4wCNptHczJhY5+7jMTc0Edqx1362A4/k5mfqKwiTjMt+5eDLth3Dtft0fAAD//w\
-            MAHTrgHxMBAAA=\"]"
+          size: 230
+          text: "[\"H4sIAAAAAAAAAwAAAP//\",\"bM6xCsMwDATQPV9hMnfslC2EDtkCgXZWakENlhSsM00p\
+            /fcuGT2/u+O+XQgh9E+Ln5vSljn2Q0CpfDnhRWgCVdhksmcGt5vVYTKZCGn09gZQ0la\
+            RTJvuQgWTKfjAI2m0dzMmFjn7uMxNzQR2rHXfrYDj+TmZ+orCJOMy37l4Mu2HcO1+3R\
+            8AAP//\",\"AwDBZYs6EwEAAA==\"]"
         cookies: []
         headers:
           - name: date
-            value: Wed, 25 Sep 2024 17:46:21 GMT
+            value: Mon, 07 Oct 2024 02:51:20 GMT
           - name: content-type
             value: text/plain; charset=utf-8
           - name: transfer-encoding
             value: chunked
           - name: connection
             value: keep-alive
-          - name: access-control-allow-credentials
-            value: "true"
-          - name: access-control-allow-origin
-            value: ""
           - name: cache-control
             value: no-cache, max-age=0
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
           - name: vary
-            value:
-              Accept-Encoding, Authorization, Cookie, Authorization, X-Requested-With,
+            value: Accept-Encoding, Authorization, Cookie, Authorization, X-Requested-With,
               Cookie
+          - name: access-control-allow-credentials
+            value: "true"
           - name: x-content-type-options
             value: nosniff
           - name: x-frame-options
             value: DENY
           - name: x-xss-protection
             value: 1; mode=block
-          - name: strict-transport-security
-            value: max-age=31536000; includeSubDomains; preload
           - name: content-encoding
             value: gzip
-        headersSize: 1258
+        headersSize: 1227
         httpVersion: HTTP/1.1
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-09-25T17:46:21.785Z
+      startedDateTime: 2024-10-07T02:51:20.473Z
+      time: 0
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 0
+    - _id: 42e644e06f9ab8606e43faa275d33108
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 921
+        cookies: []
+        headers:
+          - _fromType: array
+            name: accept-encoding
+            value: gzip;q=0
+          - _fromType: array
+            name: authorization
+            value: token
+              REDACTED_4229eb42e0efa2f15f3e6f8843764c7f92ab8051020cc4e90802f4fc0cc91bfa
+          - _fromType: array
+            name: connection
+            value: keep-alive
+          - _fromType: array
+            name: content-type
+            value: application/json; charset=utf-8
+          - _fromType: array
+            name: user-agent
+            value: enterpriseMainBranchClient / v1
+          - _fromType: array
+            name: x-timeout-ms
+            value: "7000"
+          - _fromType: array
+            name: accept
+            value: "*/*"
+          - _fromType: array
+            name: content-length
+            value: "921"
+          - name: host
+            value: sourcegraph.sourcegraph.com
+        headersSize: 448
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json; charset=utf-8
+          params: []
+          textJSON:
+            maxTokensToSample: 256
+            messages:
+              - speaker: human
+                text: >-
+                  <filename>src/sum.ts<fim_prefix>// Here is a reference snippet
+                  of code from src/squirrel.ts:
+
+                  // /**
+
+                  //  * Squirrel is an interface that mocks something completely unrelated to squirrels.
+
+                  //  * It is related to the implementation of precise code navigation in Sourcegraph.
+
+                  //  */
+
+                  // export interface Squirrel {}
+
+                  // 
+
+
+                  // Here is a reference snippet of code from src/animal.ts:
+
+                  // /* SELECTION_START */
+
+                  // export interface Animal {
+
+                  //     name: string
+
+                  //     makeAnimalSound(): string
+
+                  //     isMammal: boolean
+
+                  // }
+
+                  // /* SELECTION_END */
+
+                  // 
+
+
+                  export function sum(a: number, b: number): number {
+                     <fim_suffix>
+                  }
+
+                  <fim_middle>
+            model: fireworks/starcoder-16b
+            stopSequences:
+              - "\n\n"
+              - "\n\r\n"
+              - <fim_prefix>
+              - <fim_suffix>
+              - <fim_middle>
+              - <file_sep>
+              - <|endoftext|>
+              - <|end|>
+            stream: true
+            temperature: 0.2
+            timeoutMs: 7000
+            topK: 0
+        queryString:
+          - name: client-name
+            value: enterprisemainbranchclient
+          - name: client-version
+            value: v1
+        url: https://sourcegraph.sourcegraph.com/.api/completions/code?client-name=enterprisemainbranchclient&client-version=v1
+      response:
+        bodySize: 115
+        content:
+          mimeType: text/plain; charset=utf-8
+          size: 115
+          text: >
+            unsupported code completion model "fireworks/starcoder-16b" (default
+            "fireworks::v1::deepseek-coder-v2-lite-base")
+        cookies: []
+        headers:
+          - name: date
+            value: Mon, 07 Oct 2024 02:26:20 GMT
+          - name: content-type
+            value: text/plain; charset=utf-8
+          - name: content-length
+            value: "115"
+          - name: connection
+            value: keep-alive
+          - name: cache-control
+            value: no-cache, max-age=0
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+          - name: vary
+            value: Accept-Encoding, Authorization, Cookie, Authorization, X-Requested-With,
+              Cookie
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+        headersSize: 1196
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 400
+        statusText: Bad Request
+      startedDateTime: 2024-10-07T02:26:19.803Z
+      time: 0
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 0
+    - _id: b5e8dc052794965911e734955ebbd4d6
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 810
+        cookies: []
+        headers:
+          - _fromType: array
+            name: accept-encoding
+            value: gzip;q=0
+          - _fromType: array
+            name: authorization
+            value: token
+              REDACTED_4229eb42e0efa2f15f3e6f8843764c7f92ab8051020cc4e90802f4fc0cc91bfa
+          - _fromType: array
+            name: connection
+            value: keep-alive
+          - _fromType: array
+            name: content-type
+            value: application/json; charset=utf-8
+          - _fromType: array
+            name: user-agent
+            value: enterpriseMainBranchClient / v1
+          - _fromType: array
+            name: x-timeout-ms
+            value: "7000"
+          - _fromType: array
+            name: accept
+            value: "*/*"
+          - _fromType: array
+            name: content-length
+            value: "810"
+          - name: host
+            value: sourcegraph.sourcegraph.com
+        headersSize: 448
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json; charset=utf-8
+          params: []
+          textJSON:
+            maxTokensToSample: 256
+            messages:
+              - speaker: human
+                text: >-
+                  #src/squirrel.ts
+
+                  /**
+                   * Squirrel is an interface that mocks something completely unrelated to squirrels.
+                   * It is related to the implementation of precise code navigation in Sourcegraph.
+                   */
+                  export interface Squirrel {}
+
+
+
+                  #src/animal.ts
+
+                  /* SELECTION_START */
+
+                  export interface Animal {
+                      name: string
+                      makeAnimalSound(): string
+                      isMammal: boolean
+                  }
+
+                  /* SELECTION_END */
+
+
+
+                  #src/sum.ts
+
+                  <｜fim▁begin｜>export function sum(a: number, b: number): number {
+                     <｜fim▁hole｜>
+                  }
+
+                  <｜fim▁end｜>
+            model: fireworks/deepseek-coder-v2-lite-base
+            stopSequences:
+              - "\n\n"
+              - "\n\r\n"
+              - <｜fim▁begin｜>
+              - <｜fim▁hole｜>
+              - <｜fim▁end｜>, <|eos_token|>
+            stream: true
+            temperature: 0.2
+            timeoutMs: 7000
+            topK: 0
+        queryString:
+          - name: client-name
+            value: enterprisemainbranchclient
+          - name: client-version
+            value: v1
+        url: https://sourcegraph.sourcegraph.com/.api/completions/code?client-name=enterprisemainbranchclient&client-version=v1
+      response:
+        bodySize: 204
+        content:
+          mimeType: text/event-stream
+          size: 204
+          text: |+
+            event: completion
+            data: {"completion":" return a + b","stopReason":"stop"}
+
+            event: done
+            data: {}
+
+        cookies: []
+        headers:
+          - name: date
+            value: Mon, 07 Oct 2024 02:39:51 GMT
+          - name: content-type
+            value: text/event-stream
+          - name: transfer-encoding
+            value: chunked
+          - name: connection
+            value: keep-alive
+          - name: cache-control
+            value: no-cache
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+          - name: vary
+            value: Accept-Encoding, Authorization, Cookie, Authorization, X-Requested-With,
+              Cookie
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+        headersSize: 1184
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: 2024-10-07T02:39:50.998Z
+      time: 0
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 0
+    - _id: eddc294889b48e81fce2e896df2de46b
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 811
+        cookies: []
+        headers:
+          - _fromType: array
+            name: accept-encoding
+            value: gzip;q=0
+          - _fromType: array
+            name: authorization
+            value: token
+              REDACTED_4229eb42e0efa2f15f3e6f8843764c7f92ab8051020cc4e90802f4fc0cc91bfa
+          - _fromType: array
+            name: connection
+            value: keep-alive
+          - _fromType: array
+            name: content-type
+            value: application/json; charset=utf-8
+          - _fromType: array
+            name: user-agent
+            value: enterpriseMainBranchClient / v1
+          - _fromType: array
+            name: x-timeout-ms
+            value: "7000"
+          - _fromType: array
+            name: accept
+            value: "*/*"
+          - _fromType: array
+            name: content-length
+            value: "811"
+          - name: host
+            value: sourcegraph.sourcegraph.com
+        headersSize: 448
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json; charset=utf-8
+          params: []
+          textJSON:
+            maxTokensToSample: 256
+            messages:
+              - speaker: human
+                text: >-
+                  #src/squirrel.ts
+
+                  /**
+                   * Squirrel is an interface that mocks something completely unrelated to squirrels.
+                   * It is related to the implementation of precise code navigation in Sourcegraph.
+                   */
+                  export interface Squirrel {}
+
+
+
+                  #src/animal.ts
+
+                  /* SELECTION_START */
+
+                  export interface Animal {
+                      name: string
+                      makeAnimalSound(): string
+                      isMammal: boolean
+                  }
+
+                  /* SELECTION_END */
+
+
+
+                  #src/sum.ts
+
+                  <｜fim▁begin｜>export function sum(a: number, b: number): number {
+                      <｜fim▁hole｜>
+                  }
+
+                  <｜fim▁end｜>
+            model: fireworks/deepseek-coder-v2-lite-base
+            stopSequences:
+              - "\n\n"
+              - "\n\r\n"
+              - <｜fim▁begin｜>
+              - <｜fim▁hole｜>
+              - <｜fim▁end｜>, <|eos_token|>
+            stream: true
+            temperature: 0.2
+            timeoutMs: 7000
+            topK: 0
+        queryString:
+          - name: client-name
+            value: enterprisemainbranchclient
+          - name: client-version
+            value: v1
+        url: https://sourcegraph.sourcegraph.com/.api/completions/code?client-name=enterprisemainbranchclient&client-version=v1
+      response:
+        bodySize: 201
+        content:
+          mimeType: text/event-stream
+          size: 201
+          text: |+
+            event: completion
+            data: {"completion":"return a + b","stopReason":"stop"}
+
+            event: done
+            data: {}
+
+        cookies: []
+        headers:
+          - name: date
+            value: Mon, 07 Oct 2024 02:51:22 GMT
+          - name: content-type
+            value: text/event-stream
+          - name: transfer-encoding
+            value: chunked
+          - name: connection
+            value: keep-alive
+          - name: cache-control
+            value: no-cache
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+          - name: vary
+            value: Accept-Encoding, Authorization, Cookie, Authorization, X-Requested-With,
+              Cookie
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+        headersSize: 1184
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: 2024-10-07T02:51:21.908Z
       time: 0
       timings:
         blocked: -1
@@ -127,7 +566,7 @@ log:
           params: []
           textJSON:
             query: |-
-
+              
               query CurrentSiteCodyLlmConfiguration {
                   site {
                       codyLLMConfiguration {
@@ -146,52 +585,48 @@ log:
             value: null
         url: https://sourcegraph.sourcegraph.com/.api/graphql?CurrentSiteCodyLlmConfiguration
       response:
-        bodySize: 251
+        bodySize: 259
         content:
           encoding: base64
           mimeType: application/json
-          size: 251
-          text:
-            "[\"H4sIAAAAAAAAA4TOTQ6CMBAF4LvMmmqDEA1btrLzAmM7QAN2SH+MhvTuBjYSNXH1ksmbL\
-            28GjQGhmsGbQEsq1s/zuanZtqaLDoNhu957DA1r\",\"GqECz9Ep6hxO/V6NGDWJw64\
-            Unq2lANm72+DjwgNZD1VRSikzaNGH+g8lejRDhI/yxjqulOLbNNKy7xemiSZPNAjFmp\
-            y452I0gcQVPcHX78bOZXFKKaUXAAAA//8DADDh/dAaAQAA\"]"
+          size: 259
+          text: "[\"H4sIAAAAAAAAAwAAAP//\",\"hM5NDoIwEAXgu8yaaoMQDVu2svMCYztAA3ZIf4yG9O4G\
+            NhI1cfWSyZsvbwaNAaGawZtASyrWz/O5qdm2posOg2G73nsMDWsaoQLP0SnqHE79Xo0\
+            YNYnDrhSeraUA2bvb4OPCA1kPVVFKKTNo0Yf6DyV6NEOEj/LGOq6U4ts00rLvF6aJJk\
+            80CMWanLjnYjSBxBU9wdfvxs5lcUoppRcAAAD//wMAMOH90BoBAAA=\"]"
         cookies: []
         headers:
           - name: date
-            value: Wed, 25 Sep 2024 17:46:21 GMT
+            value: Mon, 07 Oct 2024 02:51:20 GMT
           - name: content-type
             value: application/json
           - name: transfer-encoding
             value: chunked
           - name: connection
             value: keep-alive
-          - name: access-control-allow-credentials
-            value: "true"
-          - name: access-control-allow-origin
-            value: ""
           - name: cache-control
             value: no-cache, max-age=0
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
           - name: vary
-            value:
-              Accept-Encoding, Authorization, Cookie, Authorization, X-Requested-With,
+            value: Accept-Encoding, Authorization, Cookie, Authorization, X-Requested-With,
               Cookie
+          - name: access-control-allow-credentials
+            value: "true"
           - name: x-content-type-options
             value: nosniff
           - name: x-frame-options
             value: DENY
           - name: x-xss-protection
             value: 1; mode=block
-          - name: strict-transport-security
-            value: max-age=31536000; includeSubDomains; preload
           - name: content-encoding
             value: gzip
-        headersSize: 1249
+        headersSize: 1218
         httpVersion: HTTP/1.1
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-09-25T17:46:21.367Z
+      startedDateTime: 2024-10-07T02:51:19.942Z
       time: 0
       timings:
         blocked: -1
@@ -237,7 +672,7 @@ log:
           params: []
           textJSON:
             query: |-
-
+              
               query CurrentSiteCodyLlmConfiguration {
                   site {
                       codyLLMConfiguration {
@@ -256,46 +691,42 @@ log:
           encoding: base64
           mimeType: application/json
           size: 139
-          text:
-            "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqzixJBdHJ+SmVPj6+zvl5aZnppUWJJZn5eWD53MSiE\
-            uf8vJLUipLwzLyU/HIlK6WUzOLEpJzUFKXa2tpa\",\"AAAAAP//AwArMNn0TAAAAA==\
+          text: "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqzixJBdHJ+SmVPj6+zvl5aZnppUWJJZn5eWD53MSiE\
+            uf8vJLUipLwzLyU/HIlK6WUzOLEpJzUFKXa2tpaAAAAAP//\",\"AwArMNn0TAAAAA==\
             \"]"
         cookies: []
         headers:
           - name: date
-            value: Wed, 25 Sep 2024 17:46:21 GMT
+            value: Mon, 07 Oct 2024 02:51:20 GMT
           - name: content-type
             value: application/json
           - name: transfer-encoding
             value: chunked
           - name: connection
             value: keep-alive
-          - name: access-control-allow-credentials
-            value: "true"
-          - name: access-control-allow-origin
-            value: ""
           - name: cache-control
             value: no-cache, max-age=0
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
           - name: vary
-            value:
-              Accept-Encoding, Authorization, Cookie, Authorization, X-Requested-With,
+            value: Accept-Encoding, Authorization, Cookie, Authorization, X-Requested-With,
               Cookie
+          - name: access-control-allow-credentials
+            value: "true"
           - name: x-content-type-options
             value: nosniff
           - name: x-frame-options
             value: DENY
           - name: x-xss-protection
             value: 1; mode=block
-          - name: strict-transport-security
-            value: max-age=31536000; includeSubDomains; preload
           - name: content-encoding
             value: gzip
-        headersSize: 1249
+        headersSize: 1218
         httpVersion: HTTP/1.1
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-09-25T17:46:21.416Z
+      startedDateTime: 2024-10-07T02:51:19.965Z
       time: 0
       timings:
         blocked: -1
@@ -341,7 +772,7 @@ log:
           params: []
           textJSON:
             query: |-
-
+              
               query CurrentSiteCodyLlmProvider {
                   site {
                       codyLLMConfiguration {
@@ -360,45 +791,41 @@ log:
           encoding: base64
           mimeType: application/json
           size: 131
-          text:
-            "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqzixJBdHJ+SmVPj6+zvl5aZnppUWJJZn5eSDxgqL8s\
+          text: "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqzixJBdHJ+SmVPj6+zvl5aZnppUWJJZn5eSDxgqL8s\
             syU1CIlK6Xi/NKi5NT0osSCDKXa2tpaAAAAAP//\",\"AwAfFAXARQAAAA==\"]"
         cookies: []
         headers:
           - name: date
-            value: Wed, 25 Sep 2024 17:46:21 GMT
+            value: Mon, 07 Oct 2024 02:51:20 GMT
           - name: content-type
             value: application/json
           - name: transfer-encoding
             value: chunked
           - name: connection
             value: keep-alive
-          - name: access-control-allow-credentials
-            value: "true"
-          - name: access-control-allow-origin
-            value: ""
           - name: cache-control
             value: no-cache, max-age=0
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
           - name: vary
-            value:
-              Accept-Encoding, Authorization, Cookie, Authorization, X-Requested-With,
+            value: Accept-Encoding, Authorization, Cookie, Authorization, X-Requested-With,
               Cookie
+          - name: access-control-allow-credentials
+            value: "true"
           - name: x-content-type-options
             value: nosniff
           - name: x-frame-options
             value: DENY
           - name: x-xss-protection
             value: 1; mode=block
-          - name: strict-transport-security
-            value: max-age=31536000; includeSubDomains; preload
           - name: content-encoding
             value: gzip
-        headersSize: 1249
+        headersSize: 1218
         httpVersion: HTTP/1.1
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-09-25T17:46:21.269Z
+      startedDateTime: 2024-10-07T02:51:19.943Z
       time: 0
       timings:
         blocked: -1
@@ -444,7 +871,7 @@ log:
           params: []
           textJSON:
             query: |-
-
+              
               query CurrentUser {
                   currentUser {
                       id
@@ -469,52 +896,48 @@ log:
             value: null
         url: https://sourcegraph.sourcegraph.com/.api/graphql?CurrentUser
       response:
-        bodySize: 231
+        bodySize: 239
         content:
           encoding: base64
           mimeType: application/json
-          size: 231
-          text:
-            "[\"H4sIAAAAAAAAAzSOuwrCQBBF/2XqLawXLO0kgpggiMWQncTRzWyY2Qgx7L9LfJTncricB\
-            QJmBL9AO6mS5NpIV+QAHppzFdt72hxOjy04uKE1\",\"pNwxhd2AHMF3GI0cBLYx4lz\
-            hQOBlitHBZKTyYWhTmDNZZunBAT4xo9bH/d8clQfU+ff43ZL2KPzCzElszZEUyMBfrq\
-            WU8gYAAP//AwAAXh5NtQAAAA==\"]"
+          size: 239
+          text: "[\"H4sIAAAAAAAAAwAAAP//NI67CsJAEEX/ZeotrBcs7SSCmCCIxZCdxNHNbJjZCDHsv0t8l\
+            OdyuJwFAmYEv0A7qZLk2khX5AAemnMV23vaHE6PLTi4oTWk3DGF3YAcwXcYjRwEtjHi\
+            XOFA4GWK0cFkpPJhaFOYM1lm6cEBPjGj1sf93w==\",\"HJUH1Pn3+N2S9ij8wsxJbM\
+            2RFMjAX66llPIGAAD//wMAAF4eTbUAAAA=\"]"
         cookies: []
         headers:
           - name: date
-            value: Wed, 25 Sep 2024 17:46:21 GMT
+            value: Mon, 07 Oct 2024 02:51:20 GMT
           - name: content-type
             value: application/json
           - name: transfer-encoding
             value: chunked
           - name: connection
             value: keep-alive
-          - name: access-control-allow-credentials
-            value: "true"
-          - name: access-control-allow-origin
-            value: ""
           - name: cache-control
             value: no-cache, max-age=0
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
           - name: vary
-            value:
-              Accept-Encoding, Authorization, Cookie, Authorization, X-Requested-With,
+            value: Accept-Encoding, Authorization, Cookie, Authorization, X-Requested-With,
               Cookie
+          - name: access-control-allow-credentials
+            value: "true"
           - name: x-content-type-options
             value: nosniff
           - name: x-frame-options
             value: DENY
           - name: x-xss-protection
             value: 1; mode=block
-          - name: strict-transport-security
-            value: max-age=31536000; includeSubDomains; preload
           - name: content-encoding
             value: gzip
-        headersSize: 1249
+        headersSize: 1218
         httpVersion: HTTP/1.1
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-09-25T17:46:21.318Z
+      startedDateTime: 2024-10-07T02:51:19.475Z
       time: 0
       timings:
         blocked: -1
@@ -540,7 +963,7 @@ log:
             value: application/json; charset=utf-8
           - _fromType: array
             name: traceparent
-            value: 00-a6164fcf1aee400088c7f4682a533570-2ad68d1075d0f6ea-01
+            value: 00-430c2503de0f1ee4adcf8d35514dd89d-2df1fa46ef213224-01
           - _fromType: array
             name: user-agent
             value: enterpriseMainBranchClient / v1
@@ -563,7 +986,7 @@ log:
           params: []
           textJSON:
             query: |
-
+              
               query ResolveRepoName($cloneURL: String!) {
                   repository(cloneURL: $cloneURL) {
                       name
@@ -576,50 +999,50 @@ log:
             value: null
         url: https://sourcegraph.sourcegraph.com/.api/graphql?ResolveRepoName
       response:
-        bodySize: 123
+        bodySize: 120
         content:
           encoding: base64
           mimeType: application/json
-          size: 123
-          text:
-            "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqSi3IL84syS+qBPHyEnNTlayU0jNLMkqT9JLzc/WL8\
-            0uLklPTixILMvST81MqlWprawEAAAD//wMAbAMm\",\"/T4AAAA=\"]"
+          size: 120
+          text: "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqSi3IL84syS+qBPHyEnNTlayU0jNLMkqT9JLzc/WL8\
+            0uLklPTixILMvST81MqlWprawEAAAD//wMAbAMm/T4AAAA=\"]"
+          textDecoded:
+            data:
+              repository:
+                name: github.com/sourcegraph/cody
         cookies: []
         headers:
           - name: date
-            value: Wed, 25 Sep 2024 17:46:22 GMT
+            value: Mon, 07 Oct 2024 02:51:20 GMT
           - name: content-type
             value: application/json
           - name: transfer-encoding
             value: chunked
           - name: connection
             value: keep-alive
-          - name: access-control-allow-credentials
-            value: "true"
-          - name: access-control-allow-origin
-            value: ""
           - name: cache-control
             value: no-cache, max-age=0
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
           - name: vary
-            value:
-              Accept-Encoding, Authorization, Cookie, Authorization, X-Requested-With,
+            value: Accept-Encoding, Authorization, Cookie, Authorization, X-Requested-With,
               Cookie
+          - name: access-control-allow-credentials
+            value: "true"
           - name: x-content-type-options
             value: nosniff
           - name: x-frame-options
             value: DENY
           - name: x-xss-protection
             value: 1; mode=block
-          - name: strict-transport-security
-            value: max-age=31536000; includeSubDomains; preload
           - name: content-encoding
             value: gzip
-        headersSize: 1249
+        headersSize: 1218
         httpVersion: HTTP/1.1
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-09-25T17:46:22.604Z
+      startedDateTime: 2024-10-07T02:51:20.126Z
       time: 0
       timings:
         blocked: -1
@@ -665,7 +1088,7 @@ log:
           params: []
           textJSON:
             query: |-
-
+              
               query SiteProductVersion {
                   site {
                       productVersion
@@ -677,51 +1100,148 @@ log:
             value: null
         url: https://sourcegraph.sourcegraph.com/.api/graphql?SiteProductVersion
       response:
-        bodySize: 139
+        bodySize: 143
         content:
           encoding: base64
           mimeType: application/json
-          size: 139
-          text:
-            "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqzixJBdEFRfkppcklYalFxZn5eUpWSkaWRsZmhvFGB\
-            kYmugaWukam8aZ65roGpqmmJkYpSRYpBklKtbW1\",\"AAAAAP//AwA/YNqlSQAAAA==\
-            \"]"
+          size: 143
+          text: "[\"H4sIAAAAAAAAAwAAAP//\",\"qlZKSSxJVLKqVirOLEkF0QVF+SmlySVhqUXFmfl5SlZK\
+            RpYmhgYm8UYGRia6hga6BqbxpnrmuikGKcampsbmKYaJSUq1tbUAAAAA//8DALLCSep\
+            JAAAA\"]"
         cookies: []
         headers:
           - name: date
-            value: Wed, 25 Sep 2024 17:46:21 GMT
+            value: Mon, 07 Oct 2024 02:51:20 GMT
           - name: content-type
             value: application/json
           - name: transfer-encoding
             value: chunked
           - name: connection
             value: keep-alive
-          - name: access-control-allow-credentials
-            value: "true"
-          - name: access-control-allow-origin
-            value: ""
           - name: cache-control
             value: no-cache, max-age=0
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
           - name: vary
-            value:
-              Accept-Encoding, Authorization, Cookie, Authorization, X-Requested-With,
+            value: Accept-Encoding, Authorization, Cookie, Authorization, X-Requested-With,
               Cookie
+          - name: access-control-allow-credentials
+            value: "true"
           - name: x-content-type-options
             value: nosniff
           - name: x-frame-options
             value: DENY
           - name: x-xss-protection
             value: 1; mode=block
-          - name: strict-transport-security
-            value: max-age=31536000; includeSubDomains; preload
           - name: content-encoding
             value: gzip
-        headersSize: 1249
+        headersSize: 1218
         httpVersion: HTTP/1.1
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-09-25T17:46:21.165Z
+      startedDateTime: 2024-10-07T02:51:20.011Z
+      time: 0
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 0
+    - _id: 95125ff5233bb76b0a9c866419f37bd1
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 243
+        cookies: []
+        headers:
+          - _fromType: array
+            name: authorization
+            value: token
+              REDACTED_4229eb42e0efa2f15f3e6f8843764c7f92ab8051020cc4e90802f4fc0cc91bfa
+          - _fromType: array
+            name: content-type
+            value: application/json; charset=utf-8
+          - _fromType: array
+            name: user-agent
+            value: enterpriseMainBranchClient / v1
+          - _fromType: array
+            name: accept
+            value: "*/*"
+          - _fromType: array
+            name: content-length
+            value: "243"
+          - _fromType: array
+            name: accept-encoding
+            value: gzip,deflate
+          - name: host
+            value: sourcegraph.sourcegraph.com
+        headersSize: 433
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json; charset=utf-8
+          params: []
+          textJSON:
+            query: |-
+              
+              query SnippetAttribution($snippet: String!) {
+                  snippetAttribution(snippet: $snippet) {
+                      limitHit
+                      nodes {
+                          repositoryName
+                      }
+                  }
+              }
+            variables:
+              snippet: sourcegraph.Location(new URL
+        queryString:
+          - name: SnippetAttribution
+            value: null
+        url: https://sourcegraph.sourcegraph.com/.api/graphql?SnippetAttribution
+      response:
+        bodySize: 127
+        content:
+          encoding: base64
+          mimeType: application/json
+          size: 127
+          text: "[\"H4sIAAAAAAAAAwAAAP//\",\"qlZKSSxJVLKqVirOyywoSC1xLCkpykwqLcnMzwOJ5mTm\
+            ZpZ4ZJYoWaUl5hSn6ijl5aekFitZRcfW1tYCAAAA//8DAF9MDP49AAAA\"]"
+        cookies: []
+        headers:
+          - name: date
+            value: Mon, 07 Oct 2024 02:50:08 GMT
+          - name: content-type
+            value: application/json
+          - name: transfer-encoding
+            value: chunked
+          - name: connection
+            value: keep-alive
+          - name: cache-control
+            value: no-cache, max-age=0
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+          - name: vary
+            value: Accept-Encoding, Authorization, Cookie, Authorization, X-Requested-With,
+              Cookie
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: content-encoding
+            value: gzip
+        headersSize: 1218
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: 2024-10-07T02:50:08.358Z
       time: 0
       timings:
         blocked: -1
@@ -767,7 +1287,7 @@ log:
           params: []
           textJSON:
             query: |-
-
+              
               query SnippetAttribution($snippet: String!) {
                   snippetAttribution(snippet: $snippet) {
                       limitHit
@@ -783,50 +1303,46 @@ log:
             value: null
         url: https://sourcegraph.sourcegraph.com/.api/graphql?SnippetAttribution
       response:
-        bodySize: 123
+        bodySize: 127
         content:
           encoding: base64
           mimeType: application/json
-          size: 123
-          text:
-            "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqzsssKEgtcSwpKcpMKi3JzM8DieZk5maWeGSWKFmlJ\
-            eYUp+oo5eWnpBYrWUXH1tbWAgAAAP//AwBfTAz+\",\"PQAAAA==\"]"
+          size: 127
+          text: "[\"H4sIAAAAAAAAAwAAAP//\",\"qlZKSSxJVLKqVirOyywoSC1xLCkpykwqLcnMzwOJ5mTm\
+            ZpZ4ZJYoWaUl5hSn6ijl5aekFitZRcfW1tYCAAAA//8DAF9MDP49AAAA\"]"
         cookies: []
         headers:
           - name: date
-            value: Wed, 25 Sep 2024 17:46:22 GMT
+            value: Mon, 07 Oct 2024 02:51:22 GMT
           - name: content-type
             value: application/json
           - name: transfer-encoding
             value: chunked
           - name: connection
             value: keep-alive
-          - name: access-control-allow-credentials
-            value: "true"
-          - name: access-control-allow-origin
-            value: ""
           - name: cache-control
             value: no-cache, max-age=0
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
           - name: vary
-            value:
-              Accept-Encoding, Authorization, Cookie, Authorization, X-Requested-With,
+            value: Accept-Encoding, Authorization, Cookie, Authorization, X-Requested-With,
               Cookie
+          - name: access-control-allow-credentials
+            value: "true"
           - name: x-content-type-options
             value: nosniff
           - name: x-frame-options
             value: DENY
           - name: x-xss-protection
             value: 1; mode=block
-          - name: strict-transport-security
-            value: max-age=31536000; includeSubDomains; preload
           - name: content-encoding
             value: gzip
-        headersSize: 1249
+        headersSize: 1218
         httpVersion: HTTP/1.1
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-09-25T17:46:21.893Z
+      startedDateTime: 2024-10-07T02:51:22.397Z
       time: 0
       timings:
         blocked: -1
@@ -864,64 +1380,60 @@ log:
         queryString: []
         url: https://sourcegraph.sourcegraph.com/.api/modelconfig/supported-models.json
       response:
-        bodySize: 767
+        bodySize: 773
         content:
           encoding: base64
           mimeType: text/plain; charset=utf-8
-          size: 767
-          text:
-            "[\"H4sIAAAAAAAA/+yYz0/jOBTH7/0rrFwXFzdtYTc3tit2kIYBDYg5jDi8Oq+t1SS2bKelQ\
-            vzvoyRNmDRpk6IKBENPUfx9X//4PDfPfuwQQohj+Aw=\",\"Q7hDbYSMHI84vS5zjrI\
-            2jQuRv2Zd1mV/+bjIG5WWC+GjNo5Hfqavkt9j8ZSKhJ/EQmRnWirB17FFsy+MCmD1DU\
-            JMdGeFrpA9He22ngiNS6nnpsH6vNC1tp5KOQ2wwff/TNTaVCqMQDSYXimMzi7am4bCW\
-            A1Bg+vlWvVsmz7dr3mG0sdgJ8xU8R0nJaSe5zK3T9kJZT3P4wHEPtJ+d0iNjCK0DWMa\
-            pXrS7w7JTa0+7TNX5+40d6cucwfsxGWbYRwUjEUgrMDylAoF+mKzsyxyBtYpvb6veFu\
-            cSr1KRjSGACKO/mb/xoKNk56Tp3E1i6xAnaavxkobl5HFB/tDRL5cOt4GhWxV4OEiUr\
-            G9lXOMkm4GQ8ZYzWxCeLiKbUnJGCvpnlqk2R7kqVRx02bMqZOrGm098cQ1o+26/7wVb\
-            WlnqF+KWmn5wUjPQMzjtqi/1InrWae+Gew+O30r2Ebh2+/r01eDXXxIPW/R8zxjQXPp\
-            V9N9g++NBT2q05XQbnVrhgmxlVyGKkCLrwTvQDvVZYO/W7FzhyeHROcjKoM4p+mK04V\
-            LA2GRjsE0FTP/IaobxDm5c8lXYZH8WxNTAgucyziy5tjIWHOcalCz46ySON5jHJ9pcI\
-            A0yOrVLAemGIpI0F53SGumsVnDpmLS6w7JdVVc4r3b97PqKoSH/nveAncSgJm1x3teJ\
-            98GuNb7j/r6viLf7FyYFloDyty00JoqSweNm/f6tkZUZlrr81426/urm+tYcumvaLJw\
-            VGlcCFxSxnqtrgGI7OUxu8vnNj00Q98PLnAea+Cr7XCXIGwgTOVg//Hxuq3xJn+5e7O\
-            t2H+y3cm289t8HR8nEAf2Mr/zeh5Gtkgvu+FyJmDsqF185fScQMZRVuKu71z3KOw72R\
-            yfOr8CAAD//xV7s5PXFQAA\"]"
+          size: 773
+          text: "[\"H4sIAAAAAAAA/+yYX0/bPBTG7/sprNy+uDhpC+9yxzqxIY2BBmIXExeuc9pYTWLLdloqx\
+            HefkjRhaUyTIlQEo1dR/JzHf37H9Ynvewgh5GgWQkxvQGkuEsdHjtsnzkHRpmDBy9ek\
+            T/rkvwAWZaNUYsEDUNrx0e/8Vfa7r55yEQ+yWJqY\",\"UAnJ2Tq2ag64lhFd/aAxZL\
+            qTSlfJHg62W0+5gqVQc91ifVrpOlvPhJhF0OL7tRB1NhUSEspbTC8kJCdn3U1jro2iU\
+            Yvr+Vr1aJs/3a55xiKAaCvMXPETpjWkvu8Rb4DJESau77OIpgHgQX+EtUgSMC1jGud6\
+            NOiP0JVVn/dZqkt3XLpjj3hDcuSRzTBGJZ3wiBsO9SlVCgj4ZmdFZEit79c7odZw2+j\
+            VwEyoVb5AjKWKstXmyLShJs3GlD1NmvllOKg8sRU02phIDNyZXzwJxNLxN/gU60Xvzh\
+            KZmmsxhyTrZjgihFjmE9O7i9TUlISQmu6hQwLukBNYyLRtm5b5gC4sWnsuZK5FHnjep\
+            xfOg860hQlBPRe1VOKdkQ4pn6ddUX+zie2sc98C9oAcvxZsLQGC197Xx3uDXR2xvr9w\
+            fV8bqpgImum+wffKUDW26Wpon3Rrh0lTI5iIZQQG3hg8jwz/7wTPGx29JLsAQGqAOc6\
+            XHC88HHEDeEJ1W53zBUBeAczRjYe+cwPosyWmRpYyJtLE6EMtUsVgpqgMD4si43CHcX\
+            zkwUvkQVHLFkkwg5gnHLv9EbacPJv1bS5Gbn+ELpviGvDtvvv6c57QiCbs9dHu8TR+A\
+            u40ojrsjvfUJn8KsNX7nzp/98i3+GbMS60hJl5eas2kwcPWzXt5bRHVmVp93v7n09ur\
+            qW2UmQhWOFtSLBUsOCwxIW6nywMk3DJme2ndpYf2dNhtA7fDXVJuIq4b1wHvH6/XGW/\
+            2Z7wz24b9B9utbHt/zdcJYErTyJyXN2WPwygW6Xn3Ys6UajPuFt/4ss4gw7ioftc3tT\
+            vU/L1ijg+9PwEAAP//fIckBg0WAAA=\"]"
         cookies: []
         headers:
           - name: date
-            value: Wed, 25 Sep 2024 17:46:22 GMT
+            value: Mon, 07 Oct 2024 02:51:21 GMT
           - name: content-type
             value: text/plain; charset=utf-8
           - name: content-length
-            value: "767"
+            value: "773"
           - name: connection
             value: keep-alive
-          - name: access-control-allow-credentials
-            value: "true"
-          - name: access-control-allow-origin
-            value: ""
           - name: cache-control
             value: no-cache, max-age=0
           - name: content-encoding
             value: gzip
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
           - name: vary
-            value:
-              Accept-Encoding, Authorization, Cookie, Authorization, X-Requested-With,
+            value: Accept-Encoding, Authorization, Cookie, Authorization, X-Requested-With,
               Cookie
+          - name: access-control-allow-credentials
+            value: "true"
           - name: x-content-type-options
             value: nosniff
           - name: x-frame-options
             value: DENY
           - name: x-xss-protection
             value: 1; mode=block
-          - name: strict-transport-security
-            value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1251
+        headersSize: 1220
         httpVersion: HTTP/1.1
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-09-25T17:46:21.892Z
+      startedDateTime: 2024-10-07T02:51:20.766Z
       time: 0
       timings:
         blocked: -1

--- a/agent/src/enterprise-s2.test.ts
+++ b/agent/src/enterprise-s2.test.ts
@@ -2,7 +2,7 @@ import path from 'node:path'
 
 import { spawnSync } from 'node:child_process'
 import { INCLUDE_EVERYTHING_CONTEXT_FILTERS } from '@sourcegraph/cody-shared'
-import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
 import { TESTING_CREDENTIALS } from '../../vscode/src/testutils/testing-credentials'
 import { TestClient } from './TestClient'
 import { TestWorkspace } from './TestWorkspace'
@@ -31,9 +31,7 @@ describe('Enterprise - S2 (close main branch)', { timeout: 5000 }, () => {
             stdio: 'inherit',
         })
 
-        const serverInfo = await s2EnterpriseClient.initialize({
-            autocompleteAdvancedProvider: 'fireworks',
-        })
+        const serverInfo = await s2EnterpriseClient.initialize()
 
         expect(serverInfo.authStatus?.authenticated).toBeTruthy()
         if (!serverInfo.authStatus?.authenticated) {
@@ -41,28 +39,6 @@ describe('Enterprise - S2 (close main branch)', { timeout: 5000 }, () => {
         }
         expect(serverInfo.authStatus?.username).toStrictEqual('codytesting')
     }, 10_000)
-
-    // Disabled because `attribution/search` GraphQL does not work on S2
-    // See https://sourcegraph.slack.com/archives/C05JDP433DL/p1714017586160079
-    it.skip('attribution/found', async () => {
-        const id = await s2EnterpriseClient.request('chat/new', null)
-        const { repoNames, error } = await s2EnterpriseClient.request('attribution/search', {
-            id,
-            snippet: 'sourcegraph.Location(new URL',
-        })
-        expect(repoNames).not.empty
-        expect(error).null
-    }, 20_000)
-
-    it('attribution/not found', async () => {
-        const id = await s2EnterpriseClient.request('chat/new', null)
-        const { repoNames, error } = await s2EnterpriseClient.request('attribution/search', {
-            id,
-            snippet: 'sourcegraph.Location(new LRU',
-        })
-        expect(repoNames).empty
-        expect(error).null
-    }, 20_000)
 
     // Use S2 instance for Cody Context Filters enterprise tests
     describe('Cody Context Filters for enterprise', () => {
@@ -73,13 +49,8 @@ describe('Enterprise - S2 (close main branch)', { timeout: 5000 }, () => {
                 INCLUDE_EVERYTHING_CONTEXT_FILTERS
             )
         })
-        afterEach(() => {
-            s2EnterpriseClient.unregisterNotification('ignore/didChange')
-        })
 
-        // NOTE(sqs): Run many times to find flakes better. This test has been often flaky but was
-        // fixed on 2024-09-20.
-        it.each(Array.from({ length: 25 }))('testing/ignore/overridePolicy', async () => {
+        it('testing/ignore/overridePolicy', async () => {
             await s2EnterpriseClient.openFile(sumUri)
 
             const onChangeCallback = vi.fn()
@@ -115,14 +86,12 @@ describe('Enterprise - S2 (close main branch)', { timeout: 5000 }, () => {
 
             // onChangeCallback is not called again because filters are the same
             expect(onChangeCallback).toBeCalledTimes(2)
+            s2EnterpriseClient.unregisterNotification('ignore/didChange')
         })
 
         // The site config `cody.contextFilters` value on sourcegraph.sourcegraph.com instance
         // should include `sourcegraph/cody` repo for this test to pass.
-        // Skipped because of the API error:
-        //  Request to https://sourcegraph.sourcegraph.com/.api/completions/code?client-name=vscode&client-version=v1 failed with 406 Not Acceptable: ClientCodyIgnoreCompatibilityError: Cody for vscode version "v1" doesn't match version constraint ">= 1.20.0". Please upgrade your client.
-        // https://linear.app/sourcegraph/issue/CODY-2814/fix-and-re-enable-cody-context-filters-agent-integration-test
-        it.skip('autocomplete/execute (with Cody Ignore filters)', async () => {
+        it('autocomplete/execute (with Cody Ignore filters)', async () => {
             // Documents to be used as context sources.
             await s2EnterpriseClient.openFile(animalUri)
             await s2EnterpriseClient.openFile(squirrelUri)
@@ -132,7 +101,7 @@ describe('Enterprise - S2 (close main branch)', { timeout: 5000 }, () => {
 
             const { items, completionEvent } = await s2EnterpriseClient.request('autocomplete/execute', {
                 uri: sumUri.toString(),
-                position: { line: 1, character: 3 },
+                position: { line: 1, character: 4 },
                 triggerKind: 'Invoke',
             })
 
@@ -140,7 +109,7 @@ describe('Enterprise - S2 (close main branch)', { timeout: 5000 }, () => {
             expect(items.map(item => item.insertText)).toMatchInlineSnapshot(
                 `
               [
-                "   return a + b",
+                "    return a + b",
               ]
             `
             )
@@ -155,6 +124,30 @@ describe('Enterprise - S2 (close main branch)', { timeout: 5000 }, () => {
                 completionID: items[0].id,
             })
         }, 10_000)
+    })
+
+    describe('attribution', () => {
+        // Disabled because `attribution/search` GraphQL does not work on S2
+        // See https://sourcegraph.slack.com/archives/C05JDP433DL/p1714017586160079
+        it.skip('found', async () => {
+            const id = await s2EnterpriseClient.request('chat/new', null)
+            const { repoNames, error } = await s2EnterpriseClient.request('attribution/search', {
+                id,
+                snippet: 'sourcegraph.Location(new URL',
+            })
+            expect(repoNames).not.empty
+            expect(error).null
+        }, 20_000)
+
+        it('not found', async () => {
+            const id = await s2EnterpriseClient.request('chat/new', null)
+            const { repoNames, error } = await s2EnterpriseClient.request('attribution/search', {
+                id,
+                snippet: 'sourcegraph.Location(new LRU',
+            })
+            expect(repoNames).empty
+            expect(error).null
+        }, 20_000)
     })
 
     afterAll(async () => {


### PR DESCRIPTION
- Re-enables the S2 context filters autocomplete agent tests.
- Disables 25 runs of the `testing/ignore/overridePolicy` that was flaky, but it looks like [the latest improvement](https://github.com/sourcegraph/cody/pull/5647) from @sqs stabilized it, so we can run it only once. 
- Part of https://linear.app/sourcegraph/issue/CODY-3910/add-autocomplete-integation-tests-for-server-side-model-config
- Closes https://linear.app/sourcegraph/issue/CODY-2814/fix-and-re-enable-cody-context-filters-agent-integration-test

## Test plan

CI and `pnpm vitest agent/src/enterprise-s2.test.ts`