### PR TITLE
feat(autoedit): Fix blockify range logic for tab indentation

### DIFF
--- a/vscode/src/autoedits/renderer/decorators/blockify.test.ts
+++ b/vscode/src/autoedits/renderer/decorators/blockify.test.ts
@@ -1,108 +1,148 @@
 import { describe, expect, it } from 'vitest'
+import * as vscode from 'vscode'
 import { document } from '../../../completions/test-helpers'
 import { blockify } from './blockify'
 import type { AddedLinesDecorationInfo } from './default-decorator'
 
+function blockifyAndExtractForTest(
+    document: vscode.TextDocument,
+    textToHighlight: {
+        range: vscode.Range
+        // Used to verify that our test is setup correctly.
+        // i.e. we expect to highlight "hello" and the range we did highlight matches that
+        expectedText: string
+    }[]
+): { code: string; ranges: number[][] } {
+    const addedLines: AddedLinesDecorationInfo[] = []
+    for (const { expectedText, range } of textToHighlight) {
+        const highlightedText = document.getText(range)
+
+        // Assert that the test is setup correctly, to avoid incorrectly providing the wrong range
+        expect(highlightedText).toBe(expectedText)
+
+        addedLines.push({
+            ranges: [[range.start.character, range.end.character]],
+            afterLine: range.start.line,
+            lineText: document.lineAt(range.start.line).text,
+        })
+    }
+
+    const blockified = blockify(document, addedLines)
+    return {
+        code: blockified.map(({ lineText }) => lineText).join('\n'),
+        ranges: blockified.flatMap(({ ranges }) => ranges),
+    }
+}
+
+const UNICODE_SPACE = '\u00A0'
+const FOUR_SPACE_INDENTATION = UNICODE_SPACE.repeat(4)
+
 describe('blockify', () => {
     describe('space indentation', () => {
-        // Content doesn't matter here, just the fact that this document uses spaces
-        const mockSpacesDocument = document('   hello world\n    goodbye world')
-
         it('removes leading space-indended blocks', () => {
-            const mockAddedLines: AddedLinesDecorationInfo[] = [
+            const mockSpacesDocument = document(
+                `${FOUR_SPACE_INDENTATION}hello world\n${FOUR_SPACE_INDENTATION}goodbye world`
+            )
+            const { code, ranges } = blockifyAndExtractForTest(mockSpacesDocument, [
                 {
-                    afterLine: 0,
-                    lineText: '    hello world',
-                    ranges: [[5, 10]],
+                    range: new vscode.Range(0, 4, 0, 9),
+                    expectedText: 'hello',
                 },
                 {
-                    afterLine: 1,
-                    lineText: '    goodbye world',
-                    ranges: [[5, 12]],
+                    range: new vscode.Range(1, 4, 1, 11),
+                    expectedText: 'goodbye',
                 },
-            ]
+            ])
 
-            const text = blockify(mockSpacesDocument, mockAddedLines)
-                .map(({ lineText }) => lineText)
-                .join('\n')
-            expect(text).toMatchInlineSnapshot(`
+            expect(code).toMatchInlineSnapshot(`
               "hello world  
               goodbye world"
             `)
+            expect(ranges).toStrictEqual([
+                // Indentation removed, range length maintained
+                [0, 5],
+                // Indentation removed, range length maintained
+                [0, 7],
+            ])
         })
 
         it('removes leading space-indended blocks whilst maintaining indentation levels', () => {
-            const mockAddedLines: AddedLinesDecorationInfo[] = [
-                {
-                    afterLine: 0,
-                    lineText: '    hello world',
-                    ranges: [[5, 10]],
-                },
-                {
-                    afterLine: 1,
-                    lineText: '        goodbye world',
-                    ranges: [[9, 14]],
-                },
-            ]
+            const mockSpacesDocument = document(
+                `${FOUR_SPACE_INDENTATION}hello world\n${FOUR_SPACE_INDENTATION}${FOUR_SPACE_INDENTATION}goodbye world`
+            )
 
-            const text = blockify(mockSpacesDocument, mockAddedLines)
-                .map(({ lineText }) => lineText)
-                .join('\n')
-            expect(text).toMatchInlineSnapshot(`
+            const { code, ranges } = blockifyAndExtractForTest(mockSpacesDocument, [
+                {
+                    range: new vscode.Range(0, 4, 0, 9),
+                    expectedText: 'hello',
+                },
+                {
+                    range: new vscode.Range(1, 8, 1, 15),
+                    expectedText: 'goodbye',
+                },
+            ])
+
+            expect(code).toMatchInlineSnapshot(`
               "hello world      
                   goodbye world"
             `)
+            expect(ranges).toStrictEqual([
+                // Indentation removed, range length maintained
+                [0, 5],
+                // Indentation reduced by one level, range length maintained
+                [4, 11],
+            ])
         })
     })
 
     describe('tab indentation', () => {
-        // Content doesn't matter here, just the fact that this document uses tabs
-        const mockSpacesDocument = document('\thello world\n\tgoodbye world')
-
-        it('removes leading space-indended blocks', () => {
-            const mockAddedLines: AddedLinesDecorationInfo[] = [
+        it('removes leading tab-indented blocks', () => {
+            const mockTabsDocument = document('\thello world\n\tgoodbye world')
+            const { code, ranges } = blockifyAndExtractForTest(mockTabsDocument, [
                 {
-                    afterLine: 0,
-                    lineText: '\thello world',
-                    ranges: [[5, 10]],
+                    range: new vscode.Range(0, 1, 0, 6),
+                    expectedText: 'hello',
                 },
                 {
-                    afterLine: 1,
-                    lineText: '\tgoodbye world',
-                    ranges: [[5, 12]],
+                    range: new vscode.Range(1, 1, 1, 8),
+                    expectedText: 'goodbye',
                 },
-            ]
-
-            const text = blockify(mockSpacesDocument, mockAddedLines)
-                .map(({ lineText }) => lineText)
-                .join('\n')
-            expect(text).toMatchInlineSnapshot(`
+            ])
+            expect(code).toMatchInlineSnapshot(`
               "hello world  
               goodbye world"
             `)
+            expect(ranges).toStrictEqual([
+                // Indentation removed, range length maintained
+                [0, 5],
+                // Indentation removed, range length maintained
+                [0, 7],
+            ])
         })
 
-        it('removes leading space-indended blocks whilst maintaining indentation levels', () => {
-            const mockAddedLines: AddedLinesDecorationInfo[] = [
+        it('removes leading tab-indented blocks whilst maintaining indentation levels', () => {
+            const mockTabsDocument = document('\thello world\n\t\tgoodbye world')
+            const { code, ranges } = blockifyAndExtractForTest(mockTabsDocument, [
                 {
-                    afterLine: 0,
-                    lineText: '\thello world',
-                    ranges: [[5, 10]],
+                    range: new vscode.Range(0, 1, 0, 6),
+                    expectedText: 'hello',
                 },
                 {
-                    afterLine: 1,
-                    lineText: '\t\tgoodbye world',
-                    ranges: [[9, 14]],
+                    range: new vscode.Range(1, 2, 1, 9),
+                    expectedText: 'goodbye',
                 },
-            ]
+            ])
 
-            const text = blockify(mockSpacesDocument, mockAddedLines)
-                .map(({ lineText }) => lineText)
-                .join('\n')
-            expect(text).toMatchInlineSnapshot(`
+            expect(code).toMatchInlineSnapshot(`
               "hello world      
                   goodbye world"
             `)
+            expect(ranges).toStrictEqual([
+                // Indentation removed, range length maintained
+                [0, 5],
+                // Indentation converted to whitespace and reduced by one level, range length maintained
+                [4, 11],
+            ])
         })
     })
 })

--- a/vscode/src/autoedits/renderer/decorators/blockify.ts
+++ b/vscode/src/autoedits/renderer/decorators/blockify.ts
@@ -42,14 +42,37 @@ export function convertToSpaceIndentation(
         }))
     }
 
-    // The incoming indentation is tab-based, but this will not render correctly in VS COde decorations.
+    // The incoming indentation is tab-based, but this will not render correctly in VS Code decorations.
     // We must convert it to space indentation that matches the editor's tab size
     const tabSize = getEditorTabSize(document.uri, vscode.workspace, vscode.window)
-    const tabAsSpace = UNICODE_SPACE.repeat(tabSize)
-    return addedLines.map(line => ({
-        ...line,
-        lineText: line.lineText.replace(/^(\t+)/, match => tabAsSpace.repeat(match.length)),
-    }))
+    return addedLines.map(line => {
+        // Convert the line text, replacing tabs with spaces
+        const newLineText = line.lineText.replace(/^(\t+)/, match =>
+            UNICODE_SPACE.repeat(match.length * tabSize)
+        )
+
+        // VS Code treats each tab as a single column when producing ranges, we need to reverse
+        // this as we are converting this text to use spaces.
+        // 1. Account for the fact that each tab is being replaced with tabSize spaces
+        // 2. Adjust the position based on how many tabs appear before the range
+        const newRanges = line.ranges.map(([start, end]) => {
+            // Count tabs before the start and end positions
+            const tabsBeforeStart = (line.lineText.slice(0, start).match(/\t/g) || []).length
+            const tabsBeforeEnd = (line.lineText.slice(0, end).match(/\t/g) || []).length
+
+            // Each tab expands to tabSize spaces, so we need to add (tabSize - 1) for each tab
+            const adjustedStart = start + tabsBeforeStart * (tabSize - 1)
+            const adjustedEnd = end + tabsBeforeEnd * (tabSize - 1)
+
+            return [adjustedStart, adjustedEnd] as [number, number]
+        })
+
+        return {
+            ...line,
+            lineText: newLineText,
+            ranges: newRanges,
+        }
+    })
 }
 
 function padTrailingWhitespaceBlock(addedLines: AddedLinesDecorationInfo[]): AddedLinesDecorationInfo[] {


### PR DESCRIPTION
## Description

We're not actively using this range logic _yet_ AFAIK, but we will be using it when we need to "git" highlight images to show added ranges.

This logic was broken for Tab based indentation, so I've updated it and improved the tests a lot so this is a lot more robust

## Test plan

Unit tests pass

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
