### PR TITLE
Autocomplete: enable completions preloading on cursor movement

### DIFF
--- a/lib/shared/src/configuration.ts
+++ b/lib/shared/src/configuration.ts
@@ -75,7 +75,6 @@ interface RawClientConfiguration {
     autocompleteExperimentalGraphContext: 'lsp-light' | 'tsc' | 'tsc-mixed' | null
     autocompleteExperimentalOllamaOptions: OllamaOptions
     autocompleteExperimentalFireworksOptions?: ExperimentalFireworksConfig
-    autocompleteExperimentalPreloadDebounceInterval?: number
 
     experimentalTracing: boolean
     experimentalSupercompletions: boolean

--- a/lib/shared/src/experimentation/FeatureFlagProvider.ts
+++ b/lib/shared/src/experimentation/FeatureFlagProvider.ts
@@ -47,10 +47,6 @@ export enum FeatureFlag {
     CodyAutocompleteFIMModelExperimentVariant3 = 'cody-autocomplete-model-experiment-variant-3',
     CodyAutocompleteFIMModelExperimentVariant4 = 'cody-autocomplete-model-experiment-variant-4',
 
-    CodyAutocompletePreloadingExperimentBaseFeatureFlag = 'cody-autocomplete-preloading-experiment-flag',
-    CodyAutocompletePreloadingExperimentVariant1 = 'cody-autocomplete-preloading-experiment-variant-1',
-    CodyAutocompletePreloadingExperimentVariant2 = 'cody-autocomplete-preloading-experiment-variant-2',
-
     CodyAutocompleteContextExperimentBaseFeatureFlag = 'cody-autocomplete-context-experiment-flag',
     CodyAutocompleteContextExperimentVariant1 = 'cody-autocomplete-context-experiment-variant-1',
     CodyAutocompleteContextExperimentVariant2 = 'cody-autocomplete-context-experiment-variant-2',

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -6,6 +6,8 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 
 ### Added
 
+- Autocomplete: Enabled completions preloading on cursor movement. [pull/6043](https://github.com/sourcegraph/cody/pull/6043)
+
 ### Fixed
 
 ### Changed
@@ -15,8 +17,6 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 ### Added
 
 - Proxy: Support for `cody.net.proxy` settings that enable configuation a cody specific proxy server. This also supports `cody.net.proxy.path` to provide a UNIX domain socket directly. [pull/5883](https://github.com/sourcegraph/cody/pull/5883)
-
-### Changed
 
 ### Fixed
 

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -1232,11 +1232,6 @@
             }
           }
         },
-        "cody.autocomplete.experimental.preloadDebounceInterval": {
-          "type": "number",
-          "default": 0,
-          "markdownDescription": "Changes the preload debounce interval for autocomplete requests triggered on cursor movement."
-        },
         "openctx.enable": {
           "type": "boolean",
           "markdownDescription": "Enable OpenCtx providers for Cody.",

--- a/vscode/src/completions/completion-provider-config.ts
+++ b/vscode/src/completions/completion-provider-config.ts
@@ -31,9 +31,6 @@ class CompletionProviderConfig {
             FeatureFlag.CodyAutocompleteContextExperimentVariant3,
             FeatureFlag.CodyAutocompleteContextExperimentVariant4,
             FeatureFlag.CodyAutocompleteContextExperimentControl,
-            FeatureFlag.CodyAutocompletePreloadingExperimentBaseFeatureFlag,
-            FeatureFlag.CodyAutocompletePreloadingExperimentVariant1,
-            FeatureFlag.CodyAutocompletePreloadingExperimentVariant2,
             FeatureFlag.CodyAutocompleteDataCollectionFlag,
             FeatureFlag.CodyAutocompleteTracing,
         ]
@@ -124,61 +121,6 @@ class CompletionProviderConfig {
                 }),
                 distinctUntilChanged<ContextStrategy>()
             )
-    }
-
-    private getPreloadingExperimentGroup(): Observable<'variant1' | 'variant2' | 'control'> {
-        return combineLatest(
-            featureFlagProvider.evaluatedFeatureFlag(
-                FeatureFlag.CodyAutocompletePreloadingExperimentBaseFeatureFlag
-            ),
-            featureFlagProvider.evaluatedFeatureFlag(
-                FeatureFlag.CodyAutocompletePreloadingExperimentVariant1
-            ),
-            featureFlagProvider.evaluatedFeatureFlag(
-                FeatureFlag.CodyAutocompletePreloadingExperimentVariant2
-            )
-        ).pipe(
-            map(([isContextExperimentFlagEnabled, variant1, variant2]) => {
-                if (isContextExperimentFlagEnabled) {
-                    if (variant1) {
-                        return 'variant1'
-                    }
-
-                    if (variant2) {
-                        return 'variant2'
-                    }
-                }
-
-                return 'control'
-            }),
-            distinctUntilChanged()
-        )
-    }
-
-    public get autocompletePreloadDebounceInterval(): Observable<number> {
-        return resolvedConfig.pipe(
-            switchMap(({ configuration }) => {
-                const localInterval = configuration.autocompleteExperimentalPreloadDebounceInterval
-
-                if (localInterval !== undefined && localInterval > 0) {
-                    return Observable.of(localInterval)
-                }
-
-                return this.getPreloadingExperimentGroup().pipe(
-                    map(preloadingExperimentGroup => {
-                        switch (preloadingExperimentGroup) {
-                            case 'variant1':
-                                return 150
-                            case 'variant2':
-                                return 100
-                            default:
-                                return 0
-                        }
-                    }),
-                    distinctUntilChanged()
-                )
-            })
-        )
     }
 
     public get completionDataCollectionFlag(): Observable<boolean> {

--- a/vscode/src/completions/get-inline-completions.ts
+++ b/vscode/src/completions/get-inline-completions.ts
@@ -309,7 +309,9 @@ async function doGetInlineCompletions(
     // Only log a completion as started if it's either served from cache _or_ the debounce interval
     // has passed to ensure we don't log too many start events where we end up not doing any work at
     // all.
-    CompletionAnalyticsLogger.flushActiveSuggestionRequests(isDotComUser)
+    if (triggerKind !== TriggerKind.Preload) {
+        CompletionAnalyticsLogger.flushActiveSuggestionRequests(isDotComUser)
+    }
     const multiline = Boolean(multilineTrigger)
     const logId = CompletionAnalyticsLogger.create({
         multiline,

--- a/vscode/src/completions/inline-completion-item-provider.ts
+++ b/vscode/src/completions/inline-completion-item-provider.ts
@@ -8,7 +8,6 @@ import {
     RateLimitError,
     authStatus,
     contextFiltersProvider,
-    createDisposables,
     featureFlagProvider,
     isDotCom,
     subscriptionDisposable,
@@ -221,27 +220,9 @@ export class InlineCompletionItemProvider
             )
         )
 
-        this.disposables.push(
-            subscriptionDisposable(
-                completionProviderConfig.autocompletePreloadDebounceInterval
-                    .pipe(
-                        createDisposables(preloadDebounceInterval => {
-                            this.onSelectionChangeDebounced = undefined
-                            if (preloadDebounceInterval > 0) {
-                                this.onSelectionChangeDebounced = debounce(
-                                    this.preloadCompletionOnSelectionChange.bind(this),
-                                    preloadDebounceInterval
-                                )
-
-                                return vscode.window.onDidChangeTextEditorSelection(
-                                    this.onSelectionChangeDebounced
-                                )
-                            }
-                            return undefined
-                        })
-                    )
-                    .subscribe({})
-            )
+        this.onSelectionChangeDebounced = debounce(
+            this.preloadCompletionOnSelectionChange.bind(this),
+            150
         )
 
         // Warm caches for the config feature configuration to avoid the first completion call

--- a/vscode/src/completions/inline-completion-item-provider.ts
+++ b/vscode/src/completions/inline-completion-item-provider.ts
@@ -74,6 +74,8 @@ interface CompletionRequest {
     context: vscode.InlineCompletionContext
 }
 
+export const PRELOAD_DEBOUNCE_INTERVAL = 150
+
 interface PreloadCompletionContext extends vscode.InlineCompletionContext {
     isPreload: true
 
@@ -222,7 +224,11 @@ export class InlineCompletionItemProvider
 
         this.onSelectionChangeDebounced = debounce(
             this.preloadCompletionOnSelectionChange.bind(this),
-            150
+            PRELOAD_DEBOUNCE_INTERVAL
+        )
+
+        this.disposables.push(
+            vscode.window.onDidChangeTextEditorSelection(this.onSelectionChangeDebounced)
         )
 
         // Warm caches for the config feature configuration to avoid the first completion call

--- a/vscode/src/configuration.test.ts
+++ b/vscode/src/configuration.test.ts
@@ -103,8 +103,6 @@ describe('getConfiguration', () => {
                         return undefined
                     case 'cody.autocomplete.advanced.timeout.firstCompletion':
                         return 1500
-                    case 'cody.autocomplete.experimental.preloadDebounceInterval':
-                        return 0
                     case 'cody.experimental.guardrailsTimeoutSeconds':
                         return undefined
                     case 'cody.advanced.agent.capabilities.storage':
@@ -185,7 +183,6 @@ describe('getConfiguration', () => {
                 url: OLLAMA_DEFAULT_URL,
             },
             autocompleteFirstCompletionTimeout: 1500,
-            autocompleteExperimentalPreloadDebounceInterval: 0,
             providerLimitPrompt: 123,
             devModels: [{ model: 'm', provider: 'p' }],
             experimentalGuardrailsTimeoutSeconds: undefined,

--- a/vscode/src/configuration.ts
+++ b/vscode/src/configuration.ts
@@ -128,10 +128,6 @@ export function getConfiguration(
             'autocomplete.experimental.fireworksOptions',
             undefined
         ),
-        autocompleteExperimentalPreloadDebounceInterval: getHiddenSetting(
-            'autocomplete.experimental.preloadDebounceInterval',
-            0
-        ),
 
         // Note: In spirit, we try to minimize agent-specific code paths in the VSC extension.
         // We currently use this flag for the agent to provide more helpful error messages

--- a/vscode/src/testutils/mocks.ts
+++ b/vscode/src/testutils/mocks.ts
@@ -920,7 +920,6 @@ export const DEFAULT_VSCODE_SETTINGS = {
         url: OLLAMA_DEFAULT_URL,
     },
     autocompleteFirstCompletionTimeout: 3500,
-    autocompleteExperimentalPreloadDebounceInterval: 0,
     experimentalGuardrailsTimeoutSeconds: undefined,
     overrideAuthToken: undefined,
     overrideServerEndpoint: undefined,


### PR DESCRIPTION
- Enables completions preloading on cursor movement by default based on [the A/B test results](https://sourcegraph.slack.com/archives/C0729T2PBV2/p1730438575143299?thread_ts=1723609708.830079&cid=C0729T2PBV2).
- Closes https://linear.app/sourcegraph/issue/CODY-3300/enable-the-preload-150-functionality-for-all-users-and-start-a-new

## Test plan

CI and manual testing: 
1. Enable autocomplete: `"cody.autocomplete.enabled": true`.
2. Open a new document.
3. Move the cursor to the line before the following empty line and wait a second.
4. Place the cursor at the beginning of the following empty line.
5. Observe that the completion appears instantly because it was preloaded while the cursor was on the previous line.

## Changelog

- Autocomplete: Enabled completion completions preloading on cursor movement.