### PR TITLE
omnibox: open results locally if possible

### DIFF
--- a/vscode/src/chat/chat-view/ChatController.ts
+++ b/vscode/src/chat/chat-view/ChatController.ts
@@ -92,6 +92,7 @@ import { migrateAndNotifyForOutdatedModels } from '../../models/modelMigrator'
 import { logDebug, outputChannelLogger } from '../../output-channel-logger'
 import { hydratePromptText } from '../../prompts/prompt-hydration'
 import { listPromptTags, mergedPromptsAndLegacyCommands } from '../../prompts/prompts'
+import { workspaceFolderForRepo } from '../../repository/remoteRepos'
 import { authProvider } from '../../services/AuthProvider'
 import { AuthProviderSimplified } from '../../services/AuthProviderSimplified'
 import { localStorage } from '../../services/LocalStorageProvider'
@@ -360,7 +361,7 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
                 })
                 break
             case 'openRemoteFile':
-                this.openRemoteFile(message.uri)
+                this.openRemoteFile(message.uri, message.tryLocal)
                 break
             case 'newFile':
                 await handleCodeFromSaveToNewFile(message.text, this.editor)
@@ -980,24 +981,64 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
         return
     }
 
-    private openRemoteFile(uri: vscode.Uri) {
-        const json = uri.toJSON()
-        const searchParams = (json.query || '').split('&')
+    private async openRemoteFile(uri: vscode.Uri, tryLocal?: boolean) {
+        if (tryLocal) {
+            try {
+                await this.openSourcegraphUriAsLocalFile(uri)
+                return
+            } catch {
+                // Ignore error, just continue to opening the remote file
+            }
+        }
 
-        const sourcegraphSchemaURI = vscode.Uri.from({
-            ...json,
+        const sourcegraphSchemaURI = uri.with({
             query: '',
             scheme: 'codysourcegraph',
         })
 
         // Supported line params examples: L42 (single line) or L42-45 (line range)
-        const lineParam = searchParams.find((value: string) => value.match(/^L\d+(?:-\d+)?$/)?.length)
+        const lineParam = uri.query.split('&').find(key => key.match(/^L\d+(?:-\d+)?$/))
         const range = this.lineParamToRange(lineParam)
 
         vscode.workspace.openTextDocument(sourcegraphSchemaURI).then(async doc => {
             const textEditor = await vscode.window.showTextDocument(doc)
 
             textEditor.revealRange(range)
+        })
+    }
+
+    /**
+     * Attempts to open a Sourcegraph file URL as a local file in VS Code.
+     * Fails if the URI is not a valid Sourcegraph URL for a file or if the
+     * file does not belong to the current workspace.
+     */
+    private async openSourcegraphUriAsLocalFile(uri: vscode.Uri): Promise<void> {
+        const match = uri.path.match(
+            /^\/*(?<repoName>[^@]*)(?<revision>@.*)?\/-\/blob\/(?<filePath>.*)$/
+        )
+        if (!match || !match.groups) {
+            throw new Error('failed to extract repo name and file path')
+        }
+        const { repoName, filePath } = match.groups
+
+        const workspaceFolder = await workspaceFolderForRepo(repoName)
+        if (!workspaceFolder) {
+            throw new Error('could not find workspace for repo')
+        }
+
+        const lineNumberParam = uri.query.split('&').find(key => key.match(/^L\d+(?:-\d+)?$/))
+        const selectionStart = this.lineParamToRange(lineNumberParam).start
+        // Opening the file with an active selection is awkward, so use a zero-length
+        // selection to focus the target line without highlighting anything
+        const selection = new vscode.Range(selectionStart, selectionStart)
+
+        const fileUri = workspaceFolder.uri.with({
+            path: `${workspaceFolder.uri.path}/${filePath}`,
+        })
+        const document = await vscode.workspace.openTextDocument(fileUri)
+        await vscode.window.showTextDocument(document, {
+            selection,
+            preview: true,
         })
     }
 

--- a/vscode/src/chat/chat-view/ChatController.ts
+++ b/vscode/src/chat/chat-view/ChatController.ts
@@ -361,7 +361,7 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
                 })
                 break
             case 'openRemoteFile':
-                this.openRemoteFile(message.uri, message.tryLocal)
+                this.openRemoteFile(message.uri, message.tryLocal ?? false)
                 break
             case 'newFile':
                 await handleCodeFromSaveToNewFile(message.text, this.editor)

--- a/vscode/src/chat/chat-view/ChatController.ts
+++ b/vscode/src/chat/chat-view/ChatController.ts
@@ -997,7 +997,7 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
         })
 
         // Supported line params examples: L42 (single line) or L42-45 (line range)
-        const lineParam = uri.query.split('&').find(key => key.match(/^L\d+(?:-\d+)?$/))
+        const lineParam = this.extractLineParamFromURI(uri)
         const range = this.lineParamToRange(lineParam)
 
         vscode.workspace.openTextDocument(sourcegraphSchemaURI).then(async doc => {
@@ -1026,8 +1026,8 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
             throw new Error('could not find workspace for repo')
         }
 
-        const lineNumberParam = uri.query.split('&').find(key => key.match(/^L\d+(?:-\d+)?$/))
-        const selectionStart = this.lineParamToRange(lineNumberParam).start
+        const lineParam = this.extractLineParamFromURI(uri)
+        const selectionStart = this.lineParamToRange(lineParam).start
         // Opening the file with an active selection is awkward, so use a zero-length
         // selection to focus the target line without highlighting anything
         const selection = new vscode.Range(selectionStart, selectionStart)
@@ -1040,6 +1040,10 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
             selection,
             preview: true,
         })
+    }
+
+    private extractLineParamFromURI(uri: vscode.Uri): string | undefined {
+        return uri.query.split('&').find(key => key.match(/^L\d+(?:-\d+)?$/))
     }
 
     private lineParamToRange(lineParam?: string | null): vscode.Range {

--- a/vscode/src/chat/protocol.ts
+++ b/vscode/src/chat/protocol.ts
@@ -80,7 +80,7 @@ export type WebviewMessage =
           uri: Uri
           // Attempt to open the same file locally if we can map
           // the repository to an open workspace.
-          tryLocal?: boolean
+          tryLocal?: boolean | undefined | null
       }
     | {
           command: 'openFileLink'

--- a/vscode/src/chat/protocol.ts
+++ b/vscode/src/chat/protocol.ts
@@ -74,7 +74,14 @@ export type WebviewMessage =
     | { command: 'restoreHistory'; chatID: string }
     | { command: 'links'; value: string }
     | { command: 'openURI'; uri: Uri }
-    | { command: 'openRemoteFile'; uri: Uri }
+    | {
+          // Open a file from a Sourcegraph URL
+          command: 'openRemoteFile'
+          uri: Uri
+          // Attempt to open the same file locally if we can map
+          // the repository to an open workspace.
+          tryLocal?: boolean
+      }
     | {
           command: 'openFileLink'
           uri: Uri

--- a/vscode/webviews/components/codeSnippet/CodeSnippet.tsx
+++ b/vscode/webviews/components/codeSnippet/CodeSnippet.tsx
@@ -149,6 +149,7 @@ export const FileMatchSearchResult: FC<PropsWithChildren<FileMatchSearchResultPr
             getVSCodeAPI().postMessage({
                 command: 'openRemoteFile',
                 uri,
+                tryLocal: true,
             })
         },
         [fileURL, agentIDE, onSelect]


### PR DESCRIPTION
This modifies the behavior of clicking search results to link to local files if the result represents a file in your local repo. With the [recent changes](https://github.com/sourcegraph/sourcegraph/pull/2943) that heavily prefer results from your current repo, this should now be most results.

## Test plan

[Video walkthrough](https://share.cleanshot.com/kqr06zwK)
