### PR TITLE
fix(webviews): limit user avatar height to 24px

### DIFF
--- a/vscode/webviews/components/UserAvatar.module.css
+++ b/vscode/webviews/components/UserAvatar.module.css
@@ -8,6 +8,7 @@
     justify-content: center;
     width: auto;
     height: 100%;
+    max-height: 24px;
 }
 
 .sourcegraph-gradient-border {


### PR DESCRIPTION
CLOSE: https://linear.app/sourcegraph/issue/CODY-4496/debugger-displaying-profile-picture-in-unexpected-locations

- Adds a `max-height: 24px` rule to the `.user-avatar` class in the `UserAvatar.module.css` file to ensure the user avatar component does not exceed a maximum height of 24 pixels.


## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

Check if your user avatar in the home screen is showing up at the right size.

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
