### PR TITLE
fix/agentic-context: Reveal hidden switch in context popup

### DIFF
--- a/vscode/webviews/chat/cells/messageCell/human/editor/ToolboxButton.tsx
+++ b/vscode/webviews/chat/cells/messageCell/human/editor/ToolboxButton.tsx
@@ -236,4 +236,3 @@ const Switch: FC<{ checked?: boolean; onChange?: (checked: boolean) => void; dis
             </button>
         )
     })
-

--- a/vscode/webviews/chat/cells/messageCell/human/editor/ToolboxButton.tsx
+++ b/vscode/webviews/chat/cells/messageCell/human/editor/ToolboxButton.tsx
@@ -115,12 +115,12 @@ export const ToolboxButton: FC<ToolboxButtonProps> = memo(({ settings, api, isFi
                         </h2>
                         <div
                             id="accordion-collapse-body"
-                            className="tw-ml-5 tw-p-5 tw-flex tw-flex-col tw-gap-3 tw-my-2"
+                            className="tw-p-5 tw-flex tw-flex-col tw-gap-3 tw-my-2"
                         >
                             <div className="tw-text-xs">
                                 <span>
                                     Agentic chat reflects on your request and uses tools to dynamically
-                                    retrieve relevant context, improving accuracy and response quality.
+                                    retrieve relevant context, improving accuracy and response quality.{' '}
                                     <a
                                         target="_blank"
                                         rel="noreferrer"
@@ -175,7 +175,7 @@ export const ToolboxButton: FC<ToolboxButtonProps> = memo(({ settings, api, isFi
                 )}
                 popoverRootProps={{ onOpenChange }}
                 popoverContentProps={{
-                    className: 'tw-w-[350px] !tw-p-0 tw-mr-4',
+                    className: 'tw-w-[250px] !tw-p-0 tw-mx-8',
                     onCloseAutoFocus: event => {
                         event.preventDefault()
                     },
@@ -236,3 +236,4 @@ const Switch: FC<{ checked?: boolean; onChange?: (checked: boolean) => void; dis
             </button>
         )
     })
+


### PR DESCRIPTION
Follow ups on #6596.

As a user I realized that working on a standard `13inch macbook` I was very commonly using the `Cody Chat` feature with a width that resulted in the exclusion of a feature I would have used. In effect the feature was hidden without me using an external monitor.

## Three changes made in this PR
1. Change `popover` width
2. Fix over-use of `left margin`
3. Add a `space` between sentences

## Before Screenshots
_Wider width of side bar_
<img width="1004" alt="Screenshot 2025-01-19 at 5 25 39 PM" src="https://github.com/user-attachments/assets/c10bc96a-8786-4a2d-ab04-4b8b63b84c3e" />

_Narrower width of side bar - **Notice that the switch on the right gets cuts off**_
<img width="1040" alt="Screenshot 2025-01-19 at 5 26 00 PM" src="https://github.com/user-attachments/assets/852eb80d-9008-4cdb-9608-9fef6ae64f03" />

## After Screenshots
_Wider width of side bar_
<img width="1008" alt="Screenshot 2025-01-19 at 5 23 57 PM" src="https://github.com/user-attachments/assets/56f47ff6-252d-49fe-b33b-b210cfd2506b" />

_Narrower width of side bar_
<img width="921" alt="Screenshot 2025-01-19 at 5 23 40 PM" src="https://github.com/user-attachments/assets/abf2b020-bb22-4dd0-9e91-dc47bcbd0b95" />

## Test plan

Storybook:

```
pnpm -C vscode storybook
open http://localhost:6007/?path=/story/cody-toolboxbutton--default
```

Interact with agentic context popup in the chat sidebar at different widths.
