### PR TITLE
autoedit: fix cursor movement to the end of the decoration

### DIFF
--- a/vscode/src/autoedits/renderer.ts
+++ b/vscode/src/autoedits/renderer.ts
@@ -425,6 +425,7 @@ export class AutoEditsRenderer implements vscode.Disposable {
                                 '\u00A0'.repeat(3) +
                                 replaceLeadingChars(decoration.lineText, ' ', '\u00A0'),
                             margin: `0 0 0 ${replacerCol - line.range.end.character}ch`,
+                            textDecoration: 'none; position: absolute;',
                         },
                     },
                 })
@@ -435,6 +436,7 @@ export class AutoEditsRenderer implements vscode.Disposable {
                         before: {
                             contentText:
                                 '\u00A0' + replaceLeadingChars(decoration.lineText, ' ', '\u00A0'),
+                            textDecoration: 'none; position: absolute;',
                         },
                     },
                 })
@@ -478,6 +480,7 @@ export class AutoEditsRenderer implements vscode.Disposable {
                     renderOptions: {
                         before: {
                             contentText: rangeText,
+                            textDecoration: 'none; position: absolute;',
                         },
                     },
                 })


### PR DESCRIPTION
## Context 
PR to fix the decorations. Fix details below:
1. Fixes the cursor movement to the end of the decorations. (Video below shows repro for 2 cases and before vs after rendering after the fix)

https://github.com/user-attachments/assets/7c5f8ef8-2fda-46e6-a106-e5017130b4ea


## Test plan
1. Renderer testing examples using auto-edit-renderer-testing. Examples compiled [here]( https://github.com/sourcegraph/cody-chat-eval/tree/main/code-matching-eval/edits_experiments/examples/renderer-testing-examples/have-issues)

