### PR TITLE
Implement showWindowsMessage in JetBrains

### DIFF
--- a/jetbrains/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgent.kt
+++ b/jetbrains/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgent.kt
@@ -157,7 +157,9 @@ private constructor(
                               webviewMessages =
                                   ClientCapabilities.WebviewMessagesEnum.`String-encoded`,
                               accountSwitchingInWebview =
-                                  ClientCapabilities.AccountSwitchingInWebviewEnum.Enabled)))
+                                  ClientCapabilities.AccountSwitchingInWebviewEnum.Enabled,
+                              showWindowMessage =
+                                  ClientCapabilities.ShowWindowMessageEnum.Request)))
               .thenApply { info ->
                 logger.warn("Connected to Cody agent " + info.name)
                 server.initialized(null)


### PR DESCRIPTION
Fixes https://linear.app/sourcegraph/issue/QA-265
Improves https://linear.app/sourcegraph/issue/CODY-4648

## Changes

JetBrains can now properly show error and info messages from agent.

![image](https://github.com/user-attachments/assets/3c639bb1-115e-4dd4-948a-0d691531b308)

## Test plan

1. Open Cody
2. Make sure no file is opened
3. Using @ mention attach some file to the prompt without opening it
4. Run document command
5. Error message should appear in the ballon window as on screenshot

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

## Changelog

<!-- OPTIONAL; info at https://www.notion.so/sourcegraph/Writing-a-changelog-entry-dd997f411d524caabf0d8d38a24a878c -->
