### PR TITLE
fix(deep-cody): wildcard should not be ignored in allow list for shell context

### DIFF
--- a/vscode/src/commands/context/shell.ts
+++ b/vscode/src/commands/context/shell.ts
@@ -39,7 +39,7 @@ export async function getContextFileFromShell(command: string): Promise<ContextI
         const filteredCommand = command.replaceAll(/(\s~\/)/g, ` ${HOME_DIR}${path.sep}`)
 
         // Process user config list
-        const allowList = new Set(userShellConfig?.allow ?? [])
+        const allowList = new Set(userShellConfig?.allow?.filter(cmd => cmd !== '*') ?? [])
         const blockList = new Set([...BASE_DISALLOWED_COMMANDS, ...(userShellConfig?.block ?? [])])
 
         try {


### PR DESCRIPTION
Follow up on https://github.com/sourcegraph/cody/pull/6255

- Exclude the wildcard (`*`) from the shell command allow list when processing the user configuration.
- This ensures that the allow list is properly filtered and only allows specific commands, instead of allowing all commands by default.


## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

Ask Deep Cody "what's my git config user name?"

This config should allow Deep Cody to run any shell commands and use it as chat context:

```json
	"cody.agentic.context": {
		"shell": {
			"allow": [
				"*"
			],
		}
	}
```

This config should block Deep Cody to run the `git` shell commands:

```json
	"cody.agentic.context": {
		"shell": {
			"allow": [
				"*"
			],
			"block": [
				"git"
			]
		}
	}
```


## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
