### PR TITLE
Fix chat message intent serialization

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -28,12 +28,15 @@
   "editor.insertSpaces": true,
   "cSpell.words": ["Supercompletion", "Supercompletions"],
   "[javascript][javascriptreact][json][jsonc][typescript][typescriptreact][graphql]": {
-  "editor.defaultFormatter": "biomejs.biome"
-},
+    "editor.defaultFormatter": "biomejs.biome"
+  },
   "[css]": {
     "editor.defaultFormatter": "stylelint.vscode-stylelint"
   },
   "[javascript]": {
     "editor.defaultFormatter": "vscode.typescript-language-features"
   },
+  "[typescript]": {
+    "editor.defaultFormatter": "biomejs.biome"
+  }
 }

--- a/lib/shared/src/chat/transcript/index.ts
+++ b/lib/shared/src/chat/transcript/index.ts
@@ -31,5 +31,6 @@ export function serializeChatMessage(chatMessage: ChatMessage): SerializedChatMe
         editorState: chatMessage.editorState,
         error: chatMessage.error,
         text: chatMessage.text ? chatMessage.text.toString() : undefined,
+        intent: chatMessage.intent,
     }
 }

--- a/lib/shared/src/chat/transcript/messages.ts
+++ b/lib/shared/src/chat/transcript/messages.ts
@@ -50,6 +50,7 @@ export interface SerializedChatMessage {
     speaker: 'human' | 'assistant' | 'system'
     text?: string // Changed from PromptString
     model?: string
+    intent?: ChatMessage['intent']
 }
 
 export interface ChatError {

--- a/vscode/src/chat/chat-view/ChatController.test.ts
+++ b/vscode/src/chat/chat-view/ChatController.test.ts
@@ -65,7 +65,9 @@ describe('ChatController', () => {
         vi.clearAllMocks()
         vi.useFakeTimers()
         mockAuthStatus(AUTH_STATUS_FIXTURE_AUTHED)
-        mockResolvedConfig({ auth: { serverEndpoint: AUTH_STATUS_FIXTURE_AUTHED.endpoint } })
+        mockResolvedConfig({
+            auth: { serverEndpoint: AUTH_STATUS_FIXTURE_AUTHED.endpoint },
+        })
         mockClientCapabilities(CLIENT_CAPABILITIES_FIXTURE)
         mockLocalStorage()
         vi.setSystemTime(mockNowDate)
@@ -116,6 +118,7 @@ describe('ChatController', () => {
                 {
                     speaker: 'human',
                     text: 'Test input',
+                    intent: undefined,
                     model: undefined,
                     error: undefined,
                     editorState: null,
@@ -124,6 +127,7 @@ describe('ChatController', () => {
                 {
                     speaker: 'assistant',
                     model: 'my-model',
+                    intent: undefined,
                     error: undefined,
                     editorState: undefined,
                     text: undefined,
@@ -146,6 +150,7 @@ describe('ChatController', () => {
                 {
                     speaker: 'human',
                     text: 'Test input',
+                    intent: undefined,
                     model: undefined,
                     error: undefined,
                     editorState: null,
@@ -153,6 +158,7 @@ describe('ChatController', () => {
                 },
                 {
                     speaker: 'assistant',
+                    intent: undefined,
                     model: 'my-model',
                     error: undefined,
                     editorState: undefined,
@@ -191,6 +197,7 @@ describe('ChatController', () => {
                 {
                     speaker: 'human',
                     text: 'Test input',
+                    intent: undefined,
                     model: undefined,
                     error: undefined,
                     editorState: null,
@@ -199,6 +206,7 @@ describe('ChatController', () => {
                 {
                     speaker: 'assistant',
                     model: 'my-model',
+                    intent: undefined,
                     error: undefined,
                     editorState: undefined,
                     text: 'Test reply 1',
@@ -207,6 +215,7 @@ describe('ChatController', () => {
                 {
                     speaker: 'human',
                     text: 'Test followup',
+                    intent: undefined,
                     model: undefined,
                     error: undefined,
                     editorState: null,
@@ -215,6 +224,7 @@ describe('ChatController', () => {
                 {
                     speaker: 'assistant',
                     model: 'my-model',
+                    intent: undefined,
                     error: undefined,
                     editorState: undefined,
                     text: 'Test reply 2',
@@ -251,6 +261,7 @@ describe('ChatController', () => {
                 {
                     speaker: 'human',
                     text: 'Test input',
+                    intent: undefined,
                     model: undefined,
                     error: undefined,
                     editorState: null,
@@ -259,6 +270,7 @@ describe('ChatController', () => {
                 {
                     speaker: 'assistant',
                     model: 'my-model',
+                    intent: undefined,
                     error: undefined,
                     editorState: undefined,
                     text: 'Test reply 1',
@@ -267,6 +279,7 @@ describe('ChatController', () => {
                 {
                     speaker: 'human',
                     text: 'Test edit',
+                    intent: undefined,
                     model: undefined,
                     error: undefined,
                     editorState: null,
@@ -275,6 +288,7 @@ describe('ChatController', () => {
                 {
                     speaker: 'assistant',
                     model: 'my-model',
+                    intent: undefined,
                     error: undefined,
                     editorState: undefined,
                     text: 'Test reply 3',

--- a/vscode/src/chat/chat-view/ChatController.test.ts
+++ b/vscode/src/chat/chat-view/ChatController.test.ts
@@ -338,11 +338,13 @@ describe('ChatController', () => {
                     error: undefined,
                     editorState: null,
                     contextFiles: [],
+                    intent: undefined,
                 },
                 {
                     speaker: 'assistant',
                     model: undefined,
                     error: errorToChatError(new Error('my-error')),
+                    intent: undefined,
                     editorState: undefined,
                     text: undefined,
                     contextFiles: undefined,


### PR DESCRIPTION
Some previous refactoring caused a regression bug which broke, showing a response based on intent for One Box. The intent was not getting serialized as part of the chat message. This PR fixes it. 

## Test plan

- make sure all intent executions work correctly on s2.

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
