### PR TITLE
use chat client for s2

### DIFF
--- a/lib/shared/src/configuration.ts
+++ b/lib/shared/src/configuration.ts
@@ -32,7 +32,7 @@ export interface AutoEditsTokenLimit {
 }
 
 export interface AutoEditsModelConfig {
-    provider: 'openai' | 'fireworks' | 'cody-gateway-fastpath-chat'
+    provider: 'openai' | 'fireworks' | 'cody-gateway-fastpath-chat' | 'sourcegraph-chat'
     model: string
     url: string
     apiKey: string

--- a/vscode/src/autoedits/adapters/cody-gateway.ts
+++ b/vscode/src/autoedits/adapters/cody-gateway.ts
@@ -1,47 +1,9 @@
-import type { AutoEditsTokenLimit } from '@sourcegraph/cody-shared'
-import type * as vscode from 'vscode'
-import type {
-    AutocompleteContextSnippet,
-    DocumentContext,
-} from '../../../../lib/shared/src/completions/types'
 import { autoeditsLogger } from '../logger'
-import type { AutoeditsModelAdapter, ChatPrompt, PromptResponseData } from '../prompt-provider'
+import type { AutoeditsModelAdapter } from '../prompt-provider'
 import { getModelResponse } from '../prompt-provider'
 import type { AutoeditModelOptions } from '../prompt-provider'
-import { type CodeToReplaceData, SYSTEM_PROMPT, getBaseUserPrompt } from '../prompt-utils'
 
 export class CodyGatewayAdapter implements AutoeditsModelAdapter {
-    getPrompt(
-        docContext: DocumentContext,
-        document: vscode.TextDocument,
-        position: vscode.Position,
-        context: AutocompleteContextSnippet[],
-        tokenBudget: AutoEditsTokenLimit
-    ): PromptResponseData {
-        const { codeToReplace, prompt: userPrompt } = getBaseUserPrompt(
-            docContext,
-            document,
-            position,
-            context,
-            tokenBudget
-        )
-        const promptResponse: ChatPrompt = [
-            {
-                role: 'system',
-                content: SYSTEM_PROMPT,
-            },
-            {
-                role: 'user',
-                content: userPrompt,
-            },
-        ]
-        return { codeToReplace, promptResponse }
-    }
-
-    postProcessResponse(codeToReplace: CodeToReplaceData, response: string): string {
-        return response
-    }
-
     async getModelResponse(option: AutoeditModelOptions): Promise<string> {
         try {
             const headers = {

--- a/vscode/src/autoedits/adapters/fireworks.ts
+++ b/vscode/src/autoedits/adapters/fireworks.ts
@@ -1,50 +1,9 @@
-import type { AutoEditsTokenLimit } from '@sourcegraph/cody-shared'
-import type * as vscode from 'vscode'
-import type {
-    AutocompleteContextSnippet,
-    DocumentContext,
-} from '../../../../lib/shared/src/completions/types'
 import { autoeditsLogger } from '../logger'
-import type { AutoeditsModelAdapter, ChatPrompt, PromptResponseData } from '../prompt-provider'
+import type { AutoeditsModelAdapter } from '../prompt-provider'
 import { getModelResponse } from '../prompt-provider'
 import type { AutoeditModelOptions } from '../prompt-provider'
-import { type CodeToReplaceData, SYSTEM_PROMPT, getBaseUserPrompt } from '../prompt-utils'
 
 export class FireworksAdapter implements AutoeditsModelAdapter {
-    getPrompt(
-        docContext: DocumentContext,
-        document: vscode.TextDocument,
-        position: vscode.Position,
-        context: AutocompleteContextSnippet[],
-        tokenBudget: AutoEditsTokenLimit
-    ): PromptResponseData {
-        const { codeToReplace, prompt: userPrompt } = getBaseUserPrompt(
-            docContext,
-            document,
-            position,
-            context,
-            tokenBudget
-        )
-        const prompt: ChatPrompt = [
-            {
-                role: 'system',
-                content: SYSTEM_PROMPT,
-            },
-            {
-                role: 'user',
-                content: userPrompt,
-            },
-        ]
-        return {
-            codeToReplace,
-            promptResponse: prompt,
-        }
-    }
-
-    postProcessResponse(codeToReplace: CodeToReplaceData, response: string): string {
-        return response
-    }
-
     async getModelResponse(option: AutoeditModelOptions): Promise<string> {
         try {
             const response = await getModelResponse(

--- a/vscode/src/autoedits/adapters/openai.ts
+++ b/vscode/src/autoedits/adapters/openai.ts
@@ -1,50 +1,9 @@
-import type { AutoEditsTokenLimit } from '@sourcegraph/cody-shared'
-import type * as vscode from 'vscode'
-import type {
-    AutocompleteContextSnippet,
-    DocumentContext,
-} from '../../../../lib/shared/src/completions/types'
 import { autoeditsLogger } from '../logger'
-import type { AutoeditsModelAdapter, ChatPrompt, PromptResponseData } from '../prompt-provider'
+import type { AutoeditsModelAdapter } from '../prompt-provider'
 import { getModelResponse } from '../prompt-provider'
 import type { AutoeditModelOptions } from '../prompt-provider'
-import { type CodeToReplaceData, SYSTEM_PROMPT, getBaseUserPrompt } from '../prompt-utils'
 
 export class OpenAIAdapter implements AutoeditsModelAdapter {
-    getPrompt(
-        docContext: DocumentContext,
-        document: vscode.TextDocument,
-        position: vscode.Position,
-        context: AutocompleteContextSnippet[],
-        tokenBudget: AutoEditsTokenLimit
-    ): PromptResponseData {
-        const { codeToReplace, prompt: userPrompt } = getBaseUserPrompt(
-            docContext,
-            document,
-            position,
-            context,
-            tokenBudget
-        )
-        const prompt: ChatPrompt = [
-            {
-                role: 'system',
-                content: SYSTEM_PROMPT,
-            },
-            {
-                role: 'user',
-                content: userPrompt,
-            },
-        ]
-        return {
-            codeToReplace,
-            promptResponse: prompt,
-        }
-    }
-
-    postProcessResponse(_: CodeToReplaceData, response: string): string {
-        return response
-    }
-
     async getModelResponse(option: AutoeditModelOptions): Promise<string> {
         try {
             const response = await getModelResponse(

--- a/vscode/src/autoedits/adapters/sourcegraph-chat.ts
+++ b/vscode/src/autoedits/adapters/sourcegraph-chat.ts
@@ -1,47 +1,10 @@
-import type { AutoEditsTokenLimit, ChatClient, Message } from '@sourcegraph/cody-shared'
-import type {
-    AutocompleteContextSnippet,
-    DocumentContext,
-} from '@sourcegraph/cody-shared/src/completions/types'
-import type * as vscode from 'vscode'
+import type { ChatClient, Message } from '@sourcegraph/cody-shared'
 import { autoeditsLogger } from '../logger'
-import type { AutoeditsModelAdapter, ChatPrompt, PromptResponseData } from '../prompt-provider'
+import type { AutoeditsModelAdapter, ChatPrompt } from '../prompt-provider'
 import type { AutoeditModelOptions } from '../prompt-provider'
-import { type CodeToReplaceData, SYSTEM_PROMPT, getBaseUserPrompt } from '../prompt-utils'
 
 export class SourcegraphChatAdapter implements AutoeditsModelAdapter {
     constructor(private readonly chatClient: ChatClient) {}
-
-    getPrompt(
-        docContext: DocumentContext,
-        document: vscode.TextDocument,
-        position: vscode.Position,
-        context: AutocompleteContextSnippet[],
-        tokenBudget: AutoEditsTokenLimit
-    ): PromptResponseData {
-        const { codeToReplace, prompt: userPrompt } = getBaseUserPrompt(
-            docContext,
-            document,
-            position,
-            context,
-            tokenBudget
-        )
-        const promptResponse: ChatPrompt = [
-            {
-                role: 'system',
-                content: SYSTEM_PROMPT,
-            },
-            {
-                role: 'user',
-                content: userPrompt,
-            },
-        ]
-        return { codeToReplace, promptResponse }
-    }
-
-    postProcessResponse(codeToReplace: CodeToReplaceData, response: string): string {
-        return response
-    }
 
     async getModelResponse(option: AutoeditModelOptions): Promise<string> {
         try {

--- a/vscode/src/autoedits/adapters/sourcegraph-chat.ts
+++ b/vscode/src/autoedits/adapters/sourcegraph-chat.ts
@@ -1,0 +1,85 @@
+import type { AutoEditsTokenLimit, ChatClient, Message } from '@sourcegraph/cody-shared'
+import type {
+    AutocompleteContextSnippet,
+    DocumentContext,
+} from '@sourcegraph/cody-shared/src/completions/types'
+import type * as vscode from 'vscode'
+import { autoeditsLogger } from '../logger'
+import type { AutoeditsModelAdapter, ChatPrompt, PromptResponseData } from '../prompt-provider'
+import type { AutoeditModelOptions } from '../prompt-provider'
+import { type CodeToReplaceData, SYSTEM_PROMPT, getBaseUserPrompt } from '../prompt-utils'
+
+export class SourcegraphChatAdapter implements AutoeditsModelAdapter {
+    constructor(private readonly chatClient: ChatClient) {}
+
+    getPrompt(
+        docContext: DocumentContext,
+        document: vscode.TextDocument,
+        position: vscode.Position,
+        context: AutocompleteContextSnippet[],
+        tokenBudget: AutoEditsTokenLimit
+    ): PromptResponseData {
+        const { codeToReplace, prompt: userPrompt } = getBaseUserPrompt(
+            docContext,
+            document,
+            position,
+            context,
+            tokenBudget
+        )
+        const promptResponse: ChatPrompt = [
+            {
+                role: 'system',
+                content: SYSTEM_PROMPT,
+            },
+            {
+                role: 'user',
+                content: userPrompt,
+            },
+        ]
+        return { codeToReplace, promptResponse }
+    }
+
+    postProcessResponse(codeToReplace: CodeToReplaceData, response: string): string {
+        return response
+    }
+
+    async getModelResponse(option: AutoeditModelOptions): Promise<string> {
+        try {
+            const messages = this.convertChatPromptToMessage(option.prompt)
+            const stream = await this.chatClient.chat(
+                messages,
+                {
+                    model: option.model,
+                    maxTokensToSample: 256,
+                    temperature: 0.2,
+                },
+                new AbortController().signal
+            )
+
+            let accumulated = ''
+            for await (const msg of stream) {
+                if (msg.type === 'change') {
+                    const newText = msg.text.slice(accumulated.length)
+                    accumulated += newText
+                } else if (msg.type === 'complete' || msg.type === 'error') {
+                    break
+                }
+            }
+            return accumulated
+        } catch (error) {
+            autoeditsLogger.logDebug('AutoEdits', 'Error calling Cody Gateway:', error)
+            throw error
+        }
+    }
+
+    private convertChatPromptToMessage(prompt: ChatPrompt): Message[] {
+        return prompt.map(p => ({
+            speaker: this.getSpeaker(p.role) as 'system' | 'assistant' | 'human',
+            text: p.content,
+        }))
+    }
+
+    private getSpeaker(role: string): string {
+        return role === 'user' ? 'human' : role
+    }
+}

--- a/vscode/src/autoedits/prompt-provider.ts
+++ b/vscode/src/autoedits/prompt-provider.ts
@@ -1,9 +1,4 @@
-import type { AutoEditsTokenLimit, PromptString } from '@sourcegraph/cody-shared'
-import type * as vscode from 'vscode'
-import type {
-    AutocompleteContextSnippet,
-    DocumentContext,
-} from '../../../lib/shared/src/completions/types'
+import type { PromptString } from '@sourcegraph/cody-shared'
 import type * as utils from './prompt-utils'
 
 export type ChatPrompt = {
@@ -26,15 +21,7 @@ export interface PromptResponseData {
 }
 
 export interface AutoeditsModelAdapter {
-    getPrompt(
-        docContext: DocumentContext,
-        document: vscode.TextDocument,
-        position: vscode.Position,
-        context: AutocompleteContextSnippet[],
-        tokenBudget: AutoEditsTokenLimit
-    ): PromptResponseData
     getModelResponse(args: AutoeditModelOptions): Promise<string>
-    postProcessResponse(codeToReplace: utils.CodeToReplaceData, completion: string | null): string
 }
 
 export async function getModelResponse(

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -456,7 +456,7 @@ async function registerCodyCommands(
     )
 
     // Initialize autoedit provider if experimental feature is enabled
-    registerAutoEdits(disposables)
+    registerAutoEdits(chatClient, disposables)
 
     // Initialize autoedit tester
     disposables.push(
@@ -705,7 +705,7 @@ async function tryRegisterTutorial(
     }
 }
 
-function registerAutoEdits(disposables: vscode.Disposable[]): void {
+function registerAutoEdits(chatClient: ChatClient, disposables: vscode.Disposable[]): void {
     disposables.push(
         subscriptionDisposable(
             combineLatest(
@@ -718,7 +718,7 @@ function registerAutoEdits(disposables: vscode.Disposable[]): void {
                 .pipe(
                     map(([config, authStatus, autoeditEnabled]) => {
                         if (shouldEnableExperimentalAutoedits(config, autoeditEnabled, authStatus)) {
-                            const provider = new AutoeditsProvider()
+                            const provider = new AutoeditsProvider(chatClient)
 
                             const completionRegistration =
                                 vscode.languages.registerInlineCompletionItemProvider(


### PR DESCRIPTION
Use the ChatClient for S2 for autoedits.

## Test plan
1. Switch to S2 instance (by default it will give the error `error":"Cody Gateway access not enabled`)
2. In the debug mode, using S2 will work. 