### PR TITLE
feat(autoedit): restrict autoedit to vscode

### DIFF
--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -745,7 +745,7 @@ function shouldEnableExperimentalAutoedits(
     if (config.configuration.experimentalAutoeditsEnabled !== undefined) {
         return config.configuration.experimentalAutoeditsEnabled
     }
-    return autoeditExperimentFlag && isS2(authStatus)
+    return autoeditExperimentFlag && isS2(authStatus) && isRunningInsideAgent() === false
 }
 
 /**


### PR DESCRIPTION
Restrict auto-edit to vscode.

## Test plan
Check if the auto-edit is enabled by default in debug window. 

