### PR TITLE
Add built-in prompts related fields to prompt select analytic event

### DIFF
--- a/lib/shared/src/sourcegraph-api/graphql/client.ts
+++ b/lib/shared/src/sourcegraph-api/graphql/client.ts
@@ -457,6 +457,7 @@ export interface Prompt {
     description?: string
     draft: boolean
     autoSubmit?: boolean
+    builtin?: boolean
     mode?: PromptMode
     definition: {
         text: string

--- a/vscode/src/prompts/prompts.ts
+++ b/vscode/src/prompts/prompts.ts
@@ -148,7 +148,7 @@ async function getLocalCommands(input: LocalCommandsInput): Promise<Action[]> {
     // Fetch standards (built-in) prompts from prompts library API
     if (remoteBuiltinPrompts) {
         const remoteStandardPrompts = await graphqlClient.queryBuiltinPrompts({ query })
-        return remoteStandardPrompts.map(prompt => ({ ...prompt, actionType: 'prompt' }))
+        return remoteStandardPrompts.map(prompt => ({ ...prompt, actionType: 'prompt', builtin: true }))
     }
 
     // Fallback on local commands (prompts-like or not is controlled by CodyUnifiedPrompts feature flag)

--- a/vscode/webviews/components/promptList/PromptList.tsx
+++ b/vscode/webviews/components/promptList/PromptList.tsx
@@ -21,6 +21,13 @@ import type { PromptsInput } from '@sourcegraph/cody-shared'
 import { useLocalStorage } from '../../components/hooks'
 import styles from './PromptList.module.css'
 
+const BUILT_IN_PROMPTS_CODE: Record<string, number> = {
+    'document-code': 1,
+    'explain-code': 2,
+    'find-code-smells': 3,
+    'generate-unit-tests': 4,
+}
+
 interface PromptListProps {
     showSearch: boolean
     showFirstNItems?: number
@@ -91,6 +98,7 @@ export const PromptList: FC<PromptListProps> = props => {
             }
 
             const isPrompt = action.actionType === 'prompt'
+            const isBuiltinPrompt = isPrompt && action.builtin
             const isPromptAutoSubmit = action.actionType === 'prompt' && action.autoSubmit
             const isCommand = action.actionType === 'command'
             const isBuiltInCommand = isCommand && action.type === 'default'
@@ -99,6 +107,8 @@ export const PromptList: FC<PromptListProps> = props => {
                 metadata: {
                     isPrompt: isPrompt ? 1 : 0,
                     isPromptAutoSubmit: isPromptAutoSubmit ? 1 : 0,
+                    isPromptBuiltin: isBuiltinPrompt ? 1 : 0,
+                    builtinPromptType: isBuiltinPrompt ? BUILT_IN_PROMPTS_CODE[action.name] : 0,
                     isCommand: isCommand ? 1 : 0,
                     isCommandBuiltin: isBuiltInCommand ? 1 : 0,
                     isCommandCustom: !isBuiltInCommand ? 1 : 0,

--- a/web/CHANGELOG.md
+++ b/web/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.14.0
+- Add prompts analytics over built-in prompts
+
 ## 0.13.0
 - Fix openctx mention by mocking Cody Web workspace root
 - Disable non-runnable prompts in Cody Web

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sourcegraph/cody-web",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "Cody standalone web app",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
This PR adds a minimal set of fields to make sure we can catch built-in prompt usage in our analytics dashboard (this will give us the ability to have a minimal tracking feature parity with how we track built-in commands before the prompts library)

## Test plan
- Check that after you select the built-in prompt you see a proper set of promptBuiltIn event fields ("isPromptBuiltin": 1 and "builtinPromptType": <type-code>) 

