### PR TITLE
fix(modelSelectField): missing overflow scrollbar when there isn't space to show entire list

### DIFF
--- a/vscode/webviews/components/modelSelectField/ModelSelectField.module.css
+++ b/vscode/webviews/components/modelSelectField/ModelSelectField.module.css
@@ -1,3 +1,7 @@
+.chat-model-popover {
+    max-height: var(--radix-popper-available-height);
+}
+
 .model-title-with-icon {
     flex: 1;
     display: flex;

--- a/vscode/webviews/components/modelSelectField/ModelSelectField.tsx
+++ b/vscode/webviews/components/modelSelectField/ModelSelectField.tsx
@@ -183,7 +183,7 @@ export const ModelSelectField: React.FunctionComponent<{
                     loop={true}
                     defaultValue={value}
                     tabIndex={0}
-                    className="focus:tw-outline-none"
+                    className={`focus:tw-outline-none ${styles.chatModelPopover}`}
                     data-testid="chat-model-popover"
                 >
                     <CommandList


### PR DESCRIPTION
Fixes #6097 Chat model selector not showing all options
Check out https://www.youtube.com/watch?v=4LYRRSzbh_Q for the before and after effects of this fix
both in vscode and in storybook

## Test plan
Start storybook and notice that enterprise option is not visible before this fix
http://localhost:6007/?path=/story/cody-chat--empty
here's before:
![storybook-before](https://github.com/user-attachments/assets/0c8337bd-6982-4433-90e1-b9f846623bc4)
and after:
![storybook-after](https://github.com/user-attachments/assets/b3b70f68-c59b-4e27-ab5d-13f0cba9b7a8)


<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

## Changelog
fix(modelSelectField): missing overflow scrollbar when there isn't space to show entire list
<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
