### PR TITLE
Add setContext notification for cody.serverEndpoint

### DIFF
--- a/vscode/src/services/AuthProvider.ts
+++ b/vscode/src/services/AuthProvider.ts
@@ -16,7 +16,6 @@ import {
     clientCapabilities as getClientCapabilities,
     isAbortError,
     normalizeServerEndpointURL,
-    pluck,
     resolvedConfig as resolvedConfig_,
     setAuthStatusObservable as setAuthStatusObservable_,
     startWith,
@@ -111,9 +110,18 @@ class AuthProvider implements vscode.Disposable {
 
         // Keep context updated with auth status.
         this.subscriptions.push(
-            authStatus.pipe(pluck('authenticated')).subscribe(authenticated => {
+            authStatus.subscribe(authStatus => {
                 try {
-                    vscode.commands.executeCommand('setContext', 'cody.activated', authenticated)
+                    vscode.commands.executeCommand(
+                        'setContext',
+                        'cody.activated',
+                        authStatus.authenticated
+                    )
+                    vscode.commands.executeCommand(
+                        'setContext',
+                        'cody.serverEndpoint',
+                        authStatus.endpoint
+                    )
                 } catch {}
             })
         )

--- a/vscode/src/services/AuthProvider.ts
+++ b/vscode/src/services/AuthProvider.ts
@@ -122,7 +122,9 @@ class AuthProvider implements vscode.Disposable {
                         'cody.serverEndpoint',
                         authStatus.endpoint
                     )
-                } catch {}
+                } catch (error) {
+                    logError('AuthProvider', 'Unexpected error while setting context', error)
+                }
             })
         )
 


### PR DESCRIPTION
## Changes

I've added `cody.serverEndpoint` context variable, which on the clients side is received through `window/didChangeContext` notification.  We need it on the jetbrains side in few places, e.g. when we are checking if current account is a dotcom account.

I think it might be better idea to replace this with a dedicated endpoint, but I'm not sure if `cody.activated` is currently used anywhere?
@dominiccooney @sqs WDYT?



## Test plan

Full QA with https://github.com/sourcegraph/jetbrains/pull/2382/ is needed.
It does not change anything on the Cody side.