### PR TITLE
fix(webviews): remove z-index from prompt searchbox

### DIFF
--- a/vscode/webviews/components/promptList/PromptList.module.css
+++ b/vscode/webviews/components/promptList/PromptList.module.css
@@ -7,7 +7,6 @@
     &--input-container {
         top: 0;
         position: sticky;
-        z-index: 1;
     }
 
     &--input {


### PR DESCRIPTION
CLOSE https://linear.app/sourcegraph/issue/CODY-4533/layout-bug-in-prompts-tab-and-new-user-menu-ui

Remove z-index from prompt search box that is overriding the user menu when it's opened.

## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

After

<img width="700" alt="image" src="https://github.com/user-attachments/assets/82cafda8-73f0-4a92-a2ea-6696a8338d91" />

Before

<img width="604" alt="image" src="https://github.com/user-attachments/assets/3b663eec-8c4c-4fe8-9e7b-d237a946e7f6" />

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
