### PR TITLE
chore(audoedit): decouple `codeToReplaceData` from `getPromptForModelType`

### DIFF
--- a/vscode/src/autoedits/analytics-logger/analytics-logger.ts
+++ b/vscode/src/autoedits/analytics-logger/analytics-logger.ts
@@ -631,6 +631,6 @@ export class AutoeditAnalyticsLogger {
 
 export const autoeditAnalyticsLogger = new AutoeditAnalyticsLogger()
 
-function getTimeNowInMillis(): number {
+export function getTimeNowInMillis(): number {
     return Math.floor(performance.now())
 }

--- a/vscode/src/autoedits/prompt/base.ts
+++ b/vscode/src/autoedits/prompt/base.ts
@@ -1,37 +1,22 @@
-import type * as vscode from 'vscode'
-
 import type {
     AutoEditsTokenLimit,
     AutocompleteContextSnippet,
-    DocumentContext,
     PromptString,
 } from '@sourcegraph/cody-shared'
 
 import type { AutoeditsPrompt } from '../adapters/base'
 
 import { SYSTEM_PROMPT } from './constants'
-import { type CodeToReplaceData, getCompletionsPromptWithSystemPrompt } from './prompt-utils'
+import { type CurrentFilePromptComponents, getCompletionsPromptWithSystemPrompt } from './prompt-utils'
 
-export interface UserPromptArgs {
-    docContext: DocumentContext
-    document: vscode.TextDocument
-    position: vscode.Position
+export interface UserPromptArgs
+    extends Pick<CurrentFilePromptComponents, 'areaPrompt' | 'fileWithMarkerPrompt'> {
     context: AutocompleteContextSnippet[]
     tokenBudget: AutoEditsTokenLimit
 }
 
-export interface UserPromptResponse {
-    codeToReplaceData: CodeToReplaceData
-    prompt: PromptString
-}
-
 export interface UserPromptForModelArgs extends UserPromptArgs {
     isChatModel: boolean
-}
-
-export interface UserPromptForModelResponse {
-    codeToReplaceData: CodeToReplaceData
-    prompt: AutoeditsPrompt
 }
 
 /**
@@ -39,21 +24,18 @@ export interface UserPromptForModelResponse {
  * The major difference between different strategy is the prompt rendering.
  */
 export abstract class AutoeditsUserPromptStrategy {
-    protected abstract getUserPrompt(args: UserPromptArgs): UserPromptResponse
+    protected abstract getUserPrompt(args: UserPromptArgs): PromptString
 
     public getPromptForModelType({
         isChatModel,
         ...userPromptArgs
-    }: UserPromptForModelArgs): UserPromptForModelResponse {
-        const { codeToReplaceData, prompt } = this.getUserPrompt(userPromptArgs)
+    }: UserPromptForModelArgs): AutoeditsPrompt {
+        const prompt = this.getUserPrompt(userPromptArgs)
 
         const adjustedPrompt: AutoeditsPrompt = isChatModel
             ? { systemMessage: SYSTEM_PROMPT, userMessage: prompt }
             : { userMessage: getCompletionsPromptWithSystemPrompt(SYSTEM_PROMPT, prompt) }
 
-        return {
-            codeToReplaceData,
-            prompt: adjustedPrompt,
-        }
+        return adjustedPrompt
     }
 }

--- a/vscode/src/autoedits/prompt/default-prompt-strategy.test.ts
+++ b/vscode/src/autoedits/prompt/default-prompt-strategy.test.ts
@@ -7,6 +7,7 @@ import { getCurrentDocContext } from '../../completions/get-current-doc-context'
 import { documentAndPosition } from '../../completions/test-helpers'
 import type { UserPromptArgs } from './base'
 import { DefaultUserPromptStrategy } from './default-prompt-strategy'
+import { getCurrentFilePromptComponents } from './prompt-utils'
 
 describe('DefaultUserPromptStrategy', () => {
     const promptProvider = new DefaultUserPromptStrategy()
@@ -41,7 +42,6 @@ describe('DefaultUserPromptStrategy', () => {
             maxPrefixLength: 100,
             maxSuffixLength: 100,
         })
-
         const tokenBudget: AutoEditsTokenLimit = {
             prefixTokens: 10,
             suffixTokens: 10,
@@ -57,6 +57,14 @@ describe('DefaultUserPromptStrategy', () => {
                 [RetrieverIdentifier.DiagnosticsRetriever]: 100,
             },
         }
+
+        const { fileWithMarkerPrompt, areaPrompt } = getCurrentFilePromptComponents({
+            docContext,
+            document,
+            position,
+            tokenBudget,
+        })
+
         const context: AutocompleteContextSnippet[] = shouldIncludeContext
             ? [
                   getContextItem(
@@ -163,17 +171,16 @@ describe('DefaultUserPromptStrategy', () => {
             : []
 
         return {
-            docContext,
-            document,
-            position,
             context,
+            fileWithMarkerPrompt,
+            areaPrompt,
             tokenBudget,
         }
     }
 
     it('creates prompt with the context source with context', () => {
         const userPromptData = getUserPromptData({ shouldIncludeContext: true })
-        const { prompt } = promptProvider.getUserPrompt(userPromptData)
+        const prompt = promptProvider.getUserPrompt(userPromptData)
 
         expect(prompt.toString()).toEqual(dedent`
             Help me finish a coding change. In particular, you will see a series of snippets from current open files in my editor, files I have recently viewed, the file I am editing, then a history of my recent codebase changes, then current compiler and linter errors, content I copied from my codebase. You will then rewrite the <code_to_rewrite>, to match what you think I would do next in the codebase. Note: I might have stopped in the middle of typing.
@@ -303,7 +310,7 @@ describe('DefaultUserPromptStrategy', () => {
 
     it('creates a prompt in the correct format', () => {
         const userPromptData = getUserPromptData({ shouldIncludeContext: false })
-        const { prompt } = promptProvider.getUserPrompt(userPromptData)
+        const prompt = promptProvider.getUserPrompt(userPromptData)
 
         const expectedPrompt = dedent`
             Help me finish a coding change. In particular, you will see a series of snippets from current open files in my editor, files I have recently viewed, the file I am editing, then a history of my recent codebase changes, then current compiler and linter errors, content I copied from my codebase. You will then rewrite the <code_to_rewrite>, to match what you think I would do next in the codebase. Note: I might have stopped in the middle of typing.

--- a/vscode/src/autoedits/prompt/default-prompt-strategy.ts
+++ b/vscode/src/autoedits/prompt/default-prompt-strategy.ts
@@ -1,13 +1,12 @@
-import { ps } from '@sourcegraph/cody-shared'
+import { type PromptString, ps } from '@sourcegraph/cody-shared'
 
 import { RetrieverIdentifier } from '../../completions/context/utils'
 import { autoeditsOutputChannelLogger } from '../output-channel-logger'
 
-import { AutoeditsUserPromptStrategy, type UserPromptArgs, type UserPromptResponse } from './base'
+import { AutoeditsUserPromptStrategy, type UserPromptArgs } from './base'
 import * as constants from './constants'
 import {
     getContextItemMappingWithTokenLimit,
-    getCurrentFilePromptComponents,
     getJaccardSimilarityPrompt,
     getLintErrorsPrompt,
     getPromptForTheContextSource,
@@ -15,30 +14,20 @@ import {
     getRecentCopyPrompt,
     getRecentEditsPrompt,
     getRecentlyViewedSnippetsPrompt,
-    joinPromptsWithNewlineSeperator,
+    joinPromptsWithNewlineSeparator,
 } from './prompt-utils'
 
 export class DefaultUserPromptStrategy extends AutoeditsUserPromptStrategy {
     getUserPrompt({
-        docContext,
-        document,
-        position,
         context,
         tokenBudget,
-    }: UserPromptArgs): UserPromptResponse {
+        fileWithMarkerPrompt,
+        areaPrompt,
+    }: UserPromptArgs): PromptString {
         const contextItemMapping = getContextItemMappingWithTokenLimit(
             context,
             tokenBudget.contextSpecificTokenLimit
         )
-        const { fileWithMarkerPrompt, areaPrompt, codeToReplaceData } = getCurrentFilePromptComponents({
-            docContext,
-            document,
-            position,
-            maxPrefixLinesInArea: tokenBudget.maxPrefixLinesInArea,
-            maxSuffixLinesInArea: tokenBudget.maxSuffixLinesInArea,
-            codeToRewritePrefixLines: tokenBudget.codeToRewritePrefixLines,
-            codeToRewriteSuffixLines: tokenBudget.codeToRewriteSuffixLines,
-        })
         const recentViewsPrompt = getPromptForTheContextSource(
             contextItemMapping.get(RetrieverIdentifier.RecentViewPortRetriever) || [],
             constants.LONG_TERM_SNIPPET_VIEWS_INSTRUCTION,
@@ -71,7 +60,7 @@ export class DefaultUserPromptStrategy extends AutoeditsUserPromptStrategy {
 
         const currentFilePrompt = ps`${constants.CURRENT_FILE_INSTRUCTION}${fileWithMarkerPrompt}`
 
-        const finalPrompt = joinPromptsWithNewlineSeperator(
+        const finalPrompt = joinPromptsWithNewlineSeparator(
             getPromptWithNewline(constants.BASE_USER_PROMPT),
             getPromptWithNewline(jaccardSimilarityPrompt),
             getPromptWithNewline(recentViewsPrompt),
@@ -84,9 +73,6 @@ export class DefaultUserPromptStrategy extends AutoeditsUserPromptStrategy {
         )
 
         autoeditsOutputChannelLogger.logDebug('getUserPrompt', 'Prompt\n', finalPrompt)
-        return {
-            codeToReplaceData,
-            prompt: finalPrompt,
-        }
+        return finalPrompt
     }
 }

--- a/vscode/src/autoedits/prompt/prompt-utils.test.ts
+++ b/vscode/src/autoedits/prompt/prompt-utils.test.ts
@@ -5,6 +5,7 @@ import { RetrieverIdentifier } from '../../completions/context/utils'
 import { getCurrentDocContext } from '../../completions/get-current-doc-context'
 import { documentAndPosition } from '../../completions/test-helpers'
 import {
+    type CurrentFilePromptOptions,
     getCompletionsPromptWithSystemPrompt,
     getContextItemsInTokenBudget,
     getContextPromptWithPath,
@@ -16,7 +17,7 @@ import {
     getRecentEditsContextPromptWithPath,
     getRecentEditsPrompt,
     getRecentlyViewedSnippetsPrompt,
-    joinPromptsWithNewlineSeperator,
+    joinPromptsWithNewlineSeparator,
 } from '../prompt/prompt-utils'
 
 describe('getContextPromptWithPath', () => {
@@ -60,14 +61,16 @@ describe('getCurrentFilePromptComponents', () => {
             maxSuffixLength: 100,
         })
 
-        const options = {
+        const options: CurrentFilePromptOptions = {
             docContext,
             document,
             position,
-            maxPrefixLinesInArea: 1,
-            maxSuffixLinesInArea: 1,
-            codeToRewritePrefixLines: 1,
-            codeToRewriteSuffixLines: 1,
+            tokenBudget: {
+                maxPrefixLinesInArea: 1,
+                maxSuffixLinesInArea: 1,
+                codeToRewritePrefixLines: 1,
+                codeToRewriteSuffixLines: 1,
+            },
         }
 
         const result = getCurrentFilePromptComponents(options)
@@ -122,14 +125,16 @@ describe('getCurrentFilePromptComponents', () => {
             maxSuffixLength: 30,
         })
 
-        const options = {
+        const options: CurrentFilePromptOptions = {
             docContext,
             document,
             position,
-            maxPrefixLinesInArea: 1,
-            maxSuffixLinesInArea: 1,
-            codeToRewritePrefixLines: 1,
-            codeToRewriteSuffixLines: 1,
+            tokenBudget: {
+                maxPrefixLinesInArea: 1,
+                maxSuffixLinesInArea: 1,
+                codeToRewritePrefixLines: 1,
+                codeToRewriteSuffixLines: 1,
+            },
         }
 
         const result = getCurrentFilePromptComponents(options)
@@ -169,14 +174,16 @@ describe('getCurrentFileContext', () => {
             maxSuffixLength: 100,
         })
 
-        const options = {
+        const options: CurrentFilePromptOptions = {
             docContext,
             document,
             position,
-            maxPrefixLinesInArea: 1,
-            maxSuffixLinesInArea: 1,
-            codeToRewritePrefixLines: 1,
-            codeToRewriteSuffixLines: 1,
+            tokenBudget: {
+                maxPrefixLinesInArea: 1,
+                maxSuffixLinesInArea: 1,
+                codeToRewritePrefixLines: 1,
+                codeToRewriteSuffixLines: 1,
+            },
         }
 
         const result = getCurrentFileContext(options)
@@ -203,14 +210,16 @@ describe('getCurrentFileContext', () => {
             maxSuffixLength: 100,
         })
 
-        const options = {
+        const options: CurrentFilePromptOptions = {
             docContext,
             document,
             position,
-            maxPrefixLinesInArea: 1,
-            maxSuffixLinesInArea: 1,
-            codeToRewritePrefixLines: 1,
-            codeToRewriteSuffixLines: 1,
+            tokenBudget: {
+                maxPrefixLinesInArea: 1,
+                maxSuffixLinesInArea: 1,
+                codeToRewritePrefixLines: 1,
+                codeToRewriteSuffixLines: 1,
+            },
         }
 
         const result = getCurrentFileContext(options)
@@ -233,14 +242,16 @@ describe('getCurrentFileContext', () => {
             maxSuffixLength: 100,
         })
 
-        const options = {
+        const options: CurrentFilePromptOptions = {
             docContext,
             document,
             position,
-            maxPrefixLinesInArea: 1,
-            maxSuffixLinesInArea: 1,
-            codeToRewritePrefixLines: 1,
-            codeToRewriteSuffixLines: 1,
+            tokenBudget: {
+                maxPrefixLinesInArea: 1,
+                maxSuffixLinesInArea: 1,
+                codeToRewritePrefixLines: 1,
+                codeToRewriteSuffixLines: 1,
+            },
         }
 
         const result = getCurrentFileContext(options)
@@ -264,14 +275,16 @@ describe('getCurrentFileContext', () => {
             maxSuffixLength: 100,
         })
 
-        const options = {
+        const options: CurrentFilePromptOptions = {
             docContext,
             document,
             position,
-            maxPrefixLinesInArea: 1,
-            maxSuffixLinesInArea: 1,
-            codeToRewritePrefixLines: 1,
-            codeToRewriteSuffixLines: 1,
+            tokenBudget: {
+                maxPrefixLinesInArea: 1,
+                maxSuffixLinesInArea: 1,
+                codeToRewritePrefixLines: 1,
+                codeToRewriteSuffixLines: 1,
+            },
         }
 
         const result = getCurrentFileContext(options)
@@ -295,14 +308,16 @@ describe('getCurrentFileContext', () => {
             maxSuffixLength: 100,
         })
 
-        const options = {
+        const options: CurrentFilePromptOptions = {
             docContext,
             document,
             position,
-            maxPrefixLinesInArea: 1,
-            maxSuffixLinesInArea: 1,
-            codeToRewritePrefixLines: 1,
-            codeToRewriteSuffixLines: 1,
+            tokenBudget: {
+                maxPrefixLinesInArea: 1,
+                maxSuffixLinesInArea: 1,
+                codeToRewritePrefixLines: 1,
+                codeToRewriteSuffixLines: 1,
+            },
         }
 
         const result = getCurrentFileContext(options)
@@ -328,14 +343,16 @@ describe('getCurrentFileContext', () => {
             maxSuffixLength: 100,
         })
 
-        const options = {
+        const options: CurrentFilePromptOptions = {
             docContext,
             document,
             position,
-            maxPrefixLinesInArea: 1,
-            maxSuffixLinesInArea: 1,
-            codeToRewritePrefixLines: 3, // Increased prefix lines
-            codeToRewriteSuffixLines: 1,
+            tokenBudget: {
+                maxPrefixLinesInArea: 1,
+                maxSuffixLinesInArea: 1,
+                codeToRewritePrefixLines: 3, // Increased prefix lines
+                codeToRewriteSuffixLines: 1,
+            },
         }
 
         const result = getCurrentFileContext(options)
@@ -364,14 +381,16 @@ describe('getCurrentFileContext', () => {
             maxSuffixLength: 30,
         })
 
-        const options = {
+        const options: CurrentFilePromptOptions = {
             docContext,
             document,
             position,
-            maxPrefixLinesInArea: 1,
-            maxSuffixLinesInArea: 1,
-            codeToRewritePrefixLines: 1,
-            codeToRewriteSuffixLines: 1,
+            tokenBudget: {
+                maxPrefixLinesInArea: 1,
+                maxSuffixLinesInArea: 1,
+                codeToRewritePrefixLines: 1,
+                codeToRewriteSuffixLines: 1,
+            },
         }
 
         const result = getCurrentFileContext(options)
@@ -401,14 +420,16 @@ describe('getCurrentFileContext', () => {
             maxSuffixLength: 20,
         })
 
-        const options = {
+        const options: CurrentFilePromptOptions = {
             docContext,
             document,
             position,
-            maxPrefixLinesInArea: 2,
-            maxSuffixLinesInArea: 2,
-            codeToRewritePrefixLines: 2,
-            codeToRewriteSuffixLines: 2,
+            tokenBudget: {
+                maxPrefixLinesInArea: 2,
+                maxSuffixLinesInArea: 2,
+                codeToRewritePrefixLines: 2,
+                codeToRewriteSuffixLines: 2,
+            },
         }
 
         const result = getCurrentFileContext(options)
@@ -433,14 +454,16 @@ describe('getCurrentFileContext', () => {
             maxSuffixLength: 100,
         })
 
-        const options = {
+        const options: CurrentFilePromptOptions = {
             docContext,
             document,
             position,
-            maxPrefixLinesInArea: 5, // Larger than file
-            maxSuffixLinesInArea: 5, // Larger than file
-            codeToRewritePrefixLines: 3, // Larger than file
-            codeToRewriteSuffixLines: 3, // Larger than file
+            tokenBudget: {
+                maxPrefixLinesInArea: 5, // Larger than file
+                maxSuffixLinesInArea: 5, // Larger than file
+                codeToRewritePrefixLines: 3, // Larger than file
+                codeToRewriteSuffixLines: 3, // Larger than file
+            },
         }
 
         const result = getCurrentFileContext(options)
@@ -902,7 +925,7 @@ describe('getJaccardSimilarityPrompt', () => {
 
 describe('joinPromptsWithNewlineSeperator', () => {
     it('joins multiple prompt strings with a new line separator', () => {
-        const prompt = joinPromptsWithNewlineSeperator(ps`foo`, ps`bar`)
+        const prompt = joinPromptsWithNewlineSeparator(ps`foo`, ps`bar`)
         expect(prompt.toString()).toBe(dedent`
             foo
             bar

--- a/vscode/src/autoedits/prompt/short-term-diff-prompt-strategy.test.ts
+++ b/vscode/src/autoedits/prompt/short-term-diff-prompt-strategy.test.ts
@@ -7,6 +7,7 @@ import { RetrieverIdentifier } from '../../completions/context/utils'
 import { getCurrentDocContext } from '../../completions/get-current-doc-context'
 import { documentAndPosition } from '../../completions/test-helpers'
 import type { UserPromptArgs } from './base'
+import { getCurrentFilePromptComponents } from './prompt-utils'
 import { ShortTermPromptStrategy } from './short-term-diff-prompt-strategy'
 
 describe('ShortTermPromptStrategy', () => {
@@ -61,6 +62,12 @@ describe('ShortTermPromptStrategy', () => {
                     [RetrieverIdentifier.DiagnosticsRetriever]: 100,
                 },
             }
+            const { fileWithMarkerPrompt, areaPrompt } = getCurrentFilePromptComponents({
+                docContext,
+                document,
+                position,
+                tokenBudget,
+            })
             const context: AutocompleteContextSnippet[] = shouldIncludeContext
                 ? [
                       getContextItem(
@@ -167,9 +174,8 @@ describe('ShortTermPromptStrategy', () => {
                 : []
 
             return {
-                docContext,
-                document,
-                position,
+                fileWithMarkerPrompt,
+                areaPrompt,
                 context,
                 tokenBudget,
             }
@@ -179,7 +185,7 @@ describe('ShortTermPromptStrategy', () => {
 
         it('correct prompt rendering with context', () => {
             const userPromptData = getUserPromptData({ shouldIncludeContext: false })
-            const { prompt } = strategy.getUserPrompt(userPromptData)
+            const prompt = strategy.getUserPrompt(userPromptData)
             expect(prompt.toString()).toEqual(dedent`
                 Help me finish a coding change. In particular, you will see a series of snippets from current open files in my editor, files I have recently viewed, the file I am editing, then a history of my recent codebase changes, then current compiler and linter errors, content I copied from my codebase. You will then rewrite the <code_to_rewrite>, to match what you think I would do next in the codebase. Note: I might have stopped in the middle of typing.
 
@@ -239,7 +245,7 @@ describe('ShortTermPromptStrategy', () => {
 
         it('correct prompt rendering with context', () => {
             const userPromptData = getUserPromptData({ shouldIncludeContext: true })
-            const { prompt } = strategy.getUserPrompt(userPromptData)
+            const prompt = strategy.getUserPrompt(userPromptData)
             expect(prompt.toString()).toEqual(dedent`
                 Help me finish a coding change. In particular, you will see a series of snippets from current open files in my editor, files I have recently viewed, the file I am editing, then a history of my recent codebase changes, then current compiler and linter errors, content I copied from my codebase. You will then rewrite the <code_to_rewrite>, to match what you think I would do next in the codebase. Note: I might have stopped in the middle of typing.
 

--- a/vscode/src/autoedits/prompt/test-helper.ts
+++ b/vscode/src/autoedits/prompt/test-helper.ts
@@ -29,9 +29,6 @@ export function createCodeToReplaceDataForTest(
         docContext,
         position,
         document,
-        maxPrefixLinesInArea: options.maxPrefixLinesInArea,
-        maxSuffixLinesInArea: options.maxSuffixLinesInArea,
-        codeToRewritePrefixLines: options.codeToRewritePrefixLines,
-        codeToRewriteSuffixLines: options.codeToRewriteSuffixLines,
+        tokenBudget: options,
     }).codeToReplaceData
 }


### PR DESCRIPTION
- Prepping for the analytics logger integration.  
- No functional changes included.  
- Decouples the `codeToReplaceData` computation from `getPromptForModelType`. This is necessary because `codeToReplaceData` will be used to create the analytics logger request early in the autoedits generation code path. By calculating it independently, we can have it ready earlier in the pipeline.

## Test plan

CI + updated unit tests.