### PR TITLE
Changes the default chat model in cody to DeepSeek-V3 but only once

### DIFF
--- a/lib/shared/src/experimentation/FeatureFlagProvider.ts
+++ b/lib/shared/src/experimentation/FeatureFlagProvider.ts
@@ -90,6 +90,7 @@ export enum FeatureFlag {
      * some standard out-of-the-box prompts like documentation and explain code prompts)
      */
     CodyUnifiedPrompts = 'cody-unified-prompts',
+    CodyDeepSeekChat = 'cody-deepseek-chat-4',
 
     /**
      * For internal use only. New Prompts UI and logic is behind this feature flag

--- a/lib/shared/src/experimentation/FeatureFlagProvider.ts
+++ b/lib/shared/src/experimentation/FeatureFlagProvider.ts
@@ -90,7 +90,7 @@ export enum FeatureFlag {
      * some standard out-of-the-box prompts like documentation and explain code prompts)
      */
     CodyUnifiedPrompts = 'cody-unified-prompts',
-    CodyDeepSeekChat = 'cody-deepseek-chat-4',
+    CodyDeepSeekChat = 'cody-deepseek-chat',
 
     /**
      * For internal use only. New Prompts UI and logic is behind this feature flag

--- a/lib/shared/src/models/modelsService.ts
+++ b/lib/shared/src/models/modelsService.ts
@@ -417,10 +417,9 @@ export class ModelsService {
             this.getModelsByType(type),
             this.modelsChanges,
             authStatus,
-            userProductSubscription,
-            featureFlagProvider.evaluatedFeatureFlag(FeatureFlag.CodyDeepSeekChat)
+            userProductSubscription
         ).pipe(
-            map(([models, modelsData, authStatus, userProductSubscription, deepSeekEnabled]) => {
+            map(([models, modelsData, authStatus, userProductSubscription]) => {
                 if (
                     models === pendingOperation ||
                     modelsData === pendingOperation ||
@@ -428,12 +427,14 @@ export class ModelsService {
                 ) {
                     return pendingOperation
                 }
+
+                // Free users can only use the default free model, so we just find the first model they can use
                 const firstModelUserCanUse = models.find(
                     m =>
                         this._isModelAvailable(modelsData, authStatus, userProductSubscription, m) ===
                         true
                 )
-                // First check user preferences
+
                 if (modelsData.preferences) {
                     // Check to see if the user has a selected a default model for this
                     // usage type and if not see if there is a server sent default type
@@ -452,14 +453,8 @@ export class ModelsService {
                     ) {
                         return selected
                     }
-                    return firstModelUserCanUse
                 }
-                // Finally, fall back to first available model
-                return models.find(
-                    m =>
-                        this._isModelAvailable(modelsData, authStatus, userProductSubscription, m) ===
-                        true
-                )
+                return firstModelUserCanUse
             }),
             distinctUntilChanged(),
             shareReplay()

--- a/lib/shared/src/models/modelsService.ts
+++ b/lib/shared/src/models/modelsService.ts
@@ -14,7 +14,6 @@ import {
     distinctUntilChanged,
     shareReplay,
     storeLastValue,
-    switchMap,
     tap,
 } from '../misc/observable'
 import { firstResultFromOperation, pendingOperation } from '../misc/observableOperation'
@@ -478,19 +477,9 @@ export class ModelsService {
             })
         )
     }
-
     public getDefaultChatModel(): Observable<ChatModel | undefined | typeof pendingOperation> {
-        return featureFlagProvider.evaluatedFeatureFlag(FeatureFlag.CodyDeepSeekChat).pipe(
-            switchMap(flag => {
-                if (flag) {
-                    return this.getDefaultModel(ModelUsage.Chat).pipe(
-                        map(model => (model === pendingOperation ? pendingOperation : model?.id))
-                    )
-                }
-                return this.getDefaultModel(ModelUsage.Chat).pipe(
-                    map(model => (model === pendingOperation ? pendingOperation : model?.id))
-                )
-            })
+        return this.getDefaultModel(ModelUsage.Chat).pipe(
+            map(model => (model === pendingOperation ? pendingOperation : model?.id))
         )
     }
 

--- a/lib/shared/src/models/modelsService.ts
+++ b/lib/shared/src/models/modelsService.ts
@@ -428,10 +428,14 @@ export class ModelsService {
                 ) {
                     return pendingOperation
                 }
-
+                const firstModelUserCanUse = models.find(
+                    m =>
+                        this._isModelAvailable(modelsData, authStatus, userProductSubscription, m) ===
+                        true
+                )
                 // First check user preferences
                 if (modelsData.preferences) {
-                    // Check to see if the user has selected a default model for this
+                    // Check to see if the user has a selected a default model for this
                     // usage type and if not see if there is a server sent default type
                     const selected = this.resolveModel(
                         modelsData,
@@ -448,24 +452,8 @@ export class ModelsService {
                     ) {
                         return selected
                     }
+                    return firstModelUserCanUse
                 }
-
-                // If no user selection, then check feature flag override
-                if (deepSeekEnabled) {
-                    const overrideModel = models.find(m => m.id === 'fireworks::v1::deepseek-v3')
-                    if (
-                        overrideModel &&
-                        this._isModelAvailable(
-                            modelsData,
-                            authStatus,
-                            userProductSubscription,
-                            overrideModel
-                        )
-                    ) {
-                        return overrideModel
-                    }
-                }
-
                 // Finally, fall back to first available model
                 return models.find(
                     m =>

--- a/lib/shared/src/models/modelsService.ts
+++ b/lib/shared/src/models/modelsService.ts
@@ -290,7 +290,8 @@ export class ModelsService {
                     )
 
                     // Ensures that we have the deepseek model
-                    // we want to default to in this A/B test.
+                    // we want to default to in this A/B test
+                    // The model is defined at https://sourcegraph.sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/cmd/cody-gateway-config/dotcom_models.go?L323
                     const deepseekModel = data.primaryModels.find(
                         model => model?.id === 'fireworks::v1::deepseek-v3'
                     )
@@ -304,11 +305,8 @@ export class ModelsService {
                         // They still can switch back to other models if they want.
                         currentAccountPrefs.selected.edit = gpt4oMini.id
                     }
-                    if (
-                        !isEnrolledDeepSeekChat &&
-                        shouldChatDefaultToDeepSeek &&
-                        deepseekModel
-                    ) {
+
+                    if (!isEnrolledDeepSeekChat && shouldChatDefaultToDeepSeek && deepseekModel) {
                         // For users enrolled in the A/B test, we'll default
                         // to the deepseek model when using the Chat command.
                         // They still can switch back to other models if they want.

--- a/lib/shared/src/models/modelsService.ts
+++ b/lib/shared/src/models/modelsService.ts
@@ -277,8 +277,13 @@ export class ModelsService {
                         FeatureFlag.CodyEditDefaultToGpt4oMini
                     )
 
-                    // Ensures we only change user preferences once
-                    // when they join the A/B test.
+                    // Check if this user has already been enrolled in the deepseek chat feature flag experiment.
+                    // We only want to change their default model ONCE when they first join the A/B test.
+                    // This ensures that:
+                    // 1. New users in the test group get deepseek as their default model
+                    // 2. If they later explicitly choose a different model (e.g., sonnet), we respect that choice
+                    // 3. Their chosen preference persists across sessions and new chats
+                    // 4. We don't override their preference every time they load the app
                     const isEnrolledDeepSeekChat = this.storage?.getEnrollmentHistory(
                         FeatureFlag.CodyDeepSeekChat
                     )

--- a/lib/shared/src/models/modelsService.ts
+++ b/lib/shared/src/models/modelsService.ts
@@ -266,7 +266,7 @@ export class ModelsService {
             featureFlagProvider.evaluatedFeatureFlag(FeatureFlag.CodyDeepSeekChat)
         )
             .pipe(
-                tap(([data, shouldEditDefaultToGpt4oMini, shouldDeepSeekChatDefaultToDeepSeek]) => {
+                tap(([data, shouldEditDefaultToGpt4oMini, shouldChatDefaultToDeepSeek]) => {
                     if (data === pendingOperation) {
                         return
                     }
@@ -306,7 +306,7 @@ export class ModelsService {
                     }
                     if (
                         !isEnrolledDeepSeekChat &&
-                        shouldDeepSeekChatDefaultToDeepSeek &&
+                        shouldChatDefaultToDeepSeek &&
                         deepseekModel
                     ) {
                         // For users enrolled in the A/B test, we'll default


### PR DESCRIPTION
Changes the default chat model in cody to DeepSeek-V3 but only once 

## Test plan
- Locally setup sourcegraph instance using `sg start enterprise-cody-e2e` 
- enable the feature flag 
<img width="859" alt="image" src="https://github.com/user-attachments/assets/c5929a50-32e4-4a44-8fd9-0d314c16360b" />

- Restart cody in the debugger. You will see default model as Deepseek but only once 

NOTE: Actually setting up deepseek properly with Cody requires some creds so feel free to DM me and I can send you the credentials but in order to just check the model setting logic we don't need the creds setup etc. 

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
