### PR TITLE
Cody Chat: fixed missing syntax highlighting of CSharp files and load only one copy of highlight.js in the WebView build

### DIFF
--- a/lib/shared/src/common/languages.ts
+++ b/lib/shared/src/common/languages.ts
@@ -37,7 +37,7 @@ const EXTENSION_TO_LANGUAGE: { [key: string]: string } = {
     java: ProgrammingLanguage.Java,
     c: 'C',
     cpp: 'C++',
-    cs: 'C#',
+    cs: 'Csharp',
     css: 'CSS',
     html: 'HTML',
     json: 'JSON',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -571,8 +571,8 @@ importers:
         specifier: ^1.2.0
         version: 1.2.0
       highlight.js:
-        specifier: 11.9.0
-        version: 11.9.0
+        specifier: 11.8.0
+        version: 11.8.0
       http-proxy-agent:
         specifier: ^7.0.2
         version: 7.0.2
@@ -10269,11 +10269,6 @@ packages:
 
   /highlight.js@11.8.0:
     resolution: {integrity: sha512-MedQhoqVdr0U6SSnWPzfiadUcDHfN/Wzq25AkXiQv9oiOO/sG0S7XkvpFIqWBl9Yq1UYyYOOVORs5UW2XlPyzg==}
-    engines: {node: '>=12.0.0'}
-    dev: false
-
-  /highlight.js@11.9.0:
-    resolution: {integrity: sha512-fJ7cW7fQGCYAkgv4CPfwFHrfd/cLS4Hau96JuJ+ZTOWhjnhoeN1ub1tFmALm/+lW5z4WCAuAV9bm05AP0mS6Gw==}
     engines: {node: '>=12.0.0'}
     dev: false
 

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -1422,7 +1422,7 @@
     "glob": "^7.2.3",
     "graceful-fs": "^4.2.11",
     "he": "^1.2.0",
-    "highlight.js": "11.9.0",
+    "highlight.js": "11.8.0",
     "http-proxy-agent": "^7.0.2",
     "https-proxy-agent": "^7.0.5",
     "ini": "^4.1.2",


### PR DESCRIPTION
## Test plan
1. Ask Cody to create a sample Csharp program. Check if syntax highlight loads
![person-c#](https://github.com/user-attachments/assets/d02bdd1e-0c5d-46a1-9067-ae37c356425f)
![person-csharp](https://github.com/user-attachments/assets/c6364123-87b1-4f79-b9aa-428a7bf55226)

2. Run ANALYZE=TRUE pnpm build within web folder
Check that only one copy of highlight.js is bundled
![agent-bundle](https://github.com/user-attachments/assets/da1c449d-7345-4e8b-9a7d-5908a98a60f8)
![agent-bundle-fixed](https://github.com/user-attachments/assets/9424e1b5-4cb2-4655-acde-2c2a0ac14859)


<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

## Changelog
Cody Chat: fixed missing syntax highlighting of CSharp files and load only one copy of highlight.js in the WebView build
<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
