### PR TITLE
fix: race condition in saving history before switching accounts

### DIFF
--- a/vscode/src/chat/chat-view/ChatController.ts
+++ b/vscode/src/chat/chat-view/ChatController.ts
@@ -1457,10 +1457,11 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
         })
     }
 
-    public async clearAndRestartSession(chatMessages?: ChatMessage[]): Promise<void> {
+    public async clearAndRestartSession(chatMessages?: ChatMessage[], shouldSave= true): Promise<void> {
         this.cancelSubmitOrEditOperation()
-        void this.saveSession()
-
+        if (shouldSave) {
+            void this.saveSession()
+        }
         this.chatBuilder = new ChatBuilder(this.chatBuilder.selectedModel, undefined, chatMessages)
         this.postViewTranscript()
     }

--- a/vscode/src/chat/chat-view/ChatController.ts
+++ b/vscode/src/chat/chat-view/ChatController.ts
@@ -1457,7 +1457,7 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
         })
     }
 
-    public async clearAndRestartSession(chatMessages?: ChatMessage[], shouldSave= true): Promise<void> {
+    public async clearAndRestartSession(chatMessages?: ChatMessage[], shouldSave = true): Promise<void> {
         this.cancelSubmitOrEditOperation()
         if (shouldSave) {
             void this.saveSession()

--- a/vscode/src/chat/chat-view/ChatsController.ts
+++ b/vscode/src/chat/chat-view/ChatsController.ts
@@ -82,6 +82,9 @@ export class ChatsController implements vscode.Disposable {
                     const hasSwitchedAccount =
                         this.currentAuthAccount &&
                         this.currentAuthAccount.endpoint !== authStatus.endpoint
+                    this.currentAuthAccount = authStatus.authenticated ? { ...authStatus } : undefined
+                    console.log('this.currentAuthAccount endpoint', this.currentAuthAccount?.endpoint, '\n hasLoggedOut: ', hasLoggedOut, '\n hasSwitchedAccount: ', hasSwitchedAccount, '\n authStatus endpoint: ', authStatus.endpoint)
+
                     if (hasLoggedOut) {
                         this.disposeAllChats()
                     }

--- a/vscode/src/chat/chat-view/ChatsController.ts
+++ b/vscode/src/chat/chat-view/ChatsController.ts
@@ -83,10 +83,28 @@ export class ChatsController implements vscode.Disposable {
                         this.currentAuthAccount &&
                         this.currentAuthAccount.endpoint !== authStatus.endpoint
                     if (hasLoggedOut || hasSwitchedAccount) {
-                        this.disposeAllChats()
-                    }
 
-                    this.currentAuthAccount = authStatus.authenticated ? { ...authStatus } : undefined
+                        // Update account reference before disposing
+                        this.currentAuthAccount = authStatus.authenticated
+                            ? { ...authStatus }
+                            : undefined
+
+                        // Dispose chats without saving to storage
+                        this.activeEditor = undefined
+                        const oldEditors = this.editors
+                        this.editors = []
+                        for (const editor of oldEditors) {
+                            if (editor.webviewPanelOrView) {
+                                disposeWebviewViewOrPanel(editor.webviewPanelOrView)
+                            }
+                            editor.dispose()
+                        }
+
+                        // Clear panel without saving
+                        if (this.panel) {
+                            this.panel.clearAndRestartSession([], false) // Add parameter to skip saving
+                        }
+                    }
                 })
             )
         )

--- a/vscode/src/chat/chat-view/ChatsController.ts
+++ b/vscode/src/chat/chat-view/ChatsController.ts
@@ -79,36 +79,21 @@ export class ChatsController implements vscode.Disposable {
             subscriptionDisposable(
                 authStatus.subscribe(authStatus => {
                     const hasLoggedOut = !authStatus.authenticated
-                    const hasSwitchedAccount =
-                        this.currentAuthAccount &&
-                        this.currentAuthAccount.endpoint !== authStatus.endpoint
-                    this.currentAuthAccount = authStatus.authenticated ? { ...authStatus } : undefined
-                    console.log('this.currentAuthAccount endpoint', this.currentAuthAccount?.endpoint, '\n hasLoggedOut: ', hasLoggedOut, '\n hasSwitchedAccount: ', hasSwitchedAccount, '\n authStatus endpoint: ', authStatus.endpoint)
+                    console.log(
+                        'code222: this.currentAuthAccount endpoint',
+                        this.currentAuthAccount?.endpoint,
+                        '\n hasLoggedOut: ',
+                        hasLoggedOut,
+                        '\n hasSwitchedAccount: ',
+                        hasSwitchedAccount,
+                        '\n authStatus endpoint: ',
+                        authStatus.endpoint
+                    )
+
+                    // this.currentAuthAccount = authStatus.authenticated ? { ...authStatus } : undefined
 
                     if (hasLoggedOut) {
                         this.disposeAllChats()
-                    }
-                    if (hasSwitchedAccount) {
-                        // Update account reference before disposing
-                        this.currentAuthAccount = authStatus.authenticated
-                            ? { ...authStatus }
-                            : undefined
-
-                        // Dispose chats without saving to storage
-                        this.activeEditor = undefined
-                        const oldEditors = this.editors
-                        this.editors = []
-                        for (const editor of oldEditors) {
-                            if (editor.webviewPanelOrView) {
-                                disposeWebviewViewOrPanel(editor.webviewPanelOrView)
-                            }
-                            editor.dispose()
-                        }
-
-                        // Clear panel without saving
-                        if (this.panel) {
-                            this.panel.clearAndRestartSession([], false)
-                        }
                     }
                 })
             )

--- a/vscode/src/chat/chat-view/ChatsController.ts
+++ b/vscode/src/chat/chat-view/ChatsController.ts
@@ -84,8 +84,6 @@ export class ChatsController implements vscode.Disposable {
                         this.currentAuthAccount?.endpoint,
                         '\n hasLoggedOut: ',
                         hasLoggedOut,
-                        '\n hasSwitchedAccount: ',
-                        hasSwitchedAccount,
                         '\n authStatus endpoint: ',
                         authStatus.endpoint
                     )

--- a/vscode/src/chat/chat-view/ChatsController.ts
+++ b/vscode/src/chat/chat-view/ChatsController.ts
@@ -82,8 +82,10 @@ export class ChatsController implements vscode.Disposable {
                     const hasSwitchedAccount =
                         this.currentAuthAccount &&
                         this.currentAuthAccount.endpoint !== authStatus.endpoint
-                    if (hasLoggedOut || hasSwitchedAccount) {
-
+                    if (hasLoggedOut) {
+                        this.disposeAllChats()
+                    }
+                    if (hasSwitchedAccount) {
                         // Update account reference before disposing
                         this.currentAuthAccount = authStatus.authenticated
                             ? { ...authStatus }
@@ -102,7 +104,7 @@ export class ChatsController implements vscode.Disposable {
 
                         // Clear panel without saving
                         if (this.panel) {
-                            this.panel.clearAndRestartSession([], false) // Add parameter to skip saving
+                            this.panel.clearAndRestartSession([], false)
                         }
                     }
                 })


### PR DESCRIPTION
[Linear issue
](https://linear.app/sourcegraph/issue/QA-175/vsc-chat-history-is-not-updated-on-switching-between-accounts)

## Problem
When switching between Cody accounts, the last active chat would incorrectly appear in both accounts' chat histories. This happened because:

1. During account switching, `disposeAllChats()` was called which attempts to save the current chat state
2. However, by the time `disposeAllChats()` runs, the `currentAuthAccount` had already been updated to the new account
3. This caused the chat to be saved under the wrong account's history

## Solution
Separated the logout and account switch logic:
- For logout: Continue to call `disposeAllChats()` to properly save and clear chats
- For account switch: Skip `disposeAllChats()` and directly dispose UI elements without saving
  - This is safe because:
    - Active chats are already saved during normal operation via `saveSession()`
    - We're just switching views, not losing data
    - Each account's chat history remains properly preserved in storage


## Test plan
1. Create chats in Account A
2. Switch to Account B and  check history to see if the latest chat on Account A is NOT seen on account B 
3. Make a new chat on account B
4. Switch back to Account A - verify only Account A's chats are visible
5. Switch to Account B - verify only Account B's chats are visible
6. Verify logout still properly saves chats before clearing


<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
