### PR TITLE
fix: Prevent style leaks in cody web

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,14 +82,6 @@
       "tslib": "2.1.0",
       "@lexical/react": "https://storage.googleapis.com/sourcegraph-assets/npm/lexical-react-sourcegraph-fork-31065486.tgz"
     },
-    "packageExtensions": {
-      "@vscode/webview-ui-toolkit": {
-        "dependencies": {
-          "@microsoft/fast-web-utilities": "^6.0.0",
-          "tslib": "^2.1.0"
-        }
-      }
-    },
     "neverBuiltDependencies": ["deasync", "playwright"],
     "patchedDependencies": {
       "highlight.js@11.8.0": "patches/highlight.js@11.8.0.patch"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,6 @@ overrides:
   tslib: 2.1.0
   '@lexical/react': https://storage.googleapis.com/sourcegraph-assets/npm/lexical-react-sourcegraph-fork-31065486.tgz
 
-packageExtensionsChecksum: bc809394d179d8460f9d473fc54e379a
-
 patchedDependencies:
   highlight.js@11.8.0:
     hash: bzyroljkef3byfhzbomid6liny
@@ -556,9 +554,6 @@ importers:
       '@vscode/codicons':
         specifier: ^0.0.35
         version: 0.0.35
-      '@vscode/webview-ui-toolkit':
-        specifier: ^1.2.2
-        version: 1.2.2(react@18.2.0)
       agent-base:
         specifier: ^7.1.1
         version: 7.1.1
@@ -3495,41 +3490,6 @@ packages:
       '@types/react': 18.2.79
       react: 18.3.1
     dev: true
-
-  /@microsoft/fast-element@1.13.0:
-    resolution: {integrity: sha512-iFhzKbbD0cFRo9cEzLS3Tdo9BYuatdxmCEKCpZs1Cro/93zNMpZ/Y9/Z7SknmW6fhDZbpBvtO8lLh9TFEcNVAQ==}
-    dev: false
-
-  /@microsoft/fast-foundation@2.49.6:
-    resolution: {integrity: sha512-DZVr+J/NIoskFC1Y6xnAowrMkdbf2d5o7UyWK6gW5AiQ6S386Ql8dw4KcC4kHaeE1yL2CKvweE79cj6ZhJhTvA==}
-    dependencies:
-      '@microsoft/fast-element': 1.13.0
-      '@microsoft/fast-web-utilities': 5.4.1
-      tabbable: 5.3.3
-      tslib: 2.1.0
-    dev: false
-
-  /@microsoft/fast-react-wrapper@0.1.48(react@18.2.0):
-    resolution: {integrity: sha512-9NvEjru9Kn5ZKjomAMX6v+eF0DR+eDkxKDwDfi+Wb73kTbrNzcnmlwd4diN15ygH97kldgj2+lpvI4CKLQQWLg==}
-    peerDependencies:
-      react: '>=16.9.0'
-    dependencies:
-      '@microsoft/fast-element': 1.13.0
-      '@microsoft/fast-foundation': 2.49.6
-      react: 18.2.0
-    dev: false
-
-  /@microsoft/fast-web-utilities@5.4.1:
-    resolution: {integrity: sha512-ReWYncndjV3c8D8iq9tp7NcFNc1vbVHvcBFPME2nNFKNbS1XCesYZGlIlf3ot5EmuOXPlrzUHOWzQ2vFpIkqDg==}
-    dependencies:
-      exenv-es6: 1.1.1
-    dev: false
-
-  /@microsoft/fast-web-utilities@6.0.0:
-    resolution: {integrity: sha512-ckCA4Xn91ja1Qz+jhGGL1Q3ZeuRpA5VvYcRA7GzA1NP545sl14bwz3tbHCq8jIk+PL7mkSaIveGMYuJB2L4Izg==}
-    dependencies:
-      exenv-es6: 1.1.1
-    dev: false
 
   /@microsoft/fetch-event-source@2.0.1:
     resolution: {integrity: sha512-W6CLUJ2eBMw3Rec70qrsEW0jOm/3twwJv21mrmj2yORiaVmVYGS4sSS5yUwvQc1ZlDLYGPnClVWmUUMagKNsfA==}
@@ -7316,19 +7276,6 @@ packages:
       keytar: 7.9.0
     dev: true
 
-  /@vscode/webview-ui-toolkit@1.2.2(react@18.2.0):
-    resolution: {integrity: sha512-xIQoF4FC3Xh6d7KNKIoIezSiFWYFuf6gQMdDyKueKBFGeKwaHWEn+dY2g3makvvEsNMEDji/woEwvg9QSbuUsw==}
-    peerDependencies:
-      react: '>=16.9.0'
-    dependencies:
-      '@microsoft/fast-element': 1.13.0
-      '@microsoft/fast-foundation': 2.49.6
-      '@microsoft/fast-react-wrapper': 0.1.48(react@18.2.0)
-      '@microsoft/fast-web-utilities': 6.0.0
-      react: 18.2.0
-      tslib: 2.1.0
-    dev: false
-
   /@xmldom/xmldom@0.7.13:
     resolution: {integrity: sha512-lm2GW5PkosIzccsaZIz7tp8cPADSIlIHWDFTR1N0SzfinhhYgeIQjFMz4rYzanCScr3DqQLeomUDArp6MWKm+g==}
     engines: {node: '>=10.0.0'}
@@ -9716,10 +9663,6 @@ packages:
       signal-exit: 4.1.0
       strip-final-newline: 3.0.0
     dev: true
-
-  /exenv-es6@1.1.1:
-    resolution: {integrity: sha512-vlVu3N8d6yEMpMsEm+7sUBAI81aqYYuEvfK0jNqmdb/OPXzzH7QWDDnVjMvDSY47JdHEqx/dfC/q8WkfoTmpGQ==}
-    dev: false
 
   /expand-brackets@2.1.4:
     resolution: {integrity: sha512-w/ozOKR9Obk3qoWeY/WDi6MFta9AoMR+zud60mdnbniMcBxRuFJyDt2LdX/14A1UABeqk+Uk+LDfUpvoGKppZA==}
@@ -15933,10 +15876,6 @@ packages:
       better-path-resolve: 1.0.0
       rename-overwrite: 6.0.0
     dev: true
-
-  /tabbable@5.3.3:
-    resolution: {integrity: sha512-QD9qKY3StfbZqWOPLp0++pOrAVb/HbUi5xCc8cUo4XjP19808oaMiDzn0leBY5mCespIBM0CIZePzZjgzR83kA==}
-    dev: false
 
   /table@6.8.2:
     resolution: {integrity: sha512-w2sfv80nrAh2VCbqR5AK27wswXhqcck2AhfnNW76beQXskGZ1V12GwS//yYVa3d3fcvAip2OUnbDAjW2k3v9fA==}

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -1448,7 +1448,6 @@
     "@types/react": "18.2.79",
     "@types/react-dom": "18.2.25",
     "@vscode/codicons": "^0.0.35",
-    "@vscode/webview-ui-toolkit": "^1.2.2",
     "agent-base": "^7.1.1",
     "async-mutex": "^0.4.0",
     "axios": "^1.3.6",

--- a/vscode/webviews/chat/ErrorItem.tsx
+++ b/vscode/webviews/chat/ErrorItem.tsx
@@ -5,7 +5,7 @@ import { type ChatError, RateLimitError } from '@sourcegraph/cody-shared'
 import type { UserAccountInfo } from '../Chat'
 import type { ApiPostMessage } from '../Chat'
 
-import { VSCodeButton } from '@vscode/webview-ui-toolkit/react'
+import { Button } from '../components/shadcn/ui/button'
 import { createWebviewTelemetryRecorder } from '../utils/telemetry'
 import styles from './ErrorItem.module.css'
 
@@ -104,25 +104,20 @@ const RateLimitErrorItem: React.FunctionComponent<{
                 </header>
                 <div className={styles.actions}>
                     {canUpgrade && (
-                        <VSCodeButton
-                            onClick={() => onButtonClick('upgrade', 'upgrade')}
-                            appearance="primary"
-                        >
-                            Upgrade
-                        </VSCodeButton>
+                        <Button onClick={() => onButtonClick('upgrade', 'upgrade')}>Upgrade</Button>
                     )}
                     {error.feature !== 'Deep Cody' && (
-                        <VSCodeButton
+                        <Button
                             type="button"
                             onClick={() =>
                                 canUpgrade
                                     ? onButtonClick('upgrade', 'upgrade')
                                     : onButtonClick('rate-limits', 'learn-more')
                             }
-                            appearance="secondary"
+                            variant="secondary"
                         >
                             {canUpgrade ? 'See Plans →' : 'Learn More'}
-                        </VSCodeButton>
+                        </Button>
                     )}
                 </div>
                 {error.retryMessage && <p className={styles.retryMessage}>{error.retryMessage}</p>}

--- a/vscode/webviews/chat/Transcript.test.tsx
+++ b/vscode/webviews/chat/Transcript.test.tsx
@@ -26,11 +26,6 @@ const PROPS: Omit<ComponentProps<typeof Transcript>, 'transcript'> = {
     setActiveChatContext: () => {},
 }
 
-vi.mock('@vscode/webview-ui-toolkit/react', () => ({
-    VSCodeButton: vi.fn(),
-    VSCodeCheckbox: vi.fn(),
-}))
-
 vi.mock('../utils/VSCodeApi', () => ({
     getVSCodeAPI: vi.fn().mockReturnValue({
         onMessage: () => {},

--- a/vscode/webviews/chat/cells/messageCell/human/editor/HumanMessageEditor.test.tsx
+++ b/vscode/webviews/chat/cells/messageCell/human/editor/HumanMessageEditor.test.tsx
@@ -10,11 +10,6 @@ import { AppWrapperForTest } from '../../../../../AppWrapperForTest'
 import { FIXTURE_USER_ACCOUNT_INFO } from '../../../../fixtures'
 import { HumanMessageEditor } from './HumanMessageEditor'
 
-vi.mock('@vscode/webview-ui-toolkit/react', () => ({
-    VSCodeButton: vi.fn(),
-    VSCodeCheckbox: vi.fn(),
-}))
-
 const MOCK_MODELS = getMockedDotComClientModels()
 
 const ENTER_KEYBOARD_EVENT_DATA: Pick<KeyboardEvent, 'key' | 'code' | 'keyCode'> = {

--- a/vscode/webviews/chat/components/FeedbackButtons.tsx
+++ b/vscode/webviews/chat/components/FeedbackButtons.tsx
@@ -1,7 +1,7 @@
-import { VSCodeButton, VSCodeLink } from '@vscode/webview-ui-toolkit/react'
 import { clsx } from 'clsx'
 import { useCallback, useState } from 'react'
 import { CODY_FEEDBACK_URL } from '../../../src/chat/protocol'
+import { Button } from '../../components/shadcn/ui/button'
 import styles from './FeedbackButtons.module.css'
 
 interface FeedbackButtonsProps {
@@ -28,57 +28,59 @@ export const FeedbackButtons: React.FunctionComponent<FeedbackButtonsProps> = ({
         <div className={clsx(styles.feedbackButtons, className)}>
             {!feedbackSubmitted && (
                 <>
-                    <VSCodeButton
+                    <Button
                         className={clsx('tw-text-muted-foreground', styles.feedbackButton)}
-                        appearance="icon"
+                        variant="ghostRoundedIcon"
                         type="button"
                         onClick={() => onFeedbackBtnSubmit('thumbsUp')}
                         tabIndex={-1}
                     >
                         <i className="codicon codicon-thumbsup" />
-                    </VSCodeButton>
-                    <VSCodeButton
+                    </Button>
+                    <Button
                         className={clsx('tw-text-muted-foreground', styles.feedbackButton)}
-                        appearance="icon"
+                        variant="ghostRoundedIcon"
                         type="button"
                         onClick={() => onFeedbackBtnSubmit('thumbsDown')}
                         tabIndex={-1}
                     >
                         <i className="codicon codicon-thumbsdown" />
-                    </VSCodeButton>
+                    </Button>
                 </>
             )}
             {feedbackSubmitted === 'thumbsUp' && (
-                <VSCodeButton
+                <Button
                     className={clsx(styles.feedbackButton)}
-                    appearance="icon"
+                    variant="ghostRoundedIcon"
                     type="button"
                     disabled={true}
                     title="Thanks for your feedback"
                 >
                     <i className="codicon codicon-thumbsup" />
                     <i className="codicon codicon-check" />
-                </VSCodeButton>
+                </Button>
             )}
             {feedbackSubmitted === 'thumbsDown' && (
                 <span className={styles.thumbsDownFeedbackContainer}>
-                    <VSCodeButton
+                    <Button
                         className={clsx(styles.feedbackButton)}
-                        appearance="icon"
+                        variant="ghostRoundedIcon"
                         type="button"
                         disabled={true}
                         title="Thanks for your feedback"
                     >
                         <i className="codicon codicon-thumbsdown" />
                         <i className="codicon codicon-check" />
-                    </VSCodeButton>
-                    <VSCodeLink
+                    </Button>
+                    <a
                         href={String(CODY_FEEDBACK_URL)}
                         target="_blank"
                         title="Help improve Cody by providing more feedback about the quality of this response"
+                        className="tw-text-link hover:tw-underline"
+                        rel="noreferrer"
                     >
                         Give Feedback
-                    </VSCodeLink>
+                    </a>
                 </span>
             )}
         </div>

--- a/vscode/webviews/testSetup.ts
+++ b/vscode/webviews/testSetup.ts
@@ -1,15 +1,6 @@
 import '@testing-library/jest-dom/vitest'
 import { cleanup } from '@testing-library/react'
-import { afterEach, vi } from 'vitest'
-
-vi.mock(
-    '@vscode/webview-ui-toolkit/react',
-    () =>
-        ({
-            VSCodeButton: 'VSCodeButton',
-            VSCodeBadge: 'VSCodeBadge',
-        }) satisfies Partial<Record<keyof typeof import('@vscode/webview-ui-toolkit/react'), string>>
-)
+import { afterEach } from 'vitest'
 
 class MockIntersectionObserver {
     observe() {}


### PR DESCRIPTION
This was an interesting issue to debug: In the Sourcegraph web app we have a CSS variable `--input-height`. We noticed that when cody was open, this variable was set to a different value. But nowhere in the Cody codebase to we set this value explictly.

In turns out that `@vscode/webview-ui-toolkit` constructs a stylesheet programmatically and sets a couple of global CSS variables:

![2024-12-19_22-21](https://github.com/user-attachments/assets/5a539310-46ba-4cdd-a74e-57c32eda517b)


We only use components from this library in two places and they can easily be replaced by our own components, thus avoiding this problem altogether.

NOTE: We'll have to cut a new cody web release for this to fix the web app issue.

## Test plan

Manual testing by running the web demo. I verified that the CSS variables are not created anymore and inspected the updated UI, which is slightly different (e.g. hover effects of buttons) but probably acceptable.