### PR TITLE
suggestion mode UI

### DIFF
--- a/agent/src/AgentWorkspaceConfiguration.test.ts
+++ b/agent/src/AgentWorkspaceConfiguration.test.ts
@@ -72,7 +72,7 @@ describe('AgentWorkspaceConfiguration', () => {
             expect(config.get('cody.telemetry.level')).toBe('agent')
             // clientName undefined because custom JSON specified telemetry with level alone.
             expect(config.get('cody.telemetry.clientName')).toBe('test-client')
-            expect(config.get('cody.autocomplete.enabled')).toBe(true)
+            expect(config.get('cody.suggestions.mode')).toBe('autocomplete')
             expect(config.get('cody.autocomplete.advanced.provider')).toBe('anthropic')
             expect(config.get('cody.autocomplete.advanced.model')).toBe('claude-2')
             expect(config.get('cody.advanced.agent.running')).toBe(true)

--- a/jetbrains/src/test/kotlin/com/sourcegraph/config/ConfigUtilTest.kt
+++ b/jetbrains/src/test/kotlin/com/sourcegraph/config/ConfigUtilTest.kt
@@ -16,7 +16,7 @@ class ConfigUtils {
         """
     {
       "cody.debug": true,
-      "cody.autocomplete.enabled": true
+      "cody.suggestions.mode": "autocomplete"
     }
     """
     val result = ConfigUtil.getCustomConfiguration(mockProject, input)
@@ -39,7 +39,7 @@ class ConfigUtils {
         """
     {
       "cody.debug": true,
-      "cody.autocomplete.enabled": true,
+      "cody.suggestions.mode": "autocomplete"
     }
     """
     val result = ConfigUtil.getCustomConfiguration(mockProject, input)
@@ -55,7 +55,7 @@ class ConfigUtils {
     {
        // This is a comment
       "cody.debug": true,
-      "cody.autocomplete.enabled": true,
+      "cody.suggestions.mode": "autocomplete"
     }
     """
     val result = ConfigUtil.getCustomConfiguration(mockProject, input)

--- a/lib/shared/src/configuration.ts
+++ b/lib/shared/src/configuration.ts
@@ -188,6 +188,21 @@ export enum CodyIDE {
     StandaloneWeb = 'StandaloneWeb',
 }
 
+export enum CodyAutoSuggestionMode {
+    /**
+     * The suggestion mode where suggestions come from the OpenAI completions API. This is the default mode.
+     */
+    Autocomplete = 'autocomplete',
+    /**
+     * The suggestion mode where suggestions come from the Cody AI agent chat API.
+     */
+    SuggestionAgent = 'suggestion agent',
+    /**
+     * Disable Cody suggestions altogether.
+     */
+    Off = 'off',
+}
+
 export type AutocompleteProviderID = keyof typeof AUTOCOMPLETE_PROVIDER_ID
 
 export const AUTOCOMPLETE_PROVIDER_ID = {

--- a/lib/shared/src/configuration.ts
+++ b/lib/shared/src/configuration.ts
@@ -188,6 +188,9 @@ export enum CodyIDE {
     StandaloneWeb = 'StandaloneWeb',
 }
 
+/**
+ * These values must match the enum values in cody.suggestions.mode in vscode/package.json
+ */
 export enum CodyAutoSuggestionMode {
     /**
      * The suggestion mode where suggestions come from the OpenAI completions API. This is the default mode.
@@ -196,7 +199,7 @@ export enum CodyAutoSuggestionMode {
     /**
      * The suggestion mode where suggestions come from the Cody AI agent chat API.
      */
-    SuggestionAgent = 'suggestion agent',
+    Autoedits = 'auto-edits (Experimental)',
     /**
      * Disable Cody suggestions altogether.
      */

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -1006,7 +1006,7 @@
           "enum": ["autocomplete", "auto-edits (Experimental)", "off"],
           "enumDescriptions": [
             "Enables standard autocomplete mode for suggestions.",
-            "Offers advanced context-aware suggestions by integrating autocompletion with inline editing, surpassing traditional autocomplete. Experimental feature for Pro and Enterprise users.",
+            "Offers advanced context-aware suggestions by integrating autocompletion with inline editing. Experimental feature for Pro and Enterprise users.",
             "Disables all suggestions."
           ],
           "default": "autocomplete",

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -1005,8 +1005,8 @@
           "type": "string",
           "enum": ["autocomplete", "auto-edits (Experimental)", "off"],
           "enumDescriptions": [
-            "Enables standard autocomplete mode for suggestions.",
-            "Offers advanced context-aware suggestions by integrating autocompletion with inline editing. Experimental feature for Pro and Enterprise users.",
+            "Suggests standard code completions as you type.",
+            "Suggests advanced context-aware code edits as you navigate the codebase. Experimental feature for Pro and Enterprise users.",
             "Disables all suggestions."
           ],
           "default": "autocomplete",

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -409,13 +409,13 @@
         "command": "cody.autocomplete.openTraceView",
         "category": "Cody",
         "title": "Open Autocomplete Trace View",
-        "enablement": "cody.activated && config.cody.autocomplete.enabled"
+        "enablement": "cody.activated && config.cody.suggestions.mode === 'autocomplete'"
       },
       {
         "command": "cody.autocomplete.manual-trigger",
         "category": "Cody",
         "title": "Trigger Autocomplete at Cursor",
-        "enablement": "cody.activated && config.cody.autocomplete.enabled && !editorReadonly && !editorHasSelection && !inlineSuggestionsVisible"
+        "enablement": "cody.activated && config.cody.suggestions.mode === 'autocomplete' && !editorReadonly && !editorHasSelection && !inlineSuggestionsVisible"
       },
       {
         "command": "cody.chat.signIn",
@@ -578,7 +578,7 @@
       {
         "command": "cody.command.autoedits-manual-trigger",
         "title": "Autoedits Manual Trigger",
-        "enablement": "cody.activated && config.cody.experimental.autoedits.enabled"
+        "enablement": "cody.activated && config.cody.suggestions.mode == 'suggestion agent'"
       }
     ],
     "keybindings": [
@@ -687,7 +687,7 @@
       {
         "command": "cody.autocomplete.manual-trigger",
         "key": "alt+\\",
-        "when": "editorTextFocus && !editorHasSelection && config.cody.autocomplete.enabled && !inlineSuggestionsVisible"
+        "when": "editorTextFocus && !editorHasSelection && config.cody.suggestions.mode === 'autocomplete' && !inlineSuggestionsVisible"
       },
       {
         "command": "cody.fixup.acceptNearest",
@@ -739,7 +739,7 @@
       {
         "command": "cody.supersuggest.testExample",
         "key": "ctrl+alt+enter",
-        "when": "cody.activated && config.cody.experimental.autoedits.enabled"
+        "when": "cody.activated && config.cody.suggestions.mode == 'suggestion agent'"
       }
     ],
     "submenus": [
@@ -1001,11 +1001,16 @@
             }
           ]
         },
-        "cody.autocomplete.enabled": {
-          "order": 5,
-          "type": "boolean",
-          "markdownDescription": "Enables code autocompletions.",
-          "default": true
+        "cody.suggestions.mode": {
+          "type": "string",
+          "enum": ["autocomplete", "suggestion agent", "off"],
+          "enumDescriptions": [
+            "Enable standard autocomplete mode",
+            "Enable suggestion agent mode",
+            "Disable all suggestions"
+          ],
+          "default": "autocomplete",
+          "markdownDescription": "Controls the suggestion mode for Cody"
         },
         "cody.autocomplete.triggerDelay": {
           "order": 5,

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -578,7 +578,7 @@
       {
         "command": "cody.command.autoedits-manual-trigger",
         "title": "Autoedits Manual Trigger",
-        "enablement": "cody.activated && config.cody.suggestions.mode == 'suggestion agent'"
+        "enablement": "cody.activated && config.cody.suggestions.mode == 'auto-edits (Experimental)'"
       }
     ],
     "keybindings": [
@@ -739,7 +739,7 @@
       {
         "command": "cody.supersuggest.testExample",
         "key": "ctrl+alt+enter",
-        "when": "cody.activated && config.cody.suggestions.mode == 'suggestion agent'"
+        "when": "cody.activated && config.cody.suggestions.mode == 'auto-edits (Experimental)'"
       }
     ],
     "submenus": [
@@ -1003,11 +1003,11 @@
         },
         "cody.suggestions.mode": {
           "type": "string",
-          "enum": ["autocomplete", "suggestion agent", "off"],
+          "enum": ["autocomplete", "auto-edits (Experimental)", "off"],
           "enumDescriptions": [
-            "Enable standard autocomplete mode",
-            "Enable suggestion agent mode",
-            "Disable all suggestions"
+            "Enables standard autocomplete mode for suggestions.",
+            "Offers advanced context-aware suggestions by integrating autocompletion with inline editing, surpassing traditional autocomplete. Experimental feature for Pro and Enterprise users.",
+            "Disables all suggestions."
           ],
           "default": "autocomplete",
           "markdownDescription": "Controls the suggestion mode for Cody"

--- a/vscode/src/completions/create-inline-completion-item-provider.ts
+++ b/vscode/src/completions/create-inline-completion-item-provider.ts
@@ -41,7 +41,7 @@ export function createInlineCompletionItemProvider({
         ) {
             throw new Error(
                 'The setting `config.autocomplete` evaluated to `false`. It must be true when running inside the agent. ' +
-                    'To fix this problem, make sure that the setting cody.autocomplete.enabled has the value true.'
+                    'To fix this problem, make sure that the setting cody.suggestions.mode has the value autocomplete.'
             )
         }
         return NEVER

--- a/vscode/src/configuration.test.ts
+++ b/vscode/src/configuration.test.ts
@@ -1,7 +1,12 @@
 import { assert, describe, expect, it } from 'vitest'
 import type * as vscode from 'vscode'
 
-import { type ClientConfiguration, OLLAMA_DEFAULT_URL, ps } from '@sourcegraph/cody-shared'
+import {
+    type ClientConfiguration,
+    CodyAutoSuggestionMode,
+    OLLAMA_DEFAULT_URL,
+    ps,
+} from '@sourcegraph/cody-shared'
 
 import type { ChatModelProviderConfig } from '@sourcegraph/cody-shared/src/models/sync'
 import { getConfiguration } from './configuration'
@@ -28,8 +33,8 @@ describe('getConfiguration', () => {
                             'Cache-Control': 'no-cache',
                             'Proxy-Authenticate': 'Basic',
                         }
-                    case 'cody.autocomplete.enabled':
-                        return false
+                    case 'cody.suggestions.mode':
+                        return CodyAutoSuggestionMode.Off
                     case 'cody.autocomplete.languages':
                         return { '*': true }
                     case 'cody.commandCodeLenses':
@@ -95,8 +100,6 @@ describe('getConfiguration', () => {
                         return false
                     case 'cody.experimental.supercompletions':
                         return false
-                    case 'cody.experimental.autoedits.enabled':
-                        return undefined
                     case 'cody.experimental.autoedits-renderer-testing':
                         return false
                     case 'cody.experimental.autoedits.config.override':
@@ -166,7 +169,7 @@ describe('getConfiguration', () => {
             agenticContextExperimentalShell: false,
             agenticContextExperimentalOptions: { shell: { allow: ['git'] } },
             experimentalSupercompletions: false,
-            experimentalAutoeditsEnabled: undefined,
+            experimentalAutoeditsEnabled: false,
             experimentalAutoeditsConfigOverride: undefined,
             experimentalAutoeditsRendererTesting: false,
             experimentalMinionAnthropicKey: undefined,

--- a/vscode/src/configuration.ts
+++ b/vscode/src/configuration.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode'
 
 import {
     type ClientConfiguration,
+    CodyAutoSuggestionMode,
     type CodyIDE,
     OLLAMA_DEFAULT_URL,
     type PickResolvedConfiguration,
@@ -46,6 +47,11 @@ export function getConfiguration(
         debugRegex = /.*/
     }
 
+    const codyAutoSuggestionsMode = config.get<string>(
+        CONFIG_KEY.suggestionsMode,
+        CodyAutoSuggestionMode.Autocomplete
+    )
+
     return {
         net: {
             mode: config.get<string | null | undefined>(CONFIG_KEY.netMode, undefined),
@@ -68,7 +74,7 @@ export function getConfiguration(
         debugVerbose: config.get<boolean>(CONFIG_KEY.debugVerbose, false),
         debugFilter: debugRegex,
         telemetryLevel: config.get<'all' | 'off'>(CONFIG_KEY.telemetryLevel, 'all'),
-        autocomplete: config.get(CONFIG_KEY.autocompleteEnabled, true),
+        autocomplete: codyAutoSuggestionsMode === CodyAutoSuggestionMode.Autocomplete,
         autocompleteLanguages: config.get(CONFIG_KEY.autocompleteLanguages, {
             '*': true,
         }),
@@ -119,7 +125,7 @@ export function getConfiguration(
         experimentalTracing: getHiddenSetting('experimental.tracing', false),
 
         experimentalSupercompletions: getHiddenSetting('experimental.supercompletions', false),
-        experimentalAutoeditsEnabled: getHiddenSetting('experimental.autoedits.enabled', undefined),
+        experimentalAutoeditsEnabled: codyAutoSuggestionsMode === CodyAutoSuggestionMode.SuggestionAgent,
         experimentalAutoeditsConfigOverride: getHiddenSetting(
             'experimental.autoedits.config.override',
             undefined

--- a/vscode/src/configuration.ts
+++ b/vscode/src/configuration.ts
@@ -125,7 +125,7 @@ export function getConfiguration(
         experimentalTracing: getHiddenSetting('experimental.tracing', false),
 
         experimentalSupercompletions: getHiddenSetting('experimental.supercompletions', false),
-        experimentalAutoeditsEnabled: codyAutoSuggestionsMode === CodyAutoSuggestionMode.SuggestionAgent,
+        experimentalAutoeditsEnabled: codyAutoSuggestionsMode === CodyAutoSuggestionMode.Autoedits,
         experimentalAutoeditsConfigOverride: getHiddenSetting(
             'experimental.autoedits.config.override',
             undefined

--- a/vscode/src/testutils/mocks.ts
+++ b/vscode/src/testutils/mocks.ts
@@ -898,7 +898,7 @@ export const DEFAULT_VSCODE_SETTINGS = {
     },
     commandCodeLenses: false,
     experimentalSupercompletions: false,
-    experimentalAutoeditsEnabled: undefined,
+    experimentalAutoeditsEnabled: false,
     experimentalAutoeditsRendererTesting: false,
     experimentalAutoeditsConfigOverride: undefined,
     experimentalMinionAnthropicKey: undefined,

--- a/vscode/test/e2e/auto-edits.test.ts
+++ b/vscode/test/e2e/auto-edits.test.ts
@@ -1,5 +1,6 @@
 import { expect } from '@playwright/test'
 import type { Frame, Page } from '@playwright/test'
+import { CodyAutoSuggestionMode } from '@sourcegraph/cody-shared'
 import * as mockServer from '../fixtures/mock-server'
 import { sidebarExplorer, sidebarSignin } from './common'
 import {
@@ -66,7 +67,7 @@ const test = baseTest
     .extend<DotcomUrlOverride>({ dotcomUrl: mockServer.SERVER_URL })
     .extend<ExtraWorkspaceSettings>({
         extraWorkspaceSettings: {
-            'cody.experimental.autoedits.enabled': true,
+            'cody.suggestions.mode': CodyAutoSuggestionMode.SuggestionAgent,
             'cody.experimental.autoedits.use-mock-responses': true,
         },
     })

--- a/vscode/test/e2e/auto-edits.test.ts
+++ b/vscode/test/e2e/auto-edits.test.ts
@@ -67,7 +67,7 @@ const test = baseTest
     .extend<DotcomUrlOverride>({ dotcomUrl: mockServer.SERVER_URL })
     .extend<ExtraWorkspaceSettings>({
         extraWorkspaceSettings: {
-            'cody.suggestions.mode': CodyAutoSuggestionMode.SuggestionAgent,
+            'cody.suggestions.mode': CodyAutoSuggestionMode.Autoedits,
             'cody.experimental.autoedits.use-mock-responses': true,
         },
     })

--- a/web/lib/agent/agent.client.ts
+++ b/web/lib/agent/agent.client.ts
@@ -1,4 +1,4 @@
-import { FILE_CONTEXT_MENTION_PROVIDER } from '@sourcegraph/cody-shared'
+import { CodyAutoSuggestionMode, FILE_CONTEXT_MENTION_PROVIDER } from '@sourcegraph/cody-shared'
 import type { ClientInfo, ServerInfo } from 'cody-ai/src/jsonrpc/agent-protocol'
 import {
     BrowserMessageReader,
@@ -86,7 +86,7 @@ export async function createAgentClient({
                 ...(customHeaders ?? {}),
             },
             customConfiguration: {
-                'cody.autocomplete.enabled': false,
+                'cody.suggestions.mode': CodyAutoSuggestionMode.Off,
                 'cody.experimental.urlContext': true,
                 // Will be replaced with vite in build time
                 // @ts-ignore


### PR DESCRIPTION
With `auto-edits` being a replacement of `autocomplete`. Based on the [suggestion](https://sourcegraph.slack.com/archives/C07F8LLKE06/p1735327930973269?thread_ts=1735292806.801459&cid=C07F8LLKE06) The, PR adds a `drop-down` for the users to choose between the "autocomplete", "auto-edits" and "Off".

The PR deprecates the 2 earlier `configurations`:
1. `cody.autocomplete.enabled`
2. `cody.experimental.autoedits.enabled`

And introduces the `cody.suggestions.mode: 'autocomplete' | 'auto-edits' | 'off' ` for the users to choose from.

<img width="549" alt="image" src="https://github.com/user-attachments/assets/0786fab9-9711-41ed-ab09-8d1c41e28023" />


## Test plan
Green CI
Also tested the agent test cases with the new config. Agent takes the default values from `vscode/package.json` which uses `autocomplete` as default for suggestion mode and it works.

