### PR TITLE
add changelog templating and tooling

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -14,6 +14,8 @@ This is a log of all notable changes to Cody for VS Code.
   - Removed `Shift+Ctrl+L` (previously created a new chat) due to conflict with Windows default shortcut
   - Updated `Shift+Alt+L` to create a new chat when the focus is not in the editor. When the focus is in the editor, the behavior remains unchanged (the current selection is added to the chat context).
 
+### Uncategorized
+
 ## 1.44.0
 
 ### Added

--- a/vscode/scripts/changelog.sh
+++ b/vscode/scripts/changelog.sh
@@ -2,6 +2,9 @@
 
 # kalan's poor man changelog generator, this will be replaced by the release team's changelog automation
 
+# you can find the commits at each release branch using:
+# git ls-remote https://github.com/sourcegraph/cody | grep "refs/heads/vscode-v1\.[0-9]\+\.x" | sort -r | head -n 5
+
 git log $1..$2 --pretty='%s' --boundary | sed -E 's/^(.*)\(#(.*)\)$/- \1 [pull\/\2](https:\/\/github.com\/sourcegraph\/cody\/pulls\/\2)/' > temp_changes.txt
 
 # Find first occurrence of ### Uncategorized and append the changes right after it

--- a/vscode/scripts/changelog.sh
+++ b/vscode/scripts/changelog.sh
@@ -1,0 +1,15 @@
+# !/bin/bash
+
+# kalan's poor man changelog generator, this will be replaced by the release team's changelog automation
+
+git log $1..$2 --pretty='%s' --boundary | sed -E 's/^(.*)\(#(.*)\)$/- \1 [pull\/\2](https:\/\/github.com\/sourcegraph\/cody\/pulls\/\2)/' > temp_changes.txt
+
+# Find first occurrence of ### Uncategorized and append the changes right after it
+awk '/### Uncategorized/{if (!found) {print; system("cat temp_changes.txt"); found=1; next}} 1' vscode/CHANGELOG.md > temp_changelog.md
+
+# Replace original file with new content
+mv temp_changelog.md vscode/CHANGELOG.md
+
+# Clean up
+rm temp_changes.txt
+

--- a/vscode/scripts/changelog.sh
+++ b/vscode/scripts/changelog.sh
@@ -1,6 +1,6 @@
 # !/bin/bash
 
-# kalan's poor man changelog generator, this will be replaced by the release team's changelog automation
+# kalan's poor man changelog generator (h/t unknwon), this will be replaced by the release team's changelog automation
 
 # you can find the commits at each release branch using:
 # git ls-remote https://github.com/sourcegraph/cody | grep "refs/heads/vscode-v1\.[0-9]\+\.x" | sort -r | head -n 5


### PR DESCRIPTION
This PR adds a new section `### Uncategorized` in the changelog and some tooling for changelog generation. The script will be generate all commits between versions and place them under this heading as a stop gap until we integrate the release team's changelog automation.

When the release captain runs the release, all commits between the targeted commits will be appended, and all we need to do is make sure the next unreleased section gets bumped up.

Example, to generate the changelog between v1.44 and 1.46:

First we can find the commits using:

```
git ls-remote https://github.com/sourcegraph/cody | grep "refs/heads/vscode-v1\.[0-9]\+\.x" | sort -r | head -n 5
```

Output:
```
953a73af8639446aa209e840c4f3a62d8fa79f90        refs/heads/vscode-v1.42.x
7cc607bdc0f7af9cddee9af03cd2c8ab678dd924        refs/heads/vscode-v1.46.x
70db14a86870e4df043c34547fc664518cd658bf        refs/heads/vscode-v1.40.x
6a80ca3fc05d30fe1f4f0efb0d635207b7ba2dac        refs/heads/vscode-v1.44.x
```

Then we can run the script:
```
./vscode/scripts/changelog.sh 6a80ca3fc05d30fe1f4f0efb0d635207b7ba2dac 7cc607bdc0f7af9cddee9af03cd2c8ab678dd924
```
Output:
```
## [Unreleased]

### Added

### Fixed

### Changed

- Chat: Update keyboard shortcuts:
  - Removed `Shift+Ctrl+L` (previously created a new chat) due to conflict with Windows default shortcut
  - Updated `Shift+Alt+L` to create a new chat when the focus is not in the editor. When the focus is in the editor, the behavior remains unchanged (the current selection is added to the chat context).

### Uncategorized
- [Backport vscode-v1.46.x] Add built-in prompts related fields to prompt select analytic event  [pull/6181](https://github.com/sourcegraph/cody/pulls/6181)
- [Backport vscode-v1.46.x] Fetch standard prompts from remote prompts API  [pull/6166](https://github.com/sourcegraph/cody/pulls/6166)
- [Backport vscode-v1.46.x] Prompts Picker  [pull/6168](https://github.com/sourcegraph/cody/pulls/6168)
- [Backport vscode-v1.46.x] VS Code: Release v1.44.0  [pull/6169](https://github.com/sourcegraph/cody/pulls/6169)
- feat(autoedit): fix cursor jumping issue  [pull/6156](https://github.com/sourcegraph/cody/pulls/6156)
- only activate autoedits command when experimental setting is enabled  [pull/6157](https://github.com/sourcegraph/cody/pulls/6157)
- Chat: ensure ScrollDown button only takes it's width  [pull/6143](https://github.com/sourcegraph/cody/pulls/6143)
- autoedit: Add feature flag to enable/disable autoedit feature  [pull/6145](https://github.com/sourcegraph/cody/pulls/6145)
- remove ctrl+shift+L shortcut and update shift+alt+L shortcut  [pull/6148](https://github.com/sourcegraph/cody/pulls/6148)
- Fix various JetBrains styling issues  [pull/6153](https://github.com/sourcegraph/cody/pulls/6153)
- Autoedits Context Improvements  [pull/6141](https://github.com/sourcegraph/cody/pulls/6141)
- Better rendering for auto edits  [pull/6132](https://github.com/sourcegraph/cody/pulls/6132)
- Chat: context cell improvements  [pull/6115](https://github.com/sourcegraph/cody/pulls/6115)
- Fix inline-edit prompts chat building  [pull/6003](https://github.com/sourcegraph/cody/pulls/6003)
- Cody Web: Polish cody web Prompts  [pull/6135](https://github.com/sourcegraph/cody/pulls/6135)
- Simplify protocol's TelemetryEvent  [pull/6144](https://github.com/sourcegraph/cody/pulls/6144)
- Use font size variable providd by JetBrains in webview  [pull/6134](https://github.com/sourcegraph/cody/pulls/6134)
- Update backport.yml  [pull/6137](https://github.com/sourcegraph/cody/pulls/6137)
- fix(release): Update backport action to override team_reviews  [pull/6136](https://github.com/sourcegraph/cody/pulls/6136)
- autoedit: add speculative decoding  [pull/6130](https://github.com/sourcegraph/cody/pulls/6130)
- add 1.40 changelog items  [pull/6129](https://github.com/sourcegraph/cody/pulls/6129)
- Fix for VSCode Marketplace description getting cut-off  [pull/6098](https://github.com/sourcegraph/cody/pulls/6098)
- Fix prompt name generation during prompts/commands migration  [pull/6126](https://github.com/sourcegraph/cody/pulls/6126)
- VS Code: Release v1.42.0  [pull/6122](https://github.com/sourcegraph/cody/pulls/6122)
```

then lastly, all the captain has to do is changed `unreleased` to the next version number.

gogog!
## Test plan
Tested locally, and ready for the next release (v1.46.0)
<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
