### PR TITLE
fix(audoedit): fix the scrollbar issue

### DIFF
--- a/vscode/src/autoedits/renderer.ts
+++ b/vscode/src/autoedits/renderer.ts
@@ -429,12 +429,26 @@ export class AutoEditsRenderer implements vscode.Disposable {
                 replacerDecorations.push({
                     range: new vscode.Range(j, line.range.end.character, j, line.range.end.character),
                     renderOptions: {
+                        // Show the suggested code but keep it positioned absolute to ensure
+                        // the cursor does not jump there.
                         before: {
                             contentText:
                                 '\u00A0'.repeat(3) +
                                 _replaceLeadingTrailingChars(decoration.lineText, ' ', '\u00A0'),
                             margin: `0 0 0 ${replacerCol - line.range.end.character}ch`,
                             textDecoration: 'none; position: absolute;',
+                        },
+                        // Create an empty HTML element with the width required to show the suggested code.
+                        // Required to make the viewport scrollable to view the suggestion if it's outside.
+                        after: {
+                            contentText:
+                                '\u00A0'.repeat(3) +
+                                _replaceLeadingTrailingChars(
+                                    decoration.lineText.replace(/\S/g, '\u00A0'),
+                                    ' ',
+                                    '\u00A0'
+                                ),
+                            margin: `0 0 0 ${replacerCol - line.range.end.character}ch`,
                         },
                     },
                 })
@@ -447,6 +461,15 @@ export class AutoEditsRenderer implements vscode.Disposable {
                                 '\u00A0' +
                                 _replaceLeadingTrailingChars(decoration.lineText, ' ', '\u00A0'),
                             textDecoration: 'none; position: absolute;',
+                        },
+                        after: {
+                            contentText:
+                                '\u00A0'.repeat(3) +
+                                _replaceLeadingTrailingChars(
+                                    decoration.lineText.replace(/\S/g, '\u00A0'),
+                                    ' ',
+                                    '\u00A0'
+                                ),
                         },
                     },
                 })


### PR DESCRIPTION
- Fixes the issue where it was not possible to view suggestions partially rendered outside of the viewport. [Slack thread](https://sourcegraph.slack.com/archives/C07F8LLKE06/p1732079726971429?thread_ts=1732039129.933099&cid=C07F8LLKE06).
- Issue example. Notice the scrollbar at the bottom being almost equal to the viewport width:
<img width="884" alt="Screenshot 2024-11-20 at 13 11 01" src="https://github.com/user-attachments/assets/1db2971f-95c3-4430-94c9-10ef24afb6e4">

## Test plan

1. Generate autoedits, which are partially rendered outside of the viewport
2. Ensure it's possible to fully view them by scrolling the viewport window to the right.



