### PR TITLE
Make sure precomputed intent is not stale

### DIFF
--- a/vscode/webviews/chat/Transcript.tsx
+++ b/vscode/webviews/chat/Transcript.tsx
@@ -309,7 +309,7 @@ const TranscriptInteraction: FC<TranscriptInteractionProps> = memo(props => {
         }
 
         const { intent, intentScores } = intentFromSubmit
-            ? { intent: intentFromSubmit }
+            ? { intent: intentFromSubmit, intentScores: undefined }
             : getIntentProps(editorValue, intentResults.current)
 
         const commonProps = {

--- a/vscode/webviews/chat/Transcript.tsx
+++ b/vscode/webviews/chat/Transcript.tsx
@@ -247,6 +247,12 @@ interface TranscriptInteractionProps
     }) => void
 }
 
+interface IntentResults {
+    query: string
+    intent: ChatMessage['intent']
+    allScores?: { intent: string; score: number }[]
+}
+
 const TranscriptInteraction: FC<TranscriptInteractionProps> = memo(props => {
     const {
         interaction: { humanMessage, assistantMessage },
@@ -266,14 +272,7 @@ const TranscriptInteraction: FC<TranscriptInteractionProps> = memo(props => {
         smartApplyEnabled,
         editorRef: parentEditorRef,
     } = props
-    const [intentResults, setIntentResults] = useMutatedValue<
-        | {
-              intent: ChatMessage['intent']
-              allScores?: { intent: string; score: number }[]
-          }
-        | undefined
-        | null
-    >()
+    const [intentResults, setIntentResults] = useMutatedValue<IntentResults | undefined | null>()
 
     const { activeChatContext, setActiveChatContext } = props
     const humanEditorRef = useRef<PromptEditorRefAPI | null>(null)
@@ -309,10 +308,16 @@ const TranscriptInteraction: FC<TranscriptInteractionProps> = memo(props => {
             return
         }
 
+        const { intent, intentScores } = getIntentProps(
+            editorValue,
+            intentFromSubmit,
+            intentResults.current
+        )
+
         const commonProps = {
             editorValue,
-            intent: intentFromSubmit || intentResults.current?.intent,
-            intentScores: intentFromSubmit ? undefined : intentResults.current?.allScores,
+            intent,
+            intentScores,
             manuallySelectedIntent: !!intentFromSubmit,
             traceparent,
         }
@@ -371,18 +376,16 @@ const TranscriptInteraction: FC<TranscriptInteractionProps> = memo(props => {
 
             setIntentResults(undefined)
 
-            const subscription = extensionAPI
-                .detectIntent(
-                    inputTextWithMappedContextChipsFromPromptEditorState(editorValue.editorState)
-                )
-                .subscribe({
-                    next: value => {
-                        setIntentResults(value)
-                    },
-                    error: error => {
-                        console.error('Error detecting intent:', error)
-                    },
-                })
+            const query = inputTextWithMappedContextChipsFromPromptEditorState(editorValue.editorState)
+
+            const subscription = extensionAPI.detectIntent(query).subscribe({
+                next: value => {
+                    setIntentResults(value && { ...value, query })
+                },
+                error: error => {
+                    console.error('Error detecting intent:', error)
+                },
+            })
 
             // Clean up subscription if component unmounts
             return () => subscription.unsubscribe()
@@ -774,4 +777,22 @@ function reevaluateSearchWithSelectedFilters({
         index: messageIndexInTranscript,
         selectedFilters,
     })
+}
+
+const getIntentProps = (
+    editorValue: SerializedPromptEditorValue,
+    intentFromSubmit?: ChatMessage['intent'],
+    results?: IntentResults | null
+) => {
+    if (intentFromSubmit) {
+        return { intent: intentFromSubmit, intentScores: undefined }
+    }
+
+    const query = inputTextWithMappedContextChipsFromPromptEditorState(editorValue.editorState)
+
+    if (query === results?.query) {
+        return { intent: results.intent, intentScores: results.allScores }
+    }
+
+    return {}
 }

--- a/vscode/webviews/chat/Transcript.tsx
+++ b/vscode/webviews/chat/Transcript.tsx
@@ -308,11 +308,9 @@ const TranscriptInteraction: FC<TranscriptInteractionProps> = memo(props => {
             return
         }
 
-        const { intent, intentScores } = getIntentProps(
-            editorValue,
-            intentFromSubmit,
-            intentResults.current
-        )
+        const { intent, intentScores } = intentFromSubmit
+            ? { intent: intentFromSubmit }
+            : getIntentProps(editorValue, intentResults.current)
 
         const commonProps = {
             editorValue,
@@ -779,15 +777,7 @@ function reevaluateSearchWithSelectedFilters({
     })
 }
 
-const getIntentProps = (
-    editorValue: SerializedPromptEditorValue,
-    intentFromSubmit?: ChatMessage['intent'],
-    results?: IntentResults | null
-) => {
-    if (intentFromSubmit) {
-        return { intent: intentFromSubmit, intentScores: undefined }
-    }
-
+const getIntentProps = (editorValue: SerializedPromptEditorValue, results?: IntentResults | null) => {
     const query = inputTextWithMappedContextChipsFromPromptEditorState(editorValue.editorState)
 
     if (query === results?.query) {


### PR DESCRIPTION
closes: https://linear.app/sourcegraph/issue/CODY-4613/non-deterministic-intent-detection

We precompute the intent while the user is typing the input with a 300ms debounce. It is possible that after the last intent detection the user may change the query and submit within 300ms, causing the detected intent to be stale and often different than the intent for the final query. 

This PR fixes that behavior by checking if the query has changed since the last intent detection and ignoring the pre-computed intent in case the query was changed afterwards. 


## Test plan

https://sourcegraph.slack.com/archives/C07EQBRSF35/p1735859984632339
## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
