### PR TITLE
fix(agentic chat): update rate limit telemetry event to billable

### DIFF
--- a/lib/shared/src/sourcegraph-api/errors.ts
+++ b/lib/shared/src/sourcegraph-api/errors.ts
@@ -35,7 +35,7 @@ export class RateLimitError extends Error {
         super(message)
         this.userMessage =
             feature === 'Agentic Chat'
-                ? `You've reached the daily limit for Agentic Chat. Please select another model and try again.`
+                ? `You've reached the daily limit for Agentic Chat.`
                 : `You've used all of your ${feature} for ${upgradeIsAvailable ? 'the month' : 'today'}.`
         this.retryAfterDate = retryAfter
             ? /^\d+$/.test(retryAfter)

--- a/vscode/src/chat/agentic/DeepCodyRateLimiter.ts
+++ b/vscode/src/chat/agentic/DeepCodyRateLimiter.ts
@@ -48,7 +48,7 @@ export class DeepCodyRateLimiter {
                 telemetryRecorder.recordEvent('cody.context-agent.limit', 'hit', {
                     billingMetadata: {
                         product: 'cody',
-                        category: 'core',
+                        category: 'billable',
                     },
                 })
             }


### PR DESCRIPTION
update rate limit telemetry event to billable

## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

none - event name change

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
