### PR TITLE
Edit: collect more analytics data

### DIFF
--- a/vscode/src/non-stop/FixupController.ts
+++ b/vscode/src/non-stop/FixupController.ts
@@ -595,12 +595,18 @@ export class FixupController
             reason: undefined,
         })
 
+        const originalCodeCounts = countCode(task.original)
+
         const legacyMetadata = {
             intent: EditIntentTelemetryMetadataMapping[task.intent] || task.intent,
             mode: EditModeTelemetryMetadataMapping[task.mode] || task.mode,
             source:
                 EventSourceTelemetryMetadataMapping[task.source || DEFAULT_EVENT_SOURCE] || task.source,
+            originalCharCount: originalCodeCounts.charCount,
+            originalLineCount: originalCodeCounts.lineCount,
+            languageId: document.languageId,
             model: task.model,
+            latency: performance.now() - task.createdAt,
             ...this.countEditInsertions(task),
             ...task.telemetryMetadata,
             ...charactersLoggerMetadata,

--- a/vscode/src/non-stop/FixupTask.ts
+++ b/vscode/src/non-stop/FixupTask.ts
@@ -51,6 +51,7 @@ export class FixupTask {
     public originalDiff: Edit[] | undefined
     /** The number of times we've submitted this to the LLM. */
     public spinCount = 0
+    public createdAt = performance.now()
 
     constructor(
         /**

--- a/vscode/test/e2e/__snapshots__/command-edit.test.ts/edit-fixup-task-1.txt
+++ b/vscode/test/e2e/__snapshots__/command-edit.test.ts/edit-fixup-task-1.txt
@@ -14,6 +14,18 @@
       "value": 2
     },
     {
+      "key": "originalCharCount",
+      "value": 63
+    },
+    {
+      "key": "originalLineCount",
+      "value": 5
+    },
+    {
+      "key": "latency",
+      "value": 9999
+    },
+    {
       "key": "lineCount",
       "value": 4
     },
@@ -63,6 +75,7 @@
     }
   ],
   "privateMetadata": {
+    "languageId": "typescript",
     "model": "anthropic::2023-06-01::claude-3.5-sonnet"
   },
   "billingMetadata": {

--- a/vscode/test/e2e/command-edit.test.ts
+++ b/vscode/test/e2e/command-edit.test.ts
@@ -3,7 +3,12 @@ import { expect } from '@playwright/test'
 import * as mockServer from '../fixtures/mock-server'
 
 import { openFileInEditorTab, sidebarExplorer, sidebarSignin } from './common'
-import { type DotcomUrlOverride, type ExpectedV2Events, test as baseTest } from './helpers'
+import {
+    type DotcomUrlOverride,
+    type ExpectedV2Events,
+    test as baseTest,
+    stabilizeMetadataValues,
+} from './helpers'
 
 const test = baseTest.extend<DotcomUrlOverride>({ dotcomUrl: mockServer.SERVER_URL })
 
@@ -94,6 +99,7 @@ test.extend<ExpectedV2Events>({
     const fixupApplySuccessEvent = mockServer.loggedV2Events.find(
         event => event.testId === 'cody.fixup.apply:succeeded'
     )
+    stabilizeMetadataValues(['latency'], fixupApplySuccessEvent)
     expect(JSON.stringify(fixupApplySuccessEvent?.parameters, null, 2)).toMatchSnapshot()
 })
 

--- a/vscode/test/e2e/helpers.ts
+++ b/vscode/test/e2e/helpers.ts
@@ -13,6 +13,10 @@ import {
     test as base,
     expect as baseExpect,
 } from '@playwright/test'
+import type { RepoListResponse } from '@sourcegraph/cody-shared'
+import type { RepositoryIdResponse } from '@sourcegraph/cody-shared/src/sourcegraph-api/graphql/client'
+import type { TelemetryEventInput } from '@sourcegraph/telemetry'
+import { resolveCliArgsFromVSCodeExecutablePath } from '@vscode/test-electron'
 import { _electron as electron } from 'playwright'
 import * as uuid from 'uuid'
 
@@ -25,9 +29,6 @@ import {
     sendTestInfo,
 } from '../fixtures/mock-server'
 
-import type { RepoListResponse } from '@sourcegraph/cody-shared'
-import type { RepositoryIdResponse } from '@sourcegraph/cody-shared/src/sourcegraph-api/graphql/client'
-import { resolveCliArgsFromVSCodeExecutablePath } from '@vscode/test-electron'
 import { closeSidebar, expectAuthenticated, focusSidebar } from './common'
 import { installVsCode } from './install-deps'
 import { buildCustomCommandConfigFile } from './utils/buildCustomCommands'
@@ -621,4 +622,20 @@ export function mockEnterpriseRepoMapping(server: MockServer, repoName: string):
         } satisfies RepositoryIdResponse,
     })
     server.onGraphQl('ResolveRepoName').replyJson({ data: { repository: { name: repoName } } })
+}
+
+/**
+ * Stabilizes metadata values in telemetry event parameters for consistent snapshot testing.
+ * For specified keys, replaces numeric values with '9999' and other values with 'stabilized_value_for_snapshot'.
+ */
+export function stabilizeMetadataValues(keys: string[], event?: TelemetryEventInput | null) {
+    if (!event?.parameters?.metadata) {
+        return
+    }
+
+    for (const param of event.parameters.metadata) {
+        if (keys.includes(param.key)) {
+            param.value = typeof param.value === 'number' ? 9999 : 'stabilized_value_for_snapshot'
+        }
+    }
 }

--- a/vscode/test/e2e/helpers.ts
+++ b/vscode/test/e2e/helpers.ts
@@ -624,6 +624,8 @@ export function mockEnterpriseRepoMapping(server: MockServer, repoName: string):
     server.onGraphQl('ResolveRepoName').replyJson({ data: { repository: { name: repoName } } })
 }
 
+const STABILIZED_NUMBER_VALUE_FOR_SNAPSHOT = 9999
+
 /**
  * Stabilizes metadata values in telemetry event parameters for consistent snapshot testing.
  * For specified keys, replaces numeric values with '9999' and other values with 'stabilized_value_for_snapshot'.
@@ -635,7 +637,10 @@ export function stabilizeMetadataValues(keys: string[], event?: TelemetryEventIn
 
     for (const param of event.parameters.metadata) {
         if (keys.includes(param.key)) {
-            param.value = typeof param.value === 'number' ? 9999 : 'stabilized_value_for_snapshot'
+            param.value =
+                typeof param.value === 'number'
+                    ? STABILIZED_NUMBER_VALUE_FOR_SNAPSHOT
+                    : 'stabilized_value_for_snapshot'
         }
     }
 }


### PR DESCRIPTION
- Adds latency, document language, original selection char count, and line count to the Edit command `cody.fixup.apply:succeeded` analytics events. This would allow us to conduct A/B tests focused on latency improvements.
- Closes [CODY-4301: Collect E2E latency data for the Edit commands](https://linear.app/sourcegraph/issue/CODY-4301/collect-e2e-latency-data-for-the-edit-commands)

## Test plan

CI + updated E2E test for the Edit command. You can see newly added analytics fields in the updated test snapshot.

## Changelog

- Edit: added latency and document language to the analytics event metadata.
