### PR TITLE
Add a command for testing auto-edit examples

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -756,6 +756,11 @@
         "command": "cody.experimental.suggest",
         "key": "ctrl+shift+enter",
         "when": "cody.activated"
+      },
+      {
+        "command": "cody.supersuggest.testExample",
+        "key": "ctrl+alt+enter",
+        "when": "cody.activated"
       }
     ],
     "submenus": [

--- a/vscode/src/autoedits/prompt-utils.test.ts
+++ b/vscode/src/autoedits/prompt-utils.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import { getCurrentDocContext } from '../completions/get-current-doc-context'
 import { documentAndPosition } from '../completions/test-helpers'
-import { getCurrentFileContext } from './prompt-utils'
+import { getBaseUserPrompt, getCurrentFileContext } from './prompt-utils'
 
 describe('getCurrentFileContext', () => {
     it('correctly splits content into different areas based on cursor position', () => {
@@ -299,5 +299,91 @@ describe('getCurrentFileContext', () => {
         expect(result.suffixAfterArea.toString()).toBe('')
         expect(result.range.start.line).toBe(0)
         expect(result.range.end.line).toBe(2)
+    })
+})
+
+describe('getBaseUserPrompt', () => {
+    it('creates a prompt in the correct format', () => {
+        const prefix = Array.from({ length: 50 }, (_, i) => `line ${i + 1}`).join('\n')
+        const suffix = Array.from({ length: 50 }, (_, i) => `line ${50 + i + 1}`).join('\n')
+        const textContent = `${prefix}█\n${suffix}`
+
+        const { document, position } = documentAndPosition(textContent)
+        const docContext = getCurrentDocContext({
+            document,
+            position,
+            maxPrefixLength: 100,
+            maxSuffixLength: 100,
+        })
+
+        const { prompt } = getBaseUserPrompt(docContext, document, position, [], {
+            prefixTokens: 10,
+            suffixTokens: 10,
+            maxPrefixLinesInArea: 20,
+            maxSuffixLinesInArea: 20,
+            codeToRewritePrefixLines: 3,
+            codeToRewriteSuffixLines: 3,
+            contextSpecificTokenLimit: {},
+        })
+
+        const expectedPrompt =
+            `Help me finish a coding change. In particular, you will see a series of snippets from current open files in my editor, files I have recently viewed, the file I am editing, then a history of my recent codebase changes, then current compiler and linter errors, content I copied from my codebase. You will then rewrite the <code_to_rewrite>, to match what you think I would do next in the codebase. Note: I might have stopped in the middle of typing.
+
+
+Here is the file that I am looking at (` +
+            '`' +
+            'test.ts' +
+            '`' +
+            `)
+
+<file>
+
+<<<AREA_AROUND_CODE_TO_REWRITE_WILL_BE_INSERTED_HERE>>>
+
+</file>
+
+
+
+
+
+<area_around_code_to_rewrite>
+line 37
+line 38
+line 39
+line 40
+line 41
+line 42
+line 43
+line 44
+line 45
+line 46
+
+<code_to_rewrite>
+line 47
+line 48
+line 49
+line 50
+line 51
+line 52
+line 53
+
+</code_to_rewrite>
+line 54
+line 55
+line 56
+line 57
+line 58
+line 59
+line 60
+line 61
+line 62
+line 63
+line 64
+
+</area_around_code_to_rewrite>
+
+Now, continue where I left off and finish my change by rewriting "code_to_rewrite":
+`
+        expect(prompt.toString()).toEqual(expectedPrompt)
     })
 })

--- a/vscode/src/autoedits/renderer-testing-2.ts
+++ b/vscode/src/autoedits/renderer-testing-2.ts
@@ -1,0 +1,78 @@
+import * as vscode from 'vscode'
+import { AutoEditsRenderer } from './renderer'
+
+export function registerTestRenderCommand(): vscode.Disposable {
+    return vscode.commands.registerCommand('cody.supersuggest.testExample', () => {
+        const editor = vscode.window.activeTextEditor
+        const document = editor?.document
+        if (!editor || !document) {
+            return
+        }
+        const selection = editor.selection
+        const offset = editor.document.offsetAt(selection.start)
+        const text = editor.document.getText()
+
+        // extract replace start line and end line, replacerText, and replacerCol
+        const ret = ((): [string, string, number] | undefined => {
+            const i = text.substring(0, offset).lastIndexOf('\n<<<<\n', offset)
+            if (i === -1) {
+                return undefined
+            }
+            const textToReplaceStart = i + '\n<<<<\n'.length
+
+            const j = text.indexOf('\n====\n', textToReplaceStart)
+            if (j === -1) {
+                return undefined
+            }
+            const textToReplaceEnd = j
+            const replacerTextStart = j + '\n====\n'.length
+
+            const k = text.indexOf('\n>>>>\n', textToReplaceEnd)
+            if (k === -1) {
+                return undefined
+            }
+            const replacerTextEnd = k
+
+            return [
+                text.slice(textToReplaceStart, textToReplaceEnd),
+                text.slice(replacerTextStart, replacerTextEnd),
+                replacerTextEnd + '\n~~~~\n'.length,
+            ]
+        })()
+        if (!ret) {
+            return
+        }
+        const [textToReplace, replacerText, replacerBlockEnd] = ret
+
+        // Display decoration
+        const replaceStartOffset = text.indexOf(textToReplace, replacerBlockEnd)
+        if (replaceStartOffset === -1) {
+            console.error('Could not find replacement text')
+            return
+        }
+        const replaceEndOffset = replaceStartOffset + textToReplace.length
+        const replaceStartLine = editor.document.positionAt(replaceStartOffset).line
+        const replaceEndLine = editor.document.positionAt(replaceEndOffset).line
+
+        const renderer = new AutoEditsRenderer(editor)
+        const currentFileText = document.getText()
+        // splice replacerText into currentFileText at replaceStartLine and replacenEndLine
+        const lines = currentFileText.split('\n')
+        const predictedFileText = [
+            ...lines.slice(0, replaceStartLine),
+            replacerText,
+            ...lines.slice(replaceEndLine + 1),
+        ].join('\n')
+
+        renderer.renderDecorations({
+            document,
+            currentFileText,
+            predictedFileText,
+        })
+
+        const listener = vscode.window.onDidChangeTextEditorSelection(e => {
+            renderer.clearDecorations()
+            listener.dispose()
+        })
+    })
+}

--- a/vscode/src/autoedits/renderer-testing.ts
+++ b/vscode/src/autoedits/renderer-testing.ts
@@ -60,7 +60,7 @@ class DiffDecorationManager implements vscode.Disposable {
         const currentFileText = before + marker + after
         const predictedFileText = after + '\n' + marker + after
 
-        await this.renderer.renderDecorations({
+        this.renderer.renderDecorations({
             document: this.editor.document,
             currentFileText,
             predictedFileText,

--- a/vscode/src/autoedits/renderer.ts
+++ b/vscode/src/autoedits/renderer.ts
@@ -272,7 +272,7 @@ export class AutoEditsRenderer implements vscode.Disposable {
         const removedLinesRanges = this.getNonModifiedLinesRanges(removedLines)
         this.editor.setDecorations(this.removedTextDecorationType, removedLinesRanges)
 
-        if (addedLines.length !== 0 || isOnlyAdditionsForModifiedLines === false) {
+        if (addedLines.length > 0 || !isOnlyAdditionsForModifiedLines) {
             this.renderDiffDecorations(
                 beforeLinesChunks,
                 afterLinesChunks,

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -46,6 +46,7 @@ import { showAccountMenu } from './auth/account-menu'
 import { showSignInMenu, showSignOutMenu, tokenCallbackHandler } from './auth/auth'
 import { AutoeditsProvider } from './autoedits/autoedits-provider'
 import { AutoeditTestingProvider } from './autoedits/renderer-testing'
+import { registerTestRenderCommand } from './autoedits/renderer-testing-2'
 import type { MessageProviderOptions } from './chat/MessageProvider'
 import { ChatsController, CodyChatEditorViewType } from './chat/chat-view/ChatsController'
 import { ContextRetriever } from './chat/chat-view/ContextRetriever'
@@ -454,11 +455,12 @@ async function registerCodyCommands(
 
     // Initialize autoedit provider if experimental feature is enabled
     registerAutoEdits(disposables)
+
     // Initialize autoedit tester
     disposables.push(
         enableFeature(
             ({ configuration }) => configuration.experimentalAutoeditsRendererTesting !== false,
-            () => new AutoeditTestingProvider()
+            () => vscode.Disposable.from(new AutoeditTestingProvider(), registerTestRenderCommand())
         )
     )
     disposables.push(


### PR DESCRIPTION
Adds a `ctrl+alt+enter` shortcut when `cody.experimental.autoedits-renderer-testing` is `true` to render the proposed edit using the format specified here: https://github.com/sourcegraph/cody-chat-eval/pull/72

The advantage of this format to the old one is that the proposed edit can be specified *in situ*, so we can better see how it would be rendered in a real-world file.

## Test plan

Only affects experimental test features behind the `cody.experimental.autoedits-renderer-testing` setting.