### PR TITLE
Remove repo chip from default context

### DIFF
--- a/lib/prompt-editor/src/index.ts
+++ b/lib/prompt-editor/src/index.ts
@@ -8,7 +8,7 @@ export {
     type ChatMentionsSettings,
 } from './plugins/atMentions/useChatContextItems'
 export { type PromptEditorConfig, PromptEditorConfigProvider } from './config'
-export { useInitialContextForChat } from './useInitialContext'
+export { useDefaultContextForChat } from './useInitialContext'
 export {
     type SerializedPromptEditorState,
     type SerializedPromptEditorValue,

--- a/lib/prompt-editor/src/mentions/mentionMenu/useMentionMenuData.test.tsx
+++ b/lib/prompt-editor/src/mentions/mentionMenu/useMentionMenuData.test.tsx
@@ -11,12 +11,13 @@ import { Observable } from 'observable-fns'
 import { describe, expect, test, vi } from 'vitest'
 import { URI } from 'vscode-uri'
 import { MOCK_API, useExtensionAPI } from '../../useExtensionAPI'
-import { useInitialContextForChat } from '../../useInitialContext'
+import { useCorpusContextForChat, useInitialContextForChat } from '../../useInitialContext'
 import { waitForObservableInTest } from '../../useObservable'
 import { useCallMentionMenuData, useMentionMenuData } from './useMentionMenuData'
 
 vi.mock('../../useExtensionAPI')
 vi.mock('../../useInitialContext')
+vi.mock('../../useCorpusContextForChat')
 
 describe('useMentionMenuData', () => {
     describe('initial context deduping', () => {
@@ -59,6 +60,7 @@ describe('useMentionMenuData', () => {
                 source: ContextItemSource.Initial,
             }
             vi.mocked(useInitialContextForChat).mockReturnValue([file1FromInitialContext])
+            vi.mocked(useCorpusContextForChat).mockReturnValue([])
 
             const { result } = renderHook(() =>
                 useMentionMenuData(
@@ -113,6 +115,7 @@ describe('useMentionMenuData', () => {
                 }),
         })
         vi.mocked(useInitialContextForChat).mockReturnValue([])
+        vi.mocked(useCorpusContextForChat).mockReturnValue([])
 
         const { result } = renderHook(() =>
             useMentionMenuData({ query: '', parentItem: null }, { remainingTokenBudget: 100, limit: 10 })

--- a/lib/prompt-editor/src/mentions/mentionMenu/useMentionMenuData.test.tsx
+++ b/lib/prompt-editor/src/mentions/mentionMenu/useMentionMenuData.test.tsx
@@ -11,7 +11,7 @@ import { Observable } from 'observable-fns'
 import { describe, expect, test, vi } from 'vitest'
 import { URI } from 'vscode-uri'
 import { MOCK_API, useExtensionAPI } from '../../useExtensionAPI'
-import { useCorpusContextForChat, useInitialContextForChat } from '../../useInitialContext'
+import { useDefaultContextForChat } from '../../useInitialContext'
 import { waitForObservableInTest } from '../../useObservable'
 import { useCallMentionMenuData, useMentionMenuData } from './useMentionMenuData'
 
@@ -59,8 +59,10 @@ describe('useMentionMenuData', () => {
                 ...mockContextItems[0],
                 source: ContextItemSource.Initial,
             }
-            vi.mocked(useInitialContextForChat).mockReturnValue([file1FromInitialContext])
-            vi.mocked(useCorpusContextForChat).mockReturnValue([])
+            vi.mocked(useDefaultContextForChat).mockReturnValue({
+                initialContext: [file1FromInitialContext],
+                corpusContext: [],
+            })
 
             const { result } = renderHook(() =>
                 useMentionMenuData(
@@ -114,8 +116,10 @@ describe('useMentionMenuData', () => {
                     error: 'my error',
                 }),
         })
-        vi.mocked(useInitialContextForChat).mockReturnValue([])
-        vi.mocked(useCorpusContextForChat).mockReturnValue([])
+        vi.mocked(useDefaultContextForChat).mockReturnValue({
+            initialContext: [],
+            corpusContext: [],
+        })
 
         const { result } = renderHook(() =>
             useMentionMenuData({ query: '', parentItem: null }, { remainingTokenBudget: 100, limit: 10 })

--- a/lib/prompt-editor/src/mentions/mentionMenu/useMentionMenuData.ts
+++ b/lib/prompt-editor/src/mentions/mentionMenu/useMentionMenuData.ts
@@ -16,7 +16,7 @@ import debounce from 'lodash/debounce'
 import { useCallback, useContext, useMemo, useState } from 'react'
 import { ChatMentionContext } from '../../plugins/atMentions/useChatContextItems'
 import { useExtensionAPI } from '../../useExtensionAPI'
-import { useCorpusContextForChat, useInitialContextForChat } from '../../useInitialContext'
+import { useDefaultContextForChat } from '../../useInitialContext'
 import { type UseObservableResult, useObservable } from '../../useObservable'
 
 export interface MentionMenuParams {
@@ -95,7 +95,8 @@ export function useMentionMenuData(
     const isInProvider = !!params.parentItem
 
     // Initial context items aren't filtered when we receive them, so we need to filter them here.
-    const initialContext = [...useInitialContextForChat(), ...useCorpusContextForChat()]
+    const defaultContext = useDefaultContextForChat()
+    const initialContext = [...defaultContext.initialContext, ...defaultContext.corpusContext]
     const filteredInitialContextItems = isInProvider
         ? []
         : initialContext.filter(item =>

--- a/lib/prompt-editor/src/useExtensionAPI.tsx
+++ b/lib/prompt-editor/src/useExtensionAPI.tsx
@@ -14,11 +14,17 @@ const context = createContext<WebviewToExtensionAPI | undefined>(undefined)
 export const ExtensionAPIProviderFromVSCodeAPI: FunctionComponent<{
     vscodeAPI: GenericVSCodeWrapper<any, any>
     staticInitialContext?: ContextItem[]
+    staticCorpusContext?: ContextItem[]
     children: ReactNode
-}> = ({ vscodeAPI, staticInitialContext, children }) => {
+}> = ({ vscodeAPI, staticInitialContext, staticCorpusContext, children }) => {
     const extensionAPI = useMemo<WebviewToExtensionAPI>(
-        () => createExtensionAPI(createMessageAPIForWebview(vscodeAPI), staticInitialContext),
-        [vscodeAPI, staticInitialContext]
+        () =>
+            createExtensionAPI(
+                createMessageAPIForWebview(vscodeAPI),
+                staticInitialContext,
+                staticCorpusContext
+            ),
+        [vscodeAPI, staticInitialContext, staticCorpusContext]
     )
     return <context.Provider value={extensionAPI}>{children}</context.Provider>
 }

--- a/lib/prompt-editor/src/useExtensionAPI.tsx
+++ b/lib/prompt-editor/src/useExtensionAPI.tsx
@@ -1,5 +1,5 @@
 import {
-    type ContextItem,
+    type DefaultContext,
     type GenericVSCodeWrapper,
     type Model,
     type WebviewToExtensionAPI,
@@ -13,18 +13,12 @@ const context = createContext<WebviewToExtensionAPI | undefined>(undefined)
 
 export const ExtensionAPIProviderFromVSCodeAPI: FunctionComponent<{
     vscodeAPI: GenericVSCodeWrapper<any, any>
-    staticInitialContext?: ContextItem[]
-    staticCorpusContext?: ContextItem[]
+    staticDefaultContext?: DefaultContext
     children: ReactNode
-}> = ({ vscodeAPI, staticInitialContext, staticCorpusContext, children }) => {
+}> = ({ vscodeAPI, staticDefaultContext, children }) => {
     const extensionAPI = useMemo<WebviewToExtensionAPI>(
-        () =>
-            createExtensionAPI(
-                createMessageAPIForWebview(vscodeAPI),
-                staticInitialContext,
-                staticCorpusContext
-            ),
-        [vscodeAPI, staticInitialContext, staticCorpusContext]
+        () => createExtensionAPI(createMessageAPIForWebview(vscodeAPI), staticDefaultContext),
+        [vscodeAPI, staticDefaultContext]
     )
     return <context.Provider value={extensionAPI}>{children}</context.Provider>
 }

--- a/lib/prompt-editor/src/useInitialContext.ts
+++ b/lib/prompt-editor/src/useInitialContext.ts
@@ -11,4 +11,12 @@ export function useInitialContextForChat(): ContextItem[] {
     return useObservable(useMemo(() => initialContext(), [initialContext])).value ?? EMPTY
 }
 
+/**
+ * Get the corpus context corresponding to the current editor state
+ */
+export function useCorpusContextForChat(): ContextItem[] {
+    const corpusContext = useExtensionAPI().corpusContext
+    return useObservable(useMemo(() => corpusContext(), [corpusContext])).value ?? EMPTY
+}
+
 const EMPTY: ContextItem[] = []

--- a/lib/prompt-editor/src/useInitialContext.ts
+++ b/lib/prompt-editor/src/useInitialContext.ts
@@ -1,4 +1,4 @@
-import type { ContextItem } from '@sourcegraph/cody-shared'
+import type { DefaultContext } from '@sourcegraph/cody-shared/src/codebase-context/messages'
 import { useMemo } from 'react'
 import { useExtensionAPI } from './useExtensionAPI'
 import { useObservable } from './useObservable'
@@ -6,17 +6,12 @@ import { useObservable } from './useObservable'
 /**
  * Get the initial context with which to populate the chat message input field.
  */
-export function useInitialContextForChat(): ContextItem[] {
-    const initialContext = useExtensionAPI().initialContext
-    return useObservable(useMemo(() => initialContext(), [initialContext])).value ?? EMPTY
+export function useDefaultContextForChat(): DefaultContext {
+    const defaultContext = useExtensionAPI().defaultContext
+    return useObservable(useMemo(() => defaultContext(), [defaultContext])).value ?? EMPTY
 }
 
-/**
- * Get the corpus context corresponding to the current editor state
- */
-export function useCorpusContextForChat(): ContextItem[] {
-    const corpusContext = useExtensionAPI().corpusContext
-    return useObservable(useMemo(() => corpusContext(), [corpusContext])).value ?? EMPTY
+const EMPTY: DefaultContext = {
+    initialContext: [],
+    corpusContext: [],
 }
-
-const EMPTY: ContextItem[] = []

--- a/lib/shared/src/codebase-context/messages.ts
+++ b/lib/shared/src/codebase-context/messages.ts
@@ -127,6 +127,14 @@ export type ContextItem =
     | ContextItemOpenCtx
 
 /**
+ * Context items to show by default in the chat input, or as suggestions in the chat UI.
+ */
+export interface DefaultContext {
+    initialContext: ContextItem[]
+    corpusContext: ContextItem[]
+}
+
+/**
  * A context item that represents a repository.
  */
 export interface ContextItemRepository extends ContextItemCommon {

--- a/lib/shared/src/experimentation/FeatureFlagProvider.ts
+++ b/lib/shared/src/experimentation/FeatureFlagProvider.ts
@@ -97,6 +97,11 @@ export enum FeatureFlag {
 
     /** Whether user has access to the experimental Cody Reflection / Deep Cody feature. */
     DeepCody = 'cody-deep-reflection',
+
+    /**
+     * Whether the current repo context chip is shown in the chat input by default
+     */
+    NoDefaultRepoChip = 'no-default-repo-chip',
 }
 
 const ONE_HOUR = 60 * 60 * 1000

--- a/lib/shared/src/index.ts
+++ b/lib/shared/src/index.ts
@@ -98,6 +98,7 @@ export {
     type ContextItemSymbol,
     type ContextFileType,
     type ContextMessage,
+    type DefaultContext,
     type SymbolKind,
     type ContextItemTree,
     type ContextItemRepository,

--- a/lib/shared/src/misc/rpc/webviewAPI.ts
+++ b/lib/shared/src/misc/rpc/webviewAPI.ts
@@ -2,7 +2,7 @@ import { Observable } from 'observable-fns'
 import type { AuthStatus, ModelsData, ResolvedConfiguration, UserProductSubscription } from '../..'
 import type { SerializedPromptEditorState } from '../..'
 import type { ChatMessage, UserLocalHistory } from '../../chat/transcript/messages'
-import type { ContextItem } from '../../codebase-context/messages'
+import type { ContextItem, DefaultContext } from '../../codebase-context/messages'
 import type { CodyCommand } from '../../commands/types'
 import type { FeatureFlag } from '../../experimentation/FeatureFlagProvider'
 import type { ContextMentionProviderMetadata } from '../../mentions/api'
@@ -63,14 +63,9 @@ export interface WebviewToExtensionAPI {
     setChatModel(model: Model['id']): Observable<void>
 
     /**
-     * Observe the initial context that should be populated in the chat message input field.
+     * Observe the default context that should be populated in the chat message input field and suggestions.
      */
-    initialContext(): Observable<ContextItem[]>
-
-    /**
-     * Observe the corpus context items for searching the current corpus of code
-     */
-    corpusContext(): Observable<ContextItem[]>
+    defaultContext(): Observable<DefaultContext>
 
     detectIntent(
         text: string
@@ -109,8 +104,7 @@ export function createExtensionAPI(
     messageAPI: ReturnType<typeof createMessageAPIForWebview>,
 
     // As a workaround for Cody Web, support providing static initial context.
-    staticInitialContext?: ContextItem[],
-    staticCorpusContext?: ContextItem[]
+    staticDefaultContext?: DefaultContext
 ): WebviewToExtensionAPI {
     const hydratePromptMessage = proxyExtensionAPI(messageAPI, 'hydratePromptMessage')
 
@@ -122,14 +116,12 @@ export function createExtensionAPI(
         models: proxyExtensionAPI(messageAPI, 'models'),
         chatModels: proxyExtensionAPI(messageAPI, 'chatModels'),
         highlights: proxyExtensionAPI(messageAPI, 'highlights'),
-        hydratePromptMessage: promptText => hydratePromptMessage(promptText, staticInitialContext),
+        hydratePromptMessage: promptText =>
+            hydratePromptMessage(promptText, staticDefaultContext?.initialContext),
         setChatModel: proxyExtensionAPI(messageAPI, 'setChatModel'),
-        initialContext: staticInitialContext
-            ? () => Observable.of(staticInitialContext)
-            : proxyExtensionAPI(messageAPI, 'initialContext'),
-        corpusContext: staticCorpusContext
-            ? () => Observable.of(staticCorpusContext)
-            : proxyExtensionAPI(messageAPI, 'corpusContext'),
+        defaultContext: staticDefaultContext
+            ? () => Observable.of(staticDefaultContext)
+            : proxyExtensionAPI(messageAPI, 'defaultContext'),
         detectIntent: proxyExtensionAPI(messageAPI, 'detectIntent'),
         promptsMigrationStatus: proxyExtensionAPI(messageAPI, 'promptsMigrationStatus'),
         startPromptsMigration: proxyExtensionAPI(messageAPI, 'startPromptsMigration'),

--- a/lib/shared/src/misc/rpc/webviewAPI.ts
+++ b/lib/shared/src/misc/rpc/webviewAPI.ts
@@ -109,7 +109,8 @@ export function createExtensionAPI(
     messageAPI: ReturnType<typeof createMessageAPIForWebview>,
 
     // As a workaround for Cody Web, support providing static initial context.
-    staticInitialContext?: ContextItem[]
+    staticInitialContext?: ContextItem[],
+    staticCorpusContext?: ContextItem[]
 ): WebviewToExtensionAPI {
     const hydratePromptMessage = proxyExtensionAPI(messageAPI, 'hydratePromptMessage')
 
@@ -126,7 +127,9 @@ export function createExtensionAPI(
         initialContext: staticInitialContext
             ? () => Observable.of(staticInitialContext)
             : proxyExtensionAPI(messageAPI, 'initialContext'),
-        corpusContext: proxyExtensionAPI(messageAPI, 'corpusContext'),
+        corpusContext: staticCorpusContext
+            ? () => Observable.of(staticCorpusContext)
+            : proxyExtensionAPI(messageAPI, 'corpusContext'),
         detectIntent: proxyExtensionAPI(messageAPI, 'detectIntent'),
         promptsMigrationStatus: proxyExtensionAPI(messageAPI, 'promptsMigrationStatus'),
         startPromptsMigration: proxyExtensionAPI(messageAPI, 'startPromptsMigration'),

--- a/lib/shared/src/misc/rpc/webviewAPI.ts
+++ b/lib/shared/src/misc/rpc/webviewAPI.ts
@@ -67,6 +67,11 @@ export interface WebviewToExtensionAPI {
      */
     initialContext(): Observable<ContextItem[]>
 
+    /**
+     * Observe the corpus context items for searching the current corpus of code
+     */
+    corpusContext(): Observable<ContextItem[]>
+
     detectIntent(
         text: string
     ): Observable<
@@ -121,6 +126,7 @@ export function createExtensionAPI(
         initialContext: staticInitialContext
             ? () => Observable.of(staticInitialContext)
             : proxyExtensionAPI(messageAPI, 'initialContext'),
+        corpusContext: proxyExtensionAPI(messageAPI, 'corpusContext'),
         detectIntent: proxyExtensionAPI(messageAPI, 'detectIntent'),
         promptsMigrationStatus: proxyExtensionAPI(messageAPI, 'promptsMigrationStatus'),
         startPromptsMigration: proxyExtensionAPI(messageAPI, 'startPromptsMigration'),

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -608,7 +608,7 @@
       },
       {
         "command": "cody.chat.new",
-        "key": "shift+alt+l",
+        "key": "shift+ctrl+l",
         "when": "cody.activated"
       },
       {
@@ -645,12 +645,12 @@
       },
       {
         "command": "cody.mention.selection",
-        "key": "alt+l",
+        "key": "shift+alt+l",
         "when": "cody.activated && editorTextFocus && editorHasSelection"
       },
       {
         "command": "cody.mention.selection",
-        "key": "alt+/",
+        "key": "shift+alt+/",
         "when": "cody.activated && editorTextFocus && editorHasSelection"
       },
       {

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -608,7 +608,7 @@
       },
       {
         "command": "cody.chat.new",
-        "key": "shift+ctrl+l",
+        "key": "shift+alt+l",
         "when": "cody.activated"
       },
       {
@@ -645,12 +645,12 @@
       },
       {
         "command": "cody.mention.selection",
-        "key": "shift+alt+l",
+        "key": "alt+l",
         "when": "cody.activated && editorTextFocus && editorHasSelection"
       },
       {
         "command": "cody.mention.selection",
-        "key": "shift+alt+/",
+        "key": "alt+/",
         "when": "cody.activated && editorTextFocus && editorHasSelection"
       },
       {

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -527,6 +527,14 @@
         "enablement": "cody.activated"
       },
       {
+        "command": "cody.mention.selection",
+        "category": "Cody",
+        "group": "Chat",
+        "title": "Add Selection to Cody Chat",
+        "icon": "$(mention)",
+        "enablement": "cody.activated && editorHasSelection"
+      },
+      {
         "command": "cody.mention.file",
         "category": "Cody",
         "group": "Chat",
@@ -634,6 +642,16 @@
         "args": {
           "editorFocus": false
         }
+      },
+      {
+        "command": "cody.mention.selection",
+        "key": "alt+l",
+        "when": "cody.activated && editorTextFocus && editorHasSelection"
+      },
+      {
+        "command": "cody.mention.selection",
+        "key": "alt+/",
+        "when": "cody.activated && editorTextFocus && editorHasSelection"
       },
       {
         "command": "cody.tutorial.chat",
@@ -810,6 +828,11 @@
         }
       ],
       "cody.submenu": [
+        {
+          "command": "cody.mention.selection",
+          "group": "0_cody",
+          "when": "cody.activated && editorHasSelection"
+        },
         {
           "command": "cody.mention.file",
           "group": "0_cody",

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -527,14 +527,6 @@
         "enablement": "cody.activated"
       },
       {
-        "command": "cody.mention.selection",
-        "category": "Cody",
-        "group": "Chat",
-        "title": "Add Selection to Cody Chat",
-        "icon": "$(mention)",
-        "enablement": "cody.activated && editorHasSelection"
-      },
-      {
         "command": "cody.mention.file",
         "category": "Cody",
         "group": "Chat",
@@ -642,16 +634,6 @@
         "args": {
           "editorFocus": false
         }
-      },
-      {
-        "command": "cody.mention.selection",
-        "key": "alt+l",
-        "when": "cody.activated && editorTextFocus && editorHasSelection"
-      },
-      {
-        "command": "cody.mention.selection",
-        "key": "alt+/",
-        "when": "cody.activated && editorTextFocus && editorHasSelection"
       },
       {
         "command": "cody.tutorial.chat",
@@ -828,11 +810,6 @@
         }
       ],
       "cody.submenu": [
-        {
-          "command": "cody.mention.selection",
-          "group": "0_cody",
-          "when": "cody.activated && editorHasSelection"
-        },
         {
           "command": "cody.mention.file",
           "group": "0_cody",

--- a/vscode/src/chat/chat-view/ChatController.test.ts
+++ b/vscode/src/chat/chat-view/ChatController.test.ts
@@ -108,7 +108,7 @@ describe('ChatController', () => {
             signal: new AbortController().signal,
             source: 'chat',
         })
-        expect(postMessageSpy.mock.calls.at(2)?.at(0)).toStrictEqual<
+        expect(postMessageSpy.mock.calls.at(3)?.at(0)).toStrictEqual<
             Extract<ExtensionMessage, { type: 'transcript' }>
         >({
             type: 'transcript',
@@ -140,7 +140,7 @@ describe('ChatController', () => {
         await vi.runOnlyPendingTimersAsync()
         expect(mockChatClient.chat).toBeCalledTimes(1)
         expect(addBotMessageSpy).toHaveBeenCalledWith('1', ps`Test reply 1`, 'my-model')
-        expect(postMessageSpy.mock.calls.at(4)?.at(0)).toStrictEqual<
+        expect(postMessageSpy.mock.calls.at(5)?.at(0)).toStrictEqual<
             Extract<ExtensionMessage, { type: 'transcript' }>
         >({
             type: 'transcript',
@@ -187,7 +187,7 @@ describe('ChatController', () => {
         await vi.runOnlyPendingTimersAsync()
         expect(mockChatClient.chat).toBeCalledTimes(1)
         expect(addBotMessageSpy).toHaveBeenCalledWith('2', ps`Test reply 2`, 'my-model')
-        expect(postMessageSpy.mock.calls.at(3)?.at(0)).toStrictEqual<
+        expect(postMessageSpy.mock.calls.at(4)?.at(0)).toStrictEqual<
             Extract<ExtensionMessage, { type: 'transcript' }>
         >({
             type: 'transcript',
@@ -251,7 +251,7 @@ describe('ChatController', () => {
         await vi.runOnlyPendingTimersAsync()
         expect(mockChatClient.chat).toBeCalledTimes(1)
         expect(addBotMessageSpy).toHaveBeenCalledWith('3', ps`Test reply 3`, 'my-model')
-        expect(postMessageSpy.mock.calls.at(3)?.at(0)).toStrictEqual<
+        expect(postMessageSpy.mock.calls.at(4)?.at(0)).toStrictEqual<
             Extract<ExtensionMessage, { type: 'transcript' }>
         >({
             type: 'transcript',
@@ -324,7 +324,7 @@ describe('ChatController', () => {
         await vi.runOnlyPendingTimersAsync()
         expect(mockChatClient.chat).toBeCalledTimes(1)
         expect(addBotMessageSpy).toHaveBeenCalledWith('1', ps`Test partial reply`, 'my-model')
-        expect(postMessageSpy.mock.calls.at(4)?.at(0)).toStrictEqual<
+        expect(postMessageSpy.mock.calls.at(5)?.at(0)).toStrictEqual<
             Extract<ExtensionMessage, { type: 'transcript' }>
         >({
             type: 'transcript',

--- a/vscode/src/chat/chat-view/ChatController.ts
+++ b/vscode/src/chat/chat-view/ChatController.ts
@@ -120,7 +120,7 @@ import { CodyToolProvider } from '../agentic/CodyToolProvider'
 import { DeepCodyAgent } from '../agentic/DeepCody'
 import { getMentionMenuData } from '../context/chatContext'
 import type { ChatIntentAPIClient } from '../context/chatIntentAPIClient'
-import { getCorpusContextItemsForEditorState, observeInitialContext } from '../initialContext'
+import { observeDefaultContext } from '../initialContext'
 import {
     CODY_BLOG_URL_o1_WAITLIST,
     type ConfigurationSubsetForWebview,
@@ -1693,11 +1693,9 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
         )
 
         // Listen for API calls from the webview.
-        const initialContext = observeInitialContext({
+        const defaultContext = observeDefaultContext({
             chatBuilder: this.chatBuilder.changes,
         }).pipe(shareReplay())
-
-        const corpusContext = getCorpusContextItemsForEditorState().pipe(distinctUntilChanged())
 
         this.disposables.push(
             addMessageListenersForExtensionAPI(
@@ -1759,8 +1757,7 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
                             await modelsService.setSelectedModel(ModelUsage.Chat, model)
                         })
                     },
-                    initialContext: () => initialContext.pipe(skipPendingOperation()),
-                    corpusContext: () => corpusContext.pipe(skipPendingOperation()),
+                    defaultContext: () => defaultContext.pipe(skipPendingOperation()),
                     detectIntent: text =>
                         promiseFactoryToObservable<
                             | {

--- a/vscode/src/chat/chat-view/ChatController.ts
+++ b/vscode/src/chat/chat-view/ChatController.ts
@@ -643,6 +643,8 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
                 editorState,
                 intent: detectedIntent,
             })
+            this.postViewTranscript()
+
             await this.saveSession()
             signal.throwIfAborted()
 

--- a/vscode/src/chat/chat-view/ChatController.ts
+++ b/vscode/src/chat/chat-view/ChatController.ts
@@ -15,7 +15,6 @@ import {
     shareReplay,
     skip,
     skipPendingOperation,
-    tapLog,
 } from '@sourcegraph/cody-shared'
 import * as uuid from 'uuid'
 import * as vscode from 'vscode'

--- a/vscode/src/chat/chat-view/ChatController.ts
+++ b/vscode/src/chat/chat-view/ChatController.ts
@@ -643,7 +643,7 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
                 editorState,
                 intent: detectedIntent,
             })
-            this.postViewTranscript()
+            this.postViewTranscript({ speaker: 'assistant' })
 
             await this.saveSession()
             signal.throwIfAborted()

--- a/vscode/src/chat/chat-view/ChatsController.ts
+++ b/vscode/src/chat/chat-view/ChatsController.ts
@@ -211,9 +211,6 @@ export class ChatsController implements vscode.Disposable {
             }),
 
             // Mention selection/file commands
-            vscode.commands.registerCommand('cody.mention.selection', uri =>
-                this.sendEditorContextToChat(uri)
-            ),
             vscode.commands.registerCommand('cody.mention.file', uri =>
                 this.sendEditorContextToChat(uri)
             ),

--- a/vscode/src/chat/chat-view/ChatsController.ts
+++ b/vscode/src/chat/chat-view/ChatsController.ts
@@ -211,6 +211,9 @@ export class ChatsController implements vscode.Disposable {
             }),
 
             // Mention selection/file commands
+            vscode.commands.registerCommand('cody.mention.selection', uri =>
+                this.sendEditorContextToChat(uri)
+            ),
             vscode.commands.registerCommand('cody.mention.file', uri =>
                 this.sendEditorContextToChat(uri)
             ),

--- a/vscode/src/chat/initialContext.ts
+++ b/vscode/src/chat/initialContext.ts
@@ -45,24 +45,19 @@ export function observeInitialContext({
 }): Observable<ContextItem[] | typeof pendingOperation> {
     return combineLatest(
         getCurrentFileOrSelection({ chatBuilder }).pipe(distinctUntilChanged()),
-        getCorpusContextItemsForEditorState().pipe(distinctUntilChanged()),
         getOpenCtxContextItems().pipe(distinctUntilChanged())
     ).pipe(
         debounceTime(50),
-        switchMap(
-            ([currentFileOrSelectionContext, corpusContext, openctxContext]): Observable<
-                ContextItem[] | typeof pendingOperation
-            > => {
-                if (corpusContext === pendingOperation) {
-                    return Observable.of(pendingOperation)
-                }
-                return Observable.of([
+        map(
+            ([currentFileOrSelectionContext, openctxContext]):
+                | ContextItem[]
+                | typeof pendingOperation => {
+                return [
                     ...(openctxContext === pendingOperation ? [] : openctxContext),
                     ...(currentFileOrSelectionContext === pendingOperation
                         ? []
                         : currentFileOrSelectionContext),
-                    ...corpusContext,
-                ])
+                ]
             }
         )
     )

--- a/vscode/test/e2e/uninstall.test.ts
+++ b/vscode/test/e2e/uninstall.test.ts
@@ -37,6 +37,12 @@ test('uninstall extension', async ({ openVSCode }) => {
     })
     page = await app.firstWindow()
 
+    // Handle the "Extensions have changed on disk, need to reload" dialog
+    const reloadButton = page.getByRole('button', { name: 'Reload window' })
+    if (await reloadButton.isVisible({ timeout: 1500 })) {
+        await reloadButton.click()
+    }
+
     // This will fail if the credentials are saved because the login screen will still be
     // visible, thus it acts as an implicit test that credentials were cleared out
     await signin(page)

--- a/vscode/webviews/App.tsx
+++ b/vscode/webviews/App.tsx
@@ -4,7 +4,7 @@ import styles from './App.module.css'
 
 import {
     type ChatMessage,
-    type ContextItem,
+    type DefaultContext,
     GuardrailsPost,
     PromptString,
     type TelemetryRecorder,
@@ -197,16 +197,14 @@ interface GetAppWrappersOptions {
     vscodeAPI: VSCodeWrapper
     telemetryRecorder: TelemetryRecorder
     config: Config | null
-    staticInitialContext?: ContextItem[]
-    staticCorpusContext?: ContextItem[]
+    staticDefaultContext?: DefaultContext
 }
 
 export function getAppWrappers({
     vscodeAPI,
     telemetryRecorder,
     config,
-    staticInitialContext,
-    staticCorpusContext,
+    staticDefaultContext,
 }: GetAppWrappersOptions): Wrapper[] {
     return [
         {
@@ -215,7 +213,7 @@ export function getAppWrappers({
         } satisfies Wrapper<ComponentProps<typeof TelemetryRecorderContext.Provider>['value']>,
         {
             component: ExtensionAPIProviderFromVSCodeAPI,
-            props: { vscodeAPI, staticInitialContext, staticCorpusContext },
+            props: { vscodeAPI, staticDefaultContext },
         } satisfies Wrapper<any, ComponentProps<typeof ExtensionAPIProviderFromVSCodeAPI>>,
         {
             component: ConfigProvider,

--- a/vscode/webviews/App.tsx
+++ b/vscode/webviews/App.tsx
@@ -153,7 +153,7 @@ export const App: React.FunctionComponent<{ vscodeAPI: VSCodeWrapper }> = ({ vsc
     const telemetryRecorder = useMemo(() => createWebviewTelemetryRecorder(vscodeAPI), [vscodeAPI])
 
     const wrappers = useMemo<Wrapper[]>(
-        () => getAppWrappers(vscodeAPI, telemetryRecorder, config, undefined, undefined),
+        () => getAppWrappers({ vscodeAPI, telemetryRecorder, config }),
         [vscodeAPI, telemetryRecorder, config]
     )
 
@@ -193,13 +193,21 @@ export const App: React.FunctionComponent<{ vscodeAPI: VSCodeWrapper }> = ({ vsc
     )
 }
 
-export function getAppWrappers(
-    vscodeAPI: VSCodeWrapper,
-    telemetryRecorder: TelemetryRecorder,
-    config: Config | null,
-    staticInitialContext: ContextItem[] | undefined,
-    staticCorpusContext: ContextItem[] | undefined
-): Wrapper[] {
+interface GetAppWrappersOptions {
+    vscodeAPI: VSCodeWrapper
+    telemetryRecorder: TelemetryRecorder
+    config: Config | null
+    staticInitialContext?: ContextItem[]
+    staticCorpusContext?: ContextItem[]
+}
+
+export function getAppWrappers({
+    vscodeAPI,
+    telemetryRecorder,
+    config,
+    staticInitialContext,
+    staticCorpusContext,
+}: GetAppWrappersOptions): Wrapper[] {
     return [
         {
             provider: TelemetryRecorderContext.Provider,

--- a/vscode/webviews/App.tsx
+++ b/vscode/webviews/App.tsx
@@ -153,7 +153,7 @@ export const App: React.FunctionComponent<{ vscodeAPI: VSCodeWrapper }> = ({ vsc
     const telemetryRecorder = useMemo(() => createWebviewTelemetryRecorder(vscodeAPI), [vscodeAPI])
 
     const wrappers = useMemo<Wrapper[]>(
-        () => getAppWrappers(vscodeAPI, telemetryRecorder, config, undefined),
+        () => getAppWrappers(vscodeAPI, telemetryRecorder, config, undefined, undefined),
         [vscodeAPI, telemetryRecorder, config]
     )
 
@@ -197,7 +197,8 @@ export function getAppWrappers(
     vscodeAPI: VSCodeWrapper,
     telemetryRecorder: TelemetryRecorder,
     config: Config | null,
-    staticInitialContext: ContextItem[] | undefined
+    staticInitialContext: ContextItem[] | undefined,
+    staticCorpusContext: ContextItem[] | undefined
 ): Wrapper[] {
     return [
         {
@@ -206,7 +207,7 @@ export function getAppWrappers(
         } satisfies Wrapper<ComponentProps<typeof TelemetryRecorderContext.Provider>['value']>,
         {
             component: ExtensionAPIProviderFromVSCodeAPI,
-            props: { vscodeAPI, staticInitialContext },
+            props: { vscodeAPI, staticInitialContext, staticCorpusContext },
         } satisfies Wrapper<any, ComponentProps<typeof ExtensionAPIProviderFromVSCodeAPI>>,
         {
             component: ConfigProvider,

--- a/vscode/webviews/AppWrapperForTest.tsx
+++ b/vscode/webviews/AppWrapperForTest.tsx
@@ -94,8 +94,7 @@ export const AppWrapperForTest: FunctionComponent<{ children: ReactNode }> = ({ 
                         } satisfies ModelsData),
                     chatModels: () => Observable.of(getMockedDotComClientModels()),
                     setChatModel: () => EMPTY,
-                    initialContext: () => Observable.of([]),
-                    corpusContext: () => Observable.of([]),
+                    defaultContext: () => Observable.of({ corpusContext: [], initialContext: [] }),
                     hydratePromptMessage: text =>
                         Observable.of(serializedPromptEditorStateFromText(text)),
                     promptsMigrationStatus: () => Observable.of({ type: 'no_migration_needed' }),

--- a/vscode/webviews/AppWrapperForTest.tsx
+++ b/vscode/webviews/AppWrapperForTest.tsx
@@ -95,6 +95,7 @@ export const AppWrapperForTest: FunctionComponent<{ children: ReactNode }> = ({ 
                     chatModels: () => Observable.of(getMockedDotComClientModels()),
                     setChatModel: () => EMPTY,
                     initialContext: () => Observable.of([]),
+                    corpusContext: () => Observable.of([]),
                     hydratePromptMessage: text =>
                         Observable.of(serializedPromptEditorStateFromText(text)),
                     promptsMigrationStatus: () => Observable.of({ type: 'no_migration_needed' }),

--- a/vscode/webviews/chat/Transcript.tsx
+++ b/vscode/webviews/chat/Transcript.tsx
@@ -352,7 +352,7 @@ const TranscriptInteraction: FC<TranscriptInteractionProps> = memo(props => {
     )
 
     const corpusContextItems = useCorpusContextForChat()
-    const resubmitWithAdditionalContext = useCallback(async () => {
+    const resubmitWithRepoContext = useCallback(async () => {
         const editorState = humanEditorRef.current?.getSerializedValue()
         if (editorState) {
             const editor = humanEditorRef.current
@@ -448,7 +448,7 @@ const TranscriptInteraction: FC<TranscriptInteractionProps> = memo(props => {
             )}
             {!mentionsContainRepository && assistantMessage && !assistantMessage.isLoading && (
                 <div>
-                    <Button onClick={resubmitWithAdditionalContext} type="button">
+                    <Button onClick={resubmitWithRepoContext} type="button">
                         Rerun with repository context
                     </Button>
                 </div>

--- a/vscode/webviews/chat/Transcript.tsx
+++ b/vscode/webviews/chat/Transcript.tsx
@@ -9,8 +9,11 @@ import {
     inputTextWithoutContextChipsFromPromptEditorState,
     isAbortErrorOrSocketHangUp,
 } from '@sourcegraph/cody-shared'
-import { type PromptEditorRefAPI, useExtensionAPI } from '@sourcegraph/prompt-editor'
-import { useCorpusContextForChat } from '@sourcegraph/prompt-editor/src/useInitialContext'
+import {
+    type PromptEditorRefAPI,
+    useDefaultContextForChat,
+    useExtensionAPI,
+} from '@sourcegraph/prompt-editor'
 import { clsx } from 'clsx'
 import debounce from 'lodash/debounce'
 import isEqual from 'lodash/isEqual'
@@ -351,7 +354,7 @@ const TranscriptInteraction: FC<TranscriptInteractionProps> = memo(props => {
         [onEditSubmit, telemetryRecorder, humanMessage]
     )
 
-    const corpusContextItems = useCorpusContextForChat()
+    const { corpusContext: corpusContextItems } = useDefaultContextForChat()
     const resubmitWithRepoContext = useCallback(async () => {
         const editorState = humanEditorRef.current?.getSerializedValue()
         if (editorState) {

--- a/vscode/webviews/chat/Transcript.tsx
+++ b/vscode/webviews/chat/Transcript.tsx
@@ -449,7 +449,7 @@ const TranscriptInteraction: FC<TranscriptInteractionProps> = memo(props => {
             {!mentionsContainRepository && assistantMessage && !assistantMessage.isLoading && (
                 <div>
                     <Button onClick={resubmitWithRepoContext} type="button">
-                        Rerun with repository context
+                        Resend with current repository context
                     </Button>
                 </div>
             )}

--- a/vscode/webviews/chat/Transcript.tsx
+++ b/vscode/webviews/chat/Transcript.tsx
@@ -446,13 +446,16 @@ const TranscriptInteraction: FC<TranscriptInteractionProps> = memo(props => {
                     )}
                 </InfoMessage>
             )}
-            {!mentionsContainRepository && assistantMessage && !assistantMessage.isLoading && (
-                <div>
-                    <Button onClick={resubmitWithRepoContext} type="button">
-                        Resend with current repository context
-                    </Button>
-                </div>
-            )}
+            {corpusContextItems.length > 0 &&
+                !mentionsContainRepository &&
+                assistantMessage &&
+                !assistantMessage.isLoading && (
+                    <div>
+                        <Button onClick={resubmitWithRepoContext} type="button">
+                            Resend with current repository context
+                        </Button>
+                    </div>
+                )}
             {((humanMessage.contextFiles && humanMessage.contextFiles.length > 0) ||
                 isContextLoading) && (
                 <ContextCell

--- a/vscode/webviews/chat/Transcript.tsx
+++ b/vscode/webviews/chat/Transcript.tsx
@@ -385,6 +385,10 @@ const TranscriptInteraction: FC<TranscriptInteractionProps> = memo(props => {
         editor.addMentions(contextFiles, 'before', '\n')
     }, [humanMessage.contextFiles])
 
+    const mentionsContainRepository = humanEditorRef.current
+        ?.getSerializedValue()
+        .contextItems.some(item => item.type === 'repository')
+
     return (
         <>
             <HumanMessageCell
@@ -442,12 +446,13 @@ const TranscriptInteraction: FC<TranscriptInteractionProps> = memo(props => {
                     )}
                 </InfoMessage>
             )}
-            <div>
-                {/* TODO(beyang): hide when repo mention already exists*/}
-                <Button onClick={resubmitWithAdditionalContext} type="button">
-                    Rerun with repository context
-                </Button>
-            </div>
+            {!mentionsContainRepository && assistantMessage && !assistantMessage.isLoading && (
+                <div>
+                    <Button onClick={resubmitWithAdditionalContext} type="button">
+                        Rerun with repository context
+                    </Button>
+                </div>
+            )}
             {((humanMessage.contextFiles && humanMessage.contextFiles.length > 0) ||
                 isContextLoading) && (
                 <ContextCell

--- a/vscode/webviews/chat/cells/messageCell/human/HumanMessageCell.story.tsx
+++ b/vscode/webviews/chat/cells/messageCell/human/HumanMessageCell.story.tsx
@@ -64,18 +64,21 @@ export const WithInitialContext: StoryObj<typeof meta> = {
             value={{
                 ...MOCK_API,
                 chatModels: () => Observable.of([]),
-                initialContext: () =>
-                    Observable.of([
-                        {
-                            type: 'repository',
-                            uri: URI.parse('https://example.com/foo/myrepo'),
-                            title: 'foo/myrepo',
-                            repoName: 'foo/myrepo',
-                            repoID: 'abcd',
-                            content: null,
-                        },
-                        { type: 'file', uri: URI.file('/foo.js') },
-                    ]),
+                defaultContext: () =>
+                    Observable.of({
+                        initialContext: [
+                            {
+                                type: 'repository',
+                                uri: URI.parse('https://example.com/foo/myrepo'),
+                                title: 'foo/myrepo',
+                                repoName: 'foo/myrepo',
+                                repoID: 'abcd',
+                                content: null,
+                            },
+                            { type: 'file', uri: URI.file('/foo.js') },
+                        ],
+                        corpusContext: [],
+                    }),
             }}
         >
             <HumanMessageCell {...props} />
@@ -93,18 +96,21 @@ export const WithInitialContextFileTooLarge: StoryObj<typeof meta> = {
             value={{
                 ...MOCK_API,
                 chatModels: () => Observable.of([]),
-                initialContext: () =>
-                    Observable.of([
-                        {
-                            type: 'repository',
-                            uri: URI.parse('https://example.com/foo/myrepo'),
-                            title: 'foo/myrepo',
-                            repoName: 'foo/myrepo',
-                            repoID: 'abcd',
-                            content: null,
-                        },
-                        { type: 'file', isTooLarge: true, uri: URI.file('/large_file.js') },
-                    ]),
+                defaultContext: () =>
+                    Observable.of({
+                        initialContext: [
+                            {
+                                type: 'repository',
+                                uri: URI.parse('https://example.com/foo/myrepo'),
+                                title: 'foo/myrepo',
+                                repoName: 'foo/myrepo',
+                                repoID: 'abcd',
+                                content: null,
+                            },
+                            { type: 'file', isTooLarge: true, uri: URI.file('/large_file.js') },
+                        ],
+                        corpusContext: [],
+                    }),
             }}
         >
             <HumanMessageCell {...props} />

--- a/vscode/webviews/chat/cells/messageCell/human/editor/HumanMessageEditor.tsx
+++ b/vscode/webviews/chat/cells/messageCell/human/editor/HumanMessageEditor.tsx
@@ -10,7 +10,7 @@ import {
 import {
     PromptEditor,
     type PromptEditorRefAPI,
-    useInitialContextForChat,
+    useDefaultContextForChat,
 } from '@sourcegraph/prompt-editor'
 import clsx from 'clsx'
 import {
@@ -351,8 +351,9 @@ export const HumanMessageEditor: FunctionComponent<{
 
     const currentChatModel = useMemo(() => models[0], [models[0]])
 
-    let initialContext = useInitialContextForChat()
+    const defaultContext = useDefaultContextForChat()
     useEffect(() => {
+        let { initialContext } = defaultContext
         if (!isSent && isFirstMessage) {
             const editor = editorRef.current
             if (editor) {
@@ -364,7 +365,7 @@ export const HumanMessageEditor: FunctionComponent<{
                 editor.setInitialContextMentions(initialContext)
             }
         }
-    }, [initialContext, isSent, isFirstMessage, currentChatModel])
+    }, [defaultContext, isSent, isFirstMessage, currentChatModel])
 
     const focusEditor = useCallback(() => editorRef.current?.setFocus(true), [])
 

--- a/vscode/webviews/components/StateDebugOverlay.tsx
+++ b/vscode/webviews/components/StateDebugOverlay.tsx
@@ -5,7 +5,7 @@ import type {
     ModelsData,
     ResolvedConfiguration,
 } from '@sourcegraph/cody-shared'
-import { useExtensionAPI, useInitialContextForChat, useObservable } from '@sourcegraph/prompt-editor'
+import { useDefaultContextForChat, useExtensionAPI, useObservable } from '@sourcegraph/prompt-editor'
 import clsx from 'clsx'
 import React, { type FunctionComponent, useMemo } from 'react'
 import { getVSCodeAPI } from '../utils/VSCodeApi'
@@ -35,7 +35,7 @@ const StateDebugOverlayInner: FunctionComponent<{ resolvedConfig: ResolvedConfig
     const authStatus = useAuthStatus()
     const modelsData = useModelsData()
     const transcript = useTranscript()
-    const initialContext = useInitialContextForChat()
+    const { initialContext } = useDefaultContextForChat()
 
     type TabID =
         | 'resolvedConfig'

--- a/web/lib/components/CodyWebChat.tsx
+++ b/web/lib/components/CodyWebChat.tsx
@@ -150,7 +150,7 @@ const CodyWebPanel: FC<CodyWebPanelProps> = props => {
     // V2 telemetry recorder
     const telemetryRecorder = useMemo(() => createWebviewTelemetryRecorder(vscodeAPI), [vscodeAPI])
 
-    const initialContext = useMemo<ContextItem[]>(() => {
+    const staticInitialContext = useMemo<ContextItem[]>(() => {
         const { repository, fileURL, isDirectory } = initialContextData ?? {}
 
         if (!repository) {
@@ -200,7 +200,7 @@ const CodyWebPanel: FC<CodyWebPanelProps> = props => {
 
         return mentions
     }, [initialContextData])
-    const corpusContext = useMemo<ContextItem[]>(() => {
+    const staticCorpusContext = useMemo<ContextItem[]>(() => {
         const { repository } = initialContextData ?? {}
         if (!repository) {
             return []
@@ -224,8 +224,15 @@ const CodyWebPanel: FC<CodyWebPanelProps> = props => {
     }, [initialContextData])
 
     const wrappers = useMemo<Wrapper[]>(
-        () => getAppWrappers(vscodeAPI, telemetryRecorder, config, initialContext, corpusContext),
-        [vscodeAPI, telemetryRecorder, config, initialContext, corpusContext]
+        () =>
+            getAppWrappers({
+                vscodeAPI,
+                telemetryRecorder,
+                config,
+                staticInitialContext,
+                staticCorpusContext,
+            }),
+        [vscodeAPI, telemetryRecorder, config, staticInitialContext, staticCorpusContext]
     )
 
     const CONTEXT_MENTIONS_SETTINGS = useMemo<ChatMentionsSettings>(() => {

--- a/web/lib/components/CodyWebChat.tsx
+++ b/web/lib/components/CodyWebChat.tsx
@@ -157,21 +157,7 @@ const CodyWebPanel: FC<CodyWebPanelProps> = props => {
             return []
         }
 
-        const mentions: ContextItem[] = [
-            {
-                type: 'repository',
-                id: repository.id,
-                name: repository.name,
-                repoID: repository.id,
-                repoName: repository.name,
-                description: repository.name,
-                uri: URI.parse(`repo:${repository.name}`),
-                content: null,
-                source: ContextItemSource.Initial,
-                icon: 'folder',
-                title: 'Current Repository',
-            } as ContextItemRepository,
-        ]
+        const mentions: ContextItem[] = []
 
         if (fileURL) {
             // Repository directory file url in this case is directory path
@@ -214,10 +200,32 @@ const CodyWebPanel: FC<CodyWebPanelProps> = props => {
 
         return mentions
     }, [initialContextData])
+    const corpusContext = useMemo<ContextItem[]>(() => {
+        const { repository } = initialContextData ?? {}
+        if (!repository) {
+            return []
+        }
+        const mentions: ContextItem[] = [
+            {
+                type: 'repository',
+                id: repository.id,
+                name: repository.name,
+                repoID: repository.id,
+                repoName: repository.name,
+                description: repository.name,
+                uri: URI.parse(`repo:${repository.name}`),
+                content: null,
+                source: ContextItemSource.Initial,
+                icon: 'folder',
+                title: 'Current Repository', // web chat default initial context
+            } as ContextItemRepository,
+        ]
+        return mentions
+    }, [initialContextData])
 
     const wrappers = useMemo<Wrapper[]>(
-        () => getAppWrappers(vscodeAPI, telemetryRecorder, config, initialContext),
-        [vscodeAPI, telemetryRecorder, config, initialContext]
+        () => getAppWrappers(vscodeAPI, telemetryRecorder, config, initialContext, corpusContext),
+        [vscodeAPI, telemetryRecorder, config, initialContext, corpusContext]
     )
 
     const CONTEXT_MENTIONS_SETTINGS = useMemo<ChatMentionsSettings>(() => {


### PR DESCRIPTION
Removes the repo chip from the default chat context:

<table>
<tr>
<th>Before</th><th>After</th>
</tr
<tr>
<td>
<img src="https://github.com/user-attachments/assets/14ff9f81-0ec8-4bc6-a225-9376cc185efd"/>
</td>
<td>
<img src="https://github.com/user-attachments/assets/1d8a5a74-c34d-48d2-9924-8ffb151b10bb"/>
</td>
</tr>
</table>


To make the repo context still discoverable, adds a `Rerun with repository context` button when no repo chips are present:

https://github.com/user-attachments/assets/4f8f1763-c229-4993-b198-15d41100fe32

This is behind a feature flag `no-default-repo-chip`, without which there should be no behavior change.

## Test plan

Test against S2 (feature flag is turned on):
- Ask a chat without repo context
- Observe button appear

Test against sourcegraph.com: there should be no change in behavior.
