### PR TITLE
Better rendering for auto edits

### DIFF
--- a/vscode/src/autoedits/renderer.test.ts
+++ b/vscode/src/autoedits/renderer.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest'
+import { _replaceLeadingTrailingChars } from './renderer'
+
+describe('replaceLeadingTrailingChars', () => {
+    it('replaces leading and trailing spaces with tabs', () => {
+        expect(_replaceLeadingTrailingChars('  hello  ', ' ', '\t')).toBe('\t\thello\t\t')
+    })
+
+    it('handles empty string', () => {
+        expect(_replaceLeadingTrailingChars('', ' ', '\t')).toBe('')
+    })
+
+    it('handles string with no characters to replace', () => {
+        expect(_replaceLeadingTrailingChars('hello', ' ', '\t')).toBe('hello')
+    })
+
+    it('handles string with all replaceable characters', () => {
+        expect(_replaceLeadingTrailingChars('   ', ' ', '-')).toBe('---')
+    })
+
+    it('replaces only leading characters', () => {
+        expect(_replaceLeadingTrailingChars('  hello', ' ', '\t')).toBe('\t\thello')
+    })
+
+    it('replaces only trailing characters', () => {
+        expect(_replaceLeadingTrailingChars('hello  ', ' ', '\t')).toBe('hello\t\t')
+    })
+
+    it('handles different length replacement characters', () => {
+        expect(_replaceLeadingTrailingChars('##test##', '#', '**')).toBe('****test****')
+    })
+
+    it('preserves middle content while replacing edges', () => {
+        expect(_replaceLeadingTrailingChars('__hello world__', '_', '*')).toBe('**hello world**')
+    })
+
+    it('handles single character string', () => {
+        expect(_replaceLeadingTrailingChars(' ', ' ', '*')).toBe('*')
+    })
+
+    it('preserves spaces in middle while replacing edges', () => {
+        expect(_replaceLeadingTrailingChars('  hello  world  ', ' ', '*')).toBe('**hello  world**')
+    })
+})

--- a/vscode/src/autoedits/renderer.ts
+++ b/vscode/src/autoedits/renderer.ts
@@ -432,7 +432,7 @@ export class AutoEditsRenderer implements vscode.Disposable {
                         before: {
                             contentText:
                                 '\u00A0'.repeat(3) +
-                                replaceLeadingTrailingChars(decoration.lineText, ' ', '\u00A0'),
+                                _replaceLeadingTrailingChars(decoration.lineText, ' ', '\u00A0'),
                             margin: `0 0 0 ${replacerCol - line.range.end.character}ch`,
                         },
                     },
@@ -444,7 +444,7 @@ export class AutoEditsRenderer implements vscode.Disposable {
                         before: {
                             contentText:
                                 '\u00A0' +
-                                replaceLeadingTrailingChars(decoration.lineText, ' ', '\u00A0'),
+                                _replaceLeadingTrailingChars(decoration.lineText, ' ', '\u00A0'),
                         },
                     },
                 })
