### PR TITLE
fix(agentic chat): exclude deep-cody prompt for o1 models (#6725)

### DIFF
--- a/lib/shared/src/prompt/prompt-mixin.ts
+++ b/lib/shared/src/prompt/prompt-mixin.ts
@@ -13,7 +13,14 @@ const HEDGES_PREVENTION = ps`Answer positively without apologizing. `
 /**
  * Answer guidelines for the Deep Cody model.
  */
-const DEEP_CODY = ps`Explain your reasoning in detail for coding questions. `
+const AGENTIC_CHAT = ps`Explain your reasoning in detail for coding questions. `
+
+/**
+ * Incompatible Models with Agentic Instructions
+ * Note: The chat-preview model series has limitations with detailed reasoning
+ * and chain-of-thought processes, necessitating their exclusion
+ */
+const agenticBlockedModels = ['chat-preview']
 
 /**
  * Prompt mixins elaborate every prompt presented to the LLM.
@@ -43,9 +50,13 @@ export class PromptMixin {
             mixins.push(PromptMixin.hedging)
         }
 
-        // Handle Agent specific prompts
-        if (humanMessage.agent === 'deep-cody' && !newMixins.length) {
-            mixins.push(new PromptMixin(HEDGES_PREVENTION.concat(DEEP_CODY)))
+        // Handle agent-specific prompts
+        if (
+            humanMessage.agent === 'deep-cody' &&
+            !newMixins.length &&
+            !agenticBlockedModels.some(m => modelID?.includes(m))
+        ) {
+            mixins.push(new PromptMixin(AGENTIC_CHAT))
         }
 
         // Add new mixins to the list of mixins to be prepended to the next human message.


### PR DESCRIPTION
This change ensures that the deep-cody prompt mixin is not applied to the 'chat-preview' (o1) model, preventing potential issues with the prompt generation.

## Test plan
Use o1 with agentic chat enabled and confirm the agentic chat prompt isn't getting applied.

Backport https://github.com/sourcegraph/cody/commit/e3093feed19e620726120c08b9f1175e3ce1af5f from https://github.com/sourcegraph/cody/pull/6725