### PR TITLE
fix(auto-edit): fix temperature value to be low for output consistency

### DIFF
--- a/vscode/src/autoedits/adapters/cody-gateway.test.ts
+++ b/vscode/src/autoedits/adapters/cody-gateway.test.ts
@@ -72,7 +72,7 @@ describe('CodyGatewayAdapter', () => {
             expect.objectContaining({
                 stream: false,
                 model: options.model,
-                temperature: 0.1,
+                temperature: 0.001,
                 response_format: { type: 'text' },
                 prediction: {
                     type: 'content',
@@ -100,7 +100,7 @@ describe('CodyGatewayAdapter', () => {
             expect.objectContaining({
                 stream: false,
                 model: options.model,
-                temperature: 0.1,
+                temperature: 0.001,
                 response_format: { type: 'text' },
                 prediction: {
                     type: 'content',

--- a/vscode/src/autoedits/adapters/cody-gateway.ts
+++ b/vscode/src/autoedits/adapters/cody-gateway.ts
@@ -46,7 +46,7 @@ export class CodyGatewayAdapter implements AutoeditsModelAdapter {
         const body: FireworksCompatibleRequestParams = {
             stream: false,
             model: options.model,
-            temperature: 0.1,
+            temperature: 0.001,
             max_tokens: maxTokens,
             response_format: {
                 type: 'text',

--- a/vscode/src/autoedits/adapters/fireworks.test.ts
+++ b/vscode/src/autoedits/adapters/fireworks.test.ts
@@ -64,7 +64,7 @@ describe('FireworksAdapter', () => {
             expect.objectContaining({
                 stream: false,
                 model: options.model,
-                temperature: 0.1,
+                temperature: 0.001,
                 max_tokens: expect.any(Number),
                 response_format: { type: 'text' },
                 prediction: {
@@ -92,7 +92,7 @@ describe('FireworksAdapter', () => {
             expect.objectContaining({
                 stream: false,
                 model: options.model,
-                temperature: 0.1,
+                temperature: 0.001,
                 max_tokens: expect.any(Number),
                 response_format: { type: 'text' },
                 prediction: {

--- a/vscode/src/autoedits/adapters/fireworks.ts
+++ b/vscode/src/autoedits/adapters/fireworks.ts
@@ -40,7 +40,7 @@ export class FireworksAdapter implements AutoeditsModelAdapter {
         const body: FireworksCompatibleRequestParams = {
             stream: false,
             model: options.model,
-            temperature: 0.1,
+            temperature: 0.001,
             max_tokens: maxTokens,
             response_format: {
                 type: 'text',

--- a/vscode/src/autoedits/adapters/sourcegraph-chat.test.ts
+++ b/vscode/src/autoedits/adapters/sourcegraph-chat.test.ts
@@ -64,7 +64,7 @@ describe('SourcegraphChatAdapter', () => {
         expect(chatOptions).toMatchObject({
             model: 'anthropic/claude-2',
             maxTokensToSample: getMaxOutputTokensForAutoedits(options.codeToRewrite),
-            temperature: 0.1,
+            temperature: 0.001,
             prediction: {
                 type: 'content',
                 content: 'const x = 1',

--- a/vscode/src/autoedits/adapters/sourcegraph-chat.ts
+++ b/vscode/src/autoedits/adapters/sourcegraph-chat.ts
@@ -18,7 +18,7 @@ export class SourcegraphChatAdapter implements AutoeditsModelAdapter {
                 {
                     model: option.model,
                     maxTokensToSample: maxTokens,
-                    temperature: 0.1,
+                    temperature: 0.001,
                     prediction: {
                         type: 'content',
                         content: option.codeToRewrite,

--- a/vscode/src/autoedits/adapters/sourcegraph-completions.test.ts
+++ b/vscode/src/autoedits/adapters/sourcegraph-completions.test.ts
@@ -57,7 +57,7 @@ describe('SourcegraphCompletionsAdapter', () => {
         expect(params).toMatchObject({
             model: 'anthropic/claude-2',
             maxTokensToSample: getMaxOutputTokensForAutoedits(options.codeToRewrite),
-            temperature: 0.1,
+            temperature: 0.001,
             messages: [{ speaker: 'human', text: ps`user message` }],
             prediction: {
                 type: 'content',

--- a/vscode/src/autoedits/adapters/sourcegraph-completions.ts
+++ b/vscode/src/autoedits/adapters/sourcegraph-completions.ts
@@ -28,7 +28,7 @@ export class SourcegraphCompletionsAdapter implements AutoeditsModelAdapter {
                 model: option.model as ModelRefStr,
                 messages,
                 maxTokensToSample: maxTokens,
-                temperature: 0.1,
+                temperature: 0.001,
                 prediction: {
                     type: 'content',
                     content: option.codeToRewrite,


### PR DESCRIPTION
## context
1. fix the temperature value to be low for output consistency. `0.1` temperature value still leads to inconsistency sometimes. Having more deterministic outputs would help repro and debug the model quality better. 
2. Refer for more context: https://github.com/sourcegraph/cody/pull/6848/files 

## Test plan
1. Fixed the test cases and CI.
3. Local testing on the prompt to ensure the output is consistent.
