### PR TITLE
Agent: add window state notification

### DIFF
--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/agent/protocol_generated/CodyAgentServer.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/agent/protocol_generated/CodyAgentServer.kt
@@ -180,4 +180,6 @@ interface CodyAgentServer {
   fun webview_didDisposeNative(params: Webview_DidDisposeNativeParams)
   @JsonNotification("secrets/didChange")
   fun secrets_didChange(params: Secrets_DidChangeParams)
+  @JsonNotification("window/didChangeFocus")
+  fun window_didChangeFocus(params: Window_DidChangeFocusParams)
 }

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/agent/protocol_generated/Window_DidChangeFocusParams.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/agent/protocol_generated/Window_DidChangeFocusParams.kt
@@ -1,0 +1,7 @@
+@file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
+package com.sourcegraph.cody.agent.protocol_generated;
+
+data class Window_DidChangeFocusParams(
+  val focused: Boolean,
+)
+

--- a/agent/src/agent.ts
+++ b/agent/src/agent.ts
@@ -528,6 +528,11 @@ export class Agent extends MessageHandler implements ExtensionClient {
             )
         })
 
+        this.registerNotification('window/didChangeFocus', state => {
+            this.pushPendingPromise(vscode_shim.onDidChangeWindowState.cody_fireAsync(state))
+            Object.assign(vscode_shim.window.state, state)
+        })
+
         this.registerNotification('textDocument/didFocus', (document: ProtocolTextDocument) => {
             const documentWithUri = ProtocolTextDocumentWithUri.fromDocument(document)
             this.workspace.setActiveTextEditor(

--- a/agent/src/vscode-shim.ts
+++ b/agent/src/vscode-shim.ts
@@ -152,17 +152,20 @@ const configuration = new AgentWorkspaceConfiguration(
     () => extensionConfiguration
 )
 
-export const onDidChangeWorkspaceFolders = new EventEmitter<vscode.WorkspaceFoldersChangeEvent>()
-export const onDidChangeTextEditorSelection = new EventEmitter<vscode.TextEditorSelectionChangeEvent>() // TODO: implement this
-export const onDidChangeVisibleTextEditors = new EventEmitter<readonly vscode.TextEditor[]>()
+// Sorted alphabetically
 export const onDidChangeActiveTextEditor = new EventEmitter<vscode.TextEditor | undefined>()
 export const onDidChangeConfiguration = new EventEmitter<vscode.ConfigurationChangeEvent>()
-export const onDidOpenTextDocument = new EventEmitter<vscode.TextDocument>()
 export const onDidChangeTextDocument = new EventEmitter<vscode.TextDocumentChangeEvent>()
+export const onDidChangeTextEditorSelection = new EventEmitter<vscode.TextEditorSelectionChangeEvent>()
+export const onDidChangeVisibleTextEditors = new EventEmitter<readonly vscode.TextEditor[]>()
+export const onDidChangeWindowState = new EventEmitter<vscode.WindowState>()
+export const onDidChangeWorkspaceFolders = new EventEmitter<vscode.WorkspaceFoldersChangeEvent>()
+
 export const onDidCloseTextDocument = new EventEmitter<vscode.TextDocument>()
-export const onDidSaveTextDocument = new EventEmitter<vscode.TextDocument>()
-export const onDidRenameFiles = new EventEmitter<vscode.FileRenameEvent>()
 export const onDidDeleteFiles = new EventEmitter<vscode.FileDeleteEvent>()
+export const onDidOpenTextDocument = new EventEmitter<vscode.TextDocument>()
+export const onDidRenameFiles = new EventEmitter<vscode.FileRenameEvent>()
+export const onDidSaveTextDocument = new EventEmitter<vscode.TextDocument>()
 
 export interface WorkspaceDocuments {
     workspaceRootUri?: vscode.Uri
@@ -642,7 +645,7 @@ const _window: typeof vscode.window = {
     onDidChangeTextEditorOptions: emptyEvent(),
     onDidChangeTextEditorViewColumn: emptyEvent(),
     onDidChangeVisibleNotebookEditors: emptyEvent(),
-    onDidChangeWindowState: emptyEvent(),
+    onDidChangeWindowState: onDidChangeWindowState.event,
     onDidCloseTerminal: emptyEvent(),
     onDidOpenTerminal: emptyEvent(),
     registerUriHandler: (vsceHandler: vscode.UriHandler) => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16397,6 +16397,7 @@ packages:
 
   /wcwidth@1.0.1:
     resolution: {integrity: sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==}
+    requiresBuild: true
     dependencies:
       defaults: 1.0.4
     dev: true

--- a/vscode/src/jsonrpc/agent-protocol.ts
+++ b/vscode/src/jsonrpc/agent-protocol.ts
@@ -386,6 +386,8 @@ export type ClientNotifications = {
     'webview/didDisposeNative': [{ handle: string }]
 
     'secrets/didChange': [{ key: string }]
+
+    'window/didChangeFocus': [{ focused: boolean }]
 }
 
 // ================


### PR DESCRIPTION
- Adds a window state notification to the agent so that JetBrains can tell us whether the window is focused. The characters logger uses this information to mark changes as done outside of the focused window. 
- Part of https://linear.app/sourcegraph/issue/CODY-2566/investigate-data-discrepancies-in-percent-of-code-written-by-cody
- Part of https://linear.app/sourcegraph/issue/DATA-66/add-percent-of-code-written-by-cody-metric
- Part of https://linear.app/sourcegraph/issue/CODY-4041/support-percent-code-written-in-vscode
- Part of https://linear.app/sourcegraph/issue/CODY-2877/characters-logger-does-not-work-in-jetbrains-and-vs-code

## Test plan

CI