### PR TITLE
expose agent capabilities in global clientCapabilities()

### DIFF
--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/agent/protocol_generated/WebviewNativeConfig.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/agent/protocol_generated/WebviewNativeConfig.kt
@@ -5,7 +5,7 @@ import com.google.gson.annotations.SerializedName;
 
 data class WebviewNativeConfig(
   val view: ViewEnum, // Oneof: multiple, single
-  val cspSource: String,
+  val cspSource: String? = null,
   val webviewBundleServingPrefix: String? = null,
   val skipResourceRelativization: Boolean? = null,
   val injectScript: String? = null,

--- a/agent/src/NativeWebview.ts
+++ b/agent/src/NativeWebview.ts
@@ -1,7 +1,8 @@
+import type { WebviewNativeConfig } from '@sourcegraph/cody-shared'
 import * as uuid from 'uuid'
 import * as vscode from 'vscode'
 import type { Agent } from './agent'
-import type { DefiniteWebviewOptions, WebviewNativeConfig } from './protocol-alias'
+import type { DefiniteWebviewOptions } from './protocol-alias'
 import * as vscode_shim from './vscode-shim'
 
 type NativeWebviewHandle = string
@@ -299,7 +300,7 @@ class NativeWebview implements vscode.Webview {
     }
 
     public get cspSource(): string {
-        return this.delegate.cspSource
+        return this.delegate.cspSource ?? ''
     }
 }
 

