### PR TITLE
feat(webview): replace Deep Cody with Agentic Chat

### DIFF
--- a/lib/shared/src/models/client.ts
+++ b/lib/shared/src/models/client.ts
@@ -1,4 +1,4 @@
-import { FeatureFlag, type ServerModel } from '..'
+import type { FeatureFlag, ServerModel } from '..'
 import type { ModelTag } from './tags'
 
 /**
@@ -9,27 +9,8 @@ import type { ModelTag } from './tags'
  */
 export function getExperimentalClientModelByFeatureFlag(flag: FeatureFlag): ServerModel | null {
     switch (flag) {
-        case FeatureFlag.DeepCody:
-            return getDeepCodyServerModel()
         default:
             return null
-    }
-}
-
-function getDeepCodyServerModel(): ServerModel {
-    return {
-        // This modelRef does not exist in the backend and is used to identify the model in the client.
-        modelRef: 'sourcegraph::2023-06-01::deep-cody',
-        displayName: 'Deep Cody',
-        modelName: 'deep-cody',
-        capabilities: ['chat'],
-        category: 'accuracy',
-        status: 'experimental' as ModelTag.Experimental,
-        tier: 'pro' as ModelTag.Pro,
-        contextWindow: {
-            maxInputTokens: 45000,
-            maxOutputTokens: 4000,
-        },
     }
 }
 

--- a/lib/shared/src/sourcegraph-api/errors.ts
+++ b/lib/shared/src/sourcegraph-api/errors.ts
@@ -24,7 +24,7 @@ export class RateLimitError extends Error {
     public readonly retryMessage: string | undefined
 
     constructor(
-        public readonly feature: 'autocompletions' | 'chat messages and commands' | 'Deep Cody',
+        public readonly feature: 'autocompletions' | 'chat messages and commands' | 'Agentic Chat',
         public readonly message: string,
         /* Whether an upgrade is available that would increase rate limits. */
         public readonly upgradeIsAvailable: boolean,
@@ -34,8 +34,8 @@ export class RateLimitError extends Error {
     ) {
         super(message)
         this.userMessage =
-            feature === 'Deep Cody'
-                ? `You've reached the daily limit for Deep Cody. Please select another model and try again.`
+            feature === 'Agentic Chat'
+                ? `You've reached the daily limit for Agentic Chat. Please select another model and try again.`
                 : `You've used all of your ${feature} for ${upgradeIsAvailable ? 'the month' : 'today'}.`
         this.retryAfterDate = retryAfter
             ? /^\d+$/.test(retryAfter)

--- a/lib/shared/src/telemetry-v2/events/chat-question.ts
+++ b/lib/shared/src/telemetry-v2/events/chat-question.ts
@@ -173,6 +173,7 @@ export const events = [
                                   tokenCounterUtils
                               )
                             : undefined,
+                        chatAgent: params.chatAgent,
                     },
                     billingMetadata: {
                         product: 'cody',
@@ -298,6 +299,7 @@ function publicContextSummary(globalPrefix: string, context: ContextItem[]) {
                 sortedSizes.length > 0 ? sizes.reduce((a, b) => a + b, 0) / sizes.length : undefined,
             [`${prefix}.size.median`]:
                 sortedSizes.length > 0 ? sortedSizes[Math.floor(sortedSizes.length / 2)] : undefined,
+            [`${prefix}.size.total`]: sortedSizes.reduce((a, b) => a + b, 0),
         } as const
     }
 

--- a/vscode/src/chat/agentic/DeepCodyRateLimiter.test.ts
+++ b/vscode/src/chat/agentic/DeepCodyRateLimiter.test.ts
@@ -76,7 +76,7 @@ describe('DeepCodyRateLimiter', () => {
             const error = rateLimiter.getRateLimitError('300')
 
             expect(error.name).toBe('RateLimitError')
-            expect(error.feature).toBe('Deep Cody')
+            expect(error.feature).toBe('Agentic Chat')
             expect(error.retryAfter).toBe('300')
         })
     })

--- a/vscode/src/chat/agentic/DeepCodyRateLimiter.ts
+++ b/vscode/src/chat/agentic/DeepCodyRateLimiter.ts
@@ -1,5 +1,6 @@
 import { RateLimitError, telemetryRecorder } from '@sourcegraph/cody-shared'
 import { localStorage } from './../../services/LocalStorageProvider'
