### PR TITLE
fix(webviews): standardized user avatar size

### DIFF
--- a/vscode/webviews/chat/cells/messageCell/BaseMessageCell.tsx
+++ b/vscode/webviews/chat/cells/messageCell/BaseMessageCell.tsx
@@ -29,4 +29,4 @@ export const BaseMessageCell: FunctionComponent<{
     </Cell>
 )
 
-export const MESSAGE_CELL_AVATAR_SIZE = 12
+export const MESSAGE_CELL_AVATAR_SIZE = 22

--- a/vscode/webviews/components/UserAvatar.module.css
+++ b/vscode/webviews/components/UserAvatar.module.css
@@ -6,8 +6,6 @@
     color: var(--vscode-inputOption-activeForeground);
     align-items: center;
     justify-content: center;
-    width: auto;
-    height: 100%;
 }
 
 .sourcegraph-gradient-border {

--- a/vscode/webviews/components/UserAvatar.module.css
+++ b/vscode/webviews/components/UserAvatar.module.css
@@ -8,7 +8,6 @@
     justify-content: center;
     width: auto;
     height: 100%;
-    max-height: 24px;
 }
 
 .sourcegraph-gradient-border {

--- a/vscode/webviews/components/UserAvatar.tsx
+++ b/vscode/webviews/components/UserAvatar.tsx
@@ -25,7 +25,7 @@ export const UserAvatar: FunctionComponent<Props> = ({
         <InnerUserAvatar
             user={user}
             size={sourcegraphGradientBorder ? size - SOURCEGRAPH_GRADIENT_BORDER_SIZE * 2 : size}
-            className={sourcegraphGradientBorder ? undefined : className}
+            className={className}
         />
     )
     return sourcegraphGradientBorder ? (
@@ -61,7 +61,7 @@ const InnerUserAvatar: FunctionComponent<Omit<Props, 'sourcegraphGradientBorder'
 
         return (
             <img
-                className={styles.userAvatar}
+                className={clsx(styles.userAvatar, className)}
                 src={url}
                 role="presentation"
                 title={title}
@@ -75,7 +75,7 @@ const InnerUserAvatar: FunctionComponent<Omit<Props, 'sourcegraphGradientBorder'
         <div
             title={title}
             className={clsx(styles.userAvatar, className)}
-            style={{ width: `${highDPISize}px`, height: `${highDPISize}px, fontSize: ${size / 2}px` }}
+            style={{ width: `${highDPISize}px`, height: `${highDPISize}px`, fontSize: `${size / 2}px` }}
         >
             <span className={styles.initials}>
                 {getInitials(user?.displayName || user?.username || '')}

--- a/vscode/webviews/components/UserAvatar.tsx
+++ b/vscode/webviews/components/UserAvatar.tsx
@@ -75,7 +75,7 @@ const InnerUserAvatar: FunctionComponent<Omit<Props, 'sourcegraphGradientBorder'
         <div
             title={title}
             className={clsx(styles.userAvatar, className)}
-            style={{ width: `${highDPISize}px`, height: `${highDPISize}px`, fontSize: `${size / 2}px` }}
+            style={{ width: `${size}px`, height: `${size}px`, fontSize: `${size / 3}px` }}
         >
             <span className={styles.initials}>
                 {getInitials(user?.displayName || user?.username || '')}

--- a/vscode/webviews/components/UserMenu.tsx
+++ b/vscode/webviews/components/UserMenu.tsx
@@ -317,7 +317,7 @@ export const UserMenu: React.FunctionComponent<UserMenuProps> = ({
                                             user={authStatus}
                                             size={USER_MENU_AVATAR_SIZE}
                                             sourcegraphGradientBorder={!!isProUser}
-                                            className="tw-flex tw-justify-center"
+                                            className="tw-inline-flex tw-self-center tw-items-center tw-w-auto"
                                         />
                                         <div className="tw-flex tw-self-stretch tw-flex-col tw-w-full tw-items-start tw-justify-center">
                                             <p className="tw-text-md tw-font-semibold">
@@ -431,9 +431,10 @@ export const UserMenu: React.FunctionComponent<UserMenuProps> = ({
                 user={authStatus}
                 size={USER_MENU_AVATAR_SIZE}
                 sourcegraphGradientBorder={!!isProUser}
+                className="tw-w-10 tw-h-10"
             />
         </ToolbarPopoverItem>
     )
 }
 
-export const USER_MENU_AVATAR_SIZE = 20
+export const USER_MENU_AVATAR_SIZE = 16

--- a/vscode/webviews/components/UserMenu.tsx
+++ b/vscode/webviews/components/UserMenu.tsx
@@ -315,7 +315,7 @@ export const UserMenu: React.FunctionComponent<UserMenuProps> = ({
                                     <div className="tw-flex tw-w-full tw-justify-start tw-gap-4">
                                         <UserAvatar
                                             user={authStatus}
-                                            size={16}
+                                            size={USER_MENU_AVATAR_SIZE}
                                             sourcegraphGradientBorder={!!isProUser}
                                             className="tw-flex tw-justify-center"
                                         />
@@ -427,7 +427,13 @@ export const UserMenu: React.FunctionComponent<UserMenuProps> = ({
                 },
             }}
         >
-            <UserAvatar user={authStatus} size={12} sourcegraphGradientBorder={!!isProUser} />
+            <UserAvatar
+                user={authStatus}
+                size={USER_MENU_AVATAR_SIZE}
+                sourcegraphGradientBorder={!!isProUser}
+            />
         </ToolbarPopoverItem>
     )
 }
+
+export const USER_MENU_AVATAR_SIZE = 20

--- a/vscode/webviews/components/promptList/ActionItem.module.css
+++ b/vscode/webviews/components/promptList/ActionItem.module.css
@@ -40,8 +40,6 @@
 
     &--avatar {
         flex-shrink: 0;
-        width: 22px;
-        height: 22px;
         display: flex;
         align-items: center;
         justify-content: center;

--- a/vscode/webviews/components/promptList/ActionItem.tsx
+++ b/vscode/webviews/components/promptList/ActionItem.tsx
@@ -74,7 +74,7 @@ const ActionPrompt: FC<ActionPromptProps> = props => {
         <div className={styles.prompt}>
             {prompt.createdBy && (
                 <UserAvatar
-                    size={14}
+                    size={ACTION_ITEM_AVATAR_SIZE}
                     user={{ ...prompt.createdBy, endpoint: '' }}
                     className={styles.promptAvatar}
                 />
@@ -177,3 +177,5 @@ const ActionCommand: FC<ActionCommandProps> = props => {
         </div>
     )
 }
+
+export const ACTION_ITEM_AVATAR_SIZE = 22

--- a/vscode/webviews/tabs/AccountTab.tsx
+++ b/vscode/webviews/tabs/AccountTab.tsx
@@ -15,6 +15,7 @@ import {
 } from '../../src/chat/protocol'
 import { AccountSwitcher } from '../components/AccountSwitcher'
 import { UserAvatar } from '../components/UserAvatar'
+import { USER_MENU_AVATAR_SIZE } from '../components/UserMenu'
 import { Button } from '../components/shadcn/ui/button'
 import { getVSCodeAPI } from '../utils/VSCodeApi'
 
@@ -103,8 +104,8 @@ export const AccountTab: React.FC<AccountTabProps> = ({
                     <div className="tw-flex tw-self-stretch tw-flex-col tw-w-full tw-items-center tw-justify-center">
                         <UserAvatar
                             user={authStatus}
-                            size={20}
-                            className="tw-flex-shrink-0 tw-w-[30px] tw-h-[30px] tw-flex tw-items-center tw-justify-center"
+                            size={USER_MENU_AVATAR_SIZE}
+                            className="tw-flex-shrink-0 tw-flex tw-items-center tw-justify-center"
                         />
                         <div className="tw-flex tw-self-stretch tw-flex-col tw-w-full tw-items-center tw-justify-center tw-mt-4">
                             <p className="tw-text-lg tw-font-semibold">{displayName ?? username}</p>

--- a/vscode/webviews/tabs/TabsBar.story.tsx
+++ b/vscode/webviews/tabs/TabsBar.story.tsx
@@ -1,4 +1,5 @@
 import * as Tabs from '@radix-ui/react-tabs'
+import { CodyIDE } from '@sourcegraph/cody-shared'
 import type { Meta, StoryObj } from '@storybook/react'
 import { VSCodeStandaloneComponent } from '../storybook/VSCodeStoryDecorator'
 import { TabsBar } from './TabsBar'
@@ -23,10 +24,25 @@ export default meta
 
 type Story = StoryObj<typeof TabsBar>
 
+const mockUser = {
+    isCodyProUser: false,
+    isDotComUser: true,
+    IDE: CodyIDE.VSCode,
+    user: {
+        id: '1',
+        username: 'test',
+        email: 'test@example.com',
+        isPro: false,
+        hasVerifiedEmail: true,
+        endpoint: 'https://sourcegraph.com',
+    },
+}
+
 export const ChatTab: Story = {
     args: {
         currentView: View.Chat,
         setView: () => {},
+        user: mockUser,
     },
 }
 
@@ -34,6 +50,7 @@ export const HistoryTab: Story = {
     args: {
         currentView: View.History,
         setView: () => {},
+        user: mockUser,
     },
 }
 
@@ -41,6 +58,7 @@ export const PromptsTab: Story = {
     args: {
         currentView: View.Prompts,
         setView: () => {},
+        user: mockUser,
     },
 }
 
@@ -48,6 +66,7 @@ export const SettingsTab: Story = {
     args: {
         currentView: View.Settings,
         setView: () => {},
+        user: mockUser,
     },
 }
 
@@ -55,5 +74,6 @@ export const AccountTab: Story = {
     args: {
         currentView: View.Account,
         setView: () => {},
+        user: mockUser,
     },
 }


### PR DESCRIPTION
CLOSE https://linear.app/sourcegraph/issue/CODY-4496/debugger-displaying-profile-picture-in-unexpected-locations

Follow up on https://github.com/sourcegraph/cody/pull/6319

- Remove the max-height constraint on user avatars
- Apply the provided className to the inner user avatar component
- Fix the string issue in style
- Remove fixed width and height constraints on user avatars 
- Use a consistent avatar size across different UI components 
- Introduce a constant for the user menu avatar size 
- Update storybook

This should also fix the issue reported by a Discord user:

<img width="503" alt="image" src="https://github.com/user-attachments/assets/013b6d87-3e38-4748-8042-b98a24702fe8" />


## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

Verify that user avatars are displayed correctly in the Cody web application, with consistent sizing across different UI components..

In the main chat view

<img width="596" alt="image" src="https://github.com/user-attachments/assets/5062537c-bda2-4df9-9d92-da5530053a0b" />

In the prompt library view

<img width="600" alt="image" src="https://github.com/user-attachments/assets/71ccfe32-9aa2-4bae-97d4-b88278d4ce9c" />

Check storybook

![image](https://github.com/user-attachments/assets/2681bef8-e849-4bbc-8625-e30a3453eef4)

![image](https://github.com/user-attachments/assets/104268c3-0e18-44a5-99f7-73a79f626cad)

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
