### PR TITLE
Bench: make sure to respect CODY_RECORDING_MODE

### DIFF
--- a/agent/src/cli/command-bench/command-bench.ts
+++ b/agent/src/cli/command-bench/command-bench.ts
@@ -334,7 +334,7 @@ export const benchCommand = new commander.Command('bench')
             },
         })
 
-        const recordingMode =   process.env.CODY_RECORDING_MODE === 'passthrough' ? 'passthrough' : 'replay'
+        const recordingMode = process.env.CODY_RECORDING_MODE === 'passthrough' ? 'passthrough' : 'replay'
         const recordingDirectory = path.join(path.dirname(options.evaluationConfig), 'recordings')
         const polly = startPollyRecording({
             recordingName: 'cody-bench',

--- a/agent/src/cli/command-bench/command-bench.ts
+++ b/agent/src/cli/command-bench/command-bench.ts
@@ -334,14 +334,16 @@ export const benchCommand = new commander.Command('bench')
             },
         })
 
+        const recordingMode =   process.env.CODY_RECORDING_MODE === 'passthrough' ? 'passthrough' : 'replay'
         const recordingDirectory = path.join(path.dirname(options.evaluationConfig), 'recordings')
         const polly = startPollyRecording({
             recordingName: 'cody-bench',
-            recordingMode: 'replay',
+            recordingMode: recordingMode,
             recordIfMissing: true,
             recordingDirectory,
             keepUnusedRecordings: true,
         })
+
         try {
             await Promise.all(
                 workspacesToRun.map(workspace => evaluateWorkspace(workspace, recordingDirectory))

--- a/agent/src/cli/command-bench/command-bench.ts
+++ b/agent/src/cli/command-bench/command-bench.ts
@@ -334,7 +334,8 @@ export const benchCommand = new commander.Command('bench')
             },
         })
 
-        const recordingMode = process.env.CODY_RECORDING_MODE === 'passthrough' ? 'passthrough' : 'replay'
+        const recordingMode =
+            process.env.CODY_RECORDING_MODE === 'passthrough' ? 'passthrough' : 'replay'
         const recordingDirectory = path.join(path.dirname(options.evaluationConfig), 'recordings')
         const polly = startPollyRecording({
             recordingName: 'cody-bench',


### PR DESCRIPTION
In context evals, we disable Polly recording so that responses to the Sourcegraph backend are not cached. This is important, so we can test local changes to the Sourcegraph backend and see updated eval results.

Before this PR, the command-bench code was accidentally ignoring `CODY_RECORDING_MODE` and always starting a Polly recording. 

## Test plan

Reran context evals, and everything works. Put in a `console.log` to ensure recording is disabled.