### PR TITLE
fix(ci): disable google auth login if the PR is from a fork

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,9 @@ jobs:
           node-version: ${{ matrix.node }}
       - uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2 # SECURITY: pin third-party action hashes
       - id: auth
-        uses: google-github-actions/auth@v0
+        uses: google-github-actions/auth@v2
+        # Skip auth if PR is from a fork
+        if: ${{ !github.event.pull_request.head.repo.fork }}
         with:
           workload_identity_provider: ${{ secrets.DATA_TEAM_PROVIDER_NAME }}
           service_account: ${{ secrets.DATA_TEAM_SA_EMAIL }}


### PR DESCRIPTION
Hoping to unblock #5983 and #5982.

In https://github.com/sourcegraph/cody/pull/4923 we added the google auth action to the test-unit step but did not exclude the step if the PR comes from a fork (as we do with the other auth steps).

@akalia25 Do you see any issue with this tact? Should the setup-gcloud step get skipped too?

## Test plan
Runs in CI
