### PR TITLE
Record promptText for S2

### DIFF
--- a/lib/shared/src/sourcegraph-api/environments.ts
+++ b/lib/shared/src/sourcegraph-api/environments.ts
@@ -22,3 +22,20 @@ export function isDotCom(arg: Pick<AuthStatus, 'endpoint'> | undefined | string)
         return false
     }
 }
+
+export const S2_URL = new URL('https://sourcegraph.sourcegraph.com/')
+
+// 🚨 SECURITY: This is used as a check for logging chatTranscript for S2 users only, be extremely careful if modifying this function
+export function isS2(authStatus: Pick<AuthStatus, 'endpoint'> | undefined): boolean
+export function isS2(url: string): boolean
+export function isS2(arg: Pick<AuthStatus, 'endpoint'> | undefined | string): boolean {
+    const url = typeof arg === 'string' ? arg : arg?.endpoint
+    if (url === undefined) {
+        return false
+    }
+    try {
+        return new URL(url).origin === S2_URL.origin
+    } catch {
+        return false
+    }
+}

--- a/lib/shared/src/telemetry-v2/events/chat-question.ts
+++ b/lib/shared/src/telemetry-v2/events/chat-question.ts
@@ -108,7 +108,8 @@ export const events = [
                     current: Span
                     firstToken: Span
                     addMetadata: boolean
-                }
+                },
+                tokenCounterUtils: TokenCounterUtils
             ) => {
                 const gitMetadata =
                     isDotCom(params.authStatus) && params.repoIsPublic && isArray(params.repoMetadata)
@@ -155,7 +156,11 @@ export const events = [
                         // V2 telemetry exports privateMetadata only for S2 users. The condition below is an additional safeguard measure.
                         // Check `SRC_TELEMETRY_SENSITIVEMETADATA_ADDITIONAL_ALLOWED_EVENT_TYPES` env to learn more.
                         promptText: isS2(params.authStatus)
-                            ? truncatePromptString(params.promptText, CHAT_INPUT_TOKEN_BUDGET)
+                            ? truncatePromptString(
+                                  params.promptText,
+                                  CHAT_INPUT_TOKEN_BUDGET,
+                                  tokenCounterUtils
+                              )
                             : undefined,
                     },
                     billingMetadata: {
@@ -204,7 +209,10 @@ function publicContextSummary(globalPrefix: string, context: ContextItem[]) {
         openctx: cloneDeep(defaultByTypeCount),
         repository: cloneDeep(defaultByTypeCount),
         symbol: cloneDeep(defaultByTypeCount),
-        tree: { ...cloneDeep(defaultByTypeCount), isWorkspaceRoot: undefined as number | undefined },
+        tree: {
+            ...cloneDeep(defaultByTypeCount),
+            isWorkspaceRoot: undefined as number | undefined,
+        },
     }
     const byOpenctxProvider = {
         [REMOTE_REPOSITORY_PROVIDER_URI]: cloneDeep(defaultSharedItemCount),
@@ -327,7 +335,9 @@ const defaultSharedItemCount: SharedItemCount = {
 }
 type BySourceCount = SharedItemCount & {
     isWorkspaceRoot: number | undefined
-    types: { [key in Exclude<ContextItem['type'], undefined>]: number | undefined }
+    types: {
+        [key in Exclude<ContextItem['type'], undefined>]: number | undefined
+    }
 }
 const defaultBySourceCount: BySourceCount = {
     ...defaultSharedItemCount,
@@ -342,7 +352,9 @@ const defaultBySourceCount: BySourceCount = {
 }
 
 type ByTypeCount = SharedItemCount & {
-    sources: { [key in Exclude<ContextItem['source'] | 'other', undefined>]: number | undefined }
+    sources: {
+        [key in Exclude<ContextItem['source'] | 'other', undefined>]: number | undefined
+    }
 }
 const defaultByTypeCount: ByTypeCount = {
     ...defaultSharedItemCount,

--- a/lib/shared/src/telemetry-v2/events/chat-question.ts
+++ b/lib/shared/src/telemetry-v2/events/chat-question.ts
@@ -111,8 +111,12 @@ export const events = [
                 },
                 tokenCounterUtils: TokenCounterUtils
             ) => {
+                const recordTranscript =
+                    params.authStatus.endpoint &&
+                    (isDotCom(params.authStatus) || isS2(params.authStatus))
+
                 const gitMetadata =
-                    isDotCom(params.authStatus) && params.repoIsPublic && isArray(params.repoMetadata)
+                    recordTranscript && params.repoIsPublic && isArray(params.repoMetadata)
                         ? params.repoMetadata
                         : undefined
 
@@ -136,7 +140,7 @@ export const events = [
                             ? map.intent(params.detectedIntent)
                             : undefined,
                         ...metadata,
-                        recordsPrivateMetadataTranscript: isS2(params.authStatus) ? 1 : 0,
+                        recordsPrivateMetadataTranscript: recordTranscript ? 1 : 0,
                     }),
                     privateMetadata: {
                         detectedIntentScores: params.detectedIntentScores?.length
@@ -152,10 +156,10 @@ export const events = [
                         userSpecifiedIntent: params.userSpecifiedIntent,
                         traceId: spans.current.spanContext().traceId,
                         gitMetadata,
-                        // 🚨 SECURITY: Chat transcripts are to be included only for S2 users AND for V2 telemetry.
-                        // V2 telemetry exports privateMetadata only for S2 users. The condition below is an additional safeguard measure.
+                        // 🚨 SECURITY: Chat transcripts are to be included only for S2 & Dotcom users AND for V2 telemetry.
+                        // V2 telemetry exports privateMetadata only for S2 & Dotcom users. The condition below is an additional safeguard measure.
                         // Check `SRC_TELEMETRY_SENSITIVEMETADATA_ADDITIONAL_ALLOWED_EVENT_TYPES` env to learn more.
-                        promptText: isS2(params.authStatus)
+                        promptText: recordTranscript
                             ? truncatePromptString(
                                   params.promptText,
                                   CHAT_INPUT_TOKEN_BUDGET,

--- a/vscode/src/chat/chat-view/ChatController.ts
+++ b/vscode/src/chat/chat-view/ChatController.ts
@@ -768,7 +768,8 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
                             detectedIntent: intent,
                             detectedIntentScores: intentScores,
                         },
-                        { current: span, firstToken: firstTokenSpan, addMetadata: true }
+                        { current: span, firstToken: firstTokenSpan, addMetadata: true },
+                        tokenCounterUtils
                     )
 
                     return await this.handleSearchIntent({
@@ -823,7 +824,8 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
                         addMetadata: true,
                         current: span,
                         firstToken: firstTokenSpan,
-                    }
+                    },
+                    tokenCounterUtils
                 )
 
                 signal.throwIfAborted()


### PR DESCRIPTION
Issue: https://linear.app/sourcegraph/issue/AI-337/create-way-to-query-s2-query-privatemetadata-data

We need to record `promptText` on S2 instance for learning from dog fooding. 

## Test plan

- Submit a chat and make sure that the prompt Text is being recorded. 

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
