### PR TITLE
prevent double-adding selected context

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -12,6 +12,11 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 
 ### Changed
 
+- Chat: This patch updates the chat keyboard shortcuts to be as follows, thereby avoiding the tendency to "double-add" a code snippet when using the `alt+L` shortcut:
+  - `Alt+L`: between chat and editor (this is unchanged)
+  - `Shift+Alt+L` (previously alt+L): add selection as context:
+  - `Shift+Ctrl+L` (previously shift+alt+L): new chat
+
 ## 1.40.1
 
 ### Fixed

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -608,7 +608,7 @@
       },
       {
         "command": "cody.chat.new",
-        "key": "shift+alt+l",
+        "key": "shift+ctrl+l",
         "when": "cody.activated"
       },
       {
@@ -645,12 +645,12 @@
       },
       {
         "command": "cody.mention.selection",
-        "key": "alt+l",
+        "key": "shift+alt+l",
         "when": "cody.activated && editorTextFocus && editorHasSelection"
       },
       {
         "command": "cody.mention.selection",
-        "key": "alt+/",
+        "key": "shift+alt+/",
         "when": "cody.activated && editorTextFocus && editorHasSelection"
       },
       {

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -603,7 +603,7 @@
       },
       {
         "command": "cody.chat.new",
-        "key": "shift+alt+/",
+        "key": "shift+ctrl+/",
         "when": "cody.activated"
       },
       {

--- a/vscode/test/e2e/chat-keyboard-shortcuts.test.ts
+++ b/vscode/test/e2e/chat-keyboard-shortcuts.test.ts
@@ -18,17 +18,17 @@ test('chat keyboard shortcuts for sidebar chat', async ({ page, sidebar }) => {
     const chatSidebar = getChatSidebarPanel(page)
     const chatSidebarInput = getChatInputs(chatSidebar).first()
 
-    // Shift+Alt+L with no selection opens a new chat in an editor panel (with file mention).
+    // Ctrl+Alt+L with no selection opens a new chat in an editor panel (with file mention).
     await openFileInEditorTab(page, 'buzz.ts')
     await clickEditorTab(page, 'buzz.ts')
-    await page.keyboard.press('Shift+Alt+L')
+    await page.keyboard.press('Shift+Control+l')
     await expect(chatSidebarInput).toContainText('buzz.ts', { timeout: 3_000 })
 
     await executeCommandInPalette(page, 'View: Close Primary Sidebar')
 
-    // Alt+L with a selection opens a new chat (with selection mention).
+    // Shift+Alt+L with a selection opens a new chat (with selection mention).
     await selectLineRangeInEditorTab(page, 3, 5)
-    await page.keyboard.press('Alt+/')
+    await page.keyboard.press('Shift+Alt+/')
     await expect(chatSidebarInput).toContainText('buzz.ts:3-5 ')
 })
 
@@ -43,12 +43,12 @@ test('re-opening chat adds selection', async ({ page, sidebar }) => {
 
     await clickEditorTab(page, 'buzz.ts')
     await selectLineRangeInEditorTab(page, 2, 4)
-    await page.keyboard.press('Alt+l')
+    await page.keyboard.press('Shift+Alt+l')
     await expect(chatInputMentions(lastChatInput)).toHaveText(/^buzz.ts:2-4$/)
 
     // Re-opening chat does not add duplicate selection
     await openFileInEditorTab(page, 'buzz.ts')
     await selectLineRangeInEditorTab(page, 2, 4)
-    await page.keyboard.press('Alt+l')
+    await page.keyboard.press('Shift+Alt+l')
     await expect(chatInputMentions(lastChatInput)).toHaveText(/^buzz.ts:2-4$/)
 })


### PR DESCRIPTION
Previously, using the `alt+L` shortcut would appear to double-add the same snippet of context, because that snippet will have been already been added to the default initial context of the chat input. The `alt+L` shortcut to add a selection to context also conflicts with the `alt+L` shortcut that toggles the cursor back and forth between the sidebar and the editor.

This patch updates the shortcuts to be as follows:
- alt+L: between chat and editor (this is unchanged)
- shift+alt+L (previously alt+L): add selection as context: 
- shift+ctrl+L (previously shift+alt+L): new chat

## Test plan

Test the shortcuts locally.