### PR TITLE
fix(agentic-chat): fix prompt-mixin for deep-cody agent

### DIFF
--- a/lib/shared/src/prompt/__tests__/prompt-mixin.test.ts
+++ b/lib/shared/src/prompt/__tests__/prompt-mixin.test.ts
@@ -1,0 +1,77 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+import type { ChatMessage, ChatModel } from '../..'
+import { PromptMixin } from '../prompt-mixin'
+import { ps } from '../prompt-string'
+
+describe('PromptMixin', () => {
+    interface TestCase {
+        name: string
+        input: {
+            message: ChatMessage
+            modelID?: ChatModel
+            newMixins?: PromptMixin[]
+        }
+        expected: string
+        setup?: () => void
+    }
+
+    const testCases: TestCase[] = [
+        {
+            name: 'basic message without mixins',
+            input: {
+                message: { speaker: 'human', text: ps`Hello` },
+            },
+            expected: 'Hello',
+        },
+        {
+            name: 'message with hedging prevention for apologetic model',
+            input: {
+                message: { speaker: 'assistant', text: ps`Hello` },
+                modelID: '3.5-sonnet',
+            },
+            expected: 'Answer positively without apologizing.\n\nQuestion: Hello',
+        },
+        {
+            name: 'deep-cody agent message',
+            input: {
+                message: { speaker: 'human', text: ps`How to code?`, agent: 'deep-cody' },
+            },
+            expected: 'Explain your reasoning in detail for coding questions.\n\nQuestion: How to code?',
+        },
+        {
+            name: 'message with context mixin',
+            input: {
+                message: { speaker: 'assistant', text: ps`Hello` },
+            },
+            expected: 'You have access to the provided codebase context.\n\nQuestion: Hello',
+            setup: () => {
+                PromptMixin.add(PromptMixin.getContextMixin())
+            },
+        },
+        {
+            name: 'message with multiple mixins',
+            input: {
+                message: { speaker: 'human', text: ps`Hello` },
+                modelID: '3.5-sonnet',
+                newMixins: [new PromptMixin(ps`Custom instruction.`)],
+            },
+            expected:
+                'You have access to the provided codebase context. \n\nAnswer positively without apologizing. \n\nCustom instruction.\n\nQuestion: Hello',
+        },
+    ]
+
+    beforeEach(() => {
+        // Reset static state between tests
+        vi.clearAllMocks()
+    })
+
+    test.each(testCases)('$name', ({ input, expected, setup }) => {
+        if (setup) {
+            setup()
+        }
+
+        const result = PromptMixin.mixInto(input.message, input.modelID, input.newMixins)
+
+        expect(result.text?.toString()).toBe(expected)
+    })
+})

--- a/lib/shared/src/prompt/prompt-mixin.test.ts
+++ b/lib/shared/src/prompt/prompt-mixin.test.ts
@@ -1,7 +1,5 @@
 import { beforeEach, describe, expect, test, vi } from 'vitest'
-import type { ChatMessage, ChatModel } from '../..'
-import { PromptMixin } from '../prompt-mixin'
-import { ps } from '../prompt-string'
+import { type ChatMessage, type ChatModel, PromptMixin, ps } from '..'
 
 describe('PromptMixin', () => {
     interface TestCase {
@@ -37,6 +35,14 @@ describe('PromptMixin', () => {
                 message: { speaker: 'human', text: ps`How to code?`, agent: 'deep-cody' },
             },
             expected: 'Explain your reasoning in detail for coding questions.\n\nQuestion: How to code?',
+        },
+        {
+            name: 'deep-cody agent message with custom mixin',
+            input: {
+                message: { speaker: 'human', text: ps`How to code?`, agent: 'deep-cody' },
+                newMixins: [new PromptMixin(ps`Review <input>{{USER_INPUT_TEXT}}</input>`)],
+            },
+            expected: 'Review <input>How to code?</input>',
         },
         {
             name: 'message with context mixin',

--- a/lib/shared/src/prompt/prompt-mixin.ts
+++ b/lib/shared/src/prompt/prompt-mixin.ts
@@ -62,11 +62,11 @@ export class PromptMixin {
     }
 
     private static mixedMessage(humanMessage: ChatMessage, mixins: PromptMixin[]): ChatMessage {
-        const joinedMixins = PromptMixin.join(mixins)
-        if (!humanMessage.text) {
+        if (!humanMessage.text || !mixins.length) {
             return humanMessage
         }
 
+        const joinedMixins = PromptMixin.join(mixins)
         if (humanMessage.agent && humanMessage.text.includes('{{USER_INPUT_TEXT}}')) {
             return {
                 ...humanMessage,

--- a/lib/shared/src/prompt/prompt-mixin.ts
+++ b/lib/shared/src/prompt/prompt-mixin.ts
@@ -67,7 +67,9 @@ export class PromptMixin {
         }
 
         const joinedMixins = PromptMixin.join(mixins)
-        if (humanMessage.agent && humanMessage.text.includes('{{USER_INPUT_TEXT}}')) {
+
+        // If the agent's mixins include `{{USER_INPUT_TEXT}}`, replace it with the human message text.
+        if (humanMessage.agent && joinedMixins.includes('{{USER_INPUT_TEXT}}')) {
             return {
                 ...humanMessage,
                 text: joinedMixins.replace('{{USER_INPUT_TEXT}}', humanMessage.text),


### PR DESCRIPTION
- Rename the`PromptMixin.buildPrompt` method to `PromptMixin.join` method
- Refactor the `PromptMixin.mixedMessage` method to use `PromptMixin.join` method directly and simplify the logic


## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

Check output log. Added new unit tests.