### PR TITLE
feat(auto-edit): fix problem with vim extension supressing the tab

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -685,6 +685,11 @@
         "key": "ctrl+enter"
       },
       {
+        "command": "-extension.vim_tab",
+        "key": "tab",
+        "when": "editorTextFocus && vim.active && vim.mode != 'Insert' && !inDebugRepl"
+      },
+      {
         "command": "cody.autocomplete.manual-trigger",
         "key": "alt+\\",
         "when": "editorTextFocus && !editorHasSelection && config.cody.suggestions.mode === 'autocomplete' && !inlineSuggestionsVisible"


### PR DESCRIPTION
## Context
Sometimes, auto-edits fail to accept completions when a user has Vim installed and is currently in Vim’s normal mode. This happens because of a [keybinding conflict](https://github.com/VSCodeVim/Vim/blob/master/package.json#L115) between Vim and Cody, resulting in only one command being dispatched dynamically when conflicts occur.

After checking with @olafurpg seems like `Tab` key doesn't do much in the normal mode, and should be fine to disable it by default.

PR with similar change before: https://github.com/sourcegraph/cody/pull/551

## Test plan
Run Auto-Edit with the vim extension, make some document changes and auto-edit should propose related changes. Pressing Tab should accept the suggestion with this.



