### PR TITLE
DeepCody: new model UI group

### DIFF
--- a/vscode/webviews/components/modelSelectField/ModelSelectField.tsx
+++ b/vscode/webviews/components/modelSelectField/ModelSelectField.tsx
@@ -379,6 +379,7 @@ const ChatModelIcon: FunctionComponent<{ model: string; className?: string }> = 
 
 /** Common {@link ModelsService.uiGroup} values. */
 const ModelUIGroup: Record<string, string> = {
+    DeepCody: 'Mixed models',
     Power: 'More powerful models',
     Balanced: 'Balanced for power and speed',
     Speed: 'Faster models',
@@ -387,6 +388,7 @@ const ModelUIGroup: Record<string, string> = {
 }
 
 const getModelDropDownUIGroup = (model: Model): string => {
+    if (model.id.includes('deep-cody')) return ModelUIGroup.DeepCody
     if (model.tags.includes(ModelTag.Power)) return ModelUIGroup.Power
     if (model.tags.includes(ModelTag.Balanced)) return ModelUIGroup.Balanced
     if (model.tags.includes(ModelTag.Speed)) return ModelUIGroup.Speed


### PR DESCRIPTION
CLOSE https://linear.app/sourcegraph/issue/MKT-344

Based on the discussion in the linear issue, we would like to avoid listing Deep Cody under any existing model group but on its own under 'mixed models":

- Add a new 'DeepCody' model UI group to the `ModelUIGroup` object
- Update the `getModelDropDownUIGroup` function to handle the 'deep-cody' model ID and return the new 'DeepCody' group

## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

Small UI change: 

![image](https://github.com/user-attachments/assets/1d7add00-010f-4d1d-b881-462dc8eb2e15)

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
