### PR TITLE
fix(webview): Skip webview copying for eclipse

### DIFF
--- a/agent/src/agent.ts
+++ b/agent/src/agent.ts
@@ -141,7 +141,12 @@ function copyExtensionRelativeResources(extensionPath: string, extensionClient: 
         }
     }
     copySources('win-ca-roots.exe')
-    if (extensionClient.capabilities?.webview === 'native') {
+    // Only copy the files if the client is using the native webview and they haven't opted
+    // to manage the resource files themselves.
+    if (
+        extensionClient.capabilities?.webview === 'native' &&
+        !extensionClient.capabilities?.webviewNativeConfig?.skipResourceRelativization
+    ) {
         copySources('webviews')
     }
 }

--- a/agent/src/cli/scip-codegen/emitters/JavaEmitter.ts
+++ b/agent/src/cli/scip-codegen/emitters/JavaEmitter.ts
@@ -9,7 +9,7 @@ import type { Codegen } from '../Codegen'
 import { Formatter, type LanguageOptions } from '../Formatter'
 import type { SymbolTable } from '../SymbolTable'
 import type { CodegenOptions } from '../command'
-import { TypescriptKeyword } from '../utils'
+import { TypescriptKeyword, capitalize } from '../utils'
 import type {
     DataClassOptions,
     Emitter,
@@ -122,8 +122,7 @@ export class JavaEmitter implements Emitter {
             p.line('public final class Date {}')
         } else if (info.display_name === 'Null') {
             p.line('public final class Null {}')
-        }
-        if (enum_) {
+        } else if (enum_) {
             this.emitEnum(p, enum_)
         } else {
             p.line(`public final class ${name} {} // TODO: fixme`)
@@ -260,7 +259,7 @@ export class JavaEmitter implements Emitter {
     }
 
     getFileNameForType(tpe: string): string {
-        return `${tpe}.${this.getFileType()}`
+        return `${capitalize(tpe)}.${this.getFileType()}`
     }
 
     getFileType(): string {


### PR DESCRIPTION
In the startup of the agent, we copy over the local webview assets into the cody data directory. This overwrites the template files that eclipse writes to that directory. The eclipse extension is packaged with the webview assets it's compiled with and manages serving those resources from it's own JAR. This change prevents any version mismatch issues that can occur from the double copy.

Also includes a small fix for Java code generation.

## Test plan
Manually tested with Eclipse that it resolved issues loading CSS