### PR TITLE
chore/release: Remove the changelog section from the PR template.

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,7 +2,3 @@
 ## Test plan
 
 <!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
-
-## Changelog
-
-<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->


### PR DESCRIPTION
This section of the PR template isn't used by any tools. In practice people don't fill it out and it just contributes to noise in the git log.

## Test plan

GitHub template only change.