### PR TITLE
Fix repo name resolver cache miss due to using separate RepoNameResol…

### DIFF
--- a/vscode/src/editor/utils/editor-context.ts
+++ b/vscode/src/editor/utils/editor-context.ts
@@ -31,7 +31,7 @@ import {
 import { URI } from 'vscode-uri'
 import { getOpenTabsUris } from '.'
 import { toVSCodeRange } from '../../common/range'
-import { RepoNameResolver } from '../../repository/repo-name-resolver'
+import { repoNameResolver } from '../../repository/repo-name-resolver'
 import { findWorkspaceFiles } from './findWorkspaceFiles'
 
 // Some matches we don't want to ignore because they might be valid code (for example `bin/` in Dart)
@@ -319,7 +319,6 @@ async function createContextFileFromUri(
     symbolName?: string
 ): Promise<ContextItem[]> {
     const range = toRangeData(selectionRange)
-    const repoNameResolver = new RepoNameResolver()
     const repoNames = await firstValueFrom(repoNameResolver.getRepoNamesContainingUri(uri))
     const repoName: string = Array.isArray(repoNames) ? repoNames[0] : repoNames.toString()
 


### PR DESCRIPTION
We were creating a separate instance of the RepoNameResolver which was causing cache miss and in return making graphql calls to fetch the repo name. 

RepoNameResolver internally maintains an LRU and is supposed to be a singelton.  

## Test plan

- monitor network to check getRepoName queries are not made everytime you press @.
- 
## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
