### PR TITLE
Fix prompt input and browse prompts UI 

### DIFF
--- a/vscode/webviews/components/promptList/ActionItem.module.css
+++ b/vscode/webviews/components/promptList/ActionItem.module.css
@@ -1,8 +1,13 @@
 
 .item {
     display: flex;
-    padding: 0.5rem;
     gap: 0.5rem;
+
+    /*
+        Styles order can be inconsistent in different clients (Cody Web, JB, ...etc)
+        Ensure that paddings won't be overridden in these clients.
+    */
+    padding: 0.25rem 0.5rem !important;
 
     &--indicator {
         display: none !important;

--- a/vscode/webviews/components/promptList/PromptList.module.css
+++ b/vscode/webviews/components/promptList/PromptList.module.css
@@ -1,13 +1,13 @@
 
 .list {
     outline: none;
-    background-color: transparent;
     max-height: unset !important;
+    background-color: transparent !important;
 
     &--input-container {
-        position: sticky;
         top: 0;
-        background-color: var(--vscode-quickInput-background);
+        position: sticky;
+        z-index: 1;
     }
 
     &--input {

--- a/vscode/webviews/components/promptList/PromptList.module.css
+++ b/vscode/webviews/components/promptList/PromptList.module.css
@@ -4,6 +4,12 @@
     background-color: transparent;
     max-height: unset !important;
 
+    &--input-container {
+        position: sticky;
+        top: 0;
+        background-color: var(--vscode-quickInput-background);
+    }
+
     &--input {
         margin: 0.5rem;
         padding: 0.5rem;

--- a/vscode/webviews/components/promptList/PromptList.tsx
+++ b/vscode/webviews/components/promptList/PromptList.tsx
@@ -162,7 +162,7 @@ export const PromptList: FC<PromptListProps> = props => {
         >
             <CommandList className={className}>
                 {showSearch && (
-                    <div className={inputPaddingClass}>
+                    <div className={clsx(inputPaddingClass, styles.listInputContainer)}>
                         <CommandInput
                             value={query}
                             onValueChange={setQuery}

--- a/vscode/webviews/components/promptList/PromptList.tsx
+++ b/vscode/webviews/components/promptList/PromptList.tsx
@@ -29,6 +29,7 @@ interface PromptListProps {
     showCommandOrigins?: boolean
     showPromptLibraryUnsupportedMessage?: boolean
     className?: string
+    inputClassName?: string
     paddingLevels?: 'none' | 'middle' | 'big'
     appearanceMode?: 'flat-list' | 'chips-list'
     lastUsedSorting?: boolean
@@ -52,6 +53,7 @@ export const PromptList: FC<PromptListProps> = props => {
         showInitialSelectedItem = true,
         showPromptLibraryUnsupportedMessage = true,
         className,
+        inputClassName,
         paddingLevels = 'none',
         appearanceMode = 'flat-list',
         lastUsedSorting,
@@ -162,7 +164,7 @@ export const PromptList: FC<PromptListProps> = props => {
         >
             <CommandList className={className}>
                 {showSearch && (
-                    <div className={clsx(inputPaddingClass, styles.listInputContainer)}>
+                    <div className={clsx(inputPaddingClass, inputClassName, styles.listInputContainer)}>
                         <CommandInput
                             value={query}
                             onValueChange={setQuery}

--- a/vscode/webviews/components/promptSelectField/PromptSelectField.tsx
+++ b/vscode/webviews/components/promptSelectField/PromptSelectField.tsx
@@ -59,6 +59,7 @@ export const PromptSelectField: React.FunctionComponent<{
                         showOnlyPromptInsertableCommands={true}
                         showPromptLibraryUnsupportedMessage={true}
                         lastUsedSorting={true}
+                        inputClassName="tw-bg-popover"
                     />
 
                     <footer className="tw-px-2 tw-py-1 tw-border-t tw-border-border tw-bg-muted">

--- a/vscode/webviews/components/promptSelectField/PromptSelectField.tsx
+++ b/vscode/webviews/components/promptSelectField/PromptSelectField.tsx
@@ -47,7 +47,7 @@ export const PromptSelectField: React.FunctionComponent<{
             tooltip="Insert prompt from Prompt Library"
             aria-label="Insert prompt"
             popoverContent={close => (
-                <div className="tw-flex tw-flex-col tw-gap-4">
+                <div className="tw-flex tw-flex-col tw-max-h-[500px] tw-overflow-auto">
                     <PromptList
                         onSelect={item => {
                             onSelect(item)
@@ -61,7 +61,7 @@ export const PromptSelectField: React.FunctionComponent<{
                         lastUsedSorting={true}
                     />
 
-                    <footer className="tw-px-2 tw-py-2 tw-border-t tw-border-border tw-bg-muted">
+                    <footer className="tw-px-2 tw-py-1 tw-border-t tw-border-border tw-bg-muted">
                         <Button variant="text" onClick={() => setView(View.Prompts)}>
                             <BookText size={16} /> Browse library
                         </Button>
@@ -70,8 +70,7 @@ export const PromptSelectField: React.FunctionComponent<{
             )}
             popoverRootProps={{ onOpenChange }}
             popoverContentProps={{
-                className:
-                    'tw-min-w-[325px] tw-w-[75vw] tw-max-w-[550px] !tw-p-0 tw-max-h-[500px] tw-overflow-auto',
+                className: 'tw-min-w-[325px] tw-w-[75vw] tw-max-w-[550px] !tw-p-0',
                 onKeyDown: onKeyDown,
                 onCloseAutoFocus: event => {
                     // Prevent the popover trigger from stealing focus after the user selects an

--- a/vscode/webviews/prompts/PromptsTab.module.css
+++ b/vscode/webviews/prompts/PromptsTab.module.css
@@ -1,0 +1,4 @@
+
+.prompts-input {
+    background-color: var(--vscode-sideBar-background);
+}

--- a/vscode/webviews/prompts/PromptsTab.tsx
+++ b/vscode/webviews/prompts/PromptsTab.tsx
@@ -5,6 +5,8 @@ import { PromptList } from '../components/promptList/PromptList'
 import { View } from '../tabs/types'
 import { getVSCodeAPI } from '../utils/VSCodeApi'
 
+import styles from './PromptsTab.module.css'
+
 export const PromptsTab: React.FC<{
     setView: (view: View) => void
 }> = ({ setView }) => {
@@ -20,6 +22,7 @@ export const PromptsTab: React.FC<{
                 showPromptLibraryUnsupportedMessage={true}
                 showOnlyPromptInsertableCommands={false}
                 onSelect={item => runAction(item, setView)}
+                inputClassName={styles.promptsInput}
             />
         </div>
     )

--- a/vscode/webviews/prompts/PromptsTab.tsx
+++ b/vscode/webviews/prompts/PromptsTab.tsx
@@ -11,7 +11,7 @@ export const PromptsTab: React.FC<{
     const runAction = useActionSelect()
 
     return (
-        <div className="tw-overflow-auto">
+        <div className="tw-overflow-auto tw-h-full">
             <PromptList
                 showSearch={true}
                 showCommandOrigins={true}


### PR DESCRIPTION
Fixes: https://linear.app/sourcegraph/issue/SRCH-1146/stick-browse-library-link-to-the-bottom-irrespective-of-scroll

This PR
- Makes prompt search input UI sticky 
- Fixes paddings for Cody Web
- Fixing browser prompt footer 

## Test plan
- Check that the Prompt UI list looks ok in the welcome area, prompts select field modal and prompts tab UI
