### PR TITLE
Chat: ensure ScrollDown button only takes it's width

### DIFF
--- a/vscode/webviews/components/ScrollDown.tsx
+++ b/vscode/webviews/components/ScrollDown.tsx
@@ -70,7 +70,7 @@ export const ScrollDown: FC<ScrollDownProps> = props => {
     }, [parentOnClick, scrollerAPI])
 
     return canScrollDown ? (
-        <div className="tw-sticky tw-bottom-0 tw-w-full tw-text-center tw-py-4">
+        <div className="tw-bottom-0 tw-left-1/2 tw-inline-block tw-sticky tw--translate-x-1/2 tw-py-4 tw-w-fit">
             <Button variant="outline" onClick={onClick} className="tw-py-3 hover:tw-bg-primary-hover">
                 <ArrowDownIcon size={16} /> Skip to end
             </Button>


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/cody/issues/6133

This pull request allow interaction with interactive elements if we can see them. 
Previously the button parent took full width making it impossible to interact with the other elements unless scrolling.


## Test plan
Scroll until you see the Scroll to End button.
Check that you can interact with the buttons such as Copy or Execute.

Here are some screenshots with Cody within VSCode  and with the storybook for ScrollDown
![storybook-text-select-not-possible](https://github.com/user-attachments/assets/18428a0b-06c3-4bfa-90d4-d33b4f1bd862)
<img width="670" alt="storybook-text-select" src="https://github.com/user-attachments/assets/efb53d55-662f-42ce-b79f-88a6e7eae617">
![cody-scroll-to-end-broken](https://github.com/user-attachments/assets/549dbeca-960a-42b5-94b6-791783382dff)
![cody-scroll-to-end-fixed](https://github.com/user-attachments/assets/23099ff0-8765-4f1f-b60e-d19565835e18)

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

## Changelog
Chat: ensure ScrollDown button only takes it's width allowing the interaction with other elements
<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
