### PR TITLE
Adding PerformanceObserver for long task and animation frame

### DIFF
--- a/vscode/webviews/App.tsx
+++ b/vscode/webviews/App.tsx
@@ -163,6 +163,33 @@ export const App: React.FunctionComponent<{ vscodeAPI: VSCodeWrapper }> = ({ vsc
         [vscodeAPI, telemetryRecorder, config]
     )
 
+    useEffect(() => {
+        const longTaskObserver = new PerformanceObserver((list) => {
+            list.getEntries().forEach((entry) => {
+                console.log('Long Task detected:', entry)
+                telemetryRecorder.recordEvent('cody.webview.longTask', 'longTask')
+                console.log("recorded long task")
+            })
+        })
+
+        longTaskObserver.observe({ entryTypes: ['longtask'] });
+
+        const loafObserver = new PerformanceObserver((list) => {
+            list.getEntries().forEach((entry) => {
+                console.log('Long Animation Frame detected:', entry)
+                telemetryRecorder.recordEvent('cody.webview.longAnimationFrame', 'longAnimationFrame')
+                console.log(("recorded long animation frame")
+            })
+        })
+
+        loafObserver.observe({ entryTypes: ['frame'] });
+
+        return () => {
+            longTaskObserver.disconnect();
+            loafObserver.disconnect();
+        };
+    }, []);
+
     // Wait for all the data to be loaded before rendering Chat View
     if (!view || !config) {
         return <LoadingPage />


### PR DESCRIPTION
This PR is a part of the[ linear issue](https://linear.app/sourcegraph/issue/CODY-4148/orthogonal-performance-and-quality-metrics-for-cody-extension) and @dominiccooney recommend this [here](https://sourcegraph.slack.com/archives/C07RUS5NPRQ/p1733188358073349?thread_ts=1732086943.611219&cid=C07RUS5NPRQ)


## Test plan
Add the following right below the current additions 


```
   setTimeout(() => {
            const start = performance.now();
            while (performance.now() - start < 100) {
                // Simulate a long task by blocking the main thread for 100ms
            }
            console.log('Fake long task executed');
        }, 1000);

        // Fake long animation frame
        requestAnimationFrame(() => {
            const start = performance.now();
            while (performance.now() - start < 100) {
                // Simulate a long animation frame by blocking the main thread for 100ms
            }
            console.log('Fake long animation frame executed');
        });
```
Run the code in debugger and in the console log you will see 
<img width="430" alt="image" src="https://github.com/user-attachments/assets/9737f3cb-da16-4bda-94c8-55c826e52f16">



## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
