### PR TITLE
fix/editor: Ask Cody to Fix no longer throws exceptions in TypeScript files 

### DIFF
--- a/jetbrains/src/main/kotlin/com/sourcegraph/cody/inspections/CodyFixHighlightPass.kt
+++ b/jetbrains/src/main/kotlin/com/sourcegraph/cody/inspections/CodyFixHighlightPass.kt
@@ -115,7 +115,7 @@ class CodyFixHighlightPass(val file: PsiFile, val editor: Editor) :
   @RequiresEdt
   override fun doApplyInformationToEditor() {
     for (highlight in myHighlights) {
-      highlight.unregisterQuickFix { it.familyName == CodeActionQuickFix.FAMILY_NAME }
+      highlight.unregisterQuickFix { (it as? CodeActionQuickFix)?.familyName == CodeActionQuickFix.FAMILY_NAME }
 
       if (highlight.startOffset > document.textLength ||
           highlight.endOffset > document.textLength ||


### PR DESCRIPTION
Fixes CODY-4573.

The exception in that bug happened because `TypeScriptLanguageServiceFix.getFamilyName` could block the thread, but we were calling it on EDT. The fix is to simply check that the action is related to Cody before drilling down into the name.

In theory any accessor on highlights could be poorly implemented, but in practice Ask Cody to Fix works in TypeScript files now so this is an improvement.

## Test plan

```
cd jetbrains
SKIP_CODE_SEARCH_BUILD=true ./gradlew :customRunIde \
    -PforceAgentBuild=true \
    -PplatformRuntimeType=WS -PplatformRuntimeVersion=2024.3
```

- Create or open a TypeScript file. Enter some nonsense like `function f(s: string, s: number) {`
- Use the lightbulb hover, or press Alt-Enter to show quick actions.
- "Ask Cody to Fix"
- Verify that the feature works and there's no IllegalStateException exceptions

![Screenshot 2024-12-27 at 15 47 23](https://github.com/user-attachments/assets/536ce0e7-3d0c-4010-9c65-33ec8a318eeb)
