### PR TITLE
fix(agent): Client-managed secrets bug

### DIFF
--- a/agent/src/AgentSecretStorage.test.ts
+++ b/agent/src/AgentSecretStorage.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import * as vscode from 'vscode'
+import { AgentClientManagedSecretStorage } from './AgentSecretStorage'
+import type { MessageHandler } from './jsonrpc-alias'
+
+describe('AgentClientManagedSecretStorage', () => {
+    let secretStorage: AgentClientManagedSecretStorage
+    let mockAgent: { request: ReturnType<typeof vi.fn> }
+    let mockEventEmitter: vscode.EventEmitter<vscode.SecretStorageChangeEvent>
+
+    beforeEach(() => {
+        mockAgent = {
+            request: vi.fn(),
+        }
+        mockEventEmitter = new vscode.EventEmitter<vscode.SecretStorageChangeEvent>()
+        secretStorage = new AgentClientManagedSecretStorage(
+            mockAgent as unknown as MessageHandler,
+            mockEventEmitter
+        )
+    })
+
+    afterEach(() => {
+        vi.clearAllMocks()
+    })
+
+    describe('get', () => {
+        it('returns undefined when agent returns null', async () => {
+            mockAgent.request.mockResolvedValueOnce(null)
+            const result = await secretStorage.get('test-key')
+            expect(result).toBeUndefined()
+            expect(mockAgent.request).toHaveBeenCalledWith('secrets/get', { key: 'test-key' })
+        })
+
+        it('returns value when agent returns a value', async () => {
+            mockAgent.request.mockResolvedValueOnce('secret-value')
+            const result = await secretStorage.get('test-key')
+            expect(result).toBe('secret-value')
+            expect(mockAgent.request).toHaveBeenCalledWith('secrets/get', { key: 'test-key' })
+        })
+    })
+
+    describe('store', () => {
+        it('stores value and fires change event', async () => {
+            const fireSpy = vi.spyOn(mockEventEmitter, 'fire')
+            await secretStorage.store('test-key', 'test-value')
+            expect(mockAgent.request).toHaveBeenCalledWith('secrets/store', {
+                key: 'test-key',
+                value: 'test-value',
+            })
+            expect(fireSpy).toHaveBeenCalledWith({ key: 'test-key' })
+        })
+
+        it('handles empty string value', async () => {
+            const fireSpy = vi.spyOn(mockEventEmitter, 'fire')
+            await secretStorage.store('test-key', '')
+            expect(mockAgent.request).toHaveBeenCalledWith('secrets/store', {
+                key: 'test-key',
+                value: '',
+            })
+            expect(fireSpy).toHaveBeenCalledWith({ key: 'test-key' })
+        })
+    })
+
+    describe('delete', () => {
+        it('deletes value and fires change event', async () => {
+            const fireSpy = vi.spyOn(mockEventEmitter, 'fire')
+            await secretStorage.delete('test-key')
+            expect(mockAgent.request).toHaveBeenCalledWith('secrets/delete', { key: 'test-key' })
+            expect(fireSpy).toHaveBeenCalledWith({ key: 'test-key' })
+        })
+    })
+})

--- a/agent/src/AgentSecretStorage.ts
+++ b/agent/src/AgentSecretStorage.ts
@@ -33,18 +33,27 @@ export class AgentStatelessSecretStorage implements vscode.SecretStorage {
 }
 
 export class AgentClientManagedSecretStorage implements vscode.SecretStorage {
+    onDidChange: vscode.Event<vscode.SecretStorageChangeEvent>
+
     constructor(
         private readonly agent: MessageHandler,
-        public readonly onDidChange: vscode.Event<vscode.SecretStorageChangeEvent>
-    ) {}
+        public readonly onDidChangeEvent: vscode.EventEmitter<vscode.SecretStorageChangeEvent>
+    ) {
+        this.onDidChange = onDidChangeEvent.event
+    }
+
     public async get(key: string): Promise<string | undefined> {
         const result = await this.agent.request('secrets/get', { key })
         return result ?? undefined
     }
+
     public async store(key: string, value: string): Promise<void> {
         await this.agent.request('secrets/store', { key, value })
+        this.onDidChangeEvent.fire({ key })
     }
+
     public async delete(key: string): Promise<void> {
         await this.agent.request('secrets/delete', { key })
+        this.onDidChangeEvent.fire({ key })
     }
 }

--- a/agent/src/agent.ts
+++ b/agent/src/agent.ts
@@ -439,7 +439,7 @@ export class Agent extends MessageHandler implements ExtensionClient {
             try {
                 const secrets =
                     clientInfo.capabilities?.secrets === 'client-managed'
-                        ? new AgentClientManagedSecretStorage(this, this.secretsDidChange.event)
+                        ? new AgentClientManagedSecretStorage(this, this.secretsDidChange)
                         : new AgentStatelessSecretStorage({
                               [formatURL(clientInfo.extensionConfiguration?.serverEndpoint ?? '') ?? '']:
                                   clientInfo.extensionConfiguration?.accessToken ?? undefined,


### PR DESCRIPTION
There is a bug in the current auth flow for client managed secrets. This bug only affects Eclipse because it is the only extension using the `client-managed` secrets capability. The issue is simply that the `AgentClientManagedSecretStorage` did not fire the VSCode event when the secret was updated, which caused the extension to use a cached stale value for `AuthCredentials`.

## Test plan
Added unit tests.

## Changelog
Fixes a bug in the Eclipse plugin where the extension could become unresponsive.