### PR TITLE
fix(omnibox): fix available filters when deselecting

### DIFF
--- a/vscode/webviews/chat/cells/messageCell/assistant/SearchFilters.tsx
+++ b/vscode/webviews/chat/cells/messageCell/assistant/SearchFilters.tsx
@@ -49,21 +49,22 @@ export const SearchFilters = ({
 }: SearchFiltersProps) => {
     const telemetryRecorder = useTelemetryRecorder()
     const filterGroups = useMemo(() => {
-        // selectedFilter is included just as a safeguard in case the selected filter is not in the search response filters
-        return uniqBy([...filters, ...selectedFilters], ({ value, kind }) => `${value}-${kind}`).reduce<
+
+        // Use filters available from search response, if not display previous selection
+        const availableFilters = filters.length > 0 ? [...filters] : [...selectedFilters]
+        
+        return uniqBy(availableFilters, ({ value, kind }) => `${value}-${kind}`).reduce<
             Record<NLSSearchDynamicFilterKind, NLSSearchDynamicFilter[]>
         >(
             (groups, filter) => {
                 if (supportedDynamicFilterKinds.includes(filter.kind)) {
                     groups[filter.kind as NLSSearchDynamicFilterKind].push(filter)
                 }
-
                 return groups
             },
             { repo: [], file: [], type: [], lang: [] }
         )
-    }, [filters, selectedFilters])
-
+    }, [filters])
     const onFilterSelect = useCallback(
         (filter: NLSSearchDynamicFilter) => {
             telemetryRecorder.recordEvent('onebox.filter', 'clicked', {

--- a/vscode/webviews/chat/cells/messageCell/assistant/SearchFilters.tsx
+++ b/vscode/webviews/chat/cells/messageCell/assistant/SearchFilters.tsx
@@ -49,7 +49,6 @@ export const SearchFilters = ({
 }: SearchFiltersProps) => {
     const telemetryRecorder = useTelemetryRecorder()
     const filterGroups = useMemo(() => {
-
         // Use filters available from search response, if not display previous selection
         const availableFilters = filters.length > 0 ? [...filters] : [...selectedFilters]
 

--- a/vscode/webviews/chat/cells/messageCell/assistant/SearchFilters.tsx
+++ b/vscode/webviews/chat/cells/messageCell/assistant/SearchFilters.tsx
@@ -52,7 +52,7 @@ export const SearchFilters = ({
 
         // Use filters available from search response, if not display previous selection
         const availableFilters = filters.length > 0 ? [...filters] : [...selectedFilters]
-        
+
         return uniqBy(availableFilters, ({ value, kind }) => `${value}-${kind}`).reduce<
             Record<NLSSearchDynamicFilterKind, NLSSearchDynamicFilter[]>
         >(
@@ -64,7 +64,7 @@ export const SearchFilters = ({
             },
             { repo: [], file: [], type: [], lang: [] }
         )
-    }, [filters])
+    }, [filters, selectedFilters])
     const onFilterSelect = useCallback(
         (filter: NLSSearchDynamicFilter) => {
             telemetryRecorder.recordEvent('onebox.filter', 'clicked', {


### PR DESCRIPTION
FIXES [QA-322](https://linear.app/sourcegraph/issue/QA-322/%5Bomnibox%5D-filter-screen-fails-to-display-unselected-options-in)

Previously, filters would disappear if you tried to deselect them and were not present in the search results. This PR changes what filters should be available depending on whether we get search results returned





https://github.com/user-attachments/assets/284c3964-5fe6-48b0-85e8-91564b555353







## Test plan
1. Tested keyword search with `changelog`
2. chose filters that would show 0 results
3. deselecting filters keeps them in the filter group and shows accurate update after hitting apply
4. checked whether previously selected filters remained in the filter group after each search result
<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
