### PR TITLE
Autocomplete: remove the extended language pool option

### DIFF
--- a/lib/shared/src/experimentation/FeatureFlagProvider.ts
+++ b/lib/shared/src/experimentation/FeatureFlagProvider.ts
@@ -54,10 +54,6 @@ export enum FeatureFlag {
     CodyAutocompleteContextExperimentVariant4 = 'cody-autocomplete-context-experiment-variant-4',
     CodyAutocompleteContextExperimentControl = 'cody-autocomplete-context-experiment-control',
 
-    // When enabled, it will extend the number of languages considered for context (e.g. React files
-    // will be able to use CSS files as context).
-    CodyAutocompleteContextExtendLanguagePool = 'cody-autocomplete-context-extend-language-pool',
-
     // use-ssc-for-cody-subscription is a feature flag that enables the use of SSC as the source of truth for Cody subscription data.
     UseSscForCodySubscription = 'use-ssc-for-cody-subscription',
 

--- a/vscode/src/completions/context/retrievers/jaccard-similarity/history.ts
+++ b/vscode/src/completions/context/retrievers/jaccard-similarity/history.ts
@@ -1,5 +1,5 @@
-import { FeatureFlag, featureFlagProvider, subscriptionDisposable } from '@sourcegraph/cody-shared'
 import * as vscode from 'vscode'
+
 import { type ShouldUseContextParams, shouldBeUsedAsContext } from '../../utils'
 
 interface HistoryItem {
@@ -18,7 +18,6 @@ export class VSCodeDocumentHistory implements DocumentHistory, vscode.Disposable
     private history: HistoryItem[]
 
     private subscriptions: vscode.Disposable[] = []
-    public enableExtendedLanguagePool = false
 
     constructor(
         register: () => vscode.Disposable | null = () =>
@@ -38,16 +37,6 @@ export class VSCodeDocumentHistory implements DocumentHistory, vscode.Disposable
                 this.subscriptions.push(disposable)
             }
         }
-
-        this.subscriptions.push(
-            subscriptionDisposable(
-                featureFlagProvider
-                    .evaluatedFeatureFlag(FeatureFlag.CodyAutocompleteContextExtendLanguagePool)
-                    .subscribe(resolvedFlag => {
-                        this.enableExtendedLanguagePool = Boolean(resolvedFlag)
-                    })
-            )
-        )
     }
 
     public dispose(): void {
@@ -85,7 +74,6 @@ export class VSCodeDocumentHistory implements DocumentHistory, vscode.Disposable
                 continue
             }
             const params: ShouldUseContextParams = {
-                enableExtendedLanguagePool: this.enableExtendedLanguagePool,
                 baseLanguageId: baseLanguageId,
                 languageId: item.document.languageId,
             }

--- a/vscode/src/completions/context/retrievers/jaccard-similarity/jaccard-similarity-retriever.ts
+++ b/vscode/src/completions/context/retrievers/jaccard-similarity/jaccard-similarity-retriever.ts
@@ -1,15 +1,16 @@
 import * as vscode from 'vscode'
 import type { URI } from 'vscode-uri'
 
-import { getContextRange } from '../../../doc-context-getters'
-import type { ContextRetriever, ContextRetrieverOptions } from '../../../types'
-import { type DocumentHistory, VSCodeDocumentHistory } from './history'
-
 import { isDefined } from '@sourcegraph/cody-shared'
+
+import { getContextRange } from '../../../doc-context-getters'
 import { lastNLines } from '../../../text-processing'
+import type { ContextRetriever, ContextRetrieverOptions } from '../../../types'
 import { RetrieverIdentifier, type ShouldUseContextParams, shouldBeUsedAsContext } from '../../utils'
 import { type CachedRerieverOptions, CachedRetriever } from '../cached-retriever'
+
 import { type JaccardMatch, bestJaccardMatches } from './bestJaccardMatch'