@@ -529,7 +529,7 @@ export class AutoEditsRenderer implements vscode.Disposable {
  * @param newS The character/string to replace with
  * @returns The string with leading and trailing characters replaced
  */
-function replaceLeadingTrailingChars(str: string, oldS: string, newS: string): string {
+export function _replaceLeadingTrailingChars(str: string, oldS: string, newS: string): string {
     let prefixLen = str.length
     for (let i = 0; i < str.length; i++) {
         if (str[i] !== oldS) {

--- a/vscode/src/autoedits/renderer.ts
+++ b/vscode/src/autoedits/renderer.ts
@@ -409,6 +409,8 @@ export class AutoEditsRenderer implements vscode.Disposable {
         startLine: number,
         replacerCol: number
     ): void {
+        removeLeadingWhitespaceBlock(addedLinesInfo)
+
         const replacerDecorations: vscode.DecorationOptions[] = []
 
         for (let i = 0; i < addedLinesInfo.length; i++) {
@@ -520,4 +522,41 @@ function replaceLeadingChars(str: string, oldS: string, newS: string): string {
         }
     }
     return str
+}
+
+function removeLeadingWhitespaceBlock(addedLines: AddedLinesDecorationInfo[]) {
+    let leastCommonWhitespacePrefix: undefined | string = undefined
+    for (const addedLine of addedLines) {
+        const leadingWhitespaceMatch = addedLine.lineText.match(/^\s*/)
+        if (leadingWhitespaceMatch === null) {
+            leastCommonWhitespacePrefix = ''
+            break
+        }
+        const leadingWhitespace = leadingWhitespaceMatch[0]
+        if (leastCommonWhitespacePrefix === undefined) {
+            leastCommonWhitespacePrefix = leadingWhitespace
+            continue
+        }
+        // get common prefix of leastCommonWhitespacePrefix and leadingWhitespace
+        leastCommonWhitespacePrefix = getCommonPrefix(leastCommonWhitespacePrefix, leadingWhitespace)
+    }
+    if (!leastCommonWhitespacePrefix) {
+        return
+    }
+    for (const addedLine of addedLines) {
+        addedLine.lineText = addedLine.lineText.replace(leastCommonWhitespacePrefix, '')
+    }
+}
+
+function getCommonPrefix(s1: string, s2: string): string {
+    const minLength = Math.min(s1.length, s2.length)
+    let commonPrefix = ''
+    for (let i = 0; i < minLength; i++) {
+        if (s1[i] === s2[i]) {
+            commonPrefix += s1[i]
+        } else {
+            break
+        }
+    }
+    return commonPrefix
 }

--- a/vscode/src/autoedits/renderer.ts
+++ b/vscode/src/autoedits/renderer.ts
@@ -244,9 +244,6 @@ export class AutoEditsRenderer implements vscode.Disposable {
                 isOnlyAdditionsForModifiedLines = modifiedRanges.every(
                     range => range.from1 === range.to1
                 )
-                if (!isOnlyAdditionsForModifiedLines) {
-                    break
-                }
             }
         }
         this.addDecorations(

--- a/vscode/src/autoedits/renderer.ts
+++ b/vscode/src/autoedits/renderer.ts
@@ -530,18 +530,27 @@ export class AutoEditsRenderer implements vscode.Disposable {
  * @returns The string with leading and trailing characters replaced
  */
 function replaceLeadingTrailingChars(str: string, oldS: string, newS: string): string {
+    let prefixLen = str.length
     for (let i = 0; i < str.length; i++) {
         if (str[i] !== oldS) {
-            str = newS.repeat(i) + str.substring(i)
+            // str = newS.repeat(i) + str.substring(i)
+            prefixLen = i
             break
         }
     }
-    for (let i = str.length - 1; i >= 0; i--) {
-        if (str[i] !== oldS) {
-            str = str.substring(0, i) + newS.repeat(str.length - i)
+    str = newS.repeat(prefixLen) + str.substring(prefixLen)
+
+    let suffixLen = str.length
+    for (let i = 0; i < str.length; i++) {
+        const j = str.length - 1 - i
+        if (str[j] !== oldS) {
+            // str = str.substring(0, j + 1) + newS.repeat(i)
+            suffixLen = i
             break
         }
     }
+    str = str.substring(0, str.length - suffixLen) + newS.repeat(suffixLen)
+
     return str
 }
 


### PR DESCRIPTION
This makes the following changes to how inline edit proposals are rendered:
1. Leading block whitespace in an added-line block is stripped, so that the edit doesn't render far to the right.
2. A dotted green insert indicator has been added to indicate where an added-line block will be inserted
3. Added-line blocks are now placed in a green box, rather than simply highlighting the lines in green

Before:
![image](https://github.com/user-attachments/assets/01e12484-b917-43ef-b5a9-01a137ff245b)

After:
![image](https://github.com/user-attachments/assets/e1d886cc-aec8-4e3b-9dae-a7f374d0aa5d)

Another example:
![image](https://github.com/user-attachments/assets/c7e56fc8-ca8f-414a-baf8-625936cea3af)


## Test plan

Test against the examples in sourcegraph/cody-chat-eval. This feature is still behind a feature flag.
