### PR TITLE
Agent: fix avatar in account tab

### DIFF
--- a/vscode/webviews/tabs/AccountTab.story.tsx
+++ b/vscode/webviews/tabs/AccountTab.story.tsx
@@ -1,0 +1,104 @@
+import {
+    type AuthenticatedAuthStatus,
+    type ClientCapabilitiesWithLegacyFields,
+    CodyIDE,
+} from '@sourcegraph/cody-shared'
+import type { Meta, StoryObj } from '@storybook/react'
+import type { ConfigurationSubsetForWebview, LocalEnv } from '../../src/chat/protocol'
+import { VSCodeStandaloneComponent } from '../storybook/VSCodeStoryDecorator'
+import { ConfigProvider } from '../utils/useConfig'
+import { AccountTab } from './AccountTab'
+
+const meta: Meta<typeof AccountTab> = {
+    title: 'cody/AccountTab',
+    component: AccountTab,
+    decorators: [
+        story => <div style={{ maxWidth: '700px', margin: '2rem' }}>{story()}</div>,
+        VSCodeStandaloneComponent,
+    ],
+    args: {
+        setView: () => {
+            console.log('setView called')
+        },
+    },
+}
+
+export default meta
+
+type Story = StoryObj<typeof AccountTab>
+
+const createMockConfig = (overrides = {}) => ({
+    config: {
+        smartApply: false,
+        experimentalNoodle: false,
+        serverEndpoint: 'https://sourcegraph.com',
+        uiKindIsWeb: false,
+    } as ConfigurationSubsetForWebview & LocalEnv,
+    clientCapabilities: {
+        isVSCode: false,
+        agentIDE: CodyIDE.VSCode,
+    } as ClientCapabilitiesWithLegacyFields,
+    authStatus: {
+        authenticated: true,
+        endpoint: 'https://sourcegraph.com',
+        username: 'testuser',
+        displayName: 'Test User',
+        pendingValidation: false,
+        hasVerifiedEmail: true,
+        requiresVerifiedEmail: false,
+    } as AuthenticatedAuthStatus,
+    isDotComUser: true,
+    userProductSubscription: null,
+    configFeatures: {
+        chat: true,
+        attribution: true,
+        serverSentModels: true,
+    },
+    ...overrides,
+})
+
+export const CodyProUser: Story = {
+    render: args => (
+        <ConfigProvider
+            value={createMockConfig({
+                userProductSubscription: { plan: 'PRO' },
+            })}
+        >
+            <AccountTab {...args} />
+        </ConfigProvider>
+    ),
+}
+
+export const CodyFreeUser: Story = {
+    render: args => (
+        <ConfigProvider
+            value={createMockConfig({
+                userProductSubscription: undefined,
+            })}
+        >
+            <AccountTab {...args} />
+        </ConfigProvider>
+    ),
+}
+
+export const EnterpriseUser: Story = {
+    render: args => (
+        <ConfigProvider
+            value={createMockConfig({
+                isDotComUser: false,
+                authStatus: {
+                    authenticated: true,
+                    endpoint: 'https://sourcegraph.company.com',
+                    username: 'enterpriseuser',
+                    displayName: 'Enterprise User',
+                    primaryEmail: 'enterprise@company.com',
+                    pendingValidation: false,
+                    hasVerifiedEmail: true,
+                    requiresVerifiedEmail: false,
+                } as AuthenticatedAuthStatus,
+            })}
+        >
+            <AccountTab {...args} />
+        </ConfigProvider>
+    ),
+}

