### PR TITLE
feat(auto-edits): clean auto-edits output channel

### DIFF
--- a/vscode/src/autoedits/adapters/cody-gateway.ts
+++ b/vscode/src/autoedits/adapters/cody-gateway.ts
@@ -24,11 +24,9 @@ export class CodyGatewayAdapter implements AutoeditsModelAdapter {
             }
             return response.choices[0].text
         } catch (error) {
-            autoeditsOutputChannelLogger.logError(
-                'getModelResponse',
-                'Error calling Cody Gateway:',
-                error
-            )
+            autoeditsOutputChannelLogger.logError('getModelResponse', 'Error calling Cody Gateway:', {
+                verbose: error,
+            })
             throw error
         }
     }

--- a/vscode/src/autoedits/adapters/create-adapter.ts
+++ b/vscode/src/autoedits/adapters/create-adapter.ts
@@ -30,7 +30,7 @@ export function createAutoeditsModelAdapter({
                 ? new SourcegraphChatAdapter(chatClient)
                 : new SourcegraphCompletionsAdapter()
         default:
-            autoeditsOutputChannelLogger.logDebug(
+            autoeditsOutputChannelLogger.logError(
                 'createAutoeditsModelAdapter',
                 `Provider ${providerName} not supported`
             )

--- a/vscode/src/autoedits/adapters/fireworks.ts
+++ b/vscode/src/autoedits/adapters/fireworks.ts
@@ -28,11 +28,9 @@ export class FireworksAdapter implements AutoeditsModelAdapter {
             }
             return response.choices[0].text
         } catch (error) {
-            autoeditsOutputChannelLogger.logError(
-                'getModelResponse',
-                'Error calling Fireworks API:',
-                error
-            )
+            autoeditsOutputChannelLogger.logError('getModelResponse', 'Error calling Fireworks API:', {
+                verbose: error,
+            })
             throw error
         }
     }

--- a/vscode/src/autoedits/adapters/openai.ts
+++ b/vscode/src/autoedits/adapters/openai.ts
@@ -35,7 +35,9 @@ export class OpenAIAdapter implements AutoeditsModelAdapter {
             )
             return response.choices[0].message.content
         } catch (error) {
-            autoeditsOutputChannelLogger.logError('getModelResponse', 'Error calling OpenAI API:', error)
+            autoeditsOutputChannelLogger.logError('getModelResponse', 'Error calling OpenAI API:', {
+                verbose: error,
+            })
             throw error
         }
     }

--- a/vscode/src/autoedits/adapters/sourcegraph-chat.ts
+++ b/vscode/src/autoedits/adapters/sourcegraph-chat.ts
@@ -41,7 +41,9 @@ export class SourcegraphChatAdapter implements AutoeditsModelAdapter {
             autoeditsOutputChannelLogger.logError(
                 'getModelResponse',
                 'Error calling Sourcegraph Chat:',
-                error
+                {
+                    verbose: error,
+                }
             )
             throw error
         }

--- a/vscode/src/autoedits/adapters/sourcegraph-completions.ts
+++ b/vscode/src/autoedits/adapters/sourcegraph-completions.ts
@@ -51,7 +51,7 @@ export class SourcegraphCompletionsAdapter implements AutoeditsModelAdapter {
             autoeditsOutputChannelLogger.logError(
                 'getModelResponse',
                 'Error calling Sourcegraph Completions:',
-                error
+                { verbose: error }
             )
             throw error
         }

--- a/vscode/src/autoedits/autoedits-provider.ts
+++ b/vscode/src/autoedits/autoedits-provider.ts
@@ -159,14 +159,14 @@ export class AutoeditsProvider implements vscode.InlineCompletionItemProvider, v
 
         await new Promise(resolve => setTimeout(resolve, INLINE_COMPLETION_DEFAULT_DEBOUNCE_INTERVAL_MS))
         if (abortSignal.aborted) {
-            autoeditsOutputChannelLogger.logDebug(
+            autoeditsOutputChannelLogger.logDebugIfVerbose(
                 'provideInlineCompletionItems',
                 'debounce aborted before calculating getCurrentDocContext'
             )
             return null
         }
 
-        autoeditsOutputChannelLogger.logDebug(
+        autoeditsOutputChannelLogger.logDebugIfVerbose(
             'provideInlineCompletionItems',
             'Calculating getCurrentDocContext...'
         )
@@ -189,7 +189,7 @@ export class AutoeditsProvider implements vscode.InlineCompletionItemProvider, v
             tokenBudget: autoeditsProviderConfig.tokenLimit,
         })
 
