### PR TITLE
Add new custom configuration field which supports dotted names

### DIFF
--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/agent/protocol_generated/ExtensionConfiguration.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/agent/protocol_generated/ExtensionConfiguration.kt
@@ -15,6 +15,7 @@ data class ExtensionConfiguration(
   val codebase: String? = null,
   val eventProperties: EventProperties? = null,
   val customConfiguration: Map<String, Any>? = null,
+  val customConfigurationJson: String? = null,
   val baseGlobalState: Map<String, Any>? = null,
 )
 

--- a/agent/src/AgentWorkspaceConfiguration.test.ts
+++ b/agent/src/AgentWorkspaceConfiguration.test.ts
@@ -1,0 +1,162 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import { AgentWorkspaceConfiguration } from './AgentWorkspaceConfiguration'
+import type { ClientInfo, ExtensionConfiguration } from './protocol-alias'
+
+describe('AgentWorkspaceConfiguration', () => {
+    let config: AgentWorkspaceConfiguration
+
+    const clientInfo: ClientInfo = {
+        name: 'vscode',
+        version: '1.0.0',
+        ideVersion: '1.80.0',
+        capabilities: {
+            globalState: 'server-managed',
+            webview: 'native',
+        },
+        workspaceRootUri: '/',
+    }
+
+    const customConfigJson = `
+        {
+          "http.systemCertificates": true,
+          "http.experimental.systemCertificatesV2": true,
+          "cody.debug": {
+            "verbose": true
+          },
+          "cody.autocomplete.advanced.provider": "anthropic",
+          "cody.experimental": {
+            "tracing": true
+          },
+          "cody.telemetry": {
+            "level": "agent"
+          },
+          "editor": {
+            "insertSpaces": true
+          }
+        }
+    `
+
+    const extensionConfig: ExtensionConfiguration = {
+        serverEndpoint: 'https://sourcegraph.test',
+        customHeaders: { 'X-Test': 'test' },
+        telemetryClientName: 'test-client',
+        autocompleteAdvancedProvider: 'anthropic',
+        autocompleteAdvancedModel: 'claude-2',
+        verboseDebug: true,
+        codebase: 'test-repo',
+        customConfigurationJson: customConfigJson,
+    }
+
+    beforeEach(() => {
+        config = new AgentWorkspaceConfiguration(
+            [],
+            () => clientInfo,
+            () => extensionConfig
+        )
+    })
+
+    describe('get', () => {
+        it('can return sub-configuration object', () => {
+            expect(config.get('cody.serverEndpoint')).toBe('https://sourcegraph.test')
+            expect(config.get('cody.customHeaders')).toEqual({ 'X-Test': 'test' })
+            expect(config.get('cody.telemetry.level')).toBe('agent')
+            expect(config.get('cody.telemetry.clientName')).toBe('test-client')
+            expect(config.get('cody.autocomplete.enabled')).toBe(true)
+            expect(config.get('cody.autocomplete.advanced.provider')).toBe('anthropic')
+            expect(config.get('cody.autocomplete.advanced.model')).toBe('claude-2')
+            expect(config.get('cody.advanced.agent.running')).toBe(true)
+            expect(config.get('cody.debug.verbose')).toBe(true)
+            expect(config.get('cody.experimental.tracing')).toBe(true)
+            expect(config.get('cody.codebase')).toBe('test-repo')
+            expect(config.get('editor.insertSpaces')).toBe(true)
+        })
+
+        it('returns correct values for configuration sections', () => {
+            expect(config.get('http')).toStrictEqual({
+                experimental: {
+                    systemCertificatesV2: true,
+                },
+                systemCertificates: true,
+            })
+
+            expect(config.get('http.experimental')).toStrictEqual({
+                systemCertificatesV2: true,
+            })
+
+            expect(config.get('cody')).toStrictEqual({
+                debug: {
+                    verbose: true,
+                },
+                autocomplete: {
+                    advanced: {
+                        provider: 'anthropic',
+                    },
+                },
+                experimental: {
+                    tracing: true,
+                },
+                telemetry: {
+                    level: 'agent',
+                },
+            })
+        })
+
+        it('handles agent capabilities correctly', () => {
+            expect(config.get('cody.advanced.agent.capabilities.storage')).toBe(true)
+            expect(config.get('cody.advanced.hasNativeWebview')).toBe(true)
+        })
+
+        it('returns default value for unknown sections', () => {
+            expect(config.get('unknown.section', 'default')).toBe('default')
+        })
+    })
+
+    describe('has', () => {
+        it('returns true for existing sections', () => {
+            expect(config.has('cody.serverEndpoint')).toBe(true)
+        })
+
+        it('returns false for non-existing sections', () => {
+            expect(config.has('nonexistent.section')).toBe(false)
+        })
+    })
+
+    describe('inspect', () => {
+        it('returns undefined for any section', () => {
+            expect(config.inspect('cody.serverEndpoint')).toBeUndefined()
+        })
+    })
+
+    describe('update', () => {
+        it('updates simple configuration value', async () => {
+            await config.update('cody.serverEndpoint', 'https://new-endpoint.test')
+            expect(config.get('cody.serverEndpoint')).toBe('https://new-endpoint.test')
+        })
+
+        it('updates nested configuration object', async () => {
+            await config.update('cody.debug', { verbose: false, newSetting: true })
+            expect(config.get('cody.debug')).toEqual({ verbose: false, newSetting: true })
+            expect(config.get('cody.debug.newSetting')).toEqual(true)
+        })
+
+        it('creates new configuration path if it does not exist', async () => {
+            await config.update('newSection.newSubSection', 'value')
+            expect(config.get('newSection.newSubSection')).toBe('value')
+        })
+
+        it('updates array values', async () => {
+            await config.update('testArray', [1, 2, 3])
+            expect(config.get('testArray')).toEqual([1, 2, 3])
+        })
+
+        it('handles null value', async () => {
+            await config.update('cody.serverEndpoint', null)
+            expect(config.get('cody.serverEndpoint')).toBeNull()
+        })
+
+        it('updates boolean values', async () => {
+            await config.update('feature.enabled', false)
+            expect(config.get('feature.enabled')).toBe(false)
+        })
+    })
+})

--- a/agent/src/AgentWorkspaceConfiguration.ts
+++ b/agent/src/AgentWorkspaceConfiguration.ts
@@ -1,3 +1,4 @@
+import _ from 'lodash'
 import type * as vscode from 'vscode'
 
 import { type ClientConfiguration, CodyIDE } from '@sourcegraph/cody-shared'
@@ -66,6 +67,19 @@ export class AgentWorkspaceConfiguration implements vscode.WorkspaceConfiguratio
         if (fromCustomConfiguration !== undefined) {
             return fromCustomConfiguration
         }
+        const fromCustomConfigurationJson = extensionConfig?.customConfigurationJson
+        const customConfig = {}
+        if (fromCustomConfigurationJson) {
+            const configJson = JSON.parse(fromCustomConfigurationJson)
+            for (const key of Object.keys(configJson)) {
+                _.set(customConfig, key, configJson[key])
+            }
+        }
+        const customConfigValue = _.get(customConfig, section)
+        if (customConfigValue !== undefined) {
+            return customConfigValue
+        }
+
         switch (section) {
             case 'cody.serverEndpoint':
                 return extensionConfig?.serverEndpoint

--- a/vscode/src/jsonrpc/agent-protocol.ts
+++ b/vscode/src/jsonrpc/agent-protocol.ts
@@ -595,7 +595,12 @@ export interface ExtensionConfiguration {
      */
     eventProperties?: EventProperties | undefined | null
 
+    /**
+     * @deprecated use 'customConfigurationJson' instead, it supports dotted names
+     */
     customConfiguration?: Record<string, any> | undefined | null
+
+    customConfigurationJson?: string | undefined | null
 
     baseGlobalState?: Record<string, any> | undefined | null
 }


### PR DESCRIPTION
## Changes

This PR adds `customConfigurationJson` field which allow passing json config.
This allow us to support obtaining config objects using dotted pattern.
For example, given the config bellow:

```json
{
  "http.systemCertificates": true,
  "http.experimental.systemCertificatesV2": true
}
```

Before it was only possible to get `http.systemCertificates` and `http.experimental.systemCertificatesV2` keys.
After this changes it is also possible to get `http` which would return:

```json
{
  "systemCertificates": true,
  "experimental.systemCertificatesV2": true
}
```

Or 'http.experimental' which would return:

```json
{

  "systemCertificatesV2": true
}
```

**Additionally** it will support writing json config files utilising full json syntax, e.g.:

```json
{
  "cody.debug": {
    "verbose": true
  }
}
```

## Test plan

Add the following to the settings file, restart editor, and check if logs contains debug entries:

```json
{
  "cody.debug": {
    "verbose": true
  }
}
```