### PR TITLE
track notebook for auto-edits

### DIFF
--- a/lib/shared/src/completions/types.ts
+++ b/lib/shared/src/completions/types.ts
@@ -17,6 +17,7 @@ interface AutocompleteContextSnippetMetadata {
 }
 
 export interface AutocompleteBaseContextSnippet {
+    type: 'base'
     identifier: string
     uri: URI
     content: string
@@ -28,14 +29,17 @@ export interface AutocompleteBaseContextSnippet {
     metadata?: AutocompleteContextSnippetMetadata
 }
 
-export interface AutocompleteFileContextSnippet extends AutocompleteBaseContextSnippet {
+export interface AutocompleteFileContextSnippet extends Omit<AutocompleteBaseContextSnippet, 'type'> {
+    type: 'file'
     startLine: number
     endLine: number
 }
 
-export interface AutocompleteSymbolContextSnippet extends AutocompleteFileContextSnippet {
+export interface AutocompleteSymbolContextSnippet extends Omit<AutocompleteFileContextSnippet, 'type'> {
+    type: 'symbol'
     symbol: string
 }
+
 export type AutocompleteContextSnippet =
     | AutocompleteFileContextSnippet
     | AutocompleteSymbolContextSnippet

--- a/lib/shared/src/completions/types.ts
+++ b/lib/shared/src/completions/types.ts
@@ -19,8 +19,8 @@ interface AutocompleteContextSnippetMetadata {
 export interface AutocompleteFileContextSnippet {
     identifier: string
     uri: URI
-    startLine: number
-    endLine: number
+    startLine?: number
+    endLine?: number
     content: string
     /**
      * Metadata populated by the context retriever.

--- a/lib/shared/src/completions/types.ts
+++ b/lib/shared/src/completions/types.ts
@@ -16,11 +16,9 @@ interface AutocompleteContextSnippetMetadata {
     retrieverMetadata?: AutocompleteContextSnippetMetadataFields
 }
 
-export interface AutocompleteFileContextSnippet {
+export interface AutocompleteBaseContextSnippet {
     identifier: string
     uri: URI
-    startLine?: number
-    endLine?: number
     content: string
     /**
      * Metadata populated by the context retriever.
@@ -30,12 +28,18 @@ export interface AutocompleteFileContextSnippet {
     metadata?: AutocompleteContextSnippetMetadata
 }
 
+export interface AutocompleteFileContextSnippet extends AutocompleteBaseContextSnippet {
+    startLine: number
+    endLine: number
+}
+
 export interface AutocompleteSymbolContextSnippet extends AutocompleteFileContextSnippet {
     symbol: string
 }
 export type AutocompleteContextSnippet =
     | AutocompleteFileContextSnippet
     | AutocompleteSymbolContextSnippet
+    | AutocompleteBaseContextSnippet
 
 export interface DocumentContext extends DocumentDependentContext, LinesContext {
     position: vscode.Position

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -9,5 +9,5 @@ function buildAgentForTests() {
 }
 
 export default function setup() {
-    buildAgentForTests()
+    // buildAgentForTests()
 }

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -9,5 +9,5 @@ function buildAgentForTests() {
 }
 
 export default function setup() {
-    // buildAgentForTests()
+    buildAgentForTests()
 }

--- a/vscode/src/autoedits/prompt/default-prompt-strategy.test.ts
+++ b/vscode/src/autoedits/prompt/default-prompt-strategy.test.ts
@@ -17,6 +17,7 @@ describe('DefaultUserPromptStrategy', () => {
         identifier: string,
         filePath = 'foo.ts'
     ): AutocompleteContextSnippet => ({
+        type: 'file',
         content,
         identifier,
         uri: testFileUri(filePath),

--- a/vscode/src/autoedits/prompt/prompt-utils.test.ts
+++ b/vscode/src/autoedits/prompt/prompt-utils.test.ts
@@ -464,6 +464,7 @@ describe('getCurrentFileContext', () => {
 
 describe('getContextItemsInTokenBudget', () => {
     const getContextItem = (content: string, identifier: string): AutocompleteContextSnippet => ({
+        type: 'file',
         content,
         identifier,
         uri: testFileUri('foo.ts'),
@@ -537,6 +538,7 @@ describe('getLintErrorsPrompt', () => {
         identifier: string,
         fileName = 'foo.ts'
     ): AutocompleteContextSnippet => ({
+        type: 'file',
         content,
         identifier,
         uri: testFileUri(fileName),
@@ -615,6 +617,7 @@ describe('getRecentCopyPrompt', () => {
         identifier: string,
         fileName = 'foo.ts'
     ): AutocompleteContextSnippet => ({
+        type: 'file',
         content,
         identifier,
         uri: testFileUri(fileName),
@@ -673,6 +676,7 @@ describe('getRecentEditsPrompt', () => {
         identifier: string,
         fileName = 'foo.ts'
     ): AutocompleteContextSnippet => ({
+        type: 'file',
         content,
         identifier,
         uri: testFileUri(fileName),
@@ -755,6 +759,7 @@ describe('getRecentlyViewedSnippetsPrompt', () => {
         identifier: string,
         fileName = 'foo.ts'
     ): AutocompleteContextSnippet => ({
+        type: 'file',
         content,
         identifier,
         uri: testFileUri(fileName),
@@ -833,6 +838,7 @@ describe('getJaccardSimilarityPrompt', () => {
         identifier: string,
         fileName = 'foo.ts'
     ): AutocompleteContextSnippet => ({
+        type: 'file',
         content,
         identifier,
         uri: testFileUri(fileName),

--- a/vscode/src/autoedits/prompt/prompt-utils.test.ts
+++ b/vscode/src/autoedits/prompt/prompt-utils.test.ts
@@ -926,7 +926,7 @@ function mockActiveNotebookEditor(notebook: vscode.NotebookDocument | undefined)
     )
 }
 
-describe.only('getPrefixAndSuffixForAreaForNotebook', () => {
+describe('getPrefixAndSuffixForAreaForNotebook', () => {
     beforeEach(() => {
         // Clear all mocks before each test
         vi.restoreAllMocks()

--- a/vscode/src/autoedits/prompt/short-term-diff-prompt-strategy.test.ts
+++ b/vscode/src/autoedits/prompt/short-term-diff-prompt-strategy.test.ts
@@ -21,6 +21,7 @@ describe('ShortTermPromptStrategy', () => {
             identifier: string,
             filePath = 'foo.ts'
         ): AutocompleteContextSnippet => ({
+            type: 'file',
             content,
             identifier,
             uri: testFileUri(filePath),
@@ -385,6 +386,7 @@ describe('ShortTermPromptStrategy', () => {
             filePath = 'foo.ts',
             identifier: string = RetrieverIdentifier.RecentViewPortRetriever
         ): AutocompleteContextSnippet => ({
+            type: 'file',
             content,
             identifier,
             uri: testFileUri(filePath),
@@ -451,6 +453,7 @@ describe('ShortTermPromptStrategy', () => {
             filePath = 'foo.ts',
             identifier: string = RetrieverIdentifier.RecentEditsRetriever
         ): AutocompleteContextSnippet => ({
+            type: 'file',
             content,
             identifier,
             uri: testFileUri(filePath),

--- a/vscode/src/completions/analytics-logger.ts
+++ b/vscode/src/completions/analytics-logger.ts
@@ -11,6 +11,7 @@ import {
     isDotCom,
     isNetworkError,
     telemetryRecorder,
+    AutocompleteFileContextSnippet
 } from '@sourcegraph/cody-shared'
 import type { KnownString, TelemetryEventParameters } from '@sourcegraph/telemetry'
 
@@ -768,13 +769,13 @@ function getInlineContextItemContext(
         triggerLine: position.line,
         triggerCharacter: position.character,
         context: inlineContextParams.context.map(
-            ({ identifier, content, startLine, endLine, uri, metadata }) => ({
-                identifier,
-                content,
-                startLine,
-                endLine,
-                filePath: displayPathWithoutWorkspaceFolderPrefix(uri),
-                metadata,
+            snippet => ({
+                identifier: snippet.identifier,
+                content: snippet.content,
+                filePath: displayPathWithoutWorkspaceFolderPrefix(snippet.uri),
+                metadata: snippet.metadata,
+                startLine: typeof snippet === 'AutocompleteFileContextSnippet' ? snippet.startLine : undefined,
+                endLine: typeof snippet === 'AutocompleteFileContextSnippet' ? snippet.endLine : undefined,
             })
         ),
     }

--- a/vscode/src/completions/analytics-logger.ts
+++ b/vscode/src/completions/analytics-logger.ts
@@ -11,7 +11,6 @@ import {
     isDotCom,
     isNetworkError,
     telemetryRecorder,
-    AutocompleteFileContextSnippet
 } from '@sourcegraph/cody-shared'
 import type { KnownString, TelemetryEventParameters } from '@sourcegraph/telemetry'
 
@@ -768,16 +767,16 @@ function getInlineContextItemContext(
         suffix: docContext.completeSuffix.slice(0, MAX_PREFIX_SUFFIX_SIZE_BYTES),
         triggerLine: position.line,
         triggerCharacter: position.character,
-        context: inlineContextParams.context.map(
-            snippet => ({
-                identifier: snippet.identifier,
-                content: snippet.content,
-                filePath: displayPathWithoutWorkspaceFolderPrefix(snippet.uri),
-                metadata: snippet.metadata,
-                startLine: typeof snippet === 'AutocompleteFileContextSnippet' ? snippet.startLine : undefined,
-                endLine: typeof snippet === 'AutocompleteFileContextSnippet' ? snippet.endLine : undefined,
-            })
-        ),
+        context: inlineContextParams.context.map(snippet => ({
+            identifier: snippet.identifier,
+            content: snippet.content,
+            filePath: displayPathWithoutWorkspaceFolderPrefix(snippet.uri),
+            metadata: snippet.metadata,
+            ...(snippet.type !== 'base' && {
+                startLine: snippet.startLine,
+                endLine: snippet.endLine,
+            }),
+        })),
     }
 }
 function suggestionDocumentDiffTracker(

--- a/vscode/src/completions/analytics-logger.ts
+++ b/vscode/src/completions/analytics-logger.ts
@@ -71,8 +71,8 @@ interface InlineCompletionItemRetrievedContext {
     identifier: string
     content: string
     filePath: string
-    startLine: number
-    endLine: number
+    startLine?: number
+    endLine?: number
 }
 
 interface InlineContextItemsParams extends GitIdentifiersForFile {
@@ -779,7 +779,6 @@ function getInlineContextItemContext(
         ),
     }
 }
-
 function suggestionDocumentDiffTracker(
     interactionId: CompletionAnalyticsID,
     document: vscode.TextDocument,

--- a/vscode/src/completions/context/completions-context-ranker.test.ts
+++ b/vscode/src/completions/context/completions-context-ranker.test.ts
@@ -7,6 +7,7 @@ import type { RetrievedContextResults } from './completions-context-ranker'
 describe('DefaultCompletionsContextRanker', () => {
     describe('getContextSnippetsAsPerTimeBasedStrategy', () => {
         const getContextSnippet = (time?: number): AutocompleteContextSnippet => ({
+            type: 'file',
             identifier: 'test',
             uri: vscode.Uri.parse('file:///test'),
             startLine: 1,

--- a/vscode/src/completions/context/completions-context-ranker.ts
+++ b/vscode/src/completions/context/completions-context-ranker.ts
@@ -131,7 +131,7 @@ export class DefaultCompletionsContextRanker implements CompletionsContextRanker
         const fusedResults = fuseResults(
             results.map(r => r.snippets),
             result => {
-                if (result.startLine === undefined || result.endLine === undefined) {
+                if (result.type === 'base') {
                     return [result.uri.toString()]
                 }
                 const lineIds = []

--- a/vscode/src/completions/context/completions-context-ranker.ts
+++ b/vscode/src/completions/context/completions-context-ranker.ts
@@ -131,12 +131,9 @@ export class DefaultCompletionsContextRanker implements CompletionsContextRanker
         const fusedResults = fuseResults(
             results.map(r => r.snippets),
             result => {
-                // Ensure that context retrieved works when we do not have a startLine and
-                // endLine yet.
-                if (typeof result.startLine === 'undefined' || typeof result.endLine === 'undefined') {
+                if (result.startLine === undefined || result.endLine === undefined) {
                     return [result.uri.toString()]
                 }
-
                 const lineIds = []
                 for (let i = result.startLine; i <= result.endLine; i++) {
                     lineIds.push(`${result.uri.toString()}:${i}`)

--- a/vscode/src/completions/context/context-mixer.test.ts
+++ b/vscode/src/completions/context/context-mixer.test.ts
@@ -96,6 +96,7 @@ describe('ContextMixer', () => {
                 strategyFactory: createMockStrategy([
                     [
                         {
+                            type: 'file',
                             identifier: 'jaccard-similarity',
                             uri: testFileUri('foo.ts'),
                             content: 'function foo() {}',
@@ -103,6 +104,7 @@ describe('ContextMixer', () => {
                             endLine: 0,
                         },
                         {
+                            type: 'file',
                             identifier: 'jaccard-similarity',
                             uri: testFileUri('bar.ts'),
                             content: 'function bar() {}',
@@ -155,6 +157,7 @@ describe('ContextMixer', () => {
                 strategyFactory: createMockStrategy([
                     [
                         {
+                            type: 'file',
                             identifier: 'retriever1',
                             uri: testFileUri('foo.ts'),
                             content: 'function foo1() {}',
@@ -162,6 +165,7 @@ describe('ContextMixer', () => {
                             endLine: 0,
                         },
                         {
+                            type: 'file',
                             identifier: 'retriever1',
                             uri: testFileUri('bar.ts'),
                             content: 'function bar1() {}',
@@ -172,6 +176,7 @@ describe('ContextMixer', () => {
 
                     [
                         {
+                            type: 'file',
                             identifier: 'retriever2',
                             uri: testFileUri('foo.ts'),
                             content: 'function foo3() {}',
@@ -179,6 +184,7 @@ describe('ContextMixer', () => {
                             endLine: 10,
                         },
                         {
+                            type: 'file',
                             identifier: 'retriever2',
                             uri: testFileUri('foo.ts'),
                             content: 'function foo1() {}\nfunction foo2() {}',
@@ -186,6 +192,7 @@ describe('ContextMixer', () => {
                             endLine: 1,
                         },
                         {
+                            type: 'file',
                             identifier: 'retriever2',
                             uri: testFileUri('bar.ts'),
                             content: 'function bar1() {}\nfunction bar2() {}',
@@ -283,6 +290,7 @@ describe('ContextMixer', () => {
                     strategyFactory: createMockStrategy([
                         [
                             {
+                                type: 'file',
                                 identifier: 'retriever1',
                                 uri: testFileUri('foo.ts'),
                                 content: 'function foo1() {}',
@@ -290,6 +298,7 @@ describe('ContextMixer', () => {
                                 endLine: 0,
                             },
                             {
+                                type: 'file',
                                 identifier: 'retriever1',
                                 uri: testFileUri('foo/bar.ts'),
                                 content: 'function bar1() {}',
@@ -299,6 +308,7 @@ describe('ContextMixer', () => {
                         ],
                         [
                             {
+                                type: 'file',
                                 identifier: 'retriever2',
                                 uri: testFileUri('test/foo.ts'),
                                 content: 'function foo3() {}',
@@ -306,6 +316,7 @@ describe('ContextMixer', () => {
                                 endLine: 10,
                             },
                             {
+                                type: 'file',
                                 identifier: 'retriever2',
                                 uri: testFileUri('foo.ts'),
                                 content: 'function foo1() {}\nfunction foo2() {}',
@@ -313,6 +324,7 @@ describe('ContextMixer', () => {
                                 endLine: 1,
                             },
                             {
+                                type: 'file',
                                 identifier: 'retriever2',
                                 uri: testFileUri('example/bar.ts'),
                                 content: 'function bar1() {}\nfunction bar2() {}',

--- a/vscode/src/completions/context/context-mixer.test.ts
+++ b/vscode/src/completions/context/context-mixer.test.ts
@@ -123,6 +123,7 @@ describe('ContextMixer', () => {
                     identifier: 'jaccard-similarity',
                     startLine: 0,
                     endLine: 0,
+                    type: 'file',
                 },
                 {
                     fileName: 'bar.ts',
@@ -130,6 +131,7 @@ describe('ContextMixer', () => {
                     identifier: 'jaccard-similarity',
                     startLine: 0,
                     endLine: 0,
+                    type: 'file',
                 },
             ])
             expect(logSummary).toEqual({
@@ -216,6 +218,7 @@ describe('ContextMixer', () => {
                   "fileName": "foo.ts",
                   "identifier": "retriever1",
                   "startLine": 0,
+                  "type": "file",
                 },
                 {
                   "content": "function foo1() {}
@@ -224,6 +227,7 @@ describe('ContextMixer', () => {
                   "fileName": "foo.ts",
                   "identifier": "retriever2",
                   "startLine": 0,
+                  "type": "file",
                 },
                 {
                   "content": "function bar1() {}",
@@ -231,6 +235,7 @@ describe('ContextMixer', () => {
                   "fileName": "bar.ts",
                   "identifier": "retriever1",
                   "startLine": 0,
+                  "type": "file",
                 },
                 {
                   "content": "function bar1() {}
@@ -239,6 +244,7 @@ describe('ContextMixer', () => {
                   "fileName": "bar.ts",
                   "identifier": "retriever2",
                   "startLine": 0,
+                  "type": "file",
                 },
                 {
                   "content": "function foo3() {}",
@@ -246,6 +252,7 @@ describe('ContextMixer', () => {
                   "fileName": "foo.ts",
                   "identifier": "retriever2",
                   "startLine": 10,
+                  "type": "file",
                 },
               ]
             `)

--- a/vscode/src/completions/context/retrievers/jaccard-similarity/jaccard-similarity-retriever.ts
+++ b/vscode/src/completions/context/retrievers/jaccard-similarity/jaccard-similarity-retriever.ts
@@ -89,7 +89,7 @@ export class JaccardSimilarityRetriever extends CachedRetriever implements Conte
                     continue
                 }
 
-                matches.push({ ...match, uri })
+                matches.push({ type: 'file', uri, ...match })
             }
         }
 
@@ -245,6 +245,7 @@ export class JaccardSimilarityRetriever extends CachedRetriever implements Conte
 }
 
 interface JaccardMatchWithFilename extends JaccardMatch {
+    type: 'file'
     uri: URI
 }
 

--- a/vscode/src/completions/context/retrievers/recent-user-actions/diagnostics-retriever.test.ts
+++ b/vscode/src/completions/context/retrievers/recent-user-actions/diagnostics-retriever.test.ts
@@ -426,9 +426,15 @@ describe('DiagnosticsRetriever', () => {
                 diagnostics
             )
             expect(snippets).toHaveLength(3)
-            expect(snippets[0].startLine).toBe(9)
-            expect(snippets[1].startLine).toBe(13)
-            expect(snippets[2].startLine).toBe(5)
+            const expectedStartLines: number[] = [9, 13, 5]
+            for (const [index, snippet] of snippets.entries()) {
+                expect(snippet.type).toBe('file')
+                expect(snippet).toHaveProperty('startLine')
+                expect(snippet).toHaveProperty('endLine')
+                if (snippet.type === 'file') {
+                    expect(snippet.startLine).toBe(expectedStartLines[index])
+                }
+            }
         })
     })
 

--- a/vscode/src/completions/context/retrievers/recent-user-actions/diagnostics-retriever.ts
+++ b/vscode/src/completions/context/retrievers/recent-user-actions/diagnostics-retriever.ts
@@ -98,6 +98,7 @@ export class DiagnosticsRetriever implements vscode.Disposable, ContextRetriever
         )
         return Promise.all(
             diagnosticInfos.map(async info => ({
+                type: 'file',
                 identifier: this.identifier,
                 content: await this.getDiagnosticPromptMessage(info),
                 uri: document.uri,

--- a/vscode/src/completions/context/retrievers/recent-user-actions/notebook-utils.ts
+++ b/vscode/src/completions/context/retrievers/recent-user-actions/notebook-utils.ts
@@ -1,0 +1,46 @@
+import * as vscode from 'vscode'
+import { lines } from '../../../../completions/text-processing'
+import { getLanguageConfig } from '../../../../tree-sitter/language'
+
+export function getTextFromNotebookCells(
+    notebook: vscode.NotebookDocument,
+    cells: vscode.NotebookCell[]
+): string {
+    const orderedCells = cells.sort((a, b) => a.index - b.index)
+    const cellText: string[] = []
+    const languageId = getNotebookLanguageId(notebook)
+    for (const cell of orderedCells) {
+        const text = cell.document.getText()
+        if (text.trim().length === 0) {
+            continue
+        }
+        if (cell.kind === vscode.NotebookCellKind.Code) {
+            cellText.push(text)
+        } else if (cell.kind === vscode.NotebookCellKind.Markup) {
+            // Add the markdown content as a comment
+            cellText.push(getCellMarkupContent(languageId, text))
+        }
+    }
+    return cellText.join('\n\n')
+}
+
+export function getNotebookLanguageId(notebook: vscode.NotebookDocument): string {
+    const cells = notebook.getCells()
+    for (const cell of cells) {
+        if (cell.kind === vscode.NotebookCellKind.Code) {
+            return cell.document.languageId
+        }
+    }
+    return cells.length > 0 ? cells[0].document.languageId : ''
+}
+
+export function getCellMarkupContent(languageId: string, text: string): string {
+    if (text.trim().length === 0) {
+        return ''
+    }
+    const languageConfig = getLanguageConfig(languageId)
+    const commentStart = languageConfig ? languageConfig.commentStart : '// '
+    const contentLines = lines(text)
+    const markdownContent = contentLines.map(line => `${commentStart}${line}`).join('\n')
+    return markdownContent
+}

--- a/vscode/src/completions/context/retrievers/recent-user-actions/notebook-utils.ts
+++ b/vscode/src/completions/context/retrievers/recent-user-actions/notebook-utils.ts
@@ -46,3 +46,28 @@ export function getCellMarkupContent(languageId: string, text: PromptString): Pr
     const contentLines = text.split(newLineChar).map(line => ps`${commentStart}${line}`)
     return PromptString.join(contentLines, ps`\n`)
 }
+
+/**
+ * Returns the index of a notebook cell within the currently active notebook editor.
+ * Each cell in the notebook is treated as a seperate document, so this function
+ * can be used to find the index of a cell within the notebook.
+ * @param document The VS Code text document to find the index for
+ * @returns The zero-based index of the cell within the notebook cells, or -1 if not found or no active notebook
+ */
+export function getCellIndexInActiveNotebookEditor(document: vscode.TextDocument): number {
+    const activeNotebook = vscode.window.activeNotebookEditor?.notebook
+    if (!activeNotebook || document.uri.scheme !== 'vscode-notebook-cell') {
+        return -1
+    }
+    const notebookCells = getNotebookCells(activeNotebook)
+    const currentCellIndex = notebookCells.findIndex(cell => cell.document === document)
+    return currentCellIndex
+}
+
+export function getNotebookCells(notebook: vscode.NotebookDocument): vscode.NotebookCell[] {
+    return notebook.getCells().sort((a, b) => a.index - b.index)
+}
+
+export function getActiveNotebookUri(): vscode.Uri | undefined {
+    return vscode.window.activeNotebookEditor?.notebook.uri
+}

--- a/vscode/src/completions/context/retrievers/recent-user-actions/recent-copy.test.ts
+++ b/vscode/src/completions/context/retrievers/recent-user-actions/recent-copy.test.ts
@@ -85,6 +85,7 @@ describe('RecentCopyRetriever', () => {
 
         expect(snippets).toHaveLength(1)
         expect(snippets[0]).toEqual({
+            type: 'file',
             content: mockClipboardContent,
             uri: testDocument.uri,
             startLine: selection.start.line,

--- a/vscode/src/completions/context/retrievers/recent-user-actions/recent-copy.ts
+++ b/vscode/src/completions/context/retrievers/recent-user-actions/recent-copy.ts
@@ -42,6 +42,7 @@ export class RecentCopyRetriever implements vscode.Disposable, ContextRetriever 
         const selectionItem = this.getSelectionItemIfExist(clipboardContent)
         if (selectionItem) {
             const autocompleteItem: AutocompleteContextSnippet = {
+                type: 'file',
                 identifier: this.identifier,
                 content: selectionItem.content,
                 uri: selectionItem.uri,

--- a/vscode/src/completions/context/retrievers/recent-user-actions/recent-edits-retriever.ts
+++ b/vscode/src/completions/context/retrievers/recent-user-actions/recent-edits-retriever.ts
@@ -56,6 +56,7 @@ export class RecentEditsRetriever implements vscode.Disposable, ContextRetriever
         for (const diff of diffs) {
             const content = diff.diff.toString()
             const autocompleteSnippet: AutocompleteContextSnippet = {
+                type: 'base',
                 uri: diff.uri,
                 identifier: this.identifier,
                 content,

--- a/vscode/src/completions/context/retrievers/recent-user-actions/recent-edits-retriever.ts
+++ b/vscode/src/completions/context/retrievers/recent-user-actions/recent-edits-retriever.ts
@@ -55,7 +55,7 @@ export class RecentEditsRetriever implements vscode.Disposable, ContextRetriever
         const retrievalTriggerTime = Date.now()
         for (const diff of diffs) {
             const content = diff.diff.toString()
-            const autocompleteSnippet = {
+            const autocompleteSnippet: AutocompleteContextSnippet = {
                 uri: diff.uri,
                 identifier: this.identifier,
                 content,
@@ -63,12 +63,9 @@ export class RecentEditsRetriever implements vscode.Disposable, ContextRetriever
                     timeSinceActionMs: retrievalTriggerTime - diff.latestChangeTimestamp,
                     retrieverMetadata: diff.diffStrategyMetadata,
                 },
-            } satisfies Omit<AutocompleteContextSnippet, 'startLine' | 'endLine'>
+            }
             autocompleteContextSnippets.push(autocompleteSnippet)
         }
-        // remove the startLine and endLine from the response similar to how we did
-        // it for BFG.
-        // @ts-ignore
         return autocompleteContextSnippets
     }
 

--- a/vscode/src/completions/context/retrievers/recent-user-actions/recent-edits-tracker.ts
+++ b/vscode/src/completions/context/retrievers/recent-user-actions/recent-edits-tracker.ts
@@ -88,16 +88,15 @@ export class RecentEditsTracker implements vscode.Disposable {
     }
 
     private trackDocument(document: vscode.TextDocument): void {
-        if (document.uri.scheme !== 'file') {
-            return
+        if (document.uri.scheme === 'file' || document.uri.scheme === 'vscode-notebook-cell') {
+            const trackedDocument: TrackedDocument = {
+                content: document.getText(),
+                languageId: document.languageId,
+                uri: document.uri,
+                changes: [],
+            }
+            this.trackedDocuments.set(document.uri.toString(), trackedDocument)
         }
-        const trackedDocument: TrackedDocument = {
-            content: document.getText(),
-            languageId: document.languageId,
-            uri: document.uri,
-            changes: [],
-        }
-        this.trackedDocuments.set(document.uri.toString(), trackedDocument)
     }
 
     private reconcileOutdatedChanges(): void {

--- a/vscode/src/completions/context/retrievers/recent-user-actions/recent-view-port.test.ts
+++ b/vscode/src/completions/context/retrievers/recent-user-actions/recent-view-port.test.ts
@@ -91,6 +91,12 @@ describe('RecentViewPortRetriever', () => {
                 onDidChangeActiveTextEditor() {
                     return { dispose: () => {} }
                 },
+                onDidChangeNotebookEditorVisibleRanges() {
+                    return { dispose: () => {} }
+                },
+                onDidChangeActiveNotebookEditor() {
+                    return { dispose: () => {} }
+                },
                 activeTextEditor: undefined,
             }
         )
@@ -135,8 +141,6 @@ describe('RecentViewPortRetriever', () => {
         expect(snippets).toHaveLength(1)
         expect(snippets[0]).toMatchObject({
             uri: doc.uri,
-            startLine: 1,
-            endLine: 2,
             identifier: retriever.identifier,
         })
         expect(snippets[0].content).toMatchInlineSnapshot(dedent`
@@ -156,8 +160,6 @@ describe('RecentViewPortRetriever', () => {
         const snippets = await retriever.retrieve(getContextRetrieverOptionsFromDoc(doc2))
 
         expect(snippets).toHaveLength(1)
-        expect(snippets[0].startLine).toBe(1)
-        expect(snippets[0].endLine).toBe(2)
     })
 
     it('should handle empty visible ranges', async () => {

--- a/vscode/src/completions/context/retrievers/recent-user-actions/recent-view-port.ts
+++ b/vscode/src/completions/context/retrievers/recent-user-actions/recent-view-port.ts
@@ -64,20 +64,17 @@ export class RecentViewPortRetriever implements vscode.Disposable, ContextRetrie
         const sortedViewPorts = this.getValidViewPorts(document)
 
         const snippetPromises = sortedViewPorts.map(async viewPort => {
-            const snippet = {
+            const snippet: AutocompleteContextSnippet = {
                 uri: viewPort.uri,
                 content: viewPort.content,
                 identifier: this.identifier,
                 metadata: {
                     timeSinceActionMs: Date.now() - viewPort.lastAccessTimestamp,
                 },
-            } satisfies Omit<AutocompleteContextSnippet, 'startLine' | 'endLine'>
+            }
             return snippet
         })
-        const viewPortSnippets = await Promise.all(snippetPromises)
-        // remove the startLine and endLine from the response which might not be valid for notebooks
-        // @ts-ignore
-        return viewPortSnippets
+        return await Promise.all(snippetPromises)
     }
 
     private getValidViewPorts(document: vscode.TextDocument): TrackedViewPort[] {

--- a/vscode/src/completions/context/retrievers/recent-user-actions/recent-view-port.ts
+++ b/vscode/src/completions/context/retrievers/recent-user-actions/recent-view-port.ts
@@ -4,7 +4,12 @@ import { LRUCache } from 'lru-cache'
 import * as vscode from 'vscode'
 import type { ContextRetriever, ContextRetrieverOptions } from '../../../types'
 import { RetrieverIdentifier, type ShouldUseContextParams, shouldBeUsedAsContext } from '../../utils'
-import { getNotebookLanguageId, getTextFromNotebookCells } from './notebook-utils'
+import {
+    getActiveNotebookUri,
+    getCellIndexInActiveNotebookEditor,
+    getNotebookLanguageId,
+    getTextFromNotebookCells,
+} from './notebook-utils'
 
 interface TrackedViewPort {
     uri: vscode.Uri
@@ -98,8 +103,8 @@ export class RecentViewPortRetriever implements vscode.Disposable, ContextRetrie
     }
 
     private getCurrentDocumentUri(document: vscode.TextDocument): vscode.Uri {
-        if (document.uri.scheme === 'vscode-notebook-cell') {
-            return vscode.window.activeNotebookEditor?.notebook.uri || document.uri
+        if (getCellIndexInActiveNotebookEditor(document) !== -1) {
+            return getActiveNotebookUri() ?? document.uri
         }
         return document.uri
     }

--- a/vscode/src/completions/context/retrievers/recent-user-actions/recent-view-port.ts
+++ b/vscode/src/completions/context/retrievers/recent-user-actions/recent-view-port.ts
@@ -76,7 +76,7 @@ export class RecentViewPortRetriever implements vscode.Disposable, ContextRetrie
     }
 
     private getValidViewPorts(document: vscode.TextDocument): TrackedViewPort[] {
-        const currentFileUri = document.uri.toString()
+        const currentFileUri = this.getCurrentDocumentUri(document).toString()
         const currentLanguageId = document.languageId
         const viewPorts = Array.from(this.viewportsByDocumentUri.entries())
             .map(([_, value]) => value)
@@ -95,6 +95,13 @@ export class RecentViewPortRetriever implements vscode.Disposable, ContextRetrie
             .slice(0, this.maxRetrievedViewPorts)
 
         return sortedViewPorts
+    }
+
+    private getCurrentDocumentUri(document: vscode.TextDocument): vscode.Uri {
+        if (document.uri.scheme === 'vscode-notebook-cell') {
+            return vscode.window.activeNotebookEditor?.notebook.uri || document.uri
+        }
+        return document.uri
     }
 
     public isSupportedForLanguageId(): boolean {

--- a/vscode/src/completions/context/retrievers/recent-user-actions/recent-view-port.ts
+++ b/vscode/src/completions/context/retrievers/recent-user-actions/recent-view-port.ts
@@ -160,7 +160,7 @@ export class RecentViewPortRetriever implements vscode.Disposable, ContextRetrie
             return
         }
         const visibleCells = notebookEditor.notebook.getCells(visibleRanges?.at(-1))
-        const content = getTextFromNotebookCells(notebookEditor.notebook, visibleCells)
+        const content = getTextFromNotebookCells(notebookEditor.notebook, visibleCells).toString()
 
         this.updateTrackedViewPort(
             notebookEditor.notebook.uri,

--- a/vscode/src/completions/context/retrievers/tsc/tsc-retriever.ts
+++ b/vscode/src/completions/context/retrievers/tsc/tsc-retriever.ts
@@ -536,6 +536,7 @@ class SymbolCollector {
                 // Skip module declarations because they can be too large.
                 // We still format them to queue the referenced types.
                 const snippet: AutocompleteContextSnippet = {
+                    type: 'symbol',
                     identifier: RetrieverIdentifier.TscRetriever,
                     symbol: sym.name,
                     content,

--- a/vscode/src/completions/model-helpers/__tests__/test-data.ts
+++ b/vscode/src/completions/model-helpers/__tests__/test-data.ts
@@ -1,4 +1,4 @@
-import { testFileUri } from '@sourcegraph/cody-shared'
+import { type AutocompleteContextSnippet, testFileUri } from '@sourcegraph/cody-shared'
 
 import { paramsWithInlinedCompletion } from '../../get-inline-completions-tests/helpers'
 
@@ -18,8 +18,9 @@ export const completionParams = paramsWithInlinedCompletion(
     { documentUri: testFileUri('codebase/test.ts') }
 )!
 
-export const contextSnippets = [
+export const contextSnippets: AutocompleteContextSnippet[] = [
     {
+        type: 'file',
         identifier: 'jaccard-similarity',
         uri: testFileUri('codebase/context1.ts'),
         content: 'function contextSnippetOne() {}',
@@ -27,6 +28,7 @@ export const contextSnippets = [
         endLine: 2,
     },
     {
+        type: 'file',
         identifier: 'jaccard-similarity',
         uri: testFileUri('codebase/context2.ts'),
         content: 'const contextSnippet2 = {}',
@@ -34,6 +36,7 @@ export const contextSnippets = [
         endLine: 2,
     },
     {
+        type: 'symbol',
         identifier: 'jaccard-similarity',
         uri: testFileUri('codebase/context3.ts'),
         content: 'interface ContextParams {}',

--- a/vscode/src/completions/test-helpers.ts
+++ b/vscode/src/completions/test-helpers.ts
@@ -1,6 +1,6 @@
 import fs from 'node:fs'
 import dedent from 'dedent'
-import type { Position as VSCodePosition, TextDocument as VSCodeTextDocument } from 'vscode'
+import type * as vscode from 'vscode'
 import { TextDocument } from 'vscode-languageserver-textdocument'
 
 import { type CompletionResponse, testFileUri } from '@sourcegraph/cody-shared'
@@ -39,11 +39,11 @@ export function document(
     text: string,
     languageId = 'typescript',
     uriString = testFileUri('test.ts').toString()
-): VSCodeTextDocument {
+): vscode.TextDocument {
     return wrapVSCodeTextDocument(TextDocument.create(uriString, languageId, 0, text))
 }
 
-export function documentFromFilePath(filePath: string, languageId = 'typescript'): VSCodeTextDocument {
+export function documentFromFilePath(filePath: string, languageId = 'typescript'): vscode.TextDocument {
     return wrapVSCodeTextDocument(
         TextDocument.create(
             Uri.file(filePath).toString(),
@@ -58,7 +58,7 @@ export function documentAndPosition(
     textWithCursor: string,
     languageId?: string,
     uriString?: string
-): { document: VSCodeTextDocument; position: VSCodePosition } {
+): { document: vscode.TextDocument; position: vscode.Position } {
     const { prefix, suffix, cursorIndex } = prefixAndSuffix(textWithCursor)
 
     const doc = document(prefix + suffix, languageId, uriString)
@@ -79,4 +79,176 @@ export function prefixAndSuffix(textWithCursor: string): {
     const suffix = textWithCursor.slice(cursorIndex + CURSOR_MARKER.length)
 
     return { prefix, suffix, cursorIndex }
+}
+
+//-------------------------------------------
+// vscode.NotebookDocument mocks
+//-------------------------------------------
+
+export function createMockNotebook({
+    uri,
+    cells,
+    notebookType,
+}: {
+    /**
+     * Notebook URI as a string, e.g. 'file://test.ipynb'.
+     */
+    uri: string
+    /**
+     * Cells to create.
+     * - `kind`: NotebookCellKind.Code or NotebookCellKind.Markup
+     * - `text`: Cell content
+     * - `languageId`: The language ID for the cell document
+     */
+    cells: {
+        kind: vscode.NotebookCellKind
+        text: string
+        languageId?: string
+    }[]
+    notebookType?: string
+}): vscode.NotebookDocument {
+    const mockUri = Uri.parse(uri)
+
+    const notebookDoc = new MockNotebookDocument({
+        uri: mockUri,
+        notebookType: notebookType ?? 'mock-notebook',
+        cells: [],
+    })
+
+    const mockCells: vscode.NotebookCell[] = cells.map((cellData, index) => {
+        const cellTextDoc = wrapVSCodeTextDocument(
+            TextDocument.create(
+                `vscode-notebook-cell://mock/${index}`,
+                cellData.languageId ?? 'plaintext',
+                0, // version
+                cellData.text
+            )
+        )
+
+        return new MockNotebookCell({
+            index,
+            notebook: notebookDoc,
+            kind: cellData.kind,
+            document: cellTextDoc,
+        })
+    })
+
+    // Patch the internal cells array
+    // We do not create cells first to ensure they have a
+    // parent notebook reference.
+    ;(notebookDoc as any).cellsInternal = mockCells
+    notebookDoc.cellCount = mockCells.length
+
+    return notebookDoc
+}
+
+class NotebookCellOutput implements vscode.NotebookCellOutput {
+    public readonly items: vscode.NotebookCellOutputItem[]
+    public readonly metadata: { [key: string]: any }
+
+    constructor(items: vscode.NotebookCellOutputItem[], metadata: { [key: string]: any } = {}) {
+        this.items = items
+        this.metadata = metadata
+    }
+}
+
+class MockNotebookCell implements vscode.NotebookCell {
+    public readonly index: number
+    public readonly notebook: vscode.NotebookDocument
+    public readonly kind: vscode.NotebookCellKind
+    public readonly document: vscode.TextDocument
+    public readonly metadata: { readonly [key: string]: any }
+    public readonly outputs: readonly NotebookCellOutput[]
+    public readonly executionSummary: vscode.NotebookCellExecutionSummary | undefined
+
+    constructor({
+        index,
+        notebook,
+        kind,
+        document,
+        metadata = {},
+        outputs = [],
+        executionSummary,
+    }: {
+        index: number
+        notebook: vscode.NotebookDocument
+        kind: vscode.NotebookCellKind
+        document: vscode.TextDocument
+        metadata?: { readonly [key: string]: any }
+        outputs?: NotebookCellOutput[]
+        executionSummary?: vscode.NotebookCellExecutionSummary
+    }) {
+        this.index = index
+        this.notebook = notebook
+        this.kind = kind
+        this.document = document
+        this.metadata = metadata
+        this.outputs = outputs
+        this.executionSummary = executionSummary
+    }
+}
+
+class MockNotebookDocument implements vscode.NotebookDocument {
+    public readonly uri: Uri
+    public readonly notebookType: string
+    public version: number
+    public isDirty: boolean
+    public isUntitled: boolean
+    public isClosed: boolean
+    public readonly metadata: { [key: string]: any }
+    public cellCount: number
+    private cellsInternal: vscode.NotebookCell[]
+
+    constructor({
+        uri,
+        notebookType = 'mock-notebook',
+        version = 1,
+        isDirty = false,
+        isUntitled = false,
+        isClosed = false,
+        metadata = {},
+        cells = [],
+    }: {
+        uri: Uri
+        notebookType?: string
+        version?: number
+        isDirty?: boolean
+        isUntitled?: boolean
+        isClosed?: boolean
+        metadata?: { [key: string]: any }
+        cells?: vscode.NotebookCell[]
+    }) {
+        this.uri = uri
+        this.notebookType = notebookType
+        this.version = version
+        this.isDirty = isDirty
+        this.isUntitled = isUntitled
+        this.isClosed = isClosed
+        this.metadata = metadata
+        this.cellsInternal = cells
+        this.cellCount = cells.length
+    }
+
+    public cellAt(index: number): vscode.NotebookCell {
+        const cell = this.cellsInternal[index]
+        if (!cell) {
+            throw new Error(`No cell found at index ${index}`)
+        }
+        return cell
+    }
+
+    public getCells(range?: vscode.NotebookRange): vscode.NotebookCell[] {
+        if (!range) {
+            return this.cellsInternal
+        }
+        const start = Math.max(0, range.start)
+        const end = Math.min(this.cellsInternal.length, range.end)
+        return this.cellsInternal.slice(start, end)
+    }
+
+    public async save(): Promise<boolean> {
+        // Simulate saving
+        this.isDirty = false
+        return true
+    }
 }

--- a/vscode/src/graph/lsp/symbol-context-snippets.ts
+++ b/vscode/src/graph/lsp/symbol-context-snippets.ts
@@ -127,6 +127,7 @@ async function getSnippetForLocationGetter(
     }
 
     const symbolContextSnippet = {
+        type: 'symbol',
         identifier: RetrieverIdentifier.LspLightRetriever,
         key: `${definitionUri}::${definitionRange.start.line}:${definitionRange.start.character}`,
         uri: definitionUri,

--- a/vscode/src/testutils/mocks.ts
+++ b/vscode/src/testutils/mocks.ts
@@ -229,6 +229,10 @@ export class CodeActionKind {
 
     constructor(public readonly value: string) {}
 }
+export enum NotebookCellKind {
+    Markup = 1,
+    Code = 2,
+}
 // biome-ignore lint/complexity/noStaticOnlyClass: mock
 export class QuickInputButtons {
     public static readonly Back: vscode_types.QuickInputButton = {
@@ -793,6 +797,7 @@ export const vsCodeMocks = {
         showErrorMessage(message: string) {
             console.error(message)
         },
+        activeNotebookEditor: undefined,
         activeTextEditor: {
             document: { uri: { scheme: 'not-cody' } },
             options: { tabSize: 4 },
@@ -867,6 +872,7 @@ export const vsCodeMocks = {
     FoldingRange,
     FoldingRangeKind,
     CodeActionKind,
+    NotebookCellKind,
     DiagnosticSeverity,
     ViewColumn,
     TextDocumentChangeReason,


### PR DESCRIPTION
The PR adds the support for the notebook in the `auto-edits`.
1. By default each cell is treated as a separate document, hence we get limited context for the current file. We add the content for the full file.
2. All the context sources used to ignore the notebooks. Now, all following the context sources tracks the support for notebooks and context is persisted between `py` and `ipynb`:
 - Recent Edits
 - Diagnostics
 - Recent View Port 

## Test plan
existing CI and Manual testing to check behaviour in case of notebook

