### PR TITLE
chore(autocomplete): use the correct output channel label

### DIFF
--- a/vscode/src/completions/output-channel-logger.ts
+++ b/vscode/src/completions/output-channel-logger.ts
@@ -13,110 +13,121 @@ import type {
 
 import { Logger } from '../output-channel-logger'
 
+export const completionsOutputChannelLogger = new Logger('Completions')
 export const autocompleteOutputChannelLogger = new Logger('Autocomplete')
 
-export const autocompleteLifecycleOutputChannelLogger = {
-    startCompletion(params: CompletionParameters | Record<string, never>, endpoint: string) {
-        // TODO: Use `CompletionLogID` here to allow attributing all output channel
-        // logs to a specific completion.
-        const outputChannelId = uuid.v4()
-        const start = Date.now()
+function createCompletionLogger(logger: Logger) {
+    return {
+        startCompletion(params: CompletionParameters | Record<string, never>, endpoint: string) {
+            // TODO: Use `CompletionLogID` here to allow attributing all output channel
+            // logs to a specific completion.
+            const outputChannelId = uuid.v4()
+            const start = Date.now()
 
-        // Internal setting for logging full autocomplete prompt to the output channel.
-        const shouldLogFullPrompt = vscode.workspace
-            .getConfiguration()
-            .get<boolean>('cody.autocomplete.logFullPrompt', false)
+            // Internal setting for logging full autocomplete prompt to the output channel.
+            const shouldLogFullPrompt = vscode.workspace
+                .getConfiguration()
+                .get<boolean>('cody.autocomplete.logFullPrompt', false)
 
-        let hasFinished = false
-        let lastCompletion = ''
+            let hasFinished = false
+            let lastCompletion = ''
 
-        function onError(err: string, rawError?: unknown): void {
-            if (hasFinished) {
-                return
-            }
-            hasFinished = true
-            const duration = Date.now() - start
-
-            if (process.env.NODE_ENV === 'development' && rawError) {
-                console.error(rawError)
-            }
-
-            autocompleteOutputChannelLogger.logError(
-                'onError',
-                `duration:"${duration}ms" endpoint:"${endpoint}" outputChannelId:"${outputChannelId}"`,
-                JSON.stringify({
-                    outputChannelId,
-                    duration: Date.now() - start,
-                    err,
-                }),
-                { verbose: { params } }
-            )
-        }
-
-        function onComplete({ completion, stopReason }: CompletionResponse): void {
-            if (hasFinished) {
-                return
-            }
-            hasFinished = true
-            const duration = Date.now() - start
-
-            autocompleteOutputChannelLogger.logDebug(
-                'onComplete',
-                `duration:"${duration}ms" stopReason:"${stopReason}" outputChannelId:"${outputChannelId}"`,
-                { verbose: { completion } }
-            )
-        }
-
-        function onEvents(events: Event[]): void {
-            for (const event of events) {
-                switch (event.type) {
-                    case 'completion':
-                        lastCompletion = event.completion
-                        break
-                    case 'error':
-                        onError(event.error)
-                        break
-                    case 'done':
-                        onComplete({ completion: lastCompletion })
-                        break
+            function onError(err: string, rawError?: unknown): void {
+                if (hasFinished) {
+                    return
                 }
-            }
-        }
+                hasFinished = true
+                const duration = Date.now() - start
 
-        return {
-            onFetch(
-                httpClientLabel: string,
-                body: SerializedCodeCompletionsParams | FireworksCodeCompletionParams
-            ) {
-                const bodyToLog: any = { ...body }
-                const { stopSequences = [] } = params as unknown as CompletionParameters
-
-                if (!shouldLogFullPrompt) {
-                    if ('messages' in body) {
-                        bodyToLog.messages = body.messages.map(message => {
-                            return message.text
-                                ? shortenPromptForOutputChannel(message.text, stopSequences)
-                                : message
-                        })
-                    }
-
-                    if ('prompt' in body) {
-                        bodyToLog.prompt = shortenPromptForOutputChannel(body.prompt, stopSequences)
-                    }
+                if (process.env.NODE_ENV === 'development' && rawError) {
+                    console.error(rawError)
                 }
 
-                autocompleteOutputChannelLogger.logDebug(
-                    `${httpClientLabel}:fetch`,
-                    `endpoint: "${endpoint}" outputChannelId: "${outputChannelId}"`,
-                    { verbose: bodyToLog }
+                logger.logError(
+                    'onError',
+                    `duration:"${duration}ms" endpoint:"${endpoint}" outputChannelId:"${outputChannelId}"`,
+                    JSON.stringify({
+                        outputChannelId,
+                        duration: Date.now() - start,
+                        err,
+                    }),
+                    { verbose: { params } }
                 )
-            },
-            onError,
-            onComplete,
-            onEvents,
-        }
-    },
-} satisfies CompletionLoggerInterface
+            }
+
+            function onComplete({ completion, stopReason }: CompletionResponse): void {
+                if (hasFinished) {
+                    return
+                }
+                hasFinished = true
+                const duration = Date.now() - start
+
+                logger.logDebug(
+                    'onComplete',
+                    `duration:"${duration}ms" stopReason:"${stopReason}" outputChannelId:"${outputChannelId}"`,
+                    { verbose: { completion } }
+                )
+            }
+
+            function onEvents(events: Event[]): void {
+                for (const event of events) {
+                    switch (event.type) {
+                        case 'completion':
+                            lastCompletion = event.completion
+                            break
+                        case 'error':
+                            onError(event.error)
+                            break
+                        case 'done':
+                            onComplete({ completion: lastCompletion })
+                            break
+                    }
+                }
+            }
+
+            return {
+                onFetch(
+                    httpClientLabel: string,
+                    body: SerializedCodeCompletionsParams | FireworksCodeCompletionParams
+                ) {
+                    const bodyToLog: any = { ...body }
+                    const { stopSequences = [] } = params as unknown as CompletionParameters
+
+                    if (!shouldLogFullPrompt) {
+                        if ('messages' in body) {
+                            bodyToLog.messages = body.messages.map(message => {
+                                return message.text
+                                    ? shortenPromptForOutputChannel(message.text, stopSequences)
+                                    : message
+                            })
+                        }
+
+                        if ('prompt' in body) {
+                            bodyToLog.prompt = shortenPromptForOutputChannel(body.prompt, stopSequences)
+                        }
+                    }
+
+                    logger.logDebug(
+                        `${httpClientLabel}:fetch`,
+                        `endpoint: "${endpoint}" outputChannelId: "${outputChannelId}"`,
+                        { verbose: bodyToLog }
+                    )
+                },
+                onError,
+                onComplete,
+                onEvents,
+            }
+        },
+    } satisfies CompletionLoggerInterface
+}
+
+export const completionsLifecycleOutputChannelLogger = createCompletionLogger(
+    completionsOutputChannelLogger
+)
+
+export const autocompleteLifecycleOutputChannelLogger = createCompletionLogger(
+    autocompleteOutputChannelLogger
+)
 
 // Maximum length of a segment before it gets compacted
 const MAX_SEGMENT_LENGTH = 200

--- a/vscode/src/external-services.ts
+++ b/vscode/src/external-services.ts
@@ -9,7 +9,7 @@ import {
 } from '@sourcegraph/cody-shared'
 
 import { ChatIntentAPIClient } from './chat/context/chatIntentAPIClient'
-import { autocompleteLifecycleOutputChannelLogger } from './completions/output-channel-logger'
+import { completionsLifecycleOutputChannelLogger } from './completions/output-channel-logger'
 import type { PlatformContext } from './extension.common'
 import type { SymfRunner } from './local-context/symf'
 
@@ -40,7 +40,7 @@ export async function configureExternalServices(
     const openTelemetryService = platform.createOpenTelemetryService?.()
     if (openTelemetryService) disposables.push(openTelemetryService)
 
-    const completionsClient = platform.createCompletionsClient(autocompleteLifecycleOutputChannelLogger)
+    const completionsClient = platform.createCompletionsClient(completionsLifecycleOutputChannelLogger)
 
     const symfRunner = platform.createSymfRunner?.(context)
     if (symfRunner) disposables.push(symfRunner)


### PR DESCRIPTION
Use the correct feature label in the output channel for completions API requests.

## Test plan

CI + manually review the output channel logs:
1. Completions API requests from chat should be labeled with the `Completions` prefix.
2. Completions API requests from autocomplete should be labeled with the `Autocomplete` prefix.
