### PR TITLE
feat(autoedit): fix cursor jumping issue

### DIFF
--- a/vscode/src/autoedits/renderer.ts
+++ b/vscode/src/autoedits/renderer.ts
@@ -434,6 +434,7 @@ export class AutoEditsRenderer implements vscode.Disposable {
                                 '\u00A0'.repeat(3) +
                                 _replaceLeadingTrailingChars(decoration.lineText, ' ', '\u00A0'),
                             margin: `0 0 0 ${replacerCol - line.range.end.character}ch`,
+                            textDecoration: 'none; position: absolute;',
                         },
                     },
                 })
@@ -445,6 +446,7 @@ export class AutoEditsRenderer implements vscode.Disposable {
                             contentText:
                                 '\u00A0' +
                                 _replaceLeadingTrailingChars(decoration.lineText, ' ', '\u00A0'),
+                            textDecoration: 'none; position: absolute;',
                         },
                     },
                 })


### PR DESCRIPTION
Using absolute position for the decoration to prevent cursor from jumping.

https://github.com/user-attachments/assets/7ba3498f-245f-4638-8eb2-8e8f758fdea8

## Test plan
Used rendering examples from cody-chat-eval. See video attached for the examples.
