### PR TITLE
fix(release): add GH_TOKEN for gh command

### DIFF
--- a/.github/workflows/generate-changelog.yml
+++ b/.github/workflows/generate-changelog.yml
@@ -19,6 +19,7 @@ jobs:
       - name: Generate changelog
         env:
           DEVX_SERVICE_GH_TOKEN: ${{ secrets.DEVX_SERVICE_GH_TOKEN }}
+          GH_TOKEN: ${{ secrets.DEVX_SERVICE_GH_TOKEN }} 
           GH_REPO: "sourcegraph/cody"
           CHANGELOG_SKIP_NO_CHANGELOG: "true"
           CHANGELOG_COMPACT: "true"


### PR DESCRIPTION
uses devx token when running gh commands


## Test plan
n/a 

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
