### PR TITLE
Deep Cody: skip query rewrite for search tool

### DIFF
--- a/vscode/src/chat/agentic/CodyTool.ts
+++ b/vscode/src/chat/agentic/CodyTool.ts
@@ -183,7 +183,9 @@ class SearchTool extends CodyTool {
         const context = await this.contextRetriever.retrieveContext(
             toStructuredMentions([repo]),
             PromptString.unsafe_fromLLMResponse(query),
-            span
+            span,
+            undefined,
+            true
         )
         // Store the search query to avoid running the same query again.
         this.performedSearch.add(query)

--- a/vscode/src/chat/agentic/DeepCody.ts
+++ b/vscode/src/chat/agentic/DeepCody.ts
@@ -4,7 +4,6 @@ import {
     PromptString,
     isDefined,
     logDebug,
-    modelsService,
     ps,
     telemetryRecorder,
 } from '@sourcegraph/cody-shared'
@@ -45,10 +44,7 @@ export class DeepCodyAgent extends CodyChatAgent {
         chatAbortSignal: AbortSignal,
         maxLoops = 2
     ): Promise<ContextItem[]> {
-        const fastChatModel = modelsService.getModelByID(
-            'anthropic::2024-10-22::claude-3-5-haiku-latest'
-        )
-        this.models.review = fastChatModel?.id ?? this.chatBuilder.selectedModel
+        this.models.review = this.chatBuilder.selectedModel
 
         const startTime = performance.now()
         const count = await this.reviewLoop(span, chatAbortSignal, maxLoops)

--- a/vscode/src/chat/agentic/prompts.ts
+++ b/vscode/src/chat/agentic/prompts.ts
@@ -29,7 +29,9 @@ In this environment you have access to this set of tools you can use to fetch co
 4. The user is working in the VS Code editor on ${getOSPromptString()}.
 
 [GOAL]
-Determine if you can answer the question with the given context, or if you need more information. The output will be processed by a bot to gather the necessary context for the user's question, so skip answering the question directly or comments.`
+- Determine if you can answer the question with the given context, or if you need more information.
+- Do not provide the actual answer or comments in this step. This is an auto-generated message.
+- Your response should only contains the word "CONTEXT_SUFFICIENT" or the appropriate <TOOL*> tag(s) and nothing else.`
 
 export const CODYAGENT_PROMPTS = {
     review: REVIEW_PROMPT,

--- a/vscode/src/chat/chat-view/ContextRetriever.ts
+++ b/vscode/src/chat/chat-view/ContextRetriever.ts
@@ -169,22 +169,32 @@ export class ContextRetriever implements vscode.Disposable {
         mentions: StructuredMentions,
         inputTextWithoutContextChips: PromptString,
         span: Span,
-        signal?: AbortSignal
+        signal?: AbortSignal,
+        skipQueryRewrite = false
     ): Promise<ContextItem[]> {
         const roots = await codebaseRootsFromMentions(mentions, signal)
-        return await this._retrieveContext(roots, inputTextWithoutContextChips, span, signal)
+        return await this._retrieveContext(
+            roots,
+            inputTextWithoutContextChips,
+            span,
+            signal,
+            skipQueryRewrite
+        )
     }
 
     private async _retrieveContext(
         roots: Root[],
         query: PromptString,
         span: Span,
-        signal?: AbortSignal
+        signal?: AbortSignal,
+        skipQueryRewrite = false
     ): Promise<ContextItem[]> {
         if (roots.length === 0) {
             return []
         }
-        const rewritten = await rewriteKeywordQuery(this.llms, query, signal)
+        const rewritten = skipQueryRewrite
+            ? query.toString()
+            : await rewriteKeywordQuery(this.llms, query, signal)
         const rewrittenQuery = {
             ...query,
             rewritten,


### PR DESCRIPTION
This change adds a `skipQueryRewrite` option to the `ContextRetriever.retrieveContext` method, which is used when retrieving context for the Search tool. 

This allows the Deep Cody to bypass the query rewriting step that makes an extra LLM request when using the search tool. The reason behind this is because Deep Cody has already return a proper search query that doesn't need rewritten into keyword.

The `ContextRetriever._retrieveContext` method has been updated to handle the `skipQueryRewrite` option, and the `SearchTool` class now passes `true` for this option when calling `retrieveContext`.

Minor prompt improvement (formatting and wording).

I've also notice some response quality regression after switching to use 3.5 Haiku for the reviewing step, where Haiku was not able to fetch the right context resulting in the wrong answer. Switching back to 3.5 Haiku:

![Screenshot 2024-11-07 at 1 15 23 AM](https://github.com/user-attachments/assets/dc7be0bc-af05-44b7-900c-def4a8a32a23)

## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

After: took `8797.651249999995ms` to complete **2** review loops

```sh
█ Autocomplete:onComplete duration:"2378ms" stopReason:"undefined" outputChannelId:"69506ce2-38f2-4619-879b-71ef81187d02": {
  "completion": "<TOOLSEARCH><query>convertGitCloneURLToCodebaseName function implementation</query></TOOLSEARCH>"
}
█ CodyTool searching codebase for convertGitCloneURLToCodebaseName function implementation:
█ Autocomplete:onComplete duration:"3477ms" stopReason:"undefined" outputChannelId:"739cf779-96fd-47da-8aa3-9225b699617e": {
  "completion": "<TOOLSEARCH><query>convertGitCloneURLToCodebaseName SSH URL parsing</query></TOOLSEARCH>"
}
█ CodyTool searching codebase for convertGitCloneURLToCodebaseName SSH URL parsing:
█ telemetry-v2 recordEvent: cody.deep-cody.context/reviewed: {
  "parameters": {
    "version": 0,
    "privateMetadata": {
      "durationMs": 8797.651249999995,
      "context": 42,
      "loop": 2,
      "model": "anthropic::2024-10-22::claude-3-5-haiku-latest"
    },
    "billingMetadata": {
      "product": "cody",
      "category": "billable"
    }
  },
  "timestamp": "2024-11-07T08:15:03.589Z"
}
```

Example 2: " what models are available for dotcom users defined in the codebase?"

![image](https://github.com/user-attachments/assets/fcd36e8c-5c91-4e9d-9d61-25008f39a9a8)


completion time: `6397.538499999995ms`

```
█ Autocomplete:onComplete duration:"2789ms" stopReason:"undefined" outputChannelId:"73fcb0e4-fddb-4de5-894e-d95112ab5ba7": {
  "completion": "<TOOLSEARCH><query>available LLM models for dotcom users</query></TOOLSEARCH>"
}
█ CodyTool searching codebase for available LLM models for dotcom users:
█ Autocomplete:onComplete duration:"2138ms" stopReason:"undefined" outputChannelId:"c94a48a7-0a76-4283-a097-ca2b946b70dd": {
  "completion": "<TOOLFILE><name>/lib/shared/src/models/dotcom.ts</name></TOOLFILE>"
}
█ CodyTool requesting 1 files:
█ telemetry-v2 recordEvent: cody.deep-cody.context/reviewed: {
  "parameters": {
    "version": 0,
    "privateMetadata": {
      "durationMs": 6397.538499999995,
      "context": 22,
      "loop": 2,
      "model": "anthropic::2024-10-22::claude-3-5-haiku-latest"
    },
    "billingMetadata": {
      "product": "cody",
      "category": "billable"
    }
  },
  "timestamp": "2024-11-07T08:29:32.147Z"
}
```

### Before

review loop took `14535.338709000032ms` to complete **1** review loops

```sh
█ Autocomplete:onComplete duration:"3471ms" stopReason:"undefined" outputChannelId:"265a6f8d-d103-4b52-889b-b351503c5891": {
  "completion": "<TOOLSEARCH><query>convertGitCloneURLToCodebaseName</query></TOOLSEARCH>"
}
█ CodyTool searching codebase for convertGitCloneURLToCodebaseName:
█ Autocomplete:onComplete duration:"2105ms" stopReason:"undefined" outputChannelId:"78ba1f1e-3bb8-40be-92c4-34723b604efa": {
  "completion": "<keywords>\n<keyword>\n<value>git</value>\n<variants>git github gitlab bitbucket</variants>\n<weight>0.8</weight>\n</keyword>\n<keyword>\n<value>clone</value>\n<variants>clone cloning repository repo</variants>\n<weight>0.8</weight>\n</keyword>\n<keyword>\n<value>url</value>\n<variants>url link address</variants>\n<weight>0.7</weight>\n</keyword>\n<keyword>\n<value>convert</value>\n<variants>convert conversion transform</variants>\n<weight>0.9</weight>\n</keyword>\n<keyword>\n<value>codebase</value>\n<variants>codebase code repository project</variants>\n<weight>0.9</weight>\n</keyword>\n<keyword>\n<value>name</value>\n<variants>name identifier</variants>\n<weight>0.8</weight>\n</keyword>\n</keywords>"
}
█ Autocomplete:onComplete duration:"6086ms" stopReason:"undefined" outputChannelId:"2405087e-f5c8-40b7-967e-dd5f1a4ae011": {
  "completion": "CONTEXT_SUFFICIENT\n\nThe context provided reveals that the issue is in the `convertGitCloneURLToCodebaseName` function in `/lib/shared/src/utils.ts`, which currently does not handle SSH-style git URLs (like `git@gitlab.booking.com:...`) correctly.\n\nTo fix the issue, you'll need to modify the `convertGitCloneURLToCodebaseNameOrError` function to better handle SSH-style URLs. The existing code already has a regex match for SSH URLs, but it might need refinement to handle more complex URL formats.\n\nSpecifically, the current implementation should be updated to:\n1. Handle SSH URLs with different user prefixes\n2. Support URLs with ports\n3. Handle multiple subgroup/path components\n4. Ensure consistent parsing of `.git` suffix removal\n\nThe test cases in `/lib/shared/src/utils.test.ts` provide good examples of the URL formats that need to be supported."
}
█ telemetry-v2 recordEvent: cody.deep-cody.context/reviewed: {
  "parameters": {
    "version": 0,
    "metadata": [
      {
        "key": "tier",
        "value": 2
      }
    ],
    "privateMetadata": {
      "durationMs": 14535.338709000032,
      "context": 21,
      "loop": 1,
      "model": "anthropic::2024-10-22::claude-3-5-haiku-latest"
    },
    "billingMetadata": {
      "product": "cody",
      "category": "billable"
    }
  },
  "timestamp": "2024-11-07T08:08:19.987Z"
}
```

Example 2: " what models are available for dotcom users defined in the codebase?"

completion time: `10159.913833000232ms`

![image](https://github.com/user-attachments/assets/08b857b8-1aeb-4f38-8001-688e064d0452)

```
█ Autocomplete:onComplete duration:"4173ms" stopReason:"undefined" outputChannelId:"67dee65c-2d3d-4b70-a11f-1a0f3988ba55": {
  "completion": "<TOOLSEARCH><query>available LLM models for dotcom users</query></TOOLSEARCH>"
}
█ CodyTool searching codebase for available LLM models for dotcom users:
█ Autocomplete:onComplete duration:"1156ms" stopReason:"undefined" outputChannelId:"c9a6f376-cfdb-4d26-a620-5e667a31c19b": {
  "completion": "<keywords>\n<keyword>\n<value>language models</value>\n<variants>LLM llm large language models</variants>\n<weight>0.9</weight>\n</keyword>\n<keyword>\n<value>web applications</value>\n<variants>dotcom web app webapp</variants>\n<weight>0.8</weight>\n</keyword>\n<keyword>\n<value>user documentation</value>\n<variants>user guide documentation</variants>\n<weight>0.7</weight>\n</keyword>\n</keywords>"
}
█ Autocomplete:onComplete duration:"2106ms" stopReason:"undefined" outputChannelId:"8c36152e-dbb1-4311-a9de-c498000ce509": {
  "completion": "<TOOLSEARCH><query>models available for dotcom users</query></TOOLSEARCH>"
}
█ CodyTool searching codebase for models available for dotcom users:
█ telemetry-v2 recordEvent: cody.deep-cody.context/reviewed: {
  "parameters": {
    "version": 0,
    "metadata": [
      {
        "key": "tier",
        "value": 2
      }
    ],
    "privateMetadata": {
      "durationMs": 10159.913833000232,
      "context": 42,
      "loop": 2,
      "model": "anthropic::2024-10-22::claude-3-5-haiku-latest"
    },
    "billingMetadata": {
      "product": "cody",
      "category": "billable"
    }
  },
  "timestamp": "2024-11-07T08:30:02.683Z"
}
```

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
