### PR TITLE
fix(models): remove deep-cody model replacement logic

### DIFF
--- a/lib/shared/src/models/sync.ts
+++ b/lib/shared/src/models/sync.ts
@@ -26,7 +26,6 @@ import type { CodyLLMSiteConfiguration } from '../sourcegraph-api/graphql/client
 import { RestClient } from '../sourcegraph-api/rest/client'
 import { CHAT_INPUT_TOKEN_BUDGET } from '../token/constants'
 import { isError } from '../utils'
-import { getExperimentalClientModelByFeatureFlag } from './client'
 import { type Model, type ServerModel, createModel, createModelFromServerModel } from './model'
 import type {
     DefaultsAndUserPreferencesForEndpoint,
@@ -216,30 +215,6 @@ export function syncModels({
                                                     }
                                                     return model
                                                 })
-                                            }
-
-                                            // Replace user's current sonnet model with deep-cody model.
-                                            const sonnetModel = data.primaryModels.find(m =>
-                                                m.id.includes('sonnet')
-                                            )
-                                            // DEEP CODY is enabled for all PLG users.
-                                            // Enterprise users need to have the feature flag enabled.
-                                            const isDeepCodyEnabled = isDotComUser || hasDeepCodyFlag
-                                            if (
-                                                isDeepCodyEnabled &&
-                                                sonnetModel &&
-                                                // Ensure the deep-cody model is only added once.
-                                                !data.primaryModels.some(m => m.id.includes('deep-cody'))
-                                            ) {
-                                                const DEEPCODY_MODEL =
-                                                    getExperimentalClientModelByFeatureFlag(
-                                                        FeatureFlag.DeepCody
-                                                    )!
-                                                data.primaryModels.push(
-                                                    ...maybeAdjustContextWindows([DEEPCODY_MODEL]).map(
-                                                        createModelFromServerModel
-                                                    )
-                                                )
                                             }
 
                                             return Observable.of(data)


### PR DESCRIPTION
This commit removes the logic that adds deep-cody model to user's model list.

This does so by removing the associated feature flag checks and model replacement logic.


## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

Build from this branch and confirm you don't see Deep Cody showing up in your model list with any of your accounts (PLG or Enterprise).

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
