### PR TITLE
Implement more results and intent switcher

### DIFF
--- a/lib/shared/src/chat/transcript/messages.ts
+++ b/lib/shared/src/chat/transcript/messages.ts
@@ -40,6 +40,8 @@ export interface ChatMessage extends Message {
     search?: ChatMessageSearch | undefined | null
 }
 
+export type ChatMessageWithSearch = ChatMessage & { search: ChatMessageSearch }
+
 export interface ChatMessageSearch {
     query: string
     response: NLSSearchResponse['search']

--- a/lib/shared/src/index.ts
+++ b/lib/shared/src/index.ts
@@ -74,6 +74,8 @@ export type {
     UserLocalHistory,
     SerializedChatMessage,
     RankedContext,
+    ChatMessageWithSearch,
+    ChatMessageSearch,
 } from './chat/transcript/messages'
 export {
     CODY_PASSTHROUGH_VSCODE_OPEN_COMMAND_ID,

--- a/vscode/webviews/chat/Transcript.tsx
+++ b/vscode/webviews/chat/Transcript.tsx
@@ -17,7 +17,6 @@ import {
 import { clsx } from 'clsx'
 import { isEqual } from 'lodash'
 import debounce from 'lodash/debounce'
-import { Search } from 'lucide-react'
 import {
     type FC,
     type MutableRefObject,
@@ -32,11 +31,10 @@ import {
 import { URI } from 'vscode-uri'
 import type { UserAccountInfo } from '../Chat'
 import type { ApiPostMessage } from '../Chat'
-import { Button } from '../components/shadcn/ui/button'
 import { getVSCodeAPI } from '../utils/VSCodeApi'
 import { SpanManager } from '../utils/spanManager'
 import { getTraceparentFromSpanContext, useTelemetryRecorder } from '../utils/telemetry'
-import { useExperimentalOneBox, useExperimentalOneBoxDebug } from '../utils/useExperimentalOneBox'
+import { useExperimentalOneBox } from '../utils/useExperimentalOneBox'
 import type { CodeBlockActionsProps } from './ChatMessageContent/ChatMessageContent'
 import {
     ContextCell,
@@ -48,10 +46,9 @@ import {
     makeHumanMessageInfo,
 } from './cells/messageCell/assistant/AssistantMessageCell'
 import { HumanMessageCell } from './cells/messageCell/human/HumanMessageCell'
-import { CodyIcon } from './components/CodyIcon'
-import { InfoMessage } from './components/InfoMessage'
 
 import { type Context, type Span, context, trace } from '@opentelemetry/api'
+import { SwitchIntent } from './cells/messageCell/assistant/SwitchIntent'
 interface TranscriptProps {
     activeChatContext?: Context
     setActiveChatContext: (context: Context | undefined) => void
@@ -339,7 +336,6 @@ const TranscriptInteraction: FC<TranscriptInteractionProps> = memo(props => {
 
     const extensionAPI = useExtensionAPI()
     const experimentalOneBoxEnabled = useExperimentalOneBox()
-    const experimentalOneBoxDebug = useExperimentalOneBoxDebug()
     const onChange = useMemo(() => {
         return debounce(async (editorValue: SerializedPromptEditorValue) => {
             if (!experimentalOneBoxEnabled) {
@@ -378,8 +374,11 @@ const TranscriptInteraction: FC<TranscriptInteractionProps> = memo(props => {
         })
     }, [])
 
+    const isSearchIntent = experimentalOneBoxEnabled && humanMessage.intent === 'search'
+
     const isContextLoading = Boolean(
-        humanMessage.contextFiles === undefined &&
+        !isSearchIntent &&
+            humanMessage.contextFiles === undefined &&
             isLastSentInteraction &&
             assistantMessage?.text === undefined
     )
@@ -579,44 +578,21 @@ const TranscriptInteraction: FC<TranscriptInteractionProps> = memo(props => {
                 className={!isFirstInteraction && isLastInteraction ? 'tw-mt-auto' : ''}
                 onEditorFocusChange={resetIntent}
             />
-
-            {experimentalOneBoxEnabled && experimentalOneBoxDebug && humanMessage.intent && (
-                <InfoMessage>
-                    {humanMessage.intent === 'search' ? (
-                        <div className="tw-flex tw-justify-between tw-gap-4 tw-items-center">
-                            <span>Intent detection selected a code search response.</span>
-                            <div className="tw-shrink-0 tw-self-start">
-                                <Button
-                                    size="sm"
-                                    variant="outline"
-                                    className="tw-text-prmary tw-flex tw-gap-2 tw-items-center"
-                                    onClick={reSubmitWithChatIntent}
-                                >
-                                    <CodyIcon className="tw-text-link" />
-                                    Ask the LLM
-                                </Button>
-                            </div>
-                        </div>
-                    ) : (
-                        <div className="tw-flex tw-justify-between tw-gap-4 tw-items-center">
-                            <span>Intent detection selected an LLM response.</span>
-                            <div className="tw-shrink-0 tw-self-start">
-                                <Button
-                                    size="sm"
-                                    variant="outline"
-                                    className="tw-text-prmary tw-flex tw-gap-2 tw-items-center"
-                                    onClick={reSubmitWithSearchIntent}
-                                >
-                                    <Search className="tw-size-8 tw-text-link" />
-                                    Search Code
-                                </Button>
-                            </div>
-                        </div>
-                    )}
-                </InfoMessage>
+            {experimentalOneBoxEnabled && (
+                <SwitchIntent
+                    intent={humanMessage?.intent}
+                    onSwitch={
+                        humanMessage?.intent === 'search'
+                            ? reSubmitWithChatIntent
+                            : reSubmitWithSearchIntent
+                    }
+                />
             )}
-            {(humanMessage.contextFiles || assistantMessage || isContextLoading) && (
+
+            {(humanMessage.contextFiles || assistantMessage || isContextLoading) && !isSearchIntent && (
                 <ContextCell
+                    experimentalOneBoxEnabled={experimentalOneBoxEnabled}
+                    intent={humanMessage.intent}
                     resubmitWithRepoContext={
                         corpusContextItems.length > 0 && !mentionsContainRepository && assistantMessage
                             ? resubmitWithRepoContext
@@ -655,6 +631,8 @@ const TranscriptInteraction: FC<TranscriptInteractionProps> = memo(props => {
                     }
                     smartApply={smartApply}
                     smartApplyEnabled={smartApplyEnabled}
+                    reSubmitWithChatIntent={reSubmitWithChatIntent}
+                    reSubmitWithSearchIntent={reSubmitWithSearchIntent}
                 />
             )}
         </>

--- a/vscode/webviews/chat/cells/contextCell/ContextCell.tsx
+++ b/vscode/webviews/chat/cells/contextCell/ContextCell.tsx
@@ -1,6 +1,6 @@
 import type { ContextItem, Model } from '@sourcegraph/cody-shared'
 import { pluralize } from '@sourcegraph/cody-shared'
-import type { RankedContext } from '@sourcegraph/cody-shared/src/chat/transcript/messages'
+import type { ChatMessage, RankedContext } from '@sourcegraph/cody-shared/src/chat/transcript/messages'
 import { MENTION_CLASS_NAME } from '@sourcegraph/prompt-editor'
 import { clsx } from 'clsx'
 import { BrainIcon, FilePenLine, MessagesSquareIcon } from 'lucide-react'
@@ -47,9 +47,11 @@ export const ContextCell: FunctionComponent<{
     className?: string
 
     defaultOpen?: boolean
+    intent: ChatMessage['intent']
 
     onManuallyEditContext: () => void
     editContextNode: React.ReactNode
+    experimentalOneBoxEnabled?: boolean
 }> = memo(
     ({
         contextItems,
@@ -63,6 +65,8 @@ export const ContextCell: FunctionComponent<{
         isContextLoading,
         onManuallyEditContext,
         editContextNode,
+        intent,
+        experimentalOneBoxEnabled,
     }) => {
         const __storybook__initialOpen = useContext(__ContextCellStorybookContext)?.initialOpen ?? false
 
@@ -132,16 +136,24 @@ export const ContextCell: FunctionComponent<{
 
         // Text for top header text
         const headerText: { main: string; sub?: string } = {
-            main: isContextLoading ? 'Fetching context' : 'Context',
-            sub: isContextLoading
-                ? isDeepCodyEnabled
-                    ? 'Thinking…'
-                    : 'Retrieving codebase files…'
-                : contextItems === undefined
-                  ? 'none requested'
-                  : contextItems.length === 0
-                    ? 'none fetched'
-                    : itemCountLabel,
+            main:
+                experimentalOneBoxEnabled && !intent
+                    ? 'Reviewing query'
+                    : isContextLoading
+                      ? 'Fetching context'
+                      : 'Context',
+            sub:
+                experimentalOneBoxEnabled && !intent
+                    ? 'Figuring out query intent...'
+                    : isContextLoading
+                      ? isDeepCodyEnabled
+                          ? 'Thinking…'
+                          : 'Retrieving codebase files…'
+                      : contextItems === undefined
+                        ? 'none requested'
+                        : contextItems.length === 0
+                          ? 'none fetched'
+                          : itemCountLabel,
         }
 
         return (

--- a/vscode/webviews/chat/cells/messageCell/assistant/AssistantMessageCell.tsx
+++ b/vscode/webviews/chat/cells/messageCell/assistant/AssistantMessageCell.tsx
@@ -1,5 +1,6 @@
 import {
     type ChatMessage,
+    type ChatMessageWithSearch,
     ContextItemSource,
     type Guardrails,
     type Model,
@@ -16,11 +17,7 @@ import isEqual from 'lodash/isEqual'
 import { type FunctionComponent, type RefObject, memo, useMemo } from 'react'
 import type { ApiPostMessage, UserAccountInfo } from '../../../../Chat'
 import { chatModelIconComponent } from '../../../../components/ChatModelIcon'
-import { NLSResultSnippet } from '../../../../components/NLSResultSnippet'
-import {
-    useExperimentalOneBox,
-    useExperimentalOneBoxDebug,
-} from '../../../../utils/useExperimentalOneBox'
+import { useExperimentalOneBox } from '../../../../utils/useExperimentalOneBox'
 import {
     ChatMessageContent,
     type CodeBlockActionsProps,
@@ -28,10 +25,10 @@ import {
 import { ErrorItem, RequestErrorItem } from '../../../ErrorItem'
 import { type Interaction, editHumanMessage } from '../../../Transcript'
 import { FeedbackButtons } from '../../../components/FeedbackButtons'
-import { InfoMessage } from '../../../components/InfoMessage'
 import { LoadingDots } from '../../../components/LoadingDots'
 import { BaseMessageCell, MESSAGE_CELL_AVATAR_SIZE } from '../BaseMessageCell'
 import { ContextFocusActions } from './ContextFocusActions'
+import { SearchResults } from './SearchResults'
 
 /**
  * A component that displays a chat message from the assistant.
@@ -57,6 +54,8 @@ export const AssistantMessageCell: FunctionComponent<{
 
     postMessage?: ApiPostMessage
     guardrails?: Guardrails
+    reSubmitWithChatIntent: () => void
+    reSubmitWithSearchIntent: () => void
 }> = memo(
     ({
         message,
@@ -73,6 +72,8 @@ export const AssistantMessageCell: FunctionComponent<{
         guardrails,
         smartApply,
         smartApplyEnabled,
+        reSubmitWithChatIntent,
+        reSubmitWithSearchIntent,
     }) => {
         const displayMarkdown = useMemo(
             () => (message.text ? reformatBotMessageForChat(message.text).toString() : ''),
@@ -86,13 +87,18 @@ export const AssistantMessageCell: FunctionComponent<{
         const hasLongerResponseTime = chatModel?.tags?.includes(ModelTag.StreamDisabled)
 
         const experimentalOneBoxEnabled = useExperimentalOneBox()
-        const experimentalOneBoxDebug = useExperimentalOneBoxDebug()
+
+        const isSearchIntent = experimentalOneBoxEnabled && humanMessage?.intent === 'search'
 
         return (
             <BaseMessageCell
-                speakerIcon={ModelIcon ? <ModelIcon size={NON_HUMAN_CELL_AVATAR_SIZE} /> : null}
+                speakerIcon={
+                    ModelIcon && (!isSearchIntent || isLoading) ? (
+                        <ModelIcon size={NON_HUMAN_CELL_AVATAR_SIZE} />
+                    ) : null
+                }
                 speakerTitle={
-                    message.search ? undefined : (
+                    isSearchIntent ? undefined : (
                         <span data-testid="chat-model">
                             {chatModel
                                 ? chatModel.title ?? `Model ${chatModel.id} by ${chatModel.provider}`
@@ -113,27 +119,15 @@ export const AssistantMessageCell: FunctionComponent<{
                                 />
                             )
                         ) : null}
-                        {experimentalOneBoxEnabled && message.search && (
-                            <>
-                                {experimentalOneBoxDebug && (
-                                    <InfoMessage>Query: {message.search.query}</InfoMessage>
-                                )}
-                                {!!message.search.response?.results?.results?.length && (
-                                    <ul className="tw-list-none tw-flex tw-flex-col tw-gap-2 tw-pt-2">
-                                        {message.search.response.results.results.map((result, i) => (
-                                            <li
-                                                // biome-ignore lint/correctness/useJsxKeyInIterable:
-                                                // biome-ignore lint/suspicious/noArrayIndexKey: stable order
-                                                key={i}
-                                            >
-                                                <NLSResultSnippet result={result} />
-                                            </li>
-                                        ))}
-                                    </ul>
-                                )}
-                            </>
+                        {isSearchIntent && isLoading && (
+                            <div className="tw-flex">
+                                <LoadingDots /> Searching...
+                            </div>
                         )}
-                        {!(experimentalOneBoxEnabled && message.search) && displayMarkdown ? (
+                        {experimentalOneBoxEnabled && !isLoading && message.search && (
+                            <SearchResults message={message as ChatMessageWithSearch} />
+                        )}
+                        {!isSearchIntent && displayMarkdown ? (
                             <ChatMessageContent
                                 displayMarkdown={displayMarkdown}
                                 isMessageLoading={isLoading}
@@ -175,7 +169,7 @@ export const AssistantMessageCell: FunctionComponent<{
                                         className="tw-pr-4"
                                     />
                                 )}
-                                {!isLoading && (!message.error || isAborted) && (
+                                {!isLoading && (!message.error || isAborted) && !isSearchIntent && (
                                     <ContextFocusActions
                                         humanMessage={humanMessage}
                                         longResponseTime={hasLongerResponseTime}
@@ -206,6 +200,7 @@ export interface HumanMessageInitialContextInfo {
 
 export interface PriorHumanMessageInfo {
     text?: PromptString
+    intent?: ChatMessage['intent']
     hasInitialContext: HumanMessageInitialContextInfo
     rerunWithDifferentContext: (withInitialContext: HumanMessageInitialContextInfo) => void
 
@@ -226,6 +221,7 @@ export function makeHumanMessageInfo(
 
     return {
         text: humanMessage.text,
+        intent: humanMessage.intent,
         hasInitialContext: {
             repositories: Boolean(
                 contextItems.some(item => item.type === 'repository' || item.type === 'tree')

--- a/vscode/webviews/chat/cells/messageCell/assistant/SearchResults.tsx
+++ b/vscode/webviews/chat/cells/messageCell/assistant/SearchResults.tsx
@@ -1,0 +1,73 @@
+import type { ChatMessageWithSearch } from '@sourcegraph/cody-shared'
+import { ArrowDown, ExternalLink, Search } from 'lucide-react'
+import { useState } from 'react'
+import { NLSResultSnippet } from '../../../../components/NLSResultSnippet'
+import { Button } from '../../../../components/shadcn/ui/button'
+import { useConfig } from '../../../../utils/useConfig'
+import { useExperimentalOneBoxDebug } from '../../../../utils/useExperimentalOneBox'
+import { InfoMessage } from '../../../components/InfoMessage'
+
+interface SearchResultsProps {
+    message: ChatMessageWithSearch
+}
+
+const DEFAULT_RESULTS_LIMIT = 5
+export const SearchResults = ({ message }: SearchResultsProps) => {
+    const experimentalOneBoxDebug = useExperimentalOneBoxDebug()
+
+    const [showAll, setShowAll] = useState(false)
+
+    const totalResults = message.search.response?.results?.results?.length ?? 0
+
+    const {
+        config: { serverEndpoint },
+    } = useConfig()
+
+    return (
+        <>
+            {message.search.response?.results?.results?.length > 0 && (
+                <div className="tw-flex tw-items-center tw-gap-2 tw-font-bold tw-text-muted-foreground">
+                    <Search className="tw-size-8" />
+                    Displaying {showAll ? totalResults : DEFAULT_RESULTS_LIMIT} of {totalResults} code
+                    search results
+                </div>
+            )}
+            {experimentalOneBoxDebug && <InfoMessage>Query: {message.search.query}</InfoMessage>}
+            {!!message.search.response?.results?.results?.length && (
+                <ul className="tw-list-none tw-flex tw-flex-col tw-gap-2 tw-pt-2">
+                    {message.search.response.results.results.map((result, i) =>
+                        showAll || i < DEFAULT_RESULTS_LIMIT ? (
+                            <li
+                                // biome-ignore lint/correctness/useJsxKeyInIterable:
+                                // biome-ignore lint/suspicious/noArrayIndexKey: stable order
+                                key={i}
+                            >
+                                <NLSResultSnippet result={result} />
+                            </li>
+                        ) : null
+                    )}
+                </ul>
+            )}
+            <div className="tw-flex tw-justify-between tw-gap-2 tw-my-4">
+                {!showAll && totalResults > DEFAULT_RESULTS_LIMIT ? (
+                    <Button onClick={() => setShowAll(true)} variant="outline">
+                        <ArrowDown className="tw-size-8" />
+                        More results
+                    </Button>
+                ) : (
+                    <div />
+                )}
+                <a
+                    href={`${serverEndpoint}/search`}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="tw-text-foreground"
+                >
+                    <Button variant="outline">
+                        Code search <ExternalLink className="tw-size-8" />
+                    </Button>
+                </a>
+            </div>
+        </>
+    )
+}

--- a/vscode/webviews/chat/cells/messageCell/assistant/SwitchIntent.tsx
+++ b/vscode/webviews/chat/cells/messageCell/assistant/SwitchIntent.tsx
@@ -1,0 +1,37 @@
+import type { ChatMessage } from '@sourcegraph/cody-shared'
+import { Brain, MessageSquare, Search } from 'lucide-react'
+import { Button } from '../../../../components/shadcn/ui/button'
+
+interface SwitchIntentProps {
+    intent: ChatMessage['intent']
+    onSwitch?: () => void
+}
+export const SwitchIntent = ({ intent, onSwitch }: SwitchIntentProps) => {
+    if (!['chat', 'search'].includes(intent || '')) {
+        return null
+    }
+
+    return (
+        <div className="tw-flex tw-justify-between tw-gap-4 tw-items-center">
+            <div className="tw-flex tw-gap-2 tw-text-muted-foreground tw-items-center">
+                <Brain className="tw-size-8" />
+                Query review selected a {intent === 'search' ? 'code search' : 'chat'} response
+            </div>
+            <div className="tw-shrink-0 tw-self-start">
+                <Button
+                    size="sm"
+                    variant="outline"
+                    className="tw-text-prmary tw-flex tw-gap-2 tw-items-center"
+                    onClick={onSwitch}
+                >
+                    {intent === 'search' ? (
+                        <MessageSquare className="tw-size-8" />
+                    ) : (
+                        <Search className="tw-size-8" />
+                    )}
+                    {intent === 'search' ? 'Switch to chat' : 'Switch to search'}
+                </Button>
+            </div>
+        </div>
+    )
+}


### PR DESCRIPTION
closes: https://linear.app/sourcegraph/issue/SRCH-1423/more-results
closes: https://linear.app/sourcegraph/issue/SRCH-1426/more-results-disabled
closes: https://linear.app/sourcegraph/issue/SRCH-1427/link-to-code-search
closes: https://linear.app/sourcegraph/issue/SRCH-1434/switch-between-chat-and-search-results

This PR adds `More Results`, `Code Search` and `Switch to Chat` interactions to the OneBox Search Results. For more details, check the Loom video.


## Test plan

https://www.loom.com/share/9e9c3c0a2bea4b629cabcb75273b176d
## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
