### PR TITLE
fix(omnibox): Hide header labels in narrow chat

### DIFF
--- a/vscode/webviews/chat/cells/messageCell/assistant/SearchResults.module.css
+++ b/vscode/webviews/chat/cells/messageCell/assistant/SearchResults.module.css
@@ -33,3 +33,17 @@
 .filters-sidebar {
     background-color: var(--vscode-input-background);
 }
+
+.search-results-header {
+    container-type: inline-size;
+    container-name: search-results-header
+}
+
+/*
+    Hide labels for small containers
+*/
+@container search-results-header (width < 475px) {
+    .search-results-header__label {
+        display: none;
+    }
+}

--- a/vscode/webviews/chat/cells/messageCell/assistant/SearchResults.tsx
+++ b/vscode/webviews/chat/cells/messageCell/assistant/SearchResults.tsx
@@ -178,7 +178,12 @@ export const SearchResults = ({
                     })}
                 >
                     {!!resultsToShow && (
-                        <div className="tw-flex tw-items-center tw-gap-4 tw-justify-between">
+                        <div
+                            className={classNames(
+                                'tw-flex tw-items-center tw-gap-4 tw-justify-between',
+                                styles.searchResultsHeader
+                            )}
+                        >
                             <div className="tw-flex tw-gap-2 tw-items-center tw-font-semibold tw-text-muted-foreground">
                                 <Search className="tw-size-8 tw-flex-shrink-0" />
                                 Displaying {resultsToShow.length} code search results
@@ -199,7 +204,9 @@ export const SearchResults = ({
                                             ) : (
                                                 <FilterIcon className="tw-size-8" />
                                             )}
-                                            Filters
+                                            <span className={styles.searchResultsHeaderLabel}>
+                                                Filters
+                                            </span>
                                         </Button>
                                         <Button
                                             onClick={() => {
@@ -213,12 +220,19 @@ export const SearchResults = ({
                                             ) : (
                                                 <FilterIcon className="tw-size-8" />
                                             )}
-                                            Filters
+                                            <span className={styles.searchResultsHeaderLabel}>
+                                                Filters
+                                            </span>
                                         </Button>
                                     </>
                                 )}
                                 <div className="tw-flex tw-items-center tw-gap-4">
-                                    <Label htmlFor="search-results.select-all">Add to context:</Label>
+                                    <Label
+                                        htmlFor="search-results.select-all"
+                                        className={styles.searchResultsHeaderLabel}
+                                    >
+                                        Add to context:
+                                    </Label>
                                     <input
                                         type="checkbox"
                                         id="search-results.select-all"


### PR DESCRIPTION
This commit hides the 'Filters' and 'Add to context' lables when the
chat window is narrow.

Closes https://linear.app/sourcegraph/issue/SRCH-1481/remove-labels-from-the-search-results-header-on-small-screens

## Test plan

Manual testing.

![2024-12-18_11-39](https://github.com/user-attachments/assets/fb002a21-3535-491f-983c-6f490d6a1a19)
