### PR TITLE
fix: cody://repository isn't able to resolve in cody chat

### DIFF
--- a/lib/shared/src/misc/rpc/webviewAPI.ts
+++ b/lib/shared/src/misc/rpc/webviewAPI.ts
@@ -130,7 +130,7 @@ export function createExtensionAPI(
         chatModels: proxyExtensionAPI(messageAPI, 'chatModels'),
         highlights: proxyExtensionAPI(messageAPI, 'highlights'),
         hydratePromptMessage: promptText =>
-            hydratePromptMessage(promptText, staticDefaultContext?.initialContext),
+            hydratePromptMessage(promptText, staticDefaultContext ? [...staticDefaultContext.initialContext, ...staticDefaultContext.corpusContext] : undefined),
         setChatModel: proxyExtensionAPI(messageAPI, 'setChatModel'),
         defaultContext: staticDefaultContext
             ? () => Observable.of(staticDefaultContext)

--- a/vscode/webviews/chat/cells/messageCell/human/editor/HumanMessageEditor.tsx
+++ b/vscode/webviews/chat/cells/messageCell/human/editor/HumanMessageEditor.tsx
@@ -340,12 +340,12 @@ export const HumanMessageEditor: FunctionComponent<{
                         // biome-ignore lint/suspicious/noAsyncPromiseExecutor: <explanation>
                         new Promise<void>(async resolve => {
                             // get initial context
-                            const { initialContext } = await firstValueFrom(
+                            const context = await firstValueFrom(
                                 extensionAPI.defaultContext().pipe(skipPendingOperation())
                             )
                             // hydrate raw prompt text
                             const promptEditorState = await firstValueFrom(
-                                extensionAPI.hydratePromptMessage(setPromptAsInput.text, initialContext)
+                                extensionAPI.hydratePromptMessage(setPromptAsInput.text, [...context.initialContext, ...context.corpusContext])
                             )
 
                             manuallySelectIntent(promptIntent)


### PR DESCRIPTION
Fixes SRCH-1592

Currently only for cody://repository. Other fields might be affected, too. Will check for them if the approach taken here is okay.

## Test plan

Manual testing, it works now:

<img width="380" alt="Screenshot 2025-01-30 at 12 59 29" src="https://github.com/user-attachments/assets/7a9c0c2d-6406-4331-9e86-77f15791e0e0" />

