### PR TITLE
update insider cron schedule to MWF @ 1500 UTC

### DIFF
--- a/.github/workflows/vscode-insiders-release.yml
+++ b/.github/workflows/vscode-insiders-release.yml
@@ -2,7 +2,7 @@ name: vscode-insiders-release
 
 on:
   schedule:
-    - cron: '0 15 * * *' # daily at 1500 UTC
+    - cron: '0 15 * * 1,3,5' # daily at 1500 UTC
   push:
     tags:
       - vscode-v* # automatically create a new insider build with a release


### PR DESCRIPTION
Updating insider release cron schedule to MWF @ 1500 UTC to prep builds for QA. 

see https://sourcegraph.slack.com/archives/C05AGQYD528/p1730416040305789 for more details

## Test plan
N/A
<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
