### PR TITLE
Backport 6833 to vscode.v1.64.x

### DIFF
--- a/jetbrains/src/integrationTest/resources/recordings/integration-test_2927926756/recording.har.yaml
+++ b/jetbrains/src/integrationTest/resources/recordings/integration-test_2927926756/recording.har.yaml
@@ -5,6 +5,75 @@ log:
     name: Polly.JS
     version: 6.0.6
   entries:
+    - _id: 6e977d3842ddb417bf941a0f568426d9
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 20
+        cookies: []
+        headers:
+          - name: content-type
+            value: application/json
+          - name: authorization
+            value: token
+              REDACTED_fc324d3667e841181b0779375f26dedc911d26b303d23b29b1a2d7ee63dc77eb
+          - name: user-agent
+            value: OTel-OTLP-Exporter-JavaScript/0.45.1
+          - name: host
+            value: sourcegraph.com
+        headersSize: 253
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json
+          params: []
+          textJSON:
+            resourceSpans: []
+        queryString: []
+        url: https://sourcegraph.com/-/debug/otlp/v1/traces
+      response:
+        bodySize: 21
+        content:
+          mimeType: application/json
+          size: 21
+          text: "{\"partialSuccess\":{}}"
+        cookies: []
+        headers:
+          - name: date
+            value: Tue, 28 Jan 2025 08:20:46 GMT
+          - name: content-type
+            value: application/json
+          - name: content-length
+            value: "21"
+          - name: connection
+            value: keep-alive
+          - name: cache-control
+            value: no-cache, max-age=0
+          - name: vary
+            value: Cookie,Authorization,Cookie,Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+        headersSize: 1181
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: 2025-01-28T08:20:45.420Z
+      time: 656
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 656
     - _id: 897d3731ab8e15a1549f29445eafd1e1
       _order: 0
       cache: {}
@@ -39,19 +108,19 @@ log:
         queryString: []
         url: https://sourcegraph.com/.api/client-config
       response:
-        bodySize: 227
+        bodySize: 238
         content:
           encoding: base64
           mimeType: text/plain; charset=utf-8
-          size: 227
-          text: "[\"H4sIAAAAAAAAA2w=\",\"jrEKwjAURfd+Rejs7NCtBIduhYLOr+aJgby8kneDivjvLhWX\
-            zOfcw313zjnXXzW8TpnWxKEfHErlww7uhCagCvUqW2Jwe1kNKl5FKAdrN4AS14qo+c9\
-            vlOwnmFCB1wx+4hJz0EezIxo42ThP7UoisGGp26YFHPbXUbMtKEwyztOZi0XN/eCO3a\
-            f7AgAA//8DABCILnIVAQAA\"]"
+          size: 238
+          text: "[\"H4sIAAAAAAAAAwAA\",\"AP//\",\"bI6xCsIwFEX3fkXo7OzQrQSHboWCzq/miYG8vJJ\
+            3g4r47y4Vl8zn3MN9d8451181vE6Z1sShHxxK5cMO7oQmoAr1KlticHtZDSpeRSgHaz\
+            eAEteKqPnPb5TsJ5hQgdcMfuISc9BHsyMaONk4T+1KIrBhqdumBRz211GzLShMMs7Tm\
+            YtFzf3gjt2n+wIAAP//AwAQiC5yFQEAAA==\"]"
         cookies: []
         headers:
           - name: date
-            value: Tue, 21 Jan 2025 10:17:05 GMT
+            value: Tue, 28 Jan 2025 08:20:41 GMT
           - name: content-type
             value: text/plain; charset=utf-8
           - name: transfer-encoding
@@ -82,8 +151,8 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2025-01-21T10:17:05.127Z
-      time: 243
+      startedDateTime: 2025-01-28T08:20:40.382Z
+      time: 668
       timings:
         blocked: -1
         connect: -1
@@ -91,7 +160,7 @@ log:
         receive: 0
         send: 0
         ssl: -1
-        wait: 243
+        wait: 668
     - _id: c7327f699da3de5388b86581bd3a348b
       _order: 0
       cache: {}
@@ -109,7 +178,7 @@ log:
           - name: content-type
             value: application/json
           - name: traceparent
-            value: 00-823187877b65066f4ec9016f3f282a15-1db74150fda8c401-01
+            value: 00-281dd0cc0c0cf441f73b35a696500eda-67580a8fa83c34ce-01
           - name: user-agent
             value: jetbrains/6.0-localbuild (Node.js v20.12.2)
           - name: x-requested-with
@@ -221,14 +290,14 @@ log:
             value: 6.0-localbuild
         url: https://sourcegraph.com/.api/completions/stream?api-version=2&client-name=jetbrains&client-version=6.0-localbuild
       response:
-        bodySize: 373
+        bodySize: 781
         content:
           mimeType: text/event-stream
-          size: 373
+          size: 781
           text: >+
             event: completion
 
-            data: {"deltaText":"\n/**\n * Generates and prints the first 10 numbers in the Fibonacci sequence.\n */\n","stopReason":"stop_sequence"}
+            data: {"deltaText":"\n/**\n * The `foo()` method generates a Fibonacci sequence and prints the first 10 numbers in the sequence.\n */\n","stopReason":"stop_sequence"}
 
 
             event: done
@@ -238,7 +307,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Tue, 21 Jan 2025 10:17:07 GMT
+            value: Tue, 28 Jan 2025 08:20:45 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
@@ -267,8 +336,8 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2025-01-21T10:17:06.618Z
-      time: 1389
+      startedDateTime: 2025-01-28T08:20:44.067Z
+      time: 1721
       timings:
         blocked: -1
         connect: -1
@@ -276,7 +345,103 @@ log:
         receive: 0
         send: 0
         ssl: -1
-        wait: 1389
+        wait: 1721
+    - _id: f1b1cde4cd57488b7f0137954f0302f5
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 136
+        cookies: []
+        headers:
+          - _fromType: array
+            name: authorization
+            value: token
+              REDACTED_fc324d3667e841181b0779375f26dedc911d26b303d23b29b1a2d7ee63dc77eb
+          - _fromType: array
+            name: content-type
+            value: application/json; charset=utf-8
+          - _fromType: array
+            name: user-agent
+            value: jetbrains/6.0-localbuild (Node.js v20.12.2)
+          - _fromType: array
+            name: x-requested-with
+            value: jetbrains 6.0-localbuild
+          - _fromType: array
+            name: accept
+            value: "*/*"
+          - _fromType: array
+            name: content-length
+            value: "136"
+          - _fromType: array
+            name: accept-encoding
+            value: gzip,deflate
+          - name: host
+            value: sourcegraph.com
+        headersSize: 465
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json; charset=utf-8
+          params: []
+          textJSON:
+            query: >
+
+              query CodeSearchEnabled {
+                  codeSearchEnabled: enterpriseLicenseHasFeature(feature:"code-search")
+              }
+            variables: {}
+        queryString:
+          - name: CodeSearchEnabled
+            value: null
+        url: https://sourcegraph.com/.api/graphql?CodeSearchEnabled
+      response:
+        bodySize: 35
+        content:
+          mimeType: application/json
+          size: 35
+          text: "{\"data\":{\"codeSearchEnabled\":true}}"
+        cookies: []
+        headers:
+          - name: date
+            value: Tue, 28 Jan 2025 08:20:43 GMT
+          - name: content-type
+            value: application/json
+          - name: content-length
+            value: "35"
+          - name: connection
+            value: close
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache, max-age=0
+          - name: vary
+            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
+              X-Requested-With,Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+        headersSize: 1436
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: 2025-01-28T08:20:42.524Z
+      time: 661
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 661
     - _id: a376faab1c8a1993bb48c745757f0a4a
       _order: 0
       cache: {}
@@ -316,7 +481,7 @@ log:
           params: []
           textJSON:
             query: |-
