### PR TITLE
fix/web: Fix an error in auth arising from missing Symbol.dispose.

### DIFF
--- a/lib/shared/src/sourcegraph-api/graphql/cache.ts
+++ b/lib/shared/src/sourcegraph-api/graphql/cache.ts
@@ -65,7 +65,7 @@ type GraphQLResultCacheConfig = {
  * The factory keeps its caches alive until the Observable completes. Dispose
  * the factory to clean up the subscription.
  */
-export class ObservableInvalidatedGraphQLResultCacheFactory implements Disposable {
+export class ObservableInvalidatedGraphQLResultCacheFactory {
     private readonly options: GraphQLResultCacheConfig
     private readonly subscription: Subscription<any>
     private caches: GraphQLResultCache<any>[] = []
@@ -92,7 +92,7 @@ export class ObservableInvalidatedGraphQLResultCacheFactory implements Disposabl
         })
     }
 
-    [Symbol.dispose](): void {
+    dispose(): void {
         this.subscription.unsubscribe()
         this.caches = []
     }

--- a/lib/shared/src/sourcegraph-api/graphql/client.ts
+++ b/lib/shared/src/sourcegraph-api/graphql/client.ts
@@ -672,7 +672,7 @@ type GraphQLAPIClientConfig = PickResolvedConfiguration<{
 
 const QUERY_TO_NAME_REGEXP = /^\s*(?:query|mutation)\s+(\w+)/m
 
-export class SourcegraphGraphQLAPIClient implements Disposable {
+export class SourcegraphGraphQLAPIClient {
     private isAgentTesting = process.env.CODY_SHIM_TESTING === 'true'
     private readonly resultCacheFactory: ObservableInvalidatedGraphQLResultCacheFactory
     private readonly siteVersionCache: GraphQLResultCache<string>
@@ -709,8 +709,8 @@ export class SourcegraphGraphQLAPIClient implements Disposable {
         this.siteVersionCache = this.resultCacheFactory.create<string>('SiteProductVersion')
     }
 
-    [Symbol.dispose]() {
-        this.resultCacheFactory[Symbol.dispose]()
+    dispose(): void {
+        this.resultCacheFactory.dispose()
     }
 
     public async getSiteVersion(signal?: AbortSignal): Promise<string | Error> {

--- a/web/CHANGELOG.md
+++ b/web/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.17.0
+- Fixes runtime error with `Symbol.dispose` in Firefox
+- Hides Cody Panel debug state in production mode 
+
 ## 0.16.0 
 - Fixes cody chat start up on empty local storage (new users run chat for the first time case), [Linear issue](https://linear.app/sourcegraph/issue/SRCH-1456/cody-chat-fails-with-unsupported-model-error) 
 

--- a/web/lib/agent/agent.client.ts
+++ b/web/lib/agent/agent.client.ts
@@ -88,7 +88,9 @@ export async function createAgentClient({
             customConfiguration: {
                 'cody.autocomplete.enabled': false,
                 'cody.experimental.urlContext': true,
-                'cody.internal.debug.state': !!process.env.CODY_WEB_DEMO,
+                // Will be replaced with vite in build time
+                // @ts-ignore
+                'cody.internal.debug.state': import.meta.env.MODE === 'development',
             },
         },
     } satisfies ClientInfo)

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sourcegraph/cody-web",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "Cody standalone web app",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
#6111 tried to be clever and use `using`, but Firefox does not have Symbol.dispose. Switch back to good ol' try-finally and method calls.

## Test plan

`pnpm -C web dev`

Run Firefox and open <http://localhost:5777>. Loading Cody Web will still fail, but there is no message about dispose in the console. This does *not* appear:

```
Authentication failed TypeError: Object not disposable
    Immutable 6
        __typeError
        __using
        validateCredentials
        validateAndStoreCredentials
        handleConfigChanges
        Agent
```

Run Chrome and open the same. Cody Web works and you can chat, etc.