### PR TITLE
feat(PromptList): add `promptId` & `promptName` to privateMetadata

### DIFF
--- a/vscode/webviews/components/promptList/PromptList.tsx
+++ b/vscode/webviews/components/promptList/PromptList.tsx
@@ -120,6 +120,7 @@ export const PromptList: FC<PromptListProps> = props => {
                 },
                 privateMetadata: {
                     nameWithOwner: isPrompt ? action.nameWithOwner : undefined,
+                    promptId: isPrompt ? action.id : undefined,
                 },
                 billingMetadata: { product: 'cody', category: 'core' },
             })

--- a/vscode/webviews/components/promptList/PromptList.tsx
+++ b/vscode/webviews/components/promptList/PromptList.tsx
@@ -121,6 +121,7 @@ export const PromptList: FC<PromptListProps> = props => {
                 privateMetadata: {
                     nameWithOwner: isPrompt ? action.nameWithOwner : undefined,
                     promptId: isPrompt ? action.id : undefined,
+                    promptName: isPrompt ? action.name : undefined,
                 },
                 billingMetadata: { product: 'cody', category: 'core' },
             })


### PR DESCRIPTION
This change adds the `promptId` property to the `privateMetadata` object in the `PromptList` component. This will allow for better tracking and identification of prompts in the Cody application.


## Test plan
Locally 
<img width="662" alt="image" src="https://github.com/user-attachments/assets/9e784b86-6c4a-4b8b-bbe2-e3d9c0ea369e" />

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
