### PR TITLE
remove bug: prefix in issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,9 +1,9 @@
 name: Bug report (VS Code)
 description: File a bug report to help us improve
-title: 'bug: '
+title: ''
 labels:
   - bug
-  - clients/vscode
+  - repo/cody
 projects:
   - sourcegraph/387
 body:


### PR DESCRIPTION
Originally, I added the `bug:` prefix to help categorize different types of issues like features, feedback, etc. But now that the repo is bugs only, we don't need this prefix. 

Also changing the label from `clients/vscode` to `repo/cody` to help distinguish where this issue originated from when we sync back to linear

## Test plan
N/A
<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
