### PR TITLE
Prepare cody web 0.10.0 release

### DIFF
--- a/lib/shared/src/lexicalEditor/nodes.ts
+++ b/lib/shared/src/lexicalEditor/nodes.ts
@@ -66,7 +66,16 @@ export function serializeContextItem(
     contextItem: ContextItem | SerializedContextItem
 ): SerializedContextItem {
     const uri = contextItem.uri
-    const uriString = uri instanceof Object ? uri.path : uri
+    const uriString =
+        uri instanceof Object
+            ? URI.from({
+                  scheme: uri.scheme,
+                  authority: uri.authority,
+                  path: uri.path,
+                  query: uri.query,
+                  fragment: uri.fragment,
+              }).toString()
+            : uri
 
     // Make sure we only bring over the fields on the context item that we need, or else we
     // could accidentally include tons of data (including the entire contents of files).

--- a/lib/shared/src/lexicalEditor/nodes.ts
+++ b/lib/shared/src/lexicalEditor/nodes.ts
@@ -65,11 +65,14 @@ export type SerializedTemplateInputNode = Spread<
 export function serializeContextItem(
     contextItem: ContextItem | SerializedContextItem
 ): SerializedContextItem {
+    const uri = contextItem.uri
+    const uriString = uri instanceof Object ? uri.path : uri
+
     // Make sure we only bring over the fields on the context item that we need, or else we
     // could accidentally include tons of data (including the entire contents of files).
     return {
         ...contextItem,
-        uri: contextItem.uri.toString(),
+        uri: uriString,
 
         // Don't include the `content` (if it's present) because it's quite large, and we don't need
         // to serialize it here. It can be hydrated on demand.

--- a/vscode/src/prompts/prompt-hydration.ts
+++ b/vscode/src/prompts/prompt-hydration.ts
@@ -140,6 +140,10 @@ async function hydrateWithCurrentDirectory(
         item => item.type === 'openctx' && item.providerUri === REMOTE_DIRECTORY_PROVIDER_URI
     )
 
+    if (initialContext.length > 0 && !initialContextDirectory) {
+        return [promptText, []]
+    }
+
     if (initialContextDirectory) {
         return [
             promptText.replaceAll(

--- a/vscode/webviews/chat/Transcript.tsx
+++ b/vscode/webviews/chat/Transcript.tsx
@@ -385,7 +385,7 @@ const TranscriptInteraction: FC<TranscriptInteractionProps> = memo(props => {
                     {humanMessage.intent === 'search' ? (
                         <div className="tw-flex tw-justify-between tw-gap-4 tw-items-center">
                             <span>Intent detection selected a code search response.</span>
-                            <div className='tw-shrink-0 tw-self-start'>
+                            <div className="tw-shrink-0 tw-self-start">
                                 <Button
                                     size="sm"
                                     variant="outline"
@@ -400,7 +400,7 @@ const TranscriptInteraction: FC<TranscriptInteractionProps> = memo(props => {
                     ) : (
                         <div className="tw-flex tw-justify-between tw-gap-4 tw-items-center">
                             <span>Intent detection selected an LLM response.</span>
-                            <div className='tw-shrink-0 tw-self-start'>
+                            <div className="tw-shrink-0 tw-self-start">
                                 <Button
                                     size="sm"
                                     variant="outline"

--- a/vscode/webviews/chat/Transcript.tsx
+++ b/vscode/webviews/chat/Transcript.tsx
@@ -385,7 +385,7 @@ const TranscriptInteraction: FC<TranscriptInteractionProps> = memo(props => {
                     {humanMessage.intent === 'search' ? (
                         <div className="tw-flex tw-justify-between tw-gap-4 tw-items-center">
                             <span>Intent detection selected a code search response.</span>
-                            <div>
+                            <div className='tw-shrink-0 tw-self-start'>
                                 <Button
                                     size="sm"
                                     variant="outline"
@@ -400,7 +400,7 @@ const TranscriptInteraction: FC<TranscriptInteractionProps> = memo(props => {
                     ) : (
                         <div className="tw-flex tw-justify-between tw-gap-4 tw-items-center">
                             <span>Intent detection selected an LLM response.</span>
-                            <div>
+                            <div className='tw-shrink-0 tw-self-start'>
                                 <Button
                                     size="sm"
                                     variant="outline"

--- a/vscode/webviews/chat/components/WelcomeMessage.tsx
+++ b/vscode/webviews/chat/components/WelcomeMessage.tsx
@@ -33,9 +33,8 @@ export const WelcomeMessage: FunctionComponent<WelcomeMessageProps> = ({
                     appearanceMode="chips-list"
                     telemetryLocation="PromptsTab"
                     showCommandOrigins={true}
-                    showPromptLibraryUnsupportedMessage={false}
                     showOnlyPromptInsertableCommands={false}
-                    includeEditCommandOnTop={true}
+                    showPromptLibraryUnsupportedMessage={false}
                     onSelect={item => runAction(item, setView)}
                 />
 

--- a/vscode/webviews/components/promptsMigration/PromptsMigration.tsx
+++ b/vscode/webviews/components/promptsMigration/PromptsMigration.tsx
@@ -132,9 +132,15 @@ const PromptsMigrationInitial: FC<PromptsMigrationInitial> = props => {
                     </Button>
                 )}
 
-                <Button variant="outline" className={styles.action}>
-                    Explore docs
-                    <LucideExternalLink size={16} />
+                <Button variant="outline" className={styles.action} asChild={true}>
+                    <a
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        href="https://sourcegraph.com/docs/cody/capabilities/commands#prompt-library"
+                    >
+                        Explore docs
+                        <LucideExternalLink size={16} />
+                    </a>
                 </Button>
             </div>
 

--- a/web/CHANGELOG.md
+++ b/web/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.10.0
+- Prompts UI update (new prompts list, tab and recent prompts popover)
+- Improved performance by bypassing rpc messages hydration
+
 ## 0.9.0
 - Big refactoring change around authorization (see [#5221](https://github.com/sourcegraph/cody/pull/5221))
 

--- a/web/lib/agent/agent.client.ts
+++ b/web/lib/agent/agent.client.ts
@@ -68,7 +68,7 @@ export async function createAgentClient({
 
     // Initialize
     const serverInfo: ServerInfo = await rpc.sendRequest('initialize', {
-        name: 'standalone-web',
+        name: process.env.CODY_WEB_DEMO ? 'standalone-web' : 'web',
         version: '0.0.1',
         workspaceRootUri,
         capabilities: {

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sourcegraph/cody-web",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "Cody standalone web app",
   "license": "Apache-2.0",
   "repository": {

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -11,7 +11,7 @@ const fakeProcessEnv: Record<string, string | boolean> = {
     CODY_TESTING: false,
     CODY_PROFILE_TEMP: false,
     CODY_TELEMETRY_EXPORTER: 'graphql',
-    CODY_WEB_DEMO: true,
+    CODY_WEB_DEMO: process.env.NODE_ENV === 'development',
     NODE_ENV: 'production',
     NODE_DEBUG: false,
     CODY_OVERRIDE_DOTCOM_URL: 'https://sourcegraph.com',


### PR DESCRIPTION
Just a few tweaks before the Cody Web 0.10.0 release, 
- Guard new experimental edit-like prompt execution from Cody Web
- Fix the client name for the production version of Cody Web
- Fix link in the prompt migration (unrelated to Cody Web) 

## Test plan
- Check that Cody Web demo works properly
- Check that Cody Web works in Sourcegraph Web build 
