### PR TITLE
update changelog link in release note automation

### DIFF
--- a/vscode/scripts/github-changelog.ts
+++ b/vscode/scripts/github-changelog.ts
@@ -4,7 +4,7 @@
  *
  * Example:
  *
- * ✨ See the [What’s new in v0.18](https://about.sourcegraph.com/blog/cody-vscode-0-18-release) blog post for what’s new in this release since v0.16 ✨
+ * ✨ See the [What’s new in v0.18](https://sourcegraph.com/changelog?topics=VS+Code) changelog for what’s new in this release since v0.16 ✨
  *
  * ## v0.18.6 Changes
  *
@@ -119,10 +119,7 @@ async function main(): Promise<void> {
     const previousMinor = extractPreviousMinor(minor)
 
     const intro = dedent`
-        ✨ See the [What’s new in v${minor}](https://about.sourcegraph.com/blog/cody-vscode-${minor.replaceAll(
-            '.',
-            '-'
-        )}-0-release) blog post for what’s new in this release since v${previousMinor} ✨
+        ✨ See the [What’s new in v${minor}](https://sourcegraph.com/changelog?topics=VS+Code) blog post for what’s new in this release since v${previousMinor} ✨
 
         ## v${currentVersion} Changes
     `

--- a/vscode/scripts/github-changelog.ts
+++ b/vscode/scripts/github-changelog.ts
@@ -119,7 +119,7 @@ async function main(): Promise<void> {
     const previousMinor = extractPreviousMinor(minor)
 
     const intro = dedent`
-        ✨ See the [What’s new in v${minor}](https://sourcegraph.com/changelog?topics=VS+Code) blog post for what’s new in this release since v${previousMinor} ✨
+        ✨ See the [What’s new in v${minor}](https://sourcegraph.com/changelog?topics=VS+Code) changelog for what’s new in this release since v${previousMinor} ✨
 
         ## v${currentVersion} Changes
     `


### PR DESCRIPTION
updating release notes to include sourcegraph public changelog link instead of previous blog entries

## Test plan
N/A

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
