### PR TITLE
VS Code: Release v1.40.2

### DIFF
--- a/agent/src/vscode-shim.ts
+++ b/agent/src/vscode-shim.ts
@@ -394,16 +394,14 @@ const _workspace: typeof vscode.workspace = {
     // https://github.com/sourcegraph/cody/issues/4136
     createFileSystemWatcher: () => emptyFileWatcher,
     getConfiguration: (section, scope): vscode.WorkspaceConfiguration => {
-        if (section !== undefined) {
-            if (scope === undefined) {
-                return configuration.withPrefix(section)
-            }
-
+        if (section) {
             // Ignore language-scoped configuration sections like
             // '[jsonc].editor.insertSpaces', fallback to global scope instead.
             if (section.startsWith('[')) {
                 return configuration
             }
+
+            return configuration.withPrefix(section)
         }
         return configuration
     },

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -3,7 +3,7 @@
   "name": "cody-ai",
   "private": true,
   "displayName": "Cody: AI Coding Assistant with Autocomplete & Chat",
-  "version": "1.40.1",
+  "version": "1.40.2",
   "publisher": "sourcegraph",
   "license": "Apache-2.0",
   "icon": "resources/cody.png",


### PR DESCRIPTION
Cherry pick https://github.com/sourcegraph/cody/pull/6058 into v1.40.2 patch release

## Test plan
N/A
<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
