### PR TITLE
chore/(telemetry): update `billingMetadata`

### DIFF
--- a/vscode/src/chat/chat-view/ChatController.ts
+++ b/vscode/src/chat/chat-view/ChatController.ts
@@ -1815,7 +1815,9 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
         // Restore the old session in the current window
         this.restoreSession(sessionID)
 
-        telemetryRecorder.recordEvent('cody.duplicateSession', 'clicked')
+        telemetryRecorder.recordEvent('cody.duplicateSession', 'clicked', {
+            billingMetadata: { product: 'cody', category: 'billable' },
+        })
     }
 
     public async clearAndRestartSession(chatMessages?: ChatMessage[]): Promise<void> {

--- a/vscode/src/edit/manager.ts
+++ b/vscode/src/edit/manager.ts
@@ -345,7 +345,9 @@ export class EditManager implements vscode.Disposable {
                     void vscode.window.showErrorMessage(
                         'Unable to apply this change to the file. Please try applying this code manually'
                     )
-                    telemetryRecorder.recordEvent('cody.smart-apply.selection', 'not-found')
+                    telemetryRecorder.recordEvent('cody.smart-apply.selection', 'not-found', {
+                        billingMetadata: { product: 'cody', category: 'billable' },
+                    })
                     return
                 }
 
@@ -353,6 +355,7 @@ export class EditManager implements vscode.Disposable {
                     metadata: {
                         [selection.type]: 1,
                     },
+                    billingMetadata: { product: 'cody', category: 'billable' },
                 })
 
                 // Move focus to the determined selection

--- a/vscode/webviews/components/promptList/PromptList.tsx
+++ b/vscode/webviews/components/promptList/PromptList.tsx
@@ -117,6 +117,7 @@ export const PromptList: FC<PromptListProps> = props => {
                 privateMetadata: {
                     nameWithOwner: isPrompt ? action.nameWithOwner : undefined,
                 },
+                billingMetadata: { product: 'cody', category: 'core' },
             })
 
             const prompts = result.actions.filter(action => action.actionType === 'prompt')
@@ -137,6 +138,7 @@ export const PromptList: FC<PromptListProps> = props => {
                     query: debouncedQuery,
                     usePromptsQueryErrorMessage: error?.message,
                 },
+                billingMetadata: { product: 'cody', category: 'core' },
             })
 
             parentOnSelect(action)

--- a/vscode/webviews/components/promptSelectField/PromptSelectField.tsx
+++ b/vscode/webviews/components/promptSelectField/PromptSelectField.tsx
@@ -23,7 +23,9 @@ export const PromptSelectField: React.FunctionComponent<{
     const onOpenChange = useCallback(
         (open: boolean): void => {
             if (open) {
-                telemetryRecorder.recordEvent('cody.promptSelectField', 'open', {})
+                telemetryRecorder.recordEvent('cody.promptSelectField', 'open', {
+                    billingMetadata: { product: 'cody', category: 'billable' },
+                })
             }
         },
         [telemetryRecorder.recordEvent]


### PR DESCRIPTION
This PR adds billingMetadata to key telemetry events that are considered either 'core' or 'billable' events ([as per this definition](https://www.notion.so/sourcegraph/V2-telemetry-product-and-category-documentation-b4f932118ea5421587e6e0a0d90d78e1)). Prior to this change, these events did not have any billingMetadata classifications. This change will help the analytics team group billable and core users of the product.

Key changes:

Added billingMetadata to existing telemetry events based on this [list](https://docs.google.com/spreadsheets/d/1fECquIRqzOCz-aCT25wMF1WVWbQp8u8LE2lasIzvHkM/edit?gid=949192093#gid=949192093) provided by analytics.

## Test plan
CI
<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
