### PR TITLE
fix(agentic-context): update search tool prompt and examples

### DIFF
--- a/vscode/src/chat/agentic/CodyTool.ts
+++ b/vscode/src/chat/agentic/CodyTool.ts
@@ -212,7 +212,7 @@ class SearchTool extends CodyTool {
                 instruction: ps`Perform a symbol query search in the codebase (Natural language search NOT supported)`,
                 placeholder: ps`SEARCH_QUERY`,
                 examples: [
-                    ps`Locate a symbol found in an error log: \`<TOOLSEARCH><query>$symbol_name</query></TOOLSEARCH>\``,
+                    ps`Locate a symbol found in an error log: \`<TOOLSEARCH><query>symbol name</query></TOOLSEARCH>\``,
                     ps`Search for a function named getController: \`<TOOLSEARCH><query>getController</query></TOOLSEARCH>\``,
                 ],
             },

--- a/vscode/src/chat/agentic/CodyTool.ts
+++ b/vscode/src/chat/agentic/CodyTool.ts
@@ -209,11 +209,11 @@ class SearchTool extends CodyTool {
                 subTag: ps`query`,
             },
             prompt: {
-                instruction: ps`Perform a symbol query search in the codebase-Do not support natural language search`,
+                instruction: ps`Perform a symbol query search in the codebase (Natural language search NOT supported)`,
                 placeholder: ps`SEARCH_QUERY`,
                 examples: [
-                    ps`Locate a function found in an error log: \`<TOOLSEARCH><query>function name</query></TOOLSEARCH>\``,
-                    ps`Search for a function in a file: \`<TOOLSEARCH><query>getController file:controller.py</query></TOOLSEARCH>\``,
+                    ps`Locate a symbol found in an error log: \`<TOOLSEARCH><query>$symbol_name</query></TOOLSEARCH>\``,
+                    ps`Search for a function named getController: \`<TOOLSEARCH><query>getController</query></TOOLSEARCH>\``,
                 ],
             },
         })


### PR DESCRIPTION
As discussed with @camdencheek , our search endpoint for context retrieval doesn't support Sourcegraph-style search query. This PR modifies the search examples for the "Search tool" to remove the use of Sourcegraph-style search query.

## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

Ask Cody `Write a unit test for the openExternalAuthUrl function` with agentic context enabled:

Before:  It'd run a code search with `openExternalAuthUrl file:*` as the search query

![image](https://github.com/user-attachments/assets/7cadb601-ec1c-46de-a89a-ae840e283e0b)

After: It'd run a code search with `openExternalAuthUrl` as the search query

![image](https://github.com/user-attachments/assets/54ee5002-371a-413d-9f1e-563467b722fe)
