### PR TITLE
Support endpoint param in auth flow (workspaces vscode sign-in flow)

### DIFF
--- a/vscode/src/auth/auth.ts
+++ b/vscode/src/auth/auth.ts
@@ -326,7 +326,7 @@ export async function tokenCallbackHandler(uri: vscode.Uri): Promise<void> {
     const params = new URLSearchParams(uri.query)
 
     const token = params.get('code') || params.get('token')
-    const endpoint = currentAuthStatus().endpoint
+    const endpoint = params.get('endpoint') ?? currentAuthStatus().endpoint
 
     // If we were provided an instance URL then it means we are
     // request the user setup auth with a different sourcegraph instance


### PR DESCRIPTION
Part of https://linear.app/sourcegraph/issue/DES-235/[onboarding-polish]-extensions-logout-guidance-step

This small change allows us to specify the instance URL for sigh up / auth flow, it's useful for workspace flow when we don't originally start our log-in flow from vscode and fill in the workspace URL but right from the workspace instance and we should notify cody to which URL it should try to log in with access token (code URL param) 

This PR is primarily needed for the workspace log-in into VSCode Cody PR in the Sourcegraph repository. 

https://github.com/user-attachments/assets/1dd1b90d-970e-4c2d-a71a-89cdaddf354a

@mmanela I saw your contributions about instance param in this flow, do you think we should make users go through this flow manually? I still left your logic in there so we can switch it later if we want. 

@kalanchan, this PR is important for workspace setup flow. Can I ask you to make sure it's included in the upcoming Cody release? I think it's going to be 1.62, right? 

## Test plan
- Check that the standard auth flow has no regression
- The workspace flow will be tested in the Sourcegraph repository PR
