### PR TITLE
Adding Distributed Tracing and Smart Apply to cody

### DIFF
--- a/lib/shared/src/prompt/prompt-string.ts
+++ b/lib/shared/src/prompt/prompt-string.ts
@@ -413,6 +413,10 @@ export class PromptString {
                 : undefined,
         }
     }
+
+    public match(regexp: RegExp): RegExpMatchArray | null {
+        return internal_toString(this).match(regexp)
+    }
 }
 
 type TemplateArgs = readonly (PromptString | '' | number)[]

--- a/lib/shared/src/prompt/prompt-string.ts
+++ b/lib/shared/src/prompt/prompt-string.ts
@@ -413,7 +413,7 @@ export class PromptString {
                 : undefined,
         }
     }
-
+    // TODO: Lift the results of the matches so they're also PromptStrings.
     public match(regexp: RegExp): RegExpMatchArray | null {
         return internal_toString(this).match(regexp)
     }

--- a/lib/shared/src/tracing/index.ts
+++ b/lib/shared/src/tracing/index.ts
@@ -1,4 +1,11 @@
-import opentelemetry, { SpanStatusCode, context, propagation, type Span } from '@opentelemetry/api'
+import opentelemetry, {
+    type Context,
+    ROOT_CONTEXT,
+    SpanStatusCode,
+    context,
+    propagation,
+    type Span,
+} from '@opentelemetry/api'
 import type { BrowserOrNodeResponse } from '../sourcegraph-api/graphql/client'
 
 const INSTRUMENTATION_SCOPE_NAME = 'cody'
@@ -88,4 +95,20 @@ export function recordErrorToSpan(span: Span, error: Error): Error {
     span.setStatus({ code: SpanStatusCode.ERROR })
     span.end()
     return error
+}
+
+// Extracts a context from a traceparent header for use in a wrapped function
+// that is called with context.with. This is useful for propagating the trace
+// context between webview and extension host.
+export function extractContextFromTraceparent(traceparent?: string | undefined | null): Context {
+    const carrier = { traceparent } as Record<string, any>
+    const getter = {
+        get(carrier: Record<string, any>, key: string) {
+            return carrier[key]
+        },
+        keys(carrier: Record<string, any>) {
+            return Object.keys(carrier)
+        },
+    }
+    return propagation.extract(ROOT_CONTEXT, carrier, getter)
 }

