### PR TITLE
feat: Add more control options to cody web

### DIFF
--- a/vscode/webviews/CodyPanel.tsx
+++ b/vscode/webviews/CodyPanel.tsx
@@ -2,11 +2,11 @@ import {
     type AuthStatus,
     type ChatMessage,
     type ClientCapabilitiesWithLegacyFields,
-    CodyIDE,
     type CodyNotice,
     FeatureFlag,
     type Guardrails,
     type UserProductSubscription,
+    type WebviewToExtensionAPI,
     firstValueFrom,
 } from '@sourcegraph/cody-shared'
 import { useExtensionAPI, useObservable } from '@sourcegraph/prompt-editor'
@@ -48,6 +48,7 @@ interface CodyPanelProps {
     showIDESnippetActions?: boolean
     smartApplyEnabled?: boolean
     onExternalApiReady?: (api: CodyExternalApi) => void
+    onExtensionApiReady?: (api: WebviewToExtensionAPI) => void
 }
 
 /**
@@ -56,7 +57,7 @@ interface CodyPanelProps {
 export const CodyPanel: FunctionComponent<CodyPanelProps> = ({
     view,
     setView,
-    configuration: { config, clientCapabilities, authStatus, isDotComUser, userProductSubscription },
+    configuration: { config, clientCapabilities },
     errorMessages,
     setErrorMessages,
     attributionEnabled,
@@ -70,6 +71,7 @@ export const CodyPanel: FunctionComponent<CodyPanelProps> = ({
     showWelcomeMessage,
     smartApplyEnabled,
     onExternalApiReady,
+    onExtensionApiReady,
 }) => {
     const tabContainerRef = useRef<HTMLDivElement>(null)
 
@@ -83,6 +85,10 @@ export const CodyPanel: FunctionComponent<CodyPanelProps> = ({
     useEffect(() => {
         onExternalApiReady?.(externalAPI)
     }, [onExternalApiReady, externalAPI])
+
+    useEffect(() => {
+        onExtensionApiReady?.(api)
+    }, [onExtensionApiReady, api])
 
     useEffect(() => {
         const subscription = api.clientActionBroadcast().subscribe(action => {
@@ -110,7 +116,7 @@ export const CodyPanel: FunctionComponent<CodyPanelProps> = ({
             >
                 <Notices user={user} instanceNotices={instanceNotices} />
                 {/* Hide tab bar in editor chat panels. */}