--- a/agent/src/agent.ts
+++ b/agent/src/agent.ts
@@ -5,6 +5,7 @@ import type { Polly, Request } from '@pollyjs/core'
 import {
     type AccountKeyedChatHistory,
     type ChatHistoryKey,
+    type ClientCapabilities,
     type CodyCommand,
     CodyIDE,
     ModelUsage,
@@ -1479,7 +1480,7 @@ export class Agent extends MessageHandler implements ExtensionClient {
         return this.clientInfo?.version || '0.0.0'
     }
 
-    get capabilities(): agent_protocol.ClientCapabilities | undefined {
+    get capabilities(): ClientCapabilities | undefined {
         return this.clientInfo?.capabilities ?? undefined
     }
 

--- a/agent/src/allClientCapabilitiesEnabled.ts
+++ b/agent/src/allClientCapabilitiesEnabled.ts
@@ -1,4 +1,4 @@
-import type { ClientCapabilities } from './protocol-alias'
+import type { ClientCapabilities } from '@sourcegraph/cody-shared'
 
 export const allClientCapabilitiesEnabled: ClientCapabilities = {
     progressBars: 'enabled',
@@ -11,4 +11,5 @@ export const allClientCapabilitiesEnabled: ClientCapabilities = {
     ignore: 'enabled',
     codeActions: 'enabled',
     secrets: 'client-managed',
+    authentication: 'enabled',
 }

--- a/agent/src/cli/command-bench/command-bench.ts
+++ b/agent/src/cli/command-bench/command-bench.ts
@@ -10,11 +10,7 @@ import { newAgentClient } from '../../agent'
 import { exec } from 'node:child_process'
 import fs from 'node:fs'
 import { promisify } from 'node:util'
-import {
-    isDefined,
-    modelsService,
-    setClientCapabilitiesFromConfiguration,
-} from '@sourcegraph/cody-shared'
+import { isDefined, modelsService, setClientCapabilities } from '@sourcegraph/cody-shared'
 import { sleep } from '../../../../vscode/src/completions/utils'
 import {
     getConfiguration,
@@ -361,7 +357,7 @@ async function evaluateWorkspace(options: CodyBenchOptions, recordingDirectory: 
     console.log(`starting evaluation: fixture=${options.fixture.name} workspace=${options.workspace}`)
 
     createOrUpdateTelemetryRecorderProvider(true)
-    setClientCapabilitiesFromConfiguration(getConfiguration())
+    setClientCapabilities({ configuration: getConfiguration(), agentCapabilities: undefined })
 
     const workspaceRootUri = vscode.Uri.from({ scheme: 'file', path: options.workspace })
 

--- a/agent/src/cli/command-bench/llm-judge.ts
+++ b/agent/src/cli/command-bench/llm-judge.ts
@@ -1,4 +1,4 @@
-import { type PromptString, setClientCapabilitiesFromConfiguration } from '@sourcegraph/cody-shared'
+import { type PromptString, setClientCapabilities } from '@sourcegraph/cody-shared'
 import { SourcegraphNodeCompletionsClient } from '../../../../vscode/src/completions/nodeClient'
 import { setStaticResolvedConfigurationWithAuthCredentials } from '../../../../vscode/src/configuration'
 import { localStorage } from '../../../../vscode/src/services/LocalStorageProvider'
@@ -18,7 +18,7 @@ export class LlmJudge {
             configuration: { customHeaders: undefined },
             auth: { accessToken: options.srcAccessToken, serverEndpoint: options.srcEndpoint },
         })
-        setClientCapabilitiesFromConfiguration({})
+        setClientCapabilities({ configuration: {}, agentCapabilities: undefined })
         this.client = new SourcegraphNodeCompletionsClient()
     }
 

--- a/lib/shared/src/auth/referral.ts
+++ b/lib/shared/src/auth/referral.ts
@@ -8,7 +8,7 @@ import { clientCapabilities } from '../configuration/clientCapabilities'
  * Use "CODY" as the default referral code for fallback.
  */
 export function getCodyAuthReferralCode(uriScheme: string): string | undefined {
-    const referralCodes: Record<CodyIDE, string> = {
+    const referralCodes: Partial<Record<CodyIDE, string>> = {
         [CodyIDE.JetBrains]: 'JETBRAINS',
         [CodyIDE.Neovim]: 'NEOVIM',
         [CodyIDE.Emacs]: 'CODY',

--- a/lib/shared/src/configuration.ts
+++ b/lib/shared/src/configuration.ts
@@ -1,4 +1,4 @@
-import type { ClientCapabilities } from './configuration/clientCapabilities'
+import type { ClientCapabilitiesWithLegacyFields } from './configuration/clientCapabilities'
 import type { ChatModelProviderConfig } from './models/sync'
 
 import type { PromptString } from './prompt/prompt-string'
@@ -69,28 +69,28 @@ interface RawClientConfiguration {
     /**
      * @deprecated Do not use directly. Call {@link clientCapabilities} instead
      * (`clientCapabilities().agentIDE`) and see the docstring on
-     * {@link ClientCapabilities.agentIDE}.
+     * {@link ClientCapabilitiesWithLegacyFields.agentIDE}.
      */
     agentIDE?: CodyIDE
 
     /**
      * @deprecated Do not use directly. Call {@link clientCapabilities} instead
      * (`clientCapabilities().agentIDEVersion`) and see the docstring on
-     * {@link ClientCapabilities.agentIDEVersion}.
+     * {@link ClientCapabilitiesWithLegacyFields.agentIDEVersion}.
      */
-    agentIDEVersion?: ClientCapabilities['agentIDEVersion']
+    agentIDEVersion?: ClientCapabilitiesWithLegacyFields['agentIDEVersion']
 
     /**
      * @deprecated Do not use directly. Call {@link clientCapabilities} instead
      * (`clientCapabilities().agentExtensionVersion`) and see the docstring on
-     * {@link ClientCapabilities.agentExtensionVersion}.
+     * {@link ClientCapabilitiesWithLegacyFields.agentExtensionVersion}.
      */
-    agentExtensionVersion?: ClientCapabilities['agentExtensionVersion']
+    agentExtensionVersion?: ClientCapabilitiesWithLegacyFields['agentExtensionVersion']
 
     /**
      * @deprecated Do not use directly. Call {@link clientCapabilities} instead
      * (`clientCapabilities().agentIDEVersion`) and see the docstring on
-     * {@link ClientCapabilities.agentIDEVersion}.
+     * {@link ClientCapabilitiesWithLegacyFields.agentIDEVersion}.
      */
     telemetryClientName?: string
 

--- a/lib/shared/src/configuration/clientCapabilities.ts
+++ b/lib/shared/src/configuration/clientCapabilities.ts
@@ -1,29 +1,35 @@
 import { type ClientConfiguration, CodyIDE } from '../configuration'
+import type { ContextMentionProviderID } from '../mentions/api'
 
 /**
  * The capabilities of the client, such as the editor that Cody is being used with (directly for VS
  * Code or via the agent for other editors) or the CLI.
+ *
+ * The "legacy fields" this refers to are the fields like
+ * {@link ClientCapabilitiesWithLegacyFields.agentIDE} that are inferred in an ad-hoc way from the
+ * environment and aren't self-reported by the client.
  */
-export interface ClientCapabilities {
+export interface ClientCapabilitiesWithLegacyFields {
     /**
      * The `agentIDE` value, which is the editor that Cody is being used with. If not set, it
      * defaults to {@link CodyIDE.VSCode} to match the previous behavior.
      *
-     * @deprecated Use one of the other {@link ClientCapabilities} fields instead to assert based on
-     * the client's actual capabilities at runtime and not your assumptions about their current
-     * capabilities, and to support future clients that are not in the {@link CodyIDE} enum. If you
-     * are truly interested in whether the editor is VS Code, such as to use the right link to
-     * documentation or describe the VS Code user interface, then it is OK to use this field.
+     * @deprecated Use one of the other {@link ClientCapabilitiesWithLegacyFields} fields instead to
+     * assert based on the client's actual capabilities at runtime and not your assumptions about
+     * their current capabilities, and to support future clients that are not in the {@link CodyIDE}
+     * enum. If you are truly interested in whether the editor is VS Code, such as to use the right
+     * link to documentation or describe the VS Code user interface, then it is OK to use this
+     * field.
      */
     agentIDE: CodyIDE
 
     /**
-     * @deprecated For the same reason as {@link ClientCapabilities.agentIDE}.
+     * @deprecated For the same reason as {@link ClientCapabilitiesWithLegacyFields.agentIDE}.
      */
     isVSCode: boolean
 
     /**
-     * @deprecated For the same reason as {@link ClientCapabilities.agentIDE}.
+     * @deprecated For the same reason as {@link ClientCapabilitiesWithLegacyFields.agentIDE}.
      */
     isCodyWeb: boolean
 
@@ -50,7 +56,122 @@ export interface ClientCapabilities {
 }
 
 /**
- * Get the {@link ClientCapabilities} for the current client.
+ * The capabilities of the client. The field names should match the names of the JSON-RPC methods in
+ * the agent protocol.
+ */
+export interface ClientCapabilities {
+    authentication?: 'enabled' | 'none' | undefined | null
+    completions?: 'none' | undefined | null
+
+    /**
+     * When 'streaming', handles 'chat/updateMessageInProgress' streaming notifications.
+     */
+    chat?: 'none' | 'streaming' | undefined | null
+
+    /**
+     * TODO: allow clients to implement the necessary parts of the git extension.
+     * https://github.com/sourcegraph/cody/issues/4165
+     */
+    git?: 'none' | 'enabled' | undefined | null
+
+    /**
+     * If 'enabled', the client must implement the progress/start, progress/report, and progress/end
+     * notification endpoints.
+     */
+    progressBars?: 'none' | 'enabled' | undefined | null
+
+    edit?: 'none' | 'enabled' | undefined | null
+    editWorkspace?: 'none' | 'enabled' | undefined | null
+    untitledDocuments?: 'none' | 'enabled' | undefined | null
+    showDocument?: 'none' | 'enabled' | undefined | null
+    codeLenses?: 'none' | 'enabled' | undefined | null
+    showWindowMessage?: 'notification' | 'request' | undefined | null
+    ignore?: 'none' | 'enabled' | undefined | null
+    codeActions?: 'none' | 'enabled' | undefined | null
+    disabledMentionsProviders?: ContextMentionProviderID[] | undefined | null
+
+    /**
+     * When 'object-encoded' (default), the server uses the `webview/postMessage` method to send
+     * structured JSON objects.  When 'string-encoded', the server uses the
+     * `webview/postMessageStringEncoded` method to send a JSON-encoded string. This is convenient
+     * for clients that forward the string directly to an underlying webview container.
+     */
+    webviewMessages?: 'object-encoded' | 'string-encoded' | undefined | null
+
+    /**
+     * How to deal with vscode.ExtensionContext.globalState.
+     * - Stateless: the state does not persist between agent processes. This means the client is
+     *   responsible for features like managing chat history.
+     * - Server managed: the server reads and writes the state without informing the client. The
+     *   client can optionally customize the file path of the JSON config via
+     *   `ClientInfo.globalStatePath: string`
+     * - Client managed: not implemented yet. When implemented, clients will be able to implement a
+     *   JSON-RPC request to handle the saving of the client state. This is needed to safely share
+     *   state between concurrent agent processes (assuming there is one IDE client process managing
+     *   multiple agent processes).
+     */
+    globalState?: 'stateless' | 'server-managed' | 'client-managed' | undefined | null
+
+    /**
+     * Secrets controls how the agent should handle storing secrets.
+     * - Stateless: the secrets are not persisted between agent processes.
+     * - Client managed: the client must implement the 'secrets/get', 'secrets/store', and
+     *   'secrets/delete' requests.
+     */
+    secrets?: 'stateless' | 'client-managed' | undefined | null
+
+    /**
+     * Whether the client supports the VSCode WebView API. If 'agentic', uses AgentWebViewPanel
+     * which just delegates bidirectional postMessage over the Agent protocol. If 'native',
+     * implements a larger subset of the VSCode WebView API and expects the client to run web
+     * content in the webview, which effectively means both sidebar and custom editor chat views are
+     * supported. Defaults to 'agentic'.
+     */
+    webview?: 'agentic' | 'native' | undefined | null
+
+    /**
+     * If webview === 'native', describes how the client has configured webview resources.
+     */
+    webviewNativeConfig?: WebviewNativeConfig | undefined | null
+}
+
+export interface WebviewNativeConfig {
+    /**
+     * Set the view to 'single' when the client only supports a single chat view (e.g. sidebar
+     * chat).
+     */
+    view: 'multiple' | 'single'
+
+    /**
+     * cspSource is passed to the extension as the Webview cspSource property.
+     */
+    cspSource?: string
+
+    /**
+     * webviewBundleServingPrefix is prepended to resource paths under 'dist' in
+     * asWebviewUri (note, multiple prefixes are not yet implemented.)
+     */
+    webviewBundleServingPrefix?: string | undefined | null
+
+    /**
+     * When true, resource paths are not relativized, and the client must
+     * handle serving the resources relative to the webview.
+     */
+    skipResourceRelativization?: boolean | undefined | null
+
+    /**
+     * Script to be injected into the webview.
+     */
+    injectScript?: string | undefined | null
+
+    /**
+     * Style to be injected into the webview.
+     */
+    injectStyle?: string | undefined | null
+}
+
+/**
+ * Get the {@link ClientCapabilitiesWithLegacyFields} for the current client.
  *
  * This is the only place you should fetch these values. Previously, there were many ways that the
  * logic for determining client capabilities was implemented, and you needed to remember that none
@@ -61,39 +182,47 @@ export interface ClientCapabilities {
  * set, and this function throws if it's not available. This means that it can't be used at
  * initialization time.
  */
-export function clientCapabilities(): ClientCapabilities {
+export function clientCapabilities(): ClientCapabilitiesWithLegacyFields {
     if (_mockValue) {
         return _mockValue
     }
-    if (!_configuration) {
+    if (!_value) {
         throw new Error(
             'clientCapabilities called before configuration was set with setClientCapabilitiesFromConfiguration'
         )
     }
     return {
-        agentIDE: _configuration.agentIDE ?? CodyIDE.VSCode,
-        isVSCode: !_configuration.agentIDE || _configuration.agentIDE === CodyIDE.VSCode,
-        isCodyWeb: _configuration.agentIDE === CodyIDE.Web,
-        agentExtensionVersion: _configuration.agentExtensionVersion ?? _extensionVersion,
-        agentIDEVersion: _configuration.agentIDEVersion,
-        telemetryClientName: _configuration.telemetryClientName,
+        ..._value.agentCapabilities,
+        agentIDE: _value.configuration.agentIDE ?? CodyIDE.VSCode,
+        isVSCode: !_value.configuration.agentIDE || _value.configuration.agentIDE === CodyIDE.VSCode,
+        isCodyWeb: _value.configuration.agentIDE === CodyIDE.Web,
+        agentExtensionVersion: _value.configuration.agentExtensionVersion ?? _extensionVersion,
+        agentIDEVersion: _value.configuration.agentIDEVersion,
+        telemetryClientName: _value.configuration.telemetryClientName,
     }
 }
 
-let _configuration:
-    | Pick<
-          ClientConfiguration,
-          'agentExtensionVersion' | 'agentIDE' | 'agentIDEVersion' | 'telemetryClientName'
-      >
+let _value:
+    | {
+          configuration: Pick<
+              ClientConfiguration,
+              'agentExtensionVersion' | 'agentIDE' | 'agentIDEVersion' | 'telemetryClientName'
+          >
+          agentCapabilities: ClientCapabilities | undefined
+      }
     | undefined
 
 /**
- * Set the {@link ClientCapabilities} value from the {@link ResolvedConfiguration.configuration}.
+ * Set the {@link ClientCapabilitiesWithLegacyFields} value from the
+ * {@link ResolvedConfiguration.configuration} and the agent's
+ * {@link ClientCapabilitiesWithLegacyFields}.
+ *
+ * Unlike the other global observables (such as {@link resolvedConfig} and {@link authStatus}), this
+ * value does not change over the lifetime of the process, so we do not need to use an observable
+ * here.
  */
-export function setClientCapabilitiesFromConfiguration(
-    configuration: NonNullable<typeof _configuration>
-): void {
-    _configuration = configuration
+export function setClientCapabilities(value: NonNullable<typeof _value>): void {
+    _value = value
 }
 
 let _extensionVersion: string | undefined
@@ -108,18 +237,18 @@ export function setExtensionVersion(version: string): void {
     _extensionVersion = version
 }
 
-let _mockValue: ClientCapabilities | undefined
+let _mockValue: ClientCapabilitiesWithLegacyFields | undefined
 
 /**
  * Mock the {@link clientCapabilities} result.
  *
  * For use in tests only.
  */
-export function mockClientCapabilities(value: ClientCapabilities | undefined): void {
+export function mockClientCapabilities(value: ClientCapabilitiesWithLegacyFields | undefined): void {
     _mockValue = value
 }
 
-export const CLIENT_CAPABILITIES_FIXTURE: ClientCapabilities = {
+export const CLIENT_CAPABILITIES_FIXTURE: ClientCapabilitiesWithLegacyFields = {
     agentIDE: CodyIDE.VSCode,
     isVSCode: true,
     isCodyWeb: false,

--- a/vscode/src/chat/protocol.ts
+++ b/vscode/src/chat/protocol.ts
@@ -2,7 +2,7 @@ import type {
     AuthCredentials,
     AuthStatus,
     ChatMessage,
-    ClientCapabilities,
+    ClientCapabilitiesWithLegacyFields,
     ClientConfiguration,
     CodyIDE,
     ContextItem,
@@ -136,7 +136,7 @@ export type ExtensionMessage =
     | {
           type: 'config'
           config: ConfigurationSubsetForWebview & LocalEnv
-          clientCapabilities: ClientCapabilities
+          clientCapabilities: ClientCapabilitiesWithLegacyFields
           authStatus: AuthStatus
           userProductSubscription?: UserProductSubscription | null | undefined
           configFeatures: {

--- a/vscode/src/commands/CommandsController.ts
+++ b/vscode/src/commands/CommandsController.ts
@@ -10,6 +10,7 @@ import type { CodyCommandArgs } from './types'
 import { fromSlashCommand } from './utils/common'
 
 import {
+    type ClientCapabilities,
     type CodyCommand,
     DefaultChatCommands,
     type DefaultCodyCommands,
@@ -18,7 +19,7 @@ import {
     ps,
     wrapInActiveSpan,
 } from '@sourcegraph/cody-shared'
-import type { ClientCapabilities } from '../jsonrpc/agent-protocol'
+
 /**
  * Handles commands execution with commands from CommandsProvider
  * Provides additional prompt management and execution logic

--- a/vscode/src/extension-client.ts
+++ b/vscode/src/extension-client.ts
@@ -1,6 +1,6 @@
+import type { ClientCapabilities } from '@sourcegraph/cody-shared'
 import type { TextDocument, Uri } from 'vscode'
 import type vscode from 'vscode'
-import type { ClientCapabilities } from './jsonrpc/agent-protocol'
 import { FixupCodeLenses } from './non-stop/codelenses/provider'
 import type { FixupActor, FixupFileCollection } from './non-stop/roles'
 import type { FixupControlApplicator } from './non-stop/strategies'

--- a/vscode/src/jsonrpc/agent-protocol.ts
+++ b/vscode/src/jsonrpc/agent-protocol.ts
@@ -3,9 +3,9 @@ import type * as vscode from 'vscode'
 import type {
     BillingCategory,
     BillingProduct,
+    ClientCapabilities,
     CodyCommand,
     ContextFilters,
-    ContextMentionProviderID,
     CurrentUserCodySubscription,
     Model,
     ModelAvailabilityStatus,
@@ -554,74 +554,6 @@ export interface ClientInfo {
      * Pre 5.6, servers would reject any client it did not recognize.
      */
     legacyNameForServerIdentification?: string | undefined | null
-}
-
-// The capability should match the name of the JSON-RPC methods.
-export interface ClientCapabilities {
-    authentication?: 'enabled' | 'none' | undefined | null
-    completions?: 'none' | undefined | null
-    //  When 'streaming', handles 'chat/updateMessageInProgress' streaming notifications.
-    chat?: 'none' | 'streaming' | undefined | null
-    // TODO: allow clients to implement the necessary parts of the git extension.
-    // https://github.com/sourcegraph/cody/issues/4165
-    git?: 'none' | 'enabled' | undefined | null
-    // If 'enabled', the client must implement the progress/start,
-    // progress/report, and progress/end notification endpoints.
-    progressBars?: 'none' | 'enabled' | undefined | null
-    edit?: 'none' | 'enabled' | undefined | null
-    editWorkspace?: 'none' | 'enabled' | undefined | null
-    untitledDocuments?: 'none' | 'enabled' | undefined | null
-    showDocument?: 'none' | 'enabled' | undefined | null
-    codeLenses?: 'none' | 'enabled' | undefined | null
-    showWindowMessage?: 'notification' | 'request' | undefined | null
-    ignore?: 'none' | 'enabled' | undefined | null
-    codeActions?: 'none' | 'enabled' | undefined | null
-    disabledMentionsProviders?: ContextMentionProviderID[] | undefined | null
-    // When 'object-encoded' (default), the server uses the `webview/postMessage` method
-    // to send structured JSON objects.  When 'string-encoded', the server uses the
-    // `webview/postMessageStringEncoded` method to send a JSON-encoded string. This is
-    // convenient for clients that forward the string directly to an underlying
-    // webview container.
-    webviewMessages?: 'object-encoded' | 'string-encoded' | undefined | null
-    // How to deal with vscode.ExtensionContext.globalState.
-    // - Stateless: the state does not persist between agent processes. This means the client is
-    // responsible for features like managing chat history.
-    // - Server managed: the server reads and writes the state without informing the client.
-    // The client can optionally customize the file path of the JSON config via `ClientInfo.globalStatePath: string`
-    // - Client managed: not implemented yet. When implemented, clients will be able to implement a
-    // JSON-RPC request to handle the saving of the client state. This is needed to safely share state
-    // between concurrent agent processes (assuming there is one IDE client process managing multiple agent processes).
-    globalState?: 'stateless' | 'server-managed' | 'client-managed' | undefined | null
-
-    // Secrets controls how the agent should handle storing secrets.
-    // - Stateless: the secrets are not persisted between agent processes.
-    // - Client managed: the client must implement the 'secrets/get',
-    // 'secrets/store', and 'secrets/delete' requests.
-    secrets?: 'stateless' | 'client-managed' | undefined | null
-    // Whether the client supports the VSCode WebView API. If 'agentic', uses
-    // AgentWebViewPanel which just delegates bidirectional postMessage over
-    // the Agent protocol. If 'native', implements a larger subset of the VSCode
-    // WebView API and expects the client to run web content in the webview,
-    // which effectively means both sidebar and custom editor chat views are supported.
-    // Defaults to 'agentic'.
-    webview?: 'agentic' | 'native' | undefined | null
-    // If webview === 'native', describes how the client has configured webview resources.
-    webviewNativeConfig?: WebviewNativeConfig | undefined | null
-}
-
-export interface WebviewNativeConfig {
-    // Set the view to 'single' when client only support single chat view, e.g. sidebar chat.
-    view: 'multiple' | 'single'
-    // cspSource is passed to the extension as the Webview cspSource property.
-    cspSource: string
-    // webviewBundleServingPrefix is prepended to resource paths under 'dist' in
-    // asWebviewUri (note, multiple prefixes are not yet implemented.)
-    webviewBundleServingPrefix?: string | undefined | null
-    // when true, resource paths are not relativized, and the client must
-    // handle serving the resources relative to the webview.
-    skipResourceRelativization?: boolean | undefined | null
-    injectScript?: string | undefined | null
-    injectStyle?: string | undefined | null
 }
 
 export interface ServerInfo {

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -25,7 +25,7 @@ import {
     isDotCom,
     modelsService,
     resolvedConfig,
-    setClientCapabilitiesFromConfiguration,
+    setClientCapabilities,
     setClientNameVersion,
     setEditorWindowIsFocused,
     setLogger,
@@ -130,7 +130,10 @@ export async function start(
 
     const disposables: vscode.Disposable[] = []
 
-    setClientCapabilitiesFromConfiguration(getConfiguration())
+    setClientCapabilities({
+        configuration: getConfiguration(),
+        agentCapabilities: platform.extensionClient.capabilities,
+    })
 
     setResolvedConfigurationObservable(
         combineLatest(

--- a/vscode/webviews/CodyPanel.tsx
+++ b/vscode/webviews/CodyPanel.tsx
@@ -1,4 +1,8 @@
-import { type AuthStatus, type ClientCapabilities, CodyIDE } from '@sourcegraph/cody-shared'
+import {
+    type AuthStatus,
+    type ClientCapabilitiesWithLegacyFields,
+    CodyIDE,
+} from '@sourcegraph/cody-shared'
 import { useExtensionAPI, useObservable } from '@sourcegraph/prompt-editor'
 import type React from 'react'
 import { type ComponentProps, type FunctionComponent, useMemo, useRef } from 'react'
@@ -21,7 +25,7 @@ export const CodyPanel: FunctionComponent<
         setView: (view: View) => void
         configuration: {
             config: LocalEnv & ConfigurationSubsetForWebview
-            clientCapabilities: ClientCapabilities
+            clientCapabilities: ClientCapabilitiesWithLegacyFields
             authStatus: AuthStatus
         }
         errorMessages: string[]

--- a/vscode/webviews/chat/components/WelcomeMessage.test.tsx
+++ b/vscode/webviews/chat/components/WelcomeMessage.test.tsx
@@ -1,4 +1,7 @@
-import { AUTH_STATUS_FIXTURE_AUTHED, type ClientCapabilities } from '@sourcegraph/cody-shared'
+import {
+    AUTH_STATUS_FIXTURE_AUTHED,
+    type ClientCapabilitiesWithLegacyFields,
+} from '@sourcegraph/cody-shared'
 import { fireEvent, render, screen } from '@testing-library/react'
 import { describe, expect, test, vi } from 'vitest'
 import { AppWrapperForTest } from '../../AppWrapperForTest'
@@ -29,7 +32,7 @@ describe('WelcomeMessage', () => {
         vi.spyOn(useConfigModule, 'useConfig').mockReturnValue({
             clientCapabilities: {
                 isVSCode: true,
-            } satisfies Partial<ClientCapabilities> as ClientCapabilities,
+            } satisfies Partial<ClientCapabilitiesWithLegacyFields> as ClientCapabilitiesWithLegacyFields,
             authStatus: AUTH_STATUS_FIXTURE_AUTHED,
         } satisfies Partial<useConfigModule.Config> as useConfigModule.Config)
         render(<WelcomeMessage setView={() => {}} />, {
@@ -45,7 +48,7 @@ describe('WelcomeMessage', () => {
         vi.spyOn(useConfigModule, 'useConfig').mockReturnValue({
             clientCapabilities: {
                 isVSCode: false,
-            } satisfies Partial<ClientCapabilities> as ClientCapabilities,
+            } satisfies Partial<ClientCapabilitiesWithLegacyFields> as ClientCapabilitiesWithLegacyFields,
             authStatus: AUTH_STATUS_FIXTURE_AUTHED,
         } satisfies Partial<useConfigModule.Config> as useConfigModule.Config)
         render(<WelcomeMessage setView={() => {}} />, {

--- a/web/lib/agent/agent.client.ts
+++ b/web/lib/agent/agent.client.ts
@@ -84,7 +84,6 @@ export async function createAgentClient({
             customConfiguration: {
                 'cody.autocomplete.enabled': false,
                 'cody.experimental.urlContext': true,
-                'cody.web': true,
                 'cody.internal.debug.state': !!process.env.CODY_WEB_DEMO,
             },
         },


### PR DESCRIPTION
Previously, only the agent code could read the agent capabilities, but they're actually useful throughout the Cody codebase and describe what the current client is capable of. We should use them instead of checking `agentIDE` and assuming based on what kind of editor it is on the other side, since that is coarse.

No behavior change.

## Test plan

CI