### PR TITLE
Observable: wait for client config

### DIFF
--- a/lib/shared/src/guardrails/client.ts
+++ b/lib/shared/src/guardrails/client.ts
@@ -21,7 +21,10 @@ export class SourcegraphGuardrailsClient implements Guardrails {
     public async searchAttribution(snippet: string): Promise<Attribution | Error> {
         // Short-circuit attribution search if turned off in site config.
         const clientConfig = await ClientConfigSingleton.getInstance().getConfig()
-        if (!clientConfig?.attributionEnabled) {
+        if (!clientConfig) {
+            return new Error("Couldn't get client config.")
+        }
+        if (!clientConfig.attributionEnabled) {
             return new Error('Attribution search is turned off.')
         }
 

--- a/lib/shared/src/sourcegraph-api/clientConfig.ts
+++ b/lib/shared/src/sourcegraph-api/clientConfig.ts
@@ -1,9 +1,10 @@
-import { Observable, interval, map } from 'observable-fns'
+import { type Observable, interval, map } from 'observable-fns'
 import semver from 'semver'
 import { authStatus } from '../auth/authStatus'
 import { editorWindowIsFocused } from '../editor/editorState'
 import { logDebug, logError } from '../logger'
 import {
+    NEVER,
     debounceTime,
     distinctUntilChanged,
     filter,
@@ -85,7 +86,7 @@ export class ClientConfigSingleton {
                           startWith(undefined),
                           switchMap(() => promiseFactoryToObservable(signal => this.fetchConfig(signal)))
                       )
-                    : Observable.of(undefined)
+                    : NEVER
             ),
             map(value => (isError(value) ? undefined : value)),
             distinctUntilChanged()

--- a/vscode/src/commands/execute/ask.ts
+++ b/vscode/src/commands/execute/ask.ts
@@ -22,10 +22,13 @@ export interface ExecuteChatArguments extends Omit<WebviewSubmitMessage, 'text' 
  */
 export const executeChat = async (args: ExecuteChatArguments): Promise<ChatSession | undefined> => {
     const clientConfig = await ClientConfigSingleton.getInstance().getConfig()
+    if (!clientConfig) {
+        return undefined
+    }
     const isCommand = Boolean(args.command)
     if (
-        (!isCommand && !clientConfig?.chatEnabled) ||
-        (isCommand && !clientConfig?.customCommandsEnabled)
+        (!isCommand && !clientConfig.chatEnabled) ||
+        (isCommand && !clientConfig.customCommandsEnabled)
     ) {
         void vscode.window.showErrorMessage(
             'This feature has been disabled by your Sourcegraph site admin.'

--- a/vscode/src/commands/services/runner.ts
+++ b/vscode/src/commands/services/runner.ts
@@ -80,7 +80,12 @@ export class CommandRunner implements vscode.Disposable {
 
         // Conditions checks
         const clientConfig = await ClientConfigSingleton.getInstance().getConfig()
-        if (!clientConfig?.customCommandsEnabled) {
+        if (!clientConfig) {
+            this.span.addEvent('Cancel request as clientConfig is not available yet')
+            this.span.end()
+            return
+        }
+        if (!clientConfig.customCommandsEnabled) {
             const disabledMsg = 'This feature has been disabled by your Sourcegraph site admin.'
             void vscode.window.showErrorMessage(disabledMsg)
             this.span.end()

--- a/vscode/src/edit/manager.ts
+++ b/vscode/src/edit/manager.ts
@@ -98,7 +98,10 @@ export class EditManager implements vscode.Disposable {
             telemetryMetadata,
         } = args
         const clientConfig = await ClientConfigSingleton.getInstance().getConfig()
-        if (!clientConfig?.customCommandsEnabled) {
+        if (!clientConfig) {
+            return
+        }
+        if (!clientConfig.customCommandsEnabled) {
             void vscode.window.showErrorMessage(
                 'This feature has been disabled by your Sourcegraph site admin.'
             )

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -443,7 +443,10 @@ async function registerCodyCommands(
         args?: Partial<CodyCommandArgs>
     ): Promise<CommandResult | undefined> => {
         const clientConfig = await ClientConfigSingleton.getInstance().getConfig()
-        if (!clientConfig?.customCommandsEnabled) {
+        if (!clientConfig) {
+            return undefined
+        }
+        if (!clientConfig.customCommandsEnabled) {
             void vscode.window.showErrorMessage(
                 'This feature has been disabled by your Sourcegraph site admin.'
             )


### PR DESCRIPTION
Before the ClientConfiguration would resolve immediately to undefined even if triggered right after authentication. This would cause flake in tests as commands such as chat/edit would incorrectly show a "This feature has been disabled by your site admin" message.

Now we instantly invalidate the ClientConfig if the auth status changes, but we prevent resolving of the client status until the credentials have been validated.

## Test plan

E2E tests will be added in a later PR as there's some upcoming fixes to the test framework. For now I've manually validated that everything still works as before.

In particular to trigger a invalid client config and see it resolve correctly I enabled an incorrect proxy configuration. Then upon changing the config settings a new auth session is requested and the client configuration resolves correctly.

<div class='graphite__hidden'>
          <div>🎥 Video uploaded on Graphite:</div>
            <a href="https://app.graphite.dev/media/video/onbAacT3LuCgMVcIIUAU/6ec6a1ef-9959-41b8-8f14-bcdffd211899.mp4">
              <img src="https://app.graphite.dev/api/v1/graphite/video/thumbnail/onbAacT3LuCgMVcIIUAU/6ec6a1ef-9959-41b8-8f14-bcdffd211899.mp4">
            </a>
          </div>
<video src="https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/onbAacT3LuCgMVcIIUAU/6ec6a1ef-9959-41b8-8f14-bcdffd211899.mp4">CleanShot 2024-10-17 at 17.59.45.mp4</video>