+import { type DocumentHistory, VSCodeDocumentHistory } from './history'
 
 /**
  * The size of the Jaccard distance match window in number of lines. It determines how many
@@ -125,7 +126,6 @@ export class JaccardSimilarityRetriever extends CachedRetriever implements Conte
         const files: FileContents[] = []
 
         const curLang = currentDocument.languageId
-        const { enableExtendedLanguagePool } = this.history
 
         function addDocument(document: vscode.TextDocument): void {
             // Only add files and VSCode user settings.
@@ -133,7 +133,6 @@ export class JaccardSimilarityRetriever extends CachedRetriever implements Conte
                 return
             }
             const params: ShouldUseContextParams = {
-                enableExtendedLanguagePool,
                 baseLanguageId: curLang,
                 languageId: document.languageId,
             }

--- a/vscode/src/completions/context/retrievers/recent-user-actions/recent-edits-retriever.ts
+++ b/vscode/src/completions/context/retrievers/recent-user-actions/recent-edits-retriever.ts
@@ -102,7 +102,6 @@ export class RecentEditsRetriever implements vscode.Disposable, ContextRetriever
         for (const diff of allDiffs) {
             const currentDocumentLanguageId = document.languageId
             const params: ShouldUseContextParams = {
-                enableExtendedLanguagePool: false,
                 baseLanguageId: currentDocumentLanguageId,
                 languageId: diff.languageId,
             }

--- a/vscode/src/completions/context/retrievers/recent-user-actions/recent-view-port.ts
+++ b/vscode/src/completions/context/retrievers/recent-user-actions/recent-view-port.ts
@@ -72,7 +72,6 @@ export class RecentViewPortRetriever implements vscode.Disposable, ContextRetrie
             .filter(viewport => viewport.uri.toString() !== currentFileUri)
             .filter(viewport => {
                 const params: ShouldUseContextParams = {
-                    enableExtendedLanguagePool: false,
                     baseLanguageId: currentLanguageId,
                     languageId: viewport.languageId,
                 }

--- a/vscode/src/completions/context/utils.test.ts
+++ b/vscode/src/completions/context/utils.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest'
+
 import { shouldBeUsedAsContext } from './utils'
 
 describe('shouldBeUsedAsContext', () => {
@@ -6,7 +7,6 @@ describe('shouldBeUsedAsContext', () => {
         it('returns true for the same language', () => {
             expect(
                 shouldBeUsedAsContext({
-                    enableExtendedLanguagePool: false,
                     baseLanguageId: 'javascript',
                     languageId: 'javascript',
                 })
@@ -16,14 +16,12 @@ describe('shouldBeUsedAsContext', () => {
         it('allows js as context for jsx and vice versa', () => {
             expect(
                 shouldBeUsedAsContext({
-                    enableExtendedLanguagePool: false,
                     baseLanguageId: 'javascript',
                     languageId: 'javascriptreact',
                 })
             ).toBe(true)
             expect(
                 shouldBeUsedAsContext({
-                    enableExtendedLanguagePool: false,
                     baseLanguageId: 'javascriptreact',
                     languageId: 'javascript',
                 })
@@ -33,66 +31,14 @@ describe('shouldBeUsedAsContext', () => {
         it('allows ts as context for tsx and vice versa', () => {
             expect(
                 shouldBeUsedAsContext({
-                    enableExtendedLanguagePool: false,
                     baseLanguageId: 'typescript',
                     languageId: 'typescriptreact',
                 })
             ).toBe(true)
             expect(
                 shouldBeUsedAsContext({
-                    enableExtendedLanguagePool: false,
                     baseLanguageId: 'typescriptreact',
                     languageId: 'typescript',
-                })
-            ).toBe(true)
-        })
-    })
-
-    describe('with extended language pool', () => {
-        it('allows css files as context for template languages', () => {
-            expect(
-                shouldBeUsedAsContext({
-                    enableExtendedLanguagePool: true,
-                    baseLanguageId: 'typescriptreact',
-                    languageId: 'scss',
-                })
-            ).toBe(true)
-            expect(
-                shouldBeUsedAsContext({
-                    enableExtendedLanguagePool: true,
-                    baseLanguageId: 'javascriptreact',
-                    languageId: 'less',
-                })
-            ).toBe(true)
-            expect(
-                shouldBeUsedAsContext({
-                    enableExtendedLanguagePool: true,
-                    baseLanguageId: 'handlebars',
-                    languageId: 'css',
-                })
-            ).toBe(true)
-        })
-
-        it('allows template languages to be used as context for css files', () => {
-            expect(
-                shouldBeUsedAsContext({
-                    enableExtendedLanguagePool: true,
-                    baseLanguageId: 'scss',
-                    languageId: 'typescriptreact',
-                })
-            ).toBe(true)
-            expect(
-                shouldBeUsedAsContext({
-                    enableExtendedLanguagePool: true,
-                    baseLanguageId: 'less',
-                    languageId: 'javascriptreact',
-                })
-            ).toBe(true)
-            expect(
-                shouldBeUsedAsContext({
-                    enableExtendedLanguagePool: true,
-                    baseLanguageId: 'css',
-                    languageId: 'handlebars',
                 })
             ).toBe(true)
         })

--- a/vscode/src/completions/context/utils.ts
+++ b/vscode/src/completions/context/utils.ts
@@ -1,18 +1,5 @@
 const typeScriptFamily = new Set(['typescript', 'typescriptreact'])
 const javaScriptFamily = new Set(['javascript', 'javascriptreact'])
-const cssFamily = new Set(['css', 'less', 'scss', 'sass'])
-const htmlFamily = new Set([
-    'typescriptreact',
-    'javascriptreact',
-    'html',
-    'handlebars',
-    'vue-html',
-    'razor',
-    'php',
-    'haml',
-    // This omits vue and svelte as these languages usually do not
-    // import CSS modules but define them in the same file instead.
-])
 
 export enum RetrieverIdentifier {
     RecentEditsRetriever = 'recent-edits',
@@ -25,7 +12,6 @@ export enum RetrieverIdentifier {
 }
 
 export interface ShouldUseContextParams {
-    enableExtendedLanguagePool: boolean
     baseLanguageId: string
     languageId: string
 }
@@ -34,11 +20,7 @@ export interface ShouldUseContextParams {
  * Returns true if the given language ID should be used as context for the base
  * language id.
  */
-export function shouldBeUsedAsContext({
-    enableExtendedLanguagePool,
-    baseLanguageId,
-    languageId,
-}: ShouldUseContextParams): boolean {
+export function shouldBeUsedAsContext({ baseLanguageId, languageId }: ShouldUseContextParams): boolean {
     if (baseLanguageId === languageId) {
         return true
     }
@@ -48,18 +30,6 @@ export function shouldBeUsedAsContext({
     }
     if (javaScriptFamily.has(baseLanguageId) && javaScriptFamily.has(languageId)) {
         return true
-    }
-
-    if (enableExtendedLanguagePool) {
-        // Allow template languages to use css files as context (in the hope
-        // that this allows filling class names more effectively)
-        if (htmlFamily.has(baseLanguageId) && cssFamily.has(languageId)) {
-            return true
-        }
-        // Allow css files to use template languages
-        if (cssFamily.has(baseLanguageId) && htmlFamily.has(languageId)) {
-            return true
-        }
     }
 
     return false


### PR DESCRIPTION
- Removes the extended language pool option based on A/B test results. We hypothesized that including CSS family files as context for JSX family documents would increase CAR by suggesting relevant class names more frequently. However, the metrics we collected showed this wasn't the case.

## Test plan

CI