### PR TITLE
Add NO_PROXY test that ensures dot prefixes are considered a wildcard

### DIFF
--- a/vscode/src/net/DelegatingAgent.test.ts
+++ b/vscode/src/net/DelegatingAgent.test.ts
@@ -137,10 +137,7 @@ describe.sequential('DelegatingAgent caching', () => {
             https.request(wildcardNoProxyRequest),
             wildcardNoProxyRequest
         )
-        const dotNoProxyAgent = await agent.connect(
-            https.request(dotNoProxyRequest),
-            dotNoProxyRequest
-        )
+        const dotNoProxyAgent = await agent.connect(https.request(dotNoProxyRequest), dotNoProxyRequest)
 
         // Verify different agents are used
         expect(proxiedAgent).instanceOf(HttpsProxyAgent)


### PR DESCRIPTION
Specifying `.example.com` instead of `*.example.com` is a [valid way of specifying a wildcard](https://www.browserstack.com/guide/no_proxy-environment-variable#:~:text=.example.com%3A%20Excludes%20any%20subdomains%20of%20example.com%20(wildcard).), but this is not currently tested by `DelegatingAgent`.

## Test plan

* Adds unit tests only

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
