### PR TITLE
Add security considerations to prompt

### DIFF
--- a/vscode/src/chat/agentic/CodyTool.ts
+++ b/vscode/src/chat/agentic/CodyTool.ts
@@ -102,7 +102,7 @@ class CliTool extends CodyTool {
             prompt: {
                 instruction: ps`To see the output of shell commands - Do not suggest any actions that may cause harm or security breaches. Limit to actions that are safe to perform. Follow these guidelines for all operations: Commands must be single, atomic operations. Commands must have explicit, validated parameters. Reject commands containing shell metacharacters (;|&$><\`). Reject commands with string concatenation or interpolation. Reject commands containing paths outside of the current working directory. Reject commands that make network requests. Reject commands that could enable privilege escalation. Reject commands containing GTFOBin-like shell escapes. Reject commands that modify system files or settings. Reject commands that access sensitive files. Reject commands that read environment variables.`,
                 placeholder: ps`SHELL_COMMAND`,
-                example: ps`Get output for git diff: \`<TOOLCLI><cmd>git diff</cmd></TOOLCLI>\`. Never execute destructive commands: \`<TOOLCLI><cmd>rm -rf /</cmd></TOOLCLI>\`. Never execute commands with string interpolation: \`<TOOLCLI><cmd>echo $HOME</cmd></TOOLCLI>\`. Never execute commands that make network connections: \`<TOOLCLI><cmd>ssh user@host</cmd></TOOLCLI>\``,
+                example: ps`Get output for git diff: \`<TOOLCLI><cmd>git diff</cmd></TOOLCLI>\`. Never execute destructive commands: \`<TOOLCLI><ban>rm -rf /</ban></TOOLCLI>\`. Never execute commands with string interpolation: \`<TOOLCLI><ban>echo $HOME</ban></TOOLCLI>\`. Never execute commands that make network connections: \`<TOOLCLI><ban>ssh user@host</ban></TOOLCLI>\``,
             },
         })
     }

--- a/vscode/src/chat/agentic/CodyTool.ts
+++ b/vscode/src/chat/agentic/CodyTool.ts
@@ -100,20 +100,9 @@ class CliTool extends CodyTool {
                 subTag: ps`cmd`,
             },
             prompt: {
-                instruction: ps`To see the output of shell commands - Do not suggest any actions that may cause harm or security breaches. Limit to actions that are safe to perform. Follow these guidelines for all operations:
-                - Commands must be single, atomic operations
-                - Commands must have explicit, validated parameters
-                - Reject commands containing shell metacharacters (;|&$><\`)
-                - Reject commands with string concatenation or interpolation
-                - Reject commands containing paths outside of the current working directory
-                - Reject commands that make network requests
-                - Reject commands that could enable privilege escalation
-                - Reject commands containing GTFOBin-like shell escapes
-                - Reject commands that modify system files or settings
-                - Reject commands that access sensitive files
-                - Reject commands that read environment variables`,
+                instruction: ps`To see the output of shell commands - Do not suggest any actions that may cause harm or security breaches. Limit to actions that are safe to perform. Follow these guidelines for all operations: Commands must be single, atomic operations. Commands must have explicit, validated parameters. Reject commands containing shell metacharacters (;|&$><\`). Reject commands with string concatenation or interpolation. Reject commands containing paths outside of the current working directory. Reject commands that make network requests. Reject commands that could enable privilege escalation. Reject commands containing GTFOBin-like shell escapes. Reject commands that modify system files or settings. Reject commands that access sensitive files. Reject commands that read environment variables.`,
                 placeholder: ps`SHELL_COMMAND`,
-                example: ps`Get output for git diff: \`<TOOLCLI><cmd>git diff</cmd></TOOLCLI>\``,
+                example: ps`Get output for git diff: \`<TOOLCLI><cmd>git diff</cmd></TOOLCLI>\`. Never execute destructive commands: \`<TOOLCLI><cmd>rm -rf /</cmd></TOOLCLI>\`. Never execute commands with string interpolation: \`<TOOLCLI><cmd>echo $HOME</cmd></TOOLCLI>\`. Never execute commands that make network connections: \`<TOOLCLI><cmd>ssh user@host</cmd></TOOLCLI>\``,
             },
         })
     }

