### PR TITLE
chore/release: Add support for milestone branch labels for backports

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -28,5 +28,6 @@ jobs:
       - uses: sourcegraph/backport@v2
         with:
           github_token: ${{ secrets.BACKPORT_GITHUB_TOKEN }}
-          label_pattern: '^backport (?<base>(jb|vscode)-v\d+\.\d+\.x)$'
+          # TODO: Remove the jb, vscode parts of the pattern after VSCode v1.66 and JetBrains v7.66 reach stable
+          label_pattern: '^backport (?<base>((jb|vscode)-v\d+\.\d+\.x)|(M\d+))$'
           team_reviews: "cody-core"


### PR DESCRIPTION
Per RFC1018, we will ship VSCode and JetBrains from a single release branch. These are labeled after the milestone, for example M66, M68, etc.

The legacy branch names are preserved, but we can remove them after M66 hits stable.

## Test plan

I am release captain this week and will dogfood this with M66 by backporting changes like the renamed release automation in #6879 to the M66 branch.