### PR TITLE
fix diff rendering for autoedits

### DIFF
--- a/vscode/src/autoedits/renderer/decorators/default-decorator.ts
+++ b/vscode/src/autoedits/renderer/decorators/default-decorator.ts
@@ -144,16 +144,19 @@ export class DefaultDecorator implements AutoEditsDecorator {
         const lineNumbers = addedLinesInfo.map(d => d.afterLine)
         const min = Math.min(...lineNumbers)
         const max = Math.max(...lineNumbers)
-        for (const unchangedLine of unchangedLines) {
-            const lineNumber = unchangedLine.modifiedLineNumber
-            if (lineNumber < min || lineNumber > max) {
+        const addedLineNumbers = new Set(addedLinesInfo.map(d => d.afterLine))
+
+        for (const line of [...unchangedLines, ...modifiedLines]) {
+            const lineNumber = line.modifiedLineNumber
+            if (lineNumber < min || lineNumber > max || addedLineNumbers.has(lineNumber)) {
                 continue
             }
             addedLinesInfo.push({
                 ranges: [],
                 afterLine: lineNumber,
-                lineText: unchangedLine.text,
+                lineText: 'newText' in line ? line.newText : line.text,
             })
+            addedLineNumbers.add(lineNumber)
         }
         // Sort addedLinesInfo by line number in ascending order
         addedLinesInfo.sort((a, b) => a.afterLine - b.afterLine)

--- a/vscode/src/autoedits/renderer/decorators/default-decorator.ts
+++ b/vscode/src/autoedits/renderer/decorators/default-decorator.ts
@@ -107,7 +107,7 @@ export class DefaultDecorator implements AutoEditsDecorator {
             const addedRanges: [number, number][] = []
             for (const change of changes) {
                 if (change.type === 'delete') {
-                    removedRanges.push(change.modifiedRange)
+                    removedRanges.push(change.originalRange)
                 } else if (change.type === 'insert') {
                     addedRanges.push([
                         change.modifiedRange.start.character,
@@ -154,7 +154,7 @@ export class DefaultDecorator implements AutoEditsDecorator {
             addedLinesInfo.push({
                 ranges: [],
                 afterLine: lineNumber,
-                lineText: 'newText' in line ? line.newText : line.text,
+                lineText: line.type === 'modified' ? line.newText : line.text,
             })
             addedLineNumbers.add(lineNumber)
         }
@@ -254,7 +254,7 @@ export class DefaultDecorator implements AutoEditsDecorator {
             .filter(change => change.type === 'insert')
             .map(change => {
                 return {
-                    range: change.modifiedRange,
+                    range: change.originalRange,
                     renderOptions: {
                         before: {
                             contentText: change.text,


### PR DESCRIPTION
Fixing some regressions in the rendering:
1. Fix a case for the auto-edits diff view rendering.
2. The diff view did not color the red decorations correctly because of incorrect ranges.
3. Fix ghost text rendering ranges

## Test plan

1. Press `ctrl + alt + enter`
2. See the [recent-edit example](https://github.com/sourcegraph/cody-chat-eval/blob/main/code-matching-eval/edits_experiments/examples/renderer-testing-examples/recent-edit.ts) in the cody-chat-eval repo.
Before:
<img width="1438" alt="image" src="https://github.com/user-attachments/assets/6381d59d-5246-4af7-875e-3532a9da234b" />
After:
<img width="919" alt="image" src="https://github.com/user-attachments/assets/a805ed88-e6d5-464a-a8a6-b03666be13ef" />

4. See the [example](https://github.com/sourcegraph/cody-chat-eval/blob/main/code-matching-eval/edits_experiments/examples/renderer-testing-examples/olaf-example-autoedits.ts) in cody-chat-eval repo:
Before (See the inconsistent insertion point for the second ghost text in lines):
<img width="1080" alt="image" src="https://github.com/user-attachments/assets/9c590ee2-24b0-4f46-a820-3897679efdec" />

After:
<img width="1098" alt="image" src="https://github.com/user-attachments/assets/7e77f394-109a-4937-b793-f1aecaf2fb9d" />
 