### PR TITLE
Networking: Fix leftover PR comments

### DIFF
--- a/lib/shared/src/configuration/environment.ts
+++ b/lib/shared/src/configuration/environment.ts
@@ -21,10 +21,10 @@ import type { UIKind } from 'vscode' // types are ok
 
 export const cenv = defineEnvBuilder({
     /**
-     * A combination of HTTP_PROXY, HTTPS_PROXY and NO_PROXY environment
-     * variables for easier consumption.
+     * A proxy string that falls back to Node's HTTP_PROXY and HTTPS_PROXY if
+     * not explicitly configured (or disabled with 'false').
      */
-    CODY_NODE_DEFAULT_PROXY: codyProxy,
+    CODY_NODE_DEFAULT_PROXY: proxyStringWithNodeFallback,
 
     /**
      * Enables unstable internal testing configuration to be read from settings.json
@@ -161,13 +161,14 @@ function uiKind(uiKind: string | undefined): UIKind | undefined {
     }
 }
 
-function codyProxy(envValue: string | undefined): string | undefined {
-    switch (bool(envValue)) {
-        case false:
-            // explicitly disabled
-            return undefined
-        default:
-            break
+/**
+ * If explicitly set to false no proxy value is returned. Or returns the string
+ * value set otherwise. If no explicit value is set value defaults to the
+ * default HTTPS_PROXY or HTTP_PROXY values (in that order).
+ */
+function proxyStringWithNodeFallback(envValue: string | undefined): string | undefined {
+    if (bool(envValue) === false) {
+        return undefined
     }
 
     const forcedProxy = str(envValue)

--- a/vscode/src/net/net.patch.ts
+++ b/vscode/src/net/net.patch.ts
@@ -1,4 +1,4 @@
-// 🚨 This patch file mast have NO additional dependencies as import order
+// 🚨 This patch file must have NO additional dependencies as import order
 // changes might cause modules to load before the networking is patched.
 import EventEmitter from 'node:events'
 import type * as http from 'node:http'
@@ -11,8 +11,6 @@ import type * as internalVSCodeAgent from './vscode-network-proxy'
 export const bypassVSCodeSymbol = Symbol('bypassVSCodeSymbol')
 let patched = false
 patchNetworkStack()
-// This needs to happen after so that we don't break import order
-globalAgentRef.blockEarlyAccess = true
 
 function patchNetworkStack(): void {
     if (patched) {


### PR DESCRIPTION
There were a few leftover undressed/reverted PR comments on https://github.com/sourcegraph/cody/pull/5883

Now we:

- No longer throw an exception on early agent access. The previous exception was only used during debugging of an import order issue.
- Fixed mentioned function comments / typos

## Test plan
- No functionality should have changed, existing tests pass.