### PR TITLE
fix recent edits context source

### DIFF
--- a/vscode/src/completions/context/retrievers/recent-user-actions/recent-edits-retriever.test.ts
+++ b/vscode/src/completions/context/retrievers/recent-user-actions/recent-edits-retriever.test.ts
@@ -15,6 +15,7 @@ describe('RecentEditsRetriever', () => {
     let onDidChangeTextDocument: (event: vscode.TextDocumentChangeEvent) => void
     let onDidRenameFiles: (event: vscode.FileRenameEvent) => void
     let onDidDeleteFiles: (event: vscode.FileDeleteEvent) => void
+    let onDidOpenTextDocument: (event: vscode.TextDocument) => void
 
     beforeEach(() => {
         vi.useFakeTimers()
@@ -36,6 +37,10 @@ describe('RecentEditsRetriever', () => {
                 },
                 onDidDeleteFiles(listener) {
                     onDidDeleteFiles = listener
+                    return { dispose: () => {} }
+                },
+                onDidOpenTextDocument(listener) {
+                    onDidOpenTextDocument = listener
                     return { dispose: () => {} }
                 },
             }
@@ -100,6 +105,8 @@ describe('RecentEditsRetriever', () => {
         `)
 
         it('tracks document changes and creates a git diff', async () => {
+            onDidOpenTextDocument(testDocument)
+
             replaceFooLogWithNumber(testDocument)
 
             deleteBarLog(testDocument)
@@ -125,6 +132,9 @@ describe('RecentEditsRetriever', () => {
 
         it('no-ops for blocked files due to the context filter', async () => {
             vi.spyOn(contextFiltersProvider, 'isUriIgnored').mockResolvedValueOnce('repo:foo')
+
+            onDidOpenTextDocument(testDocument)
+
             replaceFooLogWithNumber(testDocument)
 
             deleteBarLog(testDocument)
@@ -135,6 +145,8 @@ describe('RecentEditsRetriever', () => {
         })
 
         it('does not yield changes that are older than the configured timeout', async () => {
+            onDidOpenTextDocument(testDocument)
+
             replaceFooLogWithNumber(testDocument)
 
             vi.advanceTimersByTime(3 * 60 * 1000)
@@ -159,6 +171,8 @@ describe('RecentEditsRetriever', () => {
         })
 
         it('handles renames', async () => {
+            onDidOpenTextDocument(testDocument)
+
             replaceFooLogWithNumber(testDocument)
 
             vi.advanceTimersByTime(3 * 60 * 1000)
@@ -194,8 +208,12 @@ describe('RecentEditsRetriever', () => {
         })
 
         it('handles deletions', async () => {
+            onDidOpenTextDocument(testDocument)
+
             replaceFooLogWithNumber(testDocument)
+
             onDidDeleteFiles({ files: [testDocument.uri] })
+
             expect(await retriever.getDiff(testDocument.uri)).toBe(null)
         })
     })

--- a/vscode/src/completions/context/retrievers/recent-user-actions/recent-edits-retriever.ts
+++ b/vscode/src/completions/context/retrievers/recent-user-actions/recent-edits-retriever.ts
@@ -43,6 +43,7 @@ export class RecentEditsRetriever implements vscode.Disposable, ContextRetriever
     ) {
         this.maxAgeMs = options.maxAgeMs
         this.addLineNumbersForDiff = options.addLineNumbersForDiff ?? false
+        // Track the already open documents when editor was opened
         for (const document of vscode.workspace.textDocuments) {
             this.trackDocument(document)
         }

--- a/vscode/src/supercompletions/supercompletion-provider.ts
+++ b/vscode/src/supercompletions/supercompletion-provider.ts
@@ -23,7 +23,7 @@ export class SupercompletionProvider implements vscode.Disposable {
         },
         readonly workspace: Pick<
             typeof vscode.workspace,
-            'onDidChangeTextDocument' | 'onDidRenameFiles' | 'onDidDeleteFiles'
+            'onDidChangeTextDocument' | 'onDidRenameFiles' | 'onDidDeleteFiles' | 'onDidOpenTextDocument'
         > = vscode.workspace
     ) {
         this.renderer = new SupercompletionRenderer()


### PR DESCRIPTION
## Context
1. Recent edits context source outputs wrong diffs sometimes. The behaviour is not reproducible always, but can be seen from the output logs. Adding one such example in below:
<img width="1442" alt="image" src="https://github.com/user-attachments/assets/d36c8601-3a8e-42f4-a5e8-c3276a6e9e35">

2. On further inspection, it turns out that sometimes when events are received `private onDidChangeTextDocument` the text document could have changed, and reading `document.getText()` returns change with the updated text (i.e. including the change we received). Although this behaviour is not always reproducible. So, this PR reads the text document during the constructor call or when the document is first opened.

## Test plan
Manual inspection
