### PR TITLE
Trigger autoedit on the cursor movements

### DIFF
--- a/vscode/src/autoedits/autoedits-provider.ts
+++ b/vscode/src/autoedits/autoedits-provider.ts
@@ -24,8 +24,6 @@ import type { CodeToReplaceData } from './prompt-utils'
 import { AutoEditsRendererManager } from './renderer'
 
 const AUTOEDITS_CONTEXT_STRATEGY = 'auto-edits'
-const ONSELECTION_CHANGE_DEFAULT_DEBOUNCE_INTERVAL_MS = 150
-const RESET_SUGGESTION_ON_CURSOR_CHANGE_AFTER_INTERVAL_MS = 60 * 1000
 
 export interface AutoEditsProviderOptions {
     document: vscode.TextDocument
@@ -54,8 +52,8 @@ export class AutoeditsProvider implements vscode.Disposable {
     private readonly disposables: vscode.Disposable[] = []
     private readonly contextMixer: ContextMixer
     private readonly rendererManager: AutoEditsRendererManager
-    private readonly onSelectionChangeDebounceIntervalMs: number
-    private readonly resetSuggestionOnCursorChangeAfterIntervalMs: number
+    private readonly onSelectionChangeDebounceIntervalMs: number = 150
+    private readonly resetSuggestionOnCursorChangeAfterIntervalMs: number = 60 * 1000
     private readonly config: ProviderConfig
     private readonly onSelectionChangeDebounced: DebouncedFunc<typeof this.autoeditOnSelectionChange>
     // Keeps track of the last time the text was changed in the editor.
@@ -70,9 +68,6 @@ export class AutoeditsProvider implements vscode.Disposable {
             dataCollectionEnabled: false,
         })
         this.rendererManager = new AutoEditsRendererManager()
-        this.onSelectionChangeDebounceIntervalMs = ONSELECTION_CHANGE_DEFAULT_DEBOUNCE_INTERVAL_MS
-        this.resetSuggestionOnCursorChangeAfterIntervalMs =
-            RESET_SUGGESTION_ON_CURSOR_CHANGE_AFTER_INTERVAL_MS
         this.onSelectionChangeDebounced = debounce(
             (event: vscode.TextEditorSelectionChangeEvent) => this.autoeditOnSelectionChange(event),
             this.onSelectionChangeDebounceIntervalMs

--- a/vscode/src/autoedits/autoedits-provider.ts
+++ b/vscode/src/autoedits/autoedits-provider.ts
@@ -24,6 +24,8 @@ import type { CodeToReplaceData } from './prompt-utils'
 import { AutoEditsRendererManager } from './renderer'
 
 const AUTOEDITS_CONTEXT_STRATEGY = 'auto-edits'
+const ONSELECTION_CHANGE_DEFAULT_DEBOUNCE_INTERVAL_MS = 150
+const RESET_SUGGESTION_ON_CURSOR_CHANGE_AFTER_INTERVAL_MS = 60 * 1000
 
 export interface AutoEditsProviderOptions {
     document: vscode.TextDocument
@@ -52,8 +54,6 @@ export class AutoeditsProvider implements vscode.Disposable {
     private readonly disposables: vscode.Disposable[] = []
     private readonly contextMixer: ContextMixer
     private readonly rendererManager: AutoEditsRendererManager
-    private readonly onSelectionChangeDebounceIntervalMs: number = 150
-    private readonly resetSuggestionOnCursorChangeAfterIntervalMs: number = 60 * 1000
     private readonly config: ProviderConfig
     private readonly onSelectionChangeDebounced: DebouncedFunc<typeof this.autoeditOnSelectionChange>
     // Keeps track of the last time the text was changed in the editor.
@@ -70,7 +70,7 @@ export class AutoeditsProvider implements vscode.Disposable {
         this.rendererManager = new AutoEditsRendererManager()
         this.onSelectionChangeDebounced = debounce(
             (event: vscode.TextEditorSelectionChangeEvent) => this.autoeditOnSelectionChange(event),
-            this.onSelectionChangeDebounceIntervalMs
+            ONSELECTION_CHANGE_DEFAULT_DEBOUNCE_INTERVAL_MS
         )
         this.config = this.initializeConfig()
 
@@ -134,7 +134,8 @@ export class AutoeditsProvider implements vscode.Disposable {
         // Don't show suggestion on cursor movement if the text has not changed for a certain amount of time
         if (
             this.lastTextChangeTimeStamp &&
-            Date.now() - this.lastTextChangeTimeStamp < this.resetSuggestionOnCursorChangeAfterIntervalMs
+            Date.now() - this.lastTextChangeTimeStamp <
+                RESET_SUGGESTION_ON_CURSOR_CHANGE_AFTER_INTERVAL_MS
         ) {
             this.triggerAutoedits(document, lastSelection.active)
         }

--- a/vscode/src/autoedits/renderer.ts
+++ b/vscode/src/autoedits/renderer.ts
@@ -79,6 +79,10 @@ export class AutoEditsRendererManager implements vscode.Disposable {
         )
     }
 
+    public hasActiveEdit(): boolean {
+        return this.activeEdit !== null
+    }
+
     public async showEdit(options: AutoEditsManagerOptions): Promise<void> {
         await this.dismissEdit()
         const editor = vscode.window.activeTextEditor

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -712,11 +712,7 @@ function registerAutoEdits(disposables: vscode.Disposable[]): void {
             },
             () => {
                 const provider = new AutoeditsProvider()
-                const completionRegistration = vscode.languages.registerInlineCompletionItemProvider(
-                    [{ scheme: 'file', language: '*' }, { notebookType: '*' }],
-                    provider
-                )
-                return vscode.Disposable.from(provider, completionRegistration)
+                return provider
             }
         )
     )


### PR DESCRIPTION
## Context
The current version of `auto-edits` only trigger when user types something in the editor, and not on simple cursor movements. The PR adds the functionality to trigger the `auto-edits` on every cursor movement.
Since the volume of such events can be very high, following configuration works better when I experimented with the feature offline:
1. Add a debounce of `150ms` on the cursor movements.
2. Using both inline completion provider and selection change had the issue where it would trigger twice (since as user types, selection also change). So, removed the inline completion provider. 
3. Since the user can move cursor to view the current decoration, and triggering the feature in such case would lead to discarding the previous suggestion, we don't trigger if some decoration is already active.
4. The first text change in any file indicates the user's intent to edit. We track the most recent text change, and ignore cursor movements if they occur more than `60 seconds` after the last text change.

Since the current PR removes the inlineCompletion provider, here is the trade-off:
1. [Cons] We will not be able to show multi-line inline completion as inline completion. For example, below instead of the inline completion, the multi line completion will be shown as decoration:
<img width="1294" alt="image" src="https://github.com/user-attachments/assets/ec891d60-c69d-44c0-81e6-45d1b39d9e2c">

This poses another challenge where if the multiple inline completion is rendered at the end of the file, than it is not shown because of the end of the editor.

2. [Pros] The user will be able to accept changes just by moving cursor and without typing anything.

## Test plan
Still experimenting offline, will add once the offline heuristics are finalized.

