### PR TITLE
autoedits disable shrink suffix logic

### DIFF
--- a/vscode/src/autoedits/autoedits-provider.ts
+++ b/vscode/src/autoedits/autoedits-provider.ts
@@ -39,7 +39,7 @@ import {
     extractAutoEditResponseFromCurrentDocumentCommentTemplate,
     shrinkReplacerTextToCodeToReplaceRange,
 } from './renderer/renderer-testing'
-import { shrinkPredictionUntilSuffix } from './shrink-prediction'
+// import { shrinkPredictionUntilSuffix } from './shrink-prediction'
 
 const AUTOEDITS_CONTEXT_STRATEGY = 'auto-edits'
 const INLINE_COMPLETION_DEFAULT_DEBOUNCE_INTERVAL_MS = 150
@@ -219,8 +219,8 @@ export class AutoeditsProvider implements vscode.InlineCompletionItemProvider, v
             return null
         }
 
-        let { prediction, codeToReplaceData } = autoeditResponse
-        prediction = shrinkPredictionUntilSuffix(prediction, codeToReplaceData)
+        const { prediction, codeToReplaceData } = autoeditResponse
+        // prediction = shrinkPredictionUntilSuffix(prediction, codeToReplaceData)
 
         if (prediction === codeToReplaceData.codeToRewrite) {
             return null


### PR DESCRIPTION
Disable the shrinking logic causing frequent adding of prefix after the prediction.
[Slack thread for the Issue](https://sourcegraph.slack.com/archives/C07F8LLKE06/p1734437161597439) 

## Test plan
no functional change 
