### PR TITLE
chore/build: VSCode Insiders builds are manually triggered and automatically tagged

### DIFF
--- a/.github/workflows/vscode-insiders-release.yml
+++ b/.github/workflows/vscode-insiders-release.yml
@@ -1,16 +1,11 @@
 name: vscode-insiders-release
 
 on:
-  schedule:
-    - cron: '0 15 * * 1,3,5' # daily at 1500 UTC
-  push:
-    tags:
-      - vscode-v* # automatically create a new insider build with a release
   workflow_dispatch:
 
 jobs:
   release:
-    if: github.ref == 'refs/heads/main' && github.repository == 'sourcegraph/cody'
+    if: github.repository == 'sourcegraph/cody'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -28,10 +23,21 @@ jobs:
         env:
           NO_LOG_TESTING_TELEMETRY_CALLS: true
       - run: CODY_RELEASE_TYPE=insiders pnpm -C vscode run release
-        if: github.ref == 'refs/heads/main' && github.repository == 'sourcegraph/cody'
+        id: create_release
+        if: github.repository == 'sourcegraph/cody'
         env:
           VSCODE_MARKETPLACE_TOKEN: ${{ secrets.VSCODE_MARKETPLACE_TOKEN }}
           VSCODE_OPENVSX_TOKEN: ${{ secrets.VSCODE_OPENVSX_TOKEN }}
+      - name: Tag insiders release
+        uses: actions/github-script@v6
+        with:
+          script: |
+            github.rest.git.createRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: "refs/tags/${{ steps.create_release.outputs.version_tag }}",
+              sha: context.sha
+            })
       - name: Slack Notification
         if: ${{ failure() }}
         uses: rtCamp/action-slack-notify@b24d75fe0e728a4bf9fc42ee217caa686d141ee8 # SECURITY: pin third-party action hashes
@@ -41,5 +47,5 @@ jobs:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
           SLACK_MESSAGE: Insiders build failed
           SLACK_COLOR: danger
-          SLACK_FOOTER: ''
+          SLACK_FOOTER: ""
           MSG_MINIMAL: actions url

--- a/vscode/scripts/release.ts
+++ b/vscode/scripts/release.ts
@@ -123,6 +123,18 @@ if (!insidersVersion) {
     process.exit(1)
 }
 
+const githubOutputPath = process.env.GITHUB_OUTPUT
+if (releaseType === ReleaseType.Insiders && githubOutputPath) {
+    // Output a tag for the release. We only generate tags for insiders
+    // releases. For stable releases the tag already exists: The release job
+    // is triggered when the tag is created.
+    fs.writeFileSync(githubOutputPath, `version_tag=vscode-insiders-v${insidersVersion}\n`, {
+        encoding: 'utf8',
+        flush: true,
+        flag: 'a',
+    })
+}
+
 const version = releaseType === ReleaseType.Insiders ? insidersVersion : packageJSONVersion
 
 // Package (build and bundle) the extension.


### PR DESCRIPTION
This makes several changes so we can do manually triggered insiders builds from a release branch instead of nightly on `main`.

No changes to stable release builds in this PR.

## Test plan

This does a dry run of the insiders build and verifies that the version tag is written to outputs:

```
$ CODY_RELEASE_DRY_RUN=true CODY_RELEASE_TYPE=insiders GITHUB_OUTPUT=/tmp/output.txt pnpm \
  -C vscode run release
$ cat /tmp/output.txt
version_tag=vscode-insiders-v1.41.1730969154
```

Testing the workflow itself we have to upload and trigger the workflow, here's a fork with a dry run:

https://github.com/sourcegraph/cody/actions/runs/11719764387

## Changelog

- VSCode Insiders builds are now manually triggered, instead of nightly.
- VSCode Insiders builds can be triggered on branches. We intend to produce these builds from release branches sometimes.
- VSCode Insiders builds are tagged with `vscode-insiders-vN.N.NNNN`. This supports bisecting regressions in these builds.

