### PR TITLE
remove redunant function

### DIFF
--- a/vscode/src/autoedits/adapters/cody-gateway.ts
+++ b/vscode/src/autoedits/adapters/cody-gateway.ts
@@ -1,47 +1,9 @@
-import type { AutoEditsTokenLimit } from '@sourcegraph/cody-shared'
-import type * as vscode from 'vscode'
-import type {
-    AutocompleteContextSnippet,
-    DocumentContext,
-} from '../../../../lib/shared/src/completions/types'
 import { autoeditsLogger } from '../logger'
-import type { AutoeditsModelAdapter, ChatPrompt, PromptResponseData } from '../prompt-provider'
+import type { AutoeditsModelAdapter } from '../prompt-provider'
 import { getModelResponse } from '../prompt-provider'
 import type { AutoeditModelOptions } from '../prompt-provider'
-import { type CodeToReplaceData, SYSTEM_PROMPT, getBaseUserPrompt } from '../prompt-utils'
 
 export class CodyGatewayAdapter implements AutoeditsModelAdapter {
-    getPrompt(
-        docContext: DocumentContext,
-        document: vscode.TextDocument,
-        position: vscode.Position,
-        context: AutocompleteContextSnippet[],
-        tokenBudget: AutoEditsTokenLimit
-    ): PromptResponseData {
-        const { codeToReplace, prompt: userPrompt } = getBaseUserPrompt(
-            docContext,
-            document,
-            position,
-            context,
-            tokenBudget
-        )
-        const promptResponse: ChatPrompt = [
-            {
-                role: 'system',
-                content: SYSTEM_PROMPT,
-            },
-            {
-                role: 'user',
-                content: userPrompt,
-            },
-        ]
-        return { codeToReplace, promptResponse }
-    }
-
-    postProcessResponse(codeToReplace: CodeToReplaceData, response: string): string {
-        return response
-    }
-
     async getModelResponse(option: AutoeditModelOptions): Promise<string> {
         try {
             const headers = {

--- a/vscode/src/autoedits/adapters/fireworks.ts
+++ b/vscode/src/autoedits/adapters/fireworks.ts
@@ -1,50 +1,9 @@
-import type { AutoEditsTokenLimit } from '@sourcegraph/cody-shared'
-import type * as vscode from 'vscode'
-import type {
-    AutocompleteContextSnippet,
-    DocumentContext,
-} from '../../../../lib/shared/src/completions/types'
 import { autoeditsLogger } from '../logger'
-import type { AutoeditsModelAdapter, ChatPrompt, PromptResponseData } from '../prompt-provider'
+import type { AutoeditsModelAdapter } from '../prompt-provider'
 import { getModelResponse } from '../prompt-provider'
 import type { AutoeditModelOptions } from '../prompt-provider'
-import { type CodeToReplaceData, SYSTEM_PROMPT, getBaseUserPrompt } from '../prompt-utils'
 
 export class FireworksAdapter implements AutoeditsModelAdapter {
-    getPrompt(
-        docContext: DocumentContext,
-        document: vscode.TextDocument,
-        position: vscode.Position,
-        context: AutocompleteContextSnippet[],
-        tokenBudget: AutoEditsTokenLimit
-    ): PromptResponseData {
-        const { codeToReplace, prompt: userPrompt } = getBaseUserPrompt(
-            docContext,
-            document,
-            position,
-            context,
-            tokenBudget
-        )
-        const prompt: ChatPrompt = [
-            {
-                role: 'system',
-                content: SYSTEM_PROMPT,
-            },
-            {
-                role: 'user',
-                content: userPrompt,
-            },
-        ]
-        return {
-            codeToReplace,
-            promptResponse: prompt,
-        }
-    }
-
-    postProcessResponse(codeToReplace: CodeToReplaceData, response: string): string {
-        return response
-    }
-
     async getModelResponse(option: AutoeditModelOptions): Promise<string> {
         try {
             const response = await getModelResponse(

--- a/vscode/src/autoedits/adapters/openai.ts
+++ b/vscode/src/autoedits/adapters/openai.ts
@@ -1,50 +1,9 @@
-import type { AutoEditsTokenLimit } from '@sourcegraph/cody-shared'
-import type * as vscode from 'vscode'
-import type {
-    AutocompleteContextSnippet,
-    DocumentContext,
-} from '../../../../lib/shared/src/completions/types'
 import { autoeditsLogger } from '../logger'
-import type { AutoeditsModelAdapter, ChatPrompt, PromptResponseData } from '../prompt-provider'
+import type { AutoeditsModelAdapter } from '../prompt-provider'
 import { getModelResponse } from '../prompt-provider'
 import type { AutoeditModelOptions } from '../prompt-provider'
-import { type CodeToReplaceData, SYSTEM_PROMPT, getBaseUserPrompt } from '../prompt-utils'
 
 export class OpenAIAdapter implements AutoeditsModelAdapter {
-    getPrompt(
-        docContext: DocumentContext,
-        document: vscode.TextDocument,
-        position: vscode.Position,
-        context: AutocompleteContextSnippet[],
-        tokenBudget: AutoEditsTokenLimit
-    ): PromptResponseData {
-        const { codeToReplace, prompt: userPrompt } = getBaseUserPrompt(
-            docContext,
-            document,
-            position,
-            context,
-            tokenBudget
-        )
-        const prompt: ChatPrompt = [
-            {
-                role: 'system',
-                content: SYSTEM_PROMPT,
-            },
-            {
-                role: 'user',
-                content: userPrompt,
-            },
-        ]
-        return {
-            codeToReplace,
-            promptResponse: prompt,
-        }
-    }
-
-    postProcessResponse(_: CodeToReplaceData, response: string): string {
-        return response
-    }
-
     async getModelResponse(option: AutoeditModelOptions): Promise<string> {
         try {
             const response = await getModelResponse(

--- a/vscode/src/autoedits/adapters/sourcegraph-chat.ts
+++ b/vscode/src/autoedits/adapters/sourcegraph-chat.ts
@@ -1,47 +1,10 @@
-import type { AutoEditsTokenLimit, ChatClient, Message } from '@sourcegraph/cody-shared'
-import type {
-    AutocompleteContextSnippet,
-    DocumentContext,
-} from '@sourcegraph/cody-shared/src/completions/types'
-import type * as vscode from 'vscode'
+import type { ChatClient, Message } from '@sourcegraph/cody-shared'
 import { autoeditsLogger } from '../logger'
-import type { AutoeditsModelAdapter, ChatPrompt, PromptResponseData } from '../prompt-provider'
+import type { AutoeditsModelAdapter, ChatPrompt } from '../prompt-provider'
 import type { AutoeditModelOptions } from '../prompt-provider'
-import { type CodeToReplaceData, SYSTEM_PROMPT, getBaseUserPrompt } from '../prompt-utils'
 
 export class SourcegraphChatAdapter implements AutoeditsModelAdapter {
     constructor(private readonly chatClient: ChatClient) {}
-
-    getPrompt(
-        docContext: DocumentContext,
-        document: vscode.TextDocument,
-        position: vscode.Position,
-        context: AutocompleteContextSnippet[],
-        tokenBudget: AutoEditsTokenLimit
-    ): PromptResponseData {
-        const { codeToReplace, prompt: userPrompt } = getBaseUserPrompt(
-            docContext,
-            document,
-            position,
-            context,
-            tokenBudget
-        )
-        const promptResponse: ChatPrompt = [
-            {
-                role: 'system',
-                content: SYSTEM_PROMPT,
-            },
-            {
-                role: 'user',
-                content: userPrompt,
-            },
-        ]
-        return { codeToReplace, promptResponse }
-    }
-
-    postProcessResponse(codeToReplace: CodeToReplaceData, response: string): string {
-        return response
-    }
 
     async getModelResponse(option: AutoeditModelOptions): Promise<string> {
         try {

--- a/vscode/src/autoedits/prompt-provider.ts
+++ b/vscode/src/autoedits/prompt-provider.ts
@@ -1,9 +1,4 @@
-import type { AutoEditsTokenLimit, PromptString } from '@sourcegraph/cody-shared'
-import type * as vscode from 'vscode'
-import type {
-    AutocompleteContextSnippet,
-    DocumentContext,
-} from '../../../lib/shared/src/completions/types'
+import type { PromptString } from '@sourcegraph/cody-shared'
 import type * as utils from './prompt-utils'
 
 export type ChatPrompt = {
@@ -26,15 +21,7 @@ export interface PromptResponseData {
 }
 
 export interface AutoeditsModelAdapter {
-    getPrompt(
-        docContext: DocumentContext,
-        document: vscode.TextDocument,
-        position: vscode.Position,
-        context: AutocompleteContextSnippet[],
-        tokenBudget: AutoEditsTokenLimit
-    ): PromptResponseData
     getModelResponse(args: AutoeditModelOptions): Promise<string>
-    postProcessResponse(codeToReplace: utils.CodeToReplaceData, completion: string | null): string
 }
 
 export async function getModelResponse(


### PR DESCRIPTION
`getPrompt` implement is same for all the adapters and we are not doing any provider specific processing. Removed the redunant methods.

## Test plan
No functional change.
