### PR TITLE
Record telemetry when executing search

### DIFF
--- a/vscode/src/chat/chat-view/handlers/SearchHandler.ts
+++ b/vscode/src/chat/chat-view/handlers/SearchHandler.ts
@@ -22,9 +22,11 @@ import type { AgentHandler, AgentHandlerDelegate, AgentRequest } from './interfa
 
 export class SearchHandler implements AgentHandler {
     async handle(
-        { editorState, inputText, mentions, chatBuilder, signal }: AgentRequest,
+        { editorState, inputText, mentions, chatBuilder, signal, recorder, span }: AgentRequest,
         delegate: AgentHandlerDelegate
     ): Promise<void> {
+        recorder.recordChatQuestionExecuted(mentions, { addMetadata: true, current: span })
+
         const inputTextWithoutContextChips = editorState
             ? inputTextWithoutContextChipsFromPromptEditorState(editorState)
             : inputText.toString()


### PR DESCRIPTION
This commit adds the last piece for
https://linear.app/sourcegraph/issue/SRCH-1455/one-box-telemetry. Now when a message is submitted as search we also record a 'cody.chat-question/executed' event.
The intent (detected and chosen) is part of the submission as well.

I'm not sure if this is correct but I chose to pass the passed 'mentions' as context for the telemetry event, since it's from those mentions that we compute the scope(s) of the search query.


## Test plan

Code inspection