### PR TITLE
Build: Separate test and production build steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
           key: ${{ runner.os }}-${{ matrix.node }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
           restore-keys: ${{ runner.os }}-${{ matrix.node }}-pnpm-store-
       - run: pnpm install
-      - run: pnpm build
+      - run: pnpm build:for-test
       - run: pnpm run test:unit --run
         env:
           CODY_NODE_VERSION: ${{ matrix.node }}

--- a/agent/package.json
+++ b/agent/package.json
@@ -21,7 +21,8 @@
     "agent:debug": "pnpm run build && CODY_AGENT_TRACE_PATH=/tmp/agent.json CODY_AGENT_DEBUG_REMOTE=true node --enable-source-maps ./dist/index.js api jsonrpc-stdio",
     "build-ts": "tsc --build",
     "test-agent-binary": "esbuild ./scripts/test-agent-binary.ts --bundle --platform=node --alias:vscode=./src/vscode-shim.ts --outdir=dist && node ./dist/test-agent-binary.js",
-    "test": "vitest",
+    "test": "build:for-tests && vitest",
+    "test:only": "vitest",
     "prepublishOnly": "pnpm run build"
   },
   "bin": "dist/index.js",

--- a/agent/src/TestClient.ts
+++ b/agent/src/TestClient.ts
@@ -90,23 +90,7 @@ interface TestClientParams {
     extraConfiguration?: Record<string, any>
 }
 
