### PR TITLE
Hitesh/add diff strategies logging

### DIFF
--- a/lib/shared/src/completions/types.ts
+++ b/lib/shared/src/completions/types.ts
@@ -13,7 +13,7 @@ interface AutocompleteContextSnippetMetadata {
      * Additional metadata fields that can be used to store arbitrary key-value pairs.
      * The values can be either numbers or strings.
      */
-    diffStrategyMetadata?: AutocompleteContextSnippetMetadataFields
+    strategyMetadata?: AutocompleteContextSnippetMetadataFields
 }
 
 export interface AutocompleteFileContextSnippet {

--- a/lib/shared/src/completions/types.ts
+++ b/lib/shared/src/completions/types.ts
@@ -13,7 +13,7 @@ interface AutocompleteContextSnippetMetadata {
      * Additional metadata fields that can be used to store arbitrary key-value pairs.
      * The values can be either numbers or strings.
      */
-    strategyMetadata?: AutocompleteContextSnippetMetadataFields
+    retrieverMetadata?: AutocompleteContextSnippetMetadataFields
 }
 
 export interface AutocompleteFileContextSnippet {

--- a/lib/shared/src/completions/types.ts
+++ b/lib/shared/src/completions/types.ts
@@ -1,6 +1,8 @@
 import type * as vscode from 'vscode'
 import type { URI } from 'vscode-uri'
 
+export type AutocompleteContextSnippetMetadataFields = Record<string, number | string>
+
 interface AutocompleteContextSnippetMetadata {
     /**
      * This field is relevant for user action context sources such as `recent-edit`, `recent-copy` and `recent-viewport`.
@@ -8,9 +10,10 @@ interface AutocompleteContextSnippetMetadata {
      */
     timeSinceActionMs?: number
     /**
-     * The diffing strategy used by the `recent-edits-retriever` to generate the diff.
+     * Additional metadata fields that can be used to store arbitrary key-value pairs.
+     * The values can be either numbers or strings.
      */
-    recentEditsRetrieverDiffStrategy?: string
+    diffStrategyMetadata?: AutocompleteContextSnippetMetadataFields
 }
 
 export interface AutocompleteFileContextSnippet {

--- a/vscode/src/completions/context/context-data-logging.ts
+++ b/vscode/src/completions/context/context-data-logging.ts
@@ -13,7 +13,7 @@ import type { RetrievedContextResults } from './completions-context-ranker'
 import { JaccardSimilarityRetriever } from './retrievers/jaccard-similarity/jaccard-similarity-retriever'
 import { DiagnosticsRetriever } from './retrievers/recent-user-actions/diagnostics-retriever'
 import { RecentCopyRetriever } from './retrievers/recent-user-actions/recent-copy'
-import { RecentEditsRetrieverDiffStrategyIdentifier } from './retrievers/recent-user-actions/recent-edits-diff-helpers/recent-edits-diff-strategy'
+import { AutoeditWithShortTermDiffStrategy } from './retrievers/recent-user-actions/recent-edits-diff-helpers/auotedit-short-term-diff'
 import { RecentEditsRetriever } from './retrievers/recent-user-actions/recent-edits-retriever'
 import { RecentViewPortRetriever } from './retrievers/recent-user-actions/recent-view-port'
 import { RetrieverIdentifier } from './utils'
@@ -105,8 +105,7 @@ export class ContextRetrieverDataCollection implements vscode.Disposable {
             case RetrieverIdentifier.RecentEditsRetriever:
                 return new RecentEditsRetriever({
                     maxAgeMs: 10 * 60 * 1000,
-                    diffStrategyIdentifier:
-                        RecentEditsRetrieverDiffStrategyIdentifier.UnifiedDiffWithLineNumbers,
+                    diffStrategyList: [new AutoeditWithShortTermDiffStrategy()],
                 })
             case RetrieverIdentifier.DiagnosticsRetriever:
                 return new DiagnosticsRetriever({

--- a/vscode/src/completions/context/context-strategy.ts
+++ b/vscode/src/completions/context/context-strategy.ts
@@ -11,7 +11,7 @@ import { JaccardSimilarityRetriever } from './retrievers/jaccard-similarity/jacc
 import { LspLightRetriever } from './retrievers/lsp-light/lsp-light-retriever'
 import { DiagnosticsRetriever } from './retrievers/recent-user-actions/diagnostics-retriever'
 import { RecentCopyRetriever } from './retrievers/recent-user-actions/recent-copy'
-import { RecentEditsRetrieverDiffStrategyIdentifier } from './retrievers/recent-user-actions/recent-edits-diff-helpers/recent-edits-diff-strategy'
+import { UnifiedDiffStrategy } from './retrievers/recent-user-actions/recent-edits-diff-helpers/unified-diff'
 import { RecentEditsRetriever } from './retrievers/recent-user-actions/recent-edits-retriever'
 import { RecentViewPortRetriever } from './retrievers/recent-user-actions/recent-view-port'
 import { loadTscRetriever } from './retrievers/tsc/load-tsc-retriever'
@@ -55,8 +55,9 @@ export class DefaultContextStrategyFactory implements ContextStrategyFactory {
                             this.allLocalRetrievers = [
                                 new RecentEditsRetriever({
                                     maxAgeMs: 60 * 1000,
-                                    diffStrategyIdentifier:
-                                        RecentEditsRetrieverDiffStrategyIdentifier.UnifiedDiff,
+                                    diffStrategyList: [
+                                        new UnifiedDiffStrategy({ addLineNumbers: false }),
+                                    ],
                                 }),
                             ]
                             break
@@ -64,8 +65,9 @@ export class DefaultContextStrategyFactory implements ContextStrategyFactory {
                             this.allLocalRetrievers = [
                                 new RecentEditsRetriever({
                                     maxAgeMs: 60 * 1000,
-                                    diffStrategyIdentifier:
-                                        RecentEditsRetrieverDiffStrategyIdentifier.UnifiedDiff,
+                                    diffStrategyList: [
+                                        new UnifiedDiffStrategy({ addLineNumbers: false }),
+                                    ],
                                 }),
                             ]
                             break
@@ -73,8 +75,9 @@ export class DefaultContextStrategyFactory implements ContextStrategyFactory {
                             this.allLocalRetrievers = [
                                 new RecentEditsRetriever({
                                     maxAgeMs: 60 * 5 * 1000,
-                                    diffStrategyIdentifier:
-                                        RecentEditsRetrieverDiffStrategyIdentifier.UnifiedDiff,
+                                    diffStrategyList: [
+                                        new UnifiedDiffStrategy({ addLineNumbers: false }),
+                                    ],
                                 }),
                             ]
                             break
@@ -82,8 +85,9 @@ export class DefaultContextStrategyFactory implements ContextStrategyFactory {
                             this.allLocalRetrievers = [
                                 new RecentEditsRetriever({
                                     maxAgeMs: 60 * 1000,
-                                    diffStrategyIdentifier:
-                                        RecentEditsRetrieverDiffStrategyIdentifier.UnifiedDiff,
+                                    diffStrategyList: [
+                                        new UnifiedDiffStrategy({ addLineNumbers: false }),
+                                    ],
                                 }),
                                 new JaccardSimilarityRetriever(),
                             ]
@@ -127,8 +131,9 @@ export class DefaultContextStrategyFactory implements ContextStrategyFactory {
                             this.allLocalRetrievers = [
                                 new RecentEditsRetriever({
                                     maxAgeMs: 10 * 60 * 1000,
-                                    diffStrategyIdentifier:
-                                        RecentEditsRetrieverDiffStrategyIdentifier.UnifiedDiffWithLineNumbers,
+                                    diffStrategyList: [
+                                        new UnifiedDiffStrategy({ addLineNumbers: true }),
+                                    ],
                                 }),
                                 new DiagnosticsRetriever({
                                     contextLines: 0,

--- a/vscode/src/completions/context/retrievers/recent-user-actions/recent-edits-diff-helpers/auotedit-short-term-diff.ts
+++ b/vscode/src/completions/context/retrievers/recent-user-actions/recent-edits-diff-helpers/auotedit-short-term-diff.ts
@@ -1,4 +1,5 @@
 import type * as vscode from 'vscode'
+import type { AutocompleteContextSnippetMetadataFields } from '../../../../../../../lib/shared/src/completions/types'
 import type {
     DiffCalculationInput,
     DiffHunk,
@@ -61,5 +62,14 @@ export class AutoeditWithShortTermDiffStrategy implements RecentEditsRetrieverDi
         const shortTermChanges = changes.slice(0, index)
         const longTermChanges = changes.slice(index)
         return [shortTermChanges, longTermChanges]
+    }
+
+    public getDiffStrategyMetadata(): AutocompleteContextSnippetMetadataFields {
+        return {
+            strategy: 'autoedits-short-term-diff',
+            longTermContextLines: this.longTermContextLines,
+            shortTermContextLines: this.shortTermContextLines,
+            shortTermDiffWindowMs: this.shortTermDiffWindowMs,
+        }
     }
 }

--- a/vscode/src/completions/context/retrievers/recent-user-actions/recent-edits-diff-helpers/auotedit-short-term-diff.ts
+++ b/vscode/src/completions/context/retrievers/recent-user-actions/recent-edits-diff-helpers/auotedit-short-term-diff.ts
@@ -1,5 +1,5 @@
+import type { AutocompleteContextSnippetMetadataFields } from '@sourcegraph/cody-shared'
 import type * as vscode from 'vscode'
-import type { AutocompleteContextSnippetMetadataFields } from '../../../../../../../lib/shared/src/completions/types'
 import type {
     DiffCalculationInput,
     DiffHunk,

--- a/vscode/src/completions/context/retrievers/recent-user-actions/recent-edits-diff-helpers/recent-edits-diff-strategy.ts
+++ b/vscode/src/completions/context/retrievers/recent-user-actions/recent-edits-diff-helpers/recent-edits-diff-strategy.ts
@@ -1,6 +1,6 @@
 import type { PromptString } from '@sourcegraph/cody-shared'
+import type { AutocompleteContextSnippetMetadataFields } from '@sourcegraph/cody-shared'
 import type * as vscode from 'vscode'
-import type { AutocompleteContextSnippetMetadataFields } from '../../../../../../../lib/shared/src/completions/types'
 
 /**
  * Defines a strategy for processing and transforming low-level document changes into meaningful diff hunks

--- a/vscode/src/completions/context/retrievers/recent-user-actions/recent-edits-diff-helpers/recent-edits-diff-strategy.ts
+++ b/vscode/src/completions/context/retrievers/recent-user-actions/recent-edits-diff-helpers/recent-edits-diff-strategy.ts
@@ -2,8 +2,32 @@ import type { PromptString } from '@sourcegraph/cody-shared'
 import type * as vscode from 'vscode'
 import type { AutocompleteContextSnippetMetadataFields } from '../../../../../../../lib/shared/src/completions/types'
 
+/**
+ * Defines a strategy for processing and transforming low-level document changes into meaningful diff hunks
+ * that can be used as context for LLM consumption.
+ *
+ * This interface serves as a contract for different diff calculation strategies that can:
+ * 1. Take raw VSCode document changes and convert them into more coherent, higher-level edits
+ * 2. Group related changes together (like consecutive character typing or related line edits)
+ *
+ * Common implementations include:
+ * - Unified diff strategy: Combines all changes into a single coherent diff.
+ * - Line-level diff strategy: Groups character-by-character changes into logical line-based units.
+ *   The logical unit is `TextDocumentChangeGroup` interface in `utils.ts`.
+ */
 export interface RecentEditsRetrieverDiffStrategy {
+    /**
+     * Processes raw document changes and generates meaningful diff hunks.
+     * @param input Contains the document URI, original content, and array of individual changes
+     * @returns Array of DiffHunk objects representing logical groups of changes
+     */
     getDiffHunks(input: DiffCalculationInput): DiffHunk[]
+
+    /**
+     * Provides metadata about the diff strategy for analysis and logging purposes.
+     * Used to track strategy performance and tune parameters offline.
+     * @returns Metadata fields about the strategy's behavior and configuration
+     */
     getDiffStrategyMetadata(): AutocompleteContextSnippetMetadataFields
 }
 

--- a/vscode/src/completions/context/retrievers/recent-user-actions/recent-edits-diff-helpers/recent-edits-diff-strategy.ts
+++ b/vscode/src/completions/context/retrievers/recent-user-actions/recent-edits-diff-helpers/recent-edits-diff-strategy.ts
@@ -1,48 +1,10 @@
 import type { PromptString } from '@sourcegraph/cody-shared'
 import type * as vscode from 'vscode'
-import { AutoeditWithShortTermDiffStrategy } from './auotedit-short-term-diff'
-import { UnifiedDiffStrategy } from './unified-diff'
-
-/**
- * Identifiers for the different diff strategies.
- */
-export enum RecentEditsRetrieverDiffStrategyIdentifier {
-    /**
-     * Unified diff strategy that shows changes in a single patch.
-     */
-    UnifiedDiff = 'unified-diff',
-    /**
-     * Unified diff strategy that shows changes in a single patch.
-     */
-    UnifiedDiffWithLineNumbers = 'unified-diff-with-line-numbers',
-    /**
-     * Diff Strategy to use a seperate short term diff used by `auto-edits`.
-     */
-    AutoeditWithShortTermDiff = 'autoedit-with-short-term-diff',
-}
-
-/**
- * Creates a new instance of a diff strategy based on the provided identifier.
- * @param identifier The identifier of the diff strategy to create.
- * @returns A new instance of the diff strategy.
- */
-export function createDiffStrategy(
-    identifier: RecentEditsRetrieverDiffStrategyIdentifier
-): RecentEditsRetrieverDiffStrategy {
-    switch (identifier) {
-        case RecentEditsRetrieverDiffStrategyIdentifier.UnifiedDiff:
-            return new UnifiedDiffStrategy({ addLineNumbers: false })
-        case RecentEditsRetrieverDiffStrategyIdentifier.UnifiedDiffWithLineNumbers:
-            return new UnifiedDiffStrategy({ addLineNumbers: true })
-        case RecentEditsRetrieverDiffStrategyIdentifier.AutoeditWithShortTermDiff:
-            return new AutoeditWithShortTermDiffStrategy()
-        default:
-            throw new Error(`Unknown diff strategy identifier: ${identifier}`)
-    }
-}
+import type { AutocompleteContextSnippetMetadataFields } from '../../../../../../../lib/shared/src/completions/types'
 
 export interface RecentEditsRetrieverDiffStrategy {
     getDiffHunks(input: DiffCalculationInput): DiffHunk[]
+    getDiffStrategyMetadata(): AutocompleteContextSnippetMetadataFields
 }
 
 export interface TextDocumentChange {

--- a/vscode/src/completions/context/retrievers/recent-user-actions/recent-edits-diff-helpers/unified-diff.ts
+++ b/vscode/src/completions/context/retrievers/recent-user-actions/recent-edits-diff-helpers/unified-diff.ts
@@ -1,5 +1,5 @@
 import { PromptString } from '@sourcegraph/cody-shared'
-import type { AutocompleteContextSnippetMetadataFields } from '../../../../../../../lib/shared/src/completions/types'
+import type { AutocompleteContextSnippetMetadataFields } from '@sourcegraph/cody-shared'
 import type {
     DiffCalculationInput,
     DiffHunk,

--- a/vscode/src/completions/context/retrievers/recent-user-actions/recent-edits-diff-helpers/unified-diff.ts
+++ b/vscode/src/completions/context/retrievers/recent-user-actions/recent-edits-diff-helpers/unified-diff.ts
@@ -1,4 +1,5 @@
 import { PromptString } from '@sourcegraph/cody-shared'
+import type { AutocompleteContextSnippetMetadataFields } from '../../../../../../../lib/shared/src/completions/types'
 import type {
     DiffCalculationInput,
     DiffHunk,
@@ -47,5 +48,11 @@ export class UnifiedDiffStrategy implements RecentEditsRetrieverDiffStrategy {
             )
         }
         return PromptString.fromGitDiff(input.uri, input.oldContent, newContent)
+    }
+
+    public getDiffStrategyMetadata(): AutocompleteContextSnippetMetadataFields {
+        return {
+            strategy: 'unified-diff',
+        }
     }
 }

--- a/vscode/src/completions/context/retrievers/recent-user-actions/recent-edits-diff-helpers/utils.ts
+++ b/vscode/src/completions/context/retrievers/recent-user-actions/recent-edits-diff-helpers/utils.ts
@@ -7,10 +7,14 @@ import type { DiffHunk, TextDocumentChange, UnifiedPatchResponse } from './recen
 /**
  * Represents a group of text document changes with their range information.
  * The grouped changes are consecutive changes made in the document that should be treated as a single entity when computing diffs.
+ * A group is contructed by combining the consecutive changes that have overlapping ranges.
+ * i.e. If line number of `insertedRange` of the first change overlaps with the line number of `deletedRange` of the second change,
+ * they are considered to be in the same group.
  *
  * @example
  * When typing "hello world" in a document, each character typed generates a separate change event.
  * These changes are grouped together as a single entity in this interface.
+ * Please check the test cases for more examples.
  */
 export interface TextDocumentChangeGroup {
     /** Array of individual text document changes in this group */

--- a/vscode/src/completions/context/retrievers/recent-user-actions/recent-edits-retriever.test.ts
+++ b/vscode/src/completions/context/retrievers/recent-user-actions/recent-edits-retriever.test.ts
@@ -4,7 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type * as vscode from 'vscode'
 import { range } from '../../../../testutils/textDocument'
 import { document } from '../../../test-helpers'
-import { RecentEditsRetrieverDiffStrategyIdentifier } from './recent-edits-diff-helpers/recent-edits-diff-strategy'
+import { UnifiedDiffStrategy } from './recent-edits-diff-helpers/unified-diff'
 import { RecentEditsRetriever } from './recent-edits-retriever'
 
 const FIVE_MINUTES = 5 * 60 * 1000
@@ -25,7 +25,7 @@ describe('RecentEditsRetriever', () => {
         retriever = new RecentEditsRetriever(
             {
                 maxAgeMs: FIVE_MINUTES,
-                diffStrategyIdentifier: RecentEditsRetrieverDiffStrategyIdentifier.UnifiedDiff,
+                diffStrategyList: [new UnifiedDiffStrategy({ addLineNumbers: false })],
             },
             {
                 onDidChangeTextDocument(listener) {

--- a/vscode/src/completions/context/retrievers/recent-user-actions/recent-edits-retriever.ts
+++ b/vscode/src/completions/context/retrievers/recent-user-actions/recent-edits-retriever.ts
@@ -1,15 +1,14 @@
 import { type PromptString, contextFiltersProvider } from '@sourcegraph/cody-shared'
 import type { AutocompleteContextSnippet } from '@sourcegraph/cody-shared'
 import * as vscode from 'vscode'
+import type { AutocompleteContextSnippetMetadataFields } from '../../../../../../lib/shared/src/completions/types'
 import { getPositionAfterTextInsertion } from '../../../text-processing/utils'
 import type { ContextRetriever, ContextRetrieverOptions } from '../../../types'
 import { RetrieverIdentifier, type ShouldUseContextParams, shouldBeUsedAsContext } from '../../utils'
-import {
-    type DiffHunk,
-    type RecentEditsRetrieverDiffStrategy,
-    type RecentEditsRetrieverDiffStrategyIdentifier,
-    type TextDocumentChange,
-    createDiffStrategy,
+import type {
+    DiffHunk,
+    RecentEditsRetrieverDiffStrategy,
+    TextDocumentChange,
 } from './recent-edits-diff-helpers/recent-edits-diff-strategy'
 import { applyTextDocumentChanges } from './recent-edits-diff-helpers/utils'
 
@@ -20,9 +19,13 @@ interface TrackedDocument {
     changes: TextDocumentChange[]
 }
 
+interface DiffHunkWithStrategy extends DiffHunk {
+    diffStrategyMetadata: AutocompleteContextSnippetMetadataFields
+}
+
 export interface RecentEditsRetrieverOptions {
     maxAgeMs: number
-    diffStrategyIdentifier: RecentEditsRetrieverDiffStrategyIdentifier
+    diffStrategyList: RecentEditsRetrieverDiffStrategy[]
 }
 
 interface DiffAcrossDocuments {
@@ -30,6 +33,7 @@ interface DiffAcrossDocuments {
     uri: vscode.Uri
     languageId: string
     latestChangeTimestamp: number
+    diffStrategyMetadata: AutocompleteContextSnippetMetadataFields
 }
 
 export class RecentEditsRetriever implements vscode.Disposable, ContextRetriever {
@@ -39,8 +43,7 @@ export class RecentEditsRetriever implements vscode.Disposable, ContextRetriever
     public identifier = RetrieverIdentifier.RecentEditsRetriever
     private disposables: vscode.Disposable[] = []
     private readonly maxAgeMs: number
-    private readonly diffStrategyIdentifier: RecentEditsRetrieverDiffStrategyIdentifier
-    private readonly diffStrategy: RecentEditsRetrieverDiffStrategy
+    private readonly diffStrategyList: RecentEditsRetrieverDiffStrategy[]
 
     constructor(
         options: RecentEditsRetrieverOptions,
@@ -50,8 +53,7 @@ export class RecentEditsRetriever implements vscode.Disposable, ContextRetriever
         > = vscode.workspace
     ) {
         this.maxAgeMs = options.maxAgeMs
-        this.diffStrategyIdentifier = options.diffStrategyIdentifier
-        this.diffStrategy = createDiffStrategy(this.diffStrategyIdentifier)
+        this.diffStrategyList = options.diffStrategyList
 
         // Track the already open documents when editor was opened
         for (const document of vscode.workspace.textDocuments) {
@@ -72,6 +74,7 @@ export class RecentEditsRetriever implements vscode.Disposable, ContextRetriever
         diffs.sort((a, b) => b.latestChangeTimestamp - a.latestChangeTimestamp)
 
         const autocompleteContextSnippets = []
+        const retrievalTriggerTime = Date.now()
         for (const diff of diffs) {
             const content = diff.diff.toString()
             const autocompleteSnippet = {
@@ -79,8 +82,8 @@ export class RecentEditsRetriever implements vscode.Disposable, ContextRetriever
                 identifier: this.identifier,
                 content,
                 metadata: {
-                    timeSinceActionMs: Date.now() - diff.latestChangeTimestamp,
-                    recentEditsRetrieverDiffStrategy: this.diffStrategyIdentifier,
+                    timeSinceActionMs: retrievalTriggerTime - diff.latestChangeTimestamp,
+                    diffStrategyMetadata: diff.diffStrategyMetadata,
                 },
             } satisfies Omit<AutocompleteContextSnippet, 'startLine' | 'endLine'>
             autocompleteContextSnippets.push(autocompleteSnippet)
@@ -95,13 +98,17 @@ export class RecentEditsRetriever implements vscode.Disposable, ContextRetriever
         const diffs: DiffAcrossDocuments[] = []
         const diffPromises = Array.from(this.trackedDocuments.entries()).map(
             async ([uri, trackedDocument]) => {
+                if (trackedDocument.changes.length === 0) {
+                    return null
+                }
                 const diffHunks = await this.getDiff(vscode.Uri.parse(uri))
-                if (diffHunks && trackedDocument.changes.length > 0) {
+                if (diffHunks) {
                     return diffHunks.map(diffHunk => ({
                         diff: diffHunk.diff,
                         uri: trackedDocument.uri,
                         languageId: trackedDocument.languageId,
                         latestChangeTimestamp: diffHunk.latestEditTimestamp,
+                        diffStrategyMetadata: diffHunk.diffStrategyMetadata,
                     }))
                 }
                 return null
@@ -132,7 +139,7 @@ export class RecentEditsRetriever implements vscode.Disposable, ContextRetriever
         return filterCandidateDiffs
     }
 
-    public async getDiff(uri: vscode.Uri): Promise<DiffHunk[] | null> {
+    public async getDiff(uri: vscode.Uri): Promise<DiffHunkWithStrategy[] | null> {
         if (await contextFiltersProvider.isUriIgnored(uri)) {
             return null
         }
@@ -141,11 +148,20 @@ export class RecentEditsRetriever implements vscode.Disposable, ContextRetriever
         if (!trackedDocument) {
             return null
         }
-        const diffHunks = this.diffStrategy.getDiffHunks({
-            uri: trackedDocument.uri,
-            oldContent: trackedDocument.content,
-            changes: trackedDocument.changes,
-        })
+        const diffHunks: DiffHunkWithStrategy[] = []
+        for (const diffStrategy of this.diffStrategyList) {
+            const hunks = diffStrategy.getDiffHunks({
+                uri: trackedDocument.uri,
+                oldContent: trackedDocument.content,
+                changes: trackedDocument.changes,
+            })
+            for (const hunk of hunks) {
+                diffHunks.push({
+                    ...hunk,
+                    diffStrategyMetadata: diffStrategy.getDiffStrategyMetadata(),
+                })
+            }
+        }
         return diffHunks
     }
 

--- a/vscode/src/completions/context/retrievers/recent-user-actions/recent-edits-retriever.ts
+++ b/vscode/src/completions/context/retrievers/recent-user-actions/recent-edits-retriever.ts
@@ -83,7 +83,7 @@ export class RecentEditsRetriever implements vscode.Disposable, ContextRetriever
                 content,
                 metadata: {
                     timeSinceActionMs: retrievalTriggerTime - diff.latestChangeTimestamp,
-                    strategyMetadata: diff.diffStrategyMetadata,
+                    retrieverMetadata: diff.diffStrategyMetadata,
                 },
             } satisfies Omit<AutocompleteContextSnippet, 'startLine' | 'endLine'>
             autocompleteContextSnippets.push(autocompleteSnippet)

--- a/vscode/src/completions/context/retrievers/recent-user-actions/recent-edits-retriever.ts
+++ b/vscode/src/completions/context/retrievers/recent-user-actions/recent-edits-retriever.ts
@@ -1,7 +1,7 @@
 import { type PromptString, contextFiltersProvider } from '@sourcegraph/cody-shared'
 import type { AutocompleteContextSnippet } from '@sourcegraph/cody-shared'
+import type { AutocompleteContextSnippetMetadataFields } from '@sourcegraph/cody-shared'
 import * as vscode from 'vscode'
-import type { AutocompleteContextSnippetMetadataFields } from '../../../../../../lib/shared/src/completions/types'
 import { getPositionAfterTextInsertion } from '../../../text-processing/utils'
 import type { ContextRetriever, ContextRetrieverOptions } from '../../../types'
 import { RetrieverIdentifier, type ShouldUseContextParams, shouldBeUsedAsContext } from '../../utils'
@@ -83,7 +83,7 @@ export class RecentEditsRetriever implements vscode.Disposable, ContextRetriever
                 content,
                 metadata: {
                     timeSinceActionMs: retrievalTriggerTime - diff.latestChangeTimestamp,
-                    diffStrategyMetadata: diff.diffStrategyMetadata,
+                    strategyMetadata: diff.diffStrategyMetadata,
                 },
             } satisfies Omit<AutocompleteContextSnippet, 'startLine' | 'endLine'>
             autocompleteContextSnippets.push(autocompleteSnippet)

--- a/vscode/src/supercompletions/supercompletion-provider.ts
+++ b/vscode/src/supercompletions/supercompletion-provider.ts
@@ -1,6 +1,6 @@
 import type { ChatClient } from '@sourcegraph/cody-shared'
 import * as vscode from 'vscode'
-import { RecentEditsRetrieverDiffStrategyIdentifier } from '../completions/context/retrievers/recent-user-actions/recent-edits-diff-helpers/recent-edits-diff-strategy'
+import { UnifiedDiffStrategy } from '../completions/context/retrievers/recent-user-actions/recent-edits-diff-helpers/unified-diff'
 import { RecentEditsRetriever } from '../completions/context/retrievers/recent-user-actions/recent-edits-retriever'
 import type { CodyStatusBar } from '../services/StatusBar'
 import { type Supercompletion, getSupercompletions } from './get-supercompletion'
@@ -31,7 +31,7 @@ export class SupercompletionProvider implements vscode.Disposable {
         this.recentEditsRetriever = new RecentEditsRetriever(
             {
                 maxAgeMs: EDIT_HISTORY_TIMEOUT,
-                diffStrategyIdentifier: RecentEditsRetrieverDiffStrategyIdentifier.UnifiedDiff,
+                diffStrategyList: [new UnifiedDiffStrategy({ addLineNumbers: false })],
             },
             workspace
         )


### PR DESCRIPTION
change the interface schema for diff calculation to enable logging the metadata from retreivers
Build on top of PR: https://github.com/sourcegraph/cody/pull/6188 

## Test plan
1. Check the suggestion events from telemetry to see the updated metadata field.
