### PR TITLE
fix detecting the fireworks model

### DIFF
--- a/lib/shared/src/chat/chat.ts
+++ b/lib/shared/src/chat/chat.ts
@@ -45,9 +45,10 @@ export class ChatClient {
         const useApiV1 = versions.codyAPIVersion >= 1 && params.model?.includes('claude-3')
         const isLastMessageFromHuman = messages.length > 0 && messages.at(-1)!.speaker === 'human'
 
-        const isFireworks = params?.model?.startsWith('fireworks/')
+        const isFireworks =
+            params?.model?.startsWith('fireworks/') || params?.model?.startsWith('fireworks::')
         const augmentedMessages =
-            params?.model?.startsWith('fireworks/') || useApiV1
+            isFireworks || useApiV1
                 ? sanitizeMessages(messages)
                 : isLastMessageFromHuman
                   ? messages.concat([{ speaker: 'assistant' }])


### PR DESCRIPTION
## Context
With the introduction of new model configuration, the model identifiers start with `provider::`. For fireworks, this would be `fireworks::version::model_name`. This leads to missing a check when using chat completions from sourcegraph instance to fireworks, which always leads to appending the `assistant` message.
This leads to very bad quality for the fireworks auto-edit models which shouldn't have this token.
The PR corrects the condition to detect the fireworks model.

## Test plan
Green CI
