### PR TITLE
refactor(agentic-context): update status messaging

### DIFF
--- a/lib/shared/src/prompt/prompt-mixin.test.ts
+++ b/lib/shared/src/prompt/prompt-mixin.test.ts
@@ -1,0 +1,83 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+import { type ChatMessage, type ChatModel, PromptMixin, ps } from '..'
+
+describe('PromptMixin', () => {
+    interface TestCase {
+        name: string
+        input: {
+            message: ChatMessage
+            modelID?: ChatModel
+            newMixins?: PromptMixin[]
+        }
+        expected: string
+        setup?: () => void
+    }
+
+    const testCases: TestCase[] = [
+        {
+            name: 'basic message without mixins',
+            input: {
+                message: { speaker: 'human', text: ps`Hello` },
+            },
+            expected: 'Hello',
+        },
+        {
+            name: 'message with hedging prevention for apologetic model',
+            input: {
+                message: { speaker: 'assistant', text: ps`Hello` },
+                modelID: '3.5-sonnet',
+            },
+            expected: 'Answer positively without apologizing.\n\nQuestion: Hello',
+        },
+        {
+            name: 'deep-cody agent message',
+            input: {
+                message: { speaker: 'human', text: ps`How to code?`, agent: 'deep-cody' },
+            },
+            expected: 'Explain your reasoning in detail for coding questions.\n\nQuestion: How to code?',
+        },
+        {
+            name: 'deep-cody agent message with custom mixin',
+            input: {
+                message: { speaker: 'human', text: ps`How to code?`, agent: 'deep-cody' },
+                newMixins: [new PromptMixin(ps`Review <input>{{USER_INPUT_TEXT}}</input>`)],
+            },
+            expected: 'Review <input>How to code?</input>',
+        },
+        {
+            name: 'message with context mixin',
+            input: {
+                message: { speaker: 'assistant', text: ps`Hello` },
+            },
+            expected: 'You have access to the provided codebase context.\n\nQuestion: Hello',
+            setup: () => {
+                PromptMixin.add(PromptMixin.getContextMixin())
+            },
+        },
+        {
+            name: 'message with multiple mixins',
+            input: {
+                message: { speaker: 'human', text: ps`Hello` },
+                modelID: '3.5-sonnet',
+                newMixins: [new PromptMixin(ps`Custom instruction.`)],
+            },
+            expected:
+                'You have access to the provided codebase context. \n\nAnswer positively without apologizing. \n\nCustom instruction.\n\nQuestion: Hello',
+        },
+    ]
+
+    beforeEach(() => {
+        // Reset static state between tests
+        vi.clearAllMocks()
+    })
+
+    test.each(testCases)('$name', ({ input, expected, setup }) => {
+        if (setup) {
+            setup()
+        }
+
+        const result = PromptMixin.mixInto(input.message, input.modelID, input.newMixins)
+
+        expect(result.text?.toString()).toBe(expected)
+    })
+})

--- a/lib/shared/src/prompt/prompt-mixin.ts
+++ b/lib/shared/src/prompt/prompt-mixin.ts
@@ -43,19 +43,17 @@ export class PromptMixin {
             mixins.push(PromptMixin.hedging)
         }
 
-        // Handle Agent specific prompts
+        // Handle agent-specific prompts
         if (humanMessage.agent === 'deep-cody' && !newMixins.length) {
-            mixins.push(new PromptMixin(HEDGES_PREVENTION.concat(DEEP_CODY)))
+            mixins.push(new PromptMixin(DEEP_CODY))
         }
 
         // Add new mixins to the list of mixins to be prepended to the next human message.
         mixins.push(...newMixins)
-
-        const prompt = PromptMixin.buildPrompt(mixins)
-        return PromptMixin.mixedMessage(humanMessage, prompt, mixins)
+        return PromptMixin.mixedMessage(humanMessage, mixins)
     }
 
