### PR TITLE
Improve Cody logging agent protocol

### DIFF
--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/agent/protocol_generated/Constants.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/agent/protocol_generated/Constants.kt
@@ -24,6 +24,7 @@ object Constants {
   const val `class` = "class"
   const val `client-managed` = "client-managed"
   const val `create-file` = "create-file"
+  const val debug = "debug"
   const val default = "default"
   const val delete = "delete"
   const val `delete-file` = "delete-file"
@@ -84,6 +85,7 @@ object Constants {
   const val symbol = "symbol"
   const val system = "system"
   const val terminal = "terminal"
+  const val trace = "trace"
   const val tree = "tree"
   const val `tree-sitter` = "tree-sitter"
   const val unauthenticated = "unauthenticated"
@@ -92,6 +94,7 @@ object Constants {
   const val user = "user"
   const val vision = "vision"
   const val waitlist = "waitlist"
+  const val warn = "warn"
   const val warning = "warning"
   const val workspace = "workspace"
 }

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/agent/protocol_generated/DebugMessage.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/agent/protocol_generated/DebugMessage.kt
@@ -4,5 +4,6 @@ package com.sourcegraph.cody.agent.protocol_generated;
 data class DebugMessage(
   val channel: String,
   val message: String,
+  val level: DebugMessageLogLevel? = null, // Oneof: trace, debug, info, warn, error
 )
 

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/agent/protocol_generated/DebugMessageLogLevel.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/agent/protocol_generated/DebugMessageLogLevel.kt
@@ -1,0 +1,5 @@
+@file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
+package com.sourcegraph.cody.agent.protocol_generated;
+
+typealias DebugMessageLogLevel = String // One of: trace, debug, info, warn, error
+

--- a/agent/src/agent.ts
+++ b/agent/src/agent.ts
@@ -308,7 +308,7 @@ export class Agent extends MessageHandler implements ExtensionClient {
             this.notify('debug/message', {
                 channel: 'Document Sync Check',
                 message: panicMessage + '\n' + message,
-                level: 'error'
+                level: 'error',
             })
         },
         edit: (uri, callback, options) => {

--- a/agent/src/agent.ts
+++ b/agent/src/agent.ts
@@ -308,6 +308,7 @@ export class Agent extends MessageHandler implements ExtensionClient {
             this.notify('debug/message', {
                 channel: 'Document Sync Check',
                 message: panicMessage + '\n' + message,
+                level: 'error'
             })
         },
         edit: (uri, callback, options) => {

--- a/agent/src/vscode-shim.ts
+++ b/agent/src/vscode-shim.ts
@@ -53,7 +53,7 @@ import { AgentTabGroups } from './AgentTabGroups'
 import { AgentWorkspaceConfiguration } from './AgentWorkspaceConfiguration'
 import type { Agent } from './agent'
 import { matchesGlobPatterns } from './cli/command-bench/matchesGlobPatterns'
-import type { ClientInfo, ExtensionConfiguration } from './protocol-alias'
+import {ClientInfo, DebugMessageLogLevel, ExtensionConfiguration} from './protocol-alias'
 
 // Not using CODY_TESTING because it changes the URL endpoint we send requests
 // to and we want to send requests to sourcegraph.com because we record the HTTP
@@ -530,32 +530,27 @@ export namespace UriString {
 }
 
 function outputChannel(name: string): vscode.LogOutputChannel {
+    function notifyAgent(level: DebugMessageLogLevel, message: string, ...args: any[]): void {
+        if (agent) {
+            const formattedMessage = args.length ? String(message).replace(/{(\d+)}/g, (match, num) => args[num]?.toString() ?? match) : message
+            agent.notify('debug/message', { channel: name, message: formattedMessage, level })
+
+        }
+    }
     return {
         name,
-        append: message => {
-            if (agent) {
-                agent.notify('debug/message', { channel: name, message })
-            }
-        },
-        appendLine: message => {
-            if (agent) {
-                agent.notify('debug/message', { channel: name, message })
-            }
-        },
-        replace: message => {
-            if (agent) {
-                agent.notify('debug/message', { channel: name, message })
-            }
-        },
+        append: message => { notifyAgent('info', message) },
+        appendLine: message => { notifyAgent('trace', message) },
+        replace: message => { notifyAgent('trace', message) },
         clear: () => {},
         show: () => {},
         hide: () => {},
         dispose: () => {},
-        trace: () => {},
-        debug: () => {},
-        info: () => {},
-        warn: () => {},
-        error: () => {},
+        trace: (message: string, ...args: any[]) => { notifyAgent('trace', message, args) },
+        debug: (message: string, ...args: any[]) => { notifyAgent('debug', message, args) },
+        info: (message: string, ...args: any[]) => { notifyAgent('info', message, args) },
+        warn: (message: string, ...args: any[]) => { notifyAgent('warn', message, args) },
+        error: (message: string, ...args: any[]) => { notifyAgent('error', message, args) },
         logLevel: LogLevel.Trace,
         onDidChangeLogLevel: emptyEvent(),
     }

--- a/agent/src/vscode-shim.ts
+++ b/agent/src/vscode-shim.ts
@@ -53,7 +53,7 @@ import { AgentTabGroups } from './AgentTabGroups'
 import { AgentWorkspaceConfiguration } from './AgentWorkspaceConfiguration'
 import type { Agent } from './agent'
 import { matchesGlobPatterns } from './cli/command-bench/matchesGlobPatterns'
-import {ClientInfo, DebugMessageLogLevel, ExtensionConfiguration} from './protocol-alias'
+import type { ClientInfo, DebugMessageLogLevel, ExtensionConfiguration } from './protocol-alias'
 
 // Not using CODY_TESTING because it changes the URL endpoint we send requests
 // to and we want to send requests to sourcegraph.com because we record the HTTP
@@ -532,25 +532,42 @@ export namespace UriString {
 function outputChannel(name: string): vscode.LogOutputChannel {
     function notifyAgent(level: DebugMessageLogLevel, message: string, ...args: any[]): void {
         if (agent) {
-            const formattedMessage = args.length ? String(message).replace(/{(\d+)}/g, (match, num) => args[num]?.toString() ?? match) : message
+            const formattedMessage = args.length
+                ? String(message).replace(/{(\d+)}/g, (match, num) => args[num]?.toString() ?? match)
+                : message
             agent.notify('debug/message', { channel: name, message: formattedMessage, level })
-
         }
     }
     return {
         name,
-        append: message => { notifyAgent('info', message) },
-        appendLine: message => { notifyAgent('trace', message) },
-        replace: message => { notifyAgent('trace', message) },
+        append: message => {
+            notifyAgent('info', message)
+        },
+        appendLine: message => {
+            notifyAgent('trace', message)
+        },
+        replace: message => {
+            notifyAgent('trace', message)
+        },
         clear: () => {},
         show: () => {},
         hide: () => {},
         dispose: () => {},
-        trace: (message: string, ...args: any[]) => { notifyAgent('trace', message, args) },
-        debug: (message: string, ...args: any[]) => { notifyAgent('debug', message, args) },
-        info: (message: string, ...args: any[]) => { notifyAgent('info', message, args) },
-        warn: (message: string, ...args: any[]) => { notifyAgent('warn', message, args) },
-        error: (message: string, ...args: any[]) => { notifyAgent('error', message, args) },
+        trace: (message: string, ...args: any[]) => {
+            notifyAgent('trace', message, args)
+        },
+        debug: (message: string, ...args: any[]) => {
+            notifyAgent('debug', message, args)
+        },
+        info: (message: string, ...args: any[]) => {
+            notifyAgent('info', message, args)
+        },
+        warn: (message: string, ...args: any[]) => {
+            notifyAgent('warn', message, args)
+        },
+        error: (message: string, ...args: any[]) => {
+            notifyAgent('error', message, args)
+        },
         logLevel: LogLevel.Trace,
         onDidChangeLogLevel: emptyEvent(),
     }

--- a/vscode/src/jsonrpc/agent-protocol.ts
+++ b/vscode/src/jsonrpc/agent-protocol.ts
@@ -767,9 +767,12 @@ interface ExecuteCommandParams {
     arguments?: any[] | undefined | null
 }
 
+export type DebugMessageLogLevel = 'trace' | 'debug' | 'info' | 'warn' | 'error'
+
 export interface DebugMessage {
     channel: string
     message: string
+    level?: DebugMessageLogLevel | undefined | null
 }
 
 export interface ProgressStartParams {


### PR DESCRIPTION
## Changes

Fixes logging capability in agent.
Previously messages logged to output channel were visible only if added using `append` or `appendLine`.
Now `trace` / `debug` / `info` / `warn` / `error` functions are also logged properly.

## Test plan

As in https://github.com/sourcegraph/jetbrains/pull/2583