### PR TITLE
fix NonEmptyFirstMessage storybook

### DIFF
--- a/vscode/src/completions/inline-completion-item-provider.test.ts
+++ b/vscode/src/completions/inline-completion-item-provider.test.ts
@@ -128,7 +128,8 @@ describe('InlineCompletionItemProvider', () => {
 
         // Check if the trigger delay is respected
         const elapsedTime = Date.now() - startTime
-        expect(elapsedTime).toBeGreaterThanOrEqual(triggerDelay)
+        // Note: we add 1.0 here for some buffer to reduce flakiness (https://github.com/sourcegraph/cody/actions/runs/12587968355/job/35084898262?pr=6492)
+        expect(elapsedTime + 1.0).toBeGreaterThanOrEqual(triggerDelay)
         // We only check for greater than because a less than would vary depending on the CI machine
 
         // Switch to fake timers for precise control

--- a/vscode/webviews/chat/cells/messageCell/human/HumanMessageCell.story.tsx
+++ b/vscode/webviews/chat/cells/messageCell/human/HumanMessageCell.story.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react'
 
-import { PromptString, ps } from '@sourcegraph/cody-shared'
+import { FIXTURE_MODEL, PromptString, ps } from '@sourcegraph/cody-shared'
 import { ExtensionAPIProviderForTestsOnly, MOCK_API } from '@sourcegraph/prompt-editor'
 import { Observable } from 'observable-fns'
 import { URI } from 'vscode-uri'
@@ -63,7 +63,7 @@ export const WithInitialContext: StoryObj<typeof meta> = {
         <ExtensionAPIProviderForTestsOnly
             value={{
                 ...MOCK_API,
-                chatModels: () => Observable.of([]),
+                chatModels: () => Observable.of([FIXTURE_MODEL]),
                 defaultContext: () =>
                     Observable.of({
                         initialContext: [
@@ -95,7 +95,7 @@ export const WithInitialContextFileTooLarge: StoryObj<typeof meta> = {
         <ExtensionAPIProviderForTestsOnly
             value={{
                 ...MOCK_API,
-                chatModels: () => Observable.of([]),
+                chatModels: () => Observable.of([FIXTURE_MODEL]),
                 defaultContext: () =>
                     Observable.of({
                         initialContext: [

--- a/vscode/webviews/chat/cells/messageCell/human/editor/HumanMessageEditor.tsx
+++ b/vscode/webviews/chat/cells/messageCell/human/editor/HumanMessageEditor.tsx
@@ -1,6 +1,7 @@
 import {
     type ChatMessage,
     FAST_CHAT_INPUT_TOKEN_BUDGET,
+    FIXTURE_MODEL,
     FeatureFlag,
     type Model,
     ModelTag,
@@ -87,7 +88,6 @@ export const HumanMessageEditor: FunctionComponent<{
     onChange,
     onSubmit: parentOnSubmit,
     onStop,
-    isFirstInteraction,
     isLastInteraction,
     isEditorInitiallyFocused,
     className,
@@ -390,7 +390,7 @@ export const HumanMessageEditor: FunctionComponent<{
         )
     )
 
-    const currentChatModel = useMemo(() => models[0], [models[0]])
+    const currentChatModel = useMemo(() => (models ? models[0] : undefined), [models, models?.[0]])
 
     const defaultContext = useDefaultContextForChat()
     useEffect(() => {

--- a/vscode/webviews/chat/cells/messageCell/human/editor/HumanMessageEditor.tsx
+++ b/vscode/webviews/chat/cells/messageCell/human/editor/HumanMessageEditor.tsx
@@ -1,7 +1,6 @@
 import {
     type ChatMessage,
     FAST_CHAT_INPUT_TOKEN_BUDGET,
-    FIXTURE_MODEL,
     FeatureFlag,
     type Model,
     ModelTag,


### PR DESCRIPTION
Previously, the storybook was failing because the `models` prop can be `undefined`.

## Test plan

Storybook-only