### PR TITLE
VS Code: Release v1.40.2

### DIFF
--- a/agent/src/AgentWorkspaceConfiguration.ts
+++ b/agent/src/AgentWorkspaceConfiguration.ts
@@ -13,61 +13,7 @@ export class AgentWorkspaceConfiguration implements vscode.WorkspaceConfiguratio
         private clientInfo: () => ClientInfo | undefined,
         private extensionConfig: () => ExtensionConfiguration | undefined,
         private dictionary: any = {}
-    ) {
-        const config = this.extensionConfig()
-        const capabilities = this.clientInfo()?.capabilities
-
-        this.put('editor.insertSpaces', true)
-        this.put('cody', {
-            advanced: {
-                agent: {
-                    'capabilities.storage':
-                        capabilities?.globalState === 'server-managed' ||
-                        capabilities?.globalState === 'client-managed',
-                    'extension.version': this.clientInfo()?.version,
-                    ide: {
-                        name: AgentWorkspaceConfiguration.clientNameToIDE(this.clientInfo()?.name ?? ''),
-                        version: this.clientInfo()?.ideVersion,
-                    },
-                    running: true,
-                },
-                hasNativeWebview: capabilities?.webview === 'native' ?? false,
-            },
-            autocomplete: {
-                advanced: {
-                    model: config?.autocompleteAdvancedModel ?? null,
-                    provider: config?.autocompleteAdvancedProvider ?? null,
-                },
-                enabled: true,
-            },
-            codebase: config?.codebase,
-            customHeaders: config?.customHeaders,
-            'debug.verbose': config?.verboseDebug ?? false,
-            'experimental.tracing': config?.verboseDebug ?? false,
-            serverEndpoint: config?.serverEndpoint,
-            // Use the dedicated `telemetry/recordEvent` to send telemetry from
-            // agent clients.  The reason we disable telemetry via config is
-            // that we don't want to submit vscode-specific events when
-            // running inside the agent.
-            telemetry: {
-                clientName: config?.telemetryClientName,
-                level: 'agent',
-            },
-        })
-
-        const fromCustomConfigurationJson = config?.customConfigurationJson
-        if (fromCustomConfigurationJson) {
-            const configJson = JSON.parse(fromCustomConfigurationJson)
-            _.merge(this.dictionary, this.normalize(configJson))
-        }
-
-        const customConfiguration = config?.customConfiguration
-        if (customConfiguration) {
-            for (const key of Object.keys(customConfiguration)) {
-                this.put(key, customConfiguration[key])
-            }
-        }
-    }
+    ) {}
 
     public withPrefix(prefix: string): AgentWorkspaceConfiguration {
         return new AgentWorkspaceConfiguration(
@@ -78,30 +24,8 @@ export class AgentWorkspaceConfiguration implements vscode.WorkspaceConfiguratio
         )
     }
 
-    private normalize(cfg: any): any {
-        if (cfg && typeof cfg === 'object') {
-            if (Array.isArray(cfg)) {
-                const normalized = []
-                for (const value of Object.values(cfg)) {
-                    normalized.push(this.normalize(value))
-                }
-                return normalized
-            }
-
-            const normalized = {}
-            for (const key of Object.keys(cfg)) {
-                const tmp = {}
-                _.set(tmp, key, this.normalize(cfg[key]))
-                _.merge(normalized, tmp)
-            }
-            return normalized
-        }
-
-        return cfg
-    }
-
     private put(key: string, value: any): void {
-        _.set(this.dictionary, key, this.normalize(value))
+        _.set(this.dictionary, key, value)
     }
 
     private actualSection(section: string): string {
@@ -136,10 +60,89 @@ export class AgentWorkspaceConfiguration implements vscode.WorkspaceConfiguratio
 
     public get(userSection: string, defaultValue?: unknown): any {
         const section = this.actualSection(userSection)
+
+        const config = this.extensionConfig()
+        const capabilities = this.clientInfo()?.capabilities
+        const baseConfig = {
+            editor: {
+                insertSpaces: true,
+            },
+            cody: {
+                advanced: {
+                    agent: {
+                        capabilities: {
+                            storage:
+                                capabilities?.globalState === 'server-managed' ||
+                                capabilities?.globalState === 'client-managed',
+                        },
+                        extension: {
+                            version: this.clientInfo()?.version,
+                        },
+                        ide: {
+                            name: AgentWorkspaceConfiguration.clientNameToIDE(
+                                this.clientInfo()?.name ?? ''
+                            ),
+                            version: this.clientInfo()?.ideVersion,
+                        },
+                        running: true,
+                    },
+                    hasNativeWebview: capabilities?.webview === 'native',
+                },
+                autocomplete: {
+                    advanced: {
+                        model: config?.autocompleteAdvancedModel ?? null,
+                        provider: config?.autocompleteAdvancedProvider ?? null,
+                    },
+                    enabled: true,
+                },
+                codebase: config?.codebase,
+                customHeaders: config?.customHeaders,
+                debug: { verbose: config?.verboseDebug ?? false },
+                experimental: { tracing: config?.verboseDebug ?? false },
+                serverEndpoint: config?.serverEndpoint,
+                // Use the dedicated `telemetry/recordEvent` to send telemetry from
+                // agent clients.  The reason we disable telemetry via config is
+                // that we don't want to submit vscode-specific events when
+                // running inside the agent.
+                telemetry: {
+                    clientName: config?.telemetryClientName,
+                    level: 'agent',
+                },
+            },
+        }
+
+        const customConfiguration = config?.customConfiguration
+        if (customConfiguration) {
+            for (const [key, value] of Object.entries(customConfiguration)) {
+                _.set(baseConfig, key, value)
+            }
+        }
+
+        const fromCustomConfigurationJson = config?.customConfigurationJson
+        if (fromCustomConfigurationJson) {
+            const configJson = JSON.parse(fromCustomConfigurationJson)
+            for (const [key, value] of Object.entries(configJson)) {
+                _.set(baseConfig, key, value)
+            }
+        }
+
+        const fromBaseConfig = _.get(baseConfig, section)
         const fromDict = _.get(this.dictionary, section)
+        if (
+            typeof fromBaseConfig === 'object' &&
+            typeof fromDict === 'object' &&
+            !Array.isArray(fromBaseConfig) &&
+            !Array.isArray(fromDict)
+        ) {
+            return structuredClone(_.extend(fromBaseConfig, fromDict))
+        }
         if (fromDict !== undefined) {
             return structuredClone(fromDict)
         }
+        if (fromBaseConfig !== undefined) {
+            return fromBaseConfig
+        }
+
         return defaultConfigurationValue(section) ?? defaultValue
     }
 


### PR DESCRIPTION
Cherry picking #6041 to pass unit test

… (#6041)

VSCode's configuration setting parsing will split dotted names where they appear at the top level. Retrieving will walk nested property names concatenated by a dot ...but not dotted property names.

See the unit tests for details.

## Test plan

```
pnpm -C agent test
```

---------


## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
