### PR TITLE
Fix: Can actually run the changelog github action

### DIFF
--- a/.github/workflows/generate-changelog.yml
+++ b/.github/workflows/generate-changelog.yml
@@ -3,11 +3,6 @@ name: vscode-generate-changelog
 on:
   workflow_dispatch:
     inputs:
-      branch:
-        description: 'Branch to generate the changelog for'
-        required: true
-        default: 'main'
-        type: string
       version:
         description: 'The version to be released, for example: 1.60.0'
         required: true
@@ -20,23 +15,30 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.inputs.branch }}
-      - name: Update version
-        with:
-          EXT_VERSION: ${{ github.event.inputs.version }}
+      - name: Configure git
         run: |
-          sed -i 's/"version": "[0-9]\+\.[0-9]\+\.[0-9]\+"/"version": "'$EXT_VERSION'"/' package.json
-          # This will get tagged along with the changelog PR
-          git add package.json
-          git commit -m "Update version to $EXT_VERSION"
-      - name: Generate changelog
-        with:
-          EXT_VERSION: ${{ github.event.inputs.version }}
+          git config --global user.name 'sourcegraph-bot'
+          git config --global user.email 'bot@sourcegraph.com'
+      - name: Update version
         env:
-          DEVX_SERVICE_GH_TOKEN: ${{ secrets.DEVX_SERVICE_GH_TOKEN }}
+          VERSION: ${{ github.event.inputs.version }}
+        run: |
+          set +x
+          # git checkout -b version-update/$VERSION
+          sed -i 's/"version": "[0-9]\+\.[0-9]\+\.[0-9]\+"/"version": "'$VERSION'"/' vscode/package.json
+          # This will get tagged along with the changelog PR
+          git add vscode/package.json
+          git status
+          git commit -m "Update version to $VERSION"
+      - name: Generate changelog
+        env:
+          GH_TOKEN: ${{ secrets.DEVX_SERVICE_GH_TOKEN }}
           GH_REPO: "sourcegraph/cody"
           CHANGELOG_SKIP_NO_CHANGELOG: "true"
           CHANGELOG_COMPACT: "true"
+          VERSION: ${{ github.event.inputs.branchenv.VERSION }}
         run: |
+          set +x
           # Get previous tag's commit
           git fetch --tags origin
           PREV_TAG=$(git tag --sort=-v:refname | grep '^vscode-v' |  head -n 2 | tail -n 1)
@@ -59,15 +61,15 @@ jobs:
             --output.pr.body="Automated release and changelog for VS code Cody %s" \
             --output.changelog="vscode/CHANGELOG.md" \
             --output.changelog.marker='{/* CHANGELOG_START */}' \
-            --releaseregistry.version=$EXT_VERSION
+            --releaseregistry.version=$VERSION
 
           #cat vscode/CHANGELOG.md
 
-          # git checkout -b release/vscode-v$EXT_VERSION
+          # git checkout -b release/vscode-v$VERSION
           # git add vscode/CHANGELOG.md
           # git commit -m "Automated release and changelog for VS code Cody"
-          # git push -u origin release/vscode-v$EXT_VERSION
+          # git push -u origin release/vscode-v$VERSION
           # gh pr create \
-          #   --title "VS Code: Release v$EXT_VERSION" \
+          #   --title "VS Code: Release v$VERSION" \
           #   --body "Automated release and changelog for VS code Cody" \
-          #   --base main --head release/vscode-v$EXT_VERSION
+          #   --base main --head release/vscode-v$VERSION


### PR DESCRIPTION
Getting closer to a working Changelog Generator.

I've been running the action from this branch, and now it's complaining about common ancestors, which I think requires merging this branch into Main so that it can find common ancestors.

[Here's](https://github.com/sourcegraph/cody/actions/runs/12779368083/job/35623856267#step:5:1011) the latest run

## Test plan
Run the action.
<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
