### PR TITLE
Deep Cody: Move shell context behind feature flag

### DIFF
--- a/lib/shared/src/experimentation/FeatureFlagProvider.ts
+++ b/lib/shared/src/experimentation/FeatureFlagProvider.ts
@@ -99,6 +99,9 @@ export enum FeatureFlag {
      * Whether the current repo context chip is shown in the chat input by default
      */
     NoDefaultRepoChip = 'no-default-repo-chip',
+
+    /** Enable Shell Context for Deep Cody */
+    DeepCodyShellContext = 'deep-cody-shell-context',
 }
 
 const ONE_HOUR = 60 * 60 * 1000

--- a/lib/shared/src/models/sync.ts
+++ b/lib/shared/src/models/sync.ts
@@ -220,10 +220,16 @@ export function syncModels({
 
                                             // DEEP CODY - available to users with feature flag enabled only.
                                             // TODO(bee): remove once deepCody is enabled for all users.
+                                            // Replace user's current sonnet model with deep-cody model.
                                             const sonnetModel = data.primaryModels.find(m =>
                                                 m.id.includes('sonnet')
                                             )
-                                            if (deepCodyEnabled && sonnetModel) {
+                                            if (
+                                                deepCodyEnabled &&
+                                                sonnetModel &&
+                                                // Ensure the deep-cody model is only added once.
+                                                !data.primaryModels.some(m => m.id.includes('deep-cody'))
+                                            ) {
                                                 const DEEPCODY_MODEL =
                                                     getExperimentalClientModelByFeatureFlag(
                                                         FeatureFlag.DeepCody

--- a/vscode/src/chat/agentic/CodyTool.ts
+++ b/vscode/src/chat/agentic/CodyTool.ts
@@ -298,10 +298,12 @@ const TOOL_CONFIGS = {
 } as const
 
 export function getDefaultCodyTools(
+    useShellContext: boolean,
     contextRetriever: Pick<ContextRetriever, 'retrieveContext'>,
     factory: ToolFactory
 ): CodyTool[] {
     return Object.entries(TOOL_CONFIGS)
+        .filter(([name]) => name !== 'CliTool' || useShellContext)
         .map(([name]) => factory.createTool(name, contextRetriever))
         .filter(Boolean) as CodyTool[]
 }

--- a/vscode/src/chat/agentic/CodyTool.ts
+++ b/vscode/src/chat/agentic/CodyTool.ts
@@ -298,12 +298,12 @@ const TOOL_CONFIGS = {
 } as const
 
 export function getDefaultCodyTools(
-    useShellContext: boolean,
+    isShellContextEnabled: boolean,
     contextRetriever: Pick<ContextRetriever, 'retrieveContext'>,
     factory: ToolFactory
 ): CodyTool[] {
     return Object.entries(TOOL_CONFIGS)
-        .filter(([name]) => name !== 'CliTool' || useShellContext)
+        .filter(([name]) => name !== 'CliTool' || isShellContextEnabled)
         .map(([name]) => factory.createTool(name, contextRetriever))
         .filter(Boolean) as CodyTool[]
 }

--- a/vscode/src/chat/agentic/CodyToolProvider.ts
+++ b/vscode/src/chat/agentic/CodyToolProvider.ts
@@ -1,12 +1,4 @@
-import {
-    FeatureFlag,
-    authStatus,
-    featureFlagProvider,
-    firstValueFrom,
-    isDefined,
-    ps,
-    storeLastValue,
-} from '@sourcegraph/cody-shared'
+import { authStatus, firstValueFrom, isDefined, ps } from '@sourcegraph/cody-shared'
 import { getOpenCtxProviders } from '../../context/openctx'
 import type { ContextRetriever } from '../chat-view/ContextRetriever'
 import {
@@ -36,10 +28,6 @@ export class CodyToolProvider {
         this.initializeOpenCtxTools()
     }
 
-    private useShellContext = storeLastValue(
-        featureFlagProvider.evaluatedFeatureFlag(FeatureFlag.DeepCodyShellContext)
-    )
-
     public static instance(
         contextRetriever: Pick<ContextRetriever, 'retrieveContext'>
     ): CodyToolProvider {
@@ -50,9 +38,9 @@ export class CodyToolProvider {
         registerDefaultTools(this.toolFactory.registry)
     }
 
-    public async getTools(): Promise<CodyTool[]> {
+    public async getTools(isShellContextEnabled = false): Promise<CodyTool[]> {
         const defaultTools = getDefaultCodyTools(
-            !!this.useShellContext?.value.last,
+            isShellContextEnabled,
             this.contextRetriever,
             this.toolFactory
         )

--- a/vscode/src/chat/agentic/DeepCody.test.ts
+++ b/vscode/src/chat/agentic/DeepCody.test.ts
@@ -146,7 +146,8 @@ describe('DeepCody', () => {
         const result = await agent.getContext(mockSpan, { aborted: false } as AbortSignal)
 
         expect(mockChatClient.chat).toHaveBeenCalled()
-        expect(mockCodyTools).toHaveLength(4)
+        expect(mockCodyTools).toHaveLength(3)
+        expect(mockCodyTools.some(tool => tool.config.tags.tag === ps`TOOLCLI`)).toBeFalsy()
         expect(mockContextRetriever.retrieveContext).toHaveBeenCalled()
         expect(result).toHaveLength(2)
         expect(result[0].content).toBe('const example = "test";')

--- a/vscode/src/chat/chat-view/ChatController.ts
+++ b/vscode/src/chat/chat-view/ChatController.ts
@@ -531,6 +531,10 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
         featureFlagProvider.evaluatedFeatureFlag(FeatureFlag.CodyExperimentalOneBox)
     )
 
+    private featureDeepCodyShellContext = storeLastValue(
+        featureFlagProvider.evaluatedFeatureFlag(FeatureFlag.DeepCodyShellContext)
+    )
+
     private async getConfigForWebview(): Promise<ConfigurationSubsetForWebview & LocalEnv> {
         const { configuration, auth } = await currentResolvedConfig()
         const sidebarViewOnly = this.extensionClient.capabilities?.webviewNativeConfig?.view === 'single'
@@ -839,7 +843,7 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
                 const agenticContext = await new DeepCodyAgent(
                     this.chatBuilder,
                     this.chatClient,
-                    await this.toolProvider.getTools(),
+                    await this.toolProvider.getTools(!!this.featureDeepCodyShellContext.value.last),
                     corpusContext
                 ).getContext(span, signal)
                 corpusContext.push(...agenticContext)

--- a/vscode/webviews/chat/cells/contextCell/ContextCell.tsx
+++ b/vscode/webviews/chat/cells/contextCell/ContextCell.tsx
@@ -158,7 +158,7 @@ export const ContextCell: FunctionComponent<{
 
         // Text for top header text
         const headerText: { main: string; sub?: string } = {
-            main: isContextLoading ? (isDeepCodyEnabled ? 'Thinking' : 'Fetching context') : 'Context',
+            main: isContextLoading ? 'Fetching context' : 'Context',
             sub: isContextLoading
                 ? isDeepCodyEnabled
                     ? 'Retrieving context…'


### PR DESCRIPTION
CLOSE: https://linear.app/sourcegraph/issue/CODY-4385 & https://linear.app/sourcegraph/issue/CODY-4381

This PR adds a new feature flag `DeepCodyShellContext` to enable the shell context for the deep cody feature. The feature flag is used to conditionally include or exclude the `CliTool` in the default cody tools.

Currently the feature flag is only enabled for all dotcom users by default. Enterprise admins must enable this feature flag manually.

Also added a check to ensure that the deep-cody model is only added once to the user's primary models when the DeepCody feature flag is enabled.

## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

1. Connect to dotcom where the feature flag is enabled for all users
2. Ask Deep Cody: "how many files are there in the root of this codebase?"
3. Confirm the context includes `ls -1 .` command (or any shell command for getting file number).
  - <img width="745" alt="image" src="https://github.com/user-attachments/assets/34da9ee6-88e8-4f82-b34e-f15498106dc3">
4. Connect to S2 where the feature flag is not enabled for all users ( I will enable it on S2 AFTER this PR is merged so that before this is merged, you can use S2 to test)
5. Ask Deep Cody: "how many files are there in the root of this codebase?"
6. Confirm Deep Cody didn't use any shell command as context
  - <img width="1224" alt="image" src="https://github.com/user-attachments/assets/a15735ad-1a48-4217-b88a-1a9d7e9bb7dc">



## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->

Deep Cody: Move shell context behind feature flag "deep-cody-shell-context".