### PR TITLE
Deep Cody: improve shell

### DIFF
--- a/vscode/src/commands/context/shell.ts
+++ b/vscode/src/commands/context/shell.ts
@@ -29,7 +29,11 @@ class PersistentShell {
 
     private init() {
         const shell = process.platform === 'win32' ? 'powershell.exe' : 'bash'
-        this.shell = spawn(shell, [], { stdio: ['pipe', 'pipe', 'pipe'] })
+        const cwd = vscode.workspace.workspaceFolders?.[0]?.uri?.fsPath
+        this.shell = spawn(shell, [], {
+            cwd,
+            stdio: ['pipe', 'pipe', 'pipe'],
+        })
 
         this.shell.stdout?.on('data', data => {
             this.buffer += data.toString()


### PR DESCRIPTION
This change introduces a `PersistentShell` class that maintains a long-running shell session to execute context commands. The key improvements are:

- Use `spawn` instead of `exec` to create a persistent shell session that maintains state between commands.
- Implement a timeout mechanism to handle cases where the shell gets stuck.
- Sanitize the command input to prevent potential security issues.
- Fall back to a default shell based on the operating system (PowerShell on Windows, Bash on other platforms).


## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

Manually test

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
