### PR TITLE
[Backport vscode-v1.52.x] show Deep Cody to pro users only

### DIFF
--- a/lib/shared/src/experimentation/FeatureFlagProvider.ts
+++ b/lib/shared/src/experimentation/FeatureFlagProvider.ts
@@ -59,6 +59,9 @@ export enum FeatureFlag {
     // Enables gpt-4o-mini as a default Edit model
     CodyEditDefaultToGpt4oMini = 'cody-edit-default-to-gpt-4o-mini',
 
+    // Enables Claude 3.5 Haiku as a default Chat model
+    CodyChatDefaultToClaude35Haiku = 'cody-chat-default-to-claude-3-5-haiku',
+
     // use-ssc-for-cody-subscription is a feature flag that enables the use of SSC as the source of truth for Cody subscription data.
     UseSscForCodySubscription = 'use-ssc-for-cody-subscription',
 

--- a/lib/shared/src/models/modelsService.ts
+++ b/lib/shared/src/models/modelsService.ts
@@ -23,7 +23,6 @@ import {
     userProductSubscription,
 } from '../sourcegraph-api/userProductSubscription'
 import { CHAT_INPUT_TOKEN_BUDGET, CHAT_OUTPUT_TOKEN_BUDGET } from '../token/constants'
-
 import { configOverwrites } from './configOverwrites'
 import { type Model, type ServerModel, modelTier } from './model'
 import { syncModels } from './sync'
@@ -328,6 +327,7 @@ export class ModelsService {
         authStatus,
         configOverwrites,
         clientConfig: ClientConfigSingleton.getInstance().changes,
+        userProductSubscription,
     })
 
     /**

--- a/lib/shared/src/models/sync.test.ts
+++ b/lib/shared/src/models/sync.test.ts
@@ -205,6 +205,7 @@ describe('server sent models', async () => {
                 modelsAPIEnabled: true,
             } satisfies Partial<CodyClientConfig> as CodyClientConfig),
             fetchServerSideModels_: mockFetchServerSideModels,
+            userProductSubscription: Observable.of({ userCanUpgrade: true }),
         }).pipe(skipPendingOperation())
     )
     const storage = new TestLocalStorageForModelPreferences()
@@ -260,6 +261,7 @@ describe('syncModels', () => {
                 configOverwrites: configOverwritesSubject.pipe(shareReplay()),
                 clientConfig: clientConfigSubject.pipe(shareReplay()),
                 fetchServerSideModels_: mockFetchServerSideModels,
+                userProductSubscription: Observable.of({ userCanUpgrade: true }),
             })
             const { values, clearValues, unsubscribe, done } = readValuesFrom(syncModelsObservable)
 
@@ -500,6 +502,7 @@ describe('syncModels', () => {
                     modelsAPIEnabled: true,
                 } satisfies Partial<CodyClientConfig> as CodyClientConfig),
                 fetchServerSideModels_: mockFetchServerSideModels,
+                userProductSubscription: Observable.of({ userCanUpgrade: true }),
             }).pipe(skipPendingOperation())
         )
 

--- a/lib/shared/src/models/sync.test.ts
+++ b/lib/shared/src/models/sync.test.ts
@@ -5,6 +5,7 @@ import { AUTH_STATUS_FIXTURE_AUTHED, type AuthStatus } from '../auth/types'
 import { CLIENT_CAPABILITIES_FIXTURE, mockClientCapabilities } from '../configuration/clientCapabilities'
 import type { ResolvedConfiguration } from '../configuration/resolver'
 import { featureFlagProvider } from '../experimentation/FeatureFlagProvider'
+import { FeatureFlag } from '../experimentation/FeatureFlagProvider'
 import {
     firstValueFrom,
     readValuesFrom,
@@ -13,6 +14,7 @@ import {
 } from '../misc/observable'
 import { pendingOperation, skipPendingOperation } from '../misc/observableOperation'
 import type { CodyClientConfig } from '../sourcegraph-api/clientConfig'
+import { DOTCOM_URL } from '../sourcegraph-api/environments'
 import type { CodyLLMSiteConfiguration } from '../sourcegraph-api/graphql/client'
 import * as userProductSubscriptionModule from '../sourcegraph-api/userProductSubscription'
 import type { PartialDeep } from '../utils'
@@ -522,5 +524,103 @@ describe('syncModels', () => {
         // preference should not be affected and remains unchanged as this is handled in a later step.
         expect(result.preferences.selected.chat).toBe(undefined)
         expect(storage.data?.[AUTH_STATUS_FIXTURE_AUTHED.endpoint]!.selected.chat).toBe(undefined)
+    })
+
+    describe('model selection based on user tier and feature flags', () => {
+        const serverHaiku: ServerModel = {
+            modelRef: 'anthropic::unknown::claude-3-5-haiku',
+            displayName: 'Haiku',
+            modelName: 'anthropic.claude-3-5-haiku',
+            capabilities: ['chat'],
+            category: 'balanced' as ModelCategory,
+            status: 'stable',
+            tier: 'free' as ModelTier,
+            contextWindow: {
+                maxInputTokens: 7000,
+                maxOutputTokens: 4000,
+            },
+        }
+        const serverSonnet: ServerModel = {
+            modelRef: 'anthropic::unknown::sonnet',
+            displayName: 'Sonnet',
+            modelName: 'anthropic.claude-3-5-sonnet',
+            capabilities: ['chat'],
+            category: 'balanced' as ModelCategory,
+            status: 'stable',
+            tier: 'enterprise' as ModelTier,
+            contextWindow: {
+                maxInputTokens: 9000,
+                maxOutputTokens: 4000,
+            },
+        }
+        const SERVER_MODELS: ServerModelConfiguration = {
+            schemaVersion: '0.0',
+            revision: '-',
+            providers: [],
+            models: [serverHaiku, serverSonnet],
+            defaultModels: {
+                chat: serverSonnet.modelRef,
+                fastChat: serverSonnet.modelRef,
+                codeCompletion: serverSonnet.modelRef,
+            },
+        }
+        const mockFetchServerSideModels = vi.fn(() => Promise.resolve(SERVER_MODELS))
+
+        async function getModelResult(featureFlagEnabled: boolean, userCanUpgrade: boolean) {
+            // set the feature flag
+            if (featureFlagEnabled) {
+                vi.spyOn(featureFlagProvider, 'evaluatedFeatureFlag').mockImplementation(
+                    (flag: FeatureFlag) =>
+                        flag === FeatureFlag.CodyChatDefaultToClaude35Haiku
+                            ? Observable.of(featureFlagEnabled)
+                            : Observable.of(false)
+                )
+            } else {
+                vi.spyOn(featureFlagProvider, 'evaluatedFeatureFlag').mockImplementation(
+                    (flag: FeatureFlag) =>
+                        flag === FeatureFlag.CodyChatDefaultToClaude35Haiku
+                            ? Observable.of(featureFlagEnabled)
+                            : Observable.of(true)
+                )
+            }
+
+            return firstValueFrom(
+                syncModels({
+                    resolvedConfig: Observable.of({
+                        configuration: {},
+                        clientState: { modelPreferences: {} },
+                    } satisfies PartialDeep<ResolvedConfiguration> as ResolvedConfiguration),
+                    authStatus: Observable.of({
+                        ...AUTH_STATUS_FIXTURE_AUTHED,
+                        endpoint: DOTCOM_URL.toString(),
+                        userCanUpgrade,
+                    }),
+                    configOverwrites: Observable.of(null),
+                    clientConfig: Observable.of({
+                        modelsAPIEnabled: true,
+                    } satisfies Partial<CodyClientConfig> as CodyClientConfig),
+                    fetchServerSideModels_: mockFetchServerSideModels,
+                    userProductSubscription: Observable.of({ userCanUpgrade }),
+                }).pipe(skipPendingOperation())
+            )
+        }
+
+        it('sets Haiku as default chat model for free users when feature flag is enabled', async () => {
+            const result = await getModelResult(true, true)
+            expect(result.preferences.defaults.chat?.includes('claude-3-5-haiku')).toBe(true)
+            expect(result.primaryModels.some(model => model.id.includes('claude-3-5-haiku'))).toBe(true)
+        })
+
+        it('sets Sonnet as default chat model for free tier users when feature flag is disabled', async () => {
+            const result = await getModelResult(false, true)
+            expect(result.preferences.defaults.chat?.includes('sonnet')).toBe(true)
+            expect(result.primaryModels.some(model => model.id.includes('sonnet'))).toBe(true)
+        })
+
+        it('sets Sonnet as default chat model for pro tier users', async () => {
+            const result = await getModelResult(true, false)
+            expect(result.preferences.defaults.chat?.includes('sonnet')).toBe(true)
+            expect(result.primaryModels.some(model => model.id.includes('sonnet'))).toBe(true)
+        })
     })
 })

--- a/lib/shared/src/models/sync.ts
+++ b/lib/shared/src/models/sync.ts
@@ -24,7 +24,10 @@ import type { CodyClientConfig } from '../sourcegraph-api/clientConfig'
 import { isDotCom } from '../sourcegraph-api/environments'
 import type { CodyLLMSiteConfiguration } from '../sourcegraph-api/graphql/client'
 import { RestClient } from '../sourcegraph-api/rest/client'
-import { userProductSubscription } from '../sourcegraph-api/userProductSubscription'
+import {
+    type UserProductSubscription,
+    userProductSubscription,
+} from '../sourcegraph-api/userProductSubscription'
 import { CHAT_INPUT_TOKEN_BUDGET } from '../token/constants'
 import { isError } from '../utils'
 import { getExperimentalClientModelByFeatureFlag } from './client'
@@ -61,6 +64,7 @@ export function syncModels({
     configOverwrites: Observable<CodyLLMSiteConfiguration | null | typeof pendingOperation>
     clientConfig: Observable<CodyClientConfig | undefined | typeof pendingOperation>
     fetchServerSideModels_?: typeof fetchServerSideModels
+    userProductSubscription: Observable<UserProductSubscription | null | typeof pendingOperation>
 }): Observable<ModelsData | typeof pendingOperation> {
     // Refresh Ollama models when Ollama-related config changes and periodically.
     const localModels = combineLatest(


### PR DESCRIPTION
Backport https://github.com/sourcegraph/cody/pull/6368 which depends on https://github.com/sourcegraph/cody/pull/6304

## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

See https://github.com/sourcegraph/cody/pull/6368 &. https://github.com/sourcegraph/cody/pull/6304

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
