### PR TITLE
fix(audoedit): do not render removal decorations twice

### DIFF
--- a/vscode/src/autoedits/renderer/decorators/inline-diff-decorator.ts
+++ b/vscode/src/autoedits/renderer/decorators/inline-diff-decorator.ts
@@ -76,12 +76,6 @@ export class InlineDiffDecorator implements vscode.Disposable, AutoEditsDecorato
                 currentInsertPosition = null
                 currentInsertText = ''
             }
-
-            // Apply removed changes for this line
-            if (removed.length > 0) {
-                this.editor.setDecorations(this.removedTextDecorationType, removed)
-                removed.length = 0
-            }
         }
 
         return { added, removed }


### PR DESCRIPTION
- Fixes the regression from https://github.com/sourcegraph/cody/pull/6359 which made removal decorations invisible.

## Test plan

1. Add `"cody.experimental.autoedits.renderer": "inline"` to your VS Code settings
2. Try examples from the cody-chat-eval repo which cause text removal and ensure that respective decorations are present.