### PR TITLE
CLI: add `cody models list` command

### DIFF
--- a/agent/src/cli/command-models.ts
+++ b/agent/src/cli/command-models.ts
@@ -1,0 +1,38 @@
+import { Command } from 'commander'
+import { AuthenticatedAccount } from './command-auth/AuthenticatedAccount'
+import { endpointOption } from './command-auth/command-login'
+import { accessTokenOption } from './command-auth/command-login'
+
+interface ListModelsOptions {
+    accessToken: string
+    endpoint: string
+}
+
+export const modelsCommand = () =>
+    new Command('models').description('Manage models').addCommand(
+        new Command('list')
+            .addOption(accessTokenOption)
+            .addOption(endpointOption)
+            .description('List the models IDs that are supported by the connect Sourcegraph instance')
+            .action(async (options: ListModelsOptions) => {
+                const [account, spinner] =
+                    await AuthenticatedAccount.fromUserSettingsOrExitProcess(options)
+                const results = await fetch(`${account.serverEndpoint}/.api/llm/models`, {
+                    headers: {
+                        Authorization: `token ${account.accessToken}`,
+                    },
+                })
+                if (!results.ok) {
+                    spinner.fail(
+                        `Failed to list models: ${results.statusText}\n${await results.text()}\n`
+                    )
+                    process.exit(1)
+                }
+                const json: { data: { id: string }[] } = (await results.json()) as any
+                spinner.stop()
+                for (const { id } of json.data) {
+                    process.stdout.write(`${id}\n`)
+                }
+                process.exit(0)
+            })
+    )

--- a/agent/src/cli/command-root.ts
+++ b/agent/src/cli/command-root.ts
@@ -8,6 +8,7 @@ import { serverCommand } from './command-jsonrpc-websocket'
 
 import { version } from '../../package.json'
 import { contextCommand } from './command-context/command-context'
+import { modelsCommand } from './command-models'
 
 export const rootCommand = new Command()
     .name('cody')
@@ -17,5 +18,6 @@ export const rootCommand = new Command()
     )
     .addCommand(authCommand())
     .addCommand(chatCommand())
+    .addCommand(modelsCommand())
     .addCommand(new Command('api').addCommand(serverCommand).addCommand(jsonrpcCommand))
     .addCommand(new Command('internal').addCommand(benchCommand).addCommand(contextCommand))


### PR DESCRIPTION
Fixes CODY-4031

Previously, there was no easy to way to know what LLM model IDs are accepted by the backend. We have HTTP APIs to retrieve this information, but it was cumbersome to discover the APIs and construct the correct cURL invocation. Now, Cody CLI users can just run `cody models list`. I want with a `models list` command structure so that we can add more model-related commands in the future, like configuring the default model for the `cody chat` subcommand.

## Test plan
```
❯ pnpm agent models list
...

anthropic::2023-06-01::claude-3.5-sonnet
anthropic::2023-06-01::claude-3-opus
anthropic::2023-06-01::claude-3-haiku
fireworks::v1::starcoder
fireworks::v1::deepseek-coder-v2-lite-base
google::v1::gemini-1.5-pro
google::v1::gemini-1.5-flash
openai::2024-02-01::gpt-4o
openai::2024-02-01::cody-chat-preview-001
openai::2024-02-01::cody-chat-preview-002
```
There's a tiny spinner that prints to stderr, but the output only prints to stdout.
```
❯ node agent/dist/index.js models list > foo.txt
<tiny spinner that clears itself>
❯ cat foo.txt
anthropic::2023-06-01::claude-3.5-sonnet
anthropic::2023-06-01::claude-3-opus
anthropic::2023-06-01::claude-3-haiku
fireworks::v1::starcoder
fireworks::v1::deepseek-coder-v2-lite-base
google::v1::gemini-1.5-pro
google::v1::gemini-1.5-flash
openai::2024-02-01::gpt-4o
openai::2024-02-01::cody-chat-preview-001
openai::2024-02-01::cody-chat-preview-002
```
<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
