### PR TITLE
feat(auto-edits): add test case for setting context

### DIFF
--- a/vscode/src/autoedits/autoedits-provider.test.ts
+++ b/vscode/src/autoedits/autoedits-provider.test.ts
@@ -360,4 +360,20 @@ describe('AutoeditsProvider', () => {
             expect.arrayContaining(['setContext', 'cody.supersuggest.active', false])
         )
     })
+
+    it('do not trigger the editBuilder for inline completion items', async () => {
+        const prediction = 'const x = 1\n'
+        const { editBuilder } = await autoeditResultFor('const x = █\n', { prediction })
+
+        await acceptSuggestionCommand()
+        expect(editBuilder.size).toBe(0)
+    })
+
+    it('trigger the editBuilder for inline decorations items', async () => {
+        const prediction = 'const a = 1\n'
+        const { editBuilder } = await autoeditResultFor('const x = █\n', { prediction })
+
+        await acceptSuggestionCommand()
+        expect(editBuilder.size).toBe(1)
+    })
 })

--- a/vscode/src/autoedits/autoedits-provider.test.ts
+++ b/vscode/src/autoedits/autoedits-provider.test.ts
@@ -343,22 +343,34 @@ describe('AutoeditsProvider', () => {
     it('do not set the the cody.supersuggest.active context for inline completion items', async () => {
         const prediction = 'const x = 1\n'
         await autoeditResultFor('const x = █\n', { prediction })
-        expect(executedCommands).toMatchInlineSnapshot([])
+        expect(executedCommands).toMatchInlineSnapshot(`
+            []
+        `)
     })
 
     it('set the cody.supersuggest.active context for inline decoration items', async () => {
         const prediction = 'const a = 1\n'
         await autoeditResultFor('const x = █\n', { prediction })
-        expect(executedCommands).toMatchInlineSnapshot(
-            expect.arrayContaining([['setContext', 'cody.supersuggest.active', true]])
-        )
+        expect(executedCommands).toMatchInlineSnapshot(`
+            [
+              [
+                "setContext",
+                "cody.supersuggest.active",
+                true,
+              ],
+            ]
+        `)
         await acceptSuggestionCommand()
 
-        // Deactive the context after accepting the suggestion
+        // Deactives the context after accepting the suggestion
         expect(executedCommands.length).toBe(3)
-        expect(executedCommands[1]).toMatchInlineSnapshot(
-            expect.arrayContaining(['setContext', 'cody.supersuggest.active', false])
-        )
+        expect(executedCommands[1]).toMatchInlineSnapshot(`
+            [
+              "setContext",
+              "cody.supersuggest.active",
+              false,
+            ]
+        `)
     })
 
     it('do not trigger the editBuilder for inline completion items', async () => {

--- a/vscode/src/autoedits/autoedits-provider.test.ts
+++ b/vscode/src/autoedits/autoedits-provider.test.ts
@@ -339,4 +339,25 @@ describe('AutoeditsProvider', () => {
           ]
         `)
     })
+
+    it('do not set the the cody.supersuggest.active context for inline completion items', async () => {
+        const prediction = 'const x = 1\n'
+        await autoeditResultFor('const x = █\n', { prediction })
+        expect(executedCommands).toMatchInlineSnapshot([])
+    })
+
+    it('set the cody.supersuggest.active context for inline decoration items', async () => {
+        const prediction = 'const a = 1\n'
+        await autoeditResultFor('const x = █\n', { prediction })
+        expect(executedCommands).toMatchInlineSnapshot(
+            expect.arrayContaining([['setContext', 'cody.supersuggest.active', true]])
+        )
+        await acceptSuggestionCommand()
+
+        // Deactive the context after accepting the suggestion
+        expect(executedCommands.length).toBe(3)
+        expect(executedCommands[1]).toMatchInlineSnapshot(
+            expect.arrayContaining(['setContext', 'cody.supersuggest.active', false])
+        )
+    })
 })

--- a/vscode/src/autoedits/autoedits-provider.test.ts
+++ b/vscode/src/autoedits/autoedits-provider.test.ts
@@ -373,6 +373,31 @@ describe('AutoeditsProvider', () => {
         `)
     })
 
+    it('unset the cody.supersuggest.active context for inline decoration rejection', async () => {
+        const prediction = 'const a = 1\n'
+        await autoeditResultFor('const x = █\n', { prediction })
+        expect(executedCommands).toMatchInlineSnapshot(`
+            [
+              [
+                "setContext",
+                "cody.supersuggest.active",
+                true,
+              ],
+            ]
+        `)
+        await rejectSuggestionCommand()
+
+        // Deactives the context after accepting the suggestion
+        expect(executedCommands.length).toBe(3)
+        expect(executedCommands[1]).toMatchInlineSnapshot(`
+            [
+              "setContext",
+              "cody.supersuggest.active",
+              false,
+            ]
+        `)
+    })
+
     it('do not trigger the editBuilder for inline completion items', async () => {
         const prediction = 'const x = 1\n'
         const { editBuilder } = await autoeditResultFor('const x = █\n', { prediction })


### PR DESCRIPTION
Adds the test case for the two issues we faced:
1. Tab not working when conflicted with edit command decorations. [Resolves comment](https://github.com/sourcegraph/cody/pull/6581#discussion_r1909965922) - [test cases for PR](https://github.com/sourcegraph/cody/pull/6581)
2. Suffix getting duplicated because in addition to inline acceptance, we were modifying the document again on accept - [[test case for PR](https://github.com/sourcegraph/cody/pull/6583)] 

## Test plan
Added test case
