### PR TITLE
Improve edit task and smart apply destination file path computation

### DIFF
--- a/vscode/src/edit/provider.ts
+++ b/vscode/src/edit/provider.ts
@@ -26,9 +26,11 @@ import {
 } from '@sourcegraph/cody-shared/src/chat/transcript/messages'
 import { workspace } from 'vscode'
 import { doesFileExist } from '../commands/utils/workspace-files'
+import { getEditor } from '../editor/active-editor'
 import { CodyTaskState } from '../non-stop/state'
 import { splitSafeMetadata } from '../services/telemetry-v2'
 import { countCode } from '../services/utils/code-count'
+import { resolveRelativeOrAbsoluteUri } from '../services/utils/edit-create-file'
 import type { EditManagerOptions } from './manager'
 import { responseTransformer } from './output/response-transformer'
 import { buildInteraction } from './prompt'
@@ -319,18 +321,24 @@ export class EditProvider {
         const closetag = `</${PROMPT_TOPICS.FILENAME}>`
 
         const currentFileUri = task.fixupFile.uri
-        const currentFileName = uriBasename(currentFileUri)
         // remove open and close tags from text
         const newFilePath = text.trim().replaceAll(new RegExp(`${opentag}(.*)${closetag}`, 'g'), '$1')
-        const haveSameExtensions =
-            posixFilePaths.extname(currentFileName) === posixFilePaths.extname(newFilePath)
 
         // Get workspace uri using the current file uri
         const workspaceUri = workspace.getWorkspaceFolder(currentFileUri)?.uri
         const currentDirUri = Utils.joinPath(currentFileUri, '..')
+        const activeEditor = getEditor()?.active?.document?.uri
+        let newFileUri = await resolveRelativeOrAbsoluteUri(
+            workspaceUri ?? currentDirUri,
+            newFilePath,
+            activeEditor
+        )
+        if (!newFileUri) {
+            throw new Error('No editor found to insert text')
+        }
 
-        // Create a new file uri by replacing the file name of the currentFileUri with fileName
-        let newFileUri = Utils.joinPath(workspaceUri ?? currentDirUri, newFilePath)
+        const haveSameExtensions =
+            posixFilePaths.extname(uriBasename(currentFileUri)) === posixFilePaths.extname(newFilePath)
         if (haveSameExtensions && !task.destinationFile) {
             const fileIsFound = await doesFileExist(newFileUri)
             if (!fileIsFound) {

--- a/vscode/src/services/utils/codeblock-action-tracker.ts
+++ b/vscode/src/services/utils/codeblock-action-tracker.ts
@@ -9,11 +9,12 @@ import {
 } from '@sourcegraph/cody-shared'
 import { getEditor } from '../../editor/active-editor'
 
-import path from 'node:path'
+import { workspace } from 'vscode'
 import { doesFileExist } from '../../commands/utils/workspace-files'
 import { executeSmartApply } from '../../edit/smart-apply'
 import type { VSCodeEditor } from '../../editor/vscode-editor'
 import { countCode, matchCodeSnippets } from './code-count'
+import { resolveRelativeOrAbsoluteUri } from './edit-create-file'
 
 /**
  * It tracks the last stored code snippet and metadata like lines, chars, event, source etc.
@@ -139,25 +140,6 @@ function getSmartApplyModel(authStatus: AuthStatus): EditModel | undefined {
     return 'anthropic/claude-3-5-sonnet-20240620'
 }
 
-function smartJoinPath(workspaceUri: vscode.Uri, fileUri: string): vscode.Uri {
-    const workspacePath = workspaceUri.fsPath.split(path.sep)
-    const filePath = fileUri.split(path.sep)
-
-    let commonIndex = 0
-    while (
-        commonIndex < workspacePath.length &&
-        commonIndex < filePath.length &&
-        workspacePath[workspacePath.length - 1 - commonIndex] === filePath[commonIndex]
-    ) {
-        commonIndex++
-    }
-
-    const uniqueFilePath = filePath.slice(commonIndex)
-    const resultPath = path.join(workspaceUri.fsPath, ...uniqueFilePath)
-
-    return vscode.Uri.file(resultPath)
-}
-
 export async function handleSmartApply(
     id: string,
     code: string,
@@ -166,14 +148,8 @@ export async function handleSmartApply(
     fileUri?: string | null
 ): Promise<void> {
     const activeEditor = getEditor()?.active
-    const workspaceUri = vscode.workspace.workspaceFolders?.[0].uri
-
-    const uri =
-        fileUri && workspaceUri
-            ? path.isAbsolute(fileUri) && (await doesFileExist(vscode.Uri.file(fileUri || '')))
-                ? vscode.Uri.file(fileUri)
-                : smartJoinPath(workspaceUri, fileUri)
-            : activeEditor?.document.uri
+    const workspaceUri = workspace.workspaceFolders?.[0].uri
+    const uri = await resolveRelativeOrAbsoluteUri(workspaceUri, fileUri, activeEditor?.document?.uri)
 
     const isNewFile = uri && !(await doesFileExist(uri))
     if (isNewFile) {

--- a/vscode/src/services/utils/edit-create-file.test.ts
+++ b/vscode/src/services/utils/edit-create-file.test.ts
@@ -1,0 +1,73 @@
+import path from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import * as vscode from 'vscode'
+import { doesFileExist } from '../../commands/utils/workspace-files'
+import { resolveRelativeOrAbsoluteUri, smartJoinPath } from './edit-create-file'
+
+vi.mock('../../commands/utils/workspace-files', () => ({
+    doesFileExist: vi.fn(),
+}))
+
+function toUri(...paths: string[]) {
+    return vscode.Uri.file(path.join(...paths))
+}
+
+describe('resolveRelativeOrAbsoluteUri', () => {
+    const mockActiveEditorUri = toUri('/', 'mock', 'active', 'editor.ts')
+    const mockBaseDirUri = toUri('/', 'mock', 'base', 'dir')
+
+    beforeEach(() => {
+        vi.mocked(doesFileExist).mockResolvedValue(false)
+    })
+
+    afterEach(() => {
+        vi.resetAllMocks()
+    })
+
+    it('returns fallback URI when no URI is provided', async () => {
+        const result = await resolveRelativeOrAbsoluteUri(undefined, undefined, mockActiveEditorUri)
+        expect(result).toEqual(mockActiveEditorUri)
+    })
+
+    it('returns file URI when root directory exists', async () => {
+        vi.mocked(doesFileExist).mockResolvedValue(true)
+        const uri = toUri(path.sep, 'existing', 'file.ts')
+        const result = await resolveRelativeOrAbsoluteUri(undefined, uri.path, mockActiveEditorUri)
+        expect(result).toEqual(uri)
+    })
+
+    it('joins URI with base directory when root does not exist', async () => {
+        const uri = toUri('relative', 'file.ts')
+        const result = await resolveRelativeOrAbsoluteUri(mockBaseDirUri, uri.path)
+        expect(result).toEqual(toUri(path.sep, 'mock', 'base', 'dir', 'relative', 'file.ts'))
+    })
+
+    it('returns fallback URI when no base directory is provided and root does not exist', async () => {
+        const uri = toUri('non', 'existing', 'file.ts')
+        const result = await resolveRelativeOrAbsoluteUri(undefined, uri.path, mockActiveEditorUri)
+        expect(result).toEqual(mockActiveEditorUri)
+    })
+})
+
+describe('smartJoinPath', () => {
+    it('joins paths correctly when no common parts', () => {
+        const baseDirUri = toUri(path.sep, 'base', 'dir')
+        const relativeFileUri = 'file.ts'
+        const result = smartJoinPath(baseDirUri, relativeFileUri)
+        expect(result).toEqual(toUri(path.sep, 'base', 'dir', 'file.ts'))
+    })
+
+    it('joins paths correctly with common parts', () => {
+        const baseDirUri = toUri(path.sep, 'common', 'base', 'dir')
+        const relativeFileUri = toUri('base', 'dir', 'file.ts')
+        const result = smartJoinPath(baseDirUri, relativeFileUri.path)
+        expect(result).toEqual(toUri(path.sep, 'common', 'base', 'dir', 'file.ts'))
+    })
+
+    it('handles complex relative paths', () => {
+        const baseDirUri = toUri(path.sep, 'root', 'project')
+        const relativeFileUri = toUri('..', 'sibling', 'folder', 'file.ts')
+        const result = smartJoinPath(baseDirUri, relativeFileUri.path)
+        expect(result).toEqual(toUri(path.sep, 'root', 'sibling', 'folder', 'file.ts'))
+    })
+})

--- a/vscode/src/services/utils/edit-create-file.ts
+++ b/vscode/src/services/utils/edit-create-file.ts
@@ -1,0 +1,54 @@
+import path from 'node:path'
+import isEqual from 'lodash/isEqual'
+import * as vscode from 'vscode'
+import { doesFileExist } from '../../commands/utils/workspace-files'
+
+const separatorsRegex = /[/\\]/g
+
+/**
+ * Resolves URI to a workspace or absolute URI, handling various edge cases.
+ *
+ * If a URI is provided, it checks if the root directory of the URI exists. If it does, the URI is returned as-is.
+ * If the root directory does not exist, it attempts to join the URI with the base dir URI.
+ * If no URI is provided or no workspace folder is available, it falls back document URI is returned.
+ *
+ * @param baseDirUri  The base directory URI to use for joining.
+ * @param uri The URI to resolve, or `null`/`undefined` to use the active editor's document URI.
+ * @param fallbackUri
+ * @returns The resolved URI.
+ */
+export async function resolveRelativeOrAbsoluteUri(
+    baseDirUri?: vscode.Uri,
+    uri?: string | null,
+    fallbackUri?: vscode.Uri
+) {
+    const isFileProvided = uri && uri?.length > 0
+    if (!isFileProvided) {
+        return fallbackUri
+    }
+
+    const rootDir = vscode.Uri.parse(path.join(...uri.split(separatorsRegex).slice(0, 2)))
+    const hasExistingRoot = await doesFileExist(rootDir)
+    if (hasExistingRoot) {
+        return vscode.Uri.file(uri)
+    }
+
+    if (!baseDirUri) {
+        return fallbackUri
+    }
+
+    return smartJoinPath(baseDirUri, uri)
+}
+
+export function smartJoinPath(baseDirUri: vscode.Uri, relativeFileUri: string): vscode.Uri {
+    const workspacePath = baseDirUri.path.split(separatorsRegex).filter(segment => segment.length > 0)
+    const filePath = relativeFileUri.split(separatorsRegex).filter(segment => segment.length > 0)
+
+    const commonPartLength = filePath.findIndex(segment => segment === workspacePath.at(-1)) + 1
+    const hasCommonPart =
+        commonPartLength > 0 &&
+        isEqual(workspacePath.slice(-commonPartLength), filePath.slice(0, commonPartLength))
+    const uniqueFilePath = hasCommonPart ? filePath.slice(commonPartLength) : filePath
+    const resultPath = path.join(baseDirUri.path, ...uniqueFilePath)
+    return vscode.Uri.file(resultPath)
+}


### PR DESCRIPTION
Fixes https://linear.app/sourcegraph/issue/QA-116

## Test plan

It's hard to reproduce actual issue as it depends on the LLM response.
Test scenario which sometimes can reproduce it:

**For "Generate Unit Test":**

1. Opens some workspace, and then file from outside of that workspace
2. Run "Generate Unit Test" for that file
3. Make sure test file is generated properly and the location of the file looks sensible

**For "Smart Apply":**

Case1:

1. Open some workspace
2. Ask Cody to generate some code sample in totally unrelated to the existing workspace (e.g. "quicksort in haskell")
3. Click Smart Apply
4. Make sure Cody created new file for the given snipped and it's name and location looks sensible

Case 2: 

1. Open some workspace, and then unrelated file from outside of that workspace
2. Ask Cody to generate some code related to the opened file
3. Click Smart Apply
4. Make sure Cody appended code to the opened file correctly

Test on both MacOs and Windows.