### PR TITLE
allow undefined chat/edit preinstructions, read from global config

### DIFF
--- a/lib/shared/src/configuration.ts
+++ b/lib/shared/src/configuration.ts
@@ -30,8 +30,8 @@ interface RawClientConfiguration {
 
     serverEndpoint?: string
     customHeaders?: Record<string, string>
-    chatPreInstruction: PromptString
-    editPreInstruction: PromptString
+    chatPreInstruction?: PromptString
+    editPreInstruction?: PromptString
     codeActions: boolean
     commandHints: boolean
     commandCodeLenses: boolean

--- a/lib/shared/src/prompt/prompt-string.ts
+++ b/lib/shared/src/prompt/prompt-string.ts
@@ -216,7 +216,7 @@ export class PromptString {
         defaultValue: D
     ): PromptString | D {
         const raw = config.get(path, null)
-        const value = raw === null ? defaultValue : internal_createPromptString(raw, [])
+        const value = raw === null || raw === '' ? defaultValue : internal_createPromptString(raw, [])
         return value
     }
 

--- a/vscode/src/chat/agentic/DeepCody.test.ts
+++ b/vscode/src/chat/agentic/DeepCody.test.ts
@@ -1,12 +1,15 @@
 import {
     AUTH_STATUS_FIXTURE_AUTHED,
     type AuthenticatedAuthStatus,
+    CLIENT_CAPABILITIES_FIXTURE,
     type ChatClient,
     type ContextItem,
     ContextItemSource,
     DOTCOM_URL,
     featureFlagProvider,
     mockAuthStatus,
+    mockClientCapabilities,
+    mockResolvedConfig,
     modelsService,
     ps,
 } from '@sourcegraph/cody-shared'
@@ -40,6 +43,8 @@ describe('DeepCody', () => {
     let mockCurrentContext: ContextItem[]
 
     beforeEach(() => {
+        mockResolvedConfig({ configuration: {} })
+        mockClientCapabilities(CLIENT_CAPABILITIES_FIXTURE)
         mockAuthStatus(codyProAuthStatus)
         mockChatBuilder = {
             selectedModel: 'anthropic::2023-06-01::deep-cody',

--- a/vscode/src/chat/chat-view/prompt.test.ts
+++ b/vscode/src/chat/chat-view/prompt.test.ts
@@ -1,5 +1,6 @@
 import {
     AUTH_STATUS_FIXTURE_AUTHED,
+    CLIENT_CAPABILITIES_FIXTURE,
     type ContextItem,
     ContextItemSource,
     type Message,
@@ -8,6 +9,8 @@ import {
     contextFiltersProvider,
     createModel,
     mockAuthStatus,
+    mockClientCapabilities,
+    mockResolvedConfig,
     modelsService,
     ps,
 } from '@sourcegraph/cody-shared'
@@ -22,6 +25,8 @@ describe('DefaultPrompter', () => {
     beforeEach(() => {
         vi.spyOn(contextFiltersProvider, 'isUriIgnored').mockResolvedValue(false)
         mockAuthStatus(AUTH_STATUS_FIXTURE_AUTHED)
+        mockResolvedConfig({ configuration: {} })
+        mockClientCapabilities(CLIENT_CAPABILITIES_FIXTURE)
     })
     afterEach(() => {
         vi.restoreAllMocks()
@@ -102,13 +107,11 @@ describe('DefaultPrompter', () => {
     })
 
     it('adds the cody.chat.preInstruction vscode setting if set', async () => {
-        const getConfig = vi.spyOn(vscode.workspace, 'getConfiguration')
-        getConfig.mockImplementation((section, resource) => ({
-            get: vi.fn(() => 'Always respond with 🧀 emojis'),
-            has: vi.fn(() => true),
-            inspect: vi.fn(() => ({ key: 'key' })),
-            update: vi.fn(() => Promise.resolve()),
-        }))
+        mockResolvedConfig({
+            configuration: {
+                chatPreInstruction: ps`Always respond with 🧀 emojis`,
+            },
+        })
 
         vi.spyOn(modelsService, 'modelsChanges', 'get').mockReturnValue(
             Observable.of<ModelsData>({

--- a/vscode/src/chat/chat-view/prompt.ts
+++ b/vscode/src/chat/chat-view/prompt.ts
@@ -1,10 +1,8 @@
-import * as vscode from 'vscode'
-
 import {
     type ContextItem,
     type Message,
     PromptMixin,
-    PromptString,
+    currentResolvedConfig,
     firstResultFromOperation,
     getSimplePreamble,
     isDefined,
@@ -50,11 +48,7 @@ export class DefaultPrompter {
         return wrapInActiveSpan('chat.prompter', async () => {
             const contextWindow = await firstResultFromOperation(ChatBuilder.contextWindowForChat(chat))
             const promptBuilder = await PromptBuilder.create(contextWindow)
-            const preInstruction: PromptString | undefined = PromptString.fromConfig(
-                vscode.workspace.getConfiguration('cody.chat'),
-                'preInstruction',
-                undefined
-            )
+            const preInstruction = (await currentResolvedConfig()).configuration.chatPreInstruction
 
             // Add preamble messages
             const chatModel = await firstResultFromOperation(ChatBuilder.resolvedModelForChat(chat))

--- a/vscode/src/configuration.ts
+++ b/vscode/src/configuration.ts
@@ -6,7 +6,6 @@ import {
     OLLAMA_DEFAULT_URL,
     type PickResolvedConfiguration,
     PromptString,
-    ps,
     setStaticResolvedConfigurationValue,
 } from '@sourcegraph/cody-shared'
 
@@ -62,8 +61,8 @@ export function getConfiguration(
         autocompleteLanguages: config.get(CONFIG_KEY.autocompleteLanguages, {
             '*': true,
         }),
-        chatPreInstruction: PromptString.fromConfig(config, CONFIG_KEY.chatPreInstruction, ps``),
-        editPreInstruction: PromptString.fromConfig(config, CONFIG_KEY.editPreInstruction, ps``),
+        chatPreInstruction: PromptString.fromConfig(config, CONFIG_KEY.chatPreInstruction, undefined),
+        editPreInstruction: PromptString.fromConfig(config, CONFIG_KEY.editPreInstruction, undefined),
         commandCodeLenses: config.get(CONFIG_KEY.commandCodeLenses, false),
         autocompleteAdvancedProvider: config.get<ClientConfiguration['autocompleteAdvancedProvider']>(
             CONFIG_KEY.autocompleteAdvancedProvider,

--- a/vscode/src/edit/prompt/index.ts
+++ b/vscode/src/edit/prompt/index.ts
@@ -9,6 +9,7 @@ import {
     type Message,
     PromptString,
     TokenCounterUtils,
+    currentResolvedConfig,
     getModelInfo,
     getSimplePreamble,
     modelsService,
@@ -111,12 +112,9 @@ export const buildInteraction = async ({
 
     // Add pre-instruction for edit commands to end of human prompt to override the default
     // prompt. This is used for providing additional information and guidelines by the user.
-    const preInstruction = PromptString.fromConfig(
-        vscode.workspace.getConfiguration('cody.edit'),
-        'preInstruction',
-        ps``
-    )
-    const additionalRule = preInstruction.length > 0 ? ps`\nIMPORTANT: ${preInstruction.trim()}` : ps``
+    const preInstruction = (await currentResolvedConfig()).configuration.editPreInstruction
+    const additionalRule =
+        preInstruction && preInstruction.length > 0 ? ps`\nIMPORTANT: ${preInstruction.trim()}` : ps``
 
     const transcript: ChatMessage[] = [
         { speaker: 'human', text: prompt.instruction.concat(additionalRule) },

--- a/vscode/src/testutils/mocks.ts
+++ b/vscode/src/testutils/mocks.ts
@@ -9,7 +9,7 @@ import type {
     Range as VSCodeRange,
 } from 'vscode'
 
-import { type ClientConfiguration, OLLAMA_DEFAULT_URL, ps } from '@sourcegraph/cody-shared'
+import { type ClientConfiguration, OLLAMA_DEFAULT_URL } from '@sourcegraph/cody-shared'
 
 import path from 'node:path'
 import { AgentEventEmitter as EventEmitter } from './AgentEventEmitter'
@@ -873,8 +873,6 @@ export const DEFAULT_VSCODE_SETTINGS = {
     codebase: '',
     serverEndpoint: undefined,
     customHeaders: undefined,
-    chatPreInstruction: ps``,
-    editPreInstruction: ps``,
     autocomplete: true,
     autocompleteLanguages: {
         '*': true,


### PR DESCRIPTION
This fixes 2 minor problems:

- The chat and edit preinstructions were being read from global VS Code config instead of the `resolvedConfig` observable, which is now the standard way to read config.
- Each call to `getConfiguration` would result in new distinct PromptString instances being created and added to the WeakMap that implements immutability and encapsulation for PromptString. Now, in the common case where these are not set, this garbage is not created in the first place.

Neither of these were causing any problems I've observed, but these are good fixes nonetheless.

## Test plan

CI