### PR TITLE
chore/build: Bump IntelliJ supported platform version to 251

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -86,7 +86,7 @@ jobs:
           plugin-location: '*.zip'
           ide-versions: |
             ideaIC:2023.2
-            ideaIC:2024.2.4
+            ideaIC:251.14649.49
           failure-levels: |
             INVALID_PLUGIN
             MISSING_DEPENDENCIES
@@ -100,4 +100,4 @@ jobs:
           name: plugin-verifier-reports
           path: 'verification-*'
           compression-level: 9
-        
+

--- a/jetbrains/build.gradle.kts
+++ b/jetbrains/build.gradle.kts
@@ -29,7 +29,7 @@ val isForceCodeSearchBuild = properties("forceCodeSearchBuild") == "true"
 // add it to this list. Remove unsupported old versions from this list.
 // Update gradle.properties pluginSinceBuild, pluginUntilBuild
 // to match the min, max versions in this list.
-val versionsOfInterest = listOf("2023.2", "2023.3", "2024.1", "2024.2.4").sorted()
+val versionsOfInterest = listOf("2023.2", "2023.3", "2024.1", "2024.2.4", "251.14649.49").sorted()
 val versionsToValidate =
     when (project.properties["validation"]?.toString()) {
       "lite" -> listOf(versionsOfInterest.first(), versionsOfInterest.last())
@@ -48,6 +48,8 @@ val skippedFailureLevels =
         FailureLevel.EXPERIMENTAL_API_USAGES,
         FailureLevel.INTERNAL_API_USAGES,
         FailureLevel.NOT_DYNAMIC,
+        FailureLevel
+            .OVERRIDE_ONLY_API_USAGES, // Complains about BaseShowDiffAction, but it works just fine
         FailureLevel
             .SCHEDULED_FOR_REMOVAL_API_USAGES // HttpConfigurable, migration to coroutines, others
         )!!

--- a/jetbrains/gradle.properties
+++ b/jetbrains/gradle.properties
@@ -7,7 +7,7 @@ pluginVersion=6.0-localbuild
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.
 pluginSinceBuild=232
-pluginUntilBuild=243.*
+pluginUntilBuild=251.*
 # IntelliJ Platform Properties -> https://github.com/JetBrains/gradle-intellij-plugin#intellij-platform-properties
 platformType=IC
 platformVersion=2023.2


### PR DESCRIPTION
New IntelliJ EAP 2025 is out! 
https://blog.jetbrains.com/idea/2025/01/intellij-idea-2025-1-eap/

This PR upgrades supported IJ platform version to 2025.1.

## Test plan

IJ 2025 is supposed to fix code lenses on remote, so beside full QA we should test that specifically.

One can run remote IJ locally easily, by executing in the `jetbrains` directory:
`./gradlew customRunIde -PsplitMode=true -PplatformRuntimeVersion=251.14649.49`

It also can be done by downloading and installing new EAP and then installing the Cody plugin normally.