### PR TITLE
fix(logging): Add interactionId to header of Cody Client requests for autoCompletes and autoEdits

### DIFF
--- a/vscode/src/autoedits/adapters/base.ts
+++ b/vscode/src/autoedits/adapters/base.ts
@@ -27,4 +27,5 @@ export interface AutoeditModelOptions {
     codeToRewrite: string
     userId: string | null
     isChatModel: boolean
+    requestId: string
 }

--- a/vscode/src/autoedits/adapters/cody-gateway.test.ts
+++ b/vscode/src/autoedits/adapters/cody-gateway.test.ts
@@ -24,6 +24,7 @@ describe('CodyGatewayAdapter', () => {
         codeToRewrite: 'const x = 1',
         userId: 'test-user',
         isChatModel: true,
+        requestId: 'test-request-id',
     }
 
     const mockFetch = vi.fn()

--- a/vscode/src/autoedits/adapters/cody-gateway.ts
+++ b/vscode/src/autoedits/adapters/cody-gateway.ts
@@ -14,6 +14,7 @@ export class CodyGatewayAdapter implements AutoeditsModelAdapter {
     public async getModelResponse(options: AutoeditModelOptions): Promise<string> {
         const headers = {
             'X-Sourcegraph-Feature': 'code_completions',
+            'X-Sourcegraph-Interaction-ID': options.requestId,
         }
         const body = this.getMessageBody(options)
         try {

--- a/vscode/src/autoedits/adapters/fireworks.test.ts
+++ b/vscode/src/autoedits/adapters/fireworks.test.ts
@@ -20,6 +20,7 @@ describe('FireworksAdapter', () => {
         codeToRewrite: 'const x = 1',
         userId: 'test-user',
         isChatModel: true,
+        requestId: 'test-request-id',
     }
 
     const apiKey = 'test-api-key'

--- a/vscode/src/autoedits/adapters/fireworks.ts
+++ b/vscode/src/autoedits/adapters/fireworks.ts
@@ -22,7 +22,10 @@ export class FireworksAdapter implements AutoeditsModelAdapter {
                 )
                 throw new Error('No api key provided in the config override')
             }
-            const response = await getModelResponse(option.url, body, apiKey)
+            const headers = {
+                'X-Sourcegraph-Interaction-ID': option.requestId,
+            }
+            const response = await getModelResponse(option.url, body, apiKey, headers)
             if (option.isChatModel) {
                 return response.choices[0].message.content
             }

--- a/vscode/src/autoedits/adapters/sourcegraph-chat.test.ts
+++ b/vscode/src/autoedits/adapters/sourcegraph-chat.test.ts
@@ -19,6 +19,7 @@ describe('SourcegraphChatAdapter', () => {
         codeToRewrite: 'const x = 1',
         userId: 'test-user',
         isChatModel: true,
+        requestId: 'test-request-id',
     }
 
     beforeEach(() => {

--- a/vscode/src/autoedits/adapters/sourcegraph-completions.test.ts
+++ b/vscode/src/autoedits/adapters/sourcegraph-completions.test.ts
@@ -18,6 +18,7 @@ describe('SourcegraphCompletionsAdapter', () => {
         codeToRewrite: 'const x = 1',
         userId: 'test-user',
         isChatModel: false,
+        requestId: 'test-request-id',
     }
 
     beforeEach(() => {

--- a/vscode/src/autoedits/analytics-logger/analytics-logger.test.ts
+++ b/vscode/src/autoedits/analytics-logger/analytics-logger.test.ts
@@ -65,6 +65,7 @@ describe('AutoeditAnalyticsLogger', () => {
         codeToRewrite: 'This is test code to rewrite',
         userId: 'test-user-id',
         isChatModel: false,
+        requestId: 'test-request-id',
     }
 
     function getRequestStartMetadata(): Parameters<AutoeditAnalyticsLogger['createRequest']>[0] {

--- a/vscode/src/autoedits/autoedits-provider.ts
+++ b/vscode/src/autoedits/autoedits-provider.ts
@@ -253,6 +253,7 @@ export class AutoeditsProvider implements vscode.InlineCompletionItemProvider, v
                 position,
                 prompt,
                 codeToReplaceData,
+                requestId,
             })
 
             if (abortSignal?.aborted) {
@@ -449,11 +450,13 @@ export class AutoeditsProvider implements vscode.InlineCompletionItemProvider, v
         position,
         codeToReplaceData,
         prompt,
+        requestId,
     }: {
         document: vscode.TextDocument
         position: vscode.Position
         codeToReplaceData: CodeToReplaceData
         prompt: AutoeditsPrompt
+        requestId: AutoeditRequestID
     }): Promise<string | undefined> {
         if (autoeditsProviderConfig.isMockResponseFromCurrentDocumentTemplateEnabled) {
             const responseMetadata = extractAutoEditResponseFromCurrentDocumentCommentTemplate(
@@ -480,6 +483,7 @@ export class AutoeditsProvider implements vscode.InlineCompletionItemProvider, v
             codeToRewrite: codeToReplaceData.codeToRewrite,
             userId: (await currentResolvedConfig()).clientState.anonymousUserID,
             isChatModel: autoeditsProviderConfig.isChatModel,
+            requestId: requestId,
         })
     }
 

--- a/vscode/src/completions/fast-path-client.ts
+++ b/vscode/src/completions/fast-path-client.ts
@@ -98,6 +98,7 @@ export function createFastPathClient(
         headers.set('Content-Type', `application/json${fireworksConfig ? '' : '; charset=utf-8'}`)
         headers.set('Authorization', `Bearer ${fastPathAccessToken}`)
         headers.set('X-Sourcegraph-Feature', 'code_completions')
+        headers.set('X-Sourcegraph-Interaction-ID', providerOptions.completionLogId)
         headers.set('X-Timeout-Ms', requestParams.timeoutMs.toString())
         addTraceparent(headers)
 

--- a/vscode/src/completions/providers/fireworks.ts
+++ b/vscode/src/completions/providers/fireworks.ts
@@ -158,9 +158,10 @@ class FireworksProvider extends Provider {
                 })
             }
         }
-
+        const headers = this.getCustomHeaders(authStatus.isFireworksTracingEnabled)
+        headers['X-Sourcegraph-Interaction-ID'] = options.completionLogId
         return this.client.complete(requestParams, abortController, {
-            customHeaders: this.getCustomHeaders(authStatus.isFireworksTracingEnabled),
+            customHeaders: headers,
         })
     }
 


### PR DESCRIPTION
This PR adds a fix for [add interactionId to header of Cody Client
requests](https://linear.app/sourcegraph/issue/CODY-4117/add-interactionid-to-header-of-cody-client-requests).

`interactionId` was missing in autoCompletes and autoEdits before

## Test plan
'verifies interactionId is passed through chat requests' in ChatController.test.ts
<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. --> 