### PR TITLE
Add support for generic mentions in prompt messages

### DIFF
--- a/lib/prompt-editor/src/PromptEditor.tsx
+++ b/lib/prompt-editor/src/PromptEditor.tsx
@@ -55,7 +55,7 @@ export interface PromptEditorRefAPI {
     appendText(text: string, cb?: () => void): void
     addMentions(items: ContextItem[], cb?: () => void): void
     setInitialContextMentions(items: ContextItem[], cb?: () => void): void
-    setEditorState(state: SerializedPromptEditorState): void
+    setEditorState(state: SerializedPromptEditorState, cb?: () => void): void
 }
 
 /**
@@ -80,10 +80,11 @@ export const PromptEditor: FunctionComponent<Props> = ({
     useImperativeHandle(
         ref,
         (): PromptEditorRefAPI => ({
-            setEditorState(state: SerializedPromptEditorState): void {
+            setEditorState(state: SerializedPromptEditorState, onUpdate): void {
                 const editor = editorRef.current
                 if (editor) {
                     editor.setEditorState(editor.parseEditorState(state.lexicalEditorState))
+                    onUpdate?.()
                 }
             },
             getSerializedValue(): SerializedPromptEditorValue {

--- a/lib/shared/src/lexicalEditor/nodes.ts
+++ b/lib/shared/src/lexicalEditor/nodes.ts
@@ -295,6 +295,7 @@ export function contextItemMentionNodeDisplayText(contextItem: SerializedContext
         case 'openctx':
             return contextItem.title
     }
+
     // @ts-ignore
     throw new Error(`unrecognized context item type ${contextItem.type}`)
 }

--- a/lib/shared/src/misc/rpc/webviewAPI.ts
+++ b/lib/shared/src/misc/rpc/webviewAPI.ts
@@ -41,7 +41,10 @@ export interface WebviewToExtensionAPI {
 
     highlights(query: FetchHighlightFileParameters): Observable<string[][]>
 
-    hydratePromptMessage(promptText: string, initialContext?: ContextItem[]): Observable<SerializedPromptEditorState>
+    hydratePromptMessage(
+        promptText: string,
+        initialContext?: ContextItem[]
+    ): Observable<SerializedPromptEditorState>
 
     /**
      * Set the chat model.
@@ -100,8 +103,7 @@ export function createExtensionAPI(
         models: proxyExtensionAPI(messageAPI, 'models'),
         chatModels: proxyExtensionAPI(messageAPI, 'chatModels'),
         highlights: proxyExtensionAPI(messageAPI, 'highlights'),
-        hydratePromptMessage: (promptText) =>
-            hydratePromptMessage(promptText, staticInitialContext),
+        hydratePromptMessage: promptText => hydratePromptMessage(promptText, staticInitialContext),
         setChatModel: proxyExtensionAPI(messageAPI, 'setChatModel'),
         initialContext: staticInitialContext
             ? () => Observable.of(staticInitialContext)

--- a/lib/shared/src/misc/rpc/webviewAPI.ts
+++ b/lib/shared/src/misc/rpc/webviewAPI.ts
@@ -41,7 +41,7 @@ export interface WebviewToExtensionAPI {
 
     highlights(query: FetchHighlightFileParameters): Observable<string[][]>
 
-    hydratePromptMessage(promptText: string): Observable<SerializedPromptEditorState>
+    hydratePromptMessage(promptText: string, initialContext?: ContextItem[]): Observable<SerializedPromptEditorState>
 
     /**
      * Set the chat model.
@@ -92,6 +92,7 @@ export function createExtensionAPI(
     // As a workaround for Cody Web, support providing static initial context.
     staticInitialContext?: ContextItem[]
 ): WebviewToExtensionAPI {
+    const hydratePromptMessage = proxyExtensionAPI(messageAPI, 'hydratePromptMessage')
     return {
         mentionMenuData: proxyExtensionAPI(messageAPI, 'mentionMenuData'),
         evaluatedFeatureFlag: proxyExtensionAPI(messageAPI, 'evaluatedFeatureFlag'),
@@ -99,7 +100,8 @@ export function createExtensionAPI(
         models: proxyExtensionAPI(messageAPI, 'models'),
         chatModels: proxyExtensionAPI(messageAPI, 'chatModels'),
         highlights: proxyExtensionAPI(messageAPI, 'highlights'),
-        hydratePromptMessage: proxyExtensionAPI(messageAPI, 'hydratePromptMessage'),
+        hydratePromptMessage: (promptText) =>
+            hydratePromptMessage(promptText, staticInitialContext),
         setChatModel: proxyExtensionAPI(messageAPI, 'setChatModel'),
         initialContext: staticInitialContext
             ? () => Observable.of(staticInitialContext)

--- a/lib/shared/src/misc/rpc/webviewAPI.ts
+++ b/lib/shared/src/misc/rpc/webviewAPI.ts
@@ -1,5 +1,6 @@
 import { Observable } from 'observable-fns'
 import type { AuthStatus, ModelsData, ResolvedConfiguration, UserProductSubscription } from '../..'
+import type { SerializedPromptEditorState } from '../..'
 import type { ChatMessage, UserLocalHistory } from '../../chat/transcript/messages'
 import type { ContextItem } from '../../codebase-context/messages'
 import type { CodyCommand } from '../../commands/types'
@@ -39,6 +40,8 @@ export interface WebviewToExtensionAPI {
     chatModels(): Observable<Model[]>
 
     highlights(query: FetchHighlightFileParameters): Observable<string[][]>
+
+    hydratePromptMessage(promptText: string): Observable<SerializedPromptEditorState>
 
     /**
      * Set the chat model.
@@ -96,6 +99,7 @@ export function createExtensionAPI(
         models: proxyExtensionAPI(messageAPI, 'models'),
         chatModels: proxyExtensionAPI(messageAPI, 'chatModels'),
         highlights: proxyExtensionAPI(messageAPI, 'highlights'),
+        hydratePromptMessage: proxyExtensionAPI(messageAPI, 'hydratePromptMessage'),
         setChatModel: proxyExtensionAPI(messageAPI, 'setChatModel'),
         initialContext: staticInitialContext
             ? () => Observable.of(staticInitialContext)

--- a/vscode/src/chat/chat-view/ChatController.ts
+++ b/vscode/src/chat/chat-view/ChatController.ts
@@ -1612,8 +1612,8 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
                         })
                     },
                     evaluatedFeatureFlag: flag => featureFlagProvider.evaluatedFeatureFlag(flag),
-                    hydratePromptMessage: promptText =>
-                        promiseFactoryToObservable(() => hydratePromptText(promptText)),
+                    hydratePromptMessage: (promptText, initialContext) =>
+                        promiseFactoryToObservable(() => hydratePromptText(promptText, initialContext ?? [])),
                     prompts: query =>
                         promiseFactoryToObservable(signal =>
                             mergedPromptsAndLegacyCommands(query, signal)

--- a/vscode/src/chat/chat-view/ChatController.ts
+++ b/vscode/src/chat/chat-view/ChatController.ts
@@ -1613,7 +1613,9 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
                     },
                     evaluatedFeatureFlag: flag => featureFlagProvider.evaluatedFeatureFlag(flag),
                     hydratePromptMessage: (promptText, initialContext) =>
-                        promiseFactoryToObservable(() => hydratePromptText(promptText, initialContext ?? [])),
+                        promiseFactoryToObservable(() =>
+                            hydratePromptText(promptText, initialContext ?? [])
+                        ),
                     prompts: query =>
                         promiseFactoryToObservable(signal =>
                             mergedPromptsAndLegacyCommands(query, signal)

--- a/vscode/src/chat/chat-view/ChatController.ts
+++ b/vscode/src/chat/chat-view/ChatController.ts
@@ -97,6 +97,7 @@ import type { ExtensionClient } from '../../extension-client'
 import { migrateAndNotifyForOutdatedModels } from '../../models/modelMigrator'
 import { logDebug } from '../../output-channel-logger'
 import { getCategorizedMentions } from '../../prompt-builder/utils'
+import { hydratePromptText } from '../../prompts/prompt-hydration'
 import { mergedPromptsAndLegacyCommands } from '../../prompts/prompts'
 import { publicRepoMetadataIfAllWorkspaceReposArePublic } from '../../repository/githubRepoMetadata'
 import { authProvider } from '../../services/AuthProvider'
@@ -1611,6 +1612,8 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
                         })
                     },
                     evaluatedFeatureFlag: flag => featureFlagProvider.evaluatedFeatureFlag(flag),
+                    hydratePromptMessage: promptText =>
+                        promiseFactoryToObservable(() => hydratePromptText(promptText)),
                     prompts: query =>
                         promiseFactoryToObservable(signal =>
                             mergedPromptsAndLegacyCommands(query, signal)

--- a/vscode/src/commands/context/selection.ts
+++ b/vscode/src/commands/context/selection.ts
@@ -98,6 +98,25 @@ export async function getSelectionOrFileContext(): Promise<ContextItem[]> {
     })
 }
 
+export async function getFileContext(): Promise<ContextItem | null> {
+    const editor = getEditor()?.active
+    const document = editor?.document
+
+    if (!document || (await shouldIgnore(document.uri))) {
+        return null
+    }
+
+    const content = editor.document.getText()
+
+    return {
+        type: 'file',
+        uri: document.uri,
+        content,
+        source: ContextItemSource.Editor,
+        size: await TokenCounterUtils.countTokens(content),
+    } satisfies ContextItemFile
+}
+
 async function shouldIgnore(uri: URI): Promise<boolean> {
     return Boolean(await contextFiltersProvider.isUriIgnored(uri))
 }

--- a/vscode/src/commands/context/workspace.ts
+++ b/vscode/src/commands/context/workspace.ts
@@ -1,11 +1,14 @@
 import {
     type ContextItem,
+    ContextItemSource,
+    type ContextItemTree,
     contextFiltersProvider,
     isDefined,
     logError,
     wrapInActiveSpan,
 } from '@sourcegraph/cody-shared'
 import { CancellationTokenSource, workspace } from 'vscode'
+import * as vscode from 'vscode'
 import { createContextFile } from '../utils/create-context-file'
 import { getDocText } from '../utils/workspace-files'
 
@@ -55,4 +58,24 @@ export async function getWorkspaceFilesContext(
             return []
         }
     })
+}
+
+export function getWorkspaceContext(): ContextItemTree | null {
+    const workspaceFolder = vscode.workspace.workspaceFolders?.at(0)
+
+    if (workspaceFolder) {
+        return {
+            type: 'tree',
+            uri: workspaceFolder.uri,
+            title: 'Current Repository',
+            name: workspaceFolder.name,
+            description: workspaceFolder.name,
+            isWorkspaceRoot: true,
+            content: null,
+            source: ContextItemSource.Editor,
+            icon: 'folder',
+        } satisfies ContextItemTree
+    }
+
+    return null
 }

--- a/vscode/src/prompts/prompt-hydration.ts
+++ b/vscode/src/prompts/prompt-hydration.ts
@@ -1,0 +1,122 @@
+import type { SerializedPromptEditorState } from '@sourcegraph/cody-shared'
+import { PromptString, editorStateFromPromptString } from '@sourcegraph/cody-shared'
+import { getContextFileFromDirectory } from '../commands/context/directory'
+import { getContextFileFromTabs } from '../commands/context/open-tabs'
+import { getFileContext, getSelectionOrFileContext } from '../commands/context/selection'
+import { getWorkspaceContext } from '../commands/context/workspace'
+import { selectedCodePromptWithExtraFiles } from '../commands/execute'
+
+const PROMPT_CURRENT_FILE_PLACEHOLDER: string = '[[current file]]'
+const PROMPT_CURRENT_SELECTION_PLACEHOLDER: string = '[[current selection]]'
+const PROMPT_CURRENT_DIRECTORY_PLACEHOLDER: string = '[[current directory]]'
+const PROMPT_EDITOR_OPEN_TABS_PLACEHOLDER: string = '[[open tabs]]'
+const PROMPT_CURRENT_REPOSITORY_PLACEHOLDER: string = '[[current repository]]'
+
+/**
+ * This function replaces prompt generic mentions like current file, selection, directory,
+ * etc. with actual context items mentions based on Editor context information.
+ */
+export async function hydratePromptText(promptRawText: string): Promise<SerializedPromptEditorState> {
+    const promptText = PromptString.unsafe_fromUserQuery(promptRawText)
+    const promptTextMentionMatches = promptText.toString().match(/\[\[[^\]]*\]\]/gm) ?? []
+
+    let hydratedPromptText = promptText
+
+    for (const currentMatch of promptTextMentionMatches) {
+        switch (currentMatch) {
+            case PROMPT_CURRENT_FILE_PLACEHOLDER:
+                hydratedPromptText = await hydrateWithCurrentFile(hydratedPromptText)
+                continue
+            case PROMPT_CURRENT_SELECTION_PLACEHOLDER:
+                hydratedPromptText = await hydrateWithCurrentSelection(hydratedPromptText)
+                continue
+            case PROMPT_CURRENT_DIRECTORY_PLACEHOLDER:
+                hydratedPromptText = await hydrateWithCurrentDirectory(hydratedPromptText)
+                continue
+            case PROMPT_EDITOR_OPEN_TABS_PLACEHOLDER:
+                hydratedPromptText = await hydrateWithOpenTabs(hydratedPromptText)
+                continue
+            case PROMPT_CURRENT_REPOSITORY_PLACEHOLDER:
+                hydratedPromptText = await hydrateWithCurrentWorkspace(hydratedPromptText)
+        }
+    }
+
+    return editorStateFromPromptString(hydratedPromptText)
+}
+
+async function hydrateWithCurrentFile(promptText: PromptString): Promise<PromptString> {
+    const currentFileContextItem = await getFileContext()
+
+    // TODO (vk): Add support for error notification if prompt hydration fails
+    if (currentFileContextItem === null) {
+        return promptText
+    }
+
+    return promptText.replaceAll(
+        PROMPT_CURRENT_FILE_PLACEHOLDER,
+        selectedCodePromptWithExtraFiles(currentFileContextItem, [])
+    )
+}
+
+async function hydrateWithCurrentSelection(promptText: PromptString): Promise<PromptString> {
+    const currentSelection = (await getSelectionOrFileContext())[0]
+
+    // TODO (vk): Add support for error notification if prompt hydration fails
+    if (!currentSelection) {
+        return promptText
+    }
+
+    return promptText.replaceAll(
+        PROMPT_CURRENT_SELECTION_PLACEHOLDER,
+        selectedCodePromptWithExtraFiles(currentSelection, [])
+    )
+}
+
+async function hydrateWithCurrentDirectory(promptText: PromptString): Promise<PromptString> {
+    const currentFileContextItem = await getFileContext()
+
+    // TODO (vk): Add support for error notification if prompt hydration fails
+    if (!currentFileContextItem) {
+        return promptText
+    }
+
+    // Currently we just search files in the directory that contains opened files
+    // and include these files mentions, but it would be better to support openctx
+    // remote directory mentions here to enhance functionality of prompt directory
+    // mentions
+    const directoryFiles = await getContextFileFromDirectory()
+
+    return promptText.replaceAll(
+        PROMPT_CURRENT_DIRECTORY_PLACEHOLDER,
+        selectedCodePromptWithExtraFiles(currentFileContextItem, directoryFiles)
+    )
+}
+
+async function hydrateWithOpenTabs(promptText: PromptString): Promise<PromptString> {
+    const openTabs = await getContextFileFromTabs()
+
+    if (openTabs.length === 0) {
+        return promptText
+    }
+
+    const [firstOpenTab, ...otherOpenTabs] = openTabs
+
+    return promptText.replaceAll(
+        PROMPT_EDITOR_OPEN_TABS_PLACEHOLDER,
+        selectedCodePromptWithExtraFiles(firstOpenTab, otherOpenTabs)
+    )
+}
+
+async function hydrateWithCurrentWorkspace(promptText: PromptString) {
+    const currentWorkspace = getWorkspaceContext()
+
+    // TODO (vk): Add support for error notification if prompt hydration fails
+    if (!currentWorkspace) {
+        return promptText
+    }
+
+    return promptText.replaceAll(
+        PROMPT_CURRENT_REPOSITORY_PLACEHOLDER,
+        selectedCodePromptWithExtraFiles(currentWorkspace, [])
+    )
+}

