### PR TITLE
storybook: add context items with sources for steps

### DIFF
--- a/vscode/webviews/chat/cells/contextCell/ContextCell.story.tsx
+++ b/vscode/webviews/chat/cells/contextCell/ContextCell.story.tsx
@@ -172,7 +172,17 @@ export const NoContextFound: Story = {
 
 export const WithSteps: Story = {
     args: {
-        contextItems: [{ type: 'file', uri: URI.file('/foo/bar.go') }],
+        contextItems: [
+            { type: 'file', uri: URI.file('/foo/bar.go'), source: ContextItemSource.Search },
+            {
+                type: 'openctx',
+                uri: URI.file('https://linear.com/issue/openctx-issue'),
+                source: ContextItemSource.Agentic,
+                provider: 'openctx',
+                title: 'Linear Issue',
+                providerUri: '',
+            },
+        ],
         isForFirstMessage: true,
         model: 'deep-cody',
         processes: [
@@ -198,7 +208,10 @@ export const WithSteps: Story = {
 
 export const LoadingWithSteps: Story = {
     args: {
-        contextItems: [{ type: 'file', uri: URI.file('/foo/bar.go') }],
+        contextItems: [
+            { type: 'file', uri: URI.file('/foo/bar.go'), source: ContextItemSource.Search },
+            { type: 'file', uri: URI.file('git clone'), source: ContextItemSource.Terminal },
+        ],
         isForFirstMessage: true,
         model: 'deep-cody',
         processes: [

--- a/vscode/webviews/chat/cells/contextCell/ContextCell.story.tsx
+++ b/vscode/webviews/chat/cells/contextCell/ContextCell.story.tsx
@@ -210,7 +210,7 @@ export const LoadingWithSteps: Story = {
     args: {
         contextItems: [
             { type: 'file', uri: URI.file('/foo/bar.go'), source: ContextItemSource.Search },
-            { type: 'file', uri: URI.file('git clone'), source: ContextItemSource.Terminal },
+            { type: 'file', uri: URI.file('git diff'), source: ContextItemSource.Terminal },
         ],
         isForFirstMessage: true,
         model: 'deep-cody',
@@ -222,8 +222,13 @@ export const LoadingWithSteps: Story = {
             },
             {
                 id: 'Terminal',
-                status: 'pending',
+                status: 'success',
                 content: 'git diff',
+            },
+            {
+                id: 'Terminal',
+                status: 'pending',
+                content: 'git clone',
             },
         ],
         isContextLoading: true,


### PR DESCRIPTION
This change adds new context items and sources to the ContextCell component for steps:
- Adds a new 'openctx' context item with a Linear Issue as the title
- Adds a new 'file' context item with the source set to 'Terminal'
- Updates the existing 'file' context item to have the source set to 'Search'

The context items used in the storybook now reflects the step status correctly.

## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

Run storybook to check out the ContextCell story to see the updated context aligns with the step status:

![image](https://github.com/user-attachments/assets/b0d01e35-ab8b-4ffb-acfd-4f6254bbe561)

![image](https://github.com/user-attachments/assets/d6cd38e6-f1e8-4408-a3bd-fa6093a75038)

To start storybook:

```bash
pnpm run -C vscode storybook
```

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
