### PR TITLE
E2E: Ensure tests pass on Windows

### DIFF
--- a/vscode/e2e/utils/credentials.setup.ts
+++ b/vscode/e2e/utils/credentials.setup.ts
@@ -49,7 +49,7 @@ async function withMissingValues(values: Map<string, string>) {
             }
             const token = execSync(
                 `gcloud secrets versions access latest --secret ${secretName} --project cody-agent-tokens --quiet`,
-                { encoding: 'utf-8' }
+                { encoding: 'utf-8', stdio: ['inherit', 'ignore', 'ignore'] }
             )
             withMissing.set(exportedName, token)
         } catch {

--- a/vscode/e2e/utils/vscody/fixture/vscode.ts
+++ b/vscode/e2e/utils/vscody/fixture/vscode.ts
@@ -356,7 +356,7 @@ async function waitForVSCodeServerV2(
     const serverProcess = spawn(nodeExecutable, extendedArgs, {
         env: config.env,
         cwd: config.versionedServerExecutableDir,
-        stdio: ['inherit', 'pipe', 'inherit'],
+        stdio: ['inherit', 'pipe', 'ignore'],
         detached: false,
     })
     const startPromise = new Promise<boolean>(ready => {

--- a/vscode/playwright.v2.config.ts
+++ b/vscode/playwright.v2.config.ts
@@ -31,7 +31,7 @@ const debugMode =
     process.env.PWDEBUG === '1' || process.env.PWDEBUG === 'console' || process.env.VSCDEBUG === '1'
 
 export default defineConfig<WorkerOptions & TestOptions & TmpDirOptions>({
-    workers: '50%',
+    workers: isWin ? '25%' : '50%',
     retries: 0, // Flake is not allowed!
     forbidOnly: isCI,
     // Important: All tests are parallelized, even within a file. So don't save
@@ -41,7 +41,7 @@ export default defineConfig<WorkerOptions & TestOptions & TmpDirOptions>({
     // We suspend timeouts when debugging (even from VSCode editor) so that if
     // you hit a breakpoint within the extension it doesn't cause a
     // test-failure.
-    timeout: debugMode ? 0 : isWin || isCI ? 10000 : 20000,
+    timeout: debugMode ? 0 : isWin || isCI ? 30000 : 20000,
     expect: {
         timeout: debugMode ? 0 : isWin || isCI ? 20000 : 10000,
     },


### PR DESCRIPTION
Before we had fairly optimistic timeout & resource usage settings, which on Windows (x86) machines lead to tests frequently timing out.

In addition sub-commands have their stdout inherited which on Windows leads to extremely verbose logging.

Now we tweak the configuration to ensure that tests pass correctly on Windows.

## Test plan

E2E tests pass