### PR TITLE
feat(auto-edits): fix the partial decoration issue when not enough lines in the editor

### DIFF
--- a/vscode/src/autoedits/analytics-logger/analytics-logger.ts
+++ b/vscode/src/autoedits/analytics-logger/analytics-logger.ts
@@ -86,7 +86,7 @@ const validRequestTransitions = {
     started: ['contextLoaded', 'discarded'],
     contextLoaded: ['loaded', 'discarded'],
     loaded: ['postProcessed', 'discarded'],
-    postProcessed: ['suggested'],
+    postProcessed: ['suggested', 'discarded'],
     suggested: ['read', 'accepted', 'rejected'],
     read: ['accepted', 'rejected'],
     accepted: [],

--- a/vscode/src/autoedits/analytics-logger/analytics-logger.ts
+++ b/vscode/src/autoedits/analytics-logger/analytics-logger.ts
@@ -174,7 +174,7 @@ export const autoeditDiscardReason = {
     emptyPredictionAfterInlineCompletionExtraction: 6,
     noActiveEditor: 7,
     conflictingDecorationWithEdits: 8,
-    noEnoughLinesEditor: 9,
+    notEnoughLinesEditor: 9,
 } as const
 
 /** We use numeric keys to send these to the analytics backend */

--- a/vscode/src/autoedits/analytics-logger/analytics-logger.ts
+++ b/vscode/src/autoedits/analytics-logger/analytics-logger.ts
@@ -173,6 +173,8 @@ export const autoeditDiscardReason = {
     suffixOverlap: 5,
     emptyPredictionAfterInlineCompletionExtraction: 6,
     noActiveEditor: 7,
+    conflictingDecorationWithEdits: 8,
+    noEnoughLinesEditor: 9,
 } as const
 
 /** We use numeric keys to send these to the analytics backend */

--- a/vscode/src/autoedits/renderer/decorators/base.ts
+++ b/vscode/src/autoedits/renderer/decorators/base.ts
@@ -31,6 +31,16 @@ export interface AutoEditsDecorator extends vscode.Disposable {
      *        and how they should be decorated in the editor.
      */
     setDecorations(decorationInfo: DecorationInfo): void
+
+    /**
+     * Checks if the decorator can render decorations for the given decoration information.
+     *
+     * This method verifies if the current editor state allows for the decorations to be
+     * rendered properly. Some conditions that might prevent rendering include:
+     * - Insufficient lines in the editor
+     * @returns true if decorations can be rendered, false otherwise
+     */
+    canRenderDecoration(decorationInfo: DecorationInfo): boolean
 }
 
 /**

--- a/vscode/src/autoedits/renderer/decorators/default-decorator.ts
+++ b/vscode/src/autoedits/renderer/decorators/default-decorator.ts
@@ -11,15 +11,41 @@ interface AddedLinesDecorationInfo {
     lineText: string
 }
 
+interface DiffDecorationAddedLinesInfo {
+    /** Information about lines that have been added */
+    addedLinesDecorationInfo: AddedLinesDecorationInfo[]
+    /** Starting line number for the decoration */
+    startLine: number
+    /** Column position for the replacement text */
+    replacerCol: number
+}
+
+/**
+ * Information about diff decorations to be applied to lines in the editor
+ */
+interface DiffDecorationInfo {
+    /** Ranges of text that have been removed */
+    removedRangesInfo: vscode.Range[]
+    /** Information about lines that have been added */
+    addedLinesInfo?: DiffDecorationAddedLinesInfo
+}
+
 export class DefaultDecorator implements AutoEditsDecorator {
     private readonly decorationTypes: vscode.TextEditorDecorationType[]
+    private readonly editor: vscode.TextEditor
+
+    // Decoration types
     private readonly removedTextDecorationType: vscode.TextEditorDecorationType
     private readonly modifiedTextDecorationType: vscode.TextEditorDecorationType
     private readonly suggesterType: vscode.TextEditorDecorationType
-    private readonly hideRemainderDecorationType: vscode.TextEditorDecorationType
     private readonly addedLinesDecorationType: vscode.TextEditorDecorationType
     private readonly insertMarkerDecorationType: vscode.TextEditorDecorationType
-    private readonly editor: vscode.TextEditor
+
+    /**
+     * Pre-computed information about diff decorations to be applied to lines in the editor
+     */
+
+    private diffDecorationInfo: DiffDecorationInfo | undefined
 
     constructor(editor: vscode.TextEditor) {
         this.editor = editor
@@ -33,9 +59,6 @@ export class DefaultDecorator implements AutoEditsDecorator {
         this.suggesterType = vscode.window.createTextEditorDecorationType({
             before: { color: GHOST_TEXT_COLOR },
             after: { color: GHOST_TEXT_COLOR },
-        })
-        this.hideRemainderDecorationType = vscode.window.createTextEditorDecorationType({
-            opacity: '0',
         })
         this.addedLinesDecorationType = vscode.window.createTextEditorDecorationType({
             backgroundColor: 'red', // SENTINEL (should not actually appear)
@@ -55,10 +78,26 @@ export class DefaultDecorator implements AutoEditsDecorator {
             this.removedTextDecorationType,
             this.modifiedTextDecorationType,
             this.suggesterType,
-            this.hideRemainderDecorationType,
             this.addedLinesDecorationType,
             this.insertMarkerDecorationType,
         ]
+    }
+
+    public canRenderDecoration(decorationInfo: DecorationInfo): boolean {
+        if (!this.diffDecorationInfo) {
+            this.diffDecorationInfo = this.getDiffDecorationsInfo(decorationInfo)
+        }
+        const { addedLinesInfo } = this.diffDecorationInfo
+        if (addedLinesInfo) {
+            // Check if there are enough lines in the editor to render the diff decorations
+            if (
+                addedLinesInfo.startLine + addedLinesInfo.addedLinesDecorationInfo.length >=
+                this.editor.document.lineCount
+            ) {
+                return false
+            }
+        }
+        return true
     }
 
     private clearDecorations(): void {
@@ -90,6 +129,27 @@ export class DefaultDecorator implements AutoEditsDecorator {
     }
 
     private renderDiffDecorations(decorationInfo: DecorationInfo): void {
+        if (!this.diffDecorationInfo) {
+            this.diffDecorationInfo = this.getDiffDecorationsInfo(decorationInfo)
+        }
+        this.editor.setDecorations(
+            this.modifiedTextDecorationType,
+            this.diffDecorationInfo.removedRangesInfo
+        )
+        const addedLinesInfo = this.diffDecorationInfo.addedLinesInfo
+
+        if (!addedLinesInfo) {
+            return
+        }
+
+        this.renderAddedLinesDecorations(
+            addedLinesInfo.addedLinesDecorationInfo,
+            addedLinesInfo.startLine,
+            addedLinesInfo.replacerCol
+        )
+    }
+
+    private getDiffDecorationsInfo(decorationInfo: DecorationInfo): DiffDecorationInfo {
         const { modifiedLines, addedLines, unchangedLines } = decorationInfo
 
         // Display the removed range decorations
@@ -119,7 +179,6 @@ export class DefaultDecorator implements AutoEditsDecorator {
                 })
             }
         }
-        this.editor.setDecorations(this.modifiedTextDecorationType, removedRanges)
 
         // Handle fully added lines
         for (const addedLine of addedLines) {
@@ -151,13 +210,20 @@ export class DefaultDecorator implements AutoEditsDecorator {
         // Sort addedLinesInfo by line number in ascending order
         addedLinesInfo.sort((a, b) => a.afterLine - b.afterLine)
         if (addedLinesInfo.length === 0) {
-            return
+            return { removedRangesInfo: removedRanges }
         }
-        // todo (hitesh): handle case when too many lines to fit in the editor
         const oldLines = addedLinesInfo.map(info => this.editor.document.lineAt(info.afterLine))
         const replacerCol = Math.max(...oldLines.map(line => line.range.end.character))
         const startLine = Math.min(...oldLines.map(line => line.lineNumber))
-        this.renderAddedLinesDecorations(addedLinesInfo, startLine, replacerCol)
+
+        return {
+            removedRangesInfo: removedRanges,
+            addedLinesInfo: {
+                addedLinesDecorationInfo: addedLinesInfo,
+                startLine,
+                replacerCol,
+            },
+        }
     }
 
     private renderAddedLinesDecorations(

--- a/vscode/src/autoedits/renderer/decorators/default-decorator.ts
+++ b/vscode/src/autoedits/renderer/decorators/default-decorator.ts
@@ -90,7 +90,7 @@ export class DefaultDecorator implements AutoEditsDecorator {
         if (addedLinesInfo) {
             // Check if there are enough lines in the editor to render the diff decorations
             if (
-                addedLinesInfo.startLine + addedLinesInfo.addedLinesDecorationInfo.length >=
+                addedLinesInfo.startLine + addedLinesInfo.addedLinesDecorationInfo.length >
                 this.editor.document.lineCount
             ) {
                 return false

--- a/vscode/src/autoedits/renderer/decorators/default-decorator.ts
+++ b/vscode/src/autoedits/renderer/decorators/default-decorator.ts
@@ -42,9 +42,8 @@ export class DefaultDecorator implements AutoEditsDecorator {
     private readonly insertMarkerDecorationType: vscode.TextEditorDecorationType
 
     /**
-     * Pre-computed information about diff decorations to be applied to lines in the editor
+     * Pre-computed information about diff decorations to be applied to lines in the editor.
      */
-
     private diffDecorationInfo: DiffDecorationInfo | undefined
 
     constructor(editor: vscode.TextEditor) {

--- a/vscode/src/autoedits/renderer/decorators/default-decorator.ts
+++ b/vscode/src/autoedits/renderer/decorators/default-decorator.ts
@@ -211,7 +211,9 @@ export class DefaultDecorator implements AutoEditsDecorator {
         if (addedLinesInfo.length === 0) {
             return { removedRangesInfo: removedRanges }
         }
-        const oldLines = addedLinesInfo.map(info => this.editor.document.lineAt(info.afterLine))
+        const oldLines = addedLinesInfo
+            .filter(info => info.afterLine < this.editor.document.lineCount)
+            .map(info => this.editor.document.lineAt(info.afterLine))
         const replacerCol = Math.max(...oldLines.map(line => line.range.end.character))
         const startLine = Math.min(...oldLines.map(line => line.lineNumber))
 

--- a/vscode/src/autoedits/renderer/decorators/inline-diff-decorator.ts
+++ b/vscode/src/autoedits/renderer/decorators/inline-diff-decorator.ts
@@ -19,6 +19,11 @@ export class InlineDiffDecorator implements vscode.Disposable, AutoEditsDecorato
         this.editor.setDecorations(this.addedTextDecorationType, added)
     }
 
+    public canRenderDecoration(decorationInfo: DecorationInfo): boolean {
+        // Inline decorator can render any decoration, so it should always return true.
+        return true
+    }
+
     /**
      * Process modified lines to create decorations for inserted and deleted text within those lines.
      */

--- a/vscode/src/autoedits/renderer/manager.ts
+++ b/vscode/src/autoedits/renderer/manager.ts
@@ -7,7 +7,11 @@ import {
     getLatestVisibilityContext,
     isCompletionVisible,
 } from '../../completions/is-completion-visible'
-import { type AutoeditRequestID, autoeditAnalyticsLogger } from '../analytics-logger'
+import {
+    type AutoeditRequestID,
+    autoeditAnalyticsLogger,
+    autoeditDiscardReason,
+} from '../analytics-logger'
 import { autoeditsProviderConfig } from '../autoedits-config'
 import { autoeditsOutputChannelLogger } from '../output-channel-logger'
 import type { CodeToReplaceData } from '../prompt/prompt-utils'
@@ -174,10 +178,14 @@ export class AutoEditsDefaultRendererManager implements AutoEditsRendererManager
         await this.rejectActiveEdit()
 
         const request = autoeditAnalyticsLogger.getRequest(requestId)
-        if (
-            !request ||
-            this.hasConflictingDecorations(request.document, request.codeToReplaceData.range)
-        ) {
+        if (!request) {
+            return
+        }
+        if (this.hasConflictingDecorations(request.document, request.codeToReplaceData.range)) {
+            autoeditAnalyticsLogger.markAsDiscarded({
+                requestId,
+                discardReason: autoeditDiscardReason.conflictingDecorationWithEdits,
+            })
             return
         }
 
@@ -190,6 +198,10 @@ export class AutoEditsDefaultRendererManager implements AutoEditsRendererManager
             // If the decorator cannot render the decoration properly, dispose of it and return early.
             this.decorator.dispose()
             this.decorator = null
+            autoeditAnalyticsLogger.markAsDiscarded({
+                requestId,
+                discardReason: autoeditDiscardReason.noEnoughLinesEditor,
+            })
             return
         }
 

--- a/vscode/src/autoedits/renderer/manager.ts
+++ b/vscode/src/autoedits/renderer/manager.ts
@@ -184,6 +184,16 @@ export class AutoEditsDefaultRendererManager implements AutoEditsRendererManager
         this.activeRequestId = requestId
         this.decorator = this.createDecorator(vscode.window.activeTextEditor!)
 
+        if (
+            'decorationInfo' in request &&
+            request.decorationInfo &&
+            !this.decorator.canRenderDecoration(request.decorationInfo)
+        ) {
+            // If the decorator cannot render the decoration properly, dispose of it and return early.
+            this.decorator.dispose()
+            return
+        }
+
         autoeditAnalyticsLogger.markAsSuggested(requestId)
 
         // Clear any existing timeouts, only one suggestion can be shown at a time

--- a/vscode/src/autoedits/renderer/manager.ts
+++ b/vscode/src/autoedits/renderer/manager.ts
@@ -200,7 +200,7 @@ export class AutoEditsDefaultRendererManager implements AutoEditsRendererManager
             this.decorator = null
             autoeditAnalyticsLogger.markAsDiscarded({
                 requestId,
-                discardReason: autoeditDiscardReason.noEnoughLinesEditor,
+                discardReason: autoeditDiscardReason.notEnoughLinesEditor,
             })
             return
         }

--- a/vscode/src/autoedits/renderer/manager.ts
+++ b/vscode/src/autoedits/renderer/manager.ts
@@ -181,9 +181,7 @@ export class AutoEditsDefaultRendererManager implements AutoEditsRendererManager
             return
         }
 
-        this.activeRequestId = requestId
         this.decorator = this.createDecorator(vscode.window.activeTextEditor!)
-
         if (
             'decorationInfo' in request &&
             request.decorationInfo &&
@@ -195,6 +193,7 @@ export class AutoEditsDefaultRendererManager implements AutoEditsRendererManager
             return
         }
 
+        this.activeRequestId = requestId
         autoeditAnalyticsLogger.markAsSuggested(requestId)
 
         // Clear any existing timeouts, only one suggestion can be shown at a time

--- a/vscode/src/autoedits/renderer/manager.ts
+++ b/vscode/src/autoedits/renderer/manager.ts
@@ -191,6 +191,7 @@ export class AutoEditsDefaultRendererManager implements AutoEditsRendererManager
         ) {
             // If the decorator cannot render the decoration properly, dispose of it and return early.
             this.decorator.dispose()
+            this.decorator = null
             return
         }
 


### PR DESCRIPTION
Default auto-edits renderer can not render the decorations properly when there are not enough lines in the editor. The PR adds checks if the deocrator can render the decoration properly, and if it cannot do so we don't create any request for it.

[Slack Context](https://sourcegraph.slack.com/archives/C07F8LLKE06/p1736430432651569?thread_ts=1736430399.759019&cid=C07F8LLKE06)
Closes: https://linear.app/sourcegraph/issue/CODY-4656/handle-decorations-when-not-enough-lines-in-the-editor

[Example from cody-chat-eval repo](https://github.com/sourcegraph/cody-chat-eval/blob/main/code-matching-eval/edits_experiments/examples/renderer-testing-examples/not-enough-lines-editor.ts)

Before (partial decoration rendered):
<img width="629" alt="image" src="https://github.com/user-attachments/assets/e2ebe0bd-f18f-4cdd-9d54-5994ad173b12" />

After (decorations will be discarded) - notice discard event on `cody by sourcegraph`
```

█ telemetry-v2 recordEvent: cody.autoedit/discarded: {
  "parameters": {
    "version": 0,
    "interactionID": "3ca8f155-1ab9-4b37-ac37-040340fbc1c8",
    "metadata": [
      {
        "key": "otherCompletionProviderEnabled",
        "value": 0
      },
      {
        "key": "triggerKind",
        "value": 1
      },
      {
        "key": "contextSummary.duration",
        "value": 61.69170800000029
      },
      {
        "key": "contextSummary.totalChars",
        "value": 2832
      },
      {
        "key": "contextSummary.prefixChars",
        "value": 979
      },
      {
        "key": "contextSummary.suffixChars",
        "value": 57
      },
      {
        "key": "contextSummary.retrieverStats.diagnostics.suggestedItems",
        "value": 9
      },
      {
        "key": "contextSummary.retrieverStats.diagnostics.positionBitmap",
        "value": 511
      },
      {
        "key": "contextSummary.retrieverStats.diagnostics.retrieverChars",
        "value": 1796
      },
      {
        "key": "contextSummary.retrieverStats.diagnostics.retrievedItems",
        "value": 9
      },
      {
        "key": "contextSummary.retrieverStats.diagnostics.duration",
        "value": 51.03662500000064
      },
      {
        "key": "source",
        "value": 1
      },
      {
        "key": "isFuzzyMatch",
        "value": 0
      },
      {
        "key": "latency",
        "value": 68
      },
      {
        "key": "decorationStats.modifiedLines",
        "value": 1
      },
      {
        "key": "decorationStats.removedLines",
        "value": 0
      },
      {
        "key": "decorationStats.addedLines",
        "value": 4
      },
      {
        "key": "decorationStats.unchangedLines",
        "value": 40
      },
      {
        "key": "decorationStats.addedChars",
        "value": 104
      },
      {
        "key": "decorationStats.removedChars",
        "value": 45
      },
      {
        "key": "decorationStats.unchangedChars",
        "value": 951
      },
      **{
        "key": "discardReason",
        "value": 9
      },**
      {
        "key": "recordsPrivateMetadataTranscript",
        "value": 1
      }
    ],
    "privateMetadata": {
      "otherCompletionProviders": [],
      "languageId": "typescript",
      "model": "fireworks::v1::autoedits-deepseek-lite-default",
      "contextSummary": {
        "strategy": "auto-edits",
        "duration": 61.69170800000029,
        "totalChars": 2832,
        "prefixChars": 979,
        "suffixChars": 57,
        "retrieverStats": {
          "diagnostics": {
            "suggestedItems": 9,
            "positionBitmap": 511,
            "retrieverChars": 1796,
            "retrievedItems": 9,
            "duration": 51.03662500000064
          }
        }
      },
      "id": "3ca8f155-1ab9-4b37-ac37-040340fbc1c8",
      "responseHeaders": {},
      "decorationStats": {
        "modifiedLines": 1,
        "removedLines": 0,
        "addedLines": 4,
        "unchangedLines": 40,
        "addedChars": 104,
        "removedChars": 45,
        "unchangedChars": 951
      }
    },
    "billingMetadata": {
      "product": "cody",
      "category": "core"
    }
  },
  "timestamp": "2025-01-10T09:33:03.486Z"
}
```


## Test plan
Tested on all the cody-chat-eval examples.
 