-        autoeditsOutputChannelLogger.logDebug(
+        autoeditsOutputChannelLogger.logDebugIfVerbose(
             'provideInlineCompletionItems',
             'Calculating context from contextMixer...'
         )
@@ -220,14 +220,14 @@ export class AutoeditsProvider implements vscode.InlineCompletionItemProvider, v
             },
         })
         if (abortSignal.aborted) {
-            autoeditsOutputChannelLogger.logDebug(
+            autoeditsOutputChannelLogger.logDebugIfVerbose(
                 'provideInlineCompletionItems',
                 'aborted in getContext'
             )
             return null
         }
 
-        autoeditsOutputChannelLogger.logDebug(
+        autoeditsOutputChannelLogger.logDebugIfVerbose(
             'provideInlineCompletionItems',
             'Calculating prompt from promptStrategy...'
         )
@@ -239,7 +239,7 @@ export class AutoeditsProvider implements vscode.InlineCompletionItemProvider, v
             isChatModel: autoeditsProviderConfig.isChatModel,
         })
 
-        autoeditsOutputChannelLogger.logDebug(
+        autoeditsOutputChannelLogger.logDebugIfVerbose(
             'provideInlineCompletionItems',
             'Calculating prediction from getPrediction...'
         )
@@ -250,7 +250,7 @@ export class AutoeditsProvider implements vscode.InlineCompletionItemProvider, v
             codeToReplaceData,
         })
         if (abortSignal?.aborted || !initialPrediction) {
-            autoeditsOutputChannelLogger.logDebug(
+            autoeditsOutputChannelLogger.logDebugIfVerbose(
                 'provideInlineCompletionItems',
                 'aborted after getPrediction'
             )
@@ -279,7 +279,10 @@ export class AutoeditsProvider implements vscode.InlineCompletionItemProvider, v
         })
 
         if (prediction === codeToRewrite) {
-            autoeditsOutputChannelLogger.logDebug('skip', 'prediction equals to code to rewrite')
+            autoeditsOutputChannelLogger.logDebugIfVerbose(
+                'provideInlineCompletionItems',
+                'prediction equals to code to rewrite'
+            )
             return null
         }
 
@@ -290,7 +293,10 @@ export class AutoeditsProvider implements vscode.InlineCompletionItemProvider, v
         })
 
         if (shouldFilterPredictionBasedRecentEdits) {
-            autoeditsOutputChannelLogger.logDebug('skip', 'based on recent edits')
+            autoeditsOutputChannelLogger.logDebugIfVerbose(
+                'provideInlineCompletionItems',
+                'based on recent edits'
+            )
             return null
         }
 
@@ -303,7 +309,10 @@ export class AutoeditsProvider implements vscode.InlineCompletionItemProvider, v
                 suffix: codeToReplaceData.suffixInArea + codeToReplaceData.suffixAfterArea,
             })
         ) {
-            autoeditsOutputChannelLogger.logDebug('skip', 'prediction equals to code to rewrite')
+            autoeditsOutputChannelLogger.logDebugIfVerbose(
+                'provideInlineCompletionItems',
+                'skip because the prediction equals to code to rewrite'
+            )
             return null
         }
 
@@ -318,13 +327,19 @@ export class AutoeditsProvider implements vscode.InlineCompletionItemProvider, v
             })
 
         if (inlineCompletionItems === null && updatedDecorationInfo === null) {
-            autoeditsOutputChannelLogger.logDebug('skip', 'no suggestion to render')
+            autoeditsOutputChannelLogger.logDebugIfVerbose(
+                'provideInlineCompletionItems',
+                'no suggestion to render'
+            )
             return null
         }
 
         const editor = vscode.window.activeTextEditor
         if (!editor || !areSameUriDocs(document, editor.document)) {
-            autoeditsOutputChannelLogger.logDebug('skip', 'no active editor')
+            autoeditsOutputChannelLogger.logDebugIfVerbose(
+                'provideInlineCompletionItems',
+                'no active editor'
+            )
             return null
         }
 

