### PR TITLE
fix/intent: Insert detected intent scores into telemetry event metadata in acceptable format

### DIFF
--- a/lib/shared/src/telemetry-v2/events/chat-question.ts
+++ b/lib/shared/src/telemetry-v2/events/chat-question.ts
@@ -144,8 +144,9 @@ export const events = [
                             : undefined,
                         // Each intent is mapped to a `detectedIntentScores.{intent}` field inside the metadata
                         ...params.detectedIntentScores?.reduce(
-                            (scores, value) => {
-                                scores['detectedIntentScores.' + value.intent] = value.score
+                            (scores, intentScore) => {
+                                // intentScore.intent has a fixed set of values and is safe to use here - see ChatMessage['intent']
+                                scores['detectedIntentScores.' + intentScore.intent] = intentScore.score
                                 return scores
                             },
                             {} as Record<string, number>
@@ -156,13 +157,6 @@ export const events = [
                         recordsPrivateMetadataTranscript: recordTranscript ? 1 : 0,
                     }),
                     privateMetadata: {
-                        ...params.detectedIntentScores?.reduce(
-                            (scores, value) => {
-                                scores['detectedIntentScores.' + value.intent] = value.score
-                                return scores
-                            },
-                            {} as Record<string, number>
-                        ),
                         detectedIntent: params.detectedIntent,
                         // TODO: Remove this field when the transition from commands to prompts is complete
                         command: params.command,

--- a/lib/shared/src/telemetry-v2/events/chat-question.ts
+++ b/lib/shared/src/telemetry-v2/events/chat-question.ts
@@ -142,21 +142,27 @@ export const events = [
                         detectedIntent: params.detectedIntent
                             ? map.intent(params.detectedIntent)
                             : undefined,
+                        // Each intent is mapped to a `detectedIntentScores.{intent}` field inside the metadata
+                        ...params.detectedIntentScores?.reduce(
+                            (scores, value) => {
+                                scores['detectedIntentScores.' + value.intent] = value.score
+                                return scores
+                            },
+                            {} as Record<string, number>
+                        ),
                         // TODO: Remove this field when the transition from commands to prompts is complete
                         isCommand: params.command ? 1 : 0,
                         ...metadata,
                         recordsPrivateMetadataTranscript: recordTranscript ? 1 : 0,
                     }),
                     privateMetadata: {
-                        detectedIntentScores: params.detectedIntentScores?.length
-                            ? params.detectedIntentScores.reduce(
-                                  (scores, value) => {
-                                      scores[value.intent] = value.score
-                                      return scores
-                                  },
-                                  {} as Record<string, number>
-                              )
-                            : undefined,
+                        ...params.detectedIntentScores?.reduce(
+                            (scores, value) => {
+                                scores['detectedIntentScores.' + value.intent] = value.score
+                                return scores
+                            },
+                            {} as Record<string, number>
+                        ),
                         detectedIntent: params.detectedIntent,
                         // TODO: Remove this field when the transition from commands to prompts is complete
                         command: params.command,
@@ -184,6 +190,8 @@ export const events = [
             },
         {
             intent: {
+                // This mapping must remain stable to avoid breaking the telemetry data.
+                // Do not remove intents without putting in a placeholder.
                 [fallbackValue]: 0,
                 auto: 1,
                 chat: 2,
@@ -196,13 +204,6 @@ export const events = [
             >,
         }
     ),
-    // //TODO
-    // event(
-    //     'cody.chat-question/response',
-    //     ({ feature, action }) =>
-    //         () => {},
-    //     {}
-    // ),
 ]
 
 function publicContextSummary(globalPrefix: string, context: ContextItem[]) {

--- a/vscode/src/chat/chat-view/ChatController.ts
+++ b/vscode/src/chat/chat-view/ChatController.ts
@@ -827,11 +827,8 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
         })
 
         recorder.setIntentInfo({
-            userSpecifiedIntent: manuallySelectedIntent
-                ? manuallySelectedIntent
-                : this.featureCodyExperimentalOneBox
-                  ? 'auto'
-                  : 'chat',
+            userSpecifiedIntent:
+                manuallySelectedIntent ?? this.featureCodyExperimentalOneBox ? 'auto' : 'chat',
             detectedIntent: detectedIntent,
             detectedIntentScores: detectedIntentScores,
         })


### PR DESCRIPTION
Contributes to [SPLF-330](https://linear.app/sourcegraph/issue/SPLF-330/make-sure-the-collected-telemetry-is-usable-for-fine-tuning-the-model).

More context [in this Slack thread](https://sourcegraph.slack.com/archives/CN4FC7XT4/p1737021858607509).

I'm a bit worried about the mapping from intent names to numeric constants remaining stable as during a larger refactoring this can easily get changed. One way I'm thinking of mitigating it is to have the same data emitted through private metadata which we can see on S2, meaning it's easy to check. I'm open to any better ideas though.

## Test plan
Telemetry metadata contains intent scores in the expected format (`detectedIntentScores.{intent}`).
