### PR TITLE
Add Cody bench command for NLS

### DIFF
--- a/agent/src/cli/command-bench/command-bench.ts
+++ b/agent/src/cli/command-bench/command-bench.ts
@@ -26,6 +26,7 @@ import { matchesGlobPatterns } from './matchesGlobPatterns'
 import { evaluateAutocompleteStrategy } from './strategy-autocomplete'
 import { evaluateChatStrategy } from './strategy-chat'
 import { evaluateChatContextStrategy } from './strategy-chat-context'
+import { evaluateNLSStrategy } from './strategy-chat-nls'
 import { evaluateFixStrategy } from './strategy-fix'
 import { evaluateGitLogStrategy } from './strategy-git-log'
 import { evaluateUnitTestStrategy } from './strategy-unit-test'
@@ -84,6 +85,7 @@ export enum BenchStrategy {
     ChatContext = 'chat-context',
     Fix = 'fix',
     GitLog = 'git-log',
+    NLS = 'nls',
     UnitTest = 'unit-test',
 }
 
@@ -430,7 +432,10 @@ async function evaluateWorkspace(options: CodyBenchOptions, recordingDirectory: 
                 await evaluateChatStrategy(client, options)
                 break
             case BenchStrategy.ChatContext:
-                await evaluateChatContextStrategy(client, options)
+                await evaluateChatContextStrategy(options)
+                break
+            case BenchStrategy.NLS:
+                await evaluateNLSStrategy(options)
                 break
             case BenchStrategy.UnitTest:
                 await evaluateUnitTestStrategy(client, options)

--- a/agent/src/cli/command-bench/strategy-chat-context-types.ts
+++ b/agent/src/cli/command-bench/strategy-chat-context-types.ts
@@ -15,7 +15,7 @@ export interface ClientOptions {
 export interface EvalOutput {
     evaluatedAt: string
     codyClientVersion: string
-    clientOptions: ClientOptions
+    clientOptions?: ClientOptions
     siteUserMetadata: {
         url: string
         sourcegraphVersion: string


### PR DESCRIPTION
This PR adds an NLS strategy to Cody bench that uses the `nlsSearchQuery` GraphQL endpoint. This lets us run NLS evals against the actual method used to power omnibox. Previously, we were using the `getCodyContext` endpoint and adjusting it to use `patterntype:nls`. So it resolves an important piece of tech debt in our evals.

Addresses SPLF-757

## Test plan

Updated `cody-leaderboard` to use this new strategy, reran evals, and results looked as expected.

I will open a follow-up PR to update `cody-leaderboard` to use the new strategy.