### PR TITLE
chore(ci): handle concurrency with github actions

### DIFF
--- a/.github/workflows/agent-bindings.yml
+++ b/.github/workflows/agent-bindings.yml
@@ -2,12 +2,15 @@
 # Worst-case: feel free to disable this workflow here https://github.com/sourcegraph/cody/actions/workflows/agent-bindings.yml
 name: agent-bindings
 on:
-
   pull_request:
     paths:
-      - '**.ts'
-      - '**.tsx'
-      - '**.js'
+      - "**.ts"
+      - "**.tsx"
+      - "**.js"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   kotlin:

--- a/.github/workflows/agent-release.yml
+++ b/.github/workflows/agent-release.yml
@@ -5,6 +5,10 @@ on:
     tags:
       - agent-v*
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   release:
     if: github.repository == 'sourcegraph/cody'

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -5,6 +5,10 @@ on:
       - closed
       - labeled
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   backport:
     name: Backport
@@ -25,4 +29,4 @@ jobs:
         with:
           github_token: ${{ secrets.BACKPORT_GITHUB_TOKEN }}
           label_pattern: '^backport (?<base>(jb|vscode)-v\d+\.\d+\.x)$'
-          team_reviews: 'cody-core'
+          team_reviews: "cody-core"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,10 @@ on:
     types: [opened, reopened, synchronize, ready_for_review]
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   # Sets a variable that is used to determine the matrix to run fast tests (unit & integration) on.
   # Everything runs on ubuntu and windows, only commits to main run on macos.

--- a/.github/workflows/e2e-flakiness-detector.yml
+++ b/.github/workflows/e2e-flakiness-detector.yml
@@ -4,8 +4,12 @@ name: e2e-flakiness-detector
 
 on:
   schedule:
-    - cron: '0 14 * * *' # daily at 1400 UTC
+    - cron: "0 14 * * *" # daily at 1400 UTC
   workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   test-e2e:

--- a/.github/workflows/experimental-release.yml
+++ b/.github/workflows/experimental-release.yml
@@ -1,8 +1,13 @@
 name: Experimental Release
 on:
   push:
-    tags: [ "jb-*-experimental" ]
-    workflow_dispatch:
+    tags: ["jb-*-experimental"]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/generate-changelog.yml
+++ b/.github/workflows/generate-changelog.yml
@@ -4,9 +4,13 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'The version to be released, for example: 1.60.0'
+        description: "The version to be released, for example: 1.60.0"
         required: true
         type: string
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   changelog:

--- a/.github/workflows/integration-stability.yml
+++ b/.github/workflows/integration-stability.yml
@@ -3,9 +3,14 @@ on:
   workflow_dispatch:
     inputs:
       repetitions:
-        description: 'How many times to repeat each test'
+        description: "How many times to repeat each test"
         type: number
         default: 10
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     name: Build and run tests

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -3,6 +3,10 @@ on:
   issues:
     types: [opened, edited]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   issues: write
   contents: read
@@ -11,9 +15,9 @@ jobs:
   triage:
     runs-on: ubuntu-latest
     steps:
-    - uses: github/issue-labeler@v3.4
-      with:
-        configuration-path: .github/labeler.yml
-        enable-versioned-regex: 0
-        repo-token: ${{ github.token }}
-        include-title: 1
+      - uses: github/issue-labeler@v3.4
+        with:
+          configuration-path: .github/labeler.yml
+          enable-versioned-regex: 0
+          repo-token: ${{ github.token }}
+          include-title: 1

--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -5,6 +5,10 @@ on:
     types: [opened, reopened, synchronize, ready_for_review]
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   safe-prompts-lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -1,7 +1,12 @@
 name: Nightly Release
 on:
   push:
-    tags: [ "jb-*-nightly" ]
+    tags: ["jb-*-nightly"]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-auditor.yml
+++ b/.github/workflows/pr-auditor.yml
@@ -2,8 +2,11 @@
 name: pr-auditor
 on:
   pull_request_target:
-    types: [ closed, edited, opened, synchronize, ready_for_review ]
+    types: [closed, edited, opened, synchronize, ready_for_review]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   check-pr:
@@ -11,12 +14,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          repository: 'sourcegraph/devx-service'
+          repository: "sourcegraph/devx-service"
           token: ${{ secrets.PR_AUDITOR_TOKEN }}
       - uses: actions/setup-go@v4
-        with: { go-version: '1.22' }
+        with: { go-version: "1.22" }
 
-      - run: 'go run ./cmd/pr-auditor'
+      - run: "go run ./cmd/pr-auditor"
         env:
           GITHUB_EVENT_PATH: ${{ env.GITHUB_EVENT_PATH }}
           GITHUB_TOKEN: ${{ secrets.PR_AUDITOR_TOKEN }}

--- a/.github/workflows/scip-java.yml
+++ b/.github/workflows/scip-java.yml
@@ -2,10 +2,15 @@ name: Sourcegraph
 on:
   push:
     paths:
-      - '**.kt'
-      - '**.java'
-      - '**.kts'
-      - '.github/workflows/scip-java.yml'
+      - "**.kt"
+      - "**.java"
+      - "**.kts"
+      - ".github/workflows/scip-java.yml"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   scip-java:
     if: github.repository == 'sourcegraph/cody'
@@ -33,7 +38,7 @@ jobs:
             ${{ runner.os }}-gradle-
       - uses: coursier/setup-action@v1
         with:
-          jvm: 'zulu:17'
+          jvm: "zulu:17"
           apps: scip-java
       - name: Generate SCIP File
         run: |

