### PR TITLE
Promisify PromptEditorRefAPI

### DIFF
--- a/lib/prompt-editor/src/lexicalUtils.ts
+++ b/lib/prompt-editor/src/lexicalUtils.ts
@@ -76,13 +76,18 @@ export function getContextItemsForEditor(editor: LexicalEditor): SerializedConte
 export function visitContextItemsForEditor(
     editor: LexicalEditor,
     visit: (mention: ContextItemMentionNode) => void
-): void {
-    editor.update(() => {
-        walkLexicalNodes($getRoot(), node => {
-            if (node instanceof ContextItemMentionNode) {
-                visit(node)
-            }
-            return true
-        })
+): Promise<void> {
+    return new Promise(resolve => {
+        editor.update(
+            () => {
+                walkLexicalNodes($getRoot(), node => {
+                    if (node instanceof ContextItemMentionNode) {
+                        visit(node)
+                    }
+                    return true
+                })
+            },
+            { onUpdate: resolve }
+        )
     })
 }

--- a/vscode/webviews/chat/Transcript.tsx
+++ b/vscode/webviews/chat/Transcript.tsx
@@ -365,7 +365,7 @@ const TranscriptInteraction: FC<TranscriptInteractionProps> = memo(props => {
             return
         }
         editor.filterMentions(item => item.type !== 'repository')
-        editor.addMentions(contextFiles, undefined, 'before', '\n')
+        editor.addMentions(contextFiles, 'before', '\n')
     }, [humanMessage.contextFiles])
 
     return (


### PR DESCRIPTION
This PR refactors the `PromptEditorRefAPI` and converts all callbacks to promises.

This PR also fixes the auto-execution of prompt templates which was broken due to `submitState` not being = `submittable`. 

## Test plan

- Try executing a Prompt which is set for `auto excute`. That should trigger mostly all the methods on the API. 

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
