### PR TITLE
add repo/cody to labeler

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,2 +1,4 @@
 bug:
     - '(bug:)'
+repo/cody:
+    - '/.*/'


### PR DESCRIPTION
RELATED TO https://github.com/sourcegraph/jetbrains/pull/2472

Adding `repo/cody` to help distinguish where issues originate from when we sync them back into linear 


## Test plan
N/A
<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
