### PR TITLE
Chat: context cell improvements

### DIFF
--- a/lib/prompt-editor/src/useInitialContext.ts
+++ b/lib/prompt-editor/src/useInitialContext.ts
@@ -1,12 +1,19 @@
 import type { DefaultContext } from '@sourcegraph/cody-shared/src/codebase-context/messages'
-import { useMemo } from 'react'
+import { createContext, useContext, useMemo } from 'react'
 import { useExtensionAPI } from './useExtensionAPI'
 import { useObservable } from './useObservable'
+
+export const MockDefaultContext = createContext<DefaultContext | null>(null)
 
 /**
  * Get the initial context with which to populate the chat message input field.
  */
 export function useDefaultContextForChat(): DefaultContext {
+    const c = useContext(MockDefaultContext)
+    if (c) {
+        return c
+    }
+
     const defaultContext = useExtensionAPI().defaultContext
     return useObservable(useMemo(() => defaultContext(), [defaultContext])).value ?? EMPTY
 }

--- a/vscode/test/e2e/chat-context.test.ts
+++ b/vscode/test/e2e/chat-context.test.ts
@@ -20,20 +20,20 @@ test('chat followup context', async ({ page, sidebar }) => {
 
     const contextCells = getContextCell(chatFrame)
     expect(contextCells).toHaveCount(1)
-    expect(contextCells.first()).toHaveText(/Fetched context/)
+    expect(contextCells.first()).toHaveText(/Context/)
     await openContextCell(contextCells.first())
     await expect(contextCells.first()).toHaveText(/Main\.java/)
 
     // No additional context means no context cell.
     await chatInput.fill('followup1')
     await chatInput.press('Enter')
-    expect(contextCells).toHaveCount(1)
+    expect(contextCells).toHaveCount(2)
 
     // Additional context means another context cell.
     await chatInput.fill('followup2 @var.go')
     await selectMentionMenuItem(chatFrame, 'var.go')
     await chatInput.press('Enter')
-    expect(contextCells).toHaveCount(2)
+    expect(contextCells).toHaveCount(3)
     const lastContextCell = contextCells.last()
     expect(lastContextCell).toHaveText(/1 new item/)
     await openContextCell(lastContextCell)

--- a/vscode/test/e2e/chat-input.test.ts
+++ b/vscode/test/e2e/chat-input.test.ts
@@ -253,31 +253,31 @@ test.extend<ExpectedV2Events>({
     await lastChatInput.fill('One')
     await lastChatInput.press('Enter')
     await page.waitForTimeout(1000)
-    await expect(chatFrame.getByText('One')).toBeVisible()
+    await expect(chatFrame.getByText(/One/)).toBeVisible()
     await lastChatInput.fill('Two')
     await lastChatInput.press('Enter')
     await page.waitForTimeout(1000)
-    await expect(chatFrame.getByText('Two')).toBeVisible()
+    await expect(chatFrame.getByText(/Two/)).toBeVisible()
     await lastChatInput.fill('Three')
     await lastChatInput.press('Enter')
     await page.waitForTimeout(1000)
-    await expect(chatFrame.getByText('Three')).toBeVisible()
+    await expect(chatFrame.getByText(/Three/)).toBeVisible()
 
     // Click on the first input to get into the editing mode
     // The text area should automatically get the focuse,
     // and contains the original message text,
     // The submit button will also be replaced with "Update Message" button
-    await chatFrame.getByText('One').hover()
+    await chatFrame.getByText(/One/).hover()
     await focusChatInputAtEnd(firstChatInput)
     await expect(firstChatInput).toBeFocused()
-    await expect(firstChatInput).toHaveText('One')
+    await expect(firstChatInput).toHaveText(/One/)
 
     // click on the second edit button to get into the editing mode again
     // edit the message from "Two" to "Four"
     const secondChatInput = chatInputs.nth(1)
     await chatFrame.getByText('Two').hover()
     // the original message text should shows up in the text box
-    await expect(secondChatInput).toHaveText('Two')
+    await expect(secondChatInput).toHaveText(/Two/)
     await secondChatInput.click()
     await secondChatInput.fill('Four')
     await expect(chatInputs.nth(2)).toHaveText('Three')
@@ -300,10 +300,10 @@ test.extend<ExpectedV2Events>({
     // Only two messages are left after the edit (e.g. "One", "Four"),
     // as all the messages after the edited message have be removed
     await expect(chatInputs).toHaveCount(3 /* 2 + the 1 for the next not-yet-sent message */)
-    await expect(chatFrame.getByText('One')).toBeVisible()
-    await expect(chatFrame.getByText('Two')).not.toBeVisible()
-    await expect(chatFrame.getByText('Three')).not.toBeVisible()
-    await expect(chatFrame.getByText('Five')).toBeVisible()
+    await expect(chatFrame.getByText(/One/)).toBeVisible()
+    await expect(chatFrame.getByText(/Two/)).not.toBeVisible()
+    await expect(chatFrame.getByText(/Three/)).not.toBeVisible()
+    await expect(chatFrame.getByText(/Five/)).toBeVisible()
 
     // Chat input should still have focus.
     await expect(chatInputs.nth(2)).toBeFocused()

--- a/vscode/test/e2e/chat-messages.test.ts
+++ b/vscode/test/e2e/chat-messages.test.ts
@@ -26,7 +26,7 @@ test('chat assistant response code buttons', async ({ page, nap, sidebar }, test
     await chatInput.press('Enter')
 
     const messageRows = chatMessageRows(chatPanel)
-    const assistantRow = messageRows.nth(1)
+    const assistantRow = messageRows.nth(2)
     await expect(assistantRow).toContainText('Hello! Here is a code snippet:')
     await expect(assistantRow).toContainText('def fib(n):')
 

--- a/vscode/webviews/chat/Transcript.story.tsx
+++ b/vscode/webviews/chat/Transcript.story.tsx
@@ -13,10 +13,12 @@ import {
     getMockedDotComClientModels,
     ps,
 } from '@sourcegraph/cody-shared'
+import { MockDefaultContext } from '@sourcegraph/prompt-editor/src/useInitialContext'
 import { useArgs, useCallback, useEffect, useRef, useState } from '@storybook/preview-api'
 import type { ComponentProps } from 'react'
 import { URI } from 'vscode-uri'
 import { VSCodeWebview } from '../storybook/VSCodeStoryDecorator'
+import { __ContextCellStorybookContext } from './cells/contextCell/ContextCell'
 
 const mockedModels = getMockedDotComClientModels()
 
@@ -94,6 +96,29 @@ export const WithDifferentModels: StoryObj<typeof meta> = {
 export const WithContext: StoryObj<typeof meta> = {
     args: {
         transcript: FIXTURE_TRANSCRIPT.explainCode2,
+    },
+    render: () => {
+        const [args] = useArgs<Required<NonNullable<(typeof meta)['args']>>>()
+        return (
+            <__ContextCellStorybookContext.Provider value={{ initialOpen: true }}>
+                <MockDefaultContext.Provider
+                    value={{
+                        initialContext: [],
+                        corpusContext: [
+                            {
+                                uri: URI.file('https://github.com/sourcegraph/sourcegraph'),
+                                type: 'repository',
+                                repoName: 'sourcegraph/sourcegraph',
+                                repoID: 'asdf',
+                                content: null,
+                            },
+                        ],
+                    }}
+                >
+                    <Transcript {...args} />
+                </MockDefaultContext.Provider>
+            </__ContextCellStorybookContext.Provider>
+        )
     },
 }
 

--- a/vscode/webviews/chat/Transcript.test.tsx
+++ b/vscode/webviews/chat/Transcript.test.tsx
@@ -85,7 +85,12 @@ describe('Transcript', () => {
                 ]}
             />
         )
-        expectCells([{ message: 'Hello' }, { message: 'Hi' }, { message: '' }])
+        expectCells([
+            { message: 'Hello' },
+            { context: { files: 0 } },
+            { message: 'Hi' },
+            { message: '' },
+        ])
     })
 
     test('interaction with context', () => {
@@ -119,8 +124,10 @@ describe('Transcript', () => {
         )
         expectCells([
             { message: 'Foo' },
+            { context: {} },
             { message: 'Bar' },
             { message: 'Baz' },
+            { context: {} },
             { message: 'Qux' },
             { message: '' },
         ])
@@ -185,6 +192,7 @@ describe('Transcript', () => {
         )
         expectCells([
             { message: 'Foo' },
+            { context: {} },
             { message: { loading: true } },
             { message: '', canSubmit: true },
         ])
@@ -226,7 +234,12 @@ describe('Transcript', () => {
                 messageInProgress={{ speaker: 'assistant', text: ps`Bar` }}
             />
         )
-        expectCells([{ message: 'Foo' }, { message: 'Bar' }, { message: '', canSubmit: true }])
+        expectCells([
+            { message: 'Foo' },
+            { context: {} },
+            { message: 'Bar' },
+            { message: '', canSubmit: true },
+        ])
     })
 
     test('assistant message with error', () => {
@@ -239,7 +252,11 @@ describe('Transcript', () => {
                 ]}
             />
         )
-        expectCells([{ message: 'Foo' }, { message: 'Model\n\nRequest Failed: some error' }])
+        expectCells([
+            { message: 'Foo' },
+            { context: {} },
+            { message: 'Model\n\nRequest Failed: some error' },
+        ])
         expect(screen.queryByText('Try again with different context')).toBeNull()
     })
 
@@ -253,7 +270,12 @@ describe('Transcript', () => {
             '[role="row"]:last-child [data-lexical-editor="true"]'
         )! as EditorHTMLElement
         await typeInEditor(editor, 'qux')
-        expectCells([{ message: 'Foo' }, { message: 'Bar' }, { message: 'qux', canSubmit: true }])
+        expectCells([
+            { message: 'Foo' },
+            { context: {} },
+            { message: 'Bar' },
+            { message: 'qux', canSubmit: true },
+        ])
 
         rerender(
             <Transcript
@@ -264,7 +286,12 @@ describe('Transcript', () => {
         )
         await typeInEditor(editor, 'yap')
         expectCells(
-            [{ message: 'Foo' }, { message: 'Bar' }, { message: 'qux', canSubmit: true }],
+            [
+                { message: 'Foo' },
+                { context: {} },
+                { message: 'Bar' },
+                { message: 'qux', canSubmit: true },
+            ],
             container
         )
     })
@@ -295,7 +322,12 @@ describe('Transcript', () => {
                 ]}
             />
         )
-        expectCells([{ message: 'Foo' }, { message: 'Bar' }, { message: 'xyz', canSubmit: true }])
+        expectCells([
+            { message: 'Foo' },
+            { context: {} },
+            { message: 'Bar' },
+            { message: 'xyz', canSubmit: true },
+        ])
     })
 })
 
@@ -345,7 +377,9 @@ function expectCells(expectedCells: CellMatcher[], containerElement?: HTMLElemen
             expect(cell).toHaveAttribute('data-testid', 'context')
             if (expectedCell.context.files !== undefined) {
                 expect(cell.querySelector('button')).toHaveAccessibleDescription(
-                    `${expectedCell.context.files} item`
+                    expectedCell.context.files === 1
+                        ? `${expectedCell.context.files} item`
+                        : `${expectedCell.context.files} items`
                 )
             } else if (expectedCell.context.loading) {
                 expect(cell.querySelector('[role="status"]')).toHaveAttribute('aria-busy')

--- a/vscode/webviews/chat/Transcript.tsx
+++ b/vscode/webviews/chat/Transcript.tsx
@@ -17,7 +17,7 @@ import {
 import { clsx } from 'clsx'
 import debounce from 'lodash/debounce'
 import isEqual from 'lodash/isEqual'
-import { ArrowBigUp, AtSign, Search } from 'lucide-react'
+import { Search } from 'lucide-react'
 import {
     type FC,
     type MutableRefObject,
@@ -35,7 +35,11 @@ import { getVSCodeAPI } from '../utils/VSCodeApi'
 import { useTelemetryRecorder } from '../utils/telemetry'
 import { useExperimentalOneBox } from '../utils/useExperimentalOneBox'
 import type { CodeBlockActionsProps } from './ChatMessageContent/ChatMessageContent'
-import { ContextCell } from './cells/contextCell/ContextCell'
+import {
+    ContextCell,
+    EditContextButtonChat,
+    EditContextButtonSearch,
+} from './cells/contextCell/ContextCell'
 import {
     AssistantMessageCell,
     makeHumanMessageInfo,
@@ -459,8 +463,7 @@ const TranscriptInteraction: FC<TranscriptInteractionProps> = memo(props => {
                         </Button>
                     </div>
                 )}
-            {((humanMessage.contextFiles && humanMessage.contextFiles.length > 0) ||
-                isContextLoading) && (
+            {(humanMessage.contextFiles || assistantMessage || isContextLoading) && (
                 <ContextCell
                     key={`${humanMessage.index}-${humanMessage.intent}-context`}
                     contextItems={humanMessage.contextFiles}
@@ -474,19 +477,9 @@ const TranscriptInteraction: FC<TranscriptInteractionProps> = memo(props => {
                     onAddToFollowupChat={onAddToFollowupChat}
                     onManuallyEditContext={manuallyEditContext}
                     editContextText={
-                        humanMessage.intent === 'search' ? (
-                            <>
-                                <ArrowBigUp className="-tw-mr-6 tw-py-0" />
-                                <AtSign className="-tw-mr-2 tw-py-2" />
-                                <div>Edit results as mentions</div>
-                            </>
-                        ) : (
-                            <>
-                                <ArrowBigUp className="-tw-mr-6 tw-py-0" />
-                                <AtSign className="-tw-mr-2 tw-py-2" />
-                                <div>Copy and edit as mentions</div>
-                            </>
-                        )
+                        humanMessage.intent === 'search'
+                            ? EditContextButtonSearch
+                            : EditContextButtonChat
                     }
                 />
             )}

--- a/vscode/webviews/chat/Transcript.tsx
+++ b/vscode/webviews/chat/Transcript.tsx
@@ -453,18 +453,16 @@ const TranscriptInteraction: FC<TranscriptInteractionProps> = memo(props => {
                     )}
                 </InfoMessage>
             )}
-            {corpusContextItems.length > 0 &&
-                !mentionsContainRepository &&
-                assistantMessage &&
-                !assistantMessage.isLoading && (
-                    <div>
-                        <Button onClick={resubmitWithRepoContext} type="button">
-                            Resend with current repository context
-                        </Button>
-                    </div>
-                )}
             {(humanMessage.contextFiles || assistantMessage || isContextLoading) && (
                 <ContextCell
+                    resubmitWithRepoContext={
+                        corpusContextItems.length > 0 &&
+                        !mentionsContainRepository &&
+                        assistantMessage &&
+                        !assistantMessage.isLoading
+                            ? resubmitWithRepoContext
+                            : undefined
+                    }
                     key={`${humanMessage.index}-${humanMessage.intent}-context`}
                     contextItems={humanMessage.contextFiles}
                     contextAlternatives={humanMessage.contextAlternatives}
@@ -476,7 +474,7 @@ const TranscriptInteraction: FC<TranscriptInteractionProps> = memo(props => {
                     isContextLoading={isContextLoading}
                     onAddToFollowupChat={onAddToFollowupChat}
                     onManuallyEditContext={manuallyEditContext}
-                    editContextText={
+                    editContextNode={
                         humanMessage.intent === 'search'
                             ? EditContextButtonSearch
                             : EditContextButtonChat

--- a/vscode/webviews/chat/Transcript.tsx
+++ b/vscode/webviews/chat/Transcript.tsx
@@ -456,10 +456,7 @@ const TranscriptInteraction: FC<TranscriptInteractionProps> = memo(props => {
             {(humanMessage.contextFiles || assistantMessage || isContextLoading) && (
                 <ContextCell
                     resubmitWithRepoContext={
-                        corpusContextItems.length > 0 &&
-                        !mentionsContainRepository &&
-                        assistantMessage &&
-                        !assistantMessage.isLoading
+                        corpusContextItems.length > 0 && !mentionsContainRepository && assistantMessage
                             ? resubmitWithRepoContext
                             : undefined
                     }

--- a/vscode/webviews/chat/cells/contextCell/ContextCell.module.css
+++ b/vscode/webviews/chat/cells/contextCell/ContextCell.module.css
@@ -25,4 +25,5 @@
 .context-suggested-actions {
     display: flex;
     flex-wrap: wrap;
+    gap: 0.25rem;
 }

--- a/vscode/webviews/chat/cells/contextCell/ContextCell.module.css
+++ b/vscode/webviews/chat/cells/contextCell/ContextCell.module.css
@@ -10,7 +10,8 @@
 }
 
 .context-item-edit-button {
-    display: flex;
+    /* display: flex; */
+    display: none;
     align-items: center;
 
     flex-wrap: nowrap;

--- a/vscode/webviews/chat/cells/contextCell/ContextCell.module.css
+++ b/vscode/webviews/chat/cells/contextCell/ContextCell.module.css
@@ -21,3 +21,8 @@
     height: 20%;
     margin-right: 0.5rem;
 }
+
+.context-suggested-actions {
+    display: flex;
+    flex-wrap: wrap;
+}

--- a/vscode/webviews/chat/cells/contextCell/ContextCell.story.tsx
+++ b/vscode/webviews/chat/cells/contextCell/ContextCell.story.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from '@storybook/react'
 import { ContextItemSource } from '@sourcegraph/cody-shared'
 import { URI } from 'vscode-uri'
 import { VSCodeStandaloneComponent } from '../../../storybook/VSCodeStoryDecorator'
-import { ContextCell } from './ContextCell'
+import { ContextCell, EditContextButtonChat } from './ContextCell'
 
 const meta: Meta<typeof ContextCell> = {
     title: 'cody/ContextCell',
@@ -12,6 +12,7 @@ const meta: Meta<typeof ContextCell> = {
     args: {
         __storybook__initialOpen: true,
         isForFirstMessage: true,
+        editContextText: EditContextButtonChat,
     },
 }
 
@@ -141,6 +142,14 @@ export const ExcludedContext: Story = {
                 source: ContextItemSource.User,
             },
         ],
+        isForFirstMessage: true,
+        __storybook__initialOpen: true,
+    },
+}
+
+export const NoContext: Story = {
+    args: {
+        contextItems: undefined,
         isForFirstMessage: true,
         __storybook__initialOpen: true,
     },

--- a/vscode/webviews/chat/cells/contextCell/ContextCell.story.tsx
+++ b/vscode/webviews/chat/cells/contextCell/ContextCell.story.tsx
@@ -12,7 +12,7 @@ const meta: Meta<typeof ContextCell> = {
     args: {
         __storybook__initialOpen: true,
         isForFirstMessage: true,
-        editContextText: EditContextButtonChat,
+        editContextNode: EditContextButtonChat,
     },
 }
 
@@ -147,9 +147,18 @@ export const ExcludedContext: Story = {
     },
 }
 
-export const NoContext: Story = {
+export const NoContextRequested: Story = {
     args: {
         contextItems: undefined,
+        resubmitWithRepoContext: () => Promise.resolve(),
+        isForFirstMessage: true,
+        __storybook__initialOpen: true,
+    },
+}
+
+export const NoContextFound: Story = {
+    args: {
+        contextItems: [],
         isForFirstMessage: true,
         __storybook__initialOpen: true,
     },

--- a/vscode/webviews/chat/cells/contextCell/ContextCell.story.tsx
+++ b/vscode/webviews/chat/cells/contextCell/ContextCell.story.tsx
@@ -1,19 +1,28 @@
 import type { Meta, StoryObj } from '@storybook/react'
 
 import { ContextItemSource } from '@sourcegraph/cody-shared'
+import type { ComponentProps } from 'react'
 import { URI } from 'vscode-uri'
 import { VSCodeStandaloneComponent } from '../../../storybook/VSCodeStoryDecorator'
-import { ContextCell, EditContextButtonChat } from './ContextCell'
+import { ContextCell, EditContextButtonChat, __ContextCellStorybookContext } from './ContextCell'
+
+const renderWithInitialOpen = (args: ComponentProps<typeof ContextCell>) => {
+    return (
+        <__ContextCellStorybookContext.Provider value={{ initialOpen: true }}>
+            <ContextCell {...args} />
+        </__ContextCellStorybookContext.Provider>
+    )
+}
 
 const meta: Meta<typeof ContextCell> = {
     title: 'cody/ContextCell',
     component: ContextCell,
     decorators: [VSCodeStandaloneComponent],
     args: {
-        __storybook__initialOpen: true,
         isForFirstMessage: true,
         editContextNode: EditContextButtonChat,
     },
+    render: renderWithInitialOpen,
 }
 
 export default meta
@@ -143,7 +152,6 @@ export const ExcludedContext: Story = {
             },
         ],
         isForFirstMessage: true,
-        __storybook__initialOpen: true,
     },
 }
 
@@ -152,7 +160,6 @@ export const NoContextRequested: Story = {
         contextItems: undefined,
         resubmitWithRepoContext: () => Promise.resolve(),
         isForFirstMessage: true,
-        __storybook__initialOpen: true,
     },
 }
 
@@ -160,6 +167,5 @@ export const NoContextFound: Story = {
     args: {
         contextItems: [],
         isForFirstMessage: true,
-        __storybook__initialOpen: true,
     },
 }

--- a/vscode/webviews/chat/cells/contextCell/ContextCell.tsx
+++ b/vscode/webviews/chat/cells/contextCell/ContextCell.tsx
@@ -2,7 +2,7 @@ import type { ContextItem, Model } from '@sourcegraph/cody-shared'
 import { pluralize } from '@sourcegraph/cody-shared'
 import type { RankedContext } from '@sourcegraph/cody-shared/src/chat/transcript/messages'
 import { clsx } from 'clsx'
-import { ArrowBigUp, AtSign, BrainIcon, MessagesSquareIcon } from 'lucide-react'
+import { BrainIcon, FilePenLine, MessagesSquareIcon } from 'lucide-react'
 import {
     type FunctionComponent,
     createContext,
@@ -212,7 +212,7 @@ export const ContextCell: FunctionComponent<{
                             ) : (
                                 <>
                                     <AccordionContent overflow={showSnippets}>
-                                        <div>
+                                        <div className={styles.contextSuggestedActions}>
                                             {contextItems && contextItems.length > 0 && (
                                                 <Button
                                                     size="sm"
@@ -227,7 +227,12 @@ export const ContextCell: FunctionComponent<{
                                                 </Button>
                                             )}
                                             {resubmitWithRepoContext && (
-                                                <Button onClick={resubmitWithRepoContext} type="button">
+                                                <Button
+                                                    size="sm"
+                                                    variant="outline"
+                                                    onClick={resubmitWithRepoContext}
+                                                    type="button"
+                                                >
                                                     Resend with current repository context
                                                 </Button>
                                             )}
@@ -418,16 +423,14 @@ const ExcludedContextWarning: React.FC<{ message: string }> = ({ message }) => (
 
 export const EditContextButtonSearch = (
     <>
-        <ArrowBigUp className="-tw-mr-6 tw-py-0" />
-        <AtSign className="-tw-mr-2 tw-py-2" />
-        <div>Edit results as mentions</div>
+        <FilePenLine size={'1em'} />
+        <div>Edit results</div>
     </>
 )
 
 export const EditContextButtonChat = (
     <>
-        <ArrowBigUp className="-tw-mr-6 tw-py-0" />
-        <AtSign className="-tw-mr-2 tw-py-2" />
-        <div>Copy and edit as mentions</div>
+        <FilePenLine size={'1em'} />
+        <div>Edit context</div>
     </>
 )

--- a/vscode/webviews/chat/cells/contextCell/ContextCell.tsx
+++ b/vscode/webviews/chat/cells/contextCell/ContextCell.tsx
@@ -2,7 +2,7 @@ import type { ContextItem, Model } from '@sourcegraph/cody-shared'
 import { pluralize } from '@sourcegraph/cody-shared'
 import type { RankedContext } from '@sourcegraph/cody-shared/src/chat/transcript/messages'
 import { clsx } from 'clsx'
-import { BrainIcon, MessagesSquareIcon } from 'lucide-react'
+import { ArrowBigUp, AtSign, BrainIcon, MessagesSquareIcon } from 'lucide-react'
 import { type FunctionComponent, memo, useCallback, useMemo, useState } from 'react'
 import { FileContextItem } from '../../../components/FileContextItem'
 import {
@@ -392,4 +392,20 @@ const ExcludedContextWarning: React.FC<{ message: string }> = ({ message }) => (
             .
         </span>
     </div>
+)
+
+export const EditContextButtonSearch = (
+    <>
+        <ArrowBigUp className="-tw-mr-6 tw-py-0" />
+        <AtSign className="-tw-mr-2 tw-py-2" />
+        <div>Edit results as mentions</div>
+    </>
+)
+
+export const EditContextButtonChat = (
+    <>
+        <ArrowBigUp className="-tw-mr-6 tw-py-0" />
+        <AtSign className="-tw-mr-2 tw-py-2" />
+        <div>Copy and edit as mentions</div>
+    </>
 )

--- a/vscode/webviews/chat/cells/contextCell/ContextCell.tsx
+++ b/vscode/webviews/chat/cells/contextCell/ContextCell.tsx
@@ -27,28 +27,38 @@ import styles from './ContextCell.module.css'
  * A component displaying the context for a human message.
  */
 export const ContextCell: FunctionComponent<{
+    isContextLoading: boolean
     contextItems: ContextItem[] | undefined
     contextAlternatives?: RankedContext[]
-    isContextLoading: boolean
-    model?: Model['id']
+    resubmitWithRepoContext?: () => Promise<void>
+
     isForFirstMessage: boolean
+
+    model?: Model['id']
     className?: string
+
     defaultOpen?: boolean
     showSnippets?: boolean
+
     reSubmitWithChatIntent?: () => void
+
     onAddToFollowupChat?: (props: {
         repoName: string
         filePath: string
         fileURL: string
     }) => void
+
     onManuallyEditContext: () => void
-    editContextText: React.ReactNode
+    editContextNode: React.ReactNode
+
     /** For use in storybooks only. */
     __storybook__initialOpen?: boolean
 }> = memo(
     ({
         contextItems,
         contextAlternatives,
+        resubmitWithRepoContext,
+
         model,
         isForFirstMessage,
         className,
@@ -59,7 +69,7 @@ export const ContextCell: FunctionComponent<{
         isContextLoading,
         onAddToFollowupChat,
         onManuallyEditContext,
-        editContextText,
+        editContextNode,
     }) => {
         const [selectedAlternative, setSelectedAlternative] = useState<number | undefined>(undefined)
         const incrementSelectedAlternative = useCallback(
@@ -138,196 +148,200 @@ export const ContextCell: FunctionComponent<{
 
         const isDeepCodyEnabled = useMemo(() => model?.includes('deep-cody'), [model])
 
+        // Text for top header text
+        const headerText: { main: string; sub?: string } = {
+            main: isContextLoading ? (isDeepCodyEnabled ? 'Thinking' : 'Fetching context') : 'Context',
+            sub: isContextLoading
+                ? isDeepCodyEnabled
+                    ? 'Retrieving context…'
+                    : 'Retrieving codebase files…'
+                : contextItems === undefined
+                  ? 'none requested'
+                  : contextItems.length === 0
+                    ? 'none fetched'
+                    : itemCountLabel,
+        }
+
         return (
             <div>
-                {(contextItemsToDisplay === undefined || contextItemsToDisplay.length !== 0) && (
-                    <Accordion
-                        type="single"
-                        collapsible={!showSnippets}
-                        defaultValue={
-                            ((__storybook__initialOpen || defaultOpen) && 'item-1') || undefined
-                        }
-                        onValueChange={logValueChange}
-                        asChild={true}
-                        value={accordionValue}
-                    >
-                        <AccordionItem value="item-1" asChild>
-                            <Cell
-                                header={
-                                    <AccordionTrigger
-                                        onClick={triggerAccordion}
-                                        title={itemCountLabel}
-                                        className="tw-flex tw-items-center tw-gap-4"
-                                        disabled={isContextLoading}
-                                    >
-                                        <SourcegraphLogo
-                                            width={NON_HUMAN_CELL_AVATAR_SIZE}
-                                            height={NON_HUMAN_CELL_AVATAR_SIZE}
-                                        />
-                                        <span className="tw-flex tw-items-baseline">
-                                            {isContextLoading
-                                                ? isDeepCodyEnabled
-                                                    ? 'Thinking'
-                                                    : 'Fetching context'
-                                                : 'Fetched context'}
+                <Accordion
+                    type="single"
+                    collapsible={!showSnippets}
+                    defaultValue={((__storybook__initialOpen || defaultOpen) && 'item-1') || undefined}
+                    onValueChange={logValueChange}
+                    asChild={true}
+                    value={accordionValue}
+                >
+                    <AccordionItem value="item-1" asChild>
+                        <Cell
+                            header={
+                                <AccordionTrigger
+                                    onClick={triggerAccordion}
+                                    title={itemCountLabel}
+                                    className="tw-flex tw-items-center tw-gap-4"
+                                    disabled={isContextLoading}
+                                >
+                                    <SourcegraphLogo
+                                        width={NON_HUMAN_CELL_AVATAR_SIZE}
+                                        height={NON_HUMAN_CELL_AVATAR_SIZE}
+                                    />
+                                    <span className="tw-flex tw-items-baseline">
+                                        {headerText.main}
+                                        {headerText.sub && (
                                             <span className="tw-opacity-60 tw-text-sm tw-ml-2">
-                                                &mdash;{' '}
-                                                {isContextLoading
-                                                    ? isDeepCodyEnabled
-                                                        ? 'Retrieving context…'
-                                                        : 'Retrieving codebase files…'
-                                                    : itemCountLabel}
+                                                &mdash; {headerText.sub}
                                             </span>
-                                        </span>
-                                    </AccordionTrigger>
-                                }
-                                containerClassName={className}
-                                contentClassName="tw-flex tw-flex-col tw-gap-4 tw-max-w-full"
-                                data-testid="context"
-                            >
-                                {contextItems === undefined ? (
-                                    <LoadingDots />
-                                ) : (
-                                    <>
-                                        <AccordionContent overflow={showSnippets}>
+                                        )}
+                                    </span>
+                                </AccordionTrigger>
+                            }
+                            containerClassName={className}
+                            contentClassName="tw-flex tw-flex-col tw-gap-4 tw-max-w-full"
+                            data-testid="context"
+                        >
+                            {isContextLoading ? (
+                                <LoadingDots />
+                            ) : (
+                                <>
+                                    <AccordionContent overflow={showSnippets}>
+                                        {contextItems && contextItems.length > 0 && (
                                             <Button
                                                 size="sm"
                                                 variant="outline"
                                                 className={clsx('tw-pr-4', styles.contextItemEditButton)}
                                                 onClick={onEditContext}
                                             >
-                                                {editContextText}
+                                                {editContextNode}
                                             </Button>
-                                            {internalDebugContext && contextAlternatives && (
+                                        )}
+                                        {internalDebugContext && contextAlternatives && (
+                                            <div>
+                                                <button onClick={prevSelectedAlternative} type="button">
+                                                    &larr;
+                                                </button>
+                                                <button onClick={nextSelectedAlternative} type="button">
+                                                    &rarr;
+                                                </button>{' '}
+                                                Ranking mechanism:{' '}
+                                                {selectedAlternative === undefined
+                                                    ? 'actual'
+                                                    : `${
+                                                          contextAlternatives[selectedAlternative]
+                                                              .strategy
+                                                      }: (${(selectedAlternative ?? -1) + 1} of ${
+                                                          contextAlternatives.length
+                                                      })`}
+                                            </div>
+                                        )}
+                                        <ul className="tw-list-none tw-flex tw-flex-col tw-gap-2 tw-pt-2">
+                                            {contextItemsToDisplay?.map((item, i) =>
+                                                !showSnippets || showAllResults || i < 5 ? (
+                                                    <li
+                                                        // biome-ignore lint/correctness/useJsxKeyInIterable:
+                                                        // biome-ignore lint/suspicious/noArrayIndexKey: stable order
+                                                        key={i}
+                                                        data-testid="context-item"
+                                                    >
+                                                        <FileContextItem
+                                                            item={item}
+                                                            showSnippets={showSnippets}
+                                                            onAddToFollowupChat={onAddToFollowupChat}
+                                                        />
+                                                        {internalDebugContext &&
+                                                            item.metadata &&
+                                                            item.metadata.length > 0 && (
+                                                                <span
+                                                                    className={
+                                                                        styles.contextItemMetadata
+                                                                    }
+                                                                >
+                                                                    {item.metadata.join(', ')}
+                                                                </span>
+                                                            )}
+                                                    </li>
+                                                ) : null
+                                            )}
+                                            {showSnippets &&
+                                            !showAllResults &&
+                                            contextItemsToDisplay &&
+                                            contextItemsToDisplay.length > 5 ? (
+                                                <div className="tw-flex tw-justify-between">
+                                                    <Button
+                                                        variant="link"
+                                                        onClick={() => setShowAllResults(true)}
+                                                    >
+                                                        Show {contextItemsToDisplay.length - 5} more
+                                                        results
+                                                    </Button>
+                                                    <Button
+                                                        size="sm"
+                                                        variant="outline"
+                                                        className="tw-text-prmary tw-flex tw-gap-2 tw-items-center"
+                                                        onClick={reSubmitWithChatIntent}
+                                                    >
+                                                        <CodyIcon className="tw-text-link" />
+                                                        Ask the LLM
+                                                    </Button>
+                                                </div>
+                                            ) : null}
+                                            {resubmitWithRepoContext && (
                                                 <div>
-                                                    <button
-                                                        onClick={prevSelectedAlternative}
+                                                    <Button
+                                                        onClick={resubmitWithRepoContext}
                                                         type="button"
                                                     >
-                                                        &larr;
-                                                    </button>
-                                                    <button
-                                                        onClick={nextSelectedAlternative}
-                                                        type="button"
-                                                    >
-                                                        &rarr;
-                                                    </button>{' '}
-                                                    Ranking mechanism:{' '}
-                                                    {selectedAlternative === undefined
-                                                        ? 'actual'
-                                                        : `${
-                                                              contextAlternatives[selectedAlternative]
-                                                                  .strategy
-                                                          }: (${(selectedAlternative ?? -1) + 1} of ${
-                                                              contextAlternatives.length
-                                                          })`}
+                                                        Resend with current repository context
+                                                    </Button>
                                                 </div>
                                             )}
-                                            <ul className="tw-list-none tw-flex tw-flex-col tw-gap-2 tw-pt-2">
-                                                {contextItemsToDisplay?.map((item, i) =>
-                                                    !showSnippets || showAllResults || i < 5 ? (
-                                                        <li
-                                                            // biome-ignore lint/correctness/useJsxKeyInIterable:
-                                                            // biome-ignore lint/suspicious/noArrayIndexKey: stable order
-                                                            key={i}
-                                                            data-testid="context-item"
-                                                        >
-                                                            <FileContextItem
-                                                                item={item}
-                                                                showSnippets={showSnippets}
-                                                                onAddToFollowupChat={onAddToFollowupChat}
-                                                            />
-                                                            {internalDebugContext &&
-                                                                item.metadata &&
-                                                                item.metadata.length > 0 && (
-                                                                    <span
-                                                                        className={
-                                                                            styles.contextItemMetadata
-                                                                        }
-                                                                    >
-                                                                        {item.metadata.join(', ')}
-                                                                    </span>
-                                                                )}
-                                                        </li>
-                                                    ) : null
-                                                )}
-                                                {showSnippets &&
-                                                !showAllResults &&
-                                                contextItemsToDisplay &&
-                                                contextItemsToDisplay.length > 5 ? (
-                                                    <div className="tw-flex tw-justify-between">
-                                                        <Button
-                                                            variant="link"
-                                                            onClick={() => setShowAllResults(true)}
-                                                        >
-                                                            Show {contextItemsToDisplay.length - 5} more
-                                                            results
-                                                        </Button>
-                                                        <Button
-                                                            size="sm"
-                                                            variant="outline"
-                                                            className="tw-text-prmary tw-flex tw-gap-2 tw-items-center"
-                                                            onClick={reSubmitWithChatIntent}
-                                                        >
-                                                            <CodyIcon className="tw-text-link" />
-                                                            Ask the LLM
-                                                        </Button>
-                                                    </div>
-                                                ) : null}
-                                                {!isForFirstMessage && (
-                                                    <span
-                                                        className={clsx(
-                                                            styles.contextItem,
-                                                            'tw-flex tw-items-center tw-gap-2'
-                                                        )}
-                                                    >
-                                                        <MessagesSquareIcon
-                                                            size={14}
-                                                            className="tw-ml-1"
-                                                        />
-                                                        <span>
-                                                            Prior messages and context in this
-                                                            conversation
-                                                        </span>
+
+                                            {!isForFirstMessage && (
+                                                <span
+                                                    className={clsx(
+                                                        styles.contextItem,
+                                                        'tw-flex tw-items-center tw-gap-2'
+                                                    )}
+                                                >
+                                                    <MessagesSquareIcon size={14} className="tw-ml-1" />
+                                                    <span>
+                                                        Prior messages and context in this conversation
                                                     </span>
-                                                )}
-                                                <li>
-                                                    <Tooltip>
-                                                        <TooltipTrigger asChild>
-                                                            <span
-                                                                className={clsx(
-                                                                    styles.contextItem,
-                                                                    'tw-flex tw-items-center tw-gap-2'
-                                                                )}
-                                                            >
-                                                                <BrainIcon
-                                                                    size={14}
-                                                                    className="tw-ml-1"
-                                                                />
-                                                                <span>
-                                                                    {isDeepCodyEnabled
-                                                                        ? 'Reviewed by Deep Cody'
-                                                                        : 'Public knowledge'}
-                                                                </span>
-                                                            </span>
-                                                        </TooltipTrigger>
-                                                        <TooltipContent side="bottom">
+                                                </span>
+                                            )}
+                                            <li>
+                                                <Tooltip>
+                                                    <TooltipTrigger asChild>
+                                                        <span
+                                                            className={clsx(
+                                                                styles.contextItem,
+                                                                'tw-flex tw-items-center tw-gap-2'
+                                                            )}
+                                                        >
+                                                            <BrainIcon size={14} className="tw-ml-1" />
                                                             <span>
-                                                                Information and general reasoning
-                                                                capabilities trained into the model{' '}
-                                                                {model && <code>{model}</code>}
+                                                                {isDeepCodyEnabled
+                                                                    ? 'Reviewed by Deep Cody'
+                                                                    : 'Public knowledge'}
                                                             </span>
-                                                        </TooltipContent>
-                                                    </Tooltip>
-                                                </li>
-                                            </ul>
-                                        </AccordionContent>
-                                    </>
-                                )}
-                            </Cell>
-                        </AccordionItem>
-                    </Accordion>
-                )}
+                                                        </span>
+                                                    </TooltipTrigger>
+                                                    <TooltipContent side="bottom">
+                                                        <span>
+                                                            Information and general reasoning
+                                                            capabilities trained into the model{' '}
+                                                            {model && <code>{model}</code>}
+                                                        </span>
+                                                    </TooltipContent>
+                                                </Tooltip>
+                                            </li>
+                                        </ul>
+                                    </AccordionContent>
+                                </>
+                            )}
+                        </Cell>
+                    </AccordionItem>
+                </Accordion>
+
                 {contextItemsToDisplay && excludedContextInfo.length > 0 && (
                     <div className="tw-mt-2 tw-text-muted-foreground">
                         {excludedContextInfo.map(message => (

--- a/vscode/webviews/chat/cells/contextCell/ContextCell.tsx
+++ b/vscode/webviews/chat/cells/contextCell/ContextCell.tsx
@@ -3,7 +3,15 @@ import { pluralize } from '@sourcegraph/cody-shared'
 import type { RankedContext } from '@sourcegraph/cody-shared/src/chat/transcript/messages'
 import { clsx } from 'clsx'
 import { ArrowBigUp, AtSign, BrainIcon, MessagesSquareIcon } from 'lucide-react'
-import { type FunctionComponent, memo, useCallback, useMemo, useState } from 'react'
+import {
+    type FunctionComponent,
+    createContext,
+    memo,
+    useCallback,
+    useContext,
+    useMemo,
+    useState,
+} from 'react'
 import { FileContextItem } from '../../../components/FileContextItem'
 import {
     Accordion,
@@ -22,6 +30,8 @@ import { LoadingDots } from '../../components/LoadingDots'
 import { Cell } from '../Cell'
 import { NON_HUMAN_CELL_AVATAR_SIZE } from '../messageCell/assistant/AssistantMessageCell'
 import styles from './ContextCell.module.css'
+
+export const __ContextCellStorybookContext = createContext<{ initialOpen: boolean } | null>(null)
 
 /**
  * A component displaying the context for a human message.
@@ -50,9 +60,6 @@ export const ContextCell: FunctionComponent<{
 
     onManuallyEditContext: () => void
     editContextNode: React.ReactNode
-
-    /** For use in storybooks only. */
-    __storybook__initialOpen?: boolean
 }> = memo(
     ({
         contextItems,
@@ -63,7 +70,6 @@ export const ContextCell: FunctionComponent<{
         isForFirstMessage,
         className,
         defaultOpen,
-        __storybook__initialOpen,
         reSubmitWithChatIntent,
         showSnippets = false,
         isContextLoading,
@@ -71,6 +77,8 @@ export const ContextCell: FunctionComponent<{
         onManuallyEditContext,
         editContextNode,
     }) => {
+        const __storybook__initialOpen = useContext(__ContextCellStorybookContext)?.initialOpen ?? false
+
         const [selectedAlternative, setSelectedAlternative] = useState<number | undefined>(undefined)
         const incrementSelectedAlternative = useCallback(
             (increment: number): void => {
@@ -204,16 +212,26 @@ export const ContextCell: FunctionComponent<{
                             ) : (
                                 <>
                                     <AccordionContent overflow={showSnippets}>
-                                        {contextItems && contextItems.length > 0 && (
-                                            <Button
-                                                size="sm"
-                                                variant="outline"
-                                                className={clsx('tw-pr-4', styles.contextItemEditButton)}
-                                                onClick={onEditContext}
-                                            >
-                                                {editContextNode}
-                                            </Button>
-                                        )}
+                                        <div>
+                                            {contextItems && contextItems.length > 0 && (
+                                                <Button
+                                                    size="sm"
+                                                    variant="outline"
+                                                    className={clsx(
+                                                        'tw-pr-4',
+                                                        styles.contextItemEditButton
+                                                    )}
+                                                    onClick={onEditContext}
+                                                >
+                                                    {editContextNode}
+                                                </Button>
+                                            )}
+                                            {resubmitWithRepoContext && (
+                                                <Button onClick={resubmitWithRepoContext} type="button">
+                                                    Resend with current repository context
+                                                </Button>
+                                            )}
+                                        </div>
                                         {internalDebugContext && contextAlternatives && (
                                             <div>
                                                 <button onClick={prevSelectedAlternative} type="button">
@@ -284,16 +302,6 @@ export const ContextCell: FunctionComponent<{
                                                     </Button>
                                                 </div>
                                             ) : null}
-                                            {resubmitWithRepoContext && (
-                                                <div>
-                                                    <Button
-                                                        onClick={resubmitWithRepoContext}
-                                                        type="button"
-                                                    >
-                                                        Resend with current repository context
-                                                    </Button>
-                                                </div>
-                                            )}
 
                                             {!isForFirstMessage && (
                                                 <span


### PR DESCRIPTION
On a context-less chat request, we show a "none fetched" indicator in the ContextCell, along with a "Resend with current repository context" button:
![Selection_910](https://github.com/user-attachments/assets/5faefc2e-4bb5-488f-bbba-52aee2f300ea)

Clicking "Resend with current repository context" causes the repository chip to be added and the request resent:
![Selection_911](https://github.com/user-attachments/assets/8f665570-1266-46d7-84a9-43700992480e)

The "Resend with current repository context" also appears when context is at-mentioned but there is no repo chip:
![Selection_912](https://github.com/user-attachments/assets/9041d5c2-241c-4f63-94e4-da93ed8116cc)

This PR also removes the "Edit context" button (which previously caused the fetched context items to be moved to the input), because this was broken and not actually fetching context.

## Test plan

Test in local dev the scenarios in the screenshots above.
