### PR TITLE
feat(audoedit): check if suggestion is still visible before marking as read

### DIFF
--- a/vscode/src/autoedits/renderer/inline-manager.ts
+++ b/vscode/src/autoedits/renderer/inline-manager.ts
@@ -61,7 +61,7 @@ export class AutoEditsInlineRendererManager
         })
 
         // The current line suffix should not require any char removals to render the completion.
-        const isSuffixMatch = completionMatchesSuffix({ insertText }, docContext.currentLineSuffix)
+        const isSuffixMatch = completionMatchesSuffix(insertText, docContext.currentLineSuffix)
 
         let inlineCompletionItems: vscode.InlineCompletionItem[] | null = null
 

--- a/vscode/src/autoedits/test-helpers.ts
+++ b/vscode/src/autoedits/test-helpers.ts
@@ -64,6 +64,9 @@ export async function autoeditResultFor(
 
     vi.spyOn(vsCodeMocks.window, 'activeTextEditor', 'get').mockReturnValue({
         document,
+        selection: {
+            active: position,
+        },
         edit: (callback: any) => callback(editBuilder),
         setDecorations: () => {},
     } as any)

--- a/vscode/src/completions/inline-completion-item-provider.ts
+++ b/vscode/src/completions/inline-completion-item-provider.ts
@@ -44,7 +44,7 @@ import {
     type InlineCompletionItemProviderConfig,
     InlineCompletionItemProviderConfigSingleton,
 } from './inline-completion-item-provider-config-singleton'
-import { isCompletionVisible } from './is-completion-visible'
+import { getLatestVisibilityContext, isCompletionVisible } from './is-completion-visible'
 import { autocompleteOutputChannelLogger } from './output-channel-logger'
 import { RequestManager, type RequestParams } from './request-manager'
 import {
@@ -560,7 +560,7 @@ export class InlineCompletionItemProvider
 
                 const visibleItems = autocompleteItems.filter(item =>
                     isCompletionVisible(
-                        item,
+                        item.insertText as string,
                         document,
                         { invokedPosition, latestPosition: position },
                         docContext,
@@ -783,7 +783,11 @@ export class InlineCompletionItemProvider
                 }
 
                 const { activeTextEditor } = vscode.window
-                const { document: invokedDocument, position: invokedPosition } = completion.requestParams
+                const {
+                    document: invokedDocument,
+                    position: invokedPosition,
+                    docContext,
+                } = completion.requestParams
 
                 if (
                     !activeTextEditor ||
@@ -793,49 +797,30 @@ export class InlineCompletionItemProvider
                     return
                 }
 
-                const latestCursorPosition = activeTextEditor.selection.active
-
-                // If the cursor position is the same as the position of the completion request, re-use the
-                // completion context. This ensures that we still use the suggestion widget to determine if the
-                // completion is still visible.
-                // We don't have a way of determining the contents of the suggestion widget if the cursor position is different,
-                // as this is only provided with `provideInlineCompletionItems` is called.
-                const latestContext = latestCursorPosition.isEqual(invokedPosition)
-                    ? completion.context
-                    : undefined
-
-                const takeSuggestWidgetSelectionIntoAccount = latestContext
-                    ? this.shouldTakeSuggestWidgetSelectionIntoAccount(
-                          {
-                              document: invokedDocument,
-                              position: invokedPosition,
-                              context: completion.context,
-                          },
-                          {
-                              document: activeTextEditor.document,
-                              position: latestCursorPosition,
-                              context: latestContext,
-                          }
-                      )
-                    : false
+                const visibilityContext = getLatestVisibilityContext({
+                    invokedPosition,
+                    invokedDocument,
+                    activeTextEditor,
+                    docContext,
+                    inlineCompletionContext: completion.context,
+                    maxPrefixLength: this.config.provider.contextSizeHints.prefixChars,
+                    maxSuffixLength: this.config.provider.contextSizeHints.suffixChars,
+                    shouldTakeSuggestWidgetSelectionIntoAccount:
+                        this.shouldTakeSuggestWidgetSelectionIntoAccount.bind(this),
+                })
 
                 // Confirm that the completion is still visible for the user given the latest
                 // cursor position, document and associated values.
                 const isStillVisible = isCompletionVisible(
-                    completion,
-                    activeTextEditor.document,
+                    completion.insertText as string,
+                    visibilityContext.document,
                     {
                         invokedPosition,
-                        latestPosition: activeTextEditor.selection.active,
+                        latestPosition: visibilityContext.position,
                     },
-                    this.getDocContext(
-                        activeTextEditor.document,
-                        activeTextEditor.selection.active,
-                        latestContext,
-                        takeSuggestWidgetSelectionIntoAccount
-                    ),
-                    latestContext,
-                    takeSuggestWidgetSelectionIntoAccount,
+                    visibilityContext.docContext,
+                    visibilityContext.inlineCompletionContext,
+                    visibilityContext.takeSuggestWidgetSelectionIntoAccount,
                     undefined
                 )
 


### PR DESCRIPTION
- Reuses the logic we have for autocomplete that verifies that completion is still visible based on the latest cursor position in the active text editor.

## Test plan

- CI
- Check the autoedits output channel logs (added in [this PR](https://github.com/sourcegraph/cody/pull/6551)) for the completions. Generate multiple suggestions rendered as inline completion items and dismiss them by typing forward a different text. Depending on the time each completion was visible, the suggested event should be emitted with different `isRead` values.
- TODO for the follow-up: implement integration tests similar to the one [we have for autocomplete](https://github.com/sourcegraph/cody/blob/main/vscode/src/completions/inline-completion-item-provider.test.ts#L464).
    - [CODY-4621: Tests: implement tests for the timer based `isRead` checks](https://linear.app/sourcegraph/issue/CODY-4621/tests-implement-tests-for-the-timer-based-isread-checks)