### PR TITLE
Double revert the PRs for distributed tracing to finally get them merged into the codebase

### DIFF
--- a/lib/shared/src/prompt/prompt-string.ts
+++ b/lib/shared/src/prompt/prompt-string.ts
@@ -413,6 +413,10 @@ export class PromptString {
                 : undefined,
         }
     }
+    // TODO: Lift the results of the matches so they're also PromptStrings.
+    public match(regexp: RegExp): RegExpMatchArray | null {
+        return internal_toString(this).match(regexp)
+    }
 }
 
 type TemplateArgs = readonly (PromptString | '' | number)[]

--- a/lib/shared/src/tracing/index.ts
+++ b/lib/shared/src/tracing/index.ts
@@ -1,4 +1,11 @@
-import opentelemetry, { SpanStatusCode, context, propagation, type Span } from '@opentelemetry/api'
+import opentelemetry, {
+    type Context,
+    ROOT_CONTEXT,
+    SpanStatusCode,
+    context,
+    propagation,
+    type Span,
+} from '@opentelemetry/api'
 import type { BrowserOrNodeResponse } from '../sourcegraph-api/graphql/client'
 
 const INSTRUMENTATION_SCOPE_NAME = 'cody'
@@ -88,4 +95,20 @@ export function recordErrorToSpan(span: Span, error: Error): Error {
     span.setStatus({ code: SpanStatusCode.ERROR })
     span.end()
     return error
+}
+
+// Extracts a context from a traceparent header for use in a wrapped function
+// that is called with context.with. This is useful for propagating the trace
+// context between webview and extension host.
+export function extractContextFromTraceparent(traceparent?: string | undefined | null): Context {
+    const carrier = { traceparent } as Record<string, any>
+    const getter = {
+        get(carrier: Record<string, any>, key: string) {
+            return carrier[key]
+        },
+        keys(carrier: Record<string, any>) {
+            return Object.keys(carrier)
+        },
+    }
+    return propagation.extract(ROOT_CONTEXT, carrier, getter)
 }

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
   },
   "dependencies": {
     "@openctx/client": "^0.0.30",
+    "@opentelemetry/sdk-trace-web": "^1.18.1",
     "@sourcegraph/telemetry": "^0.18.0",
     "observable-fns": "^0.6.1",
     "react": "18.2.0",
@@ -78,6 +79,7 @@
   },
   "pnpm": {
     "overrides": {
+      "tslib": "2.1.0",
       "@lexical/react": "https://storage.googleapis.com/sourcegraph-assets/npm/lexical-react-sourcegraph-fork-31065486.tgz"
     },
     "packageExtensions": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,6 +9,7 @@ neverBuiltDependencies:
   - playwright
 
 overrides:
+  tslib: 2.1.0
   '@lexical/react': https://storage.googleapis.com/sourcegraph-assets/npm/lexical-react-sourcegraph-fork-31065486.tgz
 
 packageExtensionsChecksum: bc809394d179d8460f9d473fc54e379a
@@ -25,6 +26,9 @@ importers:
       '@openctx/client':
         specifier: ^0.0.30
         version: 0.0.30
+      '@opentelemetry/sdk-trace-web':
+        specifier: ^1.18.1
+        version: 1.18.1(@opentelemetry/api@1.7.0)
       '@sourcegraph/telemetry':
         specifier: ^0.18.0
         version: 0.18.0
@@ -473,13 +477,13 @@ importers:
         version: 1.18.1(@opentelemetry/api@1.7.0)
       '@opentelemetry/sdk-trace-base':
         specifier: ^1.18.1
-        version: 1.18.1(@opentelemetry/api@1.7.0)
+        version: 1.27.0(@opentelemetry/api@1.7.0)
       '@opentelemetry/sdk-trace-node':
         specifier: ^1.18.1
-        version: 1.18.1(@opentelemetry/api@1.7.0)
+        version: 1.27.0(@opentelemetry/api@1.7.0)
       '@opentelemetry/semantic-conventions':
         specifier: ^1.18.1
-        version: 1.18.1
+        version: 1.27.0
       '@radix-ui/react-accordion':
         specifier: ^1.2.0
         version: 1.2.0(@types/react-dom@18.2.25)(@types/react@18.2.79)(react-dom@18.2.0)(react@18.2.0)
@@ -3478,7 +3482,7 @@ packages:
       '@microsoft/fast-element': 1.13.0
       '@microsoft/fast-web-utilities': 5.4.1
       tabbable: 5.3.3
-      tslib: 1.14.1
+      tslib: 2.1.0
     dev: false
 
   /@microsoft/fast-react-wrapper@0.1.48(react@18.2.0):
@@ -3642,11 +3646,11 @@ packages:
     resolution: {integrity: sha512-AdY5wvN0P2vXBi3b29hxZgSFvdhdxPB9+f0B6s//P9Q8nibRWeA3cHm8UmLpio9ABigkVHJ5NMPk+Mz8VCCyrw==}
     engines: {node: '>=8.0.0'}
 
-  /@opentelemetry/context-async-hooks@1.18.1(@opentelemetry/api@1.7.0):
-    resolution: {integrity: sha512-HHfJR32NH2x0b69CACCwH8m1dpNALoCTtpgmIWMNkeMGNUeKT48d4AX4xsF4uIRuUoRTbTgtSBRvS+cF97qwCQ==}
+  /@opentelemetry/context-async-hooks@1.27.0(@opentelemetry/api@1.7.0):
+    resolution: {integrity: sha512-CdZ3qmHCwNhFAzjTgHqrDQ44Qxcpz43cVxZRhOs+Ns/79ug+Mr84Bkb626bkJLkA3+BLimA5YAEVRlJC6pFb7g==}
     engines: {node: '>=14'}
     peerDependencies:
-      '@opentelemetry/api': '>=1.0.0 <1.8.0'
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
     dependencies:
       '@opentelemetry/api': 1.7.0
     dev: false
@@ -3659,6 +3663,16 @@ packages:
     dependencies:
       '@opentelemetry/api': 1.7.0
       '@opentelemetry/semantic-conventions': 1.18.1
+    dev: false
+
+  /@opentelemetry/core@1.27.0(@opentelemetry/api@1.7.0):
+    resolution: {integrity: sha512-yQPKnK5e+76XuiqUH/gKyS8wv/7qITd5ln56QkBTf3uggr0VkXOXfcaAuG330UfdYu83wsyoBwqwxigpIG+Jkg==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+    dependencies:
+      '@opentelemetry/api': 1.7.0
+      '@opentelemetry/semantic-conventions': 1.27.0
     dev: false
 
   /@opentelemetry/exporter-trace-otlp-http@0.45.1(@opentelemetry/api@1.7.0):
@@ -3731,24 +3745,24 @@ packages:
       '@opentelemetry/sdk-trace-base': 1.18.1(@opentelemetry/api@1.7.0)
     dev: false
 
-  /@opentelemetry/propagator-b3@1.18.1(@opentelemetry/api@1.7.0):
-    resolution: {integrity: sha512-oSTUOsnt31JDx5SoEy27B5jE1/tiPvvE46w7CDKj0R5oZhCCfYH2bbSGa7NOOyDXDNqQDkgqU1DIV/xOd3f8pw==}
+  /@opentelemetry/propagator-b3@1.27.0(@opentelemetry/api@1.7.0):
+    resolution: {integrity: sha512-pTsko3gnMioe3FeWcwTQR3omo5C35tYsKKwjgTCTVCgd3EOWL9BZrMfgLBmszrwXABDfUrlAEFN/0W0FfQGynQ==}
     engines: {node: '>=14'}
     peerDependencies:
-      '@opentelemetry/api': '>=1.0.0 <1.8.0'
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
     dependencies:
       '@opentelemetry/api': 1.7.0
-      '@opentelemetry/core': 1.18.1(@opentelemetry/api@1.7.0)
+      '@opentelemetry/core': 1.27.0(@opentelemetry/api@1.7.0)
     dev: false
 
-  /@opentelemetry/propagator-jaeger@1.18.1(@opentelemetry/api@1.7.0):
-    resolution: {integrity: sha512-Kh4M1Qewv0Tbmts6D8LgNzx99IjdE18LCmY/utMkgVyU7Bg31Yuj+X6ZyoIRKPcD2EV4rVkuRI16WVMRuGbhWA==}
+  /@opentelemetry/propagator-jaeger@1.27.0(@opentelemetry/api@1.7.0):
+    resolution: {integrity: sha512-EI1bbK0wn0yIuKlc2Qv2LKBRw6LiUWevrjCF80fn/rlaB+7StAi8Y5s8DBqAYNpY7v1q86+NjU18v7hj2ejU3A==}
     engines: {node: '>=14'}
     peerDependencies:
-      '@opentelemetry/api': '>=1.0.0 <1.8.0'
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
     dependencies:
       '@opentelemetry/api': 1.7.0
-      '@opentelemetry/core': 1.18.1(@opentelemetry/api@1.7.0)
+      '@opentelemetry/core': 1.27.0(@opentelemetry/api@1.7.0)
     dev: false
 
   /@opentelemetry/resources@1.18.1(@opentelemetry/api@1.7.0):
@@ -3760,6 +3774,17 @@ packages:
       '@opentelemetry/api': 1.7.0
       '@opentelemetry/core': 1.18.1(@opentelemetry/api@1.7.0)
       '@opentelemetry/semantic-conventions': 1.18.1
+    dev: false
+
+  /@opentelemetry/resources@1.27.0(@opentelemetry/api@1.7.0):
+    resolution: {integrity: sha512-jOwt2VJ/lUD5BLc+PMNymDrUCpm5PKi1E9oSVYAvz01U/VdndGmrtV3DU1pG4AwlYhJRHbHfOUIlpBeXCPw6QQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+    dependencies:
+      '@opentelemetry/api': 1.7.0
+      '@opentelemetry/core': 1.27.0(@opentelemetry/api@1.7.0)
+      '@opentelemetry/semantic-conventions': 1.27.0
     dev: false
 
   /@opentelemetry/sdk-logs@0.45.1(@opentelemetry/api-logs@0.45.1)(@opentelemetry/api@1.7.0):
@@ -3799,23 +3824,52 @@ packages:
       '@opentelemetry/semantic-conventions': 1.18.1
     dev: false
 
-  /@opentelemetry/sdk-trace-node@1.18.1(@opentelemetry/api@1.7.0):
-    resolution: {integrity: sha512-ML0l9TNlfLoplLF1F8lb95NGKgdm6OezDS3Ymqav9sYxMd5bnH2LZVzd4xEF+ov5vpZJOGdWxJMs2nC9no7+xA==}
+  /@opentelemetry/sdk-trace-base@1.27.0(@opentelemetry/api@1.7.0):
+    resolution: {integrity: sha512-btz6XTQzwsyJjombpeqCX6LhiMQYpzt2pIYNPnw0IPO/3AhT6yjnf8Mnv3ZC2A4eRYOjqrg+bfaXg9XHDRJDWQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+    dependencies:
+      '@opentelemetry/api': 1.7.0
+      '@opentelemetry/core': 1.27.0(@opentelemetry/api@1.7.0)
+      '@opentelemetry/resources': 1.27.0(@opentelemetry/api@1.7.0)
+      '@opentelemetry/semantic-conventions': 1.27.0
+    dev: false
+
+  /@opentelemetry/sdk-trace-node@1.27.0(@opentelemetry/api@1.7.0):
+    resolution: {integrity: sha512-dWZp/dVGdUEfRBjBq2BgNuBlFqHCxyyMc8FsN0NX15X07mxSUO0SZRLyK/fdAVrde8nqFI/FEdMH4rgU9fqJfQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+    dependencies:
+      '@opentelemetry/api': 1.7.0
+      '@opentelemetry/context-async-hooks': 1.27.0(@opentelemetry/api@1.7.0)
+      '@opentelemetry/core': 1.27.0(@opentelemetry/api@1.7.0)
+      '@opentelemetry/propagator-b3': 1.27.0(@opentelemetry/api@1.7.0)
+      '@opentelemetry/propagator-jaeger': 1.27.0(@opentelemetry/api@1.7.0)
+      '@opentelemetry/sdk-trace-base': 1.27.0(@opentelemetry/api@1.7.0)
+      semver: 7.6.3
+    dev: false
+
+  /@opentelemetry/sdk-trace-web@1.18.1(@opentelemetry/api@1.7.0):
+    resolution: {integrity: sha512-WN30vxy4NY8TqFWuICXaPXjBdy6A5kDhxOqp4NfhqXfpcWWT0GqSgv05Q42quWYOFgaulnmPRRJwxzAdhBliLQ==}
     engines: {node: '>=14'}
     peerDependencies:
       '@opentelemetry/api': '>=1.0.0 <1.8.0'
     dependencies:
       '@opentelemetry/api': 1.7.0
-      '@opentelemetry/context-async-hooks': 1.18.1(@opentelemetry/api@1.7.0)
       '@opentelemetry/core': 1.18.1(@opentelemetry/api@1.7.0)
-      '@opentelemetry/propagator-b3': 1.18.1(@opentelemetry/api@1.7.0)
-      '@opentelemetry/propagator-jaeger': 1.18.1(@opentelemetry/api@1.7.0)
       '@opentelemetry/sdk-trace-base': 1.18.1(@opentelemetry/api@1.7.0)
-      semver: 7.6.0
+      '@opentelemetry/semantic-conventions': 1.18.1
     dev: false
 
   /@opentelemetry/semantic-conventions@1.18.1:
     resolution: {integrity: sha512-+NLGHr6VZwcgE/2lw8zDIufOCGnzsA5CbQIMleXZTrgkBd0TanCX+MiDYJ1TOS4KL/Tqk0nFRxawnaYr6pkZkA==}
+    engines: {node: '>=14'}
+    dev: false
+
+  /@opentelemetry/semantic-conventions@1.27.0:
+    resolution: {integrity: sha512-sAay1RrB+ONOem0OZanAR1ZI/k7yDpnOQSQmTMuGImUQb2y8EbSaCJ94FQluM74xoU03vlb2d2U90hZluL6nQg==}
     engines: {node: '>=14'}
     dev: false
 
@@ -7188,7 +7242,7 @@ packages:
       esbuild: '>=0.10.0'
     dependencies:
       esbuild: 0.18.20
-      tslib: 2.7.0
+      tslib: 2.1.0
     dev: true
 
   /@yarnpkg/fslib@2.10.3:
@@ -7196,7 +7250,7 @@ packages:
     engines: {node: '>=12 <14 || 14.2 - 14.9 || >14.10.0'}
     dependencies:
       '@yarnpkg/libzip': 2.3.0
-      tslib: 1.14.1
+      tslib: 2.1.0
     dev: true
 
   /@yarnpkg/libzip@2.3.0:
@@ -7204,7 +7258,7 @@ packages:
     engines: {node: '>=12 <14 || 14.2 - 14.9 || >14.10.0'}
     dependencies:
       '@types/emscripten': 1.39.10
-      tslib: 1.14.1
+      tslib: 2.1.0
     dev: true
 
   /@zkochan/rimraf@3.0.2:
@@ -7430,7 +7484,7 @@ packages:
     resolution: {integrity: sha512-y+CcFFwelSXpLZk/7fMB2mUbGtX9lKycf1MWJ7CaTIERyitVlyQx6C+sxcROU2BAJ24OiZyK+8wj2i8AlBoS3A==}
     engines: {node: '>=10'}
     dependencies:
-      tslib: 2.7.0
+      tslib: 2.1.0
     dev: false
 
   /aria-query@5.1.3:
@@ -7514,14 +7568,14 @@ packages:
     resolution: {integrity: sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==}
     engines: {node: '>=4'}
     dependencies:
-      tslib: 2.7.0
+      tslib: 2.1.0
     dev: false
 
   /ast-types@0.16.1:
     resolution: {integrity: sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg==}
     engines: {node: '>=4'}
     dependencies:
-      tslib: 2.7.0
+      tslib: 2.1.0
     dev: true
 
   /astral-regex@2.0.0:
@@ -7532,7 +7586,7 @@ packages:
   /async-mutex@0.4.0:
     resolution: {integrity: sha512-eJFZ1YhRR8UN8eBLoNzcDPcy/jqjsg6I1AP+KvWQX80BqOSW1oJPJXDylPUEeMr2ZQvHgnQ//Lp6f3RQ1zI7HA==}
     dependencies:
-      tslib: 2.7.0
+      tslib: 2.1.0
     dev: false
 
   /async@3.2.5:
@@ -9102,7 +9156,7 @@ packages:
     resolution: {integrity: sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==}
     dependencies:
       no-case: 3.0.4
-      tslib: 2.7.0
+      tslib: 2.1.0
     dev: true
 
   /dotenv-expand@10.0.0:
@@ -9279,7 +9333,7 @@ packages:
     dependencies:
       esbuild: 0.18.20
       find-up: 5.0.0
-      tslib: 2.7.0
+      tslib: 2.1.0
     dev: true
 
   /esbuild-plugin-alias@0.2.1:
@@ -11900,7 +11954,7 @@ packages:
   /lower-case@2.0.2:
     resolution: {integrity: sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==}
     dependencies:
-      tslib: 2.7.0
+      tslib: 2.1.0
     dev: true
 
   /lowlight@2.9.0:
@@ -12938,7 +12992,7 @@ packages:
     resolution: {integrity: sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==}
     dependencies:
       lower-case: 2.0.2
-      tslib: 2.7.0
+      tslib: 2.1.0
     dev: true
 
   /nocache@3.0.4:
@@ -14312,7 +14366,7 @@ packages:
       '@types/react': 18.2.37
       react: 18.2.0
       react-style-singleton: 2.2.1(@types/react@18.2.37)(react@18.2.0)
-      tslib: 2.7.0
+      tslib: 2.1.0
     dev: false
 
   /react-remove-scroll-bar@2.3.6(@types/react@18.2.79)(react@18.2.0):
@@ -14328,7 +14382,7 @@ packages:
       '@types/react': 18.2.79
       react: 18.2.0
       react-style-singleton: 2.2.1(@types/react@18.2.79)(react@18.2.0)
-      tslib: 2.7.0
+      tslib: 2.1.0
     dev: false
 
   /react-remove-scroll@2.5.5(@types/react@18.2.37)(react@18.2.0):
@@ -14345,7 +14399,7 @@ packages:
       react: 18.2.0
       react-remove-scroll-bar: 2.3.6(@types/react@18.2.37)(react@18.2.0)
       react-style-singleton: 2.2.1(@types/react@18.2.37)(react@18.2.0)
-      tslib: 2.7.0
+      tslib: 2.1.0
       use-callback-ref: 1.3.2(@types/react@18.2.37)(react@18.2.0)
       use-sidecar: 1.1.2(@types/react@18.2.37)(react@18.2.0)
     dev: false
@@ -14364,7 +14418,7 @@ packages:
       react: 18.2.0
       react-remove-scroll-bar: 2.3.6(@types/react@18.2.79)(react@18.2.0)
       react-style-singleton: 2.2.1(@types/react@18.2.79)(react@18.2.0)
-      tslib: 2.7.0
+      tslib: 2.1.0
       use-callback-ref: 1.3.2(@types/react@18.2.79)(react@18.2.0)
       use-sidecar: 1.1.2(@types/react@18.2.79)(react@18.2.0)
     dev: false
@@ -14383,7 +14437,7 @@ packages:
       get-nonce: 1.0.1
       invariant: 2.2.4
       react: 18.2.0
-      tslib: 2.7.0
+      tslib: 2.1.0
     dev: false
 
   /react-style-singleton@2.2.1(@types/react@18.2.79)(react@18.2.0):
@@ -14400,7 +14454,7 @@ packages:
       get-nonce: 1.0.1
       invariant: 2.2.4
       react: 18.2.0
-      tslib: 2.7.0
+      tslib: 2.1.0
     dev: false
 
   /react@18.2.0:
@@ -14510,7 +14564,7 @@ packages:
       esprima: 4.0.1
       source-map: 0.6.1
       tiny-invariant: 1.3.3
-      tslib: 2.7.0
+      tslib: 2.1.0
     dev: true
 
   /redent@3.0.0:
@@ -14878,7 +14932,7 @@ packages:
   /rxjs@7.8.1:
     resolution: {integrity: sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==}
     dependencies:
-      tslib: 2.7.0
+      tslib: 2.1.0
     dev: true
 
   /safe-buffer@5.1.2:
@@ -15145,7 +15199,7 @@ packages:
     resolution: {integrity: sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==}
     dependencies:
       dot-case: 3.0.4
-      tslib: 2.7.0
+      tslib: 2.1.0
     dev: true
 
   /snapdragon-node@2.1.1:
@@ -16123,15 +16177,8 @@ packages:
       strip-bom: 3.0.0
     dev: true
 
-  /tslib@1.14.1:
-    resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
-
   /tslib@2.1.0:
     resolution: {integrity: sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==}
-    dev: false
-
-  /tslib@2.7.0:
-    resolution: {integrity: sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==}
 
   /tsscmp@1.0.6:
     resolution: {integrity: sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA==}
@@ -16532,7 +16579,7 @@ packages:
     dependencies:
       '@types/react': 18.2.37
       react: 18.2.0
-      tslib: 2.7.0
+      tslib: 2.1.0
     dev: false
 
   /use-callback-ref@1.3.2(@types/react@18.2.79)(react@18.2.0):
@@ -16547,7 +16594,7 @@ packages:
     dependencies:
       '@types/react': 18.2.79
       react: 18.2.0
-      tslib: 2.7.0
+      tslib: 2.1.0
     dev: false
 
   /use-sidecar@1.1.2(@types/react@18.2.37)(react@18.2.0):
@@ -16563,7 +16610,7 @@ packages:
       '@types/react': 18.2.37
       detect-node-es: 1.1.0
       react: 18.2.0
-      tslib: 2.7.0
+      tslib: 2.1.0
     dev: false
 
   /use-sidecar@1.1.2(@types/react@18.2.79)(react@18.2.0):
@@ -16579,7 +16626,7 @@ packages:
       '@types/react': 18.2.79
       detect-node-es: 1.1.0
       react: 18.2.0
-      tslib: 2.7.0
+      tslib: 2.1.0
     dev: false
 
   /use@3.1.1:
@@ -17329,7 +17376,7 @@ packages:
     dev: false
 
   '@storage.googleapis.com/sourcegraph-assets/npm/lexical-react-sourcegraph-fork-31065486.tgz(react-dom@18.2.0)(react@18.2.0)(yjs@13.6.19)':
-    resolution: {tarball: https://storage.googleapis.com/sourcegraph-assets/npm/lexical-react-sourcegraph-fork-31065486.tgz}
+    resolution: {registry: https://registry.npmjs.org/, tarball: https://storage.googleapis.com/sourcegraph-assets/npm/lexical-react-sourcegraph-fork-31065486.tgz}
     id: '@storage.googleapis.com/sourcegraph-assets/npm/lexical-react-sourcegraph-fork-31065486.tgz'
     name: '@lexical/react'
     version: 0.17.0

--- a/vscode/src/chat/chat-view/ChatController.ts
+++ b/vscode/src/chat/chat-view/ChatController.ts
@@ -8,6 +8,7 @@ import {
     clientCapabilities,
     currentSiteVersion,
     distinctUntilChanged,
+    extractContextFromTraceparent,
     firstResultFromOperation,
     forceHydration,
     isAbortError,
@@ -19,9 +20,6 @@ import {
     skipPendingOperation,
     wrapInActiveSpan,
 } from '@sourcegraph/cody-shared'
-import * as uuid from 'uuid'
-import * as vscode from 'vscode'
-
 import {
     type BillingCategory,
     type BillingProduct,
@@ -79,8 +77,10 @@ import {
     truncatePromptString,
     userProductSubscription,
 } from '@sourcegraph/cody-shared'
+import * as uuid from 'uuid'
+import * as vscode from 'vscode'
 
-import type { Span } from '@opentelemetry/api'
+import { type Span, context } from '@opentelemetry/api'
 import { captureException } from '@sentry/core'
 import { getTokenCounterUtils } from '@sourcegraph/cody-shared/src/token/counter'
 import type { TelemetryEventParameters } from '@sourcegraph/telemetry'
@@ -109,6 +109,7 @@ import { authProvider } from '../../services/AuthProvider'
 import { AuthProviderSimplified } from '../../services/AuthProviderSimplified'
 import { localStorage } from '../../services/LocalStorageProvider'
 import { secretStorage } from '../../services/SecretStorageProvider'
+import { TraceSender } from '../../services/open-telemetry/trace-sender'
 import { recordExposedExperimentsToSpan } from '../../services/open-telemetry/utils'
 import {
     handleCodeFromInsertAtCursor,
@@ -294,6 +295,7 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
                     intent: message.intent,
                     intentScores: message.intentScores,
                     manuallySelectedIntent: message.manuallySelectedIntent,
+                    traceparent: message.traceparent,
                 })
                 break
             }
@@ -325,8 +327,12 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
                     message.code,
                     currentAuthStatus(),
                     message.instruction,
-                    message.fileName
+                    message.fileName,
+                    message.traceparent
                 )
+                break
+            case 'trace-export':
+                TraceSender.send(message.traceSpanEncodedJson)
                 break
             case 'smartApplyAccept':
                 await vscode.commands.executeCommand('cody.fixup.codelens.accept', message.id)
@@ -639,6 +645,7 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
         intent: detectedIntent,
         intentScores: detectedIntentScores,
         manuallySelectedIntent,
+        traceparent,
     }: {
         requestID: string
         inputText: PromptString
@@ -650,46 +657,50 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
         intent?: ChatMessage['intent'] | undefined | null
         intentScores?: { intent: string; score: number }[] | undefined | null
         manuallySelectedIntent?: boolean | undefined | null
+        traceparent?: string | undefined | null
     }): Promise<void> {
-        return tracer.startActiveSpan('chat.handleUserMessage', async (span): Promise<void> => {
-            outputChannelLogger.logDebug(
-                'ChatController',
-                'handleUserMessageSubmission',
-                `traceId: ${span.spanContext().traceId}`
-            )
-            span.setAttribute('sampled', true)
+        return context.with(extractContextFromTraceparent(traceparent), () => {
+            return tracer.startActiveSpan('chat.handleUserMessage', async (span): Promise<void> => {
+                span.setAttribute('sampled', true)
+                span.setAttribute('continued', true)
+                outputChannelLogger.logDebug(
+                    'ChatController',
+                    'handleUserMessageSubmission',
+                    `traceId: ${span.spanContext().traceId}`
+                )
 
-            if (inputText.toString().match(/^\/reset$/)) {
-                span.addEvent('clearAndRestartSession')
-                span.end()
-                return this.clearAndRestartSession()
-            }
+                if (inputText.match(/^\/reset$/)) {
+                    span.addEvent('clearAndRestartSession')
+                    span.end()
+                    return this.clearAndRestartSession()
+                }
 
-            this.chatBuilder.addHumanMessage({
-                text: inputText,
-                editorState,
-                intent: detectedIntent,
-            })
-            this.postViewTranscript({ speaker: 'assistant' })
-
-            void this.saveSession()
-            signal.throwIfAborted()
-
-            return this.sendChat(
-                {
-                    requestID,
-                    inputText,
-                    mentions,
+                this.chatBuilder.addHumanMessage({
+                    text: inputText,
                     editorState,
-                    signal,
-                    source,
-                    command,
                     intent: detectedIntent,
-                    intentScores: detectedIntentScores,
-                    manuallySelectedIntent,
-                },
-                span
-            )
+                })
+                this.postViewTranscript({ speaker: 'assistant' })
+
+                await this.saveSession()
+                signal.throwIfAborted()
+
+                return this.sendChat(
+                    {
+                        requestID,
+                        inputText,
+                        mentions,
+                        editorState,
+                        signal,
+                        source,
+                        command,
+                        intent: detectedIntent,
+                        intentScores: detectedIntentScores,
+                        manuallySelectedIntent,
+                    },
+                    span
+                )
+            })
         })
     }
 

--- a/vscode/src/chat/protocol.ts
+++ b/vscode/src/chat/protocol.ts
@@ -96,6 +96,12 @@ export type WebviewMessage =
           code: string
           instruction?: string | undefined | null
           fileName?: string | undefined | null
+          traceparent?: string | undefined | null
+      }
+    | {
+          command: 'trace-export'
+          // The traceSpan is a JSON-encoded string representing the trace data.
+          traceSpanEncodedJson: string
       }
     | {
           command: 'smartApplyAccept'
@@ -201,6 +207,7 @@ export interface WebviewSubmitMessage extends WebviewContextMessage {
     intent?: ChatMessage['intent'] | undefined | null
     intentScores?: { intent: string; score: number }[] | undefined | null
     manuallySelectedIntent?: boolean | undefined | null
+    traceparent?: string | undefined | null
 }
 
 interface WebviewEditMessage extends WebviewContextMessage {

--- a/vscode/src/edit/manager.ts
+++ b/vscode/src/edit/manager.ts
@@ -3,12 +3,15 @@ import * as vscode from 'vscode'
 import {
     type ChatClient,
     ClientConfigSingleton,
+    DEFAULT_EVENT_SOURCE,
     PromptString,
     currentSiteVersion,
+    extractContextFromTraceparent,
     firstResultFromOperation,
     modelsService,
     ps,
     telemetryRecorder,
+    wrapInActiveSpan,
 } from '@sourcegraph/cody-shared'
 
 import type { GhostHintDecorator } from '../commands/GhostHintDecorator'
@@ -17,7 +20,7 @@ import type { VSCodeEditor } from '../editor/vscode-editor'
 import { FixupController } from '../non-stop/FixupController'
 import type { FixupTask } from '../non-stop/FixupTask'
 
-import { DEFAULT_EVENT_SOURCE } from '@sourcegraph/cody-shared'
+import { context } from '@opentelemetry/api'
 import { isUriIgnoredByContextFilterWithNotification } from '../cody-ignore/context-filter'
 import type { ExtensionClient } from '../extension-client'
 import { ACTIVE_TASK_STATES } from '../non-stop/codelenses/constants'
@@ -236,196 +239,203 @@ export class EditManager implements vscode.Disposable {
         return task
     }
 
-    public async smartApplyEdit(args: SmartApplyArguments = {}): Promise<FixupTask | undefined> {
-        const { configuration, source = 'chat' } = args
-        if (!configuration) {
-            return
-        }
+    public async smartApplyEdit(args: SmartApplyArguments = {}): Promise<void> {
+        return context.with(extractContextFromTraceparent(args.configuration?.traceparent), async () => {
+            await wrapInActiveSpan('edit.smart-apply', async span => {
+                span.setAttribute('sampled', true)
+                span.setAttribute('continued', true)
+                const { configuration, source = 'chat' } = args
+                if (!configuration) {
+                    return
+                }
 
-        const document = configuration.document
-        if (await isUriIgnoredByContextFilterWithNotification(document.uri, 'edit')) {
-            return
-        }
+                const document = configuration.document
+                if (await isUriIgnoredByContextFilterWithNotification(document.uri, 'edit')) {
+                    return
+                }
 
-        const model =
-            configuration.model || (await firstResultFromOperation(modelsService.getDefaultEditModel()))
-        if (!model) {
-            throw new Error('No default edit model found. Please set one.')
-        }
+                const model =
+                    configuration.model ||
+                    (await firstResultFromOperation(modelsService.getDefaultEditModel()))
+                if (!model) {
+                    throw new Error('No default edit model found. Please set one.')
+                }
 
-        telemetryRecorder.recordEvent('cody.command.smart-apply', 'executed', {
-            billingMetadata: {
-                product: 'cody',
-                category: 'core',
-            },
-        })
-
-        const editor = await vscode.window.showTextDocument(document.uri)
-
-        if (args.configuration?.isNewFile) {
-            // We are creating a new file, this means we are only _adding_ new code and _inserting_ it into the document.
-            // We do not need to re-prompt the LLM for this, let's just add the code directly.
-            const task = await this.controller.createTask(
-                document,
-                configuration.instruction,
-                [],
-                new vscode.Range(0, 0, 0, 0),
-                'add',
-                'insert',
-                model,
-                source,
-                configuration.document.uri,
-                undefined,
-                {},
-                configuration.id
-            )
-
-            const legacyMetadata = {
-                intent: task.intent,
-                mode: task.mode,
-                source: task.source,
-            }
-            const { metadata, privateMetadata } = splitSafeMetadata(legacyMetadata)
-            telemetryRecorder.recordEvent('cody.command.edit', 'executed', {
-                metadata,
-                privateMetadata: {
-                    ...privateMetadata,
-                    model: task.model,
-                },
-                billingMetadata: {
-                    product: 'cody',
-                    category: 'core',
-                },
-            })
-
-            const provider = this.getProviderForTask(task)
-            await provider.applyEdit(configuration.replacement)
-            return task
-        }
-
-        // Apply some decorations to the editor, this showcases that Cody is working on the full file range
-        // of the document. We will narrow it down to a selection soon.
-        const documentRange = new vscode.Range(0, 0, document.lineCount, 0)
-        editor.setDecorations(SMART_APPLY_FILE_DECORATION, [documentRange])
-
-        // We need to extract the proposed code, provided by the LLM, so we can use it in future
-        // queries to ask the LLM to generate a selection, and then ultimately apply the edit.
-        const replacementCode = PromptString.unsafe_fromLLMResponse(configuration.replacement)
-
-        const versions = await currentSiteVersion()
-        if (!versions) {
-            throw new Error('unable to determine site version')
-        }
-
-        const selection = await getSmartApplySelection(
-            configuration.id,
-            configuration.instruction,
-            replacementCode,
-            configuration.document,
-            model,
-            this.options.chat,
-            versions.codyAPIVersion
-        )
-
-        // We finished prompting the LLM for the selection, we can now remove the "progress" decoration
-        // that indicated we where working on the full file.
-        editor.setDecorations(SMART_APPLY_FILE_DECORATION, [])
-
-        if (!selection) {
-            // We couldn't figure out the selection, let's inform the user and return early.
-            // TODO: Should we add a "Copy" button to this error? Then the user can copy the code directly.
-            void vscode.window.showErrorMessage(
-                'Unable to apply this change to the file. Please try applying this code manually'
-            )
-            telemetryRecorder.recordEvent('cody.smart-apply.selection', 'not-found')
-            return
-        }
-
-        telemetryRecorder.recordEvent('cody.smart-apply', 'selected', {
-            metadata: {
-                [selection.type]: 1,
-            },
-        })
-
-        // Move focus to the determined selection
-        editor.revealRange(selection.range, vscode.TextEditorRevealType.InCenter)
-
-        if (selection.range.isEmpty) {
-            let insertionRange = selection.range
-
-            if (
-                selection.type === 'insert' &&
-                document.lineAt(document.lineCount - 1).text.trim().length !== 0
-            ) {
-                // Inserting to the bottom of the file, but the last line is not empty
-                // Inject an additional new line for us to use as the insertion range.
-                await editor.edit(
-                    editBuilder => {
-                        editBuilder.insert(selection.range.start, '\n')
+                telemetryRecorder.recordEvent('cody.command.smart-apply', 'executed', {
+                    billingMetadata: {
+                        product: 'cody',
+                        category: 'core',
                     },
-                    { undoStopAfter: false, undoStopBefore: false }
+                })
+
+                const editor = await vscode.window.showTextDocument(document.uri)
+
+                if (args.configuration?.isNewFile) {
+                    // We are creating a new file, this means we are only _adding_ new code and _inserting_ it into the document.
+                    // We do not need to re-prompt the LLM for this, let's just add the code directly.
+                    const task = await this.controller.createTask(
+                        document,
+                        configuration.instruction,
+                        [],
+                        new vscode.Range(0, 0, 0, 0),
+                        'add',
+                        'insert',
+                        model,
+                        source,
+                        configuration.document.uri,
+                        undefined,
+                        {},
+                        configuration.id
+                    )
+
+                    const legacyMetadata = {
+                        intent: task.intent,
+                        mode: task.mode,
+                        source: task.source,
+                    }
+                    const { metadata, privateMetadata } = splitSafeMetadata(legacyMetadata)
+                    telemetryRecorder.recordEvent('cody.command.edit', 'executed', {
+                        metadata,
+                        privateMetadata: {
+                            ...privateMetadata,
+                            model: task.model,
+                        },
+                        billingMetadata: {
+                            product: 'cody',
+                            category: 'core',
+                        },
+                    })
+
+                    const provider = this.getProviderForTask(task)
+                    await provider.applyEdit(configuration.replacement)
+                    return task
+                }
+
+                // Apply some decorations to the editor, this showcases that Cody is working on the full file range
+                // of the document. We will narrow it down to a selection soon.
+                const documentRange = new vscode.Range(0, 0, document.lineCount, 0)
+                editor.setDecorations(SMART_APPLY_FILE_DECORATION, [documentRange])
+
+                // We need to extract the proposed code, provided by the LLM, so we can use it in future
+                // queries to ask the LLM to generate a selection, and then ultimately apply the edit.
+                const replacementCode = PromptString.unsafe_fromLLMResponse(configuration.replacement)
+
+                const versions = await currentSiteVersion()
+                if (!versions) {
+                    throw new Error('unable to determine site version')
+                }
+
+                const selection = await getSmartApplySelection(
+                    configuration.id,
+                    configuration.instruction,
+                    replacementCode,
+                    configuration.document,
+                    model,
+                    this.options.chat,
+                    versions.codyAPIVersion
                 )
 
-                // Update the range to reflect the new end of document
-                insertionRange = document.lineAt(document.lineCount - 1).range
-            }
+                // We finished prompting the LLM for the selection, we can now remove the "progress" decoration
+                // that indicated we where working on the full file.
+                editor.setDecorations(SMART_APPLY_FILE_DECORATION, [])
 
-            // We determined a selection, but it was empty. This means that we will be _adding_ new code
-            // and _inserting_ it into the document. We do not need to re-prompt the LLM for this, let's just
-            // add the code directly.
-            const task = await this.controller.createTask(
-                document,
-                configuration.instruction,
-                [],
-                insertionRange,
-                'add',
-                'insert',
-                model,
-                source,
-                configuration.document.uri,
-                undefined,
-                {},
-                configuration.id
-            )
+                if (!selection) {
+                    // We couldn't figure out the selection, let's inform the user and return early.
+                    // TODO: Should we add a "Copy" button to this error? Then the user can copy the code directly.
+                    void vscode.window.showErrorMessage(
+                        'Unable to apply this change to the file. Please try applying this code manually'
+                    )
+                    telemetryRecorder.recordEvent('cody.smart-apply.selection', 'not-found')
+                    return
+                }
 
-            const legacyMetadata = {
-                intent: task.intent,
-                mode: task.mode,
-                source: task.source,
-            }
-            const { metadata, privateMetadata } = splitSafeMetadata(legacyMetadata)
-            telemetryRecorder.recordEvent('cody.command.edit', 'executed', {
-                metadata,
-                privateMetadata: {
-                    ...privateMetadata,
-                    model: task.model,
-                },
-                billingMetadata: {
-                    product: 'cody',
-                    category: 'core',
-                },
+                telemetryRecorder.recordEvent('cody.smart-apply', 'selected', {
+                    metadata: {
+                        [selection.type]: 1,
+                    },
+                })
+
+                // Move focus to the determined selection
+                editor.revealRange(selection.range, vscode.TextEditorRevealType.InCenter)
+
+                if (selection.range.isEmpty) {
+                    let insertionRange = selection.range
+
+                    if (
+                        selection.type === 'insert' &&
+                        document.lineAt(document.lineCount - 1).text.trim().length !== 0
+                    ) {
+                        // Inserting to the bottom of the file, but the last line is not empty
+                        // Inject an additional new line for us to use as the insertion range.
+                        await editor.edit(
+                            editBuilder => {
+                                editBuilder.insert(selection.range.start, '\n')
+                            },
+                            { undoStopAfter: false, undoStopBefore: false }
+                        )
+
+                        // Update the range to reflect the new end of document
+                        insertionRange = document.lineAt(document.lineCount - 1).range
+                    }
+
+                    // We determined a selection, but it was empty. This means that we will be _adding_ new code
+                    // and _inserting_ it into the document. We do not need to re-prompt the LLM for this, let's just
+                    // add the code directly.
+                    const task = await this.controller.createTask(
+                        document,
+                        configuration.instruction,
+                        [],
+                        insertionRange,
+                        'add',
+                        'insert',
+                        model,
+                        source,
+                        configuration.document.uri,
+                        undefined,
+                        {},
+                        configuration.id
+                    )
+
+                    const legacyMetadata = {
+                        intent: task.intent,
+                        mode: task.mode,
+                        source: task.source,
+                    }
+                    const { metadata, privateMetadata } = splitSafeMetadata(legacyMetadata)
+                    telemetryRecorder.recordEvent('cody.command.edit', 'executed', {
+                        metadata,
+                        privateMetadata: {
+                            ...privateMetadata,
+                            model: task.model,
+                        },
+                        billingMetadata: {
+                            product: 'cody',
+                            category: 'core',
+                        },
+                    })
+
+                    const provider = this.getProviderForTask(task)
+                    await provider.applyEdit('\n' + configuration.replacement)
+                    return task
+                }
+
+                // We have a selection to replace, we re-prompt the LLM to generate the changes to ensure that
+                // we can reliably apply this edit.
+                // Just using the replacement code from the response is not enough, as it may contain parts that are not suitable to apply,
+                // e.g. // ...
+                return this.executeEdit({
+                    configuration: {
+                        id: configuration.id,
+                        document: configuration.document,
+                        range: selection.range,
+                        mode: 'edit',
+                        instruction: ps`Ensuring that you do not duplicate code that it outside of the selection, apply the following change:\n${replacementCode}`,
+                        model,
+                        intent: 'edit',
+                    },
+                    source,
+                })
             })
-
-            const provider = this.getProviderForTask(task)
-            await provider.applyEdit('\n' + configuration.replacement)
-            return task
-        }
-
-        // We have a selection to replace, we re-prompt the LLM to generate the changes to ensure that
-        // we can reliably apply this edit.
-        // Just using the replacement code from the response is not enough, as it may contain parts that are not suitable to apply,
-        // e.g. // ...
-        return this.executeEdit({
-            configuration: {
-                id: configuration.id,
-                document: configuration.document,
-                range: selection.range,
-                mode: 'edit',
-                instruction: ps`Ensuring that you do not duplicate code that it outside of the selection, apply the following change:\n${replacementCode}`,
-                model,
-                intent: 'edit',
-            },
-            source,
         })
     }
 

--- a/vscode/src/edit/smart-apply.ts
+++ b/vscode/src/edit/smart-apply.ts
@@ -11,6 +11,7 @@ export interface SmartApplyArguments {
         document: vscode.TextDocument
         model?: EditModel
         isNewFile?: boolean
+        traceparent: string | undefined | null
     }
     source?: EventSource
 }

--- a/vscode/src/services/open-telemetry/CodyTraceExportWeb.ts
+++ b/vscode/src/services/open-telemetry/CodyTraceExportWeb.ts
@@ -1,0 +1,191 @@
+import type { ExportResult } from '@opentelemetry/core'
+import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http'
+import type { ReadableSpan } from '@opentelemetry/sdk-trace-base'
+import type { CodyIDE } from '@sourcegraph/cody-shared/src/configuration'
+import { getVSCodeAPI } from '../../../webviews/utils/VSCodeApi'
+import { logDebug } from '../../../webviews/utils/logger'
+
+const MAX_TRACE_RETAIN_MS = 60 * 1000 * 5 // 5 minutes
+
+// Exports spans as JSON to the extension host so that it can be sent to the OTel collector on the SG instance
+export class CodyTraceExporterWeb extends OTLPTraceExporter {
+    private isTracingEnabled: boolean
+    private queuedSpans: Map<string, { span: ReadableSpan; enqueuedAt: number }> = new Map()
+    private clientPlatform: CodyIDE
+    private agentVersion?: string
+    private lastExpiryCheck = 0
+
+    constructor({
+        isTracingEnabled,
+        clientPlatform,
+        agentVersion,
+    }: { isTracingEnabled: boolean; clientPlatform: CodyIDE; agentVersion?: string }) {
+        super({
+            httpAgentOptions: {
+                rejectUnauthorized: false,
+            },
+            headers: {
+                'Content-Type': 'application/json',
+            },
+        })
+        this.isTracingEnabled = isTracingEnabled
+        this.clientPlatform = clientPlatform
+        this.agentVersion = agentVersion
+    }
+
+    private removeExpiredSpans(now: number): void {
+        for (const [spanId, { enqueuedAt }] of this.queuedSpans.entries()) {
+            if (now - enqueuedAt > MAX_TRACE_RETAIN_MS) {
+                this.queuedSpans.delete(spanId)
+                logDebug('[CodyTraceExporterWeb] Removed expired span from queue:', spanId)
+            }
+        }
+    }
+
+    export(spans: ReadableSpan[], resultCallback: (result: ExportResult) => void): void {
+        if (!this.isTracingEnabled) {
+            return
+        }
+
+        const now = performance.now()
+        if (now - this.lastExpiryCheck > MAX_TRACE_RETAIN_MS) {
+            this.removeExpiredSpans(now)
+            this.lastExpiryCheck = now
+        }
+
+        // Include queued spans for re-evaluation
+        const allSpans = [...spans, ...Array.from(this.queuedSpans.values()).map(q => q.span)]
+        for (const span of allSpans) {
+            span.attributes.clientPlatform = this.clientPlatform
+            span.attributes.agentVersion = this.agentVersion
+        }
+
+        // Build span hierarchy map
+        const spanMap = new Map<string, ReadableSpan>()
+        const spansByRoot = new Map<string, Set<ReadableSpan>>()
+
+        // First, map all spans by their ID
+        for (const span of allSpans) {
+            spanMap.set(span.spanContext().spanId, span)
+        }
+
+        // Group spans by their root span
+        for (const span of spanMap.values()) {
+            const rootSpan = getRootSpan(spanMap, span)
+            if (rootSpan) {
+                const rootId = rootSpan.spanContext().spanId
+                if (!spansByRoot.has(rootId)) {
+                    spansByRoot.set(rootId, new Set())
+                }
+                spansByRoot.get(rootId)?.add(span)
+            } else {
+                // Queue spans without a root for later
+                const spanId = span.spanContext().spanId
+                if (!this.queuedSpans.has(spanId)) {
+                    this.queuedSpans.set(spanId, { span, enqueuedAt: now })
+                }
+            }
+        }
+
+        const spansToExport: ReadableSpan[] = []
+
+        // Process each group of spans
+        for (const [rootId, spanGroup] of spansByRoot.entries()) {
+            const rootSpan = spanMap.get(rootId)
+            if (!rootSpan || !isSampled(rootSpan)) {
+                continue
+            }
+
+            // Add all spans from complete groups
+            spansToExport.push(...spanGroup)
+
+            // Remove these spans from queued spans if present
+            for (const span of spanGroup) {
+                this.queuedSpans.delete(span.spanContext().spanId)
+                logDebug('[CodyTraceExporterWeb] Removed span from queue:', span.spanContext().spanId)
+            }
+        }
+        if (spansToExport.length > 0) {
+            super.export(spansToExport, resultCallback)
+        }
+    }
+
+    send(spans: ReadableSpan[]): void {
+        try {
+            const exportData = this.convert(spans)
+
+            logDebug(
+                '[CodyTraceExporterWeb] Exporting spans',
+                JSON.stringify({
+                    count: spans.length,
+                    rootSpans: spans.filter(s => !s.parentSpanId).length,
+                    renderSpans: spans.filter(s => s.name === 'assistant-message-render').length,
+                })
+            )
+
+            // Validate and clean the export data before sending
+            const messageData = {
+                resourceSpans: (exportData.resourceSpans ?? []).map(span => ({
+                    ...span,
+                    resource: {
+                        ...span?.resource,
+                        attributes:
+                            span?.resource?.attributes?.map(attr => ({
+                                key: attr.key,
+                                value: attr.value,
+                            })) ?? [],
+                    },
+                })),
+                timestamp: performance.now(),
+            }
+
+            // Send the validated and cleaned data
+            getVSCodeAPI().postMessage({
+                command: 'trace-export',
+                traceSpanEncodedJson: JSON.stringify(messageData, getCircularReplacer()),
+            })
+        } catch (error) {
+            console.error('[CodyTraceExporterWeb] Error exporting spans:', error)
+        }
+    }
+}
+
+function getRootSpan(spanMap: Map<string, ReadableSpan>, span: ReadableSpan): ReadableSpan | null {
+    // Start with the input span
+    let currentSpan = span
+
+    while (true) {
+        // If we find a span without a parent, it's the root
+        if (!currentSpan.parentSpanId) {
+            return currentSpan
+        }
+
+        const parentSpan = spanMap.get(currentSpan.parentSpanId)
+
+        // Return null if parent ID exists but parent span not found.
+        // These spans are expected to be completed later.
+        if (!parentSpan) {
+            return null
+        }
+
+        currentSpan = parentSpan
+    }
+}
+
+function isSampled(rootSpan: ReadableSpan): boolean {
+    return rootSpan.attributes.sampled === true
+}
+
+// Helper function to handle circular references in JSON serialization
+function getCircularReplacer() {
+    const seen = new WeakSet()
+    return (key: string, value: any) => {
+        if (typeof value === 'object' && value !== null) {
+            if (seen.has(value)) {
+                return
+            }
+            seen.add(value)
+        }
+        return value
+    }
+}

--- a/vscode/src/services/open-telemetry/trace-sender.ts
+++ b/vscode/src/services/open-telemetry/trace-sender.ts
@@ -1,0 +1,46 @@
+import { currentResolvedConfig } from '@sourcegraph/cody-shared'
+import fetch from 'node-fetch'
+import { logDebug, logError } from '../../output-channel-logger'
+
+/**
+ * Sends trace data to the server without blocking
+ */
+export const TraceSender = {
+    send(spanData: any): void {
+        // Don't await - let it run in background, but do handle errors
+        void doSendTraceData(spanData).catch(error => {
+            logError('TraceSender', `Error sending trace data: ${error}`)
+        })
+    },
+}
+
+/**
+ * Sends trace data to the server using the provided span data as a json string
+ * that comes from the webview. It retrieves the current resolved configuration to obtain
+ * authentication details and constructs the trace URL. It sends a POST
+ * request with the span data as the body.
+ */
+async function doSendTraceData(spanData: any): Promise<void> {
+    const { auth } = await currentResolvedConfig()
+    if (!auth.accessToken) {
+        logError('TraceSender', 'Cannot send trace data: not authenticated')
+        throw new Error('Not authenticated')
+    }
+
+    const traceUrl = new URL('/-/debug/otlp/v1/traces', auth.serverEndpoint).toString()
+    const response = await fetch(traceUrl, {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+            ...(auth.accessToken ? { Authorization: `token ${auth.accessToken}` } : {}),
+        },
+        body: spanData,
+    })
+
+    if (!response.ok) {
+        logError('TraceSender', `Failed to send trace data: ${response.statusText}`)
+        throw new Error(`Failed to send trace data: ${response.statusText}`)
+    }
+
+    logDebug('TraceSender', 'Trace data sent successfully')
+}

--- a/vscode/src/services/utils/codeblock-action-tracker.ts
+++ b/vscode/src/services/utils/codeblock-action-tracker.ts
@@ -158,7 +158,8 @@ export async function handleSmartApply(
     code: string,
     authStatus: AuthStatus,
     instruction?: string | null,
-    fileUri?: string | null
+    fileUri?: string | null,
+    traceparent?: string | undefined | null
 ): Promise<void> {
     const activeEditor = getEditor()?.active
     const workspaceUri = vscode.workspace.workspaceFolders?.[0].uri
@@ -196,6 +197,7 @@ export async function handleSmartApply(
             model: getSmartApplyModel(authStatus),
             replacement: code,
             isNewFile,
+            traceparent,
         },
         source: 'chat',
     })

--- a/vscode/webviews/App.tsx
+++ b/vscode/webviews/App.tsx
@@ -1,7 +1,5 @@
 import { type ComponentProps, useCallback, useEffect, useMemo, useState } from 'react'
 
-import styles from './App.module.css'
-
 import {
     type ChatMessage,
     type DefaultContext,
@@ -10,9 +8,11 @@ import {
     type TelemetryRecorder,
 } from '@sourcegraph/cody-shared'
 import type { AuthMethod } from '../src/chat/protocol'
+import styles from './App.module.css'
 import { AuthPage } from './AuthPage'
 import { LoadingPage } from './LoadingPage'
 import { useClientActionDispatcher } from './client/clientState'
+import { WebviewOpenTelemetryService } from './utils/webviewOpenTelemetryService'
 
 import { ExtensionAPIProviderFromVSCodeAPI } from '@sourcegraph/prompt-editor'
 import { CodyPanel } from './CodyPanel'
@@ -141,6 +141,22 @@ export const App: React.FunctionComponent<{ vscodeAPI: VSCodeWrapper }> = ({ vsc
 
     // V2 telemetry recorder
     const telemetryRecorder = useMemo(() => createWebviewTelemetryRecorder(vscodeAPI), [vscodeAPI])
+
+    const webviewTelemetryService = useMemo(() => {
+        const service = WebviewOpenTelemetryService.getInstance()
+        return service
+    }, [])
+
+    useEffect(() => {
+        if (config) {
+            webviewTelemetryService.configure({
+                isTracingEnabled: true,
+                debugVerbose: true,
+                agentIDE: config.clientCapabilities.agentIDE,
+                extensionAgentVersion: config.clientCapabilities.agentExtensionVersion,
+            })
+        }
+    }, [config, webviewTelemetryService])
 
     const wrappers = useMemo<Wrapper[]>(
         () => getAppWrappers({ vscodeAPI, telemetryRecorder, config }),

--- a/vscode/webviews/Chat.tsx
+++ b/vscode/webviews/Chat.tsx
@@ -1,5 +1,5 @@
 import type React from 'react'
-import { useCallback, useEffect, useMemo, useRef } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import type {
     AuthenticatedAuthStatus,
@@ -12,6 +12,7 @@ import type {
 import { Transcript, focusLastHumanMessageEditor } from './chat/Transcript'
 import type { VSCodeWrapper } from './utils/VSCodeApi'
 
+import type { Context } from '@opentelemetry/api'
 import { truncateTextStart } from '@sourcegraph/cody-shared/src/prompt/truncation'
 import { CHAT_INPUT_TOKEN_BUDGET } from '@sourcegraph/cody-shared/src/token/constants'
 import styles from './Chat.module.css'
@@ -19,9 +20,9 @@ import WelcomeFooter from './chat/components/WelcomeFooter'
 import { WelcomeMessage } from './chat/components/WelcomeMessage'
 import { ScrollDown } from './components/ScrollDown'
 import type { View } from './tabs'
-import { useTelemetryRecorder } from './utils/telemetry'
+import { SpanManager } from './utils/spanManager'
+import { getTraceparentFromSpanContext, useTelemetryRecorder } from './utils/telemetry'
 import { useUserAccountInfo } from './utils/useConfig'
-
 interface ChatboxProps {
     chatEnabled: boolean
     messageInProgress: ChatMessage | null
@@ -64,6 +65,7 @@ export const Chat: React.FunctionComponent<React.PropsWithChildren<ChatboxProps>
                 thumbsUp = 1,
                 thumbsDown = 0,
             }
+
             telemetryRecorder.recordEvent('cody.feedback', 'submit', {
                 metadata: {
                     feedbackType: text === 'thumbsUp' ? FeedbackType.thumbsUp : FeedbackType.thumbsDown,
@@ -92,8 +94,10 @@ export const Chat: React.FunctionComponent<React.PropsWithChildren<ChatboxProps>
         (text: string, eventType: 'Button' | 'Keydown' = 'Button') => {
             const op = 'copy'
             // remove the additional /n added by the text area at the end of the text
+
             const code = eventType === 'Button' ? text.replace(/\n$/, '') : text
             // Log the event type and text to telemetry in chat view
+
             vscodeAPI.postMessage({
                 command: op,
                 eventType,
@@ -108,6 +112,7 @@ export const Chat: React.FunctionComponent<React.PropsWithChildren<ChatboxProps>
             return (text: string, newFile = false) => {
                 const op = newFile ? 'newFile' : 'insert'
                 // Log the event type and text to telemetry in chat view
+
                 vscodeAPI.postMessage({
                     command: op,
                     // remove the additional /n added by the text area at the end of the text
@@ -131,6 +136,15 @@ export const Chat: React.FunctionComponent<React.PropsWithChildren<ChatboxProps>
                 instruction?: PromptString,
                 fileName?: string
             ): void => {
+                const spanManager = new SpanManager('cody-webview')
+                const span = spanManager.startSpan('smartApplySubmit', {
+                    attributes: {
+                        sampled: true,
+                        'smartApply.id': id,
+                    },
+                })
+                const traceparent = getTraceparentFromSpanContext(span.spanContext())
+
                 vscodeAPI.postMessage({
                     command: 'smartApplySubmit',
                     id,
@@ -138,7 +152,9 @@ export const Chat: React.FunctionComponent<React.PropsWithChildren<ChatboxProps>
                     // remove the additional /n added by the text area at the end of the text
                     code: text.replace(/\n$/, ''),
                     fileName,
+                    traceparent,
                 })
+                span.end()
             },
             onAccept: (id: string) => {
                 vscodeAPI.postMessage({
@@ -209,6 +225,7 @@ export const Chat: React.FunctionComponent<React.PropsWithChildren<ChatboxProps>
 
         focusLastHumanMessageEditor()
     }, [transcript])
+    const [activeChatContext, setActiveChatContext] = useState<Context>()
 
     return (
         <>
@@ -218,6 +235,8 @@ export const Chat: React.FunctionComponent<React.PropsWithChildren<ChatboxProps>
                 </div>
             )}
             <Transcript
+                activeChatContext={activeChatContext}
+                setActiveChatContext={setActiveChatContext}
                 transcript={transcript}
                 models={models}
                 messageInProgress={messageInProgress}

--- a/vscode/webviews/chat/Transcript.story.tsx
+++ b/vscode/webviews/chat/Transcript.story.tsx
@@ -44,6 +44,7 @@ const meta: Meta<typeof Transcript> = {
         postMessage: () => {},
         chatEnabled: true,
         models: mockedModels,
+        setActiveChatContext: () => {},
     } satisfies ComponentProps<typeof Transcript>,
 
     decorators: [

--- a/vscode/webviews/chat/Transcript.test.tsx
+++ b/vscode/webviews/chat/Transcript.test.tsx
@@ -23,6 +23,7 @@ const PROPS: Omit<ComponentProps<typeof Transcript>, 'transcript'> = {
     chatEnabled: true,
     postMessage: () => {},
     models: MOCK_MODELS,
+    setActiveChatContext: () => {},
 }
 
 vi.mock('@vscode/webview-ui-toolkit/react', () => ({

--- a/vscode/webviews/chat/Transcript.tsx
+++ b/vscode/webviews/chat/Transcript.tsx
@@ -23,16 +23,19 @@ import {
     type MutableRefObject,
     memo,
     useCallback,
+    useEffect,
     useImperativeHandle,
     useMemo,
     useRef,
+    useState,
 } from 'react'
 import { URI } from 'vscode-uri'
 import type { UserAccountInfo } from '../Chat'
 import type { ApiPostMessage } from '../Chat'
 import { Button } from '../components/shadcn/ui/button'
 import { getVSCodeAPI } from '../utils/VSCodeApi'
-import { useTelemetryRecorder } from '../utils/telemetry'
+import { SpanManager } from '../utils/spanManager'
+import { getTraceparentFromSpanContext, useTelemetryRecorder } from '../utils/telemetry'
 import { useExperimentalOneBox } from '../utils/useExperimentalOneBox'
 import type { CodeBlockActionsProps } from './ChatMessageContent/ChatMessageContent'
 import {
@@ -48,13 +51,15 @@ import { HumanMessageCell } from './cells/messageCell/human/HumanMessageCell'
 import { CodyIcon } from './components/CodyIcon'
 import { InfoMessage } from './components/InfoMessage'
 
+import { type Context, type Span, context, trace } from '@opentelemetry/api'
 interface TranscriptProps {
+    activeChatContext?: Context
+    setActiveChatContext: (context: Context | undefined) => void
     chatEnabled: boolean
     transcript: ChatMessage[]
     models: Model[]
     userInfo: UserAccountInfo
     messageInProgress: ChatMessage | null
-
     guardrails?: Guardrails
     postMessage?: ApiPostMessage
 
@@ -67,6 +72,8 @@ interface TranscriptProps {
 
 export const Transcript: FC<TranscriptProps> = props => {
     const {
+        activeChatContext,
+        setActiveChatContext,
         chatEnabled,
         transcript,
         models,
@@ -130,6 +137,8 @@ export const Transcript: FC<TranscriptProps> = props => {
             {interactions.map((interaction, i) => (
                 <TranscriptInteraction
                     key={interaction.humanMessage.index}
+                    activeChatContext={activeChatContext}
+                    setActiveChatContext={setActiveChatContext}
                     models={models}
                     chatEnabled={chatEnabled}
                     userInfo={userInfo}
@@ -218,6 +227,8 @@ export function transcriptToInteractionPairs(
 
 interface TranscriptInteractionProps
     extends Omit<TranscriptProps, 'transcript' | 'messageInProgress' | 'chatID'> {
+    activeChatContext: Context | undefined
+    setActiveChatContext: (context: Context | undefined) => void
     interaction: Interaction
     isFirstInteraction: boolean
     isLastInteraction: boolean
@@ -251,7 +262,6 @@ const TranscriptInteraction: FC<TranscriptInteractionProps> = memo(props => {
         editorRef: parentEditorRef,
         onAddToFollowupChat,
     } = props
-
     const [intentResults, setIntentResults] = useMutatedValue<
         | {
               intent: ChatMessage['intent']
@@ -261,58 +271,104 @@ const TranscriptInteraction: FC<TranscriptInteractionProps> = memo(props => {
         | null
     >()
 
+    const { activeChatContext, setActiveChatContext } = props
     const humanEditorRef = useRef<PromptEditorRefAPI | null>(null)
     useImperativeHandle(parentEditorRef, () => humanEditorRef.current)
 
-    const onEditSubmit = useCallback(
-        (editorValue: SerializedPromptEditorValue, intentFromSubmit?: ChatMessage['intent']): void => {
+    const onUserAction = (action: 'edit' | 'submit', intentFromSubmit?: ChatMessage['intent']) => {
+        // Start the span as soon as the user initiates the action
+        const startMark = performance.mark('startSubmit')
+        const spanManager = new SpanManager('cody-webview')
+        const span = spanManager.startSpan('chat-interaction', {
+            attributes: {
+                sampled: true,
+                'render.state': 'started',
+                'startSubmit.mark': startMark.startTime,
+            },
+        })
+
+        if (!span) {
+            throw new Error('Failed to start span for chat interaction')
+        }
+
+        const spanContext = trace.setSpan(context.active(), span)
+        setActiveChatContext(spanContext)
+        const currentSpanContext = span.spanContext()
+
+        const traceparent = getTraceparentFromSpanContext(currentSpanContext)
+
+        // Serialize the editor value after starting the span
+        const editorValue = humanEditorRef.current?.getSerializedValue()
+        if (!editorValue) {
+            console.error('Failed to serialize editor value')
+            return
+        }
+
+        const commonProps = {
+            editorValue,
+            intent: intentFromSubmit || intentResults.current?.intent,
+            intentScores: intentFromSubmit ? undefined : intentResults.current?.allScores,
+            manuallySelectedIntent: !!intentFromSubmit,
+            traceparent,
+        }
+
+        if (action === 'edit') {
             editHumanMessage({
                 messageIndexInTranscript: humanMessage.index,
-                editorValue,
-                intent: intentFromSubmit || intentResults.current?.intent,
-                intentScores: intentFromSubmit ? undefined : intentResults.current?.allScores,
-                manuallySelectedIntent: !!intentFromSubmit,
+                ...commonProps,
             })
+        } else {
+            submitHumanMessage({
+                ...commonProps,
+            })
+        }
+    }
+
+    const onEditSubmit = useCallback(
+        (intentFromSubmit?: ChatMessage['intent']): void => {
+            onUserAction('edit', intentFromSubmit)
         },
-        [humanMessage.index, intentResults]
+        [onUserAction]
     )
 
     const onFollowupSubmit = useCallback(
-        (editorValue: SerializedPromptEditorValue, intentFromSubmit?: ChatMessage['intent']): void => {
-            submitHumanMessage({
-                editorValue,
-                intent: intentFromSubmit || intentResults.current?.intent,
-                intentScores: intentFromSubmit ? undefined : intentResults.current?.allScores,
-                manuallySelectedIntent: !!intentFromSubmit,
-            })
+        (intentFromSubmit?: ChatMessage['intent']): void => {
+            onUserAction('submit', intentFromSubmit)
         },
-        [intentResults]
+        [onUserAction]
     )
 
     const extensionAPI = useExtensionAPI()
     const experimentalOneBoxEnabled = useExperimentalOneBox()
     const onChange = useMemo(() => {
         return debounce(async (editorValue: SerializedPromptEditorValue) => {
-            setIntentResults(undefined)
-
             if (!experimentalOneBoxEnabled) {
                 return
             }
 
-            // Only detect intent if a repository is mentioned
             if (
-                editorValue.contextItems.find(contextItem =>
+                !editorValue.contextItems.find(contextItem =>
                     ['repository', 'tree'].includes(contextItem.type)
                 )
             ) {
-                extensionAPI
-                    .detectIntent(
-                        inputTextWithoutContextChipsFromPromptEditorState(editorValue.editorState)
-                    )
-                    .subscribe(value => {
-                        setIntentResults(value)
-                    })
+                return
             }
+
+            setIntentResults(undefined)
+
+            const subscription = extensionAPI
+                .detectIntent(inputTextWithoutContextChipsFromPromptEditorState(editorValue.editorState))
+                .subscribe({
+                    next: value => {
+                        setIntentResults(value)
+                    },
+                    error: error => {
+                        console.error('Error detecting intent:', error)
+                    },
+                })
+
+            // Clean up subscription if component unmounts
+            return () => subscription.unsubscribe()
         }, 300)
     }, [experimentalOneBoxEnabled, extensionAPI, setIntentResults])
 
@@ -327,6 +383,113 @@ const TranscriptInteraction: FC<TranscriptInteractionProps> = memo(props => {
             isLastSentInteraction &&
             assistantMessage?.text === undefined
     )
+    const spanManager = new SpanManager('cody-webview')
+    const renderSpan = useRef<Span>()
+    const timeToFirstTokenSpan = useRef<Span>()
+    const hasRecordedFirstToken = useRef(false)
+
+    const [isLoading, setIsLoading] = useState(assistantMessage?.isLoading)
+
+    useEffect(() => {
+        setIsLoading(assistantMessage?.isLoading)
+    }, [assistantMessage])
+
+    useEffect(() => {
+        if (!assistantMessage) return
+
+        const startRenderSpan = () => {
+            // Reset the spans to their initial state
+            renderSpan.current = undefined
+            timeToFirstTokenSpan.current = undefined
+            hasRecordedFirstToken.current = false
+
+            const startRenderMark = performance.mark('startRender')
+            // Start a new span for rendering the assistant message
+            renderSpan.current = spanManager.startSpan('assistant-message-render', {
+                attributes: {
+                    sampled: true,
+                    'message.index': assistantMessage.index,
+                    'render.start_time': startRenderMark.startTime,
+                    'parent.span.id': activeChatContext
+                        ? trace.getSpan(activeChatContext)?.spanContext().spanId
+                        : undefined,
+                },
+                context: activeChatContext,
+            })
+            // Start a span to measure time to first token
+            timeToFirstTokenSpan.current = spanManager.startSpan('time-to-first-token', {
+                attributes: { 'message.index': assistantMessage.index },
+                context: activeChatContext,
+            })
+        }
+
+        const endRenderSpan = () => {
+            // Mark the end of rendering
+            performance.mark('endRender')
+            // Measure the duration of the render
+            const measure = performance.measure('renderDuration', 'startRender', 'endRender')
+            if (renderSpan.current && measure.duration > 0) {
+                // Set attributes and end the render span
+                renderSpan.current.setAttributes({
+                    'render.success': !assistantMessage?.error,
+                    'message.length': assistantMessage?.text?.length ?? 0,
+                    'render.total_time': measure.duration,
+                })
+                renderSpan.current.end()
+            }
+
+            renderSpan.current = undefined
+            hasRecordedFirstToken.current = false
+
+            if (activeChatContext) {
+                const rootSpan = trace.getSpan(activeChatContext)
+                if (rootSpan) {
+                    // Calculate and set the total chat time
+                    const chatTotalTime =
+                        performance.now() - performance.getEntriesByName('startSubmit')[0].startTime
+                    rootSpan.setAttributes({
+                        'chat.completed': true,
+                        'render.state': 'completed',
+                        'chat.total_time': chatTotalTime,
+                    })
+                    rootSpan.end()
+                }
+            }
+            // Clear the active chat context
+            setActiveChatContext(undefined)
+        }
+
+        const endFirstTokenSpan = () => {
+            if (renderSpan.current && timeToFirstTokenSpan.current) {
+                // Mark the first token
+                performance.mark('firstToken')
+                // Measure the time to first token
+                performance.measure('timeToFirstToken', 'startRender', 'firstToken')
+                const firstTokenMeasure = performance.getEntriesByName('timeToFirstToken')[0]
+                if (firstTokenMeasure.duration > 0) {
+                    // Set attributes and end the time-to-first-token span
+                    timeToFirstTokenSpan.current.setAttributes({
+                        'time.to.first.token': firstTokenMeasure.duration,
+                    })
+                    timeToFirstTokenSpan.current.end()
+                    timeToFirstTokenSpan.current = undefined
+                    hasRecordedFirstToken.current = true
+                }
+            }
+        }
+        // Case 3: End the time-to-first-token span when the first token appears
+        if (assistantMessage.text && !hasRecordedFirstToken.current && timeToFirstTokenSpan.current) {
+            endFirstTokenSpan()
+        }
+        // Case 1: Start rendering if the assistant message is loading and no render span exists
+        if (assistantMessage.isLoading && !renderSpan.current && activeChatContext) {
+            context.with(activeChatContext, startRenderSpan)
+        }
+        // Case 2: End rendering if loading is complete and a render span exists
+        else if (!isLoading && renderSpan.current) {
+            endRenderSpan()
+        }
+    }, [assistantMessage, activeChatContext, setActiveChatContext, spanManager, isLoading])
 
     const humanMessageInfo = useMemo(() => {
         // See SRCH-942: it's critical to memoize this value to avoid repeated
@@ -342,7 +505,7 @@ const TranscriptInteraction: FC<TranscriptInteractionProps> = memo(props => {
         (intent: ChatMessage['intent']) => {
             const editorState = humanEditorRef.current?.getSerializedValue()
             if (editorState) {
-                onEditSubmit(editorState, intent)
+                onEditSubmit(intent)
                 telemetryRecorder.recordEvent('onebox.intentCorrection', 'clicked', {
                     metadata: {
                         recordsPrivateMetadataTranscript: 1,
@@ -367,10 +530,7 @@ const TranscriptInteraction: FC<TranscriptInteractionProps> = memo(props => {
                 return
             }
             await editor.addMentions(corpusContextItems, 'before', ' ')
-            const newEditorState = humanEditorRef.current?.getSerializedValue()
-            if (newEditorState) {
-                onEditSubmit(newEditorState, 'chat')
-            }
+            onEditSubmit('chat')
         }
     }, [corpusContextItems, onEditSubmit])
 
@@ -408,7 +568,9 @@ const TranscriptInteraction: FC<TranscriptInteractionProps> = memo(props => {
                 isSent={!humanMessage.isUnsentFollowup}
                 isPendingPriorResponse={priorAssistantMessageIsLoading}
                 onChange={onChange}
-                onSubmit={humanMessage.isUnsentFollowup ? onFollowupSubmit : onEditSubmit}
+                onSubmit={
+                    humanMessage.isUnsentFollowup ? () => onFollowupSubmit() : () => onEditSubmit()
+                }
                 onStop={onStop}
                 isFirstInteraction={isFirstInteraction}
                 isLastInteraction={isLastInteraction}
@@ -557,11 +719,13 @@ function submitHumanMessage({
     intent,
     intentScores,
     manuallySelectedIntent,
+    traceparent,
 }: {
     editorValue: SerializedPromptEditorValue
     intent?: ChatMessage['intent']
     intentScores?: { intent: string; score: number }[]
     manuallySelectedIntent?: boolean
+    traceparent: string
 }): void {
     getVSCodeAPI().postMessage({
         command: 'submit',
@@ -571,6 +735,7 @@ function submitHumanMessage({
         intent,
         intentScores,
         manuallySelectedIntent,
+        traceparent,
     })
     focusLastHumanMessageEditor()
 }

--- a/vscode/webviews/utils/spanManager.ts
+++ b/vscode/webviews/utils/spanManager.ts
@@ -1,0 +1,137 @@
+import {
+    type Attributes,
+    type Context,
+    type Span,
+    type SpanOptions,
+    SpanStatusCode,
+    type Tracer,
+    context,
+    trace,
+} from '@opentelemetry/api'
+
+// Extend SpanOptions to optionally include context
+type SpanManagerOptions = SpanOptions & {
+    context?: Context
+}
+
+/**
+ * SpanManager is responsible for managing the lifecycle of spans used in tracing.
+ * It provides methods to start, end, and manage spans, as well as to handle context propagation.
+ *
+ * Features:
+ * - Start and manage active spans with context propagation.
+ * - End spans and record exceptions.
+ * - Set attributes on spans.
+ * - Clear all spans and reset the active context.
+ */
+export class SpanManager {
+    private spans = new Map<string, Span>()
+    private endedSpans = new Set<string>()
+    private tracer: Tracer
+    private activeContext?: Context
+
+    constructor(tracerName = 'cody-webview') {
+        this.tracer = trace.getTracer(tracerName)
+    }
+
+    startActiveSpan<T>(
+        name: string,
+        optionsOrFn: SpanManagerOptions | ((span: Span) => Promise<T> | T),
+        fnOrUndefined?: (span: Span) => Promise<T> | T
+    ): Promise<T> {
+        const options = typeof optionsOrFn === 'function' ? {} : optionsOrFn
+        const fn = typeof optionsOrFn === 'function' ? optionsOrFn : fnOrUndefined
+
+        if (!fn) {
+            throw new Error('No callback function provided to startActiveSpan')
+        }
+
+        // Context is optional - if not provided, use active context
+        const parentContext = options.context || this.activeContext || context.active()
+
+        // Extract standard SpanOptions from SpanManagerOptions
+        const spanOptions: SpanOptions = {
+            attributes: options.attributes,
+            kind: options.kind,
+            links: options.links,
+            startTime: options.startTime,
+        }
+
+        return this.tracer.startActiveSpan(name, spanOptions, async span => {
+            this.spans.set(name, span)
+
+            // Create new context with this span
+            const spanContext = trace.setSpan(parentContext, span)
+            this.activeContext = spanContext
+
+            try {
+                return await context.with(spanContext, () => fn(span))
+            } catch (error) {
+                span.setStatus({
+                    code: SpanStatusCode.ERROR,
+                    message: error instanceof Error ? error.message : 'Unknown error',
+                })
+                span.recordException(error as Error)
+                throw error
+            } finally {
+                this.endSpan(name)
+            }
+        })
+    }
+
+    startSpan(name: string, options?: SpanManagerOptions): Span {
+        if (this.spans.has(name)) {
+            return this.spans.get(name)!
+        }
+
+        // Use provided context or fall back to active context
+        const parentContext = options?.context || this.activeContext || context.active()
+
+        // Extract standard SpanOptions from SpanManagerOptions
+        const spanOptions: SpanOptions = {
+            attributes: options?.attributes,
+            kind: options?.kind,
+            links: options?.links,
+            startTime: options?.startTime,
+        }
+
+        const span = this.tracer.startSpan(name, spanOptions, parentContext)
+        this.spans.set(name, span)
+        return span
+    }
+
+    getActiveContext(): Context | undefined {
+        return this.activeContext
+    }
+
+    setActiveContext(ctx: Context): void {
+        this.activeContext = ctx
+    }
+
+    endSpan(name: string): void {
+        const span = this.spans.get(name)
+        if (span && !this.endedSpans.has(name)) {
+            span.end()
+            this.endedSpans.add(name)
+            this.spans.delete(name)
+        }
+    }
+
+    setSpanAttributes(name: string, attributes: Record<string, unknown>): void {
+        const span = this.spans.get(name)
+        if (span && !this.endedSpans.has(name)) {
+            span.setAttributes(attributes as Attributes)
+        }
+    }
+
+    endAllSpans(): void {
+        this.spans.forEach((_, name) => this.endSpan(name))
+    }
+
+    clear(): void {
+        this.endAllSpans()
+        this.spans.clear()
+        this.endedSpans.clear()
+        this.activeContext = undefined
+    }
+}

--- a/vscode/webviews/utils/telemetry.ts
+++ b/vscode/webviews/utils/telemetry.ts
@@ -1,5 +1,6 @@
 import type { TelemetryRecorder } from '@sourcegraph/cody-shared'
 
+import type { SpanContext } from '@opentelemetry/api'
 import { createContext, useContext } from 'react'
 import type { WebviewRecordEventParameters } from '../../src/chat/protocol'
 import type { ApiPostMessage } from '../Chat'
@@ -36,4 +37,10 @@ export function useTelemetryRecorder(): TelemetryRecorder {
         throw new Error('no telemetryRecorder')
     }
     return telemetryRecorder
+}
+
+export function getTraceparentFromSpanContext(spanContext: SpanContext): string {
+    return `00-${spanContext.traceId}-${spanContext.spanId}-${spanContext.traceFlags
+        .toString(16)
+        .padStart(2, '0')}`
 }

--- a/vscode/webviews/utils/webviewOpenTelemetryService.ts
+++ b/vscode/webviews/utils/webviewOpenTelemetryService.ts
@@ -1,0 +1,100 @@
+import { DiagConsoleLogger, DiagLogLevel, diag } from '@opentelemetry/api'
+import { Resource } from '@opentelemetry/resources'
+import { BatchSpanProcessor, WebTracerProvider } from '@opentelemetry/sdk-trace-web'
+import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions'
+import type { CodyIDE } from '@sourcegraph/cody-shared/src/configuration'
+import { CodyTraceExporterWeb } from '../../src/services/open-telemetry/CodyTraceExportWeb'
+
+// This class is used to initialize and manage the OpenTelemetry service for the webview.
+// Its inspired by the OpenTelemetryService class in the node extension.
+// It is used to initialize the tracer provider and add a span processor that exports the spans to the webview.
+export class WebviewOpenTelemetryService {
+    private static instance: WebviewOpenTelemetryService | null = null
+    private tracerProvider?: WebTracerProvider
+    private unloadInstrumentations?: () => void
+    private isTracingEnabled = false
+    private isInitialized = false
+    private agentIDE?: CodyIDE
+    private extensionAgentVersion?: string
+    constructor() {
+        if (!WebviewOpenTelemetryService.instance) {
+            WebviewOpenTelemetryService.instance = this
+            this.reset()
+        }
+    }
+
+    public configure(options?: {
+        isTracingEnabled?: boolean
+        debugVerbose?: boolean
+        agentIDE?: CodyIDE
+        extensionAgentVersion?: string
+    }): void {
+        // If the service is already initialized or if it is not the instance that is being used, return
+        if (this.isInitialized || WebviewOpenTelemetryService.instance !== this) {
+            return
+        }
+
+        const {
+            isTracingEnabled = true,
+            debugVerbose = false,
+            agentIDE,
+            extensionAgentVersion,
+        } = options || {}
+        this.isTracingEnabled = isTracingEnabled
+        this.agentIDE = agentIDE
+        this.extensionAgentVersion = extensionAgentVersion
+        const logLevel = debugVerbose ? DiagLogLevel.INFO : DiagLogLevel.ERROR
+        diag.setLogger(new DiagConsoleLogger(), logLevel)
+
+        try {
+            this.tracerProvider = new WebTracerProvider({
+                resource: new Resource({
+                    [SemanticResourceAttributes.SERVICE_NAME]: 'cody-webview',
+                    [SemanticResourceAttributes.SERVICE_VERSION]: '1.0.0',
+                }),
+            })
+            if (this.isTracingEnabled) {
+                this.tracerProvider.addSpanProcessor(
+                    new BatchSpanProcessor(
+                        new CodyTraceExporterWeb({
+                            isTracingEnabled: true,
+                            clientPlatform: this.agentIDE ?? ('defaultIDE' as CodyIDE),
+                            agentVersion: this.extensionAgentVersion,
+                        })
+                    )
+                )
+            }
+
+            this.tracerProvider.register()
+            this.isInitialized = true
+            console.log('WebviewOpenTelemetryService initialized')
+        } catch (error) {
+            console.error('Failed to initialize OpenTelemetry:', error)
+            this.reset()
+        }
+    }
+
+    public reset(): void {
+        if (this.tracerProvider) {
+            this.unloadInstrumentations?.()
+            this.tracerProvider.shutdown()
+            this.tracerProvider = undefined
+            this.isInitialized = false
+        }
+    }
+
+    public dispose(): void {
+        if (WebviewOpenTelemetryService.instance !== this) {
+            return
+        }
+        this.reset()
+        WebviewOpenTelemetryService.instance = null
+    }
+
+    public static getInstance(): WebviewOpenTelemetryService {
+        if (!WebviewOpenTelemetryService.instance) {
+            WebviewOpenTelemetryService.instance = new WebviewOpenTelemetryService()
+        }
+        return WebviewOpenTelemetryService.instance
+    }
+}

--- a/web/lib/agent/shims/stream.ts
+++ b/web/lib/agent/shims/stream.ts
@@ -5,3 +5,7 @@ export function Readable(): unknown {
 export function Writable(): unknown {
     return null
 }
+
+export default {
+    Readable: { prototype: {} },
+}

--- a/web/lib/agent/shims/zlib.ts
+++ b/web/lib/agent/shims/zlib.ts
@@ -1,0 +1,3 @@
+export default {
+    Readable: { prototype: {} },
+}

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -57,6 +57,8 @@ export default defineProjectWithDefaults(__dirname, {
                 replacement: resolve(__dirname, 'node_modules/path-browserify'),
             },
             { find: 'node:stream', replacement: resolve(__dirname, 'node_modules/stream-browserify') },
+            { find: 'zlib', replacement: resolve(__dirname, 'lib/agent/shims/zlib.ts') },
+            { find: 'stream', replacement: resolve(__dirname, 'lib/agent/shims/stream.ts') },
             { find: /^(node:)?events$/, replacement: resolve(__dirname, 'node_modules/events') },
             { find: /^(node:)?util$/, replacement: resolve(__dirname, 'node_modules/util') },
             { find: /^(node:)?buffer$/, replacement: resolve(__dirname, 'node_modules/buffer') },


### PR DESCRIPTION
Reverts sourcegraph/cody#6268  Reverts the original  revert of  commits https://github.com/sourcegraph/cody/commit/56866996ebbc16dc7bf145220a9c461acd8ef683 and https://github.com/sourcegraph/cody/commit/6bf801bc33760b227a5a1dfe2ca27add8caa5207 because they did NOT cause the logging of the spans so its okay to have this in our codebase again. 

Related PR https://github.com/sourcegraph/cody/pull/6292#discussion_r1878230544 

[RElated Linear Issue 
](https://linear.app/sourcegraph/issue/CODY-4494/investigate-excessive-logging-and-span-operation-issues-in-jetbrains)
[Slack Thread
](https://sourcegraph.slack.com/archives/C05AGQYD528/p1733309439863749)

## Test Plan 

I tested it locally with JAegar
