### PR TITLE
chore(audo-edit): encapsulate prompt components

### DIFF
--- a/lib/shared/src/completions/types.ts
+++ b/lib/shared/src/completions/types.ts
@@ -69,6 +69,17 @@ export interface DocumentContext extends DocumentDependentContext, LinesContext 
     maxSuffixLength: number
 }
 
+export interface CodeToReplaceData {
+    codeToRewrite: string
+    prefixBeforeArea: string
+    suffixAfterArea: string
+    prefixInArea: string
+    suffixInArea: string
+    codeToRewritePrefix: string
+    codeToRewriteSuffix: string
+    range: vscode.Range
+}
+
 export interface GitContext {
     repoName: string
 }

--- a/lib/shared/src/prompt/prompt-string.ts
+++ b/lib/shared/src/prompt/prompt-string.ts
@@ -6,7 +6,12 @@ import type { ContextFiltersProvider } from '../cody-ignore/context-filters-prov
 import type { TerminalOutputArguments } from '../commands/types'
 import { markdownCodeBlockLanguageIDForFilename } from '../common/languages'
 import type { RangeData } from '../common/range'
-import type { AutocompleteContextSnippet, DocumentContext, GitContext } from '../completions/types'
+import type {
+    AutocompleteContextSnippet,
+    CodeToReplaceData,
+    DocumentContext,
+    GitContext,
+} from '../completions/types'
 import type { ActiveTextEditorDiagnostic } from '../editor'
 import { createGitDiff } from '../editor/create-git-diff'
 import { displayPath, displayPathWithLines } from '../editor/displayPath'
@@ -339,6 +344,20 @@ export class PromptString {
             injectedPrefix: docContext.injectedPrefix
                 ? internal_createPromptString(docContext.injectedPrefix, ref)
                 : null,
+        }
+    }
+
+    public static fromAutoEditCodeToReplaceData(codeToReplaceData: CodeToReplaceData, uri: vscode.Uri) {
+        const ref = [uri]
+        return {
+            range: codeToReplaceData.range,
+            codeToRewrite: internal_createPromptString(codeToReplaceData.codeToRewrite, ref),
+            prefixBeforeArea: internal_createPromptString(codeToReplaceData.prefixBeforeArea, ref),
+            suffixAfterArea: internal_createPromptString(codeToReplaceData.suffixAfterArea, ref),
+            prefixInArea: internal_createPromptString(codeToReplaceData.prefixInArea, ref),
+            suffixInArea: internal_createPromptString(codeToReplaceData.suffixInArea, ref),
+            codeToRewritePrefix: internal_createPromptString(codeToReplaceData.codeToRewritePrefix, ref),
+            codeToRewriteSuffix: internal_createPromptString(codeToReplaceData.codeToRewriteSuffix, ref),
         }
     }
 

--- a/vscode/src/autoedits/analytics-logger/analytics-logger.test.ts
+++ b/vscode/src/autoedits/analytics-logger/analytics-logger.test.ts
@@ -14,7 +14,7 @@ import { getCurrentDocContext } from '../../completions/get-current-doc-context'
 import { documentAndPosition } from '../../completions/test-helpers'
 import * as sentryModule from '../../services/sentry/sentry'
 import type { AutoeditModelOptions } from '../adapters/base'
