### PR TITLE
Add a handling for client's openctx.providers

### DIFF
--- a/vscode/src/context/openctx.ts
+++ b/vscode/src/context/openctx.ts
@@ -219,21 +219,21 @@ function getMergeConfigurationFunction(
         const providers: OpenCtxClientConfiguration['providers'] = {}
         // 1. Viewer settings (lowest priority)
         if (viewerSettingsProviders) {
-            Object.entries(viewerSettingsProviders).forEach(([k, v]) => {
+            for (const [k, v] of Object.entries(viewerSettingsProviders)) {
                 providers[k] = v
-            })
+            }
         }
         // 2. Configuration providers (middle priority)
         if (configuration.providers) {
-            Object.entries(configuration.providers).forEach(([k, v]) => {
+            for (const [k, v] of Object.entries(configuration.providers)) {
                 providers[k] = v
-            })
+            }
         }
         // 3. Local settings (highest priority)
         if (localSettingsProviders) {
-            Object.entries(localSettingsProviders).forEach(([k, v]) => {
+            for (const [k, v] of Object.entries(localSettingsProviders)) {
                 providers[k] = v
-            })
+            }
         }
 
         return {


### PR DESCRIPTION
## Test plan
1. In JetBrains client, open cody settings and set it to:
```
{
  "openctx.providers": {
    "https://gist.githubusercontent.com/thenamankumar/3708f084fb2abd57adafe7f14620bdf7/raw/e7c7059cb5b04f6feead002e7b3a90c5b1a4bb96/provider.js": true
  }
} 
```
2. Restart IDE
3. Verify the provider works (adds mention items)
<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
