### PR TITLE
chore/release: Bump package version and update changelog for 1.58

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -14,6 +14,34 @@ This is a log of all notable changes to Cody for VS Code.
 
 ### Uncategorized
 
+## 1.58.0
+
+### Added
+
+- feat(context-agent): tool status callbacks and process support  [pull/6451](https://github.com/sourcegraph/cody/pull/6451)
+- feat(nls): Add Cody bench command for NLS  [pull/6497](https://github.com/sourcegraph/cody/pull/6497)
+
+### Fixed
+
+- fix(release): add $ variable invocation  [pull/6509](https://github.com/sourcegraph/cody/pull/6509)
+- fix/editor: Ask Cody to Fix no longer throws exceptions in TypeScript files   [pull/6473](https://github.com/sourcegraph/cody/pull/6473)
+- fix(context-agent): add status callbacks back   [pull/6479](https://github.com/sourcegraph/cody/pull/6479)
+- chore(security): Fix closed events for sast scan  [pull/6512](https://github.com/sourcegraph/cody/pull/6512)
+- fix: Move BigQuery insertion after release step  [pull/6477](https://github.com/sourcegraph/cody/pull/6477)
+- chore(chat): Adding fixing save chat session overwriting  [pull/6457](https://github.com/sourcegraph/cody/pull/6457)
+
+### Changed
+
+- update `billingMetadata` for failed/disconnected type of events  [pull/6254](https://github.com/sourcegraph/cody/pull/6254)
+- feat(nls): add relevant repo boost  [pull/6502](https://github.com/sourcegraph/cody/pull/6502)
+- chore(chat): Decompose ChatController.sendChat into handlers for different request types  [pull/6469](https://github.com/sourcegraph/cody/pull/6469)
+- feat(autoedit): track notebook for auto-edits  [pull/6449](https://github.com/sourcegraph/cody/pull/6449)
+- chore(audoedit): consistent use of the output channel logger  [pull/6472](https://github.com/sourcegraph/cody/pull/6472)
+- feat(audoedit): ensure inline completions are also hidden on dismiss  [pull/6465](https://github.com/sourcegraph/cody/pull/6465)
+- feat(audoedit): remove the auto edit experimental command  [pull/6471](https://github.com/sourcegraph/cody/pull/6471)
+- feat(logging): Add interactionId to header of Cody Client requests (CODY-4117)  [pull/6450](https://github.com/sourcegraph/cody/pull/6450)
+- chore(audoedit): decouple `codeToReplaceData` from `getPromptForModelType`  [pull/6474](https://github.com/sourcegraph/cody/pull/6474)
+
 ## 1.56.0
 
 ### Added

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -3,7 +3,7 @@
   "name": "cody-ai",
   "private": true,
   "displayName": "Cody: AI Coding Assistant with Autocomplete & Chat",
-  "version": "1.56.0",
+  "version": "1.58.0",
   "publisher": "sourcegraph",
   "license": "Apache-2.0",
   "icon": "resources/cody.png",


### PR DESCRIPTION
Version bump and changelog update for the vscode-1.58 stable release.

## Test plan

CI
