### PR TITLE
Update `cody.chat-question/executed` billingMetadata

### DIFF
--- a/lib/shared/src/telemetry-v2/events/chat-question.ts
+++ b/lib/shared/src/telemetry-v2/events/chat-question.ts
@@ -169,7 +169,7 @@ export const events = [
                     },
                     billingMetadata: {
                         product: 'cody',
-                        category: 'billable',
+                        category: 'core',
                     },
                 } as const
                 telemetryRecorder.recordEvent(feature, action, telemetryData)


### PR DESCRIPTION
This PR corrects the `billingMetadata` for the event `cody.chat-question/executed` to be `core`, as per our definition [here](https://www.notion.so/sourcegraph/V2-telemetry-product-and-category-documentation-b4f932118ea5421587e6e0a0d90d78e1?pvs=4#f29991216c834cbd92ccacb2d3f161d4).

## Test plan
E2E tests + locally
<img width="768" alt="image" src="https://github.com/user-attachments/assets/ee2600b7-5058-4092-b2ba-44c589897f93">


<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
