### PR TITLE
Don't select first prompt by default

### DIFF
--- a/vscode/webviews/components/promptList/PromptList.tsx
+++ b/vscode/webviews/components/promptList/PromptList.tsx
@@ -26,7 +26,6 @@ interface PromptListProps {
     showFirstNItems?: number
     telemetryLocation: 'PromptSelectField' | 'PromptsTab'
     showOnlyPromptInsertableCommands?: boolean
-    showInitialSelectedItem?: boolean
     showCommandOrigins?: boolean
     showPromptLibraryUnsupportedMessage?: boolean
     className?: string
@@ -51,7 +50,6 @@ export const PromptList: FC<PromptListProps> = props => {
         showFirstNItems,
         telemetryLocation,
         showOnlyPromptInsertableCommands,
-        showInitialSelectedItem = true,
         showPromptLibraryUnsupportedMessage = true,
         className,
         inputClassName,
@@ -162,7 +160,7 @@ export const PromptList: FC<PromptListProps> = props => {
             loop={true}
             tabIndex={0}
             shouldFilter={false}
-            defaultValue={showInitialSelectedItem ? undefined : 'xxx-no-item'}
+            defaultValue='xxx-no-item'
             className={clsx(className, styles.list, {
                 [styles.listChips]: appearanceMode === 'chips-list',
             })}

--- a/vscode/webviews/components/promptList/PromptList.tsx
+++ b/vscode/webviews/components/promptList/PromptList.tsx
@@ -160,7 +160,7 @@ export const PromptList: FC<PromptListProps> = props => {
             loop={true}
             tabIndex={0}
             shouldFilter={false}
-            defaultValue='xxx-no-item'
+            defaultValue="xxx-no-item"
             className={clsx(className, styles.list, {
                 [styles.listChips]: appearanceMode === 'chips-list',
             })}


### PR DESCRIPTION
Fixes SRCH-1154

## Test plan
- Check that the initial prompt list has no selected items 
- There are still some confusing (once you mouse out from the list, it remembers the last selected/mouse over an item). It's part of the cure functionality of the `cmdk` library, so I leave it as is for now. 
