### PR TITLE
fix/chat: Improve performance in streaming responses in long chats

### DIFF
--- a/lib/shared/src/editor/hydrateAfterPostMessage.test.ts
+++ b/lib/shared/src/editor/hydrateAfterPostMessage.test.ts
@@ -7,36 +7,23 @@ const mockHydrateUri = (value: unknown) => {
     return { hydrated: true, originalValue: value }
 }
 
-describe('lazyHydrateAfterPostMessage', () => {
-    test('handles non-object values', () => {
-        expect(hydrateAfterPostMessage(7, mockHydrateUri)).toEqual(7)
+describe('hydrateAfterPostMessage', () => {
+    test('re-hydrates a dehydrated URI object', () => {
+        const dehydratedUri = () => ({ $mid: 1, path: '/path/to/resource', scheme: 'file' })
+        expect(isDehydratedUri(dehydratedUri())).toBe(true)
+        expect(hydrateAfterPostMessage(dehydratedUri(), mockHydrateUri)).toEqual(
+            mockHydrateUri(dehydratedUri())
+        )
     })
 
-    test('handles shallow, non-URI values', () => {
-        expect(hydrateAfterPostMessage({ foo: 7, bar: 'hello' }, mockHydrateUri)).toEqual({
-            foo: 7,
-            bar: 'hello',
-        })
+    test('re-hydrates a short array of dehydrated URIs', () => {
+        const dehydratedUris = () => [{ $mid: 1, path: '/path/to/resource', scheme: 'file' }]
+        expect(hydrateAfterPostMessage(dehydratedUris(), mockHydrateUri)).toEqual(
+            dehydratedUris().map(mockHydrateUri)
+        )
     })
 
-    test('handles deep values', () => {
-        expect(hydrateAfterPostMessage({ foo: { bar: 'qux' } }, mockHydrateUri)).toEqual({
-            foo: { bar: 'qux' },
-        })
-    })
-
-    test('handles URI values', () => {
-        const uri = { $mid: 1, path: '/path/to/resource', scheme: 'file' }
-        expect(isDehydratedUri(uri)).toBe(true)
-        expect(hydrateAfterPostMessage({ foo: uri }, mockHydrateUri)).toEqual({
-            foo: {
-                hydrated: true,
-                originalValue: { $mid: 1, path: '/path/to/resource', scheme: 'file' },
-            },
-        })
-    })
-
-    test('handles arrays', () => {
+    test('re-hydrates a multi-element array of dehydrated URIs', () => {
         const uriA = { $mid: 1, path: '/path/to/resource/1', scheme: 'file' }
         const uriB = { $mid: 2, path: '/path/to/resource/2', scheme: 'file' }
         expect(hydrateAfterPostMessage([uriA, uriB, uriA], mockHydrateUri)).toEqual([
@@ -49,36 +36,28 @@ describe('lazyHydrateAfterPostMessage', () => {
         ])
     })
 
-    test('modifications to the dehydrated object are reflected in the returned object', () => {
-        const originalValue: any = { foo: { bar: 'qux' } }
-        const hydratedValue = hydrateAfterPostMessage(originalValue, mockHydrateUri)
-        originalValue.foo = 'glorp'
-        expect(hydratedValue.foo).toEqual('glorp')
-    })
-
-    test('modifications to the returned value are reflected in the dehydrated object', () => {
-        const originalValue = { foo: { bar: 'qux' } }
-        const hydratedValue = hydrateAfterPostMessage(originalValue, mockHydrateUri)
-        hydratedValue.foo.bar = 'baz'
-        expect(originalValue.foo.bar).toEqual('baz')
-    })
-})
-
-describe('hydrateAfterPostMessage', () => {
-    // The fixture data is a function that returns the data because hydrateAfterPostMessage mutates
-    // its argument.
-    test('re-hydrates a dehydrated URI object', () => {
-        const dehydratedUri = () => ({ $mid: 1, path: '/path/to/resource', scheme: 'file' })
-        expect(hydrateAfterPostMessage(dehydratedUri(), mockHydrateUri)).toEqual(
-            mockHydrateUri(dehydratedUri())
-        )
-    })
-
-    test('re-hydrates an array of dehydrated URIs', () => {
-        const dehydratedUris = () => [{ $mid: 1, path: '/path/to/resource', scheme: 'file' }]
-        expect(hydrateAfterPostMessage(dehydratedUris(), mockHydrateUri)).toEqual(
-            dehydratedUris().map(mockHydrateUri)
-        )
+    test('re-hydrates a nested array of dehydrated URIs', () => {
+        const uriA = { $mid: 1, path: '/path/to/resource/1', scheme: 'file' }
+        const uriB = { $mid: 2, path: '/path/to/resource/2', scheme: 'file' }
+        expect(hydrateAfterPostMessage([[uriA, uriB], uriA, [uriB]], mockHydrateUri)).toEqual([
+            [
+                {
+                    hydrated: true,
+                    originalValue: { $mid: 1, path: '/path/to/resource/1', scheme: 'file' },
+                },
+                {
+                    hydrated: true,
+                    originalValue: { $mid: 2, path: '/path/to/resource/2', scheme: 'file' },
+                },
+            ],
+            { hydrated: true, originalValue: { $mid: 1, path: '/path/to/resource/1', scheme: 'file' } },
+            [
+                {
+                    hydrated: true,
+                    originalValue: { $mid: 2, path: '/path/to/resource/2', scheme: 'file' },
+                },
+            ],
+        ])
     })
 
     test('re-hydrates nested objects containing dehydrated URIs', () => {
@@ -103,5 +82,36 @@ describe('hydrateAfterPostMessage', () => {
     test('handles null and undefined values correctly', () => {
         expect(hydrateAfterPostMessage(null, mockHydrateUri)).toBeNull()
         expect(hydrateAfterPostMessage(undefined, mockHydrateUri)).toBeUndefined()
+    })
+
+    test('handles non-object values', () => {
+        expect(hydrateAfterPostMessage(7, mockHydrateUri)).toEqual(7)
+    })
+
+    test('handles shallow, non-URI values', () => {
+        expect(hydrateAfterPostMessage({ foo: 7, bar: 'hello' }, mockHydrateUri)).toEqual({
+            foo: 7,
+            bar: 'hello',
+        })
+    })
+
+    test('handles deep values', () => {
+        expect(hydrateAfterPostMessage({ foo: { bar: 'qux' } }, mockHydrateUri)).toEqual({
+            foo: { bar: 'qux' },
+        })
+    })
+
+    test('modifications to the dehydrated object are reflected in the returned object', () => {
+        const originalValue: any = { foo: { bar: 'qux' } }
+        const hydratedValue = hydrateAfterPostMessage(originalValue, mockHydrateUri)
+        originalValue.foo = 'glorp'
+        expect(hydratedValue.foo).toEqual('glorp')
+    })
+
+    test('modifications to the returned value are reflected in the dehydrated object', () => {
+        const originalValue = { foo: { bar: 'qux' } }
+        const hydratedValue = hydrateAfterPostMessage(originalValue, mockHydrateUri)
+        hydratedValue.foo.bar = 'baz'
+        expect(originalValue.foo.bar).toEqual('baz')
     })
 })

--- a/lib/shared/src/editor/hydrateAfterPostMessage.ts
+++ b/lib/shared/src/editor/hydrateAfterPostMessage.ts
@@ -13,7 +13,12 @@ export function forceHydration(object: any): any {
     if (Array.isArray(object)) {
         return object.map(forceHydration)
     }
-    const clone = Object.create(Object.getPrototypeOf(object))
+    let clone: any
+    if (object instanceof Date) {
+        clone = new Date(object)
+    } else {
+        clone = Object.create(Object.getPrototypeOf(object))
+    }
     for (const [key, value] of Object.entries(object)) {
         clone[key] = forceHydration(value)
     }

--- a/lib/shared/src/editor/hydrateAfterPostMessage.ts
+++ b/lib/shared/src/editor/hydrateAfterPostMessage.ts
@@ -1,32 +1,71 @@
 import type * as vscode from 'vscode'
 import type { URI } from 'vscode-uri'
 
+class LazyHydrationHandler implements ProxyHandler<object> {
+    readonly lazyHydrationCache = new WeakMap<object, { object: any; isUri: boolean }>()
+
+    constructor(private hydrateUri: (value: unknown) => any) {}
+
+    get(target: object, property: string | symbol, receiver: any): any {
+        let cached: any
+        if (this.lazyHydrationCache.has(target)) {
+            cached = this.lazyHydrationCache.get(target)
+        } else {
+            let clone: any
+            if (Array.isArray(target)) {
+                clone = target.map(value => {
+                    if (typeof value === 'object' && value !== null) {
+                        if (isDehydratedUri(value)) {
+                            return this.hydrateUri(value)
+                        }
+                        return new Proxy(value, this)
+                    }
+                    return value
+                })
+            } else {
+                clone = Object.create(Object.getPrototypeOf(target))
+                for (const [key, value] of Object.entries(target)) {
+                    if (typeof value === 'object' && value !== null) {
+                        if (isDehydratedUri(value)) {
+                            clone[key] = this.hydrateUri(value)
+                        } else {
+                            clone[key] = new Proxy(value, this)
+                        }
+                    } else {
+                        clone[key] = value
+                    }
+                }
+            }
+            cached = { object: clone, isUri: false }
+            this.lazyHydrationCache.set(target, cached)
+        }
+        const value = Reflect.get(cached.object, property, receiver)
+        return value
+    }
+
+    set(target: object, property: string | symbol, value: any, receiver: any): boolean {
+        const cached = this.lazyHydrationCache.get(target)!
+        return Reflect.set(cached.object, property, value, receiver)
+    }
+}
+
+export function lazyHydrateAfterPostMessage<T, U>(value: T, hydrateUri: (value: unknown) => U): T {
+    return typeof value === 'object' && value !== null
+        ? (new Proxy(value, new LazyHydrationHandler(hydrateUri)) as T)
+        : value
+}
+
 /**
  * Recursively re-hydrate {@link value}, re-creating instances of classes from the raw data that was
  * sent to us via `postMessage`. When values are sent over `postMessage` between the webview and the
  * extension host, only data is preserved, not classes/prototypes. This is a problem particularly
  * with URI instances.
- *
- * This function mutates `value`.
  */
 export function hydrateAfterPostMessage<T, U>(value: T, hydrateUri: (value: unknown) => U): T {
-    if (isDehydratedUri(value)) {
-        return hydrateUri(value) as unknown as T
-    }
-    if (Array.isArray(value)) {
-        return value.map(e => hydrateAfterPostMessage(e, hydrateUri)) as T
-    }
-    if (value instanceof Object) {
-        // Hydrate any values that are classes.
-        for (const key of Object.keys(value)) {
-            ;(value as any)[key] = hydrateAfterPostMessage((value as any)[key], hydrateUri)
-        }
-        return value
-    }
-    return value
+    return lazyHydrateAfterPostMessage({ value }, hydrateUri).value
 }
 
-function isDehydratedUri(value: unknown): value is vscode.Uri | URI {
+export function isDehydratedUri(value: unknown): value is vscode.Uri | URI {
     return (
         Boolean(value) &&
         // vscode.Uri

--- a/lib/shared/src/index.ts
+++ b/lib/shared/src/index.ts
@@ -170,7 +170,7 @@ export {
     setDisplayPathEnvInfo,
     type DisplayPathEnvInfo,
 } from './editor/displayPath'
-export { hydrateAfterPostMessage } from './editor/hydrateAfterPostMessage'
+export { forceHydration, hydrateAfterPostMessage } from './editor/hydrateAfterPostMessage'
 export * from './editor/utils'
 export {
     FeatureFlag,

--- a/vscode/src/chat/chat-view/ChatController.ts
+++ b/vscode/src/chat/chat-view/ChatController.ts
@@ -6,6 +6,7 @@ import {
     currentSiteVersion,
     distinctUntilChanged,
     firstResultFromOperation,
+    forceHydration,
     pendingOperation,
     ps,
     resolvedConfig,
@@ -1190,7 +1191,9 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
      * except within this method.
      */
     private postMessage(message: ExtensionMessage): Thenable<boolean | undefined> {
-        return this.initDoer.do(() => this.webviewPanelOrView?.webview.postMessage(message))
+        return this.initDoer.do(() =>
+            this.webviewPanelOrView?.webview.postMessage(forceHydration(message))
+        )
     }
 
     // #endregion

--- a/vscode/src/minion/MinionController.ts
+++ b/vscode/src/minion/MinionController.ts
@@ -1,5 +1,5 @@
 import type Anthropic from '@anthropic-ai/sdk'
-import { currentAuthStatus, hydrateAfterPostMessage } from '@sourcegraph/cody-shared'
+import { currentAuthStatus, forceHydration, hydrateAfterPostMessage } from '@sourcegraph/cody-shared'
 import * as vscode from 'vscode'
 import type {
     MinionExtensionMessage,
@@ -139,7 +139,7 @@ export abstract class ReactPanelController<WebviewMessageT extends {}, Extension
         message: ExtensionMessageT | BaseExtensionMessage
     ): Promise<boolean | undefined> {
         return await this.initDoer.do(() => {
-            return this.panel?.webview.postMessage(message)
+            return this.panel?.webview.postMessage(forceHydration(message))
         })
     }
 }

--- a/vscode/webviews/utils/VSCodeApi.ts
+++ b/vscode/webviews/utils/VSCodeApi.ts
@@ -41,7 +41,7 @@ export function setVSCodeWrapper(value: VSCodeWrapper): void {
 
 let genericApi: GenericVSCodeWrapper<any, any>
 
-export function getGenericVSCodeAPI<W, E>(): GenericVSCodeWrapper<W, E> {
+export function getGenericVSCodeAPI<W, E extends object>(): GenericVSCodeWrapper<W, E> {
     if (!genericApi) {
         const vsCodeApi = acquireVsCodeApi()
         genericApi = {

--- a/vscode/webviews/utils/VSCodeApi.ts
+++ b/vscode/webviews/utils/VSCodeApi.ts
@@ -41,7 +41,7 @@ export function setVSCodeWrapper(value: VSCodeWrapper): void {
 
 let genericApi: GenericVSCodeWrapper<any, any>
 
-export function getGenericVSCodeAPI<W, E extends object>(): GenericVSCodeWrapper<W, E> {
+export function getGenericVSCodeAPI<W, E>(): GenericVSCodeWrapper<W, E> {
     if (!genericApi) {
         const vsCodeApi = acquireVsCodeApi()
         genericApi = {

--- a/vscode/webviews/utils/VSCodeApi.ts
+++ b/vscode/webviews/utils/VSCodeApi.ts
@@ -1,6 +1,10 @@
 import { URI } from 'vscode-uri'
 
-import { type GenericVSCodeWrapper, hydrateAfterPostMessage } from '@sourcegraph/cody-shared'
+import {
+    type GenericVSCodeWrapper,
+    forceHydration,
+    hydrateAfterPostMessage,
+} from '@sourcegraph/cody-shared'
 
 import type { ExtensionMessage, WebviewMessage } from '../../src/chat/protocol'
 
@@ -20,7 +24,7 @@ export function getVSCodeAPI(): VSCodeWrapper {
     if (!api) {
         const vsCodeApi = acquireVsCodeApi()
         api = {
-            postMessage: message => vsCodeApi.postMessage(message),
+            postMessage: message => vsCodeApi.postMessage(forceHydration(message)),
             onMessage: callback => {
                 const listener = (event: MessageEvent<ExtensionMessage>): void => {
                     callback(hydrateAfterPostMessage(event.data, uri => URI.from(uri as any)))


### PR DESCRIPTION
Webviews' RPC system registers "a lot" (in a long chat, hundreds) of 'message' event handlers. Each of these typically causes the following work:

- Deliver the message, including creating MessageEvent.data. For chat transcripts this can be a large object.
- Walk the whole event data, testing whether each value is a URI, and if so, instantiating a URI for it.
- Examine a field, like `type` or RPC stream ID, and decide to discard the message because it is for a different subscriber.

This work is dispatched synchronously to the hundreds of listeners on the webview main thread, causing us to have long pauses where we don't produce a frame. In extreme cases we can hang the renderer enough for VSCode to trigger a webview reload, (...but our webview reloading may not be robust because we do not use `retainContextWhenHidden`) leaving users with a blank sidebar/chat panel.

This change makes the hydrate message-check one property-discard steps extremely cheap by using a Proxy to lazily do the hydration. The typical case will allocate two proxies, cache one in a WeakMap, and return the primitive string value for the message type or RPC ID by reading through the proxy to the underlying message... effectively O(1) instead of O(message size). All of the objects in this fast path are short lived so should be ~free to collect.

Using Proxies has a caveat: Proxies cannot be cloned by the structured clone algorithm, so they can't be passed back via postMessage. This makes a symmetrical change to onMessage, which lazily hydrates, to postMessage, so that it forces hydration. However the caller must remember to do this if they pass these objects to other structured cloners.

This change does not address the root cause of too many event listeners. That is recommended follow-up work. Then we can remove lazy hydration.

Before and after videos demonstrating the effect of this simple change:

https://www.loom.com/share/dd37421120114f8f805a97ff0de7f366

https://www.loom.com/share/3ca61e9ab493400884ba44e49e55dbf0

## Test plan

This is a performance change, there should be no functional difference in behavior.

To verify performance improved:

1. Run the extension
2. Load your longest chat... dozens of messages and type a new chat query with a long response like `write a Java bytecode verifier in Rust`
3. Cmd-Shift-P, Developer: Open Webview Developer Tools
4. Performance tab, start recording
5. Back in VSCode, submit the chat. Verify that the response streams smoothly.
6. Back in Webview developer tools, stop the profiler. Verify that there are no (or few) dropped frames.
7. Lastly, verify with a heap snapshot that the heap has not regressed.

Profile before this change: Note the chat response takes ~52s with ~46s of script time and there are many slow (red) tasks in excess of 100-200ms each:

![image](https://github.com/user-attachments/assets/aa82699d-ded7-4abb-ad17-d247107eb091)

Profile after this change: Note that the total time is about 13s with 7s of script time and we only had four slow tasks (red marks) of about 50ms each. The extra rendering time is good thing, reflecting we produced a lot more frames much more quickly = smoothness. Note the CPU utilization (top line) is no longer pegged and spilling onto a second core.

![image](https://github.com/user-attachments/assets/fde44b7d-1c28-424a-9753-034748723bc6)

Note, with a long enough chat and slow enough machine, this will lag again.

## Changelog

- Chat response streaming is much smoother, especially for long chats.