### PR TITLE
Fix Prompts welcome screen initial state

### DIFF
--- a/vscode/webviews/components/promptList/PromptList.tsx
+++ b/vscode/webviews/components/promptList/PromptList.tsx
@@ -181,25 +181,27 @@ export const PromptList: FC<PromptListProps> = props => {
                 {!result && !error && (
                     <CommandLoading className={itemPaddingClass}>Loading...</CommandLoading>
                 )}
-                {result && allActions.filter(action => action.actionType === 'prompt').length === 0 && (
-                    <CommandLoading className={itemPaddingClass}>
-                        {result?.query === '' && !recommendedOnly ? (
-                            <>
-                                Your Prompt Library is empty.{' '}
-                                <a
-                                    href={new URL('/prompts/new', endpointURL).toString()}
-                                    target="_blank"
-                                    rel="noreferrer"
-                                >
-                                    Add a prompt
-                                </a>{' '}
-                                to reuse and share it.
-                            </>
-                        ) : (
-                            <>No prompts found</>
-                        )}
-                    </CommandLoading>
-                )}
+                {!recommendedOnly &&
+                    result &&
+                    allActions.filter(action => action.actionType === 'prompt').length === 0 && (
+                        <CommandLoading className={itemPaddingClass}>
+                            {result?.query === '' ? (
+                                <>
+                                    Your Prompt Library is empty.{' '}
+                                    <a
+                                        href={new URL('/prompts/new', endpointURL).toString()}
+                                        target="_blank"
+                                        rel="noreferrer"
+                                    >
+                                        Add a prompt
+                                    </a>{' '}
+                                    to reuse and share it.
+                                </>
+                            ) : (
+                                <>No prompts found</>
+                            )}
+                        </CommandLoading>
+                    )}
 
                 {actions.map(action => (
                     <ActionItem


### PR DESCRIPTION
Fixes SRCH-1303

This PR hides empty zero state on the welcome area since we no longer show there all prompts but just promoted on and if you don't have any prompts we shouldn't show any prompts empty states there. 

## Test plan
- Check that you have no zero/empty prompts state on the welcome area if you don't have any prompts (promoted prompts)

