### PR TITLE
feat(audoedit): fix dupicate suggestion text

### DIFF
--- a/vscode/src/autoedits/renderer/decorators/base.ts
+++ b/vscode/src/autoedits/renderer/decorators/base.ts
@@ -42,6 +42,8 @@ export interface AddedLineInfo {
     type: 'added'
     text: string
     modifiedLineNumber: number
+    /** signifies if this part of the prediction is rendered by the inline completion item provider */
+    usedAsInlineCompletion?: boolean
 }
 
 export interface RemovedLineInfo {
@@ -71,6 +73,8 @@ export type LineChange = {
     /** `range` in the modified text relative to the document start */
     range: vscode.Range
     text: string
+    /** signifies if this part of the prediction is rendered by the inline completion item provider */
+    usedAsInlineCompletion?: boolean
 }
 
 export interface DecorationInfo {

--- a/vscode/src/autoedits/renderer/decorators/inline-diff-decorator.ts
+++ b/vscode/src/autoedits/renderer/decorators/inline-diff-decorator.ts
@@ -26,7 +26,8 @@ export class InlineDiffDecorator implements vscode.Disposable, AutoEditsDecorato
             let currentInsertPosition: vscode.Position | null = null
             let currentInsertText = ''
 
-            for (const change of line.changes) {
+            // Ignore line changes rendered as an inline completion item ghost text.
+            for (const change of line.changes.filter(c => !c.usedAsInlineCompletion)) {
                 if (change.type === 'insert') {
                     const position = change.range.end
                     if (currentInsertPosition && position.isEqual(currentInsertPosition)) {

--- a/vscode/src/autoedits/renderer/inline-manager.test.ts
+++ b/vscode/src/autoedits/renderer/inline-manager.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from 'vitest'
+
+import { getCompletionText } from './inline-manager'
+
+import { documentAndPosition } from '../../completions/test-helpers'
+import { getDecorationInfo } from './diff-utils'
+
+function getCompletionTextFromStrings(currentFileText: string, predictedFileText: string) {
+    const { position } = documentAndPosition(currentFileText)
+    const decorationInfo = getDecorationInfo(currentFileText.replace('█', ''), predictedFileText)
+
+    const completionText = getCompletionText({
+        prediction: predictedFileText,
+        cursorPosition: position,
+        decorationInfo,
+    })
+
+    return completionText
+}
+
+describe('getCompletionText', () => {
+    it('includes inserted text after the cursor on the same line', () => {
+        const currentFileText = 'const a = █'
+        const predictedFileText = 'const a = 1;'
+
+        const completionText = getCompletionTextFromStrings(currentFileText, predictedFileText)
+        expect(completionText).toBe('1;')
+    })
+
+    it('includes added lines following cursor position', () => {
+        const currentFileText = 'const a = 1;█'
+        const predictedFileText = 'const a = 1;\nconst b = 2;'
+
+        const completionText = getCompletionTextFromStrings(currentFileText, predictedFileText)
+        expect(completionText).toBe('\nconst b = 2;')
+    })
+
+    it('includes inserted text in modified line after cursor position', () => {
+        const currentFileText = 'console.log("Hello, █");'
+        const predictedFileText = 'console.log("Hello, world!");'
+
+        const completionText = getCompletionTextFromStrings(currentFileText, predictedFileText)
+        expect(completionText).toBe('world!");')
+    })
+
+    it('includes added lines inside function body after cursor', () => {
+        const currentFileText = 'function test() {█\n}'
+        const predictedFileText = 'function test() {\n  console.log("hello");\n}'
+
+        const completionText = getCompletionTextFromStrings(currentFileText, predictedFileText)
+        expect(completionText).toBe('\n  console.log("hello");')
+    })
+
+    it('excludes deleted lines from completion text', () => {
+        const currentFileText = 'const a = 1;\nconst b = 2;const c = 3;█'
+        const predictedFileText = 'const a = 1;\nconst c = 3;'
+
+        const completionText = getCompletionTextFromStrings(currentFileText, predictedFileText)
+        expect(completionText).toBe('')
+    })
+
+    it('handles empty prediction', () => {
+        const currentFileText = '█'
+        const predictedFileText = ''
+
+        const completionText = getCompletionTextFromStrings(currentFileText, predictedFileText)
+        expect(completionText).toBe('')
+    })
+
+    it('handles mixed insertions, deletions and new line additions', () => {
+        const currentFileText = 'top 10█px left 10px fixed'
+        const predictedFileText = "top: '10px',\n left: '10px',\n position: 'fixed',"
+
+        const completionText = getCompletionTextFromStrings(currentFileText, predictedFileText)
+        expect(completionText).toBe("px left: '10px fixed',\n left: '10px',\n position: 'fixed',")
+    })
+
+    it('handles multi-line insertion after cursor position', () => {
+        const currentFileText = 'function test() {█\n}'
+        const predictedFileText = 'function test() {\n  const a = 1;\n  const b = 2;\n}'
+
+        const completionText = getCompletionTextFromStrings(currentFileText, predictedFileText)
+        expect(completionText).toBe('\n  const a = 1;\n  const b = 2;')
+    })
+
+    it('handles modified lines with only insertions on empty lines after cursor', () => {
+        const currentFileText = 'line1█\nline3'
+        const predictedFileText = 'line1\nline2\nline3'
+
+        const completionText = getCompletionTextFromStrings(currentFileText, predictedFileText)
+        expect(completionText).toBe('\nline2')
+    })
+
+    it('handles disjoint new lines after the cursor', () => {
+        const currentFileText = 'function test() {█\n}'
+        const predictedFileText = 'function test() {\n  const a = 1;\n\n  const b = 2;\n}'
+
+        const completionText = getCompletionTextFromStrings(currentFileText, predictedFileText)
+        expect(completionText).toBe('\n  const a = 1;\n\n  const b = 2;')
+    })
+})

--- a/vscode/src/autoedits/utils.test.ts
+++ b/vscode/src/autoedits/utils.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest'
+
 import * as utils from './utils'
 
 describe('fixFirstLineIndentation', () => {


### PR DESCRIPTION
- Fixes an issue where the first line of a multiline autoedit suggestion gets rendered twice; once by the inline completion provider's ghost text and again by the inline decorations.  
- Improves the logic that tracks which parts of the autoedit should be included in the inline completion item, ensuring they're marked as used by the inline completion provider and excluded from the line decoration renderer.  
- Part of [CODY-4412: Implement experimental inline renderer](https://linear.app/sourcegraph/issue/CODY-4412/implement-experimental-inline-renderer)
- Closes [CODY-4414: Inline-renderer: support suggested new lines](https://linear.app/sourcegraph/issue/CODY-4414/inline-renderer-support-suggested-new-lines)
- Built on top of https://github.com/sourcegraph/cody/pull/6214

## Test plan

- CI
- Added new unit tests to cover the updated logic.
- Manually tested using the [cody-chat-eval](https://linear.app/sourcegraph/issue/CODY-eval) testing examples:
    - Add `"cody.experimental.autoedits.inline-renderer": true,` to your `settings.json` to enable the experimental renderer.
    - `code-matching-eval/edits_experiments/examples/renderer-testing-examples`. Request suggestions from the server at the places where an autoedit is expected and observe that it's rendered somewhat correctly. 