### PR TITLE
feat(agentic-context): disable setting by default

### DIFF
--- a/vscode/src/chat/agentic/ToolboxManager.ts
+++ b/vscode/src/chat/agentic/ToolboxManager.ts
@@ -34,7 +34,7 @@ type StoredToolboxSettings = {
  * NOTE: This is a Singleton class.
  */
 class ToolboxManager {
-    private static readonly STORAGE_KEY = 'CODYAGENT_TOOLBOX_SETTINGS'
+    private static readonly STORAGE_KEY = 'EXPERIMENTAL_CODYAGENT_TOOLBOX_SETTINGS'
     private static instance?: ToolboxManager
 
     private constructor() {
@@ -54,7 +54,7 @@ class ToolboxManager {
     private getStoredUserSettings(): StoredToolboxSettings {
         return (
             localStorage.get<StoredToolboxSettings>(ToolboxManager.STORAGE_KEY) ?? {
-                agent: this.isEnabled ? 'deep-cody' : undefined,
+                agent: undefined,
                 shell: false,
             }
         )


### PR DESCRIPTION
- Disable agentic context by default as this is an experimental feature that needs to be opt-in
- Use a new storage key for toolbox settings with experimental prefix

## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

<img width="484" alt="image" src="https://github.com/user-attachments/assets/2d3fb1ab-0258-4b4c-8e5c-542172b9a9a3" />

1. Build from this branch and confirm the agentic context is disabled by default
2. You can enable it and disable it using the google

<img width="492" alt="image" src="https://github.com/user-attachments/assets/63157764-ac39-4c9c-8c7f-31874d2febf6" />
