### PR TITLE
fix: rewrite symf query only once

### DIFF
--- a/vscode/src/external-services.ts
+++ b/vscode/src/external-services.ts
@@ -42,7 +42,7 @@ export async function configureExternalServices(
 
     const completionsClient = platform.createCompletionsClient(autocompleteLifecycleOutputChannelLogger)
 
-    const symfRunner = platform.createSymfRunner?.(context, completionsClient)
+    const symfRunner = platform.createSymfRunner?.(context)
     if (symfRunner) disposables.push(symfRunner)
 
     const chatClient = new ChatClient(completionsClient)


### PR DESCRIPTION
- Removes unnecessary rewriting of symf query in `SymfRunner`
- Simplifies `SymfRunner` by removing the `completionsClient` parameter, as it is no longer needed for rewriting the query
- This change ensures that the symf query is only rewritten once, improving performance

BREAKING CHANGE: `SymfRunner` constructor no longer accepts `completionsClient` parameter

## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

1. Sign in to dot com using the build on this branch
2. At mention the codebase and ask a question
3. Check the output channel to confirm the query was rewritten only once
4. Before: the query was rewritten twice 

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
