### PR TITLE
Remove client-side query rewriting in ContextRetriever

### DIFF
--- a/vscode/src/chat/chat-view/ContextRetriever.test.ts
+++ b/vscode/src/chat/chat-view/ContextRetriever.test.ts
@@ -1,0 +1,220 @@
+import { type ContextItem, type Result, ps } from '@sourcegraph/cody-shared'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import * as vscode from 'vscode'
+import type { VSCodeEditor } from '../../editor/vscode-editor'
+import type { SymfRunner } from '../../local-context/symf'
+import { ContextRetriever, type Root, toStructuredMentions } from './ContextRetriever'
+
+describe('ContextRetriever', () => {
+    let contextRetriever: ContextRetriever
+    let mockEditor: VSCodeEditor
+    let mockSymf: SymfRunner
+
+    beforeEach(() => {
+        mockEditor = {
+            getTextEditorContentForFile: vi.fn(),
+        } as unknown as VSCodeEditor
+
+        mockSymf = {
+            getLiveResults: vi.fn(),
+            dispose: vi.fn(),
+        } as unknown as SymfRunner
+
+        contextRetriever = new ContextRetriever(mockEditor, mockSymf)
+    })
+
+    afterEach(() => {
+        vi.resetAllMocks()
+    })
+
+    describe('retrieveContext', () => {
+        it('retrieves context from mentions', async () => {
+            const mentions = [
+                { type: 'repository', repoName: 'test/repo', repoID: 'repo1' },
+            ] as ContextItem[]
+            const inputText = ps`Test query`
+            const mockSpan = {} as any
+
+            vi.spyOn(contextRetriever as any, '_retrieveContext').mockResolvedValue([
+                { type: 'file', content: 'Test content', uri: vscode.Uri.file('/test/file.ts') },
+            ])
+
+            const structuredMentions = toStructuredMentions(mentions)
+            const result = await contextRetriever.retrieveContext(
+                structuredMentions,
+                inputText,
+                mockSpan
+            )
+
+            expect(result).toHaveLength(1)
+            expect(result[0]).toEqual({
+                type: 'file',
+                content: 'Test content',
+                uri: vscode.Uri.file('/test/file.ts'),
+            })
+        })
+    })
+
+    describe('_retrieveContext', () => {
+        it('retrieves context from local and remote sources', async () => {
+            const roots: Root[] = [
+                {
+                    local: vscode.Uri.file('/local/repo'),
+                    remoteRepos: [{ name: 'test/repo', id: 'repo1' }],
+                },
+            ]
+            const query = ps`Test query`
+            const mockSpan = {} as any
+
+            vi.spyOn(contextRetriever as any, 'retrieveLiveContext').mockResolvedValue([
+                { type: 'file', content: 'Live content', uri: vscode.Uri.file('/local/repo/file.ts') },
+            ])
+            vi.spyOn(contextRetriever as any, 'retrieveIndexedContext').mockResolvedValue([
+                {
+                    type: 'file',
+                    content: 'Indexed content',
+                    uri: vscode.Uri.parse('https://example.com/file.ts'),
+                },
+            ])
+
+            const result = await (contextRetriever as any)._retrieveContext(roots, query, mockSpan)
+
+            expect(result).toHaveLength(2)
+            expect(result[0]).toEqual({
+                type: 'file',
+                content: 'Live content',
+                uri: vscode.Uri.file('/local/repo/file.ts'),
+            })
+            expect(result[1]).toEqual({
+                type: 'file',
+                content: 'Indexed content',
+                uri: vscode.Uri.parse('https://example.com/file.ts'),
+            })
+        })
+    })
+
+    describe('retrieveLiveContext', () => {
+        it('calls getLiveResults with the original query', async () => {
+            const originalQuery = ps`Test query`
+            const files = ['/local/repo/file.ts']
+
+            vi.spyOn(mockSymf, 'getLiveResults').mockResolvedValue([])
+
+            await (contextRetriever as any).retrieveLiveContext(originalQuery, files)
+
+            expect(mockSymf.getLiveResults).toHaveBeenCalledWith(originalQuery, files, undefined)
+        })
+
+        it('retrieves live context using symf', async () => {
+            const originalQuery = ps`Test query`
+            const files = ['/local/repo/file.ts']
+
+            vi.spyOn(mockSymf, 'getLiveResults').mockResolvedValue([
+                {
+                    file: vscode.Uri.file('/local/repo/file.ts'),
+                    range: {
+                        startByte: 0,
+                        endByte: 0,
+                        startPoint: { row: 0, col: 0 },
+                        endPoint: { row: 5, col: 10 },
+                    },
+                },
+            ] as Result[])
+
+            vi.spyOn(mockEditor, 'getTextEditorContentForFile').mockResolvedValue('Test content')
+
+            const result = await (contextRetriever as any).retrieveLiveContext(originalQuery, files)
+
+            expect(result).toHaveLength(1)
+            expect(result[0]).toEqual({
+                type: 'file',
+                uri: vscode.Uri.file('/local/repo/file.ts'),
+                range: new vscode.Range(0, 0, 5, 10),
+                source: 'search',
+                content: 'Test content',
+                metadata: ['source:symf-live'],
+            })
+        })
+    })
+
+    describe('retrieveIndexedContext', () => {
+        it('calls retrieveIndexedContextFromRemote with the original query', async () => {
+            const roots: Root[] = [
+                {
+                    remoteRepos: [{ name: 'test/repo', id: 'repo1' }],
+                },
+            ]
+            const originalQuery = ps`Test query`
+            const mockSpan = {} as any
+
+            const spy = vi
+                .spyOn(contextRetriever as any, 'retrieveIndexedContextFromRemote')
+                .mockResolvedValue([])
+            vi.spyOn(contextRetriever as any, 'retrieveIndexedContextLocally').mockResolvedValue([])
+
+            await (contextRetriever as any).retrieveIndexedContext(roots, originalQuery, mockSpan)
+
+            expect(spy).toHaveBeenCalledWith(['repo1'], originalQuery.toString(), undefined)
+        })
+
+        it('calls retrieveIndexedContextLocally with the original query', async () => {
+            const roots: Root[] = [
+                {
+                    local: vscode.Uri.file('/local/repo'),
+                    remoteRepos: [],
+                },
+            ]
+            const originalQuery = ps`Test query`
+            const mockSpan = {} as any
+
+            vi.spyOn(contextRetriever as any, 'retrieveIndexedContextFromRemote').mockResolvedValue([])
+            const spy = vi
+                .spyOn(contextRetriever as any, 'retrieveIndexedContextLocally')
+                .mockResolvedValue([])
+
+            await (contextRetriever as any).retrieveIndexedContext(roots, originalQuery, mockSpan)
+
+            expect(spy).toBeCalled()
+        })
+
+        it('retrieves indexed context from remote and local sources', async () => {
+            const roots: Root[] = [
+                {
+                    local: vscode.Uri.file('/local/repo'),
+                    remoteRepos: [{ name: 'test/repo', id: 'repo1' }],
+                },
+            ]
+            const originalQuery = ps`Test query`
+            const mockSpan = {} as any
+
+            vi.spyOn(contextRetriever as any, 'retrieveIndexedContextFromRemote').mockResolvedValue([
+                {
+                    type: 'file',
+                    content: 'Remote content',
+                    uri: vscode.Uri.parse('https://example.com/file.ts'),
+                },
+            ])
+            vi.spyOn(contextRetriever as any, 'retrieveIndexedContextLocally').mockResolvedValue([
+                { type: 'file', content: 'Local content', uri: vscode.Uri.file('/local/repo/file.ts') },
+            ])
+
+            const result = await (contextRetriever as any).retrieveIndexedContext(
+                roots,
+                originalQuery,
+                mockSpan
+            )
+
+            expect(result).toHaveLength(2)
+            expect(result[0]).toEqual({
+                type: 'file',
+                content: 'Remote content',
+                uri: vscode.Uri.parse('https://example.com/file.ts'),
+            })
+            expect(result[1]).toEqual({
+                type: 'file',
+                content: 'Local content',
+                uri: vscode.Uri.file('/local/repo/file.ts'),
+            })
+        })
+    })
+})

