### PR TITLE
Add account switcher component in the Accounts webview tab

### DIFF
--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/agent/protocol_generated/ClientCapabilities.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/agent/protocol_generated/ClientCapabilities.kt
@@ -18,6 +18,7 @@ data class ClientCapabilities(
   val ignore: IgnoreEnum? = null, // Oneof: none, enabled
   val codeActions: CodeActionsEnum? = null, // Oneof: none, enabled
   val disabledMentionsProviders: List<ContextMentionProviderID>? = null,
+  val accountSwitchingInWebview: AccountSwitchingInWebviewEnum? = null, // Oneof: none, enabled
   val webviewMessages: WebviewMessagesEnum? = null, // Oneof: object-encoded, string-encoded
   val globalState: GlobalStateEnum? = null, // Oneof: stateless, server-managed, client-managed
   val secrets: SecretsEnum? = null, // Oneof: stateless, client-managed
@@ -85,6 +86,11 @@ data class ClientCapabilities(
   }
 
   enum class CodeActionsEnum {
+    @SerializedName("none") None,
+    @SerializedName("enabled") Enabled,
+  }
+
+  enum class AccountSwitchingInWebviewEnum {
     @SerializedName("none") None,
     @SerializedName("enabled") Enabled,
   }

--- a/lib/shared/src/configuration/clientCapabilities.ts
+++ b/lib/shared/src/configuration/clientCapabilities.ts
@@ -89,6 +89,7 @@ export interface ClientCapabilities {
     ignore?: 'none' | 'enabled' | undefined | null
     codeActions?: 'none' | 'enabled' | undefined | null
     disabledMentionsProviders?: ContextMentionProviderID[] | undefined | null
+    accountSwitchingInWebview?: 'none' | 'enabled' | undefined | null
 
     /**
      * When 'object-encoded' (default), the server uses the `webview/postMessage` method to send

--- a/vscode/src/auth/auth.ts
+++ b/vscode/src/auth/auth.ts
@@ -370,7 +370,7 @@ export async function showSignOutMenu(): Promise<void> {
 /**
  * Log user out of the selected endpoint (remove token from secret).
  */
-async function signOut(endpoint: string): Promise<void> {
+export async function signOut(endpoint: string): Promise<void> {
     const token = await secretStorage.getToken(endpoint)
     const tokenSource = await secretStorage.getTokenSource(endpoint)
     // Delete the access token from the Sourcegraph instance on signout if it was created
@@ -380,7 +380,7 @@ async function signOut(endpoint: string): Promise<void> {
         await graphqlClient.DeleteAccessToken(token)
     }
     await secretStorage.deleteToken(endpoint)
-    await localStorage.deleteEndpoint()
+    await localStorage.deleteEndpoint(endpoint)
     authProvider.refresh()
 }
 

--- a/vscode/src/chat/chat-view/ChatController.ts
+++ b/vscode/src/chat/chat-view/ChatController.ts
@@ -1,4 +1,5 @@
 import {
+    type AuthStatus,
     type ChatModel,
     type ClientActionBroadcast,
     type CodyClientConfig,
@@ -241,10 +242,10 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
 
         this.disposables.push(
             subscriptionDisposable(
-                authStatus.subscribe(() => {
+                authStatus.subscribe(authStatus => {
                     // Run this async because this method may be called during initialization
                     // and awaiting on this.postMessage may result in a deadlock
-                    void this.sendConfig()
+                    void this.sendConfig(authStatus)
                 })
             ),
 
@@ -557,12 +558,10 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
 
     // When the webview sends the 'ready' message, respond by posting the view config
     private async handleReady(): Promise<void> {
-        await this.sendConfig()
+        await this.sendConfig(currentAuthStatus())
     }
 
-    private async sendConfig(): Promise<void> {
-        const authStatus = currentAuthStatus()
-
+    private async sendConfig(authStatus: AuthStatus): Promise<void> {
         // Don't emit config if we're verifying auth status to avoid UI auth flashes on the client
         if (authStatus.pendingValidation) {
             return

--- a/vscode/src/chat/protocol.ts
+++ b/vscode/src/chat/protocol.ts
@@ -236,6 +236,7 @@ export interface ConfigurationSubsetForWebview
     webviewType?: WebviewType | undefined | null
     // Whether support running multiple webviews (e.g. sidebar w/ multiple editor panels).
     multipleWebviewsEnabled?: boolean | undefined | null
+    endpointHistory?: string[] | undefined | null
 }
 
 /**

--- a/vscode/webviews/App.tsx
+++ b/vscode/webviews/App.tsx
@@ -171,6 +171,7 @@ export const App: React.FunctionComponent<{ vscodeAPI: VSCodeWrapper }> = ({ vsc
                         uiKindIsWeb={config.config.uiKindIsWeb}
                         vscodeAPI={vscodeAPI}
                         codyIDE={config.clientCapabilities.agentIDE}
+                        endpoints={config.config.endpointHistory ?? []}
                     />
                 </div>
             ) : (

--- a/vscode/webviews/AuthPage.tsx
+++ b/vscode/webviews/AuthPage.tsx
@@ -124,6 +124,7 @@ interface LoginProps {
     uiKindIsWeb: boolean
     vscodeAPI: VSCodeWrapper
     codyIDE: CodyIDE
+    endpoints: string[]
 }
 
 const WebLogin: React.FunctionComponent<

--- a/vscode/webviews/CodyPanel.story.tsx
+++ b/vscode/webviews/CodyPanel.story.tsx
@@ -26,6 +26,10 @@ const meta: Meta<typeof CodyPanel> = {
             config: {} as any,
             clientCapabilities: CLIENT_CAPABILITIES_FIXTURE,
             authStatus: AUTH_STATUS_FIXTURE_AUTHED,
+            isDotComUser: true,
+            userProductSubscription: {
+                userCanUpgrade: true,
+            },
         },
     },
     decorators: [VSCodeWebview],
@@ -41,6 +45,10 @@ export const NetworkError: StoryObj<typeof meta> = {
             authStatus: {
                 ...AUTH_STATUS_FIXTURE_UNAUTHED,
                 showNetworkError: true,
+            },
+            isDotComUser: true,
+            userProductSubscription: {
+                userCanUpgrade: true,
             },
         },
     },

--- a/vscode/webviews/CodyPanel.tsx
+++ b/vscode/webviews/CodyPanel.tsx
@@ -5,6 +5,7 @@ import {
     CodyIDE,
     FeatureFlag,
     type Guardrails,
+    type UserProductSubscription,
     firstValueFrom,
 } from '@sourcegraph/cody-shared'
 import { useExtensionAPI, useObservable } from '@sourcegraph/prompt-editor'
@@ -30,6 +31,8 @@ interface CodyPanelProps {
         config: LocalEnv & ConfigurationSubsetForWebview
         clientCapabilities: ClientCapabilitiesWithLegacyFields
         authStatus: AuthStatus
+        isDotComUser: boolean
+        userProductSubscription?: UserProductSubscription | null | undefined
     }
     errorMessages: string[]
     attributionEnabled: boolean
@@ -51,7 +54,7 @@ interface CodyPanelProps {
 export const CodyPanel: FunctionComponent<CodyPanelProps> = ({
     view,
     setView,
-    configuration: { config, clientCapabilities, authStatus },
+    configuration: { config, clientCapabilities, authStatus, isDotComUser, userProductSubscription },
     errorMessages,
     setErrorMessages,
     attributionEnabled,
@@ -142,7 +145,15 @@ export const CodyPanel: FunctionComponent<CodyPanelProps> = ({
                             isPromptsV2Enabled={isPromptsV2Enabled}
                         />
                     )}
-                    {view === View.Account && <AccountTab setView={setView} />}
+                    {view === View.Account && (
+                        <AccountTab
+                            config={config}
+                            clientCapabilities={clientCapabilities}
+                            authStatus={authStatus}
+                            isDotComUser={isDotComUser}
+                            userProductSubscription={userProductSubscription}
+                        />
+                    )}
                     {view === View.Settings && <SettingsTab />}
                 </TabContainer>
                 <StateDebugOverlay />

--- a/vscode/webviews/components/AccountSwitcher.tsx
+++ b/vscode/webviews/components/AccountSwitcher.tsx
@@ -102,7 +102,7 @@ export const AccountSwitcher: React.FC<{ activeEndpoint: string; endpoints: stri
     const popoverRemoveAccountPanel = (
         <div className="tw-flex tw-flex-col tw-gap-4 tw-p-4">
             <b>Remove Account?</b>
-            <span>Are you sure you want to remove that account?</span>
+            <div className="tw-text-muted-foreground">{endpointToRemove}</div>
             <Button
                 variant="secondary"
                 className="tw-w-full tw-bg-popover tw-bg-red-500"
@@ -143,7 +143,6 @@ export const AccountSwitcher: React.FC<{ activeEndpoint: string; endpoints: stri
                     <FormControl
                         type="url"
                         name="endpoint"
-                        placeholder="https://example.sourcegraphcloud.com"
                         value={addFormData.endpoint}
                         required
                         onChange={handleInputChange}

--- a/vscode/webviews/components/AccountSwitcher.tsx
+++ b/vscode/webviews/components/AccountSwitcher.tsx
@@ -2,13 +2,17 @@ import { ChevronDown, ChevronRight, ChevronsUpDown, CircleMinus, Plus } from 'lu
 import type * as React from 'react'
 import { type KeyboardEventHandler, useCallback, useState } from 'react'
 import { isSourcegraphToken } from '../../src/chat/protocol'
+import { Badge } from '../components/shadcn/ui/badge'
 import { Form, FormControl, FormField, FormLabel, FormMessage } from '../components/shadcn/ui/form'
 import { getVSCodeAPI } from '../utils/VSCodeApi'
 import { Button } from './shadcn/ui/button'
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from './shadcn/ui/collapsible'
 import { Popover, PopoverContent, PopoverTrigger } from './shadcn/ui/popover'
 
-export const AccountSwitcher: React.FC<{ endpoints: string[] }> = ({ endpoints }) => {
+export const AccountSwitcher: React.FC<{ activeEndpoint: string; endpoints: string[] }> = ({
+    activeEndpoint,
+    endpoints,
+}) => {
     type PopoverState = 'switching' | 'removing' | 'adding'
     const [getPopoverState, setPopoverState] = useState<PopoverState>('switching')
     const [isOpen, setIsOpen] = useState(false)
@@ -46,11 +50,13 @@ export const AccountSwitcher: React.FC<{ endpoints: string[] }> = ({ endpoints }
                 key={`${endpoint}-switch`}
                 variant="ghost"
                 onClick={() => {
-                    getVSCodeAPI().postMessage({
-                        command: 'auth',
-                        authKind: 'signin',
-                        endpoint: endpoint,
-                    })
+                    if (endpoint !== activeEndpoint) {
+                        getVSCodeAPI().postMessage({
+                            command: 'auth',
+                            authKind: 'signin',
+                            endpoint: endpoint,
+                        })
+                    }
                     onOpenChange(false)
                 }}
             >
@@ -71,6 +77,13 @@ export const AccountSwitcher: React.FC<{ endpoints: string[] }> = ({ endpoints }
 
     const popoverSwitchAccountPanel = (
         <div>
+            <div className="tw-flex tw-items-center tw-gap-4 tw-mb-4">
+                <Badge variant="outline" className="tw-text-xxs tw-mt-0.5">
+                    Active
+                </Badge>
+                {activeEndpoint}
+            </div>
+            <div className="tw-w-full tw-border-t tw-border-border" />
             {popoverEndpointsList}
             <div className="tw-w-full tw-border-t tw-border-border" />
             <Button

--- a/vscode/webviews/components/AccountSwitcher.tsx
+++ b/vscode/webviews/components/AccountSwitcher.tsx
@@ -1,17 +1,31 @@
 import { ChevronDown, ChevronRight, ChevronsUpDown, CircleMinus, Plus } from 'lucide-react'
 import type * as React from 'react'
-import {KeyboardEvent, useCallback, useState} from 'react'
+import { type KeyboardEvent, useCallback, useState } from 'react'
 import { isSourcegraphToken } from '../../src/chat/protocol'
 import { Badge } from '../components/shadcn/ui/badge'
-import { Form, FormControl, FormField, FormLabel, FormMessage, FormSubmit } from '../components/shadcn/ui/form'
+import {
+    Form,
+    FormControl,
+    FormField,
+    FormLabel,
+    FormMessage,
+    FormSubmit,
+} from '../components/shadcn/ui/form'
 import { getVSCodeAPI } from '../utils/VSCodeApi'
 import { Button } from './shadcn/ui/button'
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from './shadcn/ui/collapsible'
 import { Popover, PopoverContent, PopoverTrigger } from './shadcn/ui/popover'
 
-export const AccountSwitcher: React.FC<{ activeEndpoint: string; endpoints: string[] }> = ({
+interface AccountSwitcherProps {
+    activeEndpoint: string
+    endpoints: string[]
+    setLoading: (loading: boolean) => void
+}
+
+export const AccountSwitcher: React.FC<AccountSwitcherProps> = ({
     activeEndpoint,
     endpoints,
+    setLoading,
 }) => {
     type PopoverView = 'switch' | 'remove' | 'add'
     const [getPopoverView, serPopoverView] = useState<PopoverView>('switch')
@@ -23,13 +37,11 @@ export const AccountSwitcher: React.FC<{ activeEndpoint: string; endpoints: stri
         accessToken: '',
     })
 
-
     const onKeyDownInPopoverContent = (event: KeyboardEvent<HTMLDivElement>): void => {
         if (event.key === 'Escape' && isOpen) {
             onOpenChange(false)
         }
     }
-
 
     const onOpenChange = (open: boolean): void => {
         setIsOpen(open)
@@ -57,6 +69,7 @@ export const AccountSwitcher: React.FC<{ activeEndpoint: string; endpoints: stri
                         })
                     }
                     onOpenChange(false)
+                    setLoading(true)
                 }}
             >
                 {endpoint}
@@ -182,7 +195,7 @@ export const AccountSwitcher: React.FC<{ activeEndpoint: string; endpoints: stri
                 </Collapsible>
                 <FormSubmit asChild>
                     <Button
-                        key={"add-account-confirmation-button"}
+                        key={'add-account-confirmation-button'}
                         type="submit"
                         variant="ghost"
                         className="tw-w-full tw-bg-blue-500"

--- a/vscode/webviews/components/AccountSwitcher.tsx
+++ b/vscode/webviews/components/AccountSwitcher.tsx
@@ -1,0 +1,61 @@
+import { ChevronDown, ChevronRight } from 'lucide-react'
+import type * as React from 'react'
+import { type KeyboardEventHandler, useCallback, useState } from 'react'
+import { getVSCodeAPI } from '../utils/VSCodeApi'
+import { Button } from './shadcn/ui/button'
+import { Popover, PopoverContent, PopoverTrigger } from './shadcn/ui/popover'
+
+export const AccountSwitcher: React.FC<{ endpoints: string[] }> = ({ endpoints }) => {
+    const [isOpen, setIsOpen] = useState(false)
+
+    const onKeyDownInPopoverContent = useCallback<KeyboardEventHandler<HTMLDivElement>>(
+        event => {
+            if (event.key === 'Escape' && isOpen) {
+                setIsOpen(false)
+            }
+        },
+        [isOpen]
+    )
+
+    const onOpenChange = (open: boolean): void => {
+        setIsOpen(open)
+    }
+
+    return (
+        <Popover open={isOpen} onOpenChange={onOpenChange}>
+            <PopoverTrigger asChild onClick={() => setIsOpen(!isOpen)}>
+                <Button variant="secondary" className="tw-w-full tw-bg-popover">
+                    <span className="tw-flex tw-justify-between tw-items-center">
+                        Switch Account
+                        <span className="tw-w-4">
+                            {isOpen ? <ChevronDown size={16} /> : <ChevronRight size={16} />}
+                        </span>
+                    </span>
+                </Button>
+            </PopoverTrigger>
+            <PopoverContent
+                className="tw-flex tw-flex-col tw-w-full"
+                side="bottom"
+                align="center"
+                onKeyDown={onKeyDownInPopoverContent}
+            >
+                {endpoints.map(endpoint => (
+                    <Button
+                        key={endpoint}
+                        variant="ghost"
+                        onClick={() => {
+                            getVSCodeAPI().postMessage({
+                                command: 'auth',
+                                authKind: 'signin',
+                                endpoint: endpoint,
+                            })
+                            setIsOpen(false)
+                        }}
+                    >
+                        {endpoint}
+                    </Button>
+                ))}
+            </PopoverContent>
+        </Popover>
+    )
+}

--- a/vscode/webviews/components/AccountSwitcher.tsx
+++ b/vscode/webviews/components/AccountSwitcher.tsx
@@ -224,7 +224,10 @@ export const AccountSwitcher: React.FC<AccountSwitcherProps> = ({
     return (
         <Popover open={isOpen} onOpenChange={onOpenChange}>
             <PopoverTrigger asChild onClick={() => setIsOpen(!isOpen)}>
-                <Button variant="secondary" className="tw-w-full tw-bg-popover">
+                <Button
+                    variant="secondary"
+                    className="tw-w-full tw-bg-popover tw-border tw-border-border"
+                >
                     <span className="tw-flex tw-justify-between tw-items-center">
                         Switch Account
                         <span className="tw-w-4">

--- a/vscode/webviews/tabs/AccountTab.story.tsx
+++ b/vscode/webviews/tabs/AccountTab.story.tsx
@@ -16,11 +16,7 @@ const meta: Meta<typeof AccountTab> = {
         story => <div style={{ maxWidth: '700px', margin: '2rem' }}>{story()}</div>,
         VSCodeStandaloneComponent,
     ],
-    args: {
-        setView: () => {
-            console.log('setView called')
-        },
-    },
+    args: {},
 }
 
 export default meta

--- a/vscode/webviews/tabs/AccountTab.tsx
+++ b/vscode/webviews/tabs/AccountTab.tsx
@@ -73,7 +73,7 @@ export const AccountTab: React.FC<AccountTabProps> = ({
     if (clientCapabilities.accountSwitchingInWebview === 'enabled') {
         const endpoints: string[] = config.endpointHistory ?? []
         const switchableEndpoints = endpoints.filter(e => e !== endpoint)
-        accountSwitcher = <AccountSwitcher endpoints={switchableEndpoints} />
+        accountSwitcher = <AccountSwitcher activeEndpoint={endpoint} endpoints={switchableEndpoints} />
     }
 
     if (isDotComUser) {

--- a/vscode/webviews/tabs/AccountTab.tsx
+++ b/vscode/webviews/tabs/AccountTab.tsx
@@ -56,7 +56,7 @@ export const AccountTab: React.FC<AccountTabProps> = ({
             <Button
                 key={text}
                 variant="secondary"
-                className="tw-w-full tw-bg-popover"
+                className="tw-w-full tw-bg-popover tw-border tw-border-border"
                 onClick={onClick}
                 title={text}
             >
@@ -117,7 +117,6 @@ export const AccountTab: React.FC<AccountTabProps> = ({
                         {clientCapabilities.accountSwitchingInWebview === 'enabled' && accountSwitcher}
                     </div>
                 </div>
-                {isLoading && <div>LOADING...</div>}
                 <div className="tw-grid tw-grid-cols-5 tw-gap-4">
                     <div>Plan:</div>
                     <div className="tw-text-muted-foreground tw-col-span-4">
@@ -131,12 +130,10 @@ export const AccountTab: React.FC<AccountTabProps> = ({
                     </div>
                 </div>
             </div>
-            <div className="tw-w-full">
-                {isDotComUser && !isProUser && upgradeButton}
-                {isDotComUser && manageAccountButton}
-                {settingButton}
-                {signOutButton}
-            </div>
+            {isDotComUser && !isProUser && upgradeButton}
+            {isDotComUser && manageAccountButton}
+            {settingButton}
+            {signOutButton}
         </div>
     )
 

--- a/vscode/webviews/tabs/AccountTab.tsx
+++ b/vscode/webviews/tabs/AccountTab.tsx
@@ -69,10 +69,11 @@ export const AccountTab: React.FC<AccountTabProps> = ({
         )
     }
 
+    let accountSwitcher = <div />
     if (clientCapabilities.accountSwitchingInWebview === 'enabled') {
         const endpoints: string[] = config.endpointHistory ?? []
         const switchableEndpoints = endpoints.filter(e => e !== endpoint)
-        actions.push(<AccountSwitcher endpoints={switchableEndpoints} />)
+        accountSwitcher = <AccountSwitcher endpoints={switchableEndpoints} />
     }
 
     if (isDotComUser) {
@@ -118,6 +119,7 @@ export const AccountTab: React.FC<AccountTabProps> = ({
                             <p className="tw-text-lg tw-font-semibold">{displayName ?? username}</p>
                             <p className="tw-text-sm tw-text-muted-foreground">{primaryEmail}</p>
                         </div>
+                        {accountSwitcher}
                     </div>
                 </div>
                 <div className="tw-grid tw-grid-cols-5 tw-gap-4">

--- a/vscode/webviews/tabs/AccountTab.tsx
+++ b/vscode/webviews/tabs/AccountTab.tsx
@@ -1,74 +1,107 @@
-import { CodyIDE } from '@sourcegraph/cody-shared'
+import {
+    type AuthStatus,
+    type AuthenticatedAuthStatus,
+    type ClientCapabilitiesWithLegacyFields,
+    type UserProductSubscription,
+    isCodyProUser,
+} from '@sourcegraph/cody-shared'
 import { useCallback } from 'react'
 import { URI } from 'vscode-uri'
-import { ACCOUNT_UPGRADE_URL, ACCOUNT_USAGE_URL } from '../../src/chat/protocol'
+import {
+    ACCOUNT_UPGRADE_URL,
+    ACCOUNT_USAGE_URL,
+    type ConfigurationSubsetForWebview,
+    type LocalEnv,
+} from '../../src/chat/protocol'
+import { AccountSwitcher } from '../components/AccountSwitcher'
 import { UserAvatar } from '../components/UserAvatar'
 import { Button } from '../components/shadcn/ui/button'
 import { getVSCodeAPI } from '../utils/VSCodeApi'
-import { useConfig, useUserAccountInfo } from '../utils/useConfig'
-import { View } from './types'
 
-interface AccountAction {
-    text: string
-    onClick: () => void
-}
 interface AccountTabProps {
-    setView: (view: View) => void
+    config: LocalEnv & ConfigurationSubsetForWebview
+    clientCapabilities: ClientCapabilitiesWithLegacyFields
+    authStatus: AuthStatus
+    isDotComUser: boolean
+    userProductSubscription: UserProductSubscription | null | undefined
 }
 
 // TODO: Implement the AccountTab component once the design is ready.
-export const AccountTab: React.FC<AccountTabProps> = ({ setView }) => {
-    const config = useConfig()
-    const userInfo = useUserAccountInfo()
-    const { user, isCodyProUser, isDotComUser } = userInfo
-    const { displayName, username, primaryEmail, endpoint } = user
-
+export const AccountTab: React.FC<AccountTabProps> = ({
+    config,
+    clientCapabilities,
+    authStatus,
+    isDotComUser,
+    userProductSubscription,
+}) => {
     // We open the native system pop-up for VS Code.
-    if (config.clientCapabilities.isVSCode) {
+    if (clientCapabilities.isVSCode) {
         return null
     }
 
-    const actions: AccountAction[] = []
+    if (!authStatus.authenticated || userProductSubscription === undefined) {
+        return <div>Authenticating...</div>
+    }
 
-    if (isDotComUser && !isCodyProUser) {
-        actions.push({
-            text: 'Upgrade',
-            onClick: () =>
-                getVSCodeAPI().postMessage({ command: 'links', value: ACCOUNT_UPGRADE_URL.toString() }),
-        })
+    const { displayName, username, primaryEmail, endpoint } = authStatus as AuthenticatedAuthStatus
+    const isProUser = isCodyProUser(authStatus, userProductSubscription)
+    const actions: JSX.Element[] = []
+
+    function createButton(text: string, onClick: () => void) {
+        return (
+            <Button
+                key={text}
+                variant="secondary"
+                className="tw-w-full tw-bg-popover"
+                onClick={onClick}
+                title={text}
+            >
+                {text}
+            </Button>
+        )
     }
+
+    if (isDotComUser && !isProUser) {
+        actions.push(
+            createButton('Upgrade', () =>
+                getVSCodeAPI().postMessage({ command: 'links', value: ACCOUNT_UPGRADE_URL.toString() })
+            )
+        )
+    }
+
+    if (clientCapabilities.accountSwitchingInWebview === 'enabled') {
+        const endpoints: string[] = config.endpointHistory ?? []
+        const switchableEndpoints = endpoints.filter(e => e !== endpoint)
+        actions.push(<AccountSwitcher endpoints={switchableEndpoints} />)
+    }
+
     if (isDotComUser) {
-        actions.push({
-            text: 'Manage Account',
-            onClick: useCallback(() => {
-                if (userInfo.user.username) {
-                    const uri = URI.parse(ACCOUNT_USAGE_URL.toString()).with({
-                        query: `cody_client_user=${encodeURIComponent(userInfo.user.username)}`,
-                    })
-                    getVSCodeAPI().postMessage({ command: 'links', value: uri.toString() })
-                }
-            }, [userInfo]),
-        })
+        actions.push(
+            createButton(
+                'Manage Account',
+                useCallback(() => {
+                    if (username) {
+                        const uri = URI.parse(ACCOUNT_USAGE_URL.toString()).with({
+                            query: `cody_client_user=${encodeURIComponent(username)}`,
+                        })
+                        getVSCodeAPI().postMessage({ command: 'links', value: uri.toString() })
+                    }
+                }, [username])
+            )
+        )
     }
-    actions.push({
-        text: 'Settings',
-        onClick: () =>
-            getVSCodeAPI().postMessage({ command: 'command', id: 'cody.status-bar.interacted' }),
-    })
-    actions.push({
-        text: 'Sign Out',
-        onClick: () => {
+
+    actions.push(
+        createButton('Settings', () =>
+            getVSCodeAPI().postMessage({ command: 'command', id: 'cody.status-bar.interacted' })
+        )
+    )
+
+    actions.push(
+        createButton('Sign Out', () => {
             getVSCodeAPI().postMessage({ command: 'auth', authKind: 'signout' })
-            // TODO: Remove when JB moves to agent based auth
-            // Set the view to the Chat tab so that if the user signs back in, they will be
-            // automatically redirected to the Chat tab, rather than the accounts tab.
-            // This is only for JB as the signout call is captured by the extension and not
-            // passed through to the agent.
-            if (config.clientCapabilities.agentIDE === CodyIDE.JetBrains) {
-                setView(View.Chat)
-            }
-        },
-    })
+        })
+    )
 
     return (
         <div className="tw-overflow-auto tw-flex-1 tw-flex tw-flex-col tw-items-start tw-w-full tw-px-8 tw-py-6 tw-gap-6">
@@ -77,7 +110,7 @@ export const AccountTab: React.FC<AccountTabProps> = ({ setView }) => {
                 <div className="tw-flex tw-justify-between tw-w-full tw-border-b tw-border-border tw-shadow-lg tw-shadow-border-500/50 tw-p-4 tw-pb-6">
                     <div className="tw-flex tw-self-stretch tw-flex-col tw-w-full tw-items-center tw-justify-center">
                         <UserAvatar
-                            user={user}
+                            user={authStatus}
                             size={30}
                             className="tw-flex-shrink-0 tw-w-[30px] tw-h-[30px] tw-flex tw-items-center tw-justify-center"
                         />
@@ -90,7 +123,7 @@ export const AccountTab: React.FC<AccountTabProps> = ({ setView }) => {
                 <div className="tw-grid tw-grid-cols-5 tw-gap-4">
                     <div>Plan:</div>
                     <div className="tw-text-muted-foreground tw-col-span-4">
-                        {isDotComUser ? (isCodyProUser ? 'Cody Pro' : 'Cody Free') : 'Enterprise'}
+                        {isDotComUser ? (isProUser ? 'Cody Pro' : 'Cody Free') : 'Enterprise'}
                     </div>
                     <div>Endpoint:</div>
                     <div className="tw-text-muted-foreground tw-col-span-4">
@@ -100,17 +133,7 @@ export const AccountTab: React.FC<AccountTabProps> = ({ setView }) => {
                     </div>
                 </div>
             </div>
-            {actions.map(a => (
-                <Button
-                    key={a.text}
-                    variant="secondary"
-                    className="tw-w-full tw-bg-popover tw-border tw-border-border"
-                    onClick={a.onClick}
-                    title={a.text}
-                >
-                    {a.text}
-                </Button>
-            ))}
+            <div className="tw-w-full">{actions}</div>
         </div>
     )
 }

--- a/vscode/webviews/themes/jetbrains.css
+++ b/vscode/webviews/themes/jetbrains.css
@@ -664,6 +664,11 @@ html[data-ide='JetBrains'] .tw-bg-muted-transparent:hover {
     background-color: var(--jetbrains-ActionButton-hoverBackground);
 }
 
+html[data-ide='JetBrains'] .tw-border-input-border {
+    border-style: solid;
+    border-width: thin;
+}
+
 /* Custom rule for cmdk heading:
  * VSCode uses input background for headings.
  * JetBrains needs different styling to distinguish headings because input background are the same as pane background. */

--- a/vscode/webviews/themes/jetbrains.css
+++ b/vscode/webviews/themes/jetbrains.css
@@ -264,7 +264,7 @@ html[data-ide='JetBrains'] {
     --vscode-input-background: var(--jetbrains-TextField-background);
     --vscode-input-border: var(--jetbrains-TextArea-inactiveForeground);
     --vscode-input-foreground: var(--jetbrains-TextField-foreground);
-    --vscode-input-placeholderForeground: var(--jetbrains-TextField-foreground);
+    --vscode-input-placeholderForeground: var(--jetbrains-TextArea-caretForeground);
     --vscode-inputOption-activeBackground: var(--jetbrains-ToolWindow-HeaderTab-underlineColor);
     --vscode-inputOption-activeBorder: var(--jetbrains-TextField-borderColor);
     --vscode-inputOption-activeForeground: var(--jetbrains-UIDesigner-Label-foreground);


### PR DESCRIPTION
## Changes

That PR:
1. Fixes webview crashes when switching accounts with Account tab open
2. Add `Switch Account` button on the Accounts tab when `accountSwitchingInWebview` capability is enabled in client.

## Test plan

Testing with jetbrains `main`:

**Fixes https://linear.app/sourcegraph/issue/QA-150**

1. Open Accounts tab
3. Click Cody icon, then `Manage Accounts`
4. Switch the account 
5. Account tab should re-render properly (after a 1-2s delay) showing new account details

**Testing with jetbrains [migrated to webview account management](https://github.com/sourcegraph/jetbrains/pull/2382):**

Account switching:

1. Open Accounts tab
2. Click Switch Account
3. Select account you want to switch to from the list
4. Account tab should re-render properly (after a 1-2s delay) showing new account details

Signing out:

1. Open Accounts tab
2. Click Sign Out
3. You should be moved to the Sign In panel

Account adding:

1. Open Accounts tab
2. Click 'Switch Account', and then 'Add another account'
3. Type url of your endpoint
4. You should be redirected to the web page to confirm adding the token
5. Account should be added and displayed as active

Note: If wrong endpoint is provided web redirection will fail, but no error is displayed in the UI.
This definitely can be improved.

Account adding with token:

1. Open Accounts tab
2. Click 'Switch Account', and then 'Add another account'
3. Type url of your endpoint
4. Click 'Access Token (optional)'
5. Type incorrect access token and click 'Add and Switch'
6. You should get error saying `Invalid access token.`
7. Type correct access token and click 'Add and Switch'
9. Account should be added and displayed as active

![image](https://github.com/user-attachments/assets/cbd9e85d-8075-45ec-a4ba-2b3a68c07fdb)
![image](https://github.com/user-attachments/assets/10b6d94f-c15d-4fe3-ae70-5b968bb8d251)
![image](https://github.com/user-attachments/assets/0d617e8b-0cc4-48d2-98b7-8e5d548f3f6c)
![image](https://github.com/user-attachments/assets/0ad531f2-5880-4d7a-a66d-31abc2112a79)

