### PR TITLE
Fix not working authorisation actions after previous one was cancelled

### DIFF
--- a/agent/src/agent.ts
+++ b/agent/src/agent.ts
@@ -1368,7 +1368,7 @@ export class Agent extends MessageHandler implements ExtensionClient {
             await this.receiveWebviewMessage(id, message)
             return null
         })
-        this.registerAuthenticatedRequest(
+        this.registerRequest(
             'webview/receiveMessageStringEncoded',
             async ({ id, messageStringEncoded }) => {
                 await this.receiveWebviewMessage(id, JSON.parse(messageStringEncoded))


### PR DESCRIPTION
Fixes https://linear.app/sourcegraph/issue/QA-220/jetbrains-clicking-cancel-instead-of-authorize-and-navigating-back-to#comment-a0acf5cb

This fixes regression introduced by https://github.com/sourcegraph/cody/pull/6365.
In fact that PR fixed a bug we had in the codebase forever (`registerAuthenticatedRequest` was allowing calls which were not authorised but just `pending`). But it surfaced problem in other place - `webview/receiveMessageStringEncoded` is used also for unauthorised requests like this:
```json
{
    "command": "recordEvent",
    "feature":"cody.webview.auth",
    "action":"simplifiedSignIngithubClick"
}
```

## Test plan

1. Have Cody plugin installed in your JB editor
2. Click on Sign in with Google/Github/Gitlab account
3. User will be redirected to Web browser 
4. Click on "Cancel" button from "Authorize JetBrains IDE?" page
5. Repeat Step 2
