### PR TITLE
fix(auto-edit): fix the cody status bar with new suggestion mode

### DIFF
--- a/vscode/src/autoedits/create-autoedits-provider.ts
+++ b/vscode/src/autoedits/create-autoedits-provider.ts
@@ -127,13 +127,6 @@ export function isUserEligibleForAutoeditsFeature(
     authStatus: AuthStatus,
     productSubscription: UserProductSubscription | null
 ): AutoeditsUserEligibilityInfo {
-    console.log({
-        autoeditsFeatureFlagEnabled,
-        isTesting: process.env.CODY_TESTING === 'true',
-        isRunningInsideAgent: isRunningInsideAgent(),
-        isFreeUser: isFreeUser(authStatus, productSubscription),
-    })
-
     // Always enable auto-edit when testing
     if (process.env.CODY_TESTING === 'true') {
         return { isUserEligible: true }


### PR DESCRIPTION
## Context 
Cody Status bar for `autocomplete` is broken right now with the introduction of new suggestion modes.
<img width="777" alt="image" src="https://github.com/user-attachments/assets/9c4dac2b-766a-49c1-8c02-83c5c9a67c56" />

- The PR adds a enum in the quick pick for selecting the suggestion model between `autocomplete`/`off`/`auto-edit` (if applicable). 
- `Auto-edit` is only shown if the user is eligible for the feature. See in the demo for the free account, we don't show this option.
- Closes https://linear.app/sourcegraph/issue/CODY-4713/status-bar-autocomplete-switch-doesnt-work 

## Test plan
- Switch between different modes in the toggle bar.
- Added a demo below

https://github.com/user-attachments/assets/a7cbb810-04b0-449e-90d3-8d8aa8211ff5
