### PR TITLE
Revert "Update backport.yml (#6137)"

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -24,5 +24,5 @@ jobs:
       - uses: sourcegraph/backport@v2
         with:
           github_token: ${{ secrets.BACKPORT_GITHUB_TOKEN }}
-          label_pattern: '^backport (?<base>v\d+\.\d+\.x)$'
+          label_pattern: '^backport (?<base>vscode-v\d+\.\d+\.x)$'
           team_reviews: ''


### PR DESCRIPTION
This reverts commit 0070f3c29e2945facce3b1d3774bd23666147e05.

Oversight on my part, I originally wanted to make it easier to type the backport label by chopping off the `vscode-` prefix, but I think this will create more confusion. Changing this back so that the backport label matches the branch that we are targetting

So if anyone needs a backport, please follow the format `backport vscode-v.major.minor.x` it should match the release branch

## Test plan
N/A

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
