### PR TITLE
bench/context: Cache repo IDs

### DIFF
--- a/agent/src/cli/command-bench/strategy-chat-context.ts
+++ b/agent/src/cli/command-bench/strategy-chat-context.ts
@@ -85,14 +85,36 @@ async function runContextCommand(
 ): Promise<ExampleOutput[]> {
     const completionsClient = new SourcegraphNodeCompletionsClient()
     const exampleOutputs: ExampleOutput[] = []
+    const repoIDNamesCache = new Map<string, string>()
 
     for (const example of examples) {
         const { targetRepoRevs, query: origQuery } = example
         const repoNames = targetRepoRevs.map(repoRev => repoRev.repoName)
-        const repoIDNames = await graphqlClient.getRepoIds(repoNames, repoNames.length + 10)
-        if (isError(repoIDNames)) {
-            throw new Error(`getRepoIds failed for [${repoNames.join(',')}]: ${repoIDNames}`)
+
+        // Get repo IDs from cache or fetch them
+        const repoIDNames: { id: string; name: string }[] = []
+        const uncachedRepoNames: string[] = []
+        for (const repoName of repoNames) {
+            const cachedId = repoIDNamesCache.get(repoName)
+            if (cachedId) {
+                repoIDNames.push({ id: cachedId, name: repoName })
+            } else {
+                uncachedRepoNames.push(repoName)
+            }
         }
+
+        if (uncachedRepoNames.length > 0) {
+            const fetchedRepoIDNames = await graphqlClient.getRepoIds(uncachedRepoNames, uncachedRepoNames.length + 10)
+            if (isError(fetchedRepoIDNames)) {
+                throw new Error(`getRepoIds failed for [${uncachedRepoNames.join(',')}]: ${fetchedRepoIDNames}`)
+            }
+            // Add fetched IDs to cache and results
+            for (const repo of fetchedRepoIDNames) {
+                repoIDNamesCache.set(repo.name, repo.id)
+                repoIDNames.push(repo)
+            }
+        }
+
         if (repoIDNames.length !== repoNames.length) {
             throw new Error(
                 `repoIDs.length (${repoIDNames.length}) !== repoNames.length (${
@@ -152,6 +174,5 @@ async function runContextCommand(
             actualContext,
         })
     }
-
     return exampleOutputs
 }

--- a/agent/src/cli/command-bench/strategy-chat-context.ts
+++ b/agent/src/cli/command-bench/strategy-chat-context.ts
@@ -104,9 +104,14 @@ async function runContextCommand(
         }
 
         if (uncachedRepoNames.length > 0) {
-            const fetchedRepoIDNames = await graphqlClient.getRepoIds(uncachedRepoNames, uncachedRepoNames.length + 10)
+            const fetchedRepoIDNames = await graphqlClient.getRepoIds(
+                uncachedRepoNames,
+                uncachedRepoNames.length + 10
+            )
             if (isError(fetchedRepoIDNames)) {
-                throw new Error(`getRepoIds failed for [${uncachedRepoNames.join(',')}]: ${fetchedRepoIDNames}`)
+                throw new Error(
+                    `getRepoIds failed for [${uncachedRepoNames.join(',')}]: ${fetchedRepoIDNames}`
+                )
             }
             // Add fetched IDs to cache and results
             for (const repo of fetchedRepoIDNames) {


### PR DESCRIPTION
I noticed that we call the server to retrieve repo IDs for every example in the eval set when running context evals. This operation takes ~250ms for me whereas the actual context search is ~1s. By caching these results, we can speed up the benchmark by 20%, which is especially noticeable with larger datasets.

## Test plan
Context bench still works and runs faster.

