### PR TITLE
Fix support for merging multiple nested objects

### DIFF
--- a/agent/src/AgentWorkspaceConfiguration.test.ts
+++ b/agent/src/AgentWorkspaceConfiguration.test.ts
@@ -92,18 +92,42 @@ describe('AgentWorkspaceConfiguration', () => {
             })
 
             expect(config.get('cody')).toStrictEqual({
-                debug: {
-                    verbose: true,
+                advanced: {
+                    agent: {
+                        capabilities: {
+                            storage: true,
+                        },
+                        extension: {
+                            version: '1.0.0',
+                        },
+                        ide: {
+                            name: 'VSCode',
+                            version: '1.80.0',
+                        },
+                        running: true,
+                    },
+                    hasNativeWebview: true,
                 },
                 autocomplete: {
                     advanced: {
+                        model: 'claude-2',
                         provider: 'anthropic',
                     },
+                    enabled: true,
+                },
+                codebase: 'test-repo',
+                customHeaders: {
+                    'X-Test': 'test',
+                },
+                debug: {
+                    verbose: true,
                 },
                 experimental: {
                     tracing: true,
                 },
+                serverEndpoint: 'https://sourcegraph.test',
                 telemetry: {
+                    clientName: 'test-client',
                     level: 'agent',
                 },
             })
@@ -122,6 +146,17 @@ describe('AgentWorkspaceConfiguration', () => {
 
         it('returns default value for unknown sections', () => {
             expect(config.get('unknown.section', 'default')).toBe('default')
+        })
+
+        it('returns new instance each time when getting the same value', () => {
+            const testObject = { key: 'value' }
+            config.update('test.object', testObject)
+
+            const firstGet = config.get('test.object')
+            firstGet.key = 'modified'
+
+            const secondGet = config.get('test.object')
+            expect(secondGet.key).toBe('value')
         })
     })
 

--- a/agent/src/AgentWorkspaceConfiguration.test.ts
+++ b/agent/src/AgentWorkspaceConfiguration.test.ts
@@ -32,6 +32,14 @@ describe('AgentWorkspaceConfiguration', () => {
           },
           "editor": {
             "insertSpaces": true
+          },
+          "foo.bar": {
+            "baz.qux": true,
+            "baz": {
+                "d1.d2": {
+                    "v": 1
+                }
+            }
           }
         }
     `
@@ -101,6 +109,12 @@ describe('AgentWorkspaceConfiguration', () => {
             })
         })
 
+        it('handles parsing nested keys as objects', () => {
+            expect(config.get('foo.bar.baz.qux')).toBe(true)
+            expect(config.get('foo.bar.baz')).toStrictEqual({ d1: { d2: { v: 1 } }, qux: true })
+            expect(config.get('foo.bar.baz.d1')).toStrictEqual({ d2: { v: 1 } })
+        })
+
         it('handles agent capabilities correctly', () => {
             expect(config.get('cody.advanced.agent.capabilities.storage')).toBe(true)
             expect(config.get('cody.advanced.hasNativeWebview')).toBe(true)
@@ -118,6 +132,14 @@ describe('AgentWorkspaceConfiguration', () => {
 
         it('returns false for non-existing sections', () => {
             expect(config.has('nonexistent.section')).toBe(false)
+        })
+
+        it('returns false for non-existing sub-sections', () => {
+            expect(config.has('http.foo')).toBe(false)
+        })
+
+        it('returns true for existing sub-sections', () => {
+            expect(config.has('http.experimental')).toBe(true)
         })
     })
 

--- a/agent/src/AgentWorkspaceConfiguration.ts
+++ b/agent/src/AgentWorkspaceConfiguration.ts
@@ -16,12 +16,24 @@ export class AgentWorkspaceConfiguration implements vscode.WorkspaceConfiguratio
     ) {
         const extensionConfigValue = this.extensionConfig()
 
+        function normalize(config: any): any {
+            if (typeof config === 'object') {
+                const normalized = {}
+                for (const key of Object.keys(config)) {
+                    const tmp = {}
+                    _.set(tmp, key, normalize(config[key]))
+                    _.merge(normalized, tmp)
+                }
+                return normalized
+            }
+
+            return config
+        }
+
         const fromCustomConfigurationJson = extensionConfigValue?.customConfigurationJson
         if (fromCustomConfigurationJson) {
             const configJson = JSON.parse(fromCustomConfigurationJson)
-            for (const key of Object.keys(configJson)) {
-                _.set(dictionary, key, configJson[key])
-            }
+            _.merge(this.dictionary, normalize(configJson))
         }
 
         const customConfiguration = extensionConfigValue?.customConfiguration

--- a/vscode/src/configuration.test.ts
+++ b/vscode/src/configuration.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { assert, describe, expect, it } from 'vitest'
 import type * as vscode from 'vscode'
 
 import { type ClientConfiguration, OLLAMA_DEFAULT_URL, ps } from '@sourcegraph/cody-shared'
@@ -81,7 +81,7 @@ describe('getConfiguration', () => {
                         return false
                     case 'cody.advanced.hasNativeWebview':
                         return true
-                    case 'cody.advanced.agent.ide':
+                    case 'cody.advanced.agent.ide.name':
                         return undefined
                     case 'cody.advanced.agent.ide.version':
                         return undefined
@@ -128,7 +128,7 @@ describe('getConfiguration', () => {
                     case 'http':
                         return undefined
                     default:
-                        throw new Error(`unexpected key: ${key}`)
+                        assert(false, `unexpected key: ${key}`)
                 }
             },
         }

--- a/vscode/src/configuration.ts
+++ b/vscode/src/configuration.ts
@@ -139,7 +139,7 @@ export function getConfiguration(
         // Rely on this flag sparingly.
         isRunningInsideAgent: getHiddenSetting('advanced.agent.running', false),
         hasNativeWebview: getHiddenSetting('advanced.hasNativeWebview', true),
-        agentIDE: getHiddenSetting<CodyIDE>('advanced.agent.ide'),
+        agentIDE: getHiddenSetting<CodyIDE>('advanced.agent.ide.name'),
         agentIDEVersion: getHiddenSetting('advanced.agent.ide.version'),
         agentExtensionVersion: getHiddenSetting('advanced.agent.extension.version'),
         agentHasPersistentStorage: getHiddenSetting('advanced.agent.capabilities.storage', false),

--- a/vscode/src/jsonrpc/agent-protocol.ts
+++ b/vscode/src/jsonrpc/agent-protocol.ts
@@ -596,10 +596,17 @@ export interface ExtensionConfiguration {
     eventProperties?: EventProperties | undefined | null
 
     /**
-     * @deprecated use 'customConfigurationJson' instead, it supports dotted names
+     * @deprecated use 'customConfigurationJson' instead, it supports nested objects
      */
     customConfiguration?: Record<string, any> | undefined | null
 
+    /**
+     * Custom configuration is parsed using the same rules as VSCode's WorkspaceConfiguration:
+     * https://code.visualstudio.com/api/references/vscode-api#WorkspaceConfiguration.get
+     * That means it supports dotted names - keys can be nested and are merged based on the prefix.
+     * Configuration objects from a nested settings can be obtained using dotted names.
+     * For the examples look at the `AgentWorkspaceConfiguration.test.ts`
+     */
     customConfigurationJson?: string | undefined | null
 
     baseGlobalState?: Record<string, any> | undefined | null


### PR DESCRIPTION
## Changes

I added support and tests for multiple nested objects like this:

```json
"foo.bar": {
    "baz.qux": true,
    "baz": {
         "d1.d2": {
             "v": 1
          }
     }
}
```

I also fixed few other minor remarks from previous review.


## Test plan

Automatic tests for new cases were added.