### PR TITLE
mention menu: migrate from codicon to lucide

### DIFF
--- a/lib/prompt-editor/src/mentions/mentionMenu/MentionMenuItem.tsx
+++ b/lib/prompt-editor/src/mentions/mentionMenu/MentionMenuItem.tsx
@@ -18,12 +18,16 @@ import {
 import { clsx } from 'clsx'
 import {
     ArrowRightIcon,
+    BoxIcon,
     DatabaseIcon,
     ExternalLinkIcon,
     FileIcon,
     FolderGitIcon,
+    FolderIcon,
+    LayoutPanelTop,
     LibraryBigIcon,
     LinkIcon,
+    ListMinusIcon,
     SmileIcon,
     SquareFunctionIcon,
 } from 'lucide-react'
@@ -89,7 +93,9 @@ export const MentionMenuContextItemContent: FunctionComponent<{
     const isClassSymbol = isSymbol && item.kind === 'class'
     const isLink = item.type === 'open-link'
 
-    const icon = item.icon || (isSymbol ? (isClassSymbol ? 'symbol-structure' : 'symbol-method') : null)
+    const iconId =
+        item.icon || (isSymbol ? (isClassSymbol ? 'symbol-structure' : 'symbol-method') : null)
+    const Icon = iconId ? iconForItem[iconId] : null
     const { title, displayName } = getMentionItemTitleAndDisplayName(item)
     const description = getDescription(item, query)
 
@@ -107,7 +113,12 @@ export const MentionMenuContextItemContent: FunctionComponent<{
     return (
         <>
             <div className={styles.row}>
-                {icon && <i className={`codicon codicon-${icon}`} title={isSymbol ? item.kind : ''} />}
+                {Icon && (
+                    <div className={styles.row} title={isSymbol ? item.kind : ''}>
+                        <Icon size={16} strokeWidth={1.75} />
+                        {isSymbol ? item.kind : ''}
+                    </div>
+                )}
                 <span className={clsx(styles.title, warning && styles.titleWithWarning)} title={title}>
                     {displayName}
                 </span>
@@ -167,4 +178,18 @@ export const iconForProvider: Record<
     [REMOTE_FILE_PROVIDER_URI]: FileIcon,
     [REMOTE_DIRECTORY_PROVIDER_URI]: FolderGitIcon,
     [WEB_PROVIDER_URI]: LinkIcon,
+}
+
+export const iconForItem: Record<
+    string,
+    React.ComponentType<{
+        size?: string | number
+        strokeWidth?: string | number
+    }>
+> = {
+    'symbol-method': BoxIcon,
+    'symbol-structure': LayoutPanelTop,
+    folder: FolderIcon,
+    'git-folder': FolderGitIcon,
+    'list-selection': ListMinusIcon,
 }

--- a/lib/prompt-editor/src/mentions/mentionMenu/MentionMenuItem.tsx
+++ b/lib/prompt-editor/src/mentions/mentionMenu/MentionMenuItem.tsx
@@ -23,7 +23,7 @@ import {
     ExternalLinkIcon,
     FileIcon,
     FolderGitIcon,
-    FolderIcon,
+    FolderOpenIcon,
     LayoutPanelTop,
     LibraryBigIcon,
     LinkIcon,
@@ -189,7 +189,7 @@ export const iconForItem: Record<
 > = {
     'symbol-method': BoxIcon,
     'symbol-structure': LayoutPanelTop,
-    folder: FolderIcon,
+    folder: FolderOpenIcon,
     'git-folder': FolderGitIcon,
     'list-selection': ListMinusIcon,
 }

--- a/vscode/src/chat/initialContext.ts
+++ b/vscode/src/chat/initialContext.ts
@@ -254,7 +254,7 @@ export function getCorpusContextItemsForEditorState(): Observable<
                         isWorkspaceRoot: true,
                         content: null,
                         source: ContextItemSource.Initial,
-                        icon: 'git-folder',
+                        icon: 'folder',
                     } satisfies ContextItemTree)
                 }
             }

--- a/vscode/src/chat/initialContext.ts
+++ b/vscode/src/chat/initialContext.ts
@@ -227,7 +227,7 @@ export function getCorpusContextItemsForEditorState(): Observable<
                         title: 'Current Repository',
                         description: repo.name,
                         source: ContextItemSource.Initial,
-                        icon: 'folder',
+                        icon: 'git-folder',
                     })
                 }
                 if (remoteReposForAllWorkspaceFolders.length === 0) {
@@ -254,7 +254,7 @@ export function getCorpusContextItemsForEditorState(): Observable<
                         isWorkspaceRoot: true,
                         content: null,
                         source: ContextItemSource.Initial,
-                        icon: 'folder',
+                        icon: 'git-folder',
                     } satisfies ContextItemTree)
                 }
             }

--- a/web/lib/components/CodyWebChat.tsx
+++ b/web/lib/components/CodyWebChat.tsx
@@ -330,6 +330,7 @@ const CodyWebPanel: FC<CodyWebPanelProps> = props => {
                         },
                         description: fileURL,
                     },
+                    icon: 'git-folder',
                 } as ContextItemOpenCtx)
             } else {
                 // Common file mention with possible file range positions
@@ -347,6 +348,7 @@ const CodyWebPanel: FC<CodyWebPanelProps> = props => {
                     remoteRepositoryName: repository.name,
                     uri: URI.file(`${repository.name}/${fileURL}`),
                     source: ContextItemSource.Initial,
+                    icon: 'file',
                 })
             }
         }


### PR DESCRIPTION
When working on dynamic @ mentions, I noticed that we didn't support the lucide icons for things like "current repository". There was some code that still used codicon, which this PR migrates over to using lucide icons.

## Test plan

Manual testing

Before:

<img width="550" alt="Screenshot 2025-01-23 at 17 51 59" src="https://github.com/user-attachments/assets/6ff74cc5-9e04-4e2c-b1fc-222686b7aa59" />

After:

<img width="561" alt="Screenshot 2025-01-23 at 17 53 48" src="https://github.com/user-attachments/assets/7d1d18a6-aad7-4419-8f8b-11b622f8e15d" />

