### PR TITLE
fix: Notice styling updates

### DIFF
--- a/vscode/webviews/components/Notices.tsx
+++ b/vscode/webviews/components/Notices.tsx
@@ -342,7 +342,7 @@ const MarkdownNotice: FunctionComponent<MarkdownNotice> = props => {
 
     return (
         <div
-            className="tw-bg-popover tw-ml-2 tw-mr-2 tw-border tw-border-border tw-relative tw-rounded-lg tw-flex tw-flex-col tw-gap-2 tw-pt-4 tw-pb-6 tw-px-6"
+            className="tw-bg-popover tw-my-2 tw-mx-2 tw-border tw-border-border tw-relative tw-rounded-lg tw-flex tw-flex-col tw-gap-2 tw-pt-4 tw-pb-6 tw-px-6"
             data-markdown-notice=""
         >
             {title && (

--- a/vscode/webviews/components/Notices.tsx
+++ b/vscode/webviews/components/Notices.tsx
@@ -342,11 +342,11 @@ const MarkdownNotice: FunctionComponent<MarkdownNotice> = props => {
 
     return (
         <div
-            className="tw-bg-subtle tw-ml-2 tw-mr-2 tw-border tw-border-border tw-relative tw-rounded-lg tw-flex tw-flex-col tw-gap-2 tw-pt-4 tw-pb-6 tw-px-6"
+            className="tw-bg-popover tw-ml-2 tw-mr-2 tw-border tw-border-border tw-relative tw-rounded-lg tw-flex tw-flex-col tw-gap-2 tw-pt-4 tw-pb-6 tw-px-6"
             data-markdown-notice=""
         >
             {title && (
-                <h1 className="tw-text-md tw-font-semibold tw-text-title tw-flex tw-flex-row tw-items-center tw-gap-3 tw-mt-1 tw-mb-2">
+                <h1 className="tw-text-md tw-font-semibold tw-text-title tw-flex tw-flex-row tw-items-center tw-gap-3 tw-my-1">
                     {title}
                 </h1>
             )}

--- a/vscode/webviews/components/Notices.tsx
+++ b/vscode/webviews/components/Notices.tsx
@@ -362,6 +362,20 @@ const MarkdownNotice: FunctionComponent<MarkdownNotice> = props => {
                 </p>
             </div>
 
+            <div className="tw-flex flex-row tw-gap-6 tw-mt-1 tw-mb-3">
+                <Button variant="outline" onClick={onDismiss} size="sm">
+                    OK, thanks!
+                </Button>
+                <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => window.open('https://docs.sourcegraph.com', '_blank')}
+                >
+                    Explore docs
+                    <ExternalLinkIcon size="14" className="tw-text-muted-foreground tw-ml-1" />
+                </Button>{' '}
+            </div>
+
             <Button variant="ghost" onClick={onDismiss} className="tw-absolute tw-top-2 tw-right-2">
                 <XIcon size="14" />
             </Button>

--- a/vscode/webviews/components/Notices.tsx
+++ b/vscode/webviews/components/Notices.tsx
@@ -346,8 +346,7 @@ const MarkdownNotice: FunctionComponent<MarkdownNotice> = props => {
             data-markdown-notice=""
         >
             {title && (
-                <h1 className="tw-text-md tw-font-semibold tw-text-title tw-flex tw-flex-row tw-items-center tw-gap-3 tw-my-2">
-                    <img src={SourcegraphIcon} alt="Sourcegraph Logo" className="tw-h-[16px]" />
+                <h1 className="tw-text-md tw-font-semibold tw-text-title tw-flex tw-flex-row tw-items-center tw-gap-3 tw-mt-1 tw-mb-2">
                     {title}
                 </h1>
             )}

--- a/vscode/webviews/components/Notices.tsx
+++ b/vscode/webviews/components/Notices.tsx
@@ -342,7 +342,7 @@ const MarkdownNotice: FunctionComponent<MarkdownNotice> = props => {
 
     return (
         <div
-            className="tw-bg-subtle tw-ml-2 tw-mr-2 tw-border tw-border-border tw-relative tw-rounded-lg tw-flex tw-flex-col tw-gap-2 tw-py-4 tw-px-6"
+            className="tw-bg-subtle tw-ml-2 tw-mr-2 tw-border tw-border-border tw-relative tw-rounded-lg tw-flex tw-flex-col tw-gap-2 tw-pt-4 tw-pb-6 tw-px-6"
             data-markdown-notice=""
         >
             {title && (
@@ -353,21 +353,7 @@ const MarkdownNotice: FunctionComponent<MarkdownNotice> = props => {
 
             <MarkdownFromCody className="tw-text-subtle tw-leading-tight">{message}</MarkdownFromCody>
 
-            <div className="tw-flex flex-row tw-gap-6 tw-my-4">
-                <Button variant="outline" onClick={onDismiss} size="sm">
-                    OK, thanks!
-                </Button>
-                <Button
-                    variant="ghost"
-                    size="sm"
-                    onClick={() => window.open('https://docs.sourcegraph.com', '_blank')}
-                >
-                    Explore docs
-                    <ExternalLinkIcon size="14" className="tw-text-muted-foreground tw-ml-1" />
-                </Button>{' '}
-            </div>
-
-            <Button variant="ghost" onClick={onDismiss} className="tw-absolute tw-top-2 tw-right-2">
+            <Button variant="ghost" onClick={onDismiss} className="tw-absolute tw-top-3 tw-right-2">
                 <XIcon size="14" />
             </Button>
         </div>

--- a/vscode/webviews/components/Notices.tsx
+++ b/vscode/webviews/components/Notices.tsx
@@ -8,6 +8,7 @@ import {
     ExternalLinkIcon,
     EyeIcon,
     HeartIcon,
+    InfoIcon,
     Users2Icon,
     XIcon,
 } from 'lucide-react'
@@ -216,7 +217,7 @@ export const Notices: React.FC<NoticesProps> = ({ user, isTeamsUpgradeCtaEnabled
     }
 
     return (
-        <div className="tw-flex tw-flex-col tw-mx-4 tw-my-2 tw-p-4 tw-gap-2">{activeNotice.content}</div>
+        <div className="tw-flex tw-flex-col tw-mx-2 tw-my-2 tw-p-2 tw-gap-2">{activeNotice.content}</div>
     )
 }
 
@@ -342,12 +343,38 @@ const MarkdownNotice: FunctionComponent<MarkdownNotice> = props => {
 
     return (
         <div
-            className="tw-bg-accent tw-bg-opacity-50 tw--ml-2 tw--mr-2 tw-border tw-border-border tw-relative tw-rounded-md tw-flex tw-flex-col tw-gap-2 tw-p-4"
+            className="tw-bg-subtle tw-ml-2 tw-mr-2 tw-border tw-border-border tw-relative tw-rounded-lg tw-flex tw-flex-col tw-gap-2 tw-py-4 tw-px-6"
             data-markdown-notice=""
         >
-            {title && <h1 className="tw-text-lg tw-font-semibold">{title}</h1>}
+            {title && (
+                <h1 className="tw-text-md tw-font-semibold tw-text-title tw-flex tw-flex-row tw-items-center tw-gap-3 tw-my-2">
+                    <img src={SourcegraphIcon} alt="Sourcegraph Logo" className="tw-h-[16px]" />
+                    {title}
+                </h1>
+            )}
 
-            <MarkdownFromCody>{message}</MarkdownFromCody>
+            <MarkdownFromCody className="tw-text-subtle tw-leading-tight">{message}</MarkdownFromCody>
+
+            <div className="tw-bg-popover tw-my-4 tw-p-3 tw-rounded-lg tw-flex tw-flex-row tw-gap-3">
+                <InfoIcon size="16" className="tw-m-1 tw-text-subtle" />
+                <p className="tw-text-subtle tw-text-sm">
+                    Always review and verify answers or code generated. Mistakes are possible with AI.{' '}
+                </p>
+            </div>
+
+            <div className="tw-flex flex-row tw-gap-6 tw-my-1">
+                <Button variant="outline" onClick={onDismiss} size="sm">
+                    OK, thanks!
+                </Button>
+                <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => window.open('https://docs.sourcegraph.com/cody', '_blank')}
+                >
+                    Explore docs
+                    <ExternalLinkIcon size="14" className="tw-text-muted-foreground" />
+                </Button>{' '}
+            </div>
 
             <Button variant="ghost" onClick={onDismiss} className="tw-absolute tw-top-2 tw-right-2">
                 <XIcon size="14" />

--- a/vscode/webviews/components/Notices.tsx
+++ b/vscode/webviews/components/Notices.tsx
@@ -356,24 +356,10 @@ const MarkdownNotice: FunctionComponent<MarkdownNotice> = props => {
             <MarkdownFromCody className="tw-text-subtle tw-leading-tight">{message}</MarkdownFromCody>
 
             <div className="tw-bg-popover tw-my-4 tw-p-3 tw-rounded-lg tw-flex tw-flex-row tw-gap-3">
-                <InfoIcon size="16" className="tw-m-1 tw-text-subtle" />
+                <InfoIcon size="14" className="tw-m-1 tw-text-subtle" />
                 <p className="tw-text-subtle tw-text-sm">
                     Always review and verify answers or code generated. Mistakes are possible with AI.{' '}
                 </p>
-            </div>
-
-            <div className="tw-flex flex-row tw-gap-6 tw-my-1">
-                <Button variant="outline" onClick={onDismiss} size="sm">
-                    OK, thanks!
-                </Button>
-                <Button
-                    variant="ghost"
-                    size="sm"
-                    onClick={() => window.open('https://docs.sourcegraph.com/cody', '_blank')}
-                >
-                    Explore docs
-                    <ExternalLinkIcon size="14" className="tw-text-muted-foreground" />
-                </Button>{' '}
             </div>
 
             <Button variant="ghost" onClick={onDismiss} className="tw-absolute tw-top-2 tw-right-2">

--- a/vscode/webviews/components/Notices.tsx
+++ b/vscode/webviews/components/Notices.tsx
@@ -8,7 +8,6 @@ import {
     ExternalLinkIcon,
     EyeIcon,
     HeartIcon,
-    InfoIcon,
     Users2Icon,
     XIcon,
 } from 'lucide-react'
@@ -355,14 +354,7 @@ const MarkdownNotice: FunctionComponent<MarkdownNotice> = props => {
 
             <MarkdownFromCody className="tw-text-subtle tw-leading-tight">{message}</MarkdownFromCody>
 
-            <div className="tw-bg-popover tw-my-4 tw-p-3 tw-rounded-lg tw-flex tw-flex-row tw-gap-3">
-                <InfoIcon size="14" className="tw-m-1 tw-text-subtle" />
-                <p className="tw-text-subtle tw-text-sm">
-                    Always review and verify answers or code generated. Mistakes are possible with AI.{' '}
-                </p>
-            </div>
-
-            <div className="tw-flex flex-row tw-gap-6 tw-mt-1 tw-mb-3">
+            <div className="tw-flex flex-row tw-gap-6 tw-my-4">
                 <Button variant="outline" onClick={onDismiss} size="sm">
                     OK, thanks!
                 </Button>


### PR DESCRIPTION
This PR updates visual styling and adds a disclaimer to the notice banner.

### Before
![CleanShot 2024-12-18 at 13 52 20@2x](https://github.com/user-attachments/assets/a0231a5e-32d4-4063-9cab-a93f824c3f81)

### After
![CleanShot 2024-12-18 at 14 32 15@2x](https://github.com/user-attachments/assets/196c9dba-343a-4a5e-a82a-6ee7915982e6)


## Test plan

Manually tested, locally.
