### PR TITLE
refactor(agentic context): update agent context settings

### DIFF
--- a/vscode/webviews/chat/cells/contextCell/ContextCell.tsx
+++ b/vscode/webviews/chat/cells/contextCell/ContextCell.tsx
@@ -156,7 +156,7 @@ export const ContextCell: FunctionComponent<{
                 experimentalOneBoxEnabled && !intent
                     ? 'Reviewing query'
                     : isDeepCodyEnabled
-                      ? 'Agentic Context'
+                      ? 'Agentic context'
                       : isContextLoading
                         ? 'Fetching context'
                         : 'Context',

--- a/vscode/webviews/chat/cells/messageCell/human/HumanMessageCell.tsx
+++ b/vscode/webviews/chat/cells/messageCell/human/HumanMessageCell.tsx
@@ -114,7 +114,9 @@ const HumanMessageCellContent = memo<HumanMessageCellContent>(props => {
             cellAction={
                 <div className="tw-flex tw-gap-2 tw-items-center tw-justify-end">
                     {isFirstMessage && <OpenInNewEditorAction />}
-                    {isLastInteraction && settings && <ToolboxButton settings={settings} api={api} />}
+                    {settings && (
+                        <ToolboxButton settings={settings} api={api} isFirstMessage={isFirstMessage} />
+                    )}
                 </div>
             }
             content={

--- a/vscode/webviews/chat/cells/messageCell/human/editor/ToolboxButton.story.tsx
+++ b/vscode/webviews/chat/cells/messageCell/human/editor/ToolboxButton.story.tsx
@@ -1,0 +1,80 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { VSCodeStandaloneComponent } from '../../../../../storybook/VSCodeStoryDecorator'
+import { ToolboxButton } from './ToolboxButton'
+
+const meta: Meta<typeof ToolboxButton> = {
+    title: 'cody/ToolboxButton',
+    component: ToolboxButton,
+    decorators: [VSCodeStandaloneComponent],
+    args: {
+        isFirstMessage: true,
+    },
+}
+
+export default meta
+
+type Story = StoryObj<typeof ToolboxButton>
+
+export const Default: Story = {
+    args: {
+        settings: {
+            agent: {
+                name: 'deep-cody',
+            },
+        },
+    },
+}
+
+export const AgentDisabled: Story = {
+    args: {
+        settings: {
+            agent: {
+                name: undefined,
+            },
+            shell: {
+                enabled: false,
+            },
+        },
+    },
+}
+
+export const FullyEnabled: Story = {
+    args: {
+        settings: {
+            agent: {
+                name: 'deep-cody',
+            },
+            shell: {
+                enabled: true,
+            },
+        },
+    },
+}
+
+export const ShellNotSupported: Story = {
+    args: {
+        settings: {
+            agent: {
+                name: 'deep-cody',
+            },
+            shell: {
+                enabled: false,
+                error: 'Terminal access is not enabled on either instance or client.',
+            },
+        },
+    },
+}
+
+export const NonFirstMessage: Story = {
+    args: {
+        settings: {
+            agent: {
+                name: 'deep-cody',
+            },
+            shell: {
+                enabled: true,
+            },
+        },
+        isFirstMessage: false,
+    },
+}

--- a/vscode/webviews/chat/cells/messageCell/human/editor/ToolboxButton.tsx
+++ b/vscode/webviews/chat/cells/messageCell/human/editor/ToolboxButton.tsx
@@ -91,8 +91,7 @@ export const ToolboxButton: FC<ToolboxButtonProps> = memo(({ settings, api, isFi
                 popoverContent={_close => (
                     <div id="accordion-collapse" data-accordion="collapse" className="tw-w-full">
                         <h2 id="accordion-collapse-heading">
-                            <button
-                                type="button"
+                            <div
                                 className="tw-flex tw-items-center tw-justify-between tw-w-full tw-p-5 tw-font-medium tw-border tw-border-border tw-rounded-t-md tw-focus:ring-4 tw-focus:ring-gray-200 tw-gap-3 tw-bg-[color-mix(in_lch,currentColor_10%,transparent)]"
                                 title="Agentic Chat Context"
                             >
@@ -114,7 +113,7 @@ export const ToolboxButton: FC<ToolboxButtonProps> = memo(({ settings, api, isFi
                                         })
                                     }
                                 />
-                            </button>
+                            </div>
                         </h2>
                         <div
                             id="accordion-collapse-body"

--- a/vscode/webviews/chat/cells/messageCell/human/editor/ToolboxButton.tsx
+++ b/vscode/webviews/chat/cells/messageCell/human/editor/ToolboxButton.tsx
@@ -1,32 +1,33 @@
 import type { AgentToolboxSettings, WebviewToExtensionAPI } from '@sourcegraph/cody-shared'
-import { FlaskConicalIcon, FlaskConicalOffIcon } from 'lucide-react'
-import { type FC, memo, useCallback, useEffect, useState } from 'react'
+import { debounce } from 'lodash'
+import { BrainIcon } from 'lucide-react'
+import { type FC, memo, useCallback, useState } from 'react'
 import { Badge } from '../../../../../components/shadcn/ui/badge'
 import { Button } from '../../../../../components/shadcn/ui/button'
-import { Command, CommandGroup, CommandList } from '../../../../../components/shadcn/ui/command'
 import { ToolbarPopoverItem } from '../../../../../components/shadcn/ui/toolbar'
 import { useTelemetryRecorder } from '../../../../../utils/telemetry'
 
 interface ToolboxButtonProps {
     api: WebviewToExtensionAPI
     settings: AgentToolboxSettings
+    isFirstMessage: boolean
 }
 
-const ToolboxOptionText = {
-    agentic:
-        'Enhances responses by searching your codebase and using available tools to gather relevant context.',
-    terminal: 'Execute command automatically for context. Enable with caution as mistakes are possible.',
-}
+// TODO: Update the link to the actual documentation when available.
+// const AGENTIC_CONTEXT_DOCS = 'https://sourcegraph.com/docs'
 
-export const ToolboxButton: FC<ToolboxButtonProps> = memo(({ settings, api }) => {
+/**
+ * A button component that provides a UI for managing agent context settings.
+ * Displays a popover with toggles for agentic context and terminal access.
+ * Includes experimental features with appropriate warnings and documentation links.
+ *
+ * @param settings - The current agent toolbox settings
+ * @param api - API interface for communicating with the extension
+ */
+export const ToolboxButton: FC<ToolboxButtonProps> = memo(({ settings, api, isFirstMessage }) => {
     const telemetryRecorder = useTelemetryRecorder()
 
     const [isLoading, setIsLoading] = useState(false)
-    const [settingsForm, setSettingsForm] = useState<AgentToolboxSettings>(settings)
-
-    useEffect(() => {
-        setSettingsForm(settings)
-    }, [settings])
 
     const onOpenChange = useCallback(
         (open: boolean): void => {
@@ -34,36 +35,33 @@ export const ToolboxButton: FC<ToolboxButtonProps> = memo(({ settings, api }) =>
                 telemetryRecorder.recordEvent('cody.toolboxSettings', 'opened', {
                     billingMetadata: { product: 'cody', category: 'billable' },
                 })
-            } else {
-                // Reset form to original settings when closing
-                setSettingsForm(settings)
             }
         },
-        [telemetryRecorder.recordEvent, settings]
+        [telemetryRecorder.recordEvent]
     )
 
-    const onSubmit = useCallback(
-        (close: () => void) => {
+    const debouncedSubmit = useCallback(
+        debounce((newSettings: AgentToolboxSettings) => {
+            if (isLoading) {
+                return
+            }
             setIsLoading(true)
-
-            if (settings !== settingsForm) {
+            if (settings !== newSettings) {
                 telemetryRecorder.recordEvent('cody.toolboxSettings', 'updated', {
                     billingMetadata: { product: 'cody', category: 'billable' },
                     metadata: {
-                        agent: settingsForm.agent?.name ? 1 : 0,
-                        shell: settingsForm.shell?.enabled ? 1 : 0,
+                        agent: newSettings.agent?.name ? 1 : 0,
+                        shell: newSettings.shell?.enabled ? 1 : 0,
                     },
                 })
             }
-
-            const subscription = api.updateToolboxSettings(settingsForm).subscribe({
+            const subscription = api.updateToolboxSettings(newSettings).subscribe({
                 next: () => {
                     setIsLoading(false)
                     close()
                 },
                 error: error => {
                     console.error('updateToolboxSettings:', error)
-                    setSettingsForm(settings)
                     setIsLoading(false)
                 },
                 complete: () => {
@@ -73,117 +71,133 @@ export const ToolboxButton: FC<ToolboxButtonProps> = memo(({ settings, api }) =>
             return () => {
                 subscription.unsubscribe()
             }
-        },
-        [api.updateToolboxSettings, settingsForm, settings, telemetryRecorder]
+        }, 500), // 500ms delay between calls
+        []
     )
+
+    function onSubmit(newSettings: AgentToolboxSettings): void {
+        setIsLoading(true)
+        debouncedSubmit(newSettings)
+    }
 
     return (
         <div className="tw-flex tw-items-center">
             <ToolbarPopoverItem
                 role="combobox"
-                iconEnd={null}
+                iconEnd="chevron"
                 className="tw-opacity-100"
                 tooltip="Chat Settings"
                 aria-label="Chat Settings"
-                popoverContent={close => (
-                    <Command>
-                        <CommandList>
-                            <header className="tw-flex tw-justify-between tw-px-6 tw-py-3 tw-border-t tw-border-border tw-bg-muted tw-w-full">
-                                <h2 className="tw-text-md tw-font-semibold">Agentic Context</h2>
-                                <Badge variant="secondary">Experimental</Badge>
-                            </header>
-                            <CommandGroup className="tw-p-6">
-                                <div className="tw-container tw-flex tw-gap-2 tw-align-baseline">
-                                    <div className="tw-flex tw-flex-1 tw-flex-col tw-gap-2 tw-w-full">
-                                        <div className="tw-flex tw-flex-1 tw-w-full tw-items-center tw-justify-between">
-                                            <h3 className="tw-text-sm">Agentic Chat</h3>
-                                            <Switch
-                                                checked={!!settingsForm.agent?.name}
-                                                onChange={() =>
-                                                    setSettingsForm({
-                                                        ...settingsForm,
-                                                        agent: {
-                                                            name: settingsForm.agent?.name
-                                                                ? undefined
-                                                                : 'deep-cody', // TODO: update name when finalized.
-                                                        },
-                                                    })
-                                                }
-                                            />
-                                        </div>
-                                        <div className="tw-flex tw-flex-1 tw-w-full tw-items-center tw-justify-between">
-                                            <h3 className="tw-text-sm tw-inline-flex tw-gap-2">
-                                                Terminal Context
-                                                {settingsForm.shell?.error && (
-                                                    <Badge
-                                                        variant="info"
-                                                        className="tw-text-xs"
-                                                        title={settingsForm.shell?.error}
-                                                    >
-                                                        Unavailable
-                                                    </Badge>
-                                                )}
-                                            </h3>
-                                            <Switch
-                                                checked={settingsForm.shell?.enabled}
-                                                disabled={!!settings.shell?.error}
-                                                onChange={() =>
-                                                    setSettingsForm({
-                                                        ...settingsForm,
-                                                        shell: {
-                                                            enabled:
-                                                                !!settingsForm.agent?.name &&
-                                                                !settingsForm.shell?.enabled,
-                                                        },
-                                                    })
-                                                }
-                                            />
-                                        </div>
-                                        <div className="tw-text-xs tw-mb-4 tw-text-muted-foreground">
-                                            {ToolboxOptionText.terminal}
-                                        </div>
+                popoverContent={_close => (
+                    <div id="accordion-collapse" data-accordion="collapse" className="tw-w-full">
+                        <h2 id="accordion-collapse-heading">
+                            <button
+                                type="button"
+                                className="tw-flex tw-items-center tw-justify-between tw-w-full tw-p-5 tw-font-medium tw-border tw-border-border tw-rounded-t-md tw-focus:ring-4 tw-focus:ring-gray-200 tw-gap-3 tw-bg-[color-mix(in_lch,currentColor_10%,transparent)]"
+                                title="Agentic Chat Context"
+                            >
+                                <span className="tw-flex tw-gap-2 tw-items-center">
+                                    <span className="tw-font-semibold tw-text-md">Agentic context</span>
+                                    <Badge variant="secondary" className="tw-text-xs">
+                                        Experimental
+                                    </Badge>
+                                </span>
+                                <Switch
+                                    disabled={isLoading}
+                                    checked={settings.agent?.name !== undefined}
+                                    onChange={() =>
+                                        onSubmit({
+                                            ...settings,
+                                            agent: {
+                                                name: settings.agent?.name ? undefined : 'deep-cody', // TODO: update name when finalized.
+                                            },
+                                        })
+                                    }
+                                />
+                            </button>
+                        </h2>
+                        <div
+                            id="accordion-collapse-body"
+                            className="tw-ml-5 tw-p-5 tw-flex tw-flex-col tw-gap-5 tw-mt-1"
+                        >
+                            <div className="tw-text-sm">
+                                <span>
+                                    Agentic context can search your codebase, browse the web, execute
+                                    shell commands (when enabled), and utilize configured tools to
+                                    retrieve necessary context.
+                                    {/* TODO: Uncomment this when the docs is available */}
+                                    {/* <a href={AGENTIC_CONTEXT_DOCS}>Read the docs</a> to learn more. */}
+                                </span>
+                            </div>
+                            {/* Only shows the Terminal access option if client and instance supports it */}
+                            {settings.agent?.name && !settings.shell?.error && (
+                                <div>
+                                    <div
+                                        className="tw-flex tw-items-center tw-justify-between tw-w-full tw-font-medium tw-gap-3"
+                                        aria-label="terminal"
+                                    >
+                                        <span className="tw-flex tw-gap-2 tw-items-center">
+                                            <span className="tw-font-semibold tw-text-md">
+                                                Terminal access
+                                            </span>
+                                        </span>
+                                        <Switch
+                                            checked={settings.shell?.enabled}
+                                            disabled={isLoading || !!settings.shell?.error}
+                                            onChange={() =>
+                                                onSubmit({
+                                                    ...settings,
+                                                    shell: {
+                                                        enabled:
+                                                            !!settings.agent?.name &&
+                                                            !settings.shell?.enabled,
+                                                    },
+                                                })
+                                            }
+                                        />
+                                    </div>
+                                    <div className="tw-text-sm tw-mt-2">
+                                        Allows agents to execute terminal commands. When enabled, this
+                                        this tool can execute <code>ls</code>, <code>dir</code>,{' '}
+                                        <code>git</code>, etc. Configure additional commands in settings.
+                                        <span className="tw-ml-1 tw-text-red-800 dark:tw-text-red-300">
+                                            Enable with caution as mistakes are possible.
+                                        </span>
                                     </div>
                                 </div>
-                            </CommandGroup>
-                        </CommandList>
-                        <footer className="tw-flex tw-justify-end tw-px-6 tw-py-2 tw-border-t tw-border-border tw-bg-muted tw-w-full">
-                            <Button onClick={close} variant="secondary" size="xs" disabled={isLoading}>
-                                Cancel
-                            </Button>
-                            <Button
-                                onClick={() => onSubmit(close)}
-                                variant="default"
-                                disabled={isLoading}
-                                size="xs"
-                                className="tw-ml-4"
-                            >
-                                {isLoading ? 'Saving...' : 'Save'}
-                            </Button>
-                        </footer>
-                    </Command>
+                            )}
+                        </div>
+                    </div>
                 )}
                 popoverRootProps={{ onOpenChange }}
                 popoverContentProps={{
-                    className: 'tw-w-[350px] !tw-p-0 tw-mr-2',
+                    className: 'tw-w-[350px] !tw-p-0 tw-mr-4',
                     onCloseAutoFocus: event => {
                         event.preventDefault()
                     },
                 }}
             >
-                <Button variant="ghost" size="none" className="hover:!tw-bg-transparent">
+                <Button
+                    variant="ghost"
+                    size="none"
+                    className={`${
+                        settings.agent?.name ? 'tw-text-foreground' : 'tw-text-muted-foreground'
+                    } hover:!tw-bg-transparent`}
+                >
                     {settings.agent?.name ? (
-                        <FlaskConicalIcon
+                        <BrainIcon
                             size={16}
-                            strokeWidth={1.25}
+                            strokeWidth={2}
                             className="tw-w-8 tw-h-8 tw-text-green-600 tw-drop-shadow-md"
                         />
                     ) : (
-                        <FlaskConicalOffIcon
+                        <BrainIcon
                             size={16}
-                            strokeWidth={1.25}
+                            strokeWidth={2}
                             className="tw-w-8 tw-h-8 tw-text-muted-foreground"
                         />
                     )}
+                    {isFirstMessage && <span className="tw-font-semibold">agentic context</span>}
                 </Button>
             </ToolbarPopoverItem>
         </div>


### PR DESCRIPTION
CLOSE https://linear.app/sourcegraph/issue/CODY-4632

Updates the `ToolboxButton` component that provides a UI for managing agent context settings with a more detailed description of the feature.

- Updates toggles for agentic context and terminal access, with appropriate warnings
- Displays the button on all messages
- Debounces the settings update to avoid excessive API calls with the removed save button
- Display button on all messages
- Display button without title text in non-first message
- Hide terminal context on unsupported instance/clients

## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

UI update without feature change - storybook updated.

![image](https://github.com/user-attachments/assets/0459f2b1-e0b9-463f-83c8-0d20e6f789b4)

![image](https://github.com/user-attachments/assets/37ee046a-0b6c-4d1c-916f-fd593d636c5a)

Hide shell command on unsupported client or instances

![image](https://github.com/user-attachments/assets/24cc5215-7118-4cfa-a5de-0b643cdf2a1f)

### Before

The current one doesn't explain what agentic context and terminal context are:

![image](https://github.com/user-attachments/assets/27da9d5f-bf5e-4a34-8ed8-6e37a80dbd48)
