### PR TITLE
fix/context: Nit, remove duplicate "this" from Agentic context popover

### DIFF
--- a/vscode/webviews/chat/cells/messageCell/human/editor/ToolboxButton.tsx
+++ b/vscode/webviews/chat/cells/messageCell/human/editor/ToolboxButton.tsx
@@ -157,7 +157,7 @@ export const ToolboxButton: FC<ToolboxButtonProps> = memo(({ settings, api, isFi
                                     </div>
                                     <div className="tw-text-sm tw-mt-2">
                                         Allows agents to execute terminal commands. When enabled, this
-                                        this tool can execute <code>ls</code>, <code>dir</code>,{' '}
+                                        tool can execute <code>ls</code>, <code>dir</code>,{' '}
                                         <code>git</code>, etc. Configure additional commands in settings.
                                         <span className="tw-ml-1 tw-text-red-800 dark:tw-text-red-300">
                                             Enable with caution as mistakes are possible.


### PR DESCRIPTION
## Test plan

Run Cody signed in to s2 and open the Agentic context popover and check "this this tool" appears as simply "this tool":

![Screenshot 2025-01-14 at 11 30 16](https://github.com/user-attachments/assets/3aca9fdb-1fbb-4ff9-ad0f-640c643afdd0)