--- a/vscode/src/autoedits/filter-prediction-edits.ts
+++ b/vscode/src/autoedits/filter-prediction-edits.ts
@@ -79,8 +79,7 @@ export class FilterPredictionBasedOnRecentEdits implements vscode.Disposable {
                 autoeditsOutputChannelLogger.logDebug(
                     'isTextDocumentChangeReverted',
                     'Filtered the prediction based on recent edits match',
-                    'Diff calculated for filtering based on recent edits\n',
-                    diff1
+                    { verbose: diff1 }
                 )
             }
             return true

--- a/vscode/src/autoedits/output-channel-logger.ts
+++ b/vscode/src/autoedits/output-channel-logger.ts
@@ -1,3 +1,23 @@
+import * as vscode from 'vscode'
+import { getConfiguration } from '../configuration'
 import { Logger } from '../output-channel-logger'
 
-export const autoeditsOutputChannelLogger = new Logger('AutoEdits')
+export class AutoEditsOutputChannelLogger extends Logger {
+    private readonly logger: Logger
+
+    constructor(feature: string) {
+        super(feature)
+        this.logger = new Logger(feature)
+    }
+
+    logDebugIfVerbose(filterLabel: string, text: string, ...args: unknown[]): void {
+        const workspaceConfig = vscode.workspace.getConfiguration()
+        const { debugVerbose } = getConfiguration(workspaceConfig)
+
+        if (debugVerbose) {
+            this.logger.logDebug(filterLabel, text, ...args)
+        }
+    }
+}
+
+export const autoeditsOutputChannelLogger = new AutoEditsOutputChannelLogger('AutoEdits')

--- a/vscode/src/autoedits/prompt/default-prompt-strategy.ts
+++ b/vscode/src/autoedits/prompt/default-prompt-strategy.ts
@@ -3,6 +3,7 @@ import { type PromptString, ps } from '@sourcegraph/cody-shared'
 import { RetrieverIdentifier } from '../../completions/context/utils'
 import { autoeditsOutputChannelLogger } from '../output-channel-logger'
 
+import { shortenPromptForOutputChannel } from '../../../src/completions/output-channel-logger'
 import { AutoeditsUserPromptStrategy, type UserPromptArgs } from './base'
 import * as constants from './constants'
 import {
@@ -72,7 +73,9 @@ export class DefaultUserPromptStrategy extends AutoeditsUserPromptStrategy {
             constants.FINAL_USER_PROMPT
         )
 
-        autoeditsOutputChannelLogger.logDebug('getUserPrompt', 'Prompt\n', finalPrompt)
+        autoeditsOutputChannelLogger.logDebugIfVerbose('DefaultUserPromptStrategy', 'getUserPrompt', {
+            verbose: shortenPromptForOutputChannel(finalPrompt.toString(), []),
+        })
         return finalPrompt
     }
 }

