### PR TITLE
fix newline indentation as per finetuning data

### DIFF
--- a/vscode/src/autoedits/prompt/default-prompt-strategy.test.ts
+++ b/vscode/src/autoedits/prompt/default-prompt-strategy.test.ts
@@ -182,10 +182,12 @@ describe('DefaultUserPromptStrategy', () => {
             <extracted_code_snippets>
             <snippet>
             (\`test1.ts\`)
+
             jaccard similarity context 1
             </snippet>
             <snippet>
             (\`test2.ts\`)
+
             jaccard similarity context 2
             </snippet>
             </extracted_code_snippets>
@@ -194,18 +196,22 @@ describe('DefaultUserPromptStrategy', () => {
             <recently_viewed_snippets>
             <snippet>
             (\`test3.ts\`)
+
             view port context 4
             </snippet>
             <snippet>
             (\`test2.ts\`)
+
             view port context 3
             </snippet>
             <snippet>
             (\`test1.ts\`)
+
             view port context 2
             </snippet>
             <snippet>
             (\`test0.ts\`)
+
             view port context 1
             </snippet>
             </recently_viewed_snippets>
@@ -232,20 +238,24 @@ describe('DefaultUserPromptStrategy', () => {
             Here are some linter errors from the code that you will rewrite.
             <lint_errors>
             (\`test1.ts\`)
+
             diagnostics context 1
 
             diagnostics context 2
 
             (\`test2.ts\`)
+
             diagnostics context 3
             </lint_errors>
 
             Here is some recent code I copied from the editor.
             <recent_copy>
             (\`test1.ts\`)
+
             recent copy context 1
 
             (\`test2.ts\`)
+
             recent copy context 2
             </recent_copy>
 

--- a/vscode/src/autoedits/prompt/default-prompt-strategy.test.ts
+++ b/vscode/src/autoedits/prompt/default-prompt-strategy.test.ts
@@ -218,7 +218,9 @@ describe('DefaultUserPromptStrategy', () => {
 
             Here is the file that I am looking at (\`test.ts\`)
             <file>
+
             <<<AREA_AROUND_CODE_TO_REWRITE_WILL_BE_INSERTED_HERE>>>
+
             </file>
 
             Here is my recent series of edits from oldest to newest.
@@ -310,7 +312,9 @@ describe('DefaultUserPromptStrategy', () => {
 
             Here is the file that I am looking at (\`test.ts\`)
             <file>
+
             <<<AREA_AROUND_CODE_TO_REWRITE_WILL_BE_INSERTED_HERE>>>
+
             </file>
 
 

--- a/vscode/src/autoedits/prompt/default-prompt-strategy.ts
+++ b/vscode/src/autoedits/prompt/default-prompt-strategy.ts
@@ -1,4 +1,4 @@
-import { ps, psDedent } from '@sourcegraph/cody-shared'
+import { ps } from '@sourcegraph/cody-shared'
 import { RetrieverIdentifier } from '../../completions/context/utils'
 import { autoeditsLogger } from '../logger'
 import type { AutoeditsUserPromptStrategy, UserPromptArgs, UserPromptResponse } from './base'
@@ -13,6 +13,7 @@ import {
     getRecentCopyPrompt,
     getRecentEditsPrompt,
     getRecentlyViewedSnippetsPrompt,
+    joinPromptsWithNewlineSeperator,
 } from './prompt-utils'
 
 export class DefaultUserPromptStrategy implements AutoeditsUserPromptStrategy {
@@ -68,16 +69,17 @@ export class DefaultUserPromptStrategy implements AutoeditsUserPromptStrategy {
 
         const currentFilePrompt = ps`${constants.CURRENT_FILE_INSTRUCTION}${fileWithMarkerPrompt}`
 
-        const finalPrompt = psDedent`
-            ${getPromptWithNewline(constants.BASE_USER_PROMPT)}
-            ${getPromptWithNewline(jaccardSimilarityPrompt)}
-            ${getPromptWithNewline(recentViewsPrompt)}
-            ${getPromptWithNewline(currentFilePrompt)}
-            ${getPromptWithNewline(recentEditsPrompt)}
-            ${getPromptWithNewline(lintErrorsPrompt)}
-            ${getPromptWithNewline(recentCopyPrompt)}
-            ${getPromptWithNewline(areaPrompt)}
-            ${getPromptWithNewline(constants.FINAL_USER_PROMPT)}`
+        const finalPrompt = joinPromptsWithNewlineSeperator(
+            getPromptWithNewline(constants.BASE_USER_PROMPT),
+            getPromptWithNewline(jaccardSimilarityPrompt),
+            getPromptWithNewline(recentViewsPrompt),
+            getPromptWithNewline(currentFilePrompt),
+            getPromptWithNewline(recentEditsPrompt),
+            getPromptWithNewline(lintErrorsPrompt),
+            getPromptWithNewline(recentCopyPrompt),
+            getPromptWithNewline(areaPrompt),
+            constants.FINAL_USER_PROMPT
+        )
 
         autoeditsLogger.logDebug('AutoEdits', 'Prompt\n', finalPrompt)
         return {

--- a/vscode/src/autoedits/prompt/prompt-utils.test.ts
+++ b/vscode/src/autoedits/prompt/prompt-utils.test.ts
@@ -16,6 +16,7 @@ import {
     getRecentEditsContextPromptWithPath,
     getRecentEditsPrompt,
     getRecentlyViewedSnippetsPrompt,
+    joinPromptsWithNewlineSeperator,
 } from '../prompt/prompt-utils'
 
 describe('getContextPromptWithPath', () => {
@@ -87,6 +88,7 @@ describe('getCurrentFilePromptComponents', () => {
             suffix-line
             suffix-line
             suffix-line
+
             </file>
         `)
         expect(result.areaPrompt.toString()).toBe(dedent`
@@ -134,7 +136,9 @@ describe('getCurrentFilePromptComponents', () => {
         expect(result.fileWithMarkerPrompt.toString()).toBe(dedent`
             (\`test.ts\`)
             <file>
+
             <<<AREA_AROUND_CODE_TO_REWRITE_WILL_BE_INSERTED_HERE>>>
+
             </file>
         `)
         expect(result.areaPrompt.toString()).toBe(dedent`
@@ -892,6 +896,16 @@ describe('getJaccardSimilarityPrompt', () => {
             qux
             </snippet>
             </extracted_code_snippets>
+        `)
+    })
+})
+
+describe('joinPromptsWithNewlineSeperator', () => {
+    it('joins multiple prompt strings with a new line separator', () => {
+        const prompt = joinPromptsWithNewlineSeperator(ps`foo`, ps`bar`)
+        expect(prompt.toString()).toBe(dedent`
+            foo
+            bar
         `)
     })
 })

