### PR TITLE
fix(release): Update backport action to override team_reviews

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -25,3 +25,4 @@ jobs:
         with:
           github_token: ${{ secrets.BACKPORT_GITHUB_TOKEN }}
           label_pattern: '^backport (?<base>vscode-v\d+\.\d+\.x)$'
+          team_reviews: ''


### PR DESCRIPTION
@kalan was debugging the Backport action here, and found a bug. 

We previously always attached the review to the release team, but that team is not a collaborator here in the Cody repo.
We could add them as collaborators, but that doesn't give us any benefit. 

So instead I've [changed the way the backport GHA works](https://github.com/sourcegraph/backport/pull/14), and made the team_reviews a parameter. Here we override it to set no team. This means that only the original author and / or merger of the PR will be tagged in the new backport PR. 

## Test plan
Add the label to this PR, and it should create a new PR that backports this one, without errors

## Changelog
N/A
