### PR TITLE
Make signout as non-blocking as possible

### DIFF
--- a/vscode/src/services/AuthProvider.ts
+++ b/vscode/src/services/AuthProvider.ts
@@ -4,6 +4,7 @@ import {
     type AuthCredentials,
     type AuthStatus,
     type ClientCapabilitiesWithLegacyFields,
+    DOTCOM_URL,
     NEVER,
     type ResolvedConfiguration,
     type Unsubscribable,
@@ -164,6 +165,15 @@ class AuthProvider implements vscode.Disposable {
     public refresh(): void {
         this.lastValidatedAndStoredCredentials.next(null)
         this.refreshRequests.next()
+    }
+
+    public signout(): void {
+        this.lastValidatedAndStoredCredentials.next(null)
+        this.status.next({
+            authenticated: false,
+            endpoint: DOTCOM_URL.toString(),
+            pendingValidation: false,
+        })
     }
 
     public async validateAndStoreCredentials(

--- a/vscode/webviews/tabs/AccountTab.tsx
+++ b/vscode/webviews/tabs/AccountTab.tsx
@@ -95,9 +95,10 @@ export const AccountTab: React.FC<AccountTabProps> = ({
         getVSCodeAPI().postMessage({ command: 'command', id: 'cody.status-bar.interacted' })
     )
 
-    const signOutButton = createButton('Sign Out', () =>
+    const signOutButton = createButton('Sign Out', () => {
         getVSCodeAPI().postMessage({ command: 'auth', authKind: 'signout' })
-    )
+        setIsLoading(true)
+    })
 
     const accountPanelView = (
         <div className="tw-overflow-auto tw-flex-1 tw-flex tw-flex-col tw-items-start tw-w-full tw-px-8 tw-py-6 tw-gap-6">


### PR DESCRIPTION
Fixes https://linear.app/sourcegraph/issue/QA-183/jetbrains-user-doesnt-get-sign-out-immediately-when-logged-in-using

## Test plan

1. Start IntelliJ and open Cody panel
2. Go to the Account tab
3. Click `Sign Out`

Expected result:
You should see loading indicator when sign out is processed.
Whole process should not take more then 1-2 sec.
