### PR TITLE
fix: Change chat input placeholder text

### DIFF
--- a/vscode/webviews/chat/cells/messageCell/human/HumanMessageCell.tsx
+++ b/vscode/webviews/chat/cells/messageCell/human/HumanMessageCell.tsx
@@ -111,7 +111,11 @@ const HumanMessageCellContent = memo<HumanMessageCellContent>(props => {
                     models={models}
                     userInfo={userInfo}
                     initialEditorState={initialEditorState}
-                    placeholder={isFirstMessage ? 'Ask anything. Use @ to specify context...' : 'Ask a followup...'}
+                    placeholder={
+                        isFirstMessage
+                            ? 'Ask anything. Use @ to specify context...'
+                            : 'Ask a followup...'
+                    }
                     isFirstMessage={isFirstMessage}
                     isSent={isSent}
                     isPendingPriorResponse={isPendingPriorResponse}

--- a/vscode/webviews/chat/cells/messageCell/human/HumanMessageCell.tsx
+++ b/vscode/webviews/chat/cells/messageCell/human/HumanMessageCell.tsx
@@ -111,7 +111,7 @@ const HumanMessageCellContent = memo<HumanMessageCellContent>(props => {
                     models={models}
                     userInfo={userInfo}
                     initialEditorState={initialEditorState}
-                    placeholder={isFirstMessage ? 'Ask...' : 'Ask a followup...'}
+                    placeholder={isFirstMessage ? 'Ask anything. Use @ to specify context.' : 'Ask a followup...'}
                     isFirstMessage={isFirstMessage}
                     isSent={isSent}
                     isPendingPriorResponse={isPendingPriorResponse}

--- a/vscode/webviews/chat/cells/messageCell/human/HumanMessageCell.tsx
+++ b/vscode/webviews/chat/cells/messageCell/human/HumanMessageCell.tsx
@@ -111,7 +111,7 @@ const HumanMessageCellContent = memo<HumanMessageCellContent>(props => {
                     models={models}
                     userInfo={userInfo}
                     initialEditorState={initialEditorState}
-                    placeholder={isFirstMessage ? 'Ask anything. Use @ to specify context.' : 'Ask a followup...'}
+                    placeholder={isFirstMessage ? 'Ask anything. Use @ to specify context...' : 'Ask a followup...'}
                     isFirstMessage={isFirstMessage}
                     isSent={isSent}
                     isPendingPriorResponse={isPendingPriorResponse}


### PR DESCRIPTION
Changes the default placeholder text for the chat input.

| Before | After |
| -- | -- |
| ![CleanShot 2024-10-28 at 11 45 44@2x](https://github.com/user-attachments/assets/7fcfb82a-43d4-4d1d-a356-a28ca348f63f) |  ![CleanShot 2024-10-28 at 11 44 56@2x](https://github.com/user-attachments/assets/507405da-82c8-4247-8648-e618847cc8d5) |

## Test plan

Manually tested, locally.
