### PR TITLE
Reset editor intent on new chat and empty editor value

### DIFF
--- a/vscode/webviews/chat/cells/messageCell/human/editor/HumanMessageEditor.tsx
+++ b/vscode/webviews/chat/cells/messageCell/human/editor/HumanMessageEditor.tsx
@@ -119,6 +119,18 @@ export const HumanMessageEditor: FunctionComponent<{
         initialIntent || (experimentalOneBoxEnabled ? undefined : 'chat')
     )
 
+    useEffect(() => {
+        // reset the input box intent when the editor is cleared
+        if (isEmptyEditorValue) {
+            setSubmitIntent(undefined)
+        }
+    }, [isEmptyEditorValue])
+
+    useEffect(() => {
+        // set the input box intent when the message is changed or a new chat is created
+        setSubmitIntent(initialIntent)
+    }, [initialIntent])
+
     const onSubmitClick = useCallback(
         (intent?: ChatMessage['intent']) => {
             if (submitState === 'emptyEditorValue') {


### PR DESCRIPTION
This PR solves a bug and implements a minor feature. Well call it bugfix or feature whatever. 

Right now if the intent of chat is set to anything search/chat/edit/insert and you create a new chat, the intent is not reset. 

why? because the react component is not re-rendered and its key={n=index}, obviously the index stays 0 when you create a new chat. 

So this PR:
1. resets the intent when the input is cleared.
2. resets the intent when the message is changes. 

## Test plan

- change the intent, clear the input, the intent should reset
- change the intent, submit the message, create a new chat, the intent should reset. 

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
