### PR TITLE
refactor(agentic-context): rename experimental feature flags

### DIFF
--- a/lib/shared/src/experimentation/FeatureFlagProvider.ts
+++ b/lib/shared/src/experimentation/FeatureFlagProvider.ts
@@ -99,21 +99,22 @@ export enum FeatureFlag {
      */
     CodyPromptsV2 = 'prompt-creation-v2',
 
-    /** Whether user has access to the experimental Deep Cody feature.
-     * This replaces the old 'cody-deep-reflection' that was used for internal testing.
+    /** Whether user has access to the experimental agentic chat (fka Deep Cody) feature.
+     * This replaces the old 'cody-deep-reflection' & 'deep-cody' that was used for internal testing.
      */
-    DeepCody = 'deep-cody',
+    DeepCody = 'agentic-chat-experimental',
 
-    /** Enable Shell Context for Deep Cody */
-    DeepCodyShellContext = 'deep-cody-shell-context',
+    /** Enable terminal access for agentic context */
+    DeepCodyShellContext = 'agentic-chat-cli-tool-experimental',
 
     /** Whether Context Agent (Deep Cody) should use the default chat model or 3.5 Haiku */
-    ContextAgentDefaultChatModel = 'context-agent-use-default-chat-model',
+    ContextAgentDefaultChatModel = 'agentic-chat-use-default-chat-model',
 
     /** Enable Rate Limit for Deep Cody */
     DeepCodyRateLimitBase = 'deep-cody-experimental-rate-limit',
     DeepCodyRateLimitMultiplier = 'deep-cody-experimental-rate-limit-multiplier',
-    AgenticContextSessionLimit = 'agentic-context-experimental-session-limit',
+    /** Enable Rate Limit per chat session for agentic chat */
+    AgenticContextSessionLimit = 'agentic-chat-experimental-session-limit',
 
     /**
      * Whether the current repo context chip is shown in the chat input by default


### PR DESCRIPTION
https://linear.app/sourcegraph/issue/CODY-4685

Updating the values of the agentic chat feature flags to match launch names.

- Update the 'deep-cody' and 'deep-cody-shell-context' feature flags to 'agentic-chat-experimental' and 'agentic-chat-cli-tool-experimental' respectively
- Rename 'context-agent-use-default-chat-model' to 'agentic-chat-use-default-chat-model'
- Rename 'agentic-context-experimental-session-limit' to 'agentic-chat-experimental-session-limit'
- Add comments to clarify the purpose of the new feature flags


## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

These feature flags are designed for enterprise as these features are accessible without feature flag for dotcom users with pro subscriptions. 