### PR TITLE
fix(ci): add cross-env dep and use with LOG_BUNDLE_SIZE

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -876,6 +876,9 @@ importers:
       concurrently:
         specifier: ^8.2.0
         version: 8.2.0
+      cross-env:
+        specifier: ^7.0.3
+        version: 7.0.3
       dedent:
         specifier: ^0.7.0
         version: 0.7.0
@@ -9028,6 +9031,14 @@ packages:
 
   /create-require@1.1.1:
     resolution: {integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==}
+
+  /cross-env@7.0.3:
+    resolution: {integrity: sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==}
+    engines: {node: '>=10.14', npm: '>=6', yarn: '>=1'}
+    hasBin: true
+    dependencies:
+      cross-spawn: 7.0.3
+    dev: true
 
   /cross-spawn@7.0.3:
     resolution: {integrity: sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==}

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -58,14 +58,7 @@
     "version-bump:dry-run": "RELEASE_TYPE=prerelease ts-node-transpile-only ./scripts/version-bump.ts",
     "measure-bundle-size": "cross-env LOG_BUNDLE_SIZE=true ts-node-transpile-only ./scripts/measure-bundle-size.ts"
   },
-  "categories": [
-    "AI",
-    "Chat",
-    "Programming Languages",
-    "Machine Learning",
-    "Snippets",
-    "Education"
-  ],
+  "categories": ["AI", "Chat", "Programming Languages", "Machine Learning", "Snippets", "Education"],
   "keywords": [
     "cody",
     "codey",
@@ -130,11 +123,7 @@
   },
   "main": "./dist/extension.node.js",
   "browser": "./dist/extension.web.js",
