### PR TITLE
Swap out visibility-sensor for react-intersection-observer

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -597,6 +597,9 @@ importers:
       postcss-scss:
         specifier: ^4.0.9
         version: 4.0.9(postcss@8.4.38)
+      react-intersection-observer:
+        specifier: ^9.13.1
+        version: 9.13.1(react-dom@18.2.0)(react@18.2.0)
       react-markdown:
         specifier: ^9.0.1
         version: 9.0.1(@types/react@18.2.79)(react@18.2.0)
@@ -13664,6 +13667,19 @@ packages:
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
     dev: true
+
+  /react-intersection-observer@9.13.1(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-tSzDaTy0qwNPLJHg8XZhlyHTgGW6drFKTtvjdL+p6um12rcnp8Z5XstE+QNBJ7c64n5o0Lj4ilUleA41bmDoMw==}
+    peerDependencies:
+      react: ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      react-dom:
+        optional: true
+    dependencies:
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    dev: false
 
   /react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -603,9 +603,6 @@ importers:
       react-markdown:
         specifier: ^9.0.1
         version: 9.0.1(@types/react@18.2.79)(react@18.2.0)
-      react-visibility-sensor:
-        specifier: ^5.1.1
-        version: 5.1.1(react-dom@18.2.0)(react@18.2.0)
       rehype-highlight:
         specifier: ^6.0.0
         version: 6.0.0
@@ -13390,6 +13387,7 @@ packages:
       loose-envify: 1.4.0
       object-assign: 4.1.1
       react-is: 16.13.1
+    dev: true
 
   /propagate@2.0.1:
     resolution: {integrity: sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==}
@@ -13683,6 +13681,7 @@ packages:
 
   /react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
+    dev: true
 
   /react-is@17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
@@ -13821,17 +13820,6 @@ packages:
       invariant: 2.2.4
       react: 18.2.0
       tslib: 2.1.0
-    dev: false
-
-  /react-visibility-sensor@5.1.1(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-cTUHqIK+zDYpeK19rzW6zF9YfT4486TIgizZW53wEZ+/GPBbK7cNS0EHyJVyHYacwFEvvHLEKfgJndbemWhB/w==}
-    peerDependencies:
-      react: '>=16.0.0'
-      react-dom: '>=16.0.0'
-    dependencies:
-      prop-types: 15.8.1
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
     dev: false
 
   /react@18.2.0:

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -1374,6 +1374,7 @@
     "mkdirp": "^3.0.1",
     "os-browserify": "^0.3.0",
     "postcss-scss": "^4.0.9",
+    "react-intersection-observer": "^9.13.1",
     "react-markdown": "^9.0.1",
     "react-visibility-sensor": "^5.1.1",
     "rehype-highlight": "^6.0.0",

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -1376,7 +1376,6 @@
     "postcss-scss": "^4.0.9",
     "react-intersection-observer": "^9.13.1",
     "react-markdown": "^9.0.1",
-    "react-visibility-sensor": "^5.1.1",
     "rehype-highlight": "^6.0.0",
     "rehype-sanitize": "^6.0.0",
     "remark-gfm": "^4.0.0",


### PR DESCRIPTION
visibility-sensor uses `findDOMNode`, which triggers a warning in strict mode. This swaps it out for a more modern and actively maintained alternative, react-intersection-observer

The warning this PR fixes:

<img width="970" alt="image" src="https://github.com/user-attachments/assets/86f4907a-546a-4969-b1b5-cfee3b066373">


There should be no end-user-visible changes.

## Test plan

Test out one box search to ensure results are still rendered properly
