### PR TITLE
feat(audo-edit): target vim normal mode only

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -687,7 +687,7 @@
       {
         "command": "-extension.vim_tab",
         "key": "tab",
-        "when": "editorTextFocus && vim.active && vim.mode != 'Insert' && !inDebugRepl"
+        "when": "editorTextFocus && vim.active && vim.mode == 'Normal' && !inDebugRepl"
       },
       {
         "command": "cody.autocomplete.manual-trigger",


### PR DESCRIPTION
The VS Code Vim plugin supports [several modes](https://github.com/VSCodeVim/Vim/?tab=readme-ov-file#vim-modes), and we probably want to disable the tab key only in normal mode, where code exploration happens. For example, if the user is in visual mode and wants to use `Tab`, we likely don’t want to interfere with auto-edit acceptance.

Let me know if you have any use cases where this isn’t the desired UX!

## Test plan

CI + tested the behavior manually.
