### PR TITLE
fix(context-agent): add status callbacks back 

### DIFF
--- a/vscode/src/chat/chat-view/ChatController.ts
+++ b/vscode/src/chat/chat-view/ChatController.ts
@@ -807,7 +807,6 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
             editor: this.editor,
             chatClient: this.chatClient,
             codyToolProvider: this.toolProvider,
-            postMessageCallback: model => this.postEmptyMessageInProgress(model),
         })
 
         recorder.setIntentInfo({

--- a/vscode/src/chat/chat-view/ChatController.ts
+++ b/vscode/src/chat/chat-view/ChatController.ts
@@ -18,6 +18,7 @@ import {
     type Guardrails,
     ModelUsage,
     type NLSSearchDynamicFilter,
+    type ProcessingStep,
     PromptString,
     type SerializedChatInteraction,
     type SerializedChatTranscript,
@@ -841,6 +842,9 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
                     postMessageInProgress: (message?: ChatMessage): void => {
                         messageInProgress = message
                         this.postViewTranscript(message)
+                    },
+                    postStatuses: (steps: ProcessingStep[]): void => {
+                        this.chatBuilder.setLastMessageProcesses(steps)
                     },
                     postDone: (op?: { abort: boolean }): void => {
                         if (op?.abort) {

--- a/vscode/src/chat/chat-view/ChatController.ts
+++ b/vscode/src/chat/chat-view/ChatController.ts
@@ -807,6 +807,7 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
             editor: this.editor,
             chatClient: this.chatClient,
             codyToolProvider: this.toolProvider,
+            postMessageCallback: model => this.postEmptyMessageInProgress(model),
         })
 
         recorder.setIntentInfo({

--- a/vscode/src/chat/chat-view/handlers/ChatHandler.ts
+++ b/vscode/src/chat/chat-view/handlers/ChatHandler.ts
@@ -57,6 +57,7 @@ export class ChatHandler implements AgentHandler {
             { text: inputText, mentions },
             editorState,
             chatBuilder,
+            delegate,
             signal
         )
         if (contextResult.error) {
@@ -223,6 +224,7 @@ export class ChatHandler implements AgentHandler {
         { text, mentions }: HumanInput,
         editorState: SerializedPromptEditorState | null,
         _chatBuilder: ChatBuilder,
+        _delegate: AgentHandlerDelegate,
         signal?: AbortSignal
     ): Promise<{
         contextItems?: ContextItem[]

--- a/vscode/src/chat/chat-view/handlers/ChatHandler.ts
+++ b/vscode/src/chat/chat-view/handlers/ChatHandler.ts
@@ -82,8 +82,6 @@ export class ChatHandler implements AgentHandler {
         recorder.recordChatQuestionExecuted(corpusContext, { addMetadata: true, current: span })
 
         signal.throwIfAborted()
-        // Display context in webview before sending the request.
-        delegate.postMessageInProgress({ speaker: 'assistant', model: this.modelId })
         this.streamAssistantResponse(requestID, prompt, this.modelId, signal, chatBuilder, delegate)
     }
 

--- a/vscode/src/chat/chat-view/handlers/ChatHandler.ts
+++ b/vscode/src/chat/chat-view/handlers/ChatHandler.ts
@@ -82,6 +82,8 @@ export class ChatHandler implements AgentHandler {
         recorder.recordChatQuestionExecuted(corpusContext, { addMetadata: true, current: span })
 
         signal.throwIfAborted()
+        // Display context in webview before sending the request.
+        delegate.postMessageInProgress({ speaker: 'assistant', model: this.modelId })
         this.streamAssistantResponse(requestID, prompt, this.modelId, signal, chatBuilder, delegate)
     }
 

--- a/vscode/src/chat/chat-view/handlers/DeepCodyHandler.ts
+++ b/vscode/src/chat/chat-view/handlers/DeepCodyHandler.ts
@@ -1,6 +1,7 @@
 import {
     type ContextItem,
     FeatureFlag,
+    type ProcessingStep,
     type SerializedPromptEditorState,
     featureFlagProvider,
     storeLastValue,
@@ -72,12 +73,9 @@ export class DeepCodyHandler extends ChatHandler implements AgentHandler {
             chatBuilder,
             this.chatClient,
             this.toolProvider.getTools(),
-            baseContext
+            baseContext,
+            (steps: ProcessingStep[]) => delegate.postStatuses(steps)
         )
-        // Use delegate instead of callback
-        agent.setStatusCallback(model => {
-            delegate.postMessageInProgress({ speaker: 'assistant', model })
-        })
         const agenticContext = await agent.getContext(requestID, signal)
         return { contextItems: [...baseContext, ...agenticContext] }
     }

--- a/vscode/src/chat/chat-view/handlers/DeepCodyHandler.ts
+++ b/vscode/src/chat/chat-view/handlers/DeepCodyHandler.ts
@@ -21,7 +21,8 @@ export class DeepCodyHandler extends ChatHandler implements AgentHandler {
         contextRetriever: Pick<ContextRetriever, 'retrieveContext'>,
         editor: ChatControllerOptions['editor'],
         chatClient: ChatControllerOptions['chatClient'],
-        private toolProvider: CodyToolProvider
+        private toolProvider: CodyToolProvider,
+        private postMessageCallback: (model: string) => void
     ) {
         super(modelId, contextRetriever, editor, chatClient)
     }
@@ -66,13 +67,14 @@ export class DeepCodyHandler extends ChatHandler implements AgentHandler {
         }
 
         const baseContext = baseContextResult.contextItems ?? []
-        const codyAgent = new DeepCodyAgent(
+        const agent = new DeepCodyAgent(
             chatBuilder,
             this.chatClient,
             this.toolProvider.getTools(),
             baseContext
         )
-        const agenticContext = await codyAgent.getContext(requestID, signal)
+        agent.setStatusCallback(model => this.postMessageCallback(model))
+        const agenticContext = await agent.getContext(requestID, signal)
         return { contextItems: [...baseContext, ...agenticContext] }
     }
 }

--- a/vscode/src/chat/chat-view/handlers/interfaces.ts
+++ b/vscode/src/chat/chat-view/handlers/interfaces.ts
@@ -2,6 +2,7 @@ import type { Span } from '@opentelemetry/api'
 import type {
     ChatMessage,
     ContextItem,
+    ProcessingStep,
     PromptString,
     SerializedPromptEditorState,
 } from '@sourcegraph/cody-shared'
@@ -24,6 +25,7 @@ export interface AgentTools {
  */
 export interface AgentHandlerDelegate {
     postError(error: Error, type?: MessageErrorType): void
+    postStatuses(steps: ProcessingStep[]): void
     postMessageInProgress(message: ChatMessage): void
     postDone(ops?: { abort: boolean }): void
 }

--- a/vscode/src/chat/chat-view/handlers/interfaces.ts
+++ b/vscode/src/chat/chat-view/handlers/interfaces.ts
@@ -17,7 +17,6 @@ export interface AgentTools {
     editor: ChatControllerOptions['editor']
     chatClient: ChatControllerOptions['chatClient']
     codyToolProvider: CodyToolProvider
-    postMessageCallback: (model: string) => void
 }
 
 /**

--- a/vscode/src/chat/chat-view/handlers/interfaces.ts
+++ b/vscode/src/chat/chat-view/handlers/interfaces.ts
@@ -17,6 +17,7 @@ export interface AgentTools {
     editor: ChatControllerOptions['editor']
     chatClient: ChatControllerOptions['chatClient']
     codyToolProvider: CodyToolProvider
+    postMessageCallback: (model: string) => void
 }
 
 /**

--- a/vscode/src/chat/chat-view/handlers/registry.ts
+++ b/vscode/src/chat/chat-view/handlers/registry.ts
@@ -25,8 +25,18 @@ export function getAgent(id: string, tools: AgentTools): AgentHandler {
 
 registerAgent(
     'sourcegraph::2023-06-01::deep-cody',
-    (id: string, { contextRetriever, editor, chatClient, codyToolProvider }: AgentTools) =>
-        new DeepCodyHandler(id, contextRetriever, editor, chatClient, codyToolProvider)
+    (
+        id: string,
+        { contextRetriever, editor, chatClient, codyToolProvider, postMessageCallback }: AgentTools
+    ) =>
+        new DeepCodyHandler(
+            id,
+            contextRetriever,
+            editor,
+            chatClient,
+            codyToolProvider,
+            postMessageCallback
+        )
 )
 registerAgent('search', (_id: string, _tools: AgentTools) => new SearchHandler())
 registerAgent(

--- a/vscode/src/chat/chat-view/handlers/registry.ts
+++ b/vscode/src/chat/chat-view/handlers/registry.ts
@@ -25,18 +25,8 @@ export function getAgent(id: string, tools: AgentTools): AgentHandler {
 
 registerAgent(
     'sourcegraph::2023-06-01::deep-cody',
-    (
-        id: string,
-        { contextRetriever, editor, chatClient, codyToolProvider, postMessageCallback }: AgentTools
-    ) =>
-        new DeepCodyHandler(
-            id,
-            contextRetriever,
-            editor,
-            chatClient,
-            codyToolProvider,
-            postMessageCallback
-        )
+    (id: string, { contextRetriever, editor, chatClient, codyToolProvider }: AgentTools) =>
+        new DeepCodyHandler(id, contextRetriever, editor, chatClient, codyToolProvider)
 )
 registerAgent('search', (_id: string, _tools: AgentTools) => new SearchHandler())
 registerAgent(


### PR DESCRIPTION
The statusCallback method was removed by #6469 by accident. This PR is to add the callback function to the Deep Cody Handler by passing delegate to computeContext so that the context agent (deep cody) can send its status update to the webview.

## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

The changes in https://github.com/sourcegraph/cody/pull/6451 should be working again:

https://github.com/user-attachments/assets/41b558fb-01fe-4a0d-a8bf-8d133bc01a1c


Added `delegate.postMessageInProgress({ speaker: 'assistant', model: this.modelId })` before `streamAssistantResponse` is invoked so that the context would show up in the UI before we stream the response to webview:

https://github.com/user-attachments/assets/98cdd891-cc36-42a8-87e7-38b813f13c07


## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
