### PR TITLE
omnibox: add callout for results from other repos

### DIFF
--- a/vscode/webviews/chat/cells/messageCell/assistant/SearchResults.tsx
+++ b/vscode/webviews/chat/cells/messageCell/assistant/SearchResults.tsx
@@ -313,7 +313,7 @@ export const SearchResults = ({
                                         key={i}
                                     >
                                         {i === firstNonBoostedRepoIndex && (
-                                            <h6 className="tw-border-b tw-text-muted-foreground tw-p-4 tw-pt-8">
+                                            <h6 className="tw-border-b tw-border-border tw-text-muted-foreground tw-p-4 tw-pt-8">
                                                 Results from other repositories
                                             </h6>
                                         )}

--- a/vscode/webviews/chat/cells/messageCell/assistant/SearchResults.tsx
+++ b/vscode/webviews/chat/cells/messageCell/assistant/SearchResults.tsx
@@ -77,6 +77,9 @@ export const SearchResults = ({
     const resultsToShow =
         initialResults?.length === totalResults?.length || showAll ? totalResults : initialResults
 
+    // mini-HACK: rather than prop drilling the current repository through to this component,
+    // just pull the boosted repo name from the query if it exists. This will break if we
+    // change how the current repo is boosted, but it at least doesn't depend on VSCode-specific APIs.
     const boostedRepo = message.search.query.match(/boost:repo\(([^)]+)\)/)?.[1]
     const firstNonBoostedRepoIndex = boostedRepo
         ? resultsToShow.findIndex(

--- a/vscode/webviews/chat/cells/messageCell/assistant/SearchResults.tsx
+++ b/vscode/webviews/chat/cells/messageCell/assistant/SearchResults.tsx
@@ -77,6 +77,13 @@ export const SearchResults = ({
     const resultsToShow =
         initialResults?.length === totalResults?.length || showAll ? totalResults : initialResults
 
+    const boostedRepo = message.search.query.match(/boost:repo\(([^)]+)\)/)?.[1]
+    const firstNonBoostedRepoIndex = boostedRepo
+        ? resultsToShow.findIndex(
+              result => result.__typename === 'FileMatch' && result.repository.name !== boostedRepo
+          )
+        : undefined
+
     // Select all results by default when the results are rendered the first time
     useLayoutEffect(() => {
         updateSelectedFollowUpResults({
@@ -302,6 +309,11 @@ export const SearchResults = ({
                                         // biome-ignore lint/suspicious/noArrayIndexKey: stable order
                                         key={i}
                                     >
+                                        {i === firstNonBoostedRepoIndex && (
+                                            <h6 className="tw-border-b tw-text-muted-foreground tw-p-4 tw-pt-8">
+                                                Results from other repositories
+                                            </h6>
+                                        )}
                                         <NLSResultSnippet
                                             result={result}
                                             selectedForContext={selectedFollowUpResults.has(result)}


### PR DESCRIPTION
This adds a separator + message when we've reached the end of results from the current (boosted) repository. This change is in conjunction with https://github.com/sourcegraph/sourcegraph/pull/2943, which will make this 

Implements the rough designs from [here](https://www.figma.com/design/eR495BJclVpdGdXf4lhSsH/One-box?node-id=7010-98964&t=Z1DJQBeiRZ1CjT4f-4). 

## Test plan

Manually tested various scenarios. 

Mix of results from current repo and other repos:
![CleanShot 2025-01-21 at 23 26 02@2x](https://github.com/user-attachments/assets/8703ab54-beb0-4ef8-9a6a-7d239dc93286)

No results from current repo:
![CleanShot 2025-01-21 at 23 26 44@2x](https://github.com/user-attachments/assets/8bdf729a-437f-43ec-b460-7dcfc9f4a814)

Only results from current repo:
![CleanShot 2025-01-21 at 23 37 55@2x](https://github.com/user-attachments/assets/e9f02579-5b37-4b6b-8fd4-7066f91a0797)
