### PR TITLE
Fix last used prompts ordering

### DIFF
--- a/vscode/webviews/components/promptList/PromptList.tsx
+++ b/vscode/webviews/components/promptList/PromptList.tsx
@@ -61,7 +61,7 @@ export const PromptList: FC<PromptListProps> = props => {
 
     const endpointURL = new URL(useConfig().authStatus.endpoint)
     const telemetryRecorder = useTelemetryRecorder()
-    const [lastUsedActions = {}] = useLocalStorage<Record<string, number>>('last-used-actions', {})
+    const [lastUsedActions = {}] = useLocalStorage<Record<string, number>>('last-used-actions-v2', {})
 
     const telemetryPublicMetadata: Record<string, number> = {
         [`in${telemetryLocation}`]: 1,

--- a/vscode/webviews/prompts/PromptsTab.tsx
+++ b/vscode/webviews/prompts/PromptsTab.tsx
@@ -28,15 +28,14 @@ export const PromptsTab: React.FC<{
 export function useActionSelect() {
     const dispatchClientAction = useClientActionDispatcher()
     const [lastUsedActions = {}, persistValue] = useLocalStorage<Record<string, number>>(
-        'last-used-actions',
+        'last-used-actions-v2',
         {}
     )
 
     return (action: Action, setView: (view: View) => void) => {
         try {
             const actionKey = action.actionType === 'prompt' ? action.id : action.key
-            const lastUsedActionCount = lastUsedActions[actionKey] ?? 0
-            persistValue({ ...lastUsedActions, [actionKey]: lastUsedActionCount + 1 })
+            persistValue({ ...lastUsedActions, [actionKey]: Date.now() })
         } catch {
             console.error('Failed to persist last used action count')
         }


### PR DESCRIPTION
Fixes https://linear.app/sourcegraph/issue/SRCH-1131/make-prompts-dropdown-menu-a-recently-used-list

This PR changes how smart recently used prompt ordering works. Previously, we counted the number of times a user clicked on prompts and used this aggregated count value to sort the list of prompts. 

Now we just set the timestamp to the used prompt and sort it by this, so it's truly the most recently used prompt (always will be on top of the list)

## Test plan
- Check that in the prompt list you can see the right order of prompts
