### PR TITLE
Autocomplete: cleanup the fast-path a/b test

### DIFF
--- a/vscode/src/completions/completion-provider-config.ts
+++ b/vscode/src/completions/completion-provider-config.ts
@@ -36,7 +36,6 @@ class CompletionProviderConfig {
             FeatureFlag.CodyAutocompletePreloadingExperimentVariant2,
             FeatureFlag.CodyAutocompleteDataCollectionFlag,
             FeatureFlag.CodyAutocompleteTracing,
-            FeatureFlag.CodyAutocompleteFastPath,
         ]
         this.prefetchSubscription = combineLatest(
             ...featureFlagsUsed.map(flag => featureFlagProvider.evaluatedFeatureFlag(flag))

--- a/vscode/src/completions/providers/fireworks.ts
+++ b/vscode/src/completions/providers/fireworks.ts
@@ -1,5 +1,3 @@
-import type * as vscode from 'vscode'
-
 import {
     type AuthenticatedAuthStatus,
     type CodeCompletionsParams,


### PR DESCRIPTION
- We [finished](https://sourcegraph.slack.com/archives/C0729T2PBV2/p1730167483283679?thread_ts=1728366545.242119&cid=C0729T2PBV2) the fast-path A/B test, so this PR removes all related logic.
- Closes https://linear.app/sourcegraph/issue/CODY-4037/ab-test-fast-path-to-get-the-up-to-date-impact-stats

## Test plan

CI