### PR TITLE
fix storybook build

### DIFF
--- a/vscode/.storybook/main.ts
+++ b/vscode/.storybook/main.ts
@@ -1,3 +1,4 @@
+import { resolve } from 'node:path'
 import type { StorybookConfig } from '@storybook/react-vite'
 import { defineProjectWithDefaults } from '../../.config/viteShared'
 
@@ -32,6 +33,14 @@ const config: StorybookConfig = {
             define: { 'process.env': '{}' },
             css: {
                 postcss: __dirname + '/../webviews',
+            },
+            resolve: {
+                alias: [
+                    {
+                        find: 'env-paths',
+                        replacement: resolve(__dirname, '../../web/lib/agent/shims/env-paths.ts'),
+                    },
+                ],
             },
         }),
     staticDirs: ['./static'],


### PR DESCRIPTION
A recent change (e9a460ebce9306ef9da39cace4e58f11826b4a3a) broke the storybook dev build, because it made `env-paths` a dependency of `lib/shared`, resulting in an error `os.homedir is not a function` in storybook's browser environment.

This fixes it by taking `env-paths` out of `lib/shared`, duplicating it `agent/` and `vscode/`. There may be a more elegant to do this through the vite config—I see a resolve override in `agent` to prevent this dep from being imported/activated, but not sure how to do that.

## Test plan

No changes
