### PR TITLE
Fix Cody Web Search

### DIFF
--- a/vscode/src/repository/repo-name-resolver.ts
+++ b/vscode/src/repository/repo-name-resolver.ts
@@ -51,6 +51,11 @@ export class RepoNameResolver {
                     )
                 }
 
+                // stop here early so combine latest won't be in pending with empty list of streams
+                if (remoteUrls.length === 0) {
+                    return Observable.of([])
+                }
+
                 return combineLatest(
                     ...remoteUrls.map(remoteUrl => this.getRepoNameCached(remoteUrl))
                 ).pipe(
@@ -89,7 +94,7 @@ export class RepoNameResolver {
                 logError('RepoNameResolver:getRemoteUrlsInfoCached', 'error', {
                     verbose: error,
                 })
-                return [pendingOperation.toString()]
+                return []
             })
             this.fsPathToRemoteUrlsInfo.set(key, remoteUrlsInfo)
         }

--- a/vscode/src/repository/repo-name-resolver.ts
+++ b/vscode/src/repository/repo-name-resolver.ts
@@ -89,7 +89,7 @@ export class RepoNameResolver {
                 logError('RepoNameResolver:getRemoteUrlsInfoCached', 'error', {
                     verbose: error,
                 })
-                return []
+                return [pendingOperation.toString()]
             })
             this.fsPathToRemoteUrlsInfo.set(key, remoteUrlsInfo)
         }


### PR DESCRIPTION
Returning an empty list on error doesn't resolve promise. Tested on both Cody Web demo and VS Code.

## Test plan

- cd web
- pnpm dev
- visit localhost:5777
- execute `@web/cody search` which should trigger search intent
- the response should not stuck at loading and resolve into no results.

Test the same on VS Code.

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
