### PR TITLE
Fix inline-edit prompts chat building

### DIFF
--- a/vscode/src/edit/provider.ts
+++ b/vscode/src/edit/provider.ts
@@ -97,8 +97,7 @@ export class EditProvider {
                 onTurnComplete: async () => {
                     typewriter.close()
                     typewriter.stop()
-                    void this.handleResponse(text, false)
-                    return Promise.resolve()
+                    return this.handleResponse(text, false)
                 },
             })
             if (this.config.task.intent === 'test') {
@@ -157,7 +156,7 @@ export class EditProvider {
                         break
                     }
                     case 'complete': {
-                        void multiplexer.notifyTurnComplete()
+                        await multiplexer.notifyTurnComplete()
                         break
                     }
                     case 'error': {


### PR DESCRIPTION
I've noticed that on the main when you run the inline prompt, the chat doesn't have any different messages from the actual inline edit task. Apparently, it looks like there is a race condition between task execution and logic that populates chat with diffs. The main problem is that at the moment when we run populate with chat messages, `task.diff` has an undefined value. 

This PR tries to fix this problem by awaiting the task finish state.

## Test plan
- Create inline prompt (s2 has `prompt-creation-v2` flag enabled already)
- Try to run it 
- You should see that chat has non-empty chat messages with actual task diffs

