### PR TITLE
Chat: move chatModels observable creation to top level

### DIFF
--- a/vscode/webviews/Chat.story.tsx
+++ b/vscode/webviews/Chat.story.tsx
@@ -1,3 +1,4 @@
+import { getMockedDotComClientModels } from '@sourcegraph/cody-shared'
 import { ExtensionAPIProviderForTestsOnly, MOCK_API } from '@sourcegraph/prompt-editor'
 import type { Meta, StoryObj } from '@storybook/react'
 import { Observable } from 'observable-fns'
@@ -5,6 +6,8 @@ import { Chat } from './Chat'
 import { FIXTURE_TRANSCRIPT } from './chat/fixtures'
 import { FIXTURE_COMMANDS, makePromptsAPIWithData } from './components/promptList/fixtures'
 import { VSCodeWebview } from './storybook/VSCodeStoryDecorator'
+
+const MOCK_MODELS = getMockedDotComClientModels()
 
 const meta: Meta<typeof Chat> = {
     title: 'cody/Chat',
@@ -16,6 +19,7 @@ const meta: Meta<typeof Chat> = {
             options: Object.keys(FIXTURE_TRANSCRIPT),
             mapping: FIXTURE_TRANSCRIPT,
             control: { type: 'select' },
+            models: MOCK_MODELS,
         },
     },
     args: {
@@ -27,6 +31,7 @@ const meta: Meta<typeof Chat> = {
             onMessage: () => () => {},
         },
         setView: () => {},
+        models: MOCK_MODELS,
     } satisfies React.ComponentProps<typeof Chat>,
 
     decorators: [VSCodeWebview],

--- a/vscode/webviews/Chat.tsx
+++ b/vscode/webviews/Chat.tsx
@@ -6,6 +6,7 @@ import type {
     ChatMessage,
     CodyIDE,
     Guardrails,
+    Model,
     PromptString,
 } from '@sourcegraph/cody-shared'
 import { Transcript, focusLastHumanMessageEditor } from './chat/Transcript'
@@ -13,7 +14,6 @@ import type { VSCodeWrapper } from './utils/VSCodeApi'
 
 import { truncateTextStart } from '@sourcegraph/cody-shared/src/prompt/truncation'
 import { CHAT_INPUT_TOKEN_BUDGET } from '@sourcegraph/cody-shared/src/token/constants'
-import { useExtensionAPI, useObservable } from '@sourcegraph/prompt-editor'
 import styles from './Chat.module.css'
 import WelcomeFooter from './chat/components/WelcomeFooter'
 import { WelcomeMessage } from './chat/components/WelcomeMessage'
