### PR TITLE
feat(auto-edit): improve error logging

### DIFF
--- a/vscode/src/autoedits/autoedits-provider.test.ts
+++ b/vscode/src/autoedits/autoedits-provider.test.ts
@@ -1,3 +1,4 @@
+import * as sentryCore from '@sentry/core'
 import * as uuid from 'uuid'
 import {
     type MockInstance,
@@ -305,6 +306,44 @@ describe('AutoeditsProvider', () => {
 
         const suggestedEventPayload = recordSpy.mock.calls[0].at(2)
         expect(suggestedEventPayload.metadata.isRead).toBe(1)
+    })
+
+    it('errors are reported via telemetry recorded and Sentry', async () => {
+        const captureExceptionSpy = vi.spyOn(sentryCore, 'captureException')
+        const testError = new Error('test-error')
+
+        const { result } = await autoeditResultFor('const x = █', {
+            prediction: 'const x = 1\n',
+            getModelResponse() {
+                throw testError
+            },
+        })
+
+        expect(result).toBe(null)
+
+        // Error is captured by the telemetry recorded
+        expect(recordSpy).toHaveBeenCalledTimes(1)
+        expect(recordSpy).toHaveBeenNthCalledWith(1, 'cody.autoedit', 'error', expect.any(Object))
+
+        const errorPayload = recordSpy.mock.calls[0].at(2)
+        expect(errorPayload).toMatchInlineSnapshot(`
+          {
+            "metadata": {
+              "count": 1,
+            },
+            "privateMetadata": {
+              "message": "test-error",
+              "traceId": undefined,
+            },
+            "version": 0,
+          }
+        `)
+
+        // Error is captured by the Sentry service
+        expect(captureExceptionSpy).toHaveBeenCalledTimes(1)
+
+        const captureExceptionPayload = captureExceptionSpy.mock.calls[0].at(0)
+        expect(captureExceptionPayload).toEqual(testError)
     })
 
     it('rejects the current suggestion when the new one is shown', async () => {

--- a/vscode/src/services/sentry/sentry.ts
+++ b/vscode/src/services/sentry/sentry.ts
@@ -92,16 +92,10 @@ export function shouldErrorBeReported(error: unknown, insideAgent: boolean): boo
         return false
     }
 
-    // TODO(valery): verify if the stack-substring condition is still applicable
-    // Reason: we don't have _any_ errors in Sentry which is suspicious.
-    // Original PR: https://github.com/sourcegraph/cody/pull/3540
+    // TODO(valery): verify if the stack-substring condition is still applicable.
+    // Condition we used: `!error.stack?.includes('sourcegraph.cody-ai')`
+    // Reason: currently, we don't have _any_ errors in Sentry which is suspicious.
+    // Original PR that introduced the condition: https://github.com/sourcegraph/cody/pull/3540
     // Follow-up issue: https://linear.app/sourcegraph/issue/CODY-4673/telemetry-verify-error-filtering-conditions-after-the-change
-    //
-    // Attempt to silence errors from other extensions (if we're inside a VS Code extension, the
-    // stack trace should include the extension name).
-    // if (isError(error) && !insideAgent && !error.stack?.includes('sourcegraph.cody-ai')) {
-    //     return false
-    // }
-
     return true
 }

--- a/vscode/src/services/sentry/sentry.ts
+++ b/vscode/src/services/sentry/sentry.ts
@@ -92,11 +92,15 @@ export function shouldErrorBeReported(error: unknown, insideAgent: boolean): boo
         return false
     }
 
+    // TODO(valery): verify if the stack-substring condition is still applicable
+    // Reason: we don't have _any_ errors in Sentry which is suspicious.
+    // Original PR: https://github.com/sourcegraph/cody/pull/3540
+    //
     // Attempt to silence errors from other extensions (if we're inside a VS Code extension, the
     // stack trace should include the extension name).
-    if (isError(error) && !insideAgent && !error.stack?.includes('sourcegraph.cody-ai')) {
-        return false
-    }
+    // if (isError(error) && !insideAgent && !error.stack?.includes('sourcegraph.cody-ai')) {
+    //     return false
+    // }
 
     return true
 }

--- a/vscode/src/services/sentry/sentry.ts
+++ b/vscode/src/services/sentry/sentry.ts
@@ -95,6 +95,7 @@ export function shouldErrorBeReported(error: unknown, insideAgent: boolean): boo
     // TODO(valery): verify if the stack-substring condition is still applicable
     // Reason: we don't have _any_ errors in Sentry which is suspicious.
     // Original PR: https://github.com/sourcegraph/cody/pull/3540
+    // Follow-up issue: https://linear.app/sourcegraph/issue/CODY-4673/telemetry-verify-error-filtering-conditions-after-the-change
     //
     // Attempt to silence errors from other extensions (if we're inside a VS Code extension, the
     // stack trace should include the extension name).


### PR DESCRIPTION
- Most changes are whitespace-related; hide them for easier review.
- Wraps the logic inside the autoedit provider's `provideInlineCompletionItems` method in a try-catch block and logs errors to our telemetry backend and Sentry.
- Eases the conditions for filtering out errors on the client by checking for the `sourcegraph.cody-ai` substring in the error stack. We haven't seen any errors in Sentry for the last 90 days, which is suspicious. Let's verify if this condition is still valid and ensure we aren't missing any false positives due to this logic.
- Closes [CODY-4649: Telemetry: integrate with Sentry for error reporting](https://linear.app/sourcegraph/issue/CODY-4649/telemetry-integrate-with-sentry-for-error-reporting)

## Test plan

CI and updated integration tests for the autoedit provider.
