### PR TITLE
support forceHydration on PromptString

### DIFF
--- a/lib/shared/src/editor/hydrateAfterPostMessage.test.ts
+++ b/lib/shared/src/editor/hydrateAfterPostMessage.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from 'vitest'
 
-import { hydrateAfterPostMessage, isDehydratedUri } from './hydrateAfterPostMessage'
+import { ps } from '../prompt/prompt-string'
+import { forceHydration, hydrateAfterPostMessage, isDehydratedUri } from './hydrateAfterPostMessage'
 
 // Mock URI hydration function
 const mockHydrateUri = (value: unknown) => {
@@ -113,5 +114,13 @@ describe('hydrateAfterPostMessage', () => {
         const hydratedValue = hydrateAfterPostMessage(originalValue, mockHydrateUri)
         hydratedValue.foo.bar = 'baz'
         expect(originalValue.foo.bar).toEqual('baz')
+    })
+})
+
+describe('forceHydration', () => {
+    test('handles PromptString', async () => {
+        const ps1 = ps`foo`
+        expect(ps1.toJSON()).toBe('foo')
+        expect(forceHydration(ps1).toJSON()).toBe('foo')
     })
 })

--- a/lib/shared/src/editor/hydrateAfterPostMessage.ts
+++ b/lib/shared/src/editor/hydrateAfterPostMessage.ts
@@ -1,5 +1,6 @@
 import type * as vscode from 'vscode'
 import type { URI } from 'vscode-uri'
+import { PromptString } from '../prompt/prompt-string'
 
 /**
  * Forces hydration by cloning any part that may be lazily hydrated. This is necessary before using
@@ -8,6 +9,11 @@ import type { URI } from 'vscode-uri'
  */
 export function forceHydration(object: any): any {
     if (typeof object !== 'object' || object === null) {
+        return object
+    }
+    if (object instanceof PromptString) {
+        // Return as-is, because PromptString object references are used as keys in a WeakMap that
+        // implements immutability and encapsulation for PromptString.
         return object
     }
     if (Array.isArray(object)) {


### PR DESCRIPTION
PromptString instances can't be cloned because their reference value is used as the key in the WeakMap that implements immutability and encapsulation for PromptString.

(This broke something on a separate branch, so I extracted the fix and test case to merge separately here.)

## Test plan

Added test case