### PR TITLE
fix: remove trailing spaces from extracted query

### DIFF
--- a/lib/shared/src/lexicalEditor/editorState.ts
+++ b/lib/shared/src/lexicalEditor/editorState.ts
@@ -203,7 +203,7 @@ export function inputTextWithoutContextChipsFromPromptEditorState(
 ): string {
     state = filterLexicalNodes(state, node => !isSerializedContextItemMentionNode(node))
 
-    return textContentFromSerializedLexicalNode(state.lexicalEditorState.root).trimStart()
+    return textContentFromSerializedLexicalNode(state.lexicalEditorState.root).trim()
 }
 
 // maps mentions to placeholders for intent detection


### PR DESCRIPTION
When we remove the mentions, for some reason we're trimming spaces from the start, but not the end. This means our exact match heuristics won't work as well for these situations because there's a rogue space at the end of the query.

This just fixes the logic to trim spaces from both the start and end

## Test plan

This query used to give less relevant results because we kept the trailing space:
![CleanShot 2024-12-20 at 10 53 31@2x](https://github.com/user-attachments/assets/f49246ee-99cf-47b2-835a-34505ab7ac5d)
