### PR TITLE
[JB] Release Omnibox: remove feature flag

### DIFF
--- a/lib/shared/src/experimentation/FeatureFlagProvider.ts
+++ b/lib/shared/src/experimentation/FeatureFlagProvider.ts
@@ -123,8 +123,6 @@ export enum FeatureFlag {
      * Whether the user will see the CTA about upgrading to Sourcegraph Teams
      */
     SourcegraphTeamsUpgradeCTA = 'teams-upgrade-available-cta',
-
-    TempCodyExperimentalOnebox = 'cody-experimental-one-box',
 }
 
 const ONE_HOUR = 60 * 60 * 1000

--- a/vscode/src/chat/chat-view/ChatController.ts
+++ b/vscode/src/chat/chat-view/ChatController.ts
@@ -14,7 +14,6 @@ import {
     DOTCOM_URL,
     type DefaultChatCommands,
     type EventSource,
-    FeatureFlag,
     type Guardrails,
     ModelUsage,
     type NLSSearchDynamicFilter,
@@ -59,7 +58,6 @@ import {
     skip,
     skipPendingOperation,
     startWith,
-    storeLastValue,
     subscriptionDisposable,
     telemetryRecorder,
     tracer,
@@ -195,7 +193,6 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
 
     public dispose(): void {
         vscode.Disposable.from(...this.disposables).dispose()
-        this.featureCodyExperimentalOneBox.subscription.unsubscribe()
         this.disposables = []
     }
 
@@ -696,15 +693,10 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
         })
     }
 
-    // TODO(naman/tom): Remove this FF check before the Cody release on 29th.
-    private featureCodyExperimentalOneBox = storeLastValue(
-        featureFlagProvider.evaluatedFeatureFlag(FeatureFlag.TempCodyExperimentalOnebox)
-    )
-
     private async isOmniBoxEnabled(): Promise<boolean> {
         const config = await ClientConfigSingleton.getInstance().getConfig()
 
-        return !!config?.omniBoxEnabled && !!this.featureCodyExperimentalOneBox.value.last
+        return !!config?.omniBoxEnabled
     }
 
     private async getIntentAndScores({

--- a/vscode/webviews/utils/useOmniBox.tsx
+++ b/vscode/webviews/utils/useOmniBox.tsx
@@ -4,10 +4,8 @@ import { useFeatureFlag } from './useFeatureFlags'
 
 export const useOmniBox = (): boolean => {
     const config = useClientConfig()
-    // TODO(naman/tom): Remove this FF check before the Cody release on 29th.
-    const tempFFCheck = useFeatureFlag(FeatureFlag.TempCodyExperimentalOnebox)
 
-    return !!config?.omniBoxEnabled && !!tempFFCheck
+    return !!config?.omniBoxEnabled
 }
 
 export const useOmniBoxDebug = (): boolean | undefined => {


### PR DESCRIPTION
This reverts the revert commit 47f03f1ff.

Intention is to restore the behaviour intended with this commit: https://github.com/sourcegraph/cody/pull/6747

We reverted as we wanted to cut a pre-release without releasing this feature to all pre-release users.

## Test plan

Make sure all omnibox features are working with s2 but not with demo.sourcegraph.com

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