--- a/vscode/src/prompts/prompt-hydration.ts
+++ b/vscode/src/prompts/prompt-hydration.ts
@@ -32,7 +32,7 @@ const PROMPT_EDITOR_OPEN_TABS_PLACEHOLDER: string = 'cody://tabs'
 const PROMPT_CURRENT_REPOSITORY_PLACEHOLDER: string = 'cody://repository'
 
 /**
- * Be default IDE itself can figure out all needed context via vscode API,
+ * Default IDE logic itself can figure out all needed context via vscode API,
  * for Cody Web where we don't hava access to this API (or way to override this)
  * we pass static initial context from the main thread (current repo, file, dir, etc.)
  */
@@ -261,7 +261,6 @@ async function hydrateWithCurrentWorkspace(
                     authStatus
                 )
             ),
-            title: 'Current Repository',
             description: repo.name,
             source: ContextItemSource.Initial,
             icon: 'folder',

--- a/vscode/src/prompts/prompt-hydration.ts
+++ b/vscode/src/prompts/prompt-hydration.ts
@@ -23,7 +23,7 @@ import { getFileContext, getSelectionOrFileContext } from '../commands/context/s
 import { selectedCodePromptWithExtraFiles } from '../commands/execute'
 import { createRepositoryMention } from '../context/openctx/common/get-repository-mentions'
 import { remoteReposForAllWorkspaceFolders } from '../repository/remoteRepos'
