### PR TITLE
use local storage to save repo accessibility

### DIFF
--- a/vscode/src/completions/context/context-mixer.test.ts
+++ b/vscode/src/completions/context/context-mixer.test.ts
@@ -7,6 +7,7 @@ import {
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type * as vscode from 'vscode'
+import { mockLocalStorage } from '../../services/LocalStorageProvider'
 import { getCurrentDocContext } from '../get-current-doc-context'
 import { documentAndPosition } from '../test-helpers'
 import type { ContextRetriever } from '../types'
@@ -61,6 +62,10 @@ const defaultOptions = {
 }
 
 describe('ContextMixer', () => {
+    beforeAll(() => {
+        mockLocalStorage()
+    })
+
     beforeEach(() => {
         vi.spyOn(contextFiltersProvider, 'isUriIgnored').mockResolvedValue(false)
     })

--- a/vscode/src/repository/githubRepoMetadata.test.ts
+++ b/vscode/src/repository/githubRepoMetadata.test.ts
@@ -4,7 +4,8 @@ import {
     fromLateSetSource,
 } from '@sourcegraph/cody-shared'
 import { Observable } from 'observable-fns'
-import { describe, expect, it, vi } from 'vitest'
+import { beforeAll, describe, expect, it, vi } from 'vitest'
+import { mockLocalStorage } from '../services/LocalStorageProvider'
 import {
     GitHubDotComRepoMetadata,
     type RepoRevMetaData,
@@ -30,6 +31,10 @@ vi.mock('./remoteRepos', () => {
 })
 
 describe('publicRepoMetadataIfAllWorkspaceReposArePublic', () => {
+    beforeAll(() => {
+        mockLocalStorage()
+    })
+
     it('should return isPublic false when no folders have public repos', async () => {
         globalThis.mockRemoteReposForAllWorkspaceFolders.setSource(
             Observable.of<remoteRepoModule.RemoteRepo[]>([

--- a/vscode/src/repository/githubRepoMetadata.test.ts
+++ b/vscode/src/repository/githubRepoMetadata.test.ts
@@ -32,6 +32,7 @@ vi.mock('./remoteRepos', () => {
 
 describe('publicRepoMetadataIfAllWorkspaceReposArePublic', () => {
     beforeAll(() => {
+        vi.useFakeTimers()
         mockLocalStorage()
     })
 
@@ -46,7 +47,11 @@ describe('publicRepoMetadataIfAllWorkspaceReposArePublic', () => {
         const mockGetRepoMetadataUsingRepoName = vi
             .spyOn(GitHubDotComRepoMetadata.getInstance(), 'getRepoMetadataUsingRepoName')
             .mockImplementation(repoName =>
-                Promise.resolve<RepoRevMetaData>({ isPublic: false, repoName })
+                Promise.resolve<RepoRevMetaData>({
+                    isPublic: false,
+                    repoName,
+                    timestamp: Date.now(),
+                })
             )
 
         const result = await firstResultFromOperation(publicRepoMetadataIfAllWorkspaceReposArePublic)
@@ -67,15 +72,20 @@ describe('publicRepoMetadataIfAllWorkspaceReposArePublic', () => {
         const mockGetRepoMetadataUsingRepoName = vi
             .spyOn(GitHubDotComRepoMetadata.getInstance(), 'getRepoMetadataUsingRepoName')
             .mockImplementation(repoName =>
-                Promise.resolve<RepoRevMetaData>({ isPublic: true, repoName, commit: 'aaa' })
+                Promise.resolve<RepoRevMetaData>({
+                    isPublic: true,
+                    repoName,
+                    commit: 'aaa',
+                    timestamp: Date.now(),
+                })
             )
 
         const result = await firstResultFromOperation(publicRepoMetadataIfAllWorkspaceReposArePublic)
         expect(result).toEqual({
             isPublic: true,
             repoMetadata: [
-                { isPublic: true, repoName: 'repo0', commit: 'aaa' },
-                { isPublic: true, repoName: 'repo1', commit: 'aaa' },
+                { isPublic: true, repoName: 'repo0', commit: 'aaa', timestamp: Date.now() },
+                { isPublic: true, repoName: 'repo1', commit: 'aaa', timestamp: Date.now() },
             ],
         })
         expect(
@@ -126,7 +136,14 @@ describe('publicRepoMetadataIfAllWorkspaceReposArePublic', () => {
             .spyOn(GitHubDotComRepoMetadata.getInstance(), 'getRepoMetadataUsingRepoName')
             .mockImplementation(repoName =>
                 Promise.resolve<RepoRevMetaData | undefined>(
-                    repoName === 'repo0' ? undefined : { isPublic: true, repoName, commit: 'aaa' }
+                    repoName === 'repo0'
+                        ? undefined
+                        : {
+                              isPublic: true,
+                              repoName,
+                              commit: 'aaa',
+                              timestamp: Date.now(),
+                          }
                 )
             )
 
@@ -151,6 +168,7 @@ describe('publicRepoMetadataIfAllWorkspaceReposArePublic', () => {
                           isPublic: true,
                           repoName,
                           commit: 'aaa',
+                          timestamp: Date.now(),
                       })
                     : Promise.reject(new Error('x'))
             )

--- a/vscode/src/repository/githubRepoMetadata.test.ts
+++ b/vscode/src/repository/githubRepoMetadata.test.ts
@@ -4,10 +4,11 @@ import {
     fromLateSetSource,
 } from '@sourcegraph/cody-shared'
 import { Observable } from 'observable-fns'
-import { beforeAll, describe, expect, it, vi } from 'vitest'
-import { mockLocalStorage } from '../services/LocalStorageProvider'
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import { localStorage, mockLocalStorage } from '../services/LocalStorageProvider'
 import {
     GitHubDotComRepoMetadata,
+    type RepoAccessibilityData,
     type RepoRevMetaData,
     publicRepoMetadataIfAllWorkspaceReposArePublic,
 } from './githubRepoMetadata'
@@ -28,6 +29,115 @@ vi.mock('./remoteRepos', () => {
             return globalThis.mockRemoteReposForAllWorkspaceFolders.observable
         },
     }
+})
+
+describe('GitHubDotComRepoMetadata', () => {
+    // Set up local storage backed by an object.
+    let localStorageData: { [key: string]: unknown } = {}
+    mockLocalStorage({
+        get: (key: string) => localStorageData[key],
+        update: (key: string, value: unknown) => {
+            localStorageData[key] = value
+        },
+    } as any)
+
+    const instance = GitHubDotComRepoMetadata.getInstance({ minLocalStorageUpdateTimeMs: 10 })
+
+    const assertRepoAccessibilityDataChange = async (
+        cachedData: RepoAccessibilityData[],
+        currentData: RepoAccessibilityData[],
+        expectedValue: boolean
+    ) => {
+        await localStorage.setGitHubRepoAccessibility(cachedData)
+        instance.populateCacheFromLocalStorage()
+        const isUpdated = instance.shouldUpdateCachedDataToLocalStorage(currentData)
+        expect(isUpdated).toEqual(expectedValue)
+    }
+
+    beforeEach(() => {
+        vi.useFakeTimers()
+        localStorageData = {}
+    })
+
+    it('should return true when the data has changed', async () => {
+        const previousData = [
+            { repoName: 'repo1', isPublic: false },
+            { repoName: 'repo2', isPublic: false },
+            { repoName: 'repo3', isPublic: true },
+        ]
+        const newData = [
+            { repoName: 'repo1', isPublic: true },
+            { repoName: 'repo2', isPublic: false },
+        ]
+        assertRepoAccessibilityDataChange(previousData, newData, true)
+    })
+
+    it('should return false when the data has not changed', async () => {
+        const data = [{ repoName: 'repo1', isPublic: true }]
+        assertRepoAccessibilityDataChange(data, data, false)
+    })
+
+    it('should return true when the new data has additional entries', async () => {
+        const previousData = [{ repoName: 'repo1', isPublic: true }]
+        const newData = [
+            { repoName: 'repo1', isPublic: true },
+            { repoName: 'repo2', isPublic: false },
+        ]
+        assertRepoAccessibilityDataChange(previousData, newData, true)
+    })
+
+    it('should return true when the new data has fewer entries', async () => {
+        const previousData = [
+            { repoName: 'repo1', isPublic: true },
+            { repoName: 'repo2', isPublic: false },
+        ]
+        const newData = [{ repoName: 'repo1', isPublic: true }]
+        assertRepoAccessibilityDataChange(previousData, newData, true)
+    })
+
+    it('should return true when the new data is empty and previous data is not', async () => {
+        const previousData = [{ repoName: 'repo1', isPublic: true }]
+        const newData: RepoRevMetaData[] = []
+        assertRepoAccessibilityDataChange(previousData, newData, true)
+    })
+
+    it('should return false when both new data and previous data are empty', async () => {
+        const previousData: RepoRevMetaData[] = []
+        const newData: RepoRevMetaData[] = []
+        assertRepoAccessibilityDataChange(previousData, newData, false)
+    })
+
+    it('should return true when previous data is undefined', async () => {
+        const newData = [{ repoName: 'repo1', isPublic: true }]
+        assertRepoAccessibilityDataChange([], newData, true)
+    })
+
+    it('should return true when new data is undefined and previous data is defined', async () => {
+        const previousData = [{ repoName: 'repo1', isPublic: true }]
+        assertRepoAccessibilityDataChange(previousData, [], true)
+    })
+
+    it('should return false when both new data and previous data are undefined', async () => {
+        assertRepoAccessibilityDataChange([], [], false)
+    })
+
+    it('should return false when repo order changes but data is the same', async () => {
+        const previousData = [
+            { repoName: 'repo1', isPublic: true },
+            { repoName: 'repo2', isPublic: false },
+        ]
+        const newData = [
+            { repoName: 'repo2', isPublic: false },
+            { repoName: 'repo1', isPublic: true },
+        ]
+        assertRepoAccessibilityDataChange(previousData, newData, false)
+    })
+
+    it('should return true when repo entries are the same but isPublic value changes', async () => {
+        const previousData = [{ repoName: 'repo1', isPublic: true }]
+        const newData = [{ repoName: 'repo1', isPublic: false }]
+        assertRepoAccessibilityDataChange(previousData, newData, true)
+    })
 })
 
 describe('publicRepoMetadataIfAllWorkspaceReposArePublic', () => {

--- a/vscode/src/repository/githubRepoMetadata.ts
+++ b/vscode/src/repository/githubRepoMetadata.ts
@@ -30,7 +30,7 @@ export class GitHubDotComRepoMetadata {
     // This class is used to get the metadata from the gitApi.
     private static instance: GitHubDotComRepoMetadata | null = null
     // Store a copy of the latest local storage data for comparison with the current cache.
-    private latestLocalStorageData: RepoAccessibilityData[] = []
+    private lastLocalStorageData: RepoAccessibilityData[] = []
     // Last time when the local storage was updated.
     private lastLocalStorageUpdateTime: number | null = null
     // Since the local storage update can be expansive, we add a minimum time between updates.
@@ -45,9 +45,9 @@ export class GitHubDotComRepoMetadata {
 
     public populateCacheFromLocalStorage(): void {
         this.cache.clear()
-        this.latestLocalStorageData = localStorage.getGitHubRepoAccessibility()
-        for (const data of this.latestLocalStorageData) {
-            this.cache.set(data.repoName, { repoName: data.repoName, isPublic: data.isPublic })
+        this.lastLocalStorageData = localStorage.getGitHubRepoAccessibility()
+        for (const data of this.lastLocalStorageData) {
+            this.cache.set(data.repoName, data)
         }
     }
 
@@ -161,7 +161,7 @@ export class GitHubDotComRepoMetadata {
         }
         if (this.shouldUpdateCachedDataToLocalStorage(repoAccessibilityData)) {
             // Updates the updated cache values to local storage
-            this.latestLocalStorageData = repoAccessibilityData
+            this.lastLocalStorageData = repoAccessibilityData
             this.lastLocalStorageUpdateTime = Date.now()
             localStorage.setGitHubRepoAccessibility(repoAccessibilityData)
         }
@@ -177,11 +177,11 @@ export class GitHubDotComRepoMetadata {
             return false
         }
 
-        if (repoAccessibilityData.length !== this.latestLocalStorageData.length) {
+        if (repoAccessibilityData.length !== this.lastLocalStorageData.length) {
             return true
         }
         const latestRepoMap = new Map(
-            this.latestLocalStorageData.map(repo => [repo.repoName, repo.isPublic])
+            this.lastLocalStorageData.map(repo => [repo.repoName, repo.isPublic])
         )
         for (const { repoName, isPublic } of repoAccessibilityData) {
             if (latestRepoMap.get(repoName) !== isPublic) {

--- a/vscode/src/services/LocalStorageProvider.ts
+++ b/vscode/src/services/LocalStorageProvider.ts
@@ -246,24 +246,18 @@ class LocalStorage implements LocalStorageForModelPreferences {
     }
 
     public getGitHubRepoAccessibility(): RepoAccessibilityData[] {
-        const accessibilityValues =
-            this.get<{ repoName: string; isPublic: boolean; timestamp: number }[] | null>(
-                this.GIT_REPO_ACCESSIBILITY_KEY
-            ) ?? []
-        const repoData: RepoAccessibilityData[] = []
-        for (const value of accessibilityValues) {
-            const currentTime = Date.now()
-            const timeDifference = currentTime - value.timestamp
-            // If the time difference is greater than 24 hours, skip this value
-            if (timeDifference > 24 * 60 * 60 * 1000) {
-                continue
-            }
-            repoData.push({
-                repoName: value.repoName,
-                isPublic: value.isPublic,
-            })
+        type RepoAccessibilityValue = {
+            repoName: string
+            isPublic: boolean
+            timestamp: number
         }
-        return repoData
+
+        const ONE_DAY_IN_MS = 24 * 60 * 60 * 1000
+        const currentTime = Date.now()
+
+        return (this.get<RepoAccessibilityValue[]>(this.GIT_REPO_ACCESSIBILITY_KEY) ?? [])
+            .filter(({ timestamp }) => currentTime - timestamp <= ONE_DAY_IN_MS)
+            .map(({ repoName, isPublic }) => ({ repoName, isPublic }))
     }
 
     public async removeChatHistory(authStatus: AuthenticatedAuthStatus): Promise<void> {


### PR DESCRIPTION
We are always using in-memory cache for calculating `repoVisibility` always. But without passing github token, we frequently hit rate limit for querying github api and cached tokens are evicted from in-memory cache when user refresh. This leads to less data logged for the autocomplete. This PR stores the tokens in `localStorage` instead of in-memory store to cache the repo visibility.

We add the following condition to decide if to set the local storage values:
1. If the local storage cache data was changed due to updates in the local cache.
2. Since the updates to local storage can be expensive (disk operation), just to make sure we don't hit the call frequently, a time check is added, which updates the cache only if we pass a certain time compare to the last update. Although this can lead to missing some updates (if the cache was updated, and user closes window) but it should be okay  git status change rarely.

### Other strategies considered.
1. Using dispose method, but since the function is not async, main thread does not update the storage at all.

## Test plan
1. CI test cases
2. Manual Testing: Adding debugger and closing and reopening vscode debug window to see if the cached values are persisted in the local storage.
