### PR TITLE
feat(auto-edits): fix the suffix duplication on inline accept

### DIFF
--- a/vscode/src/autoedits/renderer/manager.ts
+++ b/vscode/src/autoedits/renderer/manager.ts
@@ -281,9 +281,11 @@ export class AutoEditsDefaultRendererManager implements AutoEditsRendererManager
         await this.handleDidHideSuggestion(decorator)
         autoeditAnalyticsLogger.markAsAccepted(activeRequest.requestId)
 
-        await editor.edit(editBuilder => {
-            editBuilder.replace(activeRequest.codeToReplaceData.range, activeRequest.prediction)
-        })
+        if (this.activeRequest && this.hasInlineDecorationOnly()) {
+            await editor.edit(editBuilder => {
+                editBuilder.replace(activeRequest.codeToReplaceData.range, activeRequest.prediction)
+            })
+        }
     }
 
     protected async rejectActiveEdit(): Promise<void> {

--- a/vscode/src/autoedits/renderer/manager.ts
+++ b/vscode/src/autoedits/renderer/manager.ts
@@ -94,10 +94,7 @@ export class AutoEditsDefaultRendererManager implements AutoEditsRendererManager
         protected fixupController: FixupController
     ) {
         this.disposables.push(
-            vscode.commands.registerCommand('cody.supersuggest.accept', () => {
-                console.log('cody.supersuggest.accept')
-                this.acceptActiveEdit()
-            }),
+            vscode.commands.registerCommand('cody.supersuggest.accept', () => this.acceptActiveEdit()),
             vscode.commands.registerCommand('cody.supersuggest.dismiss', () => this.rejectActiveEdit()),
             vscode.workspace.onDidChangeTextDocument(event => this.onDidChangeTextDocument(event)),
             vscode.window.onDidChangeTextEditorSelection(event =>


### PR DESCRIPTION
WIP. 
Fix the suffix duplication happening on inline completion acceptance.

## Test plan
repro the issue from the cody-chat-eval https://github.com/sourcegraph/cody-chat-eval/blob/main/code-matching-eval/edits_experiments/examples/renderer-testing-examples/suffix-duplication-issue.ts
