### PR TITLE
add more debug logs to inspect autoedits issue

### DIFF
--- a/vscode/src/autoedits/renderer/manager.ts
+++ b/vscode/src/autoedits/renderer/manager.ts
@@ -236,7 +236,10 @@ export class AutoEditsDefaultRendererManager implements AutoEditsRendererManager
             )
             return { inlineCompletions: [inlineCompletionItem], updatedDecorationInfo: decorationInfo }
         }
-
+        autoeditsOutputChannelLogger.logDebug(
+            'maybeRenderDecorationsAndTryMakeInlineCompletionResponse',
+            'Rendering a diff view for auto-edits.'
+        )
         await this.showEdit({
             document,
             range: codeToReplaceData.range,

--- a/vscode/src/completions/context/context-mixer.ts
+++ b/vscode/src/completions/context/context-mixer.ts
@@ -8,6 +8,7 @@ import {
     wrapInActiveSpan,
 } from '@sourcegraph/cody-shared'
 import type { LastInlineCompletionCandidate } from '../get-inline-completions'
+import { autocompleteOutputChannelLogger } from '../output-channel-logger'
 import type { ContextRetriever } from '../types'
 import {
     DefaultCompletionsContextRanker,
@@ -152,6 +153,11 @@ export class ContextMixer implements vscode.Disposable {
 
         // Extract back the context results for the original retrievers
         const results = this.extractOriginalRetrieverResults(resultsWithDataLogging, retrievers)
+        autocompleteOutputChannelLogger.logDebug(
+            'ContextMixer',
+            `Extracted ${results.length} contexts from the retrievers`
+        )
+
         const contextLoggingSnippets =
             this.contextDataCollector?.getDataLoggingContextFromRetrievers(resultsWithDataLogging) ?? []
 
@@ -171,8 +177,13 @@ export class ContextMixer implements vscode.Disposable {
             }
         }
 
+        autocompleteOutputChannelLogger.logDebug(
+            'ContextMixer',
+            `Fusing ${results.length} context results with ${this.contextRankingStrategy}`
+        )
         const contextRanker = new DefaultCompletionsContextRanker(this.contextRankingStrategy)
         const fusedResults = contextRanker.rankAndFuseContext(results)
+        autocompleteOutputChannelLogger.logDebug('ContextMixer', 'Fused context results')
 
         // The total chars size hint is inclusive of the prefix and suffix sizes, so we seed the
         // total chars with the prefix and suffix sizes.

--- a/vscode/src/completions/context/retrievers/recent-user-actions/recent-edits-retriever.ts
+++ b/vscode/src/completions/context/retrievers/recent-user-actions/recent-edits-retriever.ts
@@ -2,6 +2,7 @@ import { type PromptString, contextFiltersProvider } from '@sourcegraph/cody-sha
 import type { AutocompleteContextSnippet } from '@sourcegraph/cody-shared'
 import type { AutocompleteContextSnippetMetadataFields } from '@sourcegraph/cody-shared'
 import * as vscode from 'vscode'
+import { autocompleteOutputChannelLogger } from '../../../output-channel-logger'
 import type { ContextRetriever, ContextRetrieverOptions } from '../../../types'
 import { RetrieverIdentifier, type ShouldUseContextParams, shouldBeUsedAsContext } from '../../utils'
 import type {
@@ -46,6 +47,11 @@ export class RecentEditsRetriever implements vscode.Disposable, ContextRetriever
     }
 
     public async retrieve(options: ContextRetrieverOptions): Promise<AutocompleteContextSnippet[]> {
+        autocompleteOutputChannelLogger.logDebug(
+            'recent edits retrieve',
+            'Retrieving recent edits context'
+        )
+
         const rawDiffs = await this.getDiffAcrossDocuments()
         const diffs = this.filterCandidateDiffs(rawDiffs, options.document)
         // Heuristics ordering by timestamp, taking the most recent diffs first.
@@ -67,6 +73,10 @@ export class RecentEditsRetriever implements vscode.Disposable, ContextRetriever
             }
             autocompleteContextSnippets.push(autocompleteSnippet)
         }
+        autocompleteOutputChannelLogger.logDebug(
+            'recent edits retrieve',
+            `Retrieved ${autocompleteContextSnippets.length} recent edits context`
+        )
         return autocompleteContextSnippets
     }
 


### PR DESCRIPTION
We had report of `auto-edits` [stops working randomly](https://sourcegraph.slack.com/archives/C05AGQYD528/p1735184987501309). One hypothesis is that the `auto-edits` pipeline unexpectedly breaks in between, adding more logs in the output channel to see at what stage does `auto-edits` break.

## Test plan
no functional change, added more logs

