### PR TITLE
Add shortcut for recently used prompts

### DIFF
--- a/lib/shared/src/misc/rpc/webviewAPI.ts
+++ b/lib/shared/src/misc/rpc/webviewAPI.ts
@@ -29,6 +29,12 @@ export interface WebviewToExtensionAPI {
      */
     prompts(input: PromptsInput): Observable<PromptsResult>
 
+    /**
+     * Stream with actions from cody agent service, serves as transport for any client
+     * based actions/effects.
+     */
+    clientActionBroadcast(): Observable<ClientActionBroadcast>
+
     /** The commands to prompts library migration information. */
     promptsMigrationStatus(): Observable<PromptsMigrationStatus>
 
@@ -106,6 +112,7 @@ export function createExtensionAPI(
         mentionMenuData: proxyExtensionAPI(messageAPI, 'mentionMenuData'),
         evaluatedFeatureFlag: proxyExtensionAPI(messageAPI, 'evaluatedFeatureFlag'),
         prompts: proxyExtensionAPI(messageAPI, 'prompts'),
+        clientActionBroadcast: proxyExtensionAPI(messageAPI, 'clientActionBroadcast'),
         models: proxyExtensionAPI(messageAPI, 'models'),
         chatModels: proxyExtensionAPI(messageAPI, 'chatModels'),
         highlights: proxyExtensionAPI(messageAPI, 'highlights'),
@@ -205,4 +212,8 @@ interface PromptsMigrationSkipStatus {
 
 interface NoPromptsMigrationNeeded {
     type: 'no_migration_needed'
+}
+
+export interface ClientActionBroadcast {
+    type: 'open-recently-prompts'
 }

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -710,7 +710,7 @@
       },
       {
         "command": "cody.show.lastUsedActions",
-        "key": "ctrl+r",
+        "key": "shift+r",
         "when": "cody.activated && !editorReadonly"
       },
       {

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -709,6 +709,11 @@
         "when": "cody.activated && !editorReadonly && cody.hasActionableEdit"
       },
       {
+        "command": "cody.show.lastUsedActions",
+        "key": "ctrl+r",
+        "when": "cody.activated && !editorReadonly"
+      },
+      {
         "command": "cody.fixup.undoNearest",
         "key": "alt+x",
         "when": "cody.activated && !editorReadonly && cody.hasActionableEdit"

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -710,7 +710,7 @@
       },
       {
         "command": "cody.show.lastUsedActions",
-        "key": "shift+r",
+        "key": "alt+p",
         "when": "cody.activated && !editorReadonly"
       },
       {

--- a/vscode/src/chat/chat-view/ChatsController.ts
+++ b/vscode/src/chat/chat-view/ChatsController.ts
@@ -206,6 +206,9 @@ export class ChatsController implements vscode.Disposable {
             vscode.commands.registerCommand(CODY_PASSTHROUGH_VSCODE_OPEN_COMMAND_ID, (...args) =>
                 this.passthroughVsCodeOpen(...args)
             ),
+            vscode.commands.registerCommand('cody.show.lastUsedActions', async () => {
+                this.panel.clientBroadcast.next({ type: 'open-recently-prompts' })
+            }),
 
             // Mention selection/file commands
             vscode.commands.registerCommand('cody.mention.selection', uri =>

--- a/vscode/webviews/AppWrapperForTest.tsx
+++ b/vscode/webviews/AppWrapperForTest.tsx
@@ -85,6 +85,7 @@ export const AppWrapperForTest: FunctionComponent<{ children: ReactNode }> = ({ 
                         commands: FIXTURE_COMMANDS,
                     }),
                     highlights: () => Observable.of([]),
+                    clientActionBroadcast: () => Observable.of(),
                     models: () =>
                         Observable.of({
                             localModels: [],

--- a/vscode/webviews/Chat.tsx
+++ b/vscode/webviews/Chat.tsx
@@ -233,7 +233,11 @@ export const Chat: React.FunctionComponent<React.PropsWithChildren<ChatboxProps>
             />
             {transcript.length === 0 && showWelcomeMessage && (
                 <>
-                    <WelcomeMessage setView={setView} isPromptsV2Enabled={isPromptsV2Enabled} />
+                    <WelcomeMessage
+                        IDE={userInfo.IDE}
+                        setView={setView}
+                        isPromptsV2Enabled={isPromptsV2Enabled}
+                    />
                     <WelcomeFooter IDE={userInfo.IDE} />
                 </>
             )}

--- a/vscode/webviews/CodyPanel.tsx
+++ b/vscode/webviews/CodyPanel.tsx
@@ -6,7 +6,7 @@ import {
 } from '@sourcegraph/cody-shared'
 import { useExtensionAPI, useObservable } from '@sourcegraph/prompt-editor'
 import type React from 'react'
-import { type ComponentProps, type FunctionComponent, useMemo, useRef } from 'react'
+import { type ComponentProps, type FunctionComponent, useEffect, useMemo, useRef } from 'react'
 import type { ConfigurationSubsetForWebview, LocalEnv } from '../src/chat/protocol'
 import styles from './App.module.css'
 import { Chat } from './Chat'
@@ -65,6 +65,22 @@ export const CodyPanel: FunctionComponent<
     const api = useExtensionAPI()
     const { value: chatModels } = useObservable(useMemo(() => api.chatModels(), [api.chatModels]))
     const isPromptsV2Enabled = useFeatureFlag(FeatureFlag.CodyPromptsV2)
+
+    useEffect(() => {
+        const subscription = api.clientActionBroadcast().subscribe(action => {
+            switch (action.type) {
+                case 'open-recently-prompts': {
+                    document
+                        .querySelector<HTMLButtonElement>("button[aria-label='Insert prompt']")
+                        ?.click()
+                }
+            }
+        })
+
+        return () => {
+            subscription.unsubscribe()
+        }
+    }, [api.clientActionBroadcast])
 
     return (
         <TabViewContext.Provider value={useMemo(() => ({ view, setView }), [view, setView])}>

--- a/vscode/webviews/chat/components/WelcomeFooter.module.css
+++ b/vscode/webviews/chat/components/WelcomeFooter.module.css
@@ -34,5 +34,4 @@
 .link {
     color: inherit;
     text-decoration: none;
-
 }

--- a/vscode/webviews/chat/components/WelcomeMessage.module.css
+++ b/vscode/webviews/chat/components/WelcomeMessage.module.css
@@ -1,0 +1,4 @@
+
+.actions {
+    --vscode-keybindingLabel-foreground: currentColor;
+}

--- a/vscode/webviews/chat/components/WelcomeMessage.test.tsx
+++ b/vscode/webviews/chat/components/WelcomeMessage.test.tsx
@@ -1,7 +1,4 @@
-import {
-    AUTH_STATUS_FIXTURE_AUTHED,
-    type ClientCapabilitiesWithLegacyFields,
-} from '@sourcegraph/cody-shared'
+import { AUTH_STATUS_FIXTURE_AUTHED, type ClientCapabilitiesWithLegacyFields, CodyIDE, } from '@sourcegraph/cody-shared'
 import { fireEvent, render, screen } from '@testing-library/react'
 import { describe, expect, test, vi } from 'vitest'
 import { AppWrapperForTest } from '../../AppWrapperForTest'
@@ -35,7 +32,7 @@ describe('WelcomeMessage', () => {
             } satisfies Partial<ClientCapabilitiesWithLegacyFields> as ClientCapabilitiesWithLegacyFields,
             authStatus: AUTH_STATUS_FIXTURE_AUTHED,
         } satisfies Partial<useConfigModule.Config> as useConfigModule.Config)
-        render(<WelcomeMessage setView={() => {}} />, {
+        render(<WelcomeMessage IDE={CodyIDE.VSCode} setView={() => {}} />, {
             wrapper: AppWrapperForTest,
         })
         openCollapsiblePanels()
@@ -51,7 +48,7 @@ describe('WelcomeMessage', () => {
             } satisfies Partial<ClientCapabilitiesWithLegacyFields> as ClientCapabilitiesWithLegacyFields,
             authStatus: AUTH_STATUS_FIXTURE_AUTHED,
         } satisfies Partial<useConfigModule.Config> as useConfigModule.Config)
-        render(<WelcomeMessage setView={() => {}} />, {
+        render(<WelcomeMessage IDE={CodyIDE.VSCode} setView={() => {}} />, {
             wrapper: AppWrapperForTest,
         })
         openCollapsiblePanels()

--- a/vscode/webviews/chat/components/WelcomeMessage.test.tsx
+++ b/vscode/webviews/chat/components/WelcomeMessage.test.tsx
@@ -1,4 +1,8 @@
-import { AUTH_STATUS_FIXTURE_AUTHED, type ClientCapabilitiesWithLegacyFields, CodyIDE, } from '@sourcegraph/cody-shared'
+import {
+    AUTH_STATUS_FIXTURE_AUTHED,
+    type ClientCapabilitiesWithLegacyFields,
+    CodyIDE,
+} from '@sourcegraph/cody-shared'
 import { fireEvent, render, screen } from '@testing-library/react'
 import { describe, expect, test, vi } from 'vitest'
 import { AppWrapperForTest } from '../../AppWrapperForTest'

--- a/vscode/webviews/chat/components/WelcomeMessage.tsx
+++ b/vscode/webviews/chat/components/WelcomeMessage.tsx
@@ -54,7 +54,7 @@ export const WelcomeMessage: FunctionComponent<WelcomeMessageProps> = ({
                         onClick={handleRecentlyUsed}
                     >
                         Recently used{' '}
-                        {IDE === CodyIDE.VSCode && <Kbd macOS="cmd+r" linuxAndWindows="ctrl+r" />}
+                        {IDE === CodyIDE.VSCode && <Kbd macOS="shift+r" linuxAndWindows="shift+r" />}
                     </Button>
 
                     <Button

--- a/vscode/webviews/chat/components/WelcomeMessage.tsx
+++ b/vscode/webviews/chat/components/WelcomeMessage.tsx
@@ -54,7 +54,7 @@ export const WelcomeMessage: FunctionComponent<WelcomeMessageProps> = ({
                         onClick={handleRecentlyUsed}
                     >
                         Recently used{' '}
-                        {IDE === CodyIDE.VSCode && <Kbd macOS="shift+r" linuxAndWindows="shift+r" />}
+                        {IDE === CodyIDE.VSCode && <Kbd macOS="opt+p" linuxAndWindows="alt+p" />}
                     </Button>
 
                     <Button

--- a/vscode/webviews/chat/components/WelcomeMessage.tsx
+++ b/vscode/webviews/chat/components/WelcomeMessage.tsx
@@ -1,25 +1,35 @@
+import { CodyIDE } from '@sourcegraph/cody-shared'
 import type { FunctionComponent } from 'react'
+import { Kbd } from '../../components/Kbd'
 import { PromptList } from '../../components/promptList/PromptList'
 import { Button } from '../../components/shadcn/ui/button'
 import { useActionSelect } from '../../prompts/PromptsTab'
 import { View } from '../../tabs'
 import { PromptMigrationWidget } from './../../components/promptsMigration/PromptsMigration'
 
+import { clsx } from 'clsx'
+import styles from './WelcomeMessage.module.css'
+
 const localStorageKey = 'chat.welcome-message-dismissed'
 
 interface WelcomeMessageProps {
     setView: (view: View) => void
+    IDE: CodyIDE
     isPromptsV2Enabled?: boolean
 }
 
 export const WelcomeMessage: FunctionComponent<WelcomeMessageProps> = ({
     setView,
+    IDE,
     isPromptsV2Enabled,
 }) => {
     // Remove the old welcome message dismissal key that is no longer used.
     localStorage.removeItem(localStorageKey)
 
     const runAction = useActionSelect()
+    const handleRecentlyUsed = () => {
+        document.querySelector<HTMLButtonElement>("button[aria-label='Insert prompt']")?.click()
+    }
 
     return (
         <div className="tw-flex-1 tw-flex tw-flex-col tw-items-start tw-w-full tw-px-8 tw-gap-6 tw-transition-all">
@@ -37,17 +47,14 @@ export const WelcomeMessage: FunctionComponent<WelcomeMessageProps> = ({
                     onSelect={item => runAction(item, setView)}
                 />
 
-                <div className="tw-flex tw-py-2 tw-gap-8 tw-justify-center">
+                <div className={clsx(styles.actions, 'tw-flex tw-py-2 tw-gap-8 tw-justify-center')}>
                     <Button
                         variant="ghost"
                         className="tw-justify-center tw-basis-0 tw-whitespace-nowrap"
-                        onClick={() =>
-                            document
-                                .querySelector<HTMLButtonElement>("button[aria-label='Insert prompt']")
-                                ?.click()
-                        }
+                        onClick={handleRecentlyUsed}
                     >
-                        Recently used
+                        Recently used{' '}
+                        {IDE === CodyIDE.VSCode && <Kbd macOS="cmd+r" linuxAndWindows="ctrl+r" />}
                     </Button>
 
                     <Button


### PR DESCRIPTION
Fixes SRCH-1133

This PR adds a shortcut for the "Recently used" button on the welcome screen, a few limitations 
- This action works only if Cody's side panel is open 
- And only when the Cody Chat tab opens (switching tab isn't supported at the moment)
- It's supported only in VSCode (Cody Web requires a completely different approach to shortcuts)

<img width="325" alt="Screenshot 2024-10-28 at 15 11 50" src="https://github.com/user-attachments/assets/93c109d0-5e9e-4472-8dba-72b10ea4d3e0">


## Test plan
- Check that cmd+R opens recently used prompts popover

