### PR TITLE
fix/accounts: Do not sign out when removing an unrelated account

### DIFF
--- a/vscode/src/auth/auth.ts
+++ b/vscode/src/auth/auth.ts
@@ -385,7 +385,7 @@ export async function signOut(endpoint: string): Promise<void> {
 
     await Promise.all([secretStorage.deleteToken(endpoint), localStorage.deleteEndpoint(endpoint)])
 
-    authProvider.signout()
+    authProvider.signout(endpoint)
 }
 
 /**

--- a/vscode/src/chat/chat-view/ChatController.ts
+++ b/vscode/src/chat/chat-view/ChatController.ts
@@ -477,6 +477,9 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
                     } else {
                         await showSignOutMenu()
                     }
+                    // Send config to refresh the endpoint history list.
+                    // TODO: Remove this when the config for webview is observable, see getConfigForWebview.
+                    await this.sendConfig(currentAuthStatus())
                     break
                 }
                 if (message.authKind === 'switch') {

--- a/vscode/src/services/AuthProvider.ts
+++ b/vscode/src/services/AuthProvider.ts
@@ -45,6 +45,7 @@ class AuthProvider implements vscode.Disposable {
      */
     private lastValidatedAndStoredCredentials =
         new Subject<ResolvedConfigurationCredentialsOnly | null>()
+    private lastEndpoint: string | undefined
 
     private hasAuthed = false
 
@@ -113,6 +114,7 @@ class AuthProvider implements vscode.Disposable {
         this.subscriptions.push(
             authStatus.subscribe(authStatus => {
                 try {
+                    this.lastEndpoint = authStatus.endpoint
                     vscode.commands.executeCommand(
                         'setContext',
                         'cody.activated',
@@ -167,7 +169,10 @@ class AuthProvider implements vscode.Disposable {
         this.refreshRequests.next()
     }
 
-    public signout(): void {
+    public signout(endpoint: String): void {
+        if (this.lastEndpoint !== endpoint) {
+            return
+        }
         this.lastValidatedAndStoredCredentials.next(null)
         this.status.next({
             authenticated: false,

--- a/vscode/src/services/AuthProvider.ts
+++ b/vscode/src/services/AuthProvider.ts
@@ -169,7 +169,7 @@ class AuthProvider implements vscode.Disposable {
         this.refreshRequests.next()
     }
 
-    public signout(endpoint: String): void {
+    public signout(endpoint: string): void {
         if (this.lastEndpoint !== endpoint) {
             return
         }

--- a/vscode/webviews/components/AccountSwitcher.tsx
+++ b/vscode/webviews/components/AccountSwitcher.tsx
@@ -28,7 +28,7 @@ export const AccountSwitcher: React.FC<AccountSwitcherProps> = ({
     setLoading,
 }) => {
     type PopoverView = 'switch' | 'remove' | 'add'
-    const [getPopoverView, serPopoverView] = useState<PopoverView>('switch')
+    const [getPopoverView, setPopoverView] = useState<PopoverView>('switch')
     const [isOpen, setIsOpen] = useState(false)
 
     const [endpointToRemove, setEndpointToRemove] = useState<string | null>(null)
@@ -47,7 +47,7 @@ export const AccountSwitcher: React.FC<AccountSwitcherProps> = ({
         setIsOpen(open)
         if (!open) {
             setEndpointToRemove(null)
-            serPopoverView('switch')
+            setPopoverView('switch')
             setAddFormData(() => ({
                 endpoint: 'https://',
                 accessToken: '',
@@ -79,7 +79,7 @@ export const AccountSwitcher: React.FC<AccountSwitcherProps> = ({
                 variant="ghost"
                 onClick={() => {
                     setEndpointToRemove(endpoint)
-                    serPopoverView('remove')
+                    setPopoverView('remove')
                 }}
             >
                 <CircleMinus size={16} />
@@ -102,7 +102,7 @@ export const AccountSwitcher: React.FC<AccountSwitcherProps> = ({
                 key={'add-account'}
                 variant="ghost"
                 onClick={() => {
-                    serPopoverView('add')
+                    setPopoverView('add')
                 }}
             >
                 <Plus size={16} />


### PR DESCRIPTION
Fixes QA-194.

## Test plan

Manual test:
- Sign in to JetBrains with two accounts.
- Switch to the Accounts tab, Switch Accounts and remove the second account.
- Verify that you stay signed in on the accounts tab, and the second account is gone from the account switcher.

## Changelog

fix/accounts: Removing a second account does not dump you back at the login screen.