### PR TITLE
(WIP) Adding logging to track the rejected completions in from the generated completions and improving the autocomplete stage logger

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,6 +9,7 @@ neverBuiltDependencies:
   - playwright
 
 overrides:
+  tslib: 2.1.0
   '@lexical/react': https://storage.googleapis.com/sourcegraph-assets/npm/lexical-react-sourcegraph-fork-31065486.tgz
 
 packageExtensionsChecksum: bc809394d179d8460f9d473fc54e379a
@@ -3333,7 +3334,7 @@ packages:
       '@microsoft/fast-element': 1.13.0
       '@microsoft/fast-web-utilities': 5.4.1
       tabbable: 5.3.3
-      tslib: 1.14.1
+      tslib: 2.1.0
     dev: false
 
   /@microsoft/fast-react-wrapper@0.1.48(react@18.2.0):
@@ -4249,7 +4250,7 @@ packages:
       '@types/react':
         optional: true
     dependencies:
-      '@babel/runtime': 7.25.6
+      '@babel/runtime': 7.24.5
       '@radix-ui/react-use-layout-effect': 1.0.1(@types/react@18.2.37)(react@18.2.0)
       '@types/react': 18.2.37
       react: 18.2.0
@@ -7112,7 +7113,7 @@ packages:
       esbuild: '>=0.10.0'
     dependencies:
       esbuild: 0.18.20
-      tslib: 2.7.0
+      tslib: 2.1.0
     dev: true
 
   /@yarnpkg/fslib@2.10.3:
@@ -7120,7 +7121,7 @@ packages:
     engines: {node: '>=12 <14 || 14.2 - 14.9 || >14.10.0'}
     dependencies:
       '@yarnpkg/libzip': 2.3.0
-      tslib: 1.14.1
+      tslib: 2.1.0
     dev: true
 
   /@yarnpkg/libzip@2.3.0:
@@ -7128,7 +7129,7 @@ packages:
     engines: {node: '>=12 <14 || 14.2 - 14.9 || >14.10.0'}
     dependencies:
       '@types/emscripten': 1.39.10
-      tslib: 1.14.1
+      tslib: 2.1.0
     dev: true
 
   /@zkochan/rimraf@3.0.2:
