### PR TITLE
chore/release: Update CHANGELOG for VSCode 1.48.0

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -12,6 +12,50 @@ This is a log of all notable changes to Cody for VS Code.
 
 ### Uncategorized
 
+## 1.48.0
+
+### Added
+- Add account switcher component in the Accounts webview tab  [pull/6159](https://github.com/sourcegraph/cody/pulls/6159)
+- Prompts Picker  [pull/6160](https://github.com/sourcegraph/cody/pulls/6160)
+- Add Sourcegraph CLI installation description to README.md  [pull/6170](https://github.com/sourcegraph/cody/pulls/6170)
+- Fetch standard prompts from remote prompts API  [pull/6150](https://github.com/sourcegraph/cody/pulls/6150)
+
+#### Autoedits
+- feat(autoedit): combine inline completion provider and selection change  [pull/6147](https://github.com/sourcegraph/cody/pulls/6147)
+- feat(autoedit): use code completion feature for auto edits  [pull/6161](https://github.com/sourcegraph/cody/pulls/6161)
+- add 10 sec diff for autoedit experiments  [pull/6191](https://github.com/sourcegraph/cody/pulls/6191)
+- adding line level diff strategy for the recent edits diff calculation  [pull/6188](https://github.com/sourcegraph/cody/pulls/6188)
+- Hitesh/add diff stratagies  [pull/6190](https://github.com/sourcegraph/cody/pulls/6190)
+- Hitesh/add diff strategies logging  [pull/6189](https://github.com/sourcegraph/cody/pulls/6189)
+
+### Fixed
+- [Backport vscode-v1.48.x] Make signout as non-blocking as possible  [pull/6213](https://github.com/sourcegraph/cody/pulls/6213)
+- do not block chat panel initialization or human message handling on current session save  [pull/6186](https://github.com/sourcegraph/cody/pulls/6186)
+- patch highlight.js to address memory leak  [pull/6146](https://github.com/sourcegraph/cody/pulls/6146)
+- fix(api): Set API identifying headers on all HTTP requests (CODY-4209)  [pull/6102](https://github.com/sourcegraph/cody/pulls/6102)
+#### Autoedits
+- feat(autoedit): fix cursor jumping issue  [pull/6156](https://github.com/sourcegraph/cody/pulls/6156)
+- fix(autoedit): fix suffix matching logic  [pull/6171](https://github.com/sourcegraph/cody/pulls/6171)
+- fix(audoedit): fix the scrollbar issue  [pull/6158](https://github.com/sourcegraph/cody/pulls/6158)
+- fix added lines sorting in autoedits  [pull/6155](https://github.com/sourcegraph/cody/pulls/6155)
+
+### Changed
+- Add default value for 'search.useIgnoreFiles' in agent config  [pull/6202](https://github.com/sourcegraph/cody/pulls/6202)
+- Deep Cody: Move shell context behind feature flag  [pull/6199](https://github.com/sourcegraph/cody/pulls/6199)
+- Add built-in prompts related fields to prompt select analytic event  [pull/6180](https://github.com/sourcegraph/cody/pulls/6180)
+#### Autoedits
+- feat(autoedit): restrict autoedit to vscode  [pull/6184](https://github.com/sourcegraph/cody/pulls/6184)
+- chore(audoedit): test diff logic with different new line chars  [pull/6176](https://github.com/sourcegraph/cody/pulls/6176)
+- chore(audoedit): simplify diff utils and renderer data structures  [pull/6172](https://github.com/sourcegraph/cody/pulls/6172)
+- feat(autoedit): refactor renderer code to simplify iteration on decor…  [pull/6163](https://github.com/sourcegraph/cody/pulls/6163)
+
+### Build & Test
+- [Backport vscode-v1.48.x] remove last line in backport GHA  [pull/6205](https://github.com/sourcegraph/cody/pulls/6205)
+- remove last line in backport GHA  [pull/6204](https://github.com/sourcegraph/cody/pulls/6204)
+- add changelog templating and tooling  [pull/6195](https://github.com/sourcegraph/cody/pulls/6195)
+- Bench: make sure to respect CODY_RECORDING_MODE  [pull/6167](https://github.com/sourcegraph/cody/pulls/6167)
+- Revert "Update backport.yml (#6137)"  [pull/6164](https://github.com/sourcegraph/cody/pulls/6164)
+
 ## [1.46.0]
 
 ### Added

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -3,7 +3,7 @@
   "name": "cody-ai",
   "private": true,
   "displayName": "Cody: AI Coding Assistant with Autocomplete & Chat",
-  "version": "1.46.0",
+  "version": "1.48.0",
   "publisher": "sourcegraph",
   "license": "Apache-2.0",
   "icon": "resources/cody.png",


### PR DESCRIPTION
## Test plan

Docs only change + version bump.

## Changelog

chore/release: Prepare changelog for VSCode v1.48.0