### PR TITLE
fix(Deep Cody): show notices for Pro and Enterprise users

### DIFF
--- a/vscode/webviews/components/Notices.tsx
+++ b/vscode/webviews/components/Notices.tsx
@@ -28,7 +28,7 @@ interface Notice {
 }
 
 type NoticeVariants = 'default' | 'warning'
-type NoticeIDs = 'DogfoodS2' | 'TeamsUpgrade' | 'DeepCody'
+type NoticeIDs = 'DogfoodS2' | 'TeamsUpgrade' | 'DeepCodyDotCom' | 'DeepCodyEnterprise'
 
 interface NoticesProps {
     user: UserAccountInfo
@@ -69,14 +69,16 @@ export const Notices: React.FC<NoticesProps> = ({ user, isTeamsUpgradeCtaEnabled
         () => [
             {
                 id: 'DeepCody',
-                isVisible: isDeepCodyEnabled && user.IDE !== CodyIDE.Web,
+                isVisible: (isDeepCodyEnabled || user.isCodyProUser) && user.IDE !== CodyIDE.Web,
                 content: (
                     <NoticeContent
-                        id="DeepCody"
+                        id={user.isCodyProUser ? 'DeepCodyDotCom' : 'DeepCodyEnterprise'}
                         variant="default"
                         title="Deep Cody (Experimental)"
                         message="An AI agent powered by Claude 3.5 Sonnet (New) and other models with tool-use capabilities to gather contextual information for enhanced responses. It can search your codebase, browse the web, execute shell commands in your terminal (when enabled), and utilize any configured tools to retrieve necessary context."
-                        onDismiss={() => dismissNotice('DeepCody')}
+                        onDismiss={() =>
+                            dismissNotice(user.isCodyProUser ? 'DeepCodyDotCom' : 'DeepCodyEnterprise')
+                        }
                         actions={
                             isDeepCodyShellContextSupported
                                 ? [
@@ -239,7 +241,12 @@ const NoticeContent: FunctionComponent<NoticeContentProps> = ({
     }[variant]
 
     const header = {
-        DeepCody: (
+        DeepCodyDotCom: (
+            <>
+                <CodyLogo size={16} />
+            </>
+        ),
+        DeepCodyEnterprise: (
             <>
                 <CodyLogo size={16} />
             </>

--- a/vscode/webviews/components/modelSelectField/ModelSelectField.story.tsx
+++ b/vscode/webviews/components/modelSelectField/ModelSelectField.story.tsx
@@ -16,6 +16,14 @@ const MODELS: Model[] = [
         usage: [ModelUsage.Chat],
         tags: [ModelTag.Ollama, ModelTag.Local],
     },
+    {
+        title: 'Deep Cody',
+        provider: 'sourcegraph',
+        id: 'deep-cody',
+        contextWindow: { input: 100, output: 100 },
+        usage: [ModelUsage.Chat],
+        tags: [ModelTag.Pro, ModelTag.Experimental],
+    },
 ]
 
 const meta: Meta<typeof ModelSelectField> = {

--- a/vscode/webviews/components/modelSelectField/ModelSelectField.tsx
+++ b/vscode/webviews/components/modelSelectField/ModelSelectField.tsx
@@ -356,21 +356,13 @@ const ModelTitleWithIcon: React.FC<{
     const modelBadge = getBadgeText(model, modelAvailability)
     const isDisabled = modelAvailability !== 'available'
 
-    if (model.id.includes('deep-cody')) {
-        return (
-            <span className={clsx(styles.modelTitleWithIcon, { [styles.disabled]: isDisabled })}>
-                {showIcon && <FlaskConicalIcon size={16} className={styles.modelIcon} />}
-                <span className={clsx('tw-flex-grow', styles.modelName)}>{model.title}</span>
-                <Badge variant="secondary" className={styles.badge}>
-                    Experimental ⓘ
-                </Badge>
-            </span>
-        )
-    }
-
     return (
         <span className={clsx(styles.modelTitleWithIcon, { [styles.disabled]: isDisabled })}>
-            {showIcon && <ChatModelIcon model={model.provider} className={styles.modelIcon} />}
+            {showIcon && model.id.includes('deep-cody') ? (
+                <FlaskConicalIcon size={16} className={styles.modelIcon} />
+            ) : (
+                <ChatModelIcon model={model.provider} className={styles.modelIcon} />
+            )}
             <span className={clsx('tw-flex-grow', styles.modelName)}>{model.title}</span>
             {modelBadge && (
                 <Badge

--- a/vscode/webviews/components/modelSelectField/ModelSelectField.tsx
+++ b/vscode/webviews/components/modelSelectField/ModelSelectField.tsx
@@ -358,11 +358,13 @@ const ModelTitleWithIcon: React.FC<{
 
     return (
         <span className={clsx(styles.modelTitleWithIcon, { [styles.disabled]: isDisabled })}>
-            {showIcon && model.id.includes('deep-cody') ? (
-                <FlaskConicalIcon size={16} className={styles.modelIcon} />
-            ) : (
-                <ChatModelIcon model={model.provider} className={styles.modelIcon} />
-            )}
+            {showIcon ? (
+                model.id.includes('deep-cody') ? (
+                    <FlaskConicalIcon size={16} className={styles.modelIcon} />
+                ) : (
+                    <ChatModelIcon model={model.provider} className={styles.modelIcon} />
+                )
+            ) : null}
             <span className={clsx('tw-flex-grow', styles.modelName)}>{model.title}</span>
             {modelBadge && (
                 <Badge


### PR DESCRIPTION
CONTEXT: https://sourcegraph.slack.com/archives/C06GFD8GFCN/p1733856027839759?thread_ts=1733844935.078399&cid=C06GFD8GFCN

Follow up on https://github.com/sourcegraph/cody/pull/6279

- Introduce new notice IDs 'DeepCodyDotCom' and 'DeepCodyEnterprise' to differentiate the Deep Cody notice for Pro and Enterprise users
- Update the `Notices` component to show the appropriate notice based on the user's plan
- Adjust the `NoticeContent` component to render the correct header for each notice variant

This fixes an issue where notice for Deep Cody does not show up for Cody Pro users, as the feature flag only applies to Enterprise users.

## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

Log in as Pro user / Enterprise user:

- Notice for Deep Cody shows up when Deep Cody is available
- The notice should not show up again after you have dismissed it

Bug originally reported by QA:

when I logged in to Enterprise instance,

1. I can see the new notification for Deep Cody
2. From the LLM dropdown, when I hove over Deep Cody info icon, the information displayed correctly
3. But when I switch account to Pro user, I cannot see this UI(I haven't dismissed it yet)

- Free user should not see the CTA for Deep Cody.
- Deep Cody should show up in the model list with "Cody Pro" badge next to it

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->

