### PR TITLE
fix(chat): Hide insert and new file buttons if there is no `edit` capability

### DIFF
--- a/vscode/src/chat/chat-view/ChatController.ts
+++ b/vscode/src/chat/chat-view/ChatController.ts
@@ -499,6 +499,10 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
         return this.extensionClient.capabilities?.edit !== 'none'
     }
 
+    private hasEditCapability(): boolean {
+        return this.extensionClient.capabilities?.edit === 'enabled' ?? false
+    }
+
     private featureCodyExperimentalOneBox = storeLastValue(
         featureFlagProvider.evaluatedFeatureFlag(FeatureFlag.CodyExperimentalOneBox)
     )
@@ -514,6 +518,7 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
             serverEndpoint: auth.serverEndpoint,
             experimentalNoodle: configuration.experimentalNoodle,
             smartApply: this.isSmartApplyEnabled(),
+            hasEditCapability: this.hasEditCapability(),
             webviewType,
             multipleWebviewsEnabled: !sidebarViewOnly,
             internalDebugContext: configuration.internalDebugContext,

--- a/vscode/src/chat/protocol.ts
+++ b/vscode/src/chat/protocol.ts
@@ -226,6 +226,7 @@ export interface ConfigurationSubsetForWebview
     extends Pick<ClientConfiguration, 'experimentalNoodle' | 'internalDebugContext'>,
         Pick<AuthCredentials, 'serverEndpoint'> {
     smartApply: boolean
+    hasEditCapability: boolean
     // Type/location of the current webview.
     webviewType?: WebviewType | undefined | null
     // Whether support running multiple webviews (e.g. sidebar w/ multiple editor panels).

--- a/vscode/webviews/App.story.tsx
+++ b/vscode/webviews/App.story.tsx
@@ -28,6 +28,7 @@ const dummyVSCodeAPI: VSCodeWrapper = {
                 uiKindIsWeb: false,
                 experimentalNoodle: false,
                 smartApply: false,
+                hasEditCapability: false,
             },
             clientCapabilities: CLIENT_CAPABILITIES_FIXTURE,
             authStatus: {

--- a/vscode/webviews/chat/ChatMessageContent/ChatMessageContent.tsx
+++ b/vscode/webviews/chat/ChatMessageContent/ChatMessageContent.tsx
@@ -131,13 +131,17 @@ export const ChatMessageContent: React.FunctionComponent<ChatMessageContentProps
                         config,
                         codeBlockName,
                         copyButtonOnSubmit,
-                        insertButtonOnSubmit,
+                        config.config.hasEditCapability ? insertButtonOnSubmit : undefined,
                         smartApplyInterceptor,
                         smartApplyId,
                         smartApplyState
                     )
                 } else {
-                    buttons = createButtons(preText, copyButtonOnSubmit, insertButtonOnSubmit)
+                    buttons = createButtons(
+                        preText,
+                        copyButtonOnSubmit,
+                        config.config.hasEditCapability ? insertButtonOnSubmit : undefined
+                    )
                 }
 
                 const metadataContainer = document.createElement('div')


### PR DESCRIPTION
Currently all clients default to showing the Insert and New file buttons on code snippets in an assistant response, but only editors which support the `edit` capability (i.e. not Eclipse or VS) should show these buttons. This simply hides the action if the capability is not set to `enabled`.

## Test plan
Tested this build in Eclipse and saw that only the Copy button was retained, but on main, all three buttons were shown

## Changelog
Hide non-functional edit buttons in chat if client does not support the functionality.