### PR TITLE
Fix missing current repo context in jetbrains

### DIFF
--- a/vscode/src/chat/initialContext.ts
+++ b/vscode/src/chat/initialContext.ts
@@ -228,7 +228,9 @@ export function getCorpusContextItemsForEditorState(): Observable<
                         icon: 'folder',
                     })
                 }
-            } else {
+            }
+
+            if (items.length === 0) {
                 // TODO(sqs): Support multi-root. Right now, this only supports the 1st workspace root.
                 const workspaceFolder = vscode.workspace.workspaceFolders?.at(0)
                 if (workspaceFolder) {

--- a/vscode/src/repository/remoteRepos.ts
+++ b/vscode/src/repository/remoteRepos.ts
@@ -50,13 +50,6 @@ export const remoteReposForAllWorkspaceFolders: Observable<
                 return Observable.of([])
             }
 
-            // NOTE(sqs): This check is to preserve prior behavior where agent/JetBrains did not use
-            // the old WorkspaceReposMonitor. We should make it so they can use it. See
-            // https://linear.app/sourcegraph/issue/CODY-3906/agent-allow-use-of-existing-fallback-that-looks-at-gitconfig-to-get.
-            if (!vscodeGitAPI) {
-                return Observable.of([])
-            }
-
             return combineLatest(
                 ...workspaceFolders.map(folder => repoNameResolver.getRepoNamesContainingUri(folder.uri))
             ).pipe(

--- a/vscode/test/e2e/chat-atFile.test.ts
+++ b/vscode/test/e2e/chat-atFile.test.ts
@@ -326,8 +326,8 @@ test.extend<ExpectedV2Events>({
     await chatInput.pressSequentially('fizzb', { delay: 10 })
     await expect(chatPanelFrame.getByRole('option', { name: 'fizzbuzz()' })).toBeVisible()
     await chatPanelFrame.getByRole('option', { name: 'fizzbuzz()' }).click()
-    await expect(chatInput).toHaveText('buzz.ts fizzbuzz() ')
-    await expect(chatInputMentions(chatInput)).toHaveText(['buzz.ts', 'fizzbuzz()'])
+    await expect(chatInput).toHaveText(/buzz.ts (workspace|sourcegraph.cody) fizzbuzz\(\) /)
+    await expect(chatInputMentions(chatInput)).toContainText(['buzz.ts', 'fizzbuzz()'])
 
     // Submit the message
     await chatInput.press('Enter')

--- a/vscode/test/e2e/chat-atFile.test.ts
+++ b/vscode/test/e2e/chat-atFile.test.ts
@@ -358,12 +358,26 @@ test.extend<ExpectedV2Events>({
     await selectLineRangeInEditorTab(page, 2, 5)
 
     const [, lastChatInput] = await createEmptyChatPanel(page)
-    await expect(chatInputMentions(lastChatInput)).toHaveText(['buzz.ts', 'buzz.ts:2-5'], {
-        timeout: 2_000,
-    })
+    await expect(chatInputMentions(lastChatInput)).toContainText(
+        [
+            'buzz.ts',
+            'buzz.ts:2-5',
+            // The repo context should appear in the chat, but depending
+            // on if you are running it locally or in CI, it may appear as
+            // sourcegraph/cody or workspace
+            /workspace|sourcegraph.cody/,
+        ],
+        {
+            timeout: 2_000,
+        }
+    )
 
     await lastChatInput.press('x')
     await selectLineRangeInEditorTab(page, 7, 10)
     await executeCommandInPalette(page, 'Cody: Add Selection to Cody Chat')
-    await expect(chatInputMentions(lastChatInput)).toHaveText(['buzz.ts', 'buzz.ts:2-5', 'buzz.ts:7-10'])
+    await expect(chatInputMentions(lastChatInput)).toContainText([
+        'buzz.ts',
+        'buzz.ts:2-5',
+        'buzz.ts:7-10',
+    ])
 })

--- a/vscode/test/e2e/chat-atFile.test.ts
+++ b/vscode/test/e2e/chat-atFile.test.ts
@@ -8,6 +8,7 @@ import {
     focusChatInputAtEnd,
     getContextCell,
     mentionMenu,
+    mentionMenuItems,
     openContextCell,
     openFileInEditorTab,
     openMentionsForProvider,
@@ -31,7 +32,7 @@ test.extend<ExpectedV2Events>({
         'cody.chat-question:executed',
         'cody.chatResponse:noCode',
     ],
-})('@-mention file in chat', async ({ page, sidebar }) => {
+})('@-mention file in chat', async ({ page, sidebar, workspaceDirectory }) => {
     // This test requires that the window be focused in the OS window manager because it deals with
     // focus.
     await page.bringToFront()
@@ -56,11 +57,10 @@ test.extend<ExpectedV2Events>({
 
     // We should only match the relative visible path, not parts of the full path outside of the workspace.
     // Eg. searching for "source" should not find all files if the project is inside `C:\Source`.
-    // TODO(dantup): After https://github.com/sourcegraph/cody/pull/2235 lands, add workspacedirectory to the test
-    //   and assert that it contains `fixtures` to ensure this check isn't passing because the fixture folder no
-    //   longer matches.
+    // Instead it should find Current Repository item.
+    await expect(workspaceDirectory).toContain('fixtures')
     await chatInput.fill('@fixtures') // fixture is in the test project folder name, but not in the relative paths.
-    await expect(atMentionMenuMessage(chatPanelFrame, 'No files found')).toBeVisible()
+    await expect(mentionMenuItems(chatPanelFrame)).toHaveText([/^Current Repository/])
 
     // Includes dotfiles after just "."
     await chatInput.fill('@.')
@@ -358,7 +358,7 @@ test.extend<ExpectedV2Events>({
     await selectLineRangeInEditorTab(page, 2, 5)
 
     const [, lastChatInput] = await createEmptyChatPanel(page)
-    await expect(chatInputMentions(lastChatInput)).toContainText(
+    await expect(chatInputMentions(lastChatInput)).toHaveText(
         [
             'buzz.ts',
             'buzz.ts:2-5',
@@ -368,16 +368,17 @@ test.extend<ExpectedV2Events>({
             /workspace|sourcegraph.cody/,
         ],
         {
-            timeout: 2_000,
+            timeout: 3_000,
         }
     )
 
     await lastChatInput.press('x')
     await selectLineRangeInEditorTab(page, 7, 10)
     await executeCommandInPalette(page, 'Cody: Add Selection to Cody Chat')
-    await expect(chatInputMentions(lastChatInput)).toContainText([
+    await expect(chatInputMentions(lastChatInput)).toHaveText([
         'buzz.ts',
         'buzz.ts:2-5',
+        /workspace|sourcegraph.cody/,
         'buzz.ts:7-10',
     ])
 })


### PR DESCRIPTION
Fixes https://linear.app/sourcegraph/issue/CODY-3906/agent-allow-use-of-existing-fallback-that-looks-at-gitconfig-to-get
Fixes https://linear.app/sourcegraph/issue/CODY-4140/jetbrains-cody-current-repo-no-longer-available-as-context

I think that was a simple mistake introduced by https://linear.app/sourcegraph/issue/CODY-3906/agent-allow-use-of-existing-fallback-that-looks-at-gitconfig-to-get

If I remove code you can see in the diff it simply works.
All git based methods themselves check if they can be executed so this safeguard was not adding any value there from what I can see.

## Test plan

1. Open jetbrains with cody repo and login to sg02 
2. `Current Repository` should be visible in the chat context by default
3. Remove `Current Repository`
4. Type `@` and then Start typing `Current Repository` - suggestion to add should appear and you should be able to accept it


<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
