### PR TITLE
feat: omnibox cheatsheet

### DIFF
--- a/vscode/webviews/chat/components/QuickStart.tsx
+++ b/vscode/webviews/chat/components/QuickStart.tsx
@@ -115,7 +115,7 @@ export function QuickStart() {
 
     return (
         <>
-            <div className="tw-mx-auto tw-my-2 tw-flex tw-max-w-3xl tw-max-w-[768px] tw-flex-col tw-gap-4 tw-py-2 tw-text-sm tw-text-muted-foreground">
+            <div className="tw-mx-auto tw-my-2 tw-flex tw-max-w-3xl tw-max-w-[768px] tw-flex-col tw-py-2 tw-text-sm tw-text-muted-foreground">
                 <div
                     className={`tw-flex tw-items-center tw-justify-between tw-gap-4 tw-text-md tw-font-medium tw-text-foreground tw-p-4 md:tw-text-base ${
                         isCollapsed ? 'hover:tw-bg-muted tw-cursor-pointer tw-rounded-lg' : ''
@@ -125,7 +125,7 @@ export function QuickStart() {
                     role="button"
                     tabIndex={isCollapsed ? 0 : undefined}
                 >
-                    <div className="tw-flex tw-items-center tw-gap-4">
+                    <div className="tw-flex tw-items-center tw-gap-4 tw-text-md">
                         <Zap className="tw-h-8 tw-w-8" strokeWidth={1.25} />
                         Quick Start
                     </div>
@@ -176,7 +176,7 @@ export function QuickStart() {
             {/* Overlay */}
             {showTipsOverlay && (
                 <div
-                    className="tw-fixed tw-inset-0 tw-flex tw-items-center tw-justify-center tw-bg-background tw-p-4 tw-animate-[fadeIn_0.2s_ease-in-out]"
+                    className="tw-fixed tw-inset-0 tw-flex tw-items-center tw-justify-center tw-bg-black/20 tw-p-4 tw-animate-[fadeIn_0.2s_ease-in-out]"
                     onClick={handleOverlayClick}
                     onKeyDown={handleOverlayKeyDown}
                     role="presentation"
@@ -191,7 +191,7 @@ export function QuickStart() {
                     >
                         {/* Overlay content */}
                         <div className="tw-flex tw-items-center tw-justify-between">
-                            <div className="tw-flex tw-items-center tw-gap-4 tw-font-medium tw-text-foreground md:tw-text-base">
+                            <div className="tw-flex tw-items-center tw-gap-4 tw-font-medium tw-text-foreground text-md md:tw-text-base">
                                 <Zap className="tw-h-8 tw-w-8" strokeWidth={1.25} />
                                 Quick Start
                             </div>
@@ -221,7 +221,7 @@ export function QuickStart() {
                                             </h4>
                                         )}
                                         {'examples' in example ? (
-                                            <div className="tw-flex tw-flex-row tw-flex-wrap tw-gap-4">
+                                            <div className="tw-flex tw-flex-row tw-flex-wrap tw-gap-8">
                                                 {example.examples?.map(ex => (
                                                     <div
                                                         key={`nested-example-${ex.input}`}

--- a/vscode/webviews/chat/components/QuickStart.tsx
+++ b/vscode/webviews/chat/components/QuickStart.tsx
@@ -54,7 +54,7 @@ export function QuickStart() {
 
     const examples: Example[] = [
         {
-            input: '=useCallBack(',
+            input: '= useCallback(',
             description: 'Deterministically find symbols',
         },
         {

--- a/vscode/webviews/chat/components/QuickStart.tsx
+++ b/vscode/webviews/chat/components/QuickStart.tsx
@@ -1,0 +1,282 @@
+import {
+    AtSignIcon,
+    ChevronDown,
+    ChevronRight,
+    type LucideProps,
+    MessageSquarePlus,
+    TextSelect,
+    X,
+    Zap,
+} from 'lucide-react'
+import type { ForwardRefExoticComponent } from 'react'
+interface ChatViewTip {
+    message: string
+    icon: ForwardRefExoticComponent<Omit<LucideProps, 'ref'>>
+    vsCodeOnly: boolean
+}
+
+const chatTips: ChatViewTip[] = [
+    {
+        message: 'Type @ to add context to your chat',
+        icon: AtSignIcon,
+        vsCodeOnly: true,
+    },
+    {
+        message: 'Start a new chat with ⇧ ⌥ L or switch to chat with ⌥ /',
+        icon: MessageSquarePlus,
+        vsCodeOnly: false,
+    },
+    {
+        message: 'To add code context from an editor, right click and use Add to Cody Chat',
+        icon: TextSelect,
+        vsCodeOnly: true,
+    },
+]
+
+import { useState } from 'react'
+import styles from './WelcomeFooter.module.css'
+interface Example {
+    input: string
+    description: string
+    maxWidth?: string
+}
+
+interface ExampleGroup {
+    title?: string
+    input?: string
+    description?: string
+    examples?: Example[]
+}
+
+export function QuickStart() {
+    const [showTipsOverlay, setShowTipsOverlay] = useState(false)
+    const [isCollapsed, setIsCollapsed] = useState(false)
+
+    const examples: Example[] = [
+        {
+            input: '=useCallBack(',
+            description: 'Deterministically find symbols',
+        },
+        {
+            input: '"// TODO"',
+            description: 'Find string literals',
+        },
+        {
+            input: 'How does this file handle error cases?',
+            description: 'Ask questions in natural language',
+        },
+    ]
+
+    const allExamples: ExampleGroup[] = [
+        ...examples,
+        {
+            title: 'Combine search and chat for power usage',
+            examples: [
+                {
+                    input: 'HttpError',
+                    description: 'Start with a search query',
+                },
+                {
+                    input: 'Analyze these error handling implementations and explain our retry and timeout strategy',
+                    description: 'Follow-up with a question about the results returned',
+                    maxWidth: '320px',
+                },
+            ],
+        },
+    ]
+
+    const handleKeyDown = (event: React.KeyboardEvent) => {
+        if (event.key === 'Enter' || event.key === ' ') {
+            setShowTipsOverlay(true)
+        }
+    }
+
+    const handleOverlayKeyDown = (event: React.KeyboardEvent) => {
+        if (event.key === 'Enter' || event.key === ' ') {
+            setShowTipsOverlay(false)
+        }
+    }
+
+    const handleOverlayClick = (event: React.MouseEvent) => {
+        if (event.target === event.currentTarget) {
+            setShowTipsOverlay(false)
+        }
+    }
+
+    const toggleCollapse = () => {
+        setIsCollapsed(!isCollapsed)
+    }
+
+    const handleCollapseKeyDown = (event: React.KeyboardEvent) => {
+        if (event.key === 'Enter' || event.key === ' ') {
+            toggleCollapse()
+        }
+    }
+
+    return (
+        <>
+            <div className="tw-mx-auto tw-my-2 tw-flex tw-max-w-3xl tw-max-w-[768px] tw-flex-col tw-gap-4 tw-py-2 tw-text-sm tw-text-muted-foreground">
+                <div
+                    className={`tw-flex tw-items-center tw-justify-between tw-gap-4 tw-text-md tw-font-medium tw-text-foreground tw-p-4 md:tw-text-base ${
+                        isCollapsed ? 'hover:tw-bg-muted tw-cursor-pointer tw-rounded-lg' : ''
+                    }`}
+                    onClick={isCollapsed ? toggleCollapse : undefined}
+                    onKeyDown={isCollapsed ? handleCollapseKeyDown : undefined}
+                    role="button"
+                    tabIndex={isCollapsed ? 0 : undefined}
+                >
+                    <div className="tw-flex tw-items-center tw-gap-4">
+                        <Zap className="tw-h-8 tw-w-8" strokeWidth={1.25} />
+                        Quick Start
+                    </div>
+                    <button
+                        type="button"
+                        onClick={toggleCollapse}
+                        onKeyDown={handleCollapseKeyDown}
+                        className="tw-p-1 hover:tw-bg-muted tw-rounded-full"
+                        aria-label={isCollapsed ? 'Expand quick start' : 'Collapse quick start'}
+                    >
+                        {isCollapsed ? (
+                            <ChevronRight className="tw-h-8 tw-w-8 tw-text-muted-foreground" />
+                        ) : (
+                            <ChevronDown className="tw-h-8 tw-w-8 tw-text-muted-foreground" />
+                        )}
+                    </button>
+                </div>
+                <div
+                    className={`tw-overflow-hidden tw-transition-[max-height] tw-duration-300 tw-ease-in-out ${
+                        isCollapsed ? 'tw-max-h-0' : 'tw-max-h-[1000px]'
+                    }`}
+                >
+                    <div className={styles.examples}>
+                        {examples.map(example => (
+                            <div key={`example-${example.input}`} className={styles.example}>
+                                <div
+                                    className={`${styles.exampleInput} tw-px-4 tw-py-2 md:tw-px-4 md:tw-py-2 md:tw-text-md`}
+                                >
+                                    {example.input}
+                                </div>
+                                <div className="tw-py-2 tw-text-sm tw-text-muted-foreground md:tw-text-md">
+                                    {example.description}
+                                </div>
+                            </div>
+                        ))}
+                    </div>
+                    <button
+                        type="button"
+                        className="tw-m-4 tw-rounded-md tw-border tw-border-muted tw-px-4 tw-py-2 tw-text-md hover:tw-bg-muted"
+                        onClick={() => setShowTipsOverlay(true)}
+                        onKeyDown={handleKeyDown}
+                    >
+                        More tips
+                    </button>
+                </div>
+            </div>
+
+            {/* Overlay */}
+            {showTipsOverlay && (
+                <div
+                    className="tw-fixed tw-inset-0 tw-flex tw-items-center tw-justify-center tw-bg-background tw-p-4 tw-animate-[fadeIn_0.2s_ease-in-out]"
+                    onClick={handleOverlayClick}
+                    onKeyDown={handleOverlayKeyDown}
+                    role="presentation"
+                >
+                    <div
+                        className="tw-w-full tw-max-h-[90vh] tw-max-w-2xl tw-overflow-y-auto tw-rounded-xl tw-bg-background tw-p-12 tw-animate-[slideUp_0.2s_ease-in-out] tw-shadow-lg"
+                        role="dialog"
+                        aria-modal="true"
+                        style={{
+                            animation: 'fadeIn 0.25s ease-in-out, slideUp 0.25s ease-in-out',
+                        }}
+                    >
+                        {/* Overlay content */}
+                        <div className="tw-flex tw-items-center tw-justify-between">
+                            <div className="tw-flex tw-items-center tw-gap-4 tw-font-medium tw-text-foreground md:tw-text-base">
+                                <Zap className="tw-h-8 tw-w-8" strokeWidth={1.25} />
+                                Quick Start
+                            </div>
+                            <button
+                                type="button"
+                                className="tw-rounded-full tw-p-1 hover:tw-bg-muted"
+                                onClick={() => setShowTipsOverlay(false)}
+                                onKeyDown={handleOverlayKeyDown}
+                                aria-label="Close quick start guide"
+                            >
+                                <X className="tw-h-8 tw-w-8" />
+                            </button>
+                        </div>
+                        <div className={styles.cheatsheet}>
+                            <div className={styles.examples}>
+                                {/* Render all examples including nested ones */}
+                                {allExamples.map(example => (
+                                    <div
+                                        key={`overlay-example-${
+                                            'input' in example ? example.input : example.title
+                                        }`}
+                                        className={styles.example}
+                                    >
+                                        {'title' in example && (
+                                            <h4 className="tw-mb-2 tw-border-t tw-border-muted tw-pt-8 tw-text-md tw-font-medium tw-text-foreground">
+                                                {example.title}
+                                            </h4>
+                                        )}
+                                        {'examples' in example ? (
+                                            <div className="tw-flex tw-flex-row tw-flex-wrap tw-gap-4">
+                                                {example.examples?.map(ex => (
+                                                    <div
+                                                        key={`nested-example-${ex.input}`}
+                                                        className={styles.example}
+                                                        style={
+                                                            ex.maxWidth
+                                                                ? { maxWidth: ex.maxWidth }
+                                                                : undefined
+                                                        }
+                                                    >
+                                                        <div
+                                                            className={`${styles.exampleInput} tw-px-4 tw-py-2 md:tw-px-4 md:tw-py-2 md:tw-text-md`}
+                                                        >
+                                                            {ex.input}
+                                                        </div>
+                                                        <div className="tw-py-2 tw-text-sm tw-text-muted-foreground md:tw-text-md">
+                                                            {ex.description}
+                                                        </div>
+                                                    </div>
+                                                ))}
+                                            </div>
+                                        ) : (
+                                            <>
+                                                <div
+                                                    className={`${styles.exampleInput} tw-px-4 tw-py-2 md:tw-px-4 md:tw-py-2 md:tw-text-md`}
+                                                >
+                                                    {example.input}
+                                                </div>
+                                                <div className="tw-py-2 tw-text-sm tw-text-muted-foreground md:tw-text-md">
+                                                    {example.description}
+                                                </div>
+                                            </>
+                                        )}
+                                    </div>
+                                ))}
+                            </div>
+                            <div className="tw-mt-8 tw-border-t tw-border-muted tw-pt-12">
+                                <div className="tw-grid tw-gap-4">
+                                    {chatTips.map(tip => (
+                                        <div
+                                            key={tip.message}
+                                            className="tw-flex tw-items-center tw-gap-3"
+                                        >
+                                            <tip.icon className="tw-h-6 tw-w-6 tw-shrink-0" />
+                                            <span className="tw-text-md tw-text-muted-foreground">
+                                                {tip.message}
+                                            </span>
+                                        </div>
+                                    ))}
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            )}
+        </>
+    )
+}

--- a/vscode/webviews/chat/components/QuickStart.tsx
+++ b/vscode/webviews/chat/components/QuickStart.tsx
@@ -1,3 +1,6 @@
+import { useState } from 'react'
+import styles from './WelcomeFooter.module.css'
+
 import {
     AtSignIcon,
     ChevronDown,
@@ -33,8 +36,6 @@ const chatTips: ChatViewTip[] = [
     },
 ]
 
-import { useState } from 'react'
-import styles from './WelcomeFooter.module.css'
 interface Example {
     input: string
     description: string
@@ -50,8 +51,10 @@ interface ExampleGroup {
 
 export function QuickStart() {
     const [showTipsOverlay, setShowTipsOverlay] = useState(false)
-    const [isCollapsed, setIsCollapsed] = useState(false)
-
+    const [isCollapsed, setIsCollapsed] = useState(() => {
+        const saved = localStorage.getItem('quickStartCollapsed')
+        return saved ? JSON.parse(saved) : false
+    })
     const examples: Example[] = [
         {
             input: '= useCallback(',
@@ -104,7 +107,11 @@ export function QuickStart() {
     }
 
     const toggleCollapse = () => {
-        setIsCollapsed(!isCollapsed)
+        setIsCollapsed((prevState: boolean) => {
+            const newState = !prevState
+            localStorage.setItem('quickStartCollapsed', JSON.stringify(newState))
+            return newState
+        })
     }
 
     const handleCollapseKeyDown = (event: React.KeyboardEvent) => {
@@ -115,33 +122,27 @@ export function QuickStart() {
 
     return (
         <>
-            <div className="tw-mx-auto tw-my-2 tw-flex tw-max-w-3xl tw-max-w-[768px] tw-flex-col tw-py-2 tw-text-sm tw-text-muted-foreground">
-                <div
-                    className={`tw-flex tw-items-center tw-justify-between tw-gap-4 tw-text-md tw-font-medium tw-text-foreground tw-p-4 md:tw-text-base ${
-                        isCollapsed ? 'hover:tw-bg-muted tw-cursor-pointer tw-rounded-lg' : ''
-                    }`}
-                    onClick={isCollapsed ? toggleCollapse : undefined}
-                    onKeyDown={isCollapsed ? handleCollapseKeyDown : undefined}
-                    role="button"
-                    tabIndex={isCollapsed ? 0 : undefined}
-                >
+            <div
+                className={`tw-mx-auto tw-my-2 tw-flex tw-max-w-3xl tw-max-w-[768px] tw-flex-col tw-py-2 tw-text-sm tw-text-muted-foreground tw-rounded-lg tw-transition-colors tw-duration-200 ${
+                    isCollapsed ? 'hover:tw-bg-muted' : 'hover:none'
+                }`}
+                onClick={toggleCollapse}
+                onKeyDown={handleCollapseKeyDown}
+                role="button"
+                tabIndex={0}
+            >
+                <div className="tw-flex tw-items-center tw-justify-between tw-gap-4 tw-text-md tw-font-medium tw-text-foreground tw-p-4 md:tw-text-base">
                     <div className="tw-flex tw-items-center tw-gap-4 tw-text-md">
                         <Zap className="tw-h-8 tw-w-8" strokeWidth={1.25} />
                         Quick Start
                     </div>
-                    <button
-                        type="button"
-                        onClick={toggleCollapse}
-                        onKeyDown={handleCollapseKeyDown}
-                        className="tw-p-1 hover:tw-bg-muted tw-rounded-full"
-                        aria-label={isCollapsed ? 'Expand quick start' : 'Collapse quick start'}
-                    >
+                    <div className="tw-p-1 hover:tw-bg-muted tw-rounded-full">
                         {isCollapsed ? (
                             <ChevronRight className="tw-h-8 tw-w-8 tw-text-muted-foreground" />
                         ) : (
                             <ChevronDown className="tw-h-8 tw-w-8 tw-text-muted-foreground" />
                         )}
-                    </button>
+                    </div>
                 </div>
                 <div
                     className={`tw-overflow-hidden tw-transition-[max-height] tw-duration-300 tw-ease-in-out ${
@@ -162,21 +163,26 @@ export function QuickStart() {
                             </div>
                         ))}
                     </div>
-                    <button
-                        type="button"
-                        className="tw-m-4 tw-rounded-md tw-border tw-border-muted tw-px-4 tw-py-2 tw-text-md hover:tw-bg-muted"
-                        onClick={() => setShowTipsOverlay(true)}
-                        onKeyDown={handleKeyDown}
-                    >
-                        More tips
-                    </button>
+                    <div className="tw-m-4">
+                        <button
+                            type="button"
+                            className="tw-rounded-md tw-border tw-border-muted tw-px-4 tw-py-2 tw-text-md hover:tw-bg-muted"
+                            onClick={e => {
+                                e.stopPropagation()
+                                setShowTipsOverlay(true)
+                            }}
+                            onKeyDown={handleKeyDown}
+                        >
+                            More tips
+                        </button>
+                    </div>
                 </div>
             </div>
 
             {/* Overlay */}
             {showTipsOverlay && (
                 <div
-                    className="tw-fixed tw-inset-0 tw-flex tw-items-center tw-justify-center tw-bg-black/20 tw-p-4 tw-animate-[fadeIn_0.2s_ease-in-out]"
+                    className="tw-fixed tw-inset-0 tw-flex tw-items-center tw-justify-center tw-bg-black/50 tw-p-4 tw-animate-[fadeIn_0.2s_ease-in-out]"
                     onClick={handleOverlayClick}
                     onKeyDown={handleOverlayKeyDown}
                     role="presentation"
@@ -216,12 +222,12 @@ export function QuickStart() {
                                         className={styles.example}
                                     >
                                         {'title' in example && (
-                                            <h4 className="tw-mb-2 tw-border-t tw-border-muted tw-pt-8 tw-text-md tw-font-medium tw-text-foreground">
+                                            <h4 className="tw-mb-2 tw-pt-8 tw-text-md tw-font-medium tw-text-foreground">
                                                 {example.title}
                                             </h4>
                                         )}
                                         {'examples' in example ? (
-                                            <div className="tw-flex tw-flex-row tw-flex-wrap tw-gap-8">
+                                            <div className="tw-flex tw-flex-row tw-flex-wrap tw-gap-4">
                                                 {example.examples?.map(ex => (
                                                     <div
                                                         key={`nested-example-${ex.input}`}

--- a/vscode/webviews/chat/components/QuickStart.tsx
+++ b/vscode/webviews/chat/components/QuickStart.tsx
@@ -2,16 +2,16 @@ import {
     AtSignIcon,
     ChevronDown,
     ChevronRight,
-    type LucideProps,
+    type LucideIcon,
     MessageSquarePlus,
     TextSelect,
     X,
     Zap,
 } from 'lucide-react'
-import type { ForwardRefExoticComponent } from 'react'
+
 interface ChatViewTip {
     message: string
-    icon: ForwardRefExoticComponent<Omit<LucideProps, 'ref'>>
+    icon: LucideIcon
     vsCodeOnly: boolean
 }
 

--- a/vscode/webviews/chat/components/WelcomeFooter.module.css
+++ b/vscode/webviews/chat/components/WelcomeFooter.module.css
@@ -1,9 +1,49 @@
 .welcome-footer {
-    padding: 1rem 1rem;
+    padding: 1rem;
     display: flex;
     flex-flow: column nowrap;
     max-width: 100%;
     color: var(--vscode-input-placeholderForeground)
+}
+
+.cheatsheet {
+    display: flex;
+    flex-flow: column nowrap;
+    width: 100%;
+    gap: 0.5rem;
+    padding: 1rem 0;
+}
+
+.title {
+    display: flex;
+    flex-flow: row nowrap;
+    align-items: center;
+    font-weight: 500;
+    gap: 0.5rem;
+}
+
+.examples {
+    display: flex;
+    flex-flow: row wrap;
+    gap: 0.25rem 1rem;
+}
+
+.example {
+    display: flex;
+    flex-flow:column nowrap;
+    gap: 0.25rem;
+    padding: 0.25rem 0;
+}
+
+.example-input {
+    display:flex;
+    flex-flow: row wrap;
+    border-radius: 4px;
+    color: var(--vscode-input-foreground);
+    border: 1px solid var(--vscode-button-secondaryBackground);
+    background-color: var(--vscode-editor-background);
+    font-family: var(--vscode-editor-font-family);
+    font-size: var(--vscode-editor-font-size);
 }
 
 .tips {
@@ -12,7 +52,7 @@
     width: 100%;
     gap: 0.5rem;
     padding: 1rem 0;
-    border-bottom: 0.25px solid var(--vscode-dropdown-border);
+    border-top: 0.25px solid var(--vscode-dropdown-border);
 }
 
 .links {

--- a/vscode/webviews/chat/components/WelcomeFooter.module.css
+++ b/vscode/webviews/chat/components/WelcomeFooter.module.css
@@ -26,6 +26,7 @@
     display: flex;
     flex-flow: row wrap;
     gap: 0.25rem 1rem;
+    padding: 0 0.5rem;
 }
 
 .example {
@@ -59,7 +60,7 @@
     display: flex;
     flex-flow: row wrap;
     padding: 0.75rem 0;
-    gap: 0.5rem;
+    gap: 1rem;
 }
 
 .item {

--- a/vscode/webviews/chat/components/WelcomeFooter.module.css
+++ b/vscode/webviews/chat/components/WelcomeFooter.module.css
@@ -31,13 +31,14 @@
 
 .example {
     display: flex;
-    flex-flow:column nowrap;
+    flex-flow: column nowrap;
+    align-items: flex-start;
     gap: 0.25rem;
     padding: 0.25rem 0;
 }
 
 .example-input {
-    display:flex;
+    display: flex;
     flex-flow: row wrap;
     border-radius: 4px;
     color: var(--vscode-input-foreground);
@@ -53,14 +54,15 @@
     width: 100%;
     gap: 0.5rem;
     padding: 1rem 0;
-    border-top: 0.25px solid var(--vscode-dropdown-border);
 }
 
 .links {
     display: flex;
     flex-flow: row wrap;
-    padding: 0.75rem 0;
-    gap: 1rem;
+    justify-content: center;
+    padding: 1rem 0;
+    gap: 1.25rem;
+    border-top: 0.5px solid var(--vscode-button-secondaryBackground);
 }
 
 .item {

--- a/vscode/webviews/chat/components/WelcomeFooter.tsx
+++ b/vscode/webviews/chat/components/WelcomeFooter.tsx
@@ -28,7 +28,7 @@ export default function WelcomeFooter({ IDE }: { IDE: CodyIDE }) {
     return (
         <div className={styles.welcomeFooter}>
             <QuickStart />
-            <div className={`${styles.links} tw-mx-auto`} style={{ maxWidth: '768px' }}>
+            <div className={styles.links}>
                 {chatLinks.map(link => (
                     <a
                         key={link.url}

--- a/vscode/webviews/chat/components/WelcomeFooter.tsx
+++ b/vscode/webviews/chat/components/WelcomeFooter.tsx
@@ -8,8 +8,11 @@ import {
     MessageCircleQuestion,
     MessageSquarePlus,
     TextSelect,
+    X,
+    Zap,
 } from 'lucide-react'
 import type { ForwardRefExoticComponent } from 'react'
+import { useState } from 'react'
 
 interface ChatViewTip {
     message: string
@@ -55,6 +58,40 @@ const chatLinks: ChatViewLink[] = [
 ]
 
 export default function WelcomeFooter({ IDE }: { IDE: CodyIDE }) {
+    const [showTipsOverlay, setShowTipsOverlay] = useState(false)
+    const examples = [
+        {
+            input: '=useCallBack(',
+            description: 'Deterministically find symbols',
+        },
+        {
+            input: '"// TODO"',
+            description: 'Find string literals',
+        },
+        {
+            input: 'How does this file handle error cases?',
+            description: '@-mention repos and files to include in search or chat',
+        },
+    ]
+
+    const allExamples = [
+        ...examples,
+        {
+            title: 'Combine search and chat for power usage',
+            examples: [
+                {
+                    input: 'HttpError',
+                    description: 'Start with a search query',
+                },
+                {
+                    input: 'Analyze these error handling implementations and explain our retry and timeout strategy',
+                    description: 'Follow-up with a question about the results returned',
+                    maxWidth: '320px',
+                },
+            ],
+        },
+    ]
+
     function tips() {
         return chatTips.map((tip, key) => {
             const Icon = tip.icon
@@ -84,10 +121,142 @@ export default function WelcomeFooter({ IDE }: { IDE: CodyIDE }) {
         })
     }
 
+    const handleKeyDown = (event: React.KeyboardEvent) => {
+        if (event.key === 'Enter' || event.key === ' ') {
+            setShowTipsOverlay(true)
+        }
+    }
+
+    const handleOverlayKeyDown = (event: React.KeyboardEvent) => {
+        if (event.key === 'Enter' || event.key === ' ') {
+            setShowTipsOverlay(false)
+        }
+    }
+
+    const handleOverlayClick = (event: React.MouseEvent) => {
+        if (event.target === event.currentTarget) {
+            setShowTipsOverlay(false)
+        }
+    }
+
     return (
         <div className={styles.welcomeFooter}>
-            <div className={styles.tips}>{tips()}</div>
-            <div className={styles.links}>{links()}</div>
+            <div className={`${styles.cheatsheet} tw-mx-auto`} style={{ maxWidth: '768px' }}>
+                <div className="tw-flex tw-items-center tw-gap-4 tw-font-medium tw-text-foreground md:tw-text-base">
+                    <Zap className="tw-w-8 tw-h-8" strokeWidth={1.25} />
+                    Quick Start
+                </div>
+                <div className={styles.examples}>
+                    {examples.map(example => (
+                        <div key={`example-${example.input}`} className={styles.example}>
+                            <div
+                                className={`${styles.exampleInput} tw-py-1 tw-px-2 md:tw-py-2 md:tw-px-4 md:tw-text-md`}
+                            >
+                                {example.input}
+                            </div>
+                            <div className="tw-text-muted-foreground tw-text-sm md:tw-text-md tw-py-2">
+                                {example.description}
+                            </div>
+                        </div>
+                    ))}
+                </div>
+                <button
+                    type="button"
+                    className="tw-text-md tw-my-2 md:tw-my-4 tw-px-4 tw-py-2 tw-border tw-border-muted tw-rounded-md hover:tw-bg-muted tw-mt-2"
+                    onClick={() => setShowTipsOverlay(true)}
+                    onKeyDown={handleKeyDown}
+                >
+                    More tips
+                </button>
+            </div>
+            <div className={`${styles.links} tw-mx-auto`} style={{ maxWidth: '768px' }}>
+                {links()}
+            </div>
+            {showTipsOverlay && (
+                <div
+                    className="tw-fixed tw-inset-0 tw-bg-black/50 tw-flex tw-items-center tw-justify-center tw-p-4"
+                    onClick={handleOverlayClick}
+                    onKeyDown={handleOverlayKeyDown}
+                    role="button"
+                    tabIndex={0}
+                >
+                    <div
+                        className="tw-bg-background tw-p-8 tw-rounded-lg tw-max-w-2xl tw-w-full tw-max-h-[80vh] tw-overflow-y-auto"
+                        role="dialog"
+                        aria-modal="true"
+                    >
+                        <div className="tw-flex tw-justify-between tw-items-center tw-mb-2">
+                            <div className="tw-flex tw-items-center tw-gap-4 tw-font-medium tw-text-foreground md:tw-text-base">
+                                <Zap className="tw-w-8 tw-h-8" strokeWidth={1.25} />
+                                Quick Start
+                            </div>
+                            <button
+                                type="button"
+                                className="tw-p-1 tw-rounded-full hover:tw-bg-muted"
+                                onClick={() => setShowTipsOverlay(false)}
+                                onKeyDown={handleOverlayKeyDown}
+                                aria-label="Close quick start guide"
+                            >
+                                <X className="tw-w-8 tw-h-8" />
+                            </button>
+                        </div>
+                        <div className={styles.cheatsheet}>
+                            <div className={styles.examples}>
+                                {allExamples.map(example => (
+                                    <div
+                                        key={`overlay-example-${
+                                            'input' in example ? example.input : example.title
+                                        }`}
+                                        className={styles.example}
+                                    >
+                                        {'title' in example && (
+                                            <h4 className="tw-text-sm tw-font-medium tw-mb-2 tw-text-foreground tw-pt-8 tw-border-t tw-border-muted">
+                                                {example.title}
+                                            </h4>
+                                        )}
+                                        {'examples' in example ? (
+                                            <div className="tw-flex tw-flex-row tw-flex-wrap tw-gap-8">
+                                                {example.examples.map(ex => (
+                                                    <div
+                                                        key={`nested-example-${ex.input}`}
+                                                        className={styles.example}
+                                                        style={
+                                                            ex.maxWidth
+                                                                ? { maxWidth: ex.maxWidth }
+                                                                : undefined
+                                                        }
+                                                    >
+                                                        <div
+                                                            className={`${styles.exampleInput} tw-py-1 tw-px-2 md:tw-py-2 md:tw-px-4 md:tw-text-md`}
+                                                        >
+                                                            {ex.input}
+                                                        </div>
+                                                        <div className="tw-text-muted-foreground tw-text-sm md:tw-text-md tw-py-2">
+                                                            {ex.description}
+                                                        </div>
+                                                    </div>
+                                                ))}
+                                            </div>
+                                        ) : (
+                                            <>
+                                                <div
+                                                    className={`${styles.exampleInput} tw-py-1 tw-px-2 md:tw-py-2 md:tw-px-4 md:tw-text-md`}
+                                                >
+                                                    {example.input}
+                                                </div>
+                                                <div className="tw-text-muted-foreground tw-text-sm md:tw-text-md tw-py-2">
+                                                    {example.description}
+                                                </div>
+                                            </>
+                                        )}
+                                    </div>
+                                ))}{' '}
+                            </div>
+                            <div className={styles.tips}>{tips()}</div>
+                        </div>
+                    </div>
+                </div>
+            )}
         </div>
     )
 }

--- a/vscode/webviews/chat/components/WelcomeFooter.tsx
+++ b/vscode/webviews/chat/components/WelcomeFooter.tsx
@@ -1,48 +1,15 @@
-import { CodyIDE } from '@sourcegraph/cody-shared'
+import type { CodyIDE } from '@sourcegraph/cody-shared'
+import { QuickStart } from './QuickStart'
 import styles from './WelcomeFooter.module.css'
 
-import {
-    AtSignIcon,
-    BookOpenText,
-    type LucideProps,
-    MessageCircleQuestion,
-    MessageSquarePlus,
-    TextSelect,
-    X,
-    Zap,
-} from 'lucide-react'
+import { BookOpenText, type LucideProps, MessageCircleQuestion } from 'lucide-react'
 import type { ForwardRefExoticComponent } from 'react'
-import { useState } from 'react'
-
-interface ChatViewTip {
-    message: string
-    icon: ForwardRefExoticComponent<Omit<LucideProps, 'ref'>>
-    vsCodeOnly: boolean
-}
 
 interface ChatViewLink {
     icon: ForwardRefExoticComponent<Omit<LucideProps, 'ref'>>
     text: string
     url: string
 }
-
-const chatTips: ChatViewTip[] = [
-    {
-        message: 'Type @ to add context to your chat',
-        icon: AtSignIcon,
-        vsCodeOnly: true,
-    },
-    {
-        message: 'Start a new chat with ⇧ ⌥ L or switch to chat with ⌥ /',
-        icon: MessageSquarePlus,
-        vsCodeOnly: false,
-    },
-    {
-        message: 'To add code context from an editor, right click and use Add to Cody Chat',
-        icon: TextSelect,
-        vsCodeOnly: true,
-    },
-]
 
 const chatLinks: ChatViewLink[] = [
     {
@@ -58,205 +25,23 @@ const chatLinks: ChatViewLink[] = [
 ]
 
 export default function WelcomeFooter({ IDE }: { IDE: CodyIDE }) {
-    const [showTipsOverlay, setShowTipsOverlay] = useState(false)
-    const examples = [
-        {
-            input: '=useCallBack(',
-            description: 'Deterministically find symbols',
-        },
-        {
-            input: '"// TODO"',
-            description: 'Find string literals',
-        },
-        {
-            input: 'How does this file handle error cases?',
-            description: '@-mention repos and files to include in search or chat',
-        },
-    ]
-
-    const allExamples = [
-        ...examples,
-        {
-            title: 'Combine search and chat for power usage',
-            examples: [
-                {
-                    input: 'HttpError',
-                    description: 'Start with a search query',
-                },
-                {
-                    input: 'Analyze these error handling implementations and explain our retry and timeout strategy',
-                    description: 'Follow-up with a question about the results returned',
-                    maxWidth: '320px',
-                },
-            ],
-        },
-    ]
-
-    function tips() {
-        return chatTips.map((tip, key) => {
-            const Icon = tip.icon
-            if (tip.vsCodeOnly && IDE !== CodyIDE.VSCode) {
-                return null
-            }
-            return (
-                <div key={`tip-${key + 1}`} className={styles.item}>
-                    <Icon className="tw-w-8 tw-h-8 tw-shrink-0" strokeWidth={1.25} />
-                    <div className="tw-text-muted-foreground">{tip.message}</div>
-                </div>
-            )
-        })
-    }
-
-    function links() {
-        return chatLinks.map((link, key) => {
-            const Icon = link.icon
-            return (
-                <div className={styles.item} key={`link-${key + 1}`}>
-                    <Icon className="tw-w-8 tw-h-8" strokeWidth={1.25} />
-                    <a href={link.url} className={styles.link} rel="noreferrer" target="_blank">
-                        {link.text}
-                    </a>
-                </div>
-            )
-        })
-    }
-
-    const handleKeyDown = (event: React.KeyboardEvent) => {
-        if (event.key === 'Enter' || event.key === ' ') {
-            setShowTipsOverlay(true)
-        }
-    }
-
-    const handleOverlayKeyDown = (event: React.KeyboardEvent) => {
-        if (event.key === 'Enter' || event.key === ' ') {
-            setShowTipsOverlay(false)
-        }
-    }
-
-    const handleOverlayClick = (event: React.MouseEvent) => {
-        if (event.target === event.currentTarget) {
-            setShowTipsOverlay(false)
-        }
-    }
-
     return (
         <div className={styles.welcomeFooter}>
-            <div className={`${styles.cheatsheet} tw-mx-auto`} style={{ maxWidth: '768px' }}>
-                <div className="tw-flex tw-items-center tw-gap-4 tw-font-medium tw-text-foreground md:tw-text-base">
-                    <Zap className="tw-w-8 tw-h-8" strokeWidth={1.25} />
-                    Quick Start
-                </div>
-                <div className={styles.examples}>
-                    {examples.map(example => (
-                        <div key={`example-${example.input}`} className={styles.example}>
-                            <div
-                                className={`${styles.exampleInput} tw-py-1 tw-px-2 md:tw-py-2 md:tw-px-4 md:tw-text-md`}
-                            >
-                                {example.input}
-                            </div>
-                            <div className="tw-text-muted-foreground tw-text-sm md:tw-text-md tw-py-2">
-                                {example.description}
-                            </div>
-                        </div>
-                    ))}
-                </div>
-                <button
-                    type="button"
-                    className="tw-text-md tw-my-2 md:tw-my-4 tw-px-4 tw-py-2 tw-border tw-border-muted tw-rounded-md hover:tw-bg-muted tw-mt-2"
-                    onClick={() => setShowTipsOverlay(true)}
-                    onKeyDown={handleKeyDown}
-                >
-                    More tips
-                </button>
-            </div>
+            <QuickStart />
             <div className={`${styles.links} tw-mx-auto`} style={{ maxWidth: '768px' }}>
-                {links()}
-            </div>
-            {showTipsOverlay && (
-                <div
-                    className="tw-fixed tw-inset-0 tw-bg-black/50 tw-flex tw-items-center tw-justify-center tw-p-4"
-                    onClick={handleOverlayClick}
-                    onKeyDown={handleOverlayKeyDown}
-                    role="button"
-                    tabIndex={0}
-                >
-                    <div
-                        className="tw-bg-background tw-p-8 tw-rounded-lg tw-max-w-2xl tw-w-full tw-max-h-[80vh] tw-overflow-y-auto"
-                        role="dialog"
-                        aria-modal="true"
+                {chatLinks.map(link => (
+                    <a
+                        key={link.url}
+                        href={link.url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="tw-flex tw-flex-row tw-gap-3 tw-items-center tw-text-muted-foreground"
                     >
-                        <div className="tw-flex tw-justify-between tw-items-center tw-mb-2">
-                            <div className="tw-flex tw-items-center tw-gap-4 tw-font-medium tw-text-foreground md:tw-text-base">
-                                <Zap className="tw-w-8 tw-h-8" strokeWidth={1.25} />
-                                Quick Start
-                            </div>
-                            <button
-                                type="button"
-                                className="tw-p-1 tw-rounded-full hover:tw-bg-muted"
-                                onClick={() => setShowTipsOverlay(false)}
-                                onKeyDown={handleOverlayKeyDown}
-                                aria-label="Close quick start guide"
-                            >
-                                <X className="tw-w-8 tw-h-8" />
-                            </button>
-                        </div>
-                        <div className={styles.cheatsheet}>
-                            <div className={styles.examples}>
-                                {allExamples.map(example => (
-                                    <div
-                                        key={`overlay-example-${
-                                            'input' in example ? example.input : example.title
-                                        }`}
-                                        className={styles.example}
-                                    >
-                                        {'title' in example && (
-                                            <h4 className="tw-text-sm tw-font-medium tw-mb-2 tw-text-foreground tw-pt-8 tw-border-t tw-border-muted">
-                                                {example.title}
-                                            </h4>
-                                        )}
-                                        {'examples' in example ? (
-                                            <div className="tw-flex tw-flex-row tw-flex-wrap tw-gap-8">
-                                                {example.examples.map(ex => (
-                                                    <div
-                                                        key={`nested-example-${ex.input}`}
-                                                        className={styles.example}
-                                                        style={
-                                                            ex.maxWidth
-                                                                ? { maxWidth: ex.maxWidth }
-                                                                : undefined
-                                                        }
-                                                    >
-                                                        <div
-                                                            className={`${styles.exampleInput} tw-py-1 tw-px-2 md:tw-py-2 md:tw-px-4 md:tw-text-md`}
-                                                        >
-                                                            {ex.input}
-                                                        </div>
-                                                        <div className="tw-text-muted-foreground tw-text-sm md:tw-text-md tw-py-2">
-                                                            {ex.description}
-                                                        </div>
-                                                    </div>
-                                                ))}
-                                            </div>
-                                        ) : (
-                                            <>
-                                                <div
-                                                    className={`${styles.exampleInput} tw-py-1 tw-px-2 md:tw-py-2 md:tw-px-4 md:tw-text-md`}
-                                                >
-                                                    {example.input}
-                                                </div>
-                                                <div className="tw-text-muted-foreground tw-text-sm md:tw-text-md tw-py-2">
-                                                    {example.description}
-                                                </div>
-                                            </>
-                                        )}
-                                    </div>
-                                ))}{' '}
-                            </div>
-                            <div className={styles.tips}>{tips()}</div>
-                        </div>
-                    </div>
-                </div>
-            )}
+                        <link.icon size={16} />
+                        {link.text}
+                    </a>
+                ))}
+            </div>
         </div>
     )
 }


### PR DESCRIPTION
This PR adds the quick start cheatsheet to the footer of the welcome area.

https://github.com/user-attachments/assets/eda30680-3162-40a2-ba10-c9db3849f050

Things left to do:
- Change its position/behaviour depending on [what's decided here](https://sourcegraph.slack.com/archives/C07EQBRSF35/p1736941478732779)
- Any tidyups/bugs/undesired behaviour
- UI should remember preference of expanded/collapsed behaviour (@thenamankumar if you could help here that would be great)
- Content check/update (@rrhyne / @camdencheek)
- Needs to be thoroughly reviewed on sg build and checked in context in the browser

_**Note: This is mostly generated code. Please check carefully!**_

## Test plan
Checked locally, manually.