### PR TITLE
Autocomplete: add git metadata to autocomplete requests

### DIFF
--- a/lib/shared/src/inferenceClient/misc.ts
+++ b/lib/shared/src/inferenceClient/misc.ts
@@ -28,6 +28,20 @@ export type CodeCompletionsParams = Omit<CompletionParameters, 'fast'> & {
     timeoutMs: number
     // TODO: apply the same type to the underlying `CompletionParameters`
     model?: LegacyModelRefStr | ModelRefStr
+    metadata?: {
+        /**
+         * File path relative to the git root.
+         */
+        gitFilePath?: string
+        /**
+         * Repository names resolved using Sourcegraph API based on remote URLs (such as `github.com/foo/bar`).
+         */
+        gitRepoNames?: string[]
+        /**
+         * git rev-parse HEAD
+         */
+        gitCommitHash?: string
+    }
 }
 export type SerializedCodeCompletionsParams = Omit<SerializedCompletionParameters, 'fast'>
 

--- a/lib/shared/src/misc/observableOperation.ts
+++ b/lib/shared/src/misc/observableOperation.ts
@@ -4,6 +4,7 @@ import { catchError, filter, firstValueFrom, shareReplay, startWith, switchMap }
 
 /** A sentinel value to indicate that the value has not yet been emitted. */
 export const pendingOperation = Symbol.for('@@pendingOperation')
+export type MaybePendingObservable<T> = Observable<T | typeof pendingOperation>
 
 /**
  * Run an operation with the outer observable as input. The result is replayed to all subscribers

--- a/vscode/src/completions/get-inline-completions-tests/helpers.ts
+++ b/vscode/src/completions/get-inline-completions-tests/helpers.ts
@@ -1,7 +1,7 @@
 import dedent from 'dedent'
 import { Observable } from 'observable-fns'
 import { vi } from 'vitest'
-import type { URI } from 'vscode-uri'
+import { URI } from 'vscode-uri'
 
 import {
     AUTH_STATUS_FIXTURE_AUTHED,
@@ -28,7 +28,7 @@ import type {
     CodeCompletionsParams,
     CompletionResponseWithMetaData,
 } from '@sourcegraph/cody-shared/src/inferenceClient/misc'
-
+import { repoNameResolver } from '../../repository/repo-name-resolver'
 import { DEFAULT_VSCODE_SETTINGS } from '../../testutils/mocks'
 import type { SupportedLanguage } from '../../tree-sitter/grammars'
 import { updateParseTreeCache } from '../../tree-sitter/parse-tree-cache'
@@ -411,6 +411,14 @@ export function initCompletionProviderConfig({
     authStatus,
 }: Partial<Pick<ParamsResult, 'configuration' | 'authStatus'>>): void {
     setEditorWindowIsFocused(() => true)
+
+    vi.spyOn(repoNameResolver, 'getRepoInfoContainingUri').mockReturnValue(
+        Observable.of({
+            rootUri: URI.file('/repoName'),
+            repoNames: ['sourcegraph/repoName'],
+        })
+    )
+
     vi.spyOn(featureFlagProvider, 'evaluateFeatureFlagEphemerally').mockResolvedValue(false)
     vi.spyOn(featureFlagProvider, 'evaluatedFeatureFlag').mockReturnValue(Observable.of(false))
     vi.spyOn(ClientConfigSingleton.getInstance(), 'getConfig').mockResolvedValue({

--- a/vscode/src/repository/repo-name-resolver.test.ts
+++ b/vscode/src/repository/repo-name-resolver.test.ts
@@ -11,6 +11,7 @@ import {
     mockResolvedConfig,
 } from '@sourcegraph/cody-shared'
 
+import { URI } from 'vscode-uri'
 import * as remoteUrlsFromParentDirs from './remote-urls-from-parent-dirs'
 import { RepoNameResolver } from './repo-name-resolver'
 import { mockFsCalls } from './test-helpers'
@@ -24,9 +25,10 @@ describe('getRepoNamesContainingUri', () => {
         mockResolvedConfig({ auth: {} })
         mockClientCapabilities(CLIENT_CAPABILITIES_FIXTURE)
 
-        vi.spyOn(remoteUrlsFromParentDirs, 'gitRemoteUrlsForUri').mockResolvedValue([
-            'git@github.com:sourcegraph/cody.git',
-        ])
+        vi.spyOn(remoteUrlsFromParentDirs, 'gitRemoteUrlsInfoForUri').mockResolvedValue({
+            rootUri: URI.file('/repo'),
+            remoteUrls: ['git@github.com:sourcegraph/cody.git'],
+        })
 
         const { fileUri } = mockFsCalls({
             filePath: '/repo/submodule/foo.ts',
@@ -55,9 +57,10 @@ describe('getRepoNamesContainingUri', () => {
         const repoNameResolver = new RepoNameResolver()
         mockAuthStatus(AUTH_STATUS_FIXTURE_AUTHED_DOTCOM)
 
-        vi.spyOn(remoteUrlsFromParentDirs, 'gitRemoteUrlsForUri').mockResolvedValue([
-            'git@github.com:sourcegraph/cody.git',
-        ])
+        vi.spyOn(remoteUrlsFromParentDirs, 'gitRemoteUrlsInfoForUri').mockResolvedValue({
+            rootUri: URI.file('/repo'),
+            remoteUrls: ['git@github.com:sourcegraph/cody.git'],
+        })
 
         const { fileUri } = mockFsCalls({
             filePath: '/repo/submodule/foo.ts',


### PR DESCRIPTION
- WIP
- Adds PCW metadata to autocomplete requests for enterprise users:
    ```ts
    metadata?: {
        /**
         * File path relative to the git root.
         */
        gitFilePath?: string
        /**
         * Repository names resolved using Sourcegraph API based on remote URLs (such as `github.com/foo/bar`).
         */
        gitRepoNames?: string[]
        /**
         * git rev-parse HEAD
         */
        gitCommitHash?: string
    }
    ```
- TODO:
    - [ ] Manual testing
    - [ ] New unit tests
    - [ ] Add `gitCommitHash`. Getting an always green commit hash will be tricky for autocomplete in the agent where we don't have the Git VS Code extension. We don't want to touch fs on every request, and we don't have any file-watching infra setup to get notifications about `.git/HEAD` being updated. I plan to add a naive timeout-based caching to start with.
- Part of https://linear.app/sourcegraph/issue/CODY-4122/ide-clients-include-repository-name-and-git-file-path-in-chat

## Test plan

CI

## Changelog

- Adds 