-import { getCurrentRepositoryInfo } from './utils';
+import { getCurrentRepositoryInfo } from './utils'
 
 const PROMPT_CURRENT_FILE_PLACEHOLDER: string = '[[current file]]'
 const PROMPT_CURRENT_SELECTION_PLACEHOLDER: string = '[[current selection]]'
@@ -38,8 +38,10 @@ const PROMPT_CURRENT_REPOSITORY_PLACEHOLDER: string = '[[current repository]]'
  */
 export type PromptHydrationInitialContext = ContextItem[]
 
-type PromptHydrationModifier = (promptText: PromptString, initialContext: PromptHydrationInitialContext) =>
-    Promise<[PromptString, ContextItem[]]>
+type PromptHydrationModifier = (
+    promptText: PromptString,
+    initialContext: PromptHydrationInitialContext
+) => Promise<[PromptString, ContextItem[]]>
 
 const PROMPT_HYDRATION_MODIFIERS: Record<string, PromptHydrationModifier> = {
     [PROMPT_CURRENT_FILE_PLACEHOLDER]: hydrateWithCurrentFile,
@@ -53,7 +55,10 @@ const PROMPT_HYDRATION_MODIFIERS: Record<string, PromptHydrationModifier> = {
  * This function replaces prompt generic mentions like current file, selection, directory,
  * etc. with actual context items mentions based on Editor context information.
  */
-export async function hydratePromptText(promptRawText: string, initialContext: PromptHydrationInitialContext): Promise<SerializedPromptEditorState> {
+export async function hydratePromptText(
+    promptRawText: string,
+    initialContext: PromptHydrationInitialContext
+): Promise<SerializedPromptEditorState> {
     const promptText = PromptString.unsafe_fromUserQuery(promptRawText)
     const promptTextMentionMatches = promptText.toString().match(/\[\[[^\]]*\]\]/gm) ?? []
 
@@ -80,10 +85,13 @@ export async function hydratePromptText(promptRawText: string, initialContext: P
     })
 }
 
-async function hydrateWithCurrentFile(promptText: PromptString, initialContext: PromptHydrationInitialContext): Promise<[PromptString, ContextItem[]]> {
+async function hydrateWithCurrentFile(
+    promptText: PromptString,
+    initialContext: PromptHydrationInitialContext
+): Promise<[PromptString, ContextItem[]]> {
     // Check if initial context already contains current file (Cody Web case)
     const initialContextFile = initialContext.find(item => item.type === 'file')
-    const currentFileContextItem = initialContextFile ?? await getFileContext()
+    const currentFileContextItem = initialContextFile ?? (await getFileContext())
 
     // TODO (vk): Add support for error notification if prompt hydration fails
     if (currentFileContextItem === null) {
@@ -104,8 +112,7 @@ async function hydrateWithCurrentSelection(
     initialContext: PromptHydrationInitialContext
 ): Promise<[PromptString, ContextItem[]]> {
     // Check if initial context already contains current file with selection (Cody Web case)
-    const initialContextFile = initialContext
-        .find(item => item.type === 'file' && item.range)
+    const initialContextFile = initialContext.find(item => item.type === 'file' && item.range)
 
     const currentSelection = initialContextFile ?? (await getSelectionOrFileContext())[0]
 
@@ -127,8 +134,9 @@ async function hydrateWithCurrentDirectory(
     promptText: PromptString,
     initialContext: PromptHydrationInitialContext
 ): Promise<[PromptString, ContextItem[]]> {
-    const initialContextDirectory = initialContext
-        .find(item => item.type === 'openctx' && item.providerUri === REMOTE_DIRECTORY_PROVIDER_URI)
+    const initialContextDirectory = initialContext.find(
+        item => item.type === 'openctx' && item.providerUri === REMOTE_DIRECTORY_PROVIDER_URI
+    )
 
     if (initialContextDirectory) {
         return [
@@ -140,10 +148,9 @@ async function hydrateWithCurrentDirectory(
         ]
     }
 
-    const initialContextFile = initialContext
-        .find(item => item.type === 'file')
+    const initialContextFile = initialContext.find(item => item.type === 'file')
 
-    const currentFileContextItem = initialContextFile ?? await getFileContext()
+    const currentFileContextItem = initialContextFile ?? (await getFileContext())
     const currentRepository = await getCurrentRepositoryInfo(initialContext)
 
     // TODO (vk): Add support for error notification if prompt hydration fails

--- a/vscode/src/prompts/prompt-hydration.ts
+++ b/vscode/src/prompts/prompt-hydration.ts
@@ -1,17 +1,23 @@
-import type { SerializedPromptEditorState } from '@sourcegraph/cody-shared'
+import type {
+    ContextItem,
+    ContextItemOpenCtx,
+    SerializedPromptEditorState,
+} from '@sourcegraph/cody-shared'
 import {
     ContextItemSource,
     PromptString,
+    REMOTE_DIRECTORY_PROVIDER_URI,
     REMOTE_REPOSITORY_PROVIDER_URI,
     contextFiltersProvider,
     currentAuthStatusAuthed,
+    displayPath,
     editorStateFromPromptString,
     firstValueFrom,
     isError,
     pendingOperation,
 } from '@sourcegraph/cody-shared'
+import { URI } from 'vscode-uri'
 import { contextItemMentionFromOpenCtxItem } from '../chat/context/chatContext'
-import { getContextFileFromDirectory } from '../commands/context/directory'
 import { getContextFileFromTabs } from '../commands/context/open-tabs'
 import { getFileContext, getSelectionOrFileContext } from '../commands/context/selection'
 import { selectedCodePromptWithExtraFiles } from '../commands/execute'
@@ -24,6 +30,16 @@ const PROMPT_CURRENT_DIRECTORY_PLACEHOLDER: string = '[[current directory]]'
 const PROMPT_EDITOR_OPEN_TABS_PLACEHOLDER: string = '[[open tabs]]'
 const PROMPT_CURRENT_REPOSITORY_PLACEHOLDER: string = '[[current repository]]'
 
+type PromptHydrationModifier = (promptText: PromptString) => Promise<[PromptString, ContextItem[]]>
+
+const PROMPT_HYDRATION_MODIFIERS: Record<string, PromptHydrationModifier> = {
+    [PROMPT_CURRENT_FILE_PLACEHOLDER]: hydrateWithCurrentFile,
+    [PROMPT_CURRENT_SELECTION_PLACEHOLDER]: hydrateWithCurrentSelection,
+    [PROMPT_CURRENT_DIRECTORY_PLACEHOLDER]: hydrateWithCurrentDirectory,
+    [PROMPT_EDITOR_OPEN_TABS_PLACEHOLDER]: hydrateWithOpenTabs,
+    [PROMPT_CURRENT_REPOSITORY_PLACEHOLDER]: hydrateWithCurrentWorkspace,
+}
+
 /**
  * This function replaces prompt generic mentions like current file, selection, directory,
  * etc. with actual context items mentions based on Editor context information.
@@ -33,100 +49,146 @@ export async function hydratePromptText(promptRawText: string): Promise<Serializ
     const promptTextMentionMatches = promptText.toString().match(/\[\[[^\]]*\]\]/gm) ?? []
 
     let hydratedPromptText = promptText
+    const contextItemsMap = new Map<string, ContextItem>()
 
     for (const currentMatch of promptTextMentionMatches) {
-        switch (currentMatch) {
-            case PROMPT_CURRENT_FILE_PLACEHOLDER:
-                hydratedPromptText = await hydrateWithCurrentFile(hydratedPromptText)
-                continue
-            case PROMPT_CURRENT_SELECTION_PLACEHOLDER:
-                hydratedPromptText = await hydrateWithCurrentSelection(hydratedPromptText)
-                continue
-            case PROMPT_CURRENT_DIRECTORY_PLACEHOLDER:
-                hydratedPromptText = await hydrateWithCurrentDirectory(hydratedPromptText)
-                continue
-            case PROMPT_EDITOR_OPEN_TABS_PLACEHOLDER:
-                hydratedPromptText = await hydrateWithOpenTabs(hydratedPromptText)
-                continue
-            case PROMPT_CURRENT_REPOSITORY_PLACEHOLDER:
-                hydratedPromptText = await hydrateWithCurrentWorkspace(hydratedPromptText)
+        const hydrateModifier = PROMPT_HYDRATION_MODIFIERS[currentMatch]
+
+        if (!hydrateModifier) {
+            continue
+        }
+
+        const [nextPromptText, contextItems] = await hydrateModifier(hydratedPromptText)
+        hydratedPromptText = nextPromptText
+
+        for (const item of contextItems) {
+            contextItemsMap.set(displayPath(item.uri), item)
         }
     }
 
-    return editorStateFromPromptString(hydratedPromptText)
+    return editorStateFromPromptString(hydratedPromptText, {
+        additionalContextItemsMap: contextItemsMap,
+    })
 }
 
-async function hydrateWithCurrentFile(promptText: PromptString): Promise<PromptString> {
+async function hydrateWithCurrentFile(promptText: PromptString): Promise<[PromptString, ContextItem[]]> {
     const currentFileContextItem = await getFileContext()
 
     // TODO (vk): Add support for error notification if prompt hydration fails
     if (currentFileContextItem === null) {
-        return promptText
+        return [promptText, []]
     }
 
-    return promptText.replaceAll(
-        PROMPT_CURRENT_FILE_PLACEHOLDER,
-        selectedCodePromptWithExtraFiles(currentFileContextItem, [])
-    )
+    return [
+        promptText.replaceAll(
+            PROMPT_CURRENT_FILE_PLACEHOLDER,
+            selectedCodePromptWithExtraFiles(currentFileContextItem, [])
+        ),
+        [currentFileContextItem],
+    ]
 }
 
-async function hydrateWithCurrentSelection(promptText: PromptString): Promise<PromptString> {
+async function hydrateWithCurrentSelection(
+    promptText: PromptString
+): Promise<[PromptString, ContextItem[]]> {
     const currentSelection = (await getSelectionOrFileContext())[0]
 
     // TODO (vk): Add support for error notification if prompt hydration fails
     if (!currentSelection) {
-        return promptText
+        return [promptText, []]
     }
 
-    return promptText.replaceAll(
-        PROMPT_CURRENT_SELECTION_PLACEHOLDER,
-        selectedCodePromptWithExtraFiles(currentSelection, [])
-    )
+    return [
+        promptText.replaceAll(
+            PROMPT_CURRENT_SELECTION_PLACEHOLDER,
+            selectedCodePromptWithExtraFiles(currentSelection, [])
+        ),
+        [currentSelection],
+    ]
 }
 
-async function hydrateWithCurrentDirectory(promptText: PromptString): Promise<PromptString> {
+async function hydrateWithCurrentDirectory(
+    promptText: PromptString
+): Promise<[PromptString, ContextItem[]]> {
     const currentFileContextItem = await getFileContext()
+    const workspaceFolders = await firstValueFrom(remoteReposForAllWorkspaceFolders)
 
     // TODO (vk): Add support for error notification if prompt hydration fails
-    if (!currentFileContextItem) {
-        return promptText
+    if (
+        !currentFileContextItem ||
+        workspaceFolders === pendingOperation ||
+        isError(workspaceFolders) ||
+        !workspaceFolders[0]
+    ) {
+        return [promptText, []]
+    }
+
+    const repository = workspaceFolders[0]
+    const directoryPath = currentFileContextItem.uri.toString().split('/').slice(0, -1).join('/')
+
+    const directoryItem: ContextItemOpenCtx = {
+        type: 'openctx',
+        provider: 'openctx',
+        title: directoryPath,
+        uri: URI.file(`${repository.name}/${directoryPath}/`),
+        providerUri: REMOTE_DIRECTORY_PROVIDER_URI,
+        description: 'Current Directory',
+        source: ContextItemSource.Initial,
+        // @ts-ignore
+        mention: {
+            description: directoryPath,
+            //uri: `${repository.name}/${directoryPath}/`,
+            data: {
+                repoName: repository.name,
+                repoID: repository.id,
+                directoryPath: `${directoryPath}/`,
+            },
+        },
     }
 
     // Currently we just search files in the directory that contains opened files
     // and include these files mentions, but it would be better to support openctx
     // remote directory mentions here to enhance functionality of prompt directory
     // mentions
-    const directoryFiles = await getContextFileFromDirectory()
+    // const directoryFiles = await getContextFileFromDirectory()
 
-    return promptText.replaceAll(
-        PROMPT_CURRENT_DIRECTORY_PLACEHOLDER,
-        selectedCodePromptWithExtraFiles(currentFileContextItem, directoryFiles)
-    )
+    return [
+        promptText.replaceAll(
+            PROMPT_CURRENT_DIRECTORY_PLACEHOLDER,
+            selectedCodePromptWithExtraFiles(directoryItem, [])
+        ),
+        [directoryItem],
+    ]
 }
 
-async function hydrateWithOpenTabs(promptText: PromptString): Promise<PromptString> {
+async function hydrateWithOpenTabs(promptText: PromptString): Promise<[PromptString, ContextItem[]]> {
     const openTabs = await getContextFileFromTabs()
 
     if (openTabs.length === 0) {
-        return promptText
+        return [promptText, []]
     }
 
     const [firstOpenTab, ...otherOpenTabs] = openTabs
 
-    return promptText.replaceAll(
-        PROMPT_EDITOR_OPEN_TABS_PLACEHOLDER,
-        selectedCodePromptWithExtraFiles(firstOpenTab, otherOpenTabs)
-    )
+    return [
+        promptText.replaceAll(
+            PROMPT_EDITOR_OPEN_TABS_PLACEHOLDER,
+            selectedCodePromptWithExtraFiles(firstOpenTab, otherOpenTabs)
+        ),
+        [firstOpenTab, ...otherOpenTabs],
+    ]
 }
 
-async function hydrateWithCurrentWorkspace(promptText: PromptString) {
+async function hydrateWithCurrentWorkspace(
+    promptText: PromptString
+): Promise<[PromptString, ContextItem[]]> {
     const authStatus = currentAuthStatusAuthed()
     const workspaceFolders = await firstValueFrom(remoteReposForAllWorkspaceFolders)
 
     const items = []
 
     if (workspaceFolders === pendingOperation) {
-        return promptText
+        return [promptText, []]
     }
 
     if (isError(workspaceFolders)) {
@@ -162,13 +224,16 @@ async function hydrateWithCurrentWorkspace(promptText: PromptString) {
 
     // TODO (vk): Add support for error notification if prompt hydration fails
     if (items.length === 0) {
-        return promptText
+        return [promptText, []]
     }
 
-    const [workspace, ...other] = items
+    const [workspace, ...otherWorkspaces] = items
 
-    return promptText.replaceAll(
-        PROMPT_CURRENT_REPOSITORY_PLACEHOLDER,
-        selectedCodePromptWithExtraFiles(workspace, other)
-    )
+    return [
+        promptText.replaceAll(
+            PROMPT_CURRENT_REPOSITORY_PLACEHOLDER,
+            selectedCodePromptWithExtraFiles(workspace, otherWorkspaces)
+        ),
+        [workspace, ...otherWorkspaces],
+    ]
 }

--- a/vscode/src/prompts/prompt-hydration.ts
+++ b/vscode/src/prompts/prompt-hydration.ts
@@ -124,7 +124,11 @@ async function hydrateWithCurrentDirectory(
     }
 
     const repository = workspaceFolders[0]
-    const directoryPath = currentFileContextItem.uri.toString().split('/').slice(0, -1).join('/')
+    const repoName = repository.name.split('/').at(-1)
+    const fullDirectoryPath = currentFileContextItem.uri.toString().split('/').slice(0, -1).join('/')
+    const directoryPath = repoName
+        ? fullDirectoryPath.split(`${repoName}/`).at(-1) ?? fullDirectoryPath
+        : fullDirectoryPath
 
     const directoryItem: ContextItemOpenCtx = {
         type: 'openctx',
@@ -134,10 +138,9 @@ async function hydrateWithCurrentDirectory(
         providerUri: REMOTE_DIRECTORY_PROVIDER_URI,
         description: 'Current Directory',
         source: ContextItemSource.Initial,
-        // @ts-ignore
         mention: {
             description: directoryPath,
-            //uri: `${repository.name}/${directoryPath}/`,
+            uri: `${repository.name}/${directoryPath}/`,
             data: {
                 repoName: repository.name,
                 repoID: repository.id,
@@ -145,12 +148,6 @@ async function hydrateWithCurrentDirectory(
             },
         },
     }
-
-    // Currently we just search files in the directory that contains opened files
-    // and include these files mentions, but it would be better to support openctx
-    // remote directory mentions here to enhance functionality of prompt directory
-    // mentions
-    // const directoryFiles = await getContextFileFromDirectory()
 
     return [
         promptText.replaceAll(

--- a/vscode/src/prompts/prompt-hydration.ts
+++ b/vscode/src/prompts/prompt-hydration.ts
@@ -25,11 +25,11 @@ import { createRepositoryMention } from '../context/openctx/common/get-repositor
 import { remoteReposForAllWorkspaceFolders } from '../repository/remoteRepos'
 import { getCurrentRepositoryInfo } from './utils'
 
-const PROMPT_CURRENT_FILE_PLACEHOLDER: string = '[[current file]]'
-const PROMPT_CURRENT_SELECTION_PLACEHOLDER: string = '[[current selection]]'
-const PROMPT_CURRENT_DIRECTORY_PLACEHOLDER: string = '[[current directory]]'
-const PROMPT_EDITOR_OPEN_TABS_PLACEHOLDER: string = '[[open tabs]]'
-const PROMPT_CURRENT_REPOSITORY_PLACEHOLDER: string = '[[current repository]]'
+const PROMPT_CURRENT_FILE_PLACEHOLDER: string = 'cody://current-file'
+const PROMPT_CURRENT_SELECTION_PLACEHOLDER: string = 'cody://selection'
+const PROMPT_CURRENT_DIRECTORY_PLACEHOLDER: string = 'cody://current-dir'
+const PROMPT_EDITOR_OPEN_TABS_PLACEHOLDER: string = 'cody://tabs'
+const PROMPT_CURRENT_REPOSITORY_PLACEHOLDER: string = 'cody://repository'
 
 /**
  * Be default IDE itself can figure out all needed context via vscode API,
@@ -60,7 +60,9 @@ export async function hydratePromptText(
     initialContext: PromptHydrationInitialContext
 ): Promise<SerializedPromptEditorState> {
     const promptText = PromptString.unsafe_fromUserQuery(promptRawText)
-    const promptTextMentionMatches = promptText.toString().match(/\[\[[^\]]*\]\]/gm) ?? []
+
+    // Match any general cody mentions in the prompt text with cody:// prefix
+    const promptTextMentionMatches = promptText.toString().match(/cody:\/\/\S+/gm) ?? []
 
     let hydratedPromptText = promptText
     const contextItemsMap = new Map<string, ContextItem>()

--- a/vscode/src/prompts/utils.ts
+++ b/vscode/src/prompts/utils.ts
@@ -1,0 +1,27 @@
+import { RemoteRepo, remoteReposForAllWorkspaceFolders } from '../repository/remoteRepos';
+import { firstValueFrom, isError, pendingOperation } from '@sourcegraph/cody-shared';
+import type { PromptHydrationInitialContext } from './prompt-hydration'
+
+export async function getCurrentRepositoryInfo(initialContext: PromptHydrationInitialContext): Promise<RemoteRepo | null> {
+    const initialContextRepository = initialContext
+        .find(item => item.type === 'repository')
+
+    if (initialContextRepository) {
+        return {
+            id: initialContextRepository.repoID,
+            name: initialContextRepository.repoName
+        }
+    }
+
+    const workspaceFolders = await firstValueFrom(remoteReposForAllWorkspaceFolders)
+
+    if (
+        workspaceFolders === pendingOperation ||
+        isError(workspaceFolders) ||
+        !workspaceFolders[0]
+    ) {
+        return null
+    }
+
+    return workspaceFolders[0]
+}

--- a/vscode/src/prompts/utils.ts
+++ b/vscode/src/prompts/utils.ts
@@ -1,25 +1,22 @@
-import { RemoteRepo, remoteReposForAllWorkspaceFolders } from '../repository/remoteRepos';
-import { firstValueFrom, isError, pendingOperation } from '@sourcegraph/cody-shared';
+import { firstValueFrom, isError, pendingOperation } from '@sourcegraph/cody-shared'
+import { type RemoteRepo, remoteReposForAllWorkspaceFolders } from '../repository/remoteRepos'
 import type { PromptHydrationInitialContext } from './prompt-hydration'
 
-export async function getCurrentRepositoryInfo(initialContext: PromptHydrationInitialContext): Promise<RemoteRepo | null> {
-    const initialContextRepository = initialContext
-        .find(item => item.type === 'repository')
+export async function getCurrentRepositoryInfo(
+    initialContext: PromptHydrationInitialContext
+): Promise<RemoteRepo | null> {
+    const initialContextRepository = initialContext.find(item => item.type === 'repository')
 
     if (initialContextRepository) {
         return {
             id: initialContextRepository.repoID,
-            name: initialContextRepository.repoName
+            name: initialContextRepository.repoName,
         }
     }
 
     const workspaceFolders = await firstValueFrom(remoteReposForAllWorkspaceFolders)
 
-    if (
-        workspaceFolders === pendingOperation ||
-        isError(workspaceFolders) ||
-        !workspaceFolders[0]
-    ) {
+    if (workspaceFolders === pendingOperation || isError(workspaceFolders) || !workspaceFolders[0]) {
         return null
     }
 

--- a/vscode/webviews/AppWrapperForTest.tsx
+++ b/vscode/webviews/AppWrapperForTest.tsx
@@ -14,6 +14,7 @@ import {
     type UserLocalHistory,
     getMockedDotComClientModels,
     promiseFactoryToObservable,
+    serializedPromptEditorStateFromText,
 } from '@sourcegraph/cody-shared'
 import { ExtensionAPIProviderForTestsOnly } from '@sourcegraph/prompt-editor'
 import { Observable } from 'observable-fns'
@@ -93,6 +94,8 @@ export const AppWrapperForTest: FunctionComponent<{ children: ReactNode }> = ({ 
                     chatModels: () => Observable.of(getMockedDotComClientModels()),
                     setChatModel: () => EMPTY,
                     initialContext: () => Observable.of([]),
+                    hydratePromptMessage: text =>
+                        Observable.of(serializedPromptEditorStateFromText(text)),
                     detectIntent: () => Observable.of(),
                     resolvedConfig: () =>
                         Observable.of({

--- a/vscode/webviews/chat/cells/messageCell/human/editor/HumanMessageEditor.tsx
+++ b/vscode/webviews/chat/cells/messageCell/human/editor/HumanMessageEditor.tsx
@@ -256,7 +256,12 @@ export const HumanMessageEditor: FunctionComponent<{
     // Set up the message listener so the extension can control the input field.
     useClientActionListener(
         useCallback<ClientActionListener>(
-            ({ editorState, addContextItemsToLastHumanInput, appendTextToLastPromptEditor, submitHumanInput }) => {
+            ({
+                editorState,
+                addContextItemsToLastHumanInput,
+                appendTextToLastPromptEditor,
+                submitHumanInput,
+            }) => {
                 // Add new context to chat from the "Cody Add Selection to Cody Chat"
                 // command, etc. Only add to the last human input field.
                 if (isSent) {
@@ -299,7 +304,7 @@ export const HumanMessageEditor: FunctionComponent<{
                 if (editorState) {
                     requestAnimationFrame(() => {
                         if (editorRef.current) {
-                            editorRef.current.setEditorState(editorState)
+                            editorRef.current.setEditorState(editorState, awaitUpdate())
                             editorRef.current.setFocus(true)
                         }
                     })

--- a/vscode/webviews/chat/cells/messageCell/human/editor/HumanMessageEditor.tsx
+++ b/vscode/webviews/chat/cells/messageCell/human/editor/HumanMessageEditor.tsx
@@ -256,7 +256,7 @@ export const HumanMessageEditor: FunctionComponent<{
     // Set up the message listener so the extension can control the input field.
     useClientActionListener(
         useCallback<ClientActionListener>(
-            ({ addContextItemsToLastHumanInput, appendTextToLastPromptEditor, submitHumanInput }) => {
+            ({ editorState, addContextItemsToLastHumanInput, appendTextToLastPromptEditor, submitHumanInput }) => {
                 // Add new context to chat from the "Cody Add Selection to Cody Chat"
                 // command, etc. Only add to the last human input field.
                 if (isSent) {
@@ -292,6 +292,15 @@ export const HumanMessageEditor: FunctionComponent<{
                     requestAnimationFrame(() => {
                         if (editorRef.current) {
                             editorRef.current.appendText(appendTextToLastPromptEditor, onUpdate)
+                        }
+                    })
+                }
+
+                if (editorState) {
+                    requestAnimationFrame(() => {
+                        if (editorRef.current) {
+                            editorRef.current.setEditorState(editorState)
+                            editorRef.current.setFocus(true)
                         }
                     })
                 }

--- a/vscode/webviews/chat/cells/messageCell/human/editor/toolbar/Toolbar.tsx
+++ b/vscode/webviews/chat/cells/messageCell/human/editor/toolbar/Toolbar.tsx
@@ -107,8 +107,8 @@ const PromptSelectFieldToolbarItem: FunctionComponent<{
     const runAction = useActionSelect()
 
     const onSelect = useCallback(
-        (item: Action) => {
-            runAction(item, () => {})
+        async (item: Action) => {
+            await runAction(item, () => {})
             focusEditor?.()
         },
         [focusEditor, runAction]

--- a/vscode/webviews/client/clientState.tsx
+++ b/vscode/webviews/client/clientState.tsx
@@ -1,3 +1,4 @@
+import type { SerializedPromptEditorState } from '@sourcegraph/cody-shared'
 import {
     type FunctionComponent,
     type ReactNode,
@@ -8,7 +9,9 @@ import {
 } from 'react'
 import type { ExtensionMessage } from '../../src/chat/protocol'
 
-type ClientActionArg = Omit<Extract<ExtensionMessage, { type: 'clientAction' }>, 'type'>
+type ClientActionArg = Omit<Extract<ExtensionMessage, { type: 'clientAction' }>, 'type'> & {
+    editorState?: SerializedPromptEditorState
+}
 
 export type ClientActionListener = (arg: ClientActionArg) => void
 

--- a/web/lib/components/CodyWebChat.tsx
+++ b/web/lib/components/CodyWebChat.tsx
@@ -197,8 +197,8 @@ const CodyWebPanel: FC<CodyWebPanelProps> = props => {
                 // Common file mention with possible file range positions
                 mentions.push({
                     type: 'file',
-                    title: initialContextData?.fileRange ? 'Current Selection' : 'Current File',
                     isIgnored: false,
+                    title: initialContextData?.fileRange ? 'Current Selection' : 'Current File',
                     range: initialContextData?.fileRange
                         ? {
                               start: { line: initialContextData.fileRange.startLine, character: 0 },


### PR DESCRIPTION
Closes SRCH-1182
Closes SRCH-1165
Closes SRCH-1166
Closes SRCH-1167
Closes SRCH-1168
Closes SRCH-1169
Closes SRCH-1170

This PR adds support for generic mention in prompt messages, now you can mention the current directory, repository, file, selection, and open tabs in a prompt message via ``[[...]]`` syntax (later we will support mention UI on the web side so you don't have to type `[[..]]` manually). 

The full generic mentions syntax 
- `[[current file]]` 
- `[[current selection]]` - fall back on the current file if we don't have any active selection
- `[[current directory]]` - currently we search for the first 10 files in the local directory and replace this mention with multiple file mentions from this directory but later we will support openctx directory mention so we can mention any directory on the instance
- `[[open tabs]]` 
- `[[current repository]]` 

Note that most of the mentions won't work in Cody Web. At this stage, this is expected; I will support Cody Web in the follow-up PRs. 

## Test plan
- Check that prompts with generic mentions produce messages with actual mentions in it
