### PR TITLE
Hitesh/heuristic recent edit based

### DIFF
--- a/vscode/src/autoedits/utils.test.ts
+++ b/vscode/src/autoedits/utils.test.ts
@@ -299,6 +299,18 @@ describe('isAllNewLineChars', () => {
 })
 
 describe('adjustPredictionIfInlineCompletionPossible', () => {
+    it('prediction when the prefix matches partially with suffix', () => {
+        const originalPrediction = '\n    private async func {\n'
+        const prefix = '\n    private '
+        const suffix = '\n\n    private async func {\n'
+        const result = utils.adjustPredictionIfInlineCompletionPossible(
+            originalPrediction,
+            prefix,
+            suffix
+        )
+        expect(result).toBe(originalPrediction)
+    })
+
     it('returns original prediction if prefix or suffix not found', () => {
         const originalPrediction = 'some code'
         const prefix = 'prefix'

--- a/vscode/src/autoedits/utils.ts
+++ b/vscode/src/autoedits/utils.ts
@@ -84,7 +84,11 @@ export function adjustPredictionIfInlineCompletionPossible(
 
     const indexPrefix = originalPrediction.indexOf(prefixWithoutNewLine)
     const indexSuffix = originalPrediction.lastIndexOf(suffixWithoutNewLine)
-    if (indexPrefix === -1 || indexSuffix === -1) {
+    if (
+        indexPrefix === -1 ||
+        indexSuffix === -1 ||
+        indexPrefix + prefixWithoutNewLine.length > indexSuffix
+    ) {
         return originalPrediction
     }
 

--- a/vscode/src/completions/context/retrievers/recent-user-actions/recent-edits-retriever.ts
+++ b/vscode/src/completions/context/retrievers/recent-user-actions/recent-edits-retriever.ts
@@ -2,22 +2,13 @@ import { type PromptString, contextFiltersProvider } from '@sourcegraph/cody-sha
 import type { AutocompleteContextSnippet } from '@sourcegraph/cody-shared'
 import type { AutocompleteContextSnippetMetadataFields } from '@sourcegraph/cody-shared'
 import * as vscode from 'vscode'
-import { getPositionAfterTextInsertion } from '../../../text-processing/utils'
 import type { ContextRetriever, ContextRetrieverOptions } from '../../../types'
 import { RetrieverIdentifier, type ShouldUseContextParams, shouldBeUsedAsContext } from '../../utils'
 import type {
     DiffHunk,
     RecentEditsRetrieverDiffStrategy,
-    TextDocumentChange,
 } from './recent-edits-diff-helpers/recent-edits-diff-strategy'
-import { applyTextDocumentChanges } from './recent-edits-diff-helpers/utils'
-
-interface TrackedDocument {
-    content: string
-    languageId: string
-    uri: vscode.Uri
-    changes: TextDocumentChange[]
-}
+import { RecentEditsTracker } from './recent-edits-tracker'
 
 interface DiffHunkWithStrategy extends DiffHunk {
     diffStrategyMetadata: AutocompleteContextSnippetMetadataFields
@@ -39,32 +30,19 @@ interface DiffAcrossDocuments {
 export class RecentEditsRetriever implements vscode.Disposable, ContextRetriever {
     // We use a map from the document URI to the set of tracked completions inside that document to
     // improve performance of the `onDidChangeTextDocument` event handler.
-    private trackedDocuments: Map<string, TrackedDocument> = new Map()
     public identifier = RetrieverIdentifier.RecentEditsRetriever
-    private disposables: vscode.Disposable[] = []
-    private readonly maxAgeMs: number
     private readonly diffStrategyList: RecentEditsRetrieverDiffStrategy[]
+    private readonly recentEditsTracker: RecentEditsTracker
 
     constructor(
         options: RecentEditsRetrieverOptions,
-        readonly workspace: Pick<
+        workspace: Pick<
             typeof vscode.workspace,
             'onDidChangeTextDocument' | 'onDidRenameFiles' | 'onDidDeleteFiles' | 'onDidOpenTextDocument'
         > = vscode.workspace
     ) {
-        this.maxAgeMs = options.maxAgeMs
+        this.recentEditsTracker = new RecentEditsTracker(options.maxAgeMs, workspace)
         this.diffStrategyList = options.diffStrategyList
-
-        // Track the already open documents when editor was opened
-        for (const document of vscode.workspace.textDocuments) {
-            this.trackDocument(document)
-        }
-        this.disposables.push(
-            workspace.onDidChangeTextDocument(this.onDidChangeTextDocument.bind(this)),
-            workspace.onDidRenameFiles(this.onDidRenameFiles.bind(this)),
-            workspace.onDidDeleteFiles(this.onDidDeleteFiles.bind(this)),
-            workspace.onDidOpenTextDocument(this.onDidOpenTextDocument.bind(this))
-        )
     }
 
     public async retrieve(options: ContextRetrieverOptions): Promise<AutocompleteContextSnippet[]> {
@@ -96,7 +74,8 @@ export class RecentEditsRetriever implements vscode.Disposable, ContextRetriever
 
     public async getDiffAcrossDocuments(): Promise<DiffAcrossDocuments[]> {
         const diffs: DiffAcrossDocuments[] = []
-        const diffPromises = Array.from(this.trackedDocuments.entries()).map(
+        const trackedDocuments = this.recentEditsTracker.getTrackedDocumentsMapping()
+        const diffPromises = Array.from(trackedDocuments.entries()).map(
             async ([uri, trackedDocument]) => {
                 if (trackedDocument.changes.length === 0) {
                     return null
@@ -143,8 +122,7 @@ export class RecentEditsRetriever implements vscode.Disposable, ContextRetriever
         if (await contextFiltersProvider.isUriIgnored(uri)) {
             return null
         }
-
-        const trackedDocument = this.trackedDocuments.get(uri.toString())
+        const trackedDocument = this.recentEditsTracker.getTrackedDocumentForUri(uri)
         if (!trackedDocument) {
             return null
         }
@@ -169,83 +147,7 @@ export class RecentEditsRetriever implements vscode.Disposable, ContextRetriever
         return true
     }
 
-    private onDidChangeTextDocument(event: vscode.TextDocumentChangeEvent): void {
-        const trackedDocument = this.trackedDocuments.get(event.document.uri.toString())
-        if (!trackedDocument) {
-            return
-        }
-
-        const now = Date.now()
-        for (const change of event.contentChanges) {
-            const insertedRange = new vscode.Range(
-                change.range.start,
-                getPositionAfterTextInsertion(change.range.start, change.text)
-            )
-            trackedDocument.changes.push({
-                timestamp: now,
-                change,
-                insertedRange,
-            })
-        }
-
-        this.reconcileOutdatedChanges()
-    }
-
-    private onDidOpenTextDocument(document: vscode.TextDocument): void {
-        if (!this.trackedDocuments.has(document.uri.toString())) {
-            this.trackDocument(document)
-        }
-    }
-
-    private onDidRenameFiles(event: vscode.FileRenameEvent): void {
-        for (const file of event.files) {
-            const trackedDocument = this.trackedDocuments.get(file.oldUri.toString())
-            if (trackedDocument) {
-                this.trackedDocuments.set(file.newUri.toString(), trackedDocument)
-                this.trackedDocuments.delete(file.oldUri.toString())
-            }
-        }
-    }
-
-    private onDidDeleteFiles(event: vscode.FileDeleteEvent): void {
-        for (const uri of event.files) {
-            this.trackedDocuments.delete(uri.toString())
-        }
-    }
-
-    private trackDocument(document: vscode.TextDocument): void {
-        if (document.uri.scheme !== 'file') {
-            return
-        }
-        const trackedDocument: TrackedDocument = {
-            content: document.getText(),
-            languageId: document.languageId,
-            uri: document.uri,
-            changes: [],
-        }
-        this.trackedDocuments.set(document.uri.toString(), trackedDocument)
-    }
-
-    private reconcileOutdatedChanges(): void {
-        const now = Date.now()
-        for (const [, trackedDocument] of this.trackedDocuments) {
-            const firstNonOutdatedChangeIndex = trackedDocument.changes.findIndex(
-                c => now - c.timestamp < this.maxAgeMs
-            )
-
-            const outdatedChanges = trackedDocument.changes.slice(0, firstNonOutdatedChangeIndex)
-            trackedDocument.content = applyTextDocumentChanges(
-                trackedDocument.content,
-                outdatedChanges.map(c => c.change)
-            )
-            trackedDocument.changes = trackedDocument.changes.slice(firstNonOutdatedChangeIndex)
-        }
-    }
-
     public dispose(): void {
-        this.trackedDocuments.clear()
-        for (const disposable of this.disposables) {
-            disposable.dispose()
-        }
+        this.recentEditsTracker.dispose()
     }
 }

--- a/vscode/src/completions/context/retrievers/recent-user-actions/recent-edits-tracker.ts
+++ b/vscode/src/completions/context/retrievers/recent-user-actions/recent-edits-tracker.ts
@@ -1,0 +1,125 @@
+import * as vscode from 'vscode'
+import { getPositionAfterTextInsertion } from '../../../text-processing/utils'
+import type { TextDocumentChange } from './recent-edits-diff-helpers/recent-edits-diff-strategy'
+import { applyTextDocumentChanges } from './recent-edits-diff-helpers/utils'
+
+export interface TrackedDocument {
+    content: string
+    languageId: string
+    uri: vscode.Uri
+    changes: TextDocumentChange[]
+}
+
+export class RecentEditsTracker implements vscode.Disposable {
+    // We use a map from the document URI to the set of tracked completions inside that document to
+    // improve performance of the `onDidChangeTextDocument` event handler.
+    private trackedDocuments: Map<string, TrackedDocument> = new Map()
+    private disposables: vscode.Disposable[] = []
+
+    constructor(
+        private readonly maxAgeMs: number,
+        readonly workspace: Pick<
+            typeof vscode.workspace,
+            'onDidChangeTextDocument' | 'onDidRenameFiles' | 'onDidDeleteFiles' | 'onDidOpenTextDocument'
+        > = vscode.workspace
+    ) {
+        // Track the already open documents when editor was opened
+        for (const document of vscode.workspace.textDocuments) {
+            this.trackDocument(document)
+        }
+        this.disposables.push(
+            workspace.onDidChangeTextDocument(this.onDidChangeTextDocument.bind(this)),
+            workspace.onDidRenameFiles(this.onDidRenameFiles.bind(this)),
+            workspace.onDidDeleteFiles(this.onDidDeleteFiles.bind(this)),
+            workspace.onDidOpenTextDocument(this.onDidOpenTextDocument.bind(this))
+        )
+    }
+
+    public getTrackedDocumentForUri(uri: vscode.Uri): TrackedDocument | undefined {
+        return this.trackedDocuments.get(uri.toString())
+    }
+
+    public getTrackedDocumentsMapping(): Map<string, TrackedDocument> {
+        return this.trackedDocuments
+    }
+
+    private onDidChangeTextDocument(event: vscode.TextDocumentChangeEvent): void {
+        const trackedDocument = this.trackedDocuments.get(event.document.uri.toString())
+        if (!trackedDocument) {
+            return
+        }
+
+        const now = Date.now()
+        for (const change of event.contentChanges) {
+            const insertedRange = new vscode.Range(
+                change.range.start,
+                getPositionAfterTextInsertion(change.range.start, change.text)
+            )
+            trackedDocument.changes.push({
+                timestamp: now,
+                change,
+                insertedRange,
+            })
+        }
+
+        this.reconcileOutdatedChanges()
+    }
+
+    private onDidOpenTextDocument(document: vscode.TextDocument): void {
+        if (!this.trackedDocuments.has(document.uri.toString())) {
+            this.trackDocument(document)
+        }
+    }
+
+    private onDidRenameFiles(event: vscode.FileRenameEvent): void {
+        for (const file of event.files) {
+            const trackedDocument = this.trackedDocuments.get(file.oldUri.toString())
+            if (trackedDocument) {
+                this.trackedDocuments.set(file.newUri.toString(), trackedDocument)
+                this.trackedDocuments.delete(file.oldUri.toString())
+            }
+        }
+    }
+
+    private onDidDeleteFiles(event: vscode.FileDeleteEvent): void {
+        for (const uri of event.files) {
+            this.trackedDocuments.delete(uri.toString())
+        }
+    }
+
+    private trackDocument(document: vscode.TextDocument): void {
+        if (document.uri.scheme !== 'file') {
+            return
+        }
+        const trackedDocument: TrackedDocument = {
+            content: document.getText(),
+            languageId: document.languageId,
+            uri: document.uri,
+            changes: [],
+        }
+        this.trackedDocuments.set(document.uri.toString(), trackedDocument)
+    }
+
+    private reconcileOutdatedChanges(): void {
+        const now = Date.now()
+        for (const [, trackedDocument] of this.trackedDocuments) {
+            const firstNonOutdatedChangeIndex = trackedDocument.changes.findIndex(
+                c => now - c.timestamp < this.maxAgeMs
+            )
+
+            const outdatedChanges = trackedDocument.changes.slice(0, firstNonOutdatedChangeIndex)
+            trackedDocument.content = applyTextDocumentChanges(
+                trackedDocument.content,
+                outdatedChanges.map(c => c.change)
+            )
+            trackedDocument.changes = trackedDocument.changes.slice(firstNonOutdatedChangeIndex)
+        }
+    }
+
+    public dispose(): void {
+        this.trackedDocuments.clear()
+        for (const disposable of this.disposables) {
+            disposable.dispose()
+        }
+    }
+}


### PR DESCRIPTION
## Context
1. The PR extracts the tracking recent edits in a seperate class, so the responsibility of tracking changes and creating a diff hunks context are seperated.
2. Build on top of https://github.com/sourcegraph/cody/pull/6381
3. This class will be reused in autoedits to filter bad completion prediction (particularly: when model predicts to undo the most recent changes made by the user)

## Test plan
no functional change 