@@ -26,6 +26,7 @@ interface ChatboxProps {
     chatEnabled: boolean
     messageInProgress: ChatMessage | null
     transcript: ChatMessage[]
+    models: Model[]
     vscodeAPI: Pick<VSCodeWrapper, 'postMessage' | 'onMessage'>
     guardrails?: Guardrails
     scrollableParent?: HTMLElement | null
@@ -38,6 +39,7 @@ interface ChatboxProps {
 export const Chat: React.FunctionComponent<React.PropsWithChildren<ChatboxProps>> = ({
     messageInProgress,
     transcript,
+    models,
     vscodeAPI,
     chatEnabled = true,
     guardrails,
@@ -53,9 +55,6 @@ export const Chat: React.FunctionComponent<React.PropsWithChildren<ChatboxProps>
     transcriptRef.current = transcript
 
     const userInfo = useUserAccountInfo()
-
-    const api = useExtensionAPI()
-    const { value: chatModels } = useObservable(useMemo(() => api.chatModels(), [api.chatModels]))
 
     const feedbackButtonsOnSubmit = useCallback(
         (text: string) => {
@@ -218,7 +217,7 @@ export const Chat: React.FunctionComponent<React.PropsWithChildren<ChatboxProps>
             )}
             <Transcript
                 transcript={transcript}
-                models={chatModels ?? []}
+                models={models}
                 messageInProgress={messageInProgress}
                 feedbackButtonsOnSubmit={feedbackButtonsOnSubmit}
                 copyButtonOnSubmit={copyButtonOnSubmit}

--- a/vscode/webviews/Chat.tsx
+++ b/vscode/webviews/Chat.tsx
@@ -6,6 +6,7 @@ import type {
     ChatMessage,
     CodyIDE,
     Guardrails,
+    Model,
     PromptString,
 } from '@sourcegraph/cody-shared'
 import { Transcript, focusLastHumanMessageEditor } from './chat/Transcript'
@@ -25,6 +26,7 @@ interface ChatboxProps {
     chatEnabled: boolean
     messageInProgress: ChatMessage | null
     transcript: ChatMessage[]
+    models: Model[]
     vscodeAPI: Pick<VSCodeWrapper, 'postMessage' | 'onMessage'>
     guardrails?: Guardrails
     scrollableParent?: HTMLElement | null
@@ -37,6 +39,7 @@ interface ChatboxProps {
 export const Chat: React.FunctionComponent<React.PropsWithChildren<ChatboxProps>> = ({
     messageInProgress,
     transcript,
+    models,
     vscodeAPI,
     chatEnabled = true,
     guardrails,
@@ -214,6 +217,7 @@ export const Chat: React.FunctionComponent<React.PropsWithChildren<ChatboxProps>
             )}
             <Transcript
                 transcript={transcript}
+                models={models}
                 messageInProgress={messageInProgress}
                 feedbackButtonsOnSubmit={feedbackButtonsOnSubmit}
                 copyButtonOnSubmit={copyButtonOnSubmit}

--- a/vscode/webviews/Chat.tsx
+++ b/vscode/webviews/Chat.tsx
@@ -6,7 +6,6 @@ import type {
     ChatMessage,
     CodyIDE,
     Guardrails,
-    Model,
     PromptString,
 } from '@sourcegraph/cody-shared'
 import { Transcript, focusLastHumanMessageEditor } from './chat/Transcript'
@@ -14,6 +13,7 @@ import type { VSCodeWrapper } from './utils/VSCodeApi'
 
 import { truncateTextStart } from '@sourcegraph/cody-shared/src/prompt/truncation'
 import { CHAT_INPUT_TOKEN_BUDGET } from '@sourcegraph/cody-shared/src/token/constants'
+import { useExtensionAPI, useObservable } from '@sourcegraph/prompt-editor'
 import styles from './Chat.module.css'
 import WelcomeFooter from './chat/components/WelcomeFooter'
 import { WelcomeMessage } from './chat/components/WelcomeMessage'
@@ -26,7 +26,6 @@ interface ChatboxProps {
     chatEnabled: boolean
     messageInProgress: ChatMessage | null
     transcript: ChatMessage[]
-    models: Model[]
     vscodeAPI: Pick<VSCodeWrapper, 'postMessage' | 'onMessage'>
     guardrails?: Guardrails
     scrollableParent?: HTMLElement | null
@@ -39,7 +38,6 @@ interface ChatboxProps {
 export const Chat: React.FunctionComponent<React.PropsWithChildren<ChatboxProps>> = ({
     messageInProgress,
     transcript,
-    models,
     vscodeAPI,
     chatEnabled = true,
     guardrails,
@@ -55,6 +53,9 @@ export const Chat: React.FunctionComponent<React.PropsWithChildren<ChatboxProps>
     transcriptRef.current = transcript
 
     const userInfo = useUserAccountInfo()
+
+    const api = useExtensionAPI()
+    const { value: chatModels } = useObservable(useMemo(() => api.chatModels(), [api.chatModels]))
 
     const feedbackButtonsOnSubmit = useCallback(
         (text: string) => {
@@ -217,7 +218,7 @@ export const Chat: React.FunctionComponent<React.PropsWithChildren<ChatboxProps>
             )}
             <Transcript
                 transcript={transcript}
-                models={models}
+                models={chatModels ?? []}
                 messageInProgress={messageInProgress}
                 feedbackButtonsOnSubmit={feedbackButtonsOnSubmit}
                 copyButtonOnSubmit={copyButtonOnSubmit}

--- a/vscode/webviews/CodyPanel.tsx
+++ b/vscode/webviews/CodyPanel.tsx
@@ -1,4 +1,5 @@
 import { type AuthStatus, type ClientCapabilities, CodyIDE } from '@sourcegraph/cody-shared'
+import { useExtensionAPI, useObservable } from '@sourcegraph/prompt-editor'
 import type React from 'react'
 import { type ComponentProps, type FunctionComponent, useMemo, useRef } from 'react'
 import type { ConfigurationSubsetForWebview, LocalEnv } from '../src/chat/protocol'
@@ -55,6 +56,9 @@ export const CodyPanel: FunctionComponent<
 }) => {
     const tabContainerRef = useRef<HTMLDivElement>(null)
 
+    const api = useExtensionAPI()
+    const { value: chatModels } = useObservable(useMemo(() => api.chatModels(), [api.chatModels]))
+
     return (
         <TabViewContext.Provider value={useMemo(() => ({ view, setView }), [view, setView])}>
             <TabRoot
@@ -79,6 +83,7 @@ export const CodyPanel: FunctionComponent<
                             chatEnabled={chatEnabled}
                             messageInProgress={messageInProgress}
                             transcript={transcript}
+                            models={chatModels || []}
                             vscodeAPI={vscodeAPI}
                             guardrails={attributionEnabled ? guardrails : undefined}
                             showIDESnippetActions={showIDESnippetActions}

--- a/vscode/webviews/CodyPanel.tsx
+++ b/vscode/webviews/CodyPanel.tsx
@@ -1,5 +1,4 @@
 import { type AuthStatus, type ClientCapabilities, CodyIDE } from '@sourcegraph/cody-shared'
-import { useExtensionAPI, useObservable } from '@sourcegraph/prompt-editor'
 import type React from 'react'
 import { type ComponentProps, type FunctionComponent, useMemo, useRef } from 'react'
 import type { ConfigurationSubsetForWebview, LocalEnv } from '../src/chat/protocol'
@@ -56,9 +55,6 @@ export const CodyPanel: FunctionComponent<
 }) => {
     const tabContainerRef = useRef<HTMLDivElement>(null)
 
-    const api = useExtensionAPI()
-    const { value: chatModels } = useObservable(useMemo(() => api.chatModels(), [api.chatModels]))
-
     return (
         <TabViewContext.Provider value={useMemo(() => ({ view, setView }), [view, setView])}>
             <TabRoot
@@ -83,7 +79,6 @@ export const CodyPanel: FunctionComponent<
                             chatEnabled={chatEnabled}
                             messageInProgress={messageInProgress}
                             transcript={transcript}
-                            models={chatModels || []}
                             vscodeAPI={vscodeAPI}
                             guardrails={attributionEnabled ? guardrails : undefined}
                             showIDESnippetActions={showIDESnippetActions}

--- a/vscode/webviews/chat/Transcript.story.tsx
+++ b/vscode/webviews/chat/Transcript.story.tsx
@@ -5,15 +5,20 @@ import { FIXTURE_TRANSCRIPT, FIXTURE_USER_ACCOUNT_INFO, transcriptFixture } from
 
 import {
     type ChatMessage,
+    ModelTag,
+    ModelUsage,
     PromptString,
     RateLimitError,
     errorToChatError,
+    getMockedDotComClientModels,
     ps,
 } from '@sourcegraph/cody-shared'
 import { useArgs, useCallback, useEffect, useRef, useState } from '@storybook/preview-api'
 import type { ComponentProps } from 'react'
 import { URI } from 'vscode-uri'
 import { VSCodeWebview } from '../storybook/VSCodeStoryDecorator'
+
+const mockedModels = getMockedDotComClientModels()
 
 const meta: Meta<typeof Transcript> = {
     title: 'ui/Transcript',
@@ -36,6 +41,7 @@ const meta: Meta<typeof Transcript> = {
         userInfo: FIXTURE_USER_ACCOUNT_INFO,
         postMessage: () => {},
         chatEnabled: true,
+        models: mockedModels,
     } satisfies ComponentProps<typeof Transcript>,
 
     decorators: [
@@ -54,6 +60,34 @@ export const Default: StoryObj<typeof meta> = {
 export const Empty: StoryObj<typeof meta> = {
     args: {
         transcript: [],
+    },
+}
+
+export const ModelSelection: StoryObj<typeof meta> = {
+    args: {
+        transcript: FIXTURE_TRANSCRIPT.simple,
+        models: mockedModels,
+        userInfo: { ...FIXTURE_USER_ACCOUNT_INFO, isCodyProUser: true },
+    },
+}
+
+export const WithDifferentModels: StoryObj<typeof meta> = {
+    args: {
+        transcript: FIXTURE_TRANSCRIPT.simple,
+        models: [
+            {
+                id: 'custom-model',
+                usage: [ModelUsage.Chat, ModelUsage.Edit, ModelUsage.Autocomplete],
+                contextWindow: {
+                    input: 16000,
+                    output: 4000,
+                },
+                provider: 'CustomAI',
+                title: 'Super AI',
+                tags: [ModelTag.Enterprise, ModelTag.Power],
+            },
+            ...mockedModels,
+        ],
     },
 }
 
@@ -227,6 +261,7 @@ export const Streaming: StoryObj<typeof meta> = {
                     model: 'my-model',
                     text: PromptString.unsafe_fromLLMResponse(`${reply}`),
                 }}
+                models={args.models}
             />
         )
     },

--- a/vscode/webviews/chat/Transcript.tsx
+++ b/vscode/webviews/chat/Transcript.tsx
@@ -1,6 +1,7 @@
 import {
     type ChatMessage,
     type Guardrails,
+    type Model,
     type SerializedPromptEditorValue,
     deserializeContextItem,
     inputTextWithoutContextChipsFromPromptEditorState,
@@ -31,6 +32,7 @@ import { InfoMessage } from './components/InfoMessage'
 interface TranscriptProps {
     chatEnabled: boolean
     transcript: ChatMessage[]
+    models: Model[]
     userInfo: UserAccountInfo
     messageInProgress: ChatMessage | null
 
@@ -48,6 +50,7 @@ export const Transcript: FC<TranscriptProps> = props => {
     const {
         chatEnabled,
         transcript,
+        models,
         userInfo,
         messageInProgress,
         guardrails,
@@ -74,6 +77,7 @@ export const Transcript: FC<TranscriptProps> = props => {
                 <TranscriptInteraction
                     // biome-ignore lint/suspicious/noArrayIndexKey: <explanation>
                     key={i}
+                    models={models}
                     chatEnabled={chatEnabled}
                     userInfo={userInfo}
                     interaction={interaction}
@@ -165,6 +169,7 @@ interface TranscriptInteractionProps
 const TranscriptInteraction: FC<TranscriptInteractionProps> = memo(props => {
     const {
         interaction: { humanMessage, assistantMessage },
+        models,
         isFirstInteraction,
         isLastInteraction,
         isLastSentInteraction,
@@ -310,6 +315,7 @@ const TranscriptInteraction: FC<TranscriptInteractionProps> = memo(props => {
                 editorRef={humanEditorRef}
                 className={!isFirstInteraction && isLastInteraction ? 'tw-mt-auto' : ''}
                 onEditorFocusChange={resetIntent}
+                models={models}
             />
 
             {experimentalOneBoxEnabled && humanMessage.intent && (

--- a/vscode/webviews/chat/cells/messageCell/human/HumanMessageCell.tsx
+++ b/vscode/webviews/chat/cells/messageCell/human/HumanMessageCell.tsx
@@ -1,5 +1,6 @@
 import {
     type ChatMessage,
+    type Model,
     type SerializedPromptEditorState,
     type SerializedPromptEditorValue,
     serializedPromptEditorStateFromChatMessage,
@@ -19,6 +20,7 @@ import { useConfig } from '../../../../utils/useConfig'
 
 interface HumanMessageCellProps {
     message: ChatMessage
+    models: Model[]
     userInfo: UserAccountInfo
     chatEnabled: boolean
 
@@ -67,6 +69,7 @@ type HumanMessageCellContent = { initialEditorState: SerializedPromptEditorState
 >
 const HumanMessageCellContent = memo<HumanMessageCellContent>(props => {
     const {
+        models,
         initialEditorState,
         userInfo,
         chatEnabled = true,
@@ -98,6 +101,7 @@ const HumanMessageCellContent = memo<HumanMessageCellContent>(props => {
             cellAction={isFirstMessage && <OpenInNewEditorAction />}
             content={
                 <HumanMessageEditor
+                    models={models}
                     userInfo={userInfo}
                     initialEditorState={initialEditorState}
                     placeholder={isFirstMessage ? 'Ask...' : 'Ask a followup...'}

--- a/vscode/webviews/chat/cells/messageCell/human/editor/HumanMessageEditor.test.tsx
+++ b/vscode/webviews/chat/cells/messageCell/human/editor/HumanMessageEditor.test.tsx
@@ -1,5 +1,6 @@
 import {
     FILE_MENTION_EDITOR_STATE_FIXTURE,
+    getMockedDotComClientModels,
     serializedPromptEditorStateFromText,
 } from '@sourcegraph/cody-shared'
 import { fireEvent, render, screen } from '@testing-library/react'
@@ -13,6 +14,8 @@ vi.mock('@vscode/webview-ui-toolkit/react', () => ({
     VSCodeButton: vi.fn(),
     VSCodeCheckbox: vi.fn(),
 }))
+
+const MOCK_MODELS = getMockedDotComClientModels()
 
 const ENTER_KEYBOARD_EVENT_DATA: Pick<KeyboardEvent, 'key' | 'code' | 'keyCode'> = {
     key: 'Enter',
@@ -138,6 +141,13 @@ describe('HumanMessageEditor', () => {
             fireEvent.keyDown(editor, ENTER_KEYBOARD_EVENT_DATA)
             expect(onSubmit).toHaveBeenCalledTimes(2)
         })
+
+        test('model selector is showing up with the default model name', () => {
+            const { container } = renderWithMocks({})
+            const modelSelector = container.querySelector('[data-testid="chat-model-selector"]')
+            expect(modelSelector).not.toBeNull()
+            expect(modelSelector?.textContent).toEqual(MOCK_MODELS[0].title)
+        })
     })
 })
 
@@ -166,6 +176,7 @@ function renderWithMocks(props: Partial<ComponentProps<typeof HumanMessageEditor
         onChange,
         onSubmit,
         onStop,
+        models: MOCK_MODELS,
     }
 
     const { container } = render(<HumanMessageEditor {...DEFAULT_PROPS} {...props} />, {

--- a/vscode/webviews/chat/cells/messageCell/human/editor/HumanMessageEditor.tsx
+++ b/vscode/webviews/chat/cells/messageCell/human/editor/HumanMessageEditor.tsx
@@ -36,6 +36,7 @@ import { Toolbar } from './toolbar/Toolbar'
  * A component to compose and edit human chat messages and the settings associated with them.
  */
 export const HumanMessageEditor: FunctionComponent<{
+    models: Model[]
     userInfo: UserAccountInfo
 
     initialEditorState: SerializedPromptEditorState | undefined
@@ -67,6 +68,7 @@ export const HumanMessageEditor: FunctionComponent<{
     /** For use in storybooks only. */
     __storybook__focus?: boolean
 }> = ({
+    models,
     userInfo,
     initialEditorState,
     placeholder,
@@ -359,6 +361,7 @@ export const HumanMessageEditor: FunctionComponent<{
             />
             {!disabled && (
                 <Toolbar
+                    models={models}
                     userInfo={userInfo}
                     isEditorFocused={focused}
                     onMentionClick={onMentionClick}

--- a/vscode/webviews/chat/cells/messageCell/human/editor/toolbar/Toolbar.tsx
+++ b/vscode/webviews/chat/cells/messageCell/human/editor/toolbar/Toolbar.tsx
@@ -1,7 +1,7 @@
 import type { Action, ChatMessage, Model } from '@sourcegraph/cody-shared'
-import { useExtensionAPI, useObservable } from '@sourcegraph/prompt-editor'
+import { useExtensionAPI } from '@sourcegraph/prompt-editor'
 import clsx from 'clsx'
-import { type FunctionComponent, useCallback, useMemo } from 'react'
+import { type FunctionComponent, useCallback } from 'react'
 import type { UserAccountInfo } from '../../../../../../Chat'
 import { ModelSelectField } from '../../../../../../components/modelSelectField/ModelSelectField'
 import { PromptSelectField } from '../../../../../../components/promptSelectField/PromptSelectField'
@@ -14,6 +14,7 @@ import { SubmitButton, type SubmitButtonState } from './SubmitButton'
  * The toolbar for the human message editor.
  */
 export const Toolbar: FunctionComponent<{
+    models: Model[]
     userInfo: UserAccountInfo
 
     isEditorFocused: boolean
@@ -40,6 +41,7 @@ export const Toolbar: FunctionComponent<{
     focusEditor,
     hidden,
     className,
+    models,
 }) => {
     /**
      * If the user clicks in a gap or on the toolbar outside of any of its buttons, report back to
@@ -69,6 +71,7 @@ export const Toolbar: FunctionComponent<{
             )}
             onMouseDown={onMaybeGapClick}
             onClick={onMaybeGapClick}
+            data-testid="chat-editor-toolbar"
         >
             <div className="tw-flex tw-items-center">
                 {/* Can't use tw-gap-1 because the popover creates an empty element when open. */}
@@ -80,6 +83,7 @@ export const Toolbar: FunctionComponent<{
                 )}
                 <PromptSelectFieldToolbarItem focusEditor={focusEditor} className="tw-ml-1 tw-mr-1" />
                 <ModelSelectFieldToolbarItem
+                    models={models}
                     userInfo={userInfo}
                     focusEditor={focusEditor}
                     className="tw-mr-1"
@@ -114,10 +118,11 @@ const PromptSelectFieldToolbarItem: FunctionComponent<{
 }
 
 const ModelSelectFieldToolbarItem: FunctionComponent<{
+    models: Model[]
     userInfo: UserAccountInfo
     focusEditor?: () => void
     className?: string
-}> = ({ userInfo, focusEditor, className }) => {
+}> = ({ userInfo, focusEditor, className, models }) => {
     const config = useConfig()
 
     const api = useExtensionAPI()
@@ -132,18 +137,17 @@ const ModelSelectFieldToolbarItem: FunctionComponent<{
         [api.setChatModel, focusEditor]
     )
 
-    const { value: chatModels } = useObservable(useMemo(() => api.chatModels(), [api.chatModels]))
-
     return (
-        !!chatModels?.length &&
+        !!models?.length &&
         (userInfo.isDotComUser || config.configFeatures.serverSentModels) && (
             <ModelSelectField
-                models={chatModels}
+                models={models}
                 onModelSelect={onModelSelect}
                 serverSentModelsEnabled={config.configFeatures.serverSentModels}
                 userInfo={userInfo}
                 onCloseByEscape={focusEditor}
                 className={className}
+                data-testid="chat-model-selector"
             />
         )
     )

--- a/vscode/webviews/components/modelSelectField/ModelSelectField.tsx
+++ b/vscode/webviews/components/modelSelectField/ModelSelectField.tsx
@@ -174,6 +174,7 @@ export const ModelSelectField: React.FunctionComponent<{
     return (
         <ToolbarPopoverItem
             role="combobox"
+            data-testid="chat-model-selector"
             iconEnd={readOnly ? undefined : 'chevron'}
             className={cn('tw-justify-between', className)}
             disabled={readOnly}
@@ -181,12 +182,22 @@ export const ModelSelectField: React.FunctionComponent<{
             tooltip={readOnly ? undefined : 'Select a model'}
             aria-label="Select a model"
             popoverContent={close => (
-                <Command loop={true} defaultValue={value} tabIndex={0} className="focus:tw-outline-none">
-                    <CommandList className={'model-selector-popover'}>
+                <Command
+                    loop={true}
+                    defaultValue={value}
+                    tabIndex={0}
+                    className="focus:tw-outline-none"
+                    data-testid="chat-model-popover"
+                >
+                    <CommandList
+                        className="model-selector-popover"
+                        data-testid="chat-model-popover-option"
+                    >
                         {optionsByGroup.map(({ group, options }) => (
                             <CommandGroup heading={group} key={group}>
                                 {options.map(option => (
                                     <CommandItem
+                                        data-testid="chat-model-popover-option"
                                         key={option.value}
                                         value={option.value}
                                         onSelect={currentValue => {


### PR DESCRIPTION
Description: This PR aims to improve the performance and reduce potential memory leaks in our chat component by lifting the chatModels observable creation to a higher-level component and passing it down as props. This change eliminates multiple subscriptions created for each chat message.

Key changes:

- Moved the chatModels observable creation from individual components to the CodyPanel component.
- Added a 'models' prop to relevant components to pass down the chat models.
- Updated the Transcript, HumanMessageCell, HumanMessageEditor, and Toolbar components to use the passed models prop instead of creating their own observable.
- Updated related test files and storybook stories to accommodate the new 'models' prop.

## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

- Verify that the chat functionality works as expected with the new changes.
- Ensure that model selection still functions correctly in the chat interface.
- Check that all chat messages display and interact properly with the selected model.
- Monitor memory usage before and after these changes to verify reduced memory consumption.
- Use browser developer tools to confirm that fewer subscriptions are being created.

After

![image](https://github.com/user-attachments/assets/1a04a195-ff5c-4967-a432-a18703273c8e)

Before 

![image](https://github.com/user-attachments/assets/a0c289c5-bccb-4620-8712-b04dcfd3f482)


## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->

Chat: tbc