### PR TITLE
Network: respect NO_PROXY settings

### DIFF
--- a/lib/shared/src/configuration/environment.ts
+++ b/lib/shared/src/configuration/environment.ts
@@ -27,6 +27,11 @@ export const cenv = defineEnvBuilder({
     CODY_NODE_DEFAULT_PROXY: proxyStringWithNodeFallback,
 
     /**
+     * Endpoints for which the proxy should be ignored
+     */
+    CODY_NODE_NO_PROXY: (envValue, _) => str(envValue) || str(getEnv('NO_PROXY')),
+
+    /**
      * A setting that is similar (and falls back to) Node's NODE_TLS_REJECT_UNAUTHORIZED setting
      */
     CODY_NODE_TLS_REJECT_UNAUTHORIZED: (envValue, _) =>

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -20,7 +20,7 @@ This is a log of all notable changes to Cody for VS Code.
 - autoedit: address dogfooding feedback  [pull/6454](https://github.com/sourcegraph/cody/pull/6454)
 - feat(audoedit): implement basic analytics logger  [pull/6430](https://github.com/sourcegraph/cody/pull/6430)
 - feat(onebox): Use new prompt editor when onebox is enabled  [pull/6288](https://github.com/sourcegraph/cody/pull/6288)
-
+- feat(network): Support for NO_PROXY (CODY_NODE_NO_PROXY) environment variable [pull/6555](https://github.com/sourcegraph/cody/pull/6555)
 
 ### Fixed
 - feat(logging): Add interactionId to header of Cody Client requests (CODY-4117)  [pull/6450](https://github.com/sourcegraph/cody/pull/6450)
@@ -34,6 +34,8 @@ This is a log of all notable changes to Cody for VS Code.
 - chore(onebox/telemetry): add `billingMetadata`   [pull/6426](https://github.com/sourcegraph/cody/pull/6426)
 - fix(audoedit): fix renderer testing command  [pull/6408](https://github.com/sourcegraph/cody/pull/6408)
 - chore/release: Bump package version and update changelog for 1.52  [pull/6414](https://github.com/sourcegraph/cody/pull/6414)
+- fix(logging): removed unecessary logging when requests are aborted [pull/6555](https://github.com/sourcegraph/cody/pull/6555)
+- fix(network): removed dangling request handlers on network requests which could potentially cause memory leaks [pull/6555](https://github.com/sourcegraph/cody/pull/6555)
 
 ### Changed
 - feat(prompt-editor): Add new ProseMirror-based implementation  [pull/6272](https://github.com/sourcegraph/cody/pull/6272)
@@ -41,6 +43,7 @@ This is a log of all notable changes to Cody for VS Code.
 - Use omnibox ff for intent detector  [pull/6419](https://github.com/sourcegraph/cody/pull/6419)
 - Enable repo boost for inactive editor  [pull/6443](https://github.com/sourcegraph/cody/pull/6443)
 - include symbol matches in search results  [pull/6441](https://github.com/sourcegraph/cody/pull/6441)
+- improved network logging with less verbose output [pull/6555](https://github.com/sourcegraph/cody/pull/6555)
 
 ## 1.54.0
 

--- a/vscode/src/net/DelegatingAgent.test.ts
+++ b/vscode/src/net/DelegatingAgent.test.ts
@@ -1,0 +1,145 @@
+import * as https from 'node:https'
+import { HttpsProxyAgent } from 'hpagent'
+import { describe, expect, test, vi } from 'vitest'
+import { DelegatingAgent } from './DelegatingAgent'
+
+vi.mock('@sourcegraph/cody-shared', async () => {
+    const actual = await vi.importActual('@sourcegraph/cody-shared')
+    return {
+        ...actual,
+        globalAgentRef: {
+            isSet: false,
+            agent: undefined,
+        },
+    }
+})
+
+// Mock Socket as before
+vi.mock('node:net', () => ({
+    Socket: vi.fn(() => ({
+        connect: vi.fn(),
+        end: vi.fn(),
+        destroy: vi.fn(),
+    })),
+}))
+
+// Mock TLS as before
+vi.mock('node:tls', () => ({
+    connect: vi.fn(() => ({
+        end: vi.fn(),
+        destroy: vi.fn(),
+    })),
+    rootCertificates: [],
+}))
+
+// Mock the entire https.request
+vi.mock('node:https', async () => {
+    const actual = await vi.importActual('node:https')
+    return {
+        ...actual,
+        request: vi.fn(() => ({
+            on: vi.fn(),
+            end: vi.fn(),
+            destroy: vi.fn(),
+        })),
+    }
+})
+
+describe.sequential('DelegatingAgent caching', () => {
+    test('reuses cached agents for identical requests', async () => {
+        const agent = await DelegatingAgent.initialize({})
+
+        const requestOptions = {
+            host: 'api.example.com',
+            port: 443,
+            protocol: 'https:',
+            method: 'GET',
+            path: '/',
+            headers: {},
+            secureEndpoint: true,
+        }
+
+        // First connection should create a new agent
+        const agent1 = await agent.connect(https.request(requestOptions), requestOptions)
+
+        // Second connection to same endpoint should return cached agent
+        const agent2 = await agent.connect(https.request(requestOptions), requestOptions)
+
+        // Verify same agent instance is returned
+        expect(agent1).toBe(agent2)
+
+        // Different endpoint should create new agent
+        const differentRequestOptions = {
+            ...requestOptions,
+            host: 'different.example.com',
+        }
+        const agent3 = await agent.connect(
+            https.request(differentRequestOptions),
+            differentRequestOptions
+        )
+
+        expect(agent3).not.toBe(agent1)
+
+        agent.dispose()
+    })
+
+    test('respects CODY_NODE_DEFAULT_PROXY and CODY_NODE_NO_PROXY', async () => {
+        vi.stubEnv('CODY_NODE_DEFAULT_PROXY', 'http://proxy.example.com:8080')
+        vi.stubEnv('CODY_NODE_NO_PROXY', 'localhost,internal.example.com,*.other.com')
+
+        const agent = await DelegatingAgent.initialize({})
+
+        // Test request that should be proxied
+        const proxyRequest = {
+            host: 'api.example.com',
+            port: 443,
+            protocol: 'https:',
+            method: 'GET',
+            path: '/',
+            headers: {},
+            secureEndpoint: true,
+        }
+
+        // Test request that should not be proxied (matches NO_PROXY)
+        const noProxyRequest = {
+            host: 'internal.example.com',
+            port: 443,
+            protocol: 'https:',
+            method: 'GET',
+            path: '/',
+            headers: {},
+            secureEndpoint: true,
+        }
+
+        const wildcardNoProxyRequest = {
+            host: 'subdomain.other.com',
+            port: 443,
+            protocol: 'https:',
+            method: 'GET',
+            path: '/subpath',
+            headers: {},
+            secureEndpoint: true,
+        }
+
+        const proxiedAgent = await agent.connect(https.request(proxyRequest), proxyRequest)
+        const noProxiedAgent = await agent.connect(https.request(noProxyRequest), noProxyRequest)
+        const wildcardNoProxyAgent = await agent.connect(
+            https.request(wildcardNoProxyRequest),
+            wildcardNoProxyRequest
+        )
+
+        // Verify different agents are used
+        expect(proxiedAgent).instanceOf(HttpsProxyAgent)
+
+        // Check that these are normal https Agents (e.g. not a subclass)
+        expect(noProxiedAgent.constructor).toBe(https.Agent)
+        expect(wildcardNoProxyAgent.constructor).toBe(https.Agent)
+
+        // They shouldn't use the same agent
+        expect(noProxiedAgent).not.toBe(wildcardNoProxyAgent)
+
+        // Clean up
+        agent.dispose()
+        vi.unstubAllEnvs()
+    })
+})

--- a/vscode/src/services/NetworkDiagnostics.ts
+++ b/vscode/src/services/NetworkDiagnostics.ts
@@ -1,3 +1,4 @@
+import type { ClientRequest } from 'node:http'
 import type { EventEmitter } from 'node:stream'
 import {
     NEVER,
@@ -26,24 +27,37 @@ interface NetworkDiagnosticsDeps {
     authProvider: AuthProvider
 }
 
+interface RequestEventHandlers {
+    onResponse: (res: any) => void
+    onTimeout: () => void
+    onError: (error: Error) => void
+    onClose: () => void
+}
+
+interface SocketEventHandlers {
+    onConnect: () => void
+    onClose: () => void
+    onError: (error: Error) => void
+}
+
+let GLOBAL_REQUEST_COUNTER = 0
+
 export class NetworkDiagnostics implements vscode.Disposable {
     private static singleton: NetworkDiagnostics | null = null
-
     private disposables: vscode.Disposable[] = []
-    // private netEvents: NetworkDiagnosticsDeps['netEvents']
-    // private agent?: NetworkDiagnosticsDeps['agent']
-    //@ts-ignore
-
+    // We use a weak map here to prevent dangling requests
+    private requestTimings = new WeakMap<ClientRequest, RequestTimings>()
     private _statusBar: Subject<CodyStatusBar | null> = new Subject()
+    private outputChannel: vscode.LogOutputChannel
+
+    //@ts-ignore
     private config = resolvedConfig.pipe(
         map(config => ({
             debugLoggingEnabled: config.configuration.debugVerbose,
         })),
-        distinctUntilChanged()
+        distinctUntilChanged((a, b) => a.debugLoggingEnabled === b.debugLoggingEnabled)
     )
-    private outputChannel: vscode.LogOutputChannel
 
-    //allows setting late
     set statusBar(statusBar: CodyStatusBar | null) {
         this._statusBar.next(statusBar)
     }
@@ -52,9 +66,11 @@ export class NetworkDiagnostics implements vscode.Disposable {
         this.outputChannel = vscode.window.createOutputChannel('Cody: Network', { log: true })
         this.outputChannel.clear()
 
-        this.disposables.push(...this.setupAuthRefresh(authProvider, agent))
-        this.disposables.push(...this.setupStatusBar(statusBar, agent))
-        this.disposables.push(...this.setupNetworkLogging(agent, globalAgentRef.netEvents ?? null))
+        this.disposables.push(
+            ...this.setupAuthRefresh(authProvider, agent),
+            ...this.setupStatusBar(statusBar, agent),
+            ...this.setupNetworkLogging(agent, globalAgentRef.netEvents ?? null)
+        )
     }
 
     static init(deps: NetworkDiagnosticsDeps): NetworkDiagnostics {
@@ -63,6 +79,218 @@ export class NetworkDiagnostics implements vscode.Disposable {
         }
         NetworkDiagnostics.singleton = new NetworkDiagnostics(deps)
         return NetworkDiagnostics.singleton
+    }
+
+    private createRequestEventHandlers(
+        req: ClientRequest,
+        url: string | URL | undefined | null,
+        protocol: string,
+        agent: string | undefined | null
+    ): RequestEventHandlers {
+        return {
+            onResponse: res => {
+                const responseCleanup = this.setupResponseEvents(req, res)
+                this.disposables.push(new vscode.Disposable(responseCleanup))
+            },
+            onTimeout: () => {
+                const requestTimings = this.requestTimings.get(req)
+                if (requestTimings) {
+                    requestTimings.timeout = new Date()
+                }
+            },
+            onError: error => {
+                const requestTimings = this.requestTimings.get(req)
+                if (requestTimings) {
+                    requestTimings.error = new Date()
+                    requestTimings.errorValue = error
+                }
+            },
+            onClose: () => {
+                const requestTimings = this.requestTimings.get(req)
+                if (!requestTimings) {
+                    return
+                }
+                requestTimings.close = new Date()
+                this.logRequestCompletion(requestTimings, url, protocol, agent)
+            },
+        }
+    }
+
+    private createSocketEventHandlers(req: ClientRequest): SocketEventHandlers {
+        return {
+            onConnect: () => {
+                const reqTiming = this.requestTimings.get(req)
+                if (reqTiming?.socket) {
+                    reqTiming.socket.connect = new Date()
+                }
+            },
+            onClose: () => {
+                const socketTimings = this.requestTimings.get(req)?.socket
+                if (socketTimings) {
+                    socketTimings.close = new Date()
+                }
+            },
+            onError: error => {
+                const socketTimings = this.requestTimings.get(req)?.socket
+                if (socketTimings) {
+                    socketTimings.error = new Date()
+                    socketTimings.errorValue = error
+                }
+            },
+        }
+    }
+
+    private setupResponseEvents(req: ClientRequest, res: any): () => void {
+        const onResClose = () => {
+            const responseTimings = this.requestTimings.get(req)?.response
+            if (responseTimings) {
+                responseTimings.close = new Date()
+            }
+        }
+
+        const onResError = (error: Error) => {
+            const responseTimings = this.requestTimings.get(req)?.response
+            if (responseTimings) {
+                responseTimings.error = new Date()
+                responseTimings.errorValue = error
+            }
+        }
+
+        res.once('close', onResClose)
+        res.once('error', onResError)
+
+        const requestTimings = this.requestTimings.get(req)
+        if (requestTimings) {
+            requestTimings.response = {
+                start: new Date(),
+                statusCode: res.statusCode,
+                statusMessage: res.statusMessage,
+            }
+        }
+
+        return () => {
+            res.removeListener('close', onResClose)
+            res.removeListener('error', onResError)
+        }
+    }
+
+    private setupRequestEvents(
+        req: ClientRequest,
+        url: string | URL | undefined | null,
+        protocol: string,
+        agent: string | undefined | null
+    ): () => void {
+        const handlers = this.createRequestEventHandlers(req, url, protocol, agent)
+
+        req.once('response', handlers.onResponse)
+        req.once('timeout', handlers.onTimeout)
+        req.once('error', handlers.onError)
+        req.once('close', handlers.onClose)
+
+        return () => {
+            req.removeListener('response', handlers.onResponse)
+            req.removeListener('timeout', handlers.onTimeout)
+            req.removeListener('error', handlers.onError)
+            req.removeListener('close', handlers.onClose)
+        }
+    }
+
+    private setupSocketEvents(req: ClientRequest): (socket: any) => void {
+        return socket => {
+            const handlers = this.createSocketEventHandlers(req)
+
+            socket.once('connect', handlers.onConnect)
+            socket.once('close', handlers.onClose)
+            socket.once('error', handlers.onError)
+
+            const reqTiming = this.requestTimings.get(req)
+            if (reqTiming) {
+                reqTiming.socket = { start: new Date() }
+            }
+
+            this.disposables.push(
+                new vscode.Disposable(() => {
+                    socket.removeListener('connect', handlers.onConnect)
+                    socket.removeListener('close', handlers.onClose)
+                    socket.removeListener('error', handlers.onError)
+                })
+            )
+        }
+    }
+
+    private logRequestCompletion(
+        requestTimings: RequestTimings,
+        url: string | URL | undefined | null,
+        protocol: string,
+        agent: string | undefined | null
+    ): void {
+        const timeline = formatTimeline(requestTimings)
+        const logData = {
+            id: requestTimings.id,
+            url,
+            protocol,
+            agent,
+            timeline,
+            error: requestTimings.errorValue,
+        }
+        if (isExpectedNetworkTermination(requestTimings.errorValue)) {
+            this.outputChannel.trace(log('Request Aborted', logData))
+        } else if (
+            requestTimings.error ||
+            requestTimings.response?.error ||
+            requestTimings.socket?.error
+        ) {
+            this.outputChannel.error(log('Request Finished with Error', logData))
+        } else {
+            this.outputChannel.debug(log('Request Finished', logData))
+        }
+    }
+
+    private setupNetworkLogging(
+        agent: DelegatingAgent | null,
+        netEvents: EventEmitter<NetEventMap> | null
+    ): vscode.Disposable[] {
+        const disposables: vscode.Disposable[] = []
+
+        if (agent) {
+            disposables.push(
+                subscriptionDisposable(
+                    agent.configurationError.subscribe(error => {
+                        if (error) {
+                            this.outputChannel.error(log('Configuration error', { error }))
+                        }
+                    })
+                )
+            )
+        }
+
+        if (netEvents) {
+            disposables.push(
+                vscode.commands.registerCommand('cody.debug.net.showOutputChannel', () => {
+                    this.outputChannel.show()
+                })
+            )
+
+            const requestHandler = ({ agent, protocol, url, req }: NetEventMap['request'][number]) => {
+                const reqId = GLOBAL_REQUEST_COUNTER++
+                this.outputChannel.trace(log('Request Created', { id: reqId, url, protocol, agent }))
+                this.requestTimings.set(req, { id: reqId, start: new Date() })
+
+                const cleanupRequest = this.setupRequestEvents(req, url, protocol, agent)
+                req.once('socket', this.setupSocketEvents(req))
+
+                this.disposables.push(new vscode.Disposable(cleanupRequest))
+            }
+
+            netEvents.on('request', requestHandler)
+            disposables.push(
+                new vscode.Disposable(() => {
+                    netEvents.off('request', requestHandler)
+                })
+            )
+        }
+
+        return disposables
     }
 
     private setupAuthRefresh(authProvider: AuthProvider, agent: DelegatingAgent | null) {
@@ -95,112 +323,6 @@ export class NetworkDiagnostics implements vscode.Disposable {
                     })
             ),
         ]
-    }
-
-    private setupNetworkLogging(
-        agent: DelegatingAgent | null,
-        netEvents: EventEmitter<NetEventMap> | null
-    ): vscode.Disposable[] {
-        const disposables: vscode.Disposable[] = []
-        if (agent) {
-            const sub = subscriptionDisposable(
-                agent.configurationError.subscribe(error => {
-                    if (error) {
-                        this.outputChannel.error(log('Configuration error', { error }))
-                    }
-                })
-            )
-            disposables.push(sub)
-        }
-
-        if (netEvents) {
-            disposables.push(
-                vscode.commands.registerCommand('cody.debug.net.showOutputChannel', () => {
-                    this.outputChannel.show()
-                })
-            )
-            const handler = (...[{ agent, protocol, url, req }]: NetEventMap['request']) => {
-                this.outputChannel.trace(log('Request Created', { url, protocol, agent }))
-                const requestTimings: RequestTimings = {
-                    start: new Date(),
-                }
-                req.once('socket', socket => {
-                    const socketTimings: RequestTimings['socket'] = {
-                        start: new Date(),
-                    }
-                    socket.once('connect', () => {
-                        socketTimings.connect = new Date()
-                    })
-                    socket.once('close', () => {
-                        socketTimings.close = new Date()
-                    })
-                    socket.once('error', error => {
-                        socketTimings.error = new Date()
-                        socketTimings.errorValue = error
-                    })
-                    requestTimings.socket = socketTimings
-                })
-                req.once('response', res => {
-                    const responseTimings: RequestTimings['response'] = {
-                        start: new Date(),
-                        statusCode: res.statusCode,
-                        statusMessage: res.statusMessage,
-                    }
-                    res.once('close', () => {
-                        responseTimings.close = new Date()
-                    })
-                    res.once('error', error => {
-                        responseTimings.error = new Date()
-                        responseTimings.errorValue = error
-                    })
-
-                    requestTimings.response = responseTimings
-                })
-                req.once('timeout', () => {
-                    requestTimings.timeout = new Date()
-                })
-                req.once('error', error => {
-                    requestTimings.error = new Date()
-                    requestTimings.errorValue = error
-                })
-                req.once('close', () => {
-                    requestTimings.close = new Date()
-                    if (
-                        requestTimings.error ||
-                        requestTimings.response?.error ||
-                        requestTimings.socket?.error
-                    ) {
-                        this.outputChannel.error(
-                            log('Request Finished with Error', {
-                                url,
-                                protocol,
-                                agent,
-                                timings: requestTimings,
-                            })
-                        )
-                    } else {
-                        this.outputChannel.debug(
-                            log('Request Finished', { url, protocol, agent, timings: requestTimings })
-                        )
-                    }
-                })
-            }
-            netEvents.on('request', handler)
-            disposables.push(
-                vscode.Disposable.from({
-                    dispose() {
-                        netEvents.off('request', handler)
-                    },
-                })
-            )
-        }
-
-        combineLatest(this.config).subscribe(
-            () => {},
-            undefined,
-            () => {}
-        )
-        return []
     }
 
     private setupStatusBar(
@@ -248,7 +370,7 @@ export class NetworkDiagnostics implements vscode.Disposable {
         return [subscriptionDisposable(sub)]
     }
 
-    dispose() {
+    dispose(): void {
         this.outputChannel.dispose()
         for (const disposable of this.disposables) {
             disposable.dispose()
@@ -258,35 +380,61 @@ export class NetworkDiagnostics implements vscode.Disposable {
     }
 }
 
-function log(message: string, data: Record<string, any> = {}): string {
-    const timestamp = new Date().toISOString()
+function isExpectedNetworkTermination(unknownError: unknown): boolean {
+    if (typeof unknownError !== 'object' || !unknownError) {
+        return false
+    }
+    const error = unknownError as { name?: unknown; code?: unknown }
     return (
-        stringifyWithErrors({
-            message,
-            ...data,
-            timestamp,
-        }) ?? ''
+        error?.name === 'AbortError' ||
+        error?.code === 'ECONNRESET' ||
+        error?.code === 'ERR_STREAM_DESTROYED'
     )
+}
+
+function log(message: string, { id, ...data }: { id?: number } & Record<string, any>): string {
+    return [`${id !== undefined ? `req<${id}>: ` : ''}${message.trim()}`, stringifyWithErrors(data)]
+        .filter(Boolean)
+        .join('\t')
 }
 
 function stringifyWithErrors(obj: object) {
-    return stringify(
-        obj,
-        (key, value) => {
-            if (value instanceof Error) {
-                return Object.getOwnPropertyNames(value).reduce((acc, prop) => {
-                    //@ts-ignore
-                    acc[prop] = value[prop]
-                    return acc
-                }, {})
-            }
-            return value
-        },
-        2
-    )
+    return stringify(obj, (key, value) => {
+        if (value instanceof Error) {
+            return Object.getOwnPropertyNames(value).reduce((acc, prop) => {
+                //@ts-ignore
+                acc[prop] = value[prop]
+                return acc
+            }, {})
+        }
+        return value
+    })
+}
+
+function formatTimeline(timings: RequestTimings): string {
+    const events: Array<[number, string]> = []
+    const start = timings.start.getTime()
+
+    events.push([0, 'start'])
+    if (timings.socket?.start) events.push([timings.socket.start.getTime() - start, 'socket'])
+    if (timings.socket?.connect) events.push([timings.socket.connect.getTime() - start, 'connected'])
+    if (timings.response?.start)
+        events.push([
+            timings.response.start.getTime() - start,
+            `response ${timings.response.statusCode}`,
+        ])
+    if (timings.error) events.push([timings.error.getTime() - start, 'error'])
+    if (timings.timeout) events.push([timings.timeout.getTime() - start, 'timeout'])
+    if (timings.close) events.push([timings.close.getTime() - start, 'close'])
+
+    // Sort by timestamp
+    events.sort((a, b) => a[0] - b[0])
+
+    return events.map(([ms, event]) => `${event}@${ms}ms`).join(' → ')
 }
 
 interface RequestTimings {
+    id: number
     start: Date
     timeout?: Date
     error?: Date


### PR DESCRIPTION
Before JetBrains would pass proxy settings to the agent using HTTP_PROXY and HTTPS_PROXY. However these settings would not allow creating of a "proxyless" http agent since they can be used directly by node libraries. Instead now settings are passed under the CODY_NODE_DEFAULT_PROXY (which falls back to HTTP_PROXY and HTTPS_PROXY).

In addition there's a new CODY_NODE_NO_PROXY environment variable that mirrors the NO_PROXY node environment variable. This now allows ignoring of proxy settings for particular endpoints.

Lastly, before the NetworkDiagnostics would output extremely verbose logging. Including error logs on cancelled requests. The logging could also potentially leave dangling requests/sockets as event handlers weren't properly cleaned up. By moving to a weak-map for timing events and cleaning up of event handlers this is now prevented. The logging output has also been made a lot more concise and readable.

![CleanShot 2025-01-08 at 12 34 43@2x](https://github.com/user-attachments/assets/7e07b8e5-1746-46af-b1e7-6548bb8fd4e0)


## Test plan

- Added unit tests to assert the correct re-use of agents depending on configuration and the new CODY_NODE_NO_PROXY setting
- Manually verified working in JetBrains and VSCode
