### PR TITLE
feat(autoedit): use code completion feature for auto edits

### DIFF
--- a/vscode/src/autoedits/adapters/cody-gateway.ts
+++ b/vscode/src/autoedits/adapters/cody-gateway.ts
@@ -45,7 +45,7 @@ export class CodyGatewayAdapter implements AutoeditsModelAdapter {
     async getModelResponse(option: AutoeditModelOptions): Promise<string> {
         try {
             const headers = {
-                'X-Sourcegraph-Feature': 'chat_completions',
+                'X-Sourcegraph-Feature': 'code_completions',
             }
             const body = {
                 stream: false,


### PR DESCRIPTION
Use the `code_completions` field for querying `cody gateway` to use existing autocomplete rate limit. The current chat based rate limits are only `400`.
Backend PR: https://github.com/sourcegraph/sourcegraph/pull/1809

## Test plan
Test plan with curl in the [backend PR](https://github.com/sourcegraph/sourcegraph/pull/1809).
Curl to repro, that it works with `code_completions` header:
```
curl --location 'http://localhost:9992/v1/completions/fireworks' \
--header 'Authorization: bearer <token>' \
--header 'X-sourcegraph-feature: code_completions' \
--header 'Content-Type: application/json' \
--data '{
    "stream": false,
    "max_tokens": 50, 
    "model": "cody-model-auto-edits-fireworks-default",
    "messages": [
        {
        "role": "system",
        "content": "You are an intelligent programmer named CodyBot. You are an expert at coding. Your goal is to help your colleague finish a code change."
        },
        {
            "role": "user",
            "content": "def "
        }
    ],
    "languageId": "python",
    "speculation": "def hello()"
}
'
```

