### PR TITLE
autoedit: Add feature flag to enable/disable autoedit feature

### DIFF
--- a/lib/shared/src/configuration.ts
+++ b/lib/shared/src/configuration.ts
@@ -81,6 +81,7 @@ interface RawClientConfiguration {
     experimentalSupercompletions: boolean
     experimentalAutoeditsRendererTesting: boolean
     experimentalAutoeditsConfigOverride: AutoEditsModelConfig | undefined
+    experimentalAutoeditsEnabled: boolean | undefined
     experimentalCommitMessage: boolean
     experimentalNoodle: boolean
     experimentalMinionAnthropicKey: string | undefined

--- a/lib/shared/src/configuration.ts
+++ b/lib/shared/src/configuration.ts
@@ -81,7 +81,6 @@ interface RawClientConfiguration {
     experimentalSupercompletions: boolean
     experimentalAutoeditsRendererTesting: boolean
     experimentalAutoeditsConfigOverride: AutoEditsModelConfig | undefined
-    experimentalAutoeditsEnabled: boolean
     experimentalCommitMessage: boolean
     experimentalNoodle: boolean
     experimentalMinionAnthropicKey: string | undefined

--- a/lib/shared/src/experimentation/FeatureFlagProvider.ts
+++ b/lib/shared/src/experimentation/FeatureFlagProvider.ts
@@ -54,6 +54,8 @@ export enum FeatureFlag {
     CodyAutocompleteContextExperimentVariant4 = 'cody-autocomplete-context-experiment-variant-4',
     CodyAutocompleteContextExperimentControl = 'cody-autocomplete-context-experiment-control',
 
+    CodyAutoeditExperimentEnabledFeatureFlag = 'cody-autoedit-experiment-enabled-flag',
+
     // Enables gpt-4o-mini as a default Edit model
     CodyEditDefaultToGpt4oMini = 'cody-edit-default-to-gpt-4o-mini',
 

--- a/vscode/src/configuration.test.ts
+++ b/vscode/src/configuration.test.ts
@@ -96,7 +96,7 @@ describe('getConfiguration', () => {
                     case 'cody.experimental.supercompletions':
                         return false
                     case 'cody.experimental.autoedits.enabled':
-                        return false
+                        return undefined
                     case 'cody.experimental.autoedits-renderer-testing':
                         return false
                     case 'cody.experimental.autoedits.config.override':

--- a/vscode/src/configuration.test.ts
+++ b/vscode/src/configuration.test.ts
@@ -160,7 +160,6 @@ describe('getConfiguration', () => {
             },
             commandCodeLenses: true,
             experimentalSupercompletions: false,
-            experimentalAutoeditsEnabled: false,
             experimentalAutoeditsConfigOverride: undefined,
             experimentalAutoeditsRendererTesting: false,
             experimentalMinionAnthropicKey: undefined,

--- a/vscode/src/configuration.test.ts
+++ b/vscode/src/configuration.test.ts
@@ -160,6 +160,7 @@ describe('getConfiguration', () => {
             },
             commandCodeLenses: true,
             experimentalSupercompletions: false,
+            experimentalAutoeditsEnabled: undefined,
             experimentalAutoeditsConfigOverride: undefined,
             experimentalAutoeditsRendererTesting: false,
             experimentalMinionAnthropicKey: undefined,

--- a/vscode/src/configuration.ts
+++ b/vscode/src/configuration.ts
@@ -112,6 +112,7 @@ export function getConfiguration(
         experimentalTracing: getHiddenSetting('experimental.tracing', false),
 
         experimentalSupercompletions: getHiddenSetting('experimental.supercompletions', false),
+        experimentalAutoeditsEnabled: getHiddenSetting('experimental.autoedits.enabled', undefined),
         experimentalAutoeditsConfigOverride: getHiddenSetting(
             'experimental.autoedits.config.override',
             undefined

--- a/vscode/src/configuration.ts
+++ b/vscode/src/configuration.ts
@@ -112,7 +112,6 @@ export function getConfiguration(
         experimentalTracing: getHiddenSetting('experimental.tracing', false),
 
         experimentalSupercompletions: getHiddenSetting('experimental.supercompletions', false),
-        experimentalAutoeditsEnabled: getHiddenSetting('experimental.autoedits.enabled', false),
         experimentalAutoeditsConfigOverride: getHiddenSetting(
             'experimental.autoedits.config.override',
             undefined

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -709,7 +709,7 @@ function registerAutoEdits(disposables: vscode.Disposable[]): void {
                 .evaluatedFeatureFlag(FeatureFlag.CodyAutoeditExperimentEnabledFeatureFlag)
                 .pipe(
                     createDisposables(autoeditEnabled => {
-                        if (autoeditEnabled) {
+                        if (shouldEnableExperimentalAutoedits(autoeditEnabled)) {
                             const provider = new AutoeditsProvider()
                             return provider
                         }

--- a/vscode/src/testutils/mocks.ts
+++ b/vscode/src/testutils/mocks.ts
@@ -892,6 +892,7 @@ export const DEFAULT_VSCODE_SETTINGS = {
     },
     commandCodeLenses: false,
     experimentalSupercompletions: false,
+    experimentalAutoeditsEnabled: undefined,
     experimentalAutoeditsRendererTesting: false,
     experimentalAutoeditsConfigOverride: undefined,
     experimentalMinionAnthropicKey: undefined,

--- a/vscode/src/testutils/mocks.ts
+++ b/vscode/src/testutils/mocks.ts
@@ -892,7 +892,6 @@ export const DEFAULT_VSCODE_SETTINGS = {
     },
     commandCodeLenses: false,
     experimentalSupercompletions: false,
-    experimentalAutoeditsEnabled: false,
     experimentalAutoeditsRendererTesting: false,
     experimentalAutoeditsConfigOverride: undefined,
     experimentalMinionAnthropicKey: undefined,


### PR DESCRIPTION
## Context
Adds a feature flag to enable if the `auto-edits` feature should be enable instead of autocomplete.

## Test plan
1. Override the userId `feature-flag` in the backend and see `autocomplete` triggers when flag is off, else `autoedits` trigger.