### PR TITLE
Edit: prep for the gpt-4o-mini edit a/b test

### DIFF
--- a/lib/shared/src/experimentation/FeatureFlagProvider.ts
+++ b/lib/shared/src/experimentation/FeatureFlagProvider.ts
@@ -54,6 +54,9 @@ export enum FeatureFlag {
     CodyAutocompleteContextExperimentVariant4 = 'cody-autocomplete-context-experiment-variant-4',
     CodyAutocompleteContextExperimentControl = 'cody-autocomplete-context-experiment-control',
 
+    // Enables gpt-4o-mini as a default Edit model
+    CodyEditDefaultToGpt4oMini = 'cody-edit-default-to-gpt-4o-mini',
+
     // use-ssc-for-cody-subscription is a feature flag that enables the use of SSC as the source of truth for Cody subscription data.
     UseSscForCodySubscription = 'use-ssc-for-cody-subscription',
 

--- a/lib/shared/src/models/sync.test.ts
+++ b/lib/shared/src/models/sync.test.ts
@@ -208,7 +208,7 @@ describe('server sent models', async () => {
         }).pipe(skipPendingOperation())
     )
     const storage = new TestLocalStorageForModelPreferences()
-    modelsService.storage = storage
+    modelsService.setStorage(storage)
     mockAuthStatus(AUTH_STATUS_FIXTURE_AUTHED)
     vi.spyOn(modelsService, 'modelsChanges', 'get').mockReturnValue(Observable.of(result))
 
@@ -504,7 +504,7 @@ describe('syncModels', () => {
         )
 
         const storage = new TestLocalStorageForModelPreferences()
-        modelsService.storage = storage
+        modelsService.setStorage(storage)
         mockAuthStatus(AUTH_STATUS_FIXTURE_AUTHED)
         expect(storage.data?.[AUTH_STATUS_FIXTURE_AUTHED.endpoint]!.selected.chat).toBe(undefined)
         vi.spyOn(modelsService, 'modelsChanges', 'get').mockReturnValue(Observable.of(result))

--- a/vscode/src/edit/manager.ts
+++ b/vscode/src/edit/manager.ts
@@ -122,7 +122,8 @@ export class EditManager implements vscode.Disposable {
         }
 
         // Set default edit configuration, if not provided
-        // It is possible that these values may be overriden later, e.g. if the user changes them in the edit input.
+        // It is possible that these values may be overridden later,
+        // e.g. if the user changes them in the edit input.
         const range = getEditLineSelection(document, proposedRange)
         const model =
             configuration.model || (await firstResultFromOperation(modelsService.getDefaultEditModel()))

--- a/vscode/src/edit/utils/edit-intent.ts
+++ b/vscode/src/edit/utils/edit-intent.ts
@@ -20,7 +20,7 @@ export function getEditIntent(
     proposedIntent?: EditIntent
 ): EditIntent {
     if (proposedIntent !== undefined && proposedIntent !== 'add') {
-        // Return provided intent that should not be overriden
+        // Return provided intent that should not be overridden
         return proposedIntent
     }
 

--- a/vscode/src/edit/utils/edit-models.ts
+++ b/vscode/src/edit/utils/edit-models.ts
@@ -1,7 +1,7 @@
 import { type AuthStatus, type EditModel, isDotCom } from '@sourcegraph/cody-shared'
 import type { EditIntent } from '../types'
 
-export function getOverridenModelForIntent(
+export function getOverriddenModelForIntent(
     intent: EditIntent,
     currentModel: EditModel,
     authStatus: AuthStatus
@@ -21,7 +21,7 @@ export function getOverridenModelForIntent(
             // Issue: https://github.com/sourcegraph/cody/issues/3512
             return 'anthropic/claude-3-5-sonnet-20240620'
         case 'doc':
-            // Doc is a case where we can sacrifice LLM performnace for improved latency and get comparable results.
+            // Doc is a case where we can sacrifice LLM performance for improved latency and get comparable results.
             return 'anthropic/claude-3-haiku-20240307'
         case 'test':
         case 'add':

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -325,7 +325,7 @@ async function initializeSingletons(
 ): Promise<void> {
     commandControllerInit(platform.createCommandsProvider?.(), platform.extensionClient.capabilities)
 
-    modelsService.storage = localStorage
+    modelsService.setStorage(localStorage)
 
     if (platform.otherInitialization) {
         disposables.push(platform.otherInitialization())

--- a/vscode/src/non-stop/FixupController.ts
+++ b/vscode/src/non-stop/FixupController.ts
@@ -30,7 +30,7 @@ import { PersistenceTracker } from '../common/persistence-tracker'
 import { lines } from '../completions/text-processing'
 import { type QuickPickInput, getInput } from '../edit/input/get-input'
 import { isStreamedIntent } from '../edit/utils/edit-intent'
-import { getOverridenModelForIntent } from '../edit/utils/edit-models'
+import { getOverriddenModelForIntent } from '../edit/utils/edit-models'
 import type { ExtensionClient } from '../extension-client'
 import { isRunningInsideAgent } from '../jsonrpc/isRunningInsideAgent'
 import { charactersLogger } from '../services/CharactersLogger'
@@ -499,7 +499,7 @@ export class FixupController
         taskId?: FixupTaskID
     ): Promise<FixupTask> {
         const authStatus = currentAuthStatus()
-        const overridenModel = getOverridenModelForIntent(intent, model, authStatus)
+        const overriddenModel = getOverriddenModelForIntent(intent, model, authStatus)
         const fixupFile = this.files.forUri(document.uri)
         const task = new FixupTask(
             fixupFile,
@@ -509,7 +509,7 @@ export class FixupController
             intent,
             selectionRange,
             mode,
-            overridenModel,
+            overriddenModel,
             source,
             destinationFile,
             insertionPoint,


### PR DESCRIPTION
- Prepares for A/B testing gpt-4o-mini as a default model for the Edit commands. 
    - Enrolled users' preferences will be switched to gpt-4o-mini automatically. They will be able to switch the model back as they see fit.
    - The `cody-edit-default-to-gpt-4o-mini` feature flag will be used to start the experiment.
    - Support for [the Predicted Outputs feature](https://platform.openai.com/docs/guides/predicted-outputs) will be added in a follow up.
- Related work:
    - https://github.com/sourcegraph/cody/pull/6095
    - https://github.com/sourcegraph/sourcegraph/pull/1591
- Part of [CODY-4306: A/B test OpenAI Predicted Outputs optimization with the Edit command](https://linear.app/sourcegraph/issue/CODY-4306/ab-test-openai-predicted-outputs-optimization-with-the-edit-command)
- Closes [CODY-4309: Make gpt-4o-mini a default Edit model for the A/B test](https://linear.app/sourcegraph/issue/CODY-4309/make-gpt-4o-mini-a-default-edit-model-for-the-ab-test)

## Test plan

- Added new unit tests.
- Tested manually
    - Go to https://sourcegraph.com/site-admin/feature-flags/configuration/cody-edit-default-to-gpt-4o-mini and add an override for your user to enable the feature flag.
    - Build the extension from the branch.
    - Singin with the DotCom account.
    - You should see the `gpt-4o-mini` as a default Edit model.
