### PR TITLE
Remove onKeyPress on AccordionTrigger

### DIFF
--- a/vscode/webviews/chat/cells/contextCell/ContextCell.tsx
+++ b/vscode/webviews/chat/cells/contextCell/ContextCell.tsx
@@ -99,12 +99,17 @@ export const ContextCell: FunctionComponent<{
         )
 
         const triggerAccordion = useCallback(() => {
-            setAccordionValue(prev => (prev ? '' : 'item-1'))
-            telemetryRecorder.recordEvent('cody.contextCell', 'opened', {
-                metadata: {
-                    fileCount: new Set(usedContext.map(file => file.uri.toString())).size,
-                    excludedAtContext: excludedContext.length,
-                },
+            setAccordionValue(prev => {
+                if (!prev) {
+                    telemetryRecorder.recordEvent('cody.contextCell', 'opened', {
+                        metadata: {
+                            fileCount: new Set(usedContext.map(file => file.uri.toString())).size,
+                            excludedAtContext: excludedContext.length,
+                        },
+                    })
+                }
+
+                return prev ? '' : 'item-1'
             })
         }, [excludedContext.length, usedContext])
 

--- a/vscode/webviews/chat/cells/contextCell/ContextCell.tsx
+++ b/vscode/webviews/chat/cells/contextCell/ContextCell.tsx
@@ -150,7 +150,6 @@ export const ContextCell: FunctionComponent<{
                                 header={
                                     <AccordionTrigger
                                         onClick={triggerAccordion}
-                                        onKeyUp={triggerAccordion}
                                         title={itemCountLabel}
                                         className="tw-flex tw-items-center tw-gap-4"
                                         disabled={isContextLoading}


### PR DESCRIPTION
context: https://sourcegraph.slack.com/archives/C05AGQYD528/p1729773000841009

Somehow `onKeyPress` causing an infinite loop of telemetry records. Also with the most recent changes the `context items opened` event is getting recorded even when the context menu is closed. 

This PR makes it so that the event is only getting recorded once. 

## Test plan
- Contact Piotr, even I don't know. 

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
