### PR TITLE
feat(auto-edits): fix tab not working when decorations are triggered on conflicting decorations

### DIFF
--- a/vscode/src/autoedits/renderer/manager.ts
+++ b/vscode/src/autoedits/renderer/manager.ts
@@ -299,7 +299,11 @@ export class AutoEditsDefaultRendererManager implements AutoEditsRendererManager
     }
 
     public async renderInlineDecorations(decorationInfo: DecorationInfo): Promise<void> {
-        this.decorator?.setDecorations(decorationInfo)
+        if (!this.decorator) {
+            // No decorator to render the decorations
+            return
+        }
+        this.decorator.setDecorations(decorationInfo)
         await vscode.commands.executeCommand('setContext', 'cody.supersuggest.active', true)
     }
 


### PR DESCRIPTION
Fixes an issues in the conflicting decoration when the tab won't work on conflicting decorations with edit command.
This happens because although the `decorator` is null in this case but `await vscode.commands.executeCommand('setContext', 'cody.supersuggest.active', true) ` was still set, which waits for dismiss unless `tab` doesn't work.

Closes https://linear.app/sourcegraph/issue/CODY-4655/fix-tab-doesnt-work-when-using-auto-edits-in-conflicting-decorations

## Test plan
1. Do a fix command in the editor
2. Try to make `auto-edits` completions from the `auto-edits`
3. Although the decorations won't be visible, but the tab won't work without this fix.

