### PR TITLE
chore/build: Do not complain about GITHUB_ENV when building locally

### DIFF
--- a/vscode/scripts/measure-bundle-size.ts
+++ b/vscode/scripts/measure-bundle-size.ts
@@ -41,8 +41,6 @@ async function measureBundleSize(): Promise<void> {
             process.env.GITHUB_ENV,
             `WEBVIEW_BUNDLE_SIZE_MB=${(webviewBundle.size / (1024 * 1024)).toFixed(2)}\n`
         )
-    } else {
-        console.error('GITHUB_ENV environment variable is not defined.')
     }
 
     if (violations.length > 0) {


### PR DESCRIPTION
Do not log this error about GITHUB_ENV: It is not an error when building locally, and the error message has no context.

## Test plan

```
pnpm -C lib/shared build && pnpm build && pnpm -C vscode build 2>&1 | grep GITHUB_ENV
```

This should not mention `GITHUB_ENV`.