-    private static buildPrompt(mixins: PromptMixin[]): PromptString {
+    private static join(mixins: PromptMixin[]): PromptString {
         // Construct the prompt by joining all the mixins.
         return PromptString.join(
             mixins.map(m => m.prompt),
@@ -63,19 +61,18 @@ export class PromptMixin {
         ).trim()
     }
 
-    private static mixedMessage(
-        humanMessage: ChatMessage,
-        prompt: PromptString,
-        mixins: PromptMixin[]
-    ): ChatMessage {
-        if (!mixins.length || !humanMessage.text) {
+    private static mixedMessage(humanMessage: ChatMessage, mixins: PromptMixin[]): ChatMessage {
+        if (!humanMessage.text || !mixins.length) {
             return humanMessage
         }
 
-        if (humanMessage.agent === 'deep-cody' && prompt.includes('{{USER_INPUT_TEXT}}')) {
+        const joinedMixins = PromptMixin.join(mixins)
+
+        // If the agent's mixins include `{{USER_INPUT_TEXT}}`, replace it with the human message text.
+        if (humanMessage.agent && joinedMixins.includes('{{USER_INPUT_TEXT}}')) {
             return {
                 ...humanMessage,
-                text: prompt.replace('{{USER_INPUT_TEXT}}', humanMessage.text),
+                text: joinedMixins.replace('{{USER_INPUT_TEXT}}', humanMessage.text),
             }
         }
 
@@ -83,7 +80,7 @@ export class PromptMixin {
         // Note we do not reflect them in ChatMessage `text`.
         return {
             ...humanMessage,
-            text: ps`${prompt}\n\nQuestion: ${humanMessage.text ?? ps``}`,
+            text: ps`${joinedMixins}\n\nQuestion: ${humanMessage.text ?? ps``}`,
         }
     }
 

--- a/vscode/src/chat/agentic/DeepCody.ts
+++ b/vscode/src/chat/agentic/DeepCody.ts
@@ -226,7 +226,7 @@ export class DeepCodyAgent {
                 return []
             }
 
-            const step = this.stepsManager.addStep({ title: 'Retrieving context' })
+            const step = this.stepsManager.addStep({ title: 'Retrieving additional context' })
 
             const results = await Promise.all(
                 this.tools.map(async tool => {

--- a/vscode/src/chat/agentic/DeepCody.ts
+++ b/vscode/src/chat/agentic/DeepCody.ts
@@ -226,7 +226,7 @@ export class DeepCodyAgent {
                 return []
             }
 
-            const step = this.stepsManager.addStep({ title: 'Retrieving additional context' })
+            const step = this.stepsManager.addStep({ title: 'Retrieving context' })
 
             const results = await Promise.all(
                 this.tools.map(async tool => {

--- a/vscode/src/chat/initialContext.ts
+++ b/vscode/src/chat/initialContext.ts
@@ -228,7 +228,9 @@ export function getCorpusContextItemsForEditorState(): Observable<
                         icon: 'folder',
                     })
                 }
-            } else {
+            }
+
+            if (items.length === 0) {
                 // TODO(sqs): Support multi-root. Right now, this only supports the 1st workspace root.
                 const workspaceFolder = vscode.workspace.workspaceFolders?.at(0)
                 if (workspaceFolder) {

--- a/vscode/src/configuration.ts
+++ b/vscode/src/configuration.ts
@@ -52,13 +52,31 @@ export function getConfiguration(
         CodyAutoSuggestionMode.Autocomplete
     )
 
-    // Backward compatibility with the older config for autocomplete. If autocomplete was turned off - override the suggestion mode to "off".
+    // Backward compatibility with the older config for autocomplete.
+    // If autocomplete was turned off - override the suggestion mode to "off".
     // TODO (Hitesh): Remove the manual override once the updated config is communicated after experimental release
+    // https://linear.app/sourcegraph/issue/CODY-4701/clean-up-backwards-compatbility-settings-after-the-release
     if (
         codyAutoSuggestionsMode === CodyAutoSuggestionMode.Autocomplete &&
         vscode.workspace.getConfiguration().get<boolean>('cody.autocomplete.enabled') === false
     ) {
         codyAutoSuggestionsMode = CodyAutoSuggestionMode.Off
+    }
+
+    // Backward compatibility with the older auto-edit config name.
+    // If auto-edit was turned on - override the suggestion mode to "auto-edit".
+    // TODO: clean up after the experimental release
+    // https://linear.app/sourcegraph/issue/CODY-4701/clean-up-backwards-compatbility-settings-after-the-release
+    if (codyAutoSuggestionsMode === 'auto-edits (Experimental)') {
+        codyAutoSuggestionsMode = CodyAutoSuggestionMode.Autoedit
+
+        void vscode.workspace
+            .getConfiguration()
+            .update(
+                CONFIG_KEY.suggestionsMode,
+                CodyAutoSuggestionMode.Autoedit,
+                vscode.ConfigurationTarget.Global
+            )
     }
 
     return {

--- a/vscode/src/repository/remoteRepos.ts
+++ b/vscode/src/repository/remoteRepos.ts
@@ -50,13 +50,6 @@ export const remoteReposForAllWorkspaceFolders: Observable<
                 return Observable.of([])
             }
 
-            // NOTE(sqs): This check is to preserve prior behavior where agent/JetBrains did not use
-            // the old WorkspaceReposMonitor. We should make it so they can use it. See
-            // https://linear.app/sourcegraph/issue/CODY-3906/agent-allow-use-of-existing-fallback-that-looks-at-gitconfig-to-get.
-            if (!vscodeGitAPI) {
-                return Observable.of([])
-            }
-
             return combineLatest(
                 ...workspaceFolders.map(folder => repoNameResolver.getRepoNamesContainingUri(folder.uri))
             ).pipe(

--- a/vscode/webviews/AuthPage.tsx
+++ b/vscode/webviews/AuthPage.tsx
@@ -1,4 +1,9 @@
-import type { AuthStatus, CodyIDE, TelemetryRecorder } from '@sourcegraph/cody-shared'
+import {
+    type AuthStatus,
+    type CodyIDE,
+    type TelemetryRecorder,
+    isDotCom,
+} from '@sourcegraph/cody-shared'
 
 import signInLogoSourcegraph from '../resources/sourcegraph-mark.svg'
 import { type AuthMethod, isSourcegraphToken } from '../src/chat/protocol'
@@ -286,7 +291,7 @@ const ClientSignInForm: React.FC<ClientSignInFormProps> = memo(
             isSubmitting: false,
             showAuthError: false,
             formData: {
-                endpoint: authStatus?.endpoint ?? '',
+                endpoint: authStatus && !isDotCom(authStatus) ? authStatus.endpoint : '',
                 accessToken: '',
             },
         })

--- a/vscode/webviews/CodyPanel.tsx
+++ b/vscode/webviews/CodyPanel.tsx
@@ -108,11 +108,7 @@ export const CodyPanel: FunctionComponent<CodyPanelProps> = ({
                 orientation="vertical"
                 className={styles.outerContainer}
             >
-                <Notices
-                    user={user}
-                    instanceNotices={instanceNotices}
-                    isTeamsUpgradeCtaEnabled={isTeamsUpgradeCtaEnabled}
-                />
+                <Notices user={user} instanceNotices={instanceNotices} />
                 {/* Hide tab bar in editor chat panels. */}
                 {(clientCapabilities.agentIDE === CodyIDE.Web || config.webviewType !== 'editor') && (
                     <TabsBar

--- a/vscode/webviews/chat/cells/agenticCell/ApprovalCell.tsx
+++ b/vscode/webviews/chat/cells/agenticCell/ApprovalCell.tsx
@@ -5,7 +5,7 @@ import { Button } from '../../../components/shadcn/ui/button'
 import type { VSCodeWrapper } from '../../../utils/VSCodeApi'
 
 const CONFIRMATION_TITLES: Record<string, string> = {
-    Terminal: 'Run command to retrieve context?',
+    Terminal: 'Allow commands to retrieve context?',
 }
 
 const ApprovalCell: FC<{ vscodeAPI: VSCodeWrapper }> = ({ vscodeAPI }) => {
@@ -68,7 +68,7 @@ const ApprovalCell: FC<{ vscodeAPI: VSCodeWrapper }> = ({ vscodeAPI }) => {
                                 className="tw-w-1/4"
                                 onClick={() => handleClick(a.id, true)}
                             >
-                                Run
+                                Allow
                             </Button>
                         </div>
                     </div>

--- a/vscode/webviews/chat/cells/agenticCell/ApprovalCell.tsx
+++ b/vscode/webviews/chat/cells/agenticCell/ApprovalCell.tsx
@@ -68,7 +68,7 @@ const ApprovalCell: FC<{ vscodeAPI: VSCodeWrapper }> = ({ vscodeAPI }) => {
                                 className="tw-w-1/4"
                                 onClick={() => handleClick(a.id, true)}
                             >
-                                Allow
+                                Run
                             </Button>
                         </div>
                     </div>

--- a/vscode/webviews/chat/cells/agenticCell/ApprovalCell.tsx
+++ b/vscode/webviews/chat/cells/agenticCell/ApprovalCell.tsx
@@ -5,7 +5,7 @@ import { Button } from '../../../components/shadcn/ui/button'
 import type { VSCodeWrapper } from '../../../utils/VSCodeApi'
 
 const CONFIRMATION_TITLES: Record<string, string> = {
-    Terminal: 'Allow commands to retrieve context?',
+    Terminal: 'Run command to retrieve context?',
 }
 
 const ApprovalCell: FC<{ vscodeAPI: VSCodeWrapper }> = ({ vscodeAPI }) => {

--- a/vscode/webviews/components/Notices.story.tsx
+++ b/vscode/webviews/components/Notices.story.tsx
@@ -37,13 +37,6 @@ const baseUser = {
     IDE: CodyIDE.VSCode,
 }
 
-export const TeamsUpgradeCTA: Story = {
-    args: {
-        user: baseUser,
-        isTeamsUpgradeCtaEnabled: true,
-    },
-}
-
 export const SgTeammateNotice: Story = {
     args: {
         user: {
@@ -58,7 +51,6 @@ export const SgTeammateNotice: Story = {
                 ],
             },
         },
-        isTeamsUpgradeCtaEnabled: false,
     },
 }
 
@@ -68,7 +60,6 @@ export const NoNotices: Story = {
             ...baseUser,
             isDotComUser: false,
         },
-        isTeamsUpgradeCtaEnabled: false,
     },
 }
 
@@ -78,6 +69,5 @@ export const WebUserNoNotices: Story = {
             ...baseUser,
             IDE: CodyIDE.Web,
         },
-        isTeamsUpgradeCtaEnabled: true,
     },
 }

--- a/vscode/webviews/components/Notices.tsx
+++ b/vscode/webviews/components/Notices.tsx
@@ -1,19 +1,15 @@
 import { CodyIDE, type CodyNotice } from '@sourcegraph/cody-shared'
-import { DOTCOM_WORKSPACE_UPGRADE_URL } from '@sourcegraph/cody-shared/src/sourcegraph-api/environments'
 import { S2_URL } from '@sourcegraph/cody-shared/src/sourcegraph-api/environments'
 import {
     ArrowLeftRightIcon,
     ArrowRightIcon,
     BuildingIcon,
-    ExternalLinkIcon,
     EyeIcon,
     HeartIcon,
-    Users2Icon,
     XIcon,
 } from 'lucide-react'
 import { type FunctionComponent, type ReactNode, useCallback, useMemo, useState } from 'react'
 import SourcegraphIcon from '../../resources/sourcegraph-mark.svg'
-import { DOTCOM_WORKSPACE_LEARN_MORE_URL } from '../../src/chat/protocol'
 import type { UserAccountInfo } from '../Chat'
 import { CodyLogo } from '../icons/CodyLogo'
 import { getVSCodeAPI } from '../utils/VSCodeApi'
@@ -33,14 +29,12 @@ type NoticeIDs = 'DogfoodS2' | 'TeamsUpgrade' | 'DeepCodyDotCom' | 'DeepCodyEnte
 
 interface NoticesProps {
     user: UserAccountInfo
-    // Whether to show the Sourcegraph Teams upgrade CTA or not.
-    isTeamsUpgradeCtaEnabled?: boolean
     instanceNotices: CodyNotice[]
 }
 
 const storageKey = 'DismissedWelcomeNotices'
 
-export const Notices: React.FC<NoticesProps> = ({ user, isTeamsUpgradeCtaEnabled, instanceNotices }) => {
+export const Notices: React.FC<NoticesProps> = ({ user, instanceNotices }) => {
     const telemetryRecorder = useTelemetryRecorder()
 
     // dismissed notices from local storage
@@ -77,41 +71,6 @@ export const Notices: React.FC<NoticesProps> = ({ user, isTeamsUpgradeCtaEnabled
                     />
                 ),
             })),
-            /**
-             * Notifies users that they are eligible for a free upgrade to Sourcegraph Teams.
-             * TODO: Update to live link https://linear.app/sourcegraph/issue/CORE-535/cody-clients-migrate-ctas-to-live-links
-             */
-            {
-                id: 'TeamsUpgrade',
-                isVisible: user.isDotComUser && isTeamsUpgradeCtaEnabled && user.IDE !== CodyIDE.Web,
-                content: (
-                    <NoticeContent
-                        id="TeamsUpgrade"
-                        variant="default"
-                        title="Sourcegraph Teams is here"
-                        message="You now are eligible for an upgrade to teams for free"
-                        onDismiss={() => dismissNotice('TeamsUpgrade')}
-                        actions={[
-                            {
-                                // TODO: Update to live link https://linear.app/sourcegraph/issue/CORE-535/cody-clients-migrate-ctas-to-live-links
-                                label: 'Upgrade to Teams',
-                                href: DOTCOM_WORKSPACE_UPGRADE_URL.href,
-                                variant: 'default',
-                                icon: <Users2Icon size={14} />,
-                                iconPosition: 'start',
-                            },
-                            {
-                                // TODO: Update to live link https://linear.app/sourcegraph/issue/CORE-535/cody-clients-migrate-ctas-to-live-links
-                                label: 'Learn More',
-                                href: DOTCOM_WORKSPACE_LEARN_MORE_URL.href,
-                                variant: 'ghost',
-                                icon: <ExternalLinkIcon size={14} />,
-                                iconPosition: 'end',
-                            },
-                        ]}
-                    />
-                ),
-            },
             /**
              * For Sourcegraph team members who are using Sourcegraph.com to remind them that we want to be dogfooding S2.
              */
@@ -151,7 +110,7 @@ export const Notices: React.FC<NoticesProps> = ({ user, isTeamsUpgradeCtaEnabled
                 ),
             },
         ],
-        [user, dismissNotice, isTeamsUpgradeCtaEnabled, instanceNotices]
+        [user, dismissNotice, instanceNotices]
     )
 
     // First, modify the activeNotice useMemo to add conditional logic for DogfoodS2


### PR DESCRIPTION
context: https://sourcegraph.slack.com/archives/C0847FJ0A73/p1736883217956529

- Simplified the title of the context retrieval step from "Retrieving additional context" to "Retrieving context"
- Updated the confirmation message for the Terminal tool from "Run command to retrieve context?" to "Allow commands to retrieve context?" to provide clearer instructions to the user


## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

Check pnpm -C vscode storybook

![image](https://github.com/user-attachments/assets/6e4d0c2c-e1fb-4e59-af52-5765080fe451)