### PR TITLE
fix(ci): Increase test timeout for uninstall test

### DIFF
--- a/vscode/test/e2e/uninstall.test.ts
+++ b/vscode/test/e2e/uninstall.test.ts
@@ -5,6 +5,8 @@ import { expectAuthenticated, focusSidebar, sidebarSignin } from './common'
 import { expect, getCodySidebar, test } from './helpers'
 
 test('uninstall extension', async ({ openVSCode }) => {
+    // This test is quite heavy so it can timeout in CI unless we grant it a longer timeout
+    test.setTimeout(60 * 1000)
     // In order to trigger the uninstall event, we need to actually install the extension
     // into the local vscode instance
     const customExtensionVSIX = path.join(process.cwd(), 'dist', 'cody.e2e.vsix')


### PR DESCRIPTION
The uninstall test could sometimes timeout in CI as it was quite heavy. This increases the timeout for that test to 1 minute.

## Test plan
Update to E2E test