### PR TITLE
fix(release): remove brackets around version number

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 This is a log of all notable changes to Cody for VS Code.
 
-## [Unreleased]
+## Unreleased
 
 ### Added
 
@@ -14,7 +14,7 @@ This is a log of all notable changes to Cody for VS Code.
 
 ### Uncategorized
 
-## [1.48.1]
+## 1.48.1
 
 ### Added
 
@@ -70,7 +70,7 @@ This is a log of all notable changes to Cody for VS Code.
 - Bench: make sure to respect CODY_RECORDING_MODE  [pull/6167](https://github.com/sourcegraph/cody/pulls/6167)
 - Revert "Update backport.yml (#6137)"  [pull/6164](https://github.com/sourcegraph/cody/pulls/6164)
 
-## [1.46.0]
+## 1.46.0
 
 ### Added
 


### PR DESCRIPTION
Fixes the errors you see when the stable release workflow runs and complains about a missing `github_changelog.md`  (ex - https://github.com/sourcegraph/cody/actions/runs/12207820901/job/34059923063#step:12:13)

The `github-changelog.ts` script will parse the existing changelog to generate a github release entry, this PR removes the `[]` in the changelog so the regex capture group will extract the version number correctly. 

## Test plan
tested locally by running `pnpm -C vscode run github-changelog` and checking the output of `GITHUB_CHANGELOG.md`
<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
