### PR TITLE
Fix issues with incorrect serialization of LocalStorageDB items

### DIFF
--- a/agent/src/global-state/AgentGlobalState.test.ts
+++ b/agent/src/global-state/AgentGlobalState.test.ts
@@ -107,4 +107,9 @@ describe('LocalStorageDB', () => {
         localStorageDB.set('undefinedKey', undefined)
         expect(localStorageDB.get('undefinedKey')).toBeUndefined()
     })
+
+    it('should handle empty string value', () => {
+        localStorageDB.set('emptyStringKey', '')
+        expect(localStorageDB.get('emptyStringKey')).toBe('')
+    })
 })

--- a/agent/src/global-state/AgentGlobalState.ts
+++ b/agent/src/global-state/AgentGlobalState.ts
@@ -135,7 +135,7 @@ export class LocalStorageDB implements DB {
         }
     }
     set(key: string, value: any): void {
-        if (value) {
+        if (value != null) {
             this.storage.setItem(key, JSON.stringify(value))
         } else {
             this.storage.removeItem(key)

--- a/agent/src/global-state/AgentGlobalState.ts
+++ b/agent/src/global-state/AgentGlobalState.ts
@@ -128,9 +128,6 @@ export class LocalStorageDB implements DB {
         try {
             return item ? JSON.parse(item) : undefined
         } catch (error) {
-            // That should never happen now, but in past it was possible to store incorrectly serialized
-            // undefined values, which were failing to deserialize during the get operation
-            this.storage.removeItem(key)
             return undefined
         }
     }

--- a/agent/src/global-state/AgentGlobalState.ts
+++ b/agent/src/global-state/AgentGlobalState.ts
@@ -132,7 +132,7 @@ export class LocalStorageDB implements DB {
         }
     }
     set(key: string, value: any): void {
-        if (value != null) {
+        if (value !== null && value !== undefined) {
             this.storage.setItem(key, JSON.stringify(value))
         } else {
             this.storage.removeItem(key)


### PR DESCRIPTION
## Changes

To avoid further doubts I adjusted behaviour and interface of `LocalStorageDB`to be more in sunc with `vscode.Memento`, that is:
* setting key to `null` or `undefined` removes key from the store
* get on non-existing key returns an `undefined`

Note that it means setting key to `null` and then doing get on it will result in `undefined` value, not a `null`.

I also added exception handling in the `LocalStorageDB::get` to make sure we won't fail on previously incorrectly serialised values.

## Test plan

Unit tests which should cover all corner cases were added.
