### PR TITLE
Add copy to clipboard full response functionality in AssistantMessage…

### DIFF
--- a/vscode/webviews/chat/cells/messageCell/assistant/AssistantMessageCell.tsx
+++ b/vscode/webviews/chat/cells/messageCell/assistant/AssistantMessageCell.tsx
@@ -26,6 +26,7 @@ import { FeedbackButtons } from '../../../components/FeedbackButtons'
 import { LoadingDots } from '../../../components/LoadingDots'
 import { BaseMessageCell, MESSAGE_CELL_AVATAR_SIZE } from '../BaseMessageCell'
 import { ContextFocusActions } from './ContextFocusActions'
+import { CopyCodeBlockIcon } from '../../../../icons/CodeBlockActionIcons'
 
 /**
  * A component that displays a chat message from the assistant.
@@ -138,24 +139,31 @@ export const AssistantMessageCell: FunctionComponent<{
                                 </div>
                             )}
                             <div className="tw-flex tw-items-center tw-divide-x tw-transition tw-divide-muted tw-opacity-65 hover:tw-opacity-100">
-                                {showFeedbackButtons && feedbackButtonsOnSubmit && (
-                                    <FeedbackButtons
-                                        feedbackButtonsOnSubmit={feedbackButtonsOnSubmit}
-                                        className="tw-pr-4"
-                                    />
-                                )}
-                                {!isLoading && (!message.error || isAborted) && (
-                                    <ContextFocusActions
-                                        humanMessage={humanMessage}
-                                        longResponseTime={hasLongerResponseTime}
-                                        className={
-                                            showFeedbackButtons && feedbackButtonsOnSubmit
-                                                ? 'tw-pl-5'
-                                                : undefined
-                                        }
-                                    />
-                                )}
-                            </div>
+    {showFeedbackButtons && feedbackButtonsOnSubmit && (
+        <FeedbackButtons
+            feedbackButtonsOnSubmit={feedbackButtonsOnSubmit}
+            className="tw-pr-4"
+        />
+    )}
+    {!isLoading && (!message.error || isAborted) && (
+        <>
+<button
+    className="tw-flex tw-items-center tw-gap-2 tw-px-4 tw-text-sm tw-text-muted-foreground hover:tw-text-foreground"
+    onClick={() => {
+        navigator.clipboard.writeText(message.text?.toString() || '')
+        copyButtonOnSubmit?.(message.text?.toString() || '')
+    }}
+>
+    <div dangerouslySetInnerHTML={{ __html: CopyCodeBlockIcon }} />
+</button>
+            <ContextFocusActions
+                humanMessage={humanMessage}
+                longResponseTime={hasLongerResponseTime}
+                className={showFeedbackButtons && feedbackButtonsOnSubmit ? 'tw-pl-5' : undefined}
+            />
+        </>
+    )}
+</div>
                         </div>
                     )
                 }

--- a/vscode/webviews/chat/cells/messageCell/assistant/AssistantMessageCell.tsx
+++ b/vscode/webviews/chat/cells/messageCell/assistant/AssistantMessageCell.tsx
@@ -161,37 +161,35 @@ export const AssistantMessageCell: FunctionComponent<{
                             )}
                             <div className="tw-flex tw-items-center tw-divide-x tw-transition tw-divide-muted tw-opacity-65 hover:tw-opacity-100">
                                 {showFeedbackButtons && feedbackButtonsOnSubmit && (
-                                    <FeedbackButtons
-                                        feedbackButtonsOnSubmit={feedbackButtonsOnSubmit}
-                                        className="tw-pr-4"
-                                    />
-                                )}
-                                {!isLoading && (!message.error || isAborted) && (
-                                    <>
-                                        <div className="tw-pl-4">
-                                            <button
-                                                type="button"
-                                                className="tw-flex tw-items-center tw-gap-2 tw-text-sm tw-text-muted-foreground hover:tw-text-foreground"
-                                                onClick={() => {
-                                                    navigator.clipboard.writeText(
-                                                        message.text?.toString() || ''
-                                                    )
-                                                    copyButtonOnSubmit?.(message.text?.toString() || '')
-                                                }}
-                                            >
-                                                <CopyIcon />
-                                            </button>
-                                        </div>
-                                        <ContextFocusActions
-                                            humanMessage={humanMessage}
-                                            longResponseTime={hasLongerResponseTime}
-                                            className={
-                                                showFeedbackButtons && feedbackButtonsOnSubmit
-                                                    ? 'tw-pl-5'
-                                                    : undefined
-                                            }
+                                    <div className="tw-flex tw-items-center">
+                                        <FeedbackButtons
+                                            feedbackButtonsOnSubmit={feedbackButtonsOnSubmit}
+                                            className="tw-pr-4"
                                         />
-                                    </>
+                                    </div>
+                                )}
+                                <div className="tw-pl-4">
+                                    <button
+                                        type="button"
+                                        className="tw-flex tw-items-center tw-gap-2 tw-text-sm tw-text-muted-foreground hover:tw-text-foreground tw-mx-4"
+                                        onClick={() => {
+                                            navigator.clipboard.writeText(message.text?.toString() || '')
+                                            copyButtonOnSubmit?.(message.text?.toString() || '')
+                                        }}
+                                    >
+                                        <CopyIcon />
+                                    </button>
+                                </div>
+                                {!isLoading && (!message.error || isAborted) && (
+                                    <ContextFocusActions
+                                        humanMessage={humanMessage}
+                                        longResponseTime={hasLongerResponseTime}
+                                        className={
+                                            showFeedbackButtons && feedbackButtonsOnSubmit
+                                                ? 'tw-pl-5'
+                                                : undefined
+                                        }
+                                    />
                                 )}
                             </div>
                         </div>

--- a/vscode/webviews/chat/cells/messageCell/assistant/AssistantMessageCell.tsx
+++ b/vscode/webviews/chat/cells/messageCell/assistant/AssistantMessageCell.tsx
@@ -26,7 +26,28 @@ import { FeedbackButtons } from '../../../components/FeedbackButtons'
 import { LoadingDots } from '../../../components/LoadingDots'
 import { BaseMessageCell, MESSAGE_CELL_AVATAR_SIZE } from '../BaseMessageCell'
 import { ContextFocusActions } from './ContextFocusActions'
-import { CopyCodeBlockIcon } from '../../../../icons/CodeBlockActionIcons'
+
+/**
+ * A small component that displays a copy icon.
+ */
+const CopyIcon: React.FC<{ className?: string }> = ({ className }) => (
+    <svg
+        role="img"
+        height={16}
+        width={16}
+        viewBox="0 0 16 16"
+        fill="currentColor"
+        className={className}
+        aria-label="Copy icon"
+    >
+        <path
+            fillRule="evenodd"
+            clipRule="evenodd"
+            d="M4 4l1-1h5.414L14 6.586V14l-1 1H5l-1-1V4zm9 3l-3-3H5v10h8V7z"
+        />
+        <path fillRule="evenodd" clipRule="evenodd" d="M3 1L2 2v10l1 1V2h6.414l-1-1H3z" />
+    </svg>
+)
 
 /**
  * A component that displays a chat message from the assistant.
@@ -139,31 +160,40 @@ export const AssistantMessageCell: FunctionComponent<{
                                 </div>
                             )}
                             <div className="tw-flex tw-items-center tw-divide-x tw-transition tw-divide-muted tw-opacity-65 hover:tw-opacity-100">
-    {showFeedbackButtons && feedbackButtonsOnSubmit && (
-        <FeedbackButtons
-            feedbackButtonsOnSubmit={feedbackButtonsOnSubmit}
-            className="tw-pr-4"
-        />
-    )}
-    {!isLoading && (!message.error || isAborted) && (
-        <>
-<button
-    className="tw-flex tw-items-center tw-gap-2 tw-px-4 tw-text-sm tw-text-muted-foreground hover:tw-text-foreground"
-    onClick={() => {
-        navigator.clipboard.writeText(message.text?.toString() || '')
-        copyButtonOnSubmit?.(message.text?.toString() || '')
-    }}
->
-    <div dangerouslySetInnerHTML={{ __html: CopyCodeBlockIcon }} />
-</button>
-            <ContextFocusActions
-                humanMessage={humanMessage}
-                longResponseTime={hasLongerResponseTime}
-                className={showFeedbackButtons && feedbackButtonsOnSubmit ? 'tw-pl-5' : undefined}
-            />
-        </>
-    )}
-</div>
+                                {showFeedbackButtons && feedbackButtonsOnSubmit && (
+                                    <FeedbackButtons
+                                        feedbackButtonsOnSubmit={feedbackButtonsOnSubmit}
+                                        className="tw-pr-4"
+                                    />
+                                )}
+                                {!isLoading && (!message.error || isAborted) && (
+                                    <>
+                                        <div className="tw-pl-4">
+                                            <button
+                                                type="button"
+                                                className="tw-flex tw-items-center tw-gap-2 tw-text-sm tw-text-muted-foreground hover:tw-text-foreground"
+                                                onClick={() => {
+                                                    navigator.clipboard.writeText(
+                                                        message.text?.toString() || ''
+                                                    )
+                                                    copyButtonOnSubmit?.(message.text?.toString() || '')
+                                                }}
+                                            >
+                                                <CopyIcon />
+                                            </button>
+                                        </div>
+                                        <ContextFocusActions
+                                            humanMessage={humanMessage}
+                                            longResponseTime={hasLongerResponseTime}
+                                            className={
+                                                showFeedbackButtons && feedbackButtonsOnSubmit
+                                                    ? 'tw-pl-5'
+                                                    : undefined
+                                            }
+                                        />
+                                    </>
+                                )}
+                            </div>
                         </div>
                     )
                 }


### PR DESCRIPTION
This PR adds a copy button to chat messages, matching the existing code block copy functionality in Cody. The button uses the same icon and styling as code blocks for visual consistency across the interface.

**Changes**

- Added copy button to AssistantMessageCell.tsx
- Imported and used existing CopyCodeBlockIcon for visual consistency
- Implemented direct clipboard copy using navigator.clipboard.writeText
- Maintained existing telemetry through copyButtonOnSubmit

## Test Plan

**Manual Testing**

1. Verified copy button appears alongside feedback buttons in chat messages
2. Tested copy functionality:
    - Clicking button copies message text to clipboard
    - Verified paste works in different applications
3. Visual consistency:
    - Button uses same CopyCodeBlockIcon as code blocks
    - Matches existing Cody design system

**Screenshots**
![image](https://github.com/user-attachments/assets/9c8fd2b8-b57f-4d9f-af16-0daef67c5a22)
