### PR TITLE
[Backport vscode-v1.52.x] Fix manual intent selection for onebox (#6325)Fix manual intent selection for onebox (#6324)

### DIFF
--- a/vscode/webviews/chat/Transcript.tsx
+++ b/vscode/webviews/chat/Transcript.tsx
@@ -558,6 +558,16 @@ const TranscriptInteraction: FC<TranscriptInteractionProps> = memo(props => {
         ?.getSerializedValue()
         .contextItems.some(item => item.type === 'repository')
 
+    const onHumanMessageSubmit = useCallback(
+        (intent?: ChatMessage['intent']) => {
+            if (humanMessage.isUnsentFollowup) {
+                onFollowupSubmit(intent)
+            }
+            onEditSubmit(intent)
+        },
+        [humanMessage.isUnsentFollowup, onFollowupSubmit, onEditSubmit]
+    )
+
     return (
         <>
             <HumanMessageCell
@@ -570,9 +580,7 @@ const TranscriptInteraction: FC<TranscriptInteractionProps> = memo(props => {
                 isSent={!humanMessage.isUnsentFollowup}
                 isPendingPriorResponse={priorAssistantMessageIsLoading}
                 onChange={onChange}
-                onSubmit={
-                    humanMessage.isUnsentFollowup ? () => onFollowupSubmit() : () => onEditSubmit()
-                }
+                onSubmit={onHumanMessageSubmit}
                 onStop={onStop}
                 isFirstInteraction={isFirstInteraction}
                 isLastInteraction={isLastInteraction}

--- a/vscode/webviews/chat/cells/messageCell/human/HumanMessageCell.tsx
+++ b/vscode/webviews/chat/cells/messageCell/human/HumanMessageCell.tsx
@@ -35,7 +35,7 @@ interface HumanMessageCellProps {
 
     onEditorFocusChange?: (focused: boolean) => void
     onChange?: (editorState: SerializedPromptEditorValue) => void
-    onSubmit: (editorState: SerializedPromptEditorValue, intent?: ChatMessage['intent']) => void
+    onSubmit: (intent?: ChatMessage['intent']) => void
     onStop: () => void
 
     isFirstInteraction?: boolean

--- a/vscode/webviews/chat/cells/messageCell/human/editor/HumanMessageEditor.tsx
+++ b/vscode/webviews/chat/cells/messageCell/human/editor/HumanMessageEditor.tsx
@@ -58,7 +58,7 @@ export const HumanMessageEditor: FunctionComponent<{
 
     onEditorFocusChange?: (focused: boolean) => void
     onChange?: (editorState: SerializedPromptEditorValue) => void
-    onSubmit: (editorState: SerializedPromptEditorValue, intent?: ChatMessage['intent']) => void
+    onSubmit: (intent?: ChatMessage['intent']) => void
     onStop: () => void
 
     isFirstInteraction?: boolean
@@ -151,7 +151,7 @@ export const HumanMessageEditor: FunctionComponent<{
             }
 
             const value = editorRef.current.getSerializedValue()
-            parentOnSubmit(value, intent)
+            parentOnSubmit(intent)
 
             telemetryRecorder.recordEvent('cody.humanMessageEditor', 'submit', {
                 metadata: {


### PR DESCRIPTION
A bug was introduced as part of
https://github.com/sourcegraph/cody/pull/6294 which causes manual selection of the intent to be ignored. This PR fixes it.

## Test plan

https://www.loom.com/share/dfcfcc6decca4ca19cfb3220d8026a07?sid=99e6d5f1-84d5-4838-8ed8-200126c17305 ## Changelog

<!-- OPTIONAL; info at
https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->