### PR TITLE
different agentIDE for Cody Web vs. this repo's standalone web/

### DIFF
--- a/agent/src/AgentWorkspaceConfiguration.ts
+++ b/agent/src/AgentWorkspaceConfiguration.ts
@@ -46,6 +46,8 @@ export class AgentWorkspaceConfiguration implements vscode.WorkspaceConfiguratio
                 return CodyIDE.VisualStudio
             case 'eclipse':
                 return CodyIDE.Eclipse
+            case 'standalone-web':
+                return CodyIDE.StandaloneWeb
             default:
                 return undefined
         }

--- a/lib/shared/src/auth/referral.ts
+++ b/lib/shared/src/auth/referral.ts
@@ -8,7 +8,7 @@ import { clientCapabilities } from '../configuration/clientCapabilities'
  * Use "CODY" as the default referral code for fallback.
  */
 export function getCodyAuthReferralCode(uriScheme: string): string | undefined {
-    const referralCodes: Record<CodyIDE, string> = {
+    const referralCodes: Partial<Record<CodyIDE, string>> = {
         [CodyIDE.JetBrains]: 'JETBRAINS',
         [CodyIDE.Neovim]: 'NEOVIM',
         [CodyIDE.Emacs]: 'CODY',

--- a/lib/shared/src/configuration.ts
+++ b/lib/shared/src/configuration.ts
@@ -124,6 +124,11 @@ export enum CodyIDE {
     Web = 'Web',
     VisualStudio = 'VisualStudio',
     Eclipse = 'Eclipse',
+
+    /**
+     * The standalone web client in the Cody repository's `web/` tree.
+     */
+    StandaloneWeb = 'StandaloneWeb',
 }
 
 export type AutocompleteProviderID = keyof typeof AUTOCOMPLETE_PROVIDER_ID

--- a/vscode/webviews/components/MarkdownFromCody.tsx
+++ b/vscode/webviews/components/MarkdownFromCody.tsx
@@ -77,14 +77,8 @@ function wrapLinksWithCodyOpenCommand(url: string): string {
     return `command:_cody.vscode.open?${encodedURL}`
 }
 
-const URL_PROCESSORS: Record<CodyIDE, UrlTransform> = {
-    [CodyIDE.Web]: defaultUrlProcessor,
-    [CodyIDE.JetBrains]: defaultUrlProcessor,
-    [CodyIDE.Neovim]: defaultUrlProcessor,
-    [CodyIDE.Emacs]: defaultUrlProcessor,
+const URL_PROCESSORS: Partial<Record<CodyIDE, UrlTransform>> = {
     [CodyIDE.VSCode]: wrapLinksWithCodyOpenCommand,
-    [CodyIDE.VisualStudio]: defaultUrlProcessor,
-    [CodyIDE.Eclipse]: defaultUrlProcessor,
 }
 
 export const MarkdownFromCody: FunctionComponent<{ className?: string; children: string }> = ({
@@ -92,7 +86,7 @@ export const MarkdownFromCody: FunctionComponent<{ className?: string; children:
     children,
 }) => {
     const clientType = useConfig().clientCapabilities.agentIDE
-    const urlTransform = useMemo(() => URL_PROCESSORS[clientType], [clientType])
+    const urlTransform = useMemo(() => URL_PROCESSORS[clientType] ?? defaultUrlProcessor, [clientType])
 
     return (
         <Markdown className={className} {...markdownPluginProps()} urlTransform={urlTransform}>

--- a/web/lib/agent/agent.client.ts
+++ b/web/lib/agent/agent.client.ts
@@ -68,13 +68,14 @@ export async function createAgentClient({
 
     // Initialize
     const serverInfo: ServerInfo = await rpc.sendRequest('initialize', {
-        name: 'web',
+        name: 'standalone-web',
         version: '0.0.1',
         workspaceRootUri,
         capabilities: {
             completions: 'none',
             webview: 'agentic',
             disabledMentionsProviders: [FILE_CONTEXT_MENTION_PROVIDER.id],
+            authentication: 'none',
         },
         extensionConfiguration: {
             accessToken,


### PR DESCRIPTION
`CodyIDE.Web` previously referred to both (1) Cody Web, i.e., the Cody sidebar in Sourcegraph Code Search and the Cody chat page, and (2) this repo's `web/` demo app. They are different and have different needs. It is generally bad to change behavior based on the identity (as opposed to capabilities) of the client, which will be addressed in https://github.com/sourcegraph/cody/pull/5889 and beyond, but for now, it's helpful for them to report different client identities.

## Test plan

CI