### PR TITLE
feat(deep-cody): implement daily usage limit

### DIFF
--- a/lib/shared/src/experimentation/FeatureFlagProvider.ts
+++ b/lib/shared/src/experimentation/FeatureFlagProvider.ts
@@ -106,8 +106,8 @@ export enum FeatureFlag {
     DeepCodyShellContext = 'deep-cody-shell-context',
 
     /** Enable Rate Limit for Deep Cody */
-    DeepCodyRateLimitBase = 'deep-cody-rate-limit',
-    DeepCodyRateLimitMultiplier = 'deep-cody-rate-limit-multiplier',
+    DeepCodyRateLimitBase = 'deep-cody-experimental-rate-limit',
+    DeepCodyRateLimitMultiplier = 'deep-cody-experimental-rate-limit-multiplier',
 
     /**
      * Whether the current repo context chip is shown in the chat input by default

--- a/lib/shared/src/experimentation/FeatureFlagProvider.ts
+++ b/lib/shared/src/experimentation/FeatureFlagProvider.ts
@@ -105,6 +105,10 @@ export enum FeatureFlag {
     /** Enable Shell Context for Deep Cody */
     DeepCodyShellContext = 'deep-cody-shell-context',
 
+    /** Enable Rate Limit for Deep Cody */
+    DeepCodyRateLimitBase = 'deep-cody-rate-limit',
+    DeepCodyRateLimitMultiplier = 'deep-cody-rate-limit-multiplier',
+
     /**
      * Whether the current repo context chip is shown in the chat input by default
      */

--- a/lib/shared/src/sourcegraph-api/errors.ts
+++ b/lib/shared/src/sourcegraph-api/errors.ts
@@ -24,7 +24,7 @@ export class RateLimitError extends Error {
     public readonly retryMessage: string | undefined
 
     constructor(
-        public readonly feature: 'autocompletions' | 'chat messages and commands',
+        public readonly feature: 'autocompletions' | 'chat messages and commands' | 'Deep Cody',
         public readonly message: string,
         /* Whether an upgrade is available that would increase rate limits. */
         public readonly upgradeIsAvailable: boolean,
@@ -33,9 +33,10 @@ export class RateLimitError extends Error {
         public readonly retryAfter?: string | null
     ) {
         super(message)
-        this.userMessage = `You've used all of your ${feature} for ${
-            upgradeIsAvailable ? 'the month' : 'today'
-        }.`
+        this.userMessage =
+            feature === 'Deep Cody'
+                ? `You've reached the daily limit for Deep Cody today. Please select another model and try again.`
+                : `You've used all of your ${feature} for ${upgradeIsAvailable ? 'the month' : 'today'}.`
         this.retryAfterDate = retryAfter
             ? /^\d+$/.test(retryAfter)
                 ? new Date(Date.now() + Number.parseInt(retryAfter, 10) * 1000)

--- a/lib/shared/src/sourcegraph-api/errors.ts
+++ b/lib/shared/src/sourcegraph-api/errors.ts
@@ -35,7 +35,7 @@ export class RateLimitError extends Error {
         super(message)
         this.userMessage =
             feature === 'Deep Cody'
-                ? `You've reached the daily limit for Deep Cody today. Please select another model and try again.`
+                ? `You've reached the daily limit for Deep Cody. Please select another model and try again.`
                 : `You've used all of your ${feature} for ${upgradeIsAvailable ? 'the month' : 'today'}.`
         this.retryAfterDate = retryAfter
             ? /^\d+$/.test(retryAfter)

--- a/vscode/src/chat/agentic/DeepCodyRateLimiter.test.ts
+++ b/vscode/src/chat/agentic/DeepCodyRateLimiter.test.ts
@@ -1,0 +1,102 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { localStorage } from './../../services/LocalStorageProvider'
+import { DeepCodyRateLimiter } from './DeepCodyRateLimiter'
+
+// Create a mock type for localStorage
+vi.mock('./../../services/LocalStorageProvider', () => ({
+    localStorage: {
+        getDeepCodyUsage: vi.fn(),
+        setDeepCodyUsage: vi.fn(),
+        setStorage: vi.fn(),
+    },
+}))
+
+describe('DeepCodyRateLimiter', () => {
+    let rateLimiter: DeepCodyRateLimiter
+    const NOW = new Date('2024-01-01T12:00:00Z')
+
+    beforeEach(() => {
+        vi.useFakeTimers()
+        vi.setSystemTime(NOW)
+
+        // Initialize storage with 'inMemory' option
+        localStorage.setStorage('inMemory')
+
+        // Clear mock calls between tests
+        vi.clearAllMocks()
+    })
+
+    afterEach(() => {
+        vi.useRealTimers()
+    })
+
+    describe('isAtLimit', () => {
+        it('returns undefined when baseQuota is 0', () => {
+            rateLimiter = new DeepCodyRateLimiter(0, 1)
+            expect(rateLimiter.isAtLimit()).toBeUndefined()
+        })
+
+        it('allows usage when quota available', () => {
+            rateLimiter = new DeepCodyRateLimiter(10, 1)
+
+            // Set up mock return value
+            const mockUsage = {
+                quota: 5,
+                lastUsed: new Date(NOW.getTime() - 3600000), // 1 hour ago
+            }
+            vi.spyOn(localStorage, 'getDeepCodyUsage').mockImplementation(() => mockUsage)
+
+            expect(rateLimiter.isAtLimit()).toBeUndefined()
+            expect(localStorage.setDeepCodyUsage).toHaveBeenCalled()
+        })
+
+        it('blocks usage when no quota available', () => {
+            rateLimiter = new DeepCodyRateLimiter(10, 1)
+
+            const mockUsage = {
+                quota: 0,
+                lastUsed: new Date(NOW.getTime() - 3600000),
+            }
+            vi.spyOn(localStorage, 'getDeepCodyUsage').mockImplementation(() => mockUsage)
+
+            const result = rateLimiter.isAtLimit()
+            expect(result).toBeDefined()
+            expect(Number(result)).toBeGreaterThan(0)
+        })
+
+        it('correctly calculates quota replenishment', () => {
+            rateLimiter = new DeepCodyRateLimiter(24, 1) // 24 tokens per day = 1 per hour
+
+            const mockUsage = {
+                quota: 0,
+                lastUsed: new Date(NOW.getTime() - 3600000),
+            }
+            vi.spyOn(localStorage, 'getDeepCodyUsage').mockImplementation(() => mockUsage)
+
+            expect(rateLimiter.isAtLimit()).toBeUndefined()
+        })
+
+        it('respects multiplier in quota calculation', () => {
+            rateLimiter = new DeepCodyRateLimiter(10, 2) // 20 tokens per day
+
+            const mockUsage = {
+                quota: 0,
+                lastUsed: new Date(NOW.getTime() - 43200000), // 12 hours ago
+            }
+            vi.spyOn(localStorage, 'getDeepCodyUsage').mockImplementation(() => mockUsage)
+
+            expect(rateLimiter.isAtLimit()).toBeUndefined()
+        })
+    })
+
+    describe('getRateLimitError', () => {
+        it('returns correct RateLimitError object', () => {
+            rateLimiter = new DeepCodyRateLimiter()
+            const error = rateLimiter.getRateLimitError('300')
+
+            expect(error.name).toBe('RateLimitError')
+            expect(error.feature).toBe('Deep Cody')
+            expect(error.retryAfter).toBe('300')
+        })
+    })
+})

--- a/vscode/src/chat/agentic/DeepCodyRateLimiter.ts
+++ b/vscode/src/chat/agentic/DeepCodyRateLimiter.ts
@@ -1,0 +1,55 @@
+import { RateLimitError } from '@sourcegraph/cody-shared'
+import { localStorage } from './../../services/LocalStorageProvider'
+
+/**
+ * NOTE: This is a temporary rate limit for deep-cody models to prevent users from
+ * running into rate limits that block them from using Cody.
+ * We should remove this once we have a more robust solution in place.
+ * Any first 2 human messages submitted with Deep Cody is counted toward the usage.
+ */
+export class DeepCodyRateLimiter {
+    private readonly ONE_DAY_MS = 24 * 60 * 60 * 1000
+
+    constructor(
+        private readonly baseQuota: number = 0,
+        private readonly multiplier: number = 1
+    ) {}
+
+    /**
+     * Returns the number of seconds the user needs to wait before they can use DeepCody again.
+     */
+    public isAtLimit(): string | undefined {
+        const DAILY_QUOTA = this.baseQuota * this.multiplier
+        if (!DAILY_QUOTA) {
+            return undefined
+        }
+
+        // Get current quota and last used time, with defaults
+        const { quota, lastUsed } = localStorage.getDeepCodyUsage()
+        const currentQuota = quota ?? DAILY_QUOTA
+        const lastUsedTime = lastUsed.getTime()
+
+        const now = new Date().getTime()
+        const timeDiff = now - lastUsedTime
+
+        // Calculate quota replenishment based on time passed
+        const quotaToAdd = DAILY_QUOTA * (timeDiff / this.ONE_DAY_MS)
+        const newQuota = Math.min(DAILY_QUOTA, currentQuota + quotaToAdd)
+
+        // If we have at least 1 quota available
+        if (newQuota >= 1) {
+            // Update quota and timestamp
+            localStorage?.setDeepCodyUsage(newQuota - 1, new Date().toISOString())
+            return undefined
+        }
+
+        // No quota available.
+        // Calculate how much time after the lastUsedTime we need to wait.
+        const timeToWait = this.ONE_DAY_MS - timeDiff
+        return Math.floor(timeToWait / 1000).toString()
+    }
+
+    public getRateLimitError(retryAfter: string): RateLimitError {
+        return new RateLimitError('Deep Cody', 'daily limit', false, undefined, retryAfter)
+    }
+}

--- a/vscode/src/chat/agentic/DeepCodyRateLimiter.ts
+++ b/vscode/src/chat/agentic/DeepCodyRateLimiter.ts
@@ -20,6 +20,8 @@ export class DeepCodyRateLimiter {
      */
     public isAtLimit(): string | undefined {
         const DAILY_QUOTA = this.baseQuota * this.multiplier
+
+        // If there is no quota set, there is no limit.
         if (!DAILY_QUOTA) {
             return undefined
         }

--- a/vscode/src/chat/agentic/prompts.ts
+++ b/vscode/src/chat/agentic/prompts.ts
@@ -26,7 +26,7 @@ In this environment you have access to this set of tools you can use to fetch co
 1. Only use <TOOL*> tags when additional context is necessary to answer the question.
 2. You may use multiple <TOOL*> tags in a single response if needed.
 3. NEVER request sensitive information or files such as passwords, API keys, or dotEnv files.
-4. The user is working in the VS Code editor on ${getOSPromptString()}.
+4. The user is working in {{CODY_IDE}} on ${getOSPromptString()}.
 
 [GOAL]
 - Determine if you can answer the question with the given context, or if you need more information.

--- a/vscode/src/chat/chat-view/ChatController.ts
+++ b/vscode/src/chat/chat-view/ChatController.ts
@@ -802,6 +802,7 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
         this.chatBuilder.setSelectedModel(model)
 
         const isDeepCodyModel = model?.includes('deep-cody')
+        // Deep Cody is only invoked for the first 2 submitted messages.
         const isDeepCodyEnabled = isDeepCodyModel && this.chatBuilder.getMessages().length < 4
         // The limit could be 0, 50 * 1 (50), 50 * 2 (100)
         const deepCodyRateLimiter = new DeepCodyRateLimiter(
@@ -921,7 +922,7 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
         }
 
         // Experimental Feature: Deep Cody
-        if (isDeepCodyModel) {
+        if (isDeepCodyEnabled) {
             const agenticContext = await new DeepCodyAgent(
                 this.chatBuilder,
                 this.chatClient,

--- a/vscode/src/chat/chat-view/ChatController.ts
+++ b/vscode/src/chat/chat-view/ChatController.ts
@@ -803,7 +803,7 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
 
         const isDeepCodyModel = model?.includes('deep-cody')
         const isDeepCodyEnabled = isDeepCodyModel && this.chatBuilder.getMessages().length < 4
-
+        // The limit could be 0, 50 * 1 (50), 50 * 2 (100)
         const deepCodyRateLimiter = new DeepCodyRateLimiter(
             this.featureDeepCodyRateLimitBase.value.last ? 50 : 0,
             this.featureDeepCodyRateLimitMultiplier.value.last ? 2 : 1

--- a/vscode/src/chat/chat-view/ChatController.ts
+++ b/vscode/src/chat/chat-view/ChatController.ts
@@ -794,6 +794,16 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
         }
         this.chatBuilder.setSelectedModel(model)
         const isDeepCodyModel = model?.includes('deep-cody')
+        if (isDeepCodyModel && localStorage.isAtDeepCodyDailyLimit()) {
+            this.postError(
+                new Error(
+                    'You have reached the daily chat limit for Deep Cody. Please use another model instead.'
+                ),
+                'transcript'
+            )
+            this.handleAbort()
+            return
+        }
         const { isPublic: repoIsPublic, repoMetadata } = await wrapInActiveSpan(
             'chat.getRepoMetadata',
             () => firstResultFromOperation(publicRepoMetadataIfAllWorkspaceReposArePublic)

--- a/vscode/src/services/LocalStorageProvider.ts
+++ b/vscode/src/services/LocalStorageProvider.ts
@@ -347,9 +347,22 @@ class LocalStorage implements LocalStorageForModelPreferences {
         await this.set(this.CODY_CHAT_MEMORY, memories)
     }
 
-    /**
-     * Returns the number of seconds the user needs to wait before they can use DeepCody again.
-     */
+    public getDeepCodyUsage(): { quota: number | undefined; lastUsed: Date } {
+        const quota = this.get<number>(this.keys.deepCodyDailyUsageCount) ?? undefined
+        const lastUsed = new Date(
+            this.get<string>(this.keys.deepCodyLastUsageTime) ?? new Date().toISOString()
+        )
+
+        return { quota, lastUsed }
+    }
+
+    public async setDeepCodyUsage(newQuota: number, lastUsed: string): Promise<void> {
+        await Promise.all([
+            localStorage.set(localStorage.keys.deepCodyDailyUsageCount, newQuota - 1),
+            localStorage.set(localStorage.keys.deepCodyLastUsageTime, lastUsed),
+        ])
+    }
+
     public isAtDeepCodyDailyLimit(DAILY_QUOTA?: number): string | undefined {
         if (!DAILY_QUOTA) {
             return undefined

--- a/vscode/src/services/LocalStorageProvider.ts
+++ b/vscode/src/services/LocalStorageProvider.ts
@@ -347,8 +347,11 @@ class LocalStorage implements LocalStorageForModelPreferences {
         await this.set(this.CODY_CHAT_MEMORY, memories)
     }
 
-    public isAtDeepCodyDailyLimit(): boolean {
-        const DAILY_QUOTA = 20
+    /**
+     * Returns the number of seconds the user needs to wait before they can use DeepCody again.
+     */
+    public isAtDeepCodyDailyLimit(): string | undefined {
+        const DAILY_QUOTA = 50
         const ONE_DAY_MS = 24 * 60 * 60 * 1000
 
         // Get current quota and last used time, with defaults
@@ -371,11 +374,13 @@ class LocalStorage implements LocalStorageForModelPreferences {
                 this.set(this.keys.deepCodyDailyUsageCount, newQuota - 1),
                 this.set(this.keys.deepCodyLastUsageTime, new Date().toISOString()),
             ])
-            return false
+            return undefined
         }
 
-        // No quota available
-        return true
+        // No quota available.
+        // Calculate how much time after the lastUsedTime we need to wait.
+        const timeToWait = ONE_DAY_MS - timeDiff
+        return Math.floor(timeToWait / 1000).toString()
     }
 
     public get<T>(key: string): T | null {

--- a/vscode/src/services/LocalStorageProvider.ts
+++ b/vscode/src/services/LocalStorageProvider.ts
@@ -357,6 +357,7 @@ class LocalStorage implements LocalStorageForModelPreferences {
         const ONE_DAY_MS = 24 * 60 * 60 * 1000
 
         // Reset count if more than 24 hours have passed
+        // Stores all values in parallel without await since we don't need to wait for the result.
         if (timeDiff > ONE_DAY_MS) {
             Promise.all([
                 this.set(this.keys.deepCodyDailyUsageCount, 1),

--- a/vscode/src/services/LocalStorageProvider.ts
+++ b/vscode/src/services/LocalStorageProvider.ts
@@ -350,8 +350,11 @@ class LocalStorage implements LocalStorageForModelPreferences {
     /**
      * Returns the number of seconds the user needs to wait before they can use DeepCody again.
      */
-    public isAtDeepCodyDailyLimit(): string | undefined {
-        const DAILY_QUOTA = 50
+    public isAtDeepCodyDailyLimit(DAILY_QUOTA?: number): string | undefined {
+        if (!DAILY_QUOTA) {
+            return undefined
+        }
+
         const ONE_DAY_MS = 24 * 60 * 60 * 1000
 
         // Get current quota and last used time, with defaults

--- a/vscode/src/services/LocalStorageProvider.ts
+++ b/vscode/src/services/LocalStorageProvider.ts
@@ -41,7 +41,7 @@ class LocalStorage implements LocalStorageForModelPreferences {
     public readonly keys = {
         // LLM waitlist for the 09/12/2024 openAI o1 models
         waitlist_o1: 'CODY_WAITLIST_LLM_09122024',
-        deepCodyLastUsageTime: 'DEEP_CODY_LAST_USED_TIMESTAMP',
+        deepCodyLastUsedDate: 'DEEP_CODY_LAST_USED_DATE',
         deepCodyDailyUsageCount: 'DEEP_CODY_DAILY_CHAT_USAGE',
     }
 
@@ -350,7 +350,7 @@ class LocalStorage implements LocalStorageForModelPreferences {
     public getDeepCodyUsage(): { quota: number | undefined; lastUsed: Date } {
         const quota = this.get<number>(this.keys.deepCodyDailyUsageCount) ?? undefined
         const lastUsed = new Date(
-            this.get<string>(this.keys.deepCodyLastUsageTime) ?? new Date().toISOString()
+            this.get<string>(this.keys.deepCodyLastUsedDate) ?? new Date().toISOString()
         )
 
         return { quota, lastUsed }
@@ -359,7 +359,7 @@ class LocalStorage implements LocalStorageForModelPreferences {
     public async setDeepCodyUsage(newQuota: number, lastUsed: string): Promise<void> {
         await Promise.all([
             localStorage.set(localStorage.keys.deepCodyDailyUsageCount, newQuota - 1),
-            localStorage.set(localStorage.keys.deepCodyLastUsageTime, lastUsed),
+            localStorage.set(localStorage.keys.deepCodyLastUsedDate, lastUsed),
         ])
     }
 
@@ -373,7 +373,7 @@ class LocalStorage implements LocalStorageForModelPreferences {
         // Get current quota and last used time, with defaults
         const currentQuota = this.get<number>(this.keys.deepCodyDailyUsageCount) ?? DAILY_QUOTA
         const lastUsedTime = new Date(
-            this.get<string>(this.keys.deepCodyLastUsageTime) ?? new Date().toISOString()
+            this.get<string>(this.keys.deepCodyLastUsedDate) ?? new Date().toISOString()
         ).getTime()
 
         const now = new Date().getTime()
@@ -388,7 +388,7 @@ class LocalStorage implements LocalStorageForModelPreferences {
             // Update quota and timestamp
             Promise.all([
                 this.set(this.keys.deepCodyDailyUsageCount, newQuota - 1),
-                this.set(this.keys.deepCodyLastUsageTime, new Date().toISOString()),
+                this.set(this.keys.deepCodyLastUsedDate, new Date().toISOString()),
             ])
             return undefined
         }

--- a/vscode/webviews/chat/ErrorItem.tsx
+++ b/vscode/webviews/chat/ErrorItem.tsx
@@ -111,17 +111,19 @@ const RateLimitErrorItem: React.FunctionComponent<{
                             Upgrade
                         </VSCodeButton>
                     )}
-                    <VSCodeButton
-                        type="button"
-                        onClick={() =>
-                            canUpgrade
-                                ? onButtonClick('upgrade', 'upgrade')
-                                : onButtonClick('rate-limits', 'learn-more')
-                        }
-                        appearance="secondary"
-                    >
-                        {canUpgrade ? 'See Plans →' : 'Learn More'}
-                    </VSCodeButton>
+                    {error.feature !== 'Deep Cody' && (
+                        <VSCodeButton
+                            type="button"
+                            onClick={() =>
+                                canUpgrade
+                                    ? onButtonClick('upgrade', 'upgrade')
+                                    : onButtonClick('rate-limits', 'learn-more')
+                            }
+                            appearance="secondary"
+                        >
+                            {canUpgrade ? 'See Plans →' : 'Learn More'}
+                        </VSCodeButton>
+                    )}
                 </div>
                 {error.retryMessage && <p className={styles.retryMessage}>{error.retryMessage}</p>}
             </div>


### PR DESCRIPTION
CLOSE: https://linear.app/sourcegraph/issue/CODY-4510

- Add `deepCodyLastUsageTime` and `deepCodyDailyUsageCount` keys to `LocalStorage` class
- Implement `isAtDeepCodyDailyLimit()` method to check if the daily usage limit for Deep Cody has been reached
- In `ChatController`, check if the selected model is Deep Cody and if the daily limit has been reached, and display an error message if so
- Update `RateLimitError` to handle Deep Cody feature
- Conditionally render the "Learn More" button in `ErrorItem` for Deep Cody errors
- Add `DeepCodyRateLimitBase` and `DeepCodyRateLimitMultiplier` feature flags to control the rate limit for Deep Cody
- Implement `isAtDeepCodyDailyLimit()` method in `LocalStorage` to check if the user has reached the daily usage limit for Deep Cody
- In `ChatController`, check the Deep Cody rate limit and display an error message if the limit has been reached

We have also limited Deep Cody from executing review loop after the first 2 human messages.

This change ensures that users do not exceed the daily usage limit for the Deep Cody model to avoid users running into rate-limiting issue.

#### Feature Flags

0 when `deep-cody-experimental-rate-limit` feature flag is off
50 when `deep-cody-experimental-rate-limit` feature flag is on
100 when `deep-cody-experimental-rate-limit` and `deep-cody-experimental-rate-limit-multiplier` flags are both on
Both feature flags are set on DotCom

## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

Try sending 100 messages using Deep Cody and confirm you are seeing an error in Chat. 
This is what happened when i update the max value to 1

<img width="793" alt="image" src="https://github.com/user-attachments/assets/e58af3ec-1d05-4336-bdf5-88cbf4bcd735" />

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
