### PR TITLE
DEEP CODY: remove user preferences on sync, update memory tool

### DIFF
--- a/lib/shared/src/models/sync.ts
+++ b/lib/shared/src/models/sync.ts
@@ -239,18 +239,10 @@ export function syncModels({
                                                         createModelFromServerModel
                                                     )
                                                 )
-                                                // Update model preferences for chat to DEEP CODY once on first sync.
+                                                // Update site preferences for chat to DEEP CODY on first sync.
                                                 data.preferences!.defaults.edit =
                                                     data.preferences!.defaults.chat
                                                 data.preferences!.defaults.chat = DEEPCODY_MODEL.modelRef
-                                                return userModelPreferences.pipe(
-                                                    take(1),
-                                                    tap(preferences => {
-                                                        preferences.selected[ModelUsage.Chat] =
-                                                            DEEPCODY_MODEL.modelRef
-                                                    }),
-                                                    map(() => data)
-                                                )
                                             }
 
                                             return Observable.of(data)

--- a/vscode/src/chat/agentic/CodyChatMemory.ts
+++ b/vscode/src/chat/agentic/CodyChatMemory.ts
@@ -2,13 +2,40 @@ import { type ContextItem, ContextItemSource } from '@sourcegraph/cody-shared'
 import { URI } from 'vscode-uri'
 import { localStorage } from '../../services/LocalStorageProvider'
 
+/**
+ * CodyChatMemory is a singleton class that manages short-term memory storage for chat conversations.
+ * It maintains a maximum of 8 most recent memory items in a static Store.
+ * We store the memory items in local storage to persist them across sessions.
+ * NOTE: The memory items set to a maximum of 8 to avoid overloading the local storage.
+ *
+ * @remarks
+ * This class should never be instantiated directly. All operations should be performed
+ * through static methods. The only instance creation happens internally during initialization.
+ *
+ * Key features:
+ * - Maintains a static Set of up to 8 chat memory items
+ * - Persists memory items to local storage
+ * - Provides memory retrieval as ContextItem for chat context
+ *
+ * Usage:
+ * - Call CodyChatMemory.initialize() once at startup
+ * - Use static methods load(), retrieve(), and unload() for memory operations
+ */
 export class CodyChatMemory {
-    private static Store = new Set<string>()
+    private static readonly MAX_MEMORY_ITEMS = 8
+    private static Store = new Set<string>([])
+
+    public static initialize(): void {
+        if (CodyChatMemory.Store.size === 0) {
+            const newMemory = new CodyChatMemory()
+            CodyChatMemory.Store = new Set(newMemory.getChatMemory())
+        }
+    }
 
     public static load(memory: string): void {
         CodyChatMemory.Store.add(memory)
-        // If store exceeds 5 items, remove oldest items
-        if (CodyChatMemory.Store.size > 5) {
+        // If store exceeds the max, remove oldest items
+        if (CodyChatMemory.Store.size > CodyChatMemory.MAX_MEMORY_ITEMS) {
             const storeArray = Array.from(CodyChatMemory.Store)
             CodyChatMemory.Store = new Set(storeArray.slice(-5))
         }
@@ -34,10 +61,7 @@ export class CodyChatMemory {
         return stored
     }
 
-    constructor() {
-        const stored = localStorage?.getChatMemory()
-        if (stored) {
-            CodyChatMemory.Store = new Set(stored)
-        }
+    private getChatMemory(): string[] {
+        return localStorage?.getChatMemory() || []
     }
 }

--- a/vscode/src/chat/agentic/CodyTool.ts
+++ b/vscode/src/chat/agentic/CodyTool.ts
@@ -102,7 +102,7 @@ class CliTool extends CodyTool {
             prompt: {
                 instruction: ps`To see the output of shell commands - NEVER execute unsafe commands`,
                 placeholder: ps`SHELL_COMMAND`,
-                example: ps`Details about GitHub issue#1234: \`<TOOLCLI><cmd>gh issue view 1234</cmd></TOOLCLI>\``,
+                example: ps`Get output for git diff: \`<TOOLCLI><cmd>git diff</cmd></TOOLCLI>\``,
             },
         })
     }
@@ -250,6 +250,7 @@ export class OpenCtxTool extends CodyTool {
  */
 class MemoryTool extends CodyTool {
     constructor() {
+        CodyChatMemory.initialize()
         super({
             tags: {
                 tag: ps`TOOLMEMORY`,


### PR DESCRIPTION
This change updates the site preferences for the chat model to DEEP CODY on the first sync, instead of updating the user's model preferences. This ensures that the chat model is set to DEEP CODY for all users on the first sync, without modifying individual user preferences.

This PR also change initializes the CodyChatMemory singleton when the MemoryTool is constructed. This ensures that the chat memory is properly loaded and available for use in the chat context across chat session.

The CodyChatMemory class has also been updated to maintain a maximum of 8 most recent memory items in the static store, and to persist the memory items to local storage.

Remove github issue example from TOOLCLI to make sure it uses openCtx Tool when configured.

## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

Minor changes that are not affecting the existing unit tests. 

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
