### PR TITLE
feat(onebox): Collect more telemetry

### DIFF
--- a/vscode/src/telemetry/onebox.ts
+++ b/vscode/src/telemetry/onebox.ts
@@ -1,0 +1,12 @@
+export const TELEMETRY_INTENT = {
+    CHAT: 1,
+    SEARCH: 2,
+}
+
+export const TELEMETRY_SEARCH_FILTER = {
+    UNKNOWN: 1,
+    REPO: 2,
+    LANGUAGE: 3,
+    FILE: 4,
+    TYPE: 5,
+}

--- a/vscode/webviews/chat/Transcript.tsx
+++ b/vscode/webviews/chat/Transcript.tsx
@@ -49,6 +49,7 @@ import {
 import { HumanMessageCell } from './cells/messageCell/human/HumanMessageCell'
 
 import { type Context, type Span, context, trace } from '@opentelemetry/api'
+import { TELEMETRY_INTENT } from '../../src/telemetry/onebox'
 import { SwitchIntent } from './cells/messageCell/assistant/SwitchIntent'
 import { LastEditorContext } from './context'
 
@@ -514,12 +515,15 @@ const TranscriptInteraction: FC<TranscriptInteractionProps> = memo(props => {
                 onEditSubmit(intent)
                 telemetryRecorder.recordEvent('onebox.intentCorrection', 'clicked', {
                     metadata: {
-                        recordsPrivateMetadataTranscript: 1,
+                        initialIntent:
+                            humanMessage.intent === 'search'
+                                ? TELEMETRY_INTENT.SEARCH
+                                : TELEMETRY_INTENT.CHAT,
+                        selectedIntent:
+                            intent === 'search' ? TELEMETRY_INTENT.SEARCH : TELEMETRY_INTENT.CHAT,
                     },
                     privateMetadata: {
-                        initialIntent: humanMessage.intent,
-                        userSpecifiedIntent: intent,
-                        promptText: editorState.text,
+                        query: editorState.text,
                     },
                 })
             }

--- a/vscode/webviews/chat/cells/messageCell/assistant/SearchFilters.tsx
+++ b/vscode/webviews/chat/cells/messageCell/assistant/SearchFilters.tsx
@@ -4,6 +4,8 @@ import type { NLSSearchDynamicFilter, NLSSearchDynamicFilterKind } from '@source
 import { uniqBy } from 'lodash'
 import { XIcon } from 'lucide-react'
 import { useCallback, useMemo } from 'react'
+import { TELEMETRY_SEARCH_FILTER } from '../../../../../src/telemetry/onebox'
+import { useTelemetryRecorder } from '../../../../utils/telemetry'
 import styles from './SearchFilters.module.css'
 export interface SearchFiltersProps {
     filters: NLSSearchDynamicFilter[]
@@ -15,6 +17,7 @@ export const SearchFilters = ({
     selectedFilters,
     onSelectedFiltersUpdate,
 }: SearchFiltersProps) => {
+    const telemetryRecorder = useTelemetryRecorder()
     const filterGroups = useMemo(() => {
         const fields: string[] = [
             'repo',
@@ -40,9 +43,16 @@ export const SearchFilters = ({
 
     const onFilterSelect = useCallback(
         (filter: NLSSearchDynamicFilter) => {
+            telemetryRecorder.recordEvent('onebox.filter', 'clicked', {
+                metadata: {
+                    filterType: getTelemetryFilterType(filter),
+                },
+                privateMetadata: { value: filter.value },
+                billingMetadata: { product: 'cody', category: 'billable' },
+            })
             onSelectedFiltersUpdate([...selectedFilters, filter])
         },
-        [selectedFilters, onSelectedFiltersUpdate]
+        [selectedFilters, onSelectedFiltersUpdate, telemetryRecorder]
     )
     const onFilterDeselect = useCallback(
         (filter: NLSSearchDynamicFilter) => {
@@ -130,3 +140,18 @@ const SearchFilter = ({
 
 const isFilterEqual = (a: NLSSearchDynamicFilter, b: NLSSearchDynamicFilter) =>
     a.kind === b.kind && a.value === b.value
+
+function getTelemetryFilterType(filter: NLSSearchDynamicFilter): number {
+    switch (filter.kind) {
+        case 'lang':
+            return TELEMETRY_SEARCH_FILTER.LANGUAGE
+        case 'type':
+            return TELEMETRY_SEARCH_FILTER.TYPE
+        case 'repo':
+            return TELEMETRY_SEARCH_FILTER.REPO
+        case 'file':
+            return TELEMETRY_SEARCH_FILTER.FILE
+        default:
+            return TELEMETRY_SEARCH_FILTER.UNKNOWN
+    }
+}

--- a/vscode/webviews/chat/cells/messageCell/assistant/SearchFilters.tsx
+++ b/vscode/webviews/chat/cells/messageCell/assistant/SearchFilters.tsx
@@ -48,7 +48,6 @@ export const SearchFilters = ({
                     filterType: getTelemetryFilterType(filter),
                 },
                 privateMetadata: { value: filter.value },
-                billingMetadata: { product: 'cody', category: 'billable' },
             })
             onSelectedFiltersUpdate([...selectedFilters, filter])
         },

--- a/vscode/webviews/chat/cells/messageCell/assistant/SearchResults.tsx
+++ b/vscode/webviews/chat/cells/messageCell/assistant/SearchResults.tsx
@@ -127,7 +127,6 @@ export const SearchResults = ({
                 selected ? 'individualSelected' : 'individualDeselected',
                 {
                     metadata: { resultRank: totalResults.indexOf(result) },
-                    billingMetadata: { product: 'cody', category: 'billable' },
                 }
             )
             updateSelectedFollowUpResults({
@@ -145,9 +144,7 @@ export const SearchResults = ({
                 selectedFilters={message.search.selectedFilters || []}
                 onSelectedFiltersUpdate={onSelectedFiltersUpdate}
                 close={() => {
-                    telemetryRecorder.recordEvent('onebox.filterModal', 'closed', {
-                        billingMetadata: { product: 'cody', category: 'billable' },
-                    })
+                    telemetryRecorder.recordEvent('onebox.filterModal', 'closed')
                     setShowFiltersModal(false)
                 }}
             />
@@ -155,9 +152,7 @@ export const SearchResults = ({
     }
 
     const onFilterSidebarClose = useCallback(() => {
-        telemetryRecorder.recordEvent('onebox.filterSidebar', 'closed', {
-            billingMetadata: { product: 'cody', category: 'billable' },
-        })
+        telemetryRecorder.recordEvent('onebox.filterSidebar', 'closed')
         setShowFiltersSidebar(false)
     }, [telemetryRecorder])
 
@@ -215,13 +210,7 @@ export const SearchResults = ({
                                             onClick={() => {
                                                 telemetryRecorder.recordEvent(
                                                     'onebox.filterModal',
-                                                    'opened',
-                                                    {
-                                                        billingMetadata: {
-                                                            product: 'cody',
-                                                            category: 'billable',
-                                                        },
-                                                    }
+                                                    'opened'
                                                 )
                                                 setShowFiltersModal(true)
                                                 setShowFiltersSidebar(true)
@@ -241,13 +230,7 @@ export const SearchResults = ({
                                                 setShowFiltersSidebar(open => {
                                                     telemetryRecorder.recordEvent(
                                                         'onebox.filterSidebar',
-                                                        open ? 'closed' : 'opened',
-                                                        {
-                                                            billingMetadata: {
-                                                                product: 'cody',
-                                                                category: 'billable',
-                                                            },
-                                                        }
+                                                        open ? 'closed' : 'opened'
                                                     )
                                                     return !open
                                                 })
@@ -276,13 +259,7 @@ export const SearchResults = ({
 
                                             telemetryRecorder.recordEvent(
                                                 'onebox.results',
-                                                checked ? 'selectAll' : 'deselectAll',
-                                                {
-                                                    billingMetadata: {
-                                                        product: 'cody',
-                                                        category: 'billable',
-                                                    },
-                                                }
+                                                checked ? 'selectAll' : 'deselectAll'
                                             )
 
                                             if (checked) {
@@ -351,10 +328,6 @@ export const SearchResults = ({
                                                         resultsAdded:
                                                             totalResults.length - resultsToShow.length,
                                                     },
-                                                    billingMetadata: {
-                                                        product: 'cody',
-                                                        category: 'billable',
-                                                    },
                                                 }
                                             )
                                             setShowAll(true)
@@ -383,10 +356,6 @@ export const SearchResults = ({
                                     metadata: {
                                         totalResults: totalResults.length,
                                         resultsAdded: totalResults.length - resultsToShow.length,
-                                    },
-                                    billingMetadata: {
-                                        product: 'cody',
-                                        category: 'billable',
                                     },
                                 })
                             }}

--- a/vscode/webviews/chat/cells/messageCell/assistant/SearchResults.tsx
+++ b/vscode/webviews/chat/cells/messageCell/assistant/SearchResults.tsx
@@ -154,6 +154,13 @@ export const SearchResults = ({
         )
     }
 
+    const onFilterSidebarClose = useCallback(() => {
+        telemetryRecorder.recordEvent('onebox.filterSidebar', 'closed', {
+            billingMetadata: { product: 'cody', category: 'billable' },
+        })
+        setShowFiltersSidebar(false)
+    }, [telemetryRecorder])
+
     return (
         <div
             className={classNames(
@@ -170,8 +177,8 @@ export const SearchResults = ({
                 >
                     <div
                         className="tw-absolute tw-top-2 tw-right-2"
-                        onClick={() => setShowFiltersSidebar(false)}
-                        onKeyDown={() => setShowFiltersSidebar(false)}
+                        onClick={onFilterSidebarClose}
+                        onKeyDown={onFilterSidebarClose}
                         role="button"
                     >
                         <PanelLeftClose className="tw-size-8" />
@@ -233,7 +240,7 @@ export const SearchResults = ({
                                             onClick={() => {
                                                 setShowFiltersSidebar(open => {
                                                     telemetryRecorder.recordEvent(
-                                                        'onebox.filterModal',
+                                                        'onebox.filterSidebar',
                                                         open ? 'closed' : 'opened',
                                                         {
                                                             billingMetadata: {


### PR DESCRIPTION
Part of https://linear.app/sourcegraph/issue/SRCH-1455/one-box-telemetry

Adds or updates the following events:

- onebox.intentCorrection:clicked
- oneBox.moreResults:clicked
- onebox.resultContext:selectAll
- onebox.resultContext:deselectAll
- onebox.resultContext:individualSelected
- onebox.resultContext:individualSelected
- onebox.filterModal:opened|closed
- onebox.filter:clicked

TODO:

- onebox.query:executed
- onebox.manualSearch:toggled
- onebox.searchResult:clicked

## Test plan

n/a