--- a/.github/workflows/scip-typescript.yml
+++ b/.github/workflows/scip-typescript.yml
@@ -6,9 +6,13 @@ on:
   pull_request:
     types: [opened, reopened, synchronize, ready_for_review]
     paths:
-      - '**.ts'
-      - '**.tsx'
-      - '**.js'
+      - "**.ts"
+      - "**.tsx"
+      - "**.js"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   scip-typescript:

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -4,6 +4,10 @@ on:
   pull_request_target:
     types: [edited, opened, synchronize, ready_for_review]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   semgrep:
     permissions:

--- a/.github/workflows/stable-release.yml
+++ b/.github/workflows/stable-release.yml
@@ -1,6 +1,10 @@
 name: Stable Release
-on:
-  workflow_dispatch
+on: workflow_dispatch
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,7 +1,11 @@
-name: 'Close stale issues and PRs'
+name: "Close stale issues and PRs"
 on:
   schedule:
-    - cron: '30 1 * * *'
+    - cron: "30 1 * * *"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   stale:
@@ -9,9 +13,9 @@ jobs:
     steps:
       - uses: actions/stale@v9
         with:
-          stale-issue-message: 'This issue is marked as stale because it has been open 60 days with no activity. Remove stale label or comment or this will be closed automatically in 5 days.'
-          stale-pr-message: 'This PR is marked as stale because it has been open 60 days with no activity. Remove stale label or comment or this will be closed automatically in 5 days.'
+          stale-issue-message: "This issue is marked as stale because it has been open 60 days with no activity. Remove stale label or comment or this will be closed automatically in 5 days."
+          stale-pr-message: "This PR is marked as stale because it has been open 60 days with no activity. Remove stale label or comment or this will be closed automatically in 5 days."
           days-before-stale: 60
           days-before-close: 5
-          exempt-issue-labels: 'neverstale'
-          exempt-pr-labels: 'neverstale'
+          exempt-issue-labels: "neverstale"
+          exempt-pr-labels: "neverstale"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,11 @@ on:
   push:
     branches:
       - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     name: JetBrains tests
@@ -65,7 +70,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: plugin
-          path: './jetbrains/build/distributions/Sourcegraph-*.zip'
+          path: "./jetbrains/build/distributions/Sourcegraph-*.zip"
           compression-level: 0
           retention-days: 7
   plugin-verifier:
@@ -83,7 +88,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          plugin-location: '*.zip'
+          plugin-location: "*.zip"
           # TODO (pkukielka): Upper range should be bumped to 251.14649.49-EAP-SNAPSHOT
           # as soon as problem with Git4Idea dependencies will get resolved
           ide-versions: |
@@ -100,6 +105,5 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: plugin-verifier-reports
-          path: 'verification-*'
+          path: "verification-*"
           compression-level: 9
-

--- a/.github/workflows/vscode-insiders-release.yml
+++ b/.github/workflows/vscode-insiders-release.yml
@@ -3,6 +3,10 @@ name: vscode-insiders-release
 on:
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   release:
     if: github.repository == 'sourcegraph/cody'
@@ -37,11 +41,11 @@ jobs:
           GITHUB_ENV: $GITHUB_ENV
       - name: Authenticate to Google Cloud
         id: auth
-        uses: 'google-github-actions/auth@v2'
+        uses: "google-github-actions/auth@v2"
         with:
-          project_id: 'cody-core-dev'
-          workload_identity_provider: 'projects/39257127245/locations/global/workloadIdentityPools/github/providers/cody'
-          service_account: 'bundle-size-tracker@cody-core-dev.iam.gserviceaccount.com'
+          project_id: "cody-core-dev"
+          workload_identity_provider: "projects/39257127245/locations/global/workloadIdentityPools/github/providers/cody"
+          service_account: "bundle-size-tracker@cody-core-dev.iam.gserviceaccount.com"
           create_credentials_file: true
           export_environment_variables: true
       - run: CODY_RELEASE_TYPE=insiders pnpm -C vscode run release
@@ -54,7 +58,7 @@ jobs:
         run: |
           # Compute the current date
           current_date=$(date +'%Y-%m-%d')
-          
+
           # Now create the JSON and insert into BigQuery
           echo "{\"release_version\": \"${{ steps.create_release.outputs.version_tag }}\", \"extension_bundle_size_mb\": $EXTENSION_BUNDLE_SIZE_MB, \"webview_bundle_size_mb\": $WEBVIEW_BUNDLE_SIZE_MB, \"date\": \"$current_date\"}" > data.json
           bq load \

--- a/.github/workflows/vscode-stable-release.yml
+++ b/.github/workflows/vscode-stable-release.yml
@@ -5,6 +5,10 @@ on:
     tags:
       - vscode-v*
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   release:
     if: github.repository == 'sourcegraph/cody'
@@ -78,7 +82,7 @@ jobs:
           echo "VERSION_ANCHOR=$version_anchor" >> $GITHUB_ENV
           echo "CURRENT_RELEASE_BRANCH=vscode-v$major.$minor.x" >> $GITHUB_ENV
           echo "NEXT_RELEASE_BRANCH=vscode-v$major.$next_minor.x" >> $GITHUB_ENV
-      - name: 'Slack notification'
+      - name: "Slack notification"
         run: |
           echo "Posting release announcement to Slack"
           ANNOUNCE_EDITORS_SLACK_WEBHOOK_URL=${{ secrets.ANNOUNCE_EDITORS_SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
Closes [DINF-644](https://linear.app/sourcegraph/issue/DINF-644/improve-github-actions-concurrency-in-cody-repo)

This helps save some GitHub action minutes by ensuring we kill previous jobs belonging to the same workflow.

## Test plan

CI

## Changelog
