### PR TITLE
fix(telemetry): add billing metadata to onebox.filterSidebar event

### DIFF
--- a/vscode/webviews/chat/cells/messageCell/assistant/SearchResults.tsx
+++ b/vscode/webviews/chat/cells/messageCell/assistant/SearchResults.tsx
@@ -153,7 +153,12 @@ export const SearchResults = ({
     )
 
     const onFilterSidebarClose = useCallback(() => {
-        telemetryRecorder.recordEvent('onebox.filterSidebar', 'closed')
+        telemetryRecorder.recordEvent('onebox.filterSidebar', 'closed', {
+            billingMetadata: {
+                product: 'cody',
+                category: 'billable',
+            },
+        })
         setShowFiltersSidebar(false)
     }, [telemetryRecorder])
 


### PR DESCRIPTION
This change adds billing metadata to the `onebox.filterSidebar` telemetry event, including the product name 'cody' and the category 'billable'. This will help with billing and cost tracking for the Cody product.


## Test plan
CI
<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
