### PR TITLE
Fix invalid range errors

### DIFF
--- a/jetbrains/src/main/kotlin/com/sourcegraph/cody/autocomplete/CodyAutocompleteManager.kt
+++ b/jetbrains/src/main/kotlin/com/sourcegraph/cody/autocomplete/CodyAutocompleteManager.kt
@@ -9,6 +9,7 @@ import com.intellij.openapi.components.Service
 import com.intellij.openapi.components.service
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.editor.EditorKind
 import com.intellij.openapi.editor.Inlay
 import com.intellij.openapi.editor.InlayModel
 import com.intellij.openapi.editor.colors.EditorColorsManager
@@ -119,6 +120,11 @@ class CodyAutocompleteManager {
     val project = editor.project
     if (project == null) {
       logger.warn("triggered autocomplete with null project")
+      return
+    }
+
+    if (editor.editorKind != EditorKind.MAIN_EDITOR) {
+      logger.warn("triggered autocomplete with non-main editor")
       return
     }
 

--- a/jetbrains/src/main/kotlin/com/sourcegraph/cody/editor/CodyLookupListener.kt
+++ b/jetbrains/src/main/kotlin/com/sourcegraph/cody/editor/CodyLookupListener.kt
@@ -6,6 +6,7 @@ import com.intellij.codeInsight.lookup.LookupListener
 import com.intellij.codeInsight.lookup.LookupManagerListener
 import com.intellij.codeInsight.lookup.impl.LookupImpl
 import com.intellij.openapi.diagnostic.Logger
+import com.intellij.openapi.editor.EditorKind
 import com.sourcegraph.cody.autocomplete.CodyAutocompleteManager.Companion.instance
 import com.sourcegraph.cody.config.CodyApplicationSettings
 import com.sourcegraph.cody.vscode.InlineCompletionTriggerKind
@@ -16,6 +17,10 @@ class CodyLookupListener : LookupManagerListener {
   override fun activeLookupChanged(oldLookup: Lookup?, newLookup: Lookup?) {
     if (newLookup != null && CodyApplicationSettings.instance.isLookupAutocompleteEnabled) {
       val newEditor = newLookup.editor
+      if (newEditor.editorKind != EditorKind.MAIN_EDITOR) {
+        return
+      }
+
       if (newLookup is LookupImpl) {
         newLookup.addLookupListener(
             object : LookupListener {

--- a/jetbrains/src/main/kotlin/com/sourcegraph/utils/CodyEditorUtil.kt
+++ b/jetbrains/src/main/kotlin/com/sourcegraph/utils/CodyEditorUtil.kt
@@ -10,6 +10,7 @@ import com.intellij.openapi.command.WriteCommandAction
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.editor.Document
 import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.editor.EditorKind
 import com.intellij.openapi.editor.ex.EditorEx
 import com.intellij.openapi.editor.impl.ImaginaryEditor
 import com.intellij.openapi.fileEditor.FileDocumentManager
@@ -101,6 +102,7 @@ object CodyEditorUtil {
     return editor.project != null &&
         !editor.isViewer &&
         !editor.isOneLineMode &&
+        editor.editorKind == EditorKind.MAIN_EDITOR &&
         editor !is EditorWindow &&
         editor !is ImaginaryEditor &&
         (editor !is EditorEx || !editor.isEmbeddedIntoDialogWrapper) &&


### PR DESCRIPTION
Closes https://github.com/sourcegraph/jetbrains/issues/2572 and probably a few others. 

## Test plan

Invoke autocomplete in the debug console. Invoke autocomplete in the evaluate expression line/dialog. Invoke autocomplete anywhere but the main editor. It should work in the main editor only.

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

## Changelog

This PR make us more strict about where we trigger the autucomplete.

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
