### PR TITLE
Fix pointer cursor displaying on line numbers in search results

### DIFF
--- a/vscode/webviews/components/codeSnippet/components/CodeExcerpt.module.css
+++ b/vscode/webviews/components/codeSnippet/components/CodeExcerpt.module.css
@@ -7,10 +7,16 @@
         padding: 0;
     }
 
+    /* this would be better written as line number */
     :global(.line) {
         min-width: 1.5rem;
         text-align: right;
         user-select: none;
+        cursor: pointer;
+
+        &:hover {
+            text-decoration: none;
+        }
 
         &::before {
             /* draw line number with css so it cannot be copied to clipboard */

--- a/vscode/webviews/components/codeSnippet/components/CodeExcerpt.module.css
+++ b/vscode/webviews/components/codeSnippet/components/CodeExcerpt.module.css
@@ -7,7 +7,6 @@
         padding: 0;
     }
 
-    /* this would be better written as line number */
     :global(.line) {
         min-width: 1.5rem;
         text-align: right;

--- a/vscode/webviews/components/codeSnippet/components/CodeExcerpt.tsx
+++ b/vscode/webviews/components/codeSnippet/components/CodeExcerpt.tsx
@@ -87,7 +87,7 @@ export const CodeExcerpt: FC<Props> = props => {
                                 key={startLine + i}
                             >
                                 <td
-                                    //rendered in css
+                                    //number is rendered in css
                                     className="line hover:tw-underline"
                                     data-line={startLine + i + 1}
                                     onClick={handleLineClick}

--- a/vscode/webviews/components/codeSnippet/components/CodeExcerpt.tsx
+++ b/vscode/webviews/components/codeSnippet/components/CodeExcerpt.tsx
@@ -88,7 +88,7 @@ export const CodeExcerpt: FC<Props> = props => {
                             >
                                 <td
                                     //rendered in css
-                                    className="line hover:tw-underline tw-cursor-pointer"
+                                    className="line hover:tw-underline"
                                     data-line={startLine + i + 1}
                                     onClick={handleLineClick}
                                     onKeyDown={handleLineClick}

--- a/vscode/webviews/components/codeSnippet/components/CodeExcerpt.tsx
+++ b/vscode/webviews/components/codeSnippet/components/CodeExcerpt.tsx
@@ -87,6 +87,7 @@ export const CodeExcerpt: FC<Props> = props => {
                                 key={startLine + i}
                             >
                                 <td
+                                    //rendered in css
                                     className="line hover:tw-underline tw-cursor-pointer"
                                     data-line={startLine + i + 1}
                                     onClick={handleLineClick}

--- a/vscode/webviews/components/codeSnippet/components/FileMatchChildren.tsx
+++ b/vscode/webviews/components/codeSnippet/components/FileMatchChildren.tsx
@@ -51,7 +51,6 @@ export const FileMatchChildren: FC<PropsWithChildren<FileMatchProps>> = props =>
                         className={clsx(
                             'test-file-match-children-item',
                             styles.chunk,
-                            resultStyles.clickable,
                             resultStyles.focusableBlock,
                             resultStyles.horizontalDividerBetween
                         )}


### PR DESCRIPTION
Resolves the bug where line numbers are showing a pointer cursor even though the line is not clickable.

Issue:
https://linear.app/sourcegraph/issue/SRCH-1521/pointer-cursor-is-dispalying-on-code-search-results-lines

Loom
https://www.loom.com/share/1259953282ed4a96aec5bed69dda2126

## Test plan

* Manually test UI for the following conditions:
* When the cursor is over the line of code, the edit cursor is displayed
* When the cursor is over the line number the pointer cursor is displayed

