### PR TITLE
Autocomplete: keep the original insert range for agent `autocomplete/execute` calls

### DIFF
--- a/agent/src/autocomplete.test.ts
+++ b/agent/src/autocomplete.test.ts
@@ -72,7 +72,7 @@ describe('Autocomplete', () => {
         expect(texts).toMatchInlineSnapshot(
             `
           [
-            "    return a + b;",
+            "return a + b;",
           ]
         `
         )
@@ -113,7 +113,7 @@ describe('Autocomplete', () => {
         expect(texts).toMatchInlineSnapshot(
             `
           [
-            "    for (let i = 0; i < arr.length; i++) {
+            "for (let i = 0; i < arr.length; i++) {
                   for (let j = 0; j < arr.length - i - 1; j++) {
                       if (arr[j] > arr[j + 1]) {
                           let temp = arr[j]

--- a/agent/src/enterprise-s2.test.ts
+++ b/agent/src/enterprise-s2.test.ts
@@ -162,7 +162,7 @@ describe('Enterprise - S2 (close main branch)', { timeout: 5000 }, () => {
             expect(items.map(item => item.insertText)).toMatchInlineSnapshot(
                 `
               [
-                "    return a + b",
+                "return a + b",
               ]
             `
             )

--- a/vscode/src/completions/inline-completion-item-provider.ts
+++ b/vscode/src/completions/inline-completion-item-provider.ts
@@ -632,7 +632,7 @@ export class InlineCompletionItemProvider
                 // return `CompletionEvent` telemetry data to the agent command `autocomplete/execute`.
                 const autocompleteResult: AutocompleteResult = {
                     logId: result.logId,
-                    items: updateInsertRangeForVSCode(visibleItems),
+                    items: visibleItems,
                     completionEvent: CompletionAnalyticsLogger.getCompletionEvent(result.logId),
                 }
 
@@ -641,6 +641,12 @@ export class InlineCompletionItemProvider
                     // that if we pass the above visibility tests, the completion is going to be
                     // rendered in the UI
                     this.unstable_handleDidShowCompletionItem(visibleItems[0])
+
+                    // Adjust the completion insert text and range to start from beginning of the current line
+                    // (instead of starting at the given position). This avoids UI jitter in VS Code; when
+                    // typing or deleting individual characters, VS Code reuses the existing completion
+                    // while it waits for the new one to come in.
+                    autocompleteResult.items = updateInsertRangeForVSCode(visibleItems)
                 }
 
                 recordExposedExperimentsToSpan(span)
@@ -660,6 +666,7 @@ export class InlineCompletionItemProvider
                         return null // Exit early if the request has been aborted
                     }
                 }
+
                 return autocompleteResult
             } catch (error) {
                 this.onError(error as Error)


### PR DESCRIPTION
- **Do not merge this until all the clients are updated**.
- This PR proposes to change the behavior of the `autocomplete/execute` requests for the agent based on the [feedback in Slack](https://sourcegraph.slack.com/archives/C073U3KE5DK/p1728559419953909). 
- `InlineCompletionItemProvider.provideInlineCompletionItems()` no longer executes the VS Code-specific logic, which makes all completions start at the beginning of the line no matter what the current cursor position is. This logic was added to avoid UI jitter in VS Code, but it does not apply to other Cody clients and requires them to implement additional post-processing logic for no apparent reason.
    - This is a breaking change for clients using the agent API `autocomplete/execute`. cc @abeatrix @PiotrKarczmarz
- Previous PR with the relevant discussion https://github.com/sourcegraph/cody/pull/2573
- Closes https://linear.app/sourcegraph/issue/CODY-4022/update-the-agent-to-stop-adjusting-the-insert-text-range-in-a-vs-code

## Test plan

- [x] Update agent integration tests 
- [x] CI
- [x] No functional changes for the VS Code client
- [x] JetBrains client is updated
- [x] Visual Studio client is updated 
- [ ] Vim client is updated 
- [ ] Emacs client is updated 

## Changelog

- Autocomplete: the agent no longer adjusts the insert text range in a VS Code-specific way.