### PR TITLE
External Authentication Providers Support for Cody

### DIFF
--- a/agent/scripts/reverse-proxy.py
+++ b/agent/scripts/reverse-proxy.py
@@ -1,0 +1,68 @@
+from aiohttp import web, ClientSession
+from urllib.parse import urlparse
+import asyncio
+
+target_url = ''
+port = 5050
+
+async def proxy_handler(request):
+    async with ClientSession(auto_decompress=False) as session:
+        print(f'Request to: {request.url}')
+
+        # Modify headers here
+        headers = dict(request.headers)
+
+        # Reset the Host header to use target server host instead of the proxy host
+        if 'Host' in headers:
+            headers['Host'] = urlparse(target_url).netloc.split(':')[0]
+
+        # 'chunked' encoding results in error 400 from Cloudflare, removing it still keeps response chunked anyway
+        if 'Transfer-Encoding' in headers:
+            del headers['Transfer-Encoding']
+
+        # Use value of 'Authorization: Bearer' to fill 'X-Forwarded-User' and remove 'Authorization' header
+        if 'Authorization' in headers:
+            values = headers['Authorization'].split()
+            if values and values[0] == 'Bearer':
+                headers['X-Forwarded-User'] = values[1]
+            del headers['Authorization']
+
+        # Forward the request to target
+        async with session.request(
+            method=request.method,
+            url=f'{target_url}{request.path_qs}',
+            headers=headers,
+            data=await request.read()
+        ) as response:
+            proxy_response = web.StreamResponse(
+                status=response.status,
+                headers=response.headers
+            )
+
+            await proxy_response.prepare(request)
+
+            # Stream the response back
+            async for chunk in response.content.iter_chunks():
+                await proxy_response.write(chunk[0])
+
+            await proxy_response.write_eof()
+            return proxy_response
+
+app = web.Application()
+app.router.add_route('*', '/{path_info:.*}', proxy_handler)
+
+
+if __name__ == '__main__':
+    print('Usage:  python reverse_proxy.py [target_url] [proxy_port]')
+
+    import sys
+    if (len(sys.argv) < 2):
+        print('Please specify target_url')
+        sys.exit(1)
+    if len(sys.argv) > 1:
+        target_url = sys.argv[1]
+    if len(sys.argv) > 2:
+        port = int(sys.argv[2])
+
+    print(f'Starting proxy server on port {port} targeting {target_url}...')
+    web.run_app(app, port=port)