--- a/vscode/src/autoedits/prompt/prompt-utils.ts
+++ b/vscode/src/autoedits/prompt/prompt-utils.ts
@@ -438,7 +438,7 @@ export function getContextItemMappingWithTokenLimit(
         if (tokenLimit !== undefined) {
             contextItemMapping.set(identifier, getContextItemsInTokenBudget(items, tokenLimit))
         } else {
-            autoeditsOutputChannelLogger.logDebug(
+            autoeditsOutputChannelLogger.logError(
                 'getContextItemMappingWithTokenLimit',
                 `No token limit for ${identifier}`
             )

--- a/vscode/src/autoedits/prompt/short-term-diff-prompt-strategy.ts
+++ b/vscode/src/autoedits/prompt/short-term-diff-prompt-strategy.ts
@@ -4,6 +4,7 @@ import { groupConsecutiveItemsByPredicate } from '../../completions/context/retr
 import { RetrieverIdentifier } from '../../completions/context/utils'
 import { autoeditsOutputChannelLogger } from '../output-channel-logger'
 
+import { shortenPromptForOutputChannel } from '../../../src/completions/output-channel-logger'
 import { AutoeditsUserPromptStrategy, type UserPromptArgs } from './base'
 import * as constants from './constants'
 import {
@@ -71,7 +72,9 @@ export class ShortTermPromptStrategy extends AutoeditsUserPromptStrategy {
             constants.FINAL_USER_PROMPT
         )
 
-        autoeditsOutputChannelLogger.logDebug('getUserPrompt', 'Prompt\n', finalPrompt)
+        autoeditsOutputChannelLogger.logDebugIfVerbose('ShortTermPromptStrategy', 'getUserPrompt', {
+            verbose: shortenPromptForOutputChannel(finalPrompt.toString(), []),
+        })
         return finalPrompt
     }
 

--- a/vscode/src/autoedits/renderer/inline-manager.ts
+++ b/vscode/src/autoedits/renderer/inline-manager.ts
@@ -3,6 +3,7 @@ import * as vscode from 'vscode'
 import { isFileURI } from '@sourcegraph/cody-shared'
 
 import { completionMatchesSuffix } from '../../completions/is-completion-visible'
+import { shortenPromptForOutputChannel } from '../../completions/output-channel-logger'
 import { getNewLineChar } from '../../completions/text-processing'
 import { autoeditAnalyticsLogger } from '../analytics-logger'
 import { autoeditsOutputChannelLogger } from '../output-channel-logger'
@@ -98,10 +99,10 @@ export class AutoEditsInlineRendererManager
                 ),
             ]
 
-            autoeditsOutputChannelLogger.logDebug(
+            autoeditsOutputChannelLogger.logDebugIfVerbose(
                 'tryMakeInlineCompletions',
                 'Autocomplete Inline Response: ',
-                completionText
+                { verbose: shortenPromptForOutputChannel(completionText, []) }
             )
         }
 

--- a/vscode/src/autoedits/renderer/manager.ts
+++ b/vscode/src/autoedits/renderer/manager.ts
@@ -252,7 +252,7 @@ export class AutoEditsDefaultRendererManager implements AutoEditsRendererManager
             autoeditsOutputChannelLogger.logDebug(
                 'tryMakeInlineCompletions',
                 'Autocomplete Inline Response: ',
-                autocompleteResponse
+                { verbose: autocompleteResponse }
             )
             return {
                 inlineCompletionItems: [inlineCompletionItem],
@@ -260,7 +260,7 @@ export class AutoEditsDefaultRendererManager implements AutoEditsRendererManager
                 updatedPrediction,
             }
         }
