### PR TITLE
Run prompts migration only over local user commands

### DIFF
--- a/vscode/src/chat/chat-view/prompts-migration.ts
+++ b/vscode/src/chat/chat-view/prompts-migration.ts
@@ -3,11 +3,8 @@ import {
     type CodyCommandMode,
     type PromptsMigrationStatus,
     checkVersion,
-    combineLatest,
     distinctUntilChanged,
-    firstResultFromOperation,
     graphqlClient,
-    isError,
     isErrorLike,
     isValidVersion,
     shareReplay,
@@ -26,10 +23,9 @@ import {
     PROMPT_CURRENT_SELECTION_PLACEHOLDER,
     PROMPT_EDITOR_OPEN_TABS_PLACEHOLDER,
 } from '../../prompts/prompt-hydration'
-import { remoteReposForAllWorkspaceFolders } from '../../repository/remoteRepos'
 import { localStorage } from '../../services/LocalStorageProvider'
 
-const PROMPTS_MIGRATION_KEY = 'CODY_PROMPTS_MIGRATION'
+const PROMPTS_MIGRATION_KEY = 'CODY_PROMPTS_COMMANDS_MIGRATION'
 const PROMPTS_MIGRATION_STATUS = new Subject<PromptsMigrationStatus>()
 const PROMPTS_MIGRATION_RESULT = PROMPTS_MIGRATION_STATUS.pipe(
     startWith({ type: 'initial_migration' } as PromptsMigrationStatus),
@@ -38,16 +34,9 @@ const PROMPTS_MIGRATION_RESULT = PROMPTS_MIGRATION_STATUS.pipe(
 )
 
 export function getPromptsMigrationInfo(): Observable<PromptsMigrationStatus> {
-    return combineLatest(
-        siteVersion.pipe(skipPendingOperation()),
-        remoteReposForAllWorkspaceFolders.pipe(skipPendingOperation())
-    ).pipe(
-        switchMap(([siteVersion, repositories]) => {
-            if (isError(repositories)) {
-                throw repositories
-            }
-
-            const repository = repositories[0]
+    return siteVersion.pipe(
+        skipPendingOperation(),
+        switchMap(siteVersion => {
             const isPromptSupportVersion =
                 siteVersion &&
                 checkVersion({
@@ -56,11 +45,14 @@ export function getPromptsMigrationInfo(): Observable<PromptsMigrationStatus> {
                 })
 
             // Don't run migration if you're already run this before (ignore any other new commands
-            // that had been added after first migration run
-            const migrationMap = localStorage.get<Record<string, boolean>>(PROMPTS_MIGRATION_KEY) ?? {}
-            const commands = getCodyCommandList().filter(command => command.type !== 'default')
+            // that had been added after first migration run)
+            const hasBeenRunBefore = localStorage.get<boolean>(PROMPTS_MIGRATION_KEY) ?? {}
 
-            if (!isPromptSupportVersion || !repository || migrationMap[repoKey(repository?.id ?? '')]) {
+            // Migrate only user-level commands (repository level commands will be migrated via
+            // instance prompts migration wizard see https://github.com/sourcegraph/sourcegraph/pull/1449)
+            const commands = getCodyCommandList().filter(command => command.type === 'user')
+
+            if (!isPromptSupportVersion || hasBeenRunBefore) {
                 return Observable.of<PromptsMigrationStatus>({
                     type: 'migration_skip',
                 })
@@ -79,7 +71,7 @@ export function getPromptsMigrationInfo(): Observable<PromptsMigrationStatus> {
 
 export async function startPromptsMigration(): Promise<void> {
     // Custom commands list
-    const commands = getCodyCommandList().filter(command => command.type !== 'default')
+    const commands = getCodyCommandList().filter(command => command.type === 'user')
     const currentUser = await graphqlClient.isCurrentUserSideAdmin()
     const isValidInstance = await isValidVersion({ minimumVersion: '5.9.0' })
 
@@ -138,7 +130,7 @@ export async function startPromptsMigration(): Promise<void> {
                 continue
             }
 
-            const newPrompt = await graphqlClient.createPrompt({
+            await graphqlClient.createPrompt({
                 owner: currentUser.id,
                 name: commandKey,
                 description: `Migrated from command ${commandKey}`,
@@ -148,12 +140,6 @@ export async function startPromptsMigration(): Promise<void> {
                 mode: commandModeToPromptMode(command.mode),
                 visibility: 'SECRET',
             })
-
-            // Change prompt visibility to PUBLIC if it's admin performing migration
-            // TODO: [VK] Remove it and use visibility field in prompt creation (current API limitation)
-            if (currentUser.siteAdmin) {
-                await graphqlClient.transferPromptOwnership({ id: newPrompt.id, visibility: 'PUBLIC' })
-            }
 
             PROMPTS_MIGRATION_STATUS.next({
                 type: 'migrating',
@@ -170,15 +156,7 @@ export async function startPromptsMigration(): Promise<void> {
         }
     }
 
-    const repositories = (await firstResultFromOperation(remoteReposForAllWorkspaceFolders)) ?? []
-    const repository = repositories[0]
-
-    if (repository) {
-        const migrationMap = localStorage.get<Record<string, boolean>>(PROMPTS_MIGRATION_KEY) ?? {}
-        migrationMap[repoKey(repository.id)] = true
-        await localStorage.set(PROMPTS_MIGRATION_KEY, migrationMap)
-    }
-
+    await localStorage.set<boolean>(PROMPTS_MIGRATION_KEY, true)
     PROMPTS_MIGRATION_STATUS.next({ type: 'migration_success' })
 }
 
@@ -223,8 +201,4 @@ function generatePromptTextFromCommand(command: CodyCommand): string {
     }
 
     return promptText
-}
-
-function repoKey(repositoryId: string) {
-    return `prefix12-${repositoryId}`
 }

--- a/vscode/src/chat/chat-view/prompts-migration.ts
+++ b/vscode/src/chat/chat-view/prompts-migration.ts
@@ -46,7 +46,7 @@ export function getPromptsMigrationInfo(): Observable<PromptsMigrationStatus> {
 
             // Don't run migration if you're already run this before (ignore any other new commands
             // that had been added after first migration run)
-            const hasBeenRunBefore = localStorage.get<boolean>(PROMPTS_MIGRATION_KEY) ?? {}
+            const hasBeenRunBefore = localStorage.get<boolean>(PROMPTS_MIGRATION_KEY) ?? false
 
             // Migrate only user-level commands (repository level commands will be migrated via
             // instance prompts migration wizard see https://github.com/sourcegraph/sourcegraph/pull/1449)

--- a/vscode/src/context/openctx.ts
+++ b/vscode/src/context/openctx.ts
@@ -73,9 +73,7 @@ export function exposeOpenCtxClient(
         createDisposables(([{ experimentalNoodle }, isValidSiteVersion, createController]) => {
             try {
                 // Enable fetching of openctx configuration from Sourcegraph instance
-                const mergeConfiguration = experimentalNoodle
-                    ? getMergeConfigurationFunction()
-                    : undefined
+                const mergeConfiguration = getMergeConfigurationFunction()
 
                 if (!openctxOutputChannel) {
                     // Don't dispose this, so that it stays around for easier debugging even if the

--- a/vscode/src/context/openctx.ts
+++ b/vscode/src/context/openctx.ts
@@ -73,7 +73,9 @@ export function exposeOpenCtxClient(
         createDisposables(([{ experimentalNoodle }, isValidSiteVersion, createController]) => {
             try {
                 // Enable fetching of openctx configuration from Sourcegraph instance
-                const mergeConfiguration = getMergeConfigurationFunction()
+                const mergeConfiguration = experimentalNoodle
+                    ? getMergeConfigurationFunction()
+                    : undefined
 
                 if (!openctxOutputChannel) {
                     // Don't dispose this, so that it stays around for easier debugging even if the

--- a/vscode/webviews/components/promptList/PromptList.tsx
+++ b/vscode/webviews/components/promptList/PromptList.tsx
@@ -150,10 +150,10 @@ export const PromptList: FC<PromptListProps> = props => {
     const actions = showFirstNItems ? sortedActions.slice(0, showFirstNItems) : sortedActions
 
     const inputPaddingClass =
-        paddingLevels !== 'none' ? (paddingLevels === 'middle' ? '!tw-p-0' : '!tw-p-0') : ''
+        paddingLevels !== 'none' ? (paddingLevels === 'middle' ? '!tw-p-0' : '!tw-p-4') : ''
 
     const itemPaddingClass =
-        paddingLevels !== 'none' ? (paddingLevels === 'middle' ? '!tw-px-6' : '!tw-px-6') : ''
+        paddingLevels !== 'none' ? (paddingLevels === 'middle' ? '!tw-px-6' : '!tw-px-8') : ''
 
     return (
         <Command


### PR DESCRIPTION
Closes SRCH-1278

This PR simply makes prompt migration wizard to migrate only local commands that you have in vs code settings. Repository-level commands will be migrated via instance-level wizard (see https://github.com/sourcegraph/sourcegraph/pull/1449)

## Test plan
- Open VSCode while you have some custom local commands 
- Check that you can see the migration wizard on the welcome screen or on the prompts tab
- Run the wizard and check that this created prompts from your local commands in prompts library
