### PR TITLE
Fix OpenTelemetryService initialization+observables code and  fix the span closure of Chat Spans

### DIFF
--- a/vscode/src/chat/chat-view/ChatController.ts
+++ b/vscode/src/chat/chat-view/ChatController.ts
@@ -923,12 +923,18 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
                             )
                         }
 
+                        // Mark the end of the span for chat.handleUserMessage here, as we do not await
+                        // the entire stream of chat messages being sent to the webview.
+                        // The span is concluded when the stream is complete.
+                        span.end()
                         this.saveSession()
                         this.postViewTranscript()
                     },
                 }
             )
         } catch (error) {
+            // This ensures that the span for chat.handleUserMessage is ended even if the operation fails
+            span.end()
             if (isAbortErrorOrSocketHangUp(error as Error)) {
                 return
             }

--- a/vscode/src/services/open-telemetry/CodyTraceExport.ts
+++ b/vscode/src/services/open-telemetry/CodyTraceExport.ts
@@ -1,30 +1,27 @@
 import type { ExportResult } from '@opentelemetry/core'
 import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http'
 import type { ReadableSpan } from '@opentelemetry/sdk-trace-base'
+import type { OpenTelemetryServiceConfig } from './OpenTelemetryService.node'
 
 const MAX_TRACE_RETAIN_MS = 60 * 1000
 
 export class CodyTraceExporter extends OTLPTraceExporter {
-    private isTracingEnabled = false
     private queuedSpans: Map<string, { span: ReadableSpan; enqueuedAt: number }> = new Map()
 
-    constructor({
-        traceUrl,
-        accessToken,
-        isTracingEnabled,
-    }: { traceUrl: string; accessToken: string | null; isTracingEnabled: boolean }) {
+    constructor(private configAccessor: () => OpenTelemetryServiceConfig | null) {
         super({
-            url: traceUrl,
-            httpAgentOptions: { rejectUnauthorized: false },
+            url: configAccessor()?.traceUrl,
             headers: {
-                ...(accessToken ? { Authorization: `token ${accessToken}` } : {}),
+                ...(configAccessor()?.accessToken ? { Authorization: `token ${configAccessor()?.accessToken}` } : {}),
             },
+            httpAgentOptions: { rejectUnauthorized: false },
         })
-        this.isTracingEnabled = isTracingEnabled
     }
 
     export(spans: ReadableSpan[], resultCallback: (result: ExportResult) => void): void {
-        if (!this.isTracingEnabled) {
+        const config = this.configAccessor()
+        if (!config?.isTracingEnabled) {
+            this.queuedSpans.clear()
             return
         }
 

--- a/vscode/src/services/open-telemetry/CodyTraceExport.ts
+++ b/vscode/src/services/open-telemetry/CodyTraceExport.ts
@@ -12,7 +12,9 @@ export class CodyTraceExporter extends OTLPTraceExporter {
         super({
             url: configAccessor()?.traceUrl,
             headers: {
-                ...(configAccessor()?.accessToken ? { Authorization: `token ${configAccessor()?.accessToken}` } : {}),
+                ...(configAccessor()?.accessToken
+                    ? { Authorization: `token ${configAccessor()?.accessToken}` }
+                    : {}),
             },
             httpAgentOptions: { rejectUnauthorized: false },
         })

--- a/vscode/src/services/open-telemetry/OpenTelemetryService.node.ts
+++ b/vscode/src/services/open-telemetry/OpenTelemetryService.node.ts
@@ -6,7 +6,6 @@ import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions'
 
 import {
     FeatureFlag,
-    type ResolvedConfiguration,
     type Unsubscribable,
     combineLatest,
     featureFlagProvider,
@@ -15,85 +14,141 @@ import {
 
 import { DiagConsoleLogger, DiagLogLevel, diag } from '@opentelemetry/api'
 import { BatchSpanProcessor } from '@opentelemetry/sdk-trace-base'
+import { isEqual } from 'lodash'
 import { version } from '../../version'
 import { CodyTraceExporter } from './CodyTraceExport'
 import { ConsoleBatchSpanExporter } from './console-batch-span-exporter'
 
+export interface OpenTelemetryServiceConfig {
+    isTracingEnabled: boolean
+    traceUrl: string
+    accessToken: string | null
+    debugVerbose: boolean
+}
 export class OpenTelemetryService {
     private tracerProvider?: NodeTracerProvider
+    private spanProcessors: BatchSpanProcessor[] = []
     private unloadInstrumentations?: () => void
     private isTracingEnabled = false
 
     private lastTraceUrl: string | undefined
     // We use a single promise object that we chain on to, to avoid multiple reconfigure calls to
     // be run in parallel
+    private lastConfig: OpenTelemetryServiceConfig | undefined
     private reconfigurePromiseMutex: Promise<void> = Promise.resolve()
-
     private configSubscription: Unsubscribable
+    private instrumentationUnload?: () => void
+    private diagLogger: DiagConsoleLogger = new DiagConsoleLogger()
+    private currentLogLevel: DiagLogLevel = DiagLogLevel.ERROR
 
     constructor() {
-        this.configSubscription = combineLatest(
-            resolvedConfig,
-            featureFlagProvider.evaluatedFeatureFlag(FeatureFlag.CodyAutocompleteTracing)
-        ).subscribe(([{ configuration, auth }, codyAutocompleteTracingFlag]) => {
-            this.reconfigurePromiseMutex = this.reconfigurePromiseMutex.then(async () => {
-                this.isTracingEnabled = configuration.experimentalTracing || codyAutocompleteTracingFlag
-
-                const traceUrl = new URL('/-/debug/otlp/v1/traces', auth.serverEndpoint).toString()
-                if (this.lastTraceUrl === traceUrl) {
-                    return
-                }
-                this.lastTraceUrl = traceUrl
-
-                const logLevel = configuration.debugVerbose ? DiagLogLevel.INFO : DiagLogLevel.ERROR
-                diag.setLogger(new DiagConsoleLogger(), logLevel)
-
-                await this.reset()
-
-                this.unloadInstrumentations = registerInstrumentations({
-                    instrumentations: [new HttpInstrumentation()],
-                })
-                this.configureTracerProvider(traceUrl, { configuration, auth })
-            })
-        })
-    }
-
-    public dispose(): void {
-        this.configSubscription.unsubscribe()
-    }
-
-    private configureTracerProvider(
-        traceUrl: string,
-        { configuration, auth }: Pick<ResolvedConfiguration, 'configuration' | 'auth'>
-    ): void {
+        // Initialize once and never replace
         this.tracerProvider = new NodeTracerProvider({
             resource: new Resource({
                 [SemanticResourceAttributes.SERVICE_NAME]: 'cody-client',
                 [SemanticResourceAttributes.SERVICE_VERSION]: version,
             }),
         })
+        // Register once at startup
+        this.tracerProvider.register()
 
-        // Add the default tracer exporter used in production.
-        this.tracerProvider.addSpanProcessor(
-            new BatchSpanProcessor(
-                new CodyTraceExporter({
-                    traceUrl,
-                    isTracingEnabled: this.isTracingEnabled,
-                    accessToken: auth.accessToken,
+        this.configSubscription = combineLatest(
+            resolvedConfig,
+            featureFlagProvider.evaluatedFeatureFlag(FeatureFlag.CodyAutocompleteTracing)
+        ).subscribe(([{ configuration, auth }, codyAutocompleteTracingFlag]) => {
+            this.reconfigurePromiseMutex = this.reconfigurePromiseMutex
+                .then(async () => {
+                    this.isTracingEnabled =
+                        configuration.experimentalTracing || codyAutocompleteTracingFlag
+
+                    const traceUrl = new URL('/-/debug/otlp/v1/traces', auth.serverEndpoint).toString()
+                    if (this.lastTraceUrl === traceUrl) {
+                        return
+                    }
+                    this.lastTraceUrl = traceUrl
+
+                    const logLevel = configuration.debugVerbose ? DiagLogLevel.INFO : DiagLogLevel.ERROR
+                    diag.setLogger(new DiagConsoleLogger(), logLevel)
+
+                    const newConfig = {
+                        isTracingEnabled: this.isTracingEnabled,
+                        traceUrl: traceUrl,
+                        debugVerbose: configuration.debugVerbose,
+                        accessToken: auth.accessToken,
+                    }
+
+                    if (isEqual(this.lastConfig, newConfig)) {
+                        return
+                    }
+                    await this.reset()
+                    await this.handleConfigUpdate(newConfig)
+                    this.lastConfig = newConfig
                 })
-            )
-        )
+                .catch(error => {
+                    console.error('Error configuring OpenTelemetry:', error)
+                })
+        })
+    }
 
-        // Add the console exporter used in development for verbose logging and debugging.
-        if (process.env.NODE_ENV === 'development' || configuration.debugVerbose) {
-            this.tracerProvider.addSpanProcessor(new BatchSpanProcessor(new ConsoleBatchSpanExporter()))
+    private async handleConfigUpdate(newConfig: OpenTelemetryServiceConfig): Promise<void> {
+        const logLevel = newConfig.debugVerbose ? DiagLogLevel.INFO : DiagLogLevel.ERROR
+        if (logLevel !== this.currentLogLevel) {
+            diag.setLogger(this.diagLogger, logLevel)
+            this.currentLogLevel = logLevel
         }
 
-        this.tracerProvider.register()
+        this.instrumentationUnload?.()
+        this.instrumentationUnload = registerInstrumentations({
+            instrumentations: [new HttpInstrumentation()],
+        })
+
+        await this.replaceSpanProcessors(newConfig)
+    }
+
+    public dispose(): void {
+        this.configSubscription.unsubscribe()
+        this.reset().catch(error => console.error('Error disposing OpenTelemetry:', error))
+    }
+
+    private async replaceSpanProcessors(config: OpenTelemetryServiceConfig): Promise<void> {
+        const newProcessors = [new BatchSpanProcessor(new CodyTraceExporter(() => config))]
+
+        if (config.debugVerbose || process.env.NODE_ENV === 'development') {
+            newProcessors.push(new BatchSpanProcessor(new ConsoleBatchSpanExporter()))
+        }
+        const provider = this.tracerProvider as any
+        const oldProcessors = this.spanProcessors
+
+        // Clear the provider's internal processor list and active processor
+        provider._registeredSpanProcessors = []
+        provider.activeSpanProcessor = {
+            forceFlush: async () => {},
+            onStart: () => {},
+            onEnd: () => {},
+            shutdown: async () => {},
+        }
+
+        // Add new processors to the provider
+        for (const processor of newProcessors) {
+            this.tracerProvider?.addSpanProcessor(processor)
+        }
+
+        // Gracefully shutdown old processors after clearing references
+        setTimeout(async () => {
+            try {
+                await Promise.all(oldProcessors.map(p => p.shutdown()))
+            } catch (error) {
+                console.error('Error shutting down old processors:', error)
+            }
+        }, 5000)
     }
 
     public async reset(): Promise<void> {
-        await this.tracerProvider?.shutdown()
+        // Shutdown span processors and instrumentations
+        if (this.spanProcessors.length > 0) {
+            await Promise.all(this.spanProcessors.map(processor => processor.shutdown()))
+            this.spanProcessors = []
+        }
         this.unloadInstrumentations?.()
     }
 }

--- a/vscode/src/services/open-telemetry/OpenTelemetryService.node.ts
+++ b/vscode/src/services/open-telemetry/OpenTelemetryService.node.ts
@@ -62,13 +62,6 @@ export class OpenTelemetryService {
                         configuration.experimentalTracing || codyAutocompleteTracingFlag
 
                     const traceUrl = new URL('/-/debug/otlp/v1/traces', auth.serverEndpoint).toString()
-                    if (this.lastTraceUrl === traceUrl) {
-                        return
-                    }
-                    this.lastTraceUrl = traceUrl
-
-                    const logLevel = configuration.debugVerbose ? DiagLogLevel.INFO : DiagLogLevel.ERROR
-                    diag.setLogger(new DiagConsoleLogger(), logLevel)
 
                     const newConfig = {
                         isTracingEnabled: this.isTracingEnabled,
@@ -77,6 +70,7 @@ export class OpenTelemetryService {
                         accessToken: auth.accessToken,
                     }
 
+                    this.lastTraceUrl = traceUrl
                     if (isEqual(this.lastConfig, newConfig)) {
                         return
                     }

--- a/vscode/src/services/open-telemetry/OpenTelemetryService.node.ts
+++ b/vscode/src/services/open-telemetry/OpenTelemetryService.node.ts
@@ -31,7 +31,6 @@ export class OpenTelemetryService {
     private unloadInstrumentations?: () => void
     private isTracingEnabled = false
 
-    private lastTraceUrl: string | undefined
     // We use a single promise object that we chain on to, to avoid multiple reconfigure calls to
     // be run in parallel
     private lastConfig: OpenTelemetryServiceConfig | undefined
@@ -70,7 +69,6 @@ export class OpenTelemetryService {
                         accessToken: auth.accessToken,
                     }
 
-                    this.lastTraceUrl = traceUrl
                     if (isEqual(this.lastConfig, newConfig)) {
                         return
                     }


### PR DESCRIPTION
## Changes

1. Fixing problem with `externalAuthRefreshChanges` not having initial value which was blocking the configuration
2. Making caching checks more correct
3. Makes sure the spans for chat are properly closed so  that we can actually see them in HoneyComb
4. Fixing different edge cases in the re-registration of OtelCollectors with observables


### Span Closure Issues
<img width="1479" alt="image" src="https://github.com/user-attachments/assets/a995c3bb-909e-4aea-992f-88009caa20a8" />
This PR ensures that the spans for handling chat messages are properly ended, so that they are properly finished and exported. This way, they can be seen in the Trace View(I have verified this behavior by testing locally too) so now honeycomb should get proper chat traces.

NOTE: This behavior was working perfectly [in the original PR](https://github.com/sourcegraph/cody/pull/6294) but in [this massive refactor ](https://github.com/sourcegraph/cody/pull/6469) the span closure got accidentally removed so now I am [adding those span closures again](https://github.com/sourcegraph/cody/pull/6807/commits/2df697c35c0f15cf34e5bcf432bbf7f4e77a8916) and adding a comment for future safety. 





### OpenTelemetry Configuration Issues
This PR resolves configuration update issues in the OpenTelemetry integration by implementing a provider recycling pattern, ensuring stable tracing across dynamic configuration changes while preventing API registration conflicts.
In the past we would re-register on this.tracerProvider on opentelemetry changes but that lead to a lot of oTel errors like 

```
"OTLPExporterError: Unprocessable Entity
\tat IncomingMessage.<anonymous> (/Users/pkukielka/Work/sourcegraph/cody2/vscode/dist/extension.node.js:183479:31)
\tat IncomingMessage.emit (node:events:530:35)
\tat IncomingMessage.emit (node:domain:489:12)
\tat endReadableNT (node:internal/streams/readable:1698:12)
\tat process.processTicksAndRejections (node:internal/process/task_queues:82:21)"


```
Or alternatively some form of re-registration errors so this PR registers TracerProvider only ones but it changes the processors so that they can account for different conditions like change in telemetry sending URL and enable/disable etc.

## Test Plan
NOTE: Every operation in the test plan like turning false to true or changing the account requires a wait time of 5 seconds atleast coz observables take time to "propagate". 

### Test 1: Tracing Flag Toggle Without Restart

**Steps:**

- Set "cody.experimental.tracing": true in settings.json of the vscode config (no restart).


- Ask a chat question.

- Verify: CodyTraceExporter::export is executed (check debugger).

- Verify: No `otlp_export_error` in debug console.

- Set `cody.experimental.tracing ` to false (no restart).

- Ask a chat question.

- Verify: CodyTraceExporter::export is not executed and blocked by trace enablement check.

- Verify: No errors in console.

- Set cody.experimental.tracing to true again (no restart).

- Ask a chat question.

- Verify: CodyTraceExporter::export executes and emits data (passes trace enablement check).

- Verify: No otlp_export_error.

### Test 2: Account Switching with Tracing

**Steps:**

Account A Setup (sourcegraph.com):

- Set "cody.experimental.tracing": true in config.

- Ask a chat question.

- Verify: CodyTraceExporter::export executes.

- Verify: No errors.

Switch to Account B (sourcegraph.sourcegraph.com):(No need to restart cody)

- Ask a chat question.

- Verify: Tracing is enabled by default in the new account; CodyTraceExporter::export is called.

- Verify: No errors.

- Ask a chat question.

- Verify: CodyTraceExporter::export executes for Account B.
- See the export function for spans being hit
 

### Test 3: Error Handling Validation
Steps:
- Across all test cases above, explicitly check the debug console for:

- Absence of otlp_export_error or other tracing-related errors.

- No unexpected authentication or network errors during account switches.