-              
+
               query CurrentSiteCodyLlmConfiguration {
                   site {
                       codyLLMConfiguration {
@@ -335,29 +500,19 @@ log:
             value: null
         url: https://sourcegraph.com/.api/graphql?CurrentSiteCodyLlmConfiguration
       response:
-        bodySize: 248
+        bodySize: 259
         content:
           encoding: base64
           mimeType: application/json
-          size: 248
-          text: "[\"H4sIAAAAAAAAA4TOTQ6CMBAF4LvMmmqDEA1btrLzAmM7QAN2SH+MhvTuBjYSNXH1ksmbL\
-            28GjQGhmsGbQEsq1s/zuanZtqaLDoNhu957DA1rGqECz9Ep6hxO/V6NGDWJw64Unq2l\
-            ANm72+DjwgNZD1VRSikzaNGH+g8lejRDhI/yxjqulOLbNNKy7xemiSZPNAjFmpy452I\
-            0gcQVPcHX78bOZXFKKaUXAAAA//8DADDh/dAaAQAA\"]"
-          textDecoded:
-            data:
-              site:
-                codyLLMConfiguration:
-                  chatModel: sourcegraph/claude-3.5-sonnet
-                  chatModelMaxTokens: 45000
-                  completionModel: sourcegraph/deepseek-coder-v2-lite-base
-                  completionModelMaxTokens: 2048
-                  fastChatModel: sourcegraph/claude-3-haiku
-                  fastChatModelMaxTokens: 7000
+          size: 259
+          text: "[\"H4sIAAAAAAAAAwAAAP//\",\"hM5NDoIwEAXgu8yaaoMQDVu2svMCYztAA3ZIf4yG9O4G\
+            NhI1cfWSyZsvbwaNAaGawZtASyrWz/O5qdm2posOg2G73nsMDWsaoQLP0SnqHE79Xo0\
+            YNYnDrhSeraUA2bvb4OPCA1kPVVFKKTNo0Yf6DyV6NEOEj/LGOq6U4ts00rLvF6aJJk\
+            80CMWanLjnYjSBxBU9wdfvxs5lcUoppRcAAAD//wMAMOH90BoBAAA=\"]"
         cookies: []
         headers:
           - name: date
-            value: Tue, 21 Jan 2025 10:17:05 GMT
+            value: Tue, 28 Jan 2025 08:20:41 GMT
           - name: content-type
             value: application/json
           - name: transfer-encoding
@@ -388,8 +543,8 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2025-01-21T10:17:05.397Z
-      time: 307
+      startedDateTime: 2025-01-28T08:20:41.102Z
+      time: 720
       timings:
         blocked: -1
         connect: -1
@@ -397,7 +552,7 @@ log:
         receive: 0
         send: 0
         ssl: -1
-        wait: 307
+        wait: 720
     - _id: 0484c4d780805faf3dd3ddabae814640
       _order: 0
       cache: {}
@@ -437,7 +592,7 @@ log:
           params: []
           textJSON:
             query: |-
-              
+
               query CurrentSiteCodyLlmConfiguration {
                   site {
                       codyLLMConfiguration {
@@ -451,18 +606,18 @@ log:
             value: null
         url: https://sourcegraph.com/.api/graphql?CurrentSiteCodyLlmConfiguration
       response:
-        bodySize: 139
+        bodySize: 143
         content:
           encoding: base64
           mimeType: application/json
-          size: 139
-          text: "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqzixJBdHJ+SmVPj6+zvl5aZnppUWJJZn5eWD53MSiE\
-            uf8vJLUipLwzLyU/HIlK6WUzOLEpJzUFKXa2tpaAAAAAP//\",\"AwArMNn0TAAAAA==\
-            \"]"
+          size: 143
+          text: "[\"H4sIAAAAAAAAAwAAAP//\",\"qlZKSSxJVLKqVirOLEkF0cn5KZU+Pr7O+XlpmemlRYkl\
+            mfl5YPncxKIS5/y8ktSKkvDMvJT8ciUrpZTM4sSknNQUpdra2loAAAAA//8DACsw2fR\
+            MAAAA\"]"
         cookies: []
         headers:
           - name: date
-            value: Tue, 21 Jan 2025 10:17:05 GMT
+            value: Tue, 28 Jan 2025 08:20:41 GMT
           - name: content-type
             value: application/json
           - name: transfer-encoding
@@ -493,8 +648,8 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2025-01-21T10:17:05.446Z
-      time: 256
+      startedDateTime: 2025-01-28T08:20:41.141Z
+      time: 721
       timings:
         blocked: -1
         connect: -1
@@ -502,7 +657,7 @@ log:
         receive: 0
         send: 0
         ssl: -1
-        wait: 256
+        wait: 721
     - _id: e141c56e63809042300db9bf8551d492
       _order: 0
       cache: {}
@@ -542,7 +697,7 @@ log:
           params: []
           textJSON:
             query: |-
-              
+
               query CurrentSiteCodyLlmProvider {
                   site {
                       codyLLMConfiguration {
@@ -571,7 +726,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Tue, 21 Jan 2025 10:17:05 GMT
+            value: Tue, 28 Jan 2025 08:20:41 GMT
           - name: content-type
             value: application/json
           - name: transfer-encoding
@@ -602,8 +757,8 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2025-01-21T10:17:05.423Z
-      time: 278
+      startedDateTime: 2025-01-28T08:20:41.123Z
+      time: 707
       timings:
         blocked: -1
         connect: -1
@@ -611,7 +766,7 @@ log:
         receive: 0
         send: 0
         ssl: -1
-        wait: 278
+        wait: 707
     - _id: 5b9030a4e18d1e000c71d6000a7cef6f
       _order: 0
       cache: {}
@@ -651,7 +806,7 @@ log:
           params: []
           textJSON:
             query: |-
-              
+
               query CurrentUser {
                   currentUser {
                       id
@@ -676,33 +831,21 @@ log:
             value: null
         url: https://sourcegraph.com/.api/graphql?CurrentUser
       response:
-        bodySize: 376
+        bodySize: 387
         content:
           encoding: base64
           mimeType: application/json
-          size: 376
-          text: "[\"H4sIAAAAAAAAA2RPy07CQBT9l7tuaQ1R2klIFAQXaOMjNBjj4nZ6aaePmToPFJr+O2kwc\
-            eHunJzHvaeHHC0C64E7rUnarSE9UpEDg3SXNLxSp+T+5eqp4nPwoESTkhZ7QfmqRdEA\
-            s9qRB7kwXYPHBFsCBm/KaU6Fxq5cKOvHYRiCB86QlheD+TNkysa1v5ffrQMP8IAW9fb\
-            1ERiU1naGBUFTTieFUkVDYwNX0pK0E67aAIO7ZREpvlnjV/ZOblFn1XW+Xp1+omyXRj\
-            gTU5Nmm2XynM4eQnc81HMT3/gcPOi0aFEff0f0QBfw77PbYhTGazB4oHSBUpzQCiXNG\
-            JMqJwPs43MYhuEMAAD//wMASoyTP04BAAA=\"]"
-          textDecoded:
-            data:
-              currentUser:
-                avatarURL: https://lh3.googleusercontent.com/a/ACg8ocKFaqbYeuBkbj5dFEzx8bXV8a7i3sVbKCNPV7G0uyvk=s96-c
-                displayName: SourcegraphBot-9000
-                hasVerifiedEmail: true
-                id: VXNlcjozNDQ1Mjc=
-                organizations:
-                  nodes: []
-                primaryEmail:
-                  email: sourcegraphbot9k@gmail.com
-                username: sourcegraphbot9k-fnwmu
+          size: 387
+          text: "[\"H4sIAAAAAAAAAwAAAP//\",\"ZE/LTsJAFP2Xu25pDVHaSUgUBBdo4yM0GOPidnppp4+Z\
+            Og8Umv47aTBx4e6cnMe9p4ccLQLrgTutSdqtIT1SkQODdJc0vFKn5P7l6qnic/CgRJO\
+            SFntB+apF0QCz2pEHuTBdg8cEWwIGb8ppToXGrlwo68dhGIIHzpCWF4P5M2TKxrW/l9\
+            +tAw/wgBb19vURGJTWdoYFQVNOJ4VSRUNjA1fSkrQTrtoAg7tlESm+WeNX9k5uUWfVd\
+            b5enX6ibJdGOBNTk2abZfKczh5CdzzUcxPf+Bw86LRoUR9/R/RAF/Dvs9tiFMZrMHig\
+            dIFSnNAKJc0YkyonA+zjcxiG4QwAAP//AwBKjJM/TgEAAA==\"]"
         cookies: []
         headers:
           - name: date
-            value: Tue, 21 Jan 2025 10:17:05 GMT
+            value: Tue, 28 Jan 2025 08:20:40 GMT
           - name: content-type
             value: application/json
           - name: transfer-encoding
@@ -733,8 +876,8 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2025-01-21T10:17:04.846Z
-      time: 276
+      startedDateTime: 2025-01-28T08:20:39.681Z
+      time: 689
       timings:
         blocked: -1
         connect: -1
@@ -742,7 +885,7 @@ log:
         receive: 0
         send: 0
         ssl: -1
-        wait: 276
+        wait: 689
     - _id: aef0c9fe7483280d9c05ac8e97e37571
       _order: 0
       cache: {}
@@ -782,7 +925,7 @@ log:
           params: []
           textJSON:
             query: |-
-              
+
               query CurrentUserCodySubscription {
                   currentUser {
                       codySubscription {
@@ -821,7 +964,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Tue, 21 Jan 2025 10:17:05 GMT
+            value: Tue, 28 Jan 2025 08:20:42 GMT
           - name: content-type
             value: application/json
           - name: transfer-encoding
@@ -852,8 +995,8 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2025-01-21T10:17:05.493Z
-      time: 343
+      startedDateTime: 2025-01-28T08:20:41.174Z
+      time: 780
       timings:
         blocked: -1
         connect: -1
@@ -861,7 +1004,7 @@ log:
         receive: 0
         send: 0
         ssl: -1
-        wait: 343
+        wait: 780
     - _id: 4504fab53d7cb602861f73dc2aa883d2
       _order: 0
       cache: {}
@@ -901,7 +1044,7 @@ log:
           params: []
           textJSON:
             query: |-
-              
+
               query SiteProductVersion {
                   site {
                       productVersion
@@ -913,21 +1056,22 @@ log:
             value: null
         url: https://sourcegraph.com/.api/graphql?SiteProductVersion
       response:
-        bodySize: 136
+        bodySize: 144
         content:
           encoding: base64
           mimeType: application/json
-          size: 136
-          text: "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqzixJBdEFRfkppcklYalFxZn5eUpWSsYGFoaWRvFGB\
-            kamugaGukaG8aZ6hoa6BuaGxsmpiWaWBkYGSrW1tQAAAAD//wMAVdD8x0oAAAA=\"]"
+          size: 144
+          text: "[\"H4sIAAAAAAAAAwAAAP//qlZKSSxJVLKqVirOLEkF0QVF+SmlySVhqUXFmfl5SlZKxgaWZ\
+            kYG8UYGRqa6Boa6RhbxpnqGhrpmJmYmSQbmxslp5uZKtbW1AAAAAP//AwDNL2nYSgAA\
+            AA==\"]"
           textDecoded:
             data:
               site:
-                productVersion: 308192_2025-01-21_5.11-0713cea69020
+                productVersion: 309620_2025-01-28_5.11-6464b073cf77
         cookies: []
         headers:
           - name: date
-            value: Tue, 21 Jan 2025 10:17:05 GMT
+            value: Tue, 28 Jan 2025 08:20:41 GMT
           - name: content-type
             value: application/json
           - name: transfer-encoding
@@ -958,8 +1102,8 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2025-01-21T10:17:05.471Z
-      time: 249
+      startedDateTime: 2025-01-28T08:20:41.159Z
+      time: 667
       timings:
         blocked: -1
         connect: -1
@@ -967,139 +1111,7 @@ log:
         receive: 0
         send: 0
         ssl: -1
-        wait: 249
-    - _id: 2481998e71355fc9ca2258fbaae1cf9a
-      _order: 0
-      cache: {}
-      request:
-        bodySize: 101
-        cookies: []
-        headers:
-          - _fromType: array
-            name: authorization
-            value: token
-              REDACTED_fc324d3667e841181b0779375f26dedc911d26b303d23b29b1a2d7ee63dc77eb
-          - _fromType: array
-            name: content-type
-            value: application/json; charset=utf-8
-          - _fromType: array
-            name: user-agent
-            value: jetbrains/6.0-localbuild (Node.js v20.12.2)
-          - _fromType: array
-            name: x-requested-with
-            value: jetbrains 6.0-localbuild
-          - _fromType: array
-            name: accept
-            value: "*/*"
-          - _fromType: array
-            name: content-length
-            value: "101"
-          - _fromType: array
-            name: accept-encoding
-            value: gzip,deflate
-          - name: host
-            value: sourcegraph.com
-        headersSize: 465
-        httpVersion: HTTP/1.1
-        method: POST
-        postData:
-          mimeType: application/json; charset=utf-8
-          params: []
-          textJSON:
-            query: |
-              
-              query TemporarySettings {
-                temporarySettings {
-                  contents
-                }
-              }
-            variables: {}
-        queryString:
-          - name: TemporarySettings
-            value: null
-        url: https://sourcegraph.com/.api/graphql?TemporarySettings
-      response:
-        bodySize: 508
-        content:
-          encoding: base64
-          mimeType: application/json
-          size: 508
-          text: "[\"H4sIAAAAAAAAA8SSy07DMBBFf8WyWFWt8yJU9Q7Bgn27AoPkJtPEwrGDPQaiKv+OnEiIB\
-            Wwoj+3M9fjcuXOktURJ+ZEidL110g1bQFSm8bFYWYNg0FNOj4IGD45p6fFaDpcVqmcQ\
-            lBNBd20gW+hJtiF5mp8LuiSCVrYemDV7K12tTMM8Qh/leWxOk2o5+HnMlQ0GYzPLPnt\
-            a2a7XgFBHCboAUeRBuqplyvQBmYMKDG6nEvgouzsK+hTADTPiZOQVeaPtXmrioLf8oV\
-            HYhr0QQsQvEm+Dq6Bxsm+TiHBGIqaRHXByUBq4g8rORK10bJCdnq1q1Sm8UZODg9R+4\
-            kPVgUfZ9TNAXMwqLVf5epdl/DzjWcHKorydJzjwQeP7GopxSX6BXzZgMHl34ZNFsjjV\
-            RlqyNF1/biP9Ixvfxk95uWabrPjnFE7LIOVlwS6+OqWfyuBDZW9x87g6mJcunABdlCz\
-            ffHn/9yMdx/ENAAD//wMAHMsNG54EAAA=\"]"
-          textDecoded:
-            data:
-              temporarySettings:
-                contents: "{\"user.lastDayActive\": \"Thu Sep 19 2024\",
-                  \"cody.onboarding.step\": 2, \"user.daysActiveCount\": 11,
-                  \"cody.onboarding.completed\": true,
-                  \"search.input.recentSearches\": [{\"query\": \"context:global
-                  repo:^github\\\\.com/sourcegraph/cody$ username:
-                  file:recording.har.yaml\", \"limitHit\": false, \"timestamp\":
-                  \"2024-05-27T11:41:13.535Z\", \"resultCount\": 3}, {\"query\":
-                  \"context:global repo:^github\\\\.com/sourcegraph/cody$
-                  username: file:agent/recordings/*/*.yaml\", \"limitHit\":
-                  false, \"timestamp\": \"2024-05-27T11:41:05.007Z\",
-                  \"resultCount\": 0}, {\"query\": \"context:global
-                  repo:^github\\\\.com/sourcegraph/cody$ username:
-                  file:agent/recordings/\", \"limitHit\": false, \"timestamp\":
-                  \"2024-05-27T11:40:57.913Z\", \"resultCount\": 3}, {\"query\":
-                  \"context:global repo:^github\\\\.com/sourcegraph/cody$
-                  username: file:agent/recordings/*.yaml\", \"limitHit\": false,
-                  \"timestamp\": \"2024-05-27T11:40:53.635Z\", \"resultCount\":
-                  0}, {\"query\": \"context:global
-                  repo:^github\\\\.com/sourcegraph/cody$
-                  sourcegraphbot9k-fnwmu\", \"limitHit\": false, \"timestamp\":
-                  \"2024-05-27T11:40:35.295Z\", \"resultCount\": 3}]}"
-        cookies: []
-        headers:
-          - name: date
-            value: Tue, 21 Jan 2025 10:17:06 GMT
-          - name: content-type
-            value: application/json
-          - name: transfer-encoding
-            value: chunked
-          - name: connection
-            value: close
-          - name: access-control-allow-credentials
-            value: "true"
-          - name: access-control-allow-origin
-            value: ""
-          - name: cache-control
-            value: no-cache, max-age=0
-          - name: vary
-            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
-              X-Requested-With,Cookie
-          - name: x-content-type-options
-            value: nosniff
-          - name: x-frame-options
-            value: DENY
-          - name: x-xss-protection
-            value: 1; mode=block
-          - name: strict-transport-security
-            value: max-age=31536000; includeSubDomains; preload
-          - name: content-encoding
-            value: gzip
-        headersSize: 1468
-        httpVersion: HTTP/1.1
-        redirectURL: ""
-        status: 200
-        statusText: OK
-      startedDateTime: 2025-01-21T10:17:05.994Z
-      time: 217
-      timings:
-        blocked: -1
-        connect: -1
-        dns: -1
-        receive: 0
-        send: 0
-        ssl: -1
-        wait: 217
+        wait: 667
     - _id: fd0fee4687419870bc82cba9d1023319
       _order: 0
       cache: {}
@@ -1139,7 +1151,7 @@ log:
           params: []
           textJSON:
             query: |
-              
+
               query ViewerSettings {
                 viewerSettings {
                   final
@@ -1172,7 +1184,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Tue, 21 Jan 2025 10:17:06 GMT
+            value: Tue, 28 Jan 2025 08:20:43 GMT
           - name: content-type
             value: application/json
           - name: transfer-encoding
@@ -1203,8 +1215,8 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2025-01-21T10:17:05.970Z
-      time: 245
+      startedDateTime: 2025-01-28T08:20:42.496Z
+      time: 704
       timings:
         blocked: -1
         connect: -1
@@ -1212,7 +1224,7 @@ log:
         receive: 0
         send: 0
         ssl: -1
-        wait: 245
+        wait: 704
     - _id: fbb23499ae0eec5c2e188687b429531b
       _order: 0
       cache: {}
@@ -1244,45 +1256,45 @@ log:
         queryString: []
         url: https://sourcegraph.com/.api/modelconfig/supported-models.json
       response:
-        bodySize: 1958
+        bodySize: 1947
         content:
           encoding: base64
           mimeType: text/plain; charset=utf-8
-          size: 1958
-          text: "[\"H4sIAAAAAAAA/w==\",\"7Jxfb9s2EMDf+ykIP21Y6VJ0lGR+a9N2K7C0xVp0D8MeaOls\
-            E5ZIgaIcB0W/+yDJlv+ItqhEri1YeXKku+NJ/Pl4JI/+/gIhhHqxN4WQfQMVcyl6Q9R\
-            z+qT3Mr+nYM5Xl0mf9MlvPsxXNyMl59wHFfeG6N/sUvr3vfiUCXE/1WVCT5WMuLfULW\
-            77PI4C9viRhZDKvS7kCrEfLw+bHnMFD1LN4grT7ws5a9MTKScBVNj9IxeyNiojEIxXG\
-            P0UgXj9wd5oyGOtWFBh9X4ptTabffpv2Z+h9CE42JmZxN8w3urS4ZASeoUdgikdDr2A\
-            JT7gAXZxLIUAjQOmIdYVrt1lamjQd9GXTA398hEeft3VyhxY6dg25bGIjXjANYftpys\
-            kwOe7WrnmlBmvL78UhjtaymCDsI3Xu+GOholUj9lL9LxEMe9x1+VYM52kzqafRmUGNQ\
-            eVwa+gdM+TQsNC/8OFLx96w50+zF8jW3wQUaK/yhmItJkrlxBieJyQLT4lekuSELIl9\
-            2OneYg1D5kG/z7tqzsZa7MPieA6Q1fLmelN8sLBzyBE3nUDo5Ny7eFa1HF3/bT4Mu3n\
-            e4DJNSbOBt8ySqpCzgpq9Mkga0Y5tYrT7xOh9PeGQbamUuopqKciGSl5QUSmmNkiedM\
-            skqaQO2V8ltSOuH+mWrah9lATzUfamvE0jgD8LpiW7hvRtSf32LF0agJwXzCtQWvOah\
-            ZOB+TmVOH0LKC8aQWT1LUe36l7TCT7q5yybt7aZaw+RApSlRLzFxpozylrLcDLguI1J\
-            Ufme18zHeEd4Us/Gya8VtiuBfUm0uc7O+vgPCc4nU04ad+x49IgaELSIHZxELYjr721\
-            Z5BeHZlByyHfIGhmsOmxvWOw/QwWmzLD4dwZDmPNlCf9cm/toPdFM3Vnktsib6+1avB\
-            YoqUnwygADS2bwFNydWsFGXWvT8YYtUesUcB8gCgGmOGMCzynOOAa8IjFVdt3bwGiLw\
-            Az9I2iv7gG9Mags4Uf8zyZCB2/imWiPJgoFk1f5Xtnr2r40cF6DFhtQbXmtFFM0x5Nx\
-            74Y+zBmSVA1TXmdaPkulUfF7jV6a9bcHpul/4izKzhtEudtFs7sa/1ESMIiAsVDELq8\
-            g900mA492VjdHjSXMSwLXfagZtqoiKfZOI6+0cOxtF6rJwJ0BJodebuz49Key0TwMQc\
-            fTxQTScAU9vl4fCxADwz2a9fmAxxwATiAOQQ4kGKCNaiw8NSP01QgzQIwYCdyO64vj+\
-            u8mCyHegIhFxw7fRcb3vNugVkmjJy+iz6XhbdoPWz3Z83LRyxgwjt9EtqS9UnHftPzu\
-            cuTBgZpn+BxwOIphkVkRyLtE/Q+VUHvDmRuJjAPNnbuxSM/M009IbqjGuje7HHTCO+A\
-            lFxtJoRmRNkH0fcm8X1h1Gj7ogpHOhSLJ95AcVlwnbMY8kX6D75d3IwwF7FWiVc1Y7r\
-            PddDt4uaNXQZaJMar/NOq2WpWW8hkOxbc3Rr1dceAkdIn0Ejp83E81HC3OVTInROrjv\
-            3KvfPMpfstWtdz6BU+89KEfO+i6IraRubwAiaYRA4dY0+GIy7AP+BSt1J6QTP3/MTWs\
-            uae0Gw3fRJpfFU5c//81SC0nWoa7bS6Oq47HrJZz2wfVp+bku7HFKfTGStWjZIGYI1y\
-            Z0ztWWStLWHWsV6Oum4e2GznMsUBRwrmHB4wIVVFc/lhWSSdlU713mhVC03Pmqqj5gP\
-            jOuDlowCXGTfrHKu7PkbgNFFSlZiuOayMolbmOwjbUzhMjzV4Y52okVWiib6aJMuDt9\
-            lia+blDTHYkml5zUXNozA46LvWFA76riWHew==\",\"rZ7J6npH4lOD4YHi4ezT6vdG\
-            lkU+96ufHVl7mvfk005p9sYs1nd2+qWDx+nADHf5ss3yZ29qVJq+yJ/xx4v/AwAA///\
-            fN1/oWkcAAA==\"]"
+          size: 1947
+          text: "[\"H4sIAAAAAAAA/+ycUW/bNhCA3/srCD9tWKlSdJRkfmvTdiuwtMVadA/DHmjpbBORSIGiH\
+            AdF//sgyVZsi7aoRK4tWHlypLvjSfx8PJJHf3+BEEKDxJ9BxL6BSrgUgxEauA4ZvCzu\
+            KZjz1WXiEIf8FsB8dTNWcs4DUMlghP7NL2V/38tPuRAPMl0m9EzJmPtL3fJ2wJM4ZA8\
+            fWQSZ3OtSrhT78XK/6QlXcC/VXVJj+n0pZ216KuU0hBq7fxRC1kZlDILxGqOfYhCvP9\
+            gbjXiiFQtrrN4upR7N5p/+W/ZnJAMI93ZmLvE3TDa6dDSihF5gl2BKRyM/ZGkAeIg9n\
+            EghQOOQaUh0jWs3uRoaOh76kquhXz7C/a/bWrkDKx3bpnwWszEPueaw+XSlBAR8W6vQ\
+            nDHj9eWXwnBHSxmuEbb2etfc0TCV6iF/ib6fKuY/bLucaKbTzNns07jKoOagcvgVVO7\
+            5UmhY6H+4COT9YLTVh8VrZIsPIk71V3kHImvmwiOEGB4nYotPqd6QJIRsyP3Yah4SzS\
+            OmIbjN+upGJtrsQyq4ztHV8s70Jnnp4GcQoui6odFJ+ejho6jrbftp8WXazfcQk0tM3\
+            DW+ZZzWhZwV1OiTQdaMcmYVZ98nQunvLYNsTaXUM1BPRTJW8oyIzDCzRfKqXSRNIXfG\
+            +F3aOOL+mWnZhtp9TbQfaRvG0yQGCPpgWrlvRNee3EPH0pkJwF3BtAGtBat5OB2Sq2O\
+            F05OA8qoTTFLPenyn3iGRdFY5ZdO8tc9YA4gVZCoV5s800J5S1lqClwfFS0oOzPeuZn\
+            rCe8KXfrZMeKOw3QjqdaRPd3bWw3lKcLrrcFLHtePSIGhC0iB2dhB2I6+9tmeQXhyYQ\
+            csh3yBoZrDtsb1nsPsMlpsyo9HcHY0SzZQvg2pvbaH3RTN1Y5LbIG+ntXrwWKqlL6M4\
+            BA0dm8BTcnFtBRn1Lo/GGLVHrFXAAoA4AbjDORd4TnHINeAxS+q2794CxF8A7tA3iv7\
+            iGtAbg84Gfsz3ZSp08iqRqfJhqlg8e1Xsnb1q4EcP6yFgtQXVmtNWMc16NBv7EhzAhK\
+            Vh3TTldarlu0welbvX6K1Zc3NslsEDzq/grElctFk6s6v1IyEJixgUj0Do6g5222C69\
+            GhjdXfQXMawPHTZg5prozKe5uM4+kb3x9JmrR4J0DFoduDtzp5Ley5TwSccAjxVTKQh\
+            Uzjgk8mhAN0z2D+6Nh/ikAvAIcwhxKEUU6xBRaWnQZKlAlkWgAG7sddzfX5cF8VkBdR\
+            TiLjg2HU8bHjP2wVmuTByHQ99rgpv0Lrf7s+al49ZyIR//CS0I+uTrv2m53OXJw0MUo\
+            fgSciSGYZFbEcidQh6n6mgd3syNxOYexs79eKRn5mmHhHdcQN0r3a4aYR3SCquthNCc\
+            6Lsg+h7k/iuMGq0fVaFIz2K5ROvobgsuC5YjPgi+wdfL67GmItEq9SvmzHdFjroenH1\
+            xi4DLRPjVf5p1Ww9qx1kshsL7l6D+rpDwEjpE2ik9Pk47mu43xwq5U6JVdd+5d595tL\
+            9Bq2Pc+gVPvPKhHznouiK2lbm8AKmmMQunWBfRmMuINjjUr9SekYz9+LE1rLmntB8N3\
+            0aa3xRO3P//NUgtJlqGu10ujquPx6yXs9sH1afm5LuxhRn0xkrVo2SBmCNcidM7Ulkr\
+            R1h1rVejrpsH9h85zLDAccK5hzuMSF1RXPFYVkka2rmbCy3PVuqj5b3jOuQV48AnGe8\
+            bHKc7vIQAdNESV1CWvJXHz2tzPcQdqdgmB5q0MY6VWOrBBN9NUlWB22zxc7Mx1tisCP\
+            T8YaLmQc=\",\"YXDoeNYUDh3PksOdVk9kVb0n8anBcE/RcP5p9Tsjy+Ke29XPjTx6W\
+            vTk005nDiYs0Td2+pUDx9nADDfFcs3y524aVJi+KJ7xx4v/AwAA///CksVcUkcAAA==\
+            \"]"
         cookies: []
         headers:
           - name: date
-            value: Tue, 21 Jan 2025 10:17:06 GMT
+            value: Tue, 28 Jan 2025 08:20:43 GMT
           - name: content-type
             value: text/plain; charset=utf-8
           - name: transfer-encoding
@@ -1313,8 +1325,8 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2025-01-21T10:17:06.224Z
-      time: 236
+      startedDateTime: 2025-01-28T08:20:43.217Z
+      time: 697
       timings:
         blocked: -1
         connect: -1
@@ -1322,6 +1334,6 @@ log:
         receive: 0
         send: 0
         ssl: -1
-        wait: 236
+        wait: 697
   pages: []
   version: "1.2"

--- a/lib/shared/src/misc/rpc/webviewAPI.ts
+++ b/lib/shared/src/misc/rpc/webviewAPI.ts
@@ -12,7 +12,6 @@ import type {
     FetchHighlightFileParameters,
     Prompt,
     PromptTag,
-    TemporarySettings,
 } from '../../sourcegraph-api/graphql/client'
 import { type createMessageAPIForWebview, proxyExtensionAPI } from './rpc'
 
@@ -110,11 +109,6 @@ export interface WebviewToExtensionAPI {
      * The current user's product subscription information (Cody Free/Pro).
      */
     userProductSubscription(): Observable<UserProductSubscription | null>
-
-    /**
-     * Edit the current user's temporary settings.
-     */
-    editTemporarySettings(settingsToEdit: Partial<TemporarySettings>): Observable<boolean>
 }
 
 export function createExtensionAPI(
@@ -150,7 +144,6 @@ export function createExtensionAPI(
         userHistory: proxyExtensionAPI(messageAPI, 'userHistory'),
         userProductSubscription: proxyExtensionAPI(messageAPI, 'userProductSubscription'),
         repos: proxyExtensionAPI(messageAPI, 'repos'),
-        editTemporarySettings: proxyExtensionAPI(messageAPI, 'editTemporarySettings'),
     }
 }
 

--- a/lib/shared/src/sourcegraph-api/clientConfig.test.ts
+++ b/lib/shared/src/sourcegraph-api/clientConfig.test.ts
@@ -18,7 +18,6 @@ const CLIENT_CONFIG_FIXTURE: CodyClientConfig = {
     userShouldUseEnterprise: false,
     intentDetection: 'enabled',
     notices: [],
-    temporarySettings: {},
     codeSearchEnabled: true,
     omniBoxEnabled: false,
     siteVersion: '5.5.0',
@@ -38,7 +37,6 @@ describe('ClientConfigSingleton', () => {
         mockAuthStatus(authStatusSubject)
         const getSiteVersionMock = vi.spyOn(graphqlClient, 'getSiteVersion').mockResolvedValue('5.5.0')
         const viewerSettingsMock = vi.spyOn(graphqlClient, 'viewerSettings').mockResolvedValue({})
-        const temporarySettingsMock = vi.spyOn(graphqlClient, 'temporarySettings').mockResolvedValue({})
         const codeSearchEnabledMock = vi
             .spyOn(graphqlClient, 'codeSearchEnabled')
             .mockResolvedValue(true)
@@ -58,7 +56,6 @@ describe('ClientConfigSingleton', () => {
         await vi.advanceTimersByTimeAsync(0)
         expect(getSiteVersionMock).toHaveBeenCalledTimes(1)
         expect(viewerSettingsMock).toHaveBeenCalledTimes(1)
-        expect(temporarySettingsMock).toHaveBeenCalledTimes(1)
         expect(codeSearchEnabledMock).toHaveBeenCalledTimes(1)
         expect(fetchHTTPMock).toHaveBeenCalledTimes(1)
         expect(await clientConfigSingleton.getConfig()).toEqual(CLIENT_CONFIG_FIXTURE)
@@ -66,7 +63,6 @@ describe('ClientConfigSingleton', () => {
         expect(fetchHTTPMock).toHaveBeenCalledTimes(1)
         getSiteVersionMock.mockClear()
         viewerSettingsMock.mockClear()
-        temporarySettingsMock.mockClear()
         codeSearchEnabledMock.mockClear()
         fetchHTTPMock.mockClear()
     })
@@ -77,7 +73,6 @@ describe('ClientConfigSingleton', () => {
         mockAuthStatus(authStatusSubject)
         const getSiteVersionMock = vi.spyOn(graphqlClient, 'getSiteVersion').mockResolvedValue('5.5.0')
         const viewerSettingsMock = vi.spyOn(graphqlClient, 'viewerSettings').mockResolvedValue({})
-        const temporarySettingsMock = vi.spyOn(graphqlClient, 'temporarySettings').mockResolvedValue({})
         const codeSearchEnabledMock = vi
             .spyOn(graphqlClient, 'codeSearchEnabled')
             .mockResolvedValue(true)
@@ -96,12 +91,10 @@ describe('ClientConfigSingleton', () => {
         await vi.advanceTimersByTimeAsync(0)
         expect(getSiteVersionMock).toHaveBeenCalledTimes(1)
         expect(viewerSettingsMock).toHaveBeenCalledTimes(1)
-        expect(temporarySettingsMock).toHaveBeenCalledTimes(1)
         expect(codeSearchEnabledMock).toHaveBeenCalledTimes(1)
         expect(fetchHTTPMock).toHaveBeenCalledTimes(1)
         getSiteVersionMock.mockClear()
         viewerSettingsMock.mockClear()
-        temporarySettingsMock.mockClear()
         codeSearchEnabledMock.mockClear()
         fetchHTTPMock.mockClear()
 
@@ -139,7 +132,6 @@ describe('ClientConfigSingleton', () => {
             .mockImplementation(() => new Promise<string>(resolve => setTimeout(resolve, 100, '5.5.0')))
 
         const viewerSettingsMock = vi.spyOn(graphqlClient, 'viewerSettings').mockResolvedValue({})
-        const temporarySettingsMock = vi.spyOn(graphqlClient, 'temporarySettings').mockResolvedValue({})
         const codeSearchEnabledMock = vi
             .spyOn(graphqlClient, 'codeSearchEnabled')
             .mockResolvedValue(true)
@@ -194,7 +186,6 @@ describe('ClientConfigSingleton', () => {
         expect(fetchHTTPMock).toHaveBeenCalledTimes(1)
         getSiteVersionMock.mockClear()
         viewerSettingsMock.mockClear()
-        temporarySettingsMock.mockClear()
         codeSearchEnabledMock.mockClear()
         fetchHTTPMock.mockClear()
     })
@@ -207,7 +198,6 @@ describe('ClientConfigSingleton', () => {
             .spyOn(graphqlClient, 'getSiteVersion')
             .mockImplementation(() => new Promise<string>(resolve => setTimeout(resolve, 100, '5.5.0')))
         const viewerSettingsMock = vi.spyOn(graphqlClient, 'viewerSettings').mockResolvedValue({})
-        const temporarySettingsMock = vi.spyOn(graphqlClient, 'temporarySettings').mockResolvedValue({})
         const codeSearchEnabledMock = vi
             .spyOn(graphqlClient, 'codeSearchEnabled')
             .mockResolvedValue(true)
@@ -228,7 +218,6 @@ describe('ClientConfigSingleton', () => {
         expect(fetchHTTPMock).toHaveBeenCalledTimes(1)
         getSiteVersionMock.mockClear()
         viewerSettingsMock.mockClear()
-        temporarySettingsMock.mockClear()
         codeSearchEnabledMock.mockClear()
         fetchHTTPMock.mockClear()
 
@@ -249,12 +238,10 @@ describe('ClientConfigSingleton', () => {
         await vi.advanceTimersByTimeAsync(ClientConfigSingleton.REFETCH_INTERVAL + 1)
         expect(getSiteVersionMock).toHaveBeenCalledTimes(1)
         expect(viewerSettingsMock).toHaveBeenCalledTimes(0)
-        expect(temporarySettingsMock).toHaveBeenCalledTimes(0)
         expect(codeSearchEnabledMock).toHaveBeenCalledTimes(0)
         expect(fetchHTTPMock).toHaveBeenCalledTimes(1)
         getSiteVersionMock.mockClear()
         viewerSettingsMock.mockClear()
-        temporarySettingsMock.mockClear()
         codeSearchEnabledMock.mockClear()
         fetchHTTPMock.mockClear()
 
@@ -262,7 +249,6 @@ describe('ClientConfigSingleton', () => {
         expect(await clientConfigSingleton.getConfig()).toEqual(CLIENT_CONFIG_FIXTURE)
         expect(getSiteVersionMock).toHaveBeenCalledTimes(0)
         expect(viewerSettingsMock).toHaveBeenCalledTimes(0)
-        expect(temporarySettingsMock).toHaveBeenCalledTimes(0)
         expect(codeSearchEnabledMock).toHaveBeenCalledTimes(0)
         expect(fetchHTTPMock).toHaveBeenCalledTimes(0)
 
@@ -273,7 +259,6 @@ describe('ClientConfigSingleton', () => {
         expect(fetchHTTPMock).toHaveBeenCalledTimes(0)
         getSiteVersionMock.mockClear()
         viewerSettingsMock.mockClear()
-        temporarySettingsMock.mockClear()
         codeSearchEnabledMock.mockClear()
         fetchHTTPMock.mockClear()
     })
@@ -286,7 +271,6 @@ describe('ClientConfigSingleton', () => {
             .spyOn(graphqlClient, 'getSiteVersion')
             .mockImplementation(() => new Promise<string>(resolve => setTimeout(resolve, 100, '5.5.0')))
         const viewerSettingsMock = vi.spyOn(graphqlClient, 'viewerSettings').mockResolvedValue({})
-        const temporarySettingsMock = vi.spyOn(graphqlClient, 'temporarySettings').mockResolvedValue({})
         const codeSearchEnabledMock = vi
             .spyOn(graphqlClient, 'codeSearchEnabled')
             .mockResolvedValue(true)
@@ -305,12 +289,10 @@ describe('ClientConfigSingleton', () => {
         await vi.advanceTimersByTimeAsync(100)
         expect(getSiteVersionMock).toHaveBeenCalledTimes(1)
         expect(viewerSettingsMock).toHaveBeenCalledTimes(1)
-        expect(temporarySettingsMock).toHaveBeenCalledTimes(1)
         expect(codeSearchEnabledMock).toHaveBeenCalledTimes(1)
         expect(fetchHTTPMock).toHaveBeenCalledTimes(1)
         getSiteVersionMock.mockClear()
         viewerSettingsMock.mockClear()
-        temporarySettingsMock.mockClear()
         codeSearchEnabledMock.mockClear()
         fetchHTTPMock.mockClear()
 
@@ -338,7 +320,6 @@ describe('ClientConfigSingleton', () => {
         expect(fetchHTTPMock).toHaveBeenCalledTimes(1)
         getSiteVersionMock.mockClear()
         viewerSettingsMock.mockClear()
-        temporarySettingsMock.mockClear()
         codeSearchEnabledMock.mockClear()
         fetchHTTPMock.mockClear()
     })

--- a/lib/shared/src/sourcegraph-api/clientConfig.ts
+++ b/lib/shared/src/sourcegraph-api/clientConfig.ts
@@ -1,4 +1,4 @@
-import { Observable, Subject, interval, map, merge } from 'observable-fns'
+import { Observable, interval, map } from 'observable-fns'
 import semver from 'semver'
 import type { AuthStatus } from '..'
 import { authStatus } from '../auth/authStatus'
@@ -20,12 +20,7 @@ import {
 } from '../misc/observableOperation'
 import { isError } from '../utils'
 import { isAbortError } from './errors'
-import {
-    type CodyConfigFeatures,
-    type GraphQLAPIClientConfig,
-    type TemporarySettings,
-    graphqlClient,
-} from './graphql/client'
+import { type CodyConfigFeatures, type GraphQLAPIClientConfig, graphqlClient } from './graphql/client'
 
 export interface CodyNotice {
     key: string
@@ -63,14 +58,11 @@ export interface CodyClientConfig {
     userShouldUseEnterprise: boolean
 
     // Whether the user should be able to use the intent detection feature.
-    // `opt-in` means the user must explicitly enable it.
-    intentDetection: 'disabled' | 'enabled' | 'opt-in'
+    intentDetection: 'disabled' | 'enabled'
 
     // List of global instance-level cody notice/banners (set only by admins in global
     // instance configuration file
     notices: CodyNotice[]
-
-    temporarySettings: Partial<TemporarySettings>
 
     // Whether code search is enabled for the SG instance.
     codeSearchEnabled: boolean
@@ -90,7 +82,6 @@ export const dummyClientConfigForTest: CodyClientConfig = {
     modelsAPIEnabled: true,
     userShouldUseEnterprise: false,
     intentDetection: 'enabled',
-    temporarySettings: {},
     notices: [],
     codeSearchEnabled: false,
     siteVersion: undefined,
@@ -118,47 +109,32 @@ export class ClientConfigSingleton {
         attribution: false,
     }
 
-    private readonly forceUpdateSubject = new Subject<any>()
-
-    /**
-     * Forces an immediate update of the client configuration by triggering a new fetch.
-     * This method is called when temporary settings are edited from the client to ensure
-     * the configuration is immediately synchronized with the latest changes.
-     *
-     * @returns A promise that resolves to the updated CodyClientConfig or undefined
-     */
-    public async forceUpdate(): Promise<CodyClientConfig | undefined> {
-        this.forceUpdateSubject.next(true)
-        return firstValueFrom(this.changes.pipe(skipPendingOperation()))
-    }
     /**
      * An observable that immediately emits the last-cached value (or fetches it if needed) and then
      * emits changes.
      */
-    public readonly changes: Observable<CodyClientConfig | undefined | typeof pendingOperation> = merge(
-        authStatus,
-        this.forceUpdateSubject
-    ).pipe(
-        debounceTime(0), // wait a tick for graphqlClient's auth to be updated
-        switchMapReplayOperation(authStatus =>
-            authStatus.authenticated
-                ? interval(ClientConfigSingleton.REFETCH_INTERVAL).pipe(
-                      map(() => undefined),
-                      // Don't update if the editor is in the background, to avoid network
-                      // activity that can cause OS warnings or authorization flows when the
-                      // user is not using Cody. See
-                      // linear.app/sourcegraph/issue/CODY-3745/codys-background-periodic-network-access-causes-2fa.
-                      filter((_value): _value is undefined => editorWindowIsFocused()),
-                      startWith(undefined),
-                      switchMap(() =>
-                          promiseFactoryToObservable(signal => this.fetchConfig(authStatus, signal))
+    public readonly changes: Observable<CodyClientConfig | undefined | typeof pendingOperation> =
+        authStatus.pipe(
+            debounceTime(0), // wait a tick for graphqlClient's auth to be updated
+            switchMapReplayOperation(authStatus =>
+                authStatus.authenticated
+                    ? interval(ClientConfigSingleton.REFETCH_INTERVAL).pipe(
+                          map(() => undefined),
+                          // Don't update if the editor is in the background, to avoid network
+                          // activity that can cause OS warnings or authorization flows when the
+                          // user is not using Cody. See
+                          // linear.app/sourcegraph/issue/CODY-3745/codys-background-periodic-network-access-causes-2fa.
+                          filter((_value): _value is undefined => editorWindowIsFocused()),
+                          startWith(undefined),
+                          switchMap(() =>
+                              promiseFactoryToObservable(signal => this.fetchConfig(authStatus, signal))
+                          )
                       )
-                  )
-                : Observable.of(undefined)
-        ),
-        map(value => (isError(value) ? undefined : value)),
-        distinctUntilChanged()
-    )
+                    : Observable.of(undefined)
+            ),
+            map(value => (isError(value) ? undefined : value)),
+            distinctUntilChanged()
+        )
 
     public readonly updates: Observable<CodyClientConfig> = this.changes.pipe(
         filter(value => value !== undefined && value !== pendingOperation),
@@ -237,14 +213,12 @@ export class ClientConfigSingleton {
 
             return Promise.all([
                 graphqlClient.viewerSettings(signal),
-                graphqlClient.temporarySettings(signal),
                 graphqlClient.codeSearchEnabled(signal),
-            ]).then(([viewerSettings, temporarySettings, codeSearchEnabled]) => {
+            ]).then(([viewerSettings, codeSearchEnabled]) => {
                 const config: CodyClientConfig = {
                     ...clientConfig,
                     intentDetection: 'enabled',
                     notices: [],
-                    temporarySettings: {},
                     siteVersion: isError(siteVersion) ? undefined : siteVersion,
                     omniBoxEnabled: omniBoxEnabled && (isError(codeSearchEnabled) || codeSearchEnabled),
                     codeSearchEnabled: isError(codeSearchEnabled) ? true : codeSearchEnabled,
@@ -252,7 +226,7 @@ export class ClientConfigSingleton {
 
                 // Don't fail the whole chat because of viewer setting (used only to show banners)
                 if (!isError(viewerSettings)) {
-                    config.intentDetection = ['disabled', 'enabled', 'opt-in'].includes(
+                    config.intentDetection = ['disabled', 'enabled'].includes(
                         viewerSettings['omnibox.intentDetection']
                     )
                         ? viewerSettings['omnibox.intentDetection']
@@ -269,8 +243,8 @@ export class ClientConfigSingleton {
                     )
                 }
 
-                if (!isError(temporarySettings)) {
-                    config.temporarySettings = temporarySettings
+                if (codeSearchEnabled === false) {
+                    config.intentDetection = 'disabled'
                 }
 
                 return config
@@ -303,9 +277,8 @@ export class ClientConfigSingleton {
             modelsAPIEnabled: false,
             userShouldUseEnterprise: false,
             notices: [],
-            temporarySettings: {},
-            codeSearchEnabled: false,
             omniBoxEnabled: false,
+            codeSearchEnabled: false,
         }
     }
 

--- a/lib/shared/src/sourcegraph-api/graphql/client.ts
+++ b/lib/shared/src/sourcegraph-api/graphql/client.ts
@@ -41,7 +41,6 @@ import {
     CURRENT_USER_INFO_QUERY,
     CURRENT_USER_ROLE_QUERY,
     DELETE_ACCESS_TOKEN_MUTATION,
-    EDIT_TEMPORARY_SETTINGS_QUERY,
     EVALUATE_FEATURE_FLAG_QUERY,
     FILE_CONTENTS_QUERY,
     FILE_MATCH_SEARCH_QUERY,
@@ -66,7 +65,6 @@ import {
     REPOS_SUGGESTIONS_QUERY,
     REPO_NAME_QUERY,
     SEARCH_ATTRIBUTION_QUERY,
-    TEMPORARY_SETTINGS_QUERY,
     VIEWER_SETTINGS_QUERY,
 } from './queries'
 import { buildGraphQLUrl } from './url'
@@ -627,18 +625,6 @@ interface ViewerSettingsResponse {
 
 interface CodeSearchEnabledResponse {
     codeSearchEnabled: boolean
-}
-
-interface TemporarySettingsResponse {
-    temporarySettings: { contents: string }
-}
-
-export interface TemporarySettings {
-    'omnibox.intentDetectionToggleOn': boolean
-}
-
-export interface EditTemporarySettingsResponse {
-    editTemporarySettings: { alwaysNil: string }
 }
 
 function extractDataOrError<T, R>(response: APIResponse<T> | Error, extract: (data: T) => R): R | Error {
@@ -1572,34 +1558,6 @@ export class SourcegraphGraphQLAPIClient {
             signal
         )
         return extractDataOrError(response, data => data.codeSearchEnabled)
-    }
-
-    public async temporarySettings(signal?: AbortSignal): Promise<Partial<TemporarySettings> | Error> {
-        const response = await this.fetchSourcegraphAPI<APIResponse<TemporarySettingsResponse>>(
-            TEMPORARY_SETTINGS_QUERY,
-            {},
-            signal
-        )
-        return extractDataOrError(response, data => {
-            try {
-                return JSON.parse(data.temporarySettings.contents)
-            } catch {
-                return {}
-            }
-        })
-    }
-
-    public async editTemporarySettings(
-        settingsToEdit: Partial<TemporarySettings>,
-        signal?: AbortSignal
-    ): Promise<{ alwaysNil: string } | Error> {
-        const response = await this.fetchSourcegraphAPI<APIResponse<EditTemporarySettingsResponse>>(
-            EDIT_TEMPORARY_SETTINGS_QUERY,
-            { settingsToEdit: JSON.stringify(settingsToEdit) },
-            signal
-        )
-
-        return extractDataOrError(response, data => data.editTemporarySettings)
     }
 
     public async fetchSourcegraphAPI<T>(

--- a/lib/shared/src/sourcegraph-api/graphql/queries.ts
+++ b/lib/shared/src/sourcegraph-api/graphql/queries.ts
@@ -628,20 +628,6 @@ query CodeSearchEnabled {
     codeSearchEnabled: enterpriseLicenseHasFeature(feature:"code-search")
 }
 `
-export const TEMPORARY_SETTINGS_QUERY = `
-query TemporarySettings {
-  temporarySettings {
-    contents
-  }
-}
-`
-export const EDIT_TEMPORARY_SETTINGS_QUERY = `
-mutation EditTemporarySettings($settingsToEdit: String!) {
-  editTemporarySettings(settingsToEdit: $settingsToEdit) {
-    alwaysNil
-  }
-}
-`
 
 export const HIGHLIGHTED_FILE_QUERY = `
    query HighlightedFile(

--- a/vscode/src/chat/chat-view/ChatController.test.ts
+++ b/vscode/src/chat/chat-view/ChatController.test.ts
@@ -87,33 +87,29 @@ describe('ChatController', () => {
         })
     })
 
-    test.fails(
-        'verifies interactionId is passed through chat requests',
-        async () => {
-            const mockRequestID = '0'
-            mockContextRetriever.retrieveContext.mockResolvedValue([])
+    test.skip('verifies interactionId is passed through chat requests', async () => {
+        const mockRequestID = '0'
+        mockContextRetriever.retrieveContext.mockResolvedValue([])
 
-            await chatController.handleUserMessage({
-                requestID: mockRequestID,
-                inputText: ps`Test input`,
-                mentions: [],
-                editorState: null,
-                signal: new AbortController().signal,
-                source: 'chat',
-            })
-            await vi.runOnlyPendingTimersAsync()
+        await chatController.handleUserMessage({
+            requestID: mockRequestID,
+            inputText: ps`Test input`,
+            mentions: [],
+            editorState: null,
+            signal: new AbortController().signal,
+            source: 'chat',
+        })
+        await vi.runOnlyPendingTimersAsync()
 
-            expect(mockChatClient.chat).toHaveBeenCalledWith(
-                expect.any(Array),
-                expect.any(Object),
-                expect.any(AbortSignal),
-                mockRequestID
-            )
-        },
-        1500
-    )
+        expect(mockChatClient.chat).toHaveBeenCalledWith(
+            expect.any(Array),
+            expect.any(Object),
+            expect.any(AbortSignal),
+            mockRequestID
+        )
+    }, 1500)
 
-    test.fails('send, followup, and edit', { timeout: 1500 }, async () => {
+    test.skip('send, followup, and edit', { timeout: 1500 }, async () => {
         const postMessageSpy = vi
             .spyOn(chatController as any, 'postMessage')
             .mockImplementation(() => {})
@@ -397,7 +393,7 @@ describe('ChatController', () => {
         })
     })
 
-    test.fails('send error', async () => {
+    test.skip('send error', async () => {
         const postMessageSpy = vi
             .spyOn(chatController as any, 'postMessage')
             .mockImplementation(() => {})

--- a/vscode/src/chat/chat-view/ChatController.ts
+++ b/vscode/src/chat/chat-view/ChatController.ts
@@ -1717,18 +1717,6 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
                         userProductSubscription.pipe(
                             map(value => (value === pendingOperation ? null : value))
                         ),
-                    editTemporarySettings: settingsToEdit => {
-                        return promiseFactoryToObservable(async () => {
-                            const dataOrError = await graphqlClient.editTemporarySettings(settingsToEdit)
-
-                            if (!isError(dataOrError)) {
-                                await ClientConfigSingleton.getInstance().forceUpdate()
-                                return true
-                            }
-
-                            return false
-                        })
-                    },
                 }
             )
         )

--- a/vscode/src/completions/inline-completion-item-provider.ts
+++ b/vscode/src/completions/inline-completion-item-provider.ts
@@ -956,7 +956,10 @@ export class InlineCompletionItemProvider
                         canUpgrade ? 'cody.upsellUsageLimitCTA' : 'cody.abuseUsageLimitCTA',
                         'shown',
                         {
-                            privateMetadata: { limit_type: 'suggestions', tier },
+                            privateMetadata: {
+                                limit_type: 'suggestions',
+                                tier,
+                            },
                         }
                     )
                 },

--- a/vscode/webviews/AppWrapperForTest.tsx
+++ b/vscode/webviews/AppWrapperForTest.tsx
@@ -90,7 +90,6 @@ export const AppWrapperForTest: FunctionComponent<{ children: ReactNode }> = ({ 
                         }
                     },
                     repos: () => Observable.of([]),
-                    editTemporarySettings: () => Observable.of(true),
                     prompts: makePromptsAPIWithData({
                         prompts: FIXTURE_PROMPTS,
                         commands: FIXTURE_COMMANDS,

--- a/vscode/webviews/chat/cells/messageCell/human/HumanMessageCell.tsx
+++ b/vscode/webviews/chat/cells/messageCell/human/HumanMessageCell.tsx
@@ -46,10 +46,7 @@ interface HumanMessageCellProps {
     editorRef?: React.RefObject<PromptEditorRefAPI | null>
 
     intent: ChatMessage['intent']
-    manuallySelectIntent: (
-        intent: ChatMessage['intent'],
-        editorState?: SerializedPromptEditorState
-    ) => void
+    manuallySelectIntent: (intent: ChatMessage['intent']) => void
 
     /** For use in storybooks only. */
     __storybook__focus?: boolean

--- a/vscode/webviews/chat/cells/messageCell/human/editor/HumanMessageEditor.test.tsx
+++ b/vscode/webviews/chat/cells/messageCell/human/editor/HumanMessageEditor.test.tsx
@@ -58,7 +58,11 @@ describe('HumanMessageEditor', () => {
                     initialEditorState: serializedPromptEditorStateFromText('abc'),
                     isSent: false,
                 }),
-                { toolbarVisible: true, submitButtonEnabled: true, submitButtonText: /send/i }
+                {
+                    toolbarVisible: true,
+                    submitButtonEnabled: true,
+                    submitButtonText: /send/i,
+                }
             )
         })
 
@@ -78,35 +82,29 @@ describe('HumanMessageEditor', () => {
                     initialEditorState: undefined,
                     isPendingPriorResponse: true,
                 }),
-                { toolbarVisible: true, submitButtonEnabled: true, submitButtonText: /stop/i }
+                {
+                    toolbarVisible: true,
+                    submitButtonEnabled: true,
+                    submitButtonText: /stop/i,
+                }
             )
         })
     })
 
     describe('submitting', () => {
-        function testNoSubmitting({
-            editor,
-            submitButton,
-            onSubmit,
-        }: ReturnType<typeof renderWithMocks>): void {
-            if (submitButton) {
-                expect(submitButton).toBeDisabled()
-                // Click
-                fireEvent.click(submitButton!)
-                expect(onSubmit).toHaveBeenCalledTimes(0)
-            }
+        test('empty editor', () => {
+            const { submitButton, editor, onSubmit } = renderWithMocks({
+                initialEditorState: FILE_MENTION_EDITOR_STATE_FIXTURE,
+            })
+            expect(submitButton).toBeEnabled()
+
+            // Click
+            fireEvent.click(submitButton!)
+            expect(onSubmit).toHaveBeenCalledTimes(1)
 
             // Enter
             fireEvent.keyDown(editor, ENTER_KEYBOARD_EVENT_DATA)
-            expect(onSubmit).toHaveBeenCalledTimes(0)
-        }
-
-        test('empty editor', () => {
-            testNoSubmitting(
-                renderWithMocks({
-                    initialEditorState: undefined,
-                })
-            )
+            expect(onSubmit).toHaveBeenCalledTimes(2)
         })
 
         test('isPendingPriorResponse', () => {
@@ -146,7 +144,9 @@ describe('HumanMessageEditor', () => {
     })
 })
 
-type EditorHTMLElement = HTMLDivElement & { dataset: { lexicalEditor: 'true' } }
+type EditorHTMLElement = HTMLDivElement & {
+    dataset: { lexicalEditor: 'true' }
+}
 
 function renderWithMocks(props: Partial<ComponentProps<typeof HumanMessageEditor>>): {
     container: HTMLElement
@@ -182,7 +182,10 @@ function renderWithMocks(props: Partial<ComponentProps<typeof HumanMessageEditor
     return {
         container,
         editor: container.querySelector<EditorHTMLElement>('[data-lexical-editor="true"]')!,
-        addContextButton: screen.queryByRole('button', { name: 'Add context', hidden: true }),
+        addContextButton: screen.queryByRole('button', {
+            name: 'Add context',
+            hidden: true,
+        }),
         submitButton: screen.queryByRole('button', {
             name: /send|stop/i,
             hidden: true,

--- a/vscode/webviews/chat/cells/messageCell/human/editor/HumanMessageEditor.tsx
+++ b/vscode/webviews/chat/cells/messageCell/human/editor/HumanMessageEditor.tsx
@@ -75,10 +75,7 @@ export const HumanMessageEditor: FunctionComponent<{
     __storybook__focus?: boolean
 
     intent?: ChatMessage['intent']
-    manuallySelectIntent: (
-        intent: ChatMessage['intent'],
-        editorState?: SerializedPromptEditorState
-    ) => void
+    manuallySelectIntent: (intent: ChatMessage['intent']) => void
 }> = ({
     models,
     userInfo,
@@ -351,7 +348,7 @@ export const HumanMessageEditor: FunctionComponent<{
                                 extensionAPI.hydratePromptMessage(setPromptAsInput.text, initialContext)
                             )
 
-                            manuallySelectIntent(promptIntent, promptEditorState)
+                            manuallySelectIntent(promptIntent)
 
                             // update editor state
                             requestAnimationFrame(async () => {
@@ -466,6 +463,7 @@ export const HumanMessageEditor: FunctionComponent<{
                     isEditorFocused={focused}
                     onMentionClick={onMentionClick}
                     onSubmitClick={onSubmitClick}
+                    manuallySelectIntent={manuallySelectIntent}
                     submitState={submitState}
                     onGapClick={onGapClick}
                     focusEditor={focusEditor}

--- a/vscode/webviews/chat/cells/messageCell/human/editor/toolbar/SubmitButton.story.tsx
+++ b/vscode/webviews/chat/cells/messageCell/human/editor/toolbar/SubmitButton.story.tsx
@@ -25,6 +25,7 @@ const meta: Meta<typeof SubmitButton> = {
                         state: args.state === 'submittable' ? 'waitingResponseComplete' : 'submittable',
                     })
                 }}
+                manuallySelectIntent={() => {}}
             />
         )
     },

--- a/vscode/webviews/chat/cells/messageCell/human/editor/toolbar/SubmitButton.tsx
+++ b/vscode/webviews/chat/cells/messageCell/human/editor/toolbar/SubmitButton.tsx
@@ -30,7 +30,6 @@ import {
     CommandList,
     CommandSeparator,
 } from '../../../../../../components/shadcn/ui/command'
-import { Switch } from '../../../../../../components/shadcn/ui/switch'
 import { useConfig } from '../../../../../../utils/useConfig'
 import { useOmniBox } from '../../../../../../utils/useOmniBox'
 
@@ -50,27 +49,25 @@ function getIntentOptions({
     isDotComUser,
     detectedIntent,
     intentDetectionDisabled,
-    intentDetectionToggleOn,
 }: {
     ide: CodyIDE
     isDotComUser: boolean
     detectedIntent: ChatMessage['intent']
     intentDetectionDisabled: boolean
-    intentDetectionToggleOn: boolean
 }): IntentOption[] {
-    const intentDetectionAvailable = !isDotComUser && !intentDetectionDisabled && intentDetectionToggleOn
+    const intentDetectionAvailable = !isDotComUser && !intentDetectionDisabled
 
     const standardOneBoxIntents: IntentOption[] = [
         {
             title: (
                 <div className="tw-flex tw-flex-col tw-self-start">
                     <p>Run detected intent</p>
-                    <p className="tw-text-sm tw-text-muted-foreground">
+                    <p className="tw-text-sm tw-text-muted-foreground tw-min-h-10">
                         {isDotComUser
                             ? 'Detects intent and runs appropriately'
-                            : `Currently: ${
-                                  detectedIntent ? (detectedIntent === 'search' ? 'Search' : 'Chat') : ''
-                              }`}
+                            : detectedIntent
+                              ? `Currently: ${detectedIntent === 'search' ? 'Search' : 'Chat'}`
+                              : ''}
                     </p>
                 </div>
             ),
@@ -147,30 +144,32 @@ export const SubmitButton: FC<{
     isEditorFocused?: boolean
     state?: SubmitButtonState
     detectedIntent?: ChatMessage['intent']
-}> = ({ onClick, state = 'submittable', detectedIntent }) => {
+    manuallySelectIntent: (intent?: ChatMessage['intent']) => void
+}> = ({ onClick, state = 'submittable', detectedIntent, manuallySelectIntent }) => {
     const experimentalOneBoxEnabled = useOmniBox()
     const {
         clientCapabilities: { agentIDE },
         isDotComUser,
     } = useConfig()
 
-    const { intentDetectionDisabled, intentDetectionToggleOn, updateIntentDetectionToggle } =
-        useIntentDetectionConfig()
+    const { intentDetectionDisabled } = useIntentDetectionConfig()
 
-    const intentOptions = useMemo(
-        () =>
-            getIntentOptions({
-                ide: agentIDE,
-                detectedIntent,
-                intentDetectionDisabled,
-                intentDetectionToggleOn,
-                isDotComUser,
-            }),
-        [agentIDE, detectedIntent, intentDetectionDisabled, intentDetectionToggleOn, isDotComUser]
-    )
+    const { intentOptions, availableIntentOptions, disabledIntentOptions } = useMemo(() => {
+        const intentOptions = getIntentOptions({
+            ide: agentIDE,
+            detectedIntent,
+            intentDetectionDisabled,
+            isDotComUser,
+        }).filter(option => !option.hidden)
+
+        return {
+            intentOptions,
+            availableIntentOptions: intentOptions.filter(option => !option.disabled),
+            disabledIntentOptions: intentOptions.filter(option => option.disabled),
+        }
+    }, [agentIDE, detectedIntent, intentDetectionDisabled, isDotComUser])
 
     const inProgress = state === 'waitingResponseComplete'
-    const disabled = state === 'emptyEditorValue'
 
     const detectedIntentOption = intentOptions.find(option => option.intent === detectedIntent)
 
@@ -179,17 +178,12 @@ export const SubmitButton: FC<{
         detectedIntentOption?.intent === 'search' ? '' : 'tw-fill-current'
     }`
 
-    const toggleIntentDetection = useCallback(() => {
-        updateIntentDetectionToggle(!intentDetectionToggleOn)
-    }, [intentDetectionToggleOn, updateIntentDetectionToggle])
-
     if (!experimentalOneBoxEnabled || inProgress) {
         return (
             <div className="tw-flex">
                 <button
                     type="submit"
                     onClick={() => onClick()}
-                    disabled={disabled}
                     className={clsx(
                         'tw-px-6 tw-py-1',
                         'tw-rounded-full',
@@ -214,7 +208,6 @@ export const SubmitButton: FC<{
             <button
                 type="submit"
                 onClick={() => onClick()}
-                disabled={disabled}
                 className={clsx(
                     'tw-px-3 tw-py-1 md:twpx-4 md:tw-py-2',
                     'tw-rounded-tl-full tw-rounded-bl-full',
@@ -231,77 +224,44 @@ export const SubmitButton: FC<{
                 popoverContent={close => (
                     <Command>
                         <CommandList className="tw-p-2">
-                            {intentOptions.map(option =>
-                                // biome-ignore lint/correctness/useJsxKeyInIterable: We don't need a key for null
-                                option.hidden || option.disabled ? null : (
-                                    <CommandItem
-                                        key={option.intent || 'auto'}
-                                        onSelect={() => {
-                                            onClick(option.intent)
-                                            close()
-                                        }}
-                                        className="tw-flex tw-text-left tw-justify-between tw-rounded-sm tw-cursor-pointer tw-px-4"
-                                    >
-                                        <div className="tw-flex tw-gap-4">
-                                            <option.icon className="tw-size-8 tw-mt-1" />
-                                            {option.title}
-                                        </div>
-                                        {option.shortcut && (
-                                            <div className="tw-flex tw-gap-2">{option.shortcut}</div>
-                                        )}
-                                    </CommandItem>
-                                )
-                            )}
-                            <CommandSeparator />
-                            {intentOptions.map(option =>
-                                // biome-ignore lint/correctness/useJsxKeyInIterable: We don't need a key for null
-                                option.hidden || !option.disabled ? null : (
-                                    <CommandItem
-                                        key={option.intent || 'auto'}
-                                        onSelect={() => {
-                                            onClick(option.intent)
-                                            close()
-                                        }}
-                                        disabled={true}
-                                        className="tw-flex tw-text-left tw-justify-between tw-rounded-sm tw-cursor-pointer"
-                                    >
-                                        <div className="tw-flex tw-gap-2">
-                                            <option.icon className="tw-size-8 tw-mt-1" />
-                                            {option.title}
-                                        </div>
-                                        {option.shortcut && (
-                                            <div className="tw-flex tw-gap-2">{option.shortcut}</div>
-                                        )}
-                                    </CommandItem>
-                                )
-                            )}
-                            {!isDotComUser && !(intentDetectionDisabled ?? false) && (
-                                <div
-                                    role="button"
-                                    tabIndex={0}
-                                    onClick={toggleIntentDetection}
-                                    onKeyDown={e => {
-                                        if (e.key === 'Enter') {
-                                            e.stopPropagation()
-                                            toggleIntentDetection()
-                                        }
+                            {availableIntentOptions.map(option => (
+                                <CommandItem
+                                    key={option.intent || 'auto'}
+                                    onSelect={() => {
+                                        manuallySelectIntent(option.intent)
+                                        close()
                                     }}
-                                    className="tw-flex tw-p-4 tw-gap-6 tw-items-center tw-cursor-pointer hover:tw-bg-button-secondary-background"
+                                    className="tw-flex tw-text-left tw-justify-between tw-rounded-sm tw-cursor-pointer tw-px-4"
                                 >
-                                    <Switch checked={intentDetectionToggleOn} />
-                                    <div className="tw-flex tw-flex-col">
-                                        <div>
-                                            <span className="tw-font-medium tw-mr-4">
-                                                Intent Detection
-                                            </span>
-                                            <Badge variant="secondary">Beta</Badge>
-                                        </div>
-                                        <p className="tw-text-sm tw-text-muted-foreground">
-                                            Automatic selection between chat and search
-                                        </p>
+                                    <div className="tw-flex tw-gap-4">
+                                        <option.icon className="tw-size-8 tw-mt-1" />
+                                        {option.title}
                                     </div>
-                                </div>
-                            )}
+                                    {option.shortcut && (
+                                        <div className="tw-flex tw-gap-2">{option.shortcut}</div>
+                                    )}
+                                </CommandItem>
+                            ))}
+                            {disabledIntentOptions.length > 0 && <CommandSeparator />}
+                            {disabledIntentOptions.map(option => (
+                                <CommandItem
+                                    key={option.intent || 'auto'}
+                                    onSelect={() => {
+                                        onClick(option.intent)
+                                        close()
+                                    }}
+                                    disabled={true}
+                                    className="tw-flex tw-text-left tw-justify-between tw-rounded-sm tw-cursor-pointer"
+                                >
+                                    <div className="tw-flex tw-gap-2">
+                                        <option.icon className="tw-size-8 tw-mt-1" />
+                                        {option.title}
+                                    </div>
+                                    {option.shortcut && (
+                                        <div className="tw-flex tw-gap-2">{option.shortcut}</div>
+                                    )}
+                                </CommandItem>
+                            ))}
                         </CommandList>
                     </Command>
                 )}
@@ -316,7 +276,6 @@ export const SubmitButton: FC<{
             >
                 <button
                     type="button"
-                    disabled={disabled}
                     className={clsx(
                         'tw-pl-1 tw-pr-2 tw-py-1 md:pl-2 md:tw-pr-3 md:tw-py-2',
                         'tw-rounded-tr-full tw-rounded-br-full tw-border-l-0',

--- a/vscode/webviews/chat/cells/messageCell/human/editor/toolbar/Toolbar.tsx
+++ b/vscode/webviews/chat/cells/messageCell/human/editor/toolbar/Toolbar.tsx
@@ -33,6 +33,8 @@ export const Toolbar: FunctionComponent<{
     hidden?: boolean
     className?: string
     intent?: ChatMessage['intent']
+
+    manuallySelectIntent: (intent: ChatMessage['intent']) => void
 }> = ({
     userInfo,
     isEditorFocused,
@@ -45,6 +47,7 @@ export const Toolbar: FunctionComponent<{
     className,
     models,
     intent,
+    manuallySelectIntent,
 }) => {
     /**
      * If the user clicks in a gap or on the toolbar outside of any of its buttons, report back to
@@ -98,6 +101,7 @@ export const Toolbar: FunctionComponent<{
                     isEditorFocused={isEditorFocused}
                     state={submitState}
                     detectedIntent={intent}
+                    manuallySelectIntent={manuallySelectIntent}
                 />
             </div>
         </menu>

--- a/vscode/webviews/components/omnibox/intentDetection.tsx
+++ b/vscode/webviews/components/omnibox/intentDetection.tsx
@@ -1,64 +1,27 @@
-import { firstValueFrom } from '@sourcegraph/cody-shared'
-import { useExtensionAPI } from '@sourcegraph/prompt-editor'
-import { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react'
+import { createContext, useContext, useMemo } from 'react'
 import { useClientConfig } from '../../utils/useClientConfig'
 
 export interface IntentDetectionConfig {
     intentDetectionDisabled: boolean
-    intentDetectionToggleOn: boolean
     doIntentDetection: boolean
-    updateIntentDetectionToggle: (enabled: boolean) => Promise<boolean>
 }
 
 const intentDetectionConfigConext = createContext<IntentDetectionConfig>({
     intentDetectionDisabled: false,
-    intentDetectionToggleOn: true,
     doIntentDetection: true,
-    updateIntentDetectionToggle: async () => false,
 })
 
 export const IntentDetectionConfigProvider = ({ children }: { children: React.ReactNode }) => {
     const config = useClientConfig()
-    const extensionAPI = useExtensionAPI()
-
-    const [intentDetectionToggleOn, setIntentDetectionToggleOn] = useState<boolean>(
-        config?.temporarySettings?.['omnibox.intentDetectionToggleOn'] ??
-            config?.intentDetection !== 'opt-in'
-    )
-
-    useEffect(() => {
-        setIntentDetectionToggleOn(
-            config?.temporarySettings?.['omnibox.intentDetectionToggleOn'] ??
-                config?.intentDetection !== 'opt-in'
-        )
-    }, [config?.temporarySettings, config?.intentDetection])
-
-    const updateIntentDetectionToggle = useCallback(
-        (enabled: boolean) => {
-            setIntentDetectionToggleOn(enabled)
-
-            return firstValueFrom(
-                extensionAPI.editTemporarySettings({ 'omnibox.intentDetectionToggleOn': enabled })
-            ).then(success => {
-                if (!success) {
-                    setIntentDetectionToggleOn(!enabled)
-                }
-
-                return success
-            })
-        },
-        [extensionAPI]
-    )
 
     const intentDetection = useMemo(
         () =>
             ({
-                intentDetectionDisabled: config?.intentDetection === 'disabled',
-                intentDetectionToggleOn,
-                doIntentDetection: config?.intentDetection !== 'disabled' && intentDetectionToggleOn,
-                updateIntentDetectionToggle,
+                intentDetectionDisabled:
+                    !config?.omniBoxEnabled || config?.intentDetection === 'disabled',
+                doIntentDetection: !!config?.omniBoxEnabled && config?.intentDetection !== 'disabled',
             }) satisfies IntentDetectionConfig,
-        [config, intentDetectionToggleOn, updateIntentDetectionToggle]
+        [config]
     )
 
     return (


### PR DESCRIPTION
backport: https://github.com/sourcegraph/cody/pull/6833
This PR:
- Removes the intent toggle feature completely.
- Changes the intent dropdown behavior to only select the intent and not execute it automatically.
- Enables the submit button even when the chat is empty.

- the intent options in the dropdown only selects the intent mode and doesn't execute it.
- after selecting the intent, changing the input, doesn't reset the intent.
- on submit the selected intent is used and the intent selection message is displayed accordingly.
- loading a chat from history and editing the message, doesn't persist the intent mode previously manually selected.
- selecting a prompt correctly executes it in chat & edit modes.
- make sure the submit button isn't disabled when the input is empty.


## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
