### PR TITLE
Fix Open Telemetry logs when used with agent

### DIFF
--- a/vscode/src/services/open-telemetry/OpenTelemetryService.node.ts
+++ b/vscode/src/services/open-telemetry/OpenTelemetryService.node.ts
@@ -85,7 +85,10 @@ export class OpenTelemetryService {
         )
 
         // Add the console exporter used in development for verbose logging and debugging.
-        if (process.env.NODE_ENV === 'development' || (configuration.debugVerbose && !configuration.isRunningInsideAgent)) {
+        if (
+            process.env.NODE_ENV === 'development' ||
+            (configuration.debugVerbose && !configuration.isRunningInsideAgent)
+        ) {
             this.tracerProvider.addSpanProcessor(new BatchSpanProcessor(new ConsoleBatchSpanExporter()))
         }
 

--- a/vscode/src/services/open-telemetry/OpenTelemetryService.node.ts
+++ b/vscode/src/services/open-telemetry/OpenTelemetryService.node.ts
@@ -85,7 +85,7 @@ export class OpenTelemetryService {
         )
 
         // Add the console exporter used in development for verbose logging and debugging.
-        if (process.env.NODE_ENV === 'development' || configuration.debugVerbose) {
+        if (process.env.NODE_ENV === 'development' || (configuration.debugVerbose && !configuration.isRunningInsideAgent)) {
             this.tracerProvider.addSpanProcessor(new BatchSpanProcessor(new ConsoleBatchSpanExporter()))
         }
 


### PR DESCRIPTION
[Linear issue 
](https://linear.app/sourcegraph/issue/CODY-4494/investigate-excessive-logging-and-span-operation-issues-in-jetbrains)

When verbose debug mode is on, both chat and completions generate overly detailed logs. They include full HTTP request/response payloads and can create a ton of noisy output. By default its turned on in agent so that leads to a lot of log bloat in Agent. 

Turning verbose logging off (or  disabling that when agent is in use) immediately reduces the excessive noise and simplifies the logs significantly in jetbrains and other things that use the agent. 


## Test plan
- Go to Jetbrains 
- Run Jetbrains using 
`CODY_DIR=/path/to/cody  ./gradlew -PforceAgentBuild=true :customRunIde
`
- Do a chat or completion operation and you will NOT see a post request in the log 

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
