### PR TITLE
Refactor external auth providers to re-generate headers on demand

### DIFF
--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/agent/protocol_generated/AuthenticationError.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/agent/protocol_generated/AuthenticationError.kt
@@ -17,6 +17,7 @@ sealed class AuthenticationError {
           "invalid-access-token" -> context.deserialize<InvalidAccessTokenError>(element, InvalidAccessTokenError::class.java)
           "enterprise-user-logged-into-dotcom" -> context.deserialize<EnterpriseUserDotComError>(element, EnterpriseUserDotComError::class.java)
           "auth-config-error" -> context.deserialize<AuthConfigError>(element, AuthConfigError::class.java)
+          "external-auth-provider-error" -> context.deserialize<ExternalAuthProviderError>(element, ExternalAuthProviderError::class.java)
           else -> throw Exception("Unknown discriminator ${element}")
         }
       }
@@ -52,13 +53,22 @@ data class EnterpriseUserDotComError(
 }
 
 data class AuthConfigError(
-  val title: String? = null,
-  val message: String,
   val type: TypeEnum, // Oneof: auth-config-error
+  val message: String,
 ) : AuthenticationError() {
 
   enum class TypeEnum {
     @SerializedName("auth-config-error") `Auth-config-error`,
+  }
+}
+
+data class ExternalAuthProviderError(
+  val type: TypeEnum, // Oneof: external-auth-provider-error
+  val message: String,
+) : AuthenticationError() {
+
+  enum class TypeEnum {
+    @SerializedName("external-auth-provider-error") `External-auth-provider-error`,
   }
 }
 

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/agent/protocol_generated/Constants.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/agent/protocol_generated/Constants.kt
@@ -41,6 +41,7 @@ object Constants {
   const val `enterprise-user-logged-into-dotcom` = "enterprise-user-logged-into-dotcom"
   const val error = "error"
   const val experimental = "experimental"
+  const val `external-auth-provider-error` = "external-auth-provider-error"
   const val file = "file"
   const val free = "free"
   const val function = "function"

--- a/agent/scripts/simple-external-auth-provider.py
+++ b/agent/scripts/simple-external-auth-provider.py
@@ -4,7 +4,7 @@ import time
 from datetime import datetime
 
 def generate_credentials():
-    current_epoch = int(time.time()) + 100
+    current_epoch = int(time.time()) + 30
 
     credentials = {
         "headers": {

--- a/lib/shared/src/auth/types.ts
+++ b/lib/shared/src/auth/types.ts
@@ -62,8 +62,14 @@ export interface EnterpriseUserDotComError {
     enterprise: string
 }
 
-export interface AuthConfigError extends AuthenticationErrorMessage {
+export interface AuthConfigError {
     type: 'auth-config-error'
+    message: string
+}
+
+export interface ExternalAuthProviderError {
+    type: 'external-auth-provider-error'
+    message: string
 }
 
 export type AuthenticationError =
@@ -71,6 +77,7 @@ export type AuthenticationError =
     | InvalidAccessTokenError
     | EnterpriseUserDotComError
     | AuthConfigError
+    | ExternalAuthProviderError
 
 export interface AuthenticationErrorMessage {
     title?: string
@@ -99,7 +106,15 @@ export function getAuthErrorMessage(error: AuthenticationError): AuthenticationE
                     'please contact your Sourcegraph admin.',
             }
         case 'auth-config-error':
-            return error
+            return {
+                title: 'Auth Config Error',
+                message: error.message,
+            }
+        case 'external-auth-provider-error':
+            return {
+                title: 'External Auth Provider Error',
+                message: error.message,
+            }
     }
 }
 

--- a/lib/shared/src/configuration.ts
+++ b/lib/shared/src/configuration.ts
@@ -23,8 +23,7 @@ export interface AuthCredentials {
 
 export interface HeaderCredential {
     // We use function instead of property to prevent accidential top level serialization - we never want to store this data
-    getHeaders(): Record<string, string>
-    expiration: number | undefined
+    getHeaders(): Promise<Record<string, string>>
 }
 
 export interface TokenCredential {

--- a/lib/shared/src/configuration/auth-resolver.test.ts
+++ b/lib/shared/src/configuration/auth-resolver.test.ts
@@ -92,8 +92,7 @@ describe('auth-resolver', () => {
         expect(auth.serverEndpoint).toBe('https://my-server.com/')
 
         const headerCredential = auth.credentials as HeaderCredential
-        expect(headerCredential.expiration).toBe(futureEpoch)
-        expect(headerCredential.getHeaders()).toStrictEqual({
+        expect(await headerCredential.getHeaders()).toStrictEqual({
             Authorization: 'token X',
         })
 
@@ -123,8 +122,9 @@ describe('auth-resolver', () => {
 
         expect(auth.serverEndpoint).toBe('https://my-server.com/')
 
-        expect(auth.credentials).toBe(undefined)
-        expect(auth.error.message).toContain('Failed to execute external auth command: Unexpected token')
+        const headerCredential = auth.credentials as HeaderCredential
+        expect(headerCredential.getHeaders).toBeInstanceOf(Function)
+        expect(headerCredential.getHeaders()).rejects.toThrowError('Unexpected token')
     })
 
     test('resolve custom auth provider error handling - bad expiration', async () => {
@@ -158,8 +158,9 @@ describe('auth-resolver', () => {
 
         expect(auth.serverEndpoint).toBe('https://my-server.com/')
 
-        expect(auth.credentials).toBe(undefined)
-        expect(auth.error.message).toContain(
+        const headerCredential = auth.credentials as HeaderCredential
+        expect(headerCredential.getHeaders).toBeInstanceOf(Function)
+        expect(headerCredential.getHeaders()).rejects.toThrowError(
             'Credentials expiration cannot be set to a date in the past'
         )
     })

--- a/lib/shared/src/configuration/auth-resolver.ts
+++ b/lib/shared/src/configuration/auth-resolver.ts
@@ -1,10 +1,15 @@
+import { Subject } from 'observable-fns'
 import type {
     AuthCredentials,
     ClientConfiguration,
     ExternalAuthCommand,
     ExternalAuthProvider,
 } from '../configuration'
+import { logError } from '../logger'
+import { ExternalProviderAuthError } from '../sourcegraph-api/errors'
 import type { ClientSecrets } from './resolver'
+
+export const externalAuthRefresh = new Subject<void>()
 
 export function normalizeServerEndpointURL(url: string): string {
     return url.endsWith('/') ? url : `${url}/`
@@ -37,20 +42,84 @@ interface HeaderCredentialResult {
     expiration?: number | undefined
 }
 
-async function getExternalProviderAuthResult(
-    serverEndpoint: string,
-    authExternalProviders: readonly ExternalAuthProvider[]
-): Promise<HeaderCredentialResult | undefined> {
-    const externalProvider = authExternalProviders.find(
-        provider => normalizeServerEndpointURL(provider.endpoint) === serverEndpoint
-    )
+let _headersCache: Promise<HeaderCredentialResult> | undefined = undefined
 
-    if (externalProvider) {
-        const result = await executeCommand(externalProvider.executable)
-        return JSON.parse(result)
+function hasExpired(expiration: number | undefined): boolean {
+    return expiration !== undefined && expiration * 1000 < Date.now()
+}
+
+async function getExternalProviderHeaders(
+    externalProvider: ExternalAuthProvider
+): Promise<HeaderCredentialResult> {
+    const result = await executeCommand(externalProvider.executable).catch(error => {
+        throw new Error(`Failed to execute external auth command: ${error.message || error}`)
+    })
+
+    const credentials = JSON.parse(result) as HeaderCredentialResult
+
+    if (!credentials?.headers) {
+        throw new Error(`Output of the external auth command is invalid: ${result}`)
     }
 
-    return undefined
+    if (credentials.expiration && hasExpired(credentials.expiration)) {
+        throw new Error(
+            'Credentials expiration cannot be set to a date in the past: ' +
+                `${new Date(credentials.expiration * 1000)} (${credentials.expiration})`
+        )
+    }
+
+    return credentials
+}
+
+async function createTokenCredentails(
+    clientSecrets: ClientSecrets,
+    serverEndpoint: string
+): Promise<AuthCredentials> {
+    const token = await clientSecrets.getToken(serverEndpoint).catch(error => {
+        throw new Error(
+            `Failed to get access token for endpoint ${serverEndpoint}: ${error.message || error}`
+        )
+    })
+
+    return {
+        credentials: token
+            ? { token, source: await clientSecrets.getTokenSource(serverEndpoint) }
+            : undefined,
+        serverEndpoint,
+    }
+}
+
+function createHeaderCredentails(
+    externalProvider: ExternalAuthProvider,
+    serverEndpoint: string
+): AuthCredentials {
+    // Needed in case of account switch so we reset the cache.
+    // We could also set it to undefined but there is no harm in pre-loading the cache.
+    _headersCache = getExternalProviderHeaders(externalProvider)
+
+    return {
+        credentials: {
+            async getHeaders() {
+                try {
+                    if (!_headersCache || hasExpired((await _headersCache)?.expiration)) {
+                        _headersCache = getExternalProviderHeaders(externalProvider)
+                        externalAuthRefresh.next()
+                    }
+
+                    return (await _headersCache).headers
+                } catch (error) {
+                    _headersCache = undefined
+                    externalAuthRefresh.next()
+
+                    logError('resolveAuth', `External Auth Provider Error: ${error}`)
+                    throw new ExternalProviderAuthError(
+                        error instanceof Error ? error.message : String(error)
+                    )
+                }
+            },
+        },
+        serverEndpoint,
+    }
 }
 
 export async function resolveAuth(
@@ -69,46 +138,13 @@ export async function resolveAuth(
             return { credentials: { token: overrideAuthToken }, serverEndpoint }
         }
 
-        const credentials = await getExternalProviderAuthResult(
-            serverEndpoint,
-            authExternalProviders
-        ).catch(error => {
-            throw new Error(`Failed to execute external auth command: ${error.message || error}`)
-        })
+        const externalProvider = authExternalProviders.find(
+            provider => normalizeServerEndpointURL(provider.endpoint) === serverEndpoint
+        )
 
-        if (credentials) {
-            if (credentials?.expiration) {
-                const expirationMs = credentials?.expiration * 1000
-                if (expirationMs < Date.now()) {
-                    throw new Error(
-                        'Credentials expiration cannot be set to a date in the past: ' +
-                            `${new Date(expirationMs)} (${credentials.expiration})`
-                    )
-                }
-            }
-            return {
-                credentials: {
-                    expiration: credentials?.expiration,
-                    getHeaders() {
-                        return credentials.headers
-                    },
-                },
-                serverEndpoint,
-            }
-        }
-
-        const token = await clientSecrets.getToken(serverEndpoint).catch(error => {
-            throw new Error(
-                `Failed to get access token for endpoint ${serverEndpoint}: ${error.message || error}`
-            )
-        })
-
-        return {
-            credentials: token
-                ? { token, source: await clientSecrets.getTokenSource(serverEndpoint) }
-                : undefined,
-            serverEndpoint,
-        }
+        return externalProvider
+            ? createHeaderCredentails(externalProvider, serverEndpoint)
+            : createTokenCredentails(clientSecrets, serverEndpoint)
     } catch (error) {
         return {
             credentials: undefined,

--- a/lib/shared/src/configuration/resolver.ts
+++ b/lib/shared/src/configuration/resolver.ts
@@ -1,13 +1,11 @@
-import { Observable, Subject, map } from 'observable-fns'
+import { Observable, map } from 'observable-fns'
 import type { AuthCredentials, ClientConfiguration, TokenSource } from '../configuration'
 import { logError } from '../logger'
 import {
-    combineLatest,
     distinctUntilChanged,
     firstValueFrom,
     fromLateSetSource,
     promiseToObservable,
-    startWith,
 } from '../misc/observable'
 import { skipPendingOperation, switchMapReplayOperation } from '../misc/observableOperation'
 import type { DefaultsAndUserPreferencesByEndpoint } from '../models/modelsService'
@@ -94,11 +92,6 @@ async function resolveConfiguration({
 
     try {
         const auth = await resolveAuth(serverEndpoint, clientConfiguration, clientSecrets)
-        const cred = auth.credentials
-        if (cred !== undefined && 'expiration' in cred && cred.expiration !== undefined) {
-            const expireInMs = cred.expiration * 1000 - Date.now()
-            setInterval(() => _refreshConfigRequests.next(), expireInMs)
-        }
         return { configuration: clientConfiguration, clientState, auth, isReinstall }
     } catch (error) {
         // We don't want to throw here, because that would cause the observable to terminate and
@@ -115,16 +108,14 @@ async function resolveConfiguration({
 
 const _resolvedConfig = fromLateSetSource<ResolvedConfiguration>()
 
-const _refreshConfigRequests = new Subject<void>()
-
 /**
  * Set the observable that will be used to provide the global {@link resolvedConfig}. This should be
  * set exactly once (except in tests).
  */
 export function setResolvedConfigurationObservable(input: Observable<ConfigurationInput>): void {
     _resolvedConfig.setSource(
-        combineLatest(input, _refreshConfigRequests.pipe(startWith(undefined))).pipe(
-            switchMapReplayOperation(([input]) => promiseToObservable(resolveConfiguration(input))),
+        input.pipe(
+            switchMapReplayOperation(input => promiseToObservable(resolveConfiguration(input))),
             skipPendingOperation(),
             map(value => {
                 if (isError(value)) {

--- a/lib/shared/src/sourcegraph-api/completions/browserClient.ts
+++ b/lib/shared/src/sourcegraph-api/completions/browserClient.ts
@@ -40,8 +40,16 @@ export class SourcegraphBrowserCompletionsClient extends SourcegraphCompletionsC
             ...requestParams.customHeaders,
         } as HeadersInit)
         addCodyClientIdentificationHeaders(headersInstance)
-        addAuthHeaders(config.auth, headersInstance, url)
         headersInstance.set('Content-Type', 'application/json; charset=utf-8')
+
+        try {
+            await addAuthHeaders(config.auth, headersInstance, url)
+        } catch (error: any) {
+            cb.onError(error.message)
+            abort.abort()
+            console.error(error)
+            return
+        }
 
         const parameters = new URLSearchParams(globalThis.location.search)
         const trace = parameters.get('trace')
@@ -132,12 +140,13 @@ export class SourcegraphBrowserCompletionsClient extends SourcegraphCompletionsC
             ...requestParams.customHeaders,
         })
         addCodyClientIdentificationHeaders(headersInstance)
-        addAuthHeaders(auth, headersInstance, url)
 
         if (new URLSearchParams(globalThis.location.search).get('trace')) {
             headersInstance.set('X-Sourcegraph-Should-Trace', 'true')
         }
         try {
+            await addAuthHeaders(auth, headersInstance, url)
+
             const response = await fetch(url.toString(), {
                 method: 'POST',
                 headers: headersInstance,

--- a/lib/shared/src/sourcegraph-api/errors.ts
+++ b/lib/shared/src/sourcegraph-api/errors.ts
@@ -136,8 +136,11 @@ export function isNetworkLikeError(error: Error): boolean {
     )
 }
 
-export class ExternalProviderAuthError extends Error {}
+export class ExternalProviderAuthError extends Error {
+    // Added to make TypeScript understand that ExternalProviderAuthError is not the same as Error.
+    public readonly isExternalProviderAuthError = true
+}
 
-export function isExternalProviderAuthError(error: unknown): boolean {
+export function isExternalProviderAuthError(error: unknown): error is ExternalProviderAuthError {
     return error instanceof ExternalProviderAuthError
 }

--- a/lib/shared/src/sourcegraph-api/errors.ts
+++ b/lib/shared/src/sourcegraph-api/errors.ts
@@ -135,3 +135,9 @@ export function isNetworkLikeError(error: Error): boolean {
         message.includes('SELF_SIGNED_CERT_IN_CHAIN')
     )
 }
+
+export class ExternalProviderAuthError extends Error {}
+
+export function isExternalProviderAuthError(error: unknown): boolean {
+    return error instanceof ExternalProviderAuthError
+}

--- a/lib/shared/src/sourcegraph-api/graphql/client.ts
+++ b/lib/shared/src/sourcegraph-api/graphql/client.ts
@@ -1615,7 +1615,12 @@ export class SourcegraphGraphQLAPIClient {
 
         addTraceparent(headers)
         addCodyClientIdentificationHeaders(headers)
-        addAuthHeaders(config.auth, headers, url)
+
+        try {
+            await addAuthHeaders(config.auth, headers, url)
+        } catch (error: any) {
+            return error
+        }
 
         const queryName = query.match(QUERY_TO_NAME_REGEXP)?.[1]
 
@@ -1663,7 +1668,12 @@ export class SourcegraphGraphQLAPIClient {
 
         addTraceparent(headers)
         addCodyClientIdentificationHeaders(headers)
-        addAuthHeaders(config.auth, headers, url)
+
+        try {
+            await addAuthHeaders(config.auth, headers, url)
+        } catch (error: any) {
+            return error
+        }
 
         const { abortController, timeoutSignal } = dependentAbortControllerWithTimeout(signal)
         return wrapInActiveSpan(`httpapi.fetch${queryName ? `.${queryName}` : ''}`, () =>

--- a/lib/shared/src/sourcegraph-api/rest/client.ts
+++ b/lib/shared/src/sourcegraph-api/rest/client.ts
@@ -32,7 +32,11 @@ export class RestClient {
 
     // Make an authenticated HTTP request to the Sourcegraph instance.
     // "name" is a developer-friendly term to label the request's trace span.
-    private getRequest<T>(name: string, urlSuffix: string, signal?: AbortSignal): Promise<T | Error> {
+    private async getRequest<T>(
+        name: string,
+        urlSuffix: string,
+        signal?: AbortSignal
+    ): Promise<T | Error> {
         const headers = new Headers(this.customHeaders)
 
         const endpoint = new URL(this.auth.serverEndpoint)
@@ -40,8 +44,13 @@ export class RestClient {
         const url = endpoint.href
 
         addCodyClientIdentificationHeaders(headers)
-        addAuthHeaders(this.auth, headers, endpoint)
         addTraceparent(headers)
+
+        try {
+            await addAuthHeaders(this.auth, headers, endpoint)
+        } catch (error: any) {
+            return error
+        }
 
         return wrapInActiveSpan(`rest-api.${name}`, () =>
             fetch(url, {

--- a/lib/shared/src/sourcegraph-api/utils.ts
+++ b/lib/shared/src/sourcegraph-api/utils.ts
@@ -36,13 +36,13 @@ export function toPartialUtf8String(buf: Buffer): { str: string; buf: Buffer } {
     }
 }
 
-export function addAuthHeaders(auth: AuthCredentials, headers: Headers, url: URL): void {
+export async function addAuthHeaders(auth: AuthCredentials, headers: Headers, url: URL): Promise<void> {
     // We want to be sure we sent authorization headers only to the valid endpoint
     if (auth.credentials && url.host === new URL(auth.serverEndpoint).host) {
         if ('token' in auth.credentials) {
             headers.set('Authorization', `token ${auth.credentials.token}`)
         } else if (typeof auth.credentials.getHeaders === 'function') {
-            for (const [key, value] of Object.entries(auth.credentials.getHeaders())) {
+            for (const [key, value] of Object.entries(await auth.credentials.getHeaders())) {
                 headers.set(key, value)
             }
         } else {

--- a/vscode/src/auth/auth.ts
+++ b/vscode/src/auth/auth.ts
@@ -23,6 +23,7 @@ import {
     telemetryRecorder,
 } from '@sourcegraph/cody-shared'
 import { resolveAuth } from '@sourcegraph/cody-shared/src/configuration/auth-resolver'
+import { isExternalProviderAuthError } from '@sourcegraph/cody-shared/src/sourcegraph-api/errors'
 import { isSourcegraphToken } from '../chat/protocol'
 import { newAuthStatus } from '../chat/utils'
 import { logDebug } from '../output-channel-logger'
@@ -453,13 +454,12 @@ export async function validateCredentials(
             pendingValidation: false,
             error: {
                 type: 'auth-config-error',
-                title: 'Auth config error',
                 message: config.auth.error?.message ?? config.auth.error,
             },
         }
     }
 
-    // An access token is needed except for Cody Web, which uses cookies.
+    // Credentials are needed except for Cody Web, which uses cookies.
     if (!config.auth.credentials && !clientCapabilities().isCodyWeb) {
         return { authenticated: false, endpoint: config.auth.serverEndpoint, pendingValidation: false }
     }
@@ -482,17 +482,28 @@ export async function validateCredentials(
         const userInfo = await client.getCurrentUserInfo(signal)
         signal?.throwIfAborted()
 
-        if (isError(userInfo) && isNetworkLikeError(userInfo)) {
-            logDebug(
-                'auth',
-                `Failed to authenticate to ${config.auth.serverEndpoint} due to likely network error`,
-                userInfo.message
-            )
-            return {
-                authenticated: false,
-                error: { type: 'network-error' },
-                endpoint: config.auth.serverEndpoint,
-                pendingValidation: false,
+        if (isError(userInfo)) {
+            if (isExternalProviderAuthError(userInfo)) {
+                logDebug('auth', userInfo.message)
+                return {
+                    authenticated: false,
+                    error: { type: 'external-auth-provider-error', message: userInfo.message },
+                    endpoint: config.auth.serverEndpoint,
+                    pendingValidation: false,
+                }
+            }
+            if (isNetworkLikeError(userInfo)) {
+                logDebug(
+                    'auth',
+                    `Failed to authenticate to ${config.auth.serverEndpoint} due to likely network error`,
+                    userInfo.message
+                )
+                return {
+                    authenticated: false,
+                    error: { type: 'network-error' },
+                    endpoint: config.auth.serverEndpoint,
+                    pendingValidation: false,
+                }
             }
         }
         if (!userInfo || isError(userInfo)) {

--- a/vscode/src/completions/default-client.ts
+++ b/vscode/src/completions/default-client.ts
@@ -72,12 +72,16 @@ class DefaultCodeCompletionsClient implements CodeCompletionsClient {
                 // c.f. https://github.com/microsoft/vscode/issues/173861
                 headers.set('Content-Type', 'application/json; charset=utf-8')
                 addCodyClientIdentificationHeaders(headers)
-                addAuthHeaders(auth, headers, url)
 
                 if (tracingFlagEnabled) {
                     headers.set('X-Sourcegraph-Should-Trace', '1')
-
                     addTraceparent(headers)
+                }
+
+                try {
+                    await addAuthHeaders(auth, headers, url)
+                } catch (error: any) {
+                    throw recordErrorToSpan(span, error)
                 }
 
                 // We enable streaming only for Node environments right now because it's hard to make

--- a/vscode/src/completions/nodeClient.ts
+++ b/vscode/src/completions/nodeClient.ts
@@ -102,7 +102,14 @@ export class SourcegraphNodeCompletionsClient extends SourcegraphCompletionsClie
                 Connection: 'keep-alive',
             })
             addCodyClientIdentificationHeaders(headers)
-            addAuthHeaders(auth, headers, url)
+
+            try {
+                await addAuthHeaders(auth, headers, url)
+            } catch (error: any) {
+                log?.onError(error.message, error)
+                onErrorOnce(error)
+                return
+            }
 
             const request = requestFn(
                 url,
@@ -307,7 +314,7 @@ export class SourcegraphNodeCompletionsClient extends SourcegraphCompletionsClie
                 })
 
                 addCodyClientIdentificationHeaders(headers)
-                addAuthHeaders(auth, headers, url)
+                await addAuthHeaders(auth, headers, url)
 
                 const response = await fetch(url.toString(), {
                     method: 'POST',

--- a/vscode/src/services/UpstreamHealthProvider.ts
+++ b/vscode/src/services/UpstreamHealthProvider.ts
@@ -97,7 +97,7 @@ class UpstreamHealthProvider implements vscode.Disposable {
 
             const url = new URL('/healthz', auth.serverEndpoint)
             const upstreamHeaders = new Headers(sharedHeaders)
-            addAuthHeaders(auth, upstreamHeaders, url)
+            await addAuthHeaders(auth, upstreamHeaders, url)
 
             const upstreamResult = await wrapInActiveSpan('upstream-latency.upstream', span => {
                 span.setAttribute('sampled', true)

--- a/vscode/src/services/open-telemetry/CodyTraceExport.ts
+++ b/vscode/src/services/open-telemetry/CodyTraceExport.ts
@@ -1,7 +1,6 @@
 import type { ExportResult } from '@opentelemetry/core'
 import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http'
 import type { ReadableSpan } from '@opentelemetry/sdk-trace-base'
-import { type AuthCredentials, addAuthHeaders } from '@sourcegraph/cody-shared'
 
 const MAX_TRACE_RETAIN_MS = 60 * 1000
 
@@ -11,16 +10,17 @@ export class CodyTraceExporter extends OTLPTraceExporter {
 
     constructor({
         traceUrl,
-        auth,
         isTracingEnabled,
-    }: { traceUrl: string; auth: AuthCredentials | null; isTracingEnabled: boolean }) {
-        const headers = new Headers()
-        if (auth) addAuthHeaders(auth, headers, new URL(traceUrl))
-
+        authHeaders,
+    }: {
+        traceUrl: string
+        isTracingEnabled: boolean
+        authHeaders: Record<string, string>
+    }) {
         super({
             url: traceUrl,
             httpAgentOptions: { rejectUnauthorized: false },
-            headers: Object.fromEntries(headers.entries()),
+            headers: authHeaders,
         })
         this.isTracingEnabled = isTracingEnabled
     }

--- a/vscode/src/services/open-telemetry/OpenTelemetryService.node.ts
+++ b/vscode/src/services/open-telemetry/OpenTelemetryService.node.ts
@@ -35,6 +35,10 @@ export class OpenTelemetryService {
 
     private configSubscription: Unsubscribable
 
+    // TODO: CODY-4720 - Race between config and auth update can lead to easy to make errors.
+    // `externalAuthRefresh` or `resolvedConfig` can emit before `auth` is updated, leading to potentially incoherent state.
+    // E.g. url endpoint may not match the endpoint for which headers were generated
+    // `addAuthHeaders` function have internal guard against this, but it would be better to solve this issue on the architecture level
     constructor() {
         this.configSubscription = combineLatest(
             externalAuthRefresh,

--- a/vscode/src/services/open-telemetry/OpenTelemetryService.node.ts
+++ b/vscode/src/services/open-telemetry/OpenTelemetryService.node.ts
@@ -8,6 +8,7 @@ import {
     FeatureFlag,
     type ResolvedConfiguration,
     type Unsubscribable,
+    addAuthHeaders,
     combineLatest,
     featureFlagProvider,
     resolvedConfig,
@@ -15,6 +16,8 @@ import {
 
 import { DiagConsoleLogger, DiagLogLevel, diag } from '@opentelemetry/api'
 import { BatchSpanProcessor } from '@opentelemetry/sdk-trace-base'
+import { externalAuthRefresh } from '@sourcegraph/cody-shared/src/configuration/auth-resolver'
+import { isEqual } from 'lodash'
 import { version } from '../../version'
 import { CodyTraceExporter } from './CodyTraceExport'
 import { ConsoleBatchSpanExporter } from './console-batch-span-exporter'
@@ -25,6 +28,7 @@ export class OpenTelemetryService {
     private isTracingEnabled = false
 
     private lastTraceUrl: string | undefined
+    private lastHeaders: Record<string, string> | undefined
     // We use a single promise object that we chain on to, to avoid multiple reconfigure calls to
     // be run in parallel
     private reconfigurePromiseMutex: Promise<void> = Promise.resolve()
@@ -33,28 +37,43 @@ export class OpenTelemetryService {
 
     constructor() {
         this.configSubscription = combineLatest(
+            externalAuthRefresh,
             resolvedConfig,
             featureFlagProvider.evaluatedFeatureFlag(FeatureFlag.CodyAutocompleteTracing)
-        ).subscribe(([{ configuration, auth }, codyAutocompleteTracingFlag]) => {
-            this.reconfigurePromiseMutex = this.reconfigurePromiseMutex.then(async () => {
-                this.isTracingEnabled = configuration.experimentalTracing || codyAutocompleteTracingFlag
+        ).subscribe(([_, { configuration, auth }, codyAutocompleteTracingFlag]) => {
+            this.reconfigurePromiseMutex = this.reconfigurePromiseMutex
+                .then(async () => {
+                    this.isTracingEnabled =
+                        configuration.experimentalTracing || codyAutocompleteTracingFlag
 
-                const traceUrl = new URL('/-/debug/otlp/v1/traces', auth.serverEndpoint).toString()
-                if (this.lastTraceUrl === traceUrl) {
-                    return
-                }
-                this.lastTraceUrl = traceUrl
+                    const traceUrl = new URL('/-/debug/otlp/v1/traces', auth.serverEndpoint).toString()
 
-                const logLevel = configuration.debugVerbose ? DiagLogLevel.INFO : DiagLogLevel.ERROR
-                diag.setLogger(new DiagConsoleLogger(), logLevel)
+                    const httpHeaders = new Headers()
+                    if (auth) await addAuthHeaders(auth, httpHeaders, new URL(traceUrl))
+                    const headers = Object.fromEntries(httpHeaders.entries())
 
-                await this.reset()
+                    if (this.lastTraceUrl === traceUrl && isEqual(headers, this.lastHeaders)) {
+                        return
+                    }
+                    this.lastTraceUrl = traceUrl
+                    this.lastHeaders = headers
 
-                this.unloadInstrumentations = registerInstrumentations({
-                    instrumentations: [new HttpInstrumentation()],
+                    const logLevel = configuration.debugVerbose ? DiagLogLevel.INFO : DiagLogLevel.ERROR
+                    diag.setLogger(new DiagConsoleLogger(), logLevel)
+
+                    await this.reset().catch(error => {
+                        console.error('Error reset OpenTelemetry:', error)
+                    })
+
+                    this.unloadInstrumentations = registerInstrumentations({
+                        instrumentations: [new HttpInstrumentation()],
+                    })
+
+                    this.configureTracerProvider(traceUrl, headers, { configuration })
                 })
-                this.configureTracerProvider(traceUrl, { configuration, auth })
-            })
+                .catch(error => {
+                    console.error('Error configuring OpenTelemetry:', error)
+                })
         })
     }
 
@@ -64,7 +83,8 @@ export class OpenTelemetryService {
 
     private configureTracerProvider(
         traceUrl: string,
-        { configuration, auth }: Pick<ResolvedConfiguration, 'configuration' | 'auth'>
+        authHeaders: Record<string, string>,
+        { configuration }: Pick<ResolvedConfiguration, 'configuration'>
     ): void {
         this.tracerProvider = new NodeTracerProvider({
             resource: new Resource({
@@ -79,7 +99,7 @@ export class OpenTelemetryService {
                 new CodyTraceExporter({
                     traceUrl,
                     isTracingEnabled: this.isTracingEnabled,
-                    auth,
+                    authHeaders,
                 })
             )
         )

--- a/vscode/src/services/open-telemetry/trace-sender.ts
+++ b/vscode/src/services/open-telemetry/trace-sender.ts
@@ -29,7 +29,7 @@ async function doSendTraceData(spanData: any): Promise<void> {
     const traceUrl = new URL('/-/debug/otlp/v1/traces', auth.serverEndpoint)
 
     const headers = new Headers({ 'Content-Type': 'application/json' })
-    addAuthHeaders(auth, headers, traceUrl)
+    await addAuthHeaders(auth, headers, traceUrl)
 
     const response = await fetch(traceUrl, {
         method: 'POST',


### PR DESCRIPTION
## Changes

That PR eliminates annoying chat reload upon an token refresh if external auth provider is used.
It does so by splitting external auth provider evaluation into two steps which happens at different stages: config resolution and http request building.

At config resolution we only evaluate config itself and prepare a function which will be later used to generate auth headers later. That function (`getHeaders`) is then used to obtain auth headers every time we are doing an authorised http request. Normally headers are cached, but if they expire `getHeaders` should internally refresh the cache and return an updated headers. If updated headers are still expired error will be shown to the user.

In opposition to the previous solution errors in executing external provider command, or token expiration, does not lead
to the config invalidation - config always remains the same unless changed by the user. The only thing which changes is result of `getHeaders` functions. 
Errors from `getHeaders` are processed and handled in the same way as e.g. `Network Error` or `Invalid Access Token`, so we do not need custom code to handle them.


![image](https://github.com/user-attachments/assets/86298a35-3aa6-4b87-9fd2-edb1689e08d2)
![image](https://github.com/user-attachments/assets/3b853a14-a6f7-44af-a50e-2d3e6db6f24f)


## Test plan

**Setup**

Set `cody.auth.externalProviders` config to use provider which support credentials expiration.
You can use configuration shown bellow.
Please also make sure you have proxy running and your sourcegraph server have http auth proxy enabled, as described in https://github.com/sourcegraph/cody/pull/6526.

```json
{
    "cody.auth.externalProviders": [
        {
            "endpoint": "http://localhost:7777",
            "executable": {
                "commandLine": ["/Users/pkukielka/Work/sourcegraph/cody2/agent/scripts/simple-external-auth-provider.py"],
                "shell": "/bin/bash",
            }
        }
    ],
    
    "cody.override.serverEndpoint": "http://localhost:7777",
}

```

**Scenario 1:**

1. Start cody, if you used `simple-external-auth-provider.py` should be successfully signed-in as `someuser`
2. Test chat and autocompletions - everything should work
3. Open `simple-external-auth-provider.py` and change `current_epoch = int(time.time()) + 30` to `current_epoch = int(time.time()) - 30`
4. Wait 30 sec and do some Cody action, e.g. ask a chat question
5. You should get an error, but your conversation should be preserved
6. Revert your changes to `simple-external-auth-provider.py`
7. Ask the question again - chat should be working again

Scenario 2:

1. Start cody, if you used `simple-external-auth-provider.py` should be successfully signed-in as `someuser`
2. Test chat and autocompletions - everything should work
3. Open `simple-external-auth-provider.py` and change `current_epoch = int(time.time()) + 30` to `current_epoch = int(time.time()) - 30`
4. Quickly do some Cody actions before 30 sec will pass.
They should be successful, but when 30 sec will pas since last action before the `simple-external-auth-provider.py` edit, you should get an credential expiration error
5. Revert your changes to `simple-external-auth-provider.py`
6. Make sure Cody works fine again

Scenario 3:

1. Open `simple-external-auth-provider.py` and change `current_epoch = int(time.time()) + 30` to `current_epoch = int(time.time()) - 30`
2. Start Cody
4. You should see a credential expiration error 
5. Click 'Sign In' - it should try to sign you in but eventually fail
6. Revert changes to `simple-external-auth-provider.py`
7. Click 'Sign In' - it should succeed
8. Make sure Cody chat and autocompletions works

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
