### PR TITLE
Webviews: add new CTA for Sourcegraph Teams

### DIFF
--- a/lib/shared/src/experimentation/FeatureFlagProvider.ts
+++ b/lib/shared/src/experimentation/FeatureFlagProvider.ts
@@ -102,6 +102,11 @@ export enum FeatureFlag {
 
     /** Enable Shell Context for Deep Cody */
     DeepCodyShellContext = 'deep-cody-shell-context',
+
+    /**
+     * Whether the user will see the CTA about upgrading to Sourcegraph Teams
+     */
+    SourcegraphTeamsUpgradeCTA = 'teams-upgrade-available-cta',
 }
 
 const ONE_HOUR = 60 * 60 * 1000

--- a/vscode/webviews/CodyPanel.tsx
+++ b/vscode/webviews/CodyPanel.tsx
@@ -20,6 +20,7 @@ import { StateDebugOverlay } from './components/StateDebugOverlay'
 import { TabContainer, TabRoot } from './components/shadcn/ui/tabs'
 import { AccountTab, HistoryTab, PromptsTab, SettingsTab, TabsBar, View } from './tabs'
 import type { VSCodeWrapper } from './utils/VSCodeApi'
+import { useUserAccountInfo } from './utils/useConfig'
 import { useFeatureFlag } from './utils/useFeatureFlags'
 import { TabViewContext } from './utils/useTabView'
 