-        autoeditsOutputChannelLogger.logDebug(
+        autoeditsOutputChannelLogger.logDebugIfVerbose(
             'tryMakeInlineCompletions',
             'Rendering a diff view for auto-edits.'
         )

--- a/vscode/src/completions/context/context-mixer.ts
+++ b/vscode/src/completions/context/context-mixer.ts
@@ -153,7 +153,7 @@ export class ContextMixer implements vscode.Disposable {
 
         // Extract back the context results for the original retrievers
         const results = this.extractOriginalRetrieverResults(resultsWithDataLogging, retrievers)
-        autoeditsOutputChannelLogger.logDebug(
+        autoeditsOutputChannelLogger.logDebugIfVerbose(
             'ContextMixer',
             `Extracted ${results.length} contexts from the retrievers`
         )
@@ -177,13 +177,13 @@ export class ContextMixer implements vscode.Disposable {
             }
         }
 
-        autoeditsOutputChannelLogger.logDebug(
+        autoeditsOutputChannelLogger.logDebugIfVerbose(
             'ContextMixer',
             `Fusing ${results.length} context results with ${this.contextRankingStrategy}`
         )
         const contextRanker = new DefaultCompletionsContextRanker(this.contextRankingStrategy)
         const fusedResults = contextRanker.rankAndFuseContext(results)
-        autoeditsOutputChannelLogger.logDebug('ContextMixer', 'Fused context results')
+        autoeditsOutputChannelLogger.logDebugIfVerbose('ContextMixer', 'Fused context results')
 
         // The total chars size hint is inclusive of the prefix and suffix sizes, so we seed the
         // total chars with the prefix and suffix sizes.

--- a/vscode/src/completions/context/context-mixer.ts
+++ b/vscode/src/completions/context/context-mixer.ts
@@ -7,8 +7,8 @@ import {
     dedupeWith,
     wrapInActiveSpan,
 } from '@sourcegraph/cody-shared'
+import { autoeditsOutputChannelLogger } from '../../autoedits/output-channel-logger'
 import type { LastInlineCompletionCandidate } from '../get-inline-completions'
-import { autocompleteOutputChannelLogger } from '../output-channel-logger'
 import type { ContextRetriever } from '../types'
 import {
     DefaultCompletionsContextRanker,
@@ -153,7 +153,7 @@ export class ContextMixer implements vscode.Disposable {
 
         // Extract back the context results for the original retrievers
         const results = this.extractOriginalRetrieverResults(resultsWithDataLogging, retrievers)
-        autocompleteOutputChannelLogger.logDebug(
+        autoeditsOutputChannelLogger.logDebug(
             'ContextMixer',
             `Extracted ${results.length} contexts from the retrievers`
         )
@@ -177,13 +177,13 @@ export class ContextMixer implements vscode.Disposable {
             }
         }
 
-        autocompleteOutputChannelLogger.logDebug(
+        autoeditsOutputChannelLogger.logDebug(
             'ContextMixer',
             `Fusing ${results.length} context results with ${this.contextRankingStrategy}`
         )
         const contextRanker = new DefaultCompletionsContextRanker(this.contextRankingStrategy)
         const fusedResults = contextRanker.rankAndFuseContext(results)
-        autocompleteOutputChannelLogger.logDebug('ContextMixer', 'Fused context results')
+        autoeditsOutputChannelLogger.logDebug('ContextMixer', 'Fused context results')
 
         // The total chars size hint is inclusive of the prefix and suffix sizes, so we seed the
         // total chars with the prefix and suffix sizes.

--- a/vscode/src/completions/context/retrievers/recent-user-actions/diagnostics-retriever.ts
+++ b/vscode/src/completions/context/retrievers/recent-user-actions/diagnostics-retriever.ts
@@ -2,7 +2,7 @@ import type { AutocompleteContextSnippet } from '@sourcegraph/cody-shared'
 import { isDefined } from '@sourcegraph/cody-shared'
 import { XMLBuilder } from 'fast-xml-parser'
 import * as vscode from 'vscode'
-import { autocompleteOutputChannelLogger } from '../../../output-channel-logger'
+import { autoeditsOutputChannelLogger } from '../../../../autoedits/output-channel-logger'
 import type { ContextRetriever, ContextRetrieverOptions } from '../../../types'
 import { RetrieverIdentifier } from '../../utils'
 import { getCellIndexInActiveNotebookEditor, getNotebookCells } from './notebook-utils'
@@ -46,7 +46,7 @@ export class DiagnosticsRetriever implements vscode.Disposable, ContextRetriever
         document,
         position,
     }: ContextRetrieverOptions): Promise<AutocompleteContextSnippet[]> {
-        autocompleteOutputChannelLogger.logDebug(
+        autoeditsOutputChannelLogger.logDebugIfVerbose(
             'diagnostics retriever',
             'Retrieving diagnostics context'
         )
@@ -56,7 +56,7 @@ export class DiagnosticsRetriever implements vscode.Disposable, ContextRetriever
                 ? await this.getDiagnosticsForNotebook(position)
                 : await this.getDiagnosticsForDocument(document, position)
 
-        autocompleteOutputChannelLogger.logDebug(
+        autoeditsOutputChannelLogger.logDebugIfVerbose(
             'diagnostics retriever',
             `Retrieved ${diagnosticsSnippets.length} diagnostics context`
         )

--- a/vscode/src/completions/context/retrievers/recent-user-actions/recent-edits-retriever.ts
+++ b/vscode/src/completions/context/retrievers/recent-user-actions/recent-edits-retriever.ts
@@ -2,7 +2,7 @@ import { type PromptString, contextFiltersProvider } from '@sourcegraph/cody-sha
 import type { AutocompleteContextSnippet } from '@sourcegraph/cody-shared'
 import type { AutocompleteContextSnippetMetadataFields } from '@sourcegraph/cody-shared'
 import * as vscode from 'vscode'
-import { autocompleteOutputChannelLogger } from '../../../output-channel-logger'
+import { autoeditsOutputChannelLogger } from '../../../../autoedits/output-channel-logger'
 import type { ContextRetriever, ContextRetrieverOptions } from '../../../types'
 import { RetrieverIdentifier, type ShouldUseContextParams, shouldBeUsedAsContext } from '../../utils'
 import type {
@@ -47,7 +47,7 @@ export class RecentEditsRetriever implements vscode.Disposable, ContextRetriever
     }
 
     public async retrieve(options: ContextRetrieverOptions): Promise<AutocompleteContextSnippet[]> {
-        autocompleteOutputChannelLogger.logDebug(
+        autoeditsOutputChannelLogger.logDebugIfVerbose(
             'recent edits retrieve',
             'Retrieving recent edits context'
         )
@@ -73,7 +73,7 @@ export class RecentEditsRetriever implements vscode.Disposable, ContextRetriever
             }
             autocompleteContextSnippets.push(autocompleteSnippet)
         }
-        autocompleteOutputChannelLogger.logDebug(
+        autoeditsOutputChannelLogger.logDebugIfVerbose(
             'recent edits retrieve',
             `Retrieved ${autocompleteContextSnippets.length} recent edits context`
         )

--- a/vscode/src/completions/context/retrievers/recent-user-actions/recent-view-port.ts
+++ b/vscode/src/completions/context/retrievers/recent-user-actions/recent-view-port.ts
@@ -2,7 +2,7 @@ import type { AutocompleteContextSnippet } from '@sourcegraph/cody-shared'
 import debounce from 'lodash/debounce'
 import { LRUCache } from 'lru-cache'
 import * as vscode from 'vscode'
-import { autocompleteOutputChannelLogger } from '../../../output-channel-logger'
+import { autoeditsOutputChannelLogger } from '../../../../autoedits/output-channel-logger'
 import type { ContextRetriever, ContextRetrieverOptions } from '../../../types'
 import { RetrieverIdentifier, type ShouldUseContextParams, shouldBeUsedAsContext } from '../../utils'
 import {
@@ -68,7 +68,7 @@ export class RecentViewPortRetriever implements vscode.Disposable, ContextRetrie
     }
 
     public async retrieve({ document }: ContextRetrieverOptions): Promise<AutocompleteContextSnippet[]> {
-        autocompleteOutputChannelLogger.logDebug(
+        autoeditsOutputChannelLogger.logDebugIfVerbose(
             'recent view port retrieve',
             'Retrieving recent view port context'
         )
@@ -98,7 +98,7 @@ export class RecentViewPortRetriever implements vscode.Disposable, ContextRetrie
             return snippet
         })
         const viewPortSnippets = await Promise.all(snippetPromises)
-        autocompleteOutputChannelLogger.logDebug(
+        autoeditsOutputChannelLogger.logDebugIfVerbose(
             'recent view port retrieve',
             `Retrieved ${viewPortSnippets.length} recent view port context`
         )

--- a/vscode/src/completions/output-channel-logger.ts
+++ b/vscode/src/completions/output-channel-logger.ts
@@ -121,7 +121,7 @@ export const autocompleteLifecycleOutputChannelLogger = {
 // Maximum length of a segment before it gets compacted
 const MAX_SEGMENT_LENGTH = 200
 
-function shortenPromptForOutputChannel(prompt: string, stopSequences: string[]): string {
+export function shortenPromptForOutputChannel(prompt: string, stopSequences: string[]): string {
     const stopSequencesWithoutNewLines = stopSequences.filter(seq => !isNewlineSequence(seq))
     const escapedSeparators = stopSequencesWithoutNewLines.map(escapeRegExp)
 


### PR DESCRIPTION
## Context 
Clean the output logger for `auto-edits`:
1. Most of the debugging calls (to check where the `auto-edits` might break are enabled only if verbose debugging true. 
2. Large logs like `prompt` are shorted similar to autocomplete prompt logs.

**Logs when verbose enabled for a single `auto-edits` request.**
<img width="1379" alt="image" src="https://github.com/user-attachments/assets/a546d3f4-7ef4-40d2-acc5-b85c53cc2d6a" />

**Logs without verbose enabled for a single `auto-edits` request.** 
- Only response is logged

<img width="1214" alt="image" src="https://github.com/user-attachments/assets/a85c6295-6bac-47a7-b2ca-c0a9f0515b7e" />

## Test plan
1. Trigger the auto-edits request
2. See the output logs by toggling `cody.debug.version` flag

