### PR TITLE
include symbol matches in search results

### DIFF
--- a/vscode/webviews/chat/cells/messageCell/assistant/SearchResults.tsx
+++ b/vscode/webviews/chat/cells/messageCell/assistant/SearchResults.tsx
@@ -66,7 +66,9 @@ export const SearchResults = ({
     const totalResults = useMemo(
         () =>
             message.search.response?.results.results.filter(
-                result => result.__typename === 'FileMatch' && result.chunkMatches?.length
+                result =>
+                    result.__typename === 'FileMatch' &&
+                    (result.chunkMatches?.length || result.symbols?.length)
             ) || [],
         [message.search.response]
     )


### PR DESCRIPTION
fixes: https://sourcegraph.slack.com/archives/C07EQBRSF35/p1734729091939879

## Test plan

- Perform `SchemeTokenSudo @sourcegraph/sourcegraph` interaction with Cody.
- That should return into results including the `SchemeTokenSudo` symbol match. 

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