@@ -7448,7 +7449,7 @@ packages:
   /async-mutex@0.4.0:
     resolution: {integrity: sha512-eJFZ1YhRR8UN8eBLoNzcDPcy/jqjsg6I1AP+KvWQX80BqOSW1oJPJXDylPUEeMr2ZQvHgnQ//Lp6f3RQ1zI7HA==}
     dependencies:
-      tslib: 2.7.0
+      tslib: 2.1.0
     dev: false
 
   /async@3.2.5:
@@ -15614,14 +15615,8 @@ packages:
       strip-bom: 3.0.0
     dev: true
 
-  /tslib@1.14.1:
-    resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
-
   /tslib@2.1.0:
     resolution: {integrity: sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==}
-
-  /tslib@2.7.0:
-    resolution: {integrity: sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==}
 
   /tsscmp@1.0.6:
     resolution: {integrity: sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA==}

--- a/vscode/src/completions/get-inline-completions-tests/analytics.test.ts
+++ b/vscode/src/completions/get-inline-completions-tests/analytics.test.ts
@@ -101,6 +101,8 @@ describe('[getInlineCompletions] completion event', () => {
                 "preDebounce",
                 "preContextRetrieval",
                 "preNetworkRequest",
+                "preCompletionTrimming",
+   "preResponseDisplay",
               ]
             `)
 
@@ -173,6 +175,8 @@ describe('[getInlineCompletions] completion event', () => {
                 "preDebounce",
                 "preContextRetrieval",
                 "preNetworkRequest",
+                "preCompletionTrimming",
+  "preResponseDisplay",
               ]
             `)
 

--- a/vscode/src/completions/get-inline-completions.ts
+++ b/vscode/src/completions/get-inline-completions.ts
@@ -511,6 +511,7 @@ async function doGetInlineCompletions(
         isCacheEnabled: triggerKind !== TriggerKind.Manual,
         isPreloadRequest: triggerKind === TriggerKind.Preload,
         tracer: tracer ? createCompletionProviderTracer(tracer) : undefined,
+        stageRecorder: stageRecorder,
     })
 
     return processRequestManagerResult({

--- a/vscode/src/completions/providers/experimental-ollama.ts
+++ b/vscode/src/completions/providers/experimental-ollama.ts
@@ -17,6 +17,7 @@ import { getLanguageConfig } from '../../tree-sitter/language'
 import { forkSignal, generatorWithTimeout, zipGenerators } from '../utils'
 
 import { map } from 'observable-fns'
+import type * as CompletionLogger from '../logger'
 import { type DefaultModel, getModelHelpers } from '../model-helpers'
 import { getSuffixAfterFirstNewline } from '../text-processing'
 import {
@@ -164,6 +165,7 @@ class ExperimentalOllamaProvider extends Provider {
     public async generateCompletions(
         options: GenerateCompletionsOptions,
         abortSignal: AbortSignal,
+        stageRecorder: CompletionLogger.AutocompleteStageRecorder,
         tracer?: CompletionProviderTracer
     ): Promise<AsyncGenerator<FetchCompletionResult[]>> {
         const { numberOfCompletionsToGenerate } = options
@@ -202,6 +204,7 @@ class ExperimentalOllamaProvider extends Provider {
                         // Increased first completion timeout value to account for the higher latency.
                         firstCompletionTimeout: 3_0000,
                     },
+                    stageRecorder,
                 })
             }
         )

--- a/vscode/src/completions/providers/shared/hot-streak.ts
+++ b/vscode/src/completions/providers/shared/hot-streak.ts
@@ -82,7 +82,7 @@ const MAX_HOT_STREAK_LINES = vscode.workspace
     .get<number>('cody.experimental.maxHotStreakLines', 5)
 
 export function createHotStreakExtractor(params: HotStreakExtractorParams): HotStreakExtractor {
-    const { completedCompletion, generateOptions, abortController } = params
+    const { completedCompletion, generateOptions, abortController, stageRecorder } = params
     const {
         docContext,
         document,
@@ -144,11 +144,15 @@ export function createHotStreakExtractor(params: HotStreakExtractorParams): HotS
                 // ... if not and we are processing the last payload, we use the whole remainder for the
                 // completion (this means we will parse the last line even when a \n is missing at
                 // the end) ...
-                const processedCompletion = processCompletion(completion, {
-                    document,
-                    position: maybeDynamicMultilineDocContext.position,
-                    docContext: maybeDynamicMultilineDocContext,
-                })
+                const processedCompletion = processCompletion(
+                    completion,
+                    {
+                        document,
+                        position: maybeDynamicMultilineDocContext.position,
+                        docContext: maybeDynamicMultilineDocContext,
+                    },
+                    stageRecorder
+                )
 
                 yield {
                     docContext: updatedDocContext,

--- a/vscode/src/completions/providers/shared/provider.ts
+++ b/vscode/src/completions/providers/shared/provider.ts
@@ -229,6 +229,7 @@ export abstract class Provider {
     public async generateCompletions(
         generateOptions: GenerateCompletionsOptions,
         abortSignal: AbortSignal,
+        stageRecorder: CompletionLogger.AutocompleteStageRecorder,
         tracer?: CompletionProviderTracer
     ): Promise<AsyncGenerator<FetchCompletionResult[]>> {
         const { docContext, numberOfCompletionsToGenerate } = generateOptions
@@ -279,6 +280,7 @@ export abstract class Provider {
                     generateOptions,
                     providerSpecificPostProcess: content =>
                         this.modelHelper.postProcess(content, docContext),
+                    stageRecorder: stageRecorder,
                 })
             }
         )

--- a/vscode/src/completions/request-manager.test.ts
+++ b/vscode/src/completions/request-manager.test.ts
@@ -8,6 +8,7 @@ import { getCurrentDocContext } from './get-current-doc-context'
 import { InlineCompletionsResultSource, TriggerKind } from './get-inline-completions'
 import { initCompletionProviderConfig } from './get-inline-completions-tests/helpers'
 import type { CompletionLogID } from './logger'
+import { AutocompleteStageRecorder } from './logger'
 import type { FetchCompletionResult } from './providers/shared/fetch-and-process-completions'
 import { STOP_REASON_HOT_STREAK } from './providers/shared/hot-streak'
 import { type GenerateCompletionsOptions, Provider } from './providers/shared/provider'
@@ -149,6 +150,7 @@ describe('RequestManager', () => {
                 isCacheEnabled: true,
                 isPreloadRequest: false,
                 logId: '1' as CompletionLogID,
+                stageRecorder: new AutocompleteStageRecorder({ isPreloadRequest: false }),
             })
         }
         checkCache = (prefix: string, suffix?: string) =>

--- a/vscode/src/completions/request-manager.ts
+++ b/vscode/src/completions/request-manager.ts
@@ -161,9 +161,15 @@ export class RequestManager {
 
                         const logMessage = `Processing Result: ${completions[0].insertText} \nCompletion size: ${completions.length}\n`
                         const logFilePath = path.join(os.tmpdir(), 'completion_log.txt')
-                        fs.appendFile(logFilePath, logMessage, (err: NodeJS.ErrnoException | null) => {
-                            if (err) console.error('Error writing to log file:', err)
-                        })
+                        if (completions[0].insertText.length > 0) {
+                            fs.appendFile(
+                                logFilePath,
+                                logMessage,
+                                (err: NodeJS.ErrnoException | null) => {
+                                    if (err) console.error('Error writing to log file:', err)
+                                }
+                            )
+                        }
                         // Shared post-processing logic
                         const processedCompletions = wrapInActiveSpan(
                             'autocomplete.shared-post-process',

--- a/vscode/src/completions/text-processing/process-inline-completions.ts
+++ b/vscode/src/completions/text-processing/process-inline-completions.ts
@@ -78,7 +78,7 @@ export function processCompletion(
     const os = require('os')
     const path = require('path')
 
-    const logMessage = "Processing Value: " + completion.insertText + "\n"
+    const logMessage = 'Processing Value: ' + completion.insertText + '\n'
     const logFilePath = path.join(os.tmpdir(), 'completion_log.txt')
     fs.appendFile(logFilePath, logMessage, (err: NodeJS.ErrnoException | null) => {
         if (err) console.error('Error writing to log file:', err)

--- a/vscode/src/services/autocomplete-stage-counter-logger.ts
+++ b/vscode/src/services/autocomplete-stage-counter-logger.ts
@@ -16,6 +16,8 @@ export const AUTOCOMPLETE_STAGE_COUNTER_INITIAL_STATE = {
     preNetworkRequest: 0,
     preFinalCancellationCheck: 0,
     preVisibilityCheck: 0,
+    preCompletionTrimming: 0,
+    preResponseDisplay: 0,
 }
 
 export type AutocompletePipelineCountedStage = keyof typeof AUTOCOMPLETE_STAGE_COUNTER_INITIAL_STATE


### PR DESCRIPTION
NOTE: This PR has a lot of usless info that won't be merged in the actual PR to log stuff in files and be able to see what we show to the user and where. I will remove all the fluff and cleanup the PR assuming I have the approval of people on the approach specified in Loom video. 


## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