--- a/agent/src/AgentWorkspaceConfiguration.ts
+++ b/agent/src/AgentWorkspaceConfiguration.ts
@@ -116,7 +116,7 @@ export class AgentWorkspaceConfiguration implements vscode.WorkspaceConfiguratio
 
         function mergeWithBaseConfig(config: any) {
             for (const [key, value] of Object.entries(config)) {
-                if (typeof value === 'object') {
+                if (typeof value === 'object' && !Array.isArray(value)) {
                     const existing = _.get(baseConfig, key) ?? {}
                     const merged = _.merge(existing, value)
                     _.set(baseConfig, key, merged)

--- a/agent/src/agent.ts
+++ b/agent/src/agent.ts
@@ -1499,7 +1499,9 @@ export class Agent extends MessageHandler implements ExtensionClient {
                         },
                         auth: {
                             serverEndpoint: config.serverEndpoint,
-                            accessTokenOrHeaders: config.accessToken ?? null,
+                            credentials: config.accessToken
+                                ? { token: config.accessToken, source: 'paste' }
+                                : undefined,
                         },
                         clientState: {
                             anonymousUserID: config.anonymousUserID ?? null,

--- a/agent/src/agent.ts
+++ b/agent/src/agent.ts
@@ -1486,11 +1486,10 @@ export class Agent extends MessageHandler implements ExtensionClient {
         config: ExtensionConfiguration,
         params?: { forceAuthentication: boolean }
     ): Promise<AuthStatus> {
-        const isAuthChange = vscode_shim.isAuthenticationChange(config)
+        const isAuthChange = vscode_shim.isTokenOrEndpointChange(config)
         vscode_shim.setExtensionConfiguration(config)
 
-        // If this is an authentication change we need to reauthenticate prior to firing events
-        // that update the clients
+        // If this is an token or endpoint change we need to save them prior to firing events that update the clients
         try {
             if ((isAuthChange || params?.forceAuthentication) && config.serverEndpoint) {
                 await authProvider.validateAndStoreCredentials(
@@ -1500,7 +1499,7 @@ export class Agent extends MessageHandler implements ExtensionClient {
                         },
                         auth: {
                             serverEndpoint: config.serverEndpoint,
-                            accessToken: config.accessToken ?? null,
+                            accessTokenOrHeaders: config.accessToken || null,
                         },
                         clientState: {
                             anonymousUserID: config.anonymousUserID ?? null,

--- a/agent/src/agent.ts
+++ b/agent/src/agent.ts
@@ -1499,7 +1499,7 @@ export class Agent extends MessageHandler implements ExtensionClient {
                         },
                         auth: {
                             serverEndpoint: config.serverEndpoint,
-                            accessTokenOrHeaders: config.accessToken || null,
+                            accessTokenOrHeaders: config.accessToken ?? null,
                         },
                         clientState: {
                             anonymousUserID: config.anonymousUserID ?? null,

--- a/agent/src/cli/command-auth/AuthenticatedAccount.ts
+++ b/agent/src/cli/command-auth/AuthenticatedAccount.ts
@@ -42,7 +42,10 @@ export class AuthenticatedAccount {
     ): Promise<AuthenticatedAccount | Error> {
         const graphqlClient = SourcegraphGraphQLAPIClient.withStaticConfig({
             configuration: { telemetryLevel: 'agent' },
-            auth: { accessTokenOrHeaders: options.accessToken, serverEndpoint: options.endpoint },
+            auth: {
+                credentials: { token: options.accessToken },
+                serverEndpoint: options.endpoint,
+            },
             clientState: { anonymousUserID: null },
         })
         const userInfo = await graphqlClient.getCurrentUserInfo()

--- a/agent/src/cli/command-auth/AuthenticatedAccount.ts
+++ b/agent/src/cli/command-auth/AuthenticatedAccount.ts
@@ -42,7 +42,7 @@ export class AuthenticatedAccount {
     ): Promise<AuthenticatedAccount | Error> {
         const graphqlClient = SourcegraphGraphQLAPIClient.withStaticConfig({
             configuration: { telemetryLevel: 'agent' },
-            auth: { accessToken: options.accessToken, serverEndpoint: options.endpoint },
+            auth: { accessTokenOrHeaders: options.accessToken, serverEndpoint: options.endpoint },
             clientState: { anonymousUserID: null },
         })
         const userInfo = await graphqlClient.getCurrentUserInfo()

--- a/agent/src/cli/command-auth/command-login.ts
+++ b/agent/src/cli/command-auth/command-login.ts
@@ -123,7 +123,7 @@ async function loginAction(
             : await captureAccessTokenViaBrowserRedirect(serverEndpoint, spinner)
     const client = SourcegraphGraphQLAPIClient.withStaticConfig({
         configuration: { telemetryLevel: 'agent' },
-        auth: { accessTokenOrHeaders: token, serverEndpoint: serverEndpoint },
+        auth: { credentials: { token: options.accessToken }, serverEndpoint: serverEndpoint },
         clientState: { anonymousUserID: null },
     })
     const userInfo = await client.getCurrentUserInfo()
@@ -256,7 +256,7 @@ async function promptUserAboutLoginMethod(spinner: Ora, options: LoginOptions): 
     try {
         const client = SourcegraphGraphQLAPIClient.withStaticConfig({
             configuration: { telemetryLevel: 'agent' },
-            auth: { accessTokenOrHeaders: options.accessToken, serverEndpoint: options.endpoint },
+            auth: { credentials: { token: options.accessToken }, serverEndpoint: options.endpoint },
             clientState: { anonymousUserID: null },
         })
         const userInfo = await client.getCurrentUserInfo()

--- a/agent/src/cli/command-auth/command-login.ts
+++ b/agent/src/cli/command-auth/command-login.ts
@@ -123,7 +123,7 @@ async function loginAction(
             : await captureAccessTokenViaBrowserRedirect(serverEndpoint, spinner)
     const client = SourcegraphGraphQLAPIClient.withStaticConfig({
         configuration: { telemetryLevel: 'agent' },
-        auth: { accessToken: token, serverEndpoint: serverEndpoint },
+        auth: { accessTokenOrHeaders: token, serverEndpoint: serverEndpoint },
         clientState: { anonymousUserID: null },
     })
     const userInfo = await client.getCurrentUserInfo()
@@ -256,7 +256,7 @@ async function promptUserAboutLoginMethod(spinner: Ora, options: LoginOptions): 
     try {
         const client = SourcegraphGraphQLAPIClient.withStaticConfig({
             configuration: { telemetryLevel: 'agent' },
-            auth: { accessToken: options.accessToken, serverEndpoint: options.endpoint },
+            auth: { accessTokenOrHeaders: options.accessToken, serverEndpoint: options.endpoint },
             clientState: { anonymousUserID: null },
         })
         const userInfo = await client.getCurrentUserInfo()

--- a/agent/src/cli/command-bench/command-bench.ts
+++ b/agent/src/cli/command-bench/command-bench.ts
@@ -331,7 +331,7 @@ export const benchCommand = new commander.Command('bench')
         setStaticResolvedConfigurationWithAuthCredentials({
             configuration: { customHeaders: {} },
             auth: {
-                accessTokenOrHeaders: options.srcAccessToken,
+                credentials: { token: options.srcAccessToken },
                 serverEndpoint: options.srcEndpoint,
             },
         })

--- a/agent/src/cli/command-bench/command-bench.ts
+++ b/agent/src/cli/command-bench/command-bench.ts
@@ -331,7 +331,7 @@ export const benchCommand = new commander.Command('bench')
         setStaticResolvedConfigurationWithAuthCredentials({
             configuration: { customHeaders: {} },
             auth: {
-                accessToken: options.srcAccessToken,
+                accessTokenOrHeaders: options.srcAccessToken,
                 serverEndpoint: options.srcEndpoint,
             },
         })

--- a/agent/src/cli/command-bench/llm-judge.ts
+++ b/agent/src/cli/command-bench/llm-judge.ts
@@ -16,7 +16,7 @@ export class LlmJudge {
         localStorage.setStorage('noop')
         setStaticResolvedConfigurationWithAuthCredentials({
             configuration: { customHeaders: undefined },
-            auth: { accessToken: options.srcAccessToken, serverEndpoint: options.srcEndpoint },
+            auth: { accessTokenOrHeaders: options.srcAccessToken, serverEndpoint: options.srcEndpoint },
         })
         setClientCapabilities({ configuration: {}, agentCapabilities: undefined })
         this.client = new SourcegraphNodeCompletionsClient()

--- a/agent/src/cli/command-bench/llm-judge.ts
+++ b/agent/src/cli/command-bench/llm-judge.ts
@@ -16,7 +16,10 @@ export class LlmJudge {
         localStorage.setStorage('noop')
         setStaticResolvedConfigurationWithAuthCredentials({
             configuration: { customHeaders: undefined },
-            auth: { accessTokenOrHeaders: options.srcAccessToken, serverEndpoint: options.srcEndpoint },
+            auth: {
+                credentials: { token: options.srcAccessToken },
+                serverEndpoint: options.srcEndpoint,
+            },
         })
         setClientCapabilities({ configuration: {}, agentCapabilities: undefined })
         this.client = new SourcegraphNodeCompletionsClient()

--- a/agent/src/local-e2e/helpers.ts
+++ b/agent/src/local-e2e/helpers.ts
@@ -97,7 +97,7 @@ export class LocalSGInstance {
         this.gqlclient = SourcegraphGraphQLAPIClient.withStaticConfig({
             configuration: { customHeaders: headers, telemetryLevel: 'agent' },
             auth: {
-                accessTokenOrHeaders: this.params.accessToken,
+                credentials: { token: this.params.accessToken },
                 serverEndpoint: this.params.serverEndpoint,
             },
             clientState: { anonymousUserID: null },

--- a/agent/src/local-e2e/helpers.ts
+++ b/agent/src/local-e2e/helpers.ts
@@ -96,7 +96,10 @@ export class LocalSGInstance {
         // for checking the LLM configuration section.
         this.gqlclient = SourcegraphGraphQLAPIClient.withStaticConfig({
             configuration: { customHeaders: headers, telemetryLevel: 'agent' },
-            auth: { accessToken: this.params.accessToken, serverEndpoint: this.params.serverEndpoint },
+            auth: {
+                accessTokenOrHeaders: this.params.accessToken,
+                serverEndpoint: this.params.serverEndpoint,
+            },
             clientState: { anonymousUserID: null },
         })
     }

--- a/agent/src/vscode-shim.ts
+++ b/agent/src/vscode-shim.ts
@@ -136,7 +136,8 @@ export let extensionConfiguration: ExtensionConfiguration | undefined
 export function setExtensionConfiguration(newConfig: ExtensionConfiguration): void {
     extensionConfiguration = newConfig
 }
-export function isAuthenticationChange(newConfig: ExtensionConfiguration): boolean {
+
+export function isTokenOrEndpointChange(newConfig: ExtensionConfiguration): boolean {
     if (!extensionConfiguration) {
         return true
     }

--- a/lib/shared/src/configuration.ts
+++ b/lib/shared/src/configuration.ts
@@ -99,7 +99,7 @@ export interface ExternalAuthProvider {
 
 export interface ExternalAuthProviderResult {
     headers: NonSerializableRecord<string, string>
-    expiration: number
+    expiration?: number // Epoch Unix Timestamp (UTC) of the expiration date
 }
 
 interface RawClientConfiguration {

--- a/lib/shared/src/configuration.ts
+++ b/lib/shared/src/configuration.ts
@@ -9,7 +9,9 @@ import type { ReadonlyDeep } from './utils'
  * A redirect flow is initiated by the user clicking a link in the browser, while a paste flow is initiated by the user
  * manually entering the access from into the VsCode App.
  */
-export type TokenSource = 'redirect' | 'paste'
+export type TokenSource = 'redirect' | 'paste' | 'custom-auth-provider'
+
+export type AuthHeaders = Record<string, string>
 
 /**
  * The user's authentication credentials, which are stored separately from the rest of the
@@ -17,8 +19,8 @@ export type TokenSource = 'redirect' | 'paste'
  */
 export interface AuthCredentials {
     serverEndpoint: string
-    accessToken: string | null
     tokenSource?: TokenSource | undefined
+    accessTokenOrHeaders: string | AuthHeaders | null
 }
 
 export interface AutoEditsTokenLimit {
@@ -69,6 +71,20 @@ export interface AgenticContextConfiguration {
         allow?: string[] | undefined | null
         block?: string[] | undefined | null
     }
+}
+
+export interface ExternalAuthCommand {
+    commandLine: string[]
+    environment?: Record<string, string>
+    workingDir?: string
+    shell?: string
+    timeout?: number
+    windowsHide?: boolean
+}
+
+export interface ExternalAuthProvider {
+    endpoint: string
+    executable: ExternalAuthCommand
 }
 
 interface RawClientConfiguration {
@@ -165,6 +181,9 @@ interface RawClientConfiguration {
      */
     overrideServerEndpoint?: string | undefined
     overrideAuthToken?: string | undefined
+
+    // External auth providers
+    authExternalProviders?: ExternalAuthProvider[]
 }
 
 /**

--- a/lib/shared/src/configuration.ts
+++ b/lib/shared/src/configuration.ts
@@ -76,7 +76,6 @@ export interface AgenticContextConfiguration {
 export interface ExternalAuthCommand {
     commandLine: readonly string[]
     environment?: Record<string, string>
-    workingDir?: string
     shell?: string
     timeout?: number
     windowsHide?: boolean
@@ -182,7 +181,6 @@ interface RawClientConfiguration {
     overrideServerEndpoint?: string | undefined
     overrideAuthToken?: string | undefined
 
-    // External auth providers
     authExternalProviders: ExternalAuthProvider[]
 }
 

--- a/lib/shared/src/configuration.ts
+++ b/lib/shared/src/configuration.ts
@@ -9,9 +9,12 @@ import type { ReadonlyDeep } from './utils'
  * A redirect flow is initiated by the user clicking a link in the browser, while a paste flow is initiated by the user
  * manually entering the access from into the VsCode App.
  */
-export type TokenSource = 'redirect' | 'paste' | 'custom-auth-provider'
+export type TokenSource = 'redirect' | 'paste'
 
-export type AuthHeaders = Record<string, string>
+const nonSerializableSymbol = Symbol('nonSerializable')
+export type NonSerializableRecord<K extends keyof any, T> = Record<K, T> & {
+    [nonSerializableSymbol]: never
+}
 
 /**
  * The user's authentication credentials, which are stored separately from the rest of the
@@ -19,8 +22,16 @@ export type AuthHeaders = Record<string, string>
  */
 export interface AuthCredentials {
     serverEndpoint: string
-    tokenSource?: TokenSource | undefined
-    accessTokenOrHeaders: string | AuthHeaders | null
+    credentials: HeaderCredential | TokenCredential | undefined
+}
+
+export interface HeaderCredential {
+    headers: NonSerializableRecord<string, string>
+}
+
+export interface TokenCredential {
+    token: string
+    source?: TokenSource
 }
 
 export interface AutoEditsTokenLimit {
@@ -84,6 +95,11 @@ export interface ExternalAuthCommand {
 export interface ExternalAuthProvider {
     endpoint: string
     executable: ExternalAuthCommand
+}
+
+export interface ExternalAuthProviderResult {
+    headers: NonSerializableRecord<string, string>
+    expiration: number
 }
 
 interface RawClientConfiguration {

--- a/lib/shared/src/configuration.ts
+++ b/lib/shared/src/configuration.ts
@@ -74,7 +74,7 @@ export interface AgenticContextConfiguration {
 }
 
 export interface ExternalAuthCommand {
-    commandLine: string[]
+    commandLine: readonly string[]
     environment?: Record<string, string>
     workingDir?: string
     shell?: string
@@ -183,7 +183,7 @@ interface RawClientConfiguration {
     overrideAuthToken?: string | undefined
 
     // External auth providers
-    authExternalProviders?: ExternalAuthProvider[]
+    authExternalProviders: ExternalAuthProvider[]
 }
 
 /**

--- a/lib/shared/src/configuration.ts
+++ b/lib/shared/src/configuration.ts
@@ -11,11 +11,6 @@ import type { ReadonlyDeep } from './utils'
  */
 export type TokenSource = 'redirect' | 'paste'
 
-const nonSerializableSymbol = Symbol('nonSerializable')
-export type NonSerializableRecord<K extends keyof any, T> = Record<K, T> & {
-    [nonSerializableSymbol]: never
-}
-
 /**
  * The user's authentication credentials, which are stored separately from the rest of the
  * configuration.
@@ -26,7 +21,9 @@ export interface AuthCredentials {
 }
 
 export interface HeaderCredential {
-    headers: NonSerializableRecord<string, string>
+    // We use function instead of property to prevent accidential top level serialization - we never want to store this data
+    getHeaders(): Record<string, string>
+    expiration: number | undefined
 }
 
 export interface TokenCredential {
@@ -95,11 +92,6 @@ export interface ExternalAuthCommand {
 export interface ExternalAuthProvider {
     endpoint: string
     executable: ExternalAuthCommand
-}
-
-export interface ExternalAuthProviderResult {
-    headers: NonSerializableRecord<string, string>
-    expiration?: number // Epoch Unix Timestamp (UTC) of the expiration date
 }
 
 interface RawClientConfiguration {

--- a/lib/shared/src/configuration/auth-resolver.test.ts
+++ b/lib/shared/src/configuration/auth-resolver.test.ts
@@ -70,7 +70,7 @@ describe('auth-resolver', () => {
                         endpoint: 'my-server.com',
                         executable: {
                             commandLine: [
-                                'echo \'{ "headers": { "Authorization": "token X" }, "expiration": 1337 }\'',
+                                'echo \'{ "headers": { "Authorization": "token X" }, "expiration": 2222222222 }\'',
                             ],
                             shell: isWindows || '/bin/bash',
                             timeout: 5000,
@@ -87,7 +87,7 @@ describe('auth-resolver', () => {
         expect(auth.serverEndpoint).toBe('my-server.com/')
 
         const headerCredential = auth.credentials as HeaderCredential
-        expect(headerCredential.expiration).toBe(1337)
+        expect(headerCredential.expiration).toBe(2222222222)
         expect(headerCredential.getHeaders()).toStrictEqual({
             Authorization: 'token X',
         })

--- a/lib/shared/src/configuration/auth-resolver.test.ts
+++ b/lib/shared/src/configuration/auth-resolver.test.ts
@@ -1,0 +1,97 @@
+//@ts-nocheck
+import { describe, expect, test } from 'vitest'
+import { type TokenSource, isWindows } from '..'
+import { resolveAuth } from './auth-resolver'
+import type { ClientSecrets } from './resolver'
+
+class TempClientSecrets implements ClientSecrets {
+    constructor(readonly store: Map<string, [string, TokenSource]>) {}
+
+    getToken(endpoint: string): Promise<string | undefined> {
+        return Promise.resolve(this.store.get(endpoint)?.at(0))
+    }
+    getTokenSource(endpoint: string): Promise<TokenSource | undefined> {
+        return Promise.resolve(this.store.get(endpoint)?.at(1))
+    }
+}
+
+describe('auth-resolver', () => {
+    test('resolve with serverEndpoint and credentials overrides', async () => {
+        const auth = await resolveAuth(
+            'sourcegraph.com',
+            {
+                authExternalProviders: [],
+                overrideServerEndpoint: 'my-endpoint.com',
+                overrideAuthToken: 'my-token',
+            },
+            new TempClientSecrets(new Map([['sourcegraph.com/', ['sgp_212323123', 'paste']]]))
+        )
+
+        expect(auth.serverEndpoint).toBe('my-endpoint.com/')
+        expect(auth.credentials).toEqual({ token: 'my-token' })
+    })
+
+    test('resolve with serverEndpoint override', async () => {
+        const auth = await resolveAuth(
+            'sourcegraph.com',
+            {
+                authExternalProviders: [],
+                overrideServerEndpoint: 'my-endpoint.com',
+                overrideAuthToken: undefined,
+            },
+            new TempClientSecrets(new Map([['my-endpoint.com/', ['sgp_212323123', 'paste']]]))
+        )
+
+        expect(auth.serverEndpoint).toBe('my-endpoint.com/')
+        expect(auth.credentials).toEqual({ token: 'sgp_212323123', source: 'paste' })
+    })
+
+    test('resolve with token override', async () => {
+        const auth = await resolveAuth(
+            'sourcegraph.com',
+            {
+                authExternalProviders: [],
+                overrideServerEndpoint: undefined,
+                overrideAuthToken: 'my-token',
+            },
+            new TempClientSecrets(new Map([['sourcegraph.com/', ['sgp_777777777', 'paste']]]))
+        )
+
+        expect(auth.serverEndpoint).toBe('sourcegraph.com/')
+        expect(auth.credentials).toEqual({ token: 'my-token' })
+    })
+
+    test('resolve custom auth provider', async () => {
+        const auth = await resolveAuth(
+            'sourcegraph.com',
+            {
+                authExternalProviders: [
+                    {
+                        endpoint: 'my-server.com',
+                        executable: {
+                            commandLine: [
+                                'echo \'{ "headers": { "Authorization": "token X" }, "expiration": 1337 }\'',
+                            ],
+                            shell: isWindows || '/bin/bash',
+                            timeout: 5000,
+                            windowsHide: true,
+                        },
+                    },
+                ],
+                overrideServerEndpoint: 'my-server.com',
+                overrideAuthToken: undefined,
+            },
+            new TempClientSecrets(new Map())
+        )
+
+        expect(auth.serverEndpoint).toBe('my-server.com/')
+
+        const headerCredential = auth.credentials as HeaderCredential
+        expect(headerCredential.expiration).toBe(1337)
+        expect(headerCredential.getHeaders()).toStrictEqual({
+            Authorization: 'token X',
+        })
+
+        expect(JSON.stringify(headerCredential)).not.toContain('token X')
+    })
+})

--- a/lib/shared/src/configuration/auth-resolver.test.ts
+++ b/lib/shared/src/configuration/auth-resolver.test.ts
@@ -1,6 +1,5 @@
-//@ts-nocheck
 import { describe, expect, test } from 'vitest'
-import { type TokenSource, isWindows } from '..'
+import { type HeaderCredential, type TokenSource, isWindows } from '..'
 import { resolveAuth } from './auth-resolver'
 import type { ClientSecrets } from './resolver'
 
@@ -8,10 +7,10 @@ class TempClientSecrets implements ClientSecrets {
     constructor(readonly store: Map<string, [string, TokenSource]>) {}
 
     getToken(endpoint: string): Promise<string | undefined> {
-        return Promise.resolve(this.store.get(endpoint)?.at(0))
+        return Promise.resolve(this.store.get(endpoint)?.[0])
     }
     getTokenSource(endpoint: string): Promise<TokenSource | undefined> {
-        return Promise.resolve(this.store.get(endpoint)?.at(1))
+        return Promise.resolve(this.store.get(endpoint)?.[1])
     }
 }
 
@@ -67,24 +66,24 @@ describe('auth-resolver', () => {
             {
                 authExternalProviders: [
                     {
-                        endpoint: 'my-server.com',
+                        endpoint: 'https://my-server.com',
                         executable: {
                             commandLine: [
                                 'echo \'{ "headers": { "Authorization": "token X" }, "expiration": 2222222222 }\'',
                             ],
-                            shell: isWindows || '/bin/bash',
+                            shell: isWindows() ? 'true' : '/bin/bash',
                             timeout: 5000,
                             windowsHide: true,
                         },
                     },
                 ],
-                overrideServerEndpoint: 'my-server.com',
+                overrideServerEndpoint: 'https://my-server.com',
                 overrideAuthToken: undefined,
             },
             new TempClientSecrets(new Map())
         )
 
-        expect(auth.serverEndpoint).toBe('my-server.com/')
+        expect(auth.serverEndpoint).toBe('https://my-server.com/')
 
         const headerCredential = auth.credentials as HeaderCredential
         expect(headerCredential.expiration).toBe(2222222222)

--- a/lib/shared/src/configuration/auth-resolver.test.ts
+++ b/lib/shared/src/configuration/auth-resolver.test.ts
@@ -61,6 +61,11 @@ describe('auth-resolver', () => {
     })
 
     test('resolve custom auth provider', async () => {
+        const credentialsJson = JSON.stringify({
+            headers: { Authorization: 'token X' },
+            expiration: 1337,
+        })
+
         const auth = await resolveAuth(
             'sourcegraph.com',
             {
@@ -69,9 +74,9 @@ describe('auth-resolver', () => {
                         endpoint: 'https://my-server.com',
                         executable: {
                             commandLine: [
-                                'echo \'{ "headers": { "Authorization": "token X" }, "expiration": 2222222222 }\'',
+                                isWindows() ? `echo ${credentialsJson}` : `echo '${credentialsJson}'`,
                             ],
-                            shell: isWindows() ? 'true' : '/bin/bash',
+                            shell: isWindows() ? process.env.ComSpec : '/bin/bash',
                             timeout: 5000,
                             windowsHide: true,
                         },
@@ -86,7 +91,7 @@ describe('auth-resolver', () => {
         expect(auth.serverEndpoint).toBe('https://my-server.com/')
 
         const headerCredential = auth.credentials as HeaderCredential
-        expect(headerCredential.expiration).toBe(2222222222)
+        expect(headerCredential.expiration).toBe(1337)
         expect(headerCredential.getHeaders()).toStrictEqual({
             Authorization: 'token X',
         })

--- a/lib/shared/src/configuration/auth-resolver.ts
+++ b/lib/shared/src/configuration/auth-resolver.ts
@@ -1,0 +1,101 @@
+import type {
+    AuthCredentials,
+    ClientConfiguration,
+    ExternalAuthCommand,
+    ExternalAuthProvider,
+} from '../configuration'
+import type { ClientSecrets } from './resolver'
+
+export function normalizeServerEndpointURL(url: string): string {
+    return url.endsWith('/') ? url : `${url}/`
+}
+
+async function executeCommand(cmd: ExternalAuthCommand): Promise<string> {
+    if (typeof process === 'undefined' || !process.version) {
+        throw new Error('Command execution is only supported in Node.js environments')
+    }
+
+    const { exec } = await import('node:child_process')
+    const { promisify } = await import('node:util')
+    const execAsync = promisify(exec)
+
+    const command = cmd.commandLine.join(' ')
+
+    // No need to check error code, promisify causes exec to throw in case of errors
+    const { stdout } = await execAsync(command, {
+        shell: cmd.shell,
+        timeout: cmd.timeout,
+        windowsHide: cmd.windowsHide,
+        env: cmd.environment ? { ...process.env, ...cmd.environment } : process.env,
+    })
+
+    return stdout.trim()
+}
+
+interface HeaderCredentialResult {
+    headers: Record<string, string>
+    expiration: number | undefined
+}
+
+async function getExternalProviderAuthResult(
+    serverEndpoint: string,
+    authExternalProviders: readonly ExternalAuthProvider[]
+): Promise<HeaderCredentialResult | undefined> {
+    const externalProvider = authExternalProviders.find(
+        provider => normalizeServerEndpointURL(provider.endpoint) === serverEndpoint
+    )
+
+    if (externalProvider) {
+        const result = await executeCommand(externalProvider.executable)
+        return JSON.parse(result)
+    }
+
+    return undefined
+}
+
+export async function resolveAuth(
+    endpoint: string,
+    configuration: Pick<
+        ClientConfiguration,
+        'authExternalProviders' | 'overrideServerEndpoint' | 'overrideAuthToken'
+    >,
+    clientSecrets: ClientSecrets
+): Promise<AuthCredentials> {
+    const { authExternalProviders, overrideServerEndpoint, overrideAuthToken } = configuration
+    const serverEndpoint = normalizeServerEndpointURL(overrideServerEndpoint || endpoint)
+
+    if (overrideAuthToken) {
+        return { credentials: { token: overrideAuthToken }, serverEndpoint }
+    }
+
+    const credentials = await getExternalProviderAuthResult(serverEndpoint, authExternalProviders).catch(
+        error => {
+            throw new Error(`Failed to execute external auth command: ${error}`)
+        }
+    )
+
+    if (credentials) {
+        return {
+            credentials: {
+                expiration: credentials.expiration,
+                getHeaders() {
+                    return credentials.headers
+                },
+            },
+            serverEndpoint,
+        }
+    }
+
+    const token = await clientSecrets.getToken(serverEndpoint).catch(error => {
+        throw new Error(
+            `Failed to get access token for endpoint ${serverEndpoint}: ${error.message || error}`
+        )
+    })
+
+    return {
+        credentials: token
+            ? { token, source: await clientSecrets.getTokenSource(serverEndpoint) }
+            : undefined,
+        serverEndpoint,
+    }
+}

--- a/lib/shared/src/configuration/auth-resolver.ts
+++ b/lib/shared/src/configuration/auth-resolver.ts
@@ -26,7 +26,7 @@ async function executeCommand(cmd: ExternalAuthCommand): Promise<string> {
         shell: cmd.shell,
         timeout: cmd.timeout,
         windowsHide: cmd.windowsHide,
-        env: cmd.environment ? { ...process.env, ...cmd.environment } : process.env,
+        env: { ...process.env, ...cmd.environment },
     })
 
     return stdout.trim()

--- a/lib/shared/src/configuration/auth-resolver.ts
+++ b/lib/shared/src/configuration/auth-resolver.ts
@@ -34,7 +34,7 @@ async function executeCommand(cmd: ExternalAuthCommand): Promise<string> {
 
 interface HeaderCredentialResult {
     headers: Record<string, string>
-    expiration: number | undefined
+    expiration?: number | undefined
 }
 
 async function getExternalProviderAuthResult(
@@ -77,7 +77,7 @@ export async function resolveAuth(
     if (credentials) {
         return {
             credentials: {
-                expiration: credentials.expiration,
+                expiration: credentials?.expiration,
                 getHeaders() {
                     return credentials.headers
                 },

--- a/lib/shared/src/configuration/resolver.ts
+++ b/lib/shared/src/configuration/resolver.ts
@@ -88,15 +88,15 @@ async function executeCommand(cmd: ExternalAuthCommand): Promise<string> {
     const execAsync = promisify(exec)
 
     const command = cmd.commandLine.join(' ')
-    const options = {
-        ...cmd,
-        env: cmd.environment ? { ...process.env, ...cmd.environment } : process.env,
-    }
 
-    const { stdout, stderr } = await execAsync(command, options)
-    if (stderr) {
-        throw new Error(`External auth command error: ${stderr}`)
-    }
+    // No need to check error code, promisify causes exec to throw in case of errors
+    const { stdout } = await execAsync(command, {
+        shell: cmd.shell,
+        timeout: cmd.timeout,
+        windowsHide: cmd.windowsHide,
+        env: cmd.environment ? { ...process.env, ...cmd.environment } : process.env,
+    })
+
     return stdout.trim()
 }
 
@@ -104,6 +104,7 @@ async function getExternalProviderAuthHeaders(
     serverEndpoint: string,
     clientConfiguration: ClientConfiguration
 ): Promise<Record<string, string> | undefined> {
+    // Check for external auth provider for this endpoint
     const externalProvider = clientConfiguration.authExternalProviders.find(
         provider => normalizeServerEndpointURL(provider.endpoint) === serverEndpoint
     )

--- a/lib/shared/src/configuration/resolver.ts
+++ b/lib/shared/src/configuration/resolver.ts
@@ -1,11 +1,13 @@
-import { Observable, map } from 'observable-fns'
+import { Observable, Subject, map } from 'observable-fns'
 import type { AuthCredentials, ClientConfiguration, TokenSource } from '../configuration'
 import { logError } from '../logger'
 import {
+    combineLatest,
     distinctUntilChanged,
     firstValueFrom,
     fromLateSetSource,
     promiseToObservable,
+    startWith,
 } from '../misc/observable'
 import { skipPendingOperation, switchMapReplayOperation } from '../misc/observableOperation'
 import type { DefaultsAndUserPreferencesByEndpoint } from '../models/modelsService'
@@ -92,6 +94,18 @@ async function resolveConfiguration({
 
     try {
         const auth = await resolveAuth(serverEndpoint, clientConfiguration, clientSecrets)
+        const cred = auth.credentials
+        if (cred !== undefined && 'expiration' in cred && cred.expiration !== undefined) {
+            const expirationMs = cred.expiration * 1000
+            const expireInMs = expirationMs - Date.now()
+            if (expireInMs < 0) {
+                throw new Error(
+                    'Credentials expiration cannot be se to the past date:' +
+                        `${new Date(expirationMs)} (${cred.expiration})`
+                )
+            }
+            setInterval(() => _refreshConfigRequests.next(), expireInMs)
+        }
         return { configuration: clientConfiguration, clientState, auth, isReinstall }
     } catch (error) {
         // We don't want to throw here, because that would cause the observable to terminate and
@@ -104,14 +118,16 @@ async function resolveConfiguration({
 
 const _resolvedConfig = fromLateSetSource<ResolvedConfiguration>()
 
+const _refreshConfigRequests = new Subject<void>()
+
 /**
  * Set the observable that will be used to provide the global {@link resolvedConfig}. This should be
  * set exactly once (except in tests).
  */
 export function setResolvedConfigurationObservable(input: Observable<ConfigurationInput>): void {
     _resolvedConfig.setSource(
-        input.pipe(
-            switchMapReplayOperation(input => promiseToObservable(resolveConfiguration(input))),
+        combineLatest(input, _refreshConfigRequests.pipe(startWith(undefined))).pipe(
+            switchMapReplayOperation(([input]) => promiseToObservable(resolveConfiguration(input))),
             skipPendingOperation(),
             map(value => {
                 if (isError(value)) {

--- a/lib/shared/src/configuration/resolver.ts
+++ b/lib/shared/src/configuration/resolver.ts
@@ -104,8 +104,7 @@ async function getExternalProviderAuthHeaders(
     serverEndpoint: string,
     clientConfiguration: ClientConfiguration
 ): Promise<Record<string, string> | undefined> {
-    // Check for external auth provider for this endpoint
-    const externalProvider = clientConfiguration.authExternalProviders?.find(
+    const externalProvider = clientConfiguration.authExternalProviders.find(
         provider => normalizeServerEndpointURL(provider.endpoint) === serverEndpoint
     )
 

--- a/lib/shared/src/experimentation/FeatureFlagProvider.test.ts
+++ b/lib/shared/src/experimentation/FeatureFlagProvider.test.ts
@@ -24,7 +24,7 @@ describe('FeatureFlagProvider', () => {
     beforeAll(() => {
         vi.useFakeTimers()
         mockResolvedConfig({
-            auth: { accessTokenOrHeaders: null, serverEndpoint: 'https://example.com' },
+            auth: { credentials: undefined, serverEndpoint: 'https://example.com' },
         })
         mockAuthStatus(AUTH_STATUS_FIXTURE_AUTHED)
     })

--- a/lib/shared/src/experimentation/FeatureFlagProvider.test.ts
+++ b/lib/shared/src/experimentation/FeatureFlagProvider.test.ts
@@ -24,7 +24,7 @@ describe('FeatureFlagProvider', () => {
     beforeAll(() => {
         vi.useFakeTimers()
         mockResolvedConfig({
-            auth: { accessToken: null, serverEndpoint: 'https://example.com' },
+            auth: { accessTokenOrHeaders: null, serverEndpoint: 'https://example.com' },
         })
         mockAuthStatus(AUTH_STATUS_FIXTURE_AUTHED)
     })

--- a/lib/shared/src/models/sync.ts
+++ b/lib/shared/src/models/sync.ts
@@ -430,11 +430,7 @@ async function fetchServerSideModels(
 ): Promise<ServerModelConfiguration | undefined> {
     // Fetch the data via REST API.
     // NOTE: We may end up exposing this data via GraphQL, it's still TBD.
-    const client = new RestClient(
-        config.auth.serverEndpoint,
-        config.auth.accessToken ?? undefined,
-        config.configuration.customHeaders
-    )
+    const client = new RestClient(config.auth, config.configuration.customHeaders)
     return await client.getAvailableModels(signal)
 }
 

--- a/lib/shared/src/sourcegraph-api/completions/browserClient.ts
+++ b/lib/shared/src/sourcegraph-api/completions/browserClient.ts
@@ -4,6 +4,7 @@ import { dependentAbortController } from '../../common/abortController'
 import { currentResolvedConfig } from '../../configuration/resolver'
 import { isError } from '../../utils'
 import { addClientInfoParams, addCodyClientIdentificationHeaders } from '../client-name-version'
+import { addAuthHeaders } from '../utils'
 
 import { CompletionsResponseBuilder } from './CompletionsResponseBuilder'
 import { type CompletionRequestParameters, SourcegraphCompletionsClient } from './client'
@@ -39,10 +40,9 @@ export class SourcegraphBrowserCompletionsClient extends SourcegraphCompletionsC
             ...requestParams.customHeaders,
         } as HeadersInit)
         addCodyClientIdentificationHeaders(headersInstance)
+        addAuthHeaders(config.auth, headersInstance, url)
         headersInstance.set('Content-Type', 'application/json; charset=utf-8')
-        if (config.auth.accessToken) {
-            headersInstance.set('Authorization', `token ${config.auth.accessToken}`)
-        }
+
         const parameters = new URLSearchParams(globalThis.location.search)
         const trace = parameters.get('trace')
         if (trace) {
@@ -132,9 +132,8 @@ export class SourcegraphBrowserCompletionsClient extends SourcegraphCompletionsC
             ...requestParams.customHeaders,
         })
         addCodyClientIdentificationHeaders(headersInstance)
-        if (auth.accessToken) {
-            headersInstance.set('Authorization', `token ${auth.accessToken}`)
-        }
+        addAuthHeaders(auth, headersInstance, url)
+
         if (new URLSearchParams(globalThis.location.search).get('trace')) {
             headersInstance.set('X-Sourcegraph-Should-Trace', 'true')
         }

--- a/lib/shared/src/sourcegraph-api/rest/client.ts
+++ b/lib/shared/src/sourcegraph-api/rest/client.ts
@@ -1,5 +1,6 @@
 import type { ServerModelConfiguration } from '../../models/modelsService'
 
+import { type AuthCredentials, addAuthHeaders } from '../..'
 import { fetch } from '../../fetch'
 import { logError } from '../../logger'
 import { addTraceparent, wrapInActiveSpan } from '../../tracing'
@@ -20,14 +21,12 @@ import { verifyResponseCode } from '../graphql/client'
  */
 export class RestClient {
     /**
-     * @param endpointUrl URL to the sourcegraph instance, e.g. "https://sourcegraph.acme.com".
-     * @param accessToken User access token to contact the sourcegraph instance.
-     * @param customHeaders Custom headers (primary is used by Cody Web case when Sourcegraph client
-     * providers set of custom headers to make sure that auth flow will work properly
+     * Creates a new REST client to interact with a Sourcegraph instance.
+     * @param auth Authentication credentials containing endpoint URL and access token
+     * @param customHeaders Additional headers for requests (used by Cody Web to ensure proper auth flow)
      */
     constructor(
-        private endpointUrl: string,
-        private accessToken: string | undefined,
+        private auth: AuthCredentials,
         private customHeaders: Record<string, string> | undefined
     ) {}
 
@@ -35,15 +34,15 @@ export class RestClient {
     // "name" is a developer-friendly term to label the request's trace span.
     private getRequest<T>(name: string, urlSuffix: string, signal?: AbortSignal): Promise<T | Error> {
         const headers = new Headers(this.customHeaders)
-        if (this.accessToken) {
-            headers.set('Authorization', `token ${this.accessToken}`)
-        }
-        addCodyClientIdentificationHeaders(headers)
-        addTraceparent(headers)
 
-        const endpoint = new URL(this.endpointUrl)
+        const endpoint = new URL(this.auth.serverEndpoint)
         endpoint.pathname = urlSuffix
         const url = endpoint.href
+
+        addCodyClientIdentificationHeaders(headers)
+        addAuthHeaders(this.auth, headers, endpoint)
+        addTraceparent(headers)
+
         return wrapInActiveSpan(`rest-api.${name}`, () =>
             fetch(url, {
                 method: 'GET',

--- a/lib/shared/src/sourcegraph-api/utils.ts
+++ b/lib/shared/src/sourcegraph-api/utils.ts
@@ -38,14 +38,15 @@ export function toPartialUtf8String(buf: Buffer): { str: string; buf: Buffer } {
 
 export function addAuthHeaders(auth: AuthCredentials, headers: Headers, url: URL): void {
     // We want to be sure we sent authorization headers only to the valid endpoint
-    if (auth.accessTokenOrHeaders && url.host === new URL(auth.serverEndpoint).host) {
-        if (typeof auth.accessTokenOrHeaders === 'string') {
-            headers.set('Authorization', `token ${auth.accessTokenOrHeaders}`)
-        } else {
-            // Add headers as-is when accessTokenOrHeaders is a record of headers
-            for (const [key, value] of Object.entries(auth.accessTokenOrHeaders)) {
+    if (auth.credentials && url.host === new URL(auth.serverEndpoint).host) {
+        if ('token' in auth.credentials) {
+            headers.set('Authorization', `token ${auth.credentials.token}`)
+        } else if ('headers' in auth.credentials) {
+            for (const [key, value] of Object.entries(auth.credentials.headers)) {
                 headers.set(key, value)
             }
+        } else {
+            console.error('Cannot add headers: neither token nor headers found')
         }
     }
 }

--- a/lib/shared/src/sourcegraph-api/utils.ts
+++ b/lib/shared/src/sourcegraph-api/utils.ts
@@ -41,7 +41,7 @@ export function addAuthHeaders(auth: AuthCredentials, headers: Headers, url: URL
     if (auth.credentials && url.host === new URL(auth.serverEndpoint).host) {
         if ('token' in auth.credentials) {
             headers.set('Authorization', `token ${auth.credentials.token}`)
-        } else if ('headers' in auth.credentials) {
+        } else if (typeof auth.credentials.getHeaders === 'function') {
             for (const [key, value] of Object.entries(auth.credentials.getHeaders())) {
                 headers.set(key, value)
             }

--- a/lib/shared/src/sourcegraph-api/utils.ts
+++ b/lib/shared/src/sourcegraph-api/utils.ts
@@ -2,6 +2,9 @@
 // of a character, returns the remaining bytes of the partial character in a
 // new buffer. Note! This assumes that the prefix of buf *is* valid UTF8--it
 // only examines the bytes of the last character in the buffer and assumes it
+
+import type { AuthCredentials } from '..'
+
 // will find an initial byte before the start of the buffer.
 export function toPartialUtf8String(buf: Buffer): { str: string; buf: Buffer } {
     if (buf.length === 0) {
@@ -30,5 +33,19 @@ export function toPartialUtf8String(buf: Buffer): { str: string; buf: Buffer } {
     return {
         str: buf.slice(0, lastValidByteOffsetExclusive).toString('utf8'),
         buf: Buffer.from(buf.slice(lastValidByteOffsetExclusive)),
+    }
+}
+
+export function addAuthHeaders(auth: AuthCredentials, headers: Headers, url: URL): void {
+    // We want to be sure we sent authorization headers only to the valid endpoint
+    if (auth.accessTokenOrHeaders && url.host === new URL(auth.serverEndpoint).host) {
+        if (typeof auth.accessTokenOrHeaders === 'string') {
+            headers.set('Authorization', `token ${auth.accessTokenOrHeaders}`)
+        } else {
+            // Add headers as-is when accessTokenOrHeaders is a record of headers
+            for (const [key, value] of Object.entries(auth.accessTokenOrHeaders)) {
+                headers.set(key, value)
+            }
+        }
     }
 }

--- a/lib/shared/src/sourcegraph-api/utils.ts
+++ b/lib/shared/src/sourcegraph-api/utils.ts
@@ -42,7 +42,7 @@ export function addAuthHeaders(auth: AuthCredentials, headers: Headers, url: URL
         if ('token' in auth.credentials) {
             headers.set('Authorization', `token ${auth.credentials.token}`)
         } else if ('headers' in auth.credentials) {
-            for (const [key, value] of Object.entries(auth.credentials.headers)) {
+            for (const [key, value] of Object.entries(auth.credentials.getHeaders())) {
                 headers.set(key, value)
             }
         } else {

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -1307,6 +1307,57 @@
             "~/.mitmproxy/mitmproxy-ca-cert.pem",
             "-----BEGIN CERTIFICATE-----\n...\n-----END CERTIFICATE-----"
           ]
+        },
+        "cody.auth.externalProviders": {
+          "type": "array",
+          "markdownDescription": "Configure external authentication providers for Cody requests. Each provider consists of a command that generates HTTP headers used for authentication for a given endpoint.\n\n**How it works:**\n1. The specified command outputs a JSON object with header-value pairs\n2. These headers are included in authenticated Cody requests to the specified endpoint\n3. HTTP authentication proxy need to be used to enable custom authentication flows (e.g. JWT tokens, Oath2, etc)\n\nSee [HTTP Authentication Proxies](https://sourcegraph.com/docs/admin/auth#http-authentication-proxies) for proxy configuration.",
+          "items": {
+            "type": "object",
+            "required": ["endpoint", "executable"],
+            "properties": {
+              "endpoint": {
+                "type": "string",
+                "description": "The endpoint URL of the Sourcegraph instance"
+              },
+              "executable": {
+                "type": "object",
+                "required": ["commandLine"],
+                "properties": {
+                  "commandLine": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "description": "Command line arguments to execute the command."
+                  },
+                  "environment": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "description": "Environment variables to set when executing the command."
+                  },
+                  "workingDir": {
+                    "type": "string",
+                    "description": "Working directory for executing the command."
+                  },
+                  "shell": {
+                    "type": "string",
+                    "description": "If true, runs command inside of a shell. Uses '/bin/sh' on Unix, and process.env.ComSpec on Windows. A different shell can be specified as a string."
+                  },
+                  "timeout": {
+                    "type": "number",
+                    "description": "Timeout for executing the command in miliseconds."
+                  },
+                  "windowsHide": {
+                    "type": "boolean",
+                    "description": "Whether to hide the console window that would normally be created for the child process on Windows."
+                  }
+                }
+              }
+            }
+          },
+          "default": []
         }
       }
     },

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -1337,17 +1337,13 @@
                     },
                     "description": "Environment variables to set when executing the command."
                   },
-                  "workingDir": {
-                    "type": "string",
-                    "description": "Working directory for executing the command."
-                  },
                   "shell": {
                     "type": "string",
                     "description": "If true, runs command inside of a shell. Uses '/bin/sh' on Unix, and process.env.ComSpec on Windows. A different shell can be specified as a string."
                   },
                   "timeout": {
                     "type": "number",
-                    "description": "Timeout for executing the command in miliseconds."
+                    "description": "Timeout for executing the command in milliseconds."
                   },
                   "windowsHide": {
                     "type": "boolean",

--- a/vscode/src/auth/auth.ts
+++ b/vscode/src/auth/auth.ts
@@ -90,21 +90,17 @@ export async function showSignInMenu(
             const { configuration } = await currentResolvedConfig()
             const auth = await resolveAuth(selectedEndpoint, configuration, secretStorage)
 
-            let authStatus = auth.accessTokenOrHeaders
+            let authStatus = auth.credentials
                 ? await authProvider.validateAndStoreCredentials(auth, 'store-if-valid')
                 : undefined
 
             if (!authStatus?.authenticated) {
-                const newToken = await showAccessTokenInputBox(selectedEndpoint)
-                if (!newToken) {
+                const token = await showAccessTokenInputBox(selectedEndpoint)
+                if (!token) {
                     return
                 }
                 authStatus = await authProvider.validateAndStoreCredentials(
-                    {
-                        serverEndpoint: selectedEndpoint,
-                        accessTokenOrHeaders: newToken,
-                        tokenSource: 'paste',
-                    },
+                    { serverEndpoint: selectedEndpoint, credentials: { token, source: 'paste' } },
                     'store-if-valid'
                 )
             }
@@ -229,12 +225,12 @@ const LoginMenuOptionItems = [
 ]
 
 async function signinMenuForInstanceUrl(instanceUrl: string): Promise<void> {
-    const accessToken = await showAccessTokenInputBox(instanceUrl)
-    if (!accessToken) {
+    const token = await showAccessTokenInputBox(instanceUrl)
+    if (!token) {
         return
     }
     const authStatus = await authProvider.validateAndStoreCredentials(
-        { serverEndpoint: instanceUrl, accessTokenOrHeaders: accessToken, tokenSource: 'paste' },
+        { serverEndpoint: instanceUrl, credentials: { token, source: 'paste' } },
         'store-if-valid'
     )
     telemetryRecorder.recordEvent('cody.auth.signin.token', 'clicked', {
@@ -313,7 +309,7 @@ export async function tokenCallbackHandler(uri: vscode.Uri): Promise<void> {
     }
 
     const authStatus = await authProvider.validateAndStoreCredentials(
-        { serverEndpoint: endpoint, accessTokenOrHeaders: token, tokenSource: 'redirect' },
+        { serverEndpoint: endpoint, credentials: { token, source: 'redirect' } },
         'store-if-valid'
     )
     telemetryRecorder.recordEvent('cody.auth.fromCallback.web', 'succeeded', {
@@ -411,7 +407,7 @@ export async function validateCredentials(
     clientConfig?: CodyClientConfig
 ): Promise<AuthStatus> {
     // An access token is needed except for Cody Web, which uses cookies.
-    if (!config.auth.accessTokenOrHeaders && !clientCapabilities().isCodyWeb) {
+    if (!config.auth.credentials && !clientCapabilities().isCodyWeb) {
         return { authenticated: false, endpoint: config.auth.serverEndpoint, pendingValidation: false }
     }
 

--- a/vscode/src/auth/auth.ts
+++ b/vscode/src/auth/auth.ts
@@ -19,9 +19,9 @@ import {
     isDotCom,
     isError,
     isNetworkLikeError,
-    resolveAuth,
     telemetryRecorder,
 } from '@sourcegraph/cody-shared'
+import { resolveAuth } from '@sourcegraph/cody-shared/src/configuration/auth-resolver'
 import { isSourcegraphToken } from '../chat/protocol'
 import { newAuthStatus } from '../chat/utils'
 import { logDebug } from '../output-channel-logger'

--- a/vscode/src/auth/token-receiver.ts
+++ b/vscode/src/auth/token-receiver.ts
@@ -14,7 +14,7 @@ const FIVE_MINUTES = 5 * 60 * 1000
 // the user follow a redirect.
 export function startTokenReceiver(
     endpoint: string,
-    onNewToken: (credentials: Pick<AuthCredentials, 'serverEndpoint' | 'accessTokenOrHeaders'>) => void,
+    onNewToken: (credentials: Pick<AuthCredentials, 'serverEndpoint' | 'credentials'>) => void,
     timeout = FIVE_MINUTES
 ): Promise<string> {
     const endpointUrl = new URL(endpoint)
@@ -48,7 +48,7 @@ export function startTokenReceiver(
                         ) {
                             onNewToken({
                                 serverEndpoint: endpoint,
-                                accessTokenOrHeaders: json.accessToken,
+                                credentials: { token: json.accessToken, source: 'redirect' },
                             })
 
                             res.writeHead(200, headers)

--- a/vscode/src/auth/token-receiver.ts
+++ b/vscode/src/auth/token-receiver.ts
@@ -14,7 +14,7 @@ const FIVE_MINUTES = 5 * 60 * 1000
 // the user follow a redirect.
 export function startTokenReceiver(
     endpoint: string,
-    onNewToken: (credentials: Pick<AuthCredentials, 'serverEndpoint' | 'accessToken'>) => void,
+    onNewToken: (credentials: Pick<AuthCredentials, 'serverEndpoint' | 'accessTokenOrHeaders'>) => void,
     timeout = FIVE_MINUTES
 ): Promise<string> {
     const endpointUrl = new URL(endpoint)
@@ -46,7 +46,10 @@ export function startTokenReceiver(
                             'accessToken' in json &&
                             typeof json.accessToken === 'string'
                         ) {
-                            onNewToken({ serverEndpoint: endpoint, accessToken: json.accessToken })
+                            onNewToken({
+                                serverEndpoint: endpoint,
+                                accessTokenOrHeaders: json.accessToken,
+                            })
 
                             res.writeHead(200, headers)
                             res.write('ok')

--- a/vscode/src/autoedits/adapters/cody-gateway.test.ts
+++ b/vscode/src/autoedits/adapters/cody-gateway.test.ts
@@ -33,7 +33,7 @@ describe('CodyGatewayAdapter', () => {
         mockResolvedConfig({
             configuration: {},
             auth: {
-                accessToken: 'sgp_local_f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0',
+                accessTokenOrHeaders: 'sgp_local_f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0',
                 serverEndpoint: DOTCOM_URL.toString(),
             },
         })

--- a/vscode/src/autoedits/adapters/cody-gateway.test.ts
+++ b/vscode/src/autoedits/adapters/cody-gateway.test.ts
@@ -33,7 +33,7 @@ describe('CodyGatewayAdapter', () => {
         mockResolvedConfig({
             configuration: {},
             auth: {
-                accessTokenOrHeaders: 'sgp_local_f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0',
+                credentials: { token: 'sgp_local_f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0' },
                 serverEndpoint: DOTCOM_URL.toString(),
             },
         })

--- a/vscode/src/autoedits/adapters/cody-gateway.ts
+++ b/vscode/src/autoedits/adapters/cody-gateway.ts
@@ -35,8 +35,8 @@ export class CodyGatewayAdapter implements AutoeditsModelAdapter {
         const resolvedConfig = await currentResolvedConfig()
         // TODO (pkukielka): Check if fastpath should support custom auth providers and how
         const accessToken =
-            typeof resolvedConfig.auth.accessTokenOrHeaders === 'string'
-                ? resolvedConfig.auth.accessTokenOrHeaders
+            resolvedConfig.auth.credentials && 'token' in resolvedConfig.auth.credentials
+                ? resolvedConfig.auth.credentials.token
                 : null
         const fastPathAccessToken = dotcomTokenToGatewayToken(accessToken)
         if (!fastPathAccessToken) {

--- a/vscode/src/autoedits/adapters/cody-gateway.ts
+++ b/vscode/src/autoedits/adapters/cody-gateway.ts
@@ -33,7 +33,12 @@ export class CodyGatewayAdapter implements AutoeditsModelAdapter {
 
     private async getApiKey(): Promise<string> {
         const resolvedConfig = await currentResolvedConfig()
-        const fastPathAccessToken = dotcomTokenToGatewayToken(resolvedConfig.auth.accessToken)
+        // TODO (pkukielka): Check if fastpath should support custom auth providers and how
+        const accessToken =
+            typeof resolvedConfig.auth.accessTokenOrHeaders === 'string'
+                ? resolvedConfig.auth.accessTokenOrHeaders
+                : null
+        const fastPathAccessToken = dotcomTokenToGatewayToken(accessToken)
         if (!fastPathAccessToken) {
             autoeditsOutputChannelLogger.logError('getApiKey', 'FastPath access token is not available')
             throw new Error('FastPath access token is not available')

--- a/vscode/src/autoedits/autoedits-provider.test.ts
+++ b/vscode/src/autoedits/autoedits-provider.test.ts
@@ -59,7 +59,7 @@ describe('AutoeditsProvider', () => {
         mockResolvedConfig({
             configuration: {},
             auth: {
-                accessToken: 'sgp_local_f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0',
+                accessTokenOrHeaders: 'sgp_local_f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0',
                 serverEndpoint: DOTCOM_URL.toString(),
             },
         })

--- a/vscode/src/autoedits/autoedits-provider.test.ts
+++ b/vscode/src/autoedits/autoedits-provider.test.ts
@@ -59,7 +59,7 @@ describe('AutoeditsProvider', () => {
         mockResolvedConfig({
             configuration: {},
             auth: {
-                accessTokenOrHeaders: 'sgp_local_f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0',
+                credentials: { token: 'sgp_local_f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0' },
                 serverEndpoint: DOTCOM_URL.toString(),
             },
         })

--- a/vscode/src/chat/agentic/DeepCody.test.ts
+++ b/vscode/src/chat/agentic/DeepCody.test.ts
@@ -56,7 +56,7 @@ describe('DeepCody', () => {
     } as any)
 
     beforeEach(async () => {
-        mockResolvedConfig({ configuration: {} })
+        mockResolvedConfig({ configuration: {}, auth: { serverEndpoint: DOTCOM_URL.toString() } })
         mockClientCapabilities(CLIENT_CAPABILITIES_FIXTURE)
         mockAuthStatus(codyProAuthStatus)
         localStorageData = {}

--- a/vscode/src/chat/chat-view/ChatController.ts
+++ b/vscode/src/chat/chat-view/ChatController.ts
@@ -54,7 +54,6 @@ import {
     ps,
     recordErrorToSpan,
     reformatBotMessageForChat,
-    resolveAuth,
     resolvedConfig,
     serializeChatMessage,
     shareReplay,
@@ -75,6 +74,7 @@ import * as vscode from 'vscode'
 import { type Span, context } from '@opentelemetry/api'
 import { captureException } from '@sentry/core'
 import type { SubMessage } from '@sourcegraph/cody-shared/src/chat/transcript/messages'
+import { resolveAuth } from '@sourcegraph/cody-shared/src/configuration/auth-resolver'
 import type { TelemetryEventParameters } from '@sourcegraph/telemetry'
 import { Subject, map } from 'observable-fns'
 import type { URI } from 'vscode-uri'

--- a/vscode/src/chat/chat-view/prompt.test.ts
+++ b/vscode/src/chat/chat-view/prompt.test.ts
@@ -8,6 +8,7 @@ import {
     type ModelsData,
     contextFiltersProvider,
     createModel,
+    graphqlClient,
     mockAuthStatus,
     mockClientCapabilities,
     mockResolvedConfig,
@@ -24,6 +25,7 @@ import { DefaultPrompter } from './prompt'
 describe('DefaultPrompter', () => {
     beforeEach(() => {
         vi.spyOn(contextFiltersProvider, 'isUriIgnored').mockResolvedValue(false)
+        vi.spyOn(graphqlClient, 'fetchSourcegraphAPI').mockResolvedValue(true)
         mockAuthStatus(AUTH_STATUS_FIXTURE_AUTHED)
         mockResolvedConfig({ configuration: {} })
         mockClientCapabilities(CLIENT_CAPABILITIES_FIXTURE)

--- a/vscode/src/completions/default-client.ts
+++ b/vscode/src/completions/default-client.ts
@@ -14,6 +14,8 @@ import {
     RateLimitError,
     type SerializedCodeCompletionsParams,
     TracedError,
+    addAuthHeaders,
+    addCodyClientIdentificationHeaders,
     addTraceparent,
     contextFiltersProvider,
     createSSEIterator,
@@ -49,8 +51,8 @@ class DefaultCodeCompletionsClient implements CodeCompletionsClient {
         const { auth, configuration } = await currentResolvedConfig()
 
         const query = new URLSearchParams(getClientInfoParams())
-        const url = new URL(`/.api/completions/code?${query.toString()}`, auth.serverEndpoint).href
-        const log = autocompleteLifecycleOutputChannelLogger?.startCompletion(params, url)
+        const url = new URL(`/.api/completions/code?${query.toString()}`, auth.serverEndpoint)
+        const log = autocompleteLifecycleOutputChannelLogger?.startCompletion(params, url.href)
         const { signal } = abortController
 
         return tracer.startActiveSpan(
@@ -69,9 +71,8 @@ class DefaultCodeCompletionsClient implements CodeCompletionsClient {
                 // Force HTTP connection reuse to reduce latency.
                 // c.f. https://github.com/microsoft/vscode/issues/173861
                 headers.set('Content-Type', 'application/json; charset=utf-8')
-                if (auth.accessToken) {
-                    headers.set('Authorization', `token ${auth.accessToken}`)
-                }
+                addCodyClientIdentificationHeaders(headers)
+                addAuthHeaders(auth, headers, url)
 
                 if (tracingFlagEnabled) {
                     headers.set('X-Sourcegraph-Should-Trace', '1')

--- a/vscode/src/completions/nodeClient.ts
+++ b/vscode/src/completions/nodeClient.ts
@@ -13,6 +13,7 @@ import {
     NetworkError,
     RateLimitError,
     SourcegraphCompletionsClient,
+    addAuthHeaders,
     addClientInfoParams,
     addCodyClientIdentificationHeaders,
     currentResolvedConfig,
@@ -95,13 +96,13 @@ export class SourcegraphNodeCompletionsClient extends SourcegraphCompletionsClie
                 // responses afterwards.
                 'Accept-Encoding': 'gzip;q=0',
                 'X-Sourcegraph-Interaction-ID': interactionId || '',
-                ...(auth.accessToken ? { Authorization: `token ${auth.accessToken}` } : null),
                 ...configuration?.customHeaders,
                 ...requestParams.customHeaders,
                 ...getTraceparentHeaders(),
                 Connection: 'keep-alive',
             })
             addCodyClientIdentificationHeaders(headers)
+            addAuthHeaders(auth, headers, url)
 
             const request = requestFn(
                 url,
@@ -299,7 +300,6 @@ export class SourcegraphNodeCompletionsClient extends SourcegraphCompletionsClie
                 const headers = new Headers({
                     'Content-Type': 'application/json',
                     'Accept-Encoding': 'gzip;q=0',
-                    ...(auth.accessToken ? { Authorization: `token ${auth.accessToken}` } : null),
                     ...configuration.customHeaders,
                     ...requestParams.customHeaders,
                     ...getTraceparentHeaders(),
@@ -307,6 +307,7 @@ export class SourcegraphNodeCompletionsClient extends SourcegraphCompletionsClie
                 })
 
                 addCodyClientIdentificationHeaders(headers)
+                addAuthHeaders(auth, headers, url)
 
                 const response = await fetch(url.toString(), {
                     method: 'POST',

--- a/vscode/src/completions/providers/fireworks.ts
+++ b/vscode/src/completions/providers/fireworks.ts
@@ -135,8 +135,8 @@ class FireworksProvider extends Provider {
         if (canFastPathBeUsed) {
             // TODO (pkukielka): Check if fastpath should support custom auth providers and how
             const accessToken =
-                typeof config.auth.accessTokenOrHeaders === 'string'
-                    ? config.auth.accessTokenOrHeaders
+                config.auth.credentials && 'token' in config.auth.credentials
+                    ? config.auth.credentials.token
                     : null
             const fastPathAccessToken = dotcomTokenToGatewayToken(accessToken)
 

--- a/vscode/src/completions/providers/fireworks.ts
+++ b/vscode/src/completions/providers/fireworks.ts
@@ -133,7 +133,12 @@ class FireworksProvider extends Provider {
             typeof process !== 'undefined'
 
         if (canFastPathBeUsed) {
-            const fastPathAccessToken = dotcomTokenToGatewayToken(config.auth.accessToken)
+            // TODO (pkukielka): Check if fastpath should support custom auth providers and how
+            const accessToken =
+                typeof config.auth.accessTokenOrHeaders === 'string'
+                    ? config.auth.accessTokenOrHeaders
+                    : null
+            const fastPathAccessToken = dotcomTokenToGatewayToken(accessToken)
 
             const localFastPathAccessToken =
                 process.env.NODE_ENV === 'development'

--- a/vscode/src/configuration.test.ts
+++ b/vscode/src/configuration.test.ts
@@ -139,7 +139,7 @@ describe('getConfiguration', () => {
                     case 'cody.agentic.context.experimentalOptions':
                         return { shell: { allow: ['git'] } }
                     case 'cody.auth.externalProviders':
-                        return undefined
+                        return []
                     default:
                         assert(false, `unexpected key: ${key}`)
                 }
@@ -208,7 +208,7 @@ describe('getConfiguration', () => {
 
             overrideAuthToken: undefined,
             overrideServerEndpoint: undefined,
-            authExternalProviders: undefined,
+            authExternalProviders: [],
         } satisfies ClientConfiguration)
     })
 })

--- a/vscode/src/configuration.test.ts
+++ b/vscode/src/configuration.test.ts
@@ -138,6 +138,8 @@ describe('getConfiguration', () => {
                         return false
                     case 'cody.agentic.context.experimentalOptions':
                         return { shell: { allow: ['git'] } }
+                    case 'cody.auth.externalProviders':
+                        return undefined
                     default:
                         assert(false, `unexpected key: ${key}`)
                 }
@@ -206,6 +208,7 @@ describe('getConfiguration', () => {
 
             overrideAuthToken: undefined,
             overrideServerEndpoint: undefined,
+            authExternalProviders: undefined,
         } satisfies ClientConfiguration)
     })
 })

--- a/vscode/src/configuration.ts
+++ b/vscode/src/configuration.ts
@@ -111,7 +111,7 @@ export function getConfiguration(
          */
         agenticContextExperimentalOptions: config.get(CONFIG_KEY.agenticContextExperimentalOptions, {}),
 
-        authExternalProviders: config.get(CONFIG_KEY.authExternalProviders, undefined),
+        authExternalProviders: config.get(CONFIG_KEY.authExternalProviders, []),
 
         /**
          * Hidden settings for internal use only.

--- a/vscode/src/configuration.ts
+++ b/vscode/src/configuration.ts
@@ -111,6 +111,8 @@ export function getConfiguration(
          */
         agenticContextExperimentalOptions: config.get(CONFIG_KEY.agenticContextExperimentalOptions, {}),
 
+        authExternalProviders: config.get(CONFIG_KEY.authExternalProviders, undefined),
+
         /**
          * Hidden settings for internal use only.
          */

--- a/vscode/src/local-context/rewrite-keyword-query.test.ts
+++ b/vscode/src/local-context/rewrite-keyword-query.test.ts
@@ -30,8 +30,9 @@ describe('rewrite-query', () => {
         mockResolvedConfig({
             configuration: { customHeaders: {} },
             auth: {
-                accessTokenOrHeaders:
-                    TESTING_CREDENTIALS.dotcom.token ?? TESTING_CREDENTIALS.dotcom.redactedToken,
+                credentials: {
+                    token: TESTING_CREDENTIALS.dotcom.token ?? TESTING_CREDENTIALS.dotcom.redactedToken,
+                },
                 serverEndpoint: TESTING_CREDENTIALS.dotcom.serverEndpoint,
             },
         })

--- a/vscode/src/local-context/rewrite-keyword-query.test.ts
+++ b/vscode/src/local-context/rewrite-keyword-query.test.ts
@@ -30,7 +30,7 @@ describe('rewrite-query', () => {
         mockResolvedConfig({
             configuration: { customHeaders: {} },
             auth: {
-                accessToken:
+                accessTokenOrHeaders:
                     TESTING_CREDENTIALS.dotcom.token ?? TESTING_CREDENTIALS.dotcom.redactedToken,
                 serverEndpoint: TESTING_CREDENTIALS.dotcom.serverEndpoint,
             },

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -678,13 +678,11 @@ async function registerTestCommands(
             }
         }),
         // Access token - this is only used in configuration tests
-        vscode.commands.registerCommand(
-            'cody.test.token',
-            async (serverEndpoint, accessTokenOrHeaders) =>
-                authProvider.validateAndStoreCredentials(
-                    { serverEndpoint, accessTokenOrHeaders },
-                    'always-store'
-                )
+        vscode.commands.registerCommand('cody.test.token', async (serverEndpoint, token) =>
+            authProvider.validateAndStoreCredentials(
+                { credentials: { token }, serverEndpoint },
+                'always-store'
+            )
         )
     )
 }

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -678,8 +678,13 @@ async function registerTestCommands(
             }
         }),
         // Access token - this is only used in configuration tests
-        vscode.commands.registerCommand('cody.test.token', async (serverEndpoint, accessToken) =>
-            authProvider.validateAndStoreCredentials({ serverEndpoint, accessToken }, 'always-store')
+        vscode.commands.registerCommand(
+            'cody.test.token',
+            async (serverEndpoint, accessTokenOrHeaders) =>
+                authProvider.validateAndStoreCredentials(
+                    { serverEndpoint, accessTokenOrHeaders },
+                    'always-store'
+                )
         )
     )
 }

--- a/vscode/src/notifications/setup-notification.ts
+++ b/vscode/src/notifications/setup-notification.ts
@@ -8,7 +8,7 @@ import { telemetryRecorder } from '@sourcegraph/cody-shared'
 import { showActionNotification } from '.'
 
 export const showSetupNotification = async (auth: AuthCredentials): Promise<void> => {
-    if (auth.serverEndpoint && auth.accessToken) {
+    if (auth.serverEndpoint && auth.accessTokenOrHeaders) {
         // User has already attempted to configure Cody.
         // Regardless of if they are authenticated or not, we don't want to prompt them.
         return

--- a/vscode/src/notifications/setup-notification.ts
+++ b/vscode/src/notifications/setup-notification.ts
@@ -8,7 +8,7 @@ import { telemetryRecorder } from '@sourcegraph/cody-shared'
 import { showActionNotification } from '.'
 
 export const showSetupNotification = async (auth: AuthCredentials): Promise<void> => {
-    if (auth.serverEndpoint && auth.accessTokenOrHeaders) {
+    if (auth.serverEndpoint && auth.credentials) {
         // User has already attempted to configure Cody.
         // Regardless of if they are authenticated or not, we don't want to prompt them.
         return

--- a/vscode/src/services/AuthProvider.test.ts
+++ b/vscode/src/services/AuthProvider.test.ts
@@ -81,7 +81,7 @@ describe('AuthProvider', () => {
         const { values, clearValues } = readValuesFrom(authStatus)
         resolvedConfig.next({
             configuration: {},
-            auth: { serverEndpoint: 'https://example.com/', accessToken: 't' },
+            auth: { serverEndpoint: 'https://example.com/', accessTokenOrHeaders: 't' },
             clientState: { anonymousUserID: '123' },
         } satisfies PartialDeep<ResolvedConfiguration> as ResolvedConfiguration)
 
@@ -108,7 +108,7 @@ describe('AuthProvider', () => {
         validateCredentialsMock.mockReturnValue(asyncValue(authedAuthStatusBob, 10))
         resolvedConfig.next({
             configuration: {},
-            auth: { serverEndpoint: 'https://other.example.com/', accessToken: 't2' },
+            auth: { serverEndpoint: 'https://other.example.com/', accessTokenOrHeaders: 't2' },
             clientState: { anonymousUserID: '123' },
         } satisfies PartialDeep<ResolvedConfiguration> as ResolvedConfiguration)
         await vi.advanceTimersByTimeAsync(1)
@@ -156,7 +156,7 @@ describe('AuthProvider', () => {
         const { values, clearValues } = readValuesFrom(authStatus)
         resolvedConfig.next({
             configuration: {},
-            auth: { serverEndpoint: 'https://example.com/', accessToken: 't' },
+            auth: { serverEndpoint: 'https://example.com/', accessTokenOrHeaders: 't' },
             clientState: { anonymousUserID: '123' },
         } satisfies PartialDeep<ResolvedConfiguration> as ResolvedConfiguration)
 
@@ -176,7 +176,7 @@ describe('AuthProvider', () => {
         const promise = authProvider.validateAndStoreCredentials(
             {
                 configuration: {},
-                auth: { serverEndpoint: 'https://other.example.com/', accessToken: 't2' },
+                auth: { serverEndpoint: 'https://other.example.com/', accessTokenOrHeaders: 't2' },
                 clientState: { anonymousUserID: '123' },
             },
             'always-store'
@@ -212,7 +212,7 @@ describe('AuthProvider', () => {
         const { values, clearValues } = readValuesFrom(authStatus)
         resolvedConfig.next({
             configuration: {},
-            auth: { serverEndpoint: 'https://example.com/', accessToken: 't' },
+            auth: { serverEndpoint: 'https://example.com/', accessTokenOrHeaders: 't' },
             clientState: { anonymousUserID: '123' },
         } satisfies PartialDeep<ResolvedConfiguration> as ResolvedConfiguration)
 

--- a/vscode/src/services/AuthProvider.test.ts
+++ b/vscode/src/services/AuthProvider.test.ts
@@ -81,7 +81,7 @@ describe('AuthProvider', () => {
         const { values, clearValues } = readValuesFrom(authStatus)
         resolvedConfig.next({
             configuration: {},
-            auth: { serverEndpoint: 'https://example.com/', accessTokenOrHeaders: 't' },
+            auth: { serverEndpoint: 'https://example.com/', credentials: { token: 't' } },
             clientState: { anonymousUserID: '123' },
         } satisfies PartialDeep<ResolvedConfiguration> as ResolvedConfiguration)
 
@@ -108,7 +108,7 @@ describe('AuthProvider', () => {
         validateCredentialsMock.mockReturnValue(asyncValue(authedAuthStatusBob, 10))
         resolvedConfig.next({
             configuration: {},
-            auth: { serverEndpoint: 'https://other.example.com/', accessTokenOrHeaders: 't2' },
+            auth: { serverEndpoint: 'https://other.example.com/', credentials: { token: 't2' } },
             clientState: { anonymousUserID: '123' },
         } satisfies PartialDeep<ResolvedConfiguration> as ResolvedConfiguration)
         await vi.advanceTimersByTimeAsync(1)
@@ -156,7 +156,7 @@ describe('AuthProvider', () => {
         const { values, clearValues } = readValuesFrom(authStatus)
         resolvedConfig.next({
             configuration: {},
-            auth: { serverEndpoint: 'https://example.com/', accessTokenOrHeaders: 't' },
+            auth: { serverEndpoint: 'https://example.com/', credentials: { token: 't' } },
             clientState: { anonymousUserID: '123' },
         } satisfies PartialDeep<ResolvedConfiguration> as ResolvedConfiguration)
 
@@ -176,7 +176,7 @@ describe('AuthProvider', () => {
         const promise = authProvider.validateAndStoreCredentials(
             {
                 configuration: {},
-                auth: { serverEndpoint: 'https://other.example.com/', accessTokenOrHeaders: 't2' },
+                auth: { serverEndpoint: 'https://other.example.com/', credentials: { token: 't2' } },
                 clientState: { anonymousUserID: '123' },
             },
             'always-store'
@@ -212,7 +212,7 @@ describe('AuthProvider', () => {
         const { values, clearValues } = readValuesFrom(authStatus)
         resolvedConfig.next({
             configuration: {},
-            auth: { serverEndpoint: 'https://example.com/', accessTokenOrHeaders: 't' },
+            auth: { serverEndpoint: 'https://example.com/', credentials: { token: 't' } },
             clientState: { anonymousUserID: '123' },
         } satisfies PartialDeep<ResolvedConfiguration> as ResolvedConfiguration)
 

--- a/vscode/src/services/AuthProvider.ts
+++ b/vscode/src/services/AuthProvider.ts
@@ -15,7 +15,6 @@ import {
     distinctUntilChanged,
     clientCapabilities as getClientCapabilities,
     isAbortError,
-    normalizeServerEndpointURL,
     resolvedConfig as resolvedConfig_,
     setAuthStatusObservable as setAuthStatusObservable_,
     startWith,
@@ -23,6 +22,7 @@ import {
     telemetryRecorder,
     withLatestFrom,
 } from '@sourcegraph/cody-shared'
+import { normalizeServerEndpointURL } from '@sourcegraph/cody-shared/src/configuration/auth-resolver'
 import isEqual from 'lodash/isEqual'
 import { Observable, Subject } from 'observable-fns'
 import * as vscode from 'vscode'

--- a/vscode/src/services/LocalStorageProvider.ts
+++ b/vscode/src/services/LocalStorageProvider.ts
@@ -116,7 +116,7 @@ class LocalStorage implements LocalStorageForModelPreferences {
      * would give an inconsistent view of the state.
      */
     public async saveEndpointAndToken(
-        credentials: Pick<AuthCredentials, 'serverEndpoint' | 'accessToken' | 'tokenSource'>
+        credentials: Pick<AuthCredentials, 'serverEndpoint' | 'accessTokenOrHeaders' | 'tokenSource'>
     ): Promise<void> {
         if (!credentials.serverEndpoint) {
             return
@@ -131,10 +131,10 @@ class LocalStorage implements LocalStorageForModelPreferences {
         // Pass `false` to avoid firing the change event until we've stored all of the values.
         await this.set(this.LAST_USED_ENDPOINT, serverEndpoint, false)
         await this.addEndpointHistory(serverEndpoint, false)
-        if (credentials.accessToken) {
+        if (credentials.accessTokenOrHeaders && typeof credentials.accessTokenOrHeaders === 'string') {
             await secretStorage.storeToken(
                 serverEndpoint,
-                credentials.accessToken,
+                credentials.accessTokenOrHeaders,
                 credentials.tokenSource
             )
         }

--- a/vscode/src/services/LocalStorageProvider.ts
+++ b/vscode/src/services/LocalStorageProvider.ts
@@ -116,26 +116,26 @@ class LocalStorage implements LocalStorageForModelPreferences {
      * would give an inconsistent view of the state.
      */
     public async saveEndpointAndToken(
-        credentials: Pick<AuthCredentials, 'serverEndpoint' | 'accessTokenOrHeaders' | 'tokenSource'>
+        auth: Pick<AuthCredentials, 'serverEndpoint' | 'credentials'>
     ): Promise<void> {
-        if (!credentials.serverEndpoint) {
+        if (!auth.serverEndpoint) {
             return
         }
         // Do not save an access token as the last-used endpoint, to prevent user mistakes.
-        if (isSourcegraphToken(credentials.serverEndpoint)) {
+        if (isSourcegraphToken(auth.serverEndpoint)) {
             return
         }
 
-        const serverEndpoint = new URL(credentials.serverEndpoint).href
+        const serverEndpoint = new URL(auth.serverEndpoint).href
 
         // Pass `false` to avoid firing the change event until we've stored all of the values.
         await this.set(this.LAST_USED_ENDPOINT, serverEndpoint, false)
         await this.addEndpointHistory(serverEndpoint, false)
-        if (credentials.accessTokenOrHeaders && typeof credentials.accessTokenOrHeaders === 'string') {
+        if (auth.credentials && 'token' in auth.credentials) {
             await secretStorage.storeToken(
                 serverEndpoint,
-                credentials.accessTokenOrHeaders,
-                credentials.tokenSource
+                auth.credentials.token,
+                auth.credentials.source
             )
         }
         this.onChange.fire()

--- a/vscode/src/services/UpstreamHealthProvider.ts
+++ b/vscode/src/services/UpstreamHealthProvider.ts
@@ -1,5 +1,6 @@
 import {
     type BrowserOrNodeResponse,
+    addAuthHeaders,
     addCodyClientIdentificationHeaders,
     addTraceparent,
     currentResolvedConfig,
@@ -94,11 +95,10 @@ class UpstreamHealthProvider implements vscode.Disposable {
             addTraceparent(sharedHeaders)
             addCodyClientIdentificationHeaders(sharedHeaders)
 
-            const upstreamHeaders = new Headers(sharedHeaders)
-            if (auth.accessToken) {
-                upstreamHeaders.set('Authorization', `token ${auth.accessToken}`)
-            }
             const url = new URL('/healthz', auth.serverEndpoint)
+            const upstreamHeaders = new Headers(sharedHeaders)
+            addAuthHeaders(auth, upstreamHeaders, url)
+
             const upstreamResult = await wrapInActiveSpan('upstream-latency.upstream', span => {
                 span.setAttribute('sampled', true)
                 return measureLatencyToUri(upstreamHeaders, url.toString())

--- a/vscode/src/services/open-telemetry/CodyTraceExport.ts
+++ b/vscode/src/services/open-telemetry/CodyTraceExport.ts
@@ -1,6 +1,7 @@
 import type { ExportResult } from '@opentelemetry/core'
 import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http'
 import type { ReadableSpan } from '@opentelemetry/sdk-trace-base'
+import { type AuthCredentials, addAuthHeaders } from '@sourcegraph/cody-shared'
 
 const MAX_TRACE_RETAIN_MS = 60 * 1000
 
@@ -10,15 +11,16 @@ export class CodyTraceExporter extends OTLPTraceExporter {
 
     constructor({
         traceUrl,
-        accessToken,
+        auth,
         isTracingEnabled,
-    }: { traceUrl: string; accessToken: string | null; isTracingEnabled: boolean }) {
+    }: { traceUrl: string; auth: AuthCredentials | null; isTracingEnabled: boolean }) {
+        const headers = new Headers()
+        if (auth) addAuthHeaders(auth, headers, new URL(traceUrl))
+
         super({
             url: traceUrl,
             httpAgentOptions: { rejectUnauthorized: false },
-            headers: {
-                ...(accessToken ? { Authorization: `token ${accessToken}` } : {}),
-            },
+            headers: Object.fromEntries(headers.entries()),
         })
         this.isTracingEnabled = isTracingEnabled
     }

--- a/vscode/src/services/open-telemetry/OpenTelemetryService.node.ts
+++ b/vscode/src/services/open-telemetry/OpenTelemetryService.node.ts
@@ -79,7 +79,7 @@ export class OpenTelemetryService {
                 new CodyTraceExporter({
                     traceUrl,
                     isTracingEnabled: this.isTracingEnabled,
-                    accessToken: auth.accessToken,
+                    auth,
                 })
             )
         )

--- a/vscode/src/services/open-telemetry/trace-sender.ts
+++ b/vscode/src/services/open-telemetry/trace-sender.ts
@@ -21,7 +21,7 @@ export const TraceSender = {
  */
 async function doSendTraceData(spanData: any): Promise<void> {
     const { auth } = await currentResolvedConfig()
-    if (!auth.accessTokenOrHeaders) {
+    if (!auth.credentials) {
         logError('TraceSender', 'Cannot send trace data: not authenticated')
         throw new Error('Not authenticated')
     }

--- a/vscode/src/services/open-telemetry/trace-sender.ts
+++ b/vscode/src/services/open-telemetry/trace-sender.ts
@@ -1,5 +1,4 @@
-import { currentResolvedConfig } from '@sourcegraph/cody-shared'
-import fetch from 'node-fetch'
+import { addAuthHeaders, currentResolvedConfig, fetch } from '@sourcegraph/cody-shared'
 import { logDebug, logError } from '../../output-channel-logger'
 
 /**
@@ -22,18 +21,19 @@ export const TraceSender = {
  */
 async function doSendTraceData(spanData: any): Promise<void> {
     const { auth } = await currentResolvedConfig()
-    if (!auth.accessToken) {
+    if (!auth.accessTokenOrHeaders) {
         logError('TraceSender', 'Cannot send trace data: not authenticated')
         throw new Error('Not authenticated')
     }
 
-    const traceUrl = new URL('/-/debug/otlp/v1/traces', auth.serverEndpoint).toString()
+    const traceUrl = new URL('/-/debug/otlp/v1/traces', auth.serverEndpoint)
+
+    const headers = new Headers({ 'Content-Type': 'application/json' })
+    addAuthHeaders(auth, headers, traceUrl)
+
     const response = await fetch(traceUrl, {
         method: 'POST',
-        headers: {
-            'Content-Type': 'application/json',
-            ...(auth.accessToken ? { Authorization: `token ${auth.accessToken}` } : {}),
-        },
+        headers: headers,
         body: spanData,
     })
 

--- a/vscode/src/testutils/mocks.ts
+++ b/vscode/src/testutils/mocks.ts
@@ -948,5 +948,5 @@ export const DEFAULT_VSCODE_SETTINGS = {
     experimentalGuardrailsTimeoutSeconds: undefined,
     overrideAuthToken: undefined,
     overrideServerEndpoint: undefined,
-    authExternalProviders: undefined,
+    authExternalProviders: [],
 } satisfies ClientConfiguration

--- a/vscode/src/testutils/mocks.ts
+++ b/vscode/src/testutils/mocks.ts
@@ -948,4 +948,5 @@ export const DEFAULT_VSCODE_SETTINGS = {
     experimentalGuardrailsTimeoutSeconds: undefined,
     overrideAuthToken: undefined,
     overrideServerEndpoint: undefined,
+    authExternalProviders: undefined,
 } satisfies ClientConfiguration

--- a/vscode/webviews/AppWrapperForTest.tsx
+++ b/vscode/webviews/AppWrapperForTest.tsx
@@ -115,7 +115,10 @@ export const AppWrapperForTest: FunctionComponent<{ children: ReactNode }> = ({ 
                     detectIntent: () => Observable.of(),
                     resolvedConfig: () =>
                         Observable.of({
-                            auth: { accessTokenOrHeaders: 'abc', serverEndpoint: 'https://example.com' },
+                            auth: {
+                                credentials: { token: 'abc' },
+                                serverEndpoint: 'https://example.com',
+                            },
                             configuration: {
                                 autocomplete: true,
                                 devModels: [{ model: 'my-model', provider: 'my-provider' }],

--- a/vscode/webviews/AppWrapperForTest.tsx
+++ b/vscode/webviews/AppWrapperForTest.tsx
@@ -115,7 +115,7 @@ export const AppWrapperForTest: FunctionComponent<{ children: ReactNode }> = ({ 
                     detectIntent: () => Observable.of(),
                     resolvedConfig: () =>
                         Observable.of({
-                            auth: { accessToken: 'abc', serverEndpoint: 'https://example.com' },
+                            auth: { accessTokenOrHeaders: 'abc', serverEndpoint: 'https://example.com' },
                             configuration: {
                                 autocomplete: true,
                                 devModels: [{ model: 'my-model', provider: 'my-provider' }],


### PR DESCRIPTION
Fixes https://linear.app/sourcegraph/issue/CODY-4642

## External Authentication Provider Support for Cody

This PR introduces support for external authentication providers in Cody, allowing users to integrate with custom authentication proxies and handle complex authentication scenarios.

### Feature Overview

This feature requires clients to have reverse proxy and custom sourcegraph instance [configured to use HTTP authentication](https://sourcegraph.com/docs/admin/auth#http-authentication-proxies).

The external authentication provider feature allows clients to generate, for a specified endpoint, custom auth headers. Those headers will be attached to every authenticated http request instead of the normal `"Authorization": "token sgp_SOME_TOKEN"` auth header.

To generate those custom headers client need to specify command that generates authentication headers for specific endpoints. The command must output a JSON object containing header key-value pairs on stdout. Those endpoints URLs needs to point to [proxies configured by client](https://sourcegraph.com/docs/admin/auth#http-authentication-proxies) which redirects requests to the custom sourcegraph instance.

Whole flow looks like this:

1. When Cody attempts to connect to a endpoint which has defined external provider it executes the specified command
2. The command outputs a JSON object containing header key-value pairs on stdout
3. These headers are attached to subsequent authorised requests to the endpoint
4. The proxy server processes these headers and converts them to appropriate `X-Forwarded-User` and/or `X-Forwarded-Email` headers as specified in the [documentation](https://sourcegraph.com/docs/admin/auth#http-authentication-proxies)
5. The Sourcegraph instance authenticates the user based on these forwarded headers

### Configuration

Users can configure custom authentication providers in their vscode settings.json using the following structure:

```json
"cody.auth.externalProviders": [
    {
        "endpoint": "http://localhost:5555",
        "executable": {
            "commandLine": ["echo '{ \"headers\": { \"Authorization\": \"Bearer SomeUser\" } }'"],
            "shell": "/bin/bash",       // Optional: Shell to execute the command with. Default: '/bin/sh' on Unix, process.env.ComSpec on Windows.
            "environment": {            // Optional: Additional environment variables
                "SOME_ENV": "VALUE"
            },
            "timeout": 5000,            // Optional: Timeout in milliseconds
            "windowsHide": true         // Optional: Hide the window on Windows
        }
    }
]
```

It can also be configured in IntelliJ using settings editor:
![image](https://github.com/user-attachments/assets/5440b226-534f-471c-a78e-3c6f6d9c76c0)

User can define as many external providers as needed.

If only one provider is needed and login using this provider should be forced, it [will be possible to accomplish](https://github.com/sourcegraph/cody/pull/6574) using `overrideServerEndpoint`.

### Configuration Options
* endpoint: The URL of the proxy server that will handle the authentication
* executable: Configuration for the command that generates authentication headers
  - commandLine: Array of command and arguments to execute
  - shell: (Optional) Specific shell to use for command execution
  - environment: (Optional) Additional environment variables for the command
  - workingDir: (Optional) Working directory for command execution
  - timeout: (Optional) Command execution timeout
  - windowsHide: (Optional) Hide window when executing on Windows

### Expected Output

Script or executable specified in the configuration have to return valid JSON object which adheres to the schema:

```json
{
  "$schema": "http://json-schema.org/draft-07/schema#",
  "type": "object",
  "required": ["headers"],
  "properties": {
    "headers": {
      "type": "object",
      "additionalProperties": {
        "type": "string"
      }
    },
    "expiration": {
      "type": "number"
    }
  }
}
```

Where:

*  `headers` *(Required)*  [Map with string keys and values] - headers which will be attached to authenticated requests to the http proxy
*  `expiration` *(Optional)* [a number] - Epoch Unix Timestamp (UTC) of the headers expiration date; after expiration date headers will be re-generated automatically using configured command
 
### Testing Locally

1. Start the provided reverse proxy:
`python agent/scripts/reverse-proxy.py https://your-sourcegraph-instance.com 5555`
You can choose different port or start a few different proxies for different endpoints.

2. Add the proxy configuration to your settings:

```json
"cody.auth.externalProviders": [
    {
        "endpoint": "http://localhost:5555",
        "executable": {
            "commandLine": ["echo '{ \"Authorization\": \"Bearer TestUser\" }'"],
            "shell": "/bin/bash"
        }
    }
]
```

3. In Cody sign in to `http://localhost:5555` endpoint
4. Verify that you're authenticated as TestUser.

### Security Considerations
1. Ensure that the proxy server properly validates and sanitizes authentication headers
2. The executable should be secured and have appropriate permissions
3. Consider using HTTPS for the proxy endpoint in production environments

### Missing features
1. Fastpath users custom tokens for authentication, we need to check if and how we can support it with custom auth providers.
2. Cli is currently not supported, but should be trivial to add support for it.

## Test plan

1. Setup local testing environment as described in the `Testing Locally` section.
3. Run a full QA.

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
