### PR TITLE
feat(onebox): Use new prompt editor when onebox is enabled

### DIFF
--- a/lib/shared/src/experimentation/FeatureFlagProvider.ts
+++ b/lib/shared/src/experimentation/FeatureFlagProvider.ts
@@ -78,6 +78,8 @@ export enum FeatureFlag {
     CodyExperimentalOneBox = 'cody-experimental-one-box',
     /** Enable debug mode for One Box feature in Cody */
     CodyExperimentalOneBoxDebug = 'cody-experimental-one-box-debug',
+    /** Enable use of new prosemirror prompt editor */
+    CodyExperimentalPromptEditor = 'cody-experimental-prompt-editor',
 
     /** Show Edit Code option in the Cody message submit dropdown */
     CodyExperimentalShowEditCodeIntent = 'cody-experimental-show-edit-code-intent',

--- a/vscode/webviews/AppWrapperForTest.tsx
+++ b/vscode/webviews/AppWrapperForTest.tsx
@@ -7,6 +7,7 @@ import {
     type ContextItemSymbol,
     EMPTY,
     FILE_CONTEXT_MENTION_PROVIDER,
+    FeatureFlag,
     type ModelsData,
     type ResolvedConfiguration,
     SYMBOL_CONTEXT_MENTION_PROVIDER,
@@ -79,7 +80,15 @@ export const AppWrapperForTest: FunctionComponent<{ children: ReactNode }> = ({ 
                                             ].filter(f => f.uri.path.includes(queryTextLower)),
                             }
                         }),
-                    evaluatedFeatureFlag: _flag => Observable.of(true),
+                    evaluatedFeatureFlag: flag => {
+                        switch (flag) {
+                            case FeatureFlag.CodyExperimentalPromptEditor:
+                                // Do not enable the experimental prompt editor in tests (yet).
+                                return Observable.of(false)
+                            default:
+                                return Observable.of(true)
+                        }
+                    },
                     prompts: makePromptsAPIWithData({
                         prompts: FIXTURE_PROMPTS,
                         commands: FIXTURE_COMMANDS,

--- a/vscode/webviews/chat/cells/messageCell/human/editor/HumanMessageEditor.tsx
+++ b/vscode/webviews/chat/cells/messageCell/human/editor/HumanMessageEditor.tsx
@@ -11,6 +11,7 @@ import {
 } from '@sourcegraph/cody-shared'
 import {
     PromptEditor,
+    PromptEditorV2,
     type PromptEditorRefAPI,
     useDefaultContextForChat,
     useExtensionAPI,
@@ -417,6 +418,7 @@ export const HumanMessageEditor: FunctionComponent<{
         currentChatModel?.contextWindow?.context?.user ||
         currentChatModel?.contextWindow?.input ||
         FAST_CHAT_INPUT_TOKEN_BUDGET
+    const Editor = experimentalOneBoxEnabled ? PromptEditorV2 : PromptEditor
 
     return (
         // biome-ignore lint/a11y/useKeyWithClickEvents: only relevant to click areas
@@ -436,7 +438,7 @@ export const HumanMessageEditor: FunctionComponent<{
             onFocus={onFocus}
             onBlur={onBlur}
         >
-            <PromptEditor
+            <Editor
                 seamless={true}
                 placeholder={placeholder}
                 initialEditorState={initialEditorState}

--- a/vscode/webviews/chat/cells/messageCell/human/editor/HumanMessageEditor.tsx
+++ b/vscode/webviews/chat/cells/messageCell/human/editor/HumanMessageEditor.tsx
@@ -1,6 +1,7 @@
 import {
     type ChatMessage,
     FAST_CHAT_INPUT_TOKEN_BUDGET,
+    FeatureFlag,
     type Model,
     ModelTag,
     type SerializedPromptEditorState,
@@ -11,8 +12,8 @@ import {
 } from '@sourcegraph/cody-shared'
 import {
     PromptEditor,
-    PromptEditorV2,
     type PromptEditorRefAPI,
+    PromptEditorV2,
     useDefaultContextForChat,
     useExtensionAPI,
 } from '@sourcegraph/prompt-editor'
@@ -32,6 +33,7 @@ import { type ClientActionListener, useClientActionListener } from '../../../../
 import { promptModeToIntent } from '../../../../../prompts/PromptsTab'
 import { useTelemetryRecorder } from '../../../../../utils/telemetry'
 import { useExperimentalOneBox } from '../../../../../utils/useExperimentalOneBox'
+import { useFeatureFlag } from '../../../../../utils/useFeatureFlags'
 import styles from './HumanMessageEditor.module.css'
 import type { SubmitButtonState } from './toolbar/SubmitButton'
 import { Toolbar } from './toolbar/Toolbar'
@@ -119,6 +121,7 @@ export const HumanMessageEditor: FunctionComponent<{
           ? 'emptyEditorValue'
           : 'submittable'
 
+    const experimentalPromptEditorEnabled = useFeatureFlag(FeatureFlag.CodyExperimentalPromptEditor)
     const experimentalOneBoxEnabled = useExperimentalOneBox()
     const [submitIntent, setSubmitIntent] = useState<ChatMessage['intent'] | undefined>(
         initialIntent || (experimentalOneBoxEnabled ? undefined : 'chat')
@@ -418,7 +421,7 @@ export const HumanMessageEditor: FunctionComponent<{
         currentChatModel?.contextWindow?.context?.user ||
         currentChatModel?.contextWindow?.input ||
         FAST_CHAT_INPUT_TOKEN_BUDGET
-    const Editor = experimentalOneBoxEnabled ? PromptEditorV2 : PromptEditor
+    const Editor = experimentalPromptEditorEnabled ? PromptEditorV2 : PromptEditor
 
     return (
         // biome-ignore lint/a11y/useKeyWithClickEvents: only relevant to click areas


### PR DESCRIPTION
This updates HumanMessageEditor to use the new prompt editor when onebox is enabled.

## Test plan

Trival code change (also not sure how to test that locally).
