### PR TITLE
VS Code: log more data from characters logger

### DIFF
--- a/vscode/src/services/CharactersLogger.test.ts
+++ b/vscode/src/services/CharactersLogger.test.ts
@@ -14,7 +14,6 @@ import {
     LOG_INTERVAL,
     RAPID_CHANGE_TIMEOUT,
     SELECTION_TIMEOUT,
-    changeBoundaries,
 } from './CharactersLogger'
 
 const testDocument = document('foo')
@@ -24,15 +23,13 @@ describe('CharactersLogger', () => {
     let tracker: CharactersLogger
 
     let onDidChangeActiveTextEditor: (event: vscode.TextEditor | undefined) => void
-    let onDidChangeTextEditorVisibleRanges: (event: vscode.TextEditorVisibleRangesChangeEvent) => void
     let onDidChangeTextDocument: (event: vscode.TextDocumentChangeEvent) => void
     let onDidCloseTextDocument: (document: vscode.TextDocument) => void
     let onDidChangeWindowState: (state: vscode.WindowState) => void
-    let onDidChangeVisibleTextEditors: (editors: vscode.TextEditor[]) => void
     let onDidChangeTextEditorSelection: (event: vscode.TextEditorSelectionChangeEvent) => void
 
     let mockWindowState: Writable<vscode.WindowState>
-    let mockVisibleTextEditors: vscode.TextEditor[]
+    let mockActiveTextEditor: Writable<vscode.TextEditor> | undefined
     let mockTextEditorSelectionEvent: vscode.TextEditorSelectionChangeEvent
 
     beforeEach(() => {
@@ -41,7 +38,10 @@ describe('CharactersLogger', () => {
         recordSpy = vi.spyOn(telemetryRecorder, 'recordEvent')
 
         mockWindowState = { focused: true }
-        mockVisibleTextEditors = [{ document: testDocument } as vscode.TextEditor]
+        mockActiveTextEditor = {
+            document: testDocument,
+            visibleRanges: [range(0, 0, 1000, 1000)],
+        } as unknown as vscode.TextEditor
 
         mockTextEditorSelectionEvent = {
             textEditor: { document: testDocument } as vscode.TextEditor,
@@ -61,31 +61,22 @@ describe('CharactersLogger', () => {
                 },
             },
             {
-                activeTextEditor: {} as any,
-                onDidChangeTextEditorVisibleRanges(listener) {
-                    onDidChangeTextEditorVisibleRanges = listener
+                state: mockWindowState,
+                activeTextEditor: mockActiveTextEditor,
+                onDidChangeWindowState(listener) {
+                    onDidChangeWindowState = listener
                     return { dispose: () => {} }
                 },
                 onDidChangeActiveTextEditor(listener) {
                     onDidChangeActiveTextEditor = listener
                     return { dispose: () => {} }
                 },
-                onDidChangeWindowState(listener) {
-                    onDidChangeWindowState = listener
-                    return { dispose: () => {} }
-                },
-                onDidChangeVisibleTextEditors(listener) {
-                    onDidChangeVisibleTextEditors = listener
-                    return { dispose: () => {} }
-                },
                 onDidChangeTextEditorSelection(listener) {
                     onDidChangeTextEditorSelection = listener
                     return { dispose: () => {} }
                 },
-                visibleTextEditors: mockVisibleTextEditors,
             }
         )
-        console.log({ onDidChangeActiveTextEditor, onDidChangeTextEditorVisibleRanges })
     })
 
     afterEach(() => {
@@ -121,400 +112,174 @@ describe('CharactersLogger', () => {
         }
     }
 
-    // Helper function to create default metadata counters with expected values
+    // Helper function to create expected counters
     function expectedCharCounters(expected: Partial<CharacterLoggerCounters>): Record<string, number> {
         return { ...DEFAULT_COUNTERS, ...expected }
     }
 
-    function advanceTimerToPreventRapidChange() {
-        vi.advanceTimersByTime(RAPID_CHANGE_TIMEOUT + 1)
-    }
-
-    it('logs inserted and deleted characters for user edits', () => {
-        onDidChangeTextEditorSelection(mockTextEditorSelectionEvent)
-        onDidChangeTextDocument(createChange({ text: 'foo', range: range(0, 0, 0, 0), rangeLength: 0 }))
-
-        advanceTimerToPreventRapidChange()
-
-        onDidChangeTextEditorSelection(mockTextEditorSelectionEvent)
-        onDidChangeTextDocument(createChange({ text: 'bar', range: range(0, 3, 0, 3), rangeLength: 0 }))
-
-        vi.advanceTimersByTime(LOG_INTERVAL)
-
-        expect(recordSpy).toHaveBeenCalledWith('cody.characters', 'char-counts', {
-            metadata: expectedCharCounters({
-                xxs_change_inserted: 6, // 'foo' + 'bar'
-            }),
-        })
-    })
-
-    it('logs changes under "window_not_focused" when window is not focused', () => {
-        onDidChangeTextEditorSelection(mockTextEditorSelectionEvent)
-        onDidChangeTextDocument(createChange({ text: 'foo', range: range(0, 0, 0, 0), rangeLength: 0 }))
-
-        mockWindowState.focused = false
-        onDidChangeWindowState(mockWindowState)
-
-        advanceTimerToPreventRapidChange()
-
-        onDidChangeTextDocument(createChange({ text: 'bar', range: range(0, 3, 0, 3), rangeLength: 0 }))
-        vi.advanceTimersByTime(LOG_INTERVAL)
-
-        expect(recordSpy).toHaveBeenNthCalledWith(1, 'cody.characters', 'char-counts', {
-            metadata: expectedCharCounters({
-                xxs_change_inserted: 3, // 'foo'
-                window_not_focused_inserted: 3, // 'bar'
-            }),
-        })
-    })
-
-    it.only('logs changes under "non_visible_document" when in non-visible documents', () => {
-        // Remove testDocument from visible editors
-        mockVisibleTextEditors = []
-        onDidChangeVisibleTextEditors(mockVisibleTextEditors)
-
-        onDidChangeTextEditorSelection(mockTextEditorSelectionEvent)
-        onDidChangeTextDocument(createChange({ text: 'foo', range: range(0, 0, 0, 0), rangeLength: 0 }))
-
-        vi.advanceTimersByTime(LOG_INTERVAL)
-
-        // Verify that changes are logged under 'non_visible_document'
-        expect(recordSpy).toHaveBeenCalledWith('cody.characters', 'flush', {
-            metadata: expectedCharCounters({
-                non_visible_document_inserted: 3,
-                non_visible_document_deleted: 0,
-            }),
-        })
-    })
-
-    it('logs changes under "stale_selection" when there has been no recent cursor movement', () => {
-        onDidChangeTextEditorSelection(mockTextEditorSelectionEvent)
-        vi.advanceTimersByTime(SELECTION_TIMEOUT + 1)
-
-        onDidChangeTextDocument(createChange({ text: 'foo', range: range(0, 0, 0, 0), rangeLength: 0 }))
-        vi.advanceTimersByTime(LOG_INTERVAL)
-
-        expect(recordSpy).toHaveBeenCalledWith('cody.characters', 'flush', {
-            metadata: expectedCharCounters({
-                stale_selection_inserted: 3,
-                stale_selection_deleted: 0,
-            }),
-        })
-    })
-
-    it('logs undo and redo changes under their respective types', () => {
-        onDidChangeTextEditorSelection(mockTextEditorSelectionEvent)
-        const textDocumentChangeReason = {
-            undo: 1,
-            redo: 2,
-        }
-
-        // Simulate undo change
-        onDidChangeTextDocument(
-            createChange({
-                text: '',
-                range: range(0, 3, 0, 0),
-                rangeLength: 3,
-                document: testDocument,
-                reason: textDocumentChangeReason.undo,
-            })
-        )
-
-        advanceTimerToPreventRapidChange()
-
-        // Simulate redo change
-        onDidChangeTextDocument(
-            createChange({
-                text: 'foo',
-                range: range(0, 0, 0, 0),
-                rangeLength: 0,
-                document: testDocument,
-                reason: textDocumentChangeReason.redo,
-            })
-        )
-
-        vi.advanceTimersByTime(LOG_INTERVAL)
-
-        // Verify that changes are logged under 'undo' and 'redo'
-        expect(recordSpy).toHaveBeenCalledWith('cody.characters', 'flush', {
-            metadata: expectedCharCounters({
-                undo_inserted: 0,
-                undo_deleted: 3,
-                redo_inserted: 3,
-                redo_deleted: 0,
-            }),
-        })
-    })
-
-    it('logs rapid changes under "rapid_change"', () => {
-        onDidChangeTextEditorSelection(mockTextEditorSelectionEvent)
-        onDidChangeTextDocument(createChange({ text: 'foo', range: range(0, 0, 0, 0), rangeLength: 0 }))
-
-        vi.advanceTimersByTime(RAPID_CHANGE_TIMEOUT / 2)
-
-        // Simulate second change within rapid change timeout
-        onDidChangeTextDocument(createChange({ text: 'bar', range: range(0, 3, 0, 3), rangeLength: 0 }))
-        vi.advanceTimersByTime(LOG_INTERVAL)
-
-        // TODO: both changes should be logged as rapid.
-        expect(recordSpy).toHaveBeenCalledWith('cody.characters', 'flush', {
-            metadata: expectedCharCounters({
-                rapid_change_inserted: 3,
-                rapid_change_deleted: 0,
-                xs_change_inserted: 3,
-                xs_change_deleted: 0,
-            }),
-        })
-    })
-
-    it('counts large changes according to their sizes if they are not rapid', () => {
+    it('should handle insertions, deletions, rapid and stale changes, and changes outside of visible range', () => {
+        // Simulate user typing in the active text editor
+        onDidChangeActiveTextEditor(mockActiveTextEditor)
         onDidChangeTextEditorSelection(mockTextEditorSelectionEvent)
 
-        advanceTimerToPreventRapidChange()
-        const largeText = 'a'.repeat(1005)
-        onDidChangeTextDocument(
-            createChange({ text: largeText, range: range(0, 0, 0, 0), rangeLength: 0 })
-        )
-
-        vi.advanceTimersByTime(LOG_INTERVAL)
-
-        // Verify that the large change is logged under 'xxl_change'
-        expect(recordSpy).toHaveBeenCalledWith('cody.characters', 'flush', {
-            metadata: expectedCharCounters({
-                xxl_change_inserted: 1005,
-                xxl_change_deleted: 0,
-            }),
-        })
-    })
-
-    it('resets counter after flushing', () => {
-        onDidChangeTextEditorSelection(mockTextEditorSelectionEvent)
-        onDidChangeTextDocument(createChange({ text: 'foo', range: range(0, 0, 0, 0), rangeLength: 0 }))
-
-        vi.advanceTimersByTime(LOG_INTERVAL)
-
-        expect(recordSpy).toHaveBeenCalledTimes(1)
-        expect(recordSpy).toHaveBeenCalledWith('cody.characters', 'flush', {
-            metadata: expectedCharCounters({
-                xs_change_inserted: 3,
-                xs_change_deleted: 0,
-            }),
-        })
-
-        onDidChangeTextEditorSelection(mockTextEditorSelectionEvent)
-        advanceTimerToPreventRapidChange()
-        onDidChangeTextDocument(createChange({ text: 'bar', range: range(0, 3, 0, 3), rangeLength: 0 }))
-
-        vi.advanceTimersByTime(LOG_INTERVAL)
-
-        expect(recordSpy).toHaveBeenCalledTimes(2)
-        expect(recordSpy).toHaveBeenCalledWith('cody.characters', 'flush', {
-            metadata: expectedCharCounters({
-                xs_change_inserted: 3,
-                xs_change_deleted: 0,
-            }),
-        })
-    })
-
-    it('logs user typing under size-based change types after cursor movement', () => {
-        onDidChangeTextEditorSelection(mockTextEditorSelectionEvent)
-        onDidChangeTextDocument(
-            createChange({ text: 'abcde', range: range(0, 0, 0, 0), rangeLength: 0 })
-        )
-
-        vi.advanceTimersByTime(LOG_INTERVAL)
-
-        // 'abcde' is 5 characters, which falls under 'xs_change' (2-5)
-        expect(recordSpy).toHaveBeenCalledWith('cody.characters', 'flush', {
-            metadata: expectedCharCounters({
-                xs_change_inserted: 5,
-                xs_change_deleted: 0,
-            }),
-        })
-    })
-
-    it('handles multiple documents and selections', () => {
-        const anotherDocument = document('bar')
-        mockVisibleTextEditors.push({
-            document: anotherDocument,
-        } as vscode.TextEditor)
-        onDidChangeVisibleTextEditors(mockVisibleTextEditors)
-
-        onDidChangeTextEditorSelection({
-            textEditor: {
-                document: testDocument,
-            } as vscode.TextEditor,
-            selections: [],
-            kind: undefined,
-        })
-
-        onDidChangeTextEditorSelection({
-            textEditor: {
-                document: anotherDocument,
-            } as vscode.TextEditor,
-            selections: [],
-            kind: undefined,
-        })
-
-        onDidChangeTextDocument(
-            createChange({
-                text: 'foo',
-                range: range(0, 0, 0, 0),
-                rangeLength: 0,
-                document: testDocument,
-            })
-        )
-
-        advanceTimerToPreventRapidChange()
-
-        onDidChangeTextDocument(
-            createChange({
-                text: 'baz',
-                range: range(0, 0, 0, 0),
-                rangeLength: 0,
-                document: anotherDocument,
-            })
-        )
-
-        vi.advanceTimersByTime(LOG_INTERVAL)
-
-        expect(recordSpy).toHaveBeenCalledWith('cody.characters', 'flush', {
-            metadata: expectedCharCounters({
-                xs_change_inserted: 6, // 'foo' + 'baz'
-                xs_change_deleted: 0,
-            }),
-        })
-    })
-
-    it('removes document from tracking on close', () => {
-        onDidChangeTextEditorSelection(mockTextEditorSelectionEvent)
-        onDidChangeTextDocument(createChange({ text: 'foo', range: range(0, 0, 0, 0), rangeLength: 0 }))
-
-        onDidCloseTextDocument(testDocument)
-
-        onDidChangeTextDocument(createChange({ text: 'bar', range: range(0, 3, 0, 3), rangeLength: 0 }))
-        vi.advanceTimersByTime(LOG_INTERVAL)
-
-        expect(recordSpy).toHaveBeenCalledWith('cody.characters', 'flush', {
-            metadata: expectedCharCounters({
-                xs_change_inserted: 3, // Only 'foo' is counted
-                xs_change_deleted: 0,
-                non_visible_document_inserted: 3,
-            }),
-        })
-    })
-
-    it('correctly classifies changes at boundary sizes', () => {
-        onDidChangeTextEditorSelection(mockTextEditorSelectionEvent)
-
-        for (const [_, boundaries] of Object.entries(changeBoundaries)) {
-            advanceTimerToPreventRapidChange()
-            const text = 'a'.repeat(boundaries.min || boundaries.max)
-            onDidChangeTextDocument(createChange({ text, range: range(0, 0, 0, 0), rangeLength: 0 }))
-        }
-
-        vi.advanceTimersByTime(LOG_INTERVAL)
-
-        const expected: any = {}
-        for (const [type, boundary] of Object.entries(changeBoundaries)) {
-            expected[`${type}_inserted`] = boundary.min || boundary.max
-            expected[`${type}_deleted`] = 0
-        }
-
-        expect(recordSpy).toHaveBeenCalledWith('cody.characters', 'flush', {
-            metadata: expectedCharCounters(expected),
-        })
-    })
-
-    it('handles a mix of different change sizes in one interval', () => {
-        onDidChangeTextEditorSelection(mockTextEditorSelectionEvent)
-        onDidChangeTextDocument(createChange({ text: 'abc', range: range(0, 0, 0, 0), rangeLength: 0 }))
-
-        advanceTimerToPreventRapidChange()
-
-        // Simulate a medium change of 30 characters
-        const mediumText = 'a'.repeat(30)
-        onDidChangeTextDocument(
-            createChange({ text: mediumText, range: range(0, 3, 0, 3), rangeLength: 0 })
-        )
-
-        advanceTimerToPreventRapidChange()
-
-        const largeText = 'b'.repeat(60)
-        onDidChangeTextDocument(
-            createChange({ text: largeText, range: range(0, 33, 0, 33), rangeLength: 0 })
-        )
-
-        vi.advanceTimersByTime(LOG_INTERVAL)
-
-        expect(recordSpy).toHaveBeenCalledWith('cody.characters', 'flush', {
-            metadata: expectedCharCounters({
-                xs_change_inserted: 3, // 'abc'
-                m_change_inserted: 30, // 30 'a's
-                l_change_inserted: 60, // 60 'b's
-                xs_change_deleted: 0,
-                m_change_deleted: 0,
-                l_change_deleted: 0,
-            }),
-        })
-    })
-
-    it('prioritizes rapid changes over size-based classification', () => {
-        onDidChangeTextEditorSelection(mockTextEditorSelectionEvent)
+        // Scenario 1: User types 'hello' (insertion)
         onDidChangeTextDocument(
             createChange({ text: 'hello', range: range(0, 0, 0, 0), rangeLength: 0 })
         )
 
-        vi.advanceTimersByTime(RAPID_CHANGE_TIMEOUT - 10)
+        // Advance time less than RAPID_CHANGE_TIMEOUT to simulate rapid change
+        vi.advanceTimersByTime(RAPID_CHANGE_TIMEOUT - 5)
+
+        // Scenario 2: User deletes 'he' (deletion)
+        onDidChangeTextDocument(createChange({ text: '', range: range(0, 0, 0, 2), rangeLength: 2 }))
+
+        // Now, advance time beyond SELECTION_TIMEOUT to make selection stale
+        vi.advanceTimersByTime(SELECTION_TIMEOUT + 1000)
+
+        // Scenario 3: User types 'there' (stale insertion)
         onDidChangeTextDocument(
-            createChange({ text: 'world', range: range(0, 5, 0, 5), rangeLength: 0 })
+            createChange({ text: 'there', range: range(0, 3, 0, 3), rangeLength: 0 })
+        )
+        // Should be counted as an insertion, stale change
+
+        // Scenario 4: Change outside of visible range
+        // Simulate that the change is outside the visible range
+        mockActiveTextEditor!.visibleRanges = [range(1, 0, 1, 0)] // Lines 1 to 1 (empty range)
+        onDidChangeActiveTextEditor(mockActiveTextEditor)
+
+        // User types 'hidden' at line 50 (outside visible range)
+        onDidChangeTextDocument(
+            createChange({
+                text: 'hidden',
+                range: range(50, 0, 50, 0), // Line 50, start
+                rangeLength: 0,
+            })
         )
 
-        advanceTimerToPreventRapidChange()
+        // Restore the visible ranges
+        mockActiveTextEditor!.visibleRanges = [range(0, 0, 1000, 0)]
 
-        const text = 'a'.repeat(10)
-        onDidChangeTextDocument(createChange({ text, range: range(0, 10, 0, 10), rangeLength: 0 }))
-
+        // Flush the log
         vi.advanceTimersByTime(LOG_INTERVAL)
 
-        // 'hello' and 'world' should be counted under 'rapid_change'
-        // The last change should be counted under 's_change' (size 10)
+        // Expected counters:
         expect(recordSpy).toHaveBeenCalledWith('cody.characters', 'flush', {
             metadata: expectedCharCounters({
-                rapid_change_inserted: 5, // 'world'
-                xs_change_inserted: 5, // 'hello'
-                s_change_inserted: 10, // 10 'a's
+                xxs_change: 1,
+                xxs_change_inserted: 5, // 'hello'
+
+                rapid_xxxs_change: 1,
+                rapid_xxxs_change_deleted: 2, // 'he'
+
+                stale_xxs_change: 1,
+                stale_xxs_change_inserted: 5, // 'there'
+
+                outside_of_visible_ranges: 1,
+                outside_of_visible_ranges_inserted: 6, // 'hidden'
             }),
         })
     })
 
-    it('handles window focus loss and regain within an interval', () => {
+    it('should handle undo, redo, window not focused, no active editor, outside of active editor, and document closing', () => {
+        onDidChangeActiveTextEditor(mockActiveTextEditor)
         onDidChangeTextEditorSelection(mockTextEditorSelectionEvent)
+
+        const changeReasons = { Undo: 1, Redo: 2 } as const
+
+        onDidChangeTextDocument(createChange({ text: 'test', range: range(0, 0, 0, 0), rangeLength: 0 }))
+
+        // Simulate undo
         onDidChangeTextDocument(
-            createChange({ text: 'focus', range: range(0, 0, 0, 0), rangeLength: 0 })
+            createChange({
+                text: '',
+                range: range(0, 4, 0, 0),
+                rangeLength: 4,
+                reason: changeReasons.Undo,
+            })
+        )
+
+        // Simulate redo
+        onDidChangeTextDocument(
+            createChange({
+                text: 'test',
+                range: range(0, 0, 0, 0),
+                rangeLength: 0,
+                reason: changeReasons.Redo,
+            })
         )
 
         mockWindowState.focused = false
         onDidChangeWindowState(mockWindowState)
 
-        advanceTimerToPreventRapidChange()
-        onDidChangeTextDocument(createChange({ text: 'blur', range: range(0, 5, 0, 5), rangeLength: 0 }))
+        // User types ' window not focused' when window not focused
+        onDidChangeTextDocument(
+            createChange({ text: 'window not focused', range: range(0, 4, 0, 4), rangeLength: 0 })
+        )
 
+        // Simulate window gaining focus
         mockWindowState.focused = true
         onDidChangeWindowState(mockWindowState)
-        onDidChangeTextEditorSelection(mockTextEditorSelectionEvent)
 
-        advanceTimerToPreventRapidChange()
-        onDidChangeTextDocument(createChange({ text: 'gain', range: range(0, 9, 0, 9), rangeLength: 0 }))
+        // Simulate no active editor
+        onDidChangeActiveTextEditor(undefined)
+        onDidChangeTextDocument(
+            createChange({ text: 'no active editor', range: range(0, 21, 0, 21), rangeLength: 0 })
+        )
+
+        // Simulate editor for different document
+        const anotherDocument = {
+            uri: { toString: () => 'file://anotherdocument' },
+        } as vscode.TextDocument
+
+        const anotherEditor = {
+            document: anotherDocument,
+            visibleRanges: [range(0, 0, 1000, 0)],
+        } as unknown as vscode.TextEditor
+
+        onDidChangeActiveTextEditor(anotherEditor)
+
+        // User types in original document (not the active editor's document)
+        onDidChangeTextDocument(
+            createChange({
+                text: 'outside active editor',
+                range: range(0, 21, 0, 21),
+                rangeLength: 0,
+                document: testDocument,
+            })
+        )
+
+        onDidCloseTextDocument(testDocument)
+        onDidChangeTextDocument(
+            createChange({
+                text: '!',
+                range: range(0, 50, 0, 50),
+                rangeLength: 0,
+                document: testDocument,
+            })
+        )
 
         vi.advanceTimersByTime(LOG_INTERVAL)
 
+        // Expected counters:
         expect(recordSpy).toHaveBeenCalledWith('cody.characters', 'flush', {
             metadata: expectedCharCounters({
-                window_not_focused_inserted: 4, // 'blur'
-                xs_change_inserted: 4 + 5, // 'gain' (after regaining focus)
-                xs_change_deleted: 0,
-                window_not_focused_deleted: 0,
+                xxs_change: 1,
+                xxs_change_inserted: 4, // 'test'
+
+                undo: 1,
+                undo_deleted: 4, // 'test' deleted
+
+                redo: 1,
+                redo_inserted: 4, // 'test' re-inserted
+
+                window_not_focused: 1,
+                window_not_focused_inserted: 18, // ' window not focused'
+
+                no_active_editor: 1,
+                no_active_editor_inserted: 16, // 'no active editor'
+
+                outside_of_active_editor: 2,
+                outside_of_active_editor_inserted: 22, //'outside active editor'
             }),
         })
     })

--- a/vscode/src/services/CharactersLogger.ts
+++ b/vscode/src/services/CharactersLogger.ts
@@ -1,94 +1,135 @@
-import { isFileURI } from '@sourcegraph/cody-shared'
 import * as vscode from 'vscode'
 
-import { telemetryRecorder } from '@sourcegraph/cody-shared'
+import { isFileURI, telemetryRecorder } from '@sourcegraph/cody-shared'
+import { outputChannelLogger } from '../output-channel-logger'
 
 export const LOG_INTERVAL = 30 * 60 * 1000 // 30 minutes
-const LARGE_CHANGE_THRESHOLD = 1000
-const LARGE_CHANGE_TIMEOUT = 1000 // Ignore large changes happened within this time.
-const SELECTION_TIMEOUT = 5000 // 5 seconds
+export const RAPID_CHANGE_TIMEOUT = 15
+export const SELECTION_TIMEOUT = 5000
 
-const DOCUMENT_CHANGE_TYPES = [
-    'normal',
+export const changeBoundaries = {
+    xxxs_change: { min: 0, max: 2 },
+    xxs_change: { min: 3, max: 10 },
+    xs_change: { min: 11, max: 50 },
+    s_change: { min: 51, max: 200 },
+    m_change: { min: 200, max: 1000 },
+    l_change: { min: 1001, max: 3000 },
+    xl_change: { min: 3001, max: 10000 },
+    xxl_change: { min: 10001, max: 50000 },
+    xxxl_change: { min: 50001, max: Number.POSITIVE_INFINITY },
+} as const
+
+const changeBoundariesKeys = Object.keys(changeBoundaries) as (keyof typeof changeBoundaries)[]
+const staleChangeBoundariesKeys = changeBoundariesKeys.map(key => `stale_selection_${key}` as const)
+
+const SPECIAL_DOCUMENT_CHANGE_TYPES = [
     'undo',
     'redo',
-    'windowNotFocused',
-    'nonVisibleDocument',
-    'inactiveSelection',
-    'rapidLargeChange',
+    'window_not_focused',
+    'non_visible_document',
+    'non_active_editor',
+    'outside_of_visible_ranges',
+    'stale_selection',
+    'rapid_change', // occurred in less than RAPID_CHANGE_TIMEOUT after/before another change
+    'unexpected', // should not be logged because all the change sizes are covered by the keys above
+] as const
+
+const DOCUMENT_CHANGE_TYPES = [
+    ...SPECIAL_DOCUMENT_CHANGE_TYPES,
+    ...changeBoundariesKeys,
+    ...staleChangeBoundariesKeys,
 ] as const
 
 type DocumentChangeType = (typeof DOCUMENT_CHANGE_TYPES)[number]
 
 // This flat structure is required by the 'metadata' field type in the telemetry event.
-export type DocumentChangeCounters = {
-    [K in `${DocumentChangeType}_${'inserted' | 'deleted'}`]: number
+export type CharacterLoggerCounters = {
+    [K in `${DocumentChangeType}_${'inserted' | 'deleted'}` | DocumentChangeType]: number
 }
 
-export const DEFAULT_COUNTERS: DocumentChangeCounters = DOCUMENT_CHANGE_TYPES.reduce(
-    (acc, changeType) => {
-        acc[`${changeType}_inserted`] = 0
-        acc[`${changeType}_deleted`] = 0
-        return acc
-    },
-    {} as DocumentChangeCounters
-)
+export const DEFAULT_COUNTERS = DOCUMENT_CHANGE_TYPES.reduce((acc, changeType) => {
+    // To count the number of characters inserted/deleted
+    acc[`${changeType}_inserted`] = 0
+    acc[`${changeType}_deleted`] = 0
+
+    // To count the number of events
+    acc[changeType] = 0
+
+    return acc
+}, {} as CharacterLoggerCounters)
 
 export class CharactersLogger implements vscode.Disposable {
     private disposables: vscode.Disposable[] = []
-    private changeCounters: DocumentChangeCounters = { ...DEFAULT_COUNTERS }
+    private changeCounters: CharacterLoggerCounters = { ...DEFAULT_COUNTERS }
     private nextTimeoutId: NodeJS.Timeout | null = null
 
     private windowFocused = true
+    private activeTextEditor: vscode.TextEditor | undefined
     private visibleDocuments = new Set<string>()
+    private visibleRangesMap: Map<string, Readonly<vscode.Range[]>> = new Map()
     private lastChangeTimestamp = 0
     private lastSelectionTimestamps = new Map<string, number>()
 
     constructor(
-        workspace: Pick<typeof vscode.workspace, 'onDidChangeTextDocument'> = vscode.workspace,
+        workspace: Pick<
+            typeof vscode.workspace,
+            'onDidChangeTextDocument' | 'onDidCloseTextDocument'
+        > = vscode.workspace,
         window: Pick<
             typeof vscode.window,
+            | 'activeTextEditor'
             | 'onDidChangeWindowState'
+            | 'onDidChangeActiveTextEditor'
             | 'onDidChangeVisibleTextEditors'
+            | 'onDidChangeTextEditorVisibleRanges'
             | 'onDidChangeTextEditorSelection'
             | 'visibleTextEditors'
         > = vscode.window
     ) {
-        this.disposables.push(workspace.onDidChangeTextDocument(this.onDidChangeTextDocument.bind(this)))
-        this.disposables.push(window.onDidChangeWindowState(this.onDidChangeWindowState.bind(this)))
         this.disposables.push(
-            window.onDidChangeVisibleTextEditors(this.onDidChangeVisibleTextEditors.bind(this))
-        )
-        this.disposables.push(
-            window.onDidChangeTextEditorSelection(this.onDidChangeTextEditorSelection.bind(this))
+            workspace.onDidChangeTextDocument(this.onDidChangeTextDocument.bind(this)),
+            workspace.onDidCloseTextDocument(document => {
+                const uri = document.uri.toString()
+                this.lastSelectionTimestamps.delete(uri)
+                this.visibleDocuments.delete(uri)
+                this.visibleRangesMap.delete(uri)
+            }),
+            window.onDidChangeWindowState(state => {
+                this.windowFocused = state.focused
+            }),
+            window.onDidChangeActiveTextEditor(editor => {
+                this.activeTextEditor = editor
+            }),
+            window.onDidChangeVisibleTextEditors(editors => {
+                this.updateVisibleDocuments(editors)
+            }),
+            window.onDidChangeTextEditorSelection(event => {
+                const documentUri = event.textEditor.document.uri.toString()
+                this.lastSelectionTimestamps.set(documentUri, Date.now())
+            }),
+            window.onDidChangeTextEditorVisibleRanges(event => {
+                const documentUri = event.textEditor.document.uri.toString()
+                this.visibleRangesMap.set(documentUri, event.visibleRanges)
+            })
         )
 
         this.updateVisibleDocuments(window.visibleTextEditors)
+        this.activeTextEditor = window.activeTextEditor
         this.nextTimeoutId = setTimeout(() => this.flush(), LOG_INTERVAL)
     }
 
     public flush(): void {
-        this.nextTimeoutId = null
-
-        telemetryRecorder.recordEvent('cody.characters', 'flush', {
-            metadata: { ...this.changeCounters },
-        })
-        this.changeCounters = { ...DEFAULT_COUNTERS }
-
-        this.nextTimeoutId = setTimeout(() => this.flush(), LOG_INTERVAL)
-    }
-
-    private onDidChangeWindowState(state: vscode.WindowState): void {
-        this.windowFocused = state.focused
-    }
-
-    private onDidChangeVisibleTextEditors(editors: Readonly<vscode.TextEditor[]>): void {
-        this.updateVisibleDocuments(editors)
-    }
-
-    private onDidChangeTextEditorSelection(event: vscode.TextEditorSelectionChangeEvent): void {
-        const documentUri = event.textEditor.document.uri.toString()
-        this.lastSelectionTimestamps.set(documentUri, Date.now())
+        try {
+            this.nextTimeoutId = null
+            telemetryRecorder.recordEvent('cody.characters', 'flush', {
+                metadata: { ...this.changeCounters },
+            })
+        } catch (error) {
+            outputChannelLogger.logError('CharactersLogger', 'Failed to record telemetry event:', error)
+        } finally {
+            this.changeCounters = { ...DEFAULT_COUNTERS }
+            this.nextTimeoutId = setTimeout(() => this.flush(), LOG_INTERVAL)
+        }
     }
 
     private onDidChangeTextDocument(event: vscode.TextDocumentChangeEvent): void {
@@ -96,66 +137,92 @@ export class CharactersLogger implements vscode.Disposable {
             return
         }
 
-        const changeType = this.getDocumentChangeType(event)
+        const totalChangeSize = event.contentChanges.reduce((sum, change) => {
+            return sum + Math.abs(change.rangeLength) + Math.abs(change.text.length)
+        }, 0)
+
+        const changeType = this.getDocumentChangeType(event, totalChangeSize)
+        this.changeCounters[changeType]++
+        const { activeTextEditor } = this
 
         for (const change of event.contentChanges) {
+            // TODO: manually test active test editor visible ranges staleness
+            const isChangeVisible = activeTextEditor?.visibleRanges.some(range =>
+                range.contains(change.range)
+            )
+
+            const isSpecialChangeType = SPECIAL_DOCUMENT_CHANGE_TYPES.find(v => v === changeType)
+            const contentChangeType =
+                !isSpecialChangeType && !isChangeVisible ? 'outside_of_visible_ranges' : changeType
+
             // We use change.rangeLength for deletions because:
             // 1. It represents the length of the text being replaced, including newline characters.
             // 2. It accurately accounts for multi-line deletions.
             // 3. For pure deletions (without insertions), this will be the number of characters removed.
             // 4. For replacements, this represents the "old" text that's being replaced.
-            this.changeCounters[`${changeType}_deleted`] += change.rangeLength
+            this.changeCounters[`${contentChangeType}_deleted`] += change.rangeLength
 
             // We use change.text.length for insertions because:
             // 1. It represents the length of the new text being inserted, including newline characters.
             // 2. It accurately accounts for multi-line insertions.
             // 3. For pure insertions (without deletions), this will be the number of characters added.
             // 4. For replacements, this represents the "new" text that's replacing the old.
-            this.changeCounters[`${changeType}_inserted`] += change.text.length
+            this.changeCounters[`${contentChangeType}_inserted`] += change.text.length
 
             // Note: In the case of replacements, both deleted and inserted will be incremented.
             // This accurately represents that some text was removed and some was added, even if
             // the lengths are the same.
         }
 
-        this.lastChangeTimestamp = Date.now()
+        if (totalChangeSize > 0) {
+            this.lastChangeTimestamp = Date.now()
+        }
+        console.log(
+            `changes: [${event.contentChanges.map(c => c.text).join(',')}]`,
+            JSON.stringify(this.changeCounters, null, 2)
+        )
     }
 
-    private getDocumentChangeType(event: vscode.TextDocumentChangeEvent): DocumentChangeType {
+    private getDocumentChangeType(
+        event: vscode.TextDocumentChangeEvent,
+        totalChangeSize: number
+    ): DocumentChangeType {
         const currentTimestamp = Date.now()
         const documentUri = event.document.uri.toString()
 
         if (event.reason === vscode.TextDocumentChangeReason.Undo) {
             return 'undo'
         }
+
         if (event.reason === vscode.TextDocumentChangeReason.Redo) {
             return 'redo'
         }
 
         if (!this.windowFocused) {
-            return 'windowNotFocused'
-        }
-        if (!this.visibleDocuments.has(documentUri)) {
-            return 'nonVisibleDocument'
+            return 'window_not_focused'
         }
 
-        const lastSelectionTimestamp = this.lastSelectionTimestamps.get(documentUri) || 0
-        const timeSinceLastSelection = currentTimestamp - lastSelectionTimestamp
-
-        if (timeSinceLastSelection > SELECTION_TIMEOUT) {
-            return 'inactiveSelection'
+        if (!vscode.window.activeTextEditor) {
+            return 'non_active_editor'
         }
 
         const timeSinceLastChange = currentTimestamp - this.lastChangeTimestamp
-        const totalChangeSize = event.contentChanges.reduce((sum, change) => {
-            return sum + Math.abs(change.rangeLength) + Math.abs(change.text.length)
-        }, 0)
-
-        if (totalChangeSize > LARGE_CHANGE_THRESHOLD && timeSinceLastChange < LARGE_CHANGE_TIMEOUT) {
-            return 'rapidLargeChange'
+        if (timeSinceLastChange < RAPID_CHANGE_TIMEOUT) {
+            return 'rapid_change'
         }
 
-        return 'normal'
+        const lastSelectionTimestamp = this.lastSelectionTimestamps.get(documentUri) || 0
+        const isSelectionStale = currentTimestamp - lastSelectionTimestamp > SELECTION_TIMEOUT
+
+        for (const [changeSizeType, boundaries] of Object.entries(changeBoundaries)) {
+            if (boundaries.min <= totalChangeSize && totalChangeSize <= boundaries.max) {
+                return (
+                    isSelectionStale ? `stale_selection_${changeSizeType}` : changeSizeType
+                ) as DocumentChangeType
+            }
+        }
+
+        return 'unexpected'
     }
 
     private updateVisibleDocuments(editors: Readonly<vscode.TextEditor[]>): void {
@@ -163,6 +230,7 @@ export class CharactersLogger implements vscode.Disposable {
         for (const editor of editors) {
             const uri = editor.document.uri.toString()
             this.visibleDocuments.add(uri)
+            this.visibleRangesMap.set(uri, editor.visibleRanges)
         }
     }
 

--- a/vscode/src/services/CharactersLogger.ts
+++ b/vscode/src/services/CharactersLogger.ts
@@ -34,6 +34,7 @@ const SPECIAL_DOCUMENT_CHANGE_TYPES = [
     'unexpected', // should not be logged because all the change sizes are covered by the keys above
 ] as const
 
+vscode.window.activeTextEditor
 const DOCUMENT_CHANGE_TYPES = [
     ...SPECIAL_DOCUMENT_CHANGE_TYPES,
     ...changeBoundariesKeys,
@@ -163,10 +164,6 @@ export class CharactersLogger implements vscode.Disposable {
         if (totalChangeSize > 0) {
             this.lastChangeTimestamp = Date.now()
         }
-        // console.log(
-        //     `changes: [${event.contentChanges.map(c => c.text).join(',')}]`,
-        //     JSON.stringify(this.changeCounters, null, 2)
-        // )
     }
 
     private getDocumentChangeType(

--- a/vscode/src/testutils/mocks.ts
+++ b/vscode/src/testutils/mocks.ts
@@ -357,6 +357,14 @@ export class Location implements VSCodeLocation {
     }
 }
 
+const isSmallerOrEqualPosition = (a: Position, b: Position): boolean => {
+    return a.line < b.line || (a.line === b.line && a.character <= b.character)
+}
+
+const isBiggerOrEqualPosition = (a: Position, b: Position): boolean => {
+    return a.line > b.line || (a.line === b.line && a.character >= b.character)
+}
+
 export class Range implements VSCodeRange {
     public start: Position
     public end: Position
@@ -418,21 +426,17 @@ export class Range implements VSCodeRange {
         return this.start.line === this.end.line
     }
     public contains(positionOrRange: Position | Range): boolean {
-        const isSmallerOrEqual = (a: Position, b: Position): boolean => {
-            return a.line < b.line || (a.line === b.line && a.character <= b.character)
-        }
-
         if ('line' in positionOrRange) {
             return (
-                isSmallerOrEqual(this.start, positionOrRange) &&
-                isSmallerOrEqual(positionOrRange, this.end)
+                isSmallerOrEqualPosition(this.start, positionOrRange) &&
+                isSmallerOrEqualPosition(positionOrRange, this.end)
             )
         }
         if ('start' in positionOrRange && 'end' in positionOrRange) {
             return (
-                isSmallerOrEqual(this.start, positionOrRange.start) &&
-                isSmallerOrEqual(positionOrRange.start, this.end) &&
-                isSmallerOrEqual(this.end, positionOrRange.end)
+                isSmallerOrEqualPosition(this.start, positionOrRange.start) &&
+                isSmallerOrEqualPosition(positionOrRange.start, this.end) &&
+                isBiggerOrEqualPosition(this.end, positionOrRange.end)
             )
         }
 


### PR DESCRIPTION
Updated `CharacterLogger` to gain more insights into the unexpectedly high number of insertions that affect our metrics. 

- Group document changes by size.
- Rely on `vscode.window.activeTextEditor` to track edits from the active window.
- Rely on `activeTextEditor.visibleRanges` to mark edits as outside of the viewport.
- There's no way to detect if the active text editor is focused using the VS Code API. Here's [the GitHub issue](https://github.com/microsoft/vscode/issues/117980) where I asked for updates. It means we cannot reliably detect cases where users switched to the integrated terminal window or to the sidebar where they can perform actions that would result in a high number of insertions/deletions (e.g., by interactive with version control CLI or UI).
- To gain more information about such changes we group edits by document selection staleness (if the cursor didn't move for the last 5 seconds) and by the speed of changes (mark them as rapid if they occurred in less than 15 ms which is the threshold I got from local testing find-and-replace/refactor commands).
- Follow up for https://github.com/sourcegraph/cody/pull/5855

The new `cody.characters` telemetry event structure:

```json
{
  "undo_inserted": 0,
  "undo_deleted": 0,
  "undo": 0,
  "redo_inserted": 0,
  "redo_deleted": 0,
  "redo": 0,
  "window_not_focused_inserted": 0,
  "window_not_focused_deleted": 0,
  "window_not_focused": 0,
  "no_active_editor_inserted": 0,
  "no_active_editor_deleted": 0,
  "no_active_editor": 0,
  "outside_of_active_editor_inserted": 0,
  "outside_of_active_editor_deleted": 0,
  "outside_of_active_editor": 0,
  "outside_of_visible_ranges_inserted": 5,
  "outside_of_visible_ranges_deleted": 0,
  "outside_of_visible_ranges": 0,
  "unexpected_inserted": 0,
  "unexpected_deleted": 0,
  "unexpected": 0,
  "xxxs_change_inserted": 0,
  "xxxs_change_deleted": 0,
  "xxxs_change": 0,
  "xxs_change_inserted": 0,
  "xxs_change_deleted": 0,
  "xxs_change": 1,
  "xs_change_inserted": 0,
  "xs_change_deleted": 0,
  "xs_change": 0,
  "s_change_inserted": 0,
  "s_change_deleted": 0,
  "s_change": 0,
  "m_change_inserted": 0,
  "m_change_deleted": 0,
  "m_change": 0,
  "l_change_inserted": 0,
  "l_change_deleted": 0,
  "l_change": 0,
  "xl_change_inserted": 0,
  "xl_change_deleted": 0,
  "xl_change": 0,
  "xxl_change_inserted": 0,
  "xxl_change_deleted": 0,
  "xxl_change": 0,
  "xxxl_change_inserted": 0,
  "xxxl_change_deleted": 0,
  "xxxl_change": 0,
  "stale_xxxs_change_inserted": 0,
  "stale_xxxs_change_deleted": 0,
  "stale_xxxs_change": 0,
  "rapid_xxxs_change_inserted": 0,
  "rapid_xxxs_change_deleted": 0,
  "rapid_xxxs_change": 0,
  "rapid_stale_xxxs_change_inserted": 0,
  "rapid_stale_xxxs_change_deleted": 0,
  "rapid_stale_xxxs_change": 0,
  "stale_xxs_change_inserted": 0,
  "stale_xxs_change_deleted": 0,
  "stale_xxs_change": 0,
  "rapid_xxs_change_inserted": 0,
  "rapid_xxs_change_deleted": 0,
  "rapid_xxs_change": 0,
  "rapid_stale_xxs_change_inserted": 0,
  "rapid_stale_xxs_change_deleted": 0,
  "rapid_stale_xxs_change": 0,
  "stale_xs_change_inserted": 0,
  "stale_xs_change_deleted": 0,
  "stale_xs_change": 0,
  "rapid_xs_change_inserted": 0,
  "rapid_xs_change_deleted": 0,
  "rapid_xs_change": 0,
  "rapid_stale_xs_change_inserted": 0,
  "rapid_stale_xs_change_deleted": 0,
  "rapid_stale_xs_change": 0,
  "stale_s_change_inserted": 0,
  "stale_s_change_deleted": 0,
  "stale_s_change": 0,
  "rapid_s_change_inserted": 0,
  "rapid_s_change_deleted": 0,
  "rapid_s_change": 0,
  "rapid_stale_s_change_inserted": 0,
  "rapid_stale_s_change_deleted": 0,
  "rapid_stale_s_change": 0,
  "stale_m_change_inserted": 0,
  "stale_m_change_deleted": 0,
  "stale_m_change": 0,
  "rapid_m_change_inserted": 0,
  "rapid_m_change_deleted": 0,
  "rapid_m_change": 0,
  "rapid_stale_m_change_inserted": 0,
  "rapid_stale_m_change_deleted": 0,
  "rapid_stale_m_change": 0,
  "stale_l_change_inserted": 0,
  "stale_l_change_deleted": 0,
  "stale_l_change": 0,
  "rapid_l_change_inserted": 0,
  "rapid_l_change_deleted": 0,
  "rapid_l_change": 0,
  "rapid_stale_l_change_inserted": 0,
  "rapid_stale_l_change_deleted": 0,
  "rapid_stale_l_change": 0,
  "stale_xl_change_inserted": 0,
  "stale_xl_change_deleted": 0,
  "stale_xl_change": 0,
  "rapid_xl_change_inserted": 0,
  "rapid_xl_change_deleted": 0,
  "rapid_xl_change": 0,
  "rapid_stale_xl_change_inserted": 0,
  "rapid_stale_xl_change_deleted": 0,
  "rapid_stale_xl_change": 0,
  "stale_xxl_change_inserted": 0,
  "stale_xxl_change_deleted": 0,
  "stale_xxl_change": 0,
  "rapid_xxl_change_inserted": 0,
  "rapid_xxl_change_deleted": 0,
  "rapid_xxl_change": 0,
  "rapid_stale_xxl_change_inserted": 0,
  "rapid_stale_xxl_change_deleted": 0,
  "rapid_stale_xxl_change": 0,
  "stale_xxxl_change_inserted": 0,
  "stale_xxxl_change_deleted": 0,
  "stale_xxxl_change": 0,
  "rapid_xxxl_change_inserted": 0,
  "rapid_xxxl_change_deleted": 0,
  "rapid_xxxl_change": 0,
  "rapid_stale_xxxl_change_inserted": 0,
  "rapid_stale_xxxl_change_deleted": 0,
  "rapid_stale_xxxl_change": 0
}
```

- Part of https://linear.app/sourcegraph/issue/CODY-2566/investigate-data-discrepancies-in-percent-of-code-written-by-cody
- Part of https://linear.app/sourcegraph/issue/DATA-66/add-percent-of-code-written-by-cody-metric
- Part of https://linear.app/sourcegraph/issue/CODY-4041/support-percent-code-written-in-vscode
- Part of https://linear.app/sourcegraph/issue/CODY-2877/characters-logger-does-not-work-in-jetbrains-and-vs-code

## Test plan

CI and updated unit tests