### PR TITLE
disable omnibox on dotcom

### DIFF
--- a/lib/shared/src/sourcegraph-api/clientConfig.ts
+++ b/lib/shared/src/sourcegraph-api/clientConfig.ts
@@ -1,5 +1,6 @@
 import { Observable, Subject, interval, map, merge } from 'observable-fns'
 import semver from 'semver'
+import type { AuthStatus } from '..'
 import { authStatus } from '../auth/authStatus'
 import { editorWindowIsFocused } from '../editor/editorState'
 import { logDebug, logError } from '../logger'
@@ -150,7 +151,9 @@ export class ClientConfigSingleton {
                       // linear.app/sourcegraph/issue/CODY-3745/codys-background-periodic-network-access-causes-2fa.
                       filter((_value): _value is undefined => editorWindowIsFocused()),
                       startWith(undefined),
-                      switchMap(() => promiseFactoryToObservable(signal => this.fetchConfig(signal)))
+                      switchMap(() =>
+                          promiseFactoryToObservable(signal => this.fetchConfig(authStatus, signal))
+                      )
                   )
                 : Observable.of(undefined)
         ),
@@ -184,7 +187,7 @@ export class ClientConfigSingleton {
         return await firstValueFrom(this.changes.pipe(skipPendingOperation()), signal)
     }
 
-    private async fetchConfig(signal?: AbortSignal): Promise<CodyClientConfig> {
+    private async fetchConfig(authStatus: AuthStatus, signal?: AbortSignal): Promise<CodyClientConfig> {
         logDebug('ClientConfigSingleton', 'refreshing configuration')
 
         try {
@@ -215,8 +218,11 @@ export class ClientConfigSingleton {
                 // Sourcegraph instances before 5.5.0 do not support the new /.api/client-config endpoint.
                 supportsClientConfig = insiderBuild || !semver.lt(siteVersion, '5.5.0')
 
+                const isDotCom =
+                    !authStatus.authenticated ||
+                    authStatus.endpoint.startsWith('https://sourcegraph.com')
                 // Enable OmniBox for Sourcegraph instances 6.0.0 and above or dev instances
-                omniBoxEnabled = insiderBuild || semver.gte(siteVersion, '6.0.0')
+                omniBoxEnabled = !isDotCom && (insiderBuild || semver.gte(siteVersion, '6.0.0'))
             }
 
             signal?.throwIfAborted()


### PR DESCRIPTION
disable omnibox on dotcom

## Test plan

- connect to s2 and omnibox should work as intended. 
- connect to dotcom all the omnibox features should be hidden.