### PR TITLE
feat(audoedit): update vscode mocks

### DIFF
--- a/vscode/src/testutils/mocks.ts
+++ b/vscode/src/testutils/mocks.ts
@@ -740,6 +740,9 @@ const languages: Partial<typeof vscode_types.languages> = {
             'vimrc',
         ])
     },
+    getDiagnostics() {
+        return []
+    },
 }
 
 export enum TextDocumentChangeReason {
@@ -805,6 +808,9 @@ export const vsCodeMocks = {
         },
         onDidChangeActiveTextEditor() {},
         onDidChangeTextEditorSelection() {},
+        onDidChangeTextEditorVisibleRanges() {},
+        onDidChangeNotebookEditorVisibleRanges() {},
+        onDidChangeActiveNotebookEditor() {},
         onDidChangeWindowState() {},
         state: { focused: false },
         createTextEditorDecorationType: () => ({
@@ -826,6 +832,7 @@ export const vsCodeMocks = {
     },
     commands: {
         registerCommand: () => ({ dispose: () => {} }),
+        executeCommand: () => Promise.resolve(),
     },
     workspace: {
         fs: workspaceFs,
@@ -852,6 +859,7 @@ export const vsCodeMocks = {
             return path.toString()
         },
         onDidChangeTextDocument() {},
+        onDidOpenTextDocument() {},
         onDidCloseTextDocument() {},
         onDidRenameFiles() {},
         onDidDeleteFiles() {},


### PR DESCRIPTION
Add some of the missing VS Code mocks to test utils. These are required for the analytics logger integration tests, which I'll add in one of the follow-up PRs.

## Test plan

CI