### PR TITLE
refactor(agentic-chat): move agentic chat toggler to top of model list

### DIFF
--- a/vscode/webviews/chat/cells/messageCell/human/HumanMessageCell.tsx
+++ b/vscode/webviews/chat/cells/messageCell/human/HumanMessageCell.tsx
@@ -5,7 +5,7 @@ import {
     type SerializedPromptEditorValue,
     serializedPromptEditorStateFromChatMessage,
 } from '@sourcegraph/cody-shared'
-import { type PromptEditorRefAPI, useExtensionAPI, useObservable } from '@sourcegraph/prompt-editor'
+import type { PromptEditorRefAPI } from '@sourcegraph/prompt-editor'
 import isEqual from 'lodash/isEqual'
 import { ColumnsIcon } from 'lucide-react'
 import { type FC, memo, useMemo } from 'react'
@@ -17,7 +17,6 @@ import { HumanMessageEditor } from './editor/HumanMessageEditor'
 import { Tooltip, TooltipContent, TooltipTrigger } from '../../../../components/shadcn/ui/tooltip'
 import { getVSCodeAPI } from '../../../../utils/VSCodeApi'
 import { useConfig } from '../../../../utils/useConfig'
-import { ToolboxButton } from './editor/ToolboxButton'
 
 interface HumanMessageCellProps {
     message: ChatMessage
@@ -96,11 +95,6 @@ const HumanMessageCellContent = memo<HumanMessageCellContent>(props => {
         manuallySelectIntent,
     } = props
 
-    const api = useExtensionAPI()
-    const { value: settings } = useObservable(
-        useMemo(() => api.toolboxSettings(), [api.toolboxSettings])
-    )
-
     return (
         <BaseMessageCell
             speakerIcon={
@@ -113,9 +107,6 @@ const HumanMessageCellContent = memo<HumanMessageCellContent>(props => {
             speakerTitle={userInfo.user.displayName ?? userInfo.user.username}
             cellAction={
                 <div className="tw-flex tw-gap-2 tw-items-center tw-justify-end">
-                    {settings && (
-                        <ToolboxButton settings={settings} api={api} isFirstMessage={isFirstMessage} />
-                    )}
                     {isFirstMessage && <OpenInNewEditorAction />}
                 </div>
             }

--- a/vscode/webviews/chat/cells/messageCell/human/editor/ToolboxButton.module.css
+++ b/vscode/webviews/chat/cells/messageCell/human/editor/ToolboxButton.module.css
@@ -1,0 +1,8 @@
+.badge {
+    margin-left: auto;
+    line-height: 16px;
+    font-size: 11px;
+    border-radius: 2px;
+    padding: 0 5px;
+    border: 1px solid var(--vscode-contrastBorder);
+}

--- a/vscode/webviews/chat/cells/messageCell/human/editor/ToolboxButton.story.tsx
+++ b/vscode/webviews/chat/cells/messageCell/human/editor/ToolboxButton.story.tsx
@@ -6,9 +6,6 @@ const meta: Meta<typeof ToolboxButton> = {
     title: 'cody/ToolboxButton',
     component: ToolboxButton,
     decorators: [VSCodeStandaloneComponent],
-    args: {
-        isFirstMessage: true,
-    },
 }
 
 export default meta
@@ -75,6 +72,5 @@ export const NonFirstMessage: Story = {
                 enabled: true,
             },
         },
-        isFirstMessage: false,
     },
 }

--- a/vscode/webviews/chat/cells/messageCell/human/editor/ToolboxButton.tsx
+++ b/vscode/webviews/chat/cells/messageCell/human/editor/ToolboxButton.tsx
@@ -2,7 +2,6 @@ import type { AgentToolboxSettings, WebviewToExtensionAPI } from '@sourcegraph/c
 import { debounce } from 'lodash'
 import { BrainIcon } from 'lucide-react'
 import { type FC, memo, useCallback, useState } from 'react'
-import { CODY_DOCS_AGENTIC_CHAT_URL } from '../../../../../../src/chat/protocol'
 import { Badge } from '../../../../../components/shadcn/ui/badge'
 import { Switch } from '../../../../../components/shadcn/ui/switch'
 import { Tooltip, TooltipContent, TooltipTrigger } from '../../../../../components/shadcn/ui/tooltip'
@@ -104,41 +103,6 @@ export const ToolboxButton: FC<ToolboxButtonProps> = memo(({ settings, api }) =>
                     </span>
                 </TooltipContent>
             </Tooltip>
-            {/* Only shows the Terminal access option if client and instance supports it */}
-            {settings.agent?.name && !settings.shell?.error && (
-                <div className="tw-ml-4 tw-pl-4 tw-flex tw-flex-col tw-gap-2 tw-my-2 tw-text-left tw-border-l-2 tw-border-l-muted-transparent">
-                    <div
-                        className="tw-flex tw-items-center tw-justify-between tw-w-full tw-font-medium tw-gap-2"
-                        aria-label="terminal"
-                    >
-                        <span className="tw-flex tw-gap-2 tw-items-center">
-                            <span className="tw-text-md">Terminal access</span>
-                        </span>
-                        <Switch
-                            className="tw-bg-slate-400"
-                            checked={settings.shell?.enabled}
-                            disabled={isLoading || !!settings.shell?.error}
-                            onClick={() =>
-                                onSubmit({
-                                    ...settings,
-                                    shell: {
-                                        enabled: !!settings.agent?.name && !settings.shell?.enabled,
-                                    },
-                                })
-                            }
-                        />
-                    </div>
-                    <div className="tw-text-xs tw-text-muted-foreground">
-                        Allows agents to execute commands like <code>ls</code>, <code>dir</code>,{' '}
-                        <code>git</code>, and other commands for context. The agent will ask permission
-                        each time it would like to run a command.{' '}
-                        <a target="_blank" rel="noreferrer" href={CODY_DOCS_AGENTIC_CHAT_URL.href}>
-                            Read the docs
-                        </a>{' '}
-                        to learn more.
-                    </div>
-                </div>
-            )}
         </div>
     )
 })

--- a/vscode/webviews/chat/cells/messageCell/human/editor/ToolboxButton.tsx
+++ b/vscode/webviews/chat/cells/messageCell/human/editor/ToolboxButton.tsx
@@ -4,7 +4,7 @@ import { BrainIcon } from 'lucide-react'
 import { type FC, memo, useCallback, useState } from 'react'
 import { CODY_DOCS_CAPABILITIES_URL } from '../../../../../../src/chat/protocol'
 import { Badge } from '../../../../../components/shadcn/ui/badge'
-import { Button } from '../../../../../components/shadcn/ui/button'
+import { Switch } from '../../../../../components/shadcn/ui/switch'
 import { ToolbarPopoverItem } from '../../../../../components/shadcn/ui/toolbar'
 import { useTelemetryRecorder } from '../../../../../utils/telemetry'
 
@@ -79,160 +79,104 @@ export const ToolboxButton: FC<ToolboxButtonProps> = memo(({ settings, api, isFi
     }
 
     return (
-        <div className="tw-flex tw-items-center">
+        <div className="tw-flex tw-items-center tw-w-full">
             <ToolbarPopoverItem
                 role="combobox"
-                iconEnd="chevron"
-                className="tw-opacity-100"
-                tooltip="Chat Settings"
+                iconEnd={null}
+                className="tw-opacity-100 tw-w-full tw-p-0"
+                tooltip={
+                    <span className="tw-text-left">
+                        Agentic chat reflects on your request and uses tools to dynamically retrieve
+                        relevant context, improving accuracy and response quality.{' '}
+                        <a
+                            target="_blank"
+                            rel="noreferrer"
+                            href={CODY_DOCS_CAPABILITIES_URL.href} // TODO: Replace with CODY_DOCS_AGENTIC_CHAT_URL
+                        >
+                            Read the docs
+                        </a>{' '}
+                        to learn more.
+                    </span>
+                }
                 aria-label="Chat Settings"
                 popoverContent={_close => (
                     <div id="accordion-collapse" data-accordion="collapse" className="tw-w-full">
-                        <h2 id="accordion-collapse-heading">
+                        {/* Only shows the Terminal access option if client and instance supports it */}
+                        {settings.agent?.name && !settings.shell?.error && (
                             <div
-                                className="tw-flex tw-items-center tw-justify-between tw-w-full tw-py-3 tw-px-5 tw-font-medium tw-border tw-border-border tw-rounded-t-md tw-focus:ring-4 tw-focus:ring-gray-200 tw-gap-3 tw-bg-[color-mix(in_lch,currentColor_10%,transparent)]"
-                                title="Agentic Chat Context"
+                                id="accordion-collapse-body"
+                                className="tw-p-5 tw-flex tw-flex-col tw-gap-3 tw-my-2 tw-text-left"
                             >
-                                <span className="tw-flex tw-gap-2 tw-items-center">
-                                    <span className="tw-font-semibold tw-text-md">Agentic chat</span>
-                                    <Badge variant="secondary" className="tw-text-xs">
-                                        Experimental
-                                    </Badge>
-                                </span>
-                                <Switch
-                                    disabled={isLoading}
-                                    checked={settings.agent?.name !== undefined}
-                                    onChange={() =>
-                                        onSubmit({
-                                            ...settings,
-                                            agent: {
-                                                name: settings.agent?.name ? undefined : 'deep-cody', // TODO: update name when finalized.
-                                            },
-                                        })
-                                    }
-                                />
-                            </div>
-                        </h2>
-                        <div
-                            id="accordion-collapse-body"
-                            className="tw-p-5 tw-flex tw-flex-col tw-gap-3 tw-my-2"
-                        >
-                            <div className="tw-text-xs">
-                                <span>
-                                    Agentic chat reflects on your request and uses tools to dynamically
-                                    retrieve relevant context, improving accuracy and response quality.{' '}
-                                    <a
-                                        target="_blank"
-                                        rel="noreferrer"
-                                        href={CODY_DOCS_CAPABILITIES_URL.href} // TODO: Replace with CODY_DOCS_AGENTIC_CHAT_URL
-                                    >
-                                        Read the docs
-                                    </a>{' '}
-                                    to learn more.
-                                </span>
-                            </div>
-                            {/* Seperator */}
-                            {settings.agent?.name && !settings.shell?.error && (
-                                <div className="tw-border-b tw-border-border tw-my-2" />
-                            )}
-                            {/* Only shows the Terminal access option if client and instance supports it */}
-                            {settings.agent?.name && !settings.shell?.error && (
-                                <div>
-                                    <div
-                                        className="tw-flex tw-items-center tw-justify-between tw-w-full tw-font-medium tw-gap-3"
-                                        aria-label="terminal"
-                                    >
-                                        <span className="tw-flex tw-gap-2 tw-items-center">
-                                            <span className="tw-font-semibold tw-text-md">
-                                                Terminal access
-                                            </span>
+                                <div
+                                    className="tw-flex tw-items-center tw-justify-between tw-w-full tw-font-medium tw-gap-3"
+                                    aria-label="terminal"
+                                >
+                                    <span className="tw-flex tw-gap-2 tw-items-center">
+                                        <span className="tw-font-semibold tw-text-md">
+                                            Terminal access
                                         </span>
-                                        <Switch
-                                            checked={settings.shell?.enabled}
-                                            disabled={isLoading || !!settings.shell?.error}
-                                            onChange={() =>
-                                                onSubmit({
-                                                    ...settings,
-                                                    shell: {
-                                                        enabled:
-                                                            !!settings.agent?.name &&
-                                                            !settings.shell?.enabled,
-                                                    },
-                                                })
-                                            }
-                                        />
-                                    </div>
-                                    <div className="tw-text-xs tw-mt-2">
-                                        Allows agents to execute commands like <code>ls</code>,{' '}
-                                        <code>dir</code>, <code>git</code>, and other commands for
-                                        context. The agent will ask permission each time it would like to
-                                        run a command.
-                                    </div>
+                                    </span>
+                                    <Switch
+                                        className="tw-bg-slate-400"
+                                        checked={settings.shell?.enabled}
+                                        disabled={isLoading || !!settings.shell?.error}
+                                        onClick={() =>
+                                            onSubmit({
+                                                ...settings,
+                                                shell: {
+                                                    enabled:
+                                                        !!settings.agent?.name &&
+                                                        !settings.shell?.enabled,
+                                                },
+                                            })
+                                        }
+                                    />
                                 </div>
-                            )}
-                        </div>
+                                <div className="tw-text-xs tw-mt-2">
+                                    Allows agents to execute commands like <code>ls</code>,{' '}
+                                    <code>dir</code>, <code>git</code>, and other commands for context.
+                                    The agent will ask permission each time it would like to run a
+                                    command.
+                                </div>
+                            </div>
+                        )}
                     </div>
                 )}
                 popoverRootProps={{ onOpenChange }}
                 popoverContentProps={{
-                    className: 'tw-w-[250px] !tw-p-0 tw-mx-8',
+                    side: 'bottom',
+                    className: 'tw-max-w-1/2 !tw-p-0 tw-mr-4',
                     onCloseAutoFocus: event => {
                         event.preventDefault()
                     },
                 }}
             >
-                <Button
-                    variant="ghost"
-                    size="none"
-                    className={`${
-                        settings.agent?.name ? 'tw-text-foreground' : 'tw-text-muted-foreground'
-                    } hover:!tw-bg-transparent`}
-                >
-                    {settings.agent?.name ? (
+                <div className="tw-flex tw-items-center tw-justify-between tw-w-full tw-py-3 tw-px-5 tw-font-medium tw-border tw-border-border tw-rounded-t-md tw-focus:ring-4 tw-focus:ring-gray-200 tw-gap-3 tw-bg-[color-mix(in_lch,currentColor_10%,transparent)]">
+                    <span className="tw-flex tw-gap-2 tw-items-center tw-py-2">
                         <BrainIcon
                             size={16}
-                            strokeWidth={2}
-                            className="tw-w-8 tw-h-8 tw-text-green-600 tw-drop-shadow-md"
-                        />
-                    ) : (
-                        <BrainIcon
-                            size={16}
-                            strokeWidth={2}
+                            strokeWidth={2.5}
                             className="tw-w-8 tw-h-8 tw-text-muted-foreground"
                         />
-                    )}
-                    {isFirstMessage && <span className="tw-font-semibold">agentic chat</span>}
-                </Button>
+                        <span className="tw-font-semibold tw-text-md">Agentic chat</span>
+                        <Badge variant="secondary" className="tw-text-xs tw-py-1">
+                            Experimental
+                        </Badge>
+                    </span>
+                    <Switch
+                        className="tw-bg-slate-400"
+                        checked={settings.agent?.name !== undefined}
+                        onClick={() =>
+                            onSubmit({
+                                ...settings,
+                                agent: {
+                                    name: settings.agent?.name ? undefined : 'deep-cody', // TODO: update name when finalized.
+                                },
+                            })
+                        }
+                    />
+                </div>
             </ToolbarPopoverItem>
         </div>
     )
 })
-
-const Switch: FC<{ checked?: boolean; onChange?: (checked: boolean) => void; disabled?: boolean }> =
-    memo(({ checked = false, onChange, disabled = false }) => {
-        return (
-            <button
-                onClick={e => {
-                    e.preventDefault()
-                    onChange?.(!checked)
-                }}
-                className={`tw-relative tw-flex tw-items-center tw-justify-center tw-w-11 tw-h-6 tw-rounded-full tw-ease tw-transform focus:tw-outline-offset-1 focus:tw-outline-2 tw-ring-1 ${
-                    checked && !disabled
-                        ? 'tw-bg-green-700 tw-ring-green-400'
-                        : 'tw-bg-gray-300 tw-ring-gray-400 tw-shadow-sm'
-                }`}
-                type="button"
-                role="switch"
-                aria-checked={checked}
-                disabled={disabled}
-            >
-                <div
-                    className={`
-                tw-absolute tw-left-0 tw-w-5 tw-h-6 tw-rounded-full
-                tw-transition-all tw-duration-300 tw-transform tw-shadow-md
-                ${checked ? 'tw-translate-x-6 tw-bg-gray-200' : 'tw-translate-x-0 tw-bg-gray-600'}
-            `}
-                />
-            </button>
-        )
-    })

--- a/vscode/webviews/chat/cells/messageCell/human/editor/ToolboxButton.tsx
+++ b/vscode/webviews/chat/cells/messageCell/human/editor/ToolboxButton.tsx
@@ -2,16 +2,16 @@ import type { AgentToolboxSettings, WebviewToExtensionAPI } from '@sourcegraph/c
 import { debounce } from 'lodash'
 import { BrainIcon } from 'lucide-react'
 import { type FC, memo, useCallback, useState } from 'react'
-import { CODY_DOCS_CAPABILITIES_URL } from '../../../../../../src/chat/protocol'
+import { CODY_DOCS_AGENTIC_CHAT_URL } from '../../../../../../src/chat/protocol'
 import { Badge } from '../../../../../components/shadcn/ui/badge'
 import { Switch } from '../../../../../components/shadcn/ui/switch'
-import { ToolbarPopoverItem } from '../../../../../components/shadcn/ui/toolbar'
+import { Tooltip, TooltipContent, TooltipTrigger } from '../../../../../components/shadcn/ui/tooltip'
 import { useTelemetryRecorder } from '../../../../../utils/telemetry'
+import styles from './ToolboxButton.module.css'
 
 interface ToolboxButtonProps {
     api: WebviewToExtensionAPI
     settings: AgentToolboxSettings
-    isFirstMessage: boolean
 }
 
 /**
@@ -22,21 +22,10 @@ interface ToolboxButtonProps {
  * @param settings - The current agent toolbox settings
  * @param api - API interface for communicating with the extension
  */
-export const ToolboxButton: FC<ToolboxButtonProps> = memo(({ settings, api, isFirstMessage }) => {
+export const ToolboxButton: FC<ToolboxButtonProps> = memo(({ settings, api }) => {
     const telemetryRecorder = useTelemetryRecorder()
 
     const [isLoading, setIsLoading] = useState(false)
-
-    const onOpenChange = useCallback(
-        (open: boolean): void => {
-            if (open) {
-                telemetryRecorder.recordEvent('cody.toolboxSettings', 'opened', {
-                    billingMetadata: { product: 'cody', category: 'billable' },
-                })
-            }
-        },
-        [telemetryRecorder.recordEvent]
-    )
 
     const debouncedSubmit = useCallback(
         debounce((newSettings: AgentToolboxSettings) => {
@@ -79,104 +68,77 @@ export const ToolboxButton: FC<ToolboxButtonProps> = memo(({ settings, api, isFi
     }
 
     return (
-        <div className="tw-flex tw-items-center tw-w-full">
-            <ToolbarPopoverItem
-                role="combobox"
-                iconEnd={null}
-                className="tw-opacity-100 tw-w-full tw-p-0"
-                tooltip={
+        <div className="tw-flex tw-items-center tw-w-full tw-flex-col tw-border-b tw-border-b-border tw-p-5">
+            <Tooltip>
+                <TooltipTrigger asChild>
+                    <div className="tw-flex tw-items-center tw-justify-between tw-w-full tw-font-medium tw-rounded-t-md tw-focus:ring-4 tw-focus:ring-gray-200 tw-gap-2">
+                        <span className="tw-flex tw-gap-2 tw-items-center tw-py-2">
+                            <BrainIcon
+                                size={16}
+                                strokeWidth={2.5}
+                                className="tw-w-8 tw-h-8 tw-text-muted-foreground"
+                            />
+                            <span className="tw-text-md">Agentic Chat</span>
+                            <Badge variant="secondary" className={styles.badge}>
+                                Experimental
+                            </Badge>
+                        </span>
+                        <Switch
+                            className="tw-bg-slate-400"
+                            checked={settings.agent?.name !== undefined}
+                            onClick={() =>
+                                onSubmit({
+                                    ...settings,
+                                    agent: {
+                                        name: settings.agent?.name ? undefined : 'deep-cody', // TODO: update name when finalized.
+                                    },
+                                })
+                            }
+                        />
+                    </div>
+                </TooltipTrigger>
+                <TooltipContent side="bottom">
                     <span className="tw-text-left">
                         Agentic chat reflects on your request and uses tools to dynamically retrieve
-                        relevant context, improving accuracy and response quality.{' '}
-                        <a
-                            target="_blank"
-                            rel="noreferrer"
-                            href={CODY_DOCS_CAPABILITIES_URL.href} // TODO: Replace with CODY_DOCS_AGENTIC_CHAT_URL
-                        >
+                        relevant context, improving accuracy and response quality.
+                    </span>
+                </TooltipContent>
+            </Tooltip>
+            {/* Only shows the Terminal access option if client and instance supports it */}
+            {settings.agent?.name && !settings.shell?.error && (
+                <div className="tw-ml-4 tw-pl-4 tw-flex tw-flex-col tw-gap-2 tw-my-2 tw-text-left tw-border-l-2 tw-border-l-muted-transparent">
+                    <div
+                        className="tw-flex tw-items-center tw-justify-between tw-w-full tw-font-medium tw-gap-2"
+                        aria-label="terminal"
+                    >
+                        <span className="tw-flex tw-gap-2 tw-items-center">
+                            <span className="tw-text-md">Terminal access</span>
+                        </span>
+                        <Switch
+                            className="tw-bg-slate-400"
+                            checked={settings.shell?.enabled}
+                            disabled={isLoading || !!settings.shell?.error}
+                            onClick={() =>
+                                onSubmit({
+                                    ...settings,
+                                    shell: {
+                                        enabled: !!settings.agent?.name && !settings.shell?.enabled,
+                                    },
+                                })
+                            }
+                        />
+                    </div>
+                    <div className="tw-text-xs tw-text-muted-foreground">
+                        Allows agents to execute commands like <code>ls</code>, <code>dir</code>,{' '}
+                        <code>git</code>, and other commands for context. The agent will ask permission
+                        each time it would like to run a command.{' '}
+                        <a target="_blank" rel="noreferrer" href={CODY_DOCS_AGENTIC_CHAT_URL.href}>
                             Read the docs
                         </a>{' '}
                         to learn more.
-                    </span>
-                }
-                aria-label="Chat Settings"
-                popoverContent={_close => (
-                    <div id="accordion-collapse" data-accordion="collapse" className="tw-w-full">
-                        {/* Only shows the Terminal access option if client and instance supports it */}
-                        {settings.agent?.name && !settings.shell?.error && (
-                            <div
-                                id="accordion-collapse-body"
-                                className="tw-p-5 tw-flex tw-flex-col tw-gap-3 tw-my-2 tw-text-left"
-                            >
-                                <div
-                                    className="tw-flex tw-items-center tw-justify-between tw-w-full tw-font-medium tw-gap-3"
-                                    aria-label="terminal"
-                                >
-                                    <span className="tw-flex tw-gap-2 tw-items-center">
-                                        <span className="tw-font-semibold tw-text-md">
-                                            Terminal access
-                                        </span>
-                                    </span>
-                                    <Switch
-                                        className="tw-bg-slate-400"
-                                        checked={settings.shell?.enabled}
-                                        disabled={isLoading || !!settings.shell?.error}
-                                        onClick={() =>
-                                            onSubmit({
-                                                ...settings,
-                                                shell: {
-                                                    enabled:
-                                                        !!settings.agent?.name &&
-                                                        !settings.shell?.enabled,
-                                                },
-                                            })
-                                        }
-                                    />
-                                </div>
-                                <div className="tw-text-xs tw-mt-2">
-                                    Allows agents to execute commands like <code>ls</code>,{' '}
-                                    <code>dir</code>, <code>git</code>, and other commands for context.
-                                    The agent will ask permission each time it would like to run a
-                                    command.
-                                </div>
-                            </div>
-                        )}
                     </div>
-                )}
-                popoverRootProps={{ onOpenChange }}
-                popoverContentProps={{
-                    side: 'bottom',
-                    className: 'tw-max-w-1/2 !tw-p-0 tw-mr-4',
-                    onCloseAutoFocus: event => {
-                        event.preventDefault()
-                    },
-                }}
-            >
-                <div className="tw-flex tw-items-center tw-justify-between tw-w-full tw-py-3 tw-px-5 tw-font-medium tw-border tw-border-border tw-rounded-t-md tw-focus:ring-4 tw-focus:ring-gray-200 tw-gap-3 tw-bg-[color-mix(in_lch,currentColor_10%,transparent)]">
-                    <span className="tw-flex tw-gap-2 tw-items-center tw-py-2">
-                        <BrainIcon
-                            size={16}
-                            strokeWidth={2.5}
-                            className="tw-w-8 tw-h-8 tw-text-muted-foreground"
-                        />
-                        <span className="tw-font-semibold tw-text-md">Agentic chat</span>
-                        <Badge variant="secondary" className="tw-text-xs tw-py-1">
-                            Experimental
-                        </Badge>
-                    </span>
-                    <Switch
-                        className="tw-bg-slate-400"
-                        checked={settings.agent?.name !== undefined}
-                        onClick={() =>
-                            onSubmit({
-                                ...settings,
-                                agent: {
-                                    name: settings.agent?.name ? undefined : 'deep-cody', // TODO: update name when finalized.
-                                },
-                            })
-                        }
-                    />
                 </div>
-            </ToolbarPopoverItem>
+            )}
         </div>
     )
 })

--- a/vscode/webviews/components/modelSelectField/ModelSelectField.tsx
+++ b/vscode/webviews/components/modelSelectField/ModelSelectField.tsx
@@ -193,7 +193,7 @@ export const ModelSelectField: React.FunctionComponent<{
                 >
                     {settings && (
                         <header className="tw-w-full tw-border-t tw-border-border tw-flex tw-justify-between tw-items-center">
-                            <ToolboxButton settings={settings} api={api} isFirstMessage={true} />
+                            <ToolboxButton settings={settings} api={api} />
                         </header>
                     )}
                     <CommandList
@@ -391,7 +391,7 @@ const ChatModelIcon: FunctionComponent<{ model: string; className?: string }> = 
 
 /** Common {@link ModelsService.uiGroup} values. */
 const ModelUIGroup: Record<string, string> = {
-    Agents: 'Agents with tools',
+    Agents: 'Agent, extensive context fetching',
     Power: 'More powerful models',
     Balanced: 'Balanced for power and speed',
     Speed: 'Faster models',

--- a/vscode/webviews/components/modelSelectField/ModelSelectField.tsx
+++ b/vscode/webviews/components/modelSelectField/ModelSelectField.tsx
@@ -1,8 +1,10 @@
 import { type Model, ModelTag, isCodyProModel, isWaitlistModel } from '@sourcegraph/cody-shared'
+import { useExtensionAPI, useObservable } from '@sourcegraph/prompt-editor'
 import { clsx } from 'clsx'
 import { BookOpenIcon, BuildingIcon, ExternalLinkIcon } from 'lucide-react'
 import { type FunctionComponent, type ReactNode, useCallback, useMemo } from 'react'
 import type { UserAccountInfo } from '../../Chat'
+import { ToolboxButton } from '../../chat/cells/messageCell/human/editor/ToolboxButton'
 import { getVSCodeAPI } from '../../utils/VSCodeApi'
 import { useTelemetryRecorder } from '../../utils/telemetry'
 import { chatModelIconComponent } from '../ChatModelIcon'
@@ -161,6 +163,11 @@ export const ModelSelectField: React.FunctionComponent<{
         [onCloseByEscape]
     )
 
+    const api = useExtensionAPI()
+    const { value: settings } = useObservable(
+        useMemo(() => api.toolboxSettings(), [api.toolboxSettings])
+    )
+
     if (!models.length || models.length < 1) {
         return null
     }
@@ -175,7 +182,7 @@ export const ModelSelectField: React.FunctionComponent<{
             disabled={readOnly}
             __storybook__open={__storybook__open}
             tooltip={readOnly ? undefined : 'Select a model'}
-            aria-label="Select a model"
+            aria-label="Select a model or an agent"
             popoverContent={close => (
                 <Command
                     loop={true}
@@ -184,6 +191,11 @@ export const ModelSelectField: React.FunctionComponent<{
                     className={`focus:tw-outline-none ${styles.chatModelPopover}`}
                     data-testid="chat-model-popover"
                 >
+                    {settings && (
+                        <header className="tw-w-full tw-border-t tw-border-border tw-flex tw-justify-between tw-items-center">
+                            <ToolboxButton settings={settings} api={api} isFirstMessage={true} />
+                        </header>
+                    )}
                     <CommandList
                         className="model-selector-popover tw-max-h-[80vh] tw-overflow-y-auto"
                         data-testid="chat-model-popover-option"
@@ -269,7 +281,7 @@ export const ModelSelectField: React.FunctionComponent<{
             )}
             popoverRootProps={{ onOpenChange }}
             popoverContentProps={{
-                className: 'tw-min-w-[325px] tw-w-[unset] tw-max-w-[90%] !tw-p-0',
+                className: 'tw-min-w-[325px] tw-w-[unset] tw-max-w-[200px] !tw-p-0',
                 onKeyDown: onKeyDown,
                 onCloseAutoFocus: event => {
                     // Prevent the popover trigger from stealing focus after the user selects an


### PR DESCRIPTION
Context: https://sourcegraph.slack.com/archives/C0847FJ0A73/p1737392795310389

Moving the agentic chat toggler button to the top of the model selector.

## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

- Verify the agentic chat settings is showing up at the top of the model dropdown
- Ensure the agentic chat and terminal access switches work as expected

Demo: 

![v1](https://github.com/user-attachments/assets/4d86cc4a-cabe-49ce-903c-5e9673c6c122)
