### PR TITLE
Agent: set client environment based on client configuration info

### DIFF
--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/agent/protocol_generated/ClientCapabilities.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/agent/protocol_generated/ClientCapabilities.kt
@@ -19,6 +19,7 @@ data class ClientCapabilities(
   val codeActions: CodeActionsEnum? = null, // Oneof: none, enabled
   val disabledMentionsProviders: List<ContextMentionProviderID>? = null,
   val accountSwitchingInWebview: AccountSwitchingInWebviewEnum? = null, // Oneof: none, enabled
+  val shell: ShellEnum? = null, // Oneof: none, enabled
   val webviewMessages: WebviewMessagesEnum? = null, // Oneof: object-encoded, string-encoded
   val globalState: GlobalStateEnum? = null, // Oneof: stateless, server-managed, client-managed
   val secrets: SecretsEnum? = null, // Oneof: stateless, client-managed
@@ -91,6 +92,11 @@ data class ClientCapabilities(
   }
 
   enum class AccountSwitchingInWebviewEnum {
+    @SerializedName("none") None,
+    @SerializedName("enabled") Enabled,
+  }
+
+  enum class ShellEnum {
     @SerializedName("none") None,
     @SerializedName("enabled") Enabled,
   }

--- a/agent/src/vscode-shim.ts
+++ b/agent/src/vscode-shim.ts
@@ -129,6 +129,7 @@ export function setClientInfo(newClientInfo: ClientInfo): void {
     if (newClientInfo.extensionConfiguration) {
         setExtensionConfiguration(newClientInfo.extensionConfiguration)
     }
+    setClientEnv(newClientInfo)
 }
 
 export let extensionConfiguration: ExtensionConfiguration | undefined
@@ -1075,8 +1076,8 @@ export const commands = _commands as typeof vscode.commands
 
 const _env: Partial<typeof vscode.env> = {
     uriScheme: 'file',
-    appName: clientInfo?.name,
-    shell: clientInfo?.capabilities?.shell === 'enabled' ? 'agent' : undefined,
+    appName: undefined,
+    shell: undefined,
     appRoot: process.cwd?.(),
     uiKind: UIKind.Desktop,
     language: process.env.language,
@@ -1099,7 +1100,14 @@ const _env: Partial<typeof vscode.env> = {
         }
     },
 }
-export const env = _env as typeof vscode.env
+export let env = _env as typeof vscode.env
+export function setClientEnv(clientInfo: ClientInfo): void {
+    env = {
+        ...env,
+        appName: clientInfo.name,
+        shell: clientInfo.capabilities?.shell === 'enabled' ? 'agent' : undefined,
+    } as typeof vscode.env
+}
 
 const newCodeActionProvider = new EventEmitter<vscode.CodeActionProvider>()
 const removeCodeActionProvider = new EventEmitter<vscode.CodeActionProvider>()

