### PR TITLE
fix: Remove search context chip on resubmission

### DIFF
--- a/vscode/src/context/openctx/codeSearch.ts
+++ b/vscode/src/context/openctx/codeSearch.ts
@@ -1,8 +1,10 @@
 import type { Item } from '@openctx/client'
 import {
     CODE_SEARCH_PROVIDER_URI,
+    type ContextItem,
     type ContextItemOpenCtx,
     ContextItemSource,
+    type SerializedContextItem,
     currentResolvedConfig,
     graphqlClient,
     isDefined,
@@ -113,4 +115,12 @@ export function createContextItem(results: Result[]): ContextItemOpenCtx {
         },
         source: ContextItemSource.User,
     }
+}
+
+/**
+ * @param item The context item to check.
+ * @returns True if the given context item is a code search context item.
+ */
+export function isCodeSearchContextItem(item: ContextItem | SerializedContextItem): boolean {
+    return item.type === 'openctx' && item.providerUri === CODE_SEARCH_PROVIDER_URI
 }

--- a/vscode/webviews/chat/Transcript.tsx
+++ b/vscode/webviews/chat/Transcript.tsx
@@ -23,6 +23,7 @@ import {
     type MutableRefObject,
     memo,
     useCallback,
+    useContext,
     useEffect,
     useImperativeHandle,
     useMemo,
@@ -49,6 +50,7 @@ import {
 import { HumanMessageCell } from './cells/messageCell/human/HumanMessageCell'
 
 import { type Context, type Span, context, trace } from '@opentelemetry/api'
+import { isCodeSearchContextItem } from '../../src/context/openctx/codeSearch'
 import { TELEMETRY_INTENT } from '../../src/telemetry/onebox'
 import { SwitchIntent } from './cells/messageCell/assistant/SwitchIntent'
 import { LastEditorContext } from './context'
@@ -275,6 +277,7 @@ const TranscriptInteraction: FC<TranscriptInteractionProps> = memo(props => {
 
     const { activeChatContext, setActiveChatContext } = props
     const humanEditorRef = useRef<PromptEditorRefAPI | null>(null)
+    const lastEditorRef = useContext(LastEditorContext)
     useImperativeHandle(parentEditorRef, () => humanEditorRef.current)
 
     const onUserAction = (action: 'edit' | 'submit', intentFromSubmit?: ChatMessage['intent']) => {
@@ -315,6 +318,16 @@ const TranscriptInteraction: FC<TranscriptInteractionProps> = memo(props => {
         }
 
         if (action === 'edit') {
+            // Remove search context chips from the next input so that the user cannot
+            // reference search results that don't exist anymore.
+            // This is a no-op if the input does not contain any search context chips.
+            // NOTE: Doing this for the penultimate input only seems to suffice because
+            // editing a message earlier in the transcript will clear the converstation
+            // and reset the last input anyway.
+            if (isLastSentInteraction) {
+                lastEditorRef.current?.filterMentions(item => !isCodeSearchContextItem(item))
+            }
+
             editHumanMessage({
                 messageIndexInTranscript: humanMessage.index,
                 ...commonProps,

--- a/vscode/webviews/chat/cells/messageCell/assistant/SearchResults.tsx
+++ b/vscode/webviews/chat/cells/messageCell/assistant/SearchResults.tsx
@@ -1,5 +1,4 @@
 import {
-    CODE_SEARCH_PROVIDER_URI,
     type ChatMessageWithSearch,
     type NLSSearchDynamicFilter,
     type NLSSearchResult,
@@ -16,7 +15,10 @@ import {
     Search,
 } from 'lucide-react'
 import { useCallback, useContext, useLayoutEffect, useMemo, useReducer, useState } from 'react'
-import { createContextItem } from '../../../../../src/context/openctx/codeSearch'
+import {
+    createContextItem,
+    isCodeSearchContextItem,
+} from '../../../../../src/context/openctx/codeSearch'
 import { LastEditorContext } from '../../../../chat/context'
 import { NLSResultSnippet } from '../../../../components/NLSResultSnippet'
 import { Button } from '../../../../components/shadcn/ui/button'
@@ -116,9 +118,7 @@ export const SearchResults = ({
             )
             lastEditorRef.current?.upsertMentions([contextItem], 'before', ' ', false)
         } else {
-            lastEditorRef.current?.filterMentions(
-                mention => mention.type !== 'openctx' || mention.providerUri !== CODE_SEARCH_PROVIDER_URI
-            )
+            lastEditorRef.current?.filterMentions(mention => !isCodeSearchContextItem(mention))
         }
     }, [enableContextSelection, selectedFollowUpResults, lastEditorRef])
 


### PR DESCRIPTION
This commit adds logic to remove the search result context chip when the query is resubmitted.

We can only implement this for the penultimate input because we only have a reference to the last input. That suffices however
because when editing a message earlier in the thread, all the following messages are cleared anyway.

Fixes https://linear.app/sourcegraph/issue/PROD-421/previous-context-remains-in-follow-up-chatbox-after-resubmitting-query

## Test plan

Manually tested locally in vscode. I created a chat with multiple messages and edited the first, middle and last one. In all cases the input was cleared.