+import { toolboxManager } from './ToolboxManager'
 
 /**
  * NOTE: This is a temporary rate limit for deep-cody models to prevent users from
@@ -51,6 +52,7 @@ export class DeepCodyRateLimiter {
                     },
                 })
             }
+            toolboxManager.setIsRateLimited(newQuota === 1)
             return undefined
         }
 

--- a/vscode/src/chat/agentic/DeepCodyRateLimiter.ts
+++ b/vscode/src/chat/agentic/DeepCodyRateLimiter.ts
@@ -1,4 +1,4 @@
-import { RateLimitError } from '@sourcegraph/cody-shared'
+import { RateLimitError, telemetryRecorder } from '@sourcegraph/cody-shared'
 import { localStorage } from './../../services/LocalStorageProvider'
 
 /**
@@ -43,6 +43,14 @@ export class DeepCodyRateLimiter {
         // If we have at least 1 quota available
         if (newQuota >= 1) {
             localStorage.setDeepCodyUsage(newQuota - 1, now.toISOString())
+            if (newQuota === 1) {
+                telemetryRecorder.recordEvent('cody.context-agent.limit', 'hit', {
+                    billingMetadata: {
+                        product: 'cody',
+                        category: 'core',
+                    },
+                })
+            }
             return undefined
         }
 

--- a/vscode/src/chat/agentic/DeepCodyRateLimiter.ts
+++ b/vscode/src/chat/agentic/DeepCodyRateLimiter.ts
@@ -52,6 +52,6 @@ export class DeepCodyRateLimiter {
     }
 
     public getRateLimitError(retryAfter: string): RateLimitError {
-        return new RateLimitError('Deep Cody', 'daily limit', false, undefined, retryAfter)
+        return new RateLimitError('Agentic Chat', 'daily limit', false, undefined, retryAfter)
     }
 }

--- a/vscode/src/chat/agentic/ToolboxManager.ts
+++ b/vscode/src/chat/agentic/ToolboxManager.ts
@@ -42,6 +42,7 @@ class ToolboxManager {
     }
 
     private isEnabled = false
+    private isRateLimited = false
     private readonly changeNotifications = new Subject<void>()
     private shellConfig = { ...DEFAULT_SHELL_CONFIG }
 
@@ -66,9 +67,16 @@ class ToolboxManager {
         const { agent, shell } = this.getStoredUserSettings()
         const isShellEnabled = this.shellConfig.instance && this.shellConfig.client ? shell : undefined
         return {
-            agent: { name: agent },
+            agent: { name: this.isRateLimited ? undefined : agent },
             // Only show shell option if it's supported by instance and client.
             shell: { enabled: isShellEnabled ?? false },
+        }
+    }
+
+    public setIsRateLimited(hasHitLimit: boolean): void {
+        if (this.isEnabled && this.isRateLimited !== hasHitLimit) {
+            this.isRateLimited = hasHitLimit
+            this.changeNotifications.next()
         }
     }
 

--- a/vscode/src/chat/chat-view/handlers/DeepCodyHandler.ts
+++ b/vscode/src/chat/chat-view/handlers/DeepCodyHandler.ts
@@ -50,7 +50,7 @@ export class DeepCodyHandler extends ChatHandler implements AgentHandler {
         }
         const deepCodyRateLimiter = new DeepCodyRateLimiter(
             this.featureDeepCodyRateLimitBase.value.last ? 50 : 0,
-            this.featureDeepCodyRateLimitMultiplier.value.last ? 2 : 1
+            this.featureDeepCodyRateLimitMultiplier.value.last ? 4 : 2
         )
 
         const deepCodyLimit = deepCodyRateLimiter.isAtLimit()

--- a/vscode/webviews/chat/ErrorItem.tsx
+++ b/vscode/webviews/chat/ErrorItem.tsx
@@ -106,7 +106,7 @@ const RateLimitErrorItem: React.FunctionComponent<{
                     {canUpgrade && (
                         <Button onClick={() => onButtonClick('upgrade', 'upgrade')}>Upgrade</Button>
                     )}
-                    {error.feature !== 'Deep Cody' && (
+                    {error.feature !== 'Agentic Chat' && (
                         <Button
                             type="button"
                             onClick={() =>

--- a/vscode/webviews/chat/cells/contextCell/ContextCell.tsx
+++ b/vscode/webviews/chat/cells/contextCell/ContextCell.tsx
@@ -190,9 +190,7 @@ export const ContextCell: FunctionComponent<{
                                     onClick={triggerAccordion}
                                     title={itemCountLabel}
                                     className="tw-flex tw-items-center tw-gap-4"
-                                    disabled={
-                                        isContextLoading || (isDeepCodyEnabled && !contextItems?.length)
-                                    }
+                                    disabled={isContextLoading}
                                 >
                                     <SourcegraphLogo
                                         width={NON_HUMAN_CELL_AVATAR_SIZE}

--- a/vscode/webviews/chat/cells/contextCell/ContextCell.tsx
+++ b/vscode/webviews/chat/cells/contextCell/ContextCell.tsx
@@ -155,10 +155,10 @@ export const ContextCell: FunctionComponent<{
             main:
                 experimentalOneBoxEnabled && !intent
                     ? 'Reviewing query'
-                    : isContextLoading
-                      ? 'Fetching context'
-                      : isDeepCodyEnabled
-                        ? 'Agentic Context'
+                    : isDeepCodyEnabled
+                      ? 'Agentic Context'
+                      : isContextLoading
+                        ? 'Fetching context'
                         : 'Context',
             sub:
                 experimentalOneBoxEnabled && !intent

--- a/vscode/webviews/components/FileLink.tsx
+++ b/vscode/webviews/components/FileLink.tsx
@@ -37,7 +37,7 @@ const IGNORE_WARNING = 'File ignored by an admin setting'
 
 const hoverSourceLabels: Record<ContextItemSource, string | undefined> = {
     // Shown in the format `Included ${label}`
-    agentic: 'via Deep Cody',
+    agentic: 'agentic chat context',
     unified: 'via remote repository search',
     search: 'via local repository index (symf)',
     editor: 'from workspace files',


### PR DESCRIPTION
CLOSE https://linear.app/sourcegraph/issue/CODY-4638/change-the-daily-hard-limit-to-200

- Updates the rate limit error message in the DeepCodyRateLimiter class to use 'Agentic Chat' instead of 'Deep Cody'.
- This change increases the Deep Cody rate limit multiplier from 2 to 4 when the feature flag is enabled. This will allow more requests to be processed for Deep Cody (200 max), improving the overall user experience.
- Remove Deep Cody client model as we have moved it out of the Model dropdown.

## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

Green CI - No additional testing required as this is a configuration change. All current unit tests should continue to pass.

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
