### PR TITLE
VS Code: point releases to `./vscode/changelog.md`

### DIFF
--- a/vscode/scripts/github-changelog.ts
+++ b/vscode/scripts/github-changelog.ts
@@ -4,7 +4,7 @@
  *
  * Example:
  *
- * ✨ See the [What’s new in v0.18](https://sourcegraph.com/changelog?topics=VS+Code) changelog for what’s new in this release since v0.16 ✨
+ * ✨ See the [What’s new in v0.18](https://github.com/sourcegraph/cody/blob/main/vscode/CHANGELOG.md) changelog for what’s new in this release since v0.16 ✨
  *
  * ## v0.18.6 Changes
  *
@@ -119,7 +119,7 @@ async function main(): Promise<void> {
     const previousMinor = extractPreviousMinor(minor)
 
     const intro = dedent`
-        ✨ See the [What’s new in v${minor}](https://sourcegraph.com/changelog?topics=VS+Code) changelog for what’s new in this release since v${previousMinor} ✨
+        ✨ See the [What’s new in v${minor}](https://github.com/sourcegraph/cody/blob/main/vscode/CHANGELOG.md) changelog for what’s new in this release since v${previousMinor} ✨
 
         ## v${currentVersion} Changes
     `

--- a/vscode/src/chat/protocol.ts
+++ b/vscode/src/chat/protocol.ts
@@ -238,6 +238,9 @@ export interface ConfigurationSubsetForWebview
  */
 export const CODY_DOC_URL = new URL('https://sourcegraph.com/docs/cody')
 export const SG_CHANGELOG_URL = new URL('https://sourcegraph.com/changelog')
+export const VSCODE_CHANGELOG_URL = new URL(
+    'https://github.com/sourcegraph/cody/blob/main/vscode/CHANGELOG.md'
+)
 
 // Community and support
 export const DISCORD_URL = new URL('https://discord.gg/s2qDtYGnAE')

--- a/vscode/src/release.test.ts
+++ b/vscode/src/release.test.ts
@@ -43,19 +43,19 @@ describe('getReleaseTypeByIDE', () => {
 describe('getReleaseNotesURLByIDE', () => {
     it('returns stable release blog post URL for VS Code stable builds', () => {
         expect(getReleaseNotesURLByIDE('1.24.0', CodyIDE.VSCode)).toEqual(
-            'https://sourcegraph.com/changelog?topics=VS+Code'
+            'https://github.com/sourcegraph/cody/blob/main/vscode/CHANGELOG.md'
         )
     })
 
     it('returns stable release blog post URL for VS Code patch release', () => {
         expect(getReleaseNotesURLByIDE('1.24.2', CodyIDE.VSCode)).toEqual(
-            'https://sourcegraph.com/changelog?topics=VS+Code'
+            'https://github.com/sourcegraph/cody/blob/main/vscode/CHANGELOG.md'
         )
     })
 
     it('returns stable release blog post URL for VS Code insiders builds', () => {
         expect(getReleaseNotesURLByIDE('1.25.1720624657', CodyIDE.VSCode)).toEqual(
-            'https://sourcegraph.com/changelog?topics=VS+Code'
+            'https://github.com/sourcegraph/cody/blob/main/vscode/CHANGELOG.md'
         )
     })
 

--- a/vscode/src/release.ts
+++ b/vscode/src/release.ts
@@ -1,5 +1,5 @@
 import { CodyIDE } from '@sourcegraph/cody-shared'
-import { SG_CHANGELOG_URL } from './chat/protocol'
+import { SG_CHANGELOG_URL, VSCODE_CHANGELOG_URL } from './chat/protocol'
 
 type ReleaseType = 'stable' | 'insiders'
 
@@ -57,6 +57,11 @@ const IDE_BLOG_TOPICS = {
  */
 export function getReleaseNotesURLByIDE(version: string, IDE: CodyIDE): string {
     const blogTopic = IDE in IDE_BLOG_TOPICS && IDE_BLOG_TOPICS[IDE as keyof typeof IDE_BLOG_TOPICS]
+
+    if (IDE === CodyIDE.VSCode && blogTopic) {
+        return new URL(VSCODE_CHANGELOG_URL).href
+    }
+
     if (IDE in IDE_BLOG_TOPICS && blogTopic) {
         const blogURL = new URL(SG_CHANGELOG_URL)
         blogURL.searchParams.set('topics', blogTopic)


### PR DESCRIPTION
- Changed VS Code changelog links to `./vscode/changelod.md` to decouple our releases from marketing blog posts. We want all in-product messaging to point to our GitHub changelog, as we discussed with @kalanchan.
- We plan to move the changelog to the root of the repo and implement changes necessary to maintain one changelog for multiple IDEs in a follow up.

## Test plan

CI
