### PR TITLE
refactor(deep-cody): show model to Pro users only

### DIFF
--- a/lib/shared/src/models/sync.ts
+++ b/lib/shared/src/models/sync.ts
@@ -235,7 +235,8 @@ export function syncModels({
                                                 )
                                                 // DEEP CODY is enabled for all PLG users.
                                                 // Enterprise users need to have the feature flag enabled.
-                                                const isDeepCodyEnabled = isDotComUser || hasDeepCodyFlag
+                                                const isDeepCodyEnabled =
+                                                    (isDotComUser && !isCodyFreeUser) || hasDeepCodyFlag
                                                 if (
                                                     isDeepCodyEnabled &&
                                                     sonnetModel &&


### PR DESCRIPTION
This PR fixes the logic for display Deep Cody to only enable it for PLG users, not for Cody Free users. Previously, Deep Cody is visible for all DotCom users.

## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

Log in as Free users on VS Code to make sure you don't see Deep Cody on the list:

<img width="624" alt="image" src="https://github.com/user-attachments/assets/78d43e35-dca0-4e95-a1b4-75c3c6a5aa40" />

Log in as Pro or S2 user to make sure you can see it on the model list.

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
