### PR TITLE
fix: Move BigQuery insertion after release step

### DIFF
--- a/.github/workflows/vscode-insiders-release.yml
+++ b/.github/workflows/vscode-insiders-release.yml
@@ -44,6 +44,12 @@ jobs:
           service_account: 'bundle-size-tracker@cody-core-dev.iam.gserviceaccount.com'
           create_credentials_file: true
           export_environment_variables: true
+      - run: CODY_RELEASE_TYPE=insiders pnpm -C vscode run release
+        id: create_release
+        if: github.repository == 'sourcegraph/cody'
+        env:
+          VSCODE_MARKETPLACE_TOKEN: ${{ secrets.VSCODE_MARKETPLACE_TOKEN }}
+          VSCODE_OPENVSX_TOKEN: ${{ secrets.VSCODE_OPENVSX_TOKEN }}
       - name: Insert data into BigQuery
         run: |
           # Compute the current date
@@ -59,12 +65,6 @@ jobs:
         env:
           EXTENSION_BUNDLE_SIZE_MB: ${{ env.EXTENSION_BUNDLE_SIZE_MB }}
           WEBVIEW_BUNDLE_SIZE_MB: ${{ env.WEBVIEW_BUNDLE_SIZE_MB }}
-      - run: CODY_RELEASE_TYPE=insiders pnpm -C vscode run release
-        id: create_release
-        if: github.repository == 'sourcegraph/cody'
-        env:
-          VSCODE_MARKETPLACE_TOKEN: ${{ secrets.VSCODE_MARKETPLACE_TOKEN }}
-          VSCODE_OPENVSX_TOKEN: ${{ secrets.VSCODE_OPENVSX_TOKEN }}
       - name: Tag insiders release
         uses: actions/github-script@v6
         with:


### PR DESCRIPTION
## Problem
The BigQuery insertion step was giving nothing in the version tag because it attempted to access `steps.create_release.outputs.version_tag` before the release step had run, resulting in missing version data in our bundle size tracking.

<img width="832" alt="image" src="https://github.com/user-attachments/assets/498db61a-3671-4ae1-93c6-8645fee8641b" />


## Solution
Reordered the GitHub Actions workflow steps to ensure the BigQuery insertion happens after the release step, when the version tag is available.

## Changes
- Moved the "Insert data into BigQuery" step to execute after the `create_release` step
- No changes to the logic or data structure, just workflow ordering

## Test plan
- Checked github actions

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
