### PR TITLE
autoedit: address dogfooding feedback

### DIFF
--- a/vscode/src/autoedits/renderer/decorators/default-decorator.ts
+++ b/vscode/src/autoedits/renderer/decorators/default-decorator.ts
@@ -95,11 +95,6 @@ export class DefaultDecorator implements AutoEditsDecorator {
         const removedRanges: vscode.Range[] = []
         const addedLinesInfo: AddedLinesDecorationInfo[] = []
 
-        let firstModifiedLineMatch: {
-            beforeLine: number
-            afterLine: number
-        } | null = null
-
         // Handle modified lines - collect removed ranges and added decorations
         for (const modifiedLine of modifiedLines) {
             const changes = modifiedLine.changes
@@ -116,12 +111,6 @@ export class DefaultDecorator implements AutoEditsDecorator {
                 }
             }
             if (addedRanges.length > 0) {
-                if (!firstModifiedLineMatch) {
-                    firstModifiedLineMatch = {
-                        beforeLine: modifiedLine.modifiedLineNumber,
-                        afterLine: modifiedLine.modifiedLineNumber,
-                    }
-                }
                 addedLinesInfo.push({
                     ranges: addedRanges,
                     afterLine: modifiedLine.modifiedLineNumber,
@@ -163,16 +152,10 @@ export class DefaultDecorator implements AutoEditsDecorator {
         if (addedLinesInfo.length === 0) {
             return
         }
-        let startLine = this.editor.selection.active.line
-        if (firstModifiedLineMatch) {
-            startLine =
-                firstModifiedLineMatch.beforeLine -
-                (firstModifiedLineMatch.afterLine - addedLinesInfo[0].afterLine)
-        }
-
         // todo (hitesh): handle case when too many lines to fit in the editor
         const oldLines = addedLinesInfo.map(info => this.editor.document.lineAt(info.afterLine))
         const replacerCol = Math.max(...oldLines.map(line => line.range.end.character))
+        const startLine = Math.min(...oldLines.map(line => line.lineNumber))
         this.renderAddedLinesDecorations(addedLinesInfo, startLine, replacerCol)
     }
 


### PR DESCRIPTION
The PR address dogfooding feedback:
1. Earlier `auto-edit` diff view would render on the line where the cursor is currently placed instead of where the completion is supposed to be inserted.
2.  This caused issue with rendering where, the current line text would be shifted to the right, because the text insertion range is different from where cursor could be placed.
3. The PR replaces the diff view location to where it is actually supposed to insert instead of where cursor is located. 


## Test plan
1. Ran on all the [cody-chat-eval](https://github.com/sourcegraph/cody-chat-eval/tree/main/code-matching-eval/edits_experiments/examples/renderer-testing-examples) examples
2. Fixes [this example](https://github.com/sourcegraph/cody-chat-eval/blob/main/code-matching-eval/edits_experiments/examples/renderer-testing-examples/recent-edit-v3.ts) reported by @abeatrix here [in slack](https://sourcegraph.slack.com/archives/C07F8LLKE06/p1734818194339659?thread_ts=1734811534.717699&cid=C07F8LLKE06)
**Before:**
<img width="742" alt="image" src="https://github.com/user-attachments/assets/2563e350-36ae-418e-905f-4ccfa64d3da4" />

**After:**
<img width="647" alt="image" src="https://github.com/user-attachments/assets/aa4ac790-fc6e-42b9-81b6-03f09ec9757e" />

4. Fixes [this example](https://github.com/sourcegraph/cody-chat-eval/blob/main/code-matching-eval/edits_experiments/examples/renderer-testing-examples/recent-edit-v2.ts) 
**Before**
<img width="904" alt="image" src="https://github.com/user-attachments/assets/d7f2c37a-5214-495b-9592-640341e9296e" />

 **After:**
<img width="739" alt="image" src="https://github.com/user-attachments/assets/f0f39c55-bad8-435e-9cf1-a8fa4078e131" />


