### PR TITLE
chore: disable flaky test

### DIFF
--- a/vscode/test/e2e/uninstall.test.ts
+++ b/vscode/test/e2e/uninstall.test.ts
@@ -4,7 +4,7 @@ import { loggedV2Events } from '../fixtures/mock-server'
 import { expectAuthenticated, focusSidebar, sidebarSignin } from './common'
 import { expect, getCodySidebar, test } from './helpers'
 
-test('uninstall extension', async ({ openVSCode }) => {
+test.fixme('uninstall extension', async ({ openVSCode }) => {
     // This test is quite heavy so it can timeout in CI unless we grant it a longer timeout
     test.setTimeout(60 * 1000)
     // In order to trigger the uninstall event, we need to actually install the extension


### PR DESCRIPTION
This test failed [three attempts in a row](https://github.com/sourcegraph/cody/actions/runs/12937850063/job/36087981771?pr=6781) before finally passing on the fourth attempt. This PR disables the flaky test. I created a linear issue to track re-enabling [here](https://linear.app/sourcegraph/issue/CODY-4755/test-flake-uninstall-extension)

## Test plan

CI passes without flakes
