### PR TITLE
chore(onebox/telemetry): add `billingMetadata` 

### DIFF
--- a/vscode/webviews/chat/Transcript.tsx
+++ b/vscode/webviews/chat/Transcript.tsx
@@ -525,6 +525,7 @@ const TranscriptInteraction: FC<TranscriptInteractionProps> = memo(props => {
                     privateMetadata: {
                         query: editorState.text,
                     },
+                    billingMetadata: { product: 'cody', category: 'billable' },
                 })
             }
         },

--- a/vscode/webviews/chat/cells/messageCell/assistant/SearchFilters.tsx
+++ b/vscode/webviews/chat/cells/messageCell/assistant/SearchFilters.tsx
@@ -48,6 +48,7 @@ export const SearchFilters = ({
                     filterType: getTelemetryFilterType(filter),
                 },
                 privateMetadata: { value: filter.value },
+                billingMetadata: { product: 'cody', category: 'billable' },
             })
             onSelectedFiltersUpdate([...selectedFilters, filter])
         },

--- a/vscode/webviews/chat/cells/messageCell/assistant/SearchResults.tsx
+++ b/vscode/webviews/chat/cells/messageCell/assistant/SearchResults.tsx
@@ -127,6 +127,7 @@ export const SearchResults = ({
                 selected ? 'individualSelected' : 'individualDeselected',
                 {
                     metadata: { resultRank: totalResults.indexOf(result) },
+                    billingMetadata: { product: 'cody', category: 'billable' },
                 }
             )
             updateSelectedFollowUpResults({
@@ -144,7 +145,9 @@ export const SearchResults = ({
                 selectedFilters={message.search.selectedFilters || []}
                 onSelectedFiltersUpdate={onSelectedFiltersUpdate}
                 close={() => {
-                    telemetryRecorder.recordEvent('onebox.filterModal', 'closed')
+                    telemetryRecorder.recordEvent('onebox.filterModal', 'closed', {
+                        billingMetadata: { product: 'cody', category: 'billable' },
+                    })
                     setShowFiltersModal(false)
                 }}
             />
@@ -216,7 +219,13 @@ export const SearchResults = ({
                                                 onClick={() => {
                                                     telemetryRecorder.recordEvent(
                                                         'onebox.filterModal',
-                                                        'opened'
+                                                        'opened',
+                                                        {
+                                                            billingMetadata: {
+                                                                product: 'cody',
+                                                                category: 'billable',
+                                                            },
+                                                        }
                                                     )
                                                     setShowFiltersModal(true)
                                                     setShowFiltersSidebar(true)
@@ -238,7 +247,13 @@ export const SearchResults = ({
                                                     setShowFiltersSidebar(open => {
                                                         telemetryRecorder.recordEvent(
                                                             'onebox.filterSidebar',
-                                                            open ? 'closed' : 'opened'
+                                                            open ? 'closed' : 'opened',
+                                                            {
+                                                                billingMetadata: {
+                                                                    product: 'cody',
+                                                                    category: 'billable',
+                                                                },
+                                                            }
                                                         )
                                                         return !open
                                                     })
@@ -276,7 +291,13 @@ export const SearchResults = ({
 
                                                 telemetryRecorder.recordEvent(
                                                     'onebox.results',
-                                                    checked ? 'selectAll' : 'deselectAll'
+                                                    checked ? 'selectAll' : 'deselectAll',
+                                                    {
+                                                        billingMetadata: {
+                                                            product: 'cody',
+                                                            category: 'billable',
+                                                        },
+                                                    }
                                                 )
 
                                                 if (checked) {
@@ -351,6 +372,10 @@ export const SearchResults = ({
                                                                 totalResults.length -
                                                                 resultsToShow.length,
                                                         },
+                                                        billingMetadata: {
+                                                            product: 'cody',
+                                                            category: 'billable',
+                                                        },
                                                     }
                                                 )
                                                 setShowAll(true)
@@ -380,6 +405,7 @@ export const SearchResults = ({
                                             totalResults: totalResults.length,
                                             resultsAdded: totalResults.length - resultsToShow.length,
                                         },
+                                        billingMetadata: { product: 'cody', category: 'core' },
                                     })
                                 }}
                             >


### PR DESCRIPTION
This PR adds `billingMetadata` to the onebox telemetry events. As listed in [this linear ticket](https://linear.app/sourcegraph/issue/SRCH-1455/one-box-telemetry) all onebox telemetry events are billable, with the exception of `onebox.codeSearch`/`clicked` which is a core event.


## Test plan
CI
<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
