### PR TITLE
Adding the context computation time span to the chat trace

### DIFF
--- a/vscode/src/chat/chat-view/ChatController.ts
+++ b/vscode/src/chat/chat-view/ChatController.ts
@@ -755,13 +755,16 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
         // forgot to set the source, assume it's from the user.
         mentions = mentions.map(m => (m.source ? m : { ...m, source: ContextItemSource.User }))
 
-        const contextAlternatives = await this.computeContext(
-            { text: inputText, mentions },
-            requestID,
-            editorState,
-            span,
-            signal
-        )
+        const contextAlternatives = await wrapInActiveSpan('chat.computeContext', () => {
+            return this.computeContext(
+                { text: inputText, mentions },
+                requestID,
+                editorState,
+                span,
+                signal
+            )
+        })
+
         signal.throwIfAborted()
         const corpusContext = contextAlternatives[0].items
 


### PR DESCRIPTION
Title says it all

I am adding this because its a very expensive call and raise the time to first token by a lot. 

## Test plan
Tested it in Jaegar

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