@@ -69,10 +70,12 @@ export const CodyPanel: FunctionComponent<CodyPanelProps> = ({
 }) => {
     const tabContainerRef = useRef<HTMLDivElement>(null)
 
+    const user = useUserAccountInfo()
     const externalAPI = useExternalAPI()
     const api = useExtensionAPI()
     const { value: chatModels } = useObservable(useMemo(() => api.chatModels(), [api.chatModels]))
     const isPromptsV2Enabled = useFeatureFlag(FeatureFlag.CodyPromptsV2)
+    const isTeamsUpgradeCtaEnabled = useFeatureFlag(FeatureFlag.SourcegraphTeamsUpgradeCTA)
 
     useEffect(() => {
         onExternalApiReady?.(externalAPI)
@@ -102,7 +105,7 @@ export const CodyPanel: FunctionComponent<CodyPanelProps> = ({
                 orientation="vertical"
                 className={styles.outerContainer}
             >
-                <Notices />
+                <Notices user={user} isTeamsUpgradeCtaEnabled={isTeamsUpgradeCtaEnabled} />
                 {/* Hide tab bar in editor chat panels. */}
                 {(clientCapabilities.agentIDE === CodyIDE.Web || config.webviewType !== 'editor') && (
                     <TabsBar currentView={view} setView={setView} IDE={clientCapabilities.agentIDE} />

--- a/vscode/webviews/CodyPanel.tsx
+++ b/vscode/webviews/CodyPanel.tsx
@@ -102,12 +102,12 @@ export const CodyPanel: FunctionComponent<CodyPanelProps> = ({
                 orientation="vertical"
                 className={styles.outerContainer}
             >
+                <Notices />
                 {/* Hide tab bar in editor chat panels. */}
                 {(clientCapabilities.agentIDE === CodyIDE.Web || config.webviewType !== 'editor') && (
                     <TabsBar currentView={view} setView={setView} IDE={clientCapabilities.agentIDE} />
                 )}
                 {errorMessages && <ErrorBanner errors={errorMessages} setErrors={setErrorMessages} />}
-                <Notices />
                 <TabContainer value={view} ref={tabContainerRef}>
                     {view === View.Chat && (
                         <Chat

--- a/vscode/webviews/components/Notices.story.tsx
+++ b/vscode/webviews/components/Notices.story.tsx
@@ -1,0 +1,75 @@
+import { CodyIDE } from '@sourcegraph/cody-shared'
+import type { Meta, StoryObj } from '@storybook/react'
+import { Notices } from './Notices'
+
+const meta: Meta<typeof Notices> = {
+    title: 'cody/Notices',
+    component: Notices,
+    parameters: {
+        layout: 'centered',
+    },
+}
+
+export default meta
+
+type Story = StoryObj<typeof Notices>
+
+// Mock user data
+const baseUser = {
+    isDotComUser: true,
+    isCodyProUser: false,
+    user: {
+        id: 'user-1',
+        username: 'test-user',
+        displayName: 'Test User',
+        avatarURL: '',
+        organizations: [],
+        endpoint: 'https://example.com',
+    },
+    IDE: CodyIDE.VSCode,
+}
+
+export const TeamsUpgradeCTA: Story = {
+    args: {
+        user: baseUser,
+        isTeamsUpgradeCtaEnabled: true,
+    },
+}
+
+export const SgTeammateNotice: Story = {
+    args: {
+        user: {
+            ...baseUser,
+            user: {
+                ...baseUser.user,
+                organizations: [
+                    {
+                        name: 'sourcegraph',
+                        id: 'sourcegraph-01',
+                    },
+                ],
+            },
+        },
+        isTeamsUpgradeCtaEnabled: false,
+    },
+}
+
+export const NoNotices: Story = {
+    args: {
+        user: {
+            ...baseUser,
+            isDotComUser: false,
+        },
+        isTeamsUpgradeCtaEnabled: false,
+    },
+}
+
+export const WebUserNoNotices: Story = {
+    args: {
+        user: {
+            ...baseUser,
+            IDE: CodyIDE.Web,
+        },
+        isTeamsUpgradeCtaEnabled: true,
+    },
+}

--- a/vscode/webviews/components/Notices.tsx
+++ b/vscode/webviews/components/Notices.tsx
@@ -53,13 +53,13 @@ export const Notices: React.FC<NoticesProps> = ({ user, isTeamsUpgradeCtaEnabled
                         id="TeamsUpgrade"
                         variant="default"
                         title="Sourcegraph Teams is here"
-                        message="You now are eligible for a upgrade to teams for free"
+                        message="You now are eligible for an upgrade to teams for free"
                         onDismiss={() => dismissNotice('TeamsUpgrade')}
                         actions={[
                             {
                                 // TODO: Update to live link https://linear.app/sourcegraph/issue/CORE-535/cody-clients-migrate-ctas-to-live-links
                                 label: 'Upgrade to Teams',
-                                href: 'https://sourcegraph.com',
+                                href: 'https://sourcegraph.com/cody/manage',
                                 variant: 'default',
                                 icon: <Users2Icon size={14} />,
                                 iconPosition: 'start',

--- a/vscode/webviews/components/Notices.tsx
+++ b/vscode/webviews/components/Notices.tsx
@@ -36,7 +36,8 @@ export const Notices: FunctionComponent = () => {
     const notices: Notice[] = useMemo(
         () => [
             /**
-             * TODO: update this to be based on user's subscription status once we have that information.
+             * Notifies users that they are eligible for a free upgrade to Sourcegraph Teams.
+             * TODO: Update to live link https://linear.app/sourcegraph/issue/CORE-535/cody-clients-migrate-ctas-to-live-links
              */
             {
                 id: 'TeamsUpgrade',
@@ -49,12 +50,14 @@ export const Notices: FunctionComponent = () => {
                         message="You now are eligible for a upgrade to teams for free"
                         onDismiss={() => dismissNotice('TeamsUpgrade')}
                         actions={[
-                            { // TODO: Update to live link https://linear.app/sourcegraph/issue/CORE-535/cody-clients-migrate-ctas-to-live-links
+                            {
+                                // TODO: Update to live link https://linear.app/sourcegraph/issue/CORE-535/cody-clients-migrate-ctas-to-live-links
                                 label: 'Upgrade to Teams',
                                 href: 'https://sourcegraph.com',
                                 variant: 'default',
                             },
-                            { // TODO: Update to live link https://linear.app/sourcegraph/issue/CORE-535/cody-clients-migrate-ctas-to-live-links
+                            {
+                                // TODO: Update to live link https://linear.app/sourcegraph/issue/CORE-535/cody-clients-migrate-ctas-to-live-links
                                 label: 'Learn More',
                                 href: 'https://sourcegraph.com/docs',
                                 variant: 'ghost',

--- a/vscode/webviews/components/Notices.tsx
+++ b/vscode/webviews/components/Notices.tsx
@@ -49,12 +49,12 @@ export const Notices: FunctionComponent = () => {
                         message="You now are eligible for a upgrade to teams for free"
                         onDismiss={() => dismissNotice('TeamsUpgrade')}
                         actions={[
-                            {
+                            { // TODO: Update to live link https://linear.app/sourcegraph/issue/CORE-535/cody-clients-migrate-ctas-to-live-links
                                 label: 'Upgrade to Teams',
                                 href: 'https://sourcegraph.com',
                                 variant: 'default',
                             },
-                            {
+                            { // TODO: Update to live link https://linear.app/sourcegraph/issue/CORE-535/cody-clients-migrate-ctas-to-live-links
                                 label: 'Learn More',
                                 href: 'https://sourcegraph.com/docs',
                                 variant: 'ghost',

--- a/vscode/webviews/components/Notices.tsx
+++ b/vscode/webviews/components/Notices.tsx
@@ -6,6 +6,7 @@ import SourcegraphIcon from '../../resources/sourcegraph-mark.svg'
 import { CodyLogo } from '../icons/CodyLogo'
 import { getVSCodeAPI } from '../utils/VSCodeApi'
 import { useUserAccountInfo } from '../utils/useConfig'
+import { useSourcegraphTeamsUpgradeCtaFlag } from '../utils/useExperimentalFeature'
 import { Button } from './shadcn/ui/button'
 
 interface Notice {
@@ -20,8 +21,11 @@ type NoticeIDs = 'DogfoodS2' | 'TeamsUpgrade'
 export const Notices: FunctionComponent = () => {
     const user = useUserAccountInfo()
     const isDotComUser = isDotCom(user.user.endpoint)
-    const isSourcegraphTeamMember = user.user.organizations?.some(org => org.name === 'sourcegraph')
+    const isSourcegraphOrgMember = user.user.organizations?.some(org => org.name === 'sourcegraph')
     const isCodyWeb = user.IDE === CodyIDE.Web
+
+    // Whether to show the Sourcegraph Teams upgrade CTA or not.
+    const isTeamsUpgradeCtaEnabled = useSourcegraphTeamsUpgradeCtaFlag()
 
     const [dismissedNotices, setDismissedNotices] = useState<Set<string>>(new Set())
 
@@ -36,7 +40,7 @@ export const Notices: FunctionComponent = () => {
              */
             {
                 id: 'TeamsUpgrade',
-                isVisible: true,
+                isVisible: isDotComUser && isTeamsUpgradeCtaEnabled && !isCodyWeb,
                 content: (
                     <NoticeContent
                         id="TeamsUpgrade"
@@ -64,7 +68,7 @@ export const Notices: FunctionComponent = () => {
              */
             {
                 id: 'DogfoodS2',
-                isVisible: isDotComUser && isSourcegraphTeamMember && !isCodyWeb,
+                isVisible: isDotComUser && isSourcegraphOrgMember && !isCodyWeb,
                 content: (
                     <NoticeContent
                         id="DogfoodS2"
@@ -93,7 +97,7 @@ export const Notices: FunctionComponent = () => {
                 ),
             },
         ],
-        [dismissNotice, isDotComUser, isSourcegraphTeamMember, isCodyWeb]
+        [dismissNotice, isDotComUser, isSourcegraphOrgMember, isCodyWeb, isTeamsUpgradeCtaEnabled]
     )
 
     const activeNotice = useMemo(

--- a/vscode/webviews/components/Notices.tsx
+++ b/vscode/webviews/components/Notices.tsx
@@ -1,7 +1,16 @@
 import { CodyIDE, isDotCom } from '@sourcegraph/cody-shared'
 import { S2_URL } from '@sourcegraph/cody-shared/src/sourcegraph-api/environments'
-import { ArrowRightIcon, BuildingIcon, EyeIcon, HeartIcon, XIcon } from 'lucide-react'
-import { type FunctionComponent, useCallback, useMemo, useState } from 'react'
+import {
+    ArrowLeftRightIcon,
+    ArrowRightIcon,
+    BuildingIcon,
+    ExternalLinkIcon,
+    EyeIcon,
+    HeartIcon,
+    Users2Icon,
+    XIcon,
+} from 'lucide-react'
+import { type FunctionComponent, type ReactNode, useCallback, useMemo, useState } from 'react'
 import SourcegraphIcon from '../../resources/sourcegraph-mark.svg'
 import { CodyLogo } from '../icons/CodyLogo'
 import { getVSCodeAPI } from '../utils/VSCodeApi'
@@ -55,12 +64,16 @@ export const Notices: FunctionComponent = () => {
                                 label: 'Upgrade to Teams',
                                 href: 'https://sourcegraph.com',
                                 variant: 'default',
+                                icon: <Users2Icon size={14} />,
+                                iconPosition: 'start',
                             },
                             {
                                 // TODO: Update to live link https://linear.app/sourcegraph/issue/CORE-535/cody-clients-migrate-ctas-to-live-links
                                 label: 'Learn More',
                                 href: 'https://sourcegraph.com/docs',
                                 variant: 'ghost',
+                                icon: <ExternalLinkIcon size={14} />,
+                                iconPosition: 'end',
                             },
                         ]}
                     />
@@ -89,6 +102,8 @@ export const Notices: FunctionComponent = () => {
                                         endpoint: S2_URL.href,
                                     }),
                                 variant: 'default',
+                                icon: <ArrowLeftRightIcon size={14} />,
+                                iconPosition: 'end',
                             },
                             {
                                 label: 'Dismiss',
@@ -127,6 +142,8 @@ interface NoticeContentProps {
         onClick?: () => void
         href?: string
         variant: 'default' | 'ghost' | 'secondary'
+        icon?: ReactNode
+        iconPosition?: 'start' | 'end'
     }>
     onDismiss: () => void
 }
@@ -155,7 +172,7 @@ const NoticeContent: FunctionComponent<NoticeContentProps> = ({
         TeamsUpgrade: (
             <>
                 <CodyLogo size={16} />
-                <ArrowRightIcon className="tw-h-[16px]" />
+                <ArrowRightIcon size={16} />
                 <img src={SourcegraphIcon} alt="Sourcegraph Logo" className="tw-h-[16px]" />
             </>
         ),
@@ -173,7 +190,9 @@ const NoticeContent: FunctionComponent<NoticeContentProps> = ({
                         variant={action.variant}
                         size="sm"
                         onClick={action.onClick}
+                        className="tw-flex tw-gap-1"
                     >
+                        {action.iconPosition === 'start' && action.icon}
                         {action.href ? (
                             <a
                                 href={action.href}
@@ -186,6 +205,7 @@ const NoticeContent: FunctionComponent<NoticeContentProps> = ({
                         ) : (
                             <span>{action.label}</span>
                         )}
+                        {action.iconPosition === 'end' && action.icon}
                     </Button>
                 ))}
             </div>

--- a/vscode/webviews/utils/useExperimentalFeature.tsx
+++ b/vscode/webviews/utils/useExperimentalFeature.tsx
@@ -1,0 +1,6 @@
+import { FeatureFlag } from '@sourcegraph/cody-shared'
+import { useFeatureFlag } from './useFeatureFlags'
+
+export const useSourcegraphTeamsUpgradeCtaFlag = (): boolean | undefined => {
+    return useFeatureFlag(FeatureFlag.SourcegraphTeamsUpgradeCTA)
+}


### PR DESCRIPTION
CLOSE https://linear.app/sourcegraph/issue/CODY-4458/implement-ui-for-cta-upsell

This change introduces a new Sourcegraph Teams upgrade CTA feature flag and updates the `Notices` component that displays various notices to the user based on their account information and Cody configuration.

The new feature flag `SourcegraphTeamsUpgradeCTA` is used to control the visibility of the Sourcegraph Teams upgrade CTA in the Notices component. The CTA will now only be shown to Sourcegraph.com users when the feature flag is enabled.

The notices can be dismissed per-session, and the component will only display the active notice.

## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

1. Enable the `teams-upgrade-available-cta` feature flag for your account on DotCom and S2
2. Start Cody from this branch
3. Log into DotCom and verify you can see the CTA showing
4. Log into S2 and verify you cannot see the CTA even when the feature flag is enabled
5. Remove the feature flags from your accounts
6. Repeat step 3 and 4 to confirm the CTA are not showing up for you

After: Display the Teams CTA when user is logged in as DotCom user with the feature flag `teams-upgrade-available-cta` enabled

![image](https://github.com/user-attachments/assets/c594c6aa-49d5-42dc-bc4f-f9b0d786bda8)

After: updated styles based on figma design

![image](https://github.com/user-attachments/assets/500649fe-917f-4cbc-b47c-1a97ab4b5ec7)


Before: Notices component with the current styles

![image](https://github.com/user-attachments/assets/f5919bd8-c146-40ed-b0d0-17f8f4b543b1)


Added storybook for the updated component:

![image](https://github.com/user-attachments/assets/43dd30dc-139f-4a21-83e7-a537b5462c8c)


## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
