### PR TITLE
Agent: disable the flaky edit test

### DIFF
--- a/agent/src/edit.test.ts
+++ b/agent/src/edit.test.ts
@@ -101,7 +101,9 @@ describe('Edit', { timeout: 5000 }, () => {
         )
     }, 20_000)
 
-    it('editCommand/code (generate new code)', async () => {
+    // TODO: fix flakiness and re-enable
+    // https://linear.app/sourcegraph/issue/CODY-4300/agent-integration-test-editcommandcode-generate-new-code-is-flaky
+    it.skip('editCommand/code (generate new code)', async () => {
         const uri = workspace.file('src', 'Heading.tsx')
         await client.openFile(uri)
         const task = await client.request('editCommands/code', {


### PR DESCRIPTION
- Disabled the flaky test based on CI runs [here](https://github.com/sourcegraph/cody/actions/runs/11726530828/job/32666794309?pr=5956).
- Linear issue to fix and re-enable this test.

## Test plan

CI
