### PR TITLE
Add separate command to run cody web in standalone mode

### DIFF
--- a/web/lib/agent/agent.client.ts
+++ b/web/lib/agent/agent.client.ts
@@ -66,7 +66,7 @@ export async function createAgentClient({
 
     // Initialize
     const serverInfo: ServerInfo = await rpc.sendRequest('initialize', {
-        name: process.env.CODY_WEB_DEMO ? 'standalone-web' : 'web',
+        name: process.env.CODY_WEB_DEMO_STANDALONE_MODE === 'true' ? 'standalone-web' : 'web',
         version: '0.0.1',
         // Empty root URI leads to openctx configuration resolution failure, any non-empty
         // mock value (Cody Web doesn't really use any workspace related features)
@@ -82,7 +82,9 @@ export async function createAgentClient({
             accessToken,
             serverEndpoint,
             telemetryClientName,
-            customHeaders: customHeaders ?? {},
+            customHeaders: {
+                ...(customHeaders ?? {}),
+            },
             customConfiguration: {
                 'cody.autocomplete.enabled': false,
                 'cody.experimental.urlContext': true,

--- a/web/package.json
+++ b/web/package.json
@@ -14,6 +14,7 @@
   "files": ["dist/*"],
   "scripts": {
     "dev": "vite --mode development",
+    "dev:standalone": "CODY_WEB_DEMO_STANDALONE_MODE=true vite --mode development",
     "build": "vite build --mode production && tsc --build",
     "test": "vitest",
     "build-ts": "tsc --build"

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -11,7 +11,6 @@ const fakeProcessEnv: Record<string, string | boolean> = {
     CODY_TESTING: false,
     CODY_PROFILE_TEMP: false,
     CODY_TELEMETRY_EXPORTER: 'graphql',
-    CODY_WEB_DEMO: process.env.NODE_ENV === 'development',
     NODE_ENV: 'production',
     NODE_DEBUG: false,
     CODY_OVERRIDE_DOTCOM_URL: 'https://sourcegraph.com',
@@ -19,6 +18,8 @@ const fakeProcessEnv: Record<string, string | boolean> = {
     LSP_LIGHT_LOGGING_ENABLED: false,
     LSP_LIGHT_CACHE_DISABLED: false,
     language: 'en-US',
+    CODY_WEB_DEMO: true,
+    CODY_WEB_DEMO_STANDALONE_MODE: process.env.CODY_WEB_DEMO_STANDALONE_MODE,
 }
 
 export default defineProjectWithDefaults(__dirname, {


### PR DESCRIPTION
Prior to this PR cody web demo was running in standalone mode by default, this confused me a few times already because the standalone mode doesn't match cody web mode (the one we run eventually in production) 100% accurate. 

This PR adds clear separation between the two modes, now by default we run cody web mode and if you want to use standalone for some reason you can run `pnpm dev:standalone` in the web directory

## Test plan
- Check new pnpm command
