### PR TITLE
Fix: Changelog generator action frfr no cap

### DIFF
--- a/.github/workflows/generate-changelog.yml
+++ b/.github/workflows/generate-changelog.yml
@@ -19,39 +19,36 @@ jobs:
         run: |
           git config --global user.name 'sourcegraph-bot'
           git config --global user.email 'bot@sourcegraph.com'
-      - name: Update version
+          git fetch --tags origin
+          git checkout main
+          git pull
+      - name: Download changelog
         env:
-          VERSION: ${{ github.event.inputs.version }}
+          GH_TOKEN: ${{ secrets.DEVX_SERVICE_GH_TOKEN }}
         run: |
-          set +x
-          # git checkout -b version-update/$VERSION
-          sed -i 's/"version": "[0-9]\+\.[0-9]\+\.[0-9]\+"/"version": "'$VERSION'"/' vscode/package.json
-          # This will get tagged along with the changelog PR
-          git add vscode/package.json
-          git status
-          git commit -m "Update version to $VERSION"
+          # Download and run changelog generator
+          tagName=$(gh release -R sourcegraph/devx-service list --exclude-drafts --exclude-pre-releases -L 1 --json tagName -q '.[] | .tagName')
+          gh release -R sourcegraph/devx-service download ${tagName} --pattern changelog
+          chmod +x changelog
       - name: Generate changelog
         env:
           GH_TOKEN: ${{ secrets.DEVX_SERVICE_GH_TOKEN }}
           GH_REPO: "sourcegraph/cody"
           CHANGELOG_SKIP_NO_CHANGELOG: "true"
           CHANGELOG_COMPACT: "true"
-          VERSION: ${{ github.event.inputs.branchenv.VERSION }}
+          VERSION: ${{ github.event.inputs.version }}
         run: |
           set +x
           # Get previous tag's commit
-          git fetch --tags origin
           PREV_TAG=$(git tag --sort=-v:refname | grep '^vscode-v' |  head -n 2 | tail -n 1)
           export RELEASE_LATEST_RELEASE=$(git rev-parse $PREV_TAG)
 
           # Get current release commit
           export RELEASE_LATEST_COMMIT=$(git rev-parse HEAD)
-
-          # Download and run changelog generator
-          tagName=$(gh release -R sourcegraph/devx-service list --exclude-drafts --exclude-pre-releases -L 1 --json tagName -q '.[] | .tagName')
-          gh release -R sourcegraph/devx-service download ${tagName} --pattern changelog
-          chmod +x changelog
-
+          echo "Latest Commit: $RELEASE_LATEST_COMMIT"
+          echo "Latest Release: $RELEASE_LATEST_RELEASE"
+          git rev-parse --abbrev-ref HEAD
+          git log -n 5
           ./changelog update-as-pr \
             --github.repo=$GH_REPO \
             --output.repo.base="main" \
@@ -73,3 +70,16 @@ jobs:
           #   --title "VS Code: Release v$VERSION" \
           #   --body "Automated release and changelog for VS code Cody" \
           #   --base main --head release/vscode-v$VERSION
+      - name: Update version
+        env:
+          VERSION: ${{ github.event.inputs.version }}
+        run: |
+          set +x
+          # git checkout -b version-update/$VERSION
+          sed -i 's/"version": "[0-9]\+\.[0-9]\+\.[0-9]\+"/"version": "'$VERSION'"/' vscode/package.json
+          # This will get tagged along with the changelog PR
+          git add vscode/package.json
+          git pull
+          git checkout release/vscode-$VERSION
+          git commit -m "Update version to $VERSION"
+          git push

--- a/.github/workflows/generate-changelog.yml
+++ b/.github/workflows/generate-changelog.yml
@@ -47,8 +47,6 @@ jobs:
           export RELEASE_LATEST_COMMIT=$(git rev-parse HEAD)
           echo "Latest Commit: $RELEASE_LATEST_COMMIT"
           echo "Latest Release: $RELEASE_LATEST_RELEASE"
-          git rev-parse --abbrev-ref HEAD
-          git log -n 5
           ./changelog update-as-pr \
             --github.repo=$GH_REPO \
             --output.repo.base="main" \


### PR DESCRIPTION
- **Moved the version update to happen _after_ changelog**
- **misc: remove extra debugging logs**

Finally!!! :party:

## Test plan
I've run the [action](https://github.com/sourcegraph/cody/actions/runs/12797290344/job/35678849540) and it's successfully generated the [changelog](https://github.com/sourcegraph/cody/pull/6658) and version update in a single PR
<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
