### PR TITLE
Autocomplete: deflake hot-streak tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "check:build": "pnpm run -C vscode check:build",
     "biome": "biome check --apply --error-on-warnings .",
     "test": "vitest",
-    "test:unit": "vitest vscode/src/completions/get-inline-completions-tests/hot-streak.test.ts",
+    "test:unit": "vitest run",
     "test:integration": "pnpm -C vscode test:integration",
     "test:e2e": "pnpm -C vscode test:e2e",
     "test:local-e2e": "RUN_LOCAL_E2E_TESTS=true pnpm test agent/src/local-e2e/template.test.ts",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "check:build": "pnpm run -C vscode check:build",
     "biome": "biome check --apply --error-on-warnings .",
     "test": "vitest",
-    "test:unit": "vitest run",
+    "test:unit": "vitest vscode/src/completions/get-inline-completions-tests/hot-streak.test.ts",
     "test:integration": "pnpm -C vscode test:integration",
     "test:e2e": "pnpm -C vscode test:e2e",
     "test:local-e2e": "RUN_LOCAL_E2E_TESTS=true pnpm test agent/src/local-e2e/template.test.ts",

--- a/vscode/src/completions/get-inline-completions-tests/hot-streak.test.ts
+++ b/vscode/src/completions/get-inline-completions-tests/hot-streak.test.ts
@@ -1,10 +1,11 @@
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { nextTick } from '@sourcegraph/cody-shared'
+
 import { resetParsersCache } from '../../tree-sitter/parser'
 import { InlineCompletionsResultSource } from '../get-inline-completions'
 import { initTreeSitterParser } from '../test-helpers'
 
