### PR TITLE
feat(webview): add Sourcegraph Workspaces upgrade CTA

### DIFF
--- a/vscode/src/chat/protocol.ts
+++ b/vscode/src/chat/protocol.ts
@@ -264,7 +264,6 @@ export const SG_CHANGELOG_URL = new URL('https://sourcegraph.com/changelog')
 export const VSCODE_CHANGELOG_URL = new URL(
     'https://github.com/sourcegraph/cody/blob/main/vscode/CHANGELOG.md'
 )
-
 // Community and support
 export const DISCORD_URL = new URL('https://discord.gg/s2qDtYGnAE')
 export const CODY_FEEDBACK_URL = new URL('https://github.com/sourcegraph/cody/issues/new/choose')
@@ -273,6 +272,8 @@ export const CODY_OLLAMA_DOCS_URL = new URL(
     'https://sourcegraph.com/docs/cody/clients/install-vscode#supported-local-ollama-models-with-cody'
 )
 // Account
+export const ENTERPRISE_PRICING_URL = new URL('https://sourcegraph.com/pricing')
+export const CODY_PRO_SUBSCRIPTION_URL = new URL('https://accounts.sourcegraph.com/cody/subscription')
 export const ACCOUNT_UPGRADE_URL = new URL('https://sourcegraph.com/cody/subscription')
 export const ACCOUNT_USAGE_URL = new URL('https://sourcegraph.com/cody/manage')
 export const ACCOUNT_LIMITS_INFO_URL = new URL(

--- a/vscode/webviews/CodyPanel.tsx
+++ b/vscode/webviews/CodyPanel.tsx
@@ -120,6 +120,7 @@ export const CodyPanel: FunctionComponent<CodyPanelProps> = ({
                         currentView={view}
                         setView={setView}
                         endpointHistory={config.endpointHistory ?? []}
+                        isTeamsUpgradeCtaEnabled={isTeamsUpgradeCtaEnabled}
                     />
                 )}
                 {errorMessages && <ErrorBanner errors={errorMessages} setErrors={setErrorMessages} />}

--- a/vscode/webviews/components/UserMenu.tsx
+++ b/vscode/webviews/components/UserMenu.tsx
@@ -311,9 +311,14 @@ export const UserMenu: React.FunctionComponent<UserMenuProps> = ({
                                 </CommandItem>
                             </CommandGroup>
 
-                            {isTeamsUpgradeCtaEnabled && (
+                            {!isTeamsUpgradeCtaEnabled && (
                                 <CommandGroup>
-                                    <CommandItem className="tw-flex tw-w-full tw-justify-start tw-gap-4 tw-align-center tw-flex-col tw-bg-inherit">
+                                    <CommandLink
+                                        href="https://workspaces.sourcegraph.com"
+                                        target="_blank"
+                                        rel="noreferrer"
+                                        className="tw-flex tw-w-full tw-justify-start tw-gap-4 tw-align-center tw-flex-col tw-bg-inherit tw-font-left"
+                                    >
                                         <div className="tw-flex tw-w-full tw-justify-start tw-gap-4 tw-align-center">
                                             {/* TODO: Replace with new logo */}
                                             <SourcegraphLogo
@@ -328,7 +333,7 @@ export const UserMenu: React.FunctionComponent<UserMenuProps> = ({
                                                 Enterprise Starter
                                             </Badge>
                                         </div>
-                                        <div className="tw-text-lg tw-font-semibold tw-text-left">
+                                        <div className="tw-w-full tw-text-lg tw-font-semibold tw-text-left tw-mt-2">
                                             Unlock the Sourcegraph platform
                                         </div>
                                         <div className="tw-text-md tw-text-muted-foreground">
@@ -336,21 +341,14 @@ export const UserMenu: React.FunctionComponent<UserMenuProps> = ({
                                             Code Search, AI chat, autocompletes, inline edits and more
                                             for your team.
                                         </div>
-                                        <a
-                                            href="https://workspaces.sourcegraph.com"
-                                            target="_blank"
-                                            rel="noreferrer"
-                                            className="tw-flex-grow tw-w-full tw-my-2"
+                                        <Button
+                                            key="workspace-create-button"
+                                            variant="outline"
+                                            className="tw-flex-grow tw-rounded-md tw-text-center tw-w-full tw-text-foreground tw-my-2"
                                         >
-                                            <Button
-                                                key="workspace-create-button"
-                                                variant="outline"
-                                                className="tw-flex-grow tw-rounded-md tw-text-center tw-w-full  tw-text-foreground tw-cursor-pointer"
-                                            >
-                                                Create a workspace
-                                            </Button>
-                                        </a>
-                                    </CommandItem>
+                                            Create a workspace
+                                        </Button>
+                                    </CommandLink>
                                 </CommandGroup>
                             )}
                         </CommandList>
@@ -476,7 +474,7 @@ export const UserMenu: React.FunctionComponent<UserMenuProps> = ({
             )}
             popoverRootProps={{ onOpenChange }}
             popoverContentProps={{
-                className: '!tw-p-2',
+                className: '!tw-p-2 tw-mr-6',
                 onKeyDown: onKeyDown,
                 onCloseAutoFocus: event => {
                     event.preventDefault()

--- a/vscode/webviews/components/UserMenu.tsx
+++ b/vscode/webviews/components/UserMenu.tsx
@@ -311,7 +311,7 @@ export const UserMenu: React.FunctionComponent<UserMenuProps> = ({
                                 </CommandItem>
                             </CommandGroup>
 
-                            {!isTeamsUpgradeCtaEnabled && (
+                            {isTeamsUpgradeCtaEnabled && (
                                 <CommandGroup>
                                     <CommandLink
                                         href="https://workspaces.sourcegraph.com"

--- a/vscode/webviews/components/UserMenu.tsx
+++ b/vscode/webviews/components/UserMenu.tsx
@@ -15,6 +15,7 @@ import {
 import { useCallback, useState } from 'react'
 import { URI } from 'vscode-uri'
 import { ACCOUNT_USAGE_URL, isSourcegraphToken } from '../../src/chat/protocol'
+import { SourcegraphLogo } from '../icons/SourcegraphLogo'
 import { getVSCodeAPI } from '../utils/VSCodeApi'
 import { useTelemetryRecorder } from '../utils/telemetry'
 import { UserAvatar } from './UserAvatar'
@@ -34,6 +35,8 @@ interface UserMenuProps {
     onCloseByEscape?: () => void
     allowEndpointChange: boolean
     __storybook__open?: boolean
+    // Whether to show the Sourcegraph Teams upgrade CTA or not.
+    isTeamsUpgradeCtaEnabled?: boolean
 }
 
 type MenuView = 'main' | 'switch' | 'add' | 'remove'
@@ -46,6 +49,7 @@ export const UserMenu: React.FunctionComponent<UserMenuProps> = ({
     onCloseByEscape,
     allowEndpointChange,
     __storybook__open,
+    isTeamsUpgradeCtaEnabled,
 }) => {
     const telemetryRecorder = useTelemetryRecorder()
     const { displayName, username, primaryEmail, endpoint } = authStatus
@@ -306,6 +310,49 @@ export const UserMenu: React.FunctionComponent<UserMenuProps> = ({
                                     <span className="tw-flex-grow">Add another account</span>
                                 </CommandItem>
                             </CommandGroup>
+
+                            {isTeamsUpgradeCtaEnabled && (
+                                <CommandGroup>
+                                    <CommandItem className="tw-flex tw-w-full tw-justify-start tw-gap-4 tw-align-center tw-flex-col tw-bg-inherit">
+                                        <div className="tw-flex tw-w-full tw-justify-start tw-gap-4 tw-align-center">
+                                            {/* TODO: Replace with new logo */}
+                                            <SourcegraphLogo
+                                                width={16}
+                                                height={16}
+                                                className="tw-mr-2"
+                                            />
+                                            <Badge
+                                                variant="secondary"
+                                                className="tw-opacity-85 tw-text-xs tw-h-fit tw-self-center"
+                                            >
+                                                Enterprise Starter
+                                            </Badge>
+                                        </div>
+                                        <div className="tw-text-lg tw-font-semibold tw-text-left">
+                                            Unlock the Sourcegraph platform
+                                        </div>
+                                        <div className="tw-text-md tw-text-muted-foreground">
+                                            Create a workspace and connect GitHub repositories to unlock
+                                            Code Search, AI chat, autocompletes, inline edits and more
+                                            for your team.
+                                        </div>
+                                        <a
+                                            href="https://workspaces.sourcegraph.com"
+                                            target="_blank"
+                                            rel="noreferrer"
+                                            className="tw-flex-grow tw-w-full tw-my-2"
+                                        >
+                                            <Button
+                                                key="workspace-create-button"
+                                                variant="outline"
+                                                className="tw-flex-grow tw-rounded-md tw-text-center tw-w-full  tw-text-foreground tw-cursor-pointer"
+                                            >
+                                                Create a workspace
+                                            </Button>
+                                        </a>
+                                    </CommandItem>
+                                </CommandGroup>
+                            )}
                         </CommandList>
                     ) : (
                         <CommandList>

--- a/vscode/webviews/components/UserMenu.tsx
+++ b/vscode/webviews/components/UserMenu.tsx
@@ -11,10 +11,16 @@ import {
     PlusIcon,
     Settings2Icon,
     UserCircleIcon,
+    ZapIcon,
 } from 'lucide-react'
 import { useCallback, useState } from 'react'
 import { URI } from 'vscode-uri'
-import { ACCOUNT_USAGE_URL, isSourcegraphToken } from '../../src/chat/protocol'
+import {
+    ACCOUNT_USAGE_URL,
+    CODY_PRO_SUBSCRIPTION_URL,
+    ENTERPRISE_PRICING_URL,
+    isSourcegraphToken,
+} from '../../src/chat/protocol'
 import { SourcegraphLogo } from '../icons/SourcegraphLogo'
 import { getVSCodeAPI } from '../utils/VSCodeApi'
 import { useTelemetryRecorder } from '../utils/telemetry'
@@ -391,6 +397,44 @@ export const UserMenu: React.FunctionComponent<UserMenuProps> = ({
                             </CommandGroup>
 
                             <CommandGroup>
+                                {isDotComUser && !isProUser && (
+                                    <CommandLink
+                                        href={CODY_PRO_SUBSCRIPTION_URL.toString()}
+                                        target="_blank"
+                                        rel="noreferrer"
+                                        onSelect={() => {
+                                            telemetryRecorder.recordEvent(
+                                                'cody.userMenu.upgradeToProLink',
+                                                'open',
+                                                {}
+                                            )
+                                            close()
+                                        }}
+                                    >
+                                        <svg className="tw-w-8 tw-h-8 tw-mr-2">
+                                            <title>zapIconGradient</title>
+                                            <defs>
+                                                <linearGradient
+                                                    id="zapIconGradient"
+                                                    x1="100%"
+                                                    y1="100%"
+                                                    x2="0%"
+                                                    y2="0%"
+                                                >
+                                                    <stop offset="0%" stopColor="#00cbec" />
+                                                    <stop offset="50%" stopColor="#a112ff" />
+                                                    <stop offset="100%" stopColor="#ff5543" />
+                                                </linearGradient>
+                                            </defs>
+                                            <ZapIcon
+                                                size={16}
+                                                strokeWidth={1.25}
+                                                style={{ stroke: 'url(#zapIconGradient)' }}
+                                            />
+                                        </svg>
+                                        <span className="tw-flex-grow">Upgrade to Pro</span>
+                                    </CommandLink>
+                                )}
                                 {isDotComUser && (
                                     <CommandItem
                                         onSelect={() => {
@@ -431,6 +475,25 @@ export const UserMenu: React.FunctionComponent<UserMenuProps> = ({
                                     <Settings2Icon size={16} strokeWidth={1.25} className="tw-mr-2" />
                                     <span className="tw-flex-grow">Extension Settings</span>
                                 </CommandItem>
+                                {isDotComUser && (
+                                    <CommandLink
+                                        href={ENTERPRISE_PRICING_URL.toString()}
+                                        target="_blank"
+                                        rel="noreferrer"
+                                        onSelect={() => {
+                                            telemetryRecorder.recordEvent(
+                                                'cody.userMenu.exploreEnterprisePlanLink',
+                                                'open',
+                                                {}
+                                            )
+                                            close()
+                                        }}
+                                    >
+                                        <SourcegraphLogo width={16} height={16} className="tw-mr-2" />
+                                        <span className="tw-flex-grow">Explore Enterprise Plans</span>
+                                        <ExternalLinkIcon size={16} strokeWidth={1.25} />
+                                    </CommandLink>
+                                )}
                             </CommandGroup>
 
                             <CommandGroup>

--- a/vscode/webviews/components/UserMenu.tsx
+++ b/vscode/webviews/components/UserMenu.tsx
@@ -311,7 +311,7 @@ export const UserMenu: React.FunctionComponent<UserMenuProps> = ({
                                 </CommandItem>
                             </CommandGroup>
 
-                            {isTeamsUpgradeCtaEnabled && (
+                            {!isTeamsUpgradeCtaEnabled && (
                                 <CommandGroup>
                                     <CommandLink
                                         href="https://workspaces.sourcegraph.com"
@@ -333,10 +333,10 @@ export const UserMenu: React.FunctionComponent<UserMenuProps> = ({
                                                 Enterprise Starter
                                             </Badge>
                                         </div>
-                                        <div className="tw-w-full tw-text-lg tw-font-semibold tw-text-left tw-mt-2">
+                                        <div className="tw-w-full tw-text-[14px] tw-font-semibold tw-text-left tw-mt-2">
                                             Unlock the Sourcegraph platform
                                         </div>
-                                        <div className="tw-text-md tw-text-muted-foreground">
+                                        <div className="tw-text-[12px] tw-text-muted-foreground">
                                             Create a workspace and connect GitHub repositories to unlock
                                             Code Search, AI chat, autocompletes, inline edits and more
                                             for your team.
@@ -344,7 +344,7 @@ export const UserMenu: React.FunctionComponent<UserMenuProps> = ({
                                         <Button
                                             key="workspace-create-button"
                                             variant="outline"
-                                            className="tw-flex-grow tw-rounded-md tw-text-center tw-w-full tw-text-foreground tw-my-2"
+                                            className="tw-flex-grow tw-rounded-md tw-text-center tw-w-full tw-text-foreground tw-my-2 tw-text-[12px]"
                                         >
                                             Create a workspace
                                         </Button>

--- a/vscode/webviews/components/UserMenu.tsx
+++ b/vscode/webviews/components/UserMenu.tsx
@@ -311,13 +311,13 @@ export const UserMenu: React.FunctionComponent<UserMenuProps> = ({
                                 </CommandItem>
                             </CommandGroup>
 
-                            {!isTeamsUpgradeCtaEnabled && (
+                            {isTeamsUpgradeCtaEnabled && (
                                 <CommandGroup>
                                     <CommandLink
                                         href="https://workspaces.sourcegraph.com"
                                         target="_blank"
                                         rel="noreferrer"
-                                        className="tw-flex tw-w-full tw-justify-start tw-gap-4 tw-align-center tw-flex-col tw-bg-inherit tw-font-left"
+                                        className="tw-flex tw-w-full tw-justify-start tw-gap-8 tw-align-center tw-flex-col tw-font-left !tw-bg-transparent hover:!tw-bg-transparent [&[aria-selected]]:!tw-bg-transparent tw-pt-[15px]"
                                     >
                                         <div className="tw-flex tw-w-full tw-justify-start tw-gap-4 tw-align-center">
                                             {/* TODO: Replace with new logo */}
@@ -333,17 +333,19 @@ export const UserMenu: React.FunctionComponent<UserMenuProps> = ({
                                                 Enterprise Starter
                                             </Badge>
                                         </div>
-                                        <div className="tw-w-full tw-text-[14px] tw-font-semibold tw-text-left tw-mt-2">
-                                            Unlock the Sourcegraph platform
-                                        </div>
-                                        <div className="tw-text-[12px] tw-text-muted-foreground">
-                                            Create a workspace and connect GitHub repositories to unlock
-                                            Code Search, AI chat, autocompletes, inline edits and more
-                                            for your team.
+                                        <div>
+                                            <div className="tw-w-full tw-text-[14px] tw-font-semibold tw-text-left tw-mb-5">
+                                                Unlock the Sourcegraph platform
+                                            </div>
+                                            <div className="tw-text-[12px] tw-text-muted-foreground">
+                                                Create a workspace and connect GitHub repositories to
+                                                unlock Code Search, AI chat, autocompletes, inline edits
+                                                and more for your team.
+                                            </div>
                                         </div>
                                         <Button
                                             key="workspace-create-button"
-                                            variant="outline"
+                                            variant="secondary"
                                             className="tw-flex-grow tw-rounded-md tw-text-center tw-w-full tw-text-foreground tw-my-2 tw-text-[12px]"
                                         >
                                             Create a workspace

--- a/vscode/webviews/tabs/TabsBar.tsx
+++ b/vscode/webviews/tabs/TabsBar.tsx
@@ -34,6 +34,8 @@ interface TabsBarProps {
     currentView: View
     setView: (view: View) => void
     endpointHistory: string[]
+    // Whether to show the Sourcegraph Teams upgrade CTA or not.
+    isTeamsUpgradeCtaEnabled?: boolean
 }
 
 type IconComponent = React.ForwardRefExoticComponent<
@@ -157,6 +159,7 @@ export const TabsBar = memo<TabsBarProps>(props => {
                                 endpointHistory={endpointHistory}
                                 allowEndpointChange={allowEndpointChange}
                                 className="!tw-opacity-100 tw-h-full"
+                                isTeamsUpgradeCtaEnabled={props.isTeamsUpgradeCtaEnabled}
                             />
                         )}
                     </div>


### PR DESCRIPTION
CLOSE  https://linear.app/sourcegraph/issue/CODY-4658/switch-account-add-create-workspace-cta-if-they-are-on-plg

![image](https://github.com/user-attachments/assets/a5f1ea71-831a-4a2e-a1b0-39fa0435f520)


- Adds a Sourcegraph Teams upgrade CTA to the user menu and tabs bar
- The CTA is conditionally rendered based on the `isTeamsUpgradeCtaEnabled` prop
- The CTA provides a link to create a Sourcegraph workspace

## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

1. Verify the CTA is displayed when `isTeamsUpgradeCtaEnabled` is true
2. Verify the CTA is not displayed when `isTeamsUpgradeCtaEnabled` is false
3. Verify clicking the "Create a workspace" button navigates to the correct URL
