### PR TITLE
Bench: add option to disable Polly

### DIFF
--- a/agent/src/cli/command-bench/command-bench.ts
+++ b/agent/src/cli/command-bench/command-bench.ts
@@ -339,14 +339,16 @@ export const benchCommand = new commander.Command('bench')
         const recordingMode =
             process.env.CODY_RECORDING_MODE === 'passthrough' ? 'passthrough' : 'replay'
         const recordingDirectory = path.join(path.dirname(options.evaluationConfig), 'recordings')
-        const polly = process.env.DISABLE_POLLY === 'true' ?
-            null : startPollyRecording({
-            recordingName: 'cody-bench',
-            recordingMode: recordingMode,
-            recordIfMissing: true,
-            recordingDirectory,
-            keepUnusedRecordings: true,
-        })
+        const polly =
+            recordingMode === 'replay'
+                ? startPollyRecording({
+                      recordingName: 'cody-bench',
+                      recordingMode: recordingMode,
+                      recordIfMissing: true,
+                      recordingDirectory,
+                      keepUnusedRecordings: true,
+                  })
+                : null
 
         try {
             await Promise.all(

--- a/agent/src/cli/command-bench/command-bench.ts
+++ b/agent/src/cli/command-bench/command-bench.ts
@@ -339,7 +339,8 @@ export const benchCommand = new commander.Command('bench')
         const recordingMode =
             process.env.CODY_RECORDING_MODE === 'passthrough' ? 'passthrough' : 'replay'
         const recordingDirectory = path.join(path.dirname(options.evaluationConfig), 'recordings')
-        const polly = startPollyRecording({
+        const polly = process.env.DISABLE_POLLY === 'true' ?
+            null : startPollyRecording({
             recordingName: 'cody-bench',
             recordingMode: recordingMode,
             recordIfMissing: true,
@@ -352,7 +353,7 @@ export const benchCommand = new commander.Command('bench')
                 workspacesToRun.map(workspace => evaluateWorkspace(workspace, recordingDirectory))
             )
         } finally {
-            await polly.stop()
+            await polly?.stop()
         }
         process.exit(0)
     })

--- a/agent/src/cli/command-bench/command-bench.ts
+++ b/agent/src/cli/command-bench/command-bench.ts
@@ -336,19 +336,27 @@ export const benchCommand = new commander.Command('bench')
             },
         })
 
-        const recordingMode =
-            process.env.CODY_RECORDING_MODE === 'passthrough' ? 'passthrough' : 'replay'
+        const recordingMode = (() => {
+            switch (process.env.CODY_RECORDING_MODE) {
+                case 'passthrough':
+                    return 'passthrough'
+                case 'disabled':
+                    return 'disabled'
+                default:
+                    return 'replay'
+            }
+        })()
         const recordingDirectory = path.join(path.dirname(options.evaluationConfig), 'recordings')
         const polly =
-            recordingMode === 'replay'
-                ? startPollyRecording({
+            recordingMode === 'disabled'
+                ? null
+                : startPollyRecording({
                       recordingName: 'cody-bench',
                       recordingMode: recordingMode,
                       recordIfMissing: true,
                       recordingDirectory,
                       keepUnusedRecordings: true,
                   })
-                : null
 
         try {
             await Promise.all(


### PR DESCRIPTION
Polly often randomly fails on requests with no clear error even if passthrough mode is enabled. Since we don't want it enabled for context evals anyway, it's probably better to disable it outright.

## Test plan
Running bench with a larger eval set like DS1000 for context now works without errors.