-  "activationEvents": [
-    "onLanguage",
-    "onStartupFinished",
-    "onWebviewPanel:cody.editorPanel"
-  ],
+  "activationEvents": ["onLanguage", "onStartupFinished", "onWebviewPanel:cody.editorPanel"],
   "contributes": {
     "walkthroughs": [
       {
@@ -732,17 +721,13 @@
       },
       {
         "command": "cody.supercompletion.jumpTo",
-        "args": [
-          "next"
-        ],
+        "args": ["next"],
         "key": "shift+ctrl+down",
         "when": "cody.activated && !editorReadonly && cody.hasActionableSupercompletion"
       },
       {
         "command": "cody.supercompletion.jumpTo",
-        "args": [
-          "previous"
-        ],
+        "args": ["previous"],
         "key": "shift+ctrl+up",
         "when": "cody.activated && !editorReadonly && cody.hasActionableSupercompletion"
       },
@@ -1007,10 +992,7 @@
           "order": 2,
           "type": "string",
           "markdownDescription": "A Git repository URL to use instead of allowing Cody to infer the Git repository from the workspace.",
-          "examples": [
-            "https://github.com/sourcegraph/cody",
-            "ssh://git@github.com/sourcegraph/cody"
-          ]
+          "examples": ["https://github.com/sourcegraph/cody", "ssh://git@github.com/sourcegraph/cody"]
         },
         "cody.customHeaders": {
           "order": 4,
@@ -1026,11 +1008,7 @@
         },
         "cody.suggestions.mode": {
           "type": "string",
-          "enum": [
-            "autocomplete",
-            "auto-edit (Experimental)",
-            "off"
-          ],
+          "enum": ["autocomplete", "auto-edit (Experimental)", "off"],
           "enumDescriptions": [
             "Suggests standard code completions as you type.",
             "Suggests advanced context-aware code edits as you navigate the codebase. Experimental feature for Pro and Enterprise users.",
@@ -1069,18 +1047,12 @@
           "order": 6,
           "type": "string",
           "markdownDescription": "A custom instruction to be included at the start of all chat messages (e.g. \"Answer all my questions in Spanish.\")",
-          "examples": [
-            "Answer all my questions in Spanish."
-          ]
+          "examples": ["Answer all my questions in Spanish."]
         },
         "cody.chat.defaultLocation": {
           "order": 6,
           "type": "string",
-          "enum": [
-            "sticky",
-            "sidebar",
-            "editor"
-          ],
+          "enum": ["sticky", "sidebar", "editor"],
           "markdownDescription": "Controls where the Cody chat view opens when the user invokes the `Cody: New Chat` command, or the Alt+L and Alt+/ shortcuts.",
           "enumDescriptions": [
             "Opens in the last-activated view location, which is set whenever the user explicitly chooses to open chat in a given location",
@@ -1093,9 +1065,7 @@
           "order": 7,
           "type": "string",
           "markdownDescription": "A custom instruction to be included at the end of all instructions for edit commands (e.g. \"Write all unit tests with Jest instead of detected framework.\")",
-          "examples": [
-            "Write all unit tests with Jest instead of detected framework."
-          ]
+          "examples": ["Write all unit tests with Jest instead of detected framework."]
         },
         "cody.codeActions.enabled": {
           "order": 11,
@@ -1146,24 +1116,15 @@
         "cody.telemetry.level": {
           "order": 99,
           "type": "string",
-          "enum": [
-            "all",
-            "off"
-          ],
-          "enumDescriptions": [
-            "Sends usage data and errors.",
-            "Disables all extension telemetry."
-          ],
+          "enum": ["all", "off"],
+          "enumDescriptions": ["Sends usage data and errors.", "Disables all extension telemetry."],
           "markdownDescription": "Controls the telemetry about Cody usage and errors. See [Cody usage and privacy notice](https://about.sourcegraph.com/terms/cody-notice).",
           "default": "all"
         },
         "cody.autocomplete.advanced.provider": {
           "type": "string",
           "default": "default",
-          "enum": [
-            "default",
-            "experimental-ollama"
-          ],
+          "enum": ["default", "experimental-ollama"],
           "enumDescriptions": [
             "Our recommended setup with the best balance of quality and latency. We continuously update this for optimal performance.",
             "Experimental support for Ollama users. Use `cody.autocomplete.experimental.ollamaOptions` to configure requests to Ollama server."
@@ -1187,10 +1148,7 @@
         },
         "cody.experimental.foldingRanges": {
           "type": "string",
-          "enum": [
-            "lsp",
-            "indentation-based"
-          ],
+          "enum": ["lsp", "indentation-based"],
           "enumDescriptions": [
             "Use folding ranges that are enabled by default in VS Code, and are usually powered by LSP",
             "Use custom implementation of folding ranges that is indentation based. This is the implementation that is used by other Cody clients like the JetBrains plugin"
@@ -1201,11 +1159,7 @@
         "cody.autocomplete.experimental.graphContext": {
           "type": "string",
           "default": null,
-          "enum": [
-            null,
-            "tsc",
-            "tsc-mixed"
-          ],
+          "enum": [null, "tsc", "tsc-mixed"],
           "markdownDescription": "Use the code graph to retrieve context for autocomplete requests."
         },
         "cody.autocomplete.experimental.fireworksOptions": {
@@ -1298,11 +1252,7 @@
         },
         "cody.net.mode": {
           "type": "string",
-          "enum": [
-            "auto",
-            "bypass",
-            "vscode"
-          ],
+          "enum": ["auto", "bypass", "vscode"],
           "enumDescriptions": [
             "Default behavior. If `cody.net.proxy.endpoint` is configured, bypassing is automatically enabled, otherwise direct is used.",
             "Bypass VSCode's network stack, using Cody's instead.",
@@ -1316,11 +1266,7 @@
           "type": "string",
           "default": "",
           "pattern": "^((http|https|socks|socks4|socks4a|socks5|socks5h)://[^:]+:\\d+|unix://(~|/|[a-zA-Z]:\\\\).+)?$",
-          "examples": [
-            "https://localhost:7080",
-            "socks5://1.2.3.4:1080",
-            "unix://~/cody-proxy.sock"
-          ]
+          "examples": ["https://localhost:7080", "socks5://1.2.3.4:1080", "unix://~/cody-proxy.sock"]
         },
         "cody.net.proxy.skipCertValidation": {
           "description": "Whether to skip proxy server CA cert validation. Useful if the proxy server uses a self-signed certificate.",
@@ -1351,16 +1297,8 @@
           "examples": [
             {
               "shell": {
-                "allow": [
-                  "git",
-                  "ls",
-                  "find"
-                ],
-                "block": [
-                  "history",
-                  "sudo",
-                  "rm"
-                ]
+                "allow": ["git", "ls", "find"],
+                "block": ["history", "sudo", "rm"]
               }
             }
           ],
@@ -1454,9 +1392,7 @@
     "untrustedWorkspaces": {
       "supported": "limited",
       "description": "Cody only uses providers (configured in `openctx.providers`) from trusted workspaces because providers may execute arbitrary code.",
-      "restrictedConfigurations": [
-        "openctx.providers"
-      ]
+      "restrictedConfigurations": ["openctx.providers"]
     }
   },
   "dependencies": {

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -56,9 +56,16 @@
     "version-bump:minor": "RELEASE_TYPE=minor ts-node-transpile-only ./scripts/version-bump.ts",
     "version-bump:patch": "RELEASE_TYPE=patch ts-node-transpile-only ./scripts/version-bump.ts",
     "version-bump:dry-run": "RELEASE_TYPE=prerelease ts-node-transpile-only ./scripts/version-bump.ts",
-    "measure-bundle-size": "LOG_BUNDLE_SIZE=true ts-node-transpile-only ./scripts/measure-bundle-size.ts"
+    "measure-bundle-size": "cross-env LOG_BUNDLE_SIZE=true ts-node-transpile-only ./scripts/measure-bundle-size.ts"
   },
-  "categories": ["AI", "Chat", "Programming Languages", "Machine Learning", "Snippets", "Education"],
+  "categories": [
+    "AI",
+    "Chat",
+    "Programming Languages",
+    "Machine Learning",
+    "Snippets",
+    "Education"
+  ],
   "keywords": [
     "cody",
     "codey",
@@ -123,7 +130,11 @@
   },
   "main": "./dist/extension.node.js",
   "browser": "./dist/extension.web.js",
-  "activationEvents": ["onLanguage", "onStartupFinished", "onWebviewPanel:cody.editorPanel"],
+  "activationEvents": [
+    "onLanguage",
+    "onStartupFinished",
+    "onWebviewPanel:cody.editorPanel"
+  ],
   "contributes": {
     "walkthroughs": [
       {
@@ -721,13 +732,17 @@
       },
       {
         "command": "cody.supercompletion.jumpTo",
-        "args": ["next"],
+        "args": [
+          "next"
+        ],
         "key": "shift+ctrl+down",
         "when": "cody.activated && !editorReadonly && cody.hasActionableSupercompletion"
       },
       {
         "command": "cody.supercompletion.jumpTo",
-        "args": ["previous"],
+        "args": [
+          "previous"
+        ],
         "key": "shift+ctrl+up",
         "when": "cody.activated && !editorReadonly && cody.hasActionableSupercompletion"
       },
@@ -992,7 +1007,10 @@
           "order": 2,
           "type": "string",
           "markdownDescription": "A Git repository URL to use instead of allowing Cody to infer the Git repository from the workspace.",
-          "examples": ["https://github.com/sourcegraph/cody", "ssh://git@github.com/sourcegraph/cody"]
+          "examples": [
+            "https://github.com/sourcegraph/cody",
+            "ssh://git@github.com/sourcegraph/cody"
+          ]
         },
         "cody.customHeaders": {
           "order": 4,
@@ -1008,7 +1026,11 @@
         },
         "cody.suggestions.mode": {
           "type": "string",
-          "enum": ["autocomplete", "auto-edit (Experimental)", "off"],
+          "enum": [
+            "autocomplete",
+            "auto-edit (Experimental)",
+            "off"
+          ],
           "enumDescriptions": [
             "Suggests standard code completions as you type.",
             "Suggests advanced context-aware code edits as you navigate the codebase. Experimental feature for Pro and Enterprise users.",
@@ -1047,12 +1069,18 @@
           "order": 6,
           "type": "string",
           "markdownDescription": "A custom instruction to be included at the start of all chat messages (e.g. \"Answer all my questions in Spanish.\")",
-          "examples": ["Answer all my questions in Spanish."]
+          "examples": [
+            "Answer all my questions in Spanish."
+          ]
         },
         "cody.chat.defaultLocation": {
           "order": 6,
           "type": "string",
-          "enum": ["sticky", "sidebar", "editor"],
+          "enum": [
+            "sticky",
+            "sidebar",
+            "editor"
+          ],
           "markdownDescription": "Controls where the Cody chat view opens when the user invokes the `Cody: New Chat` command, or the Alt+L and Alt+/ shortcuts.",
           "enumDescriptions": [
             "Opens in the last-activated view location, which is set whenever the user explicitly chooses to open chat in a given location",
@@ -1065,7 +1093,9 @@
           "order": 7,
           "type": "string",
           "markdownDescription": "A custom instruction to be included at the end of all instructions for edit commands (e.g. \"Write all unit tests with Jest instead of detected framework.\")",
-          "examples": ["Write all unit tests with Jest instead of detected framework."]
+          "examples": [
+            "Write all unit tests with Jest instead of detected framework."
+          ]
         },
         "cody.codeActions.enabled": {
           "order": 11,
@@ -1116,15 +1146,24 @@
         "cody.telemetry.level": {
           "order": 99,
           "type": "string",
-          "enum": ["all", "off"],
-          "enumDescriptions": ["Sends usage data and errors.", "Disables all extension telemetry."],
+          "enum": [
+            "all",
+            "off"
+          ],
+          "enumDescriptions": [
+            "Sends usage data and errors.",
+            "Disables all extension telemetry."
+          ],
           "markdownDescription": "Controls the telemetry about Cody usage and errors. See [Cody usage and privacy notice](https://about.sourcegraph.com/terms/cody-notice).",
           "default": "all"
         },
         "cody.autocomplete.advanced.provider": {
           "type": "string",
           "default": "default",
-          "enum": ["default", "experimental-ollama"],
+          "enum": [
+            "default",
+            "experimental-ollama"
+          ],
           "enumDescriptions": [
             "Our recommended setup with the best balance of quality and latency. We continuously update this for optimal performance.",
             "Experimental support for Ollama users. Use `cody.autocomplete.experimental.ollamaOptions` to configure requests to Ollama server."
@@ -1148,7 +1187,10 @@
         },
         "cody.experimental.foldingRanges": {
           "type": "string",
-          "enum": ["lsp", "indentation-based"],
+          "enum": [
+            "lsp",
+            "indentation-based"
+          ],
           "enumDescriptions": [
             "Use folding ranges that are enabled by default in VS Code, and are usually powered by LSP",
             "Use custom implementation of folding ranges that is indentation based. This is the implementation that is used by other Cody clients like the JetBrains plugin"
@@ -1159,7 +1201,11 @@
         "cody.autocomplete.experimental.graphContext": {
           "type": "string",
           "default": null,
-          "enum": [null, "tsc", "tsc-mixed"],
+          "enum": [
+            null,
+            "tsc",
+            "tsc-mixed"
+          ],
           "markdownDescription": "Use the code graph to retrieve context for autocomplete requests."
         },
         "cody.autocomplete.experimental.fireworksOptions": {
@@ -1252,7 +1298,11 @@
         },
         "cody.net.mode": {
           "type": "string",
-          "enum": ["auto", "bypass", "vscode"],
+          "enum": [
+            "auto",
+            "bypass",
+            "vscode"
+          ],
           "enumDescriptions": [
             "Default behavior. If `cody.net.proxy.endpoint` is configured, bypassing is automatically enabled, otherwise direct is used.",
             "Bypass VSCode's network stack, using Cody's instead.",
@@ -1266,7 +1316,11 @@
           "type": "string",
           "default": "",
           "pattern": "^((http|https|socks|socks4|socks4a|socks5|socks5h)://[^:]+:\\d+|unix://(~|/|[a-zA-Z]:\\\\).+)?$",
-          "examples": ["https://localhost:7080", "socks5://1.2.3.4:1080", "unix://~/cody-proxy.sock"]
+          "examples": [
+            "https://localhost:7080",
+            "socks5://1.2.3.4:1080",
+            "unix://~/cody-proxy.sock"
+          ]
         },
         "cody.net.proxy.skipCertValidation": {
           "description": "Whether to skip proxy server CA cert validation. Useful if the proxy server uses a self-signed certificate.",
@@ -1297,8 +1351,16 @@
           "examples": [
             {
               "shell": {
-                "allow": ["git", "ls", "find"],
-                "block": ["history", "sudo", "rm"]
+                "allow": [
+                  "git",
+                  "ls",
+                  "find"
+                ],
+                "block": [
+                  "history",
+                  "sudo",
+                  "rm"
+                ]
               }
             }
           ],
@@ -1392,7 +1454,9 @@
     "untrustedWorkspaces": {
       "supported": "limited",
       "description": "Cody only uses providers (configured in `openctx.providers`) from trusted workspaces because providers may execute arbitrary code.",
-      "restrictedConfigurations": ["openctx.providers"]
+      "restrictedConfigurations": [
+        "openctx.providers"
+      ]
     }
   },
   "dependencies": {
@@ -1530,6 +1594,7 @@
     "chokidar": "^3.6.0",
     "commander": "^11.1.0",
     "concurrently": "^8.2.0",
+    "cross-env": "^7.0.3",
     "dedent": "^0.7.0",
     "dotenv": "^16.4.5",
     "esbuild": "^0.18.20",


### PR DESCRIPTION
The windows e2e test fails because `LOG_BUNDLE_SIZE` isn't recognized as a env var on windows. Using `cross-env` allows us to easily set it across platforms

## Test plan
CI
