### PR TITLE
VS Code: fix repo name resolution cache

### DIFF
--- a/lib/shared/src/misc/observable.ts
+++ b/lib/shared/src/misc/observable.ts
@@ -564,12 +564,12 @@ export type UnsubscribableLike = Unsubscribable | (() => void) | void | null
 
 export type ShareReplayConfig = {
     /**
-     * When `shouldRefCount` is true (default), the source observable will be unsubscribed when the number of
+     * When `shouldCountRefs` is true (default), the source observable will be unsubscribed when the number of
      * subscribers (reference count) drops to zero. This means that when there are no active subscribers,
      * the observable will stop emitting values and release resources, and future subscribers will trigger
      * a new subscription to the source observable.
      *
-     * If `shouldRefCount` is false (the default behavior in RxJS), the source observable will remain
+     * If `shouldCountRefs` is false (the default behavior in RxJS), the source observable will remain
      * active even when there are no subscribers. This is useful when you want to keep an expensive
      * or long-running observable alive, avoiding the need for a costly re-subscription when new
      * subscribers join later.
@@ -577,7 +577,7 @@ export type ShareReplayConfig = {
      * See more context and examples at: https://rxjs.dev/api/operators/shareReplay
      * It has a similar but _not_ identical implementation.
      */
-    shouldRefCount: boolean
+    shouldCountRefs: boolean
 }
 
 let shareReplaySeq = 0
