### PR TITLE
Pass query as 'content' in NLS bench

### DIFF
--- a/agent/src/cli/command-bench/strategy-chat-nls.ts
+++ b/agent/src/cli/command-bench/strategy-chat-nls.ts
@@ -75,10 +75,7 @@ async function runNLSSearch(examples: Example[]): Promise<ExampleOutput[]> {
         const repoNames = targetRepoRevs.map(repoRev => repoRev.repoName)
         const repoFilter = 'repo:' + repoNames.join('|')
 
-        const fullQuery = `${repoFilter} content:"${query.replaceAll(
-            '"',
-            '\\"'
-        )}"`
+        const fullQuery = `${repoFilter} content:"${query.replaceAll('"', '\\"')}"`
         const resultsResp = await graphqlClient.nlsSearchQuery({
             query: fullQuery,
         })

--- a/agent/src/cli/command-bench/strategy-chat-nls.ts
+++ b/agent/src/cli/command-bench/strategy-chat-nls.ts
@@ -75,7 +75,10 @@ async function runNLSSearch(examples: Example[]): Promise<ExampleOutput[]> {
         const repoNames = targetRepoRevs.map(repoRev => repoRev.repoName)
         const repoFilter = 'repo:' + repoNames.join('|')
 
-        const fullQuery = repoFilter + ' ' + query
+        const fullQuery = `${repoFilter} content:"${query.replaceAll(
+            '"',
+            '\\"'
+        )}"`
         const resultsResp = await graphqlClient.nlsSearchQuery({
             query: fullQuery,
         })


### PR DESCRIPTION
For NLS search, we pass the user's query string through `content:"..."` to avoid interpreting predicates, ANDs, and ORs as search syntax. This PR updates the NLS bench strategy to do the same.

## Test plan

Reran evals and checked results didn't change.