### PR TITLE
Chat: Display 'other' model category

### DIFF
--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/agent/protocol_generated/Constants.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/agent/protocol_generated/Constants.kt
@@ -61,6 +61,7 @@ object Constants {
   const val ollama = "ollama"
   const val `on-waitlist` = "on-waitlist"
   const val openctx = "openctx"
+  const val other = "other"
   const val power = "power"
   const val pro = "pro"
   const val `recently-used` = "recently used"

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/agent/protocol_generated/ModelTag.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/agent/protocol_generated/ModelTag.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
 package com.sourcegraph.cody.agent.protocol_generated;
 
-typealias ModelTag = String // One of: power, speed, balanced, recommended, deprecated, experimental, waitlist, on-waitlist, early-access, internal, pro, free, enterprise, gateway, byok, local, ollama, dev, stream-disabled, vision
+typealias ModelTag = String // One of: power, speed, balanced, other, recommended, deprecated, experimental, waitlist, on-waitlist, early-access, internal, pro, free, enterprise, gateway, byok, local, ollama, dev, stream-disabled, vision
 

--- a/lib/shared/src/models/dotcom.ts
+++ b/lib/shared/src/models/dotcom.ts
@@ -49,7 +49,7 @@ const MOCKED_SERVER_MODELS_CONFIG = {
             displayName: 'Claude 3 Opus',
             modelName: 'claude-3-opus-20240229',
             capabilities: ['edit', 'chat'],
-            category: 'other',
+            category: 'other' as ModelTag.Other,
             status: 'stable',
             tier: 'pro' as ModelTag.Pro,
             contextWindow: {

--- a/lib/shared/src/models/model.ts
+++ b/lib/shared/src/models/model.ts
@@ -235,8 +235,6 @@ export function getServerModelTags(
     }
     if (category === 'accuracy') {
         tags.push(ModelTag.Power)
-    } else if (category === 'other') {
-        tags.push(ModelTag.Balanced)
     } else {
         tags.push(category)
     }

--- a/lib/shared/src/models/modelsService.test.ts
+++ b/lib/shared/src/models/modelsService.test.ts
@@ -305,4 +305,109 @@ describe('modelsService', () => {
             expect(await firstValueFrom(modelsService.isModelAvailable(proModel.id))).toBe(true)
         })
     })
+
+    describe('ModelCategory', () => {
+        it('includes ModelTag.Other', () => {
+            const otherModel = createModel({
+                id: 'other-model',
+                usage: [ModelUsage.Chat],
+                tags: [ModelTag.Other],
+            })
+
+            const modelsService = modelsServiceWithModels([otherModel])
+
+            vi.spyOn(modelsService, 'modelsChanges', 'get').mockReturnValue(
+                Observable.of({
+                    ...EMPTY_MODELS_DATA,
+                    primaryModels: [otherModel],
+                })
+            )
+
+            expect(otherModel.tags).toContain(ModelTag.Other)
+            expect(modelsService.models).toContain(otherModel)
+        })
+
+        it('correctly categorizes models with different tags', () => {
+            const powerModel = createModel({
+                id: 'power-model',
+                usage: [ModelUsage.Chat],
+                tags: [ModelTag.Power],
+            })
+            const balancedModel = createModel({
+                id: 'balanced-model',
+                usage: [ModelUsage.Chat],
+                tags: [ModelTag.Balanced],
+            })
+            const speedModel = createModel({
+                id: 'speed-model',
+                usage: [ModelUsage.Chat],
+                tags: [ModelTag.Speed],
+            })
+            const accuracyModel = createModel({
+                id: 'accuracy-model',
+                usage: [ModelUsage.Chat],
+                tags: ['accuracy' as ModelTag],
+            })
+
+            const modelsService = modelsServiceWithModels([
+                powerModel,
+                balancedModel,
+                speedModel,
+                accuracyModel,
+            ])
+
+            vi.spyOn(modelsService, 'modelsChanges', 'get').mockReturnValue(
+                Observable.of({
+                    ...EMPTY_MODELS_DATA,
+                    primaryModels: [powerModel, balancedModel, speedModel, accuracyModel],
+                })
+            )
+
+            expect(modelsService.models).toContain(powerModel)
+            expect(modelsService.models).toContain(balancedModel)
+            expect(modelsService.models).toContain(speedModel)
+            expect(modelsService.models).toContain(accuracyModel)
+        })
+
+        it('handles models with multiple category tags', () => {
+            const multiCategoryModel = createModel({
+                id: 'multi-category-model',
+                usage: [ModelUsage.Chat],
+                tags: [ModelTag.Power, ModelTag.Balanced],
+            })
+
+            const modelsService = modelsServiceWithModels([multiCategoryModel])
+
+            vi.spyOn(modelsService, 'modelsChanges', 'get').mockReturnValue(
+                Observable.of({
+                    ...EMPTY_MODELS_DATA,
+                    primaryModels: [multiCategoryModel],
+                })
+            )
+
+            expect(multiCategoryModel.tags).toContain(ModelTag.Power)
+            expect(multiCategoryModel.tags).toContain(ModelTag.Balanced)
+            expect(modelsService.models).toContain(multiCategoryModel)
+        })
+
+        it('correctly handles models without category tags', () => {
+            const uncategorizedModel = createModel({
+                id: 'uncategorized-model',
+                usage: [ModelUsage.Chat],
+                tags: [],
+            })
+
+            const modelsService = modelsServiceWithModels([uncategorizedModel])
+
+            vi.spyOn(modelsService, 'modelsChanges', 'get').mockReturnValue(
+                Observable.of({
+                    ...EMPTY_MODELS_DATA,
+                    primaryModels: [uncategorizedModel],
+                })
+            )
+
+            expect(uncategorizedModel.tags).toHaveLength(0)
+            expect(modelsService.models).toContain(uncategorizedModel)
+        })
+    })
 })

