### PR TITLE
fix(auto-edit): fix the feature name

### DIFF
--- a/vscode/src/autoedits/autoedit-onboarding.ts
+++ b/vscode/src/autoedits/autoedit-onboarding.ts
@@ -46,12 +46,12 @@ export class AutoEditOnboarding implements vscode.Disposable {
     private async showAutoEditOnboardingPopup(): Promise<void> {
         const { timesShown } = await this.getAutoEditOnboardingNotificationInfo()
 
-        const enableAutoeditText = 'Enable Auto-Edit'
+        const enableAutoeditText = 'Enable Auto-edit'
         const dontShowAgainText = "Don't Show Again"
 
         const selection = await Promise.race([
             vscode.window.showInformationMessage(
-                'Try Cody Auto-Edit (experimental)? Cody will intelligently suggest next edits as you navigate the codebase.',
+                'Try Cody Auto-edit (experimental)? Cody will intelligently suggest next edits as you navigate the codebase.',
                 enableAutoeditText,
                 dontShowAgainText
             ),

--- a/vscode/src/autoedits/create-autoedits-provider.ts
+++ b/vscode/src/autoedits/create-autoedits-provider.ts
@@ -22,10 +22,10 @@ import { AutoeditsProvider } from './autoedits-provider'
 import { autoeditsOutputChannelLogger } from './output-channel-logger'
 
 const AUTOEDITS_NON_ELIGIBILITY_MESSAGES = {
-    ONLY_VSCODE_SUPPORT: 'Auto-Edit is currently only supported in VS Code.',
-    PRO_USER_ONLY: 'Auto-Edit requires Cody Pro subscription.',
+    ONLY_VSCODE_SUPPORT: 'Auto-edit is currently only supported in VS Code.',
+    PRO_USER_ONLY: 'Auto-edit requires Cody Pro subscription.',
     FEATURE_FLAG_NOT_ELIGIBLE:
-        'Auto-Edit is an experimental feature and currently not enabled for your account. Please check back later.',
+        'Auto-edit is an experimental feature and currently not enabled for your account. Please check back later.',
 }
 
 /**

--- a/vscode/test/e2e/auto-edits.test.ts
+++ b/vscode/test/e2e/auto-edits.test.ts
@@ -12,7 +12,7 @@ import {
 } from './helpers'
 
 /**
- * Auto-Edit Visual Regression Tests
+ * Auto-edit Visual Regression Tests
  *
  * Currently these tests run only on macOS due to cross-platform rendering inconsistencies.
  *


### PR DESCRIPTION
Fix the feature name from `Auto-Edit` to `Auto-edit` as per [release doc](https://www.notion.so/sourcegraph/FAQ-6-0-Release-Jan-29-2024-159a8e112658804ca222f7073427ce10#159a8e112658800aa9aad14bc11fa697)

## Test plan
no functional change
