### PR TITLE
Autocomplete: fix the fast-path feature flag

### DIFF
--- a/vscode/src/completions/providers/fireworks.ts
+++ b/vscode/src/completions/providers/fireworks.ts
@@ -96,7 +96,7 @@ class FireworksProvider extends Provider {
         this.disposables.push(
             subscriptionDisposable(
                 featureFlagProvider
-                    .evaluatedFeatureFlag(FeatureFlag.CodyAutocompleteTracing)
+                    .evaluatedFeatureFlag(FeatureFlag.CodyAutocompleteFastPath)
                     .subscribe(isFastPathEnabled => {
                         this.isFastPathEnabled = Boolean(isFastPathEnabled)
                     })


### PR DESCRIPTION
- Fixing the bug where the wrong feature flag was used for the A/B test. 

## Test plan

CI and manually tested the feature flag via setting the override value on my account on DotCom