### PR TITLE
fix(webview): update context cell for deep cody

### DIFF
--- a/vscode/src/chat/agentic/ToolboxManager.ts
+++ b/vscode/src/chat/agentic/ToolboxManager.ts
@@ -1,9 +1,11 @@
 import {
     type AgentToolboxSettings,
     FeatureFlag,
+    authStatus,
     combineLatest,
     distinctUntilChanged,
     featureFlagProvider,
+    isDotCom,
     logDebug,
     modelsService,
     pendingOperation,
@@ -87,6 +89,7 @@ class ToolboxManager {
      * Use this when you need to react to settings changes over time.
      */
     public readonly observable: Observable<AgentToolboxSettings | null> = combineLatest(
+        authStatus,
         featureFlagProvider.evaluatedFeatureFlag(FeatureFlag.DeepCody),
         featureFlagProvider.evaluatedFeatureFlag(FeatureFlag.ContextAgentDefaultChatModel),
         featureFlagProvider.evaluatedFeatureFlag(FeatureFlag.DeepCodyShellContext),
@@ -97,9 +100,17 @@ class ToolboxManager {
         ),
         this.changeNotifications.pipe(startWith(undefined))
     ).pipe(
-        map(([deepCodyEnabled, useDefaultChatModel, instanceShellContextFlag, sub, models]) => {
-            // Return null if subscription is pending or user can upgrade (free user)
-            if (sub === pendingOperation || sub?.userCanUpgrade || !models || !deepCodyEnabled) {
+        map(([auth, deepCodyEnabled, useDefaultChatModel, instanceShellContextFlag, sub, models]) => {
+            // Return null if:
+            // - Subscription is pending
+            // - Users can upgrade (free user)
+            // - Enterprise without deep-cody feature flag
+            if (
+                sub === pendingOperation ||
+                sub?.userCanUpgrade ||
+                !models ||
+                (!isDotCom(auth.endpoint) && !deepCodyEnabled)
+            ) {
                 this.isEnabled = false
                 return null
             }

--- a/vscode/webviews/chat/Transcript.tsx
+++ b/vscode/webviews/chat/Transcript.tsx
@@ -641,9 +641,7 @@ const TranscriptInteraction: FC<TranscriptInteractionProps> = memo(props => {
                             ? EditContextButtonSearch
                             : EditContextButtonChat
                     }
-                    defaultOpen={
-                        isContextLoading && humanMessage.agent === 'deep-cody' && humanMessage.index < 3
-                    } // Open the context cell for the first 2 human messages when Deep Cody is run.
+                    defaultOpen={isContextLoading && humanMessage.agent === 'deep-cody'}
                     processes={humanMessage?.processes ?? undefined}
                     agent={humanMessage?.agent}
                 />

--- a/vscode/webviews/chat/cells/contextCell/ContextCell.tsx
+++ b/vscode/webviews/chat/cells/contextCell/ContextCell.tsx
@@ -505,13 +505,13 @@ const ProcessItem: FC<{ process: ProcessingStep; isContextLoading: boolean }> = 
                         <CircleXIcon
                             strokeWidth={2}
                             size={14}
-                            className="high-contrast-dark:tw-text-red-500"
+                            className="tw-text-red-500 tw-drop-shadow-md"
                         />
                     ) : (
                         <CheckCircle
                             strokeWidth={2}
                             size={14}
-                            className="tw-text-green-500 tw-drop-shadow-md tw-shadow-md"
+                            className="tw-text-green-500 tw-drop-shadow-md"
                         />
                     )}
                 </div>

--- a/vscode/webviews/chat/cells/contextCell/ContextCell.tsx
+++ b/vscode/webviews/chat/cells/contextCell/ContextCell.tsx
@@ -157,7 +157,9 @@ export const ContextCell: FunctionComponent<{
                     ? 'Reviewing query'
                     : isContextLoading
                       ? 'Fetching context'
-                      : 'Context',
+                      : isDeepCodyEnabled
+                        ? 'Agentic Context'
+                        : 'Context',
             sub:
                 experimentalOneBoxEnabled && !intent
                     ? 'Figuring out query intent...'
@@ -188,7 +190,9 @@ export const ContextCell: FunctionComponent<{
                                     onClick={triggerAccordion}
                                     title={itemCountLabel}
                                     className="tw-flex tw-items-center tw-gap-4"
-                                    disabled={isContextLoading && processes === undefined}
+                                    disabled={
+                                        isContextLoading || (isDeepCodyEnabled && !contextItems?.length)
+                                    }
                                 >
                                     <SourcegraphLogo
                                         width={NON_HUMAN_CELL_AVATAR_SIZE}
@@ -212,27 +216,32 @@ export const ContextCell: FunctionComponent<{
                                 <LoadingDots />
                             ) : (
                                 <>
-                                    <AccordionContent className="tw-ml-6" overflow={false}>
-                                        {isDeepCodyEnabled && (
+                                    <AccordionContent
+                                        className="tw-ml-6 tw-flex tw-flex-col tw-gap-2"
+                                        overflow={false}
+                                    >
+                                        {isDeepCodyEnabled && processes && (
                                             <ProcessList
-                                                processes={processes ?? []}
+                                                processes={processes}
                                                 isContextLoading={isContextLoading}
                                             />
                                         )}
                                         <div className={styles.contextSuggestedActions}>
-                                            {contextItems && contextItems.length > 0 && (
-                                                <Button
-                                                    size="sm"
-                                                    variant="outline"
-                                                    className={clsx(
-                                                        'tw-pr-4',
-                                                        styles.contextItemEditButton
-                                                    )}
-                                                    onClick={onEditContext}
-                                                >
-                                                    {editContextNode}
-                                                </Button>
-                                            )}
+                                            {contextItems &&
+                                                contextItems.length > 0 &&
+                                                !isDeepCodyEnabled && (
+                                                    <Button
+                                                        size="sm"
+                                                        variant="outline"
+                                                        className={clsx(
+                                                            'tw-pr-4',
+                                                            styles.contextItemEditButton
+                                                        )}
+                                                        onClick={onEditContext}
+                                                    >
+                                                        {editContextNode}
+                                                    </Button>
+                                                )}
                                             {resubmitWithRepoContext && !isDeepCodyEnabled && (
                                                 <Button
                                                     size="sm"
@@ -263,7 +272,7 @@ export const ContextCell: FunctionComponent<{
                                                       })`}
                                             </div>
                                         )}
-                                        <ul className="tw-list-none tw-flex tw-flex-col tw-gap-2 tw-pt-2">
+                                        <ul className="tw-list-none tw-flex tw-flex-col tw-gap-2">
                                             {contextItemsToDisplay?.map((item, i) => (
                                                 <li
                                                     // biome-ignore lint/correctness/useJsxKeyInIterable:
@@ -310,35 +319,31 @@ export const ContextCell: FunctionComponent<{
                                                     </span>
                                                 </span>
                                             )}
-                                            {!isContextLoading &&
-                                                isDeepCodyEnabled &&
-                                                processes?.length && (
-                                                    <li>
-                                                        <Tooltip>
-                                                            <TooltipTrigger asChild>
-                                                                <span
-                                                                    className={clsx(
-                                                                        styles.contextItem,
-                                                                        'tw-flex tw-items-center tw-gap-2 tw-text-muted-foreground'
-                                                                    )}
-                                                                >
-                                                                    <BrainIcon
-                                                                        size={14}
-                                                                        className="tw-ml-1"
-                                                                    />
-                                                                    <span>
-                                                                        Reviewed by context agent
-                                                                    </span>
-                                                                </span>
-                                                            </TooltipTrigger>
-                                                            <TooltipContent side="bottom">
-                                                                Deep Cody fetches additional context to
-                                                                improve response quality when needed
-                                                            </TooltipContent>
-                                                        </Tooltip>
-                                                    </li>
-                                                )}
-                                            {!isContextLoading && !processes?.length && (
+                                            {!isContextLoading && isDeepCodyEnabled && (
+                                                <li>
+                                                    <Tooltip>
+                                                        <TooltipTrigger asChild>
+                                                            <span
+                                                                className={clsx(
+                                                                    styles.contextItem,
+                                                                    'tw-flex tw-items-center tw-gap-2 tw-text-muted-foreground'
+                                                                )}
+                                                            >
+                                                                <BrainIcon
+                                                                    size={14}
+                                                                    className="tw-ml-1"
+                                                                />
+                                                                <span>Reviewed by context agent</span>
+                                                            </span>
+                                                        </TooltipTrigger>
+                                                        <TooltipContent side="bottom">
+                                                            Fetches additional context to improve
+                                                            response quality when needed
+                                                        </TooltipContent>
+                                                    </Tooltip>
+                                                </li>
+                                            )}
+                                            {!isContextLoading && !isDeepCodyEnabled && (
                                                 <li>
                                                     <Tooltip>
                                                         <TooltipTrigger asChild>
@@ -456,8 +461,8 @@ const ProcessList: FC<{ processes: ProcessingStep[]; isContextLoading: boolean }
     isContextLoading,
 }) => {
     return (
-        <div className="tw-flex tw-flex-col tw-mb-2">
-            <div className="tw-flex tw-flex-col tw-mb-2">
+        <div className="tw-flex tw-flex-col tw-gap-2">
+            <div className="tw-flex tw-flex-col tw-gap-2">
                 {processes.map(process => (
                     <ProcessItem
                         key={process.id}

--- a/vscode/webviews/chat/cells/messageCell/human/HumanMessageCell.tsx
+++ b/vscode/webviews/chat/cells/messageCell/human/HumanMessageCell.tsx
@@ -112,7 +112,7 @@ const HumanMessageCellContent = memo<HumanMessageCellContent>(props => {
             }
             speakerTitle={userInfo.user.displayName ?? userInfo.user.username}
             cellAction={
-                <div className="tw-flex tw-gap-4 tw-items-center tw-justify-end">
+                <div className="tw-flex tw-gap-2 tw-items-center tw-justify-end">
                     {settings && <ToolboxButton settings={settings} api={api} />}
                     {isFirstMessage && <OpenInNewEditorAction />}
                 </div>

--- a/vscode/webviews/chat/cells/messageCell/human/editor/ToolboxButton.tsx
+++ b/vscode/webviews/chat/cells/messageCell/human/editor/ToolboxButton.tsx
@@ -173,7 +173,7 @@ export const ToolboxButton: FC<ToolboxButtonProps> = memo(({ settings, api }) =>
                         <FlaskConicalIcon
                             size={16}
                             strokeWidth={1.25}
-                            className="tw-w-8 tw-h-8 tw-text-green-700"
+                            className="tw-w-8 tw-h-8 tw-text-green-600 tw-drop-shadow-md"
                         />
                     ) : (
                         <FlaskConicalOffIcon

--- a/vscode/webviews/chat/cells/messageCell/human/editor/ToolboxButton.tsx
+++ b/vscode/webviews/chat/cells/messageCell/human/editor/ToolboxButton.tsx
@@ -155,12 +155,12 @@ export const ToolboxButton: FC<ToolboxButtonProps> = memo(({ settings, api }) =>
                     },
                 }}
             >
-                <Button variant="ghost" size="none">
+                <Button variant="ghost" size="none" className="hover:!tw-bg-transparent">
                     {settings.agent?.name ? (
                         <FlaskConicalIcon
                             size={16}
                             strokeWidth={1.25}
-                            className="tw-w-8 tw-h-8 tw-text-green-500"
+                            className="tw-w-8 tw-h-8 tw-text-green-700"
                         />
                     ) : (
                         <FlaskConicalOffIcon


### PR DESCRIPTION
Updates the context cell component to be opened by default for Deep Cody instead of just the first 2 messages,  as we now run Deep Cody on all messages.

Also some minor UI updates.

## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

The context cell is defaulted to be opened on all messages when it first loaded for Deep Cody:

<img width="517" alt="image" src="https://github.com/user-attachments/assets/5784aad8-4afd-46fd-a147-a961e3eded3f" />

Fixed drop shadow on light theme issue:

<img width="529" alt="image" src="https://github.com/user-attachments/assets/f75136d0-faea-4ba2-9aaf-70bbfeb0384f" />


## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
