### PR TITLE
fix: do not filter out path-only results

### DIFF
--- a/vscode/webviews/chat/cells/messageCell/assistant/SearchResults.tsx
+++ b/vscode/webviews/chat/cells/messageCell/assistant/SearchResults.tsx
@@ -2,7 +2,6 @@ import {
     CODE_SEARCH_PROVIDER_URI,
     type ChatMessageWithSearch,
     type NLSSearchDynamicFilter,
-    NLSSearchFileMatch,
     type NLSSearchResult,
     isDefined,
 } from '@sourcegraph/cody-shared'
@@ -67,7 +66,7 @@ export const SearchResults = ({
     const totalResults = useMemo(
         () =>
             message.search.response?.results.results.filter(
-                (result): result is NLSSearchFileMatch => result.__typename === 'FileMatch'
+                (result): result is NLSSearchResult => result.__typename === 'FileMatch'
             ) || [],
         [message.search.response]
     )

--- a/vscode/webviews/chat/cells/messageCell/assistant/SearchResults.tsx
+++ b/vscode/webviews/chat/cells/messageCell/assistant/SearchResults.tsx
@@ -2,6 +2,7 @@ import {
     CODE_SEARCH_PROVIDER_URI,
     type ChatMessageWithSearch,
     type NLSSearchDynamicFilter,
+    NLSSearchFileMatch,
     type NLSSearchResult,
     isDefined,
 } from '@sourcegraph/cody-shared'
@@ -66,9 +67,7 @@ export const SearchResults = ({
     const totalResults = useMemo(
         () =>
             message.search.response?.results.results.filter(
-                result =>
-                    result.__typename === 'FileMatch' &&
-                    (result.chunkMatches?.length || result.symbols?.length)
+                (result): result is NLSSearchFileMatch => result.__typename === 'FileMatch'
             ) || [],
         [message.search.response]
     )


### PR DESCRIPTION
The API supports searching for file paths and returns the results correctly, but the client was filtering them out of the results. This removes that filter.

Fixes SRCH-1514

## Test plan


![CleanShot 2025-01-07 at 17 02 04@2x](https://github.com/user-attachments/assets/e2eb65ed-4e21-4bb6-88d5-8ba4e435ff12)

