### PR TITLE
feat(nls): add relevant repo boost

### DIFF
--- a/vscode/src/chat/chat-view/handlers/SearchHandler.ts
+++ b/vscode/src/chat/chat-view/handlers/SearchHandler.ts
@@ -11,6 +11,7 @@ import {
     errorToChatError,
     graphqlClient,
     inputTextWithoutContextChipsFromPromptEditorState,
+    isValidVersion,
     ps,
 } from '@sourcegraph/cody-shared'
 import * as vscode from 'vscode'
@@ -37,12 +38,15 @@ export class SearchHandler implements AgentHandler {
         const currentFile = getEditor()?.active?.document?.uri || workspaceRoot
         const repoName = currentFile ? await getFirstRepoNameContainingUri(currentFile) : undefined
 
-        const boostParameter = repoName ? `boost:repo(${repoName})` : ''
+        const currentRepoBoost = repoName ? `boost:repo(${repoName})` : ''
+        const myProjectsBoost = (await isValidVersion({ minimumVersion: '6.0.0' }))
+            ? 'boost:relevant.repos()'
+            : ''
 
         const query = `content:"${inputTextWithoutContextChips.replaceAll(
             '"',
             '\\"'
-        )}" ${boostParameter} ${scopes.length ? `(${scopes.join(' OR ')})` : ''}`
+        )}" ${currentRepoBoost} ${myProjectsBoost} ${scopes.length ? `(${scopes.join(' OR ')})` : ''}`
 
         try {
             const response = await graphqlClient.nlsSearchQuery({


### PR DESCRIPTION
This adds the search param to boost a user's relevant repos. It is only added if the server version supports it (min version 6.0.0 or insiders build).

I did not yet implement the UI to enable/disable boosting, but wanted to get this out ASAP for dogfooding. Will work on the interactions next.

## Test plan

Manual testing of a local build.
