### PR TITLE
fix/accounts: Do not prefill the dotcom URL in the Enterprise login field

### DIFF
--- a/vscode/webviews/AuthPage.tsx
+++ b/vscode/webviews/AuthPage.tsx
@@ -1,4 +1,10 @@
-import type { AuthStatus, CodyIDE, TelemetryRecorder } from '@sourcegraph/cody-shared'
+import {
+    type AuthStatus,
+    type CodyIDE,
+    DOTCOM_URL,
+    type TelemetryRecorder,
+    isDotCom,
+} from '@sourcegraph/cody-shared'
 
 import signInLogoSourcegraph from '../resources/sourcegraph-mark.svg'
 import { type AuthMethod, isSourcegraphToken } from '../src/chat/protocol'
@@ -352,11 +358,16 @@ const ClientSignInForm: React.FC<ClientSignInFormProps> = memo(
                 <Form onSubmit={onSubmit}>
                     <FormField name="endpoint" className="tw-m-2">
                         <FormLabel title="Sourcegraph Instance URL" />
+                        {formState.formData.endpoint} is dot com?{' '}
+                        {isDotCom(formState.formData.endpoint) ? 'YES' : 'NO'}, dotcom is
+                        {DOTCOM_URL.toString()} / ${DOTCOM_URL.origin}
                         <FormControl
                             type="url"
                             name="endpoint"
                             placeholder="Example: https://instance.sourcegraph.com"
-                            value={formState.formData.endpoint}
+                            value={
+                                isDotCom(formState.formData.endpoint) ? '' : formState.formData.endpoint
+                            }
                             className="tw-w-full tw-my-2 !tw-p-4"
                             required
                             onChange={handleInputChange}

--- a/vscode/webviews/AuthPage.tsx
+++ b/vscode/webviews/AuthPage.tsx
@@ -1,7 +1,6 @@
 import {
     type AuthStatus,
     type CodyIDE,
-    DOTCOM_URL,
     type TelemetryRecorder,
     isDotCom,
 } from '@sourcegraph/cody-shared'
@@ -358,9 +357,6 @@ const ClientSignInForm: React.FC<ClientSignInFormProps> = memo(
                 <Form onSubmit={onSubmit}>
                     <FormField name="endpoint" className="tw-m-2">
                         <FormLabel title="Sourcegraph Instance URL" />
-                        {formState.formData.endpoint} is dot com?{' '}
-                        {isDotCom(formState.formData.endpoint) ? 'YES' : 'NO'}, dotcom is
-                        {DOTCOM_URL.toString()} / ${DOTCOM_URL.origin}
                         <FormControl
                             type="url"
                             name="endpoint"

--- a/vscode/webviews/AuthPage.tsx
+++ b/vscode/webviews/AuthPage.tsx
@@ -291,7 +291,7 @@ const ClientSignInForm: React.FC<ClientSignInFormProps> = memo(
             isSubmitting: false,
             showAuthError: false,
             formData: {
-                endpoint: authStatus?.endpoint ?? '',
+                endpoint: authStatus && !isDotCom(authStatus) ? authStatus.endpoint : '',
                 accessToken: '',
             },
         })
@@ -361,9 +361,7 @@ const ClientSignInForm: React.FC<ClientSignInFormProps> = memo(
                             type="url"
                             name="endpoint"
                             placeholder="Example: https://instance.sourcegraph.com"
-                            value={
-                                isDotCom(formState.formData.endpoint) ? '' : formState.formData.endpoint
-                            }
+                            value={formState.formData.endpoint}
                             className="tw-w-full tw-my-2 !tw-p-4"
                             required
                             onChange={handleInputChange}


### PR DESCRIPTION
When you last logged into dot com, we pre-fill the enterprise login URL with https://sourcegraph.com. This is contrary to our efforts to get Enterprise users to log into the right endpoint.

You can still log in to dot com using the handy enterprise login method/hack. We just won't prefill that URL.

Fixes CODY-4534.

## Test plan

1. Sign out of all your accounts.
2. Sign in to dotcom. This works with social login buttons or signing into https://sourcegraph.com as an "Enterprise" URL.
3. Go to https://sourcegraph.com/user/settings/tokens and delete the token you are using.
4. Reload VSCode, or wait for it to log you out.
5. Go to sign in to an enterprise account. Verify that the URL field has a placeholder like https://instance. and NOT https://sourcegraph.com
6. Sign in to s2.
7. Go to https://sourcegraph.sourcegraph.com/user/settings/tokens and delete the token you are using.
8. Reload VSCode, or wait for it to log you out.
9. Go to sign in to an enterprise account. Verify that the URL field is prefilled with https://sourcegraph.sourcegraph.com
10. Run a new instance of VSCode with `--user-data-dir=/tmp/foo --profile-temp` to simulate a fresh install.
11. Go to sign in to an enterprise account. Verify that the URL field has a placeholder like https://instance. and NOT https://sourcegraph.com 

Note, if you sign out (cmd-shift-p Cody: Sign Out) etc. then the field is *not* prefilled, we delete the record of that account. It is new installs, or when accounts are left over from expired tokens, that you get the prefilling.

Note: This is not easily e2e testable because Cody Web has fixed the dotcom override URL in the vite config, which is a compile-time static. To make this testable we would need to configure the dotcom override URL as the webview boots up. This is a big job because DOTCOM_URL is a module-level constant, etc.