### PR TITLE
Fix: Respect autocomplete enabled setting for keyboard shortcut trigger

### DIFF
--- a/jetbrains/src/main/kotlin/com/sourcegraph/cody/autocomplete/action/TriggerAutocompleteActionHandler.kt
+++ b/jetbrains/src/main/kotlin/com/sourcegraph/cody/autocomplete/action/TriggerAutocompleteActionHandler.kt
@@ -13,7 +13,8 @@ class TriggerAutocompleteActionHandler : EditorActionHandler() {
   val logger = Logger.getInstance(TriggerAutocompleteActionHandler::class.java)
 
   override fun isEnabledForCaret(editor: Editor, caret: Caret, dataContext: DataContext): Boolean =
-      CodyEditorUtil.isEditorInstanceSupported(editor)
+      CodyEditorUtil.isEditorInstanceSupported(editor) &&
+      CodyEditorUtil.isImplicitAutocompleteEnabledForEditor(editor)
 
   override fun doExecute(editor: Editor, caret: Caret?, dataContext: DataContext) {
     val offset = caret?.offset ?: editor.caretModel.currentCaret.offset


### PR DESCRIPTION
[Solves Linear ](https://linear.app/sourcegraph/issue/QA-237/jetbrains-cody-autocomplete-gets-triggered-after-pressing)

## Description:
Currently, the keyboard shortcut (Ctrl+Alt+P/Control+Option+P) triggers Cody autocomplete even when autocomplete is disabled via "Disable Cody Autocomplete". This PR fixes the issue by checking if autocomplete is enabled before allowing the keyboard shortcut to trigger.

## Changes:
Added check for isImplicitAutocompleteEnabledForEditor in TriggerAutocompleteActionHandler
Ensures consistent behavior between automatic and manual autocomplete triggers


## Test plan

1. Disable Cody Autocomplete
Try triggering autocomplete with Control+Option+P (Mac) or Ctrl+Alt+P (Windows/Linux)
3. Verify no autocomplete suggestions appear
Enable Cody Autocomplete

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
