### PR TITLE
Update tracing for chat

### DIFF
--- a/lib/shared/src/telemetry-v2/events/chat-question.ts
+++ b/lib/shared/src/telemetry-v2/events/chat-question.ts
@@ -109,7 +109,6 @@ export const events = [
                 } & SharedProperties,
                 spans: {
                     current: Span
-                    firstToken: Span
                     addMetadata: boolean
                 },
                 tokenCounterUtils: TokenCounterUtils
@@ -131,7 +130,6 @@ export const events = [
                       }
                 if (spans.addMetadata) {
                     spans.current.setAttributes(metadata)
-                    spans.firstToken.setAttributes(metadata)
                 }
 
                 const telemetryData = {

--- a/vscode/src/chat/agentic/DeepCody.ts
+++ b/vscode/src/chat/agentic/DeepCody.ts
@@ -6,6 +6,7 @@ import {
     logDebug,
     ps,
     telemetryRecorder,
+    wrapInActiveSpan,
 } from '@sourcegraph/cody-shared'
 import { CodyChatAgent } from './CodyChatAgent'
 import { CODYAGENT_PROMPTS } from './prompts'
@@ -40,6 +41,16 @@ export class DeepCodyAgent extends CodyChatAgent {
      * @returns The context items retrieved for the current chat.
      */
     public async getContext(
+        span: Span,
+        chatAbortSignal: AbortSignal,
+        maxLoops = 2
+    ): Promise<ContextItem[]> {
+        return wrapInActiveSpan('DeepCody.getContext', () =>
+            this._getContext(span, chatAbortSignal, maxLoops)
+        )
+    }
+
+    private async _getContext(
         span: Span,
         chatAbortSignal: AbortSignal,
         maxLoops = 2

--- a/vscode/src/chat/chat-view/ChatController.test.ts
+++ b/vscode/src/chat/chat-view/ChatController.test.ts
@@ -100,7 +100,7 @@ describe('ChatController', () => {
         mockContextRetriever.retrieveContext.mockResolvedValue([])
 
         // Send the first message in a new chat.
-        await chatController.handleUserMessageSubmission({
+        await chatController.handleUserMessage({
             requestID: '1',
             inputText: PromptString.unsafe_fromUserQuery('Test input'),
             mentions: [],
@@ -176,7 +176,7 @@ describe('ChatController', () => {
                 yield { type: 'complete', text: 'Test reply 2' }
             })() satisfies AsyncGenerator<CompletionGeneratorValue>
         )
-        await chatController.handleUserMessageSubmission({
+        await chatController.handleUserMessage({
             requestID: '2',
             inputText: PromptString.unsafe_fromUserQuery('Test followup'),
             mentions: [],
@@ -313,7 +313,7 @@ describe('ChatController', () => {
         mockContextRetriever.retrieveContext.mockResolvedValue([])
 
         // Send the first message in a new chat.
-        await chatController.handleUserMessageSubmission({
+        await chatController.handleUserMessage({
             requestID: '1',
             inputText: PromptString.unsafe_fromUserQuery('Test input'),
             mentions: [],

--- a/vscode/src/chat/chat-view/ChatsController.ts
+++ b/vscode/src/chat/chat-view/ChatsController.ts
@@ -365,7 +365,7 @@ export class ChatsController implements vscode.Disposable {
         await provider.clearAndRestartSession()
         const abortSignal = provider.startNewSubmitOrEditOperation()
         const editorState = editorStateFromPromptString(text)
-        await provider.handleUserMessageSubmission({
+        await provider.handleUserMessage({
             requestID: uuid.v4(),
             inputText: text,
             mentions: contextItems ?? [],

--- a/vscode/test/integration/single-root/chat.test.ts
+++ b/vscode/test/integration/single-root/chat.test.ts
@@ -32,7 +32,7 @@ suite('Chat', function () {
     test('sends and receives a message', async () => {
         await vscode.commands.executeCommand('cody.chat.newEditorPanel')
         const chatView = await getChatViewProvider()
-        await chatView.handleUserMessageSubmission({
+        await chatView.handleUserMessage({
             requestID: 'test',
             inputText: getPs()`hello from the human`,
             mentions: [],
@@ -51,7 +51,7 @@ suite('Chat', function () {
         await getTextEditorWithSelection()
         await vscode.commands.executeCommand('cody.chat.newEditorPanel')
         const chatView = await getChatViewProvider()
-        await chatView.handleUserMessageSubmission({
+        await chatView.handleUserMessage({
             requestID: 'test',
             inputText: getPs()`hello from the human`,
             mentions: [],


### PR DESCRIPTION
Make the following changes to tracing for chat:
    
- Removes the span tracking time-to-first-token. This didn't really make sense to track as a separate span, since all it did was track the time from the start of the chat handler to the first token emitted. This is better tracked as an event on the root span.
- Add a span that tracks the duration of the LLM response (and records an event for the first token)
- Add spans for other preprocessing actions, such as prompt construction and context fetching.

*Reviewer note:*: the warnings about invocations of `unsafe_` are due to removing the `startSpan` call corresponding to the "firstToken" span, which led to a big dedent in `ChatController.ts`.

## Test plan

No behavior changes, verify locally.

Code is best reviewed with `?w=1`