### PR TITLE
Visual Studio: update at-mention token colors

### DIFF
--- a/vscode/webviews/themes/visual-studio.css
+++ b/vscode/webviews/themes/visual-studio.css
@@ -267,9 +267,9 @@ html[data-ide='VisualStudio'] {
     --vscode-input-border: var(--visualstudio-comboboxborder);
     --vscode-input-foreground: var(--visualstudio-comboboxtext);
     --vscode-input-placeholderForeground: var(--visualstudio-comboboxitemtextinactive);
-    --vscode-inputOption-activeBackground: var(--visualstudio-startpagebuttonunpinned);
-    --vscode-inputOption-activeBorder: var(--visualstudio-startpagebuttonborder);
-    --vscode-inputOption-activeForeground: var(--visualstudio-startpagebuttontext);
+    --vscode-inputOption-activeBackground: var(--visualstudio-startpagetextcontrollinkselected);
+    --vscode-inputOption-activeBorder: var(--visualstudio-startpagetextcontrollinkselected);
+    --vscode-inputOption-activeForeground: var(--visualstudio-startpagetextbody);
     --vscode-inputValidation-errorBackground: var(--visualstudio-statusbardebugging);
     --vscode-inputValidation-errorBorder: var(--visualstudio-statusbardebugging);
     --vscode-inputValidation-infoBackground: var(--visualstudio-statusbarbuilding);


### PR DESCRIPTION
CLOSE https://linear.app/sourcegraph/issue/CODY-3954/visual-studio-fix-color-on-light-theme

- Updates the `--vscode-inputOption-activeBackground`, `--vscode-inputOption-activeBorder`, and `--vscode-inputOption-activeForeground` variables in the visual-studio theme to use more appropriate colors.
- The previous colors were using the `--visualstudio-startpagebuttonunpinned`, `--visualstudio-startpagebuttonborder`, and `--visualstudio-startpagebuttontext` variables, which were not the best fit for input option active styles.
- The new colors use the `--visualstudio-startpagetextcontrollinkselected` and `--visualstudio-startpagetextbody` variables, which works better in both light and dark theme in Visual Studio for @-mention tokens


## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

Build Visual Studio with this branch to confirm the @ mention tokens background color are improved

Blue theme:

![image](https://github.com/user-attachments/assets/d11f07ee-2af7-43a2-8f03-6d2db58e5668)

Light theme:

![image](https://github.com/user-attachments/assets/caf9191c-8b76-4518-95e9-eed6d82f16e1)

Dark theme:

![image](https://github.com/user-attachments/assets/491e0221-ad88-4d51-896e-06dbe1ae515b)

Before

![image](https://github.com/user-attachments/assets/235524ae-1a72-43ed-b810-85951bcf7578)


## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
