### PR TITLE
add 10 sec diff for autoedit experiments

### DIFF
--- a/vscode/src/completions/analytics-logger.ts
+++ b/vscode/src/completions/analytics-logger.ts
@@ -803,6 +803,7 @@ function suggestionDocumentDiffTracker(
     const documentText = document.getText(trackingRange)
 
     const persistenceTimeoutList = [
+        10 * 1000, // 10 seconds
         20 * 1000, // 20 seconds
         60 * 1000, // 60 seconds
         120 * 1000, // 120 seconds


### PR DESCRIPTION
Shorter 20 sec diff have been helpful for generating shorter diff, adding 10 sec diff for offline autoedit model experiment.

## Test plan
no functional change 