### PR TITLE
Support promoted prompts

### DIFF
--- a/lib/shared/src/experimentation/FeatureFlagProvider.ts
+++ b/lib/shared/src/experimentation/FeatureFlagProvider.ts
@@ -89,6 +89,12 @@ export enum FeatureFlag {
      */
     CodyUnifiedPrompts = 'cody-unified-prompts',
 
+    /**
+     * For internal use only. New Prompts UI and logic is behind this feature flag
+     * will be removed as soon as commands will be deprecated.
+     */
+    CodyPromptsV2 = 'prompt-creation-v2',
+
     /** Whether user has access to the experimental Cody Reflection / Deep Cody feature. */
     DeepCody = 'cody-deep-reflection',
 }

--- a/lib/shared/src/misc/rpc/webviewAPI.ts
+++ b/lib/shared/src/misc/rpc/webviewAPI.ts
@@ -27,7 +27,7 @@ export interface WebviewToExtensionAPI {
      * includes matching builtin commands and custom commands (which are both deprecated in favor of
      * the Prompt Library).
      */
-    prompts(query: string): Observable<PromptsResult>
+    prompts(input: PromptsInput): Observable<PromptsResult>
 
     /** The commands to prompts library migration information. */
     promptsMigrationStatus(): Observable<PromptsMigrationStatus>
@@ -142,6 +142,12 @@ export interface PromptAction extends Prompt {
 
 export interface CommandAction extends CodyCommand {
     actionType: 'command'
+}
+
+export interface PromptsInput {
+    query: string
+    first?: number
+    recommendedOnly: boolean
 }
 
 export type Action = PromptAction | CommandAction

--- a/lib/shared/src/sourcegraph-api/graphql/client.ts
+++ b/lib/shared/src/sourcegraph-api/graphql/client.ts
@@ -53,6 +53,7 @@ import {
     LOG_EVENT_MUTATION_DEPRECATED,
     PACKAGE_LIST_QUERY,
     PROMPTS_QUERY,
+    PromptsOrderBy,
     RECORD_TELEMETRY_EVENTS_MUTATION,
     REPOSITORY_IDS_QUERY,
     REPOSITORY_ID_QUERY,
@@ -417,6 +418,7 @@ export interface Prompt {
     id: string
     name: string
     nameWithOwner: string
+    recommended: boolean
     owner: {
         namespaceName: string
     }
@@ -1150,12 +1152,27 @@ export class SourcegraphGraphQLAPIClient {
         return result
     }
 
-    public async queryPrompts(query: string, signal?: AbortSignal): Promise<Prompt[]> {
+    public async queryPrompts({
+        query,
+        first,
+        recommendedOnly,
+        signal,
+    }: {
+        query: string
+        first: number | undefined
+        recommendedOnly: boolean
+        signal?: AbortSignal
+    }): Promise<Prompt[]> {
         const hasIncludeViewerDraftsArg = await this.isValidSiteVersion({ minimumVersion: '5.9.0' })
 
         const response = await this.fetchSourcegraphAPI<APIResponse<{ prompts: { nodes: Prompt[] } }>>(
             hasIncludeViewerDraftsArg ? PROMPTS_QUERY : LEGACY_PROMPTS_QUERY_5_8,
-            { query },
+            {
+                query,
+                first: first ?? 100,
+                recommendedOnly: recommendedOnly,
+                orderBy: [PromptsOrderBy.PROMPT_RECOMMENDED, PromptsOrderBy.PROMPT_UPDATED_AT],
+            },
             signal
         )
         const result = extractDataOrError(response, data => data.prompts.nodes)

--- a/lib/shared/src/sourcegraph-api/graphql/client.ts
+++ b/lib/shared/src/sourcegraph-api/graphql/client.ts
@@ -1171,7 +1171,7 @@ export class SourcegraphGraphQLAPIClient {
                 query,
                 first: first ?? 100,
                 recommendedOnly: recommendedOnly,
-                orderBy: [PromptsOrderBy.PROMPT_RECOMMENDED, PromptsOrderBy.PROMPT_UPDATED_AT],
+                orderByMultiple: [PromptsOrderBy.PROMPT_RECOMMENDED, PromptsOrderBy.PROMPT_UPDATED_AT],
             },
             signal
         )

--- a/lib/shared/src/sourcegraph-api/graphql/queries.ts
+++ b/lib/shared/src/sourcegraph-api/graphql/queries.ts
@@ -349,13 +349,20 @@ query ViewerPrompts($query: String!) {
     }
 }`
 
+export enum PromptsOrderBy {
+    PROMPT_NAME_WITH_OWNER = 'PROMPT_NAME_WITH_OWNER',
+    PROMPT_UPDATED_AT = 'PROMPT_UPDATED_AT',
+    PROMPT_RECOMMENDED = 'PROMPT_RECOMMENDED',
+}
+
 export const PROMPTS_QUERY = `
-query ViewerPrompts($query: String!) {
-    prompts(query: $query, first: 100, includeDrafts: false, includeViewerDrafts: true, viewerIsAffiliated: true, orderBy: PROMPT_UPDATED_AT) {
+query ViewerPrompts($query: String!, $first: Int!, $recommendedOnly: Boolean!, $orderBy: [PromptsOrderBy!]) {
+    prompts(query: $query, first: $first, includeDrafts: false, recommendedOnly: $recommendedOnly, includeViewerDrafts: true, viewerIsAffiliated: true, orderByMultiple: $orderBy) {
         nodes {
             id
             name
             nameWithOwner
+            recommended
             owner {
                 namespaceName
             }
@@ -375,10 +382,6 @@ query ViewerPrompts($query: String!) {
             }
         }
         totalCount
-        pageInfo {
-            hasNextPage
-            endCursor
-        }
     }
 }`
 

--- a/lib/shared/src/sourcegraph-api/graphql/queries.ts
+++ b/lib/shared/src/sourcegraph-api/graphql/queries.ts
@@ -356,8 +356,8 @@ export enum PromptsOrderBy {
 }
 
 export const PROMPTS_QUERY = `
-query ViewerPrompts($query: String!, $first: Int!, $recommendedOnly: Boolean!, $orderBy: [PromptsOrderBy!]) {
-    prompts(query: $query, first: $first, includeDrafts: false, recommendedOnly: $recommendedOnly, includeViewerDrafts: true, viewerIsAffiliated: true, orderByMultiple: $orderBy) {
+query ViewerPrompts($query: String!, $first: Int!, $recommendedOnly: Boolean!, $orderByMultiple: [PromptsOrderBy!]) {
+    prompts(query: $query, first: $first, includeDrafts: false, recommendedOnly: $recommendedOnly, includeViewerDrafts: true, viewerIsAffiliated: true, orderByMultiple: $orderByMultiple) {
         nodes {
             id
             name

--- a/vscode/src/chat/chat-view/ChatController.ts
+++ b/vscode/src/chat/chat-view/ChatController.ts
@@ -1711,9 +1711,9 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
                         ),
                     promptsMigrationStatus: () => getPromptsMigrationInfo(),
                     startPromptsMigration: () => promiseFactoryToObservable(startPromptsMigration),
-                    prompts: query =>
+                    prompts: input =>
                         promiseFactoryToObservable(signal =>
-                            mergedPromptsAndLegacyCommands(query, signal)
+                            mergedPromptsAndLegacyCommands(input, signal)
                         ),
                     models: () =>
                         modelsService.modelsChanges.pipe(

--- a/vscode/src/chat/chat-view/prompts-migration.ts
+++ b/vscode/src/chat/chat-view/prompts-migration.ts
@@ -104,7 +104,11 @@ export async function startPromptsMigration(): Promise<void> {
         const commandKey = command.key ?? command.slashCommand
 
         try {
-            const prompts = await graphqlClient.queryPrompts(commandKey.replace(/\s+/g, '-'))
+            const prompts = await graphqlClient.queryPrompts({
+                query: commandKey.replace(/\s+/g, '-'),
+                first: undefined,
+                recommendedOnly: false,
+            })
 
             // If there is no prompts associated with the command include this
             // command to migration

--- a/vscode/webviews/Chat.tsx
+++ b/vscode/webviews/Chat.tsx
@@ -34,7 +34,7 @@ interface ChatboxProps {
     showIDESnippetActions?: boolean
     setView: (view: View) => void
     smartApplyEnabled?: boolean
-    isUnifiedPromptsEnabled?: boolean
+    isPromptsV2Enabled?: boolean
 }
 
 export const Chat: React.FunctionComponent<React.PropsWithChildren<ChatboxProps>> = ({
@@ -49,7 +49,7 @@ export const Chat: React.FunctionComponent<React.PropsWithChildren<ChatboxProps>
     showIDESnippetActions = true,
     setView,
     smartApplyEnabled,
-    isUnifiedPromptsEnabled,
+    isPromptsV2Enabled,
 }) => {
     const telemetryRecorder = useTelemetryRecorder()
 
@@ -233,10 +233,7 @@ export const Chat: React.FunctionComponent<React.PropsWithChildren<ChatboxProps>
             />
             {transcript.length === 0 && showWelcomeMessage && (
                 <>
-                    <WelcomeMessage
-                        setView={setView}
-                        isUnifiedPromptsEnabled={isUnifiedPromptsEnabled}
-                    />
+                    <WelcomeMessage setView={setView} isPromptsV2Enabled={isPromptsV2Enabled} />
                     <WelcomeFooter IDE={userInfo.IDE} />
                 </>
             )}

--- a/vscode/webviews/CodyPanel.tsx
+++ b/vscode/webviews/CodyPanel.tsx
@@ -64,7 +64,7 @@ export const CodyPanel: FunctionComponent<
 
     const api = useExtensionAPI()
     const { value: chatModels } = useObservable(useMemo(() => api.chatModels(), [api.chatModels]))
-    const isUnifiedPromptsEnabled = useFeatureFlag(FeatureFlag.CodyUnifiedPrompts)
+    const isPromptsV2Enabled = useFeatureFlag(FeatureFlag.CodyPromptsV2)
 
     return (
         <TabViewContext.Provider value={useMemo(() => ({ view, setView }), [view, setView])}>
@@ -97,7 +97,7 @@ export const CodyPanel: FunctionComponent<
                             showWelcomeMessage={showWelcomeMessage}
                             scrollableParent={tabContainerRef.current}
                             smartApplyEnabled={smartApplyEnabled}
-                            isUnifiedPromptsEnabled={isUnifiedPromptsEnabled}
+                            isPromptsV2Enabled={isPromptsV2Enabled}
                             setView={setView}
                         />
                     )}
@@ -110,10 +110,7 @@ export const CodyPanel: FunctionComponent<
                         />
                     )}
                     {view === View.Prompts && (
-                        <PromptsTab
-                            setView={setView}
-                            isUnifiedPromptsEnabled={isUnifiedPromptsEnabled}
-                        />
+                        <PromptsTab setView={setView} isPromptsV2Enabled={isPromptsV2Enabled} />
                     )}
                     {view === View.Account && <AccountTab setView={setView} />}
                     {view === View.Settings && <SettingsTab />}

--- a/vscode/webviews/chat/cells/messageCell/human/editor/toolbar/SubmitButton.tsx
+++ b/vscode/webviews/chat/cells/messageCell/human/editor/toolbar/SubmitButton.tsx
@@ -144,7 +144,7 @@ export const SubmitButton: FC<{
                     aria-label="Insert prompt"
                     popoverContent={close => (
                         <Command>
-                            <CommandList>
+                            <CommandList className="tw-p-2">
                                 {intentOptions.map(option => (
                                     <CommandItem
                                         key={option.intent ?? option.title}
@@ -152,7 +152,7 @@ export const SubmitButton: FC<{
                                             onSelectIntent?.(option.intent)
                                             close()
                                         }}
-                                        className="tw-flex tw-text-left tw-justify-between"
+                                        className="tw-flex tw-text-left tw-justify-between tw-rounded-sm"
                                     >
                                         <div className="tw-flex tw-items-center tw-gap-2">
                                             <option.icon className="tw-size-8" />

--- a/vscode/webviews/chat/components/WelcomeMessage.tsx
+++ b/vscode/webviews/chat/components/WelcomeMessage.tsx
@@ -9,12 +9,12 @@ const localStorageKey = 'chat.welcome-message-dismissed'
 
 interface WelcomeMessageProps {
     setView: (view: View) => void
-    isUnifiedPromptsEnabled?: boolean
+    isPromptsV2Enabled?: boolean
 }
 
 export const WelcomeMessage: FunctionComponent<WelcomeMessageProps> = ({
     setView,
-    isUnifiedPromptsEnabled,
+    isPromptsV2Enabled,
 }) => {
     // Remove the old welcome message dismissal key that is no longer used.
     localStorage.removeItem(localStorageKey)
@@ -23,9 +23,7 @@ export const WelcomeMessage: FunctionComponent<WelcomeMessageProps> = ({
 
     return (
         <div className="tw-flex-1 tw-flex tw-flex-col tw-items-start tw-w-full tw-px-6 tw-gap-4 tw-transition-all">
-            {isUnifiedPromptsEnabled && (
-                <PromptMigrationWidget dismissible={true} className="tw-w-full" />
-            )}
+            {isPromptsV2Enabled && <PromptMigrationWidget dismissible={true} className="tw-w-full" />}
             <div className="tw-flex tw-flex-col tw-gap-4 tw-w-full">
                 <PromptList
                     showSearch={false}

--- a/vscode/webviews/chat/components/WelcomeMessage.tsx
+++ b/vscode/webviews/chat/components/WelcomeMessage.tsx
@@ -35,6 +35,7 @@ export const WelcomeMessage: FunctionComponent<WelcomeMessageProps> = ({
                     showCommandOrigins={true}
                     showOnlyPromptInsertableCommands={false}
                     showPromptLibraryUnsupportedMessage={false}
+                    recommendedOnly={true}
                     onSelect={item => runAction(item, setView)}
                 />
 

--- a/vscode/webviews/components/promptList/ActionItem.module.css
+++ b/vscode/webviews/components/promptList/ActionItem.module.css
@@ -50,6 +50,7 @@
         min-width: 0;
         display: flex;
         gap: 0.25rem;
+        align-items: center;
     }
 
     &--name {

--- a/vscode/webviews/components/promptList/ActionItem.tsx
+++ b/vscode/webviews/components/promptList/ActionItem.tsx
@@ -79,7 +79,7 @@ const ActionPrompt: FC<ActionPromptProps> = props => {
                             <TooltipTrigger asChild>
                                 <BookUp2 size={12} className={styles.promptIcon} />
                             </TooltipTrigger>
-                            <TooltipContent>This prompt was put here by your admin</TooltipContent>
+                            <TooltipContent>This prompt was promoted by your admin</TooltipContent>
                         </Tooltip>
                     )}
                 </div>

--- a/vscode/webviews/components/promptList/ActionItem.tsx
+++ b/vscode/webviews/components/promptList/ActionItem.tsx
@@ -8,12 +8,23 @@ import {
     type PromptAction,
 } from '@sourcegraph/cody-shared'
 
+import {
+    BookOpen,
+    BookUp2,
+    FileQuestion,
+    Hammer,
+    PencilLine,
+    PencilRuler,
+    TextSearch,
+} from 'lucide-react'
+
 import { UserAvatar } from '../../components/UserAvatar'
 import { Badge } from '../../components/shadcn/ui/badge'
 import { CommandItem } from '../../components/shadcn/ui/command'
+import { Tooltip, TooltipContent, TooltipTrigger } from '../../components/shadcn/ui/tooltip'
+
 import { commandRowValue } from './utils'
 
-import { BookOpen, FileQuestion, Hammer, PencilLine, PencilRuler, TextSearch } from 'lucide-react'
 import styles from './ActionItem.module.css'
 
 interface ActionItemProps {
@@ -62,6 +73,14 @@ const ActionPrompt: FC<ActionPromptProps> = props => {
                         <Badge variant="secondary" className="tw-text-xxs tw-mt-0.5">
                             Draft
                         </Badge>
+                    )}
+                    {prompt.recommended && (
+                        <Tooltip>
+                            <TooltipTrigger asChild>
+                                <BookUp2 size={12} className={styles.promptIcon} />
+                            </TooltipTrigger>
+                            <TooltipContent>This prompt was put here by your admin</TooltipContent>
+                        </Tooltip>
                     )}
                 </div>
 

--- a/vscode/webviews/components/promptList/PromptList.tsx
+++ b/vscode/webviews/components/promptList/PromptList.tsx
@@ -1,5 +1,5 @@
 import clsx from 'clsx'
-import { type FC, useCallback, useState } from 'react'
+import { type FC, useCallback, useMemo, useState } from 'react'
 
 import type { Action } from '@sourcegraph/cody-shared'
 
@@ -17,6 +17,7 @@ import { ActionItem } from './ActionItem'
 import { usePromptsQuery } from './usePromptsQuery'
 import { commandRowValue } from './utils'
 
+import type { PromptsInput } from '@sourcegraph/cody-shared'
 import { useLocalStorage } from '../../components/hooks'
 import styles from './PromptList.module.css'
 
@@ -33,7 +34,7 @@ interface PromptListProps {
     paddingLevels?: 'none' | 'middle' | 'big'
     appearanceMode?: 'flat-list' | 'chips-list'
     lastUsedSorting?: boolean
-    includeEditCommandOnTop?: boolean
+    recommendedOnly?: boolean
     onSelect: (item: Action) => void
 }
 
@@ -57,7 +58,7 @@ export const PromptList: FC<PromptListProps> = props => {
         paddingLevels = 'none',
         appearanceMode = 'flat-list',
         lastUsedSorting,
-        includeEditCommandOnTop,
+        recommendedOnly,
         onSelect: parentOnSelect,
     } = props
 
@@ -71,7 +72,17 @@ export const PromptList: FC<PromptListProps> = props => {
 
     const [query, setQuery] = useState('')
     const debouncedQuery = useDebounce(query, 250)
-    const { value: result, error } = usePromptsQuery(debouncedQuery)
+
+    const promptInput = useMemo<PromptsInput>(
+        () => ({
+            query: debouncedQuery,
+            first: showFirstNItems,
+            recommendedOnly: recommendedOnly ?? false,
+        }),
+        [debouncedQuery, showFirstNItems, recommendedOnly]
+    )
+
+    const { value: result, error } = usePromptsQuery(promptInput)
 
     const onSelect = useCallback(
         (rowValue: string): void => {
@@ -137,18 +148,7 @@ export const PromptList: FC<PromptListProps> = props => {
         ? result?.actions.filter(action => action.actionType === 'prompt' || action.mode === 'ask') ?? []
         : result?.actions ?? []
 
-    const sortedActions = lastUsedSorting ? getSortedActions(allActions, lastUsedActions) : allActions
-
-    const editCommandIndex = sortedActions.findIndex(
-        action => action.actionType === 'command' && action.key === 'edit'
-    )
-
-    // Bring Edit command on top of the command list
-    if (includeEditCommandOnTop && editCommandIndex !== -1) {
-        sortedActions.unshift(sortedActions.splice(editCommandIndex, 1)[0])
-    }
-
-    const actions = showFirstNItems ? sortedActions.slice(0, showFirstNItems) : sortedActions
+    const actions = lastUsedSorting ? getSortedActions(allActions, lastUsedActions) : allActions
 
     const inputPaddingClass =
         paddingLevels !== 'none' ? (paddingLevels === 'middle' ? '!tw-p-2' : '!tw-p-4') : ''
@@ -184,7 +184,7 @@ export const PromptList: FC<PromptListProps> = props => {
                 )}
                 {result && allActions.filter(action => action.actionType === 'prompt').length === 0 && (
                     <CommandLoading className={itemPaddingClass}>
-                        {result?.query === '' ? (
+                        {result?.query === '' && !recommendedOnly ? (
                             <>
                                 Your Prompt Library is empty.{' '}
                                 <a

--- a/vscode/webviews/components/promptList/PromptList.tsx
+++ b/vscode/webviews/components/promptList/PromptList.tsx
@@ -148,7 +148,8 @@ export const PromptList: FC<PromptListProps> = props => {
         ? result?.actions.filter(action => action.actionType === 'prompt' || action.mode === 'ask') ?? []
         : result?.actions ?? []
 
-    const actions = lastUsedSorting ? getSortedActions(allActions, lastUsedActions) : allActions
+    const sortedActions = lastUsedSorting ? getSortedActions(allActions, lastUsedActions) : allActions
+    const actions = showFirstNItems ? sortedActions.slice(0, showFirstNItems) : sortedActions
 
     const inputPaddingClass =
         paddingLevels !== 'none' ? (paddingLevels === 'middle' ? '!tw-p-2' : '!tw-p-4') : ''

--- a/vscode/webviews/components/promptList/fixtures.ts
+++ b/vscode/webviews/components/promptList/fixtures.ts
@@ -66,8 +66,9 @@ export function makePromptsAPIWithData(data: {
     prompts: Prompt[]
     commands?: CodyCommand[]
 }): WebviewToExtensionAPI['prompts'] {
-    return query =>
+    return input =>
         promiseFactoryToObservable<PromptsResult>(async () => {
+            const { query } = input
             const { arePromptsSupported = true, prompts, commands = [] } = data
             await new Promise<void>(resolve => setTimeout(resolve, 500))
 

--- a/vscode/webviews/components/promptList/usePromptsQuery.tsx
+++ b/vscode/webviews/components/promptList/usePromptsQuery.tsx
@@ -1,11 +1,11 @@
-import type { PromptsResult } from '@sourcegraph/cody-shared'
+import type { PromptsInput, PromptsResult } from '@sourcegraph/cody-shared'
 import { type UseObservableResult, useExtensionAPI, useObservable } from '@sourcegraph/prompt-editor'
 import { useMemo } from 'react'
 
 /**
  * React hook to query for prompts in the prompt library.
  */
-export function usePromptsQuery(query: string): UseObservableResult<PromptsResult> {
+export function usePromptsQuery(input: PromptsInput): UseObservableResult<PromptsResult> {
     const prompts = useExtensionAPI().prompts
-    return useObservable(useMemo(() => prompts(query), [prompts, query]))
+    return useObservable(useMemo(() => prompts(input), [prompts, input]))
 }

--- a/vscode/webviews/components/promptSelectField/PromptSelectField.tsx
+++ b/vscode/webviews/components/promptSelectField/PromptSelectField.tsx
@@ -59,6 +59,7 @@ export const PromptSelectField: React.FunctionComponent<{
                         showOnlyPromptInsertableCommands={true}
                         showPromptLibraryUnsupportedMessage={true}
                         lastUsedSorting={true}
+                        recommendedOnly={false}
                         inputClassName="tw-bg-popover"
                     />
 

--- a/vscode/webviews/components/promptSelectField/fixtures.ts
+++ b/vscode/webviews/components/promptSelectField/fixtures.ts
@@ -10,6 +10,7 @@ export const FIXTURE_PROMPTS: Prompt[] = [
         draft: false,
         definition: { text: 'Generate unit tests for vitest' },
         url: 'https://example.com',
+        recommended: false,
         createdBy: {
             id: '001',
             username: 'kevin.chen',
@@ -24,6 +25,7 @@ export const FIXTURE_PROMPTS: Prompt[] = [
         owner: { namespaceName: 'alice' },
         description: 'Suggest improvements for an OpenCtx provider',
         draft: true,
+        recommended: false,
         definition: { text: 'Review the following OpenCtx provider code' },
         url: 'https://example.com',
         createdBy: {
@@ -39,6 +41,7 @@ export const FIXTURE_PROMPTS: Prompt[] = [
         nameWithOwner: 'myorg/generate-junit-integration-test',
         owner: { namespaceName: 'myorg' },
         draft: false,
+        recommended: false,
         definition: { text: 'Generate a JUnit integration test' },
         url: 'https://example.com',
         createdBy: {
@@ -54,6 +57,7 @@ export const FIXTURE_PROMPTS: Prompt[] = [
         nameWithOwner: 'myorg/fix-bazel-build-file',
         owner: { namespaceName: 'myorg' },
         draft: false,
+        recommended: false,
         definition: { text: 'Fix common issues in this Bazel BUILD file' },
         url: 'https://example.com',
         createdBy: {
@@ -71,6 +75,7 @@ export const FIXTURE_PROMPTS: Prompt[] = [
         // Long text to test wrapping.
         description: 'Convert from a React class component to a function component',
         draft: false,
+        recommended: false,
         definition: { text: 'Convert from a React class component to a function component' },
         url: 'https://example.com',
         createdBy: {

--- a/vscode/webviews/prompts/PromptsTab.tsx
+++ b/vscode/webviews/prompts/PromptsTab.tsx
@@ -27,8 +27,9 @@ export const PromptsTab: React.FC<{
                 showCommandOrigins={true}
                 paddingLevels="big"
                 telemetryLocation="PromptsTab"
-                showPromptLibraryUnsupportedMessage={true}
+                recommendedOnly={false}
                 showOnlyPromptInsertableCommands={false}
+                showPromptLibraryUnsupportedMessage={true}
                 onSelect={item => runAction(item, setView)}
                 className={styles.promptsContainer}
                 inputClassName={styles.promptsInput}

--- a/vscode/webviews/prompts/PromptsTab.tsx
+++ b/vscode/webviews/prompts/PromptsTab.tsx
@@ -13,13 +13,13 @@ import styles from './PromptsTab.module.css'
 
 export const PromptsTab: React.FC<{
     setView: (view: View) => void
-    isUnifiedPromptsEnabled?: boolean
-}> = ({ setView, isUnifiedPromptsEnabled }) => {
+    isPromptsV2Enabled?: boolean
+}> = ({ setView, isPromptsV2Enabled }) => {
     const runAction = useActionSelect()
 
     return (
         <div className="tw-overflow-auto tw-h-full tw-flex tw-flex-col tw-gap-6">
-            {isUnifiedPromptsEnabled && (
+            {isPromptsV2Enabled && (
                 <PromptMigrationWidget dismissible={false} className={styles.promptMigrationWidget} />
             )}
             <PromptList


### PR DESCRIPTION
Adds support for promoted prompts, a feature that has been added in 5.9.0 

| | |
| ------- | ------- | 
| <img width="352" alt="Screenshot 2024-10-24 at 11 13 50" src="https://github.com/user-attachments/assets/e72fdf97-430f-44f4-96df-d980e22320cc"> | <img width="353" alt="Screenshot 2024-10-24 at 11 13 59" src="https://github.com/user-attachments/assets/84c8a606-8f22-4064-887d-5c4ba5d26473"> |

## Test plan
- Check that the welcome area prompts section shows only promoted prompts and out-of-the-box prompts/commands. 
- Check that order of this list is by most updated prompts
- Check that promoted prompts are always on top of the list in the prompts tab + ordered by most recent updated prompts
- Check that promoted prompts have promoted icon 

## Changelog
- Add support for promoted prompts. Now the welcome area prompts section shows only out-of-the-box prompts and promoted prompts

