### PR TITLE
Fixing file path for saving new files from chat in windows 

### DIFF
--- a/jetbrains/src/main/kotlin/com/sourcegraph/utils/CodyUriUtil.kt
+++ b/jetbrains/src/main/kotlin/com/sourcegraph/utils/CodyUriUtil.kt
@@ -1,0 +1,37 @@
+package com.sourcegraph.utils
+
+import java.io.File
+import java.net.URI
+import java.nio.file.Path
+import java.nio.file.Paths
+
+object CodyUriUtil {
+    /**
+     * Normalizes a URI string to a consistent format across platforms.
+     */
+    @JvmStatic
+    fun normalizeUri(uriString: String): URI {
+        if (uriString.isBlank()) {
+            throw IllegalArgumentException("URI string cannot be empty")
+        }
+
+        return when {
+            uriString.contains("://") -> URI.create(uriString)
+            uriString.startsWith("untitled:") -> URI.create(uriString).withScheme("file")
+            File(uriString).isAbsolute -> File(uriString).toURI()
+            else -> Paths.get(uriString).toUri()
+        }
+    }
+
+    @JvmStatic
+    fun toPath(uriString: String): Path = 
+        Paths.get(normalizeUri(uriString))
+
+    @JvmStatic
+    fun areEquivalent(uri1: String, uri2: String): Boolean =
+        normalizeUri(uri1).normalize() == normalizeUri(uri2).normalize()
+
+    @JvmStatic
+    fun toNormalizedString(uriString: String): String =
+        normalizeUri(uriString).toString()
+}

--- a/jetbrains/src/test/kotlin/utils/CodyUriUtilTest.kt
+++ b/jetbrains/src/test/kotlin/utils/CodyUriUtilTest.kt
@@ -1,0 +1,130 @@
+package com.sourcegraph.utils
+
+import org.junit.Assert.*
+import org.junit.Test
+import java.io.File
+import java.net.URI
+
+class CodyUriUtilTest {
+    
+    @Test
+    fun `test standard file URIs`() {
+        val expected = "file:///path/to/file.txt"
+        val inputs = listOf(
+            "/path/to/file.txt",
+            "file:///path/to/file.txt",
+            File("/path/to/file.txt").absolutePath
+        )
+        
+        inputs.forEach { input ->
+            val result = CodyUriUtil.normalizeUri(input)
+            assertEquals(expected, result.toString())
+        }
+    }
+
+    @Test
+    fun `test Windows paths`() {
+        val inputs = mapOf(
+            "C:\\Users\\test\\file.txt" to "file:///C:/Users/test/file.txt",
+            "C:/Users/test/file.txt" to "file:///C:/Users/test/file.txt",
+            "file:///C:/Users/test/file.txt" to "file:///C:/Users/test/file.txt"
+        )
+        
+        inputs.forEach { (input, expected) ->
+            val result = CodyUriUtil.normalizeUri(input)
+            assertEquals(expected, result.toString())
+        }
+    }
+
+    @Test
+    fun `test WSL paths`() {
+        val inputs = mapOf(
+            "\\\\wsl\$\\Ubuntu\\home\\user\\file.txt" to "file:////wsl$/Ubuntu/home/user/file.txt",
+            "//wsl$/Ubuntu/home/user/file.txt" to "file:////wsl$/Ubuntu/home/user/file.txt"
+        )
+        
+        inputs.forEach { (input, expected) ->
+            val result = CodyUriUtil.normalizeUri(input)
+            assertEquals(expected, result.toString())
+        }
+    }
+
+    @Test
+    fun `test untitled URIs`() {
+        val input = "untitled:Untitled-1"
+        val result = CodyUriUtil.normalizeUri(input)
+        assertEquals("file:Untitled-1", result.toString())
+    }
+
+    @Test
+    fun `test network paths`() {
+        val inputs = mapOf(
+            "\\\\server\\share\\file.txt" to "file:////server/share/file.txt",
+            "//server/share/file.txt" to "file:////server/share/file.txt"
+        )
+        
+        inputs.forEach { (input, expected) ->
+            val result = CodyUriUtil.normalizeUri(input)
+            assertEquals(expected, result.toString())
+        }
+    }
+
+    @Test
+    fun `test URI equivalence`() {
+        val equivalentPairs = listOf(
+            Pair("C:\\Users\\test\\file.txt", "file:///C:/Users/test/file.txt"),
+            Pair("/path/to/file.txt", "file:///path/to/file.txt"),
+            Pair("\\\\server\\share\\file.txt", "file:////server/share/file.txt")
+        )
+        
+        equivalentPairs.forEach { (uri1, uri2) ->
+            assertTrue(CodyUriUtil.areEquivalent(uri1, uri2))
+        }
+    }
+
+    @Test
+    fun `test path conversion`() {
+        val inputs = mapOf(
+            "file:///path/to/file.txt" to "/path/to/file.txt",
+            "file:///C:/Users/test/file.txt" to "C:\\Users\\test\\file.txt"
+        )
+        
+        inputs.forEach { (input, expected) ->
+            val result = CodyUriUtil.toPath(input)
+            assertEquals(File(expected).absolutePath, result.toFile().absolutePath)
+        }
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `test empty URI string`() {
+        CodyUriUtil.normalizeUri("")
+    }
+
+    @Test
+    fun `test special characters in paths`() {
+        val inputs = mapOf(
+            "/path/with spaces/file.txt" to "file:///path/with%20spaces/file.txt",
+            "/path/with#hash/file.txt" to "file:///path/with%23hash/file.txt",
+            "/path/with?question/file.txt" to "file:///path/with%3Fquestion/file.txt"
+        )
+        
+        inputs.forEach { (input, expected) ->
+            val result = CodyUriUtil.normalizeUri(input)
+            assertEquals(expected, result.toString())
+        }
+    }
+
+    @Test
+    fun `test remote URIs`() {
+        val inputs = listOf(
+            "http://example.com/file.txt",
+            "https://example.com/file.txt",
+            "ftp://example.com/file.txt"
+        )
+        
+        inputs.forEach { input ->
+            val result = CodyUriUtil.normalizeUri(input)
+            assertEquals(input, result.toString())
+        }
+    }
+}


### PR DESCRIPTION
Solves [Linear issue](https://linear.app/sourcegraph/issue/QA-196/jetbrains-crash-occurred-when-user-tries-to-save-searched-code-file-in)

## Problem
On Windows systems, file operations were failing due to incorrect URI handling, specifically:
- Windows paths (e.g., C:\path\to\file) were being incorrectly interpreted as URIs
- Backslashes were being URL-encoded (%5C) causing path resolution failures
- The system was interpreting drive letters (e.g., "C:") as URI schemes instead of part of the path

This resulted in errors like:
- Provider "C" not installed
- The network path was not found
- URISyntaxException with "Expected scheme-specific part"

## Solution
Added proper Windows path normalization in CodyEditorUtil.kt to handle file paths correctly before URI creation:
1. Added path normalization for Windows-style paths:

2. Applied this normalization in both findFileOrScratch and createFileOrScratchFromUntitled methods


## Test plan
- Follow the [steps of this video in windows](https://drive.google.com/file/d/1oOPFVuPkHSzz7BNjXwzbGXBpTW16iAgx/view)
- Notice that the file will be saved successfully without errors 
- Check the logs which will be clean


## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
