### PR TITLE
fix(audoedit): fix renderer testing command

### DIFF
--- a/vscode/src/autoedits/renderer/renderer-testing.ts
+++ b/vscode/src/autoedits/renderer/renderer-testing.ts
@@ -108,8 +108,12 @@ export function registerAutoEditTestRenderCommand(): vscode.Disposable {
         }
 
         const replacerText = ret.replacer.text
-        const replaceStartOffset = ret.replacer.startOffset
-        const replaceEndOffset = ret.replacer.endOffset
+        const replaceStartOffset = text.indexOf(ret.initial.text, ret.replacer.endOffset)
+        if (replaceStartOffset === -1) {
+            console.error('Could not find replacement text')
+            return
+        }
+        const replaceEndOffset = replaceStartOffset + ret.initial.text.length
 
         const replaceStartLine = editor.document.positionAt(replaceStartOffset).line
         const replaceEndLine = editor.document.positionAt(replaceEndOffset).line


### PR DESCRIPTION
- Fixes the default renderer testing command

## Test plan

Use `ctrl + alt + enter` in the `code-chat-eval` renderer-testing examples.