-                {(clientCapabilities.agentIDE === CodyIDE.Web || config.webviewType !== 'editor') && (
+                {config.webviewType !== 'editor' && (
                     <TabsBar
                         user={user}
                         currentView={view}

--- a/vscode/webviews/chat/components/WelcomeMessage.tsx
+++ b/vscode/webviews/chat/components/WelcomeMessage.tsx
@@ -1,4 +1,5 @@
 import { CodyIDE } from '@sourcegraph/cody-shared'
+import { BookCopy } from 'lucide-react'
 import type { FunctionComponent } from 'react'
 import { Kbd } from '../../components/Kbd'
 import { PromptList } from '../../components/promptList/PromptList'
@@ -64,6 +65,7 @@ export const WelcomeMessage: FunctionComponent<WelcomeMessageProps> = ({
                         className="tw-justify-center tw-basis-0 tw-whitespace-nowrap"
                         onClick={() => setView(View.Prompts)}
                     >
+                        <BookCopy width={16} />
                         All Prompts
                     </Button>
                 </div>

--- a/vscode/webviews/components/promptList/PromptList.module.css
+++ b/vscode/webviews/components/promptList/PromptList.module.css
@@ -23,10 +23,19 @@
     }
 
     &-chips {
+       --gap: 0.5rem;
+       --min-width: 240px;
+       --max-width: calc(50% - (var(--gap)/2));
+
        [cmdk-list-sizer] {
-           display: flex;
-           flex-direction: column;
-           gap: 0.5rem
+           display: grid;
+           /*
+            * This creates a responsive grid with one or two columns, depending on the available space.
+            * See https://css-tricks.com/an-auto-filling-css-grid-with-max-columns/ for more information.
+            */
+           grid-template-columns: repeat(auto-fill, minmax(max(var(--min-width), var(--max-width)), 1fr));
+           gap: var(--gap);
+
        }
 
         .list--item {

--- a/web/demo/App.tsx
+++ b/web/demo/App.tsx
@@ -48,6 +48,7 @@ export const App: FC = () => {
                 createAgentWorker={CREATE_AGENT_WORKER}
                 telemetryClientName="codydemo.testing"
                 initialContext={MOCK_INITIAL_CONTEXT}
+                viewType="sidebar"
             />
         </div>
     )

--- a/web/lib/components/CodyWebChat.tsx
+++ b/web/lib/components/CodyWebChat.tsx
@@ -1,5 +1,13 @@
 import classNames from 'classnames'
-import { type FC, type FunctionComponent, useLayoutEffect, useMemo, useState } from 'react'
+import {
+    type FC,
+    type FunctionComponent,
+    useCallback,
+    useLayoutEffect,
+    useMemo,
+    useRef,
+    useState,
+} from 'react'
 import { URI } from 'vscode-uri'
 
 import {
@@ -11,6 +19,7 @@ import {
     ContextItemSource,
     PromptString,
     REMOTE_DIRECTORY_PROVIDER_URI,
+    type WebviewToExtensionAPI,
     isErrorLike,
     setDisplayPathEnvInfo,
 } from '@sourcegraph/cody-shared'
@@ -33,8 +42,15 @@ import { useCodyWebAgent } from './use-cody-agent'
 // Include global Cody Web styles to the styles bundle
 import '../global-styles/styles.css'
 import type { DefaultContext } from '@sourcegraph/cody-shared/src/codebase-context/messages'
+import type { WebviewType } from 'cody-ai/src/chat/protocol'
+import { downloadChatHistory } from 'cody-ai/webviews/chat/downloadChatHistory'
 import styles from './CodyWebChat.module.css'
 import { ChatSkeleton } from './skeleton/ChatSkeleton'
+
+/**
+ * Controls the rendering of the Cody Web Chat component.
+ */
+export type ViewType = 'page' | 'sidebar'
 
 // Internal API mock call in order to set up web version of
 // the cody agent properly (completely mock data)
@@ -42,6 +58,34 @@ setDisplayPathEnvInfo({
     isWindows: false,
     workspaceFolders: [],
 })
+
+export type ControllerMessage =
+    | { type: 'view.change'; view: View }
+    | { type: 'chat.new' }
+    | { type: 'history.clear' }
+    | { type: 'history.download' }
+
+export type CodyWebChatMessage =
+    | { type: 'chat.change'; chat: ChatMessage[] }
+    | { type: 'view.change'; view: View }
+
+export type MessageHandler = (message: ControllerMessage) => void
+export type Unsubscriber = () => void
+
+/**
+ * The host system can pass an instance of this controller to the Cody Web Chat component to have finer control over its behavior.
+ * The controller allows the host system to change which view to show and get information about the current state of the chat.
+ */
+export interface CodyWebChatController {
+    /**
+     * Sends messages from the chat component to the controller.
+     */
+    postMessage(message: CodyWebChatMessage): void
+    /**
+     * Handles messages from the controller to the chat component.
+     */
+    onMessage(handler: MessageHandler): Unsubscriber
+}
 
 export interface CodyWebChatProps {
     serverEndpoint: string
@@ -51,6 +95,12 @@ export interface CodyWebChatProps {
     initialContext?: InitialContext
     customHeaders?: Record<string, string>
     className?: string
+
+    /** A controller that allows the host system to control the behavior of the chat. */
+    controller?: CodyWebChatController
+
+    /** How to render the chat, either as standalone page or sidebar. Defaults to 'sidebar'. */
+    viewType?: ViewType
 
     /**
      * Whenever an external (imperative) Cody Chat API instance is ready,
@@ -76,6 +126,8 @@ export const CodyWebChat: FunctionComponent<CodyWebChatProps> = ({
     customHeaders,
     className,
     onExternalApiReady,
+    controller,
+    viewType,
 }) => {
     const { client, vscodeAPI } = useCodyWebAgent({
         serverEndpoint,
@@ -102,6 +154,8 @@ export const CodyWebChat: FunctionComponent<CodyWebChatProps> = ({
                     initialContext={initialContext}
                     className={styles.container}
                     onExternalApiReady={onExternalApiReady}
+                    webview={viewType === 'page' ? 'editor' : 'sidebar'}
+                    controller={controller}
                 />
             </div>
         </AppWrapper>
@@ -113,10 +167,19 @@ interface CodyWebPanelProps {
     initialContext: InitialContext | undefined
     className?: string
     onExternalApiReady?: (api: CodyExternalApi) => void
+    webview: WebviewType
+    controller?: CodyWebChatController
 }
 
 const CodyWebPanel: FC<CodyWebPanelProps> = props => {
-    const { vscodeAPI, initialContext: initialContextData, className, onExternalApiReady } = props
+    const {
+        vscodeAPI,
+        initialContext: initialContextData,
+        className,
+        onExternalApiReady,
+        webview,
+        controller,
+    } = props
 
     const dispatchClientAction = useClientActionDispatcher()
     const [errorMessages, setErrorMessages] = useState<string[]>([])
@@ -125,6 +188,61 @@ const CodyWebPanel: FC<CodyWebPanelProps> = props => {
     const [config, setConfig] = useState<Config | null>(null)
     const [clientConfig, setClientConfig] = useState<CodyClientConfig | null>(null)
     const [view, setView] = useState<View | undefined>()
+    const extensionApiRef = useRef<WebviewToExtensionAPI | null>(null)
+
+    useLayoutEffect(() => {
+        return controller?.onMessage(message => {
+            switch (message.type) {
+                case 'view.change':
+                    setView(message.view)
+                    break
+                case 'chat.new':
+                    vscodeAPI.postMessage({ command: 'command', id: 'cody.chat.new' })
+                    break
+                case 'history.clear':
+                    // For some reason the view doesnt' update after the history is cleared. We force create a new chat
+                    // as a workaround.
+                    // FIXME: Invoking these two commands in a row doesn't work either.
+                    vscodeAPI.postMessage({ command: 'command', id: 'cody.chat.new' })
+                    vscodeAPI.postMessage({
+                        command: 'command',
+                        id: 'cody.chat.history.clear',
+                        arg: 'clear-all-no-confirm',
+                    })
+                    break
+                case 'history.download': {
+                    if (extensionApiRef.current) {
+                        downloadChatHistory(extensionApiRef.current)
+                    }
+                    break
+                }
+            }
+        })
+    }, [controller, vscodeAPI])
+
+    const onExtensionApiReady = useCallback((api: WebviewToExtensionAPI) => {
+        extensionApiRef.current = api
+    }, [])
+
+    const handleViewChange = useCallback(
+        (view: View) => {
+            if (controller) {
+                // Let the controller decide how to handle the view change
+                controller.postMessage({ type: 'view.change', view })
+            } else {
+                setView(view)
+            }
+        },
+        [controller]
+    )
+
+    const handleTranscriptChange = useCallback(
+        (transcript: ChatMessage[]) => {
+            setTranscript(transcript)
+            controller?.postMessage({ type: 'chat.change', chat: transcript })
+        },
+        [controller]
+    )
 
     useLayoutEffect(() => {
         vscodeAPI.onMessage(message => {
@@ -135,10 +253,10 @@ const CodyWebPanel: FC<CodyWebPanelProps> = props => {
                     )
                     if (message.isMessageInProgress) {
                         const msgLength = deserializedMessages.length - 1
-                        setTranscript(deserializedMessages.slice(0, msgLength))
+                        handleTranscriptChange(deserializedMessages.slice(0, msgLength))
                         setMessageInProgress(deserializedMessages[msgLength])
                     } else {
-                        setTranscript(deserializedMessages)
+                        handleTranscriptChange(deserializedMessages)
                         setMessageInProgress(null)
                     }
                     break
@@ -147,10 +265,10 @@ const CodyWebPanel: FC<CodyWebPanelProps> = props => {
                     setErrorMessages(prev => [...prev, message.errors].slice(-5))
                     break
                 case 'view':
-                    setView(message.view)
+                    handleViewChange(message.view)
                     break
                 case 'config':
-                    message.config.webviewType = 'sidebar'
+                    message.config.webviewType = webview
                     message.config.multipleWebviewsEnabled = false
                     setConfig(message)
                     break
@@ -164,7 +282,7 @@ const CodyWebPanel: FC<CodyWebPanelProps> = props => {
                     break
             }
         })
-    }, [vscodeAPI, dispatchClientAction])
+    }, [vscodeAPI, dispatchClientAction, handleTranscriptChange, handleViewChange, webview])
 
     // V2 telemetry recorder
     const telemetryRecorder = useMemo(() => createWebviewTelemetryRecorder(vscodeAPI), [vscodeAPI])
@@ -266,7 +384,7 @@ const CodyWebPanel: FC<CodyWebPanelProps> = props => {
                     <ComposedWrappers wrappers={wrappers}>
                         <CodyPanel
                             view={view}
-                            setView={setView}
+                            setView={handleViewChange}
                             errorMessages={errorMessages}
                             setErrorMessages={setErrorMessages}
                             attributionEnabled={false}
@@ -279,6 +397,7 @@ const CodyWebPanel: FC<CodyWebPanelProps> = props => {
                             transcript={transcript}
                             vscodeAPI={vscodeAPI}
                             onExternalApiReady={onExternalApiReady}
+                            onExtensionApiReady={onExtensionApiReady}
                         />
                     </ComposedWrappers>
                 </ChatMentionContext.Provider>

--- a/web/lib/index.ts
+++ b/web/lib/index.ts
@@ -1,12 +1,19 @@
-export { CodyWebChat, type CodyWebChatProps } from './components/CodyWebChat'
+export {
+    CodyWebChat,
+    type CodyWebChatProps,
+    type CodyWebChatController,
+    type ViewType,
+    type MessageHandler,
+    type ControllerMessage,
+    type CodyWebChatMessage,
+} from './components/CodyWebChat'
 export { CodyPromptTemplate, type CodyPromptTemplateProps } from './components/CodyPromptTemplate'
 export { ChatSkeleton } from './components/skeleton/ChatSkeleton'
 
-export type { Repository, InitialContext, CodyExternalApi } from './types'
+export type { Repository, InitialContext, CodyExternalApi, PromptEditorRefAPI } from './types'
 
 export {
     serialize,
     deserialize,
+    type ChatMessage,
 } from '@sourcegraph/cody-shared'
-
-export { type PromptEditorRefAPI } from './types'

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sourcegraph/cody-web",
-  "version": "0.23.1",
+  "version": "0.24.0",
   "description": "Cody standalone web app",
   "license": "Apache-2.0",
   "repository": {

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sourcegraph/cody-web",
-  "version": "0.24.0",
+  "version": "0.23.1",
   "description": "Cody standalone web app",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
This PR makes changes to cody web which are necessary for the new cody web page updates.

> [!NOTE]
> It's possible that I have to make additional changes to this code as I'm finalizing the Svelte and React app updates, but the core changes are ready.

Contributes to https://linear.app/sourcegraph/issue/DES-267/implement-omnibox-submenu-for-web

### Changes

#### Host / cody web communication

This PR adds a way to have more control over the behaviorTrigger a new chat. of cody web from the host. This is enabled by cody web
accepting a controller object that has a similar API as the vscode API. It allows the host and cody web to
send messages to each other.

In particular the host can now do the following:

- Intercept view changes. This allows us to navigate to the native `/prompts` page instead of cody's prompts panel.
- Get the current transcript. This allows us to show a title on the cody web page.
- Trigger history deletion and export.
- Start a new chat.

With this abilities we can now implement cody web specific control elements in the web apps themselves.

#### UI changes

The main change is that it's now possible to render cody web without the tab bar. The component now accepts a prop to
either render it in 'page' or 'sidebar' mode (cody sidebar will still show the tabs).

Some additional tweaks have been made according to the new desings, such as rending the prompts cards in two columns if there
is enough space.

## Test plan

Manual testing in the Svelte app:

- Clicking the history button opens the history panel.
- Clicking the export button downloads the history.
- Clicking the `<-` or `New Thread` buttons starts a new chat
- Clicking on links that would navigate to the prompts panel will load the prompts page instead.

I'm still finalizing the changes in the Svelte and React apps.

![2025-01-21_12-51_2](https://github.com/user-attachments/assets/bc329589-178c-4d96-a08f-7f21be83a454)
![2025-01-21_12-51_1](https://github.com/user-attachments/assets/9e7a9742-7be5-4d17-a5da-5c04fde64324)
![2025-01-21_12-51](https://github.com/user-attachments/assets/b50380e6-b20c-4208-b5e0-5ad661d29a43)
