### PR TITLE
Fix bugs in workspace::getConfiguration vscode shim

### DIFF
--- a/agent/src/vscode-shim.ts
+++ b/agent/src/vscode-shim.ts
@@ -394,16 +394,14 @@ const _workspace: typeof vscode.workspace = {
     // https://github.com/sourcegraph/cody/issues/4136
     createFileSystemWatcher: () => emptyFileWatcher,
     getConfiguration: (section, scope): vscode.WorkspaceConfiguration => {
-        if (section !== undefined) {
-            if (scope === undefined) {
-                return configuration.withPrefix(section)
-            }
-
+        if (section) {
             // Ignore language-scoped configuration sections like
             // '[jsonc].editor.insertSpaces', fallback to global scope instead.
             if (section.startsWith('[')) {
                 return configuration
             }
+
+            return configuration.withPrefix(section)
         }
         return configuration
     },


### PR DESCRIPTION
## Changes

`getConfiguration` was working incorrectly when scope was provided.
Currently agent ignores scopes, but should respect configuration sections.
In the buggy case if scope was give, `getConfiguration` was always returning top level scope ignoring section.

## Test plan

Unittests are added. Test scenario with openctx providers:

1. Add the following configuration in the cody jetbrains settings:

```
  "cody.experimental.noodle": true,
  "openctx": {
    "providers": {
      "https://gist.githubusercontent.com/thenamankumar/3708f084fb2abd57adafe7f14620bdf7/raw/e7c7059cb5b04f6feead002e7b3a90c5b1a4bb96/provider.js": true

    },
    "enable": true
  }
```
2. Restart IDE
3. You should see new @ provider
![image](https://github.com/user-attachments/assets/608881fb-90d6-4328-a427-2b13388d3db8)
