### PR TITLE
Adding more checks for absolute paths while generating new files with smart Apply

### DIFF
--- a/vscode/src/services/utils/codeblock-action-tracker.ts
+++ b/vscode/src/services/utils/codeblock-action-tracker.ts
@@ -170,7 +170,7 @@ export async function handleSmartApply(
 
     const uri =
         fileUri && workspaceUri
-            ? path.isAbsolute(fileUri)
+            ? path.isAbsolute(fileUri) && (await doesFileExist(vscode.Uri.file(fileUri || '')))
                 ? vscode.Uri.file(fileUri)
                 : smartJoinPath(workspaceUri, fileUri)
             : activeEditor?.document.uri


### PR DESCRIPTION
[Loom Video
](https://www.loom.com/share/bea3a44d28764ebd91170858915a5139)

[Linear Issue
](https://linear.app/sourcegraph/issue/QA-82/vsc-continuous-loading-is-shown-on-clicking-apply-button-when-source)

## Test plan
Tested locally and attached a video showing the solution 
<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
