### PR TITLE
Fix for VSCode Marketplace description getting cut-off

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -7,7 +7,7 @@
   "publisher": "sourcegraph",
   "license": "Apache-2.0",
   "icon": "resources/cody.png",
-  "description": "AI coding assistant that uses search and codebase context to help you write code faster. Cody brings autocomplete, chat, and commands to VS Code, so you can generate code, write unit tests, create docs, and explain complex code using AI. Choose from the latest LLMs, including GPT-4o and Claude 3.5 Sonnet.",
+  "description": "AI coding assistant that uses search & codebase context to help you write code faster. Cody brings you autocomplete, chat, and commands, so you can generate code, write unit tests, create docs, and explain complex code using AI. Choose from the best LLMs, including GPT-4o and Claude 3.5 Sonnet.",
   "scripts": {
     "build:root": "pnpm -C .. run -s build",
     "postinstall": "pnpm download-wasm && pnpm copy-win-ca-roots",


### PR DESCRIPTION
Slight re-wording of the description to solve the problem with it cutting off due to exceeding the character limits by 6 characters

Changed one instance of "and" to an ampersand (&), removed "to VS Code" (wasn't really needed as this only shows within the VSCode Marketplace, and wouldn't be any benefit to SEO)

Changed "latest" in the LLMs selection, to "best" - this gives a better "feeling" than "latest" as the latest LLM could be a tiny 1b parameter model which means nothing for Cody.