### PR TITLE
Add default value for 'search.useIgnoreFiles' in agent config

### DIFF
--- a/agent/src/AgentWorkspaceConfiguration.test.ts
+++ b/agent/src/AgentWorkspaceConfiguration.test.ts
@@ -31,9 +31,6 @@ describe('AgentWorkspaceConfiguration', () => {
           "cody.telemetry": {
             "level": "agent"
           },
-          "editor": {
-            "insertSpaces": true
-          },
           "foo.bar": {
             "baz.qux": true,
             "baz": {
@@ -189,6 +186,11 @@ describe('AgentWorkspaceConfiguration', () => {
 
             const secondGet = config.get('test.object')
             expect(secondGet.key).toBe('value')
+        })
+
+        it('have some VSC defaults', () => {
+            expect(config.get('editor.insertSpaces')).toBe(true)
+            expect(config.get('search.useIgnoreFiles')).toBe(true)
         })
     })
 

--- a/agent/src/AgentWorkspaceConfiguration.ts
+++ b/agent/src/AgentWorkspaceConfiguration.ts
@@ -67,6 +67,9 @@ export class AgentWorkspaceConfiguration implements vscode.WorkspaceConfiguratio
             editor: {
                 insertSpaces: true,
             },
+            search: {
+                useIgnoreFiles: true,
+            },
             cody: {
                 advanced: {
                     agent: {


### PR DESCRIPTION
## Test plan

1. Open IntelliJ with this branch (using `CODY_DIR`)
2. Add context file in the chat - start searching for some file which is specified as ignored in '.gitignore'
3. It should not show up in the file search results

This partially solves https://linear.app/sourcegraph/issue/CODY-4379/ but perhaps we should think about general solution which should be better.