### PR TITLE
chore(client): update display name for agentic model

### DIFF
--- a/lib/shared/src/models/client.ts
+++ b/lib/shared/src/models/client.ts
@@ -20,7 +20,7 @@ function getDeepCodyServerModel(): ServerModel {
     return {
         // This modelRef does not exist in the backend and is used to identify the model in the client.
         modelRef: 'sourcegraph::2023-06-01::deep-cody',
-        displayName: 'Agentic Chat',
+        displayName: 'Agentic chat',
         modelName: 'deep-cody',
         capabilities: ['chat'],
         category: 'accuracy',


### PR DESCRIPTION
The display name for the deep-cody model has been updated from 'Agentic Chat' to 'Agentic chat'.


## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

Verify the name update:

<img width="496" alt="image" src="https://github.com/user-attachments/assets/8e1cc5a3-d8bc-44ea-94c9-1a1488e39541" />
