### PR TITLE
[VS Code] Temp add Omnibox FF

### DIFF
--- a/lib/shared/src/experimentation/FeatureFlagProvider.ts
+++ b/lib/shared/src/experimentation/FeatureFlagProvider.ts
@@ -123,6 +123,8 @@ export enum FeatureFlag {
      * Whether the user will see the CTA about upgrading to Sourcegraph Teams
      */
     SourcegraphTeamsUpgradeCTA = 'teams-upgrade-available-cta',
+
+    TempCodyExperimentalOnebox = 'cody-experimental-one-box',
 }
 
 const ONE_HOUR = 60 * 60 * 1000

--- a/vscode/src/chat/chat-view/ChatController.ts
+++ b/vscode/src/chat/chat-view/ChatController.ts
@@ -14,6 +14,7 @@ import {
     DOTCOM_URL,
     type DefaultChatCommands,
     type EventSource,
+    FeatureFlag,
     type Guardrails,
     ModelUsage,
     type NLSSearchDynamicFilter,
@@ -58,6 +59,7 @@ import {
     skip,
     skipPendingOperation,
     startWith,
+    storeLastValue,
     subscriptionDisposable,
     telemetryRecorder,
     tracer,
@@ -193,6 +195,7 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
 
     public dispose(): void {
         vscode.Disposable.from(...this.disposables).dispose()
+        this.featureCodyExperimentalOneBox.subscription.unsubscribe()
         this.disposables = []
     }
 
@@ -693,10 +696,15 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
         })
     }
 
+    // TODO(naman/tom): Remove this FF check before the Cody release on 29th.
+    private featureCodyExperimentalOneBox = storeLastValue(
+        featureFlagProvider.evaluatedFeatureFlag(FeatureFlag.TempCodyExperimentalOnebox)
+    )
+
     private async isOmniBoxEnabled(): Promise<boolean> {
         const config = await ClientConfigSingleton.getInstance().getConfig()
 
-        return !!config?.omniBoxEnabled
+        return !!config?.omniBoxEnabled && !!this.featureCodyExperimentalOneBox.value.last
     }
 
     private async getIntentAndScores({

--- a/vscode/webviews/utils/useOmniBox.tsx
+++ b/vscode/webviews/utils/useOmniBox.tsx
@@ -4,8 +4,10 @@ import { useFeatureFlag } from './useFeatureFlags'
 
 export const useOmniBox = (): boolean => {
     const config = useClientConfig()
+    // TODO(naman/tom): Remove this FF check before the Cody release on 29th.
+    const tempFFCheck = useFeatureFlag(FeatureFlag.TempCodyExperimentalOnebox)
 
-    return !!config?.omniBoxEnabled
+    return !!config?.omniBoxEnabled && !!tempFFCheck
 }
 
 export const useOmniBoxDebug = (): boolean | undefined => {


### PR DESCRIPTION
As per the thread: https://sourcegraph.slack.com/archives/C05AGQYD528/p1738076320715949?thread_ts=1738004127.714799&cid=C05AGQYD528

This PR adds the Omnibox FF back. 

THIS MUST BE REVERTED BEFORE THE CODY RELEASE ON 29th. 

@umpox 

## Test plan

- set overrides for ff `cody-experimental-one-box` on s2
- when the ff is on, the omnibox elements, intent dropdown in the submit button, auto intent detection and search results should work
- when the ff is off, all the omnibox elements should be hidden and auto intent detection also should not work. 

Tested manually. 