### PR TITLE
Add context item to chat action

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -38,5 +38,8 @@
   },
   "[typescript]": {
     "editor.defaultFormatter": "biomejs.biome"
+  },
+  "[typescriptreact]": {
+    "editor.defaultFormatter": "biomejs.biome"
   }
 }

--- a/vscode/src/chat/chat-view/ChatController.ts
+++ b/vscode/src/chat/chat-view/ChatController.ts
@@ -881,6 +881,7 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
         signal.throwIfAborted()
 
         this.chatBuilder.setLastMessageContext(context, contextAlternatives)
+        this.chatBuilder.setLastMessageIntent('search')
         this.chatBuilder.addBotMessage(
             {
                 text: ps`"cody-experimental-one-box" feature flag is turned on.`,
@@ -1047,6 +1048,15 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
                 category: 'billable',
                 product: 'cody',
             },
+        })
+    }
+
+    public async addContextItemsToLastHumanInput(
+        contextItems: ContextItem[]
+    ): Promise<boolean | undefined> {
+        return this.postMessage({
+            type: 'clientAction',
+            addContextItemsToLastHumanInput: contextItems,
         })
     }
 
@@ -1462,11 +1472,11 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
         telemetryRecorder.recordEvent('cody.duplicateSession', 'clicked')
     }
 