-import { getCurrentFilePromptComponents } from '../prompt/prompt-utils'
+import { getCodeToReplaceData } from '../prompt/prompt-utils'
 import { getDecorationInfo } from '../renderer/diff-utils'
 
 import {
@@ -43,7 +43,7 @@ describe('AutoeditAnalyticsLogger', () => {
         maxSuffixLength: 1000,
     })
 
-    const { codeToReplaceData } = getCurrentFilePromptComponents({
+    const codeToReplaceData = getCodeToReplaceData({
         docContext,
         position,
         document,

--- a/vscode/src/autoedits/autoedits-provider.ts
+++ b/vscode/src/autoedits/autoedits-provider.ts
@@ -14,8 +14,8 @@ import { ContextMixer } from '../completions/context/context-mixer'
 import { DefaultContextStrategyFactory } from '../completions/context/context-strategy'
 import { getCurrentDocContext } from '../completions/get-current-doc-context'
 import { isRunningInsideAgent } from '../jsonrpc/isRunningInsideAgent'
-
 import type { FixupController } from '../non-stop/FixupController'
+
 import type { AutoeditsModelAdapter, AutoeditsPrompt } from './adapters/base'
 import { createAutoeditsModelAdapter } from './adapters/create-adapter'
 import {
@@ -29,7 +29,7 @@ import {
 import { autoeditsProviderConfig } from './autoedits-config'
 import { FilterPredictionBasedOnRecentEdits } from './filter-prediction-edits'
 import { autoeditsOutputChannelLogger } from './output-channel-logger'
-import { type CodeToReplaceData, getCurrentFilePromptComponents } from './prompt/prompt-utils'
+import { type CodeToReplaceData, getCodeToReplaceData } from './prompt/prompt-utils'
 import { ShortTermPromptStrategy } from './prompt/short-term-diff-prompt-strategy'
 import type { DecorationInfo } from './renderer/decorators/base'
 import { DefaultDecorator } from './renderer/decorators/default-decorator'
@@ -186,12 +186,7 @@ export class AutoeditsProvider implements vscode.InlineCompletionItemProvider, v
                 maxSuffixLength: tokensToChars(autoeditsProviderConfig.tokenLimit.suffixTokens),
             })
 
-            const {
-                fileWithMarkerPrompt,
-                areaPrompt,
-                codeToReplaceData,
-                codeToReplaceData: { codeToRewrite },
-            } = getCurrentFilePromptComponents({
+            const codeToReplaceData = getCodeToReplaceData({
                 docContext,
                 document,
                 position,
@@ -202,6 +197,7 @@ export class AutoeditsProvider implements vscode.InlineCompletionItemProvider, v
                 'provideInlineCompletionItems',
                 'Calculating context from contextMixer...'
             )
+            const { codeToRewrite } = codeToReplaceData
             const requestId = autoeditAnalyticsLogger.createRequest({
                 startedAt: performance.now(),
                 codeToReplaceData,
@@ -241,8 +237,8 @@ export class AutoeditsProvider implements vscode.InlineCompletionItemProvider, v
                 'Calculating prompt from promptStrategy...'
             )
             const prompt = this.promptStrategy.getPromptForModelType({
-                fileWithMarkerPrompt,
-                areaPrompt,
+                document,
+                codeToReplaceData,
                 context,
                 tokenBudget: autoeditsProviderConfig.tokenLimit,
                 isChatModel: autoeditsProviderConfig.isChatModel,

--- a/vscode/src/autoedits/prompt/base.ts
+++ b/vscode/src/autoedits/prompt/base.ts
@@ -1,16 +1,20 @@
+import type * as vscode from 'vscode'
+
 import type {
     AutoEditsTokenLimit,
     AutocompleteContextSnippet,
+    CodeToReplaceData,
     PromptString,
 } from '@sourcegraph/cody-shared'
 
 import type { AutoeditsPrompt } from '../adapters/base'
 
 import { SYSTEM_PROMPT } from './constants'
-import { type CurrentFilePromptComponents, getCompletionsPromptWithSystemPrompt } from './prompt-utils'
+import { getCompletionsPromptWithSystemPrompt } from './prompt-utils'
 
-export interface UserPromptArgs
-    extends Pick<CurrentFilePromptComponents, 'areaPrompt' | 'fileWithMarkerPrompt'> {
+export interface UserPromptArgs {
+    document: vscode.TextDocument
+    codeToReplaceData: CodeToReplaceData
     context: AutocompleteContextSnippet[]
     tokenBudget: AutoEditsTokenLimit
 }

--- a/vscode/src/autoedits/prompt/default-prompt-strategy.test.ts
+++ b/vscode/src/autoedits/prompt/default-prompt-strategy.test.ts
@@ -1,13 +1,19 @@
-import { type AutoEditsTokenLimit, testFileUri } from '@sourcegraph/cody-shared'
-import type { AutocompleteContextSnippet } from '@sourcegraph/cody-shared/src/completions/types'
 import dedent from 'dedent'
 import { describe, expect, it } from 'vitest'
+
+import {
+    type AutoEditsTokenLimit,
+    type AutocompleteContextSnippet,
+    testFileUri,
+} from '@sourcegraph/cody-shared'
+
 import { RetrieverIdentifier } from '../../completions/context/utils'
 import { getCurrentDocContext } from '../../completions/get-current-doc-context'
 import { documentAndPosition } from '../../completions/test-helpers'
+
 import type { UserPromptArgs } from './base'
 import { DefaultUserPromptStrategy } from './default-prompt-strategy'
-import { getCurrentFilePromptComponents } from './prompt-utils'
+import { getCodeToReplaceData } from './prompt-utils'
 
 describe('DefaultUserPromptStrategy', () => {
     const promptProvider = new DefaultUserPromptStrategy()
@@ -59,7 +65,7 @@ describe('DefaultUserPromptStrategy', () => {
             },
         }
 
-        const { fileWithMarkerPrompt, areaPrompt } = getCurrentFilePromptComponents({
+        const codeToReplaceData = getCodeToReplaceData({
             docContext,
             document,
             position,
@@ -173,8 +179,8 @@ describe('DefaultUserPromptStrategy', () => {
 
         return {
             context,
-            fileWithMarkerPrompt,
-            areaPrompt,
+            codeToReplaceData,
+            document,
             tokenBudget,
         }
     }

--- a/vscode/src/autoedits/prompt/short-term-diff-prompt-strategy.test.ts
+++ b/vscode/src/autoedits/prompt/short-term-diff-prompt-strategy.test.ts
@@ -1,13 +1,19 @@
 import { beforeEach } from 'node:test'
-import { type AutocompleteContextSnippet, testFileUri } from '@sourcegraph/cody-shared'
-import type { AutoEditsTokenLimit } from '@sourcegraph/cody-shared'
 import dedent from 'dedent'
 import { describe, expect, it, vi } from 'vitest'
+
+import {
+    type AutoEditsTokenLimit,
+    type AutocompleteContextSnippet,
+    testFileUri,
+} from '@sourcegraph/cody-shared'
+
 import { RetrieverIdentifier } from '../../completions/context/utils'
 import { getCurrentDocContext } from '../../completions/get-current-doc-context'
 import { documentAndPosition } from '../../completions/test-helpers'
+
 import type { UserPromptArgs } from './base'
-import { getCurrentFilePromptComponents } from './prompt-utils'
+import { getCodeToReplaceData } from './prompt-utils'
 import { ShortTermPromptStrategy } from './short-term-diff-prompt-strategy'
 
 describe('ShortTermPromptStrategy', () => {
@@ -63,12 +69,13 @@ describe('ShortTermPromptStrategy', () => {
                     [RetrieverIdentifier.DiagnosticsRetriever]: 100,
                 },
             }
-            const { fileWithMarkerPrompt, areaPrompt } = getCurrentFilePromptComponents({
+            const codeToReplaceData = getCodeToReplaceData({
                 docContext,
                 document,
                 position,
                 tokenBudget,
             })
+
             const context: AutocompleteContextSnippet[] = shouldIncludeContext
                 ? [
                       getContextItem(
@@ -175,8 +182,8 @@ describe('ShortTermPromptStrategy', () => {
                 : []
 
             return {
-                fileWithMarkerPrompt,
-                areaPrompt,
+                codeToReplaceData,
+                document,
                 context,
                 tokenBudget,
             }

--- a/vscode/src/autoedits/prompt/short-term-diff-prompt-strategy.ts
+++ b/vscode/src/autoedits/prompt/short-term-diff-prompt-strategy.ts
@@ -10,6 +10,7 @@ import * as constants from './constants'
 import {
     getContextItemMappingWithTokenLimit,
     getContextItemsForIdentifier,
+    getCurrentFilePromptComponents,
     getJaccardSimilarityPrompt,
     getLintErrorsPrompt,
     getPromptForTheContextSource,
@@ -23,12 +24,7 @@ import {
 export class ShortTermPromptStrategy extends AutoeditsUserPromptStrategy {
     private readonly SHORT_TERM_SNIPPET_VIEW_TIME_MS = 60 * 1000 // 1 minute
 
-    getUserPrompt({
-        context,
-        tokenBudget,
-        fileWithMarkerPrompt,
-        areaPrompt,
-    }: UserPromptArgs): PromptString {
+    getUserPrompt({ context, tokenBudget, codeToReplaceData, document }: UserPromptArgs): PromptString {
         const contextItemMapping = getContextItemMappingWithTokenLimit(
             context,
             tokenBudget.contextSpecificTokenLimit
@@ -56,6 +52,12 @@ export class ShortTermPromptStrategy extends AutoeditsUserPromptStrategy {
             constants.JACCARD_SIMILARITY_INSTRUCTION,
             getJaccardSimilarityPrompt
         )
+
+        const { fileWithMarkerPrompt, areaPrompt } = getCurrentFilePromptComponents(
+            document,
+            codeToReplaceData
+        )
+
         const currentFilePrompt = ps`${constants.CURRENT_FILE_INSTRUCTION}${fileWithMarkerPrompt}`
 
         const finalPrompt = joinPromptsWithNewlineSeparator(

--- a/vscode/src/autoedits/prompt/test-helper.ts
+++ b/vscode/src/autoedits/prompt/test-helper.ts
@@ -1,7 +1,8 @@
 import dedent from 'dedent'
+
 import { getCurrentDocContext } from '../../completions/get-current-doc-context'
 import { documentAndPosition } from '../../completions/test-helpers'
-import { type CodeToReplaceData, getCurrentFilePromptComponents } from '../prompt/prompt-utils'
+import { type CodeToReplaceData, getCodeToReplaceData } from '../prompt/prompt-utils'
 
 interface CodeToReplaceTestOptions {
     maxPrefixLength: number
@@ -25,10 +26,28 @@ export function createCodeToReplaceDataForTest(
         maxSuffixLength: options.maxSuffixLength,
     })
 
-    return getCurrentFilePromptComponents({
+    return getCodeToReplaceData({
         docContext,
         position,
         document,
         tokenBudget: options,
-    }).codeToReplaceData
+    })
+}
+
+export function getCodeToReplaceForRenderer(
+    code: TemplateStringsArray,
+    ...values: unknown[]
+): CodeToReplaceData {
+    return createCodeToReplaceDataForTest(
+        code,
+        {
+            maxPrefixLength: 100,
+            maxSuffixLength: 100,
+            maxPrefixLinesInArea: 2,
+            maxSuffixLinesInArea: 2,
+            codeToRewritePrefixLines: 1,
+            codeToRewriteSuffixLines: 1,
+        },
+        ...values
+    )
 }

--- a/vscode/src/autoedits/renderer/manager.test.ts
+++ b/vscode/src/autoedits/renderer/manager.test.ts
@@ -1,35 +1,18 @@
 import dedent from 'dedent'
 import { beforeEach, describe, expect, it } from 'vitest'
 import type * as vscode from 'vscode'
+
 import { getCurrentDocContext } from '../../completions/get-current-doc-context'
 import { documentAndPosition } from '../../completions/test-helpers'
 import { defaultVSCodeExtensionClient } from '../../extension-client'
 import { FixupController } from '../../non-stop/FixupController'
 import type { AutoeditRequestID } from '../analytics-logger'
 import { getDecorationInfoFromPrediction } from '../autoedits-provider'
-import type { CodeToReplaceData } from '../prompt/prompt-utils'
-import { createCodeToReplaceDataForTest } from '../prompt/test-helper'
+import { getCodeToReplaceForRenderer } from '../prompt/test-helper'
 import { AutoEditsDefaultRendererManager } from '../renderer/manager'
+
 import { DefaultDecorator } from './decorators/default-decorator'
 import type { TryMakeInlineCompletionsArgs } from './manager'
-
-function getCodeToReplaceForManager(
-    code: TemplateStringsArray,
-    ...values: unknown[]
-): CodeToReplaceData {
-    return createCodeToReplaceDataForTest(
-        code,
-        {
-            maxPrefixLength: 100,
-            maxSuffixLength: 100,
-            maxPrefixLinesInArea: 2,
-            maxSuffixLinesInArea: 2,
-            codeToRewritePrefixLines: 1,
-            codeToRewriteSuffixLines: 1,
-        },
-        ...values
-    )
-}
 
 describe('AutoEditsDefaultRendererManager', () => {
     const getAutoeditRendererManagerArgs = (
@@ -43,7 +26,7 @@ describe('AutoEditsDefaultRendererManager', () => {
             maxPrefixLength: 100,
             maxSuffixLength: 100,
         })
-        const codeToReplaceData = getCodeToReplaceForManager`${documentText}`
+        const codeToReplaceData = getCodeToReplaceForRenderer`${documentText}`
         const decorationInfo = getDecorationInfoFromPrediction(document, prediction, codeToReplaceData)
         return {
             requestId: 'test-request-id' as AutoeditRequestID,

--- a/vscode/src/autoedits/renderer/mock-renderer.test.ts
+++ b/vscode/src/autoedits/renderer/mock-renderer.test.ts
@@ -1,9 +1,10 @@
 import dedent from 'dedent'
 import { describe, expect, it, vi } from 'vitest'
 import * as vscode from 'vscode'
+
 import { documentAndPosition } from '../../completions/test-helpers'
-import type { CodeToReplaceData } from '../prompt/prompt-utils'
-import { createCodeToReplaceDataForTest } from '../prompt/test-helper'
+
+import { getCodeToReplaceForRenderer } from '../prompt/test-helper'
 import {
     INITIAL_TEXT_START_MARKER,
     REPLACER_TEXT_END_MARKER,
@@ -12,24 +13,6 @@ import {
     getTextBetweenMarkers,
     shrinkReplacerTextToCodeToReplaceRange,
 } from './mock-renderer'
-
-function getCodeToReplaceForRenderer(
-    code: TemplateStringsArray,
-    ...values: unknown[]
-): CodeToReplaceData {
-    return createCodeToReplaceDataForTest(
-        code,
-        {
-            maxPrefixLength: 100,
-            maxSuffixLength: 100,
-            maxPrefixLinesInArea: 2,
-            maxSuffixLinesInArea: 2,
-            codeToRewritePrefixLines: 1,
-            codeToRewriteSuffixLines: 1,
-        },
-        ...values
-    )
-}
 
 describe('renderer-testing', () => {
     const createDocumentTextForMockRenderer = (param: {

--- a/vscode/src/autoedits/shrink-prediction.test.ts
+++ b/vscode/src/autoedits/shrink-prediction.test.ts
@@ -1,5 +1,6 @@
 import dedent from 'dedent'
 import { describe, expect, it } from 'vitest'
+
 import type { CodeToReplaceData } from './prompt/prompt-utils'
 import { createCodeToReplaceDataForTest } from './prompt/test-helper'
 import { shrinkPredictionUntilSuffix } from './shrink-prediction'


### PR DESCRIPTION
- No functional changes.
- This addresses the review comment [here](https://github.com/sourcegraph/cody/pull/6474#discussion_r1898337793) by hiding prompt components from the autoedit provider. The `CodeToReplaceData` object is now created independently and stores raw string values. For prompt construction, these string values are wrapped in a `PromptString`, like we do for the `DocumentContext`.
- Closes [CODY-4596: Hide prompt component management logic from the autoedits provider](https://linear.app/sourcegraph/issue/CODY-4596/hide-prompt-component-management-logic-from-the-autoedits-provider)

## Test plan

CI