@@ -586,7 +586,7 @@ export function shareReplay<T>(
 ): (observable: ObservableLike<T>) => Observable<T> {
     // NOTE(sqs): This is helpful for debugging why shareReplay does not have a buffered value.
     const shouldLog = false
-    const shouldRefCount = config?.shouldRefCount ?? true
+    const shouldCountRefs = config?.shouldCountRefs ?? true
     const logID = shareReplaySeq++
     function logDebug(msg: string, ...args: any[]): void {
         if (shouldLog) console.debug(`shareReplay#${logID}:`, msg, ...args)
@@ -622,7 +622,7 @@ export function shareReplay<T>(
             return () => {
                 refCount--
                 innerSub.unsubscribe()
-                if (shouldRefCount && refCount === 0) {
+                if (shouldCountRefs && refCount === 0) {
                     if (subscription) {
                         unsubscribe(subscription)
                         subscription = null

--- a/lib/shared/src/misc/observable.ts
+++ b/lib/shared/src/misc/observable.ts
@@ -562,10 +562,31 @@ export function pick<T, K extends keyof T>(
 // biome-ignore lint/suspicious/noConfusingVoidType:
 export type UnsubscribableLike = Unsubscribable | (() => void) | void | null
 
+export type ShareReplayConfig = {
+    /**
+     * When `shouldRefCount` is true (default), the source observable will be unsubscribed when the number of
+     * subscribers (reference count) drops to zero. This means that when there are no active subscribers,
+     * the observable will stop emitting values and release resources, and future subscribers will trigger
+     * a new subscription to the source observable.
+     *
+     * If `shouldRefCount` is false (the default behavior in RxJS), the source observable will remain
+     * active even when there are no subscribers. This is useful when you want to keep an expensive
+     * or long-running observable alive, avoiding the need for a costly re-subscription when new
+     * subscribers join later.
+     *
+     * See more context and examples at: https://rxjs.dev/api/operators/shareReplay
+     * It has a similar but _not_ identical implementation.
+     */
+    shouldRefCount: boolean
+}
+
 let shareReplaySeq = 0
-export function shareReplay<T>(): (observable: ObservableLike<T>) => Observable<T> {
+export function shareReplay<T>(
+    config?: ShareReplayConfig
+): (observable: ObservableLike<T>) => Observable<T> {
     // NOTE(sqs): This is helpful for debugging why shareReplay does not have a buffered value.
     const shouldLog = false
+    const shouldRefCount = config?.shouldRefCount ?? true
     const logID = shareReplaySeq++
     function logDebug(msg: string, ...args: any[]): void {
         if (shouldLog) console.debug(`shareReplay#${logID}:`, msg, ...args)
@@ -601,7 +622,7 @@ export function shareReplay<T>(): (observable: ObservableLike<T>) => Observable<
             return () => {
                 refCount--
                 innerSub.unsubscribe()
-                if (refCount === 0) {
+                if (shouldRefCount && refCount === 0) {
                     if (subscription) {
                         unsubscribe(subscription)
                         subscription = null

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -10,15 +10,19 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 
 ### Changed
 
+### Fixed
+
+- Context Filters: fixed repo name resolution cache. [pull/5978](https://github.com/sourcegraph/cody/pull/5978)
+
 ## 1.38.2
 
 ### Changed
 
 - Telemetry: Account for visible ranges in the characters logger. [pull/5931](https://github.com/sourcegraph/cody/pull/5931)
-### Fixed 
+
+### Fixed
 
 - Chat: Improved handling of duplicated priority context items. [pull/5860](https://github.com/sourcegraph/cody/pull/5860)
-
 - Chat: Improved handling of duplicated priority context items. [pull/5860](https://github.com/sourcegraph/cody/pull/5860)
 
 ### Changed

--- a/vscode/src/repository/remote-urls-from-parent-dirs.test.ts
+++ b/vscode/src/repository/remote-urls-from-parent-dirs.test.ts
@@ -75,9 +75,9 @@ describe('gitRemoteUrlsForUri', () => {
 
         const remoteUrls = await gitRemoteUrlsForUri(fileUri)
         expect(remoteUrls).toEqual([
-            'https://github.com/username/yourproject.git',
-            'https://github.com/originalauthor/yourproject.git',
             'git@backupserver:repositories/yourproject.git',
+            'https://github.com/originalauthor/yourproject.git',
+            'https://github.com/username/yourproject.git',
         ])
     })
 

--- a/vscode/src/repository/remote-urls-from-parent-dirs.test.ts
+++ b/vscode/src/repository/remote-urls-from-parent-dirs.test.ts
@@ -81,7 +81,7 @@ describe('gitRemoteUrlsForUri', () => {
         ])
     })
 
-    it('returns `undefined` from the .git/config file with no remotes specified', async () => {
+    it('returns `[]` from the .git/config file with no remotes specified', async () => {
         const { fileUri } = mockFsCalls({
             filePath: '/repo/src/dir/foo.ts',
             gitRepoPath: '/repo',
@@ -99,10 +99,10 @@ describe('gitRemoteUrlsForUri', () => {
         })
 
         const remoteUrls = await gitRemoteUrlsForUri(fileUri)
-        expect(remoteUrls).toBe(undefined)
+        expect(remoteUrls).toEqual([])
     })
 
-    it('returns `undefined` if .git/config is not found', async () => {
+    it('returns `[]` if .git/config is not found', async () => {
         const statMock = vi
             .spyOn(vscode.workspace.fs, 'stat')
             .mockResolvedValueOnce({ type: vscode.FileType.File } as vscode.FileStat)
@@ -112,7 +112,7 @@ describe('gitRemoteUrlsForUri', () => {
         const remoteUrls = await gitRemoteUrlsForUri(uri)
 
         expect(statMock).toBeCalledTimes(5)
-        expect(remoteUrls).toBe(undefined)
+        expect(remoteUrls).toEqual([])
     })
 
     it('finds remote urls in a submodule', async () => {
@@ -175,7 +175,7 @@ describe('gitRemoteUrlsForUri', () => {
         expect(remoteUrls).toEqual(['https://github.com/nested/submodule.git'])
     })
 
-    it('returns `undefined` for a submodule without a remote url', async () => {
+    it('returns `[]` for a submodule without a remote url', async () => {
         const { fileUri } = mockFsCalls({
             filePath: '/repo/submodule/foo.ts',
             gitRepoPath: '/repo',
@@ -199,7 +199,7 @@ describe('gitRemoteUrlsForUri', () => {
         })
 
         const remoteUrls = await gitRemoteUrlsForUri(fileUri)
-        expect(remoteUrls).toBe(undefined)
+        expect(remoteUrls).toEqual([])
     })
 
     it('refuses to work on non-file URIs', async () => {
@@ -209,10 +209,10 @@ describe('gitRemoteUrlsForUri', () => {
             gitConfig: 'a',
         })
 
-        expect(await gitRemoteUrlsForUri(URI.parse('https://example.com/foo/bar'))).toBe(undefined)
-        expect(await gitRemoteUrlsForUri(URI.parse('https://gitlab.com/foo/bar'))).toBe(undefined)
-        expect(await gitRemoteUrlsForUri(URI.parse('https://github.com/foo/bar'))).toBe(undefined)
-        expect(await gitRemoteUrlsForUri(URI.parse('ssh://git@github.com:foo/bar.git'))).toBe(undefined)
+        expect(await gitRemoteUrlsForUri(URI.parse('https://example.com/foo/bar'))).toEqual([])
+        expect(await gitRemoteUrlsForUri(URI.parse('https://gitlab.com/foo/bar'))).toEqual([])
+        expect(await gitRemoteUrlsForUri(URI.parse('https://github.com/foo/bar'))).toEqual([])
+        expect(await gitRemoteUrlsForUri(URI.parse('ssh://git@github.com:foo/bar.git'))).toEqual([])
         expect(statMock).toBeCalledTimes(0)
         expect(readFileMock).toBeCalledTimes(0)
     })

--- a/vscode/src/repository/repo-name-resolver.ts
+++ b/vscode/src/repository/repo-name-resolver.ts
@@ -1,7 +1,10 @@
+import { LRUCache } from 'lru-cache'
+import { Observable, map } from 'observable-fns'
 import type * as vscode from 'vscode'
 
 import {
     ContextFiltersProvider,
+    type MaybePendingObservable,
     authStatus,
     combineLatest,
     convertGitCloneURLToCodebaseName,
@@ -19,9 +22,13 @@ import {
     switchMapReplayOperation,
 } from '@sourcegraph/cody-shared'
 
-import { Observable, map } from 'observable-fns'
 import { logDebug } from '../output-channel-logger'
+
 import { gitRemoteUrlsForUri } from './remote-urls-from-parent-dirs'
+
+type RemoteUrl = string
+type RepoName = string
+type UriFsPath = string
 
 export class RepoNameResolver {
     /**
@@ -31,36 +38,34 @@ export class RepoNameResolver {
      * ❗️ For enterprise, this uses the Sourcegraph API to resolve repo names instead of the local
      * conversion function. ❗️
      */
-    public getRepoNamesContainingUri(uri: vscode.Uri): Observable<string[] | typeof pendingOperation> {
+    public getRepoNamesContainingUri(uri: vscode.Uri): MaybePendingObservable<RepoName[]> {
         return combineLatest(
-            promiseFactoryToObservable(signal => this.getUniqueRemoteUrlsCached(uri, signal)),
+            promiseFactoryToObservable(signal => this.getRemoteUrlsCached(uri, signal)),
             authStatus
         ).pipe(
-            switchMapReplayOperation(
-                ([uniqueRemoteUrls, authStatus]): Observable<string[] | typeof pendingOperation> => {
-                    // Use local conversion function for non-enterprise accounts.
-                    if (isDotCom(authStatus)) {
-                        return Observable.of(
-                            uniqueRemoteUrls.map(convertGitCloneURLToCodebaseName).filter(isDefined)
-                        )
-                    }
-
-                    return combineLatest(
-                        ...uniqueRemoteUrls.map(remoteUrl => this.getRepoNameCached(remoteUrl))
-                    ).pipe(
-                        map(repoNames =>
-                            repoNames.includes(pendingOperation)
-                                ? pendingOperation
-                                : (
-                                      repoNames as Exclude<
-                                          (typeof repoNames)[number],
-                                          typeof pendingOperation
-                                      >[]
-                                  ).filter(isDefined)
-                        )
+            switchMapReplayOperation(([remoteUrls, authStatus]) => {
+                // Use local conversion function for non-enterprise accounts.
+                if (isDotCom(authStatus)) {
+                    return Observable.of(
+                        remoteUrls.map(convertGitCloneURLToCodebaseName).filter(isDefined)
                     )
                 }
-            ),
+
+                return combineLatest(
+                    ...remoteUrls.map(remoteUrl => this.getRepoNameCached(remoteUrl))
+                ).pipe(
+                    map(repoNames =>
+                        repoNames.includes(pendingOperation)
+                            ? pendingOperation
+                            : (
+                                  repoNames as Exclude<
+                                      (typeof repoNames)[number],
+                                      typeof pendingOperation
+                                  >[]
+                              ).filter(isDefined)
+                    )
+                )
+            }),
             map(value => {
                 if (isError(value)) {
                     logDebug('RepoNameResolver:getRepoNamesContainingUri', 'error', { verbose: value })
@@ -71,40 +76,49 @@ export class RepoNameResolver {
         )
     }
 
-    private getUniqueRemoteUrlsCache: Partial<Record<string, Promise<string[]>>> = {}
-    private async getUniqueRemoteUrlsCached(uri: vscode.Uri, signal?: AbortSignal): Promise<string[]> {
+    private fsPathToRemoteUrlsInfo = new LRUCache<UriFsPath, ReturnType<typeof gitRemoteUrlsForUri>>({
+        max: 1000,
+    })
+
+    private async getRemoteUrlsCached(uri: vscode.Uri, signal?: AbortSignal): Promise<RemoteUrl[]> {
         const key = uri.toString()
-        let uniqueRemoteUrls: Promise<string[]> | undefined = this.getUniqueRemoteUrlsCache[key]
-        if (!uniqueRemoteUrls) {
-            uniqueRemoteUrls = gitRemoteUrlsForUri(uri, signal)
-                .then(remoteUrls => {
-                    const uniqueRemoteUrls = Array.from(new Set(remoteUrls ?? [])).sort()
-                    return uniqueRemoteUrls
+        let remoteUrlsInfo = this.fsPathToRemoteUrlsInfo.get(key)
+
+        if (!remoteUrlsInfo) {
+            remoteUrlsInfo = gitRemoteUrlsForUri(uri, signal).catch(error => {
+                logError('RepoNameResolver:getRemoteUrlsInfoCached', 'error', {
+                    verbose: error,
                 })
-                .catch(error => {
-                    logError('RepoNameResolver:getUniqueRemoteUrlsCached', 'error', {
-                        verbose: error,
-                    })
-                    return []
-                })
-            this.getUniqueRemoteUrlsCache[key] = uniqueRemoteUrls
+                return []
+            })
+            this.fsPathToRemoteUrlsInfo.set(key, remoteUrlsInfo)
         }
-        return uniqueRemoteUrls
+        return remoteUrlsInfo
     }
 
-    private getRepoNameCache: Partial<
-        Record<string, Observable<string | null | typeof pendingOperation>>
-    > = {}
-    private getRepoNameCached(remoteUrl: string): Observable<string | null | typeof pendingOperation> {
+    private remoteUrlToRepoName = new LRUCache<RemoteUrl, ReturnType<typeof this.getRepoNameCached>>({
+        max: 100,
+    })
+    private getRepoNameCached(remoteUrl: string): MaybePendingObservable<RepoName | null> {
         const key = remoteUrl
-        let observable: ReturnType<typeof this.getRepoNameCached> | undefined =
-            this.getRepoNameCache[key]
+        let observable = this.remoteUrlToRepoName.get(key)
+
         if (!observable) {
             observable = resolvedConfig.pipe(
                 pluck('auth'),
                 distinctUntilChanged(),
-                switchMapReplayOperation(() =>
-                    promiseFactoryToObservable(signal => graphqlClient.getRepoName(remoteUrl, signal))
+                switchMapReplayOperation(
+                    () =>
+                        promiseFactoryToObservable(signal =>
+                            graphqlClient.getRepoName(remoteUrl, signal)
+                        ),
+                    {
+                        // Keep this observable alive with cached repo names,
+                        // even without active subscribers. It's essential for
+                        // `getRepoNameCached` in `ContextFiltersProvider`, which is
+                        // part of the latency-sensitive autocomplete critical path.
+                        shouldRefCount: false,
+                    }
                 ),
                 map(value => {
                     if (isError(value)) {
@@ -114,7 +128,7 @@ export class RepoNameResolver {
                     return value
                 })
             )
-            this.getRepoNameCache[key] = observable
+            this.remoteUrlToRepoName.set(key, observable)
         }
         return observable
     }

--- a/vscode/src/repository/repo-name-resolver.ts
+++ b/vscode/src/repository/repo-name-resolver.ts
@@ -117,7 +117,7 @@ export class RepoNameResolver {
                         // even without active subscribers. It's essential for
                         // `getRepoNameCached` in `ContextFiltersProvider`, which is
                         // part of the latency-sensitive autocomplete critical path.
-                        shouldRefCount: false,
+                        shouldCountRefs: false,
                     }
                 ),
                 map(value => {


### PR DESCRIPTION
- Ensures the repo name resolution is cached and we don't make unexpected API calls for already resolved remote URLs.
- This fix is critical for enterprise clients because the regression significantly increases the repo-name resolution latency, which is used by every enterprise client with Cody Context filters and is on the critical path for every autocomplete request. In my local tests, it adds ~500-600ms to every repo name resolution call.
- [Slack thread](https://sourcegraph.slack.com/archives/C07RUS5NPRQ/p1729595412265549?thread_ts=1729571680.266529&cid=C07RUS5NPRQ) with more technical details.
- Closes https://linear.app/sourcegraph/issue/CODY-4139/investigate-repo-name-resolution-latency-increase

## Test plan

CI with updated unit tests.

## Changelog

- Context Filters: fixed repo name resolution cache.