### PR TITLE
chore(audoedit): simplify output channel logger

### DIFF
--- a/vscode/src/autoedits/output-channel-logger.ts
+++ b/vscode/src/autoedits/output-channel-logger.ts
@@ -1,21 +1,15 @@
 import * as vscode from 'vscode'
+
 import { getConfiguration } from '../configuration'
 import { Logger } from '../output-channel-logger'
 
 export class AutoEditsOutputChannelLogger extends Logger {
-    private readonly logger: Logger
-
-    constructor(feature: string) {
-        super(feature)
-        this.logger = new Logger(feature)
-    }
-
     logDebugIfVerbose(filterLabel: string, text: string, ...args: unknown[]): void {
         const workspaceConfig = vscode.workspace.getConfiguration()
         const { debugVerbose } = getConfiguration(workspaceConfig)
 
         if (debugVerbose) {
-            this.logger.logDebug(filterLabel, text, ...args)
+            this.logDebug(filterLabel, text, ...args)
         }
     }
 }


### PR DESCRIPTION
- No functional changes
- Removes the redundant `logger` instance from the `AutoEditsOutputChannelLogger` class.

## Test plan

CI
