### PR TITLE
feat(audoedit): avoid decoration info mutation

### DIFF
--- a/vscode/src/autoedits/renderer/decorators/base.ts
+++ b/vscode/src/autoedits/renderer/decorators/base.ts
@@ -43,8 +43,6 @@ export interface AddedLineInfo {
     type: 'added'
     text: string
     modifiedLineNumber: number
-    /** signifies if this part of the prediction is rendered by the inline completion item provider */
-    usedAsInlineCompletion?: boolean
 }
 
 export interface RemovedLineInfo {
@@ -78,8 +76,6 @@ export type LineChange = {
     /** `range` in the modified text relative to the document start */
     range: vscode.Range
     text: string
-    /** signifies if this part of the prediction is rendered by the inline completion item provider */
-    usedAsInlineCompletion?: boolean
 }
 
 export interface DecorationInfo {

--- a/vscode/src/autoedits/renderer/decorators/base.ts
+++ b/vscode/src/autoedits/renderer/decorators/base.ts
@@ -39,6 +39,7 @@ export interface AutoEditsDecorator extends vscode.Disposable {
 export type DecorationLineInfo = AddedLineInfo | RemovedLineInfo | ModifiedLineInfo | UnchangedLineInfo
 
 export interface AddedLineInfo {
+    id: string
     type: 'added'
     text: string
     modifiedLineNumber: number
@@ -47,12 +48,14 @@ export interface AddedLineInfo {
 }
 
 export interface RemovedLineInfo {
+    id: string
     type: 'removed'
     text: string
     originalLineNumber: number
 }
 
 export interface ModifiedLineInfo {
+    id: string
     type: 'modified'
     oldText: string
     newText: string
@@ -62,6 +65,7 @@ export interface ModifiedLineInfo {
 }
 
 export interface UnchangedLineInfo {
+    id: string
     type: 'unchanged'
     text: string
     originalLineNumber: number
@@ -69,6 +73,7 @@ export interface UnchangedLineInfo {
 }
 
 export type LineChange = {
+    id: string
     type: 'insert' | 'delete' | 'unchanged'
     /** `range` in the modified text relative to the document start */
     range: vscode.Range

--- a/vscode/src/autoedits/renderer/decorators/inline-diff-decorator.ts
+++ b/vscode/src/autoedits/renderer/decorators/inline-diff-decorator.ts
@@ -23,7 +23,7 @@ export class InlineDiffDecorator implements vscode.Disposable, AutoEditsDecorato
             let currentInsertText = ''
 
             // Ignore line changes rendered as an inline completion item ghost text.
-            for (const change of line.changes.filter(c => !c.usedAsInlineCompletion)) {
+            for (const change of line.changes) {
                 if (change.type === 'insert') {
                     const position = change.range.end
                     if (currentInsertPosition && position.isEqual(currentInsertPosition)) {

--- a/vscode/src/autoedits/renderer/diff-utils.test.ts
+++ b/vscode/src/autoedits/renderer/diff-utils.test.ts
@@ -18,6 +18,7 @@ describe('getDecorationInfo', () => {
                     removedLines: [],
                     modifiedLines: [
                         {
+                            id: expect.any(String),
                             type: 'modified',
                             originalLineNumber: 1,
                             modifiedLineNumber: 1,
@@ -25,11 +26,13 @@ describe('getDecorationInfo', () => {
                             newText: 'modified2',
                             changes: [
                                 {
+                                    id: expect.any(String),
                                     type: 'delete',
                                     range: expect.anything(),
                                     text: 'line2',
                                 },
                                 {
+                                    id: expect.any(String),
                                     type: 'insert',
                                     range: expect.anything(),
                                     text: 'modified2',
@@ -39,12 +42,14 @@ describe('getDecorationInfo', () => {
                     ],
                     unchangedLines: [
                         {
+                            id: expect.any(String),
                             type: 'unchanged',
                             originalLineNumber: 0,
                             modifiedLineNumber: 0,
                             text: 'line1',
                         },
                         {
+                            id: expect.any(String),
                             type: 'unchanged',
                             originalLineNumber: 2,
                             modifiedLineNumber: 2,
@@ -63,17 +68,26 @@ describe('getDecorationInfo', () => {
                 const decorationInfo = getDecorationInfo(originalText, modifiedText)
 
                 const expected: DecorationInfo = {
-                    addedLines: [{ type: 'added', modifiedLineNumber: 2, text: 'line3' }],
+                    addedLines: [
+                        {
+                            id: expect.any(String),
+                            type: 'added',
+                            modifiedLineNumber: 2,
+                            text: 'line3',
+                        },
+                    ],
                     removedLines: [],
                     modifiedLines: [],
                     unchangedLines: [
                         {
+                            id: expect.any(String),
                             type: 'unchanged',
                             originalLineNumber: 0,
                             modifiedLineNumber: 0,
                             text: 'line1',
                         },
                         {
+                            id: expect.any(String),
                             type: 'unchanged',
                             originalLineNumber: 1,
                             modifiedLineNumber: 1,
@@ -93,16 +107,25 @@ describe('getDecorationInfo', () => {
 
                 const expected: DecorationInfo = {
                     addedLines: [],
-                    removedLines: [{ type: 'removed', originalLineNumber: 1, text: 'line2' }],
+                    removedLines: [
+                        {
+                            id: expect.any(String),
+                            type: 'removed',
+                            originalLineNumber: 1,
+                            text: 'line2',
+                        },
+                    ],
                     modifiedLines: [],
                     unchangedLines: [
                         {
+                            id: expect.any(String),
                             type: 'unchanged',
                             originalLineNumber: 0,
                             modifiedLineNumber: 0,
                             text: 'line1',
                         },
                         {
+                            id: expect.any(String),
                             type: 'unchanged',
                             originalLineNumber: 2,
                             modifiedLineNumber: 1,
@@ -125,6 +148,7 @@ describe('getDecorationInfo', () => {
                     removedLines: [],
                     modifiedLines: [
                         {
+                            id: expect.any(String),
                             type: 'modified',
                             originalLineNumber: 1,
                             modifiedLineNumber: 1,
@@ -132,11 +156,13 @@ describe('getDecorationInfo', () => {
                             newText: 'modified2',
                             changes: [
                                 {
+                                    id: expect.any(String),
                                     type: 'delete',
                                     range: expect.anything(),
                                     text: 'line2',
                                 },
                                 {
+                                    id: expect.any(String),
                                     type: 'insert',
                                     range: expect.anything(),
                                     text: 'modified2',
@@ -144,6 +170,7 @@ describe('getDecorationInfo', () => {
                             ],
                         },
                         {
+                            id: expect.any(String),
                             type: 'modified',
                             originalLineNumber: 2,
                             modifiedLineNumber: 2,
@@ -151,11 +178,13 @@ describe('getDecorationInfo', () => {
                             newText: 'newline',
                             changes: [
                                 {
+                                    id: expect.any(String),
                                     type: 'delete',
                                     range: expect.anything(),
                                     text: 'line3',
                                 },
                                 {
+                                    id: expect.any(String),
                                     type: 'insert',
                                     range: expect.anything(),
                                     text: 'newline',
@@ -165,12 +194,14 @@ describe('getDecorationInfo', () => {
                     ],
                     unchangedLines: [
                         {
+                            id: expect.any(String),
                             type: 'unchanged',
                             originalLineNumber: 0,
                             modifiedLineNumber: 0,
                             text: 'line1',
                         },
                         {
+                            id: expect.any(String),
                             type: 'unchanged',
                             originalLineNumber: 3,
                             modifiedLineNumber: 3,
@@ -194,6 +225,7 @@ describe('getDecorationInfo', () => {
                     modifiedLines: [],
                     unchangedLines: [
                         {
+                            id: expect.any(String),
                             originalLineNumber: 0,
                             modifiedLineNumber: 0,
                             text: '',
@@ -212,9 +244,17 @@ describe('getDecorationInfo', () => {
                 const decorationInfo = getDecorationInfo(originalText, modifiedText)
 
                 const expected: DecorationInfo = {
-                    addedLines: [{ type: 'added', modifiedLineNumber: 5, text: 'add2' }],
+                    addedLines: [
+                        {
+                            id: expect.any(String),
+                            type: 'added',
+                            modifiedLineNumber: 5,
+                            text: 'add2',
+                        },
+                    ],
                     removedLines: [
                         {
+                            id: expect.any(String),
                             originalLineNumber: 2,
                             text: 'removeLine1',
                             type: 'removed',
@@ -222,6 +262,7 @@ describe('getDecorationInfo', () => {
                     ],
                     modifiedLines: [
                         {
+                            id: expect.any(String),
                             type: 'modified',
                             originalLineNumber: 1,
                             modifiedLineNumber: 1,
@@ -229,11 +270,13 @@ describe('getDecorationInfo', () => {
                             newText: 'modified1',
                             changes: [
                                 {
+                                    id: expect.any(String),
                                     type: 'delete',
                                     range: expect.anything(),
                                     text: 'remove1',
                                 },
                                 {
+                                    id: expect.any(String),
                                     type: 'insert',
                                     range: expect.anything(),
                                     text: 'modified1',
@@ -241,6 +284,7 @@ describe('getDecorationInfo', () => {
                             ],
                         },
                         {
+                            id: expect.any(String),
                             type: 'modified',
                             originalLineNumber: 4,
                             modifiedLineNumber: 3,
@@ -248,11 +292,13 @@ describe('getDecorationInfo', () => {
                             newText: 'add1',
                             changes: [
                                 {
+                                    id: expect.any(String),
                                     type: 'delete',
                                     range: expect.anything(),
                                     text: 'remove2',
                                 },
                                 {
+                                    id: expect.any(String),
                                     type: 'insert',
                                     range: expect.anything(),
                                     text: 'add1',
@@ -260,6 +306,7 @@ describe('getDecorationInfo', () => {
                             ],
                         },
                         {
+                            id: expect.any(String),
                             type: 'modified',
                             originalLineNumber: 5,
                             modifiedLineNumber: 4,
@@ -267,11 +314,13 @@ describe('getDecorationInfo', () => {
                             newText: 'modified2',
                             changes: [
                                 {
+                                    id: expect.any(String),
                                     type: 'delete',
                                     range: expect.anything(),
                                     text: 'modify2',
                                 },
                                 {
+                                    id: expect.any(String),
                                     type: 'insert',
                                     range: expect.anything(),
                                     text: 'modified2',
@@ -281,18 +330,21 @@ describe('getDecorationInfo', () => {
                     ],
                     unchangedLines: [
                         {
+                            id: expect.any(String),
                             type: 'unchanged',
                             originalLineNumber: 0,
                             modifiedLineNumber: 0,
                             text: 'keep1',
                         },
                         {
+                            id: expect.any(String),
                             type: 'unchanged',
                             originalLineNumber: 3,
                             modifiedLineNumber: 2,
                             text: 'keep2',
                         },
                         {
+                            id: expect.any(String),
                             type: 'unchanged',
                             originalLineNumber: 6,
                             modifiedLineNumber: 6,
@@ -315,6 +367,7 @@ describe('getDecorationInfo', () => {
                     removedLines: [],
                     modifiedLines: [
                         {
+                            id: expect.any(String),
                             type: 'modified',
                             originalLineNumber: 0,
                             modifiedLineNumber: 0,
@@ -322,11 +375,13 @@ describe('getDecorationInfo', () => {
                             newText: 'different1',
                             changes: [
                                 {
+                                    id: expect.any(String),
                                     type: 'delete',
                                     range: expect.anything(),
                                     text: 'line1',
                                 },
                                 {
+                                    id: expect.any(String),
                                     type: 'insert',
                                     range: expect.anything(),
                                     text: 'different1',
@@ -334,6 +389,7 @@ describe('getDecorationInfo', () => {
                             ],
                         },
                         {
+                            id: expect.any(String),
                             type: 'modified',
                             originalLineNumber: 1,
                             modifiedLineNumber: 1,
@@ -341,11 +397,13 @@ describe('getDecorationInfo', () => {
                             newText: 'different2',
                             changes: [
                                 {
+                                    id: expect.any(String),
                                     type: 'delete',
                                     range: expect.anything(),
                                     text: 'line2',
                                 },
                                 {
+                                    id: expect.any(String),
                                     type: 'insert',
                                     range: expect.anything(),
                                     text: 'different2',
@@ -353,6 +411,7 @@ describe('getDecorationInfo', () => {
                             ],
                         },
                         {
+                            id: expect.any(String),
                             type: 'modified',
                             originalLineNumber: 2,
                             modifiedLineNumber: 2,
@@ -360,11 +419,13 @@ describe('getDecorationInfo', () => {
                             newText: 'different3',
                             changes: [
                                 {
+                                    id: expect.any(String),
                                     type: 'delete',
                                     range: expect.anything(),
                                     text: 'line3',
                                 },
                                 {
+                                    id: expect.any(String),
                                     type: 'insert',
                                     range: expect.anything(),
                                     text: 'different3',
@@ -386,11 +447,22 @@ describe('getDecorationInfo', () => {
 
                 const expected: DecorationInfo = {
                     addedLines: [
-                        { type: 'added', modifiedLineNumber: 1, text: 'line2' },
-                        { type: 'added', modifiedLineNumber: 2, text: 'line3' },
+                        {
+                            id: expect.any(String),
+                            type: 'added',
+                            modifiedLineNumber: 1,
+                            text: 'line2',
+                        },
+                        {
+                            id: expect.any(String),
+                            type: 'added',
+                            modifiedLineNumber: 2,
+                            text: 'line3',
+                        },
                     ],
                     modifiedLines: [
                         {
+                            id: expect.any(String),
                             type: 'modified',
                             originalLineNumber: 0,
                             modifiedLineNumber: 0,
@@ -398,6 +470,7 @@ describe('getDecorationInfo', () => {
                             newText: 'line1',
                             changes: [
                                 {
+                                    id: expect.any(String),
                                     type: 'insert',
                                     range: expect.anything(),
                                     text: 'line1',
@@ -421,11 +494,22 @@ describe('getDecorationInfo', () => {
                 const expected: DecorationInfo = {
                     addedLines: [],
                     removedLines: [
-                        { type: 'removed', originalLineNumber: 1, text: 'line2' },
-                        { type: 'removed', originalLineNumber: 2, text: 'line3' },
+                        {
+                            id: expect.any(String),
+                            type: 'removed',
+                            originalLineNumber: 1,
+                            text: 'line2',
+                        },
+                        {
+                            id: expect.any(String),
+                            type: 'removed',
+                            originalLineNumber: 2,
+                            text: 'line3',
+                        },
                     ],
                     modifiedLines: [
                         {
+                            id: expect.any(String),
                             type: 'modified',
                             originalLineNumber: 0,
                             modifiedLineNumber: 0,
@@ -433,6 +517,7 @@ describe('getDecorationInfo', () => {
                             newText: '',
                             changes: [
                                 {
+                                    id: expect.any(String),
                                     type: 'delete',
                                     range: expect.anything(),
                                     text: 'line1',
@@ -457,6 +542,7 @@ describe('getDecorationInfo', () => {
                     removedLines: [],
                     modifiedLines: [
                         {
+                            id: expect.any(String),
                             type: 'modified',
                             originalLineNumber: 0,
                             modifiedLineNumber: 0,
@@ -464,11 +550,13 @@ describe('getDecorationInfo', () => {
                             newText: 'line1',
                             changes: [
                                 {
+                                    id: expect.any(String),
                                     type: 'delete',
                                     range: expect.anything(),
                                     text: '  ',
                                 },
                                 {
+                                    id: expect.any(String),
                                     type: 'unchanged',
                                     range: expect.anything(),
                                     text: 'line1',
@@ -476,6 +564,7 @@ describe('getDecorationInfo', () => {
                             ],
                         },
                         {
+                            id: expect.any(String),
                             type: 'modified',
                             originalLineNumber: 1,
                             modifiedLineNumber: 1,
@@ -483,11 +572,13 @@ describe('getDecorationInfo', () => {
                             newText: 'line2',
                             changes: [
                                 {
+                                    id: expect.any(String),
                                     type: 'unchanged',
                                     range: expect.anything(),
                                     text: 'line2',
                                 },
                                 {
+                                    id: expect.any(String),
                                     type: 'delete',
                                     range: expect.anything(),
                                     text: '  ',
@@ -495,6 +586,7 @@ describe('getDecorationInfo', () => {
                             ],
                         },
                         {
+                            id: expect.any(String),
                             type: 'modified',
                             originalLineNumber: 2,
                             modifiedLineNumber: 2,
@@ -502,16 +594,19 @@ describe('getDecorationInfo', () => {
                             newText: 'line3',
                             changes: [
                                 {
+                                    id: expect.any(String),
                                     type: 'delete',
                                     range: expect.anything(),
                                     text: ' ',
                                 },
                                 {
+                                    id: expect.any(String),
                                     type: 'unchanged',
                                     range: expect.anything(),
                                     text: 'line3',
                                 },
                                 {
+                                    id: expect.any(String),
                                     type: 'delete',
                                     range: expect.anything(),
                                     text: ' ',
@@ -536,6 +631,7 @@ describe('getDecorationInfo', () => {
                     removedLines: [],
                     modifiedLines: [
                         {
+                            id: expect.any(String),
                             type: 'modified',
                             originalLineNumber: 0,
                             modifiedLineNumber: 0,
@@ -543,46 +639,55 @@ describe('getDecorationInfo', () => {
                             newText: 'const span = trace.getActiveTrace()',
                             changes: [
                                 {
+                                    id: expect.any(String),
                                     type: 'unchanged',
                                     range: expect.anything(),
                                     text: 'const',
                                 },
                                 {
+                                    id: expect.any(String),
                                     type: 'unchanged',
                                     range: expect.anything(),
                                     text: ' ',
                                 },
                                 {
+                                    id: expect.any(String),
                                     type: 'delete',
                                     range: expect.anything(),
                                     text: 'value',
                                 },
                                 {
+                                    id: expect.any(String),
                                     type: 'insert',
                                     range: expect.anything(),
                                     text: 'span',
                                 },
                                 {
+                                    id: expect.any(String),
                                     type: 'unchanged',
                                     range: expect.anything(),
                                     text: ' ',
                                 },
                                 {
+                                    id: expect.any(String),
                                     type: 'unchanged',
                                     range: expect.anything(),
                                     text: '=',
                                 },
                                 {
+                                    id: expect.any(String),
                                     type: 'unchanged',
                                     range: expect.anything(),
                                     text: ' ',
                                 },
                                 {
+                                    id: expect.any(String),
                                     type: 'delete',
                                     range: expect.anything(),
                                     text: '123',
                                 },
                                 {
+                                    id: expect.any(String),
                                     type: 'insert',
                                     range: expect.anything(),
                                     text: 'trace.getActiveTrace()',

--- a/vscode/src/autoedits/renderer/diff-utils.ts
+++ b/vscode/src/autoedits/renderer/diff-utils.ts
@@ -1,4 +1,5 @@
 import { diff } from 'fast-myers-diff'
+import * as uuid from 'uuid'
 import * as vscode from 'vscode'
 
 import { getNewLineChar } from '../../completions/text-processing'
@@ -66,6 +67,7 @@ function computeDiffOperations(originalLines: string[], modifiedLines: string[])
         // Process unchanged lines before the current diff
         while (originalIndex < originalStart && modifiedIndex < modifiedStart) {
             lineInfos.push({
+                id: uuid.v4(),
                 type: 'unchanged',
                 originalLineNumber: originalIndex,
                 modifiedLineNumber: modifiedIndex,
@@ -97,6 +99,7 @@ function computeDiffOperations(originalLines: string[], modifiedLines: string[])
                 )
             } else {
                 lineInfos.push({
+                    id: uuid.v4(),
                     type: 'unchanged',
                     originalLineNumber: originalStart + i,
                     modifiedLineNumber: modifiedStart + i,
@@ -109,6 +112,7 @@ function computeDiffOperations(originalLines: string[], modifiedLines: string[])
         // Process remaining deletions (removed lines)
         for (let j = i; j < numDeletions; j++) {
             lineInfos.push({
+                id: uuid.v4(),
                 type: 'removed',
                 originalLineNumber: originalStart + j,
                 text: originalLines[originalStart + j],
@@ -118,6 +122,7 @@ function computeDiffOperations(originalLines: string[], modifiedLines: string[])
         // Process remaining insertions (added lines)
         for (let j = i; j < numInsertions; j++) {
             lineInfos.push({
+                id: uuid.v4(),
                 type: 'added',
                 modifiedLineNumber: modifiedStart + j,
                 text: modifiedLines[modifiedStart + j],
@@ -132,6 +137,7 @@ function computeDiffOperations(originalLines: string[], modifiedLines: string[])
     // Process any remaining unchanged lines after the last diff chunk.
     while (originalIndex < originalLines.length && modifiedIndex < modifiedLines.length) {
         lineInfos.push({
+            id: uuid.v4(),
             type: 'unchanged',
             originalLineNumber: originalIndex,
             modifiedLineNumber: modifiedIndex,
@@ -163,6 +169,7 @@ function createModifiedLineInfo({
     const lineChanges = computeLineChanges({ oldChunks, newChunks, lineNumber: modifiedLineNumber })
 
     return {
+        id: uuid.v4(),
         type: 'modified',
         originalLineNumber,
         modifiedLineNumber,
@@ -202,6 +209,7 @@ function computeLineChanges({
                     oldOffset
                 )
                 changes.push({
+                    id: uuid.v4(),
                     type: 'unchanged',
                     range: unchangedRange,
                     text: unchangedText,
@@ -230,6 +238,7 @@ function computeLineChanges({
                     oldOffset
                 )
                 changes.push({
+                    id: uuid.v4(),
                     type: 'delete',
                     range: deleteRange,
                     text: deletionText,
@@ -255,6 +264,7 @@ function computeLineChanges({
                 )
 
                 changes.push({
+                    id: uuid.v4(),
                     type: 'insert',
                     range: insertRange,
                     text: insertionText,
@@ -277,6 +287,7 @@ function computeLineChanges({
                 oldOffset
             )
             changes.push({
+                id: uuid.v4(),
                 type: 'unchanged',
                 range: unchangedRange,
                 text: unchangedText,

--- a/vscode/src/autoedits/renderer/inline-manager.test.ts
+++ b/vscode/src/autoedits/renderer/inline-manager.test.ts
@@ -9,13 +9,13 @@ function getCompletionTextFromStrings(currentFileText: string, predictedFileText
     const { position } = documentAndPosition(currentFileText)
     const decorationInfo = getDecorationInfo(currentFileText.replace('█', ''), predictedFileText)
 
-    const completionText = getCompletionText({
+    const { insertText } = getCompletionText({
         prediction: predictedFileText,
         cursorPosition: position,
         decorationInfo,
     })
 
-    return completionText
+    return insertText
 }
 
 describe('getCompletionText', () => {

--- a/vscode/src/autoedits/renderer/inline-manager.ts
+++ b/vscode/src/autoedits/renderer/inline-manager.ts
@@ -44,22 +44,19 @@ export class AutoEditsInlineRendererManager
             codeToReplaceData.codeToRewriteSuffix
         )
 
-        const completionTextAfterCursor = getCompletionText({
+        const { insertText, usedChangeIds } = getCompletionText({
             prediction: originalPrediction,
             cursorPosition: position,
             decorationInfo,
         })
 
         // The current line suffix should not require any char removals to render the completion.
-        const isSuffixMatch = completionMatchesSuffix(
-            { insertText: completionTextAfterCursor },
-            docContext.currentLineSuffix
-        )
+        const isSuffixMatch = completionMatchesSuffix({ insertText }, docContext.currentLineSuffix)
 
         let inlineCompletions: vscode.InlineCompletionItem[] | null = null
 
         if (isSuffixMatch) {
-            const completionText = docContext.currentLinePrefix + completionTextAfterCursor
+            const completionText = docContext.currentLinePrefix + insertText
 
             inlineCompletions = [
                 new vscode.InlineCompletionItem(
@@ -74,11 +71,26 @@ export class AutoEditsInlineRendererManager
             autoeditsLogger.logDebug('Autocomplete Inline Response: ', completionText)
         }
 
+        function withoutUsedChanges<T extends { id: string }>(array: T[]): T[] {
+            return array.filter(item => !usedChangeIds.has(item.id))
+        }
+
+        // Filter out changes that were used to render the inline completion.
+        const decorationInfoWithoutUsedChanges = {
+            addedLines: withoutUsedChanges(decorationInfo.addedLines),
+            removedLines: withoutUsedChanges(decorationInfo.removedLines),
+            modifiedLines: withoutUsedChanges(decorationInfo.modifiedLines).map(c => ({
+                ...c,
+                changes: withoutUsedChanges(c.changes),
+            })),
+            unchangedLines: withoutUsedChanges(decorationInfo.unchangedLines),
+        }
+
         await this.showEdit({
             document,
             range: codeToReplaceData.range,
             prediction,
-            decorationInfo,
+            decorationInfo: decorationInfoWithoutUsedChanges,
         })
 
         return { inlineCompletions, updatedDecorationInfo: decorationInfo }
@@ -127,7 +139,15 @@ export function getCompletionText({
     prediction,
     cursorPosition,
     decorationInfo,
-}: { prediction: string; cursorPosition: vscode.Position; decorationInfo: DecorationInfo }): string {
+}: {
+    prediction: string
+    cursorPosition: vscode.Position
+    decorationInfo: DecorationInfo
+}): {
+    insertText: string
+    usedChangeIds: Set<string>
+} {
+    const usedChangeIds = new Set<string>()
     const candidates = [...decorationInfo.modifiedLines, ...decorationInfo.addedLines]
 
     let currentLine = cursorPosition.line
@@ -154,10 +174,9 @@ export function getCompletionText({
         }
 
         if (candidate.type === 'added') {
-            // TODO(valery): avoid modifying array items in place, make side-effects obvious to the caller.
-            // Mark this added line as rendered as a part of the inline completion item
+            // Collect candidate IDs rendered as a part of the inline completion item
             // so that we don't decorate it with line decorations later.
-            candidate.usedAsInlineCompletion = true
+            usedChangeIds.add(candidate.id)
             candidateText = candidate.text
         }
 
@@ -184,10 +203,9 @@ export function getCompletionText({
                         )
 
                         if (textAfterCursor.length && lineChange.type === 'insert') {
-                            // TODO(valery): avoid modifying array items in place, make side-effects obvious to the caller.
-                            // Mark this line change as rendered as a part of the inline completion item
+                            // Collect this line change IDs rendered as a part of the inline completion item
                             // so that we don't decorate it with line decorations later.
-                            lineChange.usedAsInlineCompletion = true
+                            usedChangeIds.add(lineChange.id)
                         }
 
                         lineChangeText += textAfterCursor
@@ -206,7 +224,9 @@ export function getCompletionText({
             candidate.changes.every(c => c.type === 'insert')
         ) {
             for (const change of candidate.changes) {
-                change.usedAsInlineCompletion = true
+                // Collect this line change IDs rendered as a part of the inline completion item
+                // so that we don't decorate it with line decorations later.
+                usedChangeIds.add(change.id)
             }
 
             candidateText = candidate.newText
@@ -223,5 +243,8 @@ export function getCompletionText({
         break
     }
 
-    return lines.join(getNewLineChar(prediction))
+    return {
+        insertText: lines.join(getNewLineChar(prediction)),
+        usedChangeIds,
+    }
 }


### PR DESCRIPTION
- Addressing a comment from the recent PR review: https://github.com/sourcegraph/cody/pull/6235#discussion_r1876279079
- Removes the direct mutation of the decoration info in favor of creating a new decoration info object with filtered changes (we remove changes used for the inline completion item rendering from the object). 
    - I considered using array indices instead of change IDs, but that would make the code more complex and less flexible. By adding IDs, we can uniquely identify each change in any new structure we create from these object, without needing to maintain the original order or number of changes.

## Test plan

CI + updated unit tests.