### PR TITLE
Fix VSCode CHANGELOG after merge

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -16,10 +16,9 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 
 ### Changed
 
-## 1.38.1
 - Network: Changed configuration of network libraries to better support VSCode's patching of `http` and `https` modules. Also disabled the use of `keep-alive` headers until more robust testing is in place around VSCode's ongoing network changes. No performance changes are expected as the previous use of `keep-alive` didn't properly create re-usable connections.
 
-## 1.38.0
+## 1.38.1
 
 ### Changed
 


### PR DESCRIPTION
A merge messed up the CHANGELOG. This fixes it.

## Test plan

Read `vscode/CHANGELOG.md` and ensure that 1.38.1 and 1.38.0 are correct. Reference [this commit](https://sourcegraph.sourcegraph.com/github.com/sourcegraph/cody@d21f7c00ab158485dc487ff61ea6dd8d40af67f1/-/raw/vscode/CHANGELOG.md) to ensure.