-let isBuilt = false
-export function buildAgentBinary(): void {
-    if (isBuilt) {
-        return
-    }
-    isBuilt = true
-    // Bundle the agent. When running `pnpm run test`, vitest doesn't re-run this step.
-    //
-    // ! If this line fails when running unit tests, chances are that the error is being swallowed.
-    // To see the full error, run this file in isolation:
-    //
-    //   pnpm test agent/src/index.test.ts
-    execSync('pnpm run build:for-tests ', {
-        cwd: getAgentDir(),
-        stdio: 'inherit',
-    })
-
+export function setupRecording(): void {
     const mayRecord =
         process.env.CODY_RECORDING_MODE === 'record' || process.env.CODY_RECORD_IF_MISSING === 'true'
     if (mayRecord) {
@@ -135,7 +119,7 @@ export class TestClient extends MessageHandler {
     private secrets = new AgentStatelessSecretStorage()
     private extensionConfigurationDuringInitialization: ExtensionConfiguration | undefined
     public static create({ bin = 'node', ...params }: TestClientParams): TestClient {
-        buildAgentBinary()
+        setupRecording()
         const agentDir = getAgentDir()
         const recordingDirectory = path.join(agentDir, 'recordings')
         const agentScript = path.join(agentDir, 'dist', 'index.js')

--- a/agent/src/cli/command-chat.test.ts
+++ b/agent/src/cli/command-chat.test.ts
@@ -5,7 +5,7 @@ import { afterAll, beforeAll, expect, it } from 'vitest'
 import YAML from 'yaml'
 import { startPollyRecording } from '../../../vscode/src/testutils/polly'
 import { TESTING_CREDENTIALS } from '../../../vscode/src/testutils/testing-credentials'
-import { buildAgentBinary, getAgentDir } from '../TestClient'
+import { getAgentDir, setupRecording } from '../TestClient'
 import { TestWorkspace } from '../TestWorkspace'
 import { Streams, StringBufferStream } from './Streams'
 import { isWindows } from './command-bench/isWindows'
@@ -82,7 +82,7 @@ describe('cody chat', () => {
 
     beforeAll(() => {
         tmp.beforeAll()
-        buildAgentBinary()
+        setupRecording()
         polly = startPollyRecording({
             recordingName: 'cody-chat',
             keepUnusedRecordings: process.env.CODY_KEEP_UNUSED_RECORDINGS === 'true',

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "scripts": {
     "agent": "pnpm -C agent agent",
     "build": "tsc --build",
+    "build:for-tests": "pnpm run build && pnpm -C vscode build && pnpm -C agent run build:for-tests",
     "watch": "tsc --build --watch",
     "check": "pnpm run -s check:build && pnpm run -s biome && pnpm run -s check:css",
     "check:css": "stylelint --quiet --cache '**/*.css'",

--- a/scripts/nukeTSBuildInfo.ts
+++ b/scripts/nukeTSBuildInfo.ts
@@ -1,0 +1,109 @@
+import fs from 'node:fs'
+import path from 'node:path'
+/// <reference types="@types/bun" >
+import { parseArgs } from 'node:util'
+
+const HELP_TEXT = `
+clean-ts-artifacts.ts - Clean up TypeScript build artifacts
+
+This script removes leftover incremental build artifacts that can sometimes cause
+stale TypeScript errors. It cleans:
+- .tsbuildinfo files (TypeScript incremental build info)
+- dist/ directories (compiled output)
+- out/ directories (compiled output)
+
+Usage:
+  bun run scripts/clean-ts-artifacts.ts [options]
+
+Options:
+  --force    Actually delete the files (default: dry run only)
+  --help     Show this help message
+`
+const IGNORED_PATHS = [
+    '.test',
+    'vscode/test-results',
+    // Add more paths here
+].map(p => path.normalize(p))
+
+function shouldIgnorePath(pathToCheck: string): boolean {
+    const relativePath = path.relative(process.cwd(), pathToCheck)
+    return IGNORED_PATHS.some(
+        ignorePath =>
+            relativePath.startsWith(ignorePath) ||
+            relativePath.includes(`${path.sep}${ignorePath}${path.sep}`)
+    )
+}
+
+const args = parseArgs({
+    args: Bun.argv.slice(2),
+    options: {
+        force: { type: 'boolean', default: false },
+        help: { type: 'boolean', default: false },
+    },
+    allowPositionals: false,
+})
+
+if (args.values.help) {
+    console.log(HELP_TEXT)
+    process.exit(0)
+}
+
+function cleanTSArtifacts(dir: string, force: boolean): void {
+    if (shouldIgnorePath(dir)) {
+        return
+    }
+    let items: string[]
+    try {
+        items = fs.readdirSync(dir)
+    } catch (err: any) {
+        if (err.code === 'ENOENT') {
+            console.error(`⚠️  Directory not found: ${path.relative(process.cwd(), dir)}`)
+            return
+        }
+        throw err
+    }
+
+    for (const item of items) {
+        const fullPath = path.join(dir, item)
+        let stat
+        try {
+            stat = fs.statSync(fullPath)
+        } catch (err: any) {
+            if (err.code === 'ENOENT') {
+                console.error(`⚠️  File not found: ${path.relative(process.cwd(), fullPath)}`)
+                continue
+            }
+            throw err
+        }
+
+        if (stat.isDirectory() && !item.includes('node_modules')) {
+            // Recurse into directories, excluding node_modules
+            cleanTSArtifacts(fullPath, force)
+        } else if (
+            item.endsWith('.tsbuildinfo') ||
+            (item === 'dist' && stat.isDirectory()) ||
+            (item === 'out' && stat.isDirectory())
+        ) {
+            if (force) {
+                try {
+                    if (stat.isDirectory()) {
+                        fs.rmSync(fullPath, { recursive: true, force: true })
+                    } else {
+                        fs.unlinkSync(fullPath)
+                    }
+                    console.log(`✓ Removed: ${path.relative(process.cwd(), fullPath)}`)
+                } catch (err) {
+                    console.error(`✗ Failed to remove ${path.relative(process.cwd(), fullPath)}:`, err)
+                }
+            } else {
+                console.log(`Would remove: ${path.relative(process.cwd(), fullPath)}`)
+            }
+        }
+    }
+}
+
+// Start cleaning from the current directory
+console.log(
+    args.values.force ? 'Cleaning artifacts...' : 'Dry run (use --force to actually delete)...\n'
+)
+cleanTSArtifacts(process.cwd(), args.values.force)


### PR DESCRIPTION
Before the agent tests would invoke a build during the tests. This would cause issues on slow execution environments (e.g. Windows CI builds) where builds would try to overwrite files that were in use by other tests.

Now we ensure that the build happens before the tests are executed and never during the testing.

## Test plan

Tests should pass. No new functionality

To test yourself simply eliminate all prior builds, run `pnpm run build:for-tests` and `pnpm run test:unit` (which is what the CI pipeline runs)