### PR TITLE
fix(deep-cody): missing experimental badge on model list

### DIFF
--- a/lib/shared/src/models/model.ts
+++ b/lib/shared/src/models/model.ts
@@ -232,6 +232,8 @@ export function getServerModelTags(
         }
     } else if (status === 'internal') {
         tags.push(ModelTag.Internal)
+    } else if (status === 'experimental') {
+        tags.push(ModelTag.Experimental)
     }
     if (category === 'accuracy') {
         tags.push(ModelTag.Power)

--- a/vscode/webviews/components/Notices.tsx
+++ b/vscode/webviews/components/Notices.tsx
@@ -95,6 +95,7 @@ export const Notices: React.FC<NoticesProps> = ({ user, isTeamsUpgradeCtaEnabled
                                 ? 'Contact admins to enable Command Execution'
                                 : ''
                         }
+                        actions={[]}
                     />
                 ),
             },

--- a/vscode/webviews/components/Notices.tsx
+++ b/vscode/webviews/components/Notices.tsx
@@ -65,6 +65,13 @@ export const Notices: React.FC<NoticesProps> = ({ user, isTeamsUpgradeCtaEnabled
         [telemetryRecorder, setDismissedNotices]
     )
 
+    const settingsNameByIDE =
+        user.IDE === CodyIDE.JetBrains
+            ? 'Settings Editor'
+            : user.IDE === CodyIDE.VSCode
+              ? 'settings.json'
+              : 'Extension Settings'
+
     const notices: Notice[] = useMemo(
         () => [
             {
@@ -74,8 +81,11 @@ export const Notices: React.FC<NoticesProps> = ({ user, isTeamsUpgradeCtaEnabled
                     <NoticeContent
                         id={user.isCodyProUser ? 'DeepCodyDotCom' : 'DeepCodyEnterprise'}
                         variant="default"
-                        title="Deep Cody (Experimental with daily usage limit)"
-                        message="An advanced AI agent powered by Claude 3.5 Sonnet (New) and additional models that uses tools to gather contextual information for better responses. Deep Cody can search your codebase, browse the web, run terminal commands (when enabled), and leverage configured tools to obtain relevant context. To enable terminal commands, set 'cody.agentic.context.experimentalShell' to true in your settings."
+                        title="Deep Cody (Experimental)"
+                        message={
+                            "An early preview of agentic experience powered by Claude 3.5 Sonnet and other models to enrich context and leverage different tools for better quality responses. Deep Cody does this by searching your codebase, browsing the web, and running terminal commands (once enabled)! To enable terminal commands, set `cody.agentic.context.experimentalShell' to true in your " +
+                            settingsNameByIDE
+                        }
                         onDismiss={() =>
                             dismissNotice(user.isCodyProUser ? 'DeepCodyDotCom' : 'DeepCodyEnterprise')
                         }
@@ -186,6 +196,7 @@ export const Notices: React.FC<NoticesProps> = ({ user, isTeamsUpgradeCtaEnabled
             isTeamsUpgradeCtaEnabled,
             isDeepCodyEnabled,
             isDeepCodyShellContextSupported,
+            settingsNameByIDE,
         ]
     )
 
@@ -276,6 +287,7 @@ const NoticeContent: FunctionComponent<NoticeContentProps> = ({
         >
             <div className="tw-flex tw-gap-3 tw-mb-2">{header}</div>
             {title && <h1 className="tw-text-lg tw-font-semibold">{title}</h1>}
+            {info && <p className="tw-mb-2">ⓘ {info}</p>}
             <p>{message}</p>
             <div className="tw-mt-3 tw-flex tw-gap-3">
                 {actions.map((action, _index) => (
@@ -308,7 +320,6 @@ const NoticeContent: FunctionComponent<NoticeContentProps> = ({
                     </Button>
                 ))}
             </div>
-            {info && <p className="tw-mt-2">ⓘ {info}</p>}
             {/* Dismiss button. */}
             <Button variant="ghost" onClick={onDismiss} className="tw-absolute tw-top-2 tw-right-2">
                 <XIcon size="14" />

--- a/vscode/webviews/components/Notices.tsx
+++ b/vscode/webviews/components/Notices.tsx
@@ -7,7 +7,6 @@ import {
     ExternalLinkIcon,
     EyeIcon,
     HeartIcon,
-    TerminalIcon,
     Users2Icon,
     XIcon,
 } from 'lucide-react'
@@ -84,34 +83,17 @@ export const Notices: React.FC<NoticesProps> = ({ user, isTeamsUpgradeCtaEnabled
                         title="Deep Cody (Experimental)"
                         message={
                             "An early preview of agentic experience powered by Claude 3.5 Sonnet and other models to enrich context and leverage different tools for better quality responses. Deep Cody does this by searching your codebase, browsing the web, and running terminal commands (once enabled)! To enable terminal commands, set `cody.agentic.context.experimentalShell' to true in your " +
-                            settingsNameByIDE
+                            settingsNameByIDE +
+                            '.'
                         }
                         onDismiss={() =>
                             dismissNotice(user.isCodyProUser ? 'DeepCodyDotCom' : 'DeepCodyEnterprise')
                         }
                         info="Usage limits apply during the experimental phase."
-                        actions={
-                            isDeepCodyShellContextSupported
-                                ? [
-                                      {
-                                          label: 'Enable Command Execution in Settings',
-                                          onClick: () =>
-                                              getVSCodeAPI().postMessage({
-                                                  command: 'command',
-                                                  id: 'cody.status-bar.interacted',
-                                              }),
-                                          variant: 'default',
-                                          icon: <TerminalIcon size={14} />,
-                                          iconPosition: 'start',
-                                      },
-                                  ]
-                                : [
-                                      {
-                                          label: 'Contact admins to enable Command Execution',
-                                          onClick: () => {},
-                                          variant: 'secondary',
-                                      },
-                                  ]
+                        footer={
+                            !isDeepCodyShellContextSupported
+                                ? 'Contact admins to enable Command Execution'
+                                : ''
                         }
                     />
                 ),
@@ -236,6 +218,7 @@ interface NoticeContentProps {
     }>
     onDismiss: () => void
     info?: string
+    footer?: string
 }
 
 const NoticeContent: FunctionComponent<NoticeContentProps> = ({
@@ -245,6 +228,7 @@ const NoticeContent: FunctionComponent<NoticeContentProps> = ({
     actions,
     id,
     info,
+    footer,
     onDismiss,
 }) => {
     const telemetryRecorder = useTelemetryRecorder()
@@ -320,6 +304,7 @@ const NoticeContent: FunctionComponent<NoticeContentProps> = ({
                     </Button>
                 ))}
             </div>
+            {footer && <p className="tw-mt-2">{footer}</p>}
             {/* Dismiss button. */}
             <Button variant="ghost" onClick={onDismiss} className="tw-absolute tw-top-2 tw-right-2">
                 <XIcon size="14" />

--- a/vscode/webviews/components/Notices.tsx
+++ b/vscode/webviews/components/Notices.tsx
@@ -74,11 +74,12 @@ export const Notices: React.FC<NoticesProps> = ({ user, isTeamsUpgradeCtaEnabled
                     <NoticeContent
                         id={user.isCodyProUser ? 'DeepCodyDotCom' : 'DeepCodyEnterprise'}
                         variant="default"
-                        title="Deep Cody (Experimental)"
-                        message="An AI agent powered by Claude 3.5 Sonnet (New) and other models with tool-use capabilities to gather contextual information for enhanced responses. It can search your codebase, browse the web, execute shell commands in your terminal (when enabled), and utilize any configured tools to retrieve necessary context."
+                        title="Deep Cody (Experimental with daily usage limit)"
+                        message="An advanced AI agent powered by Claude 3.5 Sonnet (New) and additional models that uses tools to gather contextual information for better responses. Deep Cody can search your codebase, browse the web, run terminal commands (when enabled), and leverage configured tools to obtain relevant context. To enable terminal commands, set 'cody.agentic.context.experimentalShell' to true in your settings."
                         onDismiss={() =>
                             dismissNotice(user.isCodyProUser ? 'DeepCodyDotCom' : 'DeepCodyEnterprise')
                         }
+                        info="Usage limits apply during the experimental phase."
                         actions={
                             isDeepCodyShellContextSupported
                                 ? [
@@ -223,6 +224,7 @@ interface NoticeContentProps {
         iconPosition?: 'start' | 'end'
     }>
     onDismiss: () => void
+    info?: string
 }
 
 const NoticeContent: FunctionComponent<NoticeContentProps> = ({
@@ -231,6 +233,7 @@ const NoticeContent: FunctionComponent<NoticeContentProps> = ({
     message,
     actions,
     id,
+    info,
     onDismiss,
 }) => {
     const telemetryRecorder = useTelemetryRecorder()
@@ -305,6 +308,7 @@ const NoticeContent: FunctionComponent<NoticeContentProps> = ({
                     </Button>
                 ))}
             </div>
+            {info && <p className="tw-mt-2">ⓘ {info}</p>}
             {/* Dismiss button. */}
             <Button variant="ghost" onClick={onDismiss} className="tw-absolute tw-top-2 tw-right-2">
                 <XIcon size="14" />


### PR DESCRIPTION
CLOSE: https://linear.app/sourcegraph/issue/CODY-4518
CONTEXT: https://sourcegraph.slack.com/archives/C0847FJ0A73/p1734027061624399

This PR adds the `ModelTag.Experimental` tag to the `getServerModelTags` function which is the cause of Deep Cody currently missing the experimental tag in pre-release. This tag will be used to identify models that are in an experimental phase, which can be useful for displaying additional information or handling these models differently.

Also update the CTA for Deep Cody and add an info section about that daily usage limit.

![image](https://github.com/user-attachments/assets/ca91742a-18c3-433b-93ca-c187eb1fd5e5)

## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

Minor CTA update:

![image](https://github.com/user-attachments/assets/b4e08a8c-8fb0-4ec7-8cb0-1af4b03bc009)


## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
