### PR TITLE
fix: make default chat input taller

### DIFF
--- a/vscode/webviews/chat/cells/messageCell/human/editor/HumanMessageEditor.module.css
+++ b/vscode/webviews/chat/cells/messageCell/human/editor/HumanMessageEditor.module.css
@@ -7,7 +7,7 @@
     display: flex;
     flex-direction: column;
     gap: var(--human-message-editor-gap);
-    border-radius: 2px;
+    border-radius: 4px;
     background-color: color-mix(in srgb, var(--vscode-input-background) 50%, transparent);
     color: var(--vscode-input-foreground);
     outline: solid 1px var(--vscode-input-border);
@@ -26,7 +26,10 @@
 }
 
 .container:not(.focused, [data-keep-toolbar-open]) {
-    --human-message-editor-gap: 0px;
+
+    .editor-content-editable {
+        min-height: 1lh;
+    }
 
     .toolbar {
         height: 0;
@@ -48,5 +51,5 @@
 }
 
 .editor-content-editable {
-    min-height: 1lh;
+    min-height: 3lh;
 }


### PR DESCRIPTION
This is an update that increases the default height of the chat input.

@vovakulikov @thenamankumar @jasonhawkharris Can you test this rigorously?


**Before** | **After**
-- | --
![CleanShot 2024-10-25 at 13 41 49@2x](https://github.com/user-attachments/assets/b64b7d2a-cd50-4398-bdb4-6141f356804a) |  ![CleanShot 2024-10-25 at 13 40 57@2x](https://github.com/user-attachments/assets/49ebd9f8-5432-418a-8c5a-5929decfc35e)

## Test plan

Manually tested locally.