### PR TITLE
disable intent menu item for testing

### DIFF
--- a/vscode/webviews/chat/cells/messageCell/human/editor/toolbar/SubmitButton.tsx
+++ b/vscode/webviews/chat/cells/messageCell/human/editor/toolbar/SubmitButton.tsx
@@ -61,31 +61,31 @@ function getIntentOptions({
     const intentDetectionAvailable = !isDotComUser && !intentDetectionDisabled && intentDetectionToggleOn
 
     const standardOneBoxIntents: IntentOption[] = [
-        {
-            title: (
-                <div className="tw-flex tw-flex-col tw-self-start">
-                    <p>Run detected intent</p>
-                    <p className="tw-text-sm tw-text-muted-foreground">
-                        {isDotComUser
-                            ? 'Detects intent and runs appropriately'
-                            : `Currently: ${
-                                  detectedIntent ? (detectedIntent === 'search' ? 'Search' : 'Chat') : ''
-                              }`}
-                    </p>
-                </div>
-            ),
-            icon: Sparkles,
-            intent: undefined,
-            hidden: !intentDetectionAvailable,
-            disabled: isDotComUser,
-            shortcut: isDotComUser ? (
-                <Badge>
-                    Enterprise <InfoIcon className="tw-size-4 tw-ml-1" />
-                </Badge>
-            ) : (
-                <Kbd macOS="return" linuxAndWindows="return" />
-            ),
-        },
+        // {
+        //     title: (
+        //         <div className="tw-flex tw-flex-col tw-self-start">
+        //             <p>Run detected intent</p>
+        //             <p className="tw-text-sm tw-text-muted-foreground">
+        //                 {isDotComUser
+        //                     ? 'Detects intent and runs appropriately'
+        //                     : `Currently: ${
+        //                           detectedIntent ? (detectedIntent === 'search' ? 'Search' : 'Chat') : ''
+        //                       }`}
+        //             </p>
+        //         </div>
+        //     ),
+        //     icon: Sparkles,
+        //     intent: undefined,
+        //     hidden: !intentDetectionAvailable,
+        //     disabled: isDotComUser,
+        //     shortcut: isDotComUser ? (
+        //         <Badge>
+        //             Enterprise <InfoIcon className="tw-size-4 tw-ml-1" />
+        //         </Badge>
+        //     ) : (
+        //         <Kbd macOS="return" linuxAndWindows="return" />
+        //     ),
+        // },
         {
             title: 'Run as chat',
             icon: MessageSquare,
@@ -275,7 +275,7 @@ export const SubmitButton: FC<{
                                     </CommandItem>
                                 )
                             )}
-                            {!isDotComUser && !(intentDetectionDisabled ?? false) && (
+                            {/* {!isDotComUser && !(intentDetectionDisabled ?? false) && (
                                 <div
                                     role="button"
                                     tabIndex={0}
@@ -301,7 +301,7 @@ export const SubmitButton: FC<{
                                         </p>
                                     </div>
                                 </div>
-                            )}
+                            )} */}
                         </CommandList>
                     </Command>
                 )}


### PR DESCRIPTION
Comments out the intent selector option and removes the intent detector toggle button to test how this would work for end users. 

_This is not something I think should be merged right now, hence commenting the code out._

(Toggle would need to be relocated to some setting area.)

Before:
![image](https://github.com/user-attachments/assets/ae4326e6-e8ba-4f4e-8b00-dc928b4bfeb9)


After:
<img width="531" alt="image" src="https://github.com/user-attachments/assets/d4a36228-9685-4fcd-9417-328dcadb3b09" />


## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
