### PR TITLE
fix(vscode): adjust user avatar image size in UserMenu and TabsBar

### DIFF
--- a/vscode/webviews/components/UserMenu.story.tsx
+++ b/vscode/webviews/components/UserMenu.story.tsx
@@ -89,3 +89,17 @@ export const LongEmail: Story = {
         },
     },
 }
+
+export const LargeUserAvatarImage: Story = {
+    args: {
+        isProUser: false,
+        authStatus: {
+            ...AUTH_STATUS_FIXTURE_AUTHED,
+            username: 'ara',
+            primaryEmail: '',
+            endpoint: 'https://sourcegraph.com',
+            avatarURL:
+                'https://lh3.googleusercontent.com/a/ACg8ocLFLnpSkpj-ZEhngxhMMD-BZGmFBsIObP8rin6oTuPs',
+        },
+    },
+}

--- a/vscode/webviews/components/UserMenu.tsx
+++ b/vscode/webviews/components/UserMenu.tsx
@@ -312,12 +312,12 @@ export const UserMenu: React.FunctionComponent<UserMenuProps> = ({
                         <CommandList>
                             <CommandGroup title="Main Account Menu">
                                 <CommandItem>
-                                    <div className="tw-flex tw-w-full tw-justify-start tw-gap-4 tw-align-middle">
+                                    <div className="tw-flex tw-w-full tw-justify-start tw-gap-4 tw-align-middle tw-max-h-9">
                                         <UserAvatar
                                             user={authStatus}
                                             size={USER_MENU_AVATAR_SIZE}
                                             sourcegraphGradientBorder={!!isProUser}
-                                            className="tw-inline-flex tw-self-center tw-items-center tw-w-auto tw-flex-none"
+                                            className="tw-inline-flex tw-self-center tw-items-center tw-w-auto tw-flex-none tw-max-h-9"
                                         />
                                         <div className="tw-flex tw-self-stretch tw-flex-col tw-w-full tw-items-start tw-justify-center tw-flex-auto tw-overflow-hidden">
                                             <p
@@ -438,7 +438,7 @@ export const UserMenu: React.FunctionComponent<UserMenuProps> = ({
                 user={authStatus}
                 size={USER_MENU_AVATAR_SIZE}
                 sourcegraphGradientBorder={!!isProUser}
-                className="tw-w-10 tw-h-10"
+                className="tw-max-h-full tw-width-auto"
             />
         </ToolbarPopoverItem>
     )

--- a/vscode/webviews/tabs/TabsBar.tsx
+++ b/vscode/webviews/tabs/TabsBar.tsx
@@ -156,7 +156,7 @@ export const TabsBar = memo<TabsBarProps>(props => {
                                 isProUser={isCodyProUser}
                                 endpointHistory={endpointHistory}
                                 setView={setView}
-                                className="!tw-opacity-100"
+                                className="!tw-opacity-100 tw-h-full"
                             />
                         )}
                     </div>


### PR DESCRIPTION
CLOSE https://linear.app/sourcegraph/issue/CODY-4607/profile-picture-size-issue-when-clicked-in-the-app

This commit addresses the following changes:

1. In the `UserMenu` component, the user avatar is now constrained to a maximum height of 9 units and the width is set to auto to maintain aspect ratio.
2. In the `TabsBar` component, the user avatar container is now set to full height to ensure proper vertical alignment.

These changes improve the visual appearance and consistency of the user avatar across different UI elements.

## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

Updated story book with problematic image src:

![image](https://github.com/user-attachments/assets/59c0cf90-bacb-46be-8964-9f920a84d8cb)


## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
