### PR TITLE
update changelog messaging

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -1,8 +1,16 @@
 # Changelog
 
-This is a log of all notable changes to Cody for VS Code. [Unreleased] changes are included in the nightly pre-release builds.
+This is a log of all notable changes to Cody for VS Code.
 
 ## [Unreleased]
+
+### Added
+
+### Fixed
+
+### Changed
+## [1.42.0]
+For developers who want to track detailed technical changes, we will be updating this changelog to provide more comprehensive updates on new features, improvements, and fixes. For major releases and announcements, check out our [public changelog](https://sourcegraph.com/changelog). 
 
 ### Added
 
@@ -14,7 +22,37 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
   - `Alt+L`: between chat and editor (this is unchanged)
   - `Shift+Alt+L` (previously alt+L): add selection as context:
   - `Shift+Ctrl+L` (previously shift+alt+L): new chat
-### Changed
+
+### Uncategorized
+
+- Fix issue with merging configs [pull/6084](https://github.com/sourcegraph/cody/pull/6084)
+- chore/build: VSCode Insiders builds are manually triggered and automatically tagged [pull/6083](https://github.com/sourcegraph/cody/pull/6083)
+- Add Deep Cody back to model list, revert button change [pull/6077](https://github.com/sourcegraph/cody/pull/6077)
+- Fix configuration inspect method [pull/6075](https://github.com/sourcegraph/cody/pull/6075)
+- Improve Cody logging agent protocol [pull/6069](https://github.com/sourcegraph/cody/pull/6069)
+- Ensure CompletionBookkeepingEvent timestamps are not floating point [pull/6073](https://github.com/sourcegraph/cody/pull/6073)
+- VS Code: Release v1.40.2 [pull/6062](https://github.com/sourcegraph/cody/pull/6062)
+- Autocomplete: remove the extended language pool option [pull/6072](https://github.com/sourcegraph/cody/pull/6072)
+- Deep Cody: Allow toggle in UI & implement CodyChatMemory [pull/6066](https://github.com/sourcegraph/cody/pull/6066)
+- Autocomplete: add characters logger metadata to `accepted` events [pull/6068](https://github.com/sourcegraph/cody/pull/6068)
+- fix: rewrite symf query only once [pull/6070](https://github.com/sourcegraph/cody/pull/6070)
+- Run prompts migration only over local user commands [pull/6056](https://github.com/sourcegraph/cody/pull/6056)
+- Context: make error message more concise [pull/6065](https://github.com/sourcegraph/cody/pull/6065)
+- prevent double-adding selected context [pull/6059](https://github.com/sourcegraph/cody/pull/6059)
+- Fix bugs in workspace::getConfiguration vscode shim [pull/6058](https://github.com/sourcegraph/cody/pull/6058)
+- Autocomplete: deflake hot-streak tests [pull/6040](https://github.com/sourcegraph/cody/pull/6040)
+- Remove repo chip from default context (feature flagged) [pull/6034](https://github.com/sourcegraph/cody/pull/6034)
+- update insider cron schedule to MWF @ 1500 UTC [pull/6052](https://github.com/sourcegraph/cody/pull/6052)
+- VS Code: Release v1.40.1 [pull/6051](https://github.com/sourcegraph/cody/pull/6051)
+- Auth: UI conditional rendering logic [pull/6047](https://github.com/sourcegraph/cody/pull/6047)
+- Change nested configuration object handling to match VSCode behavior. [pull/6041](https://github.com/sourcegraph/cody/pull/6041)
+- Update marketplace description [pull/6046](https://github.com/sourcegraph/cody/pull/6046)
+- Fix OpenCtx include initial context integeration. [pull/6045](https://github.com/sourcegraph/cody/pull/6045)
+- Network: Fallback to CODY_NODE_TLS_REJECT_UNAUTHORIZED for cert auth [pull/6037](https://github.com/sourcegraph/cody/pull/6037)
+- Autocomplete: cleanup the fast-path a/b test [pull/6039](https://github.com/sourcegraph/cody/pull/6039)
+- fix(ci): Increase test timeout for uninstall test [pull/6038](https://github.com/sourcegraph/cody/pull/6038)
+- Fix Prompts welcome screen initial state [pull/6036](https://github.com/sourcegraph/cody/pull/6036)
+- VS Code: add characters logger metadata to chat code-gen events [pull/6019](https://github.com/sourcegraph/cody/pull/6019)
 
 ## 1.40.2
 


### PR DESCRIPTION
Updating the changelog messaging to inform users that we will be improving our communications around updates to each new release. 

## Test plan
N/A
<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