--- a/vscode/src/autoedits/prompt/prompt-utils.test.ts
+++ b/vscode/src/autoedits/prompt/prompt-utils.test.ts
@@ -25,6 +25,7 @@ describe('getContextPromptWithPath', () => {
         const prompt = getContextPromptWithPath(filePath, content)
         expect(prompt.toString()).toBe(dedent`
             (\`/path/to/file.js\`)
+
             const foo = 1
         `)
     })
@@ -545,6 +546,7 @@ describe('getLintErrorsPrompt', () => {
         expect(prompt.toString()).toBe(dedent`
             <lint_errors>
             (\`foo.ts\`)
+
             foo
             Err | Defined foo
 
@@ -579,6 +581,7 @@ describe('getLintErrorsPrompt', () => {
         expect(prompt.toString()).toBe(dedent`
             <lint_errors>
             (\`foo.ts\`)
+
             foo
             Err | Defined foo
 
@@ -586,6 +589,7 @@ describe('getLintErrorsPrompt', () => {
             Err | Defined another foo
 
             (\`bar.ts\`)
+
             bar
             Err | Defined bar
 
@@ -620,6 +624,7 @@ describe('getRecentCopyPrompt', () => {
         expect(prompt.toString()).toBe(dedent`
             <recent_copy>
             (\`foo.ts\`)
+
             baz
             </recent_copy>
         `)
@@ -642,9 +647,11 @@ describe('getRecentCopyPrompt', () => {
         expect(prompt.toString()).toBe(dedent`
             <recent_copy>
             (\`foo.ts\`)
+
             foo copy content
 
             (\`bar.ts\`)
+
             bar copy content
             </recent_copy>
         `)
@@ -758,10 +765,12 @@ describe('getRecentlyViewedSnippetsPrompt', () => {
             <recently_viewed_snippets>
             <snippet>
             (\`foo.ts\`)
+
             bar
             </snippet>
             <snippet>
             (\`foo.ts\`)
+
             foo
             </snippet>
             </recently_viewed_snippets>
@@ -786,18 +795,22 @@ describe('getRecentlyViewedSnippetsPrompt', () => {
             <recently_viewed_snippets>
             <snippet>
             (\`qux.ts\`)
+
             qux
             </snippet>
             <snippet>
             (\`baz.ts\`)
+
             bax
             </snippet>
             <snippet>
             (\`bar.ts\`)
+
             bar
             </snippet>
             <snippet>
             (\`foo.ts\`)
+
             foo
             </snippet>
             </recently_viewed_snippets>
@@ -830,10 +843,12 @@ describe('getJaccardSimilarityPrompt', () => {
             <extracted_code_snippets>
             <snippet>
             (\`foo.ts\`)
+
             foo
             </snippet>
             <snippet>
             (\`foo.ts\`)
+
             bar
             </snippet>
             </extracted_code_snippets>
@@ -858,18 +873,22 @@ describe('getJaccardSimilarityPrompt', () => {
             <extracted_code_snippets>
             <snippet>
             (\`foo.ts\`)
+
             foo
             </snippet>
             <snippet>
             (\`bar.ts\`)
+
             bar
             </snippet>
             <snippet>
             (\`baz.ts\`)
+
             bax
             </snippet>
             <snippet>
             (\`qux.ts\`)
+
             qux
             </snippet>
             </extracted_code_snippets>

--- a/vscode/src/autoedits/prompt/prompt-utils.ts
+++ b/vscode/src/autoedits/prompt/prompt-utils.ts
@@ -99,7 +99,7 @@ export function getCurrentFilePromptComponents(
         ${constants.AREA_FOR_CODE_MARKER}
         ${currentFileContext.suffixAfterArea}`
 
-    const filePrompt = getContextPromptWithPath(
+    const filePrompt = getCurrentFileContextPromptWithPath(
         PromptString.fromDisplayPath(options.document.uri),
         psDedent`
             ${constants.FILE_TAG_OPEN}
@@ -377,6 +377,13 @@ export function getContextItemsForIdentifier(
 }
 
 export function getContextPromptWithPath(filePath: PromptString, content: PromptString): PromptString {
+    return ps`(\`${filePath}\`)\n\n${content}`
+}
+
+export function getCurrentFileContextPromptWithPath(
+    filePath: PromptString,
+    content: PromptString
+): PromptString {
     return ps`(\`${filePath}\`)\n${content}`
 }
 

--- a/vscode/src/autoedits/prompt/prompt-utils.ts
+++ b/vscode/src/autoedits/prompt/prompt-utils.ts
@@ -3,7 +3,6 @@ import {
     type DocumentContext,
     PromptString,
     ps,
-    psDedent,
     tokensToChars,
 } from '@sourcegraph/cody-shared'
 import { Uri } from 'vscode'
@@ -94,27 +93,30 @@ export function getCurrentFilePromptComponents(
         suffixInArea: currentFileContext.suffixInArea.toString(),
     } satisfies CodeToReplaceData
 
-    const fileWithMarker = psDedent`
-        ${currentFileContext.prefixBeforeArea}
-        ${constants.AREA_FOR_CODE_MARKER}
-        ${currentFileContext.suffixAfterArea}`
+    const fileWithMarker = joinPromptsWithNewlineSeperator(
+        currentFileContext.prefixBeforeArea,
+        constants.AREA_FOR_CODE_MARKER,
+        currentFileContext.suffixAfterArea
+    )
 
     const filePrompt = getCurrentFileContextPromptWithPath(
         PromptString.fromDisplayPath(options.document.uri),
-        psDedent`
-            ${constants.FILE_TAG_OPEN}
-            ${fileWithMarker}
-            ${constants.FILE_TAG_CLOSE}`
+        joinPromptsWithNewlineSeperator(
+            constants.FILE_TAG_OPEN,
+            fileWithMarker,
+            constants.FILE_TAG_CLOSE
+        )
     )
 
-    const areaPrompt = psDedent`
-        ${constants.AREA_FOR_CODE_MARKER_OPEN}
-        ${currentFileContext.prefixInArea}
-        ${constants.CODE_TO_REWRITE_TAG_OPEN}
-        ${currentFileContext.codeToRewrite}
-        ${constants.CODE_TO_REWRITE_TAG_CLOSE}
-        ${currentFileContext.suffixInArea}
-        ${constants.AREA_FOR_CODE_MARKER_CLOSE}`
+    const areaPrompt = joinPromptsWithNewlineSeperator(
+        constants.AREA_FOR_CODE_MARKER_OPEN,
+        currentFileContext.prefixInArea,
+        constants.CODE_TO_REWRITE_TAG_OPEN,
+        currentFileContext.codeToRewrite,
+        constants.CODE_TO_REWRITE_TAG_CLOSE,
+        currentFileContext.suffixInArea,
+        constants.AREA_FOR_CODE_MARKER_CLOSE
+    )
 
     return { fileWithMarkerPrompt: filePrompt, areaPrompt: areaPrompt, codeToReplace: codeToReplace }
 }
@@ -217,10 +219,11 @@ export function getLintErrorsPrompt(contextItems: AutocompleteContextSnippet[]):
     }
 
     const lintErrorsPrompt = PromptString.join(combinedPrompts, ps`\n\n`)
-    return psDedent`
-        ${constants.LINT_ERRORS_TAG_OPEN}
-        ${lintErrorsPrompt}
-        ${constants.LINT_ERRORS_TAG_CLOSE}`
+    return joinPromptsWithNewlineSeperator(
+        constants.LINT_ERRORS_TAG_OPEN,
+        lintErrorsPrompt,
+        constants.LINT_ERRORS_TAG_CLOSE
+    )
 }
 
 export function getRecentCopyPrompt(contextItems: AutocompleteContextSnippet[]): PromptString {
@@ -238,10 +241,11 @@ export function getRecentCopyPrompt(contextItems: AutocompleteContextSnippet[]):
         )
     )
     const recentCopyPrompt = PromptString.join(recentCopyPrompts, ps`\n\n`)
-    return psDedent`
-        ${constants.RECENT_COPY_TAG_OPEN}
-        ${recentCopyPrompt}
-        ${constants.RECENT_COPY_TAG_CLOSE}`
+    return joinPromptsWithNewlineSeperator(
+        constants.RECENT_COPY_TAG_OPEN,
+        recentCopyPrompt,
+        constants.RECENT_COPY_TAG_CLOSE
+    )
 }
 
 export function getRecentEditsPrompt(contextItems: AutocompleteContextSnippet[]): PromptString {
@@ -260,10 +264,11 @@ export function getRecentEditsPrompt(contextItems: AutocompleteContextSnippet[])
         )
     )
     const recentEditsPrompt = PromptString.join(recentEditsPrompts, ps`\n`)
-    return psDedent`
-        ${constants.RECENT_EDITS_TAG_OPEN}
-        ${recentEditsPrompt}
-        ${constants.RECENT_EDITS_TAG_CLOSE}`
+    return joinPromptsWithNewlineSeperator(
+        constants.RECENT_EDITS_TAG_OPEN,
+        recentEditsPrompt,
+        constants.RECENT_EDITS_TAG_CLOSE
+    )
 }
 
 export function getRecentlyViewedSnippetsPrompt(
@@ -277,22 +282,23 @@ export function getRecentlyViewedSnippetsPrompt(
     if (recentViewedSnippets.length === 0) {
         return ps``
     }
-    const recentViewedSnippetPrompts = recentViewedSnippets.map(
-        item =>
-            psDedent`
-                ${constants.SNIPPET_TAG_OPEN}
-                ${getContextPromptWithPath(
-                    PromptString.fromDisplayPath(item.uri),
-                    PromptString.fromAutocompleteContextSnippet(item).content
-                )}
-                ${constants.SNIPPET_TAG_CLOSE}`
+    const recentViewedSnippetPrompts = recentViewedSnippets.map(item =>
+        joinPromptsWithNewlineSeperator(
+            constants.SNIPPET_TAG_OPEN,
+            getContextPromptWithPath(
+                PromptString.fromDisplayPath(item.uri),
+                PromptString.fromAutocompleteContextSnippet(item).content
+            ),
+            constants.SNIPPET_TAG_CLOSE
+        )
     )
 
     const snippetsPrompt = PromptString.join(recentViewedSnippetPrompts, ps`\n`)
-    return psDedent`
-        ${constants.RECENT_SNIPPET_VIEWS_TAG_OPEN}
-        ${snippetsPrompt}
-        ${constants.RECENT_SNIPPET_VIEWS_TAG_CLOSE}`
+    return joinPromptsWithNewlineSeperator(
+        constants.RECENT_SNIPPET_VIEWS_TAG_OPEN,
+        snippetsPrompt,
+        constants.RECENT_SNIPPET_VIEWS_TAG_CLOSE
+    )
 }
 
 export function getJaccardSimilarityPrompt(contextItems: AutocompleteContextSnippet[]): PromptString {
@@ -303,23 +309,24 @@ export function getJaccardSimilarityPrompt(contextItems: AutocompleteContextSnip
     if (jaccardSimilarity.length === 0) {
         return ps``
     }
-    const jaccardSimilarityPrompts = jaccardSimilarity.map(
-        item =>
-            psDedent`
-                ${constants.SNIPPET_TAG_OPEN}
-                ${getContextPromptWithPath(
-                    PromptString.fromDisplayPath(item.uri),
-                    PromptString.fromAutocompleteContextSnippet(item).content
-                )}
-                ${constants.SNIPPET_TAG_CLOSE}`
+    const jaccardSimilarityPrompts = jaccardSimilarity.map(item =>
+        joinPromptsWithNewlineSeperator(
+            constants.SNIPPET_TAG_OPEN,
+            getContextPromptWithPath(
+                PromptString.fromDisplayPath(item.uri),
+                PromptString.fromAutocompleteContextSnippet(item).content
+            ),
+            constants.SNIPPET_TAG_CLOSE
+        )
     )
 
     const snippetsPrompt = PromptString.join(jaccardSimilarityPrompts, ps`\n`)
 
-    return psDedent`
-        ${constants.EXTRACTED_CODE_SNIPPETS_TAG_OPEN}
-        ${snippetsPrompt}
-        ${constants.EXTRACTED_CODE_SNIPPETS_TAG_CLOSE}`
+    return joinPromptsWithNewlineSeperator(
+        constants.EXTRACTED_CODE_SNIPPETS_TAG_OPEN,
+        snippetsPrompt,
+        constants.EXTRACTED_CODE_SNIPPETS_TAG_CLOSE
+    )
 }
 
 //  Helper functions
@@ -392,4 +399,8 @@ export function getRecentEditsContextPromptWithPath(
     content: PromptString
 ): PromptString {
     return ps`${filePath}\n${content}`
+}
+
+export function joinPromptsWithNewlineSeperator(...args: PromptString[]): PromptString {
+    return PromptString.join(args, ps`\n`)
 }

--- a/vscode/src/autoedits/prompt/short-term-diff-prompt-strategy.test.ts
+++ b/vscode/src/autoedits/prompt/short-term-diff-prompt-strategy.test.ts
@@ -245,10 +245,12 @@ describe('ShortTermPromptStrategy', () => {
                 <extracted_code_snippets>
                 <snippet>
                 (\`test1.ts\`)
+
                 jaccard similarity context 1
                 </snippet>
                 <snippet>
                 (\`test2.ts\`)
+
                 jaccard similarity context 2
                 </snippet>
                 </extracted_code_snippets>
@@ -257,10 +259,12 @@ describe('ShortTermPromptStrategy', () => {
                 <recently_viewed_snippets>
                 <snippet>
                 (\`test3.ts\`)
+
                 view port context 4
                 </snippet>
                 <snippet>
                 (\`test2.ts\`)
+
                 view port context 3
                 </snippet>
                 </recently_viewed_snippets>
@@ -274,10 +278,12 @@ describe('ShortTermPromptStrategy', () => {
                 <recently_viewed_snippets>
                 <snippet>
                 (\`test1.ts\`)
+
                 view port context 2
                 </snippet>
                 <snippet>
                 (\`test0.ts\`)
+
                 view port context 1
                 </snippet>
                 </recently_viewed_snippets>
@@ -297,20 +303,24 @@ describe('ShortTermPromptStrategy', () => {
                 Here are some linter errors from the code that you will rewrite.
                 <lint_errors>
                 (\`test1.ts\`)
+
                 diagnostics context 1
 
                 diagnostics context 2
 
                 (\`test2.ts\`)
+
                 diagnostics context 3
                 </lint_errors>
 
                 Here is some recent code I copied from the editor.
                 <recent_copy>
                 (\`test1.ts\`)
+
                 recent copy context 1
 
                 (\`test2.ts\`)
+
                 recent copy context 2
                 </recent_copy>
 
@@ -403,10 +413,12 @@ describe('ShortTermPromptStrategy', () => {
                 <recently_viewed_snippets>
                 <snippet>
                 (\`test1.ts\`)
+
                 const test1 = true
                 </snippet>
                 <snippet>
                 (\`test0.ts\`)
+
                 const test0 = true
                 </snippet>
                 </recently_viewed_snippets>
@@ -416,10 +428,12 @@ describe('ShortTermPromptStrategy', () => {
                 <recently_viewed_snippets>
                 <snippet>
                 (\`test3.ts\`)
+
                 const test3 = null
                 </snippet>
                 <snippet>
                 (\`test2.ts\`)
+
                 const test2 = false
                 </snippet>
                 </recently_viewed_snippets>

--- a/vscode/src/autoedits/prompt/short-term-diff-prompt-strategy.test.ts
+++ b/vscode/src/autoedits/prompt/short-term-diff-prompt-strategy.test.ts
@@ -187,7 +187,9 @@ describe('ShortTermPromptStrategy', () => {
 
                 Here is the file that I am looking at (\`test.ts\`)
                 <file>
+
                 <<<AREA_AROUND_CODE_TO_REWRITE_WILL_BE_INSERTED_HERE>>>
+
                 </file>
 
 
@@ -271,7 +273,9 @@ describe('ShortTermPromptStrategy', () => {
 
                 Here is the file that I am looking at (\`test.ts\`)
                 <file>
+
                 <<<AREA_AROUND_CODE_TO_REWRITE_WILL_BE_INSERTED_HERE>>>
+
                 </file>
 
                 Here are some snippets of code I just looked at:

--- a/vscode/src/autoedits/prompt/short-term-diff-prompt-strategy.ts
+++ b/vscode/src/autoedits/prompt/short-term-diff-prompt-strategy.ts
@@ -1,9 +1,4 @@
-import {
-    type AutocompleteContextSnippet,
-    type PromptString,
-    ps,
-    psDedent,
-} from '@sourcegraph/cody-shared'
+import { type AutocompleteContextSnippet, type PromptString, ps } from '@sourcegraph/cody-shared'
 import { groupConsecutiveItemsByPredicate } from '../../completions/context/retrievers/recent-user-actions/recent-edits-diff-helpers/utils'
 import { RetrieverIdentifier } from '../../completions/context/utils'
 import { autoeditsLogger } from '../logger'
@@ -20,6 +15,7 @@ import {
     getRecentCopyPrompt,
     getRecentEditsPrompt,
     getRecentlyViewedSnippetsPrompt,
+    joinPromptsWithNewlineSeperator,
 } from './prompt-utils'
 
 export class ShortTermPromptStrategy implements AutoeditsUserPromptStrategy {
@@ -70,18 +66,19 @@ export class ShortTermPromptStrategy implements AutoeditsUserPromptStrategy {
         )
         const currentFilePrompt = ps`${constants.CURRENT_FILE_INSTRUCTION}${fileWithMarkerPrompt}`
 
-        const finalPrompt = psDedent`
-            ${getPromptWithNewline(constants.BASE_USER_PROMPT)}
-            ${getPromptWithNewline(jaccardSimilarityPrompt)}
-            ${getPromptWithNewline(longTermViewPrompt)}
-            ${getPromptWithNewline(currentFilePrompt)}
-            ${getPromptWithNewline(shortTermViewPrompt)}
-            ${getPromptWithNewline(longTermEditsPrompt)}
-            ${getPromptWithNewline(lintErrorsPrompt)}
-            ${getPromptWithNewline(recentCopyPrompt)}
-            ${getPromptWithNewline(areaPrompt)}
-            ${getPromptWithNewline(shortTermEditsPrompt)}
-            ${getPromptWithNewline(constants.FINAL_USER_PROMPT)}`
+        const finalPrompt = joinPromptsWithNewlineSeperator(
+            getPromptWithNewline(constants.BASE_USER_PROMPT),
+            getPromptWithNewline(jaccardSimilarityPrompt),
+            getPromptWithNewline(longTermViewPrompt),
+            getPromptWithNewline(currentFilePrompt),
+            getPromptWithNewline(shortTermViewPrompt),
+            getPromptWithNewline(longTermEditsPrompt),
+            getPromptWithNewline(lintErrorsPrompt),
+            getPromptWithNewline(recentCopyPrompt),
+            getPromptWithNewline(areaPrompt),
+            getPromptWithNewline(shortTermEditsPrompt),
+            constants.FINAL_USER_PROMPT
+        )
 
         autoeditsLogger.logDebug('AutoEdits', 'Prompt\n', finalPrompt)
         return {
@@ -114,16 +111,18 @@ export class ShortTermPromptStrategy implements AutoeditsUserPromptStrategy {
 
         const shortTermViewPrompt =
             shortTermViewedSnippets.length > 0
-                ? psDedent`
-                    ${constants.SHORT_TERM_SNIPPET_VIEWS_INSTRUCTION}
-                    ${getRecentlyViewedSnippetsPrompt(shortTermViewedSnippets)}`
+                ? joinPromptsWithNewlineSeperator(
+                      constants.SHORT_TERM_SNIPPET_VIEWS_INSTRUCTION,
+                      getRecentlyViewedSnippetsPrompt(shortTermViewedSnippets)
+                  )
                 : ps``
 
         const longTermViewPrompt =
             longTermViewedSnippets.length > 0
-                ? psDedent`
-                    ${constants.LONG_TERM_SNIPPET_VIEWS_INSTRUCTION}
-                    ${getRecentlyViewedSnippetsPrompt(longTermViewedSnippets)}`
+                ? joinPromptsWithNewlineSeperator(
+                      constants.LONG_TERM_SNIPPET_VIEWS_INSTRUCTION,
+                      getRecentlyViewedSnippetsPrompt(longTermViewedSnippets)
+                  )
                 : ps``
 
         return {
@@ -178,8 +177,9 @@ export class ShortTermPromptStrategy implements AutoeditsUserPromptStrategy {
             combinedContextItems.push(combinedItem)
         }
 
-        return psDedent`
-            ${constants.RECENT_EDITS_INSTRUCTION}
-            ${getRecentEditsPrompt(combinedContextItems)}`
+        return joinPromptsWithNewlineSeperator(
+            constants.RECENT_EDITS_INSTRUCTION,
+            getRecentEditsPrompt(combinedContextItems)
+        )
     }
 }


### PR DESCRIPTION
1. Fixes the indentation issue in the auto-edits which was happening because of using `psDedent`.
2. Added a helper function to join prompts on the new lines instead of using `psDedent`.

## Test plan
Added CI test cases
