### PR TITLE
autoedit: add speculative decoding

### DIFF
--- a/vscode/src/autoedits/adapters/cody-gateway.ts
+++ b/vscode/src/autoedits/adapters/cody-gateway.ts
@@ -57,6 +57,7 @@ export class CodyGatewayAdapter implements AutoeditsModelAdapter {
                     type: 'text',
                 },
                 speculation: option.codeToRewrite,
+                user: option.userId,
             }
             const response = await getModelResponse(
                 option.url,

--- a/vscode/src/autoedits/adapters/cody-gateway.ts
+++ b/vscode/src/autoedits/adapters/cody-gateway.ts
@@ -7,6 +7,7 @@ import type {
 import { autoeditsLogger } from '../logger'
 import type { AutoeditsModelAdapter, ChatPrompt, PromptResponseData } from '../prompt-provider'
 import { getModelResponse } from '../prompt-provider'
+import type { AutoeditModelOptions } from '../prompt-provider'
 import { type CodeToReplaceData, SYSTEM_PROMPT, getBaseUserPrompt } from '../prompt-utils'
 
 export class CodyGatewayAdapter implements AutoeditsModelAdapter {
@@ -41,27 +42,28 @@ export class CodyGatewayAdapter implements AutoeditsModelAdapter {
         return response
     }
 
-    async getModelResponse(
-        url: string,
-        model: string,
-        apiKey: string,
-        prompt: ChatPrompt
-    ): Promise<string> {
+    async getModelResponse(option: AutoeditModelOptions): Promise<string> {
         try {
             const headers = {
                 'X-Sourcegraph-Feature': 'chat_completions',
             }
             const body = {
                 stream: false,
-                model: model,
-                messages: prompt,
+                model: option.model,
+                messages: option.prompt,
                 temperature: 0.2,
                 max_tokens: 256,
                 response_format: {
                     type: 'text',
                 },
+                speculation: option.codeToRewrite,
             }
-            const response = await getModelResponse(url, JSON.stringify(body), apiKey, headers)
+            const response = await getModelResponse(
+                option.url,
+                JSON.stringify(body),
+                option.apiKey,
+                headers
+            )
             return response.choices[0].message.content
         } catch (error) {
             autoeditsLogger.logDebug('AutoEdits', 'Error calling Cody Gateway:', error)

--- a/vscode/src/autoedits/adapters/fireworks.ts
+++ b/vscode/src/autoedits/adapters/fireworks.ts
@@ -7,6 +7,7 @@ import type {
 import { autoeditsLogger } from '../logger'
 import type { AutoeditsModelAdapter, ChatPrompt, PromptResponseData } from '../prompt-provider'
 import { getModelResponse } from '../prompt-provider'
+import type { AutoeditModelOptions } from '../prompt-provider'
 import { type CodeToReplaceData, SYSTEM_PROMPT, getBaseUserPrompt } from '../prompt-utils'
 
 export class FireworksAdapter implements AutoeditsModelAdapter {
@@ -44,25 +45,21 @@ export class FireworksAdapter implements AutoeditsModelAdapter {
         return response
     }
 
-    async getModelResponse(
-        url: string,
-        model: string,
-        apiKey: string,
-        prompt: ChatPrompt
-    ): Promise<string> {
+    async getModelResponse(option: AutoeditModelOptions): Promise<string> {
         try {
             const response = await getModelResponse(
-                url,
+                option.url,
                 JSON.stringify({
-                    model: model,
-                    messages: prompt,
+                    model: option.model,
+                    messages: option.prompt,
                     temperature: 0.2,
                     max_tokens: 256,
                     response_format: {
                         type: 'text',
                     },
+                    speculation: option.codeToRewrite,
                 }),
-                apiKey
+                option.apiKey
             )
             return response.choices[0].message.content
         } catch (error) {

--- a/vscode/src/autoedits/adapters/fireworks.ts
+++ b/vscode/src/autoedits/adapters/fireworks.ts
@@ -58,6 +58,7 @@ export class FireworksAdapter implements AutoeditsModelAdapter {
                         type: 'text',
                     },
                     speculation: option.codeToRewrite,
+                    user: option.userId,
                 }),
                 option.apiKey
             )

--- a/vscode/src/autoedits/adapters/openai.ts
+++ b/vscode/src/autoedits/adapters/openai.ts
@@ -7,6 +7,7 @@ import type {
 import { autoeditsLogger } from '../logger'
 import type { AutoeditsModelAdapter, ChatPrompt, PromptResponseData } from '../prompt-provider'
 import { getModelResponse } from '../prompt-provider'
+import type { AutoeditModelOptions } from '../prompt-provider'
 import { type CodeToReplaceData, SYSTEM_PROMPT, getBaseUserPrompt } from '../prompt-utils'
 
 export class OpenAIAdapter implements AutoeditsModelAdapter {
@@ -44,25 +45,20 @@ export class OpenAIAdapter implements AutoeditsModelAdapter {
         return response
     }
 
-    async getModelResponse(
-        url: string,
-        model: string,
-        apiKey: string,
-        prompt: ChatPrompt
-    ): Promise<string> {
+    async getModelResponse(option: AutoeditModelOptions): Promise<string> {
         try {
             const response = await getModelResponse(
-                url,
+                option.url,
                 JSON.stringify({
-                    model: model,
-                    messages: prompt,
+                    model: option.model,
+                    messages: option.prompt,
                     temperature: 0.5,
                     max_tokens: 256,
                     response_format: {
                         type: 'text',
                     },
                 }),
-                apiKey
+                option.apiKey
             )
             return response.choices[0].message.content
         } catch (error) {

--- a/vscode/src/autoedits/autoedits-provider.ts
+++ b/vscode/src/autoedits/autoedits-provider.ts
@@ -200,12 +200,13 @@ export class AutoeditsProvider implements vscode.Disposable {
             this.config.tokenLimit
         )
         const apiKey = await this.getApiKey()
-        const response = await this.config.provider.getModelResponse(
-            this.config.url,
-            this.config.model,
+        const response = await this.config.provider.getModelResponse({
+            url: this.config.url,
+            model: this.config.model,
             apiKey,
-            prompt
-        )
+            prompt,
+            codeToRewrite: codeToReplace.codeToRewrite,
+        })
         const postProcessedResponse = this.config.provider.postProcessResponse(codeToReplace, response)
 
         if (options.abortSignal?.aborted || !postProcessedResponse) {

--- a/vscode/src/autoedits/autoedits-provider.ts
+++ b/vscode/src/autoedits/autoedits-provider.ts
@@ -206,6 +206,7 @@ export class AutoeditsProvider implements vscode.Disposable {
             apiKey,
             prompt,
             codeToRewrite: codeToReplace.codeToRewrite,
+            userId: (await currentResolvedConfig()).clientState.anonymousUserID,
         })
         const postProcessedResponse = this.config.provider.postProcessResponse(codeToReplace, response)
 

--- a/vscode/src/autoedits/prompt-provider.ts
+++ b/vscode/src/autoedits/prompt-provider.ts
@@ -17,6 +17,7 @@ export interface AutoeditModelOptions {
     apiKey: string
     prompt: ChatPrompt
     codeToRewrite: string
+    userId: string | null
 }
 
 export interface PromptResponseData {

--- a/vscode/src/autoedits/prompt-provider.ts
+++ b/vscode/src/autoedits/prompt-provider.ts
@@ -11,6 +11,14 @@ export type ChatPrompt = {
     content: PromptString
 }[]
 
+export interface AutoeditModelOptions {
+    url: string
+    model: string
+    apiKey: string
+    prompt: ChatPrompt
+    codeToRewrite: string
+}
+
 export interface PromptResponseData {
     codeToReplace: utils.CodeToReplaceData
     promptResponse: ChatPrompt
@@ -24,7 +32,7 @@ export interface AutoeditsModelAdapter {
         context: AutocompleteContextSnippet[],
         tokenBudget: AutoEditsTokenLimit
     ): PromptResponseData
-    getModelResponse(url: string, model: string, apiKey: string, prompt: ChatPrompt): Promise<string>
+    getModelResponse(args: AutoeditModelOptions): Promise<string>
     postProcessResponse(codeToReplace: utils.CodeToReplaceData, completion: string | null): string
 }
 


### PR DESCRIPTION
## Context
Enable speculative decoding for the auto-edits deployment. The PR passes the existing code we rewrite in the file as the speculative string. Since only certain parts of the code that we rewrite change, most of the tokens are present in the speculative string that we pass.

Backend PR: https://github.com/sourcegraph/sourcegraph/pull/1673 

## Test plan
Monitor the `Fireworks-Speculation-Matched-Tokens` header from fireworks. This shows the number of tokens matched, which is linearly related to prefix match between the code that we rewrite and response.

## Changelog
- autoedits: Enable speculative decoding.
