### PR TITLE
feat(deep-cody): add selected agent tracking and update telemetry

### DIFF
--- a/lib/shared/src/chat/transcript/messages.ts
+++ b/lib/shared/src/chat/transcript/messages.ts
@@ -116,7 +116,7 @@ export interface SerializedChatMessage {
     intent?: ChatMessage['intent']
     manuallySelectedIntent?: ChatMessage['manuallySelectedIntent']
     search?: ChatMessage['search']
-    agent?: string
+    agent?: string | undefined | null
     processes?: ProcessingStep[] | undefined | null
     subMessages?: SubMessage[]
 }

--- a/lib/shared/src/chat/transcript/messages.ts
+++ b/lib/shared/src/chat/transcript/messages.ts
@@ -45,7 +45,7 @@ export interface ChatMessage extends Message {
     intent?: 'search' | 'chat' | 'edit' | 'insert' | undefined | null
     manuallySelectedIntent?: 'search' | 'chat' | 'edit' | 'insert' | undefined | null
     search?: ChatMessageSearch | undefined | null
-    agent?: string
+    agent?: string | undefined | null
     processes?: ProcessingStep[] | undefined | null
 
     /**

--- a/lib/shared/src/telemetry-v2/events/chat-question.ts
+++ b/lib/shared/src/telemetry-v2/events/chat-question.ts
@@ -31,6 +31,7 @@ export interface SharedProperties {
     sessionID: string
     repoIsPublic: boolean
     repoMetadata?: { commit?: string; remoteID?: string }[]
+    chatAgent?: string | undefined | null
 }
 export const events = [
     event(
@@ -76,6 +77,7 @@ export const events = [
                               )
                             : undefined,
                         gitMetadata,
+                        chatAgent: params.chatAgent,
                     },
                     billingMetadata: {
                         product: 'cody',

--- a/vscode/src/chat/agentic/DeepCody.ts
+++ b/vscode/src/chat/agentic/DeepCody.ts
@@ -54,6 +54,12 @@ export class DeepCodyAgent {
     private stepsManager: ProcessManager
 
     protected context: ContextItem[] = []
+    /**
+     * Context stats during the review:
+     * - context: how many context was fetched via tools.
+     * - loop: how many loop was run.
+     */
+    private stats = { context: 0, loop: 0 }
 
     constructor(
         protected readonly chatBuilder: ChatBuilder,
@@ -62,12 +68,9 @@ export class DeepCodyAgent {
     ) {
         // Initialize tools, handlers and mixins in constructor
         this.tools = CodyToolProvider.getTools()
-
         this.initializeMultiplexer(this.tools)
         this.buildPrompt(this.tools)
-
         this.stepsManager = new ProcessManager(steps => statusUpdateCallback(steps))
-
         this.statusCallback = {
             onStart: () => {
                 this.stepsManager.initializeStep()
@@ -143,16 +146,17 @@ export class DeepCodyAgent {
         span.setAttribute('sampled', true)
         this.statusCallback?.onStart()
         const startTime = performance.now()
-        const { stats, contextItems } = await this.reviewLoop(requestID, span, chatAbortSignal, maxLoops)
-
+        await this.reviewLoop(requestID, span, chatAbortSignal, maxLoops)
         telemetryRecorder.recordEvent('cody.deep-cody.context', 'reviewed', {
             privateMetadata: {
+                requestID,
                 model: DeepCodyAgent.model,
                 traceId: span.spanContext().traceId,
             },
             metadata: {
-                context: stats.context,
-                loop: stats.loop,
+                loop: this.stats.loop, // Number of loops run.
+                fetched: this.stats.context, // Number of context fetched.
+                context: this.context.length, // Number of context used.
                 durationMs: performance.now() - startTime,
             },
             billingMetadata: {
@@ -160,10 +164,8 @@ export class DeepCodyAgent {
                 category: 'billable',
             },
         })
-
         this.statusCallback?.onComplete()
-
-        return contextItems
+        return this.context
     }
 
     private async reviewLoop(
@@ -171,23 +173,19 @@ export class DeepCodyAgent {
         span: Span,
         chatAbortSignal: AbortSignal,
         maxLoops: number
-    ): Promise<{ stats: { context: number; loop: number }; contextItems: ContextItem[] }> {
+    ): Promise<void> {
         span.addEvent('reviewLoop')
-        const stats = { context: 0, loop: 0 }
         for (let i = 0; i < maxLoops && !chatAbortSignal.aborted; i++) {
-            stats.loop++
+            this.stats.loop++
             const newContext = await this.review(requestID, span, chatAbortSignal)
             if (!newContext.length) break
 
             // Filter and add new context items in one pass
             const validItems = newContext.filter(c => c.title !== 'TOOLCONTEXT')
             this.context.push(...validItems)
-
-            stats.context += validItems.length
-
+            this.stats.context += validItems.length
             if (newContext.every(isUserAddedItem)) break
         }
-        return { stats, contextItems: this.context }
     }
 
     /**
@@ -261,7 +259,9 @@ export class DeepCodyAgent {
                 return reviewed
             }
 
-            return results.flat().filter(isDefined)
+            const newContextFetched = results.flat().filter(isDefined)
+            this.stats.context = this.stats.context + newContextFetched.length
+            return newContextFetched
         } catch (error) {
             await this.multiplexer.notifyTurnComplete()
             logDebug('Deep Cody', `context review failed: ${error}`, {

--- a/vscode/src/chat/chat-view/ChatBuilder.ts
+++ b/vscode/src/chat/chat-view/ChatBuilder.ts
@@ -22,6 +22,7 @@ import {
 } from '@sourcegraph/cody-shared'
 
 import { Observable, Subject, map } from 'observable-fns'
+import { toolboxManager } from '../agentic/ToolboxManager'
 import { getChatPanelTitle } from './chat-helpers'
 
 /**
@@ -95,7 +96,8 @@ export class ChatBuilder {
 
         public readonly sessionID: string = new Date(Date.now()).toUTCString(),
         private messages: ChatMessage[] = [],
-        private customChatTitle?: string
+        private customChatTitle?: string,
+        private selectedChatAgent: string | undefined | null = null
     ) {}
 
     /** An observable that emits whenever the {@link ChatBuilder}'s chat changes. */
@@ -111,6 +113,18 @@ export class ChatBuilder {
     public setSelectedModel(newModelID: ChatModel | undefined): void {
         this.selectedModel = newModelID
         this.changeNotifications.next()
+    }
+
+    public setSelectedAgent(newAgentName?: string): void {
+        this.selectedChatAgent = newAgentName
+    }
+
+    public get selectedAgent(): string | undefined {
+        // SelectedChatAgent initially is null, so we will set it to the last user's agent.
+        if (this.selectedChatAgent === null) {
+            this.setSelectedAgent(toolboxManager.getSettings()?.agent?.name)
+        }
+        return this.selectedChatAgent || undefined
     }
 
     public isEmpty(): boolean {

--- a/vscode/src/chat/chat-view/handlers/DeepCodyHandler.ts
+++ b/vscode/src/chat/chat-view/handlers/DeepCodyHandler.ts
@@ -44,7 +44,7 @@ export class DeepCodyHandler extends ChatHandler implements AgentHandler {
             signal,
             skipQueryRewrite
         )
-        const isEnabled = chatBuilder.getMessages().length < 4
+        const isEnabled = chatBuilder.getLastHumanMessage()?.agent === 'deep-cody'
         if (!isEnabled || baseContextResult.error || baseContextResult.abort) {
             return baseContextResult
         }

--- a/vscode/webviews/chat/Transcript.tsx
+++ b/vscode/webviews/chat/Transcript.tsx
@@ -645,7 +645,7 @@ const TranscriptInteraction: FC<TranscriptInteractionProps> = memo(props => {
                         isContextLoading && humanMessage.agent === 'deep-cody' && humanMessage.index < 3
                     } // Open the context cell for the first 2 human messages when Deep Cody is run.
                     processes={humanMessage?.processes ?? undefined}
-                    agent={humanMessage?.agent}
+                    agent={humanMessage?.agent ?? undefined}
                 />
             )}
             {assistantMessage &&

--- a/vscode/webviews/chat/cells/messageCell/human/HumanMessageCell.tsx
+++ b/vscode/webviews/chat/cells/messageCell/human/HumanMessageCell.tsx
@@ -112,9 +112,9 @@ const HumanMessageCellContent = memo<HumanMessageCellContent>(props => {
             }
             speakerTitle={userInfo.user.displayName ?? userInfo.user.username}
             cellAction={
-                <div className="tw-flex tw-gap-4 tw-items-center tw-justify-end">
-                    {settings && <ToolboxButton settings={settings} api={api} />}
+                <div className="tw-flex tw-gap-2 tw-items-center tw-justify-end">
                     {isFirstMessage && <OpenInNewEditorAction />}
+                    {isLastInteraction && settings && <ToolboxButton settings={settings} api={api} />}
                 </div>
             }
             content={

--- a/vscode/webviews/chat/cells/messageCell/human/editor/ToolboxButton.tsx
+++ b/vscode/webviews/chat/cells/messageCell/human/editor/ToolboxButton.tsx
@@ -31,7 +31,9 @@ export const ToolboxButton: FC<ToolboxButtonProps> = memo(({ settings, api }) =>
     const onOpenChange = useCallback(
         (open: boolean): void => {
             if (open) {
-                telemetryRecorder.recordEvent('cody.toolboxSettings', 'open', {})
+                telemetryRecorder.recordEvent('cody.toolboxSettings', 'opened', {
+                    billingMetadata: { product: 'cody', category: 'billable' },
+                })
             } else {
                 // Reset form to original settings when closing
                 setSettingsForm(settings)
@@ -43,6 +45,17 @@ export const ToolboxButton: FC<ToolboxButtonProps> = memo(({ settings, api }) =>
     const onSubmit = useCallback(
         (close: () => void) => {
             setIsLoading(true)
+
+            if (settings !== settingsForm) {
+                telemetryRecorder.recordEvent('cody.toolboxSettings', 'updated', {
+                    billingMetadata: { product: 'cody', category: 'billable' },
+                    metadata: {
+                        agent: settingsForm.agent?.name ? 1 : 0,
+                        shell: settingsForm.shell?.enabled ? 1 : 0,
+                    },
+                })
+            }
+
             const subscription = api.updateToolboxSettings(settingsForm).subscribe({
                 next: () => {
                     setIsLoading(false)
@@ -61,7 +74,7 @@ export const ToolboxButton: FC<ToolboxButtonProps> = memo(({ settings, api }) =>
                 subscription.unsubscribe()
             }
         },
-        [api.updateToolboxSettings, settingsForm, settings]
+        [api.updateToolboxSettings, settingsForm, settings, telemetryRecorder]
     )
 
     return (


### PR DESCRIPTION
- Adds a `selectedAgent` property to the `ChatController` and `ChatBuilder` to track the currently selected agent
- Updates the `handleUserMessage` method in `ChatController` to use the selected agent for the human message
- Adds the `chatAgent` property to the `SharedProperties` in the `chat-question` telemetry event
- Updates the `ToolboxButton` component to record telemetry events for opening, updating, and closing the toolbox settings


## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

Example Events:

```
█ telemetry-v2 recordEvent: cody.toolboxSettings/opened: {
  "parameters": {
    "version": 0,
    "billingMetadata": {
      "product": "cody",
      "category": "billable"
    }
  },
  "timestamp": "2025-01-07T23:07:15.949Z"
}
█ telemetry-v2 recordEvent: cody.toolboxSettings/updated: {
  "parameters": {
    "version": 0,
    "metadata": [
      {
        "key": "agent",
        "value": 0
      },
      {
        "key": "shell",
        "value": 0
      }
    ],
    "billingMetadata": {
      "product": "cody",
      "category": "billable"
    }
  },
  "timestamp": "2025-01-07T23:07:17.676Z"
}
```

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
