### PR TITLE
fix: add z-index to quick start modal

### DIFF
--- a/vscode/webviews/chat/components/QuickStart.tsx
+++ b/vscode/webviews/chat/components/QuickStart.tsx
@@ -182,7 +182,7 @@ export function QuickStart() {
             {/* Overlay */}
             {showTipsOverlay && (
                 <div
-                    className="tw-fixed tw-inset-0 tw-flex tw-items-center tw-justify-center tw-bg-black/50 tw-p-4 tw-animate-[fadeIn_0.2s_ease-in-out]"
+                    className="tw-fixed tw-inset-0 tw-flex tw-items-center tw-justify-center tw-bg-black/50 tw-p-4 tw-animate-[fadeIn_0.2s_ease-in-out] tw-z-50"
                     onClick={handleOverlayClick}
                     onKeyDown={handleOverlayKeyDown}
                     role="presentation"


### PR DESCRIPTION
Fixes [SRCH-1554
](https://github.com/sourcegraph/cody/pull/6711)
This PR adds z-index to the quick start modal to ensure it stays above all other elements.

![CleanShot 2025-01-21 at 08 23 45](https://github.com/user-attachments/assets/9e8aca08-c749-4449-b710-bf4e8ae3e405)

Uses Tailwind's z-index scaling: https://tailwindcss.com/docs/z-index

## Test plan
Visually tested.