### PR TITLE
Hitesh/use ds v2 autoedits

### DIFF
--- a/vscode/src/autoedits/adapters/cody-gateway.test.ts
+++ b/vscode/src/autoedits/adapters/cody-gateway.test.ts
@@ -57,7 +57,7 @@ describe('CodyGatewayAdapter', () => {
             expect.objectContaining({
                 stream: false,
                 model: options.model,
-                temperature: 0.2,
+                temperature: 0,
                 response_format: { type: 'text' },
                 prediction: {
                     type: 'content',
@@ -85,7 +85,7 @@ describe('CodyGatewayAdapter', () => {
             expect.objectContaining({
                 stream: false,
                 model: options.model,
-                temperature: 0.2,
+                temperature: 0,
                 response_format: { type: 'text' },
                 prediction: {
                     type: 'content',

--- a/vscode/src/autoedits/adapters/cody-gateway.ts
+++ b/vscode/src/autoedits/adapters/cody-gateway.ts
@@ -30,7 +30,7 @@ export class CodyGatewayAdapter implements AutoeditsModelAdapter {
         const body: FireworksCompatibleRequestParams = {
             stream: false,
             model: option.model,
-            temperature: 0.2,
+            temperature: 0,
             max_tokens: maxTokens,
             response_format: {
                 type: 'text',

--- a/vscode/src/autoedits/adapters/fireworks.test.ts
+++ b/vscode/src/autoedits/adapters/fireworks.test.ts
@@ -53,7 +53,7 @@ describe('FireworksAdapter', () => {
             expect.objectContaining({
                 stream: false,
                 model: options.model,
-                temperature: 0.2,
+                temperature: 0,
                 max_tokens: expect.any(Number),
                 response_format: { type: 'text' },
                 prediction: {
@@ -81,7 +81,7 @@ describe('FireworksAdapter', () => {
             expect.objectContaining({
                 stream: false,
                 model: options.model,
-                temperature: 0.2,
+                temperature: 0,
                 max_tokens: expect.any(Number),
                 response_format: { type: 'text' },
                 prediction: {

--- a/vscode/src/autoedits/adapters/fireworks.ts
+++ b/vscode/src/autoedits/adapters/fireworks.ts
@@ -28,7 +28,7 @@ export class FireworksAdapter implements AutoeditsModelAdapter {
         const body: FireworksCompatibleRequestParams = {
             stream: false,
             model: options.model,
-            temperature: 0.2,
+            temperature: 0,
             max_tokens: maxTokens,
             response_format: {
                 type: 'text',

--- a/vscode/src/autoedits/adapters/sourcegraph-chat.test.ts
+++ b/vscode/src/autoedits/adapters/sourcegraph-chat.test.ts
@@ -65,7 +65,7 @@ describe('SourcegraphChatAdapter', () => {
         expect(chatOptions).toMatchObject({
             model: 'anthropic/claude-2',
             maxTokensToSample: getMaxOutputTokensForAutoedits(options.codeToRewrite),
-            temperature: 0.2,
+            temperature: 0,
             prediction: {
                 type: 'content',
                 content: 'const x = 1',

--- a/vscode/src/autoedits/adapters/sourcegraph-chat.ts
+++ b/vscode/src/autoedits/adapters/sourcegraph-chat.ts
@@ -18,7 +18,7 @@ export class SourcegraphChatAdapter implements AutoeditsModelAdapter {
                 {
                     model: option.model,
                     maxTokensToSample: maxTokens,
-                    temperature: 0.2,
+                    temperature: 0,
                     prediction: {
                         type: 'content',
                         content: option.codeToRewrite,

--- a/vscode/src/autoedits/adapters/sourcegraph-completions.test.ts
+++ b/vscode/src/autoedits/adapters/sourcegraph-completions.test.ts
@@ -58,7 +58,7 @@ describe('SourcegraphCompletionsAdapter', () => {
         expect(params).toMatchObject({
             model: 'anthropic/claude-2',
             maxTokensToSample: getMaxOutputTokensForAutoedits(options.codeToRewrite),
-            temperature: 0.2,
+            temperature: 0,
             messages: [{ speaker: 'human', text: ps`user message` }],
             prediction: {
                 type: 'content',

--- a/vscode/src/autoedits/adapters/sourcegraph-completions.ts
+++ b/vscode/src/autoedits/adapters/sourcegraph-completions.ts
@@ -28,7 +28,7 @@ export class SourcegraphCompletionsAdapter implements AutoeditsModelAdapter {
                 model: option.model as ModelRefStr,
                 messages,
                 maxTokensToSample: maxTokens,
-                temperature: 0.2,
+                temperature: 0,
                 prediction: {
                     type: 'content',
                     content: option.codeToRewrite,

--- a/vscode/src/autoedits/adapters/utils.ts
+++ b/vscode/src/autoedits/adapters/utils.ts
@@ -17,7 +17,7 @@ export interface FireworksCompatibleRequestParams {
 }
 
 export function getMaxOutputTokensForAutoedits(codeToRewrite: string): number {
-    const MAX_NEW_GENERATED_TOKENS = 256
+    const MAX_NEW_GENERATED_TOKENS = 512
     const codeToRewriteTokens = charsToTokens(codeToRewrite.length)
     return codeToRewriteTokens + MAX_NEW_GENERATED_TOKENS
 }

--- a/vscode/src/autoedits/autoedits-provider.ts
+++ b/vscode/src/autoedits/autoedits-provider.ts
@@ -28,8 +28,8 @@ import { SourcegraphCompletionsAdapter } from './adapters/sourcegraph-completion
 import { autoeditsLogger } from './logger'
 import type { AutoeditsUserPromptStrategy } from './prompt/base'
 import { SYSTEM_PROMPT } from './prompt/constants'
-import { DefaultUserPromptStrategy } from './prompt/default-prompt-strategy'
 import { type CodeToReplaceData, getCompletionsPromptWithSystemPrompt } from './prompt/prompt-utils'
+import { ShortTermPromptStrategy } from './prompt/short-term-diff-prompt-strategy'
 import { DefaultDecorator } from './renderer/decorators/default-decorator'
 import { InlineDiffDecorator } from './renderer/decorators/inline-diff-decorator'
 import { getDecorationInfo } from './renderer/diff-utils'
@@ -80,7 +80,7 @@ export class AutoeditsProvider implements vscode.InlineCompletionItemProvider, v
     private readonly onSelectionChangeDebounced: DebouncedFunc<typeof this.autoeditOnSelectionChange>
     /** Keeps track of the last time the text was changed in the editor. */
     private lastTextChangeTimeStamp: number | undefined
-    private readonly promptProvider: AutoeditsUserPromptStrategy = new DefaultUserPromptStrategy()
+    private readonly promptProvider: AutoeditsUserPromptStrategy = new ShortTermPromptStrategy()
 
     private isMockResponseFromCurrentDocumentTemplateEnabled = vscode.workspace
         .getConfiguration()
@@ -373,16 +373,16 @@ export class AutoeditsProvider implements vscode.InlineCompletionItemProvider, v
                 model: 'cody-model-auto-edits-fireworks-default',
                 url: 'https://cody-gateway.sourcegraph.com/v1/completions/fireworks',
                 tokenLimit: defaultTokenLimit,
-                isChatModel: true,
+                isChatModel: false,
             }
         }
         return {
             provider: 'sourcegraph',
-            model: 'fireworks::v1::autoedits-default',
+            model: 'fireworks::v1::autoedits-deepseek-v2-lite',
             tokenLimit: defaultTokenLimit,
-            // We use chat completions client for sourcegraph-chat, so we don't need to specify url.
+            // We use completions client for sourcegraph provider, so we don't need to specify url.
             url: '',
-            isChatModel: true,
+            isChatModel: false,
         }
     }
 

--- a/vscode/src/autoedits/autoedits-provider.ts
+++ b/vscode/src/autoedits/autoedits-provider.ts
@@ -370,7 +370,7 @@ export class AutoeditsProvider implements vscode.InlineCompletionItemProvider, v
         if (isDotComAuthed()) {
             return {
                 provider: 'cody-gateway',
-                model: 'cody-model-auto-edits-fireworks-default',
+                model: 'autoedits-deepseek-lite-default',
                 url: 'https://cody-gateway.sourcegraph.com/v1/completions/fireworks',
                 tokenLimit: defaultTokenLimit,
                 isChatModel: false,
@@ -378,7 +378,7 @@ export class AutoeditsProvider implements vscode.InlineCompletionItemProvider, v
         }
         return {
             provider: 'sourcegraph',
-            model: 'fireworks::v1::autoedits-deepseek-v2-lite',
+            model: 'fireworks::v1::autoedits-deepseek-lite-default',
             tokenLimit: defaultTokenLimit,
             // We use completions client for sourcegraph provider, so we don't need to specify url.
             url: '',

--- a/vscode/src/autoedits/prompt/default-prompt-strategy.test.ts
+++ b/vscode/src/autoedits/prompt/default-prompt-strategy.test.ts
@@ -182,10 +182,12 @@ describe('DefaultUserPromptStrategy', () => {
             <extracted_code_snippets>
             <snippet>
             (\`test1.ts\`)
+
             jaccard similarity context 1
             </snippet>
             <snippet>
             (\`test2.ts\`)
+
             jaccard similarity context 2
             </snippet>
             </extracted_code_snippets>
@@ -194,18 +196,22 @@ describe('DefaultUserPromptStrategy', () => {
             <recently_viewed_snippets>
             <snippet>
             (\`test3.ts\`)
+
             view port context 4
             </snippet>
             <snippet>
             (\`test2.ts\`)
+
             view port context 3
             </snippet>
             <snippet>
             (\`test1.ts\`)
+
             view port context 2
             </snippet>
             <snippet>
             (\`test0.ts\`)
+
             view port context 1
             </snippet>
             </recently_viewed_snippets>
@@ -232,20 +238,24 @@ describe('DefaultUserPromptStrategy', () => {
             Here are some linter errors from the code that you will rewrite.
             <lint_errors>
             (\`test1.ts\`)
+
             diagnostics context 1
 
             diagnostics context 2
 
             (\`test2.ts\`)
+
             diagnostics context 3
             </lint_errors>
 
             Here is some recent code I copied from the editor.
             <recent_copy>
             (\`test1.ts\`)
+
             recent copy context 1
 
             (\`test2.ts\`)
+
             recent copy context 2
             </recent_copy>
 

--- a/vscode/src/autoedits/prompt/default-prompt-strategy.test.ts
+++ b/vscode/src/autoedits/prompt/default-prompt-strategy.test.ts
@@ -218,7 +218,9 @@ describe('DefaultUserPromptStrategy', () => {
 
             Here is the file that I am looking at (\`test.ts\`)
             <file>
+
             <<<AREA_AROUND_CODE_TO_REWRITE_WILL_BE_INSERTED_HERE>>>
+
             </file>
 
             Here is my recent series of edits from oldest to newest.
@@ -310,7 +312,9 @@ describe('DefaultUserPromptStrategy', () => {
 
             Here is the file that I am looking at (\`test.ts\`)
             <file>
+
             <<<AREA_AROUND_CODE_TO_REWRITE_WILL_BE_INSERTED_HERE>>>
+
             </file>
 
 

--- a/vscode/src/autoedits/prompt/default-prompt-strategy.ts
+++ b/vscode/src/autoedits/prompt/default-prompt-strategy.ts
@@ -1,4 +1,4 @@
-import { ps, psDedent } from '@sourcegraph/cody-shared'
+import { ps } from '@sourcegraph/cody-shared'
 import { RetrieverIdentifier } from '../../completions/context/utils'
 import { autoeditsLogger } from '../logger'
 import type { AutoeditsUserPromptStrategy, UserPromptArgs, UserPromptResponse } from './base'
@@ -13,6 +13,7 @@ import {
     getRecentCopyPrompt,
     getRecentEditsPrompt,
     getRecentlyViewedSnippetsPrompt,
+    joinPromptsWithNewlineSeperator,
 } from './prompt-utils'
 
 export class DefaultUserPromptStrategy implements AutoeditsUserPromptStrategy {
@@ -68,16 +69,17 @@ export class DefaultUserPromptStrategy implements AutoeditsUserPromptStrategy {
 
         const currentFilePrompt = ps`${constants.CURRENT_FILE_INSTRUCTION}${fileWithMarkerPrompt}`
 
-        const finalPrompt = psDedent`
-            ${getPromptWithNewline(constants.BASE_USER_PROMPT)}
-            ${getPromptWithNewline(jaccardSimilarityPrompt)}
-            ${getPromptWithNewline(recentViewsPrompt)}
-            ${getPromptWithNewline(currentFilePrompt)}
-            ${getPromptWithNewline(recentEditsPrompt)}
-            ${getPromptWithNewline(lintErrorsPrompt)}
-            ${getPromptWithNewline(recentCopyPrompt)}
-            ${getPromptWithNewline(areaPrompt)}
-            ${getPromptWithNewline(constants.FINAL_USER_PROMPT)}`
+        const finalPrompt = joinPromptsWithNewlineSeperator(
+            getPromptWithNewline(constants.BASE_USER_PROMPT),
+            getPromptWithNewline(jaccardSimilarityPrompt),
+            getPromptWithNewline(recentViewsPrompt),
+            getPromptWithNewline(currentFilePrompt),
+            getPromptWithNewline(recentEditsPrompt),
+            getPromptWithNewline(lintErrorsPrompt),
+            getPromptWithNewline(recentCopyPrompt),
+            getPromptWithNewline(areaPrompt),
+            constants.FINAL_USER_PROMPT
+        )
 
         autoeditsLogger.logDebug('AutoEdits', 'Prompt\n', finalPrompt)
         return {

--- a/vscode/src/autoedits/prompt/prompt-utils.test.ts
+++ b/vscode/src/autoedits/prompt/prompt-utils.test.ts
@@ -16,6 +16,7 @@ import {
     getRecentEditsContextPromptWithPath,
     getRecentEditsPrompt,
     getRecentlyViewedSnippetsPrompt,
+    joinPromptsWithNewlineSeperator,
 } from '../prompt/prompt-utils'
 
 describe('getContextPromptWithPath', () => {
@@ -87,6 +88,7 @@ describe('getCurrentFilePromptComponents', () => {
             suffix-line
             suffix-line
             suffix-line
+
             </file>
         `)
         expect(result.areaPrompt.toString()).toBe(dedent`
@@ -134,7 +136,9 @@ describe('getCurrentFilePromptComponents', () => {
         expect(result.fileWithMarkerPrompt.toString()).toBe(dedent`
             (\`test.ts\`)
             <file>
+
             <<<AREA_AROUND_CODE_TO_REWRITE_WILL_BE_INSERTED_HERE>>>
+
             </file>
         `)
         expect(result.areaPrompt.toString()).toBe(dedent`
@@ -892,6 +896,16 @@ describe('getJaccardSimilarityPrompt', () => {
             qux
             </snippet>
             </extracted_code_snippets>
+        `)
+    })
+})
+
+describe('joinPromptsWithNewlineSeperator', () => {
+    it('joins multiple prompt strings with a new line separator', () => {
+        const prompt = joinPromptsWithNewlineSeperator(ps`foo`, ps`bar`)
+        expect(prompt.toString()).toBe(dedent`
+            foo
+            bar
         `)
     })
 })

--- a/vscode/src/autoedits/prompt/prompt-utils.test.ts
+++ b/vscode/src/autoedits/prompt/prompt-utils.test.ts
@@ -25,6 +25,7 @@ describe('getContextPromptWithPath', () => {
         const prompt = getContextPromptWithPath(filePath, content)
         expect(prompt.toString()).toBe(dedent`
             (\`/path/to/file.js\`)
+
             const foo = 1
         `)
     })
@@ -545,6 +546,7 @@ describe('getLintErrorsPrompt', () => {
         expect(prompt.toString()).toBe(dedent`
             <lint_errors>
             (\`foo.ts\`)
+
             foo
             Err | Defined foo
 
@@ -579,6 +581,7 @@ describe('getLintErrorsPrompt', () => {
         expect(prompt.toString()).toBe(dedent`
             <lint_errors>
             (\`foo.ts\`)
+
             foo
             Err | Defined foo
 
@@ -586,6 +589,7 @@ describe('getLintErrorsPrompt', () => {
             Err | Defined another foo
 
             (\`bar.ts\`)
+
             bar
             Err | Defined bar
 
@@ -620,6 +624,7 @@ describe('getRecentCopyPrompt', () => {
         expect(prompt.toString()).toBe(dedent`
             <recent_copy>
             (\`foo.ts\`)
+
             baz
             </recent_copy>
         `)
@@ -642,9 +647,11 @@ describe('getRecentCopyPrompt', () => {
         expect(prompt.toString()).toBe(dedent`
             <recent_copy>
             (\`foo.ts\`)
+
             foo copy content
 
             (\`bar.ts\`)
+
             bar copy content
             </recent_copy>
         `)
@@ -758,10 +765,12 @@ describe('getRecentlyViewedSnippetsPrompt', () => {
             <recently_viewed_snippets>
             <snippet>
             (\`foo.ts\`)
+
             bar
             </snippet>
             <snippet>
             (\`foo.ts\`)
+
             foo
             </snippet>
             </recently_viewed_snippets>
@@ -786,18 +795,22 @@ describe('getRecentlyViewedSnippetsPrompt', () => {
             <recently_viewed_snippets>
             <snippet>
             (\`qux.ts\`)
+
             qux
             </snippet>
             <snippet>
             (\`baz.ts\`)
+
             bax
             </snippet>
             <snippet>
             (\`bar.ts\`)
+
             bar
             </snippet>
             <snippet>
             (\`foo.ts\`)
+
             foo
             </snippet>
             </recently_viewed_snippets>
@@ -830,10 +843,12 @@ describe('getJaccardSimilarityPrompt', () => {
             <extracted_code_snippets>
             <snippet>
             (\`foo.ts\`)
+
             foo
             </snippet>
             <snippet>
             (\`foo.ts\`)
+
             bar
             </snippet>
             </extracted_code_snippets>
@@ -858,18 +873,22 @@ describe('getJaccardSimilarityPrompt', () => {
             <extracted_code_snippets>
             <snippet>
             (\`foo.ts\`)
+
             foo
             </snippet>
             <snippet>
             (\`bar.ts\`)
+
             bar
             </snippet>
             <snippet>
             (\`baz.ts\`)
+
             bax
             </snippet>
             <snippet>
             (\`qux.ts\`)
+
             qux
             </snippet>
             </extracted_code_snippets>

--- a/vscode/src/autoedits/prompt/prompt-utils.ts
+++ b/vscode/src/autoedits/prompt/prompt-utils.ts
@@ -99,7 +99,7 @@ export function getCurrentFilePromptComponents(
         ${constants.AREA_FOR_CODE_MARKER}
         ${currentFileContext.suffixAfterArea}`
 
-    const filePrompt = getContextPromptWithPath(
+    const filePrompt = getCurrentFileContextPromptWithPath(
         PromptString.fromDisplayPath(options.document.uri),
         psDedent`
             ${constants.FILE_TAG_OPEN}
@@ -377,6 +377,13 @@ export function getContextItemsForIdentifier(
 }
 
 export function getContextPromptWithPath(filePath: PromptString, content: PromptString): PromptString {
+    return ps`(\`${filePath}\`)\n\n${content}`
+}
+
+export function getCurrentFileContextPromptWithPath(
+    filePath: PromptString,
+    content: PromptString
+): PromptString {
     return ps`(\`${filePath}\`)\n${content}`
 }
 

--- a/vscode/src/autoedits/prompt/prompt-utils.ts
+++ b/vscode/src/autoedits/prompt/prompt-utils.ts
@@ -3,7 +3,6 @@ import {
     type DocumentContext,
     PromptString,
     ps,
-    psDedent,
     tokensToChars,
 } from '@sourcegraph/cody-shared'
 import { Uri } from 'vscode'
@@ -94,27 +93,30 @@ export function getCurrentFilePromptComponents(
         suffixInArea: currentFileContext.suffixInArea.toString(),
     } satisfies CodeToReplaceData
 
-    const fileWithMarker = psDedent`
-        ${currentFileContext.prefixBeforeArea}
-        ${constants.AREA_FOR_CODE_MARKER}
-        ${currentFileContext.suffixAfterArea}`
+    const fileWithMarker = joinPromptsWithNewlineSeperator(
+        currentFileContext.prefixBeforeArea,
+        constants.AREA_FOR_CODE_MARKER,
+        currentFileContext.suffixAfterArea
+    )
 
     const filePrompt = getCurrentFileContextPromptWithPath(
         PromptString.fromDisplayPath(options.document.uri),
-        psDedent`
-            ${constants.FILE_TAG_OPEN}
-            ${fileWithMarker}
-            ${constants.FILE_TAG_CLOSE}`
+        joinPromptsWithNewlineSeperator(
+            constants.FILE_TAG_OPEN,
+            fileWithMarker,
+            constants.FILE_TAG_CLOSE
+        )
     )
 
-    const areaPrompt = psDedent`
-        ${constants.AREA_FOR_CODE_MARKER_OPEN}
-        ${currentFileContext.prefixInArea}
-        ${constants.CODE_TO_REWRITE_TAG_OPEN}
-        ${currentFileContext.codeToRewrite}
-        ${constants.CODE_TO_REWRITE_TAG_CLOSE}
-        ${currentFileContext.suffixInArea}
-        ${constants.AREA_FOR_CODE_MARKER_CLOSE}`
+    const areaPrompt = joinPromptsWithNewlineSeperator(
+        constants.AREA_FOR_CODE_MARKER_OPEN,
+        currentFileContext.prefixInArea,
+        constants.CODE_TO_REWRITE_TAG_OPEN,
+        currentFileContext.codeToRewrite,
+        constants.CODE_TO_REWRITE_TAG_CLOSE,
+        currentFileContext.suffixInArea,
+        constants.AREA_FOR_CODE_MARKER_CLOSE
+    )
 
     return { fileWithMarkerPrompt: filePrompt, areaPrompt: areaPrompt, codeToReplace: codeToReplace }
 }
@@ -217,10 +219,11 @@ export function getLintErrorsPrompt(contextItems: AutocompleteContextSnippet[]):
     }
 
     const lintErrorsPrompt = PromptString.join(combinedPrompts, ps`\n\n`)
-    return psDedent`
-        ${constants.LINT_ERRORS_TAG_OPEN}
-        ${lintErrorsPrompt}
-        ${constants.LINT_ERRORS_TAG_CLOSE}`
+    return joinPromptsWithNewlineSeperator(
+        constants.LINT_ERRORS_TAG_OPEN,
+        lintErrorsPrompt,
+        constants.LINT_ERRORS_TAG_CLOSE
+    )
 }
 
 export function getRecentCopyPrompt(contextItems: AutocompleteContextSnippet[]): PromptString {
@@ -238,10 +241,11 @@ export function getRecentCopyPrompt(contextItems: AutocompleteContextSnippet[]):
         )
     )
     const recentCopyPrompt = PromptString.join(recentCopyPrompts, ps`\n\n`)
-    return psDedent`
-        ${constants.RECENT_COPY_TAG_OPEN}
-        ${recentCopyPrompt}
-        ${constants.RECENT_COPY_TAG_CLOSE}`
+    return joinPromptsWithNewlineSeperator(
+        constants.RECENT_COPY_TAG_OPEN,
+        recentCopyPrompt,
+        constants.RECENT_COPY_TAG_CLOSE
+    )
 }
 
 export function getRecentEditsPrompt(contextItems: AutocompleteContextSnippet[]): PromptString {
@@ -260,10 +264,11 @@ export function getRecentEditsPrompt(contextItems: AutocompleteContextSnippet[])
         )
     )
     const recentEditsPrompt = PromptString.join(recentEditsPrompts, ps`\n`)
-    return psDedent`
-        ${constants.RECENT_EDITS_TAG_OPEN}
-        ${recentEditsPrompt}
-        ${constants.RECENT_EDITS_TAG_CLOSE}`
+    return joinPromptsWithNewlineSeperator(
+        constants.RECENT_EDITS_TAG_OPEN,
+        recentEditsPrompt,
+        constants.RECENT_EDITS_TAG_CLOSE
+    )
 }
 
 export function getRecentlyViewedSnippetsPrompt(
@@ -277,22 +282,23 @@ export function getRecentlyViewedSnippetsPrompt(
     if (recentViewedSnippets.length === 0) {
         return ps``
     }
-    const recentViewedSnippetPrompts = recentViewedSnippets.map(
-        item =>
-            psDedent`
-                ${constants.SNIPPET_TAG_OPEN}
-                ${getContextPromptWithPath(
-                    PromptString.fromDisplayPath(item.uri),
-                    PromptString.fromAutocompleteContextSnippet(item).content
-                )}
-                ${constants.SNIPPET_TAG_CLOSE}`
+    const recentViewedSnippetPrompts = recentViewedSnippets.map(item =>
+        joinPromptsWithNewlineSeperator(
+            constants.SNIPPET_TAG_OPEN,
+            getContextPromptWithPath(
+                PromptString.fromDisplayPath(item.uri),
+                PromptString.fromAutocompleteContextSnippet(item).content
+            ),
+            constants.SNIPPET_TAG_CLOSE
+        )
     )
 
     const snippetsPrompt = PromptString.join(recentViewedSnippetPrompts, ps`\n`)
-    return psDedent`
-        ${constants.RECENT_SNIPPET_VIEWS_TAG_OPEN}
-        ${snippetsPrompt}
-        ${constants.RECENT_SNIPPET_VIEWS_TAG_CLOSE}`
+    return joinPromptsWithNewlineSeperator(
+        constants.RECENT_SNIPPET_VIEWS_TAG_OPEN,
+        snippetsPrompt,
+        constants.RECENT_SNIPPET_VIEWS_TAG_CLOSE
+    )
 }
 
 export function getJaccardSimilarityPrompt(contextItems: AutocompleteContextSnippet[]): PromptString {
@@ -303,23 +309,24 @@ export function getJaccardSimilarityPrompt(contextItems: AutocompleteContextSnip
     if (jaccardSimilarity.length === 0) {
         return ps``
     }
-    const jaccardSimilarityPrompts = jaccardSimilarity.map(
-        item =>
-            psDedent`
-                ${constants.SNIPPET_TAG_OPEN}
-                ${getContextPromptWithPath(
-                    PromptString.fromDisplayPath(item.uri),
-                    PromptString.fromAutocompleteContextSnippet(item).content
-                )}
-                ${constants.SNIPPET_TAG_CLOSE}`
+    const jaccardSimilarityPrompts = jaccardSimilarity.map(item =>
+        joinPromptsWithNewlineSeperator(
+            constants.SNIPPET_TAG_OPEN,
+            getContextPromptWithPath(
+                PromptString.fromDisplayPath(item.uri),
+                PromptString.fromAutocompleteContextSnippet(item).content
+            ),
+            constants.SNIPPET_TAG_CLOSE
+        )
     )
 
     const snippetsPrompt = PromptString.join(jaccardSimilarityPrompts, ps`\n`)
 
-    return psDedent`
-        ${constants.EXTRACTED_CODE_SNIPPETS_TAG_OPEN}
-        ${snippetsPrompt}
-        ${constants.EXTRACTED_CODE_SNIPPETS_TAG_CLOSE}`
+    return joinPromptsWithNewlineSeperator(
+        constants.EXTRACTED_CODE_SNIPPETS_TAG_OPEN,
+        snippetsPrompt,
+        constants.EXTRACTED_CODE_SNIPPETS_TAG_CLOSE
+    )
 }
 
 //  Helper functions
@@ -392,4 +399,8 @@ export function getRecentEditsContextPromptWithPath(
     content: PromptString
 ): PromptString {
     return ps`${filePath}\n${content}`
+}
+
+export function joinPromptsWithNewlineSeperator(...args: PromptString[]): PromptString {
+    return PromptString.join(args, ps`\n`)
 }

--- a/vscode/src/autoedits/prompt/short-term-diff-prompt-strategy.test.ts
+++ b/vscode/src/autoedits/prompt/short-term-diff-prompt-strategy.test.ts
@@ -245,10 +245,12 @@ describe('ShortTermPromptStrategy', () => {
                 <extracted_code_snippets>
                 <snippet>
                 (\`test1.ts\`)
+
                 jaccard similarity context 1
                 </snippet>
                 <snippet>
                 (\`test2.ts\`)
+
                 jaccard similarity context 2
                 </snippet>
                 </extracted_code_snippets>
@@ -257,10 +259,12 @@ describe('ShortTermPromptStrategy', () => {
                 <recently_viewed_snippets>
                 <snippet>
                 (\`test3.ts\`)
+
                 view port context 4
                 </snippet>
                 <snippet>
                 (\`test2.ts\`)
+
                 view port context 3
                 </snippet>
                 </recently_viewed_snippets>
@@ -274,10 +278,12 @@ describe('ShortTermPromptStrategy', () => {
                 <recently_viewed_snippets>
                 <snippet>
                 (\`test1.ts\`)
+
                 view port context 2
                 </snippet>
                 <snippet>
                 (\`test0.ts\`)
+
                 view port context 1
                 </snippet>
                 </recently_viewed_snippets>
@@ -297,20 +303,24 @@ describe('ShortTermPromptStrategy', () => {
                 Here are some linter errors from the code that you will rewrite.
                 <lint_errors>
                 (\`test1.ts\`)
+
                 diagnostics context 1
 
                 diagnostics context 2
 
                 (\`test2.ts\`)
+
                 diagnostics context 3
                 </lint_errors>
 
                 Here is some recent code I copied from the editor.
                 <recent_copy>
                 (\`test1.ts\`)
+
                 recent copy context 1
 
                 (\`test2.ts\`)
+
                 recent copy context 2
                 </recent_copy>
 
@@ -403,10 +413,12 @@ describe('ShortTermPromptStrategy', () => {
                 <recently_viewed_snippets>
                 <snippet>
                 (\`test1.ts\`)
+
                 const test1 = true
                 </snippet>
                 <snippet>
                 (\`test0.ts\`)
+
                 const test0 = true
                 </snippet>
                 </recently_viewed_snippets>
@@ -416,10 +428,12 @@ describe('ShortTermPromptStrategy', () => {
                 <recently_viewed_snippets>
                 <snippet>
                 (\`test3.ts\`)
+
                 const test3 = null
                 </snippet>
                 <snippet>
                 (\`test2.ts\`)
+
                 const test2 = false
                 </snippet>
                 </recently_viewed_snippets>

--- a/vscode/src/autoedits/prompt/short-term-diff-prompt-strategy.test.ts
+++ b/vscode/src/autoedits/prompt/short-term-diff-prompt-strategy.test.ts
@@ -187,7 +187,9 @@ describe('ShortTermPromptStrategy', () => {
 
                 Here is the file that I am looking at (\`test.ts\`)
                 <file>
+
                 <<<AREA_AROUND_CODE_TO_REWRITE_WILL_BE_INSERTED_HERE>>>
+
                 </file>
 
 
@@ -271,7 +273,9 @@ describe('ShortTermPromptStrategy', () => {
 
                 Here is the file that I am looking at (\`test.ts\`)
                 <file>
+
                 <<<AREA_AROUND_CODE_TO_REWRITE_WILL_BE_INSERTED_HERE>>>
+
                 </file>
 
                 Here are some snippets of code I just looked at:

--- a/vscode/src/autoedits/prompt/short-term-diff-prompt-strategy.ts
+++ b/vscode/src/autoedits/prompt/short-term-diff-prompt-strategy.ts
@@ -1,9 +1,4 @@
-import {
-    type AutocompleteContextSnippet,
-    type PromptString,
-    ps,
-    psDedent,
-} from '@sourcegraph/cody-shared'
+import { type AutocompleteContextSnippet, type PromptString, ps } from '@sourcegraph/cody-shared'
 import { groupConsecutiveItemsByPredicate } from '../../completions/context/retrievers/recent-user-actions/recent-edits-diff-helpers/utils'
 import { RetrieverIdentifier } from '../../completions/context/utils'
 import { autoeditsLogger } from '../logger'
@@ -20,6 +15,7 @@ import {
     getRecentCopyPrompt,
     getRecentEditsPrompt,
     getRecentlyViewedSnippetsPrompt,
+    joinPromptsWithNewlineSeperator,
 } from './prompt-utils'
 
 export class ShortTermPromptStrategy implements AutoeditsUserPromptStrategy {
@@ -70,18 +66,19 @@ export class ShortTermPromptStrategy implements AutoeditsUserPromptStrategy {
         )
         const currentFilePrompt = ps`${constants.CURRENT_FILE_INSTRUCTION}${fileWithMarkerPrompt}`
 
-        const finalPrompt = psDedent`
-            ${getPromptWithNewline(constants.BASE_USER_PROMPT)}
-            ${getPromptWithNewline(jaccardSimilarityPrompt)}
-            ${getPromptWithNewline(longTermViewPrompt)}
-            ${getPromptWithNewline(currentFilePrompt)}
-            ${getPromptWithNewline(shortTermViewPrompt)}
-            ${getPromptWithNewline(longTermEditsPrompt)}
-            ${getPromptWithNewline(lintErrorsPrompt)}
-            ${getPromptWithNewline(recentCopyPrompt)}
-            ${getPromptWithNewline(areaPrompt)}
-            ${getPromptWithNewline(shortTermEditsPrompt)}
-            ${getPromptWithNewline(constants.FINAL_USER_PROMPT)}`
+        const finalPrompt = joinPromptsWithNewlineSeperator(
+            getPromptWithNewline(constants.BASE_USER_PROMPT),
+            getPromptWithNewline(jaccardSimilarityPrompt),
+            getPromptWithNewline(longTermViewPrompt),
+            getPromptWithNewline(currentFilePrompt),
+            getPromptWithNewline(shortTermViewPrompt),
+            getPromptWithNewline(longTermEditsPrompt),
+            getPromptWithNewline(lintErrorsPrompt),
+            getPromptWithNewline(recentCopyPrompt),
+            getPromptWithNewline(areaPrompt),
+            getPromptWithNewline(shortTermEditsPrompt),
+            constants.FINAL_USER_PROMPT
+        )
 
         autoeditsLogger.logDebug('AutoEdits', 'Prompt\n', finalPrompt)
         return {
@@ -114,16 +111,18 @@ export class ShortTermPromptStrategy implements AutoeditsUserPromptStrategy {
 
         const shortTermViewPrompt =
             shortTermViewedSnippets.length > 0
-                ? psDedent`
-                    ${constants.SHORT_TERM_SNIPPET_VIEWS_INSTRUCTION}
-                    ${getRecentlyViewedSnippetsPrompt(shortTermViewedSnippets)}`
+                ? joinPromptsWithNewlineSeperator(
+                      constants.SHORT_TERM_SNIPPET_VIEWS_INSTRUCTION,
+                      getRecentlyViewedSnippetsPrompt(shortTermViewedSnippets)
+                  )
                 : ps``
 
         const longTermViewPrompt =
             longTermViewedSnippets.length > 0
-                ? psDedent`
-                    ${constants.LONG_TERM_SNIPPET_VIEWS_INSTRUCTION}
-                    ${getRecentlyViewedSnippetsPrompt(longTermViewedSnippets)}`
+                ? joinPromptsWithNewlineSeperator(
+                      constants.LONG_TERM_SNIPPET_VIEWS_INSTRUCTION,
+                      getRecentlyViewedSnippetsPrompt(longTermViewedSnippets)
+                  )
                 : ps``
 
         return {
@@ -178,8 +177,9 @@ export class ShortTermPromptStrategy implements AutoeditsUserPromptStrategy {
             combinedContextItems.push(combinedItem)
         }
 
-        return psDedent`
-            ${constants.RECENT_EDITS_INSTRUCTION}
-            ${getRecentEditsPrompt(combinedContextItems)}`
+        return joinPromptsWithNewlineSeperator(
+            constants.RECENT_EDITS_INSTRUCTION,
+            getRecentEditsPrompt(combinedContextItems)
+        )
     }
 }

--- a/vscode/src/completions/context/context-strategy.ts
+++ b/vscode/src/completions/context/context-strategy.ts
@@ -11,6 +11,7 @@ import { JaccardSimilarityRetriever } from './retrievers/jaccard-similarity/jacc
 import { LspLightRetriever } from './retrievers/lsp-light/lsp-light-retriever'
 import { DiagnosticsRetriever } from './retrievers/recent-user-actions/diagnostics-retriever'
 import { RecentCopyRetriever } from './retrievers/recent-user-actions/recent-copy'
+import { LineLevelDiffStrategy } from './retrievers/recent-user-actions/recent-edits-diff-helpers/line-level-diff'
 import { UnifiedDiffStrategy } from './retrievers/recent-user-actions/recent-edits-diff-helpers/unified-diff'
 import { RecentEditsRetriever } from './retrievers/recent-user-actions/recent-edits-retriever'
 import { RecentViewPortRetriever } from './retrievers/recent-user-actions/recent-view-port'
@@ -132,8 +133,12 @@ export class DefaultContextStrategyFactory implements ContextStrategyFactory {
                                 new RecentEditsRetriever({
                                     maxAgeMs: 10 * 60 * 1000,
                                     diffStrategyList: [
-                                        new UnifiedDiffStrategy({
-                                            addLineNumbers: true,
+                                        new LineLevelDiffStrategy({
+                                            contextLines: 3,
+                                            longTermDiffCombinationStrategy: 'unified-diff',
+                                            minShortTermEvents: 1,
+                                            minShortTermTimeMs: 2 * 60 * 1000, // 2 minutes,
+                                            trimSurroundingContext: true,
                                         }),
                                     ],
                                 }),


### PR DESCRIPTION
## Context
1. Changes the fine-tuned model for autoedits from `mixtral` to `deepseek v2`.
2. Use the more granular inline diff format for `auto-edits` instead of `unified-diff`. 
3. Build on top of https://github.com/sourcegraph/cody/pull/6333
4. Offline performance is much better than Mixtral in terms of both quality and latency. In addition, the cases where the model suggest deletion of the most recently added line is much less frequent than mixtral model.
5. Backend PR: https://github.com/sourcegraph/sourcegraph/pull/2350

## Test plan 
Offline evaluation for the model performance and played with the model in debug mode for quality check

