### PR TITLE
Adding agentVersion  clientPlatform to OpenTelemetryService

### DIFF
--- a/vscode/src/services/open-telemetry/OpenTelemetryService.node.ts
+++ b/vscode/src/services/open-telemetry/OpenTelemetryService.node.ts
@@ -5,10 +5,10 @@ import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node'
 import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions'
 
 import {
-    type CodyIDE,
     FeatureFlag,
     type ResolvedConfiguration,
     type Unsubscribable,
+    clientCapabilities,
     combineLatest,
     featureFlagProvider,
     resolvedConfig,
@@ -73,16 +73,16 @@ export class OpenTelemetryService {
                 [SemanticResourceAttributes.SERVICE_VERSION]: version,
             }),
         })
-
         // Add the default tracer exporter used in production.
+
         this.tracerProvider.addSpanProcessor(
             new BatchSpanProcessor(
                 new CodyTraceExporter({
                     traceUrl,
                     isTracingEnabled: this.isTracingEnabled,
                     accessToken: auth.accessToken,
-                    clientPlatform: configuration.agentIDE ?? ('defaultIDE' as CodyIDE),
-                    agentVersion: configuration.agentExtensionVersion,
+                    clientPlatform: clientCapabilities().agentIDE,
+                    agentVersion: clientCapabilities().agentExtensionVersion,
                 })
             )
         )

--- a/vscode/src/services/open-telemetry/OpenTelemetryService.node.ts
+++ b/vscode/src/services/open-telemetry/OpenTelemetryService.node.ts
@@ -5,6 +5,7 @@ import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node'
 import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions'
 
 import {
+    type CodyIDE,
     FeatureFlag,
     type ResolvedConfiguration,
     type Unsubscribable,
@@ -80,6 +81,8 @@ export class OpenTelemetryService {
                     traceUrl,
                     isTracingEnabled: this.isTracingEnabled,
                     accessToken: auth.accessToken,
+                    clientPlatform: configuration.agentIDE ?? ('defaultIDE' as CodyIDE),
+                    agentVersion: configuration.agentExtensionVersion,
                 })
             )
         )


### PR DESCRIPTION
We have agent version and ClientPlatform in OpenTelemetryService

## Test plan
Tested locally with an otel collector
<img width="587" alt="image" src="https://github.com/user-attachments/assets/82dcaaff-9f61-4196-9cdd-27c4a3f3a731" />


<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
