### PR TITLE
Add Sourcegraph CLI installation description to README.md

### DIFF
--- a/agent/README.md
+++ b/agent/README.md
@@ -121,6 +121,9 @@ recordings. For example, this can happen when we make changes to the prompt the
 agent test to not be able to replay the autocomplete requests from old
 recordings.
 
+Before you start, make sure you have Sourcegraph CLI installed. 
+See: [Installation in Quickstart for src](https://sourcegraph.com/docs/cli/quickstart#installation).
+
 To fix this problem, update the HTTP recordings with the following command:
 
 ```sh


### PR DESCRIPTION
Running the tests in recording mode assumes that the CLI is installed. The requirement was not described before. I was unobvious for me what is the tool and how to install it. This PR adds missing description.

## Test plan
n/a

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

## Changelog
This PR adds missing description.

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
