### PR TITLE
Deep Cody: loading message for context fetching step

### DIFF
--- a/vscode/src/chat/agentic/CodyChatMemory.ts
+++ b/vscode/src/chat/agentic/CodyChatMemory.ts
@@ -48,9 +48,9 @@ export class CodyChatMemory {
             ? {
                   type: 'file',
                   content: Array.from(CodyChatMemory.Store).join('\n'),
-                  uri: URI.file('MEMORY'),
+                  uri: URI.file('Cody Memory'),
                   source: ContextItemSource.Agentic,
-                  title: 'Chat Memory',
+                  title: 'Cody Chat Memory',
               }
             : undefined
     }

--- a/vscode/src/prompt-builder/index.ts
+++ b/vscode/src/prompt-builder/index.ts
@@ -181,7 +181,11 @@ export class PromptBuilder {
             this.contextItems = getUniqueContextItems(this.contextItems)
         }
 
-        result.added = this.contextItems.filter(c => result.added.includes(c))
+        // Remove the Cody Chat Memory from showing up in the context list.
+        // TODO: Remove this once the Cody Chat Memory is out of experimental.
+        result.added = this.contextItems.filter(
+            c => result.added.includes(c) && c.title !== 'Cody Chat Memory'
+        )
         return result
     }
 }

--- a/vscode/webviews/chat/cells/contextCell/ContextCell.tsx
+++ b/vscode/webviews/chat/cells/contextCell/ContextCell.tsx
@@ -212,7 +212,7 @@ export const ContextCell: FunctionComponent<{
                                     <div className="tw-flex tw-items-center tw-rounded-md tw-bg-muted-transparent tw-p-4">
                                         <LoadingDots />
                                         <div className="tw-ml-4">
-                                            May take a few seconds to fetch relevannt context to improve
+                                            May take a few seconds to fetch relevant context to improve
                                             response quality
                                         </div>
                                     </div>

--- a/vscode/webviews/chat/cells/contextCell/ContextCell.tsx
+++ b/vscode/webviews/chat/cells/contextCell/ContextCell.tsx
@@ -208,7 +208,17 @@ export const ContextCell: FunctionComponent<{
                             data-testid="context"
                         >
                             {isContextLoading ? (
-                                <LoadingDots />
+                                isDeepCodyEnabled ? (
+                                    <div className="tw-flex tw-align-middle tw-rounded-md tw-bg-muted-transparent tw-p-4">
+                                        <LoadingDots />
+                                        <div className="tw-ml-4">
+                                            May take a few seconds to fetch relevannt context to improve
+                                            response quality
+                                        </div>
+                                    </div>
+                                ) : (
+                                    <LoadingDots />
+                                )
                             ) : (
                                 <>
                                     <AccordionContent overflow={showSnippets}>

--- a/vscode/webviews/chat/cells/contextCell/ContextCell.tsx
+++ b/vscode/webviews/chat/cells/contextCell/ContextCell.tsx
@@ -209,7 +209,7 @@ export const ContextCell: FunctionComponent<{
                         >
                             {isContextLoading ? (
                                 isDeepCodyEnabled ? (
-                                    <div className="tw-flex tw-align-middle tw-rounded-md tw-bg-muted-transparent tw-p-4">
+                                    <div className="tw-flex tw-items-center tw-rounded-md tw-bg-muted-transparent tw-p-4">
                                         <LoadingDots />
                                         <div className="tw-ml-4">
                                             May take a few seconds to fetch relevannt context to improve

--- a/vscode/webviews/chat/cells/contextCell/ContextCell.tsx
+++ b/vscode/webviews/chat/cells/contextCell/ContextCell.tsx
@@ -211,7 +211,7 @@ export const ContextCell: FunctionComponent<{
                                 isDeepCodyEnabled ? (
                                     <div className="tw-flex tw-items-center tw-rounded-md tw-bg-muted-transparent tw-p-4">
                                         <LoadingDots />
-                                        <div className="tw-ml-4">
+                                        <div className="tw-ml-4 tw-text-sm">
                                             May take a few seconds to fetch relevant context to improve
                                             response quality
                                         </div>

--- a/vscode/webviews/components/shadcn/ui/accordion.tsx
+++ b/vscode/webviews/components/shadcn/ui/accordion.tsx
@@ -28,9 +28,14 @@ const AccordionTrigger = React.forwardRef<
             {...props}
         >
             {children}
-            <ChevronRight
-                className={cn('tw-h-8 tw-w-8 tw-text-muted-foreground', styles.accordionTriggerChevron)}
-            />
+            {!props.disabled && (
+                <ChevronRight
+                    className={cn(
+                        'tw-h-8 tw-w-8 tw-text-muted-foreground',
+                        styles.accordionTriggerChevron
+                    )}
+                />
+            )}
         </AccordionPrimitive.Trigger>
     </AccordionPrimitive.Header>
 ))


### PR DESCRIPTION
Part of https://linear.app/sourcegraph/issue/CODY-4282/implement-ui

This PR adds a new loading message for Deep Cody during the context fetch as shown in [figma](https://www.figma.com/design/f078wFMKsIOaEwj7Iwj5xy/Unified-Cody?node-id=7560-12708&node-type=canvas&t=eABWAYKAZQhp2lCP-0):

![image](https://github.com/user-attachments/assets/9d468550-de58-4fff-936b-d91796dce25a)

Will be continued in [bee/deep-cody-flow-ui](https://github.com/sourcegraph/cody/compare/bee/deep-cody-flow-ui?expand=1).

## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

1. Enable Deep Cody
2. Ask Deep Cody a question
3. Confirm the new loading message is showing up during the context fetching step

![image](https://github.com/user-attachments/assets/b403767b-2435-4c81-b608-7a76eafe35c1)

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
