### PR TITLE
Simplify protocol's TelemetryEvent

### DIFF
--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/agent/protocol_generated/ParametersParams.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/agent/protocol_generated/ParametersParams.kt
@@ -2,8 +2,8 @@
 package com.sourcegraph.cody.agent.protocol_generated;
 
 data class ParametersParams(
-  val metadata: Map<String, Long>,
-  val privateMetadata: Map<String, Any>,
-  val billingMetadata: BillingMetadataParams,
+  val metadata: Map<String, Long>? = null,
+  val privateMetadata: Map<String, Any>? = null,
+  val billingMetadata: BillingMetadataParams? = null,
 )
 

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/agent/protocol_generated/TelemetryEvent.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/agent/protocol_generated/TelemetryEvent.kt
@@ -4,5 +4,6 @@ package com.sourcegraph.cody.agent.protocol_generated;
 data class TelemetryEvent(
   val feature: String,
   val action: String,
+  val parameters: ParametersParams,
 )
 

--- a/vscode/src/jsonrpc/agent-protocol.ts
+++ b/vscode/src/jsonrpc/agent-protocol.ts
@@ -1,8 +1,6 @@
 import type * as vscode from 'vscode'
 
 import type {
-    BillingCategory,
-    BillingProduct,
     ClientCapabilities,
     CodyCommand,
     ContextFilters,
@@ -13,12 +11,7 @@ import type {
     SerializedChatTranscript,
     event,
 } from '@sourcegraph/cody-shared'
-import type {
-    KnownKeys,
-    KnownString,
-    TelemetryEventMarketingTrackingInput,
-    TelemetryEventParameters,
-} from '@sourcegraph/telemetry'
+import type { TelemetryEventMarketingTrackingInput } from '@sourcegraph/telemetry'
 
 import type { ExtensionMessage, WebviewMessage } from '../chat/protocol'
 import type { CompletionBookkeepingEvent, CompletionItemID } from '../completions/analytics-logger'
@@ -615,9 +608,6 @@ export interface ExtensionConfiguration {
 /**
  * TelemetryEvent is a JSON RPC format of the arguments to a typical
  * TelemetryEventRecorder implementation from '@sourcegraph/telemetry'.
- * This type is intended for use in the Agent RPC handler only - clients sending
- * events to the Agent should use 'newTelemetryEvent()' to create event objects,
- * which uses the same type constraints as '(TelemetryEventRecorder).recordEvent()'.
  * @param feature must be camelCase and '.'-delimited, e.g. 'myFeature.subFeature'.
  * Features should NOT include the client platform, e.g. 'vscode' - information
  * about the client is automatically attached to all events. Note that Cody
@@ -630,30 +620,14 @@ export interface ExtensionConfiguration {
 interface TelemetryEvent {
     feature: string
     action: string
-    parameters?:
-        | TelemetryEventParameters<{ [key: string]: number }, BillingProduct, BillingCategory>
-        | undefined
-        | null
-}
-
-/**
- * newTelemetryEvent is a constructor for TelemetryEvent that shares the same
- * type constraints as '(TelemetryEventRecorder).recordEvent()'.
- */
-export function newTelemetryEvent<
-    Feature extends string,
-    Action extends string,
-    MetadataKey extends string,
->(
-    feature: KnownString<Feature>,
-    action: KnownString<Action>,
-    parameters?: TelemetryEventParameters<
-        KnownKeys<MetadataKey, { [key in MetadataKey]: number }>,
-        BillingProduct,
-        BillingCategory
-    >
-): TelemetryEvent {
-    return { feature, action, parameters }
+    parameters: {
+        metadata?: Record<string, number>
+        privateMetadata?: Record<string, any>
+        billingMetadata?: {
+            product: string
+            category: string
+        }
+    }
 }
 
 /**

--- a/vscode/src/jsonrpc/agent-protocol.ts
+++ b/vscode/src/jsonrpc/agent-protocol.ts
@@ -621,12 +621,15 @@ interface TelemetryEvent {
     feature: string
     action: string
     parameters: {
-        metadata?: Record<string, number>
-        privateMetadata?: Record<string, any>
-        billingMetadata?: {
-            product: string
-            category: string
-        }
+        metadata?: Record<string, number> | undefined | null
+        privateMetadata?: Record<string, any> | undefined | null
+        billingMetadata?:
+            | {
+                  product: string
+                  category: string
+              }
+            | undefined
+            | null
     }
 }
 


### PR DESCRIPTION
This change is required for the ongoing migration to the generated API in the JetBrains client.

Related PR: https://github.com/sourcegraph/jetbrains/pull/2661

Some more advanced types are skipped to simplify the code gen. We used internal types too casually. We should be more precise about the protocol. 

Related thread: https://sourcegraph.slack.com/archives/C05AGQYD528/p1728049089597009

## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

Verified with JB. Telemetry goes through the API.

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
