### PR TITLE
only activate autoedits command when experimental setting is enabled

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -756,12 +756,12 @@
       {
         "command": "cody.experimental.suggest",
         "key": "ctrl+shift+enter",
-        "when": "cody.activated"
+        "when": "cody.activated && config.cody.experimental.autoedits.enabled"
       },
       {
         "command": "cody.supersuggest.testExample",
         "key": "ctrl+alt+enter",
-        "when": "cody.activated"
+        "when": "cody.activated && config.cody.experimental.autoedits.enabled"
       }
     ],
     "submenus": [


### PR DESCRIPTION
Fix https://linear.app/sourcegraph/issue/QA-171

## Test plan

Attempt to reproduce the issue in the report.