--- a/vscode/webviews/tabs/AccountTab.tsx
+++ b/vscode/webviews/tabs/AccountTab.tsx
@@ -85,7 +85,7 @@ export const AccountTab: React.FC<AccountTabProps> = ({ setView }) => {
                             size={30}
                             className="tw-flex-shrink-0 tw-w-[30px] tw-h-[30px] tw-flex tw-items-center tw-justify-center"
                         />
-                        <div className="tw-mt-4">
+                        <div className="tw-flex tw-self-stretch tw-flex-col tw-w-full tw-items-center tw-justify-center tw-mt-4">
                             <p className="tw-text-lg tw-font-semibold">{displayName ?? username}</p>
                             <p className="tw-text-sm tw-text-muted-foreground">{primaryEmail}</p>
                         </div>

--- a/vscode/webviews/tabs/AccountTab.tsx
+++ b/vscode/webviews/tabs/AccountTab.tsx
@@ -2,7 +2,6 @@ import { CodyIDE } from '@sourcegraph/cody-shared'
 import { useCallback } from 'react'
 import { URI } from 'vscode-uri'
 import { ACCOUNT_UPGRADE_URL, ACCOUNT_USAGE_URL } from '../../src/chat/protocol'
-import { MESSAGE_CELL_AVATAR_SIZE } from '../chat/cells/messageCell/BaseMessageCell'
 import { UserAvatar } from '../components/UserAvatar'
 import { Button } from '../components/shadcn/ui/button'
 import { getVSCodeAPI } from '../utils/VSCodeApi'
@@ -80,9 +79,13 @@ export const AccountTab: React.FC<AccountTabProps> = ({ setView }) => {
             <h2>Account</h2>
             <div className="tw-w-full tw-px-8 tw-py-4 tw-flex tw-flex-col tw-gap-4 tw-bg-popover tw-border tw-border-border tw-rounded-lg">
                 <div className="tw-flex tw-justify-between tw-w-full tw-border-b tw-border-border tw-shadow-lg tw-shadow-border-500/50 tw-p-4 tw-pb-6">
-                    <div className="tw-flex tw-self-stretch">
-                        <UserAvatar user={user} size={MESSAGE_CELL_AVATAR_SIZE} />
-                        <div className="tw-ml-4">
+                    <div className="tw-flex tw-self-stretch tw-flex-col tw-w-full tw-items-center tw-justify-center">
+                        <UserAvatar
+                            user={user}
+                            size={30}
+                            className="tw-flex-shrink-0 tw-w-[30px] tw-h-[30px] tw-flex tw-items-center tw-justify-center"
+                        />
+                        <div className="tw-mt-4">
                             <p className="tw-text-lg tw-font-semibold">{displayName ?? username}</p>
                             <p className="tw-text-sm tw-text-muted-foreground">{primaryEmail}</p>
                         </div>
@@ -94,7 +97,11 @@ export const AccountTab: React.FC<AccountTabProps> = ({ setView }) => {
                         {isDotComUser ? (isCodyProUser ? 'Cody Pro' : 'Cody Free') : 'Enterprise'}
                     </div>
                     <div>Endpoint:</div>
-                    <div className="tw-text-muted-foreground tw-col-span-4">{endpoint}</div>
+                    <div className="tw-text-muted-foreground tw-col-span-4">
+                        <a href={endpoint} target="_blank" rel="noreferrer">
+                            {endpoint}
+                        </a>
+                    </div>
                 </div>
             </div>
             {actions.map(a => (


### PR DESCRIPTION
https://linear.app/sourcegraph/issue/CODY-4066/avatar-is-not-scaled-correctly-on-agent-account-page

Chat: update account tab UI

- Adjust user avatar size and position
- Add link to account endpoint URL

NOTE: The account tab is currently used by non-VS Code IDE clients only.

### Storybook

![image](https://github.com/user-attachments/assets/c75e84cd-8ab0-4c59-a4f9-daf5c46a613f)

## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

Starts Cody with this branch in Visual Studio / JetBrains / Eclipse, or run the storybook to verify the user avatar in the account tab is showing up nicely:

![image](https://github.com/user-attachments/assets/0dacd739-fac1-4daf-a168-e5801609acea)



### Before:

![image](https://github.com/user-attachments/assets/387f0b8b-b69b-4038-b350-5122599bf6c4)


## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