--- a/vscode/src/chat/chat-view/ChatController.ts
+++ b/vscode/src/chat/chat-view/ChatController.ts
@@ -80,7 +80,7 @@ import {
 import * as uuid from 'uuid'
 import * as vscode from 'vscode'
 
-import type { Span } from '@opentelemetry/api'
+import { type Span, context } from '@opentelemetry/api'
 import { captureException } from '@sentry/core'
 import { getTokenCounterUtils } from '@sourcegraph/cody-shared/src/token/counter'
 import type { TelemetryEventParameters } from '@sourcegraph/telemetry'
@@ -143,7 +143,6 @@ import { getChatPanelTitle } from './chat-helpers'
 import { type HumanInput, getPriorityContext } from './context'
 import { DefaultPrompter, type PromptInfo } from './prompt'
 import { getPromptsMigrationInfo, startPromptsMigration } from './prompts-migration'
-const { context, propagation, ROOT_CONTEXT } = require('@opentelemetry/api')
 
 export interface ChatControllerOptions {
     extensionUri: vscode.Uri

--- a/vscode/src/chat/protocol.ts
+++ b/vscode/src/chat/protocol.ts
@@ -96,6 +96,7 @@ export type WebviewMessage =
           code: string
           instruction?: string | undefined | null
           fileName?: string | undefined | null
+          traceparent?: string | undefined | null
       }
     | {
           command: 'trace-export'
@@ -206,6 +207,7 @@ export interface WebviewSubmitMessage extends WebviewContextMessage {
     intent?: ChatMessage['intent'] | undefined | null
     intentScores?: { intent: string; score: number }[] | undefined | null
     manuallySelectedIntent?: boolean | undefined | null
+    traceparent?: string | undefined | null
 }
 
 interface WebviewEditMessage extends WebviewContextMessage {

--- a/vscode/src/edit/manager.ts
+++ b/vscode/src/edit/manager.ts
@@ -9,6 +9,7 @@ import {
     modelsService,
     ps,
     telemetryRecorder,
+    wrapInActiveSpan,
 } from '@sourcegraph/cody-shared'
 
 import type { GhostHintDecorator } from '../commands/GhostHintDecorator'
@@ -17,6 +18,8 @@ import type { VSCodeEditor } from '../editor/vscode-editor'
 import { FixupController } from '../non-stop/FixupController'
 import type { FixupTask } from '../non-stop/FixupTask'
 
+import { ROOT_CONTEXT, context } from '@opentelemetry/api'
+import { propagation } from '@opentelemetry/api'
 import { DEFAULT_EVENT_SOURCE } from '@sourcegraph/cody-shared'
 import { isUriIgnoredByContextFilterWithNotification } from '../cody-ignore/context-filter'
 import type { ExtensionClient } from '../extension-client'
@@ -236,196 +239,217 @@ export class EditManager implements vscode.Disposable {
         return task
     }
 
-    public async smartApplyEdit(args: SmartApplyArguments = {}): Promise<FixupTask | undefined> {
-        const { configuration, source = 'chat' } = args
-        if (!configuration) {
-            return
-        }
-
-        const document = configuration.document
-        if (await isUriIgnoredByContextFilterWithNotification(document.uri, 'edit')) {
-            return
-        }
-
-        const model =
-            configuration.model || (await firstResultFromOperation(modelsService.getDefaultEditModel()))
-        if (!model) {
-            throw new Error('No default edit model found. Please set one.')
-        }
-
-        telemetryRecorder.recordEvent('cody.command.smart-apply', 'executed', {
-            billingMetadata: {
-                product: 'cody',
-                category: 'core',
+    public async smartApplyEdit(args: SmartApplyArguments = {}): Promise<void> {
+        const carrier = {
+            traceparent: args.configuration?.traceparent,
+        } as Record<string, any>
+        const getter = {
+            get(carrier: Record<string, any>, key: string) {
+                return carrier[key]
             },
-        })
-
-        const editor = await vscode.window.showTextDocument(document.uri)
-
-        if (args.configuration?.isNewFile) {
-            // We are creating a new file, this means we are only _adding_ new code and _inserting_ it into the document.
-            // We do not need to re-prompt the LLM for this, let's just add the code directly.
-            const task = await this.controller.createTask(
-                document,
-                configuration.instruction,
-                [],
-                new vscode.Range(0, 0, 0, 0),
-                'add',
-                'insert',
-                model,
-                source,
-                configuration.document.uri,
-                undefined,
-                {},
-                configuration.id
-            )
-
-            const legacyMetadata = {
-                intent: task.intent,
-                mode: task.mode,
-                source: task.source,
-            }
-            const { metadata, privateMetadata } = splitSafeMetadata(legacyMetadata)
-            telemetryRecorder.recordEvent('cody.command.edit', 'executed', {
-                metadata,
-                privateMetadata: {
-                    ...privateMetadata,
-                    model: task.model,
-                },
-                billingMetadata: {
-                    product: 'cody',
-                    category: 'core',
-                },
-            })
-
-            const provider = this.getProviderForTask(task)
-            await provider.applyEdit(configuration.replacement)
-            return task
-        }
-
-        // Apply some decorations to the editor, this showcases that Cody is working on the full file range
-        // of the document. We will narrow it down to a selection soon.
-        const documentRange = new vscode.Range(0, 0, document.lineCount, 0)
-        editor.setDecorations(SMART_APPLY_FILE_DECORATION, [documentRange])
-
-        // We need to extract the proposed code, provided by the LLM, so we can use it in future
-        // queries to ask the LLM to generate a selection, and then ultimately apply the edit.
-        const replacementCode = PromptString.unsafe_fromLLMResponse(configuration.replacement)
-
-        const versions = await currentSiteVersion()
-        if (!versions) {
-            throw new Error('unable to determine site version')
-        }
-
-        const selection = await getSmartApplySelection(
-            configuration.id,
-            configuration.instruction,
-            replacementCode,
-            configuration.document,
-            model,
-            this.options.chat,
-            versions.codyAPIVersion
-        )
-
-        // We finished prompting the LLM for the selection, we can now remove the "progress" decoration
-        // that indicated we where working on the full file.
-        editor.setDecorations(SMART_APPLY_FILE_DECORATION, [])
-
-        if (!selection) {
-            // We couldn't figure out the selection, let's inform the user and return early.
-            // TODO: Should we add a "Copy" button to this error? Then the user can copy the code directly.
-            void vscode.window.showErrorMessage(
-                'Unable to apply this change to the file. Please try applying this code manually'
-            )
-            telemetryRecorder.recordEvent('cody.smart-apply.selection', 'not-found')
-            return
-        }
-
-        telemetryRecorder.recordEvent('cody.smart-apply', 'selected', {
-            metadata: {
-                [selection.type]: 1,
+            keys(carrier: Record<string, any>) {
+                return Object.keys(carrier)
             },
-        })
+        }
 
-        // Move focus to the determined selection
-        editor.revealRange(selection.range, vscode.TextEditorRevealType.InCenter)
+        const extractedContext = propagation.extract(ROOT_CONTEXT, carrier, getter)
 
-        if (selection.range.isEmpty) {
-            let insertionRange = selection.range
+        return context.with(extractedContext, async () => {
+            await wrapInActiveSpan('edit.smart-apply', async span => {
+                span.setAttribute('sampled', true)
+                span.setAttribute('continued', true)
+                const { configuration, source = 'chat' } = args
+                if (!configuration) {
+                    return
+                }
 
-            if (
-                selection.type === 'insert' &&
-                document.lineAt(document.lineCount - 1).text.trim().length !== 0
-            ) {
-                // Inserting to the bottom of the file, but the last line is not empty
-                // Inject an additional new line for us to use as the insertion range.
-                await editor.edit(
-                    editBuilder => {
-                        editBuilder.insert(selection.range.start, '\n')
+                const document = configuration.document
+                if (await isUriIgnoredByContextFilterWithNotification(document.uri, 'edit')) {
+                    return
+                }
+
+                const model =
+                    configuration.model ||
+                    (await firstResultFromOperation(modelsService.getDefaultEditModel()))
+                if (!model) {
+                    throw new Error('No default edit model found. Please set one.')
+                }
+
+                telemetryRecorder.recordEvent('cody.command.smart-apply', 'executed', {
+                    billingMetadata: {
+                        product: 'cody',
+                        category: 'core',
                     },
-                    { undoStopAfter: false, undoStopBefore: false }
+                })
+
+                const editor = await vscode.window.showTextDocument(document.uri)
+
+                if (args.configuration?.isNewFile) {
+                    // We are creating a new file, this means we are only _adding_ new code and _inserting_ it into the document.
+                    // We do not need to re-prompt the LLM for this, let's just add the code directly.
+                    const task = await this.controller.createTask(
+                        document,
+                        configuration.instruction,
+                        [],
+                        new vscode.Range(0, 0, 0, 0),
+                        'add',
+                        'insert',
+                        model,
+                        source,
+                        configuration.document.uri,
+                        undefined,
+                        {},
+                        configuration.id
+                    )
+
+                    const legacyMetadata = {
+                        intent: task.intent,
+                        mode: task.mode,
+                        source: task.source,
+                    }
+                    const { metadata, privateMetadata } = splitSafeMetadata(legacyMetadata)
+                    telemetryRecorder.recordEvent('cody.command.edit', 'executed', {
+                        metadata,
+                        privateMetadata: {
+                            ...privateMetadata,
+                            model: task.model,
+                        },
+                        billingMetadata: {
+                            product: 'cody',
+                            category: 'core',
+                        },
+                    })
+
+                    const provider = this.getProviderForTask(task)
+                    await provider.applyEdit(configuration.replacement)
+                    return task
+                }
+
+                // Apply some decorations to the editor, this showcases that Cody is working on the full file range
+                // of the document. We will narrow it down to a selection soon.
+                const documentRange = new vscode.Range(0, 0, document.lineCount, 0)
+                editor.setDecorations(SMART_APPLY_FILE_DECORATION, [documentRange])
+
+                // We need to extract the proposed code, provided by the LLM, so we can use it in future
+                // queries to ask the LLM to generate a selection, and then ultimately apply the edit.
+                const replacementCode = PromptString.unsafe_fromLLMResponse(configuration.replacement)
+
+                const versions = await currentSiteVersion()
+                if (!versions) {
+                    throw new Error('unable to determine site version')
+                }
+
+                const selection = await getSmartApplySelection(
+                    configuration.id,
+                    configuration.instruction,
+                    replacementCode,
+                    configuration.document,
+                    model,
+                    this.options.chat,
+                    versions.codyAPIVersion
                 )
 
-                // Update the range to reflect the new end of document
-                insertionRange = document.lineAt(document.lineCount - 1).range
-            }
+                // We finished prompting the LLM for the selection, we can now remove the "progress" decoration
+                // that indicated we where working on the full file.
+                editor.setDecorations(SMART_APPLY_FILE_DECORATION, [])
 
-            // We determined a selection, but it was empty. This means that we will be _adding_ new code
-            // and _inserting_ it into the document. We do not need to re-prompt the LLM for this, let's just
-            // add the code directly.
-            const task = await this.controller.createTask(
-                document,
-                configuration.instruction,
-                [],
-                insertionRange,
-                'add',
-                'insert',
-                model,
-                source,
-                configuration.document.uri,
-                undefined,
-                {},
-                configuration.id
-            )
+                if (!selection) {
+                    // We couldn't figure out the selection, let's inform the user and return early.
+                    // TODO: Should we add a "Copy" button to this error? Then the user can copy the code directly.
+                    void vscode.window.showErrorMessage(
+                        'Unable to apply this change to the file. Please try applying this code manually'
+                    )
+                    telemetryRecorder.recordEvent('cody.smart-apply.selection', 'not-found')
+                    return
+                }
 
-            const legacyMetadata = {
-                intent: task.intent,
-                mode: task.mode,
-                source: task.source,
-            }
-            const { metadata, privateMetadata } = splitSafeMetadata(legacyMetadata)
-            telemetryRecorder.recordEvent('cody.command.edit', 'executed', {
-                metadata,
-                privateMetadata: {
-                    ...privateMetadata,
-                    model: task.model,
-                },
-                billingMetadata: {
-                    product: 'cody',
-                    category: 'core',
-                },
+                telemetryRecorder.recordEvent('cody.smart-apply', 'selected', {
+                    metadata: {
+                        [selection.type]: 1,
+                    },
+                })
+
+                // Move focus to the determined selection
+                editor.revealRange(selection.range, vscode.TextEditorRevealType.InCenter)
+
+                if (selection.range.isEmpty) {
+                    let insertionRange = selection.range
+
+                    if (
+                        selection.type === 'insert' &&
+                        document.lineAt(document.lineCount - 1).text.trim().length !== 0
+                    ) {
+                        // Inserting to the bottom of the file, but the last line is not empty
+                        // Inject an additional new line for us to use as the insertion range.
+                        await editor.edit(
+                            editBuilder => {
+                                editBuilder.insert(selection.range.start, '\n')
+                            },
+                            { undoStopAfter: false, undoStopBefore: false }
+                        )
+
+                        // Update the range to reflect the new end of document
+                        insertionRange = document.lineAt(document.lineCount - 1).range
+                    }
+
+                    // We determined a selection, but it was empty. This means that we will be _adding_ new code
+                    // and _inserting_ it into the document. We do not need to re-prompt the LLM for this, let's just
+                    // add the code directly.
+                    const task = await this.controller.createTask(
+                        document,
+                        configuration.instruction,
+                        [],
+                        insertionRange,
+                        'add',
+                        'insert',
+                        model,
+                        source,
+                        configuration.document.uri,
+                        undefined,
+                        {},
+                        configuration.id
+                    )
+
+                    const legacyMetadata = {
+                        intent: task.intent,
+                        mode: task.mode,
+                        source: task.source,
+                    }
+                    const { metadata, privateMetadata } = splitSafeMetadata(legacyMetadata)
+                    telemetryRecorder.recordEvent('cody.command.edit', 'executed', {
+                        metadata,
+                        privateMetadata: {
+                            ...privateMetadata,
+                            model: task.model,
+                        },
+                        billingMetadata: {
+                            product: 'cody',
+                            category: 'core',
+                        },
+                    })
+
+                    const provider = this.getProviderForTask(task)
+                    await provider.applyEdit('\n' + configuration.replacement)
+                    return task
+                }
+
+                // We have a selection to replace, we re-prompt the LLM to generate the changes to ensure that
+                // we can reliably apply this edit.
+                // Just using the replacement code from the response is not enough, as it may contain parts that are not suitable to apply,
+                // e.g. // ...
+                return this.executeEdit({
+                    configuration: {
+                        id: configuration.id,
+                        document: configuration.document,
+                        range: selection.range,
+                        mode: 'edit',
+                        instruction: ps`Ensuring that you do not duplicate code that it outside of the selection, apply the following change:\n${replacementCode}`,
+                        model,
+                        intent: 'edit',
+                    },
+                    source,
+                })
             })
-
-            const provider = this.getProviderForTask(task)
-            await provider.applyEdit('\n' + configuration.replacement)
-            return task
-        }
-
-        // We have a selection to replace, we re-prompt the LLM to generate the changes to ensure that
-        // we can reliably apply this edit.
-        // Just using the replacement code from the response is not enough, as it may contain parts that are not suitable to apply,
-        // e.g. // ...
-        return this.executeEdit({
-            configuration: {
-                id: configuration.id,
-                document: configuration.document,
-                range: selection.range,
-                mode: 'edit',
-                instruction: ps`Ensuring that you do not duplicate code that it outside of the selection, apply the following change:\n${replacementCode}`,
-                model,
-                intent: 'edit',
-            },
-            source,
         })
     }
 

--- a/vscode/src/edit/manager.ts
+++ b/vscode/src/edit/manager.ts
@@ -3,8 +3,10 @@ import * as vscode from 'vscode'
 import {
     type ChatClient,
     ClientConfigSingleton,
+    DEFAULT_EVENT_SOURCE,
     PromptString,
     currentSiteVersion,
+    extractContextFromTraceparent,
     firstResultFromOperation,
     modelsService,
     ps,
@@ -19,8 +21,6 @@ import { FixupController } from '../non-stop/FixupController'
 import type { FixupTask } from '../non-stop/FixupTask'
 
 import { context } from '@opentelemetry/api'
-import { DEFAULT_EVENT_SOURCE } from '@sourcegraph/cody-shared'
-import { extractContextFromTraceparent } from '@sourcegraph/cody-shared'
 import { isUriIgnoredByContextFilterWithNotification } from '../cody-ignore/context-filter'
 import type { ExtensionClient } from '../extension-client'
 import { ACTIVE_TASK_STATES } from '../non-stop/codelenses/constants'

--- a/vscode/src/edit/provider.ts
+++ b/vscode/src/edit/provider.ts
@@ -57,7 +57,7 @@ export class EditProvider {
     public async startEdit(): Promise<void> {
         return wrapInActiveSpan('command.edit.start', async span => {
             span.setAttribute('sampled', true)
-            const mySpan = tracer.startSpan('cody.edit.provider.startTask')
+            const editTimeToFirstTokenSpan = tracer.startSpan('cody.edit.provider.timeToFirstToken')
             this.config.controller.startTask(this.config.task)
             const model = this.config.task.model
             const contextWindow = modelsService.getContextWindowByID(model)
@@ -157,19 +157,16 @@ export class EditProvider {
             )
 
             let textConsumed = 0
-            let someTextConsumed = 0
+            let firstTokenReceived = false
             for await (const message of stream) {
                 switch (message.type) {
                     case 'change': {
-                        mySpan.addEvent('change')
-
                         if (textConsumed === 0 && responsePrefix) {
                             void multiplexer.publish(responsePrefix)
                         }
-                        if (someTextConsumed === 0 && message.text.length > 1) {
-                            mySpan.addEvent('complete')
-                            mySpan.end()
-                            someTextConsumed++
+                        if (!firstTokenReceived && message.text.length > 1) {
+                            editTimeToFirstTokenSpan.end()
+                            firstTokenReceived = true
                         }
                         const text = message.text.slice(textConsumed)
                         textConsumed += text.length
@@ -177,10 +174,7 @@ export class EditProvider {
                         break
                     }
                     case 'complete': {
-                        wrapInActiveSpan('cody.edit.provider.complete', async span => {
-                            span.setAttribute('sampled', true)
-                            await multiplexer.notifyTurnComplete()
-                        })
+                        await multiplexer.notifyTurnComplete()
                         break
                     }
                     case 'error': {

--- a/vscode/src/edit/smart-apply.ts
+++ b/vscode/src/edit/smart-apply.ts
@@ -11,6 +11,7 @@ export interface SmartApplyArguments {
         document: vscode.TextDocument
         model?: EditModel
         isNewFile?: boolean
+        traceparent: string | undefined | null
     }
     source?: EventSource
 }

--- a/vscode/src/services/open-telemetry/CodyTraceExport.ts
+++ b/vscode/src/services/open-telemetry/CodyTraceExport.ts
@@ -60,6 +60,7 @@ export class CodyTraceExporter extends OTLPTraceExporter {
                     isContinued(effectiveRootSpan)
                 ) {
                     spansToExport.push(span)
+                    // Since we pushed the spans, we don't need to queue them
                     continue
                 }
 
@@ -71,7 +72,7 @@ export class CodyTraceExporter extends OTLPTraceExporter {
                     this.queuedSpans.set(spanId, { span, enqueuedAt: now })
                 }
             } else {
-                if (isRootSampled(rootSpan)) {
+                if (isSampled(rootSpan)) {
                     spansToExport.push(span)
                 }
                 // else: The span is dropped
@@ -114,6 +115,8 @@ function isSampled(span: ReadableSpan): boolean {
     return span.attributes.sampled === true
 }
 
+// This function finds the root span of a given span so that we can check eventually check if it is sampled.
+// This is useful to put all the spans that are part of the same trace together.
 function getRootSpan(spanMap: Map<string, ReadableSpan>, span: ReadableSpan): ReadableSpan | null {
     if (span.parentSpanId) {
         const parentSpan = spanMap.get(span.parentSpanId)
@@ -123,8 +126,4 @@ function getRootSpan(spanMap: Map<string, ReadableSpan>, span: ReadableSpan): Re
         return getRootSpan(spanMap, parentSpan)
     }
     return span
-}
-
-function isRootSampled(rootSpan: ReadableSpan): boolean {
-    return rootSpan.attributes.sampled === true
 }

--- a/vscode/src/services/utils/codeblock-action-tracker.ts
+++ b/vscode/src/services/utils/codeblock-action-tracker.ts
@@ -158,7 +158,8 @@ export async function handleSmartApply(
     code: string,
     authStatus: AuthStatus,
     instruction?: string | null,
-    fileUri?: string | null
+    fileUri?: string | null,
+    traceparent?: string | undefined | null
 ): Promise<void> {
     const activeEditor = getEditor()?.active
     const workspaceUri = vscode.workspace.workspaceFolders?.[0].uri
@@ -196,6 +197,7 @@ export async function handleSmartApply(
             model: getSmartApplyModel(authStatus),
             replacement: code,
             isNewFile,
+            traceparent,
         },
         source: 'chat',
     })

--- a/vscode/webviews/Chat.tsx
+++ b/vscode/webviews/Chat.tsx
@@ -140,10 +140,8 @@ export const Chat: React.FunctionComponent<React.PropsWithChildren<ChatboxProps>
                 const span = spanManager.startSpan('smartApplySubmit', {
                     attributes: {
                         sampled: true,
+                        'smartApply.id': id,
                     },
-                })
-                span.setAttributes({
-                    'smartApply.id': id,
                 })
                 const traceparent = getTraceparentFromSpanContext(span.spanContext())
 

--- a/vscode/webviews/chat/Transcript.tsx
+++ b/vscode/webviews/chat/Transcript.tsx
@@ -35,7 +35,7 @@ import type { ApiPostMessage } from '../Chat'
 import { Button } from '../components/shadcn/ui/button'
 import { getVSCodeAPI } from '../utils/VSCodeApi'
 import { SpanManager } from '../utils/spanManager'
-import { useTelemetryRecorder } from '../utils/telemetry'
+import { getTraceparentFromSpanContext, useTelemetryRecorder } from '../utils/telemetry'
 import { useExperimentalOneBox } from '../utils/useExperimentalOneBox'
 import type { CodeBlockActionsProps } from './ChatMessageContent/ChatMessageContent'
 import {
@@ -293,6 +293,9 @@ const TranscriptInteraction: FC<TranscriptInteractionProps> = memo(props => {
 
         const spanContext = trace.setSpan(context.active(), span)
         setActiveChatContext(spanContext)
+        const currentSpanContext = span.spanContext()
+
+        const traceparent = getTraceparentFromSpanContext(currentSpanContext)
 
         // Serialize the editor value after starting the span
         const editorValue = humanEditorRef.current?.getSerializedValue()
@@ -306,6 +309,7 @@ const TranscriptInteraction: FC<TranscriptInteractionProps> = memo(props => {
             intent: intentFromSubmit || intentResults.current?.intent,
             intentScores: intentFromSubmit ? undefined : intentResults.current?.allScores,
             manuallySelectedIntent: !!intentFromSubmit,
+            traceparent,
         }
 
         if (action === 'edit') {
@@ -433,6 +437,7 @@ const TranscriptInteraction: FC<TranscriptInteractionProps> = memo(props => {
                 })
                 renderSpan.current.end()
             }
+
             renderSpan.current = undefined
             hasRecordedFirstToken.current = false
 
@@ -714,11 +719,13 @@ function submitHumanMessage({
     intent,
     intentScores,
     manuallySelectedIntent,
+    traceparent,
 }: {
     editorValue: SerializedPromptEditorValue
     intent?: ChatMessage['intent']
     intentScores?: { intent: string; score: number }[]
     manuallySelectedIntent?: boolean
+    traceparent: string
 }): void {
     getVSCodeAPI().postMessage({
         command: 'submit',
@@ -728,6 +735,7 @@ function submitHumanMessage({
         intent,
         intentScores,
         manuallySelectedIntent,
+        traceparent,
     })
     focusLastHumanMessageEditor()
 }

--- a/vscode/webviews/utils/spanManager.ts
+++ b/vscode/webviews/utils/spanManager.ts
@@ -79,9 +79,9 @@ export class SpanManager {
         })
     }
 
-    startSpan(name: string, options?: SpanManagerOptions): Span | undefined {
+    startSpan(name: string, options?: SpanManagerOptions): Span {
         if (this.spans.has(name)) {
-            return this.spans.get(name)
+            return this.spans.get(name)!
         }
 
         // Use provided context or fall back to active context

--- a/vscode/webviews/utils/telemetry.ts
+++ b/vscode/webviews/utils/telemetry.ts
@@ -1,5 +1,6 @@
 import type { TelemetryRecorder } from '@sourcegraph/cody-shared'
 
+import type { SpanContext } from '@opentelemetry/api'
 import { createContext, useContext } from 'react'
 import type { WebviewRecordEventParameters } from '../../src/chat/protocol'
 import type { ApiPostMessage } from '../Chat'
@@ -36,4 +37,10 @@ export function useTelemetryRecorder(): TelemetryRecorder {
         throw new Error('no telemetryRecorder')
     }
     return telemetryRecorder
+}
+
+export function getTraceparentFromSpanContext(spanContext: SpanContext): string {
+    return `00-${spanContext.traceId}-${spanContext.spanId}-${spanContext.traceFlags
+        .toString(16)
+        .padStart(2, '0')}`
 }

--- a/vscode/webviews/utils/webviewOpenTelemetryService.ts
+++ b/vscode/webviews/utils/webviewOpenTelemetryService.ts
@@ -49,7 +49,7 @@ export class WebviewOpenTelemetryService {
         try {
             this.tracerProvider = new WebTracerProvider({
                 resource: new Resource({
-                    [SemanticResourceAttributes.SERVICE_NAME]: 'cody-webview',
+                    [SemanticResourceAttributes.SERVICE_NAME]: 'cody-client',
                     [SemanticResourceAttributes.SERVICE_VERSION]: '1.0.0',
                 }),
             })

--- a/vscode/webviews/utils/webviewOpenTelemetryService.ts
+++ b/vscode/webviews/utils/webviewOpenTelemetryService.ts
@@ -49,7 +49,7 @@ export class WebviewOpenTelemetryService {
         try {
             this.tracerProvider = new WebTracerProvider({
                 resource: new Resource({
-                    [SemanticResourceAttributes.SERVICE_NAME]: 'cody-client',
+                    [SemanticResourceAttributes.SERVICE_NAME]: 'cody-webview',
                     [SemanticResourceAttributes.SERVICE_VERSION]: '1.0.0',
                 }),
             })


### PR DESCRIPTION
This PR introduces distributed tracing to connect traces originating in the UX with those starting in the extension host. This ensures unified and all-encompassing traces for operations spanning both the web view and the extension host.

NOTE: this PR has been rebased to the main and is ready for review

## Changes Made


1.  Distributed Tracing for Chat Interaction: Traces starting in the UX are now connected to corresponding traces in the extension host for chat interactions.
2. Distributed Tracing for Smart Apply: Similarly, traces for Smart Apply now span both the UX and the extension host.

These changes are in alignment with the milestone goals and aim to deliver foundational support for distributed tracing in these areas.




## Next Steps

- Immediate Goal: Ensure distributed tracing is functional and provides value for chat interaction and Smart Apply use cases.
- I will rebase the PR and resolve merge conflicts AFTER the proper merge of https://github.com/sourcegraph/cody/pull/6100 it was reverted last time because [of some issues](https://sourcegraph.slack.com/archives/C05AGQYD528/p1732289326228309) 
- Follow-Up Work for next PR:
- Refactor naming conventions for better consistency.
- Eliminate redundant metric names.



## Test plan
- Run sourcegraph instance locally
- Run `sg start otel `
- Run the debugger for vscode cody locally on this branch
- Perform some chat operations 
- Go to `http://localhost:16686`  to see if Jaegar is running
- Select Cody-Client as the service
- See a trace with the title `chat-interaction  ` this is a collection of spans that show a single trace for spans from both  webview and extension host

<img width="1483" alt="image" src="https://github.com/user-attachments/assets/1db63541-46c4-4055-80ef-0a9dab1e165e">


## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
