### PR TITLE
Temporarily remove switch account button

### DIFF
--- a/vscode/webviews/tabs/AccountTab.tsx
+++ b/vscode/webviews/tabs/AccountTab.tsx
@@ -37,10 +37,6 @@ export const AccountTab: React.FC<AccountTabProps> = ({ setView }) => {
                 getVSCodeAPI().postMessage({ command: 'links', value: ACCOUNT_UPGRADE_URL.toString() }),
         })
     }
-    actions.push({
-        text: 'Switch Account...',
-        onClick: () => getVSCodeAPI().postMessage({ command: 'command', id: 'cody.auth.switchAccount' }),
-    })
     if (isDotComUser) {
         actions.push({
             text: 'Manage Account',


### PR DESCRIPTION
## Test plan

In the client:

1. Open Accounts tab
2. There should be no `witch Account...` button.

In JetBrains switching accounts is still possible using native account management panel (accessible e.g. using Cody icon on the status bar or from the Cody settings).