### PR TITLE
fix rendering issue on the same line for ghost text

### DIFF
--- a/vscode/src/autoedits/renderer.ts
+++ b/vscode/src/autoedits/renderer.ts
@@ -476,7 +476,7 @@ export class AutoEditsRenderer implements vscode.Disposable {
                         endRange
                     ),
                     renderOptions: {
-                        after: {
+                        before: {
                             contentText: rangeText,
                         },
                     },


### PR DESCRIPTION
Fixes ghost text rendering for autoedits on the same line. [Linear Issue](https://linear.app/sourcegraph/issue/CODY-4320/fix-ui-rendering-on-the-same-line-when-other-extension-show-their-own)

**Before:**
<img width="1131" alt="image" src="https://github.com/user-attachments/assets/f341a394-a9b7-4f85-8f62-f5894c0898ec">


**After:**
<img width="745" alt="image" src="https://github.com/user-attachments/assets/55a43d4f-7b70-4c12-af3d-b5146ebb68ca">

## Test plan
1. Turn on the auto-edit renderer tester: `"cody.experimental.autoedits-renderer-testing": true,`
2. Use [this file](https://github.com/sourcegraph/cody-chat-eval/blob/main/code-matching-eval/edits_experiments/examples/renderer-testing-examples/rendering-issue-inline-ghost-text-autoedits.go) to repro the issue.
3. Trigger `Ctrl+Option+Enter` on [line](https://github.com/sourcegraph/cody-chat-eval/blob/main/code-matching-eval/edits_experiments/examples/renderer-testing-examples/rendering-issue-inline-ghost-text-autoedits.go#L47C3-L47C20)
4. Without the fix, it will show decoration from other extension `gitLens` first. 