--- a/lib/shared/src/models/modelsService.ts
+++ b/lib/shared/src/models/modelsService.ts
@@ -43,7 +43,12 @@ export interface ModelRef {
     modelId: ModelId
 }
 
-export type ModelCategory = ModelTag.Power | ModelTag.Balanced | ModelTag.Speed | 'accuracy' | 'other'
+export type ModelCategory =
+    | ModelTag.Power
+    | ModelTag.Balanced
+    | ModelTag.Speed
+    | 'accuracy'
+    | ModelTag.Other
 export type ModelStatus =
     | ModelTag.Experimental
     | ModelTag.EarlyAccess

--- a/lib/shared/src/models/tags.ts
+++ b/lib/shared/src/models/tags.ts
@@ -8,6 +8,7 @@ export enum ModelTag {
     Power = 'power',
     Speed = 'speed',
     Balanced = 'balanced',
+    Other = 'other',
 
     // Statuses
     Recommended = 'recommended',


### PR DESCRIPTION
CLOSE : https://linear.app/sourcegraph/issue/CODY-4059/opus-should-be-listed-under-othe

The issue: When processing the Opus model, which had a category of 'other', the getServerModelTags function was adding the ModelTag.Balanced tag to it. This is why it was showing up under the "Balanced" category in the UI.

The fix:  This change adds a new 'other' model category to the ModelTag enum and updates the related model service and configuration code to handle this new category. This change allows the 'other' category to be directly used without being converted to 'Balanced'.

The changes include:
- Adding 'other' as a new ModelTag enum value
- Updating the ModelCategory type to include 'other'
- Updating the getServerModelTags function to handle the 'other' category
- Updating the mocked server models config to use the 'other' category for the 'Claude 3 Opus' model

This change allows for more flexibility in categorizing models that don't fit into the existing 'power', 'balanced', or 'speed' categories.

## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

Added new unit tests for covering the model category.

Manual Test Plan:

Open the model drop down list to confirm Opus is listed under Other:

![image](https://github.com/user-attachments/assets/4b8d2473-78ec-48f5-8547-218a1038d93a)

Before:

![image](https://github.com/user-attachments/assets/a2b5ae65-beaa-4898-97ed-959a03cdfa02)


## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
