### PR TITLE
patch highlight.js to address memory leak

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,6 +88,9 @@
         }
       }
     },
-    "neverBuiltDependencies": ["deasync", "playwright"]
+    "neverBuiltDependencies": ["deasync", "playwright"],
+    "patchedDependencies": {
+      "highlight.js@11.8.0": "patches/highlight.js@11.8.0.patch"
+    }
   }
 }

--- a/patches/highlight.js@11.8.0.patch
+++ b/patches/highlight.js@11.8.0.patch
@@ -1,0 +1,39 @@
+diff --git a/lib/core.js b/lib/core.js
+index 25fa54ab011a7bfc80791748a8df0d769e6f628a..1fc53527940fa7ca88f2be274ba67e0ccc353e66 100644
+--- a/lib/core.js
++++ b/lib/core.js
+@@ -2373,8 +2373,17 @@ const HLJS = function(hljs) {
+    * auto-highlights all pre>code elements on the page
+    */
+   function highlightAll() {
++    function boot() {
++      // if a highlight was requested before DOM was loaded, do now
++      highlightAll();
++    }
++
+     // if we are called too early in the loading process
+     if (document.readyState === "loading") {
++      // make sure the event listener is only added once
++      if (!wantsHighlight) {
++        window.addEventListener('DOMContentLoaded', boot, false);
++      }
+       wantsHighlight = true;
+       return;
+     }
+@@ -2383,16 +2392,6 @@ const HLJS = function(hljs) {
+     blocks.forEach(highlightElement);
+   }
+ 
+-  function boot() {
+-    // if a highlight was requested before DOM was loaded, do now
+-    if (wantsHighlight) highlightAll();
+-  }
+-
+-  // make sure we are in the browser environment
+-  if (typeof window !== 'undefined' && window.addEventListener) {
+-    window.addEventListener('DOMContentLoaded', boot, false);
+-  }
+-
+   /**
+    * Register a language grammar module
+    *

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,6 +13,11 @@ overrides:
 
 packageExtensionsChecksum: bc809394d179d8460f9d473fc54e379a
 
+patchedDependencies:
+  highlight.js@11.8.0:
+    hash: bzyroljkef3byfhzbomid6liny
+    path: patches/highlight.js@11.8.0.patch
+
 importers:
 
   .:
@@ -588,7 +593,7 @@ importers:
         version: 1.2.0
       highlight.js:
         specifier: 11.8.0
-        version: 11.8.0
+        version: 11.8.0(patch_hash=bzyroljkef3byfhzbomid6liny)
       hpagent:
         specifier: ^1.2.0
         version: 1.2.0
@@ -10561,10 +10566,11 @@ packages:
     engines: {node: '>=10.0.0'}
     dev: true
 
-  /highlight.js@11.8.0:
+  /highlight.js@11.8.0(patch_hash=bzyroljkef3byfhzbomid6liny):
     resolution: {integrity: sha512-MedQhoqVdr0U6SSnWPzfiadUcDHfN/Wzq25AkXiQv9oiOO/sG0S7XkvpFIqWBl9Yq1UYyYOOVORs5UW2XlPyzg==}
     engines: {node: '>=12.0.0'}
     dev: false
+    patched: true
 
   /hosted-git-info@2.8.9:
     resolution: {integrity: sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==}
@@ -11902,7 +11908,7 @@ packages:
     dependencies:
       '@types/hast': 2.3.10
       fault: 2.0.1
-      highlight.js: 11.8.0
+      highlight.js: 11.8.0(patch_hash=bzyroljkef3byfhzbomid6liny)
     dev: false
 
   /lru-cache@10.0.0:


### PR DESCRIPTION
Pull in https://github.com/highlightjs/highlight.js/commit/19819d5e6d6323c047923a13a16729554e6af040

This patch can be removed (`highlight.js@11.8.0`) once `highlight.js@11.11.0` is released and we've updated to it.

## Test plan

N/A