### PR TITLE
feat(audoedit): smartly merge whitespace line changes

### DIFF
--- a/vscode/src/autoedits/renderer/decorators/base.ts
+++ b/vscode/src/autoedits/renderer/decorators/base.ts
@@ -73,8 +73,10 @@ export interface UnchangedLineInfo {
 export type LineChange = {
     id: string
     type: 'insert' | 'delete' | 'unchanged'
+    /** `range` in the original text relative to the document start */
+    originalRange: vscode.Range
     /** `range` in the modified text relative to the document start */
-    range: vscode.Range
+    modifiedRange: vscode.Range
     text: string
 }
 

--- a/vscode/src/autoedits/renderer/decorators/default-decorator.ts
+++ b/vscode/src/autoedits/renderer/decorators/default-decorator.ts
@@ -107,9 +107,12 @@ export class DefaultDecorator implements AutoEditsDecorator {
             const addedRanges: [number, number][] = []
             for (const change of changes) {
                 if (change.type === 'delete') {
-                    removedRanges.push(change.range)
+                    removedRanges.push(change.modifiedRange)
                 } else if (change.type === 'insert') {
-                    addedRanges.push([change.range.start.character, change.range.end.character])
+                    addedRanges.push([
+                        change.modifiedRange.start.character,
+                        change.modifiedRange.end.character,
+                    ])
                 }
             }
             if (addedRanges.length > 0) {
@@ -248,7 +251,7 @@ export class DefaultDecorator implements AutoEditsDecorator {
             .filter(change => change.type === 'insert')
             .map(change => {
                 return {
-                    range: change.range,
+                    range: change.modifiedRange,
                     renderOptions: {
                         before: {
                             contentText: change.text,

--- a/vscode/src/autoedits/renderer/decorators/inline-diff-decorator.ts
+++ b/vscode/src/autoedits/renderer/decorators/inline-diff-decorator.ts
@@ -25,7 +25,7 @@ export class InlineDiffDecorator implements vscode.Disposable, AutoEditsDecorato
             // Ignore line changes rendered as an inline completion item ghost text.
             for (const change of line.changes) {
                 if (change.type === 'insert') {
-                    const position = change.range.end
+                    const position = change.originalRange.end
                     if (currentInsertPosition && position.isEqual(currentInsertPosition)) {
                         // Same position as previous, accumulate the text
                         currentInsertText += change.text
@@ -69,7 +69,7 @@ export class InlineDiffDecorator implements vscode.Disposable, AutoEditsDecorato
                     // Handle deletions
                     if (change.type === 'delete') {
                         removedRanges.push({
-                            range: change.range,
+                            range: change.originalRange,
                             renderOptions: {
                                 before: {
                                     contentText: '\u00A0'.repeat(change.text.length),

--- a/vscode/src/autoedits/renderer/diff-utils.test.ts
+++ b/vscode/src/autoedits/renderer/diff-utils.test.ts
@@ -1,4 +1,7 @@
 import { describe, expect, it } from 'vitest'
+
+import { Position, Range } from '../../testutils/mocks'
+
 import type { DecorationInfo } from './decorators/base'
 import { getDecorationInfo } from './diff-utils'
 
@@ -28,14 +31,16 @@ describe('getDecorationInfo', () => {
                                 {
                                     id: expect.any(String),
                                     type: 'delete',
-                                    range: expect.anything(),
                                     text: 'line2',
+                                    originalRange: new Range(new Position(1, 0), new Position(1, 5)),
+                                    modifiedRange: new Range(new Position(1, 0), new Position(1, 0)),
                                 },
                                 {
                                     id: expect.any(String),
                                     type: 'insert',
-                                    range: expect.anything(),
                                     text: 'modified2',
+                                    originalRange: new Range(new Position(1, 5), new Position(1, 5)),
+                                    modifiedRange: new Range(new Position(1, 0), new Position(1, 9)),
                                 },
                             ],
                         },
@@ -158,14 +163,16 @@ describe('getDecorationInfo', () => {
                                 {
                                     id: expect.any(String),
                                     type: 'delete',
-                                    range: expect.anything(),
                                     text: 'line2',
+                                    originalRange: new Range(new Position(1, 0), new Position(1, 5)),
+                                    modifiedRange: new Range(new Position(1, 0), new Position(1, 0)),
                                 },
                                 {
                                     id: expect.any(String),
                                     type: 'insert',
-                                    range: expect.anything(),
                                     text: 'modified2',
+                                    originalRange: new Range(new Position(1, 5), new Position(1, 5)),
+                                    modifiedRange: new Range(new Position(1, 0), new Position(1, 9)),
                                 },
                             ],
                         },
@@ -180,14 +187,16 @@ describe('getDecorationInfo', () => {
                                 {
                                     id: expect.any(String),
                                     type: 'delete',
-                                    range: expect.anything(),
                                     text: 'line3',
+                                    originalRange: new Range(new Position(2, 0), new Position(2, 5)),
+                                    modifiedRange: new Range(new Position(2, 0), new Position(2, 0)),
                                 },
                                 {
                                     id: expect.any(String),
                                     type: 'insert',
-                                    range: expect.anything(),
                                     text: 'newline',
+                                    originalRange: new Range(new Position(2, 5), new Position(2, 5)),
+                                    modifiedRange: new Range(new Position(2, 0), new Position(2, 7)),
                                 },
                             ],
                         },
@@ -272,14 +281,16 @@ describe('getDecorationInfo', () => {
                                 {
                                     id: expect.any(String),
                                     type: 'delete',
-                                    range: expect.anything(),
                                     text: 'remove1',
+                                    originalRange: new Range(new Position(1, 0), new Position(1, 7)),
+                                    modifiedRange: new Range(new Position(1, 0), new Position(1, 0)),
                                 },
                                 {
                                     id: expect.any(String),
                                     type: 'insert',
-                                    range: expect.anything(),
                                     text: 'modified1',
+                                    originalRange: new Range(new Position(1, 7), new Position(1, 7)),
+                                    modifiedRange: new Range(new Position(1, 0), new Position(1, 9)),
                                 },
                             ],
                         },
@@ -294,14 +305,16 @@ describe('getDecorationInfo', () => {
                                 {
                                     id: expect.any(String),
                                     type: 'delete',
-                                    range: expect.anything(),
                                     text: 'remove2',
+                                    originalRange: new Range(new Position(4, 0), new Position(4, 7)),
+                                    modifiedRange: new Range(new Position(3, 0), new Position(3, 0)),
                                 },
                                 {
                                     id: expect.any(String),
                                     type: 'insert',
-                                    range: expect.anything(),
                                     text: 'add1',
+                                    originalRange: new Range(new Position(4, 7), new Position(4, 7)),
+                                    modifiedRange: new Range(new Position(3, 0), new Position(3, 4)),
                                 },
                             ],
                         },
@@ -316,14 +329,16 @@ describe('getDecorationInfo', () => {
                                 {
                                     id: expect.any(String),
                                     type: 'delete',
-                                    range: expect.anything(),
                                     text: 'modify2',
+                                    originalRange: new Range(new Position(5, 0), new Position(5, 7)),
+                                    modifiedRange: new Range(new Position(4, 0), new Position(4, 0)),
                                 },
                                 {
                                     id: expect.any(String),
                                     type: 'insert',
-                                    range: expect.anything(),
                                     text: 'modified2',
+                                    originalRange: new Range(new Position(5, 7), new Position(5, 7)),
+                                    modifiedRange: new Range(new Position(4, 0), new Position(4, 9)),
                                 },
                             ],
                         },
@@ -377,14 +392,16 @@ describe('getDecorationInfo', () => {
                                 {
                                     id: expect.any(String),
                                     type: 'delete',
-                                    range: expect.anything(),
                                     text: 'line1',
+                                    originalRange: new Range(new Position(0, 0), new Position(0, 5)),
+                                    modifiedRange: new Range(new Position(0, 0), new Position(0, 0)),
                                 },
                                 {
                                     id: expect.any(String),
                                     type: 'insert',
-                                    range: expect.anything(),
                                     text: 'different1',
+                                    originalRange: new Range(new Position(0, 5), new Position(0, 5)),
+                                    modifiedRange: new Range(new Position(0, 0), new Position(0, 10)),
                                 },
                             ],
                         },
@@ -399,14 +416,16 @@ describe('getDecorationInfo', () => {
                                 {
                                     id: expect.any(String),
                                     type: 'delete',
-                                    range: expect.anything(),
                                     text: 'line2',
+                                    originalRange: new Range(new Position(1, 0), new Position(1, 5)),
+                                    modifiedRange: new Range(new Position(1, 0), new Position(1, 0)),
                                 },
                                 {
                                     id: expect.any(String),
                                     type: 'insert',
-                                    range: expect.anything(),
                                     text: 'different2',
+                                    originalRange: new Range(new Position(1, 5), new Position(1, 5)),
+                                    modifiedRange: new Range(new Position(1, 0), new Position(1, 10)),
                                 },
                             ],
                         },
@@ -421,14 +440,16 @@ describe('getDecorationInfo', () => {
                                 {
                                     id: expect.any(String),
                                     type: 'delete',
-                                    range: expect.anything(),
                                     text: 'line3',
+                                    originalRange: new Range(new Position(2, 0), new Position(2, 5)),
+                                    modifiedRange: new Range(new Position(2, 0), new Position(2, 0)),
                                 },
                                 {
                                     id: expect.any(String),
                                     type: 'insert',
-                                    range: expect.anything(),
                                     text: 'different3',
+                                    originalRange: new Range(new Position(2, 5), new Position(2, 5)),
+                                    modifiedRange: new Range(new Position(2, 0), new Position(2, 10)),
                                 },
                             ],
                         },
@@ -472,8 +493,9 @@ describe('getDecorationInfo', () => {
                                 {
                                     id: expect.any(String),
                                     type: 'insert',
-                                    range: expect.anything(),
                                     text: 'line1',
+                                    originalRange: new Range(new Position(0, 0), new Position(0, 0)),
+                                    modifiedRange: new Range(new Position(0, 0), new Position(0, 5)),
                                 },
                             ],
                         },
@@ -519,8 +541,9 @@ describe('getDecorationInfo', () => {
                                 {
                                     id: expect.any(String),
                                     type: 'delete',
-                                    range: expect.anything(),
                                     text: 'line1',
+                                    originalRange: new Range(new Position(0, 0), new Position(0, 5)),
+                                    modifiedRange: new Range(new Position(0, 0), new Position(0, 0)),
                                 },
                             ],
                         },
@@ -552,14 +575,16 @@ describe('getDecorationInfo', () => {
                                 {
                                     id: expect.any(String),
                                     type: 'delete',
-                                    range: expect.anything(),
                                     text: '  ',
+                                    originalRange: new Range(new Position(0, 0), new Position(0, 2)),
+                                    modifiedRange: new Range(new Position(0, 0), new Position(0, 0)),
                                 },
                                 {
                                     id: expect.any(String),
                                     type: 'unchanged',
-                                    range: expect.anything(),
                                     text: 'line1',
+                                    originalRange: new Range(new Position(0, 2), new Position(0, 7)),
+                                    modifiedRange: new Range(new Position(0, 0), new Position(0, 5)),
                                 },
                             ],
                         },
@@ -574,14 +599,16 @@ describe('getDecorationInfo', () => {
                                 {
                                     id: expect.any(String),
                                     type: 'unchanged',
-                                    range: expect.anything(),
                                     text: 'line2',
+                                    originalRange: new Range(new Position(1, 0), new Position(1, 5)),
+                                    modifiedRange: new Range(new Position(1, 0), new Position(1, 5)),
                                 },
                                 {
                                     id: expect.any(String),
                                     type: 'delete',
-                                    range: expect.anything(),
                                     text: '  ',
+                                    originalRange: new Range(new Position(1, 5), new Position(1, 7)),
+                                    modifiedRange: new Range(new Position(1, 5), new Position(1, 5)),
                                 },
                             ],
                         },
@@ -596,20 +623,23 @@ describe('getDecorationInfo', () => {
                                 {
                                     id: expect.any(String),
                                     type: 'delete',
-                                    range: expect.anything(),
                                     text: ' ',
+                                    originalRange: new Range(new Position(2, 0), new Position(2, 1)),
+                                    modifiedRange: new Range(new Position(2, 0), new Position(2, 0)),
                                 },
                                 {
                                     id: expect.any(String),
                                     type: 'unchanged',
-                                    range: expect.anything(),
                                     text: 'line3',
+                                    originalRange: new Range(new Position(2, 1), new Position(2, 6)),
+                                    modifiedRange: new Range(new Position(2, 0), new Position(2, 5)),
                                 },
                                 {
                                     id: expect.any(String),
                                     type: 'delete',
-                                    range: expect.anything(),
                                     text: ' ',
+                                    originalRange: new Range(new Position(2, 6), new Position(2, 7)),
+                                    modifiedRange: new Range(new Position(2, 5), new Position(2, 5)),
                                 },
                             ],
                         },
@@ -641,56 +671,120 @@ describe('getDecorationInfo', () => {
                                 {
                                     id: expect.any(String),
                                     type: 'unchanged',
-                                    range: expect.anything(),
                                     text: 'const',
+                                    originalRange: new Range(new Position(0, 0), new Position(0, 5)),
+                                    modifiedRange: new Range(new Position(0, 0), new Position(0, 5)),
                                 },
                                 {
                                     id: expect.any(String),
                                     type: 'unchanged',
-                                    range: expect.anything(),
                                     text: ' ',
+                                    originalRange: new Range(new Position(0, 5), new Position(0, 6)),
+                                    modifiedRange: new Range(new Position(0, 5), new Position(0, 6)),
                                 },
                                 {
                                     id: expect.any(String),
                                     type: 'delete',
-                                    range: expect.anything(),
                                     text: 'value',
+                                    originalRange: new Range(new Position(0, 6), new Position(0, 11)),
+                                    modifiedRange: new Range(new Position(0, 6), new Position(0, 6)),
                                 },
                                 {
                                     id: expect.any(String),
                                     type: 'insert',
-                                    range: expect.anything(),
                                     text: 'span',
+                                    originalRange: new Range(new Position(0, 11), new Position(0, 11)),
+                                    modifiedRange: new Range(new Position(0, 6), new Position(0, 10)),
                                 },
                                 {
                                     id: expect.any(String),
                                     type: 'unchanged',
-                                    range: expect.anything(),
                                     text: ' ',
+                                    originalRange: new Range(new Position(0, 11), new Position(0, 12)),
+                                    modifiedRange: new Range(new Position(0, 10), new Position(0, 11)),
                                 },
                                 {
                                     id: expect.any(String),
                                     type: 'unchanged',
-                                    range: expect.anything(),
                                     text: '=',
+                                    originalRange: new Range(new Position(0, 12), new Position(0, 13)),
+                                    modifiedRange: new Range(new Position(0, 11), new Position(0, 12)),
                                 },
                                 {
                                     id: expect.any(String),
                                     type: 'unchanged',
-                                    range: expect.anything(),
                                     text: ' ',
+                                    originalRange: new Range(new Position(0, 13), new Position(0, 14)),
+                                    modifiedRange: new Range(new Position(0, 12), new Position(0, 13)),
                                 },
                                 {
                                     id: expect.any(String),
                                     type: 'delete',
-                                    range: expect.anything(),
                                     text: '123',
+                                    originalRange: new Range(new Position(0, 14), new Position(0, 17)),
+                                    modifiedRange: new Range(new Position(0, 13), new Position(0, 13)),
                                 },
                                 {
                                     id: expect.any(String),
                                     type: 'insert',
-                                    range: expect.anything(),
                                     text: 'trace.getActiveTrace()',
+                                    originalRange: new Range(new Position(0, 17), new Position(0, 17)),
+                                    modifiedRange: new Range(new Position(0, 13), new Position(0, 35)),
+                                },
+                            ],
+                        },
+                    ],
+                    unchangedLines: [],
+                }
+
+                expect(decorationInfo).toEqual(expected)
+            })
+
+            it('should merge adjacent insertions and deletions into separate changes', () => {
+                const originalText = '            '
+                const modifiedText = `        elif field == "email":${newLineChar}            return self.email`
+
+                const decorationInfo = getDecorationInfo(originalText, modifiedText)
+
+                const expected: DecorationInfo = {
+                    addedLines: [
+                        {
+                            id: expect.any(String),
+                            type: 'added',
+                            text: '            return self.email',
+                            modifiedLineNumber: 1,
+                        },
+                    ],
+                    removedLines: [],
+                    modifiedLines: [
+                        {
+                            id: expect.any(String),
+                            type: 'modified',
+                            originalLineNumber: 0,
+                            modifiedLineNumber: 0,
+                            oldText: '            ',
+                            newText: '        elif field == "email":',
+                            changes: [
+                                {
+                                    id: expect.any(String),
+                                    type: 'unchanged',
+                                    text: '        ',
+                                    originalRange: new Range(new Position(0, 0), new Position(0, 8)),
+                                    modifiedRange: new Range(new Position(0, 0), new Position(0, 8)),
+                                },
+                                {
+                                    id: expect.any(String),
+                                    type: 'delete',
+                                    text: '    ',
+                                    originalRange: new Range(new Position(0, 8), new Position(0, 12)),
+                                    modifiedRange: new Range(new Position(0, 8), new Position(0, 8)),
+                                },
+                                {
+                                    id: expect.any(String),
+                                    type: 'insert',
+                                    text: 'elif field == "email":',
+                                    originalRange: new Range(new Position(0, 12), new Position(0, 12)),
+                                    modifiedRange: new Range(new Position(0, 8), new Position(0, 30)),
                                 },
                             ],
                         },

--- a/vscode/src/autoedits/renderer/inline-manager.ts
+++ b/vscode/src/autoedits/renderer/inline-manager.ts
@@ -194,12 +194,17 @@ export function getCompletionText({
             // To do that we extract all the inserted text after the cursor position.
             if (candidate.type === 'modified') {
                 candidateText = candidate.changes
-                    .filter(lineChange => lineChange.range.end.character >= cursorPosition.character)
-                    .sort((a, b) => a.range.start.compareTo(b.range.start))
+                    .filter(
+                        lineChange => lineChange.originalRange.end.character >= cursorPosition.character
+                    )
+                    .sort((a, b) => a.originalRange.start.compareTo(b.originalRange.start))
                     .reduce((lineChangeText, lineChange) => {
                         // If a line change starts before the cursor position, cut if off from this point.
                         const textAfterCursor = lineChange.text.slice(
-                            Math.max(cursorPosition.character - lineChange.range.start.character, 0)
+                            Math.max(
+                                cursorPosition.character - lineChange.originalRange.start.character,
+                                0
+                            )
                         )
 
                         if (textAfterCursor.length && lineChange.type === 'insert') {


### PR DESCRIPTION
- Fixes the two rendering issues:
    - The first was caused by the fact that consecutive whitespaces are considered as one diff chunk. The line changes factory was updated to smartly merge overlapping whitespace deletions and insertions.
   - The second issue was caused by incorrect line change ranges. This is fixed by introducing `originalRange` and `modifiedRange` so that we can get a change position in the existing document text as well as in the updated document when all the changes are already applied.
- Diff utils unit tests were updated to assert line change ranges as they were a root cause of a bug fixed in this PR.
- Part of [CODY-4412: Implement experimental inline renderer](https://linear.app/sourcegraph/issue/CODY-4412/implement-experimental-inline-renderer)
- Closes [CODY-4521: Inline-renderer: smartly merge whitespace changes](https://linear.app/sourcegraph/issue/CODY-4521/inline-renderer-smartly-merge-whitespace-changes)
- Closes [CODY-4522: Inline-renderer: fix new line insertions being rendered on the wrong line.](https://linear.app/sourcegraph/issue/CODY-4522/inline-renderer-fix-new-line-insertions-being-rendered-on-wrong-line)

#### Before

<img width="375" alt="Screenshot 2024-12-13 at 11 18 00" src="https://github.com/user-attachments/assets/cac77242-6b0f-4718-b601-0a8de9a14c78" />
<hr />
<img width="474" alt="Screenshot 2024-12-13 at 11 16 30" src="https://github.com/user-attachments/assets/97f0d691-4149-4640-9b55-87c4f869b33c" />

#### After 

<img width="375" alt="Screenshot 2024-12-13 at 11 18 00" src="https://github.com/user-attachments/assets/ba9b8c77-44c6-4cac-bd31-da6e263209d4" />
<hr />
<img width="474" alt="Screenshot 2024-12-13 at 11 16 30" src="https://github.com/user-attachments/assets/3552599e-8745-4d2f-8a67-c90571e34bc6" />

## Test plan

1. CI
2. New unit tests.
3. Manual testing in the cody-chat-eval repo, specifically with `codium-add-email-field-autoedits.py`. See the exact cursor position to repro on the attached screenshots above.
