### PR TITLE
Improve release process with slack notifications and automated branching

### DIFF
--- a/.github/workflows/vscode-stable-release.yml
+++ b/.github/workflows/vscode-stable-release.yml
@@ -103,24 +103,24 @@ jobs:
               echo "Posted to slack."
             fi
           done
-      - name: Check if branch or label exists
+      - name: Check if the next release branch and backport label exist
         id: check-exists
         run: |
           # Check if branch exists
           if git ls-remote --heads origin ${{ env.NEXT_RELEASE_BRANCH }} | grep -q "${{ env.NEXT_RELEASE_BRANCH }}"; then
             echo "Branch ${{ env.NEXT_RELEASE_BRANCH }} already exists"
-            echo "SKIP_CREATION=true" >> $GITHUB_ENV
+            echo "SKIP_BRANCH_CREATION=true" >> $GITHUB_ENV
             exit 0
           fi
           
           # Check if label exists
           if gh label list | grep -q "backport ${{ env.NEXT_RELEASE_BRANCH }}"; then
             echo "Label backport ${{ env.NEXT_RELEASE_BRANCH }} already exists"
-            echo "SKIP_CREATION=true" >> $GITHUB_ENV
+            echo "SKIP_LABEL_CREATION=true" >> $GITHUB_ENV
             exit 0
           fi
       - name: Create backport label
-        if: ${{ !env.SKIP_CREATION }}
+        if: ${{ !env.SKIP_LABEL_CREATION }}
         uses: actions/github-script@v6
         with:
           script: |
@@ -133,8 +133,9 @@ jobs:
               description: `Backport to ${nextReleaseBranch} branch`
             })      
       - name: Create and push next release branch
-        if: ${{ !env.SKIP_CREATION }}
+        if: ${{ !env.SKIP_BRANCH_CREATION }}
         run: |
+          git checkout main
           git checkout -b ${{ env.NEXT_RELEASE_BRANCH }}
 
           if ! git push origin ${{ env.NEXT_RELEASE_BRANCH }}; then

--- a/.github/workflows/vscode-stable-release.yml
+++ b/.github/workflows/vscode-stable-release.yml
@@ -68,3 +68,76 @@ jobs:
           asset_path: ./vscode/dist/cody.vsix
           asset_name: cody-vscode-${{ env.EXT_VERSION }}.vsix
           asset_content_type: application/zip
+      - name: Determine version numbers
+        run: |
+          tag="${{ env.EXT_VERSION }}"
+          version_anchor=$(echo $tag | sed 's/[^0-9]//g')
+          major=$(echo $tag | sed 's/\([0-9]*\)\.\([0-9]*\)\.\([0-9]*\)/\1/')
+          minor=$(echo $tag | sed 's/\([0-9]*\)\.\([0-9]*\)\.\([0-9]*\)/\2/')
+          next_minor=$(($minor + 2))
+          echo "VERSION_ANCHOR=$version_anchor" >> $GITHUB_ENV
+          echo "CURRENT_RELEASE_BRANCH=vscode-v$major.$minor.x" >> $GITHUB_ENV
+          echo "NEXT_RELEASE_BRANCH=vscode-v$major.$next_minor.x" >> $GITHUB_ENV
+      - name: 'Slack notification'
+        run: |
+          echo "Posting release announcement to Slack"
+          ANNOUNCE_EDITORS_SLACK_WEBHOOK_URL=${{ secrets.ANNOUNCE_EDITORS_SLACK_WEBHOOK_URL }}
+
+          # treat this like an array, add a space for the next webhook secret
+          webhooks=("$ANNOUNCE_EDITORS_SLACK_WEBHOOK_URL")
+          for webhook in "${webhooks[@]}"; do
+            response=$(curl -s -w "%{http_code}" -X POST -H "Content-Type: application/json" -d '{
+              "type": "mrkdwn",
+              "text": ":cody: :vscode: Cody for VS Code `v${{ env.EXT_VERSION }}` has been published, see the <https://github.com/sourcegraph/cody/blob/main/vscode/CHANGELOG.md#${{ env.VERSION_ANCHOR }} | github changelog> for more details. \n\n\n :next: :next: :next: :bullettrain_side: \n\n\n The next pre-release will be built off the `${{ env.NEXT_RELEASE_BRANCH }}` branch, see a preview of all changes <https://github.com/sourcegraph/cody/compare/${{ env.CURRENT_RELEASE_BRANCH }}...${{ env.NEXT_RELEASE_BRANCH }} | here>"
+            }' "$webhook")
+            status_code=${response: -3}
+            body=${response:0:${#response}-3}
+
+            if [ "$status_code" != "200" ]; then
+              echo "❌ Unable to post message to slack, got:"
+              echo "--- raw body ---"
+              echo "$body"
+              echo "--- raw body ---"
+              exit 1
+            else
+              echo "Posted to slack."
+            fi
+          done
+      - name: Check if branch or label exists
+        id: check-exists
+        run: |
+          # Check if branch exists
+          if git ls-remote --heads origin ${{ env.NEXT_RELEASE_BRANCH }} | grep -q "${{ env.NEXT_RELEASE_BRANCH }}"; then
+            echo "Branch ${{ env.NEXT_RELEASE_BRANCH }} already exists"
+            echo "SKIP_CREATION=true" >> $GITHUB_ENV
+            exit 0
+          fi
+          
+          # Check if label exists
+          if gh label list | grep -q "backport ${{ env.NEXT_RELEASE_BRANCH }}"; then
+            echo "Label backport ${{ env.NEXT_RELEASE_BRANCH }} already exists"
+            echo "SKIP_CREATION=true" >> $GITHUB_ENV
+            exit 0
+          fi
+      - name: Create backport label
+        if: ${{ !env.SKIP_CREATION }}
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const nextReleaseBranch = process.env.NEXT_RELEASE_BRANCH;
+            const nextBackportLabel = `backport ${nextReleaseBranch}`;
+            github.rest.issues.createLabel({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              name: `${nextBackportLabel}`,
+              description: `Backport to ${nextReleaseBranch} branch`
+            })      
+      - name: Create and push next release branch
+        if: ${{ !env.SKIP_CREATION }}
+        run: |
+          git checkout -b ${{ env.NEXT_RELEASE_BRANCH }}
+
+          if ! git push origin ${{ env.NEXT_RELEASE_BRANCH }}; then
+            echo "Failed to push the next release branch ${{ env.NEXT_RELEASE_BRANCH }} to origin"
+            exit 1
+          fi


### PR DESCRIPTION
This will PR will do the following:
1. push a notification to a slack channel informing us that the release is successful
2. calculates the next prerelease version, and provides a preview of the changes going into the next version (stopgap solution for GTM and PMM)
3. creates the next backport label
4. creates the next prerelease branch and pushes it to main

It will only create new prerelease branches and backport labels when there is a new minor version, patch increments will be skipped. 

The slack notification will look something like:

![CleanShot 2024-11-28 at 15 48 33](https://github.com/user-attachments/assets/5626500f-aaed-43af-bb0d-56cc34cf02af)

This will reduce the cognitive load on the release captain to always remembering to cut the next release branches, reducing the chance of error. The release captain just needs to make sure that they merge changelog and version bumps first. 

next up is doing this for the pre-release and JetBrains repos

## Test plan
N/A - tested in private [slack channel](https://sourcegraph.slack.com/archives/C04JD75GY2U) 
<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
