### PR TITLE
feat(agentic-context): add feature flag for session usage limit 

### DIFF
--- a/lib/shared/src/experimentation/FeatureFlagProvider.ts
+++ b/lib/shared/src/experimentation/FeatureFlagProvider.ts
@@ -113,6 +113,7 @@ export enum FeatureFlag {
     /** Enable Rate Limit for Deep Cody */
     DeepCodyRateLimitBase = 'deep-cody-experimental-rate-limit',
     DeepCodyRateLimitMultiplier = 'deep-cody-experimental-rate-limit-multiplier',
+    DeepCodyRateSessionLimit = 'deep-cody-experimental-session-limit',
 
     /**
      * Whether the current repo context chip is shown in the chat input by default

--- a/lib/shared/src/experimentation/FeatureFlagProvider.ts
+++ b/lib/shared/src/experimentation/FeatureFlagProvider.ts
@@ -113,7 +113,7 @@ export enum FeatureFlag {
     /** Enable Rate Limit for Deep Cody */
     DeepCodyRateLimitBase = 'deep-cody-experimental-rate-limit',
     DeepCodyRateLimitMultiplier = 'deep-cody-experimental-rate-limit-multiplier',
-    DeepCodyRateSessionLimit = 'deep-cody-experimental-session-limit',
+    AgenticContextSessionLimit = 'agentic-context-experimental-session-limit',
 
     /**
      * Whether the current repo context chip is shown in the chat input by default

--- a/lib/shared/src/sourcegraph-api/errors.ts
+++ b/lib/shared/src/sourcegraph-api/errors.ts
@@ -35,7 +35,7 @@ export class RateLimitError extends Error {
         super(message)
         this.userMessage =
             feature === 'Agentic Chat'
-                ? `You've reached the daily limit for Agentic Chat.`
+                ? `You've reached the daily limit for agentic context (experimental).`
                 : `You've used all of your ${feature} for ${upgradeIsAvailable ? 'the month' : 'today'}.`
         this.retryAfterDate = retryAfter
             ? /^\d+$/.test(retryAfter)

--- a/vscode/src/chat/chat-view/handlers/DeepCodyHandler.ts
+++ b/vscode/src/chat/chat-view/handlers/DeepCodyHandler.ts
@@ -20,8 +20,8 @@ export class DeepCodyHandler extends ChatHandler implements AgentHandler {
     private featureDeepCodyRateLimitMultiplier = storeLastValue(
         featureFlagProvider.evaluatedFeatureFlag(FeatureFlag.DeepCodyRateLimitMultiplier)
     )
-    private featureDeepCodySessionLimit = storeLastValue(
-        featureFlagProvider.evaluatedFeatureFlag(FeatureFlag.DeepCodyRateSessionLimit)
+    private featureSessionLimit = storeLastValue(
+        featureFlagProvider.evaluatedFeatureFlag(FeatureFlag.AgenticContextSessionLimit)
     )
 
     override async computeContext(
@@ -56,7 +56,7 @@ export class DeepCodyHandler extends ChatHandler implements AgentHandler {
         const wordsCount = text.split(' ').length
         // Only runs deep-cody for the first 5 human messages if the session limit flag is enabled.
         // NOTE: Times 2 as the human and agent messages are counted as pair.
-        const isSessionLimitFlagEnabled = this.featureDeepCodySessionLimit.value.last
+        const isSessionLimitFlagEnabled = this.featureSessionLimit.value.last
         const isAtSessionLimit = (chatBuilder.getLastSpeakerMessageIndex('human') ?? 0) > 5 * 2
         if (wordsCount < 3 || (isSessionLimitFlagEnabled && isAtSessionLimit)) {
             return baseContextResult


### PR DESCRIPTION
This adds a new feature flag, `AgenticContextSessionLimit,` to limit the usage of agentic context to the first 5 human messages in a chat session, which can be used as a fallback if needed.

This change ensures that we have a fallback plan when the agentic context is causing issues and being used excessively, especially in long-running chat sessions, to optimize performance when needed.

Record events:
- `cody.agentic-chat.sessionLimit:skipped` when query is less than 3 words
- `cody.agentic-chat.sessionLimit:hit` when `AgenticContextSessionLimit` is enabled and the chat messages in current session is over 5 human messages

## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

Manual testing to ensure agentic context is only used for the first 5 human messages when the session limit flag is enabled.

When hit:

![image](https://github.com/user-attachments/assets/431ee086-9cca-410f-a830-5a350f70a3e2)