-    public async clearAndRestartSession(): Promise<void> {
+    public async clearAndRestartSession(chatMessages?: ChatMessage[]): Promise<void> {
         this.cancelSubmitOrEditOperation()
         await this.saveSession()
 
-        this.chatBuilder = new ChatBuilder()
+        this.chatBuilder = new ChatBuilder(this.chatBuilder.selectedModel, undefined, chatMessages)
         this.postViewTranscript()
     }
 

--- a/vscode/src/chat/chat-view/ChatsController.ts
+++ b/vscode/src/chat/chat-view/ChatsController.ts
@@ -136,25 +136,41 @@ export class ChatsController implements vscode.Disposable {
             vscode.commands.registerCommand('cody.chat.signIn', () =>
                 vscode.commands.executeCommand('cody.chat.focus')
             ),
-
-            vscode.commands.registerCommand('cody.chat.newPanel', async () => {
+            vscode.commands.registerCommand('cody.chat.newPanel', async args => {
                 localStorage.setLastUsedChatModality('sidebar')
                 const isVisible = this.panel.isVisible()
                 await this.panel.clearAndRestartSession()
+
+                try {
+                    const { contextItems } = JSON.parse(args) || {}
+                    if (contextItems?.length) {
+                        await this.panel.addContextItemsToLastHumanInput(contextItems)
+                    }
+                } catch {}
+
                 if (!isVisible) {
                     await vscode.commands.executeCommand('cody.chat.focus')
                 }
             }),
-            vscode.commands.registerCommand('cody.chat.newEditorPanel', () => {
+            vscode.commands.registerCommand('cody.chat.newEditorPanel', async args => {
                 localStorage.setLastUsedChatModality('editor')
-                return this.getOrCreateEditorChatController()
+                const panel = await this.getOrCreateEditorChatController()
+
+                try {
+                    const { contextItems } = JSON.parse(args) || {}
+                    if (contextItems?.length) {
+                        await panel.addContextItemsToLastHumanInput(contextItems)
+                    }
+                } catch {}
+
+                return panel
             }),
-            vscode.commands.registerCommand('cody.chat.new', async () => {
+            vscode.commands.registerCommand('cody.chat.new', async args => {
                 switch (getNewChatLocation()) {
                     case 'editor':
-                        return vscode.commands.executeCommand('cody.chat.newEditorPanel')
+                        return vscode.commands.executeCommand('cody.chat.newEditorPanel', args)
                     case 'sidebar':
-                        return vscode.commands.executeCommand('cody.chat.newPanel')
+                        return vscode.commands.executeCommand('cody.chat.newPanel', args)
                 }
             }),
 

--- a/vscode/webviews/chat/cells/contextCell/ContextCell.tsx
+++ b/vscode/webviews/chat/cells/contextCell/ContextCell.tsx
@@ -36,6 +36,11 @@ export const ContextCell: FunctionComponent<{
     defaultOpen?: boolean
     showSnippets?: boolean
     reSubmitWithChatIntent?: () => void
+    onAddToFollowupChat?: (props: {
+        repoName: string
+        filePath: string
+        fileURL: string
+    }) => void
 
     /** For use in storybooks only. */
     __storybook__initialOpen?: boolean
@@ -51,6 +56,7 @@ export const ContextCell: FunctionComponent<{
         reSubmitWithChatIntent,
         showSnippets = false,
         isContextLoading,
+        onAddToFollowupChat,
     }) => {
         const [selectedAlternative, setSelectedAlternative] = useState<number | undefined>(undefined)
         const incrementSelectedAlternative = useCallback(
@@ -198,6 +204,7 @@ export const ContextCell: FunctionComponent<{
                                                             <FileContextItem
                                                                 item={item}
                                                                 showSnippets={showSnippets}
+                                                                onAddToFollowupChat={onAddToFollowupChat}
                                                             />
                                                             {internalDebugContext &&
                                                                 item.metadata &&

--- a/vscode/webviews/components/FileContextItem.tsx
+++ b/vscode/webviews/components/FileContextItem.tsx
@@ -11,9 +11,18 @@ import styles from './FileContextItem.module.css'
 interface FileContextItemProps {
     item: ContextItem
     showSnippets: boolean
+    onAddToFollowupChat?: (props: {
+        repoName: string
+        filePath: string
+        fileURL: string
+    }) => void
 }
 
-export const FileContextItem: FC<FileContextItemProps> = ({ item, showSnippets }) => {
+export const FileContextItem: FC<FileContextItemProps> = ({
+    item,
+    showSnippets,
+    onAddToFollowupChat,
+}) => {
     // Fallback on link for any non file context items (like openctx items)
     if (item.type !== 'file' || !showSnippets) {
         return (
@@ -33,5 +42,11 @@ export const FileContextItem: FC<FileContextItemProps> = ({ item, showSnippets }
         )
     }
 
-    return <FileSnippet item={item} className={styles.codeBlock} />
+    return (
+        <FileSnippet
+            item={item}
+            className={styles.codeBlock}
+            onAddToFollowupChat={onAddToFollowupChat}
+        />
+    )
 }

--- a/vscode/webviews/components/FileSnippet.tsx
+++ b/vscode/webviews/components/FileSnippet.tsx
@@ -11,11 +11,16 @@ import type { ContentMatch } from './codeSnippet/types'
 
 interface FileSnippetProps {
     item: ContextItemFile
+    onAddToFollowupChat?: (props: {
+        repoName: string
+        filePath: string
+        fileURL: string
+    }) => void
     className?: string
 }
 
 export const FileSnippet: FC<FileSnippetProps> = props => {
-    const { item, className } = props
+    const { item, className, onAddToFollowupChat } = props
 
     const highlights = useExtensionAPI().highlights
     const {
@@ -71,6 +76,7 @@ export const FileSnippet: FC<FileSnippetProps> = props => {
             fetchHighlightedFileLineRanges={fetchHighlights}
             className={className}
             onSelect={logSelection}
+            onAddToFollowupChat={onAddToFollowupChat}
         />
     )
 }

--- a/vscode/webviews/components/codeSnippet/CodeSnippet.tsx
+++ b/vscode/webviews/components/codeSnippet/CodeSnippet.tsx
@@ -77,6 +77,12 @@ interface FileContentSearchResultProps {
 
     /** Called when the file's search result is selected. */
     onSelect: () => void
+
+    onAddToFollowupChat?: (props: {
+        repoName: string
+        filePath: string
+        fileURL: string
+    }) => void
 }
 
 export const FileContentSearchResult: FC<PropsWithChildren<FileContentSearchResultProps>> = props => {
@@ -90,6 +96,7 @@ export const FileContentSearchResult: FC<PropsWithChildren<FileContentSearchResu
         serverEndpoint,
         fetchHighlightedFileLineRanges,
         onSelect,
+        onAddToFollowupChat,
     } = props
 
     const unhighlightedGroups: MatchGroup[] = useMemo(() => matchesToMatchGroups(result), [result])
@@ -188,6 +195,7 @@ export const FileContentSearchResult: FC<PropsWithChildren<FileContentSearchResu
             className={styles.titleInner}
             collapsed={hidden}
             onToggleCollapse={() => setHidden(current => !current)}
+            onAddToFollowupChat={onAddToFollowupChat}
         />
     )
 
@@ -284,7 +292,7 @@ const ResultContainer: ForwardReferenceExoticComponent<
     return (
         <Component
             ref={reference}
-            className={clsx(className, styles.resultContainer)}
+            className={clsx(className, styles.resultContainer, 'tw-group')}
             onClick={onResultClicked}
         >
             <article>


### PR DESCRIPTION
closes: https://linear.app/sourcegraph/issue/SRCH-1119/add-to-chat-from-search-results

This PR adds 2 actions for search result snippets shown under One Box experiment. 
1. Add to follow-up question
2. Add to new Cody chat

Both actions add the file as @-mention to the chat inputs

Loom: https://www.loom.com/share/e062d698613b422fbe919738cd024594

## Test plan

- Perform a search intent query and try both actions.

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
