### PR TITLE
Autocomplete: add characters logger metadata to `accepted` events

### DIFF
--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/agent/protocol_generated/WorkspaceEditEntryMetadata.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/agent/protocol_generated/WorkspaceEditEntryMetadata.kt
@@ -5,6 +5,6 @@ data class WorkspaceEditEntryMetadata(
   val needsConfirmation: Boolean,
   val label: String,
   val description: String? = null,
-  val iconPath: Uri,
+  val iconPath: Uri? = null,
 )
 

--- a/vscode/src/completions/analytics-logger.test.ts
+++ b/vscode/src/completions/analytics-logger.test.ts
@@ -80,7 +80,14 @@ describe('analytics-logger', () => {
             document,
             position,
         })
-        CompletionAnalyticsLogger.accepted(id, document, item, range(0, 0, 0, 0), false)
+        CompletionAnalyticsLogger.accepted({
+            id,
+            document,
+            completion: item,
+            trackedRange: range(0, 0, 0, 0),
+            isDotComUser: false,
+            position,
+        })
 
         expect(recordSpy).toHaveBeenCalledWith('cody.completion', 'suggested', {
             version: 0,
@@ -139,7 +146,14 @@ describe('analytics-logger', () => {
             document,
             position,
         })
-        CompletionAnalyticsLogger.accepted(id2, document, item, range(0, 0, 0, 0), false)
+        CompletionAnalyticsLogger.accepted({
+            id: id2,
+            document,
+            completion: item,
+            trackedRange: range(0, 0, 0, 0),
+            isDotComUser: false,
+            position,
+        })
 
         const loggerItem2 = CompletionAnalyticsLogger.getCompletionEvent(id2)
         expect(loggerItem2?.params.id).toBe(completionId)

--- a/vscode/src/completions/get-inline-completions-tests/analytics.test.ts
+++ b/vscode/src/completions/get-inline-completions-tests/analytics.test.ts
@@ -1,14 +1,21 @@
 import omit from 'lodash/omit'
+import pick from 'lodash/pick'
+import { Response } from 'node-fetch'
 import * as uuid from 'uuid'
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
 
+import {
+    AUTH_STATUS_FIXTURE_AUTHED,
+    AUTH_STATUS_FIXTURE_AUTHED_DOTCOM,
+    telemetryRecorder,
+} from '@sourcegraph/cody-shared'
+
+import type { CodeGenEventMetadata } from '../../services/CharactersLogger'
 import { resetParsersCache } from '../../tree-sitter/parser'
 import * as CompletionAnalyticsLogger from '../analytics-logger'
 import type { CompletionBookkeepingEvent } from '../analytics-logger'
 import { initTreeSitterParser } from '../test-helpers'
 
-import { AUTH_STATUS_FIXTURE_AUTHED, AUTH_STATUS_FIXTURE_AUTHED_DOTCOM } from '@sourcegraph/cody-shared'
-import { Response } from 'node-fetch'
 import { getInlineCompletions, params } from './helpers'
 
 describe('[getInlineCompletions] completion event', () => {
@@ -36,36 +43,44 @@ describe('[getInlineCompletions] completion event', () => {
             },
         })
 
-        await getInlineCompletions(
-            params(
-                code,
-                [
-                    {
-                        completionResponse: {
-                            completion,
-                            stopReason: 'unit-test',
-                        },
-                        metadata: {
-                            response,
-                        },
-                    },
-                ],
+        const generateParams = params(
+            code,
+            [
                 {
-                    configuration: {
-                        configuration: {
-                            autocompleteAdvancedProvider: 'fireworks',
-                        },
+                    completionResponse: {
+                        completion,
+                        stopReason: 'unit-test',
                     },
-                    authStatus: additionalParams.isDotComUser
-                        ? AUTH_STATUS_FIXTURE_AUTHED_DOTCOM
-                        : AUTH_STATUS_FIXTURE_AUTHED,
-                }
-            )
+                    metadata: {
+                        response,
+                    },
+                },
+            ],
+            {
+                configuration: {
+                    configuration: {
+                        autocompleteAdvancedProvider: 'fireworks',
+                    },
+                },
+                authStatus: additionalParams.isDotComUser
+                    ? AUTH_STATUS_FIXTURE_AUTHED_DOTCOM
+                    : AUTH_STATUS_FIXTURE_AUTHED,
+            }
         )
+        const completionResponse = await getInlineCompletions(generateParams)
 
         // Get `suggestionId` from `CompletionAnalyticsLogger.loaded` call.
         const suggestionId: CompletionAnalyticsLogger.CompletionLogID = spy.mock.calls[0][0].logId
         const completionEvent = CompletionAnalyticsLogger.getCompletionEvent(suggestionId)!
+
+        CompletionAnalyticsLogger.accepted({
+            id: suggestionId,
+            document: generateParams.document,
+            completion: completionResponse!.items[0],
+            trackedRange: undefined,
+            isDotComUser: true,
+            position: generateParams.position,
+        })
 
         return completionEvent
     }
@@ -249,6 +264,44 @@ describe('[getInlineCompletions] completion event', () => {
         it('does not log `inlineCompletionItemContext` for enterprise users', async () => {
             const event = await getAnalyticsEvent('function foo() {\n  return█}', '"foo"')
             expect(event.params?.inlineCompletionItemContext).toBeUndefined()
+        })
+    })
+
+    describe('fills all the expected fields on `CompletionAnalyticsLogger.accepted` call', async () => {
+        it('add character logger metadata to `accepted` events', async () => {
+            const recordEventSpy = vi.spyOn(telemetryRecorder, 'recordEvent')
+
+            await getAnalyticsEvent('function foo() {\n  return█}', '"foo"')
+
+            const [feature, action, event] = recordEventSpy.mock.calls.find(
+                callArguments => callArguments[1] === 'accepted'
+            )! as [string, string, Record<string, unknown>]
+
+            expect(feature).toBe('cody.completion')
+            expect(action).toBe('accepted')
+            expect(event.metadata).toMatchObject({})
+
+            const characterLoggerMetadata = pick(event.metadata, [
+                'isDisjoint',
+                'isFullyOutsideOfVisibleRanges',
+                'isPartiallyOutsideOfVisibleRanges',
+                'isSelectionStale',
+                'noActiveTextEditor',
+                'outsideOfActiveEditor',
+                'windowNotFocused',
+            ] satisfies (keyof CodeGenEventMetadata)[])
+
+            expect(characterLoggerMetadata).toMatchInlineSnapshot(`
+              {
+                "isDisjoint": 0,
+                "isFullyOutsideOfVisibleRanges": 1,
+                "isPartiallyOutsideOfVisibleRanges": 1,
+                "isSelectionStale": 1,
+                "noActiveTextEditor": 0,
+                "outsideOfActiveEditor": 1,
+                "windowNotFocused": 1,
+              }
+            `)
         })
     })
 })

--- a/vscode/src/completions/inline-completion-item-provider.ts
+++ b/vscode/src/completions/inline-completion-item-provider.ts
@@ -678,13 +678,14 @@ export class InlineCompletionItemProvider
 
         this.lastAcceptedCompletionItem = completion
 
-        CompletionAnalyticsLogger.accepted(
-            completion.logId,
-            completion.requestParams.document,
-            completion.analyticsItem,
-            completion.trackedRange,
-            this.isDotComUser
-        )
+        CompletionAnalyticsLogger.accepted({
+            id: completion.logId,
+            document: completion.requestParams.document,
+            completion: completion.analyticsItem,
+            trackedRange: completion.trackedRange,
+            isDotComUser: this.isDotComUser,
+            position: completion.requestParams.position,
+        })
     }
 
     /**

--- a/vscode/src/services/CharactersLogger.ts
+++ b/vscode/src/services/CharactersLogger.ts
@@ -87,6 +87,18 @@ interface ChangeEventMetadata {
     charsDeleted: number
 }
 
+export interface CodeGenEventMetadata {
+    isSelectionStale: number
+    isDisjoint: number
+    isPartiallyOutsideOfVisibleRanges: number
+    isFullyOutsideOfVisibleRanges: number
+    windowNotFocused: number
+    noActiveTextEditor: number
+    outsideOfActiveEditor: number
+    charsInserted: number
+    charsDeleted: number
+}
+
 export class CharactersLogger implements vscode.Disposable {
     private disposables: vscode.Disposable[] = []
     private changeCounters: CharacterLoggerCounters = { ...DEFAULT_COUNTERS }
@@ -321,17 +333,9 @@ export class CharactersLogger implements vscode.Disposable {
         }
     }
 
-    public getChangeEventMetadataForCodyCodeGenEvents(event: Partial<vscode.TextDocumentChangeEvent>): {
-        isSelectionStale: number
-        isDisjoint: number
-        isPartiallyOutsideOfVisibleRanges: number
-        isFullyOutsideOfVisibleRanges: number
-        windowNotFocused: number
-        noActiveTextEditor: number
-        outsideOfActiveEditor: number
-        charsInserted: number
-        charsDeleted: number
-    } {
+    public getChangeEventMetadataForCodyCodeGenEvents(
+        event: Partial<vscode.TextDocumentChangeEvent>
+    ): CodeGenEventMetadata {
         const rawMetadata = omit(this.getChangeEventMetadata(event), [
             'changeSize',
             'isRedo',


### PR DESCRIPTION
- Enhances `cody.completion:accepted` events by adding boolean fields to improve PCW tracking and avoid double-counting Cody's contributions. The updated logic now leverages the `CharactersLogger` logic for classifying document changes. 
    - For example, when the accepted completion produces a change partially outside of visible ranges, it is flagged by both the autocomplete logic and `CharactersLogger` telemetry. This ensures that partially-visible changes, previously excluded due to non-manual nature, can now be accurately counted in PCW calculations because they are flagged accordingly.
- Part of [CODY-4197: Add metadata to Cody code-gen analytics events to prevent double-counting](https://linear.app/sourcegraph/issue/CODY-4197/add-metadata-to-cody-code-gen-analytics-events-to-prevent-double). See more context and related discussion there.
- Closes [CODY-4197: Add metadata to Cody code-gen analytics events to prevent double-counting](https://linear.app/sourcegraph/issue/CODY-4197/add-metadata-to-cody-code-gen-analytics-events-to-prevent-double)
- Closes [CODY-4198: Add char-counts metadata to autocomplete events](https://linear.app/sourcegraph/issue/CODY-4198/add-char-counts-metadata-to-autocomplete-events)

## Test plan

CI + updated unit tests. 
