### PR TITLE
feat(rel): add backport workflow

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,0 +1,27 @@
+name: Backport
+on:
+  pull_request_target:
+    types:
+      - closed
+      - labeled
+
+jobs:
+  backport:
+    name: Backport
+    runs-on: ubuntu-latest
+    # Only react to merged PRs for security reasons.
+    # See https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target.
+    if: >
+      github.event.pull_request.merged
+      && (
+        github.event.action == 'closed'
+        || (
+          github.event.action == 'labeled'
+          && contains(github.event.label.name, 'backport')
+        )
+      )
+    steps:
+      - uses: sourcegraph/backport@v2
+        with:
+          github_token: ${{ secrets.BACKPORT_GITHUB_TOKEN }}
+          label_pattern: '^cherrypick (?<base>vscode-v\d+\.\d+\.x)$'


### PR DESCRIPTION
This PR adds a backport github action based our backport tooling in `sourcegraph/backport`
It uses different labels (`cherrypick vscode-v<version-number>`) which is slightly different than the current label. Importantly, this allows it to pick up the `base` branch to be used (in this case `vscode-vX.YZ.x`) so it knows to backport to the branch.
Testing in this repo first, and if it works as anticipated, will port it over to the JetBrains repo too. 

## Test plan
Manually running this?
<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

## Changelog
N/A
<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
