### PR TITLE
fix(autoedits): Fix E2E tests on main

### DIFF
--- a/vscode/src/autoedits/create-autoedits-provider.ts
+++ b/vscode/src/autoedits/create-autoedits-provider.ts
@@ -127,6 +127,11 @@ export function isUserEligibleForAutoeditsFeature(
     authStatus: AuthStatus,
     productSubscription: UserProductSubscription | null
 ): AutoeditsUserEligibilityInfo {
+    // Always enable auto-edits when testing
+    if (process.env.CODY_TESTING === 'true') {
+        return { isUserEligible: true }
+    }
+
     // Editors other than vscode are not eligible for auto-edits
     if (isRunningInsideAgent()) {
         return {
@@ -134,6 +139,7 @@ export function isUserEligibleForAutoeditsFeature(
             nonEligibilityReason: AUTOEDITS_NON_ELIGIBILITY_MESSAGES.ONLY_VSCODE_SUPPORT,
         }
     }
+
     // Free users are not eligible for auto-edits
     if (isFreeUser(authStatus, productSubscription)) {
         return {


### PR DESCRIPTION
## Description

E2E tests are failing on `main` right now since https://github.com/sourcegraph/cody/pull/6463

## Test plan

E2E tests pass locally and in CI

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
