### PR TITLE
Chat: E2E tests for chat PCW events.

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -7,6 +7,7 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 ### Added
 
 - Autocomplete: Enabled completions preloading on cursor movement. [pull/6043](https://github.com/sourcegraph/cody/pull/6043)
+- Telemetry: Added `cody.command.logCharacterCounters` for debugging. [pull/6057](https://github.com/sourcegraph/cody/pull/6057)
 
 ### Fixed
 

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -7,7 +7,7 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 ### Added
 
 - Autocomplete: Enabled completions preloading on cursor movement. [pull/6043](https://github.com/sourcegraph/cody/pull/6043)
-- Telemetry: Added `cody.command.logCharacterCounters` for debugging. [pull/6057](https://github.com/sourcegraph/cody/pull/6057)
+- Telemetry: Added `cody.debug.logCharacterCounters` for debugging. [pull/6057](https://github.com/sourcegraph/cody/pull/6057)
 
 ### Fixed
 

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -575,6 +575,13 @@
         "title": "Copy Cody Extension Version"
       },
       {
+        "command": "cody.command.logCharacterCounters",
+        "title": "[Internal] Log character logger counters",
+        "category": "Cody Debug",
+        "group": "Debug",
+        "when": "cody.activated"
+      },
+      {
         "command": "cody.test.set-context-filters",
         "title": "[Internal] Set Context Filters Overwrite",
         "enablement": "cody.activated && cody.devOrTest"

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -575,7 +575,7 @@
         "title": "Copy Cody Extension Version"
       },
       {
-        "command": "cody.command.logCharacterCounters",
+        "command": "cody.debug.logCharacterCounters",
         "title": "[Internal] Log character logger counters",
         "category": "Cody Debug",
         "group": "Debug",

--- a/vscode/src/chat/chat-view/ChatsController.ts
+++ b/vscode/src/chat/chat-view/ChatsController.ts
@@ -225,7 +225,15 @@ export class ChatsController implements vscode.Disposable {
             ),
             vscode.commands.registerCommand(
                 'cody.command.insertCodeToCursor',
-                (args: { text: string }) => handleCodeFromInsertAtCursor(args.text)
+                (args: { text: string }) => {
+                    const text =
+                        // Used in E2E tests where OS-native buttons dropdown is inaccessible.
+                        process.env.CODY_TESTING === 'true'
+                            ? 'cody.command.insertCodeToCursor:cody_testing'
+                            : args.text
+
+                    return handleCodeFromInsertAtCursor(text)
+                }
             ),
             vscode.commands.registerCommand(
                 'cody.command.insertCodeToNewFile',

--- a/vscode/src/non-stop/FixupTask.ts
+++ b/vscode/src/non-stop/FixupTask.ts
@@ -176,7 +176,7 @@ export class FixupTask {
                         // We should consider doing that for initial ranges too.
                         range: document.validateRange(edit.range),
                         rangeOffset: document.offsetAt(edit.range.start),
-                        rangeLength: edit.text.length,
+                        rangeLength: 0,
                         text: edit.text,
                     })
                     break

--- a/vscode/src/services/CharactersLogger.ts
+++ b/vscode/src/services/CharactersLogger.ts
@@ -125,6 +125,11 @@ export class CharactersLogger implements vscode.Disposable {
             window.onDidChangeTextEditorSelection(event => {
                 const documentUri = event.textEditor.document.uri.toString()
                 this.lastSelectionTimestamps.set(documentUri, Date.now())
+            }),
+            vscode.commands.registerCommand('cody.command.logCharacterCounters', () => {
+                outputChannelLogger.logDebug('CharactersLogger', 'Current character counters:', {
+                    verbose: this.changeCounters,
+                })
             })
         )
 

--- a/vscode/src/services/CharactersLogger.ts
+++ b/vscode/src/services/CharactersLogger.ts
@@ -126,7 +126,7 @@ export class CharactersLogger implements vscode.Disposable {
                 const documentUri = event.textEditor.document.uri.toString()
                 this.lastSelectionTimestamps.set(documentUri, Date.now())
             }),
-            vscode.commands.registerCommand('cody.command.logCharacterCounters', () => {
+            vscode.commands.registerCommand('cody.debug.logCharacterCounters', () => {
                 outputChannelLogger.logDebug('CharactersLogger', 'Current character counters:', {
                     verbose: this.changeCounters,
                 })

--- a/vscode/test/e2e/__snapshots__/chat-messages.test.ts/chat-assistant-response-code-buttons-1.txt
+++ b/vscode/test/e2e/__snapshots__/chat-messages.test.ts/chat-assistant-response-code-buttons-1.txt
@@ -1,0 +1,60 @@
+{
+  "copyClickedEvent": {
+    "version": 0,
+    "metadata": [
+      {
+        "key": "source",
+        "value": 1
+      },
+      {
+        "key": "lineCount",
+        "value": 5
+      },
+      {
+        "key": "charCount",
+        "value": 75
+      },
+      {
+        "key": "tier",
+        "value": 2
+      }
+    ],
+    "privateMetadata": {
+      "source": "chat",
+      "op": "copy"
+    },
+    "billingMetadata": {
+      "product": "cody",
+      "category": "core"
+    }
+  },
+  "insertClickedEvent": {
+    "version": 0,
+    "metadata": [
+      {
+        "key": "source",
+        "value": 1
+      },
+      {
+        "key": "lineCount",
+        "value": 1
+      },
+      {
+        "key": "charCount",
+        "value": 44
+      },
+      {
+        "key": "tier",
+        "value": 2
+      }
+    ],
+    "privateMetadata": {
+      "source": "chat",
+      "op": "insert"
+    },
+    "billingMetadata": {
+      "product": "cody",
+      "category": "core"
+    }
+  }
+}

--- a/vscode/test/e2e/__snapshots__/command-edit.test.ts/edit-fixup-task-1.txt
+++ b/vscode/test/e2e/__snapshots__/command-edit.test.ts/edit-fixup-task-1.txt
@@ -55,7 +55,7 @@
     },
     {
       "key": "charsDeleted",
-      "value": 90
+      "value": 44
     },
     {
       "key": "tier",

--- a/vscode/test/e2e/chat-messages.test.ts
+++ b/vscode/test/e2e/chat-messages.test.ts
@@ -63,9 +63,13 @@ test('chat assistant response code buttons', async ({ page, nap, sidebar }, test
 
     // We expect the pasted code to be categorized as cody_chat and
     // the relevant inserted characters counter to be incremented appropriately.
-    expect(outputChannelWithPaste).toContain('Current character counters:')
-    expect(outputChannelWithPaste).toContain(`"cody_chat_inserted": ${codeToPaste.length}`)
-    expect(outputChannelWithPaste).toContain('"cody_chat": 1')
+    const idx = outputChannelWithPaste.lastIndexOf('Current character counters:')
+    const outputChannelWithPasteAfter = outputChannelWithPaste.slice(idx)
+    console.log('outputChannelWithPasteAfter ', outputChannelWithPasteAfter)
+
+    expect(idx).toBeGreaterThan(0)
+    expect(outputChannelWithPasteAfter).toContain(`"cody_chat_inserted": ${codeToPaste.length}`)
+    expect(outputChannelWithPasteAfter).toContain('"cody_chat": 1')
 
     await actionsDropdown.click()
     await executeCommandInPalette(page, 'cody.command.insertCodeToCursor')
@@ -79,14 +83,17 @@ test('chat assistant response code buttons', async ({ page, nap, sidebar }, test
     // Currently defined in: vscode/src/chat/chat-view/ChatsController.ts
     const codeToInsert = 'cody.command.insertCodeToCursor:cody_testing'
     const outputChannelWithInsert = await fs.readFile(getTmpLogFile(testInfo.title), 'utf-8')
+    const idx2 = outputChannelWithInsert.lastIndexOf('Current character counters:')
+    const outputChannelWithInsertAfter = outputChannelWithInsert.slice(idx2)
+    console.log('outputChannelWithInsertAfter ', outputChannelWithInsertAfter)
 
     // We expect the inserted code to be categorized as cody_chat and
     // the relevant inserted characters counter to be incremented appropriately.
-    expect(outputChannelWithPaste).toContain('Current character counters:')
-    expect(outputChannelWithInsert).toContain(
+    expect(idx2).toBeGreaterThan(0)
+    expect(outputChannelWithInsertAfter).toContain(
         `"cody_chat_inserted": ${codeToPaste.length + codeToInsert.length}`
     )
-    expect(outputChannelWithInsert).toContain('"cody_chat": 2')
+    expect(outputChannelWithInsertAfter).toContain('"cody_chat": 2')
 
     const copyClickedEvent = mockServer.loggedV2Events.find(
         event => event.testId === 'cody.copyButton:clicked'

--- a/vscode/test/e2e/chat-messages.test.ts
+++ b/vscode/test/e2e/chat-messages.test.ts
@@ -3,7 +3,7 @@ import { expect } from '@playwright/test'
 
 import * as mockServer from '../fixtures/mock-server'
 
-import { isWindows } from '@sourcegraph/cody-shared'
+import { isMacOS, isWindows } from '@sourcegraph/cody-shared'
 import { chatMessageRows, createEmptyChatPanel, sidebarExplorer, sidebarSignin } from './common'
 import { executeCommandInPalette, getTmpLogFile, test } from './helpers'
 
@@ -49,7 +49,7 @@ test('chat assistant response code buttons', async ({ page, nap, sidebar }, test
     await copyButton.click()
     // Place the cursor on some text in the document
     await page.getByText('appleName').click()
-    await page.keyboard.press(isWindows() ? 'Control+V' : 'Meta+V')
+    await page.keyboard.press(isMacOS() ? 'Meta+V' : 'Control+V')
 
     const codeToPaste =
         'def fib(n):\n  if n < 0:\n    return n\n  else:\n    return fib(n-1) + fib(n-2)\n'

--- a/vscode/test/e2e/chat-messages.test.ts
+++ b/vscode/test/e2e/chat-messages.test.ts
@@ -58,7 +58,7 @@ test('chat assistant response code buttons', async ({ page, nap, sidebar }, test
 
     await executeCommandInPalette(page, 'cody.command.logCharacterCounters')
     // Wait for the logCharacterCounters command to update the log file.
-    await nap()
+    await nap(600)
     const outputChannelWithPaste = await fs.readFile(getTmpLogFile(testInfo.title), 'utf-8')
 
     // We expect the pasted code to be categorized as cody_chat and
@@ -71,7 +71,7 @@ test('chat assistant response code buttons', async ({ page, nap, sidebar }, test
     await nap()
     await executeCommandInPalette(page, 'cody.command.logCharacterCounters')
     // Wait for the logCharacterCounters command to update the log file.
-    await nap()
+    await nap(600)
 
     // Static value hardcoded for testing because I did not find a way to
     // reliably access the native OS-dropdown used for the insert code button.

--- a/vscode/test/e2e/chat-messages.test.ts
+++ b/vscode/test/e2e/chat-messages.test.ts
@@ -56,22 +56,23 @@ test('chat assistant response code buttons', async ({ page, nap, sidebar }, test
     const consoleLogMessage = await consoleLogPromise
     expect(await consoleLogMessage.args()[1].jsonValue()).toBe(codeToPaste)
 
-    await executeCommandInPalette(page, 'cody.command.logCharacterCounters')
+    await executeCommandInPalette(page, 'cody.debug.logCharacterCounters')
     // Wait for the logCharacterCounters command to update the log file.
-    await nap(600)
+    await nap(1000)
     const outputChannelWithPaste = await fs.readFile(getTmpLogFile(testInfo.title), 'utf-8')
 
     // We expect the pasted code to be categorized as cody_chat and
     // the relevant inserted characters counter to be incremented appropriately.
+    expect(outputChannelWithPaste).toContain('Current character counters:')
     expect(outputChannelWithPaste).toContain(`"cody_chat_inserted": ${codeToPaste.length}`)
     expect(outputChannelWithPaste).toContain('"cody_chat": 1')
 
     await actionsDropdown.click()
     await executeCommandInPalette(page, 'cody.command.insertCodeToCursor')
     await nap()
-    await executeCommandInPalette(page, 'cody.command.logCharacterCounters')
+    await executeCommandInPalette(page, 'cody.debug.logCharacterCounters')
     // Wait for the logCharacterCounters command to update the log file.
-    await nap(600)
+    await nap(1000)
 
     // Static value hardcoded for testing because I did not find a way to
     // reliably access the native OS-dropdown used for the insert code button.
@@ -81,6 +82,7 @@ test('chat assistant response code buttons', async ({ page, nap, sidebar }, test
 
     // We expect the inserted code to be categorized as cody_chat and
     // the relevant inserted characters counter to be incremented appropriately.
+    expect(outputChannelWithPaste).toContain('Current character counters:')
     expect(outputChannelWithInsert).toContain(
         `"cody_chat_inserted": ${codeToPaste.length + codeToInsert.length}`
     )

--- a/vscode/test/e2e/chat-messages.test.ts
+++ b/vscode/test/e2e/chat-messages.test.ts
@@ -1,11 +1,26 @@
+import { promises as fs } from 'node:fs'
 import { expect } from '@playwright/test'
-import { chatMessageRows, createEmptyChatPanel, sidebarSignin } from './common'
-import { test } from './helpers'
 
-test.use({ permissions: ['clipboard-read', 'clipboard-write'] })
+import * as mockServer from '../fixtures/mock-server'
 
-test('chat assistant response code buttons', async ({ page, sidebar, context, contextOptions }) => {
+import { isWindows } from '@sourcegraph/cody-shared'
+import { chatMessageRows, createEmptyChatPanel, sidebarExplorer, sidebarSignin } from './common'
+import { executeCommandInPalette, getTmpLogFile, test } from './helpers'
+
+test.use({
+    permissions: ['clipboard-read', 'clipboard-write'],
+    extraWorkspaceSettings: {
+        'cody.debug.verbose': true,
+    },
+})
+
+test('chat assistant response code buttons', async ({ page, nap, sidebar }, testInfo) => {
     await sidebarSignin(page, sidebar)
+
+    await sidebarExplorer(page).click()
+    await page.getByRole('treeitem', { name: 'type.ts' }).locator('a').dblclick()
+    await page.getByRole('tab', { name: 'type.ts' }).hover()
+
     const [chatPanel, chatInput] = await createEmptyChatPanel(page)
     await chatInput.fill('show me a code snippet')
     await chatInput.press('Enter')
@@ -32,8 +47,55 @@ test('chat assistant response code buttons', async ({ page, sidebar, context, co
         timeout: 5000,
     })
     await copyButton.click()
-    const consoleLogMessage = await consoleLogPromise
-    expect(await consoleLogMessage.args()[1].jsonValue()).toBe(
+    // Place the cursor on some text in the document
+    await page.getByText('appleName').click()
+    await page.keyboard.press(isWindows() ? 'Control+V' : 'Meta+V')
+
+    const codeToPaste =
         'def fib(n):\n  if n < 0:\n    return n\n  else:\n    return fib(n-1) + fib(n-2)\n'
+    const consoleLogMessage = await consoleLogPromise
+    expect(await consoleLogMessage.args()[1].jsonValue()).toBe(codeToPaste)
+
+    await executeCommandInPalette(page, 'cody.command.logCharacterCounters')
+    // Wait for the logCharacterCounters command to update the log file.
+    await nap()
+    const outputChannelWithPaste = await fs.readFile(getTmpLogFile(testInfo.title), 'utf-8')
+
+    // We expect the pasted code to be categorized as cody_chat and
+    // the relevant inserted characters counter to be incremented appropriately.
+    expect(outputChannelWithPaste).toContain(`"cody_chat_inserted": ${codeToPaste.length}`)
+    expect(outputChannelWithPaste).toContain('"cody_chat": 1')
+
+    await actionsDropdown.click()
+    await executeCommandInPalette(page, 'cody.command.insertCodeToCursor')
+    await nap()
+    await executeCommandInPalette(page, 'cody.command.logCharacterCounters')
+    // Wait for the logCharacterCounters command to update the log file.
+    await nap()
+
+    // Static value hardcoded for testing because I did not find a way to
+    // reliably access the native OS-dropdown used for the insert code button.
+    // Currently defined in: vscode/src/chat/chat-view/ChatsController.ts
+    const codeToInsert = 'cody.command.insertCodeToCursor:cody_testing'
+    const outputChannelWithInsert = await fs.readFile(getTmpLogFile(testInfo.title), 'utf-8')
+
+    // We expect the inserted code to be categorized as cody_chat and
+    // the relevant inserted characters counter to be incremented appropriately.
+    expect(outputChannelWithInsert).toContain(
+        `"cody_chat_inserted": ${codeToPaste.length + codeToInsert.length}`
     )
+    expect(outputChannelWithInsert).toContain('"cody_chat": 2')
+
+    const copyClickedEvent = mockServer.loggedV2Events.find(
+        event => event.testId === 'cody.copyButton:clicked'
+    )
+    const insertClickedEvent = mockServer.loggedV2Events.find(
+        event => event.testId === 'cody.insertButton:clicked'
+    )
+    const chatEventsParameters = {
+        copyClickedEvent: copyClickedEvent?.parameters,
+        insertClickedEvent: insertClickedEvent?.parameters,
+    }
+    // We expect events being logged for the copy and insert button clicks.
+    expect(JSON.stringify(chatEventsParameters, null, 2)).toMatchSnapshot()
 })

--- a/vscode/test/e2e/chat-messages.test.ts
+++ b/vscode/test/e2e/chat-messages.test.ts
@@ -3,7 +3,7 @@ import { expect } from '@playwright/test'
 
 import * as mockServer from '../fixtures/mock-server'
 
-import { isMacOS, isWindows } from '@sourcegraph/cody-shared'
+import { isMacOS } from '@sourcegraph/cody-shared'
 import { chatMessageRows, createEmptyChatPanel, sidebarExplorer, sidebarSignin } from './common'
 import { executeCommandInPalette, getTmpLogFile, test } from './helpers'
 

--- a/vscode/test/e2e/helpers.ts
+++ b/vscode/test/e2e/helpers.ts
@@ -74,6 +74,9 @@ export const getAssetsDir = (testName: string): string =>
 export const testAssetsTmpDir = (testName: string, label: string): string =>
     path.join(getAssetsDir(testName), `temp-${label}`)
 
+export const getTmpLogFile = (testTitle: string): string =>
+    path.join(testAssetsTmpDir(testTitle, 'log'), 'logger.log')
+
 export interface OpenVSCodeOptions {
     // A list of extensions to install or uninstall before starting VSCode. These can
     // be extensions that are already published to the VSCode Marketplace, or they can
@@ -174,7 +177,7 @@ export const test = base
                 dotcomUrlOverride = { CODY_OVERRIDE_DOTCOM_URL: dotcomUrl }
             }
 
-            const tmpLogFile = path.join(testAssetsTmpDir(testInfo.title, 'log'), 'logger.log')
+            const tmpLogFile = getTmpLogFile(testInfo.title)
             await mkdir(path.dirname(tmpLogFile), { recursive: true })
             await writeFile(tmpLogFile, '')
             console.error('Cody output channel:', tmpLogFile)


### PR DESCRIPTION
- Adds E2E tests for telemetry events for code buttons in chat. Asserts that changes they produce in a document are correctly categorized as `cody_chat`.
- Adds a new "[Internal] Log character logger counters" for characters logger debugging.
- Closes https://linear.app/sourcegraph/issue/CODY-4233/implement-e2e-vs-code-tests-for-pcw-events-from-chat

## Test plan

- CI with the updated E2E test.
- Open command palette in VS Code and run "[Internal] Log character logger counters". It should output the character logger counters in the Cody output channel. Enable verbose debugging by adding "'cody.debug.verbose': true" to your VS Code settings.