### PR TITLE
Chat: use memoized models props in HumanMessageEditor

### DIFF
--- a/vscode/webviews/chat/Transcript.tsx
+++ b/vscode/webviews/chat/Transcript.tsx
@@ -75,8 +75,7 @@ export const Transcript: FC<TranscriptProps> = props => {
         >
             {interactions.map((interaction, i) => (
                 <TranscriptInteraction
-                    // biome-ignore lint/suspicious/noArrayIndexKey: <explanation>
-                    key={i}
+                    key={interaction.humanMessage.index}
                     models={models}
                     chatEnabled={chatEnabled}
                     userInfo={userInfo}

--- a/vscode/webviews/chat/cells/messageCell/human/editor/HumanMessageEditor.tsx
+++ b/vscode/webviews/chat/cells/messageCell/human/editor/HumanMessageEditor.tsx
@@ -10,9 +10,7 @@ import {
 import {
     PromptEditor,
     type PromptEditorRefAPI,
-    useExtensionAPI,
     useInitialContextForChat,
-    useObservable,
 } from '@sourcegraph/prompt-editor'
 import clsx from 'clsx'
 import {
@@ -297,7 +295,7 @@ export const HumanMessageEditor: FunctionComponent<{
         )
     )
 
-    const model = useCurrentChatModel()
+    const currentChatModel = useMemo(() => models[0], [models[0]])
 
     let initialContext = useInitialContextForChat()
     useEffect(() => {
@@ -306,13 +304,13 @@ export const HumanMessageEditor: FunctionComponent<{
             if (editor) {
                 // Don't show the initial codebase context if the model doesn't support streaming
                 // as including context result in longer processing time.
-                if (model?.tags?.includes(ModelTag.StreamDisabled)) {
+                if (currentChatModel?.tags?.includes(ModelTag.StreamDisabled)) {
                     initialContext = initialContext.filter(item => item.type !== 'tree')
                 }
                 editor.setInitialContextMentions(initialContext)
             }
         }
-    }, [initialContext, isSent, isFirstMessage, model])
+    }, [initialContext, isSent, isFirstMessage, currentChatModel])
 
     const focusEditor = useCallback(() => editorRef.current?.setFocus(true), [])
 
@@ -324,8 +322,8 @@ export const HumanMessageEditor: FunctionComponent<{
 
     const focused = Boolean(isEditorFocused || isFocusWithin || __storybook__focus)
     const contextWindowSizeInTokens =
-        model?.contextWindow?.context?.user ||
-        model?.contextWindow?.input ||
+        currentChatModel?.contextWindow?.context?.user ||
+        currentChatModel?.contextWindow?.input ||
         FAST_CHAT_INPUT_TOKEN_BUDGET
 
     return (
@@ -375,9 +373,4 @@ export const HumanMessageEditor: FunctionComponent<{
             )}
         </div>
     )
-}
-
-function useCurrentChatModel(): Model | undefined {
-    const models = useExtensionAPI().chatModels
-    return useObservable(useMemo(() => models(), [models])).value?.at(0)
 }


### PR DESCRIPTION
Follow up on https://github.com/sourcegraph/cody/pull/5866

- Use `useMemo` to get the first current chat model instead of `useObservable` to avoid unnecessary re-renders
- Update `Transcript` to use the `humanMessage.index` as the key for `TranscriptInteraction` components

## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

Green CI

Same test plan as https://github.com/sourcegraph/cody/pull/5866

### After 

![image](https://github.com/user-attachments/assets/728ee17b-54ce-445c-a18e-2a4883d161e6)


### Before

![image](https://github.com/user-attachments/assets/5e52162f-f4e3-481e-9f38-b7f7131ee0ef)

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->

Chat: Fix performance issue with Chat webview.