### PR TITLE
Fix OpenTelemetryService initialisation code

### DIFF
--- a/lib/shared/src/configuration/auth-resolver.ts
+++ b/lib/shared/src/configuration/auth-resolver.ts
@@ -6,10 +6,12 @@ import type {
     ExternalAuthProvider,
 } from '../configuration'
 import { logError } from '../logger'
+import { startWith } from '../misc/observable'
 import { ExternalProviderAuthError } from '../sourcegraph-api/errors'
 import type { ClientSecrets } from './resolver'
 
-export const externalAuthRefresh = new Subject<void>()
+const externalAuthRefreshNotifications = new Subject<void>()
+export const externalAuthRefreshChanges = externalAuthRefreshNotifications.pipe(startWith(undefined))
 
 export function normalizeServerEndpointURL(url: string): string {
     return url.endsWith('/') ? url : `${url}/`
@@ -113,7 +115,7 @@ function createHeaderCredentials(
                     }
                 } catch (error) {
                     _headersCache = undefined
-                    externalAuthRefresh.next()
+                    externalAuthRefreshNotifications.next()
 
                     logError('resolveAuth', `External Auth Provider Error: ${error}`)
                     throw new ExternalProviderAuthError(

--- a/vscode/src/services/open-telemetry/CodyTraceExport.ts
+++ b/vscode/src/services/open-telemetry/CodyTraceExport.ts
@@ -1,6 +1,7 @@
 import type { ExportResult } from '@opentelemetry/core'
 import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http'
 import type { ReadableSpan } from '@opentelemetry/sdk-trace-base'
+import type { OpenTelemetryServiceConfig } from './OpenTelemetryService.node'
 
 const MAX_TRACE_RETAIN_MS = 60 * 1000
 
@@ -8,21 +9,13 @@ export class CodyTraceExporter extends OTLPTraceExporter {
     private isTracingEnabled = false
     private queuedSpans: Map<string, { span: ReadableSpan; enqueuedAt: number }> = new Map()
 
-    constructor({
-        traceUrl,
-        isTracingEnabled,
-        authHeaders,
-    }: {
-        traceUrl: string
-        isTracingEnabled: boolean
-        authHeaders: Record<string, string>
-    }) {
+    constructor(config: OpenTelemetryServiceConfig) {
         super({
-            url: traceUrl,
+            url: config.traceUrl,
             httpAgentOptions: { rejectUnauthorized: false },
-            headers: authHeaders,
+            headers: config.headers,
         })
-        this.isTracingEnabled = isTracingEnabled
+        this.isTracingEnabled = config.isTracingEnabled
     }
 
     export(spans: ReadableSpan[], resultCallback: (result: ExportResult) => void): void {

--- a/vscode/src/services/open-telemetry/OpenTelemetryService.node.ts
+++ b/vscode/src/services/open-telemetry/OpenTelemetryService.node.ts
@@ -6,7 +6,6 @@ import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions'
 
 import {
     FeatureFlag,
-    type ResolvedConfiguration,
     type Unsubscribable,
     addAuthHeaders,
     combineLatest,
@@ -16,19 +15,25 @@ import {
 
 import { DiagConsoleLogger, DiagLogLevel, diag } from '@opentelemetry/api'
 import { BatchSpanProcessor } from '@opentelemetry/sdk-trace-base'
-import { externalAuthRefresh } from '@sourcegraph/cody-shared/src/configuration/auth-resolver'
+import { externalAuthRefreshChanges } from '@sourcegraph/cody-shared/src/configuration/auth-resolver'
 import { isEqual } from 'lodash'
 import { version } from '../../version'
 import { CodyTraceExporter } from './CodyTraceExport'
 import { ConsoleBatchSpanExporter } from './console-batch-span-exporter'
 
+export interface OpenTelemetryServiceConfig {
+    isTracingEnabled: boolean
+    traceUrl: string
+    headers: Record<string, string>
+    debugVerbose: boolean
+}
+
 export class OpenTelemetryService {
     private tracerProvider?: NodeTracerProvider
     private unloadInstrumentations?: () => void
-    private isTracingEnabled = false
 
-    private lastTraceUrl: string | undefined
-    private lastHeaders: Record<string, string> | undefined
+    private lastConfig: OpenTelemetryServiceConfig | undefined
+
     // We use a single promise object that we chain on to, to avoid multiple reconfigure calls to
     // be run in parallel
     private reconfigurePromiseMutex: Promise<void> = Promise.resolve()
@@ -41,13 +46,13 @@ export class OpenTelemetryService {
     // `addAuthHeaders` function have internal guard against this, but it would be better to solve this issue on the architecture level
     constructor() {
         this.configSubscription = combineLatest(
-            externalAuthRefresh,
+            externalAuthRefreshChanges,
             resolvedConfig,
             featureFlagProvider.evaluatedFeatureFlag(FeatureFlag.CodyAutocompleteTracing)
         ).subscribe(([_, { configuration, auth }, codyAutocompleteTracingFlag]) => {
             this.reconfigurePromiseMutex = this.reconfigurePromiseMutex
                 .then(async () => {
-                    this.isTracingEnabled =
+                    const isTracingEnabled =
                         configuration.experimentalTracing || codyAutocompleteTracingFlag
 
                     const traceUrl = new URL('/-/debug/otlp/v1/traces', auth.serverEndpoint).toString()
@@ -56,11 +61,17 @@ export class OpenTelemetryService {
                     if (auth) await addAuthHeaders(auth, httpHeaders, new URL(traceUrl))
                     const headers = Object.fromEntries(httpHeaders.entries())
 
-                    if (this.lastTraceUrl === traceUrl && isEqual(headers, this.lastHeaders)) {
+                    const newConfig = {
+                        isTracingEnabled: isTracingEnabled,
+                        traceUrl: traceUrl,
+                        headers: headers,
+                        debugVerbose: configuration.debugVerbose,
+                    }
+
+                    if (isEqual(this.lastConfig, newConfig)) {
                         return
                     }
-                    this.lastTraceUrl = traceUrl
-                    this.lastHeaders = headers
+                    this.lastConfig = newConfig
 
                     const logLevel = configuration.debugVerbose ? DiagLogLevel.INFO : DiagLogLevel.ERROR
                     diag.setLogger(new DiagConsoleLogger(), logLevel)
@@ -73,7 +84,7 @@ export class OpenTelemetryService {
                         instrumentations: [new HttpInstrumentation()],
                     })
 
-                    this.configureTracerProvider(traceUrl, headers, { configuration })
+                    this.configureTracerProvider(this.lastConfig)
                 })
                 .catch(error => {
                     console.error('Error configuring OpenTelemetry:', error)
@@ -85,11 +96,7 @@ export class OpenTelemetryService {
         this.configSubscription.unsubscribe()
     }
 
-    private configureTracerProvider(
-        traceUrl: string,
-        authHeaders: Record<string, string>,
-        { configuration }: Pick<ResolvedConfiguration, 'configuration'>
-    ): void {
+    private configureTracerProvider(config: OpenTelemetryServiceConfig): void {
         this.tracerProvider = new NodeTracerProvider({
             resource: new Resource({
                 [SemanticResourceAttributes.SERVICE_NAME]: 'cody-client',
@@ -98,18 +105,10 @@ export class OpenTelemetryService {
         })
 
         // Add the default tracer exporter used in production.
-        this.tracerProvider.addSpanProcessor(
-            new BatchSpanProcessor(
-                new CodyTraceExporter({
-                    traceUrl,
-                    isTracingEnabled: this.isTracingEnabled,
-                    authHeaders,
-                })
-            )
-        )
+        this.tracerProvider.addSpanProcessor(new BatchSpanProcessor(new CodyTraceExporter(config)))
 
         // Add the console exporter used in development for verbose logging and debugging.
-        if (process.env.NODE_ENV === 'development' || configuration.debugVerbose) {
+        if (process.env.NODE_ENV === 'development' || config.debugVerbose) {
             this.tracerProvider.addSpanProcessor(new BatchSpanProcessor(new ConsoleBatchSpanExporter()))
         }
 


### PR DESCRIPTION
## Changes

1. Fixing problem with `externalAuthRefreshChanges` not having initial value which was blocking the configuration
2. Making caching checks more correct

I discovered one problem though.

Restarting trace exported does not really work.
It always throw an error:

```
"OTLPExporterError: Unprocessable Entity
\tat IncomingMessage.<anonymous> (/Users/pkukielka/Work/sourcegraph/cody2/vscode/dist/extension.node.js:183479:31)
\tat IncomingMessage.emit (node:events:530:35)
\tat IncomingMessage.emit (node:domain:489:12)
\tat endReadableNT (node:internal/streams/readable:1698:12)
\tat process.processTicksAndRejections (node:internal/process/task_queues:82:21)"
```

We catch this error and re-initialisation seems to be passing, but then `CodyTraceExporter::export` is never called after that.

## Test plan

Tested with debugger by:

1. Adding `"cody.experimental.tracing": true` to the config
4. Starting VSC
5. Asking a chat question
6. Making sure `CodyTraceExporter::export` was executed

Then

1. Setting `cody.experimental.tracing` to `false`
2. Restarting VSC
3. Asking a chat question
4. Making sure `CodyTraceExporter::export` was NOT executed
7. 
<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
