### PR TITLE
fix: changelog generator with titles instead of changelog entries

### DIFF
--- a/.github/workflows/generate-changelog.yml
+++ b/.github/workflows/generate-changelog.yml
@@ -60,14 +60,6 @@ jobs:
             --output.changelog.marker='<!--- {/_ CHANGELOG_START _/} --->' \
             --releaseregistry.version=$text
 
-          #cat vscode/CHANGELOG.md
-
-          # git checkout -b release/vscode-v$VERSION
-          # git add vscode/CHANGELOG.md
-          # priority realHow can I store floats in s;,
-          # git commit -m "Automated release and changelog for VS code Cody"
-          # git push -u origin release/vscode-v$VERSION
-          # gh pr create \
           #   --title "VS Code: Release v$VERSION" \
           #   --body "Automated release and changelog for VS code Cody" \
           #   --base main --head release/vscode-v$VERSION

--- a/.github/workflows/generate-changelog.yml
+++ b/.github/workflows/generate-changelog.yml
@@ -57,13 +57,14 @@ jobs:
             --output.pr.title="Changelog for %s" \
             --output.pr.body="Automated release and changelog for VS code Cody %s" \
             --output.changelog="vscode/CHANGELOG.md" \
-            --output.changelog.marker='{/_ CHANGELOG_START _/}' \
-            --releaseregistry.version=$VERSION
+            --output.changelog.marker='<!--- {/_ CHANGELOG_START _/} --->' \
+            --releaseregistry.version=$text
 
           #cat vscode/CHANGELOG.md
 
           # git checkout -b release/vscode-v$VERSION
           # git add vscode/CHANGELOG.md
+          # priority realHow can I store floats in s;,
           # git commit -m "Automated release and changelog for VS code Cody"
           # git push -u origin release/vscode-v$VERSION
           # gh pr create \

--- a/.github/workflows/generate-changelog.yml
+++ b/.github/workflows/generate-changelog.yml
@@ -39,6 +39,8 @@ jobs:
           VERSION: ${{ github.event.inputs.version }}
         run: |
           set +x
+          export CHANGELOG_SKIP_NO_CHANGELOG="false"
+          export CHANGELOG_COMPACT="false"
           # Get previous tag's commit
           PREV_TAG=$(git tag --sort=-v:refname | grep '^vscode-v' |  head -n 2 | tail -n 1)
           export RELEASE_LATEST_RELEASE=$(git rev-parse $PREV_TAG)
@@ -55,7 +57,7 @@ jobs:
             --output.pr.title="Changelog for %s" \
             --output.pr.body="Automated release and changelog for VS code Cody %s" \
             --output.changelog="vscode/CHANGELOG.md" \
-            --output.changelog.marker='{/* CHANGELOG_START */}' \
+            --output.changelog.marker='{/_ CHANGELOG_START _/}' \
             --releaseregistry.version=$VERSION
 
           #cat vscode/CHANGELOG.md

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 This is a log of all notable changes to Cody for VS Code.
 
-{/_ CHANGELOG_START _/}
+<!--- {/_ CHANGELOG_START _/} -->
 
 ## Unreleased
 


### PR DESCRIPTION
This works by using the title as the changelog entry instead.
We cannot use the compact mode version with this feature enabled, it
fails to find a `section` `formatEntry` command and exits before the
changelog is generated.

Also updated the changelog marker since it's different now?


## Test plan
I ran the [action](https://github.com/sourcegraph/cody/actions/runs/12799005063/job/35684227555) which produced this [PR](https://github.com/sourcegraph/cody/pull/6668)
<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