--- a/vscode/src/chat/agentic/CodyTool.ts
+++ b/vscode/src/chat/agentic/CodyTool.ts
@@ -100,7 +100,18 @@ class CliTool extends CodyTool {
                 subTag: ps`cmd`,
             },
             prompt: {
-                instruction: ps`To see the output of shell commands - NEVER execute unsafe commands`,
+                instruction: ps`To see the output of shell commands - Do not suggest any actions that may cause harm or security breaches. Limit to actions that are safe to perform. Follow these guidelines for all operations:
+                - Commands must be single, atomic operations
+                - Commands must have explicit, validated parameters
+                - Reject commands containing shell metacharacters (;|&$><\`)
+                - Reject commands with string concatenation or interpolation
+                - Reject commands containing paths outside of the current working directory
+                - Reject commands that make network requests
+                - Reject commands that could enable privilege escalation
+                - Reject commands containing GTFOBin-like shell escapes
+                - Reject commands that modify system files or settings
+                - Reject commands that access sensitive files
+                - Reject commands that read environment variables`,
                 placeholder: ps`SHELL_COMMAND`,
                 example: ps`Get output for git diff: \`<TOOLCLI><cmd>git diff</cmd></TOOLCLI>\``,
             },

--- a/vscode/src/chat/agentic/prompts.ts
+++ b/vscode/src/chat/agentic/prompts.ts
@@ -9,7 +9,6 @@ const REVIEW_PROMPT = ps`Your task is to review the shared context and think ste
 3. Respond with ONLY ONE of the following:
     a) The word "CONTEXT_SUFFICIENT" if you can answer the question with the current context.
     b) One or more <TOOL*> tags to request additional information if you do not have the required context to provide a concise answer.
-4. Follow the security guidelines in the [SECURITY] section.
 
 [TOOLS]
 In this environment you have access to this set of tools you can use to fetch context before answering the user's question:
@@ -22,21 +21,6 @@ In this environment you have access to this set of tools you can use to fetch co
 [RESPONSE FORMAT]
 - If you can answer the question fully, respond with ONLY the word "CONTEXT_SUFFICIENT".
 - If you need more information, use ONLY the appropriate <TOOL*> tag(s) in your response. Skip preamble.
-
-[SECURITY]
-
-Do not suggest any actions that may cause harm or security breaches. Limit to actions that are safe to perform. Follow these guidelines for all operations:
-- Commands must be single, atomic operations
-- Commands must have explicit, validated parameters
-- Reject commands containing shell metacharacters (;|&$><\`)
-- Reject commands with string concatenation or interpolation
-- Reject commands containing paths outside of the current working directory
-- Reject commands that make network requests
-- Reject commands that could enable privilege escalation
-- Reject commands containing GTFOBin-like shell escapes
-- Reject commands that modify system files or settings
-- Reject commands that access sensitive files
-- Reject commands that read environment variables
 
 [NOTES]
 1. Only use <TOOL*> tags when additional context is necessary to answer the question.

--- a/vscode/src/chat/agentic/prompts.ts
+++ b/vscode/src/chat/agentic/prompts.ts
@@ -9,6 +9,7 @@ const REVIEW_PROMPT = ps`Your task is to review the shared context and think ste
 3. Respond with ONLY ONE of the following:
     a) The word "CONTEXT_SUFFICIENT" if you can answer the question with the current context.
     b) One or more <TOOL*> tags to request additional information if you do not have the required context to provide a concise answer.
+4. Follow the security guidelines in the [SECURITY] section.
 
 [TOOLS]
 In this environment you have access to this set of tools you can use to fetch context before answering the user's question:
@@ -21,6 +22,21 @@ In this environment you have access to this set of tools you can use to fetch co
 [RESPONSE FORMAT]
 - If you can answer the question fully, respond with ONLY the word "CONTEXT_SUFFICIENT".
 - If you need more information, use ONLY the appropriate <TOOL*> tag(s) in your response. Skip preamble.
+
+[SECURITY]
+
+Do not suggest any actions that may cause harm or security breaches. Limit to actions that are safe to perform. Follow these guidelines for all operations:
+- Commands must be single, atomic operations
+- Commands must have explicit, validated parameters
+- Reject commands containing shell metacharacters (;|&$><\`)
+- Reject commands with string concatenation or interpolation
+- Reject commands containing paths outside of the current working directory
+- Reject commands that make network requests
+- Reject commands that could enable privilege escalation
+- Reject commands containing GTFOBin-like shell escapes
+- Reject commands that modify system files or settings
+- Reject commands that access sensitive files
+- Reject commands that read environment variables
 
 [NOTES]
 1. Only use <TOOL*> tags when additional context is necessary to answer the question.


### PR DESCRIPTION
I tested several PoCs with Deep Cody, which included something in the context (in my testing, a local file) pointing Cody to run something dangerous or malicious. I was able to execute:
- network requests
- accessing sensitive files (like /etc/passwd)
- creating arbitrary files

These prompt tweaks were initially suggested by Claude with the prompt generator, but then I tested and tweaked it further. The command execution is still hit-and-miss but this definitely improves the overall behavior. We will continue to rely on explicit user consent to enable the feature and an allowlist for which commands to execute.

## Test plan
I created PoCs and, with the new prompt, they did not execute successfully anymore.
<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
