### PR TITLE
fix(deep-cody): agent can removes memory from storage

### DIFF
--- a/vscode/src/chat/agentic/CodyChatMemory.ts
+++ b/vscode/src/chat/agentic/CodyChatMemory.ts
@@ -1,4 +1,4 @@
-import { type ContextItem, ContextItemSource } from '@sourcegraph/cody-shared'
+import { type ContextItem, ContextItemSource, logDebug } from '@sourcegraph/cody-shared'
 import { URI } from 'vscode-uri'
 import { localStorage } from '../../services/LocalStorageProvider'
 
@@ -41,6 +41,7 @@ export class CodyChatMemory {
         }
         // TODO - persist to local file system
         localStorage?.setChatMemory(Array.from(CodyChatMemory.Store))
+        logDebug('CodyChatMemory', 'memory added', { verbose: memory })
     }
 
     public static retrieve(): ContextItem | undefined {
@@ -58,10 +59,14 @@ export class CodyChatMemory {
     public static unload(): ContextItem | undefined {
         const stored = CodyChatMemory.retrieve()
         CodyChatMemory.Store = new Set<string>()
+        localStorage?.setChatMemory(null)
+        logDebug('CodyChatMemory', 'memory reset')
         return stored
     }
 
     private getChatMemory(): string[] {
-        return localStorage?.getChatMemory() || []
+        const memory = localStorage?.getChatMemory() || []
+        logDebug('CodyChatMemory', 'memory retrieved', { verbose: memory })
+        return memory
     }
 }

--- a/vscode/src/services/LocalStorageProvider.ts
+++ b/vscode/src/services/LocalStorageProvider.ts
@@ -343,7 +343,7 @@ class LocalStorage implements LocalStorageForModelPreferences {
         return this.get<string[]>(this.CODY_CHAT_MEMORY) ?? null
     }
 
-    public async setChatMemory(memories: string[]): Promise<void> {
+    public async setChatMemory(memories: string[] | null): Promise<void> {
         await this.set(this.CODY_CHAT_MEMORY, memories)
     }
 


### PR DESCRIPTION
- Add logging for chat memory operations
- Handle null values when setting chat memory

Fix an issue where memory is persisted after Deep Cody tries to reset the chat memory


## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

1. Ask Cody to forget what's in your memory
2. In a new chat, ask Deep Cody about what is stored in its memory. Deep Cody should tell you there is nothing.

### After

<img width="620" alt="image" src="https://github.com/user-attachments/assets/6ff5d6cf-093b-4032-b6dd-bc2ed3a97ab0" />

### Before

<img width="631" alt="image" src="https://github.com/user-attachments/assets/ec12d9d6-dc2a-4bfe-94d0-9253e134a03e" />


<img width="625" alt="image" src="https://github.com/user-attachments/assets/cb48676f-73ba-4b8a-b39a-16cdc78bcfb1" />



## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
