### PR TITLE
fix(webviews): update avatar sizes in UI

### DIFF
--- a/vscode/webviews/components/UserMenu.tsx
+++ b/vscode/webviews/components/UserMenu.tsx
@@ -15,6 +15,7 @@ import {
 import { useCallback, useState } from 'react'
 import { URI } from 'vscode-uri'
 import { ACCOUNT_USAGE_URL, isSourcegraphToken } from '../../src/chat/protocol'
+import { MESSAGE_CELL_AVATAR_SIZE } from '../chat/cells/messageCell/BaseMessageCell'
 import type { View } from '../tabs'
 import { getVSCodeAPI } from '../utils/VSCodeApi'
 import { useTelemetryRecorder } from '../utils/telemetry'
@@ -315,7 +316,7 @@ export const UserMenu: React.FunctionComponent<UserMenuProps> = ({
                                     <div className="tw-flex tw-w-full tw-justify-start tw-gap-4">
                                         <UserAvatar
                                             user={authStatus}
-                                            size={16}
+                                            size={MESSAGE_CELL_AVATAR_SIZE}
                                             sourcegraphGradientBorder={!!isProUser}
                                             className="tw-flex tw-justify-center"
                                         />
@@ -427,7 +428,11 @@ export const UserMenu: React.FunctionComponent<UserMenuProps> = ({
                 },
             }}
         >
-            <UserAvatar user={authStatus} size={12} sourcegraphGradientBorder={!!isProUser} />
+            <UserAvatar
+                user={authStatus}
+                size={MESSAGE_CELL_AVATAR_SIZE}
+                sourcegraphGradientBorder={!!isProUser}
+            />
         </ToolbarPopoverItem>
     )
 }

--- a/vscode/webviews/components/promptList/ActionItem.tsx
+++ b/vscode/webviews/components/promptList/ActionItem.tsx
@@ -25,6 +25,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '../../components/shadcn
 
 import { commandRowValue } from './utils'
 
+import { MESSAGE_CELL_AVATAR_SIZE } from '../../chat/cells/messageCell/BaseMessageCell'
 import { useConfig } from '../../utils/useConfig'
 import styles from './ActionItem.module.css'
 
@@ -74,7 +75,7 @@ const ActionPrompt: FC<ActionPromptProps> = props => {
         <div className={styles.prompt}>
             {prompt.createdBy && (
                 <UserAvatar
-                    size={14}
+                    size={MESSAGE_CELL_AVATAR_SIZE}
                     user={{ ...prompt.createdBy, endpoint: '' }}
                     className={styles.promptAvatar}
                 />

--- a/vscode/webviews/tabs/AccountTab.tsx
+++ b/vscode/webviews/tabs/AccountTab.tsx
@@ -103,7 +103,7 @@ export const AccountTab: React.FC<AccountTabProps> = ({
                     <div className="tw-flex tw-self-stretch tw-flex-col tw-w-full tw-items-center tw-justify-center">
                         <UserAvatar
                             user={authStatus}
-                            size={20}
+                            size={12}
                             className="tw-flex-shrink-0 tw-w-[30px] tw-h-[30px] tw-flex tw-items-center tw-justify-center"
                         />
                         <div className="tw-flex tw-self-stretch tw-flex-col tw-w-full tw-items-center tw-justify-center tw-mt-4">


### PR DESCRIPTION
CLOSE https://linear.app/sourcegraph/issue/CODY-4496/debugger-displaying-profile-picture-in-unexpected-locations

This change updates the avatar sizes in the UserMenu, ActionItem, and AccountTab components to use the consistent MESSAGE_CELL_AVATAR_SIZE constant.

The changes include:
- Update the avatar size in the UserMenu component to use the MESSAGE_CELL_AVATAR_SIZE constant
- Update the avatar size in the ActionItem component to use the MESSAGE_CELL_AVATAR_SIZE constant
- Update the avatar size in the AccountTab component to use a smaller size of 12


## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

UI change. Check storybook

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
