### PR TITLE
fix(release): add $ variable invocation

### DIFF
--- a/.github/workflows/vscode-stable-release.yml
+++ b/.github/workflows/vscode-stable-release.yml
@@ -85,7 +85,7 @@ jobs:
           ANNOUNCE_RELEASES_SLACK_WEBHOOK_URL=${{ secrets.ANNOUNCE_RELEASES_SLACK_WEBHOOK_URL }}
 
           # treat this like an array, add a space for the next webhook secret
-          webhooks=("$ANNOUNCE_EDITORS_SLACK_WEBHOOK_URL" "ANNOUNCE_RELEASES_SLACK_WEBHOOK_URL")
+          webhooks=("$ANNOUNCE_EDITORS_SLACK_WEBHOOK_URL" "$ANNOUNCE_RELEASES_SLACK_WEBHOOK_URL")
           for webhook in "${webhooks[@]}"; do
             response=$(curl -s -w "%{http_code}" -X POST -H "Content-Type: application/json" -d '{
               "type": "mrkdwn",


### PR DESCRIPTION
Fixes error in last step of [release workflow](https://github.com/sourcegraph/cody/actions/runs/12587100152/job/35086752028) where we send off slack notifications, I forgot to add $ so the GHA kept failing. 


## Test plan
N/A


<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
