### PR TITLE
fix(agentic chat): exclude deep-cody prompt for o1 models

### DIFF
--- a/lib/shared/src/prompt/prompt-mixin.ts
+++ b/lib/shared/src/prompt/prompt-mixin.ts
@@ -13,7 +13,10 @@ const HEDGES_PREVENTION = ps`Answer positively without apologizing. `
 /**
  * Answer guidelines for the Deep Cody model.
  */
-const DEEP_CODY = ps`Explain your reasoning in detail for coding questions. `
+const AGENTIC_CHAT = ps`Explain your reasoning in detail for coding questions. `
+
+//  Models that do not work well with agentic prompts
+const agenticBlockedModels = ['chat-preview']
 
 /**
  * Prompt mixins elaborate every prompt presented to the LLM.
@@ -44,8 +47,12 @@ export class PromptMixin {
         }
 
         // Handle agent-specific prompts
-        if (humanMessage.agent === 'deep-cody' && !newMixins.length) {
-            mixins.push(new PromptMixin(DEEP_CODY))
+        if (
+            humanMessage.agent === 'deep-cody' &&
+            !newMixins.length &&
+            !agenticBlockedModels.some(m => modelID?.includes(m))
+        ) {
+            mixins.push(new PromptMixin(AGENTIC_CHAT))
         }
 
         // Add new mixins to the list of mixins to be prepended to the next human message.

--- a/lib/shared/src/prompt/prompt-mixin.ts
+++ b/lib/shared/src/prompt/prompt-mixin.ts
@@ -17,7 +17,7 @@ const AGENTIC_CHAT = ps`Explain your reasoning in detail for coding questions. `
 
 /**
  * Incompatible Models with Agentic Instructions
- * Note: The chat-preview model series has limitations with detailed reasoning 
+ * Note: The chat-preview model series has limitations with detailed reasoning
  * and chain-of-thought processes, necessitating their exclusion
  */
 const agenticBlockedModels = ['chat-preview']

--- a/lib/shared/src/prompt/prompt-mixin.ts
+++ b/lib/shared/src/prompt/prompt-mixin.ts
@@ -15,7 +15,11 @@ const HEDGES_PREVENTION = ps`Answer positively without apologizing. `
  */
 const AGENTIC_CHAT = ps`Explain your reasoning in detail for coding questions. `
 
-//  Models that do not work well with agentic prompts
+/**
+ * Incompatible Models with Agentic Instructions
+ * Note: The chat-preview model series has limitations with detailed reasoning 
+ * and chain-of-thought processes, necessitating their exclusion
+ */
 const agenticBlockedModels = ['chat-preview']
 
 /**


### PR DESCRIPTION
This change ensures that the deep-cody prompt mixin is not applied to the 'chat-preview' (o1) model, preventing potential issues with the prompt generation.

## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

Use o1 with agentic chat enabled and confirm the agentic chat prompt isn't getting applied.