### PR TITLE
fix(autoedit): fix suffix matching logic

### DIFF
--- a/vscode/src/autoedits/autoedits-provider.ts
+++ b/vscode/src/autoedits/autoedits-provider.ts
@@ -212,10 +212,7 @@ export class AutoeditsProvider implements vscode.InlineCompletionItemProvider, v
         const isPrefixMatch = prediction.startsWith(codeToReplace.codeToRewritePrefix)
         const isSuffixMatch =
             // The current line suffix should not require any char removals to render the completion.
-            completionMatchesSuffix(
-                { insertText: codeToReplace.codeToRewriteSuffix },
-                docContext.currentLineSuffix
-            ) &&
+            completionMatchesSuffix({ insertText: prediction }, docContext.currentLineSuffix) &&
             // The new lines suggested after the current line must be equal to the prediction.
             prediction.endsWith(codeToRewriteAfterCurrentLine)
 


### PR DESCRIPTION
Fixes the issue where the inline completion item provider is used in cases where chars deletions are required after the cursor because of the incorrect suffix matching logic.

## Test plan

Manually tested by renaming the `attributes` to `values` in the following code and placing the cursor on the `const { currentLinePrefix, text, ...rest } = values` line: 

```ts
export const addAutocompleteDebugEvent = (
    name: string,
    attributes: Record<string, unknown> = {}
): Span | undefined => {
    if (process.env.NODE_ENV === 'development') {
        const activeSpan = trace.getActiveSpan()

        const { currentLinePrefix, text, ...rest } = attributes
        if (typeof currentLinePrefix === 'string' && typeof text === 'string') {
            const formattedText = `${currentLinePrefix}█${text.trimStart()}`
            return activeSpan?.addEvent(name, { text: formattedText, ...rest })
        }

        return activeSpan?.addEvent(name, attributes as Attributes)
    }
    return undefined
}
```

Currently, we don't have automated tests for the renderer and provider. We plan to implement them early next week
