### PR TITLE
[Backport] Cherry-pick fixes from main to vscode-v1.42.x

### DIFF
--- a/vscode/src/chat/agentic/CodyTool.ts
+++ b/vscode/src/chat/agentic/CodyTool.ts
@@ -183,7 +183,9 @@ class SearchTool extends CodyTool {
         const context = await this.contextRetriever.retrieveContext(
             toStructuredMentions([repo]),
             PromptString.unsafe_fromLLMResponse(query),
-            span
+            span,
+            undefined,
+            true
         )
         // Store the search query to avoid running the same query again.
         this.performedSearch.add(query)

--- a/vscode/src/chat/agentic/CodyTool.ts
+++ b/vscode/src/chat/agentic/CodyTool.ts
@@ -193,7 +193,7 @@ class SearchTool extends CodyTool {
             content: 'Queries performed: ' + Array.from(this.performedSearch).join(', '),
             uri: URI.file('search-history'),
             source: ContextItemSource.Agentic,
-            title: 'TOOL',
+            title: 'TOOLCONTEXT',
         } satisfies ContextItem
         context.push(searchQueryItem)
         return context.slice(-maxSearchItems)

--- a/vscode/src/chat/agentic/DeepCody.ts
+++ b/vscode/src/chat/agentic/DeepCody.ts
@@ -64,9 +64,7 @@ export class DeepCodyAgent extends CodyChatAgent {
                 category: 'billable',
             },
         })
-
-        // Remove the TOOL context item that is only used during the review process.
-        return this.context.filter(c => c.title !== 'TOOL')
+        return this.context
     }
 
     private async reviewLoop(
@@ -81,7 +79,9 @@ export class DeepCodyAgent extends CodyChatAgent {
             const newContext = await this.review(span, chatAbortSignal)
             if (!newContext.length) break
 
-            this.context.push(...newContext)
+            // Remove the TOOL context item that is only used during the review process.
+            this.context.push(...newContext.filter(c => c.title !== 'TOOLCONTEXT'))
+
             context += newContext.length
             loop++
         }

--- a/vscode/src/chat/agentic/DeepCody.ts
+++ b/vscode/src/chat/agentic/DeepCody.ts
@@ -4,7 +4,6 @@ import {
     PromptString,
     isDefined,
     logDebug,
-    modelsService,
     ps,
     telemetryRecorder,
 } from '@sourcegraph/cody-shared'
@@ -45,10 +44,7 @@ export class DeepCodyAgent extends CodyChatAgent {
         chatAbortSignal: AbortSignal,
         maxLoops = 2
     ): Promise<ContextItem[]> {
-        const fastChatModel = modelsService.getModelByID(
-            'anthropic::2024-10-22::claude-3-5-haiku-latest'
-        )
-        this.models.review = fastChatModel?.id ?? this.chatBuilder.selectedModel
+        this.models.review = this.chatBuilder.selectedModel
 
         const startTime = performance.now()
         const count = await this.reviewLoop(span, chatAbortSignal, maxLoops)

--- a/vscode/src/chat/agentic/prompts.ts
+++ b/vscode/src/chat/agentic/prompts.ts
@@ -29,7 +29,9 @@ In this environment you have access to this set of tools you can use to fetch co
 4. The user is working in the VS Code editor on ${getOSPromptString()}.
 
 [GOAL]
-Determine if you can answer the question with the given context, or if you need more information. The output will be processed by a bot to gather the necessary context for the user's question, so skip answering the question directly or comments.`
+- Determine if you can answer the question with the given context, or if you need more information.
+- Do not provide the actual answer or comments in this step. This is an auto-generated message.
+- Your response should only contains the word "CONTEXT_SUFFICIENT" or the appropriate <TOOL*> tag(s) and nothing else.`
 
 export const CODYAGENT_PROMPTS = {
     review: REVIEW_PROMPT,

--- a/vscode/src/chat/chat-view/ContextRetriever.ts
+++ b/vscode/src/chat/chat-view/ContextRetriever.ts
@@ -169,22 +169,32 @@ export class ContextRetriever implements vscode.Disposable {
         mentions: StructuredMentions,
         inputTextWithoutContextChips: PromptString,
         span: Span,
-        signal?: AbortSignal
+        signal?: AbortSignal,
+        skipQueryRewrite = false
     ): Promise<ContextItem[]> {
         const roots = await codebaseRootsFromMentions(mentions, signal)
-        return await this._retrieveContext(roots, inputTextWithoutContextChips, span, signal)
+        return await this._retrieveContext(
+            roots,
+            inputTextWithoutContextChips,
+            span,
+            signal,
+            skipQueryRewrite
+        )
     }
 
     private async _retrieveContext(
         roots: Root[],
         query: PromptString,
         span: Span,
-        signal?: AbortSignal
+        signal?: AbortSignal,
+        skipQueryRewrite = false
     ): Promise<ContextItem[]> {
         if (roots.length === 0) {
             return []
         }
-        const rewritten = await rewriteKeywordQuery(this.llms, query, signal)
+        const rewritten = skipQueryRewrite
+            ? query.toString()
+            : await rewriteKeywordQuery(this.llms, query, signal)
         const rewrittenQuery = {
             ...query,
             rewritten,


### PR DESCRIPTION
This PR backports the following commits from `main` branch to `vscode-v1.42.x`:
- 45b9ff21
- bc8b14e1

These commits contain fixes for Deep Cody

## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

merged to main.

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
