### PR TITLE
Corrected parsing logic for essentialContext

### DIFF
--- a/agent/src/cli/command-bench/strategy-chat-context-types.ts
+++ b/agent/src/cli/command-bench/strategy-chat-context-types.ts
@@ -81,10 +81,10 @@ function parseNewlineList(input: string): string[] {
 
 function parseContextList(input: string): EvalContextItem[] {
     return input
-        .split('\n')
+        .split(',')
         .map(s => s.trim())
         .filter(rr => rr.length > 0)
-        .flatMap(s => contextItemFromString(s))
+        .map(s => contextItemFromString(s))
 }
 
 export interface Example {


### PR DESCRIPTION
Corrected Parsing logic for essentialContext with comma separated instead of newline separated

## Test plan

No review required: deploys tested changes.