### PR TITLE
Fix OpenCtx include initial context integeration.

### DIFF
--- a/vscode/src/chat/context/chatContext.ts
+++ b/vscode/src/chat/context/chatContext.ts
@@ -197,7 +197,7 @@ export const activeEditorContextForOpenCtxMentions: Observable<
             return repoNameResolver.getRepoNamesContainingUri(uri).pipe(
                 map(repoNames =>
                     repoNames === pendingOperation
-                        ? pendingOperation
+                        ? { uri: uri.toString(), codebase: undefined }
                         : {
                               uri: uri.toString(),
                               codebase: repoNames.at(0),


### PR DESCRIPTION
Resolves: https://sourcegraph.slack.com/archives/C07NNEEAU4B/p1730256382790879?thread_ts=1729002871.765829&cid=C07NNEEAU4B

## Background
OpenCtx providers can define `mentions: { autoInclude: true }` to get called for retrieving initial context items. This was implemented to support Bridgewater's feature request for Pinned Context. 

However, the provider is not getting called for files not inside a git repo with the remote set. This is because the `codebase` is not recognized, and we don't call the provider in that case. We recognize the codebase based on the current working directory and the git remote set.

This PR solves it by calling the provider even when the codebase is not resolved. 

Demo: https://www.loom.com/share/1c6724808f164b798f578d7c47481fdf?sid=00219b3a-8691-4d63-8978-d31f50ce6328

## Test plan

Follow the demo

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
