### PR TITLE
fix(webview): reorder human editor menu buttons

### DIFF
--- a/vscode/webviews/chat/cells/messageCell/human/HumanMessageCell.tsx
+++ b/vscode/webviews/chat/cells/messageCell/human/HumanMessageCell.tsx
@@ -113,10 +113,10 @@ const HumanMessageCellContent = memo<HumanMessageCellContent>(props => {
             speakerTitle={userInfo.user.displayName ?? userInfo.user.username}
             cellAction={
                 <div className="tw-flex tw-gap-2 tw-items-center tw-justify-end">
-                    {isFirstMessage && <OpenInNewEditorAction />}
                     {settings && (
                         <ToolboxButton settings={settings} api={api} isFirstMessage={isFirstMessage} />
                     )}
+                    {isFirstMessage && <OpenInNewEditorAction />}
                 </div>
             }
             content={


### PR DESCRIPTION
CLOSE https://linear.app/sourcegraph/issue/CODY-469

- Moved the `OpenInNewEditorAction` component to be displayed after the `ToolboxButton` component
- This ensures the open in new editor action is displayed after the toolbox button, maintaining the current layout and user experience


## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

Ensure the brain icon is showing up on the left side of the open in editor btn.

![image](https://github.com/user-attachments/assets/31fc5153-ffb4-47ad-83b9-902fdd36e09a)
