### PR TITLE
fix: hide edit prompts on the web

### DIFF
--- a/vscode/webviews/components/promptList/utils.ts
+++ b/vscode/webviews/components/promptList/utils.ts
@@ -3,3 +3,10 @@ import type { Action } from '@sourcegraph/cody-shared'
 export function commandRowValue(row: Action): string {
     return row.actionType === 'prompt' ? `prompt-${row.id}` : `command-${row.key}`
 }
+
+export const shouldShowAction = (action: Action, isEditEnabled: boolean): boolean => {
+    const isActionEditLike =
+        action.actionType === 'prompt' ? action.mode !== 'CHAT' : action.mode !== 'ask'
+
+    return isEditEnabled || !isActionEditLike
+}

--- a/vscode/webviews/components/promptList/utils.ts
+++ b/vscode/webviews/components/promptList/utils.ts
@@ -4,7 +4,7 @@ export function commandRowValue(row: Action): string {
     return row.actionType === 'prompt' ? `prompt-${row.id}` : `command-${row.key}`
 }
 
-export const shouldShowAction = (action: Action, isEditEnabled: boolean): boolean => {
+export function shouldShowAction(action: Action, isEditEnabled: boolean): boolean {
     const isActionEditLike =
         action.actionType === 'prompt' ? action.mode !== 'CHAT' : action.mode !== 'ask'
 


### PR DESCRIPTION
This PR completely hides edit prompts from the web client (where edits aren't possible).

## Web

| Before | After |
|--------|-------|
| ![CleanShot 2025-01-27 at 12 41 57@2x](https://github.com/user-attachments/assets/a22541a2-9740-4469-96ff-a2f7137b116a) | ![CleanShot 2025-01-27 at 12 40 29@2x](https://github.com/user-attachments/assets/08e82f3f-13dd-4062-b201-fd6ccab58367) |

## Client

No change.

## Test plan

Manually tested, locally.