--- a/vscode/src/chat/chat-view/ContextRetriever.test.ts
+++ b/vscode/src/chat/chat-view/ContextRetriever.test.ts
@@ -95,18 +95,18 @@ describe('ContextRetriever', () => {
 
     describe('retrieveLiveContext', () => {
         it('calls getLiveResults with the original query', async () => {
-            const originalQuery = ps`Test query`
+            const query = ps`Test query`
             const files = ['/local/repo/file.ts']
 
             vi.spyOn(mockSymf, 'getLiveResults').mockResolvedValue([])
 
-            await (contextRetriever as any).retrieveLiveContext(originalQuery, files)
+            await (contextRetriever as any).retrieveLiveContext(query, files)
 
-            expect(mockSymf.getLiveResults).toHaveBeenCalledWith(originalQuery, files, undefined)
+            expect(mockSymf.getLiveResults).toHaveBeenCalledWith(query, files, undefined)
         })
 
         it('retrieves live context using symf', async () => {
-            const originalQuery = ps`Test query`
+            const query = ps`Test query`
             const files = ['/local/repo/file.ts']
 
             vi.spyOn(mockSymf, 'getLiveResults').mockResolvedValue([
@@ -123,7 +123,7 @@ describe('ContextRetriever', () => {
 
             vi.spyOn(mockEditor, 'getTextEditorContentForFile').mockResolvedValue('Test content')
 
-            const result = await (contextRetriever as any).retrieveLiveContext(originalQuery, files)
+            const result = await (contextRetriever as any).retrieveLiveContext(query, files)
 
             expect(result).toHaveLength(1)
             expect(result[0]).toEqual({
@@ -144,7 +144,7 @@ describe('ContextRetriever', () => {
                     remoteRepos: [{ name: 'test/repo', id: 'repo1' }],
                 },
             ]
-            const originalQuery = ps`Test query`
+            const query = ps`Test query`
             const mockSpan = {} as any
 
             const spy = vi
@@ -152,9 +152,9 @@ describe('ContextRetriever', () => {
                 .mockResolvedValue([])
             vi.spyOn(contextRetriever as any, 'retrieveIndexedContextLocally').mockResolvedValue([])
 
-            await (contextRetriever as any).retrieveIndexedContext(roots, originalQuery, mockSpan)
+            await (contextRetriever as any).retrieveIndexedContext(roots, query, mockSpan)
 
-            expect(spy).toHaveBeenCalledWith(['repo1'], originalQuery.toString(), undefined)
+            expect(spy).toHaveBeenCalledWith(['repo1'], query.toString(), undefined)
         })
 
         it('calls retrieveIndexedContextLocally with the original query', async () => {
@@ -164,7 +164,7 @@ describe('ContextRetriever', () => {
                     remoteRepos: [],
                 },
             ]
-            const originalQuery = ps`Test query`
+            const query = ps`Test query`
             const mockSpan = {} as any
 
             vi.spyOn(contextRetriever as any, 'retrieveIndexedContextFromRemote').mockResolvedValue([])
@@ -172,7 +172,7 @@ describe('ContextRetriever', () => {
                 .spyOn(contextRetriever as any, 'retrieveIndexedContextLocally')
                 .mockResolvedValue([])
 
-            await (contextRetriever as any).retrieveIndexedContext(roots, originalQuery, mockSpan)
+            await (contextRetriever as any).retrieveIndexedContext(roots, query, mockSpan)
 
             expect(spy).toBeCalled()
         })
@@ -184,7 +184,7 @@ describe('ContextRetriever', () => {
                     remoteRepos: [{ name: 'test/repo', id: 'repo1' }],
                 },
             ]
-            const originalQuery = ps`Test query`
+            const query = ps`Test query`
             const mockSpan = {} as any
 
             vi.spyOn(contextRetriever as any, 'retrieveIndexedContextFromRemote').mockResolvedValue([
@@ -198,11 +198,7 @@ describe('ContextRetriever', () => {
                 { type: 'file', content: 'Local content', uri: vscode.Uri.file('/local/repo/file.ts') },
             ])
 
-            const result = await (contextRetriever as any).retrieveIndexedContext(
-                roots,
-                originalQuery,
-                mockSpan
-            )
+            const result = await (contextRetriever as any).retrieveIndexedContext(roots, query, mockSpan)
 
             expect(result).toHaveLength(2)
             expect(result[0]).toEqual({

--- a/vscode/src/chat/chat-view/ContextRetriever.ts
+++ b/vscode/src/chat/chat-view/ContextRetriever.ts
@@ -220,7 +220,7 @@ export class ContextRetriever implements vscode.Disposable {
     }
 
     private async retrieveLiveContext(
-        originalQuery: PromptString,
+        query: PromptString,
         files: string[],
         signal?: AbortSignal
     ): Promise<ContextItem[]> {
@@ -231,7 +231,7 @@ export class ContextRetriever implements vscode.Disposable {
             logDebug('ContextRetriever', 'symf not available, skipping live context')
             return []
         }
-        const results = await this.symf.getLiveResults(originalQuery, files, signal)
+        const results = await this.symf.getLiveResults(query, files, signal)
         return (
             await Promise.all(
                 results.map(async (r): Promise<ContextItem | ContextItem[]> => {
@@ -265,7 +265,7 @@ export class ContextRetriever implements vscode.Disposable {
 
     private async retrieveIndexedContext(
         roots: Root[],
-        originalQuery: PromptString,
+        query: PromptString,
         span: Span,
         signal?: AbortSignal
     ): Promise<ContextItem[]> {
@@ -316,12 +316,12 @@ export class ContextRetriever implements vscode.Disposable {
 
         const remoteResultsPromise = this.retrieveIndexedContextFromRemote(
             [...repoIDsOnRemote],
-            originalQuery.toString(),
+            query.toString(),
             signal
         )
         const localResultsPromise = this.retrieveIndexedContextLocally(
             [...localRootURIs.values()],
-            originalQuery,
+            query,
             span
         )
 
@@ -355,7 +355,7 @@ export class ContextRetriever implements vscode.Disposable {
 
     private async retrieveIndexedContextLocally(
         localRootURIs: vscode.Uri[],
-        originalQuery: PromptString,
+        query: PromptString,
         span: Span
     ): Promise<ContextItem[]> {
         if (localRootURIs.length === 0) {
@@ -369,7 +369,7 @@ export class ContextRetriever implements vscode.Disposable {
                       // TODO(beyang): retire searchSymf and retrieveContextGracefully
                       // (see invocation of symf in retrieveLiveContext)
                       retrieveContextGracefully(
-                          searchSymf(symf, this.editor, rootURI, originalQuery),
+                          searchSymf(symf, this.editor, rootURI, query),
                           `symf ${rootURI.path}`
                       )
                   )

--- a/vscode/src/local-context/symf.ts
+++ b/vscode/src/local-context/symf.ts
@@ -140,10 +140,10 @@ export class SymfRunner implements vscode.Disposable {
 
     public async getLiveResults(
         userQuery: PromptString,
-        keywordQuery: string,
         files: string[],
         signal?: AbortSignal
     ): Promise<Result[]> {
+        const keywordQuery = userQuery.toString()
         const symfPath = await this.mustSymfPath()
         const args = [
             'live-query',

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -197,7 +197,6 @@ const register = async (
     // Initialize external services
     const {
         chatClient,
-        completionsClient,
         guardrails,
         symfRunner,
         chatIntentAPIClient,
@@ -206,7 +205,7 @@ const register = async (
     disposables.push({ dispose: disposeExternalServices })
 
     const editor = new VSCodeEditor()
-    const contextRetriever = new ContextRetriever(editor, symfRunner, completionsClient)
+    const contextRetriever = new ContextRetriever(editor, symfRunner)
 
     const { chatsController } = registerChat(
         {


### PR DESCRIPTION
Previously, the `ContextRetriever` class was using a `rewriteKeywordQuery` function to modify the original query before sending it to the server for indexed context retrieval. This client-side query rewriting is now redundant.

This PR removes the client-side query rewriting in the `ContextRetriever` class. The changes include:

1. Removing the `rewriteKeywordQuery` function call from the `ContextRetriever` class.
2. Passing the original query directly to the server for indexed context retrieval.
3. Updating the `SymfRunner` class to use the original query for live results.
4. Updating tests to reflect these changes and ensure the original query is used throughout the retrieval process.
5. Updated and added tests in `ContextRetriever.test.ts` to verify the correct usage of the original query.

The server-side now handles query rewriting for remote searches, making the client-side rewriting unnecessary. This change simplifies the client-side code, removes the needs of rewriting the search query repeatedly.

symf is still using the `rewriteKeywordQuery` function in the getResults method.

## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

- Updated existing unit tests to reflect the new behavior.
- Added new tests to ensure the original query is used in all relevant methods.
- Manually tested to confirm that context retrieval still functions correctly with these changes.

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
