### PR TITLE
fix(release): remove checkout and pull steps to keep workflow referen…

### DIFF
--- a/.github/workflows/generate-changelog.yml
+++ b/.github/workflows/generate-changelog.yml
@@ -20,8 +20,6 @@ jobs:
           git config --global user.name 'sourcegraph-bot'
           git config --global user.email 'bot@sourcegraph.com'
           git fetch --tags origin
-          git checkout main
-          git pull
       - name: Download changelog
         env:
           GH_TOKEN: ${{ secrets.DEVX_SERVICE_GH_TOKEN }}


### PR DESCRIPTION
running into errors in generate changelog action where it can't create the PRs due to conflicts, this removes the non essential git configuration steps to keep the reference branch the same


## Test plan
N/A, couldn't test locally need the github UI
<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
