### PR TITLE
Fix intent telemetry

### DIFF
--- a/vscode/src/chat/chat-view/ChatController.ts
+++ b/vscode/src/chat/chat-view/ChatController.ts
@@ -832,7 +832,7 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
         const omniBoxEnabled = await this.isOmniBoxEnabled()
 
         recorder.setIntentInfo({
-            userSpecifiedIntent: manuallySelectedIntent ?? omniBoxEnabled ? 'auto' : 'chat',
+            userSpecifiedIntent: manuallySelectedIntent ?? (omniBoxEnabled ? 'auto' : 'chat'),
             detectedIntent: detectedIntent,
             detectedIntentScores: detectedIntentScores,
         })

--- a/vscode/webviews/chat/Transcript.tsx
+++ b/vscode/webviews/chat/Transcript.tsx
@@ -350,8 +350,8 @@ const TranscriptInteraction: FC<TranscriptInteractionProps> = memo(props => {
 
             const commonProps = {
                 editorValue,
-                intent,
-                intentScores,
+                preDetectedIntent: intent,
+                preDetectedIntentScores: intentScores,
                 manuallySelectedIntent:
                     intentFromSubmit ||
                     manuallySelectedIntent.intent ||


### PR DESCRIPTION
This fixes a regression in the intent telemetry (described [here](https://linear.app/sourcegraph/issue/SPLF-330), originally fixed in https://github.com/sourcegraph/cody/pull/6637).
Two fixes:
- we weren't using the right fields in `commonProps`, meaning that the values weren't assigned to the message and thus weren't accessible in the chat controller where we emit metadata.
- we were accidentally overriding the `userSpecifiedIntent` field with `auto` because of operator precedence.

We now get the correct data emitted in the `chat/executed` telemetry events.

## Backport
I want to backport this to vscode-1.64 and jb-7.12.
Why? Telemetry data will help us improve intent detection significantly and it's important we have the pipeline functioning well at launch. Furthermore, the changes are quite low-risk.

## Test plan
Tested manually.

