### PR TITLE
VS Code: add characters logger metadata to chat code-gen events

### DIFF
--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -100,7 +100,6 @@ import { VSCodeSecretStorage, secretStorage } from './services/SecretStorageProv
 import { registerSidebarCommands } from './services/SidebarCommands'
 import { CodyStatusBar } from './services/StatusBar'
 import { createOrUpdateTelemetryRecorderProvider } from './services/telemetry-v2'
-import { onTextDocumentChange } from './services/utils/codeblock-action-tracker'
 import {
     enableVerboseDebugMode,
     exportOutputLog,
@@ -233,7 +232,6 @@ const register = async (
     disposables.push(await initVSCodeGitApi())
 
     registerParserListeners(disposables)
-    registerChatListeners(disposables)
 
     // Initialize external services
     const {
@@ -338,20 +336,6 @@ function registerParserListeners(disposables: vscode.Disposable[]) {
     void parseAllVisibleDocuments()
     disposables.push(vscode.window.onDidChangeVisibleTextEditors(parseAllVisibleDocuments))
     disposables.push(vscode.workspace.onDidChangeTextDocument(updateParseTreeOnEdit))
-}
-
-function registerChatListeners(disposables: vscode.Disposable[]) {
-    // Enable tracking for pasting chat responses into editor text
-    disposables.push(
-        vscode.workspace.onDidChangeTextDocument(async e => {
-            const changedText = e.contentChanges[0]?.text
-            // Skip if the document is not a file or if the copied text is from insert
-            if (!changedText || e.document.uri.scheme !== 'file') {
-                return
-            }
-            await onTextDocumentChange(changedText)
-        })
-    )
 }
 
 async function registerOtherCommands(disposables: vscode.Disposable[]) {

--- a/vscode/src/non-stop/FixupController.ts
+++ b/vscode/src/non-stop/FixupController.ts
@@ -25,7 +25,6 @@ import {
     DEFAULT_EVENT_SOURCE,
     EventSourceTelemetryMetadataMapping,
 } from '@sourcegraph/cody-shared/src/chat/transcript/messages'
-import omit from 'lodash/omit'
 import type { SmartApplyResult } from '../chat/protocol'
 import { PersistenceTracker } from '../common/persistence-tracker'
 import { lines } from '../completions/text-processing'
@@ -590,7 +589,7 @@ export class FixupController
     }
 
     private logTaskCompletion(task: FixupTask, document: vscode.TextDocument, editOk: boolean): void {
-        const charactersLoggerMetadata = charactersLogger.getChangeEventMetadata({
+        const charactersLoggerMetadata = charactersLogger.getChangeEventMetadataForCodyCodeGenEvents({
             document,
             contentChanges: task.getContentChanges(),
             reason: undefined,
@@ -604,13 +603,7 @@ export class FixupController
             model: task.model,
             ...this.countEditInsertions(task),
             ...task.telemetryMetadata,
-            ...omit(charactersLoggerMetadata, [
-                'changeSize',
-                'changeType',
-                'isRedo',
-                'isUndo',
-                'isRapidChange',
-            ]),
+            ...charactersLoggerMetadata,
         }
         const { metadata, privateMetadata } = splitSafeMetadata(legacyMetadata)
         if (!editOk) {

--- a/vscode/src/services/CharactersLogger.test.ts
+++ b/vscode/src/services/CharactersLogger.test.ts
@@ -15,6 +15,7 @@ import {
     RAPID_CHANGE_TIMEOUT,
     SELECTION_TIMEOUT,
 } from './CharactersLogger'
+import * as codeBlockUtils from './utils/codeblock-action-tracker'
 
 const testDocument = document('foo')
 
@@ -217,6 +218,24 @@ describe('CharactersLogger', () => {
             })
         )
 
+        const codeFromChat = 'insert_from_chat'
+        vi.spyOn(codeBlockUtils, 'isCodeFromChatCodeBlockAction').mockResolvedValueOnce({
+            operation: 'insert',
+            code: codeFromChat,
+            lineCount: 1,
+            charCount: codeFromChat.length,
+            eventName: 'insert',
+            source: 'chat',
+        })
+
+        await onDidChangeTextDocument(
+            createChange({
+                text: codeFromChat,
+                range: range(0, 0, 0, 0),
+                rangeLength: 0,
+            })
+        )
+
         mockWindowState.focused = false
         onDidChangeWindowState(mockWindowState)
 
@@ -272,6 +291,9 @@ describe('CharactersLogger', () => {
         // Expected counters:
         expect(recordSpy).toHaveBeenCalledWith('cody.characters', 'flush', {
             metadata: expectedCharCounters({
+                cody_chat: 1,
+                cody_chat_inserted: 16, // 'insert_from_chat'
+
                 xxs_change: 1,
                 xxs_change_inserted: 4, // 'test'
 

--- a/vscode/src/services/CharactersLogger.test.ts
+++ b/vscode/src/services/CharactersLogger.test.ts
@@ -23,7 +23,7 @@ describe('CharactersLogger', () => {
     let tracker: CharactersLogger
 
     let onDidChangeActiveTextEditor: (event: vscode.TextEditor | undefined) => void
-    let onDidChangeTextDocument: (event: vscode.TextDocumentChangeEvent) => void
+    let onDidChangeTextDocument: (event: vscode.TextDocumentChangeEvent) => Promise<void>
     let onDidCloseTextDocument: (document: vscode.TextDocument) => void
     let onDidChangeWindowState: (state: vscode.WindowState) => void
     let onDidChangeTextEditorSelection: (event: vscode.TextEditorSelectionChangeEvent) => void
@@ -117,13 +117,13 @@ describe('CharactersLogger', () => {
         return { ...DEFAULT_COUNTERS, ...expected }
     }
 
-    it('should handle insertions, deletions, rapid and stale changes, and changes outside of visible range', () => {
+    it('should handle insertions, deletions, rapid and stale changes, and changes outside of visible range', async () => {
         // Simulate user typing in the active text editor
         onDidChangeActiveTextEditor(mockActiveTextEditor)
         onDidChangeTextEditorSelection(mockTextEditorSelectionEvent)
 
         // Scenario 1: User types 'hello' (insertion)
-        onDidChangeTextDocument(
+        await onDidChangeTextDocument(
             createChange({ text: 'hello', range: range(0, 0, 0, 0), rangeLength: 0 })
         )
 
@@ -131,13 +131,15 @@ describe('CharactersLogger', () => {
         vi.advanceTimersByTime(RAPID_CHANGE_TIMEOUT - 5)
 
         // Scenario 2: User deletes 'he' (deletion)
-        onDidChangeTextDocument(createChange({ text: '', range: range(0, 0, 0, 2), rangeLength: 2 }))
+        await onDidChangeTextDocument(
+            createChange({ text: '', range: range(0, 0, 0, 2), rangeLength: 2 })
+        )
 
         // Now, advance time beyond SELECTION_TIMEOUT to make selection stale
         vi.advanceTimersByTime(SELECTION_TIMEOUT + 1000)
 
         // Scenario 3: User types 'there' (stale insertion)
-        onDidChangeTextDocument(
+        await onDidChangeTextDocument(
             createChange({ text: 'there', range: range(0, 3, 0, 3), rangeLength: 0 })
         )
         // Should be counted as an insertion, stale change
@@ -148,7 +150,7 @@ describe('CharactersLogger', () => {
         onDidChangeActiveTextEditor(mockActiveTextEditor)
 
         // User types 'hidden' at line 50 (outside visible range)
-        onDidChangeTextDocument(
+        await onDidChangeTextDocument(
             createChange({
                 text: 'hidden',
                 range: range(50, 0, 50, 0), // Line 50, start
@@ -180,23 +182,23 @@ describe('CharactersLogger', () => {
         })
     })
 
-    it('should handle undo, redo, window not focused, no active editor, outside of active editor, and document closing', () => {
+    it('should handle undo, redo, window not focused, no active editor, outside of active editor, and document closing', async () => {
         onDidChangeActiveTextEditor(mockActiveTextEditor)
         onDidChangeTextEditorSelection(mockTextEditorSelectionEvent)
 
         const changeReasons = { Undo: 1, Redo: 2 } as const
 
         const xxsChangeEvent = createChange({ text: 'test', range: range(0, 0, 0, 0), rangeLength: 0 })
-        onDidChangeTextDocument(xxsChangeEvent)
+        await onDidChangeTextDocument(xxsChangeEvent)
 
         const disjointChange = createChange({ text: 'test', range: range(2, 0, 0, 0), rangeLength: 0 })
-        onDidChangeTextDocument({
+        await onDidChangeTextDocument({
             ...xxsChangeEvent,
             contentChanges: [xxsChangeEvent.contentChanges[0], disjointChange.contentChanges[0]],
         })
 
         // Simulate undo
-        onDidChangeTextDocument(
+        await onDidChangeTextDocument(
             createChange({
                 text: '',
                 range: range(0, 4, 0, 0),
@@ -206,7 +208,7 @@ describe('CharactersLogger', () => {
         )
 
         // Simulate redo
-        onDidChangeTextDocument(
+        await onDidChangeTextDocument(
             createChange({
                 text: 'test',
                 range: range(0, 0, 0, 0),
@@ -219,7 +221,7 @@ describe('CharactersLogger', () => {
         onDidChangeWindowState(mockWindowState)
 
         // User types ' window not focused' when window not focused
-        onDidChangeTextDocument(
+        await onDidChangeTextDocument(
             createChange({ text: 'window not focused', range: range(0, 4, 0, 4), rangeLength: 0 })
         )
 
@@ -229,7 +231,7 @@ describe('CharactersLogger', () => {
 
         // Simulate no active editor
         onDidChangeActiveTextEditor(undefined)
-        onDidChangeTextDocument(
+        await onDidChangeTextDocument(
             createChange({ text: 'no active editor', range: range(0, 21, 0, 21), rangeLength: 0 })
         )
 
@@ -246,7 +248,7 @@ describe('CharactersLogger', () => {
         onDidChangeActiveTextEditor(anotherEditor)
 
         // User types in original document (not the active editor's document)
-        onDidChangeTextDocument(
+        await onDidChangeTextDocument(
             createChange({
                 text: 'outside active editor',
                 range: range(0, 21, 0, 21),
@@ -256,7 +258,7 @@ describe('CharactersLogger', () => {
         )
 
         onDidCloseTextDocument(testDocument)
-        onDidChangeTextDocument(
+        await onDidChangeTextDocument(
             createChange({
                 text: '!',
                 range: range(0, 50, 0, 50),

--- a/vscode/src/services/CharactersLogger.ts
+++ b/vscode/src/services/CharactersLogger.ts
@@ -1,7 +1,15 @@
+import omit from 'lodash/omit'
 import * as vscode from 'vscode'
 
 import { isFileURI, telemetryRecorder } from '@sourcegraph/cody-shared'
+
 import { outputChannelLogger } from '../output-channel-logger'
+
+import { splitSafeMetadata } from './telemetry-v2'
+import {
+    isCodeFromChatCodeBlockAction,
+    recordPasteFromChatEvent,
+} from './utils/codeblock-action-tracker'
 
 export const LOG_INTERVAL = 30 * 60 * 1000 // 30 minutes
 export const RAPID_CHANGE_TIMEOUT = 15
@@ -25,6 +33,7 @@ const staleAndRapidChangeBoundariesKeys = changeBoundariesKeys.flatMap(
 )
 
 const SPECIAL_DOCUMENT_CHANGE_TYPES = [
+    'cody_chat',
     'undo',
     'redo',
     'window_not_focused',
@@ -76,7 +85,6 @@ interface ChangeEventMetadata {
     changeSize: DocumentChangeSize | undefined
     charsInserted: number
     charsDeleted: number
-    changeType: DocumentChangeType
 }
 
 export class CharactersLogger implements vscode.Disposable {
@@ -139,12 +147,36 @@ export class CharactersLogger implements vscode.Disposable {
         }
     }
 
-    private onDidChangeTextDocument(event: vscode.TextDocumentChangeEvent): void {
+    private async onDidChangeTextDocument(event: vscode.TextDocumentChangeEvent): Promise<void> {
         if (!isFileURI(event.document.uri)) {
             return
         }
 
-        const { changeType, charsDeleted, charsInserted } = this.getChangeEventMetadata(event)
+        const changedText = event.contentChanges[0]?.text ?? ''
+        let isChangeEventFromCodyChat = false
+
+        if (changedText.length !== 0) {
+            // We record paste events in the `onDidChangeTextDocument` handler to avoid race conditions,
+            // since we synchronously mutate the internal state in `codeblock-action-tracker.ts`.
+            //
+            // Additionally, the characters logger needs to know if the change is coming from Cody
+            // to accurately classify it.
+            const codeBlockActionMatch = await isCodeFromChatCodeBlockAction(
+                event.contentChanges[0]?.text
+            )
+            if (codeBlockActionMatch?.operation === 'paste') {
+                // Sends the `cody.keyDown:paste` event.
+                recordPasteFromChatEvent(codeBlockActionMatch)
+            }
+
+            // Marks the change as originating from Cody Chat to prevent double-counting.
+            // For example, double-counting occurs when a change is counted both as a manual user input
+            // and as characters from the `cody.keyDown:paste` event.
+            isChangeEventFromCodyChat = Boolean(codeBlockActionMatch)
+        }
+
+        const changeEventMetadata = this.getChangeEventMetadata(event)
+        const changeType = this.getDocumentChangeType(changeEventMetadata, isChangeEventFromCodyChat)
         this.changeCounters[changeType]++
 
         for (const change of event.contentChanges) {
@@ -167,14 +199,19 @@ export class CharactersLogger implements vscode.Disposable {
             // the lengths are the same.
         }
 
-        if (charsDeleted > 0 || charsInserted > 0) {
+        if (changeEventMetadata.charsDeleted > 0 || changeEventMetadata.charsInserted > 0) {
             this.lastChangeTimestamp = Date.now()
         }
     }
 
     private getDocumentChangeType(
-        metadata: Omit<ChangeEventMetadata, 'changeType'>
+        metadata: Omit<ChangeEventMetadata, 'changeType'>,
+        isChangeEventFromCodyChat = false
     ): DocumentChangeType {
+        if (isChangeEventFromCodyChat) {
+            return 'cody_chat'
+        }
+
         if (metadata.isUndo) {
             return 'undo'
         }
@@ -217,11 +254,11 @@ export class CharactersLogger implements vscode.Disposable {
         return 'unexpected'
     }
 
-    public getChangeEventMetadata(event: vscode.TextDocumentChangeEvent): ChangeEventMetadata {
-        const { document, contentChanges } = event
+    private getChangeEventMetadata(event: Partial<vscode.TextDocumentChangeEvent>): ChangeEventMetadata {
+        const { document, contentChanges = [] } = event
 
         const currentTimestamp = Date.now()
-        const uriString = document.uri.toString()
+        const uriString = document?.uri.toString() || 'document-not-provided'
 
         const isUndo = event.reason === vscode.TextDocumentChangeReason.Undo
         const isRedo = event.reason === vscode.TextDocumentChangeReason.Redo
@@ -264,7 +301,7 @@ export class CharactersLogger implements vscode.Disposable {
             this.activeTextEditor && this.activeTextEditor.document.uri.toString() !== uriString
         )
 
-        const changeEventMetadata = {
+        return {
             isUndo,
             isRedo,
             isSelectionStale,
@@ -278,12 +315,28 @@ export class CharactersLogger implements vscode.Disposable {
             changeSize: changeSizePair ? (changeSizePair[0] as DocumentChangeSize) : undefined,
             charsInserted: charCounts.inserted,
             charsDeleted: charCounts.deleted,
-        } satisfies Omit<ChangeEventMetadata, 'changeType'>
-
-        return {
-            ...changeEventMetadata,
-            changeType: this.getDocumentChangeType(changeEventMetadata),
         }
+    }
+
+    public getChangeEventMetadataForCodyCodeGenEvents(event: Partial<vscode.TextDocumentChangeEvent>): {
+        isSelectionStale: number
+        isDisjoint: number
+        isPartiallyOutsideOfVisibleRanges: number
+        isFullyOutsideOfVisibleRanges: number
+        windowNotFocused: number
+        noActiveTextEditor: number
+        outsideOfActiveEditor: number
+        charsInserted: number
+        charsDeleted: number
+    } {
+        const rawMetadata = omit(this.getChangeEventMetadata(event), [
+            'changeSize',
+            'isRedo',
+            'isUndo',
+            'isRapidChange',
+        ])
+
+        return splitSafeMetadata(rawMetadata).metadata
     }
 
     public dispose(): void {

--- a/vscode/src/services/telemetry-v2.ts
+++ b/vscode/src/services/telemetry-v2.ts
@@ -119,7 +119,9 @@ export function createOrUpdateTelemetryRecorderProvider(
  * that collects the keys of an object where the corresponding value is of a
  * given type as a type.
  */
-type KeysWithNumericValues<T> = keyof { [P in keyof T as T[P] extends number ? P : never]: P }
+type KeysWithNumericOrBooleanValues<T> = keyof {
+    [P in keyof T as T[P] extends number | boolean ? P : never]: P
+}
 
 /**
  * splitSafeMetadata is a helper for legacy telemetry helpers that accept typed
@@ -140,7 +142,7 @@ type KeysWithNumericValues<T> = keyof { [P in keyof T as T[P] extends number ? P
 export function splitSafeMetadata<Properties extends { [key: string]: any }>(
     properties: Properties
 ): {
-    metadata: { [key in KeysWithNumericValues<Properties>]: number }
+    metadata: { [key in KeysWithNumericOrBooleanValues<Properties>]: number }
     privateMetadata: { [key in keyof Properties]?: any }
 } {
     const safe: { [key in keyof Properties]?: number } = {}
@@ -179,7 +181,7 @@ export function splitSafeMetadata<Properties extends { [key: string]: any }>(
         // We know we've constructed an object with only numeric values, so
         // we cast it into the desired type where all the keys with number values
         // are present. Unit tests ensures this property holds.
-        metadata: safe as { [key in KeysWithNumericValues<Properties>]: number },
+        metadata: safe as { [key in KeysWithNumericOrBooleanValues<Properties>]: number },
         privateMetadata: unsafe,
     }
 }

--- a/vscode/src/services/utils/codeblock-action-tracker.ts
+++ b/vscode/src/services/utils/codeblock-action-tracker.ts
@@ -7,27 +7,37 @@ import {
     isDotCom,
     telemetryRecorder,
 } from '@sourcegraph/cody-shared'
-import { getEditor } from '../../editor/active-editor'
 
-import { workspace } from 'vscode'
 import { doesFileExist } from '../../commands/utils/workspace-files'
 import { executeSmartApply } from '../../edit/smart-apply'
+import { getEditor } from '../../editor/active-editor'
 import type { VSCodeEditor } from '../../editor/vscode-editor'
+import { charactersLogger } from '../CharactersLogger'
+
 import { countCode, matchCodeSnippets } from './code-count'
 import { resolveRelativeOrAbsoluteUri } from './edit-create-file'
+
+const defaultLastStoredCode = {
+    code: '',
+    lineCount: 0,
+    charCount: 0,
+    eventName: '',
+    source: '',
+} satisfies LastStoredCode
+
+type LastStoredCode = {
+    code: string
+    lineCount: number
+    charCount: number
+    eventName: string
+    source: string
+}
 
 /**
  * It tracks the last stored code snippet and metadata like lines, chars, event, source etc.
  * This is used to track acceptance of generated code by Cody for Chat and Commands
  */
-let lastStoredCode = {
-    code: 'init',
-    lineCount: 0,
-    charCount: 0,
-    eventName: '',
-    source: '',
-    requestID: '',
-}
+let lastStoredCode: LastStoredCode = { ...defaultLastStoredCode }
 let insertInProgress = false
 let lastClipboardText = ''
 
@@ -43,16 +53,23 @@ enum SourceMetadataMapping {
  *
  * This is used to track code generation events in VS Code.
  */
-function setLastStoredCode(
-    code: string,
-    eventName: 'copyButton' | 'keyDown.Copy' | 'applyButton' | 'insertButton' | 'saveButton',
-    source = 'chat',
-    requestID = ''
-): void {
+function setLastStoredCode({
+    code,
+    eventName,
+    changeEvent,
+}: {
+    code: string
+    eventName: 'copyButton' | 'keyDown.Copy' | 'applyButton' | 'insertButton' | 'saveButton'
+    /**
+     * Used to add the characters logger metadata to the telemetry event.
+     */
+    changeEvent?: vscode.TextDocumentChangeEvent
+}): void {
     // All non-copy events are considered as insertions since we don't need to listen for paste events
+    const source = 'chat'
     insertInProgress = !eventName.includes('copy')
     const { lineCount, charCount } = countCode(code)
-    const codeCount = { code, lineCount, charCount, eventName, source, requestID }
+    const codeCount = { code, lineCount, charCount, eventName, source }
 
     lastStoredCode = codeCount
 
@@ -77,13 +94,17 @@ function setLastStoredCode(
             break
     }
 
+    const charactersLoggerMetadata = changeEvent
+        ? charactersLogger.getChangeEventMetadataForCodyCodeGenEvents(changeEvent)
+        : {}
+
     telemetryRecorder.recordEvent(`cody.${eventName}`, 'clicked', {
         metadata: {
             source: SourceMetadataMapping[source as keyof typeof SourceMetadataMapping] || 0, // Use 0 as default if source is not found
             lineCount,
             charCount,
+            ...charactersLoggerMetadata,
         },
-        interactionID: requestID,
         privateMetadata: {
             source,
             op: operation,
@@ -100,6 +121,31 @@ async function setLastTextFromClipboard(clipboardText?: string): Promise<void> {
     lastClipboardText = clipboardText || (await vscode.env.clipboard.readText())
 }
 
+function workspaceEditToDocumentChangeEvent({
+    workspaceEdit,
+    document,
+    selection,
+}: {
+    workspaceEdit: vscode.WorkspaceEdit
+    document: vscode.TextDocument
+    selection: vscode.Selection
+}): vscode.TextDocumentChangeEvent {
+    const contentChanges = workspaceEdit.get(document.uri).map(edit => {
+        return {
+            range: document.validateRange(edit.range),
+            rangeOffset: document.offsetAt(selection.start),
+            rangeLength: getRangeLength(edit.range, document),
+            text: edit.newText,
+        }
+    })
+
+    return {
+        document,
+        contentChanges,
+        reason: undefined,
+    }
+}
+
 /**
  * Handles insert event to insert text from code block at cursor position
  * Replace selection if there is one and then log insert event
@@ -108,20 +154,30 @@ async function setLastTextFromClipboard(clipboardText?: string): Promise<void> {
 export async function handleCodeFromInsertAtCursor(text: string): Promise<void> {
     const editor = getEditor()
     const activeEditor = editor.active
-    const selectionRange = activeEditor?.selection
-    if (!activeEditor || !selectionRange) {
+    const selection = activeEditor?.selection
+    if (!activeEditor || !selection) {
         throw new Error('No editor or selection found to insert text')
     }
 
-    const edit = new vscode.WorkspaceEdit()
+    const { document } = activeEditor
+    const workspaceEdit = new vscode.WorkspaceEdit()
+
     // trimEnd() to remove new line added by Cody
-    if (selectionRange.isEmpty) {
-        edit.insert(activeEditor.document.uri, selectionRange.start, text.trimEnd())
+    if (selection.isEmpty) {
+        workspaceEdit.insert(document.uri, selection.start, text.trimEnd())
     } else {
-        edit.replace(activeEditor.document.uri, selectionRange, text.trimEnd())
+        workspaceEdit.replace(document.uri, selection, text.trimEnd())
     }
-    setLastStoredCode(text, 'insertButton')
-    await vscode.workspace.applyEdit(edit)
+
+    // Required for characters logger metadata generation.
+    const changeEvent = workspaceEditToDocumentChangeEvent({
+        workspaceEdit,
+        document,
+        selection,
+    })
+
+    setLastStoredCode({ code: text, eventName: 'insertButton', changeEvent })
+    await vscode.workspace.applyEdit(workspaceEdit)
 }
 
 function getSmartApplyModel(authStatus: AuthStatus): EditModel | undefined {
@@ -148,7 +204,7 @@ export async function handleSmartApply(
     fileUri?: string | null
 ): Promise<void> {
     const activeEditor = getEditor()?.active
-    const workspaceUri = workspace.workspaceFolders?.[0].uri
+    const workspaceUri = vscode.workspace.workspaceFolders?.[0].uri
     const uri = await resolveRelativeOrAbsoluteUri(workspaceUri, fileUri, activeEditor?.document?.uri)
 
     const isNewFile = uri && !(await doesFileExist(uri))
@@ -174,7 +230,7 @@ export async function handleSmartApply(
         viewColumn: visibleEditor?.viewColumn,
     })
 
-    setLastStoredCode(code, 'applyButton')
+    setLastStoredCode({ code, eventName: 'applyButton' })
     await executeSmartApply({
         configuration: {
             id,
@@ -192,7 +248,7 @@ export async function handleSmartApply(
  * Handles insert event to insert text from code block to new file
  */
 export async function handleCodeFromSaveToNewFile(text: string, editor: VSCodeEditor): Promise<void> {
-    setLastStoredCode(text, 'saveButton')
+    setLastStoredCode({ code: text, eventName: 'saveButton' })
     return editor.createWorkspaceFile(text)
 }
 
@@ -205,45 +261,58 @@ export async function handleCopiedCode(text: string, isButtonClickEvent: boolean
     const eventName = isButtonClickEvent ? 'copyButton' : 'keyDown.Copy'
     // Set for tracking
     if (copiedCode) {
-        setLastStoredCode(copiedCode, eventName)
+        setLastStoredCode({ code: copiedCode, eventName })
     }
 }
 
 // For tracking paste events for inline-chat
-export async function onTextDocumentChange(newCode: string): Promise<void> {
-    const { code, lineCount, charCount, source, requestID } = lastStoredCode
+export function recordPasteFromChatEvent({ lineCount, charCount, source }: LastStoredCode) {
+    telemetryRecorder.recordEvent('cody.keyDown', 'paste', {
+        metadata: {
+            lineCount,
+            charCount,
+            source: SourceMetadataMapping[source as keyof typeof SourceMetadataMapping] || 0, // Use 0 as default if source is not found
+        },
+        privateMetadata: {
+            source,
+            op: 'paste',
+        },
+        billingMetadata: {
+            product: 'cody',
+            category: 'core',
+        },
+    })
+}
 
-    if (!code) {
-        return
+export async function isCodeFromChatCodeBlockAction(
+    newCode: string
+): Promise<({ operation: 'insert' | 'paste' } & LastStoredCode) | null> {
+    const storedCode = { ...lastStoredCode }
+
+    if (storedCode.code.length === 0) {
+        return null
+    }
+
+    if (!matchCodeSnippets(storedCode.code, newCode)) {
+        return null
     }
 
     if (insertInProgress) {
+        lastStoredCode = { ...defaultLastStoredCode }
         insertInProgress = false
-        return
+        return { ...storedCode, operation: 'insert' }
     }
 
     await setLastTextFromClipboard()
-
-    // the copied code should be the same as the clipboard text
-    if (matchCodeSnippets(code, lastClipboardText) && matchCodeSnippets(code, newCode)) {
-        const op = 'paste'
-        const eventType = 'keyDown'
-
-        telemetryRecorder.recordEvent(`cody.${eventType}`, 'paste', {
-            metadata: {
-                lineCount,
-                charCount,
-                source: SourceMetadataMapping[source as keyof typeof SourceMetadataMapping] || 0, // Use 0 as default if source is not found
-            },
-            interactionID: requestID,
-            privateMetadata: {
-                source,
-                op,
-            },
-            billingMetadata: {
-                product: 'cody',
-                category: 'core',
-            },
-        })
+    if (matchCodeSnippets(storedCode.code, lastClipboardText)) {
+        return { ...storedCode, operation: 'paste' }
     }
+
+    return null
+}
+
+function getRangeLength(range: vscode.Range, document: vscode.TextDocument): number {
+    const startOffset = document.offsetAt(range.start)
+    const endOffset = document.offsetAt(range.end)
+    return endOffset - startOffset
 }


### PR DESCRIPTION
- Adds new fields to the `cody.characters:flush` analytics event. This way, we can identify all code generation events coming from chat and always include them once in our PCW calculation.
    - `cody_chat` — to identify document change events originating from `insert at cursor` and `copy-paste` chat actions.
    - `cody_chat_inserted`
    - `cody_chat_deleted`
- Part of https://linear.app/sourcegraph/issue/CODY-4197/add-metadata-to-cody-code-gen-analytics-events-to-prevent-double. See more context and related discussion there.
- Closes https://linear.app/sourcegraph/issue/CODY-4200/add-char-counts-metadata-to-chat-events

## Test plan

CI and updated unit tests.