### PR TITLE
chore(security): Fix closed events for sast scan

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -2,7 +2,7 @@ name: Semgrep - SAST Scan
 
 on:
   pull_request_target:
-    types: [ closed, edited, opened, synchronize, ready_for_review ]
+    types: [edited, opened, synchronize, ready_for_review]
 
 jobs:
   semgrep:


### PR DESCRIPTION
CI has been failing for closed pull request events, fixing that by removing the closed events as this already runs on pre-merge events

## Test plan

- CI 🟢 

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
