### PR TITLE
feat(audoedit): reactive config singleton

### DIFF
--- a/vscode/src/autoedits/autoedits-config.ts
+++ b/vscode/src/autoedits/autoedits-config.ts
@@ -3,6 +3,7 @@ import * as vscode from 'vscode'
 import {
     type AutoEditsModelConfig,
     type AutoEditsTokenLimit,
+    authStatus,
     isDotComAuthed,
 } from '@sourcegraph/cody-shared'
 
@@ -85,6 +86,10 @@ export function getAutoeditsProviderConfig(): AutoeditsProviderConfig {
 
 /**
  * A singleton for the static autoedits provider config.
- * TODO: make it reactive to VS Code settings changes.
  */
-export const autoeditsProviderConfig = getAutoeditsProviderConfig()
+export let autoeditsProviderConfig = getAutoeditsProviderConfig()
+
+// Recompute autoedits config on auth status change.
+authStatus.subscribe(() => {
+    autoeditsProviderConfig = getAutoeditsProviderConfig()
+})


### PR DESCRIPTION
Makes autoedits config singleton reactive to auth status. This is not enough to make autoedits fully reactive and remove the requirement to reload VS Code, but this part is required for analytics logger integration tests I'll add in one of the follow-up PRs.

## Test plan

CI 