### PR TITLE
Implement edit/insert prompts

### DIFF
--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/agent/protocol_generated/SerializedChatMessage.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/agent/protocol_generated/SerializedChatMessage.kt
@@ -10,7 +10,7 @@ data class SerializedChatMessage(
   val speaker: SpeakerEnum, // Oneof: human, assistant, system
   val text: String? = null,
   val model: String? = null,
-  val intent: IntentEnum? = null, // Oneof: search, chat
+  val intent: IntentEnum? = null, // Oneof: search, chat, edit, insert
 ) {
 
   enum class SpeakerEnum {
@@ -22,6 +22,8 @@ data class SerializedChatMessage(
   enum class IntentEnum {
     @SerializedName("search") Search,
     @SerializedName("chat") Chat,
+    @SerializedName("edit") Edit,
+    @SerializedName("insert") Insert,
   }
 }
 

--- a/lib/prompt-editor/src/PromptEditor.tsx
+++ b/lib/prompt-editor/src/PromptEditor.tsx
@@ -157,8 +157,6 @@ export const PromptEditor: FunctionComponent<Props> = ({
                 const existingMentions = getContextItemsForEditor(editor)
                 const ops = getMentionOperations(existingMentions, newContextItems)
 
-                console.log(newContextItems, existingMentions, ops)
-
                 if (ops.modify.size + ops.delete.size > 0) {
                     visitContextItemsForEditor(editor, existing => {
                         const update = ops.modify.get(existing.contextItem)

--- a/lib/prompt-editor/src/PromptEditor.tsx
+++ b/lib/prompt-editor/src/PromptEditor.tsx
@@ -157,6 +157,8 @@ export const PromptEditor: FunctionComponent<Props> = ({
                 const existingMentions = getContextItemsForEditor(editor)
                 const ops = getMentionOperations(existingMentions, newContextItems)
 
+                console.log(newContextItems, existingMentions, ops)
+
                 if (ops.modify.size + ops.delete.size > 0) {
                     visitContextItemsForEditor(editor, existing => {
                         const update = ops.modify.get(existing.contextItem)

--- a/lib/prompt-editor/src/nodes/ContextItemMentionNode.tsx
+++ b/lib/prompt-editor/src/nodes/ContextItemMentionNode.tsx
@@ -177,7 +177,9 @@ function iconForContextItem(contextItem: SerializedContextItem): React.Component
               ? SYMBOL_CONTEXT_MENTION_PROVIDER.id
               : contextItem.type === 'repository' || contextItem.type === 'tree'
                 ? REMOTE_REPOSITORY_PROVIDER_URI
-                : contextItem.providerUri
+                : contextItem.type === 'openctx'
+                  ? contextItem.providerUri
+                  : 'unknown'
     return iconForProvider[providerUri] ?? AtSignIcon
 }
 

--- a/lib/shared/src/chat/transcript/messages.ts
+++ b/lib/shared/src/chat/transcript/messages.ts
@@ -35,7 +35,7 @@ export interface ChatMessage extends Message {
     model?: string
 
     /* The detected intent of the message */
-    intent?: 'search' | 'chat' | undefined | null
+    intent?: 'search' | 'chat' | 'edit' | 'insert' | undefined | null
 }
 
 // An unsafe version of the {@link ChatMessage} that has the PromptString

--- a/lib/shared/src/sourcegraph-api/graphql/client.ts
+++ b/lib/shared/src/sourcegraph-api/graphql/client.ts
@@ -415,6 +415,7 @@ export interface Prompt {
     description?: string
     draft: boolean
     autoSubmit?: boolean
+    mode?: PromptMode
     definition: {
         text: string
     }
@@ -426,6 +427,8 @@ export interface Prompt {
         avatarURL: string
     }
 }
+
+export type PromptMode = 'CHAT' | 'EDIT' | 'INSERT'
 
 interface ContextFiltersResponse {
     site: {

--- a/lib/shared/src/sourcegraph-api/graphql/queries.ts
+++ b/lib/shared/src/sourcegraph-api/graphql/queries.ts
@@ -354,6 +354,7 @@ query ViewerPrompts($query: String!) {
             description
             draft
             autoSubmit
+            mode
             definition {
                 text
             }

--- a/lib/shared/src/telemetry-v2/events/chat-question.ts
+++ b/lib/shared/src/telemetry-v2/events/chat-question.ts
@@ -180,6 +180,8 @@ export const events = [
                 auto: 1,
                 chat: 2,
                 search: 3,
+                edit: 4,
+                insert: 5,
             } satisfies Record<
                 typeof fallbackValue | 'auto' | Exclude<ChatMessage['intent'], null | undefined>,
                 number
@@ -215,6 +217,7 @@ function publicContextSummary(globalPrefix: string, context: ContextItem[]) {
         openctx: cloneDeep(defaultByTypeCount),
         repository: cloneDeep(defaultByTypeCount),
         symbol: cloneDeep(defaultByTypeCount),
+        mode: cloneDeep(defaultByTypeCount),
         tree: {
             ...cloneDeep(defaultByTypeCount),
             isWorkspaceRoot: undefined as number | undefined,

--- a/vscode/src/chat/chat-view/ChatController.ts
+++ b/vscode/src/chat/chat-view/ChatController.ts
@@ -952,7 +952,7 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
 
         const task = result.task
 
-        let responseMessage = `Following is the response for the ${task.intent} instruction:\n`
+        let responseMessage = `Here is the response for the ${task.intent} instruction:\n`
         task.diff?.map(diff => {
             responseMessage += '\n```diff\n'
             if (diff.type === 'deletion') {
@@ -985,7 +985,7 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
             {
                 text: ps`${PromptString.unsafe_fromLLMResponse(responseMessage)}`,
             },
-            ChatBuilder.NO_MODEL
+            this.chatBuilder.selectedModel || ChatBuilder.NO_MODEL
         )
 
         void this.saveSession()

--- a/vscode/src/chat/protocol.ts
+++ b/vscode/src/chat/protocol.ts
@@ -169,6 +169,7 @@ export type ExtensionMessage =
           type: 'clientAction'
           addContextItemsToLastHumanInput?: ContextItem[] | null | undefined
           appendTextToLastPromptEditor?: string | null | undefined
+          setLastHumanInputIntent?: ChatMessage['intent'] | null | undefined
           smartApplyResult?: SmartApplyResult | undefined | null
           submitHumanInput?: boolean | undefined | null
       }

--- a/vscode/src/commands/CommandsController.ts
+++ b/vscode/src/commands/CommandsController.ts
@@ -76,7 +76,7 @@ class CommandsController implements vscode.Disposable {
 
             // Process default commands
             if (isDefaultChatCommand(commandKey) || isDefaultEditCommand(commandKey)) {
-                return executeDefaultCommand(commandKey, additionalInstruction)
+                return executeDefaultCommand(commandKey, { ...args, additionalInstruction })
             }
 
             const command = this.provider?.get(commandKey)

--- a/vscode/src/commands/execute/index.ts
+++ b/vscode/src/commands/execute/index.ts
@@ -8,6 +8,7 @@ import {
 } from '@sourcegraph/cody-shared'
 import type { CommandResult } from '../../CommandResult'
 import { executeEdit } from '../../edit/execute'
+import type { CodyCommandArgs } from '../types'
 import { executeDocCommand } from './doc'
 import { executeExplainCommand } from './explain'
 import { executeSmellCommand } from './smell'
@@ -47,20 +48,20 @@ export function isDefaultEditCommand(id: string): DefaultEditCommands | undefine
  */
 export async function executeDefaultCommand(
     id: DefaultCodyCommands | string,
-    additionalInstruction?: PromptString
+    args?: CodyCommandArgs
 ): Promise<CommandResult | undefined> {
     const key = id.replace(/^\//, '').trim() as DefaultCodyCommands
     switch (key) {
         case DefaultChatCommands.Explain:
-            return executeExplainCommand({ additionalInstruction })
+            return executeExplainCommand(args)
         case DefaultChatCommands.Smell:
-            return executeSmellCommand({ additionalInstruction })
+            return executeSmellCommand(args)
         case DefaultEditCommands.Test:
-            return executeTestEditCommand({ additionalInstruction })
+            return executeTestEditCommand(args)
         case DefaultEditCommands.Doc:
-            return executeDocCommand({ additionalInstruction })
+            return executeDocCommand(args)
         case DefaultEditCommands.Edit:
-            return { task: await executeEdit({}), type: 'edit' }
+            return { task: await executeEdit(args || {}), type: 'edit' }
         default:
             console.log('not a default command')
             return undefined

--- a/vscode/webviews/chat/cells/messageCell/human/HumanMessageCell.tsx
+++ b/vscode/webviews/chat/cells/messageCell/human/HumanMessageCell.tsx
@@ -60,13 +60,19 @@ export const HumanMessageCell: FC<HumanMessageCellProps> = ({ message, ...otherP
         [messageJSON]
     )
 
-    return <HumanMessageCellContent {...otherProps} initialEditorState={initialEditorState} />
+    return (
+        <HumanMessageCellContent
+            {...otherProps}
+            initialEditorState={initialEditorState}
+            intent={message.intent}
+        />
+    )
 }
 
-type HumanMessageCellContent = { initialEditorState: SerializedPromptEditorState } & Omit<
-    HumanMessageCellProps,
-    'message'
->
+type HumanMessageCellContent = {
+    initialEditorState: SerializedPromptEditorState
+    intent: ChatMessage['intent']
+} & Omit<HumanMessageCellProps, 'message'>
 const HumanMessageCellContent = memo<HumanMessageCellContent>(props => {
     const {
         models,
@@ -86,6 +92,7 @@ const HumanMessageCellContent = memo<HumanMessageCellContent>(props => {
         editorRef,
         __storybook__focus,
         onEditorFocusChange,
+        intent,
     } = props
 
     return (
@@ -118,6 +125,7 @@ const HumanMessageCellContent = memo<HumanMessageCellContent>(props => {
                     editorRef={editorRef}
                     __storybook__focus={__storybook__focus}
                     onEditorFocusChange={onEditorFocusChange}
+                    initialIntent={intent}
                 />
             }
             className={className}

--- a/vscode/webviews/chat/cells/messageCell/human/editor/HumanMessageEditor.tsx
+++ b/vscode/webviews/chat/cells/messageCell/human/editor/HumanMessageEditor.tsx
@@ -26,6 +26,7 @@ import {
 import type { UserAccountInfo } from '../../../../../Chat'
 import { type ClientActionListener, useClientActionListener } from '../../../../../client/clientState'
 import { useTelemetryRecorder } from '../../../../../utils/telemetry'
+import { useExperimentalOneBox } from '../../../../../utils/useExperimentalOneBox'
 import styles from './HumanMessageEditor.module.css'
 import type { SubmitButtonState } from './toolbar/SubmitButton'
 import { Toolbar } from './toolbar/Toolbar'
@@ -65,6 +66,8 @@ export const HumanMessageEditor: FunctionComponent<{
 
     /** For use in storybooks only. */
     __storybook__focus?: boolean
+
+    initialIntent?: ChatMessage['intent']
 }> = ({
     models,
     userInfo,
@@ -84,6 +87,7 @@ export const HumanMessageEditor: FunctionComponent<{
     editorRef: parentEditorRef,
     __storybook__focus,
     onEditorFocusChange: parentOnEditorFocusChange,
+    initialIntent,
 }) => {
     const telemetryRecorder = useTelemetryRecorder()
 
@@ -109,6 +113,11 @@ export const HumanMessageEditor: FunctionComponent<{
         : isEmptyEditorValue
           ? 'emptyEditorValue'
           : 'submittable'
+
+    const experimentalOneBoxEnabled = useExperimentalOneBox()
+    const [submitIntent, setSubmitIntent] = useState<ChatMessage['intent'] | undefined>(
+        initialIntent || (experimentalOneBoxEnabled ? undefined : 'chat')
+    )
 
     const onSubmitClick = useCallback(
         (intent?: ChatMessage['intent']) => {
@@ -156,19 +165,21 @@ export const HumanMessageEditor: FunctionComponent<{
 
             // Submit search intent query when CMD + Options + Enter is pressed.
             if ((event.metaKey || event.ctrlKey) && event.altKey) {
+                setSubmitIntent('search')
                 onSubmitClick('search')
                 return
             }
 
             // Submit chat intent query when CMD + Enter is pressed.
             if (event.metaKey || event.ctrlKey) {
+                setSubmitIntent('chat')
                 onSubmitClick('chat')
                 return
             }
 
-            onSubmitClick()
+            onSubmitClick(submitIntent)
         },
-        [isEmptyEditorValue, onSubmitClick]
+        [isEmptyEditorValue, onSubmitClick, submitIntent]
     )
 
     const [isEditorFocused, setIsEditorFocused] = useState(false)
@@ -261,6 +272,7 @@ export const HumanMessageEditor: FunctionComponent<{
                 addContextItemsToLastHumanInput,
                 appendTextToLastPromptEditor,
                 submitHumanInput,
+                setLastHumanInputIntent,
             }) => {
                 // Add new context to chat from the "Cody Add Selection to Cody Chat"
                 // command, etc. Only add to the last human input field.
@@ -302,19 +314,25 @@ export const HumanMessageEditor: FunctionComponent<{
                 }
 
                 if (editorState) {
+                    const onUpdate = awaitUpdate()
                     requestAnimationFrame(() => {
                         if (editorRef.current) {
-                            editorRef.current.setEditorState(editorState, awaitUpdate())
+                            editorRef.current.setEditorState(editorState, onUpdate)
                             editorRef.current.setFocus(true)
                         }
                     })
                 }
+                if (setLastHumanInputIntent) {
+                    setSubmitIntent(setLastHumanInputIntent)
+                }
 
                 if (submitHumanInput) {
-                    Promise.all(updates).then(() => onSubmitClick())
+                    Promise.all(updates).then(() =>
+                        onSubmitClick(setLastHumanInputIntent || submitIntent)
+                    )
                 }
             },
-            [isSent, onSubmitClick]
+            [isSent, onSubmitClick, submitIntent]
         )
     )
 
@@ -392,6 +410,8 @@ export const HumanMessageEditor: FunctionComponent<{
                     focusEditor={focusEditor}
                     hidden={!focused && isSent}
                     className={styles.toolbar}
+                    intent={submitIntent}
+                    onSelectIntent={setSubmitIntent}
                 />
             )}
         </div>

--- a/vscode/webviews/chat/cells/messageCell/human/editor/toolbar/SubmitButton.tsx
+++ b/vscode/webviews/chat/cells/messageCell/human/editor/toolbar/SubmitButton.tsx
@@ -1,7 +1,7 @@
 import type { ChatMessage } from '@sourcegraph/cody-shared'
 import clsx from 'clsx'
-import { BadgeCheck, Search } from 'lucide-react'
-import type { FunctionComponent } from 'react'
+import { BadgeCheck, BetweenHorizonalEnd, Pencil, Search } from 'lucide-react'
+import type { FC } from 'react'
 import { Kbd } from '../../../../../../components/Kbd'
 import { Button } from '../../../../../../components/shadcn/ui/button'
 import { Command, CommandItem, CommandList } from '../../../../../../components/shadcn/ui/command'
@@ -12,12 +12,46 @@ import { CodyIcon } from '../../../../../components/CodyIcon'
 
 export type SubmitButtonState = 'submittable' | 'emptyEditorValue' | 'waitingResponseComplete'
 
-export const SubmitButton: FunctionComponent<{
+const IntentOptions: {
+    title: string
+    icon: React.FC<{ className?: string }>
+    intent: ChatMessage['intent']
+}[] = [
+    {
+        title: 'Best for question',
+        icon: BadgeCheck,
+        intent: undefined,
+    },
+    {
+        title: 'Ask the LLM',
+        icon: CodyIcon,
+        intent: 'chat',
+    },
+    {
+        title: 'Search Code',
+        icon: Search,
+        intent: 'search',
+    },
+    {
+        title: 'Edit Code',
+        icon: Pencil,
+        intent: 'edit',
+    },
+    {
+        title: 'Insert Code',
+        icon: BetweenHorizonalEnd,
+        intent: 'insert',
+    },
+]
+
+export const SubmitButton: FC<{
     onClick: (intent?: ChatMessage['intent']) => void
     isEditorFocused?: boolean
     state?: SubmitButtonState
     className?: string
-}> = ({ onClick, state = 'submittable', className }) => {
+    intent?: ChatMessage['intent']
+    onSelectIntent?: (intent: ChatMessage['intent']) => void
+}> = ({ onClick, state = 'submittable', className, intent, onSelectIntent }) => {
     const experimentalOneBoxEnabled = useExperimentalOneBox()
 
     if (state === 'waitingResponseComplete') {
@@ -45,79 +79,67 @@ export const SubmitButton: FunctionComponent<{
         )
     }
 
-    if (experimentalOneBoxEnabled) {
-        return (
-            <div className="tw-flex tw-items-center">
-                <Button
-                    variant="primaryRoundedIcon"
-                    onClick={() => onClick()}
-                    disabled={state === 'emptyEditorValue'}
-                    type="submit"
-                    className={clsx('tw-relative tw-w-[20px] tw-h-[20px]', className)}
-                    title="Send"
-                >
-                    {/* biome-ignore lint/a11y/noSvgWithoutTitle: */}
-                    <svg
-                        width="8"
-                        height="10"
-                        viewBox="0 0 8 10"
-                        className="tw-translate-x-[1px]"
-                        fill="currentColor"
+    const selectedIntent = IntentOptions.find(option => option.intent === intent)
+
+    return (
+        <div className="tw-flex tw-items-center">
+            {experimentalOneBoxEnabled && selectedIntent && (
+                <selectedIntent.icon className="tw-size-8 tw-mr-2" />
+            )}
+            <Tooltip>
+                <TooltipTrigger asChild>
+                    <Button
+                        variant="primaryRoundedIcon"
+                        onClick={() => onClick(intent)}
+                        disabled={state === 'emptyEditorValue'}
+                        type="submit"
+                        className={clsx('tw-relative tw-w-[20px] tw-h-[20px]', className)}
+                        title="Send"
                     >
-                        <path
-                            d="M1.25 1L7.25 5L1.25 9V1Z"
-                            strokeLinecap="round"
-                            strokeLinejoin="round"
-                        />
-                    </svg>
-                </Button>
+                        {/* biome-ignore lint/a11y/noSvgWithoutTitle: */}
+                        <svg
+                            width="8"
+                            height="10"
+                            viewBox="0 0 8 10"
+                            className="tw-translate-x-[1px]"
+                            fill="currentColor"
+                        >
+                            <path
+                                d="M1.25 1L7.25 5L1.25 9V1Z"
+                                strokeLinecap="round"
+                                strokeLinejoin="round"
+                            />
+                        </svg>
+                    </Button>
+                </TooltipTrigger>
+                <TooltipContent side="bottom">
+                    Send <Kbd macOS="return" linuxAndWindows="return" />
+                </TooltipContent>
+            </Tooltip>
+            {experimentalOneBoxEnabled && (
                 <ToolbarPopoverItem
                     role="combobox"
                     iconEnd="chevron"
                     className="tw-justify-between tw-inline-flex"
                     aria-label="Insert prompt"
-                    popoverContent={() => (
+                    popoverContent={close => (
                         <Command>
                             <CommandList>
-                                <CommandItem
-                                    onSelect={() => onClick()}
-                                    className="tw-flex tw-text-left tw-justify-between"
-                                >
-                                    <div className="tw-flex tw-items-center tw-gap-2">
-                                        <BadgeCheck className="tw-size-8" />
-                                        Best for question
-                                    </div>
-                                    <div className="tw-flex tw-gap-2">
-                                        <Kbd macOS="return" linuxAndWindows="return" />
-                                    </div>
-                                </CommandItem>
-                                <CommandItem
-                                    onSelect={() => onClick('chat')}
-                                    className="tw-flex tw-text-left tw-justify-between"
-                                >
-                                    <div className="tw-flex tw-items-center tw-gap-2">
-                                        <CodyIcon />
-                                        Ask the LLM
-                                    </div>
-                                    <div className="tw-flex tw-gap-2">
-                                        <Kbd macOS="cmd" linuxAndWindows="ctrl" />
-                                        <Kbd macOS="return" linuxAndWindows="return" />
-                                    </div>
-                                </CommandItem>
-                                <CommandItem
-                                    onSelect={() => onClick('search')}
-                                    className="tw-flex tw-text-left tw-justify-between"
-                                >
-                                    <div className="tw-flex tw-items-center tw-gap-2">
-                                        <Search className="tw-size-8" />
-                                        Search Code
-                                    </div>
-                                    <div className="tw-flex tw-gap-2">
-                                        <Kbd macOS="cmd" linuxAndWindows="ctrl" />
-                                        <Kbd macOS="opt" linuxAndWindows="alt" />
-                                        <Kbd macOS="return" linuxAndWindows="return" />
-                                    </div>
-                                </CommandItem>
+                                {IntentOptions.map(option => (
+                                    <CommandItem
+                                        key={option.intent}
+                                        onSelect={() => {
+                                            onSelectIntent?.(option.intent)
+                                            close()
+                                        }}
+                                        className="tw-flex tw-text-left tw-justify-between"
+                                    >
+                                        <div className="tw-flex tw-items-center tw-gap-2">
+                                            <option.icon className="tw-size-8" />
+                                            {option.title}
+                                        </div>
+                                    </CommandItem>
+                                ))}
                             </CommandList>
                         </Command>
                     )}
@@ -130,39 +152,7 @@ export const SubmitButton: FunctionComponent<{
                         },
                     }}
                 />
-            </div>
-        )
-    }
-    return (
-        <Tooltip>
-            <TooltipTrigger asChild>
-                <Button
-                    variant="primaryRoundedIcon"
-                    onClick={() => onClick()}
-                    disabled={state === 'emptyEditorValue'}
-                    type="submit"
-                    className={clsx('tw-relative tw-w-[20px] tw-h-[20px]', className)}
-                    title="Send"
-                >
-                    {/* biome-ignore lint/a11y/noSvgWithoutTitle: */}
-                    <svg
-                        width="8"
-                        height="10"
-                        viewBox="0 0 8 10"
-                        className="tw-translate-x-[1px]"
-                        fill="currentColor"
-                    >
-                        <path
-                            d="M1.25 1L7.25 5L1.25 9V1Z"
-                            strokeLinecap="round"
-                            strokeLinejoin="round"
-                        />
-                    </svg>
-                </Button>
-            </TooltipTrigger>
-            <TooltipContent side="bottom">
-                Send <Kbd macOS="return" linuxAndWindows="return" />
-            </TooltipContent>
-        </Tooltip>
+            )}
+        </div>
     )
 }

--- a/vscode/webviews/chat/cells/messageCell/human/editor/toolbar/Toolbar.tsx
+++ b/vscode/webviews/chat/cells/messageCell/human/editor/toolbar/Toolbar.tsx
@@ -31,6 +31,8 @@ export const Toolbar: FunctionComponent<{
 
     hidden?: boolean
     className?: string
+    intent?: ChatMessage['intent']
+    onSelectIntent?: (intent: ChatMessage['intent']) => void
 }> = ({
     userInfo,
     isEditorFocused,
@@ -42,6 +44,8 @@ export const Toolbar: FunctionComponent<{
     hidden,
     className,
     models,
+    intent,
+    onSelectIntent,
 }) => {
     /**
      * If the user clicks in a gap or on the toolbar outside of any of its buttons, report back to
@@ -94,6 +98,8 @@ export const Toolbar: FunctionComponent<{
                     onClick={onSubmitClick}
                     isEditorFocused={isEditorFocused}
                     state={submitState}
+                    intent={intent}
+                    onSelectIntent={onSelectIntent}
                 />
             </div>
         </menu>

--- a/vscode/webviews/prompts/PromptsTab.tsx
+++ b/vscode/webviews/prompts/PromptsTab.tsx
@@ -1,4 +1,4 @@
-import type { Action } from '@sourcegraph/cody-shared'
+import type { Action, ChatMessage } from '@sourcegraph/cody-shared'
 import { useClientActionDispatcher } from '../client/clientState'
 import { useLocalStorage } from '../components/hooks'
 import { PromptList } from '../components/promptList/PromptList'
@@ -6,6 +6,7 @@ import { View } from '../tabs/types'
 import { getVSCodeAPI } from '../utils/VSCodeApi'
 
 import { firstValueFrom } from '@sourcegraph/cody-shared'
+import type { PromptMode } from '@sourcegraph/cody-shared/src/sourcegraph-api/graphql/client'
 import { useExtensionAPI } from '@sourcegraph/prompt-editor'
 import styles from './PromptsTab.module.css'
 
@@ -28,6 +29,19 @@ export const PromptsTab: React.FC<{
             />
         </div>
     )
+}
+
+const promptModeToIntent = (mode?: PromptMode): ChatMessage['intent'] => {
+    switch (mode) {
+        case 'CHAT':
+            return 'chat'
+        case 'EDIT':
+            return 'edit'
+        case 'INSERT':
+            return 'insert'
+        default:
+            return 'chat'
+    }
 }
 
 export function useActionSelect() {
@@ -56,6 +70,7 @@ export function useActionSelect() {
                 dispatchClientAction(
                     {
                         editorState: promptEditorState,
+                        setLastHumanInputIntent: promptModeToIntent(action.mode),
                         submitHumanInput: action.autoSubmit,
                     },
                     // Buffer because PromptEditor is not guaranteed to be mounted after the `setView`


### PR DESCRIPTION
closes: https://linear.app/sourcegraph/issue/SRCH-1172/prompts-can-output-into-3-places

This PR integrates with the prompt mode (chat | edit | insert) from the SG API. Prompts with edit or insert mode are executed using the `executeEdit`, the same way the commands are executed. The prompt is used as the instruction text for `executeEdit`. First the chat transcript is created, context is fetched and then the `executeEdit` is called. The `FixupTask` from the execution is used to construct the response in chat. The response for now shows the diff only. 

In BG, the state for interactions mode is saved as intent. The dropdown and icon indicator for to allow users to manually change the mode and to see which mode is set, is only available behind the OneBox feature flag and will not be released yet. 

![CleanShot 2024-10-21 at 18 28 08@2x](https://github.com/user-attachments/assets/5cb3e6b1-b53a-41b8-824b-a74f35d1a4b9)

## Test plan
- create a edit/insert prompt
- execute it from Cody
- it should work as expected.

## Changelog

- Add ability to execute prompts to perform edits or insert code.
