### PR TITLE
Measuring node main thread occupancy

### DIFF
--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -104,6 +104,7 @@ import { VSCodeSecretStorage, secretStorage } from './services/SecretStorageProv
 import { registerSidebarCommands } from './services/SidebarCommands'
 import { CodyStatusBar } from './services/StatusBar'
 import { createOrUpdateTelemetryRecorderProvider } from './services/telemetry-v2'
+import { ThreadOccupancyMonitor } from './services/thread-occupancy-monitor'
 import {
     enableVerboseDebugMode,
     exportOutputLog,
@@ -113,7 +114,6 @@ import { openCodyIssueReporter } from './services/utils/issue-reporter'
 import { SupercompletionProvider } from './supercompletions/supercompletion-provider'
 import { parseAllVisibleDocuments, updateParseTreeOnEdit } from './tree-sitter/parse-tree-cache'
 import { version } from './version'
-import { ThreadOccupancyMonitor } from './services/thread-occupancy-monitor'
 
 /**
  * Start the extension, watching all relevant configuration and secrets for changes.
@@ -124,11 +124,9 @@ export async function start(
 ): Promise<vscode.Disposable> {
     const disposables: vscode.Disposable[] = []
 
-    // Initialize thread monitoring
     const threadMonitor = new ThreadOccupancyMonitor()
     threadMonitor.start()
 
-    // Add to disposables to clean up on extension deactivation
     disposables.push(new vscode.Disposable(() => threadMonitor.stop()))
 
     //TODO: Add override flag

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -113,6 +113,7 @@ import { openCodyIssueReporter } from './services/utils/issue-reporter'
 import { SupercompletionProvider } from './supercompletions/supercompletion-provider'
 import { parseAllVisibleDocuments, updateParseTreeOnEdit } from './tree-sitter/parse-tree-cache'
 import { version } from './version'
+import { ThreadOccupancyMonitor } from './services/thread-occupancy-monitor'
 
 /**
  * Start the extension, watching all relevant configuration and secrets for changes.
@@ -122,6 +123,13 @@ export async function start(
     platform: PlatformContext
 ): Promise<vscode.Disposable> {
     const disposables: vscode.Disposable[] = []
+
+    // Initialize thread monitoring
+    const threadMonitor = new ThreadOccupancyMonitor()
+    threadMonitor.start()
+
+    // Add to disposables to clean up on extension deactivation
+    disposables.push(new vscode.Disposable(() => threadMonitor.stop()))
 
     //TODO: Add override flag
     const isExtensionModeDevOrTest =

--- a/vscode/src/services/thread-occupancy-monitor.ts
+++ b/vscode/src/services/thread-occupancy-monitor.ts
@@ -1,0 +1,63 @@
+import { telemetryRecorder } from '@sourcegraph/cody-shared'
+
+export class ThreadOccupancyMonitor {
+    private lastMeasurement: number = performance.now()
+    private measurements: number[] = []
+    private measurementInterval: NodeJS.Timeout | null = null
+
+    // Sample interval in ms (e.g. every 1 minute)
+    private readonly SAMPLE_INTERVAL = 60_000
+    // How many samples to keep for rolling average
+    private readonly SAMPLE_WINDOW = 6
+
+    start(): void {
+        if (this.measurementInterval) {
+            return
+        }
+
+        this.measurementInterval = setInterval(() => {
+            this.measure()
+        }, this.SAMPLE_INTERVAL)
+    }
+
+    stop(): void {
+        if (this.measurementInterval) {
+            clearInterval(this.measurementInterval)
+            this.measurementInterval = null
+        }
+    }
+
+    private measure(): void {
+        const now = performance.now()
+        const elapsed = now - this.lastMeasurement
+        this.lastMeasurement = now
+
+        // Get CPU usage for the main thread
+        const cpuUsage = process.cpuUsage()
+        const userCPUMs = cpuUsage.user / 1000 // Convert to ms
+        const systemCPUMs = cpuUsage.system / 1000
+
+        // Calculate occupancy as percentage
+        const occupancy = ((userCPUMs + systemCPUMs) / elapsed) * 100
+
+        // Keep rolling window of measurements
+        this.measurements.push(occupancy)
+        if (this.measurements.length > this.SAMPLE_WINDOW) {
+            this.measurements.shift()
+        }
+
+        // Emit telemetry with the current measurement
+        this.emitTelemetry(occupancy)
+    }
+
+    private emitTelemetry(occupancy: number): void {
+        telemetryRecorder.recordEvent('cody.performance', 'threadOccupancy', {
+            metadata: {
+                occupancyPercent: Math.round(occupancy),
+                rollingAveragePercent: Math.round(
+                    this.measurements.reduce((a, b) => a + b, 0) / this.measurements.length
+                )
+            }
+        })
+    }
+}

--- a/vscode/src/services/thread-occupancy-monitor.ts
+++ b/vscode/src/services/thread-occupancy-monitor.ts
@@ -46,7 +46,6 @@ export class ThreadOccupancyMonitor {
             this.measurements.shift()
         }
 
-        // Emit telemetry with the current measurement
         this.emitTelemetry(occupancy)
     }
 
@@ -56,8 +55,8 @@ export class ThreadOccupancyMonitor {
                 occupancyPercent: Math.round(occupancy),
                 rollingAveragePercent: Math.round(
                     this.measurements.reduce((a, b) => a + b, 0) / this.measurements.length
-                )
-            }
+                ),
+            },
         })
     }
 }


### PR DESCRIPTION
[Linear Issue
](https://linear.app/sourcegraph/issue/CODY-4148/orthogonal-performance-and-quality-metrics-for-cody-extension)

This pull request introduces a new feature to monitor the Node.js main thread occupancy within the VSCode extension. The feature aims to provide insights into the extension's performance by measuring CPU usage and emitting telemetry data.

Key Changes
- ThreadOccupancyMonitor Class: A new class is added to measure the main thread's CPU usage at regular intervals. It calculates the occupancy percentage and maintains a rolling average.  The ThreadOccupancyMonitor is initialized and started during the extension's activation process. It is also properly disposed of during deactivation to ensure clean resource management.


- Proactive Alerts: Potential to set up alerts based on occupancy data to detect and address performance issues proactively.



## Test plan
Tested in the Cody DEbugger that runs locally or you can use console.log to see the output of this
NOTE: This stuff is fairly straightforward so I assume I don't need any unit testing for this etc. 

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
