### PR TITLE
Fix initial context for chats

### DIFF
--- a/vscode/src/chat/initialContext.ts
+++ b/vscode/src/chat/initialContext.ts
@@ -31,7 +31,7 @@ import * as vscode from 'vscode'
 import { URI } from 'vscode-uri'
 import { getSelectionOrFileContext } from '../commands/context/selection'
 import { createRepositoryMention } from '../context/openctx/common/get-repository-mentions'
-import { remoteReposForAllWorkspaceFolders } from '../repository/remoteRepos'
+import { type RemoteRepo, remoteReposForAllWorkspaceFolders } from '../repository/remoteRepos'
 import { ChatBuilder } from './chat-view/ChatBuilder'
 import {
     activeEditorContextForOpenCtxMentions,
@@ -196,7 +196,8 @@ export function getCorpusContextItemsForEditorState(): Observable<
             // TODO(sqs): Make this consistent between self-serve (no remote search) and enterprise (has
             // remote search). There should be a single internal thing in Cody that lets you monitor the
             // user's current codebase.
-            if (authStatus.allowRemoteContext) {
+            const remoteRepos = (remoteReposForAllWorkspaceFolders as RemoteRepo[]) || []
+            if (authStatus.allowRemoteContext && remoteRepos.length > 0) {
                 if (remoteReposForAllWorkspaceFolders === pendingOperation) {
                     return pendingOperation
                 }


### PR DESCRIPTION
[The recent changes](https://github.com/sourcegraph/cody/pull/5717/files#diff-15f0129edbd2591b7accebaedd0990b749a2171b5b476f3fb966bb94ec024b5aL174) caused the regression. Looks like a simple error in conditioning. 

## Test plan
Switch b/w models in the chat. Current Repository should be added in the initial context.

I selected all models in dotcom and enterprise.

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
