### PR TITLE
fix added lines sorting in autoedits

### DIFF
--- a/vscode/src/autoedits/utils.test.ts
+++ b/vscode/src/autoedits/utils.test.ts
@@ -634,3 +634,33 @@ describe('countNewLineCharsStart', () => {
         expect(utils.countNewLineCharsStart('')).toBe(0)
     })
 })
+
+describe('isPredictedTextAlreadyInSuffix', () => {
+    it('should return false when there are no added lines', () => {
+        const result = utils.isPredictedTextAlreadyInSuffix({
+            codeToRewrite: 'const x = 1;\nconst y = 2;',
+            prediction: 'const x = 1;\nconst y = 2;',
+            suffix: '',
+        })
+        expect(result).toBe(false)
+    })
+
+    it('should return false when predicted text is different from suffix', () => {
+        const result = utils.isPredictedTextAlreadyInSuffix({
+            codeToRewrite: 'function test() {\n    \n}',
+            prediction: 'function test() {\n    console.log("hello");\n}',
+            suffix: 'return true;\n}',
+        })
+        expect(result).toBe(false)
+    })
+
+    it('should handle multiline predictions correctly', () => {
+        const result = utils.isPredictedTextAlreadyInSuffix({
+            codeToRewrite: 'function test() {\n',
+            prediction:
+                'function test() {\n    const a = 1;\n    const b = 2;\n    console.log(a + b);\n}\n',
+            suffix: '    const a = 1;\n    const b = 2;\n    console.log(a + b);\n}\n',
+        })
+        expect(result).toBe(true)
+    })
+})

--- a/vscode/src/autoedits/utils.ts
+++ b/vscode/src/autoedits/utils.ts
@@ -73,8 +73,6 @@ export function isPredictedTextAlreadyInSuffix(params: {
     const maxAddedLineIndex = addedLines[addedLines.length - 1]
     const allAddedLines = predictedFileLines.slice(minAddedLineIndex, maxAddedLineIndex + 1)
     const allAddedLinesText = allAddedLines.join('\n')
-    console.log(params.suffix)
-    console.log(allAddedLinesText)
     if (params.suffix.startsWith(allAddedLinesText)) {
         return true
     }

--- a/vscode/src/autoedits/utils.ts
+++ b/vscode/src/autoedits/utils.ts
@@ -1,4 +1,5 @@
 import { lines } from '../completions/text-processing'
+import { getLineLevelDiff } from './diff-utils'
 
 export function fixFirstLineIndentation(source: string, target: string): string {
     // Check the first line indentation of source string and replaces in target string.
@@ -54,6 +55,30 @@ export function trimExtraNewLineCharsFromSuggestion(
 function getNumberOfNewLineCharsAtSuffix(text: string): number {
     const match = text.match(/\n+$/)
     return match ? match[0].length : 0
+}
+
+export function isPredictedTextAlreadyInSuffix(params: {
+    codeToRewrite: string
+    prediction: string
+    suffix: string
+}): boolean {
+    const currentFileLines = lines(params.codeToRewrite)
+    const predictedFileLines = lines(params.prediction)
+    let { addedLines } = getLineLevelDiff(currentFileLines, predictedFileLines)
+    if (addedLines.length === 0) {
+        return false
+    }
+    addedLines = addedLines.sort((a, b) => a - b)
+    const minAddedLineIndex = addedLines[0]
+    const maxAddedLineIndex = addedLines[addedLines.length - 1]
+    const allAddedLines = predictedFileLines.slice(minAddedLineIndex, maxAddedLineIndex + 1)
+    const allAddedLinesText = allAddedLines.join('\n')
+    console.log(params.suffix)
+    console.log(allAddedLinesText)
+    if (params.suffix.startsWith(allAddedLinesText)) {
+        return true
+    }
+    return false
 }
 
 /**


### PR DESCRIPTION
Fix the lines sorting, the default method converts the numbers to string for sorting which was messing up the behaviour of skipping suggestions 

## Test plan
CI test case
