### PR TITLE
feat/cody: Prep for the A/B test on Claude 3.5 Haiku as the default chat model for Free users (CODY-4455)

### DIFF
--- a/lib/shared/src/experimentation/FeatureFlagProvider.ts
+++ b/lib/shared/src/experimentation/FeatureFlagProvider.ts
@@ -59,6 +59,9 @@ export enum FeatureFlag {
     // Enables gpt-4o-mini as a default Edit model
     CodyEditDefaultToGpt4oMini = 'cody-edit-default-to-gpt-4o-mini',
 
+    // Enables Claude 3.5 Haiku as a default Chat model
+    CodyChatDefaultToClaude35Haiku = 'cody-chat-default-to-claude-3-5-haiku',
+
     // use-ssc-for-cody-subscription is a feature flag that enables the use of SSC as the source of truth for Cody subscription data.
     UseSscForCodySubscription = 'use-ssc-for-cody-subscription',
 

--- a/lib/shared/src/models/modelsService.ts
+++ b/lib/shared/src/models/modelsService.ts
@@ -23,7 +23,6 @@ import {
     userProductSubscription,
 } from '../sourcegraph-api/userProductSubscription'
 import { CHAT_INPUT_TOKEN_BUDGET, CHAT_OUTPUT_TOKEN_BUDGET } from '../token/constants'
-
 import { configOverwrites } from './configOverwrites'
 import { type Model, type ServerModel, modelTier } from './model'
 import { syncModels } from './sync'
@@ -328,6 +327,7 @@ export class ModelsService {
         authStatus,
         configOverwrites,
         clientConfig: ClientConfigSingleton.getInstance().changes,
+        userProductSubscription,
     })
 
     /**

--- a/lib/shared/src/models/sync.test.ts
+++ b/lib/shared/src/models/sync.test.ts
@@ -43,9 +43,6 @@ vi.mock('../experimentation/FeatureFlagProvider')
 
 // Returns true for all feature flags enabled during synctests.
 vi.spyOn(featureFlagProvider, 'evaluatedFeatureFlag').mockReturnValue(Observable.of(true))
-vi.spyOn(userProductSubscriptionModule, 'userProductSubscription', 'get').mockReturnValue(
-    Observable.of({ userCanUpgrade: true })
-)
 
 mockClientCapabilities(CLIENT_CAPABILITIES_FIXTURE)
 
@@ -210,6 +207,7 @@ describe('server sent models', async () => {
                 modelsAPIEnabled: true,
             } satisfies Partial<CodyClientConfig> as CodyClientConfig),
             fetchServerSideModels_: mockFetchServerSideModels,
+            userProductSubscription: Observable.of({ userCanUpgrade: true }),
         }).pipe(skipPendingOperation())
     )
     const storage = new TestLocalStorageForModelPreferences()
@@ -265,6 +263,7 @@ describe('syncModels', () => {
                 configOverwrites: configOverwritesSubject.pipe(shareReplay()),
                 clientConfig: clientConfigSubject.pipe(shareReplay()),
                 fetchServerSideModels_: mockFetchServerSideModels,
+                userProductSubscription: Observable.of({ userCanUpgrade: true }),
             })
             const { values, clearValues, unsubscribe, done } = readValuesFrom(syncModelsObservable)
 
@@ -505,6 +504,7 @@ describe('syncModels', () => {
                     modelsAPIEnabled: true,
                 } satisfies Partial<CodyClientConfig> as CodyClientConfig),
                 fetchServerSideModels_: mockFetchServerSideModels,
+                userProductSubscription: Observable.of({ userCanUpgrade: true }),
             }).pipe(skipPendingOperation())
         )
 
@@ -584,11 +584,6 @@ describe('syncModels', () => {
                 )
             }
 
-            // set user tier
-            vi.spyOn(userProductSubscriptionModule, 'userProductSubscription', 'get').mockReturnValue(
-                Observable.of({ userCanUpgrade })
-            )
-
             return firstValueFrom(
                 syncModels({
                     resolvedConfig: Observable.of({
@@ -605,6 +600,7 @@ describe('syncModels', () => {
                         modelsAPIEnabled: true,
                     } satisfies Partial<CodyClientConfig> as CodyClientConfig),
                     fetchServerSideModels_: mockFetchServerSideModels,
+                    userProductSubscription: Observable.of({ userCanUpgrade }),
                 }).pipe(skipPendingOperation())
             )
         }

--- a/lib/shared/src/models/sync.test.ts
+++ b/lib/shared/src/models/sync.test.ts
@@ -5,6 +5,7 @@ import { AUTH_STATUS_FIXTURE_AUTHED, type AuthStatus } from '../auth/types'
 import { CLIENT_CAPABILITIES_FIXTURE, mockClientCapabilities } from '../configuration/clientCapabilities'
 import type { ResolvedConfiguration } from '../configuration/resolver'
 import { featureFlagProvider } from '../experimentation/FeatureFlagProvider'
+import { FeatureFlag } from '../experimentation/FeatureFlagProvider'
 import {
     firstValueFrom,
     readValuesFrom,
@@ -13,6 +14,7 @@ import {
 } from '../misc/observable'
 import { pendingOperation, skipPendingOperation } from '../misc/observableOperation'
 import type { CodyClientConfig } from '../sourcegraph-api/clientConfig'
+import { DOTCOM_URL } from '../sourcegraph-api/environments'
 import type { CodyLLMSiteConfiguration } from '../sourcegraph-api/graphql/client'
 import * as userProductSubscriptionModule from '../sourcegraph-api/userProductSubscription'
 import type { PartialDeep } from '../utils'
@@ -41,6 +43,9 @@ vi.mock('../experimentation/FeatureFlagProvider')
 
 // Returns true for all feature flags enabled during synctests.
 vi.spyOn(featureFlagProvider, 'evaluatedFeatureFlag').mockReturnValue(Observable.of(true))
+vi.spyOn(userProductSubscriptionModule, 'userProductSubscription', 'get').mockReturnValue(
+    Observable.of({ userCanUpgrade: true })
+)
 
 mockClientCapabilities(CLIENT_CAPABILITIES_FIXTURE)
 
@@ -519,5 +524,107 @@ describe('syncModels', () => {
         // preference should not be affected and remains unchanged as this is handled in a later step.
         expect(result.preferences.selected.chat).toBe(undefined)
         expect(storage.data?.[AUTH_STATUS_FIXTURE_AUTHED.endpoint]!.selected.chat).toBe(undefined)
+    })
+
+    describe('model selection based on user tier and feature flags', () => {
+        const serverHaiku: ServerModel = {
+            modelRef: 'anthropic::unknown::claude-3-5-haiku',
+            displayName: 'Haiku',
+            modelName: 'anthropic.claude-3-5-haiku',
+            capabilities: ['chat'],
+            category: 'balanced' as ModelCategory,
+            status: 'stable',
+            tier: 'free' as ModelTier,
+            contextWindow: {
+                maxInputTokens: 7000,
+                maxOutputTokens: 4000,
+            },
+        }
+        const serverSonnet: ServerModel = {
+            modelRef: 'anthropic::unknown::sonnet',
+            displayName: 'Sonnet',
+            modelName: 'anthropic.claude-3-5-sonnet',
+            capabilities: ['chat'],
+            category: 'balanced' as ModelCategory,
+            status: 'stable',
+            tier: 'enterprise' as ModelTier,
+            contextWindow: {
+                maxInputTokens: 9000,
+                maxOutputTokens: 4000,
+            },
+        }
+        const SERVER_MODELS: ServerModelConfiguration = {
+            schemaVersion: '0.0',
+            revision: '-',
+            providers: [],
+            models: [serverHaiku, serverSonnet],
+            defaultModels: {
+                chat: serverSonnet.modelRef,
+                fastChat: serverSonnet.modelRef,
+                codeCompletion: serverSonnet.modelRef,
+            },
+        }
+        const mockFetchServerSideModels = vi.fn(() => Promise.resolve(SERVER_MODELS))
+
+        async function getModelResult(featureFlagEnabled: boolean, userCanUpgrade: boolean) {
+            // set the feature flag
+            if (featureFlagEnabled) {
+                vi.spyOn(featureFlagProvider, 'evaluatedFeatureFlag').mockImplementation(
+                    (flag: FeatureFlag) =>
+                        flag === FeatureFlag.CodyChatDefaultToClaude35Haiku
+                            ? Observable.of(featureFlagEnabled)
+                            : Observable.of(false)
+                )
+            } else {
+                vi.spyOn(featureFlagProvider, 'evaluatedFeatureFlag').mockImplementation(
+                    (flag: FeatureFlag) =>
+                        flag === FeatureFlag.CodyChatDefaultToClaude35Haiku
+                            ? Observable.of(featureFlagEnabled)
+                            : Observable.of(true)
+                )
+            }
+
+            // set user tier
+            vi.spyOn(userProductSubscriptionModule, 'userProductSubscription', 'get').mockReturnValue(
+                Observable.of({ userCanUpgrade })
+            )
+
+            return firstValueFrom(
+                syncModels({
+                    resolvedConfig: Observable.of({
+                        configuration: {},
+                        clientState: { modelPreferences: {} },
+                    } satisfies PartialDeep<ResolvedConfiguration> as ResolvedConfiguration),
+                    authStatus: Observable.of({
+                        ...AUTH_STATUS_FIXTURE_AUTHED,
+                        endpoint: DOTCOM_URL.toString(),
+                        userCanUpgrade,
+                    }),
+                    configOverwrites: Observable.of(null),
+                    clientConfig: Observable.of({
+                        modelsAPIEnabled: true,
+                    } satisfies Partial<CodyClientConfig> as CodyClientConfig),
+                    fetchServerSideModels_: mockFetchServerSideModels,
+                }).pipe(skipPendingOperation())
+            )
+        }
+
+        it('sets Haiku as default chat model for free users when feature flag is enabled', async () => {
+            const result = await getModelResult(true, true)
+            expect(result.preferences.defaults.chat?.includes('claude-3-5-haiku')).toBe(true)
+            expect(result.primaryModels.some(model => model.id.includes('claude-3-5-haiku'))).toBe(true)
+        })
+
+        it('sets Sonnet as default chat model for free tier users when feature flag is disabled', async () => {
+            const result = await getModelResult(false, true)
+            expect(result.preferences.defaults.chat?.includes('sonnet')).toBe(true)
+            expect(result.primaryModels.some(model => model.id.includes('sonnet'))).toBe(true)
+        })
+
+        it('sets Sonnet as default chat model for pro tier users', async () => {
+            const result = await getModelResult(true, false)
+            expect(result.preferences.defaults.chat?.includes('sonnet')).toBe(true)
+            expect(result.primaryModels.some(model => model.id.includes('sonnet'))).toBe(true)
+        })
     })
 })

--- a/lib/shared/src/models/sync.ts
+++ b/lib/shared/src/models/sync.ts
@@ -24,6 +24,7 @@ import type { CodyClientConfig } from '../sourcegraph-api/clientConfig'
 import { isDotCom } from '../sourcegraph-api/environments'
 import type { CodyLLMSiteConfiguration } from '../sourcegraph-api/graphql/client'
 import { RestClient } from '../sourcegraph-api/rest/client'
+import { userProductSubscription } from '../sourcegraph-api/userProductSubscription'
 import { CHAT_INPUT_TOKEN_BUDGET } from '../token/constants'
 import { isError } from '../utils'
 import { getExperimentalClientModelByFeatureFlag } from './client'
@@ -196,54 +197,89 @@ export function syncModels({
                                         featureFlagProvider.evaluatedFeatureFlag(
                                             FeatureFlag.CodyEarlyAccess
                                         ),
-                                        featureFlagProvider.evaluatedFeatureFlag(FeatureFlag.DeepCody)
+                                        featureFlagProvider.evaluatedFeatureFlag(FeatureFlag.DeepCody),
+                                        featureFlagProvider.evaluatedFeatureFlag(
+                                            FeatureFlag.CodyChatDefaultToClaude35Haiku
+                                        ),
+                                        userProductSubscription
                                     ).pipe(
-                                        switchMap(([hasEarlyAccess, hasDeepCodyFlag]) => {
-                                            // TODO(sqs): remove waitlist from localStorage when user has access
-                                            const isOnWaitlist = config.clientState.waitlist_o1
-                                            if (isDotComUser && (hasEarlyAccess || isOnWaitlist)) {
-                                                data.primaryModels = data.primaryModels.map(model => {
-                                                    if (model.tags.includes(ModelTag.Waitlist)) {
-                                                        const newTags = model.tags.filter(
-                                                            tag => tag !== ModelTag.Waitlist
-                                                        )
-                                                        newTags.push(
-                                                            hasEarlyAccess
-                                                                ? ModelTag.EarlyAccess
-                                                                : ModelTag.OnWaitlist
-                                                        )
-                                                        return { ...model, tags: newTags }
-                                                    }
-                                                    return model
-                                                })
-                                            }
-
-                                            // Replace user's current sonnet model with deep-cody model.
-                                            const sonnetModel = data.primaryModels.find(m =>
-                                                m.id.includes('sonnet')
-                                            )
-                                            // DEEP CODY is enabled for all PLG users.
-                                            // Enterprise users need to have the feature flag enabled.
-                                            const isDeepCodyEnabled = isDotComUser || hasDeepCodyFlag
-                                            if (
-                                                isDeepCodyEnabled &&
-                                                sonnetModel &&
-                                                // Ensure the deep-cody model is only added once.
-                                                !data.primaryModels.some(m => m.id.includes('deep-cody'))
-                                            ) {
-                                                const DEEPCODY_MODEL =
-                                                    getExperimentalClientModelByFeatureFlag(
-                                                        FeatureFlag.DeepCody
-                                                    )!
-                                                data.primaryModels.push(
-                                                    ...maybeAdjustContextWindows([DEEPCODY_MODEL]).map(
-                                                        createModelFromServerModel
+                                        switchMap(
+                                            ([
+                                                hasEarlyAccess,
+                                                hasDeepCodyFlag,
+                                                defaultToHaiku,
+                                                userSubscription,
+                                            ]) => {
+                                                // TODO(sqs): remove waitlist from localStorage when user has access
+                                                const isOnWaitlist = config.clientState.waitlist_o1
+                                                if (isDotComUser && (hasEarlyAccess || isOnWaitlist)) {
+                                                    data.primaryModels = data.primaryModels.map(
+                                                        model => {
+                                                            if (model.tags.includes(ModelTag.Waitlist)) {
+                                                                const newTags = model.tags.filter(
+                                                                    tag => tag !== ModelTag.Waitlist
+                                                                )
+                                                                newTags.push(
+                                                                    hasEarlyAccess
+                                                                        ? ModelTag.EarlyAccess
+                                                                        : ModelTag.OnWaitlist
+                                                                )
+                                                                return { ...model, tags: newTags }
+                                                            }
+                                                            return model
+                                                        }
                                                     )
-                                                )
-                                            }
+                                                }
 
-                                            return Observable.of(data)
-                                        })
+                                                // Replace user's current sonnet model with deep-cody model.
+                                                const sonnetModel = data.primaryModels.find(m =>
+                                                    m.id.includes('sonnet')
+                                                )
+                                                // DEEP CODY is enabled for all PLG users.
+                                                // Enterprise users need to have the feature flag enabled.
+                                                const isDeepCodyEnabled = isDotComUser || hasDeepCodyFlag
+                                                if (
+                                                    isDeepCodyEnabled &&
+                                                    sonnetModel &&
+                                                    // Ensure the deep-cody model is only added once.
+                                                    !data.primaryModels.some(m =>
+                                                        m.id.includes('deep-cody')
+                                                    )
+                                                ) {
+                                                    const DEEPCODY_MODEL =
+                                                        getExperimentalClientModelByFeatureFlag(
+                                                            FeatureFlag.DeepCody
+                                                        )!
+                                                    data.primaryModels.push(
+                                                        ...maybeAdjustContextWindows([
+                                                            DEEPCODY_MODEL,
+                                                        ]).map(createModelFromServerModel)
+                                                    )
+                                                }
+                                                const isFreeTier =
+                                                    userSubscription !== null &&
+                                                    typeof userSubscription === 'object' &&
+                                                    'userCanUpgrade' in userSubscription &&
+                                                    userSubscription.userCanUpgrade
+
+                                                // set the default model to Haiku for free users
+                                                if (isDotComUser && isFreeTier && defaultToHaiku) {
+                                                    const haikuModel = data.primaryModels.find(m =>
+                                                        m.id.includes('claude-3-5-haiku')
+                                                    )
+                                                    if (haikuModel) {
+                                                        if (!data.preferences) {
+                                                            data.preferences = {
+                                                                defaults: {},
+                                                            }
+                                                        }
+                                                        data.preferences.defaults.chat = haikuModel.id
+                                                    }
+                                                }
+
+                                                return Observable.of(data)
+                                            }
+                                        )
                                     )
                                 })
                             )

--- a/lib/shared/src/models/sync.ts
+++ b/lib/shared/src/models/sync.ts
@@ -268,12 +268,7 @@ export function syncModels({
                                                         m.id.includes('claude-3-5-haiku')
                                                     )
                                                     if (haikuModel) {
-                                                        if (!data.preferences) {
-                                                            data.preferences = {
-                                                                defaults: {},
-                                                            }
-                                                        }
-                                                        data.preferences.defaults.chat = haikuModel.id
+                                                        data.preferences!.defaults.chat = haikuModel.id
                                                     }
                                                 }
 

--- a/lib/shared/src/models/sync.ts
+++ b/lib/shared/src/models/sync.ts
@@ -24,7 +24,7 @@ import type { CodyClientConfig } from '../sourcegraph-api/clientConfig'
 import { isDotCom } from '../sourcegraph-api/environments'
 import type { CodyLLMSiteConfiguration } from '../sourcegraph-api/graphql/client'
 import { RestClient } from '../sourcegraph-api/rest/client'
-import { userProductSubscription } from '../sourcegraph-api/userProductSubscription'
+import type { UserProductSubscription } from '../sourcegraph-api/userProductSubscription'
 import { CHAT_INPUT_TOKEN_BUDGET } from '../token/constants'
 import { isError } from '../utils'
 import { getExperimentalClientModelByFeatureFlag } from './client'
@@ -49,6 +49,7 @@ export function syncModels({
     configOverwrites,
     clientConfig,
     fetchServerSideModels_ = fetchServerSideModels,
+    userProductSubscription = Observable.of(null),
 }: {
     resolvedConfig: Observable<
         PickResolvedConfiguration<{
@@ -61,6 +62,7 @@ export function syncModels({
     configOverwrites: Observable<CodyLLMSiteConfiguration | null | typeof pendingOperation>
     clientConfig: Observable<CodyClientConfig | undefined | typeof pendingOperation>
     fetchServerSideModels_?: typeof fetchServerSideModels
+    userProductSubscription: Observable<UserProductSubscription | null | typeof pendingOperation>
 }): Observable<ModelsData | typeof pendingOperation> {
     // Refresh Ollama models when Ollama-related config changes and periodically.
     const localModels = combineLatest(


### PR DESCRIPTION
This PR does [Run experiment on Claude 3.5 Haiku as the default chat model for Free users](https://linear.app/sourcegraph/issue/CODY-4455/run-experiment-on-claude-35-haiku-as-the-default-chat-model-for-free). This is part of [LLM cost reduction for PLG users](https://linear.app/sourcegraph/project/llm-cost-reduction-for-plg-users-57f5801d7ea1/issues).

Problem: We want to reduce the LLM cost for PLG users.

This PR prepares for A/B test on Claude 3.5 Haiku as a default chat model Free users.
Free users with cody-chat-default-to-claude-3-5-haiku feature flag set to true will have Claude 3.5 Haiku as the default model. 
The success criteria are defined in the linear ticket above.

Things the PR does:
- `FeatureFlagProvider.ts` and `sync.ts`: Add the new feature flag and the main logic.
- `sync.test.ts`: Add tests.

## Test plan
Added tests in `sync.test.ts`

Test this manually
- Go to https://sourcegraph.com/site-admin/feature-flags/configuration/cody-chat-default-to-claude-3-5-haiku and add an override for your user to enable the feature flag.
- Build the extension from the branch.
- Singin with the DotCom account.
- You should see Claude 3.5 Haiku as a default Edit model.
<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