-import { nextTick } from '@sourcegraph/cody-shared'
 import { getInlineCompletionsWithInlinedChunks } from './helpers'
 
 describe('[getInlineCompletions] hot streak', () => {
@@ -19,17 +20,17 @@ describe('[getInlineCompletions] hot streak', () => {
     beforeEach(() => {
         vi.useFakeTimers()
         vi.clearAllTimers()
-        vi.resetAllMocks()
+        vi.restoreAllMocks()
     })
 
     afterEach(() => {
-        vi.resetAllMocks()
+        vi.restoreAllMocks()
         vi.clearAllTimers()
     })
 
     it(
         'does not attempt to extract hot streak completions if the resolves completion duplicates suffix',
-        { timeout: 1000, repeats: 1000 },
+        { repeats: 1000 },
         async () => {
             let request = await getInlineCompletionsWithInlinedChunks(
                 `from experimental table

--- a/vscode/src/completions/get-inline-completions-tests/hot-streak.test.ts
+++ b/vscode/src/completions/get-inline-completions-tests/hot-streak.test.ts
@@ -28,12 +28,9 @@ describe('[getInlineCompletions] hot streak', () => {
         vi.clearAllTimers()
     })
 
-    it(
-        'does not attempt to extract hot streak completions if the resolves completion duplicates suffix',
-        { repeats: 1000 },
-        async () => {
-            let request = await getInlineCompletionsWithInlinedChunks(
-                `from experimental table
+    it('does not attempt to extract hot streak completions if the resolves completion duplicates suffix', async () => {
+        let request = await getInlineCompletionsWithInlinedChunks(
+            `from experimental table
                 █where other_completion_provider_enabled = false
                 █and read = true
                 █and whatever = false
@@ -41,28 +38,27 @@ describe('[getInlineCompletions] hot streak', () => {
                 where other_completion_provider_enabled = false
                 and read = true
                 `,
-                {
+            {
+                configuration: {
                     configuration: {
-                        configuration: {
-                            autocompleteAdvancedProvider: 'fireworks',
-                        },
+                        autocompleteAdvancedProvider: 'fireworks',
                     },
-                    delayBetweenChunks: 50,
-                }
-            )
+                },
+                delayBetweenChunks: 50,
+            }
+        )
 
-            await vi.runOnlyPendingTimersAsync()
+        await vi.runOnlyPendingTimersAsync()
 
-            // No completion is resolved here because the suggested text is the suffix duplicate.
-            expect(request.items).toEqual([])
+        // No completion is resolved here because the suggested text is the suffix duplicate.
+        expect(request.items).toEqual([])
 
-            // Go to the next line and wait for the new completion from the cache.
-            request = await request.pressEnter()
+        // Go to the next line and wait for the new completion from the cache.
+        request = await request.pressEnter()
 
-            // No hot-streak completions are expected because the previous line didn't get a completion.
-            expect(request.items).toEqual([])
-        }
-    )
+        // No hot-streak completions are expected because the previous line didn't get a completion.
+        expect(request.items).toEqual([])
+    })
 
     describe('static multiline', () => {
         it('caches hot streaks completions that are streamed in', async () => {
@@ -186,13 +182,10 @@ describe('[getInlineCompletions] hot streak', () => {
             expect(request.source).toBe(InlineCompletionsResultSource.HotStreak)
         })
 
-        it(
-            'yields a singleline completion early if `firstCompletionTimeout` elapses before the multiline completion is ready',
-            { repeats: 1000 },
-            async () => {
-                let abortController: AbortController | undefined
-                const completionsPromise = getInlineCompletionsWithInlinedChunks(
-                    `function myFunction█() {
+        it('yields a singleline completion early if `firstCompletionTimeout` elapses before the multiline completion is ready', async () => {
+            let abortController: AbortController | undefined
+            const completionsPromise = getInlineCompletionsWithInlinedChunks(
+                `function myFunction█() {
                     if(i > 1) {█
                         console.log(2)
                     }
@@ -206,42 +199,42 @@ describe('[getInlineCompletions] hot streak', () => {
                 myFunction()
                 █
                 const`,
-                    {
-                        delayBetweenChunks: 50,
+                {
+                    delayBetweenChunks: 50,
+                    configuration: {
                         configuration: {
-                            configuration: {
-                                autocompleteFirstCompletionTimeout: 50,
-                            },
+                            autocompleteFirstCompletionTimeout: 50,
                         },
-                        abortSignal: new AbortController().signal,
-                        onNetworkRequest(_, requestManagerAbortController) {
-                            abortController = requestManagerAbortController
-                        },
-                    }
-                )
+                    },
+                    abortSignal: new AbortController().signal,
+                    onNetworkRequest(_, requestManagerAbortController) {
+                        abortController = requestManagerAbortController
+                    },
+                }
+            )
 
-                // Nothing happens until the first completion chunk is resolved
-                await vi.advanceTimersByTimeAsync(30)
-                expect(abortController?.signal.aborted).toBe(false)
+            // Nothing happens until the first completion chunk is resolved
+            await vi.advanceTimersByTimeAsync(30)
+            expect(abortController?.signal.aborted).toBe(false)
 
-                // Wait for the first hot streak completion to be ready
-                await vi.advanceTimersByTimeAsync(30)
-                // We anticipate that the streaming will be cancelled because the hot
-                // streak text exceeds the maximum number of lines defined by `MAX_HOT_STREAK_LINES`.
-                // TODO: expose completion chunks, enabling more explicit verification of this behavior.
-                expect(abortController?.signal.aborted).toBe(true)
+            // Wait for the first hot streak completion to be ready
+            await vi.advanceTimersByTimeAsync(30)
+            // We anticipate that the streaming will be cancelled because the hot
+            // streak text exceeds the maximum number of lines defined by `MAX_HOT_STREAK_LINES`.
+            // TODO: expose completion chunks, enabling more explicit verification of this behavior.
+            expect(abortController?.signal.aborted).toBe(true)
 
-                // Release the `completionsPromise`
-                await vi.runOnlyPendingTimersAsync()
+            // Release the `completionsPromise`
+            await vi.runOnlyPendingTimersAsync()
 
-                let request = await completionsPromise
-                await request.completionResponseGeneratorPromise
-                expect(request.items[0].insertText).toEqual('() {')
+            let request = await completionsPromise
+            await request.completionResponseGeneratorPromise
+            expect(request.items[0].insertText).toEqual('() {')
 
-                request = await request.acceptFirstCompletionAndPressEnter()
-                expect(request.source).toBe(InlineCompletionsResultSource.HotStreak)
-                expect(request.items[0].insertText).toMatchInlineSnapshot(
-                    `
+            request = await request.acceptFirstCompletionAndPressEnter()
+            expect(request.source).toBe(InlineCompletionsResultSource.HotStreak)
+            expect(request.items[0].insertText).toMatchInlineSnapshot(
+                `
               "if(i > 1) {
                       console.log(2)
                   }
@@ -253,16 +246,15 @@ describe('[getInlineCompletions] hot streak', () => {
                   }
               }"
             `
-                )
+            )
 
-                request = await request.acceptFirstCompletionAndPressEnter()
-                expect(request.source).toBe(InlineCompletionsResultSource.HotStreak)
-                expect(request.items[0].insertText).toMatchInlineSnapshot(
-                    `
+            request = await request.acceptFirstCompletionAndPressEnter()
+            expect(request.source).toBe(InlineCompletionsResultSource.HotStreak)
+            expect(request.items[0].insertText).toMatchInlineSnapshot(
+                `
               "myFunction()"
             `
-                )
-            }
-        )
+            )
+        })
     })
 })

--- a/vscode/src/completions/get-inline-completions-tests/hot-streak.test.ts
+++ b/vscode/src/completions/get-inline-completions-tests/hot-streak.test.ts
@@ -18,10 +18,13 @@ describe('[getInlineCompletions] hot streak', () => {
 
     beforeEach(() => {
         vi.useFakeTimers()
+        vi.clearAllTimers()
+        vi.resetAllMocks()
     })
 
     afterEach(() => {
-        vi.restoreAllMocks()
+        vi.resetAllMocks()
+        vi.clearAllTimers()
     })
 
     it(
@@ -226,7 +229,6 @@ describe('[getInlineCompletions] hot streak', () => {
                 // streak text exceeds the maximum number of lines defined by `MAX_HOT_STREAK_LINES`.
                 // TODO: expose completion chunks, enabling more explicit verification of this behavior.
                 expect(abortController?.signal.aborted).toBe(true)
-                // throw new Error('kek')
 
                 // Release the `completionsPromise`
                 await vi.runOnlyPendingTimersAsync()


### PR DESCRIPTION
- Deflakes hot-streak unit tests by ensuring we reset timers and mocks after every test.
- Closes of https://linear.app/sourcegraph/issue/CODY-4217/completion-hot-streak-tests-are-flaky

## Test plan

[Ran](https://github.com/sourcegraph/cody/pull/6040/commits/f57d96002680e24cb2bafb56e803997b6cdfe2fd) problematic unit tests 1000 times in CI without failures.
