### PR TITLE
Auth: UI conditional rendering logic

### DIFF
--- a/agent/src/vscode-shim.ts
+++ b/agent/src/vscode-shim.ts
@@ -1066,7 +1066,7 @@ export const commands = _commands as typeof vscode.commands
 const _env: Partial<typeof vscode.env> = {
     uriScheme: 'file',
     appRoot: process.cwd?.(),
-    uiKind: UIKind.Web,
+    uiKind: UIKind.Desktop,
     language: process.env.language,
     clipboard: {
         readText: () => Promise.resolve(''),

--- a/vscode/webviews/AuthPage.tsx
+++ b/vscode/webviews/AuthPage.tsx
@@ -29,8 +29,6 @@ export const AuthPage: React.FunctionComponent<React.PropsWithoutRef<LoginProps>
     const otherSignInClick = (): void => {
         vscodeAPI.postMessage({ command: 'auth', authKind: 'signin' })
     }
-    const isNonVSCodeIDE = codyIDE !== CodyIDE.Web && codyIDE !== CodyIDE.VSCode
-    const isCodyWebUI = (uiKindIsWeb || codyIDE === CodyIDE.Web) && !isNonVSCodeIDE
     return (
         <div className="tw-flex tw-flex-col tw-items-center tw-gap-8 tw-h-full tw-py-10 tw-px-8">
             <div className="tw-w-full tw-max-w-md tw-flex tw-justify-center">
@@ -38,11 +36,12 @@ export const AuthPage: React.FunctionComponent<React.PropsWithoutRef<LoginProps>
             </div>
             <section className="tw-bg-sidebar-background tw-text-sidebar-foreground tw-border tw-border-border tw-rounded-lg tw-p-6 tw-w-full tw-max-w-md">
                 <h2 className="tw-font-semibold tw-text-lg tw-mb-4">Cody Enterprise</h2>
-                {isCodyWebUI || codyIDE === CodyIDE.VSCode ? (
+                {codyIDE === CodyIDE.VSCode ? (
                     <div className="tw-flex tw-flex-col tw-gap-6 tw-w-full">
                         <Button onClick={otherSignInClick}>Sign In to Your Enterprise Instance</Button>
                     </div>
                 ) : (
+                    // All non-VSCode clients use the sign-in form
                     <ClientSignInForm authStatus={authStatus} vscodeAPI={vscodeAPI} />
                 )}
                 <p className="tw-mt-4 tw-mb-0 tw-text-muted-foreground">
@@ -52,11 +51,11 @@ export const AuthPage: React.FunctionComponent<React.PropsWithoutRef<LoginProps>
             <section className="tw-bg-sidebar-background tw-text-sidebar-foreground tw-border tw-border-border tw-rounded-lg tw-p-6 tw-w-full tw-max-w-md">
                 <h2 className="tw-font-semibold tw-text-lg tw-mb-4">Cody Free or Cody Pro</h2>
                 <div className="tw-flex tw-flex-col tw-gap-6 tw-w-full">
-                    {isCodyWebUI ? (
+                    {codyIDE === CodyIDE.Web ? (
                         <WebLogin
                             telemetryRecorder={telemetryRecorder}
                             vscodeAPI={vscodeAPI}
-                            isCodyWeb={isCodyWebUI}
+                            isCodyWeb={codyIDE === CodyIDE.Web}
                         />
                     ) : (
                         <>

--- a/vscode/webviews/AuthPage.tsx
+++ b/vscode/webviews/AuthPage.tsx
@@ -51,11 +51,11 @@ export const AuthPage: React.FunctionComponent<React.PropsWithoutRef<LoginProps>
             <section className="tw-bg-sidebar-background tw-text-sidebar-foreground tw-border tw-border-border tw-rounded-lg tw-p-6 tw-w-full tw-max-w-md">
                 <h2 className="tw-font-semibold tw-text-lg tw-mb-4">Cody Free or Cody Pro</h2>
                 <div className="tw-flex tw-flex-col tw-gap-6 tw-w-full">
-                    {codyIDE === CodyIDE.Web ? (
+                    {uiKindIsWeb ? (
                         <WebLogin
                             telemetryRecorder={telemetryRecorder}
                             vscodeAPI={vscodeAPI}
-                            isCodyWeb={codyIDE === CodyIDE.Web}
+                            isCodyWeb={uiKindIsWeb}
                         />
                     ) : (
                         <>


### PR DESCRIPTION
CLOSE https://linear.app/sourcegraph/issue/CODY-4219

This change improves the conditional rendering logic in the `AuthPage` component. It removes the `isNonVSCodeIDE` and `isCodyWebUI` variables and simplifies the rendering logic based on the `codyIDE` value.

This change is to fix a regression caused by the logic we use for setting "isCodyWebUI" that is affecting all the non-VS Code clients as `isCodyWebUI` is now returning true for all clients. We set the uiKindIsWeb here: https://sourcegraph.com/github.com/sourcegraph/cody/-/blob/vscode/src/chat/chat-view/ChatController.ts?L511

But Agent sets uiKind to Web for ALL clients: https://sourcegraph.com/github.com/sourcegraph/cody/-/blob/agent/src/vscode-shim.ts?L1069

The key changes are:
- update uiKind to Desktop by default
- Removed the `isNonVSCodeIDE` and `isCodyWebUI` variables
- Simplified the conditional rendering to only check for `codyIDE === CodyIDE.VSCode`
- Moved the comment about non-VSCode clients using the sign-in form to the appropriate else block


## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

Run it in VS Code to make sure it doesn't change anything for VS Code.
Run it in Eclipse to confirm the Sing In Form is showing up correctly:
Run it in Visual Studio to confirm the Sing In Form is showing up correctly:
![image](https://github.com/user-attachments/assets/b1aa52b5-5d4d-4d6c-995a-086cbe394ef0)

Before

![image](https://github.com/user-attachments/assets/ada7339e-b8e6-4936-8b65-c11bc8cdb6fa)



## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
