### PR TITLE
Fix tests on windows

### DIFF
--- a/agent/src/TestClient.ts
+++ b/agent/src/TestClient.ts
@@ -90,23 +90,7 @@ interface TestClientParams {
     extraConfiguration?: Record<string, any>
 }
 
-let isBuilt = false
-export function buildAgentBinary(): void {
-    if (isBuilt) {
-        return
-    }
-    isBuilt = true
-    // Bundle the agent. When running `pnpm run test`, vitest doesn't re-run this step.
-    //
-    // ! If this line fails when running unit tests, chances are that the error is being swallowed.
-    // To see the full error, run this file in isolation:
-    //
-    //   pnpm test agent/src/index.test.ts
-    execSync('pnpm run build:for-tests ', {
-        cwd: getAgentDir(),
-        stdio: 'inherit',
-    })
-
+export function setupRecording(): void {
     const mayRecord =
         process.env.CODY_RECORDING_MODE === 'record' || process.env.CODY_RECORD_IF_MISSING === 'true'
     if (mayRecord) {
@@ -135,7 +119,7 @@ export class TestClient extends MessageHandler {
     private secrets = new AgentStatelessSecretStorage()
     private extensionConfigurationDuringInitialization: ExtensionConfiguration | undefined
     public static create({ bin = 'node', ...params }: TestClientParams): TestClient {
-        buildAgentBinary()
+        setupRecording()
         const agentDir = getAgentDir()
         const recordingDirectory = path.join(agentDir, 'recordings')
         const agentScript = path.join(agentDir, 'dist', 'index.js')

--- a/agent/src/cli/command-chat.test.ts
+++ b/agent/src/cli/command-chat.test.ts
@@ -5,7 +5,7 @@ import { afterAll, beforeAll, expect, it } from 'vitest'
 import YAML from 'yaml'
 import { startPollyRecording } from '../../../vscode/src/testutils/polly'
 import { TESTING_CREDENTIALS } from '../../../vscode/src/testutils/testing-credentials'
-import { buildAgentBinary, getAgentDir } from '../TestClient'
+import { getAgentDir } from '../TestClient'
 import { TestWorkspace } from '../TestWorkspace'
 import { Streams, StringBufferStream } from './Streams'
 import { isWindows } from './command-bench/isWindows'
@@ -82,7 +82,6 @@ describe('cody chat', () => {
 
     beforeAll(() => {
         tmp.beforeAll()
-        buildAgentBinary()
         polly = startPollyRecording({
             recordingName: 'cody-chat',
             keepUnusedRecordings: process.env.CODY_KEEP_UNUSED_RECORDINGS === 'true',

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+    test: {
+        globalSetup: ['./vitest.setup.ts'],
+    },
+})

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,0 +1,13 @@
+import { execSync } from 'node:child_process'
+import path from 'node:path'
+
+function buildAgentForTests() {
+    execSync('pnpm run build:for-tests', {
+        cwd: path.join(__dirname, 'agent'),
+        stdio: 'inherit',
+    })
+}
+
+export default function setup() {
+    buildAgentForTests()
+}


### PR DESCRIPTION
## Test plan

1. Run the following command: `pnpm run test`
a) in the root cody workspace dir
b) in the agent dir

1. Run the following command: `pnpm run test:unit`
a) in the root cody workspace dir
b) in the agent dir

In every case before running tests it should rebuild an agent dir.

## Changelog

Fixes errors like this:
https://github.com/sourcegraph/cody/actions/runs/12316198852/job/34378863340
