### PR TITLE
Fix prompt execution in existing chat

### DIFF
--- a/vscode/webviews/chat/ChatMessageContent/ChatMessageContent.tsx
+++ b/vscode/webviews/chat/ChatMessageContent/ChatMessageContent.tsx
@@ -76,6 +76,8 @@ export const ChatMessageContent: React.FunctionComponent<ChatMessageContentProps
     }, [smartApply])
 
     useClientActionListener(
+        // Always subscribe but listen only smart apply result events
+        { isActive: true, selector: event => !!event.smartApplyResult },
         useCallback<ClientActionListener>(({ smartApplyResult }) => {
             if (smartApplyResult) {
                 setSmartApplyStates(prev => ({

--- a/vscode/webviews/chat/cells/messageCell/human/editor/HumanMessageEditor.tsx
+++ b/vscode/webviews/chat/cells/messageCell/human/editor/HumanMessageEditor.tsx
@@ -284,6 +284,9 @@ export const HumanMessageEditor: FunctionComponent<{
 
     // Set up the message listener so the extension can control the input field.
     useClientActionListener(
+        // Add new context to chat from the "Cody Add Selection to Cody Chat"
+        // command, etc. Only add to the last human input field.
+        { isActive: !isSent },
         useCallback<ClientActionListener>(
             ({
                 editorState,
@@ -293,12 +296,6 @@ export const HumanMessageEditor: FunctionComponent<{
                 setLastHumanInputIntent,
                 setPromptAsInput,
             }) => {
-                // Add new context to chat from the "Cody Add Selection to Cody Chat"
-                // command, etc. Only add to the last human input field.
-                if (isSent) {
-                    return
-                }
-
                 const updates: Promise<unknown>[] = []
 
                 if (addContextItemsToLastHumanInput && addContextItemsToLastHumanInput.length > 0) {
@@ -384,13 +381,7 @@ export const HumanMessageEditor: FunctionComponent<{
                     )
                 }
             },
-            [
-                isSent,
-                onSubmitClick,
-                submitIntent,
-                extensionAPI.hydratePromptMessage,
-                extensionAPI.defaultContext,
-            ]
+            [onSubmitClick, submitIntent, extensionAPI.hydratePromptMessage, extensionAPI.defaultContext]
         )
     )
 

--- a/vscode/webviews/prompts/PromptsTab.tsx
+++ b/vscode/webviews/prompts/PromptsTab.tsx
@@ -84,6 +84,10 @@ export function useActionSelect() {
                 )
                 break
             }
+
+            // Deprecated commands handler, starting with sg 5.10 and vscode 1.46 we
+            // should never reach this case branch (since commands were replaces with prompts)
+            // TODO (vk): Remove this when backward compatible commands support is sunset
             case 'command': {
                 if (action.slashCommand) {
                     getVSCodeAPI().postMessage({

--- a/web/CHANGELOG.md
+++ b/web/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.15.0
+- Fixes problem with not working prompts when chat has some sent messages 
+
 ## 0.14.0
 - Add prompts analytics over built-in prompts
 

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sourcegraph/cody-web",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "description": "Cody standalone web app",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
Fixes: https://linear.app/sourcegraph/issue/QA-186/jetbrains-new-session-is-not-generated-when-user-run-any-prompt-from

## Problem 

Prior to this PR, if a chat had some sent messages, you couldn't run prompts (selecting prompts does nothing). You had to create a new chat first and then run some prompts. 

## Running prompts in new chat or reusing existing chat
When we had commands, each command ran a new chat and emitted the command's output to this newly created chat. However, prompts should try to reuse existing chat (otherwise, we will bloat out our history panel since we are tracking all prompts' execution now).
    
Also, on a technical note, running prompts in a new chat requires a big refactoring in how we work with the postMessage API. Currently, it's not possible to properly await commands execution, which is essential for running prompts in a new chat. (User selects prompt, then we create a new chat from the client, and only then we run prompt setting but only after new chat was created), the last step is problematic at the moment.

## Solution 

I modified action buffer logic for the client dispatcher "stream" API, so now only the last human text editor will read the event about the prompt setting.    

_(Video demonstrates that prompts works after you've submitted some message already, also shows that prompts with auto submit setting also works, like standard prompts like explain code)_

https://github.com/user-attachments/assets/8cba534a-5be3-4668-bc19-a457c78e0f64

## Test plan
- Check that you can execute the prompt from the prompts tab after you have sent some messages in chat already.

