### PR TITLE
add code llama model for the a/b test

### DIFF
--- a/lib/shared/src/experimentation/FeatureFlagProvider.ts
+++ b/lib/shared/src/experimentation/FeatureFlagProvider.ts
@@ -39,13 +39,13 @@ export enum FeatureFlag {
     CodyAutocompleteFastPath = 'cody-autocomplete-fast-path',
 
     // Enable various feature flags to experiment with FIM trained fine-tuned models via Fireworks
-    CodyAutocompleteFIMModelExperimentBaseFeatureFlag = 'cody-autocomplete-model-v1-experiment-flag',
-    CodyAutocompleteFIMModelExperimentControl = 'cody-autocomplete-model-v1-experiment-control',
-    CodyAutocompleteFIMModelExperimentCurrentBest = 'cody-autocomplete-model-v1-experiment-current-best',
-    CodyAutocompleteFIMModelExperimentVariant1 = 'cody-autocomplete-model-v1-experiment-variant-1',
-    CodyAutocompleteFIMModelExperimentVariant2 = 'cody-autocomplete-model-v1-experiment-variant-2',
-    CodyAutocompleteFIMModelExperimentVariant3 = 'cody-autocomplete-model-v1-experiment-variant-3',
-    CodyAutocompleteFIMModelExperimentVariant4 = 'cody-autocomplete-model-v1-experiment-variant-4',
+    CodyAutocompleteFIMModelExperimentBaseFeatureFlag = 'cody-autocomplete-model-v2-experiment-flag',
+    CodyAutocompleteFIMModelExperimentControl = 'cody-autocomplete-model-experiment-control',
+    CodyAutocompleteFIMModelExperimentCurrentBest = 'cody-autocomplete-model-experiment-current-best',
+    CodyAutocompleteFIMModelExperimentVariant1 = 'cody-autocomplete-model-experiment-variant-1',
+    CodyAutocompleteFIMModelExperimentVariant2 = 'cody-autocomplete-model-experiment-variant-2',
+    CodyAutocompleteFIMModelExperimentVariant3 = 'cody-autocomplete-model-experiment-variant-3',
+    CodyAutocompleteFIMModelExperimentVariant4 = 'cody-autocomplete-model-experiment-variant-4',
 
     CodyAutocompletePreloadingExperimentBaseFeatureFlag = 'cody-autocomplete-preloading-experiment-flag',
     CodyAutocompletePreloadingExperimentVariant1 = 'cody-autocomplete-preloading-experiment-variant-1',

--- a/vscode/src/completions/providers/fireworks.ts
+++ b/vscode/src/completions/providers/fireworks.ts
@@ -34,6 +34,7 @@ export const DEEPSEEK_CODER_V2_LITE_BASE_WINDOW_8192 = 'deepseek-coder-v2-lite-b
 export const DEEPSEEK_CODER_V2_LITE_BASE_WINDOW_16384 = 'deepseek-coder-v2-lite-base-context-16384'
 
 export const CODE_QWEN_7B_V2P5 = 'code-qwen-7b-v2p5'
+export const CODE_LLAMA_7B = 'codellama-7b'
 
 // Model identifiers can be found in https://docs.fireworks.ai/explore/ and in our internal
 // conversations
@@ -50,6 +51,7 @@ const MODEL_MAP = {
     [DEEPSEEK_CODER_V2_LITE_BASE_WINDOW_8192]: 'accounts/fireworks/models/deepseek-coder-v2-lite-base',
     [DEEPSEEK_CODER_V2_LITE_BASE_WINDOW_16384]: 'accounts/fireworks/models/deepseek-coder-v2-lite-base',
     [CODE_QWEN_7B_V2P5]: 'accounts/fireworks/models/qwen-v2p5-7b',
+    [CODE_LLAMA_7B]: 'accounts/fireworks/models/code-llama-7b',
 } as const
 
 type FireworksModel =
@@ -72,6 +74,7 @@ function getMaxContextTokens(model: FireworksModel): number {
             // compare the results
             return 2048
         case DEEPSEEK_CODER_V2_LITE_BASE:
+        case CODE_LLAMA_7B:
         case CODE_QWEN_7B_V2P5: {
             return 2048
         }

--- a/vscode/src/completions/providers/shared/get-experiment-model.ts
+++ b/vscode/src/completions/providers/shared/get-experiment-model.ts
@@ -10,13 +10,7 @@ import {
 
 import { Observable, map } from 'observable-fns'
 import * as vscode from 'vscode'
-import {
-    CODE_QWEN_7B_V2P5,
-    DEEPSEEK_CODER_V2_LITE_BASE,
-    DEEPSEEK_CODER_V2_LITE_BASE_WINDOW_4096,
-    DEEPSEEK_CODER_V2_LITE_BASE_WINDOW_8192,
-    DEEPSEEK_CODER_V2_LITE_BASE_WINDOW_16384,
-} from '../fireworks'
+import { CODE_LLAMA_7B, DEEPSEEK_CODER_V2_LITE_BASE } from '../fireworks'
 
 interface ProviderConfigFromFeatureFlags {
     provider: string
@@ -79,39 +73,19 @@ export function getDotComExperimentModel({
 function resolveFIMModelExperimentFromFeatureFlags(): ReturnType<typeof getDotComExperimentModel> {
     return combineLatest(
         featureFlagProvider.evaluatedFeatureFlag(FeatureFlag.CodyAutocompleteFIMModelExperimentControl),
-        featureFlagProvider.evaluatedFeatureFlag(FeatureFlag.CodyAutocompleteFIMModelExperimentVariant1),
-        featureFlagProvider.evaluatedFeatureFlag(FeatureFlag.CodyAutocompleteFIMModelExperimentVariant2),
-        featureFlagProvider.evaluatedFeatureFlag(FeatureFlag.CodyAutocompleteFIMModelExperimentVariant3),
-        featureFlagProvider.evaluatedFeatureFlag(FeatureFlag.CodyAutocompleteFIMModelExperimentVariant4)
+        featureFlagProvider.evaluatedFeatureFlag(FeatureFlag.CodyAutocompleteFIMModelExperimentVariant1)
     ).pipe(
-        map(
-            ([
-                fimModelControl,
-                fimModelVariant1,
-                fimModelVariant2,
-                fimModelVariant3,
-                fimModelVariant4,
-            ]) => {
-                if (fimModelVariant1) {
-                    return { provider: 'fireworks', model: DEEPSEEK_CODER_V2_LITE_BASE_WINDOW_4096 }
-                }
-                if (fimModelVariant2) {
-                    return { provider: 'fireworks', model: CODE_QWEN_7B_V2P5 }
-                }
-                if (fimModelVariant3) {
-                    return { provider: 'fireworks', model: DEEPSEEK_CODER_V2_LITE_BASE_WINDOW_8192 }
-                }
-                if (fimModelVariant4) {
-                    return { provider: 'fireworks', model: DEEPSEEK_CODER_V2_LITE_BASE_WINDOW_16384 }
-                }
-                if (fimModelControl) {
-                    // Current production model
-                    return { provider: 'fireworks', model: DEEPSEEK_CODER_V2_LITE_BASE }
-                }
-                // Extra free traffic - redirect to the current production model which could be different than control
+        map(([fimModelControl, fimModelVariant1]) => {
+            if (fimModelVariant1) {
+                return { provider: 'fireworks', model: CODE_LLAMA_7B }
+            }
+            if (fimModelControl) {
+                // Current production model
                 return { provider: 'fireworks', model: DEEPSEEK_CODER_V2_LITE_BASE }
             }
-        ),
+            // Extra free traffic - redirect to the current production model which could be different than control
+            return { provider: 'fireworks', model: DEEPSEEK_CODER_V2_LITE_BASE }
+        }),
         distinctUntilChanged()
     )
 }


### PR DESCRIPTION
Adding the code llama model for the A/B test.
Backend PR: https://github.com/sourcegraph/sourcegraph/pull/1371

## Test plan
Manual testing by:
1. Overriding userid in `cody-autocomplete-model-experiment-variant-1` feature flag.
2. Checking the logging prompt to make sure we trigger code llama with correct infill prompt.
3. Check model response.