### PR TITLE
Context: make error message more concise

### DIFF
--- a/vscode/src/chat/chat-view/ChatController.ts
+++ b/vscode/src/chat/chat-view/ChatController.ts
@@ -1048,7 +1048,7 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
         const [priorityContext, retrievedContext, openCtxContext] = await Promise.all([
             priorityContextPromise,
             retrievedContextPromise.catch(e => {
-                this.postError(new Error(`Error retrieving context, no search context was used: ${e}`))
+                this.postError(new Error(`Failed to retrieve search context: ${e}`))
                 return []
             }),
             openCtxContextPromise,


### PR DESCRIPTION
Tiny change to streamline the context error message.

Relates to [SPLF-667](https://linear.app/sourcegraph/issue/SPLF-667)

## Test plan

N/A