--- a/agent/src/vscode-shim.ts
+++ b/agent/src/vscode-shim.ts
@@ -1076,7 +1076,7 @@ export const commands = _commands as typeof vscode.commands
 const _env: Partial<typeof vscode.env> = {
     uriScheme: 'file',
     appName: clientInfo?.name,
-    shell: clientInfo?.capabilities?.shell ?? '',
+    shell: clientInfo?.capabilities?.shell === 'enabled' ? 'agent' : undefined,
     appRoot: process.cwd?.(),
     uiKind: UIKind.Desktop,
     language: process.env.language,

--- a/agent/src/vscode-shim.ts
+++ b/agent/src/vscode-shim.ts
@@ -1075,6 +1075,8 @@ export const commands = _commands as typeof vscode.commands
 
 const _env: Partial<typeof vscode.env> = {
     uriScheme: 'file',
+    appName: clientInfo?.name,
+    shell: clientInfo?.capabilities?.shell ?? '',
     appRoot: process.cwd?.(),
     uiKind: UIKind.Desktop,
     language: process.env.language,

--- a/lib/shared/src/configuration/clientCapabilities.ts
+++ b/lib/shared/src/configuration/clientCapabilities.ts
@@ -92,6 +92,7 @@ export interface ClientCapabilities {
     accountSwitchingInWebview?: 'none' | 'enabled' | undefined | null
 
     /**
+     * 🚨 SECURITY: Please tag the Security Team for PR review when enabling shell context.
      * When enabled, the client must be running with node integration enabled that supports
      * child_process.spawn. This is needed for the agent to spawn a shell process to run commands.
      */

--- a/lib/shared/src/configuration/clientCapabilities.ts
+++ b/lib/shared/src/configuration/clientCapabilities.ts
@@ -92,6 +92,12 @@ export interface ClientCapabilities {
     accountSwitchingInWebview?: 'none' | 'enabled' | undefined | null
 
     /**
+     * When enabled, the client must be running with node integration enabled that supports
+     * child_process.spawn. This is needed for the agent to spawn a shell process to run commands.
+     */
+    shell?: 'none' | 'enabled' | undefined | null
+
+    /**
      * When 'object-encoded' (default), the server uses the `webview/postMessage` method to send
      * structured JSON objects.  When 'string-encoded', the server uses the
      * `webview/postMessageStringEncoded` method to send a JSON-encoded string. This is convenient

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -6,6 +6,8 @@ This is a log of all notable changes to Cody for VS Code.
 
 ### Added
 
+Agent: Add shell capability to enable agent shell process spawning.
+
 ### Fixed
 
 ### Changed
@@ -52,6 +54,7 @@ This is a log of all notable changes to Cody for VS Code.
 - Deep Cody: remove TOOL context item after review [pull/6079](https://github.com/sourcegraph/cody/pull/6079)
 
 ## 1.42.0
+
 Hey Cody users! For those who want to track detailed technical changes, we will be updating this changelog to provide more comprehensive updates on new features, improvements, and fixes. For major releases and announcements, check out our [public changelog](https://sourcegraph.com/changelog).
 
 ### Added
@@ -60,14 +63,16 @@ Hey Cody users! For those who want to track detailed technical changes, we will 
 - Telemetry: Added `cody.debug.logCharacterCounters` for debugging. [pull/6057](https://github.com/sourcegraph/cody/pull/6057)
 
 ### Fixed
+
 - Chat: This patch updates the chat keyboard shortcuts to be as follows, thereby avoiding the tendency to "double-add" a code snippet when using the `alt+L` shortcut:
   - `Alt+L`: between chat and editor (this is unchanged)
   - `Shift+Alt+L` (previously alt+L): add selection as context:
   - `Shift+Ctrl+L` (previously shift+alt+L): new chat
 - Markdown files were not bundled in the VSIX leading to onboarding views not displaying or showing an error.
 - Ensured that a correct http/https agent is loaded depending on endpoint protocol and that secureConnection correclty passes CA certs via [hpagent](https://github.com/delvedor/hpagent)
-  
+
 ### Changed
+
 - Networking: In addition to Node and user configured manual CA certs, we now automatically attempt to load CA certs in your system's trust store. This is done using [rustls](https://github.com/rustls/rustls) via a new [napi-rs](https://napi.rs/) library `lib/noxide`. This behaviour is enabled by default but can be diasabled by setting the `experimental.noxide.enabled` to `false` in your settings. Any issues loading the library will be logged to the usual error output channels and we will fallback to the previous behaviour. This will replace the previous method of loading system CA certs using shell commands or bundled executables such as `win-ca.exe`.
 
 ### Uncategorized
@@ -104,11 +109,13 @@ Hey Cody users! For those who want to track detailed technical changes, we will 
 ## 1.40.2
 
 ### Fixed
+
 - Agent: Fixed bugs in `workspace::getConfiguration` vscode shim [pull/6058](https://github.com/sourcegraph/cody/pull/6058)
 
 ## 1.40.1
 
 ### Fixed
+
 - Auth: Fixed UI conditional rendering logic for non VS Code clients. [pull/6047](https://github.com/sourcegraph/cody/pull/6047)
 
 ## 1.40.0

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -6,8 +6,6 @@ This is a log of all notable changes to Cody for VS Code.
 
 ### Added
 
-Agent: Add shell capability to enable agent shell process spawning.
-
 ### Fixed
 
 ### Changed

--- a/vscode/src/commands/context/shell.ts
+++ b/vscode/src/commands/context/shell.ts
@@ -23,7 +23,7 @@ Terminal output from the \`{command}\` command enclosed between <OUTPUT0412> tag
 
 export async function getContextFileFromShell(command: string): Promise<ContextItem[]> {
     return wrapInActiveSpan('commands.context.command', async () => {
-        if (vscode.env.shell === undefined || isDisabled) {
+        if (!vscode.env.shell || isDisabled) {
             void vscode.window.showErrorMessage(
                 'Shell command is not supported in your current workspace.'
             )
@@ -48,8 +48,6 @@ export async function getContextFileFromShell(command: string): Promise<ContextI
 
             const content = OUTPUT_WRAPPER.replace('{command}', command).replace('{output}', output)
             const size = await TokenCounterUtils.countTokens(content)
-
-            console.error(content, 'content')
 
             return [
                 {

--- a/vscode/src/commands/context/shell.ts
+++ b/vscode/src/commands/context/shell.ts
@@ -23,7 +23,7 @@ Terminal output from the \`{command}\` command enclosed between <OUTPUT0412> tag
 
 export async function getContextFileFromShell(command: string): Promise<ContextItem[]> {
     return wrapInActiveSpan('commands.context.command', async () => {
-        if (!vscode.env.shell || isDisabled) {
+        if (vscode.env.shell === undefined || isDisabled) {
             void vscode.window.showErrorMessage(
                 'Shell command is not supported in your current workspace.'
             )
@@ -48,6 +48,8 @@ export async function getContextFileFromShell(command: string): Promise<ContextI
 
             const content = OUTPUT_WRAPPER.replace('{command}', command).replace('{output}', output)
             const size = await TokenCounterUtils.countTokens(content)
+
+            console.error(content, 'content')
 
             return [
                 {


### PR DESCRIPTION
CLOSE https://linear.app/sourcegraph/issue/CODY-3817

1. set shell capability based on client configuration.

This change updates the `vscode-shim` to set the `shell` capability based on the client's reported capabilities. If the client set the `shell` environment variable to `enabled`, it will be set to `'agent'`, otherwise it is set to `undefined`.

When enabled, the client must be running with node integration enabled that supports `child_process.spawn`. This is needed for the agent to spawn a shell process to run commands in IDEs that support node runtime.

This ensures that the shell command functionality is only enabled when the client has the necessary support.

2. set client environment based on configuration

This change updates the `vscode-shim` to set the client environment variables based on the client's reported capabilities. The `appName` and `shell` environment variables are now set dynamically using the `setClientEnv` function, which is called when the client information is updated.

This ensures that the environment variables are properly configured to match the client's capabilities, enabling features like the agent shell process spawning when the `shell` capability is enabled.

### Notes

Currently, no clients have enabled this feature yet.

## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

![image](https://github.com/user-attachments/assets/49e358ce-1a72-4ca4-af3d-85eb9c099b66)

1. Build JB / VS with agent built with this branch and set `clientInfo?.capabilities?.shell` to `enabled`
2. Only Deep Cody is using the shell context right now, so you can ask Deep Cody a question and see if it is able to use shell context to answer your question. Something like "how many files are in the root of this codebase"

### Before

Before in JB: 

> Cody by Sourcegraph: █ CodyTool executing 1 commands...:
> window.showErrorMessage: Shell command is not supported in your current workspace.

![image](https://github.com/user-attachments/assets/ae0b686f-7deb-4bb7-aaf6-ea6ca7a8792c)


After

![image](https://github.com/user-attachments/assets/cdd20a67-4f5a-4432-8b12-9495f36477c0)

![image](https://github.com/user-attachments/assets/a0320f0c-d3b0-4f48-86ef-53b9b16fb38f)


## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->

Agent: Add shell capability to enable agent shell process spawning.