### PR TITLE
fix(cody): fix empty local storage cody chat run

### DIFF
--- a/web/CHANGELOG.md
+++ b/web/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.16.0 
+- Fixes cody chat start up on empty local storage (new users run chat for the first time case), [Linear issue](https://linear.app/sourcegraph/issue/SRCH-1456/cody-chat-fails-with-unsupported-model-error) 
+
 ## 0.15.0
 - Fixes problem with not working prompts when chat has some sent messages 
 

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sourcegraph/cody-web",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "description": "Cody standalone web app",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
Fixes https://linear.app/sourcegraph/issue/SRCH-1456/cody-chat-fails-with-unsupported-model-error

## Problem 
When the user runs Cody Web (in theory this problem exists in all Cody chat clients) for the first time they don't have any configuration information in their local storage (IndexDB in the case of Cody Web) 

Seeding local storage on the initial run, we fire a lot of configuration updates, which triggers invalidation logic. Sometimes (it's a race condition between requests an configuration updates), some important requests are pending, and invalidation works in a way that cancels all ongoing flights. When we cancel all of them, we don't fetch vital information for proper chat work. 

## Solution 

Currently, it just omits `clientState` field from cache invalidation but ideally, we should map it to a minimal viable configuration object that has any request-related fields 

## Test plan
- Run any Cody client with empty local storage (In the case of Cody Web it's IndexDB table)
- Check that the chat works properly and you don't have any cancelled requests in the network tab)


