### PR TITLE
feat(edit): enable predicted outputs for gpt-4o models

### DIFF
--- a/lib/shared/src/sourcegraph-api/completions/types.ts
+++ b/lib/shared/src/sourcegraph-api/completions/types.ts
@@ -37,6 +37,14 @@ export interface CompletionParameters {
     topP?: number
     model?: string
     stream?: boolean
+    // Configuration for a Predicted Output, which can greatly improve response
+    // times when large parts of the model response are known ahead of time.
+    // https://platform.openai.com/docs/guides/latency-optimization#use-predicted-outputs
+    // https://platform.openai.com/docs/api-reference/chat/create#chat-create-prediction
+    prediction?: {
+        type: 'content'
+        content: string
+    }
 }
 
 export interface SerializedCompletionParameters extends Omit<CompletionParameters, 'messages'> {

--- a/vscode/src/edit/provider.ts
+++ b/vscode/src/edit/provider.ts
@@ -134,6 +134,16 @@ export class EditProvider {
                 stopSequences,
                 maxTokensToSample: contextWindow.output,
             } as CompletionParameters
+
+            if (model.includes('gpt-4o')) {
+                // Use Predicted Output for gpt-4o models.
+                // https://platform.openai.com/docs/guides/predicted-outputs
+                params.prediction = {
+                    type: 'content',
+                    content: this.config.task.original,
+                }
+            }
+
             // Set stream param only when the model is disabled for streaming.
             if (modelsService.isStreamDisabled(model)) {
                 params.stream = false


### PR DESCRIPTION
- Enables [the Predicted Outputs feature](https://platform.openai.com/docs/guides/predicted-outputs) for gpt-4o models used with Edit commands.
- Related work:
    - https://github.com/sourcegraph/cody/pull/6095
    - https://github.com/sourcegraph/sourcegraph/pull/1591
    - https://github.com/sourcegraph/cody/pull/6110
- Part of [CODY-4306: A/B test OpenAI Predicted Outputs optimization with the Edit command](https://linear.app/sourcegraph/issue/CODY-4306/ab-test-openai-predicted-outputs-optimization-with-the-edit-command)
- Closes [CODY-4321: Add the predicted outputs feature support to the clients](https://linear.app/sourcegraph/issue/CODY-4321/add-the-predicted-outputs-feature-support-to-the-clients)

## Test plan

CI and manual testing:
1. Start the local Sourcegraph instance from [this PR](https://github.com/sourcegraph/sourcegraph/pull/1625): `sg start enterprise`.
2. Use the local instance to sign in to the VS Code extension.
3. Pick `gpt-4o-mini` as your model for the next Edit command.
4. Execute the Edit.
5. Go to https://sourcegraph.test:3443/site-admin/outbound-requests and verify that `{ type: 'content', content: $SELECTED_CODE }` is present in the Cody Gateway completions request (http://localhost:9992/v1/completions/openai).

## Changelog

- Edit: Enabled [the Predicted Outputs feature](https://platform.openai.com/docs/guides/predicted-outputs) for GPT-4o models.
