### PR TITLE
omnibox: link file path to the line of the first match

### DIFF
--- a/vscode/webviews/components/codeSnippet/CodeSnippet.tsx
+++ b/vscode/webviews/components/codeSnippet/CodeSnippet.tsx
@@ -213,7 +213,7 @@ export const FileMatchSearchResult: FC<PropsWithChildren<FileMatchSearchResultPr
             repoName={result.repository.name}
             repoURL={repoAtRevisionURL}
             filePath={result.file.path}
-            onFilePathClick={openRemoteFile}
+            onFilePathClick={() => openRemoteFile(expandedGroups.at(0)?.startLine)}
             pathMatchRanges={result.pathMatches ?? []}
             fileURL={fileURL}
             repoDisplayName={


### PR DESCRIPTION
It's not immediately obvious that the line numbers are links, so users often end up opening the search result by clicking the file path. However, the file path doesn't currently link to a line number, just the beginning of the file. This modifies the link to point to the first line in the first chunk shown. 

Related [feedback thread](https://sourcegraph.slack.com/archives/C08754AFLMB/p1737387320315939)

## Test plan

Quick manual test that clicking the file path navigates the user to a specific line (though it's not highlighted, which isn't ideal, but unrelated and I don't see a super quick way to fix that)
