### PR TITLE
Network: Fallback to CODY_NODE_TLS_REJECT_UNAUTHORIZED for cert auth

### DIFF
--- a/lib/shared/src/configuration/environment.ts
+++ b/lib/shared/src/configuration/environment.ts
@@ -27,6 +27,12 @@ export const cenv = defineEnvBuilder({
     CODY_NODE_DEFAULT_PROXY: proxyStringWithNodeFallback,
 
     /**
+     * A setting that is similar (and falls back to) Node's NODE_TLS_REJECT_UNAUTHORIZED setting
+     */
+    CODY_NODE_TLS_REJECT_UNAUTHORIZED: (envValue, _) =>
+        bool(envValue) ?? bool(getEnv('NODE_TLS_REJECT_UNAUTHORIZED')),
+
+    /**
      * Enables unstable internal testing configuration to be read from settings.json
      */
     CODY_CONFIG_ENABLE_INTERNAL_UNSTABLE: (envValue, _) =>

--- a/vscode/src/net/DelegatingAgent.ts
+++ b/vscode/src/net/DelegatingAgent.ts
@@ -251,7 +251,10 @@ function normalizeSettings(raw: NetConfiguration): [Error, null] | [null, Normal
                 bypassVSCode:
                     raw.mode?.toLowerCase() === 'bypass' ||
                     (raw.mode?.toLowerCase() !== 'vscode' && (!!proxyServer || !!proxyPath)),
-                skipCertValidation: raw.proxy?.skipCertValidation || false,
+                skipCertValidation:
+                    raw.proxy?.skipCertValidation ??
+                    cenv.CODY_NODE_TLS_REJECT_UNAUTHORIZED === false ??
+                    false,
                 ...caCertConfig,
                 proxyPath,
                 proxyServer,
@@ -309,11 +312,12 @@ async function resolveSettings([error, settings]:
             }
         }
     }
+    const ca = await buildCaCerts(caCert ? [caCert] : null)
     return {
         error: err,
         proxyServer: settings.proxyServer || null,
         proxyPath,
-        ca: await buildCaCerts(caCert ? [caCert] : null),
+        ca,
         skipCertValidation: settings.skipCertValidation,
         bypassVSCode: settings.bypassVSCode,
         vscode: settings.vscode,


### PR DESCRIPTION
Before we ignored the `NODE_TLS_REJECT_UNAUTHORIZED` environment variable. This variable is used by JetBrains to pass along UI config.

Now we respect the environment variable if set.

## Test plan
@PiotrKarczmarz I've not been able to test that this works yet because suddenly my JB build broke. Could you give it a spin?