### PR TITLE
fix(autoedit): Ensure suffix decorations do not visually interfere with other decorations

### DIFF
--- a/vscode/src/autoedits/renderer/decorators/default-decorator.ts
+++ b/vscode/src/autoedits/renderer/decorators/default-decorator.ts
@@ -3,6 +3,7 @@ import * as vscode from 'vscode'
 import { GHOST_TEXT_COLOR } from '../../../commands/GhostHintDecorator'
 
 import type { AutoEditsDecorator, DecorationInfo, ModifiedLineInfo } from './base'
+import { cssPropertiesToString } from './utils'
 
 interface AddedLinesDecorationInfo {
     ranges: [number, number][]
@@ -170,6 +171,13 @@ export class DefaultDecorator implements AutoEditsDecorator {
             const j = i + startLine
             const line = this.editor.document.lineAt(j)
             const decoration = addedLinesInfo[i]
+            const decorationStyle = cssPropertiesToString({
+                // Absolutely position the suggested code so that the cursor does not jump there
+                position: 'absolute',
+                // Due the the absolute position, the decoration may interfere with other decorations (e.g. GitLens)
+                // Apply a background blur to avoid interference
+                'backdrop-filter': 'blur(5px)',
+            })
 
             if (replacerCol >= line.range.end.character) {
                 replacerDecorations.push({
@@ -182,7 +190,7 @@ export class DefaultDecorator implements AutoEditsDecorator {
                                 '\u00A0'.repeat(3) +
                                 _replaceLeadingTrailingChars(decoration.lineText, ' ', '\u00A0'),
                             margin: `0 0 0 ${replacerCol - line.range.end.character}ch`,
-                            textDecoration: 'none; position: absolute;',
+                            textDecoration: `none;${decorationStyle}`,
                         },
                         // Create an empty HTML element with the width required to show the suggested code.
                         // Required to make the viewport scrollable to view the suggestion if it's outside.
@@ -206,7 +214,7 @@ export class DefaultDecorator implements AutoEditsDecorator {
                             contentText:
                                 '\u00A0' +
                                 _replaceLeadingTrailingChars(decoration.lineText, ' ', '\u00A0'),
-                            textDecoration: 'none; position: absolute;',
+                            textDecoration: `none;${decorationStyle}`,
                         },
                         after: {
                             contentText:

--- a/vscode/src/autoedits/renderer/decorators/utils.test.ts
+++ b/vscode/src/autoedits/renderer/decorators/utils.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest'
+import { cssPropertiesToString } from './utils'
+
+describe('cssPropertiesToString', () => {
+    it('works for single properties', () => {
+        expect(cssPropertiesToString({ color: 'red' })).toBe('color: red;')
+    })
+
+    it('works for multiple properties', () => {
+        expect(
+            cssPropertiesToString({ color: 'red', background: 'blue', display: 'inline-block' })
+        ).toBe('color: red;background: blue;display: inline-block;')
+    })
+})

--- a/vscode/src/autoedits/renderer/decorators/utils.ts
+++ b/vscode/src/autoedits/renderer/decorators/utils.ts
@@ -1,0 +1,5 @@
+export function cssPropertiesToString(properties: object): string {
+    return Object.entries(properties)
+        .map(([key, value]) => `${key}: ${value};`)
+        .join('')
+}


### PR DESCRIPTION
## Description

closes https://linear.app/sourcegraph/issue/CODY-4609/address-overlapping-decorations-with-proposed-css-solutions

Fixes an issue where our absolutely positioned decorations can conflict with another decoration (most likely GitLens)

### Before

<img width="918" alt="image" src="https://github.com/user-attachments/assets/abf78e85-7be3-494b-8d92-1709a9bb795b" />


### After

<img width="896" alt="image" src="https://github.com/user-attachments/assets/1f459b2f-68c2-4ba2-a278-9790b1901d5b" />


## Test plan

- Manually triggering an AutoEdit on lines that have a GitLens blame decoration attached
- Ensuring that this still looks as expected in different color themes
