### PR TITLE
Revert "Support endpoint param in auth flow (workspaces vscode sign-in flow)

### DIFF
--- a/vscode/src/auth/auth.ts
+++ b/vscode/src/auth/auth.ts
@@ -326,7 +326,7 @@ export async function tokenCallbackHandler(uri: vscode.Uri): Promise<void> {
     const params = new URLSearchParams(uri.query)
 
     const token = params.get('code') || params.get('token')
-    const endpoint = params.get('endpoint') ?? currentAuthStatus().endpoint
+    const endpoint = currentAuthStatus().endpoint
 
     // If we were provided an instance URL then it means we are
     // request the user setup auth with a different sourcegraph instance


### PR DESCRIPTION
Revert https://github.com/sourcegraph/cody/pull/6730
This reverts commit 7e4dbf904d5265e58f3919ce3e26625331e72b8d.

This is basically a security issue, for more details see https://github.com/sourcegraph/sourcegraph/pull/2942#issuecomment-2607120685

## Test plan
- CI is green

