### PR TITLE
Chat: update logic to select Deep Cody as default model when available

### DIFF
--- a/lib/shared/src/models/sync.test.ts
+++ b/lib/shared/src/models/sync.test.ts
@@ -16,6 +16,7 @@ import type { CodyClientConfig } from '../sourcegraph-api/clientConfig'
 import type { CodyLLMSiteConfiguration } from '../sourcegraph-api/graphql/client'
 import * as userProductSubscriptionModule from '../sourcegraph-api/userProductSubscription'
 import type { PartialDeep } from '../utils'
+import { getExperimentalClientModelByFeatureFlag } from './client'
 import {
     type Model,
     type ServerModel,
@@ -34,7 +35,6 @@ import {
 import { maybeAdjustContextWindows, syncModels } from './sync'
 import { ModelTag } from './tags'
 import { ModelUsage } from './types'
-import { getExperimentalClientModelByFeatureFlag } from './client'
 
 vi.mock('graphqlClient')
 vi.mock('../services/LocalStorageProvider')
@@ -522,5 +522,4 @@ describe('syncModels', () => {
         expect(result.preferences.selected.chat).toBe(undefined)
         expect(storage.data?.[AUTH_STATUS_FIXTURE_AUTHED.endpoint]!.selected.chat).toBe(undefined)
     })
-
 })

--- a/lib/shared/src/models/sync.test.ts
+++ b/lib/shared/src/models/sync.test.ts
@@ -4,7 +4,7 @@ import { mockAuthStatus } from '../auth/authStatus'
 import { AUTH_STATUS_FIXTURE_AUTHED, type AuthStatus } from '../auth/types'
 import { CLIENT_CAPABILITIES_FIXTURE, mockClientCapabilities } from '../configuration/clientCapabilities'
 import type { ResolvedConfiguration } from '../configuration/resolver'
-import { featureFlagProvider } from '../experimentation/FeatureFlagProvider'
+import { FeatureFlag, featureFlagProvider } from '../experimentation/FeatureFlagProvider'
 import {
     firstValueFrom,
     readValuesFrom,
@@ -34,6 +34,7 @@ import {
 import { maybeAdjustContextWindows, syncModels } from './sync'
 import { ModelTag } from './tags'
 import { ModelUsage } from './types'
+import { getExperimentalClientModelByFeatureFlag } from './client'
 
 vi.mock('graphqlClient')
 vi.mock('../services/LocalStorageProvider')
@@ -457,4 +458,69 @@ describe('syncModels', () => {
             await done
         }
     )
+
+    it('sets DeepCody as default chat model when feature flag is enabled', async () => {
+        const serverOpus: ServerModel = {
+            modelRef: 'anthropic::unknown::anthropic.claude-3-opus',
+            displayName: 'Opus',
+            modelName: 'anthropic.claude-3-opus',
+            capabilities: ['chat'],
+            category: 'balanced' as ModelCategory,
+            status: 'stable',
+            tier: 'enterprise' as ModelTier,
+            contextWindow: {
+                maxInputTokens: 9000,
+                maxOutputTokens: 4000,
+            },
+        }
+
+        const SERVER_MODELS: ServerModelConfiguration = {
+            schemaVersion: '0.0',
+            revision: '-',
+            providers: [],
+            models: [serverOpus],
+            defaultModels: {
+                chat: serverOpus.modelRef,
+                fastChat: serverOpus.modelRef,
+                codeCompletion: serverOpus.modelRef,
+            },
+        }
+
+        const mockFetchServerSideModels = vi.fn(() => Promise.resolve(SERVER_MODELS))
+        vi.mocked(featureFlagProvider).evaluatedFeatureFlag.mockReturnValue(Observable.of(true))
+
+        const DEEPCODY_MODEL = getExperimentalClientModelByFeatureFlag(FeatureFlag.DeepCody)!
+
+        const result = await firstValueFrom(
+            syncModels({
+                resolvedConfig: Observable.of({
+                    configuration: {},
+                    clientState: { modelPreferences: {} },
+                } satisfies PartialDeep<ResolvedConfiguration> as ResolvedConfiguration),
+                authStatus: Observable.of(AUTH_STATUS_FIXTURE_AUTHED),
+                configOverwrites: Observable.of(null),
+                clientConfig: Observable.of({
+                    modelsAPIEnabled: true,
+                } satisfies Partial<CodyClientConfig> as CodyClientConfig),
+                fetchServerSideModels_: mockFetchServerSideModels,
+            }).pipe(skipPendingOperation())
+        )
+
+        const storage = new TestLocalStorageForModelPreferences()
+        modelsService.storage = storage
+        mockAuthStatus(AUTH_STATUS_FIXTURE_AUTHED)
+        expect(storage.data?.[AUTH_STATUS_FIXTURE_AUTHED.endpoint]!.selected.chat).toBe(undefined)
+        vi.spyOn(modelsService, 'modelsChanges', 'get').mockReturnValue(Observable.of(result))
+
+        // Check if DeepCody model is in the primary models
+        expect(result.primaryModels.some(model => model.id === DEEPCODY_MODEL.modelRef)).toBe(true)
+
+        // Check if DeepCody is set as the default chat model
+        expect(result.preferences.defaults.chat).toBe(DEEPCODY_MODEL.modelRef)
+
+        // user preference should not be affected and remains unchanged as this is handled in a later step.
+        expect(result.preferences.selected.chat).toBe(undefined)
+        expect(storage.data?.[AUTH_STATUS_FIXTURE_AUTHED.endpoint]!.selected.chat).toBe(undefined)
+    })
+
 })

--- a/lib/shared/src/models/sync.ts
+++ b/lib/shared/src/models/sync.ts
@@ -38,7 +38,6 @@ import { ModelUsage } from './types'
 import { getEnterpriseContextWindow } from './utils'
 
 const EMPTY_PREFERENCES: DefaultsAndUserPreferencesForEndpoint = { defaults: {}, selected: {} }
-const DEEPCODY_MODEL = getExperimentalClientModelByFeatureFlag(FeatureFlag.DeepCody)!
 
 /**
  * Observe the list of all available models.
@@ -203,6 +202,10 @@ export function syncModels({
                                             // DEEP CODY - available to users with feature flag enabled only.
                                             // TODO(bee): remove once deepCody is enabled for all users.
                                             if (deepCodyEnabled && serverModelsConfig) {
+                                                const DEEPCODY_MODEL =
+                                                    getExperimentalClientModelByFeatureFlag(
+                                                        FeatureFlag.DeepCody
+                                                    )!
                                                 data.primaryModels.push(
                                                     ...maybeAdjustContextWindows([DEEPCODY_MODEL]).map(
                                                         createModelFromServerModel

--- a/vscode/src/chat/agentic/DeepCody.test.ts
+++ b/vscode/src/chat/agentic/DeepCody.test.ts
@@ -91,7 +91,7 @@ describe('DeepCody', () => {
         )
     })
 
-    it('initializes correctly for dotcom user', async () => {
+    it('initializes correctly when invoked', async () => {
         const agent = new DeepCodyAgent(
             mockChatBuilder,
             mockChatClient,

--- a/vscode/src/chat/agentic/DeepCody.ts
+++ b/vscode/src/chat/agentic/DeepCody.ts
@@ -2,7 +2,6 @@ import {
     BotResponseMultiplexer,
     type ChatClient,
     type ContextItem,
-    FeatureFlag,
     type PromptMixin,
     PromptString,
     logDebug,
@@ -11,7 +10,6 @@ import {
 } from '@sourcegraph/cody-shared'
 import { getOSPromptString } from '../../os'
 import { getCategorizedMentions } from '../../prompt-builder/utils'
-import { logFirstEnrollmentEvent } from '../../services/utils/enrollment-event'
 import type { ChatBuilder } from '../chat-view/ChatBuilder'
 import { DefaultPrompter } from '../chat-view/prompt'
 import type { CodyTool } from './CodyTool'
@@ -28,8 +26,6 @@ type AgenticContext = {
 export class DeepCodyAgent {
     public static readonly ModelRef = 'sourcegraph::2023-06-01::deep-cody'
 
-    private static enrolled = false
-
     private readonly promptMixins: PromptMixin[] = []
     private readonly multiplexer = new BotResponseMultiplexer()
     private context: AgenticContext = { explicit: [], implicit: [] }
@@ -43,9 +39,6 @@ export class DeepCodyAgent {
         this.sort(mentions)
         this.promptMixins.push(newPromptMixin(this.buildPrompt()))
         this.initializeMultiplexer()
-        // Log Enrollment event if needed.
-        DeepCodyAgent.enrolled =
-            DeepCodyAgent.enrolled || logFirstEnrollmentEvent(FeatureFlag.DeepCody, true)
     }
 
     private initializeMultiplexer(): void {

--- a/vscode/src/chat/chat-view/ChatController.ts
+++ b/vscode/src/chat/chat-view/ChatController.ts
@@ -1604,21 +1604,7 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
                     chatModels: () =>
                         modelsService.getModels(ModelUsage.Chat).pipe(
                             startWith([]),
-                            map(models => {
-                                if (models === pendingOperation) {
-                                    return []
-                                }
-                                // If Deep Cody is available but the user has not enrolled before,
-                                // enroll the user and set the model as the default for chat.
-                                if (DeepCodyAgent.isEnrolled(models)) {
-                                    this.chatBuilder.setSelectedModel(DeepCodyAgent.ModelRef)
-                                    modelsService.setSelectedModel(
-                                        ModelUsage.Chat,
-                                        DeepCodyAgent.ModelRef
-                                    )
-                                }
-                                return models
-                            })
+                            map(models => (models === pendingOperation ? [] : models))
                         ),
                     highlights: parameters =>
                         promiseFactoryToObservable(() =>


### PR DESCRIPTION
CLOSE https://linear.app/sourcegraph/issue/CODY-3988/move-enrollment-out-of-models-getter that addresses comment in https://github.com/sourcegraph/cody/pull/5687/files#r1788676940 

Main change

Eemove the logic that mutate user-selected model from the "getter" in ChatController on models changes & add new logic handles setting Deep Cody as the default on first sync:

- Set Deep Cody as default chat model on first sync when it is available.
- Add logic to set the user's selected chat model to Deep Cody during the first sync.

This also fixes the issue where Deep Cody is showing up in the Edit model dropdown as we updated to set `data.preferences!.defaults.edit` and `data.preferences!.defaults.chat` separately:

![image](https://github.com/user-attachments/assets/59639a82-a3f6-4889-a2a2-6e1b2d4f3ea8)

#### Before

![image](https://github.com/user-attachments/assets/53869690-d70e-4a55-966f-1206e5c3c48e)


## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

Manual Test Plan:

1. Log into S2 and make sure you can see `Deep Cody` is selected as the default model for you in the Chat model dropdown list.
2. Verify you can switch chat model
3. Log into DotCom to ensure everything works as expected 

Added new unit test for syncing Deep Cody model

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
