### PR TITLE
feat(deep cody): available in pre-release versions only

### DIFF
--- a/lib/shared/src/configuration/clientCapabilities.ts
+++ b/lib/shared/src/configuration/clientCapabilities.ts
@@ -263,3 +263,17 @@ export const CLIENT_CAPABILITIES_FIXTURE: ClientCapabilitiesWithLegacyFields = {
     agentExtensionVersion: '1.2.3',
     agentIDEVersion: '4.5.6',
 }
+
+export function isClientOnStableVersion(): boolean {
+    if (!_extensionVersion || _extensionVersion.endsWith('nightly')) {
+        return false
+    }
+
+    // Check JetBrains IDE nightly version
+    if (_value?.configuration.agentIDEVersion?.endsWith('nightly')) {
+        return false
+    }
+
+    const [, minorVersion] = _extensionVersion.split('.')
+    return !!(minorVersion && Number.parseInt(minorVersion, 10) % 2 === 0)
+}


### PR DESCRIPTION
CLOSE https://linear.app/sourcegraph/issue/CODY-4506/show-deep-cody-on-pre-release-version-only

This PR adds a new function `isClientOnStableVersion` to the `clientCapabilities` module. This function checks if the client is on a stable version of the extension by parsing the version string and checking if the minor version is even. Example: Here is what the current version number on our latest pre-release looks like

<img width="886" alt="image" src="https://github.com/user-attachments/assets/b8061570-ef2c-4042-9f69-aefebbebd09b">


This is used in the `syncModels` function to only display the Deep Cody feature in pre-release versions of the extension.


## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

When building from this branch, the version number is set to 1.48.1 which is a stable version number. In this case, Deep Cody should not show up in your model dropdown list:

<img width="1282" alt="image" src="https://github.com/user-attachments/assets/fabd56e8-4a84-401b-9423-33df35b1afcc">

When you update the version number to a pre-release version number, where the minor number is not a even number, Deep Cody should show up in your model dropdown list:

<img width="1289" alt="image" src="https://github.com/user-attachments/assets/7bcc4359-1355-4469-98da-9bb03ee946c5">

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
