### PR TITLE
fix line level aggregation logic for recent edits

### DIFF
--- a/vscode/src/completions/context/retrievers/recent-user-actions/recent-edits-diff-helpers/helper.ts
+++ b/vscode/src/completions/context/retrievers/recent-user-actions/recent-edits-diff-helpers/helper.ts
@@ -10,16 +10,18 @@ export function getTextDocumentChangesForText(text: string): {
 } {
     const { originalText, changeEvents } = parseTextAndGenerateChangeEvents(text)
     const documentChanges: TextDocumentChange[] = []
+    let currentTimeStamp = Date.now()
     for (const change of changeEvents) {
         const insertedRange = new vscode.Range(
             change.range.start,
             getPositionAfterTextInsertion(change.range.start, change.text)
         )
         documentChanges.push({
-            timestamp: Date.now(),
+            timestamp: currentTimeStamp,
             change: change,
             insertedRange,
         })
+        currentTimeStamp += 1
     }
     return { originalText, changes: documentChanges }
 }

--- a/vscode/src/completions/context/retrievers/recent-user-actions/recent-edits-diff-helpers/two-stage-unified-diff.test.ts
+++ b/vscode/src/completions/context/retrievers/recent-user-actions/recent-edits-diff-helpers/two-stage-unified-diff.test.ts
@@ -13,8 +13,10 @@ const processComputedDiff = (text: string): string => {
 describe('TwoStageUnifiedDiffStrategy', () => {
     const getTextDocumentChanges = (text: string) => {
         const { originalText, changes } = getTextDocumentChangesForText(text)
-        // Advance the time to simulate Date.now() at a later time compared to when the changes were made
-        vi.advanceTimersByTime(1)
+        const changesMaxTimestamp =
+            changes.length === 0 ? Date.now() : Math.max(...changes.map(change => change.timestamp))
+        vi.setSystemTime(changesMaxTimestamp + 1)
+
         return {
             originalText,
             changes,
@@ -30,6 +32,7 @@ describe('TwoStageUnifiedDiffStrategy', () => {
 
     beforeEach(() => {
         vi.useFakeTimers()
+        vi.setSystemTime(Date.now())
     })
 
     it('handles multiple changes across different lines', () => {

--- a/vscode/src/completions/context/retrievers/recent-user-actions/recent-edits-diff-helpers/utils.test.ts
+++ b/vscode/src/completions/context/retrievers/recent-user-actions/recent-edits-diff-helpers/utils.test.ts
@@ -65,6 +65,30 @@ describe('groupChangesForLines', () => {
         `)
     })
 
+    it('should create only a single change if made at the same timestamp', () => {
+        const text = dedent`
+            <D>let</D><I>const</I> x = 5;
+            <D>var</D><I>let</I> y = 10;
+            console.log(<D>x +</D><I>x *</I> y);
+        `
+        let { originalText, changes } = getTextDocumentChangesForText(text)
+        // Override the timestamp to use the same time for all changes
+        changes = changes.map(change => ({ ...change, timestamp: Date.now() }))
+
+        const result = groupOverlappingDocumentChanges(changes)
+        expect(result.length).toBe(1)
+        const diffs = getDiffsForContentChanges(originalText, result)
+        expect(processComputedDiff(diffs[0])).toMatchInlineSnapshot(`
+        "-let x = 5;
+        -var y = 10;
+        -console.log(x + y);
+        +const x = 5;
+        +let y = 10;
+        +console.log(x * y);
+        "
+        `)
+    })
+
     it('handles interleaved insertions and deletions', () => {
         const text = dedent`
             <D>let</D><I>const</I> x = 5;

--- a/vscode/src/completions/context/retrievers/recent-user-actions/recent-edits-diff-helpers/utils.ts
+++ b/vscode/src/completions/context/retrievers/recent-user-actions/recent-edits-diff-helpers/utils.ts
@@ -31,6 +31,12 @@ export interface TextDocumentChangeGroup {
     replacementRange?: vscode.Range
 }
 
+interface TextDocumentChangeWithRange {
+    change: TextDocumentChange
+    insertedRange: vscode.Range
+    replacementRange: vscode.Range
+}
+
 /**
  * Groups consecutive text document changes together based on line overlap.
  * This function helps create more meaningful diffs by combining related changes that occur on overlapping lines.
@@ -44,15 +50,35 @@ export interface TextDocumentChangeGroup {
 export function groupOverlappingDocumentChanges(
     documentChanges: TextDocumentChange[]
 ): TextDocumentChangeGroup[] {
+    const textDocumentChangesWithRanges = documentChanges.map(change =>
+        getTextDocumentWithRanges(change)
+    )
+
+    const mergePredicate = (
+        lastItem: TextDocumentChangeWithRange,
+        currentItem: TextDocumentChangeWithRange
+    ) => {
+        const doLinesOverlap = doLineOverlapForRanges(
+            lastItem.insertedRange,
+            currentItem.replacementRange
+        )
+        const doTimeOverlap = lastItem.change.timestamp === currentItem.change.timestamp
+        return doLinesOverlap || doTimeOverlap
+    }
+
     return mergeDocumentChanges({
-        items: documentChanges.map(change => ({
-            insertedRange: change.insertedRange,
-            replacementRange: change.change.range,
-            originalChange: change,
-        })),
-        mergePredicate: (a, b) => Boolean(a && b && doLineOverlapForRanges(a, b)),
-        getChanges: item => [item.originalChange],
+        items: textDocumentChangesWithRanges,
+        mergePredicate,
+        getChanges: item => [item.change],
     })
+}
+
+function getTextDocumentWithRanges(change: TextDocumentChange): TextDocumentChangeWithRange {
+    return {
+        change,
+        insertedRange: change.insertedRange,
+        replacementRange: change.change.range,
+    }
 }
 
 /**
@@ -70,9 +96,16 @@ export function groupOverlappingDocumentChanges(
 export function groupNonOverlappingChangeGroups(
     groupedChanges: TextDocumentChangeGroup[]
 ): TextDocumentChangeGroup[] {
+    const mergePredicate = (lastItem: TextDocumentChangeGroup, currentItem: TextDocumentChangeGroup) => {
+        if (!lastItem.insertedRange || !currentItem.replacementRange) {
+            return false
+        }
+        return !doLineOverlapForRanges(lastItem.insertedRange, currentItem.replacementRange)
+    }
+
     return mergeDocumentChanges({
         items: groupedChanges,
-        mergePredicate: (a, b) => Boolean(a && b && !doLineOverlapForRanges(a, b)),
+        mergePredicate,
         getChanges: group => group.changes,
     })
 }
@@ -89,7 +122,7 @@ function mergeDocumentChanges<
     T extends { insertedRange?: vscode.Range; replacementRange?: vscode.Range },
 >(args: {
     items: T[]
-    mergePredicate: (a?: vscode.Range, b?: vscode.Range) => boolean
+    mergePredicate: (a: T, b: T) => boolean
     getChanges: (item: T) => TextDocumentChange[]
 }): TextDocumentChangeGroup[] {
     if (args.items.length === 0) {
@@ -97,7 +130,7 @@ function mergeDocumentChanges<
     }
 
     const mergedGroups = groupConsecutiveItemsByPredicate(args.items, (lastItem, currentItem) => {
-        return args.mergePredicate(lastItem.insertedRange, currentItem.replacementRange)
+        return args.mergePredicate(lastItem, currentItem)
     })
 
     return mergedGroups

--- a/vscode/src/completions/context/retrievers/recent-user-actions/recent-edits-diff-helpers/utils.ts
+++ b/vscode/src/completions/context/retrievers/recent-user-actions/recent-edits-diff-helpers/utils.ts
@@ -50,10 +50,6 @@ interface TextDocumentChangeWithRange {
 export function groupOverlappingDocumentChanges(
     documentChanges: TextDocumentChange[]
 ): TextDocumentChangeGroup[] {
-    const textDocumentChangesWithRanges = documentChanges.map(change =>
-        getTextDocumentWithRanges(change)
-    )
-
     const mergePredicate = (
         lastItem: TextDocumentChangeWithRange,
         currentItem: TextDocumentChangeWithRange
@@ -67,18 +63,14 @@ export function groupOverlappingDocumentChanges(
     }
 
     return mergeDocumentChanges({
-        items: textDocumentChangesWithRanges,
+        items: documentChanges.map(change => ({
+            change,
+            insertedRange: change.insertedRange,
+            replacementRange: change.change.range,
+        })),
         mergePredicate,
         getChanges: item => [item.change],
     })
-}
-
-function getTextDocumentWithRanges(change: TextDocumentChange): TextDocumentChangeWithRange {
-    return {
-        change,
-        insertedRange: change.insertedRange,
-        replacementRange: change.change.range,
-    }
 }
 
 /**


### PR DESCRIPTION
## Context
We aggregate the changes which are made on the same lines together for recent edits diff calculation. However, if we replace the text block in the vscode editor, the vscode editor create seperate events for each line even though the change is a single replacement. In the PR we group the changes to if the timestamps are same 2 different change even if they are added on different lines.

## Test plan
Added test cases
