### PR TITLE
autoedit: fix inline completion extraction when deletion

### DIFF
--- a/vscode/src/autoedits/utils.test.ts
+++ b/vscode/src/autoedits/utils.test.ts
@@ -299,6 +299,18 @@ describe('isAllNewLineChars', () => {
 })
 
 describe('adjustPredictionIfInlineCompletionPossible', () => {
+    it('prediction when the prefix matches partially with suffix', () => {
+        const originalPrediction = '\n    private async func {\n'
+        const prefix = '\n    private '
+        const suffix = '\n\n    private async func {\n'
+        const result = utils.adjustPredictionIfInlineCompletionPossible(
+            originalPrediction,
+            prefix,
+            suffix
+        )
+        expect(result).toBe(originalPrediction)
+    })
+
     it('returns original prediction if prefix or suffix not found', () => {
         const originalPrediction = 'some code'
         const prefix = 'prefix'

--- a/vscode/src/autoedits/utils.ts
+++ b/vscode/src/autoedits/utils.ts
@@ -84,7 +84,11 @@ export function adjustPredictionIfInlineCompletionPossible(
 
     const indexPrefix = originalPrediction.indexOf(prefixWithoutNewLine)
     const indexSuffix = originalPrediction.lastIndexOf(suffixWithoutNewLine)
-    if (indexPrefix === -1 || indexSuffix === -1) {
+    if (
+        indexPrefix === -1 ||
+        indexSuffix === -1 ||
+        indexPrefix + prefixWithoutNewLine.length > indexSuffix
+    ) {
         return originalPrediction
     }
 


### PR DESCRIPTION
## Context
The PR fixes the inline completions extraction when the suggestions is to delete content and prefix matches with the suffix in the code.

## Test plan
Added unit test 
