### PR TITLE
remove ctrl+shift+L shortcut and update shift+alt+L shortcut

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -10,6 +10,10 @@ This is a log of all notable changes to Cody for VS Code.
 
 ### Changed
 
+- Chat: Update keyboard shortcuts:
+  - Removed `Shift+Ctrl+L` (previously created a new chat) due to conflict with Windows default shortcut
+  - Updated `Shift+Alt+L` to create a new chat when the focus is not in the editor. When the focus is in the editor, the behavior remains unchanged (the current selection is added to the chat context).
+
 ## 1.42.0
 Hey Cody users! For those who want to track detailed technical changes, we will be updating this changelog to provide more comprehensive updates on new features, improvements, and fixes. For major releases and announcements, check out our [public changelog](https://sourcegraph.com/changelog).
 

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -610,16 +610,6 @@
         "when": "!cody.activated"
       },
       {
-        "command": "cody.chat.new",
-        "key": "shift+ctrl+/",
-        "when": "cody.activated"
-      },
-      {
-        "command": "cody.chat.new",
-        "key": "shift+ctrl+l",
-        "when": "cody.activated"
-      },
-      {
         "command": "cody.chat.toggle",
         "key": "alt+l",
         "when": "cody.activated && editorTextFocus",
@@ -660,6 +650,16 @@
         "command": "cody.mention.selection",
         "key": "shift+alt+/",
         "when": "cody.activated && editorTextFocus && editorHasSelection"
+      },
+      {
+        "command": "cody.chat.new",
+        "key": "shift+alt+l",
+        "when": "cody.activated && !editorTextFocus"
+      },
+      {
+        "command": "cody.chat.new",
+        "key": "shift+alt+/",
+        "when": "cody.activated && !editorTextFocus"
       },
       {
         "command": "cody.tutorial.chat",


### PR DESCRIPTION
- Removed `Shift+Ctrl+L` (previously created a new chat) due to conflict with Windows default shortcut.
- Updated `Shift+Alt+L` to create a new chat when the focus is not in the editor. When the focus is in the editor, the behavior remains unchanged (the current selection is added to the chat context).

## Test plan

Test both shortcuts locally