### PR TITLE
Fix Ghost Text and CodeLens issue in Jetbrains

### DIFF
--- a/jetbrains/src/main/kotlin/com/sourcegraph/cody/edit/lenses/LensesService.kt
+++ b/jetbrains/src/main/kotlin/com/sourcegraph/cody/edit/lenses/LensesService.kt
@@ -63,13 +63,16 @@ class LensesService(val project: Project) {
 
     runInEdt {
       if (project.isDisposed) return@runInEdt
-      CodyEditorUtil.getSelectedEditors(project).forEach { editor ->
-        CodeVisionInitializer.getInstance(project)
-            .getCodeVisionHost()
-            .invalidateProvider(
-                CodeVisionHost.LensInvalidateSignal(
-                    editor, EditCodeVisionProvider.allEditProviders().map { it.id }))
-      }
+      // Find the specific editor matching the file
+      CodyEditorUtil.getAllOpenEditors()
+        .find { editor -> editor.virtualFile == vf }
+        ?.let { matchingEditor ->
+          CodeVisionInitializer.getInstance(project)
+              .getCodeVisionHost()
+              .invalidateProvider(
+                  CodeVisionHost.LensInvalidateSignal(
+                      matchingEditor, EditCodeVisionProvider.allEditProviders().map { it.id }))
+        }
     }
     listeners.forEach { it.onLensesUpdate(vf, codeLens) }
   }


### PR DESCRIPTION
[Linear Issue
](https://linear.app/sourcegraph/issue/QA-132/jetbrains-ghost-text-gets-stuck-on-screen-when-user-click-accept)

## Problem
Codelens would remain stuck on screen after accepting edits through the chat section's show diff feature. 

## Solution
Modified the `LensesService` to properly handle editor invalidation by:
- Targeting the specific codelens that matches the file being updated instead of the file currently open in the editor
- Using `getAllOpenEditors()` to find the correct editor context
- Ensuring code vision providers are properly invalidated for the matching editor

## Testing
Verified that:
- CodeLens clears properly after accepting edits through show diff
- The behavior in [this video](https://drive.google.com/file/d/1nrMij3E7khjYAuJlI5kDwlG5VrUeMQ1h/view) does NOT happen anymore 

## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
