### PR TITLE
Enable repo boost for inactive editor

### DIFF
--- a/vscode/src/chat/chat-view/ChatController.ts
+++ b/vscode/src/chat/chat-view/ChatController.ts
@@ -1029,7 +1029,8 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
         this.chatBuilder.setLastMessageIntent('search')
         const scopes: string[] = await this.getSearchScopesFromMentions(mentions)
 
-        const currentFile = getEditor()?.active?.document?.uri
+        const workspaceRoot = vscode.workspace.workspaceFolders?.[0]?.uri
+        const currentFile = getEditor()?.active?.document?.uri || workspaceRoot
         const repoName = currentFile ? await getFirstRepoNameContainingUri(currentFile) : undefined
         const boostParameter = repoName ? `boost:repo(${repoName})` : ''
 


### PR DESCRIPTION
closes: https://linear.app/sourcegraph/issue/SRCH-1491/get-current-repository-without-a-file-being-open

This PR uses the workspace root folder as a fallback when the active editor is null.

## Test plan
- execute search without mentioning a repo while no file from the repo is opened.
<img width="2056" alt="Screenshot 2024-12-23 at 3 40 35 PM" src="https://github.com/user-attachments/assets/9f94fd51-2d02-458a-8f8b-86d0d26bf04a" />
<img width="2056" alt="Screenshot 2024-12-23 at 3 47 17 PM" src="https://github.com/user-attachments/assets/d96ce460-1bcc-4488-8167-d92edd3a8f6f" />


## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
