### PR TITLE
Deep Cody: remove TOOL context item after review

### DIFF
--- a/vscode/src/chat/agentic/CodyTool.ts
+++ b/vscode/src/chat/agentic/CodyTool.ts
@@ -193,7 +193,7 @@ class SearchTool extends CodyTool {
             content: 'Queries performed: ' + Array.from(this.performedSearch).join(', '),
             uri: URI.file('search-history'),
             source: ContextItemSource.Agentic,
-            title: 'TOOL',
+            title: 'TOOLCONTEXT',
         } satisfies ContextItem
         context.push(searchQueryItem)
         return context.slice(-maxSearchItems)

--- a/vscode/src/chat/agentic/DeepCody.ts
+++ b/vscode/src/chat/agentic/DeepCody.ts
@@ -64,9 +64,7 @@ export class DeepCodyAgent extends CodyChatAgent {
                 category: 'billable',
             },
         })
-
-        // Remove the TOOL context item that is only used during the review process.
-        return this.context.filter(c => c.title !== 'TOOL')
+        return this.context
     }
 
     private async reviewLoop(
@@ -81,7 +79,9 @@ export class DeepCodyAgent extends CodyChatAgent {
             const newContext = await this.review(span, chatAbortSignal)
             if (!newContext.length) break
 
-            this.context.push(...newContext)
+            // Remove the TOOL context item that is only used during the review process.
+            this.context.push(...newContext.filter(c => c.title !== 'TOOL'))
+
             context += newContext.length
             loop++
         }

--- a/vscode/src/chat/agentic/DeepCody.ts
+++ b/vscode/src/chat/agentic/DeepCody.ts
@@ -80,7 +80,7 @@ export class DeepCodyAgent extends CodyChatAgent {
             if (!newContext.length) break
 
             // Remove the TOOL context item that is only used during the review process.
-            this.context.push(...newContext.filter(c => c.title !== 'TOOL'))
+            this.context.push(...newContext.filter(c => c.title !== 'TOOLCONTEXT'))
 
             context += newContext.length
             loop++


### PR DESCRIPTION
This change removes the `TOOLCONTEXT` context item from the `DeepCodyAgent` after the review process is complete. The `TOOLCONTEXT` context item is only used during the review process and should not be included in the final context.

## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

After: the search history (which should only be used during the review process) should not showing in the UI

![image](https://github.com/user-attachments/assets/ecc07576-a680-4d4a-98e4-70e21a2a7c77)

Before: the search history and chat memory are showing in the UI

![image](https://github.com/user-attachments/assets/675be551-0e5f-40cb-b4d3-3af692e54b59)

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
