### PR TITLE
VS Code: Release v1.40.2

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -12,6 +12,11 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 
 ### Changed
 
+## 1.40.2
+
+### Fixed
+- Fixed bugs in workspace::getConfiguration vscode shim [pull/6058](https://github.com/sourcegraph/cody/pull/6058)
+
 ## 1.40.1
 
 ### Fixed

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -15,7 +15,7 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 ## 1.40.2
 
 ### Fixed
-- Fixed bugs in workspace::getConfiguration vscode shim [pull/6058](https://github.com/sourcegraph/cody/pull/6058)
+- Agent: Fixed bugs in `workspace::getConfiguration` vscode shim [pull/6058](https://github.com/sourcegraph/cody/pull/6058)
 
 ## 1.40.1
 

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -3,7 +3,7 @@
   "name": "cody-ai",
   "private": true,
   "displayName": "Cody: AI Coding Assistant with Autocomplete & Chat",
-  "version": "1.40.1",
+  "version": "1.40.2",
   "publisher": "sourcegraph",
   "license": "Apache-2.0",
   "icon": "resources/cody.png",


### PR DESCRIPTION
Patch release from the `v1.40.x` branch, see https://github.com/sourcegraph/cody/commits/vscode-v1.40.x/ for details

## Test plan
N/A
<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
