### PR TITLE
Chat: use memoized chat models in AssistantMessageCell

### DIFF
--- a/vscode/webviews/chat/Transcript.tsx
+++ b/vscode/webviews/chat/Transcript.tsx
@@ -374,6 +374,7 @@ const TranscriptInteraction: FC<TranscriptInteractionProps> = memo(props => {
                         userInfo={userInfo}
                         chatEnabled={chatEnabled}
                         message={assistantMessage}
+                        models={models}
                         feedbackButtonsOnSubmit={feedbackButtonsOnSubmit}
                         copyButtonOnSubmit={copyButtonOnSubmit}
                         insertButtonOnSubmit={insertButtonOnSubmit}

--- a/vscode/webviews/chat/cells/messageCell/assistant/AssistantMessageCell.tsx
+++ b/vscode/webviews/chat/cells/messageCell/assistant/AssistantMessageCell.tsx
@@ -12,7 +12,7 @@ import {
     reformatBotMessageForChat,
     serializedPromptEditorStateFromChatMessage,
 } from '@sourcegraph/cody-shared'
-import { type PromptEditorRefAPI, useExtensionAPI, useObservable } from '@sourcegraph/prompt-editor'
+import type { PromptEditorRefAPI } from '@sourcegraph/prompt-editor'
 import isEqual from 'lodash/isEqual'
 import { type FunctionComponent, type RefObject, memo, useMemo } from 'react'
 import type { ApiPostMessage, UserAccountInfo } from '../../../../Chat'
@@ -33,7 +33,7 @@ import { ContextFocusActions } from './ContextFocusActions'
  */
 export const AssistantMessageCell: FunctionComponent<{
     message: ChatMessage
-
+    models: Model[]
     /** Information about the human message that led to this assistant response. */
     humanMessage: PriorHumanMessageInfo | null
 
@@ -55,6 +55,7 @@ export const AssistantMessageCell: FunctionComponent<{
 }> = memo(
     ({
         message,
+        models,
         humanMessage,
         userInfo,
         chatEnabled,
@@ -73,7 +74,7 @@ export const AssistantMessageCell: FunctionComponent<{
             [message]
         )
 
-        const chatModel = useChatModelByID(message.model)
+        const chatModel = useChatModelByID(message.model, models)
         const ModelIcon = chatModel ? chatModelIconComponent(chatModel.id) : null
         const isAborted = isAbortErrorOrSocketHangUp(message.error)
 
@@ -234,10 +235,9 @@ export function makeHumanMessageInfo(
 }
 
 function useChatModelByID(
-    model: string | undefined
+    model: string | undefined,
+    chatModels: Model[]
 ): Pick<Model, 'id' | 'title' | 'provider' | 'tags'> | undefined {
-    const models = useExtensionAPI().chatModels
-    const chatModels = useObservable(useMemo(() => models(), [models])).value
     return (
         chatModels?.find(m => m.id === model) ??
         (model


### PR DESCRIPTION
- Use the `models` prop passed down from the parent component instead of creating a new observable for the chat models for each assistant message cell
- Update `useChatModelByID` to use the passed `chatModels` array instead of creating a new observable
- Update `Transcript` to pass the `models` prop to `AssistantMessageCell`

## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->


No behavior changes. Everything including the tests are expected to work the same.

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
