### PR TITLE
Fix problem with race between auth and config causing issues with models loading

### DIFF
--- a/agent/recordings/auth_2503977039/recording.har.yaml
+++ b/agent/recordings/auth_2503977039/recording.har.yaml
@@ -96,6 +96,118 @@ log:
         send: 0
         ssl: -1
         wait: 263
+    - _id: c0ae8299223e083d38e2187b031df2e1
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 565
+        cookies: []
+        headers:
+          - name: accept-encoding
+            value: gzip;q=0
+          - name: authorization
+            value: token
+              REDACTED_fc324d3667e841181b0779375f26dedc911d26b303d23b29b1a2d7ee63dc77eb
+          - name: connection
+            value: keep-alive
+          - name: content-type
+            value: application/json
+          - name: traceparent
+            value: 00-ba0ae6df12d9a5620c952748c98845af-983c56755379042a-01
+          - name: user-agent
+            value: auth/v1 (Node.js v20.4.0)
+          - name: x-requested-with
+            value: auth v1
+          - name: host
+            value: sourcegraph.com
+        headersSize: 508
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json
+          params: []
+          textJSON:
+            maxTokensToSample: 4000
+            messages:
+              - speaker: system
+                text: >-
+                  You are Cody, an AI coding assistant from Sourcegraph.If your
+                  answer contains fenced code blocks in Markdown, include the
+                  relevant full file path in the code block tag using this
+                  structure: ```$LANGUAGE:$FILEPATH```
+
+                  For executable terminal commands: enclose each command in individual "bash" language code block without comments and new lines inside.
+              - speaker: human
+                text: hello after reauthentication
+            model: anthropic::2023-06-01::claude-3-haiku
+            temperature: 0
+            topK: -1
+            topP: -1
+        queryString:
+          - name: api-version
+            value: "2"
+          - name: client-name
+            value: auth
+          - name: client-version
+            value: v1
+        url: https://sourcegraph.com/.api/completions/stream?api-version=2&client-name=auth&client-version=v1
+      response:
+        bodySize: 578
+        content:
+          mimeType: text/event-stream
+          size: 578
+          text: >+
+            event: completion
+
+            data: {"deltaText":"Hello! I'm Cody, an AI coding assistant from Sourcegraph. How can I assist you today?","stopReason":"end_turn"}
+
+
+            event: done
+
+            data: {}
+
+        cookies: []
+        headers:
+          - name: date
+            value: Thu, 30 Jan 2025 08:57:44 GMT
+          - name: content-type
+            value: text/event-stream
+          - name: transfer-encoding
+            value: chunked
+          - name: connection
+            value: keep-alive
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache
+          - name: vary
+            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
+              X-Requested-With,Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+        headersSize: 1299
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: 2025-01-30T08:57:41.968Z
+      time: 2782
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 2782
     - _id: f1b1cde4cd57488b7f0137954f0302f5
       _order: 0
       cache: {}
@@ -1019,114 +1131,6 @@ log:
         send: 0
         ssl: -1
         wait: 251
-    - _id: 2481998e71355fc9ca2258fbaae1cf9a
-      _order: 0
-      cache: {}
-      request:
-        bodySize: 101
-        cookies: []
-        headers:
-          - _fromType: array
-            name: authorization
-            value: token
-              REDACTED_fc324d3667e841181b0779375f26dedc911d26b303d23b29b1a2d7ee63dc77eb
-          - _fromType: array
-            name: content-type
-            value: application/json; charset=utf-8
-          - _fromType: array
-            name: user-agent
-            value: auth/v1 (Node.js v20.4.0)
-          - _fromType: array
-            name: x-requested-with
-            value: auth v1
-          - _fromType: array
-            name: accept
-            value: "*/*"
-          - _fromType: array
-            name: content-length
-            value: "101"
-          - _fromType: array
-            name: accept-encoding
-            value: gzip,deflate
-          - name: host
-            value: sourcegraph.com
-        headersSize: 407
-        httpVersion: HTTP/1.1
-        method: POST
-        postData:
-          mimeType: application/json; charset=utf-8
-          params: []
-          textJSON:
-            query: |
-              
-              query TemporarySettings {
-                temporarySettings {
-                  contents
-                }
-              }
-            variables: {}
-        queryString:
-          - name: TemporarySettings
-            value: null
-        url: https://sourcegraph.com/.api/graphql?TemporarySettings
-      response:
-        bodySize: 519
-        content:
-          encoding: base64
-          mimeType: application/json
-          size: 519
-          text: "[\"H4sIAAAAAAAAAwAAAP//\",\"xJLLTsMwEEV/xbJYVa3zIlT1DsGCfbsCg+Qm08TCsYM9\
-            BqIq/46cSIgFbCiP7cz1+Ny5c6S1REn5kSJ0vXXSDVtAVKbxsVhZg2DQU06PggYPjmn\
-            p8VoOlxWqZxCUE0F3bSBb6Em2IXmanwu6JIJWth6YNXsrXa1MwzxCH+V5bE6Tajn4ec\
-            yVDQZjM8s+e1rZrteAUEcJugBR5EG6qmXK9AGZgwoMbqcS+Ci7Owr6FMANM+Jk5BV5o\
-            +1eauKgt/yhUdiGvRBCxC8Sb4OroHGyb5OIcEYippEdcHJQGriDys5ErXRskJ2erWrV\
-            KbxRk4OD1H7iQ9WBR9n1M0BczCotV/l6l2X8PONZwcqivJ0nOPBB4/sainFJfoFfNmA\
-            weXfhk0WyONVGWrI0XX9uI/0jG9/GT3m5Zpus+OcUTssg5WXBLr46pZ/K4ENlb3HzuD\
-            qYly6cAF2ULN98ef/3Ix3H8Q0AAP//AwAcyw0bngQAAA==\"]"
-        cookies: []
-        headers:
-          - name: date
-            value: Fri, 17 Jan 2025 13:17:22 GMT
-          - name: content-type
-            value: application/json
-          - name: transfer-encoding
-            value: chunked
-          - name: connection
-            value: close
-          - name: access-control-allow-credentials
-            value: "true"
-          - name: access-control-allow-origin
-            value: ""
-          - name: cache-control
-            value: no-cache, max-age=0
-          - name: vary
-            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
-              X-Requested-With,Cookie
-          - name: x-content-type-options
-            value: nosniff
-          - name: x-frame-options
-            value: DENY
-          - name: x-xss-protection
-            value: 1; mode=block
-          - name: strict-transport-security
-            value: max-age=31536000; includeSubDomains; preload
-          - name: content-encoding
-            value: gzip
-        headersSize: 1468
-        httpVersion: HTTP/1.1
-        redirectURL: ""
-        status: 200
-        statusText: OK
-      startedDateTime: 2025-01-17T13:17:21.350Z
-      time: 752
-      timings:
-        blocked: -1
-        connect: -1
-        dns: -1
-        receive: 0
-        send: 0
-        ssl: -1
-        wait: 752
     - _id: fd0fee4687419870bc82cba9d1023319
       _order: 0
       cache: {}
@@ -1355,5 +1359,1229 @@ log:
         send: 0
         ssl: -1
         wait: 200
+    - _id: 773f06f412e7171a41a163edff09aae3
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 0
+        cookies: []
+        headers:
+          - _fromType: array
+            name: authorization
+            value: token
+              REDACTED_1858aad0e1ff07ae26d4042086acb9da455866ad617afd2cb9ab9419e1be1104
+          - _fromType: array
+            name: content-type
+            value: application/json; charset=utf-8
+          - _fromType: array
+            name: user-agent
+            value: auth/v1 (Node.js v20.4.0)
+          - _fromType: array
+            name: x-requested-with
+            value: auth v1
+          - _fromType: array
+            name: accept
+            value: "*/*"
+          - _fromType: array
+            name: accept-encoding
+            value: gzip,deflate
+          - name: host
+            value: sourcegraph.sourcegraph.com
+        headersSize: 397
+        httpVersion: HTTP/1.1
+        method: GET
+        queryString: []
+        url: https://sourcegraph.sourcegraph.com/.api/client-config
+      response:
+        bodySize: 227
+        content:
+          encoding: base64
+          mimeType: text/plain; charset=utf-8
+          size: 227
+          text: "[\"H4sIAAAAAAAAAwAAAP//\",\"bM6xCsMwDATQPV9hMnfukC2EDtkCgXZWakENlhSsM00p\
+            /fcuGT2/u+O+XQgh9E+Ln5vSljn2Q0CpfDnhRWgCVdhksmcGt5vVYTKZCGn09gZQ0la\
+            RTJvuQgWTKfjAI2m0dzMmFjn7uMxNzQR2rHXfrYDj+TmZ+orCJOMy37l4Mu2HcO1+3R\
+            8AAP//AwBKrYKQEwEAAA==\"]"
+        cookies: []
+        headers:
+          - name: date
+            value: Thu, 30 Jan 2025 08:57:59 GMT
+          - name: content-type
+            value: text/plain; charset=utf-8
+          - name: transfer-encoding
+            value: chunked
+          - name: connection
+            value: close
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache, max-age=0
+          - name: vary
+            value: Accept-Encoding, Authorization, Cookie, Authorization, X-Requested-With,
+              Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+          - name: content-encoding
+            value: gzip
+        headersSize: 1428
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: 2025-01-30T08:57:58.783Z
+      time: 270
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 270
+    - _id: 8d0097a3fcdb40cb9eccbcf3b5c958b2
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 629
+        cookies: []
+        headers:
+          - name: accept-encoding
+            value: gzip;q=0
+          - name: authorization
+            value: token
+              REDACTED_1858aad0e1ff07ae26d4042086acb9da455866ad617afd2cb9ab9419e1be1104
+          - name: connection
+            value: keep-alive
+          - name: content-type
+            value: application/json
+          - name: traceparent
+            value: 00-f3ef78fa83d506d97d128a1a74e1b314-9650733e91575ea5-01
+          - name: user-agent
+            value: auth/v1 (Node.js v20.4.0)
+          - name: x-requested-with
+            value: auth v1
+          - name: host
+            value: sourcegraph.sourcegraph.com
+        headersSize: 532
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json
+          params: []
+          textJSON:
+            maxTokensToSample: 4000
+            messages:
+              - speaker: system
+                text: >-
+                  You are Cody, an AI coding assistant from Sourcegraph.If your
+                  answer contains fenced code blocks in Markdown, include the
+                  relevant full file path in the code block tag using this
+                  structure: ```$LANGUAGE:$FILEPATH```
+
+                  For executable terminal commands: enclose each command in individual "bash" language code block without comments and new lines inside.
+              - speaker: human
+                text: |-
+                  Answer positively without apologizing.
+
+                  Question: hello after switching accounts
+            model: anthropic::2024-10-22::claude-3-5-sonnet-latest
+            temperature: 0
+            topK: -1
+            topP: -1
+        queryString:
+          - name: api-version
+            value: "2"
+          - name: client-name
+            value: auth
+          - name: client-version
+            value: v1
+        url: https://sourcegraph.sourcegraph.com/.api/completions/stream?api-version=2&client-name=auth&client-version=v1
+      response:
+        bodySize: 433
+        content:
+          mimeType: text/event-stream
+          size: 433
+          text: >+
+            event: completion
+
+            data: {"deltaText":"Hi there! Welcome back! I'm ready to help you with any coding or development questions you have with your new account. What would you like to work on?","stopReason":"end_turn"}
+
+
+            event: done
+
+            data: {}
+
+        cookies: []
+        headers:
+          - name: date
+            value: Thu, 30 Jan 2025 08:58:01 GMT
+          - name: content-type
+            value: text/event-stream
+          - name: transfer-encoding
+            value: chunked
+          - name: connection
+            value: keep-alive
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache
+          - name: vary
+            value: Accept-Encoding, Authorization, Cookie, Authorization, X-Requested-With,
+              Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+        headersSize: 1390
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: 2025-01-30T08:58:00.167Z
+      time: 1406
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 1406
+    - _id: 79737937a4644c3089fa4bbf7b7a14ee
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 611
+        cookies: []
+        headers:
+          - name: accept-encoding
+            value: gzip;q=0
+          - name: authorization
+            value: token
+              REDACTED_1858aad0e1ff07ae26d4042086acb9da455866ad617afd2cb9ab9419e1be1104
+          - name: connection
+            value: keep-alive
+          - name: content-type
+            value: application/json
+          - name: traceparent
+            value: 00-9d52cd17207bc80c68211daa93dc69b7-b8510b4f05ebc130-01
+          - name: user-agent
+            value: auth/v1 (Node.js v20.4.0)
+          - name: x-requested-with
+            value: auth v1
+          - name: host
+            value: sourcegraph.sourcegraph.com
+        headersSize: 532
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json
+          params: []
+          textJSON:
+            maxTokensToSample: 4000
+            messages:
+              - speaker: system
+                text: >-
+                  You are Cody, an AI coding assistant from Sourcegraph.If your
+                  answer contains fenced code blocks in Markdown, include the
+                  relevant full file path in the code block tag using this
+                  structure: ```$LANGUAGE:$FILEPATH```
+
+                  For executable terminal commands: enclose each command in individual "bash" language code block without comments and new lines inside.
+              - speaker: human
+                text: |-
+                  Answer positively without apologizing.
+
+                  Question: hello after switching accounts
+            model: sourcegraph/claude-3.5-sonnet
+            temperature: 0
+            topK: -1
+            topP: -1
+        queryString:
+          - name: api-version
+            value: "2"
+          - name: client-name
+            value: auth
+          - name: client-version
+            value: v1
+        url: https://sourcegraph.sourcegraph.com/.api/completions/stream?api-version=2&client-name=auth&client-version=v1
+      response:
+        bodySize: 128
+        content:
+          mimeType: text/plain; charset=utf-8
+          size: 128
+          text: >
+            status 400, reason model "sourcegraph/claude-3.5-sonnet" is not
+            supported (default: "anthropic::2023-06-01::claude-3.5-sonnet")
+        cookies: []
+        headers:
+          - name: date
+            value: Thu, 30 Jan 2025 10:15:04 GMT
+          - name: content-type
+            value: text/plain; charset=utf-8
+          - name: content-length
+            value: "128"
+          - name: connection
+            value: keep-alive
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache, max-age=0
+          - name: vary
+            value: Accept-Encoding, Authorization, Cookie, Authorization, X-Requested-With,
+              Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+        headersSize: 1402
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 400
+        statusText: Bad Request
+      startedDateTime: 2025-01-30T10:15:03.821Z
+      time: 413
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 413
+    - _id: 5d0e29776bf0857beffb22b778ce488b
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 136
+        cookies: []
+        headers:
+          - _fromType: array
+            name: authorization
+            value: token
+              REDACTED_1858aad0e1ff07ae26d4042086acb9da455866ad617afd2cb9ab9419e1be1104
+          - _fromType: array
+            name: content-type
+            value: application/json; charset=utf-8
+          - _fromType: array
+            name: user-agent
+            value: auth/v1 (Node.js v20.4.0)
+          - _fromType: array
+            name: x-requested-with
+            value: auth v1
+          - _fromType: array
+            name: accept
+            value: "*/*"
+          - _fromType: array
+            name: content-length
+            value: "136"
+          - _fromType: array
+            name: accept-encoding
+            value: gzip,deflate
+          - name: host
+            value: sourcegraph.sourcegraph.com
+        headersSize: 431
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json; charset=utf-8
+          params: []
+          textJSON:
+            query: >
+              
+              query CodeSearchEnabled {
+                  codeSearchEnabled: enterpriseLicenseHasFeature(feature:"code-search")
+              }
+            variables: {}
+        queryString:
+          - name: CodeSearchEnabled
+            value: null
+        url: https://sourcegraph.sourcegraph.com/.api/graphql?CodeSearchEnabled
+      response:
+        bodySize: 35
+        content:
+          mimeType: application/json
+          size: 35
+          text: "{\"data\":{\"codeSearchEnabled\":true}}"
+        cookies: []
+        headers:
+          - name: date
+            value: Thu, 30 Jan 2025 08:57:59 GMT
+          - name: content-type
+            value: application/json
+          - name: content-length
+            value: "35"
+          - name: connection
+            value: close
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache, max-age=0
+          - name: vary
+            value: Accept-Encoding, Authorization, Cookie, Authorization, X-Requested-With,
+              Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+        headersSize: 1387
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: 2025-01-30T08:57:59.097Z
+      time: 233
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 233
+    - _id: 58da5ef844152e12a476118b9211dca4
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 318
+        cookies: []
+        headers:
+          - _fromType: array
+            name: authorization
+            value: token
+              REDACTED_1858aad0e1ff07ae26d4042086acb9da455866ad617afd2cb9ab9419e1be1104
+          - _fromType: array
+            name: content-type
+            value: application/json; charset=utf-8
+          - _fromType: array
+            name: user-agent
+            value: auth/v1 (Node.js v20.4.0)
+          - _fromType: array
+            name: x-requested-with
+            value: auth v1
+          - _fromType: array
+            name: accept
+            value: "*/*"
+          - _fromType: array
+            name: content-length
+            value: "318"
+          - _fromType: array
+            name: accept-encoding
+            value: gzip,deflate
+          - name: host
+            value: sourcegraph.sourcegraph.com
+        headersSize: 445
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json; charset=utf-8
+          params: []
+          textJSON:
+            query: |-
+              
+              query CurrentSiteCodyLlmConfiguration {
+                  site {
+                      codyLLMConfiguration {
+                          chatModel
+                          chatModelMaxTokens
+                          fastChatModel
+                          fastChatModelMaxTokens
+                          completionModel
+                          completionModelMaxTokens
+                      }
+                  }
+              }
+            variables: {}
+        queryString:
+          - name: CurrentSiteCodyLlmConfiguration
+            value: null
+        url: https://sourcegraph.sourcegraph.com/.api/graphql?CurrentSiteCodyLlmConfiguration
+      response:
+        bodySize: 248
+        content:
+          encoding: base64
+          mimeType: application/json
+          size: 248
+          text: "[\"H4sIAAAAAAAAA4TOTQ6CMBAF4LvMmmqDEA1btrLzAmM7QAN2SH+MhvTuBjYSNXH1ksmbL\
+            28GjQGhmsGbQEsq1s/zuanZtqaLDoNhu957DA1rGqECz9Ep6hxO/V6NGDWJw64Unq2l\
+            ANm72+DjwgNZD1VRSikzaNGH+g8lejRDhI/yxjqulOLbNNKy7xemiSZPNAjFmpy452I\
+            0gcQVPcHX78bOZXFKKaUXAAAA//8DADDh/dAaAQAA\"]"
+          textDecoded:
+            data:
+              site:
+                codyLLMConfiguration:
+                  chatModel: sourcegraph/claude-3.5-sonnet
+                  chatModelMaxTokens: 45000
+                  completionModel: sourcegraph/deepseek-coder-v2-lite-base
+                  completionModelMaxTokens: 2048
+                  fastChatModel: sourcegraph/claude-3-haiku
+                  fastChatModelMaxTokens: 7000
+        cookies: []
+        headers:
+          - name: date
+            value: Thu, 30 Jan 2025 08:57:58 GMT
+          - name: content-type
+            value: application/json
+          - name: transfer-encoding
+            value: chunked
+          - name: connection
+            value: close
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache, max-age=0
+          - name: vary
+            value: Accept-Encoding, Authorization, Cookie, Authorization, X-Requested-With,
+              Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+          - name: content-encoding
+            value: gzip
+        headersSize: 1419
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: 2025-01-30T08:57:58.483Z
+      time: 293
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 293
+    - _id: be6903eacbfb1c4d597835d9a7e88367
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 165
+        cookies: []
+        headers:
+          - _fromType: array
+            name: authorization
+            value: token
+              REDACTED_1858aad0e1ff07ae26d4042086acb9da455866ad617afd2cb9ab9419e1be1104
+          - _fromType: array
+            name: content-type
+            value: application/json; charset=utf-8
+          - _fromType: array
+            name: user-agent
+            value: auth/v1 (Node.js v20.4.0)
+          - _fromType: array
+            name: x-requested-with
+            value: auth v1
+          - _fromType: array
+            name: accept
+            value: "*/*"
+          - _fromType: array
+            name: content-length
+            value: "165"
+          - _fromType: array
+            name: accept-encoding
+            value: gzip,deflate
+          - name: host
+            value: sourcegraph.sourcegraph.com
+        headersSize: 445
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json; charset=utf-8
+          params: []
+          textJSON:
+            query: |-
+              
+              query CurrentSiteCodyLlmConfiguration {
+                  site {
+                      codyLLMConfiguration {
+                          smartContextWindow
+                      }
+                  }
+              }
+            variables: {}
+        queryString:
+          - name: CurrentSiteCodyLlmConfiguration
+            value: null
+        url: https://sourcegraph.sourcegraph.com/.api/graphql?CurrentSiteCodyLlmConfiguration
+      response:
+        bodySize: 136
+        content:
+          encoding: base64
+          mimeType: application/json
+          size: 136
+          text: "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqzixJBdHJ+SmVPj6+zvl5aZnppUWJJZn5eWD53MSiE\
+            uf8vJLUipLwzLyU/HIlK6WUzOLEpJzUFKXa2tpaAAAAAP//AwArMNn0TAAAAA==\"]"
+          textDecoded:
+            data:
+              site:
+                codyLLMConfiguration:
+                  smartContextWindow: disabled
+        cookies: []
+        headers:
+          - name: date
+            value: Thu, 30 Jan 2025 08:57:58 GMT
+          - name: content-type
+            value: application/json
+          - name: transfer-encoding
+            value: chunked
+          - name: connection
+            value: close
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache, max-age=0
+          - name: vary
+            value: Accept-Encoding, Authorization, Cookie, Authorization, X-Requested-With,
+              Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+          - name: content-encoding
+            value: gzip
+        headersSize: 1419
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: 2025-01-30T08:57:58.526Z
+      time: 292
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 292
+    - _id: 81ba454ac92cd2681c8368b6be845186
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 150
+        cookies: []
+        headers:
+          - _fromType: array
+            name: authorization
+            value: token
+              REDACTED_1858aad0e1ff07ae26d4042086acb9da455866ad617afd2cb9ab9419e1be1104
+          - _fromType: array
+            name: content-type
+            value: application/json; charset=utf-8
+          - _fromType: array
+            name: user-agent
+            value: auth/v1 (Node.js v20.4.0)
+          - _fromType: array
+            name: x-requested-with
+            value: auth v1
+          - _fromType: array
+            name: accept
+            value: "*/*"
+          - _fromType: array
+            name: content-length
+            value: "150"
+          - _fromType: array
+            name: accept-encoding
+            value: gzip,deflate
+          - name: host
+            value: sourcegraph.sourcegraph.com
+        headersSize: 440
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json; charset=utf-8
+          params: []
+          textJSON:
+            query: |-
+              
+              query CurrentSiteCodyLlmProvider {
+                  site {
+                      codyLLMConfiguration {
+                          provider
+                      }
+                  }
+              }
+            variables: {}
+        queryString:
+          - name: CurrentSiteCodyLlmProvider
+            value: null
+        url: https://sourcegraph.sourcegraph.com/.api/graphql?CurrentSiteCodyLlmProvider
+      response:
+        bodySize: 131
+        content:
+          encoding: base64
+          mimeType: application/json
+          size: 131
+          text: "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqzixJBdHJ+SmVPj6+zvl5aZnppUWJJZn5eSDxgqL8s\
+            syU1CIlK6Xi/NKi5NT0osSCDKXa2tpaAAAAAP//\",\"AwAfFAXARQAAAA==\"]"
+        cookies: []
+        headers:
+          - name: date
+            value: Thu, 30 Jan 2025 08:57:58 GMT
+          - name: content-type
+            value: application/json
+          - name: transfer-encoding
+            value: chunked
+          - name: connection
+            value: close
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache, max-age=0
+          - name: vary
+            value: Accept-Encoding, Authorization, Cookie, Authorization, X-Requested-With,
+              Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+          - name: content-encoding
+            value: gzip
+        headersSize: 1419
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: 2025-01-30T08:57:58.505Z
+      time: 314
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 314
+    - _id: d073147da6f716938816120f32876189
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 341
+        cookies: []
+        headers:
+          - _fromType: array
+            name: authorization
+            value: token
+              REDACTED_1858aad0e1ff07ae26d4042086acb9da455866ad617afd2cb9ab9419e1be1104
+          - _fromType: array
+            name: content-type
+            value: application/json; charset=utf-8
+          - _fromType: array
+            name: user-agent
+            value: auth/v1 (Node.js v20.4.0)
+          - _fromType: array
+            name: x-requested-with
+            value: auth v1
+          - _fromType: array
+            name: accept
+            value: "*/*"
+          - _fromType: array
+            name: content-length
+            value: "341"
+          - _fromType: array
+            name: accept-encoding
+            value: gzip,deflate
+          - name: host
+            value: sourcegraph.sourcegraph.com
+        headersSize: 425
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json; charset=utf-8
+          params: []
+          textJSON:
+            query: |-
+              
+              query CurrentUser {
+                  currentUser {
+                      id
+                      hasVerifiedEmail
+                      displayName
+                      username
+                      avatarURL
+                      primaryEmail {
+                          email
+                      }
+                      organizations {
+                          nodes {
+                              id
+                              name
+                          }
+                      }
+                  }
+              }
+            variables: {}
+        queryString:
+          - name: CurrentUser
+            value: null
+        url: https://sourcegraph.sourcegraph.com/.api/graphql?CurrentUser
+      response:
+        bodySize: 228
+        content:
+          encoding: base64
+          mimeType: application/json
+          size: 228
+          text: "[\"H4sIAAAAAAAAAzSOuwrCQBBF/2XqLawXLO0kgpggiMWQncTRzWyY2Qgx7L9LfJTncricB\
+            QJmBL9AO6mS5NpIV+QAHppzFdt72hxOjy04uKE1pNwxhd2AHMF3GI0cBLYx4lzhQOBl\
+            itHBZKTyYWhTmDNZZunBAT4xo9bH/d8clQfU+ff43ZL2KPzCzElszZEUyMBfrqWU8gY\
+            AAP//AwAAXh5NtQAAAA==\"]"
+          textDecoded:
+            data:
+              currentUser:
+                avatarURL: null
+                displayName: null
+                hasVerifiedEmail: false
+                id: VXNlcjo0OTk=
+                organizations:
+                  nodes: []
+                primaryEmail: null
+                username: codytesting
+        cookies: []
+        headers:
+          - name: date
+            value: Thu, 30 Jan 2025 08:57:58 GMT
+          - name: content-type
+            value: application/json
+          - name: transfer-encoding
+            value: chunked
+          - name: connection
+            value: close
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache, max-age=0
+          - name: vary
+            value: Accept-Encoding, Authorization, Cookie, Authorization, X-Requested-With,
+              Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+          - name: content-encoding
+            value: gzip
+        headersSize: 1419
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: 2025-01-30T08:57:58.078Z
+      time: 347
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 347
+    - _id: 7a3c4ac24a98ecb58b4610a5ba34a76c
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 101
+        cookies: []
+        headers:
+          - _fromType: array
+            name: authorization
+            value: token
+              REDACTED_1858aad0e1ff07ae26d4042086acb9da455866ad617afd2cb9ab9419e1be1104
+          - _fromType: array
+            name: content-type
+            value: application/json; charset=utf-8
+          - _fromType: array
+            name: user-agent
+            value: auth/v1 (Node.js v20.4.0)
+          - _fromType: array
+            name: x-requested-with
+            value: auth v1
+          - _fromType: array
+            name: accept
+            value: "*/*"
+          - _fromType: array
+            name: content-length
+            value: "101"
+          - _fromType: array
+            name: accept-encoding
+            value: gzip,deflate
+          - name: host
+            value: sourcegraph.sourcegraph.com
+        headersSize: 432
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json; charset=utf-8
+          params: []
+          textJSON:
+            query: |-
+              
+              query SiteProductVersion {
+                  site {
+                      productVersion
+                  }
+              }
+            variables: {}
+        queryString:
+          - name: SiteProductVersion
+            value: null
+        url: https://sourcegraph.sourcegraph.com/.api/graphql?SiteProductVersion
+      response:
+        bodySize: 139
+        content:
+          encoding: base64
+          mimeType: application/json
+          size: 139
+          text: "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqzixJBdEFRfkppcklYalFxZn5eUpWSsYGlpYmxvFGB\
+            kamugaGusYG8WZ6BrqpqcmGlsnJ5saG5kZKtbW1AAAAAP//\",\"AwA9O5uJSQAAAA==\
+            \"]"
+        cookies: []
+        headers:
+          - name: date
+            value: Thu, 30 Jan 2025 08:57:58 GMT
+          - name: content-type
+            value: application/json
+          - name: transfer-encoding
+            value: chunked
+          - name: connection
+            value: close
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache, max-age=0
+          - name: vary
+            value: Accept-Encoding, Authorization, Cookie, Authorization, X-Requested-With,
+              Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+          - name: content-encoding
+            value: gzip
+        headersSize: 1419
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: 2025-01-30T08:57:58.549Z
+      time: 229
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 229
+    - _id: 58db5729e7d9b6a2c9f5fd6d707dfc97
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 92
+        cookies: []
+        headers:
+          - _fromType: array
+            name: authorization
+            value: token
+              REDACTED_1858aad0e1ff07ae26d4042086acb9da455866ad617afd2cb9ab9419e1be1104
+          - _fromType: array
+            name: content-type
+            value: application/json; charset=utf-8
+          - _fromType: array
+            name: user-agent
+            value: auth/v1 (Node.js v20.4.0)
+          - _fromType: array
+            name: x-requested-with
+            value: auth v1
+          - _fromType: array
+            name: accept
+            value: "*/*"
+          - _fromType: array
+            name: content-length
+            value: "92"
+          - _fromType: array
+            name: accept-encoding
+            value: gzip,deflate
+          - name: host
+            value: sourcegraph.sourcegraph.com
+        headersSize: 427
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json; charset=utf-8
+          params: []
+          textJSON:
+            query: |
+              
+              query ViewerSettings {
+                viewerSettings {
+                  final
+                }
+              }
+            variables: {}
+        queryString:
+          - name: ViewerSettings
+            value: null
+        url: https://sourcegraph.sourcegraph.com/.api/graphql?ViewerSettings
+      response:
+        bodySize: 679
+        content:
+          encoding: base64
+          mimeType: application/json
+          size: 679
+          text: "[\"H4sIAAAAAAAA/9STsY4rNRSGX+VgGlZKJtKlQZHQVYQIuwVXywZEkdnC8ZzMWPH4jHyOZ\
+            3ZulI6enoaWR4DX4QXgEZA9CVnYCwVUt3Djc85v//9nH1WlRavlUfUWBwwbFLG+5rSz\
+            t147tVTHUhmqxsKTWINcquX2WKoDjqValkqQ08R8p73HMD/gOP+4VLNStcisa8xNXze\
+            WwTJoMJGFWpi6QRotoJ2jgaHV4VDR4AvYNBQF0hICaRA+owphgzqYBgR1W+QDxIqb5G\
+            9xnMGGYjBYB901H5Tq9DgrFT51GGyLXrRbo5YY8vUnQ/gleSsUrK+/xd0t0SHVJEScT\
+            Ybf/H+/52Y417If5OQtgMfhksalPGnOgPUIjU3da3T2CfYhNxWwvdVdN0JDzlZ65MeP\
+            GpGOl4vFMAzFSFHiDgtD7WLQYprX/aeff1K3q4cv+nt3dwNl6WHlK+AOjdUO+HnO/xa\
+            vfVe4+/j27bi2vsKwcu4ancdh0npAjk7W1gkGvtce/7mJv7m71jgXvooYxjvfRcl36F\
+            /lS/HzoVVdB6y1WPKJ0l47xlMS/wu4ynJrme0uuzmf4cjkuQkpdS8I/vrdL7/9/D2sA\
+            sJIERzRIYHcUwDr90GDNgaZM9FAceeQGyKBLtDOYcuv4d6hZoTeshXY1rTgV3PqzsyW\
+            i8WfOzdZ1eOTAAt2XMADatNcwGw/rCybyDw3jmJ11Ujc+cqlYKfNIdNPGdkeefFi8gb\
+            sPhvyiBU06LqiVKfZ8W+JNNTii0h+//GHn+ANCU7fVtIbr7BzNKYfBo1m6ILttSCk7w\
+            U6PTX0bMX2eH7qGDjlR6HNh8E8e6+wJZ5BNyUWGWGbtorn7gy1V9vvqt6A9Syoq4uj/\
+            wb+fXL5eFKn0+mPAAAA///s90ktxAUAAA==\"]"
+          textDecoded:
+            data:
+              viewerSettings:
+                final: "{\"cody.notices\":[{\"key\":\"testing-banner-key-3\",\"message\":\"This
+                  is a custom banner that allows markdown. Shout out to the Code
+                  Search team.\",\"title\":\"Hey,
+                  Sourcegraph!\"}],\"experimentalFeatures\":{\"codeMonitoringWe\
+                  bHooks\":true,\"codyNotices\":[{\"key\":\"testing-banner-key-3\
+                  \",\"message\":\"This is testing message to test our new
+                  custom message banner, say hi to Felix from me. [Happy
+                  holidays](https://www.youtube.com/watch?v=E8gmARGvPlI) \\n And
+                  special shout out to Search team.\",\"title\":\"Hi
+                  Sourcegraph!\"}],\"fuzzyFinderAll\":true,\"newSearchResultFil\
+                  tersPanel\":true,\"newSearchResultsUI\":true,\"searchQueryInp\
+                  ut\":\"v2\",\"searchResultsAggregations\":false},\"notices\":\
+                  [{\"dismissible\":true,\"location\":\"top\",\"message\":\"ℹ️
+                  Are you looking for infra access to troubleshoot problems?
+                  Please visit [go/s2-ops](http://go/s2-ops) for next steps.
+                  Reach out to
+                  [#discuss-cloud-ops](https://sourcegraph.slack.com/archives/d\
+                  iscuss-cloud-ops) if you need
+                  help.\"},{\"location\":\"home\",\"message\":\"🚨 Note that
+                  this deployment has private code and sensitive customers
+                  information - for demos, please use
+                  [demo.sourcegraph.com](https://demo.sourcegraph.com)
+                  instead.\"},{\"dismissible\":true,\"location\":\"top\",\"mess\
+                  age\":\"🚨 Note that this deployment has private code and
+                  sensitive customers information - for demos, please use
+                  [demo.sourcegraph.com](https://demo.sourcegraph.com)
+                  instead.\"}]}"
+        cookies: []
+        headers:
+          - name: date
+            value: Thu, 30 Jan 2025 08:57:59 GMT
+          - name: content-type
+            value: application/json
+          - name: content-length
+            value: "679"
+          - name: connection
+            value: close
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache, max-age=0
+          - name: content-encoding
+            value: gzip
+          - name: vary
+            value: Accept-Encoding, Authorization, Cookie, Authorization, X-Requested-With,
+              Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+        headersSize: 1412
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: 2025-01-30T08:57:59.059Z
+      time: 317
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 317
+    - _id: 088f4011556a3aad423d546bd2bd19fe
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 0
+        cookies: []
+        headers:
+          - _fromType: array
+            name: authorization
+            value: token
+              REDACTED_1858aad0e1ff07ae26d4042086acb9da455866ad617afd2cb9ab9419e1be1104
+          - _fromType: array
+            name: user-agent
+            value: auth/v1 (Node.js v20.4.0)
+          - _fromType: array
+            name: x-requested-with
+            value: auth v1
+          - _fromType: array
+            name: accept
+            value: "*/*"
+          - _fromType: array
+            name: accept-encoding
+            value: gzip,deflate
+          - name: host
+            value: sourcegraph.sourcegraph.com
+        headersSize: 320
+        httpVersion: HTTP/1.1
+        method: GET
+        queryString: []
+        url: https://sourcegraph.sourcegraph.com/.api/modelconfig/supported-models.json
+      response:
+        bodySize: 1423
+        content:
+          encoding: base64
+          mimeType: text/plain; charset=utf-8
+          size: 1423
+          text: "[\"H4sIAAAAAAAA/+yc0W+juBPH3/tXWHn6/XRrapzS7vHW7W7vVnfdVteqp9PpHhyYJFYIR\
+            sYkrVb9309AQpPgBNMNTXIhTwhmxgN8+NrGQ76fIIRQJ/aGMGaPIGMuwo6LOrZFOh/y\
+            YxImfL6bWMQiP/kwmR+MpJhwH2TccdHf2a70973Yyoy4n/qyUA2liLg38y0O+zyOAvb\
+            8jY0htbss7Aqzlw+bQ/e5hKmQo7gi9HVhZxx6IMQggIq4v+RGxkFFBCHjFUFvIwgvv5\
+            oHHfNYSRZURL2ZWRmHZRLXvnPo01+3vy00kW39M0NmLHwINvKSWfwB/SVqXJcSeoZtg\
+            il1XS9giQ+4ix0cizAEhQOmIFYVGV5lbqhrOeg+c0P/+wbT/696ZQnMfUyb8ljEejzg\
+            isPy2RUW4PNVr9xzyLT7Z8+d5ogSIliAeOHyLqSjYCDkc3YRPS+RzHteTTlWTCVpsul\
+            Wr4y54iCz50tC6ZgnQgVP6k8e+mLacVfuYX4Z2dPXMErUgxhBmDZz5hBCNKczZk+3iV\
+            qyJIQs2b2sNA+x4mOmwL9J79WViJU+hyTkKns6lBjpriQvEryDMMxvXVebpHjN8NXUd\
+            lbzNHiw1vPdxeQcE3uBbxElVao2hxrdamz1KKdRcfo8EUp/3jLIxlQKNQT5ViQjKY6I\
+            yBQzUyQvtoukTnKHjI+S2or7a+plKrWbmti+0tbU0zgC8FsxLR3XomtObtNaOtQBuE5\
+            Ma9Cas5rJaZdc7EpO9wLKi4NgkjrG/Tt1mkTSmo8p645b2xGrD5GE1KXE/JEK7T6NWg\
+            vwMlE8p6Rhvtc10xLeEj7Lc8uE15LtWlAvIr2/s7MWzn2C016Ek1q2GZcaQx2SGrOjg\
+            /AwxrUfzRmkZw0zaNjlawz1DG67b28ZPHwGi3Uf153YrhsrJj3hl+/WCnr3iskrnd0S\
+            eWujVYPHEiU8MY4CUHBgE3hKzj4aQUad850xRs0R2ypgPkAUA4xwxgWeUBxwBbjH4qo\
+            Vws8A0T3ACD1S9DtXgD5pfJbwY54nklDFp7FIpAcDyaLhab52dlojjxbWJmA1BdWY02\
+            YwnXSNsSxZ6mEsWiqhWG6rGr16HXH1jBmeIpB8DKEqr4P/h6Yl+01fqifpyCvGPvRZE\
+            lRNki8TJb6k9qgoz0Cf9Z7LI0PhP+NsD06bxHmbRTLrWt+RIL4nmjZt0axEcyZbWcdp\
+            DmrmjQrZzEaR6JFuFs96re4I0B4o1vBie8ulOZdJyPscfDyQLEwCJrHP+/2mAN0w1Hx\
+            NbdLFAQ8BBzCBAAciHGAFclxk6sfpQDQdg2LAduS0XB8f13m1ZA71AMY85Ni2HKy5zq\
+            sVlJkxsi0H3ZWNl2jdHPe93gr1WMBCb/dToAN5O26bL7n/6MtxDYPUIrgfsHiI4SkyI\
+            5FaBF2nLujLhpGbDsyNje176dKRzKB6NdC9WJOmFt4uKaW6HQnNiDIX0Wud+ToZ1cY+\
+            qrKlFsXijBdQzD9TmFWBEpqt7wwihc8qe/O7B43RMn7aOAddr9EWLC9W2JmvhjeHKU4\
+            lzohVraUGWK3dHlN77Opar8jeFNnz7QObvc1MccCRhAmHKSakqowj/0IMiYoqDpPI7/\
+            +ufsq4Cni5KPU49bLOBx7nTQimjpLSW6N1/FWrp1H4FsLDKWGjTXXaWCWyZzTARA86y\
+            3KnrY94MOVDW2LwMKqH7JoTnEYY7FqOMYVdyzHkcG3UPZlptyS+VQx/uJRy4RP7OY02\
+            pheuKyEGJr0hnpVBToWo+sD/HjwJCmVXZCOTJrHfv0fePCOBUIGMJNfUOb1l3YaQt6N\
+            4srw1/3eD2aLuzQ==\",\"/E8OXvPIL9Xbvgnr9Fmsrsz8S585poMvuMrX1Wb/41Gjr\
+            u0kP8eXk38DAAD//7i8tOQrRAAA\"]"
+        cookies: []
+        headers:
+          - name: date
+            value: Thu, 30 Jan 2025 08:57:59 GMT
+          - name: content-type
+            value: text/plain; charset=utf-8
+          - name: content-length
+            value: "1423"
+          - name: connection
+            value: close
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache, max-age=0
+          - name: content-encoding
+            value: gzip
+          - name: vary
+            value: Accept-Encoding, Authorization, Cookie, Authorization, X-Requested-With,
+              Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+        headersSize: 1422
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: 2025-01-30T08:57:59.382Z
+      time: 263
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 263
   pages: []
   version: "1.2"

--- a/agent/recordings/unauthed_2245427793/recording.har.yaml
+++ b/agent/recordings/unauthed_2245427793/recording.har.yaml
@@ -771,114 +771,6 @@ log:
         send: 0
         ssl: -1
         wait: 267
-    - _id: fbb23499ae0eec5c2e188687b429531b
-      _order: 0
-      cache: {}
-      request:
-        bodySize: 0
-        cookies: []
-        headers:
-          - name: accept
-            value: "*/*"
-          - name: accept-encoding
-            value: gzip,deflate
-          - name: authorization
-            value: token
-              REDACTED_fc324d3667e841181b0779375f26dedc911d26b303d23b29b1a2d7ee63dc77eb
-          - name: connection
-            value: close
-          - name: user-agent
-            value: unauthed/v1 (Node.js v20.10.0)
-          - name: x-requested-with
-            value: unauthed v1
-          - name: host
-            value: sourcegraph.com
-        headersSize: 324
-        httpVersion: HTTP/1.1
-        method: GET
-        queryString: []
-        url: https://sourcegraph.com/.api/modelconfig/supported-models.json
-      response:
-        bodySize: 1803
-        content:
-          encoding: base64
-          mimeType: text/plain; charset=utf-8
-          size: 1803
-          text: "[\"H4sIAAAAAAAA/+ycQXPaOBTH7/0UGk67sxWVBQ5Zbm263e3MpslsMtnDTg/CfoAGY3kkm\
-            ZDp5Lvv2AYTsMByAgUP7sm1/+/pgX486UlyfrxDCKGW8sYwZQ8gFRdhq49aTpu03mfP\
-            JMz48jZpkzb5zYfZ8mEkxYz7IFWrj/5LbyX/fuRXqYj7iS0L9ViKiHsL2/yxz1UUsKd\
-            vbAqJ7mOuy2XP73e7HnIJj0JOVInrL7nO2vVIiFEAJX7/zETWTkUEIeMlTm8iCD9+tX\
-            c65UpLFpR4vV6oVm7Tq++L/pwKH4KdnZkq/oHhWpf2+5TQLnYIprTf9wIW+4A72MVKh\
-            CFoHDANSpeEdpWaoU7bRXepGfrlGzz+ummVBrC0sW3KYxEb8IBrDuufLleAzzetMssx\
-            M95f/CjWHnwvtKphJORT+l15XiyZ97QZmdJMx0lMydWgiJrmIFPGJRSeeSLUMNf/8tA\
-            Xj63+Rldl3xabfw2jWN+LCYRJM12XEGL4PFM2v4n1mpIQsqZ73mgelOZTpsG/TrrkSi\
-            htjiEOuU4J1WJi+ip5HuAthGHWQx1jkGIV4UrquJtxWvxmtmPcweQCE+cFxiKKyzLLk\
-            l10Y9CaiU284uRnQyj9fc+8WlMp9Bjka5GMpDgjIhPMbJHs7RdJU2YdMz6JKyfWvxIr\
-            24y6q4mfBaiKAPwmZxaeGwm1B/TQKXNs4mxbzqwAZYZkmjU7pHfWUPZqwSR1rYdx6h4\
-            SyfZyhlh1Fno2808fIgmJSQHtM82npzQHzflKc98FJQfGeFszDcgNyG8CuVISrsTuS3\
-            JPt6Rq4DwlOJ2XcNK2Y8elQWhC0iA7OwjrMUu9tGeQdg/MoOXIbhCaGdz3EN4wWH8G8\
-            w2Tfn/m9PtKM+kJv9hbG+jdaSavTLo18rZ6KwePxVp4YhoFoKFm5Tgl3UsryKh7cbxq\
-            3B6xvQLmA0QKYIJTLvCM4oBrwAOmyrbWPgNEdwAT9EDR31wD+mSwWcOPeZ6IQ60+KBF\
-            LD0aSReMP2b7WhwpxNLAeAlZbUK053SumSY8mY5/CPgxZHJSVKR9jLf5I9CjfWUafzZ\
-            brY7Pwn3B6BydN4qzNPJhtrR8JSZhHIPkUQl3cXd43mA492lhdHzQXOWyRvSwYTQ1Rn\
-            krTIRw90Fen0RfBqCSMLp00zJqEZ8ZsdlgmA3YEUx5y7LRdbNgn3jxAk4qR03bRbVG8\
-            xuVuvz+rthmwgIXe8QfymqzxOPbbQG9d4tnC4DBgamxP4ReTfBuHRt9ntRd5RAwHFTD\
-            sbQnTCGKHFEKtiOLiRF7G4pTPk//gy3lvgHmotIy9svnldWaDLue9T3aDdT5rWA7VVs\
-            2Ws1pDJuux6uNWOLJxCBgpfQWNlL4dx10NNyuUue6UWHXsl4+cN64frdG6KjeW+MwKt\
-            cvWynxJ7V7KnRBGmEQOHWJPTAc8BH9HSE3pc0alT3akf3Fak9B0S2cUadwtLX1u7w2i\
-            9amm0U8dTmI054dfnoSzz55vnXlupxEnVYsVkkalgUuj7vhwnsQctCZoOtbV+cX+uUw\
-            Xw5Nex5GEGYdHTEjZOYzs3SgknKVN+XJ7WQv7roHKk+Mj4zrgxbOi55keq7xecXGI/G\
-            iipGyaueKwNFlauW8grM9ZNHqoMRrrWA6spo3o3qQsjtFmj7WpsvfEYE2K7IpLlAdhs\
-            NN2rSnstF1LDrd6PZG18obE1ybDHefR0g==\",\"q+Xr5YtN4uvlW+arSLOefN1rPK0\
-            hU/rKzr7wZloyMMNVtgiz+CsHFQ4vvcs+4/O7/wMAAP//tB2mgElBAAA=\"]"
-        cookies: []
-        headers:
-          - name: date
-            value: Thu, 12 Dec 2024 15:50:09 GMT
-          - name: content-type
-            value: text/plain; charset=utf-8
-          - name: transfer-encoding
-            value: chunked
-          - name: connection
-            value: close
-          - name: access-control-allow-credentials
-            value: "true"
-          - name: access-control-allow-origin
-            value: ""
-          - name: cache-control
-            value: no-cache, max-age=0
-          - name: content-encoding
-            value: gzip
-          - name: observed-calculated-ip-from-forwarded-for
-            value: 80.82.18.146
-          - name: observed-x-forwarded-for
-            value: 80.82.18.146
-          - name: vary
-            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
-              X-Requested-With,Cookie
-          - name: x-content-type-options
-            value: nosniff
-          - name: x-frame-options
-            value: DENY
-          - name: x-xss-protection
-            value: 1; mode=block
-          - name: strict-transport-security
-            value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1434
-        httpVersion: HTTP/1.1
-        redirectURL: ""
-        status: 200
-        statusText: OK
-      startedDateTime: 2024-12-12T15:50:08.622Z
-      time: 1096
-      timings:
-        blocked: -1
-        connect: -1
-        dns: -1
-        receive: 0
-        send: 0
-        ssl: -1
-        wait: 1096
     - _id: 773f06f412e7171a41a163edff09aae3
       _order: 0
       cache: {}
@@ -968,6 +860,102 @@ log:
         send: 0
         ssl: -1
         wait: 460
+    - _id: 5d0e29776bf0857beffb22b778ce488b
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 136
+        cookies: []
+        headers:
+          - _fromType: array
+            name: authorization
+            value: token
+              REDACTED_1858aad0e1ff07ae26d4042086acb9da455866ad617afd2cb9ab9419e1be1104
+          - _fromType: array
+            name: content-type
+            value: application/json; charset=utf-8
+          - _fromType: array
+            name: user-agent
+            value: unauthed/v1 (Node.js v20.4.0)
+          - _fromType: array
+            name: x-requested-with
+            value: unauthed v1
+          - _fromType: array
+            name: accept
+            value: "*/*"
+          - _fromType: array
+            name: content-length
+            value: "136"
+          - _fromType: array
+            name: accept-encoding
+            value: gzip,deflate
+          - name: host
+            value: sourcegraph.sourcegraph.com
+        headersSize: 443
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json; charset=utf-8
+          params: []
+          textJSON:
+            query: >
+              
+              query CodeSearchEnabled {
+                  codeSearchEnabled: enterpriseLicenseHasFeature(feature:"code-search")
+              }
+            variables: {}
+        queryString:
+          - name: CodeSearchEnabled
+            value: null
+        url: https://sourcegraph.sourcegraph.com/.api/graphql?CodeSearchEnabled
+      response:
+        bodySize: 35
+        content:
+          mimeType: application/json
+          size: 35
+          text: "{\"data\":{\"codeSearchEnabled\":true}}"
+        cookies: []
+        headers:
+          - name: date
+            value: Thu, 30 Jan 2025 13:51:03 GMT
+          - name: content-type
+            value: application/json
+          - name: content-length
+            value: "35"
+          - name: connection
+            value: close
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache, max-age=0
+          - name: vary
+            value: Accept-Encoding, Authorization, Cookie, Authorization, X-Requested-With,
+              Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+        headersSize: 1387
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: 2025-01-30T13:51:03.514Z
+      time: 250
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 250
     - _id: 58da5ef844152e12a476118b9211dca4
       _order: 0
       cache: {}
@@ -1536,72 +1524,114 @@ log:
         send: 0
         ssl: -1
         wait: 351
-    - _id: 088f4011556a3aad423d546bd2bd19fe
+    - _id: 58db5729e7d9b6a2c9f5fd6d707dfc97
       _order: 0
       cache: {}
       request:
-        bodySize: 0
+        bodySize: 92
         cookies: []
         headers:
-          - name: accept
-            value: "*/*"
-          - name: accept-encoding
-            value: gzip,deflate
-          - name: authorization
+          - _fromType: array
+            name: authorization
             value: token
               REDACTED_1858aad0e1ff07ae26d4042086acb9da455866ad617afd2cb9ab9419e1be1104
-          - name: connection
-            value: close
-          - name: user-agent
-            value: unauthed/v1 (Node.js v20.10.0)
-          - name: x-requested-with
+          - _fromType: array
+            name: content-type
+            value: application/json; charset=utf-8
+          - _fromType: array
+            name: user-agent
+            value: unauthed/v1 (Node.js v20.4.0)
+          - _fromType: array
+            name: x-requested-with
             value: unauthed v1
+          - _fromType: array
+            name: accept
+            value: "*/*"
+          - _fromType: array
+            name: content-length
+            value: "92"
+          - _fromType: array
+            name: accept-encoding
+            value: gzip,deflate
           - name: host
             value: sourcegraph.sourcegraph.com
-        headersSize: 348
+        headersSize: 439
         httpVersion: HTTP/1.1
-        method: GET
-        queryString: []
-        url: https://sourcegraph.sourcegraph.com/.api/modelconfig/supported-models.json
+        method: POST
+        postData:
+          mimeType: application/json; charset=utf-8
+          params: []
+          textJSON:
+            query: |
+              
+              query ViewerSettings {
+                viewerSettings {
+                  final
+                }
+              }
+            variables: {}
+        queryString:
+          - name: ViewerSettings
+            value: null
+        url: https://sourcegraph.sourcegraph.com/.api/graphql?ViewerSettings
       response:
-        bodySize: 1220
+        bodySize: 679
         content:
           encoding: base64
-          mimeType: text/plain; charset=utf-8
-          size: 1220
-          text: "[\"H4sIAAAAAAAA/+yb0W/iuBPH3/tXWDz9fro1dQxp9/LW697erXTdVteq93DaB5NMwSLEk\
-            e3QVqv+7yc7kBZiGqcLSxHwFCXfGQ/4w0yccb4fIYRQR8UjmLBbkIqLrBOhTtAlnQ/l\
-            NQlTPj9NuqRLfklgOr+YSzHlCUjVidC/9pT5fK+OrIgnxpZleiRFzuOZbXU54SpP2eN\
-            XNgGjO6t0lezpw+uu77iEeyHHqsH150rn7XooxDCFBr9/lCJvpyKHjPEGp5c5ZGdf/J\
-            1OuNKSpQ1eL2aqZ7f26NtsPicigfTVybSKv+FuYUqjiBLaxwHBlEZRnLIiAdzDIVYiy\
-            0DjlGlQuiG0c2uGet0QXVsz9L+vcP//ZSsbwNzGd6iY5WzAU645LH67SgEJX7YqLUfM\
-            eX72p1i48K02qoahkI/2t4rjQrL4cTkypZkuTEzmaFBHTXOQlnEJtWuxyDQ86H94loj\
-            7TrQ0VeWvxR6+ZHmhb8QYMjNMPySEOL7PhD1cFnpBSQhZ0D0tDQ9K8wnTkFyYKTkXSr\
-            tjKDKuLaFajF0/Ja8CvIIsK2eo5wxSPEf4LA3C5Tg9/jOrMe5hcoJJ8AJjkRdNmWXOL\
-            rp0aN3EGq/Y/G0Ipb+umVdvKoUegXwrkrkUe0SkwcwXydP1IunKrCPGx0XrxPqnsfLN\
-            qK8N8bMAVTlAcsiZtetOQv0B3XTKHLk4W5UzW0BZImmzZo+c7jWUpzvBJA29yzgNN4l\
-            kd36H2PYudG/uPxPIJRiTGtp7mk/f0z1oxZfNfSeUbBjjVcMcQD6A/EMgt0rCrdh9Se\
-            77XVId4HxPcAYv4aTdwI9Lh9CFpEO2dxDuxl3qR38GaX/DDHpWdofQzeC6S/iBwd1ns\
-            GqYRNE0iCKlmYxFUp+tJfSuNZPnLt0CeSu9NYPHCi1iMclT0LBjy3FK+h+9IKPhyfZW\
-            4/6IrRWwBCBXAGNsucBTilOuAQ+YamqtfQLIrwHG6Jaiv7gG9JvDZgE/FseiyLQ6VqK\
-            QMQwly0fHZV/ruEUcB1g3AasvqN6crhVTM6Om9imcwB0r0qZlylmhxe9Gj6rOMvrktl\
-            yszSJ5xPYMNkPicswqmFWjbwlJeMhB8glkut5dXjeYAd1ard4dNGc5bJa9PBi1hqhKp\
-            baEo1v65jT6IhhlwujT8YFZl3DPmC03y5TADmHCM46DbogdfeLlDTRWjIJuiK7q4gUu\
-            X/f7s9Y2A5ayLN5+Id+RZzyBfxvoRx/xrGDwLmVq5E/hZ5d8FYdO33vVi9wihoMWGJ6\
-            uCNMJYo/UQm2JYrnNb7aDg1D7mGeYa9xvTIdXNw7RIn5OP7vQnTnsKXrZHfd/9r05Gr\
-            HJZF5IOpUOLp267cO577my3XY3XzJP1s+lXSCbWce5hCmHe0xIU2+m3C+NRDC3aV6CN\
-            43QTGy7Wt2cHO8Z1ymv7x/Zz/TYZsvlySbyo4uS2rJ5JYeNydLL/QHC3elP003VaKwL\
-            OfC6bUQ3LmW9Rrs97kxvcE0M7kZrMGi5bNkIg71u6E1hrxt6crjS6ztZPx9IfGsyfKV\
-            HbY/mr5zNHhxfzN88e460nMm3be3t3DGlz/3sa7vVTWGG8/KZ9OzNxxYNzaPyOz4d/R\
-            cAAP//5Zc8gF05AAA=\"]"
+          mimeType: application/json
+          size: 679
+          text: "[\"H4sIAAAAAAAA/9STsY4rNRSGX+VgGlZKJtKlQZHQVYQIuwVXywZEkdnC8ZzMWPH4jHyOZ\
+            3ZulI6enoaWR4DX4QXgEZA9CVnYCwVUt3Djc85v//9nH1WlRavlUfUWBwwbFLG+5rSz\
+            t147tVTHUhmqxsKTWINcquX2WKoDjqValkqQ08R8p73HMD/gOP+4VLNStcisa8xNXze\
+            WwTJoMJGFWpi6QRotoJ2jgaHV4VDR4AvYNBQF0hICaRA+owphgzqYBgR1W+QDxIqb5G\
+            9xnMGGYjBYB901H5Tq9DgrFT51GGyLXrRbo5YY8vUnQ/gleSsUrK+/xd0t0SHVJEScT\
+            Ybf/H+/52Y417If5OQtgMfhksalPGnOgPUIjU3da3T2CfYhNxWwvdVdN0JDzlZ65MeP\
+            GpGOl4vFMAzFSFHiDgtD7WLQYprX/aeff1K3q4cv+nt3dwNl6WHlK+AOjdUO+HnO/xa\
+            vfVe4+/j27bi2vsKwcu4ancdh0npAjk7W1gkGvtce/7mJv7m71jgXvooYxjvfRcl36F\
+            /lS/HzoVVdB6y1WPKJ0l47xlMS/wu4ynJrme0uuzmf4cjkuQkpdS8I/vrdL7/9/D2sA\
+            sJIERzRIYHcUwDr90GDNgaZM9FAceeQGyKBLtDOYcuv4d6hZoTeshXY1rTgV3PqzsyW\
+            i8WfOzdZ1eOTAAt2XMADatNcwGw/rCybyDw3jmJ11Ujc+cqlYKfNIdNPGdkeefFi8gb\
+            sPhvyiBU06LqiVKfZ8W+JNNTii0h+//GHn+ANCU7fVtIbr7BzNKYfBo1m6ILttSCk7w\
+            U6PTX0bMX2eH7qGDjlR6HNh8E8e6+wJZ5BNyUWGWGbtorn7gy1V9vvqt6A9Syoq4uj/\
+            wb+fXL5eFKn0+mPAAAA///s90ktxAUAAA==\"]"
+          textDecoded:
+            data:
+              viewerSettings:
+                final: "{\"cody.notices\":[{\"key\":\"testing-banner-key-3\",\"message\":\"This
+                  is a custom banner that allows markdown. Shout out to the Code
+                  Search team.\",\"title\":\"Hey,
+                  Sourcegraph!\"}],\"experimentalFeatures\":{\"codeMonitoringWe\
+                  bHooks\":true,\"codyNotices\":[{\"key\":\"testing-banner-key-3\
+                  \",\"message\":\"This is testing message to test our new
+                  custom message banner, say hi to Felix from me. [Happy
+                  holidays](https://www.youtube.com/watch?v=E8gmARGvPlI) \\n And
+                  special shout out to Search team.\",\"title\":\"Hi
+                  Sourcegraph!\"}],\"fuzzyFinderAll\":true,\"newSearchResultFil\
+                  tersPanel\":true,\"newSearchResultsUI\":true,\"searchQueryInp\
+                  ut\":\"v2\",\"searchResultsAggregations\":false},\"notices\":\
+                  [{\"dismissible\":true,\"location\":\"top\",\"message\":\"ℹ️
+                  Are you looking for infra access to troubleshoot problems?
+                  Please visit [go/s2-ops](http://go/s2-ops) for next steps.
+                  Reach out to
+                  [#discuss-cloud-ops](https://sourcegraph.slack.com/archives/d\
+                  iscuss-cloud-ops) if you need
+                  help.\"},{\"location\":\"home\",\"message\":\"🚨 Note that
+                  this deployment has private code and sensitive customers
+                  information - for demos, please use
+                  [demo.sourcegraph.com](https://demo.sourcegraph.com)
+                  instead.\"},{\"dismissible\":true,\"location\":\"top\",\"mess\
+                  age\":\"🚨 Note that this deployment has private code and
+                  sensitive customers information - for demos, please use
+                  [demo.sourcegraph.com](https://demo.sourcegraph.com)
+                  instead.\"}]}"
         cookies: []
         headers:
           - name: date
-            value: Fri, 13 Dec 2024 09:42:43 GMT
+            value: Thu, 30 Jan 2025 13:51:03 GMT
           - name: content-type
-            value: text/plain; charset=utf-8
+            value: application/json
           - name: content-length
-            value: "1220"
+            value: "679"
           - name: connection
             value: close
           - name: access-control-allow-credentials
@@ -1612,10 +1642,6 @@ log:
             value: no-cache, max-age=0
           - name: content-encoding
             value: gzip
-          - name: observed-calculated-ip-from-forwarded-for
-            value: 34.117.155.115
-          - name: observed-x-forwarded-for
-            value: 80.82.18.146, 172.68.159.58, 34.117.155.115
           - name: vary
             value: Accept-Encoding, Authorization, Cookie, Authorization, X-Requested-With,
               Cookie
@@ -1627,13 +1653,13 @@ log:
             value: 1; mode=block
           - name: strict-transport-security
             value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1377
+        headersSize: 1412
         httpVersion: HTTP/1.1
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-12-13T09:42:42.827Z
-      time: 321
+      startedDateTime: 2025-01-30T13:51:03.493Z
+      time: 297
       timings:
         blocked: -1
         connect: -1
@@ -1641,6 +1667,115 @@ log:
         receive: 0
         send: 0
         ssl: -1
-        wait: 321
+        wait: 297
+    - _id: 088f4011556a3aad423d546bd2bd19fe
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 0
+        cookies: []
+        headers:
+          - _fromType: array
+            name: authorization
+            value: token
+              REDACTED_1858aad0e1ff07ae26d4042086acb9da455866ad617afd2cb9ab9419e1be1104
+          - _fromType: array
+            name: user-agent
+            value: unauthed/v1 (Node.js v20.4.0)
+          - _fromType: array
+            name: x-requested-with
+            value: unauthed v1
+          - _fromType: array
+            name: accept
+            value: "*/*"
+          - _fromType: array
+            name: accept-encoding
+            value: gzip,deflate
+          - name: host
+            value: sourcegraph.sourcegraph.com
+        headersSize: 328
+        httpVersion: HTTP/1.1
+        method: GET
+        queryString: []
+        url: https://sourcegraph.sourcegraph.com/.api/modelconfig/supported-models.json
+      response:
+        bodySize: 1423
+        content:
+          encoding: base64
+          mimeType: text/plain; charset=utf-8
+          size: 1423
+          text: "[\"H4sIAAAAAAAA/+yc0W+juBPH3/tXWHn6/XRrapzS7vHW7W7vVnfdVteqp9PpHhyYJFYIR\
+            sYkrVb9309AQpPgBNMNTXIhTwhmxgN8+NrGQ76fIIRQJ/aGMGaPIGMuwo6LOrZFOh/y\
+            YxImfL6bWMQiP/kwmR+MpJhwH2TccdHf2a70973Yyoy4n/qyUA2liLg38y0O+zyOAvb\
+            8jY0htbss7Aqzlw+bQ/e5hKmQo7gi9HVhZxx6IMQggIq4v+RGxkFFBCHjFUFvIwgvv5\
+            oHHfNYSRZURL2ZWRmHZRLXvnPo01+3vy00kW39M0NmLHwINvKSWfwB/SVqXJcSeoZtg\
+            il1XS9giQ+4ix0cizAEhQOmIFYVGV5lbqhrOeg+c0P/+wbT/696ZQnMfUyb8ljEejzg\
+            isPy2RUW4PNVr9xzyLT7Z8+d5ogSIliAeOHyLqSjYCDkc3YRPS+RzHteTTlWTCVpsul\
+            Wr4y54iCz50tC6ZgnQgVP6k8e+mLacVfuYX4Z2dPXMErUgxhBmDZz5hBCNKczZk+3iV\
+            qyJIQs2b2sNA+x4mOmwL9J79WViJU+hyTkKns6lBjpriQvEryDMMxvXVebpHjN8NXUd\
+            lbzNHiw1vPdxeQcE3uBbxElVao2hxrdamz1KKdRcfo8EUp/3jLIxlQKNQT5ViQjKY6I\
+            yBQzUyQvtoukTnKHjI+S2or7a+plKrWbmti+0tbU0zgC8FsxLR3XomtObtNaOtQBuE5\
+            Ma9Cas5rJaZdc7EpO9wLKi4NgkjrG/Tt1mkTSmo8p645b2xGrD5GE1KXE/JEK7T6NWg\
+            vwMlE8p6Rhvtc10xLeEj7Lc8uE15LtWlAvIr2/s7MWzn2C016Ek1q2GZcaQx2SGrOjg\
+            /AwxrUfzRmkZw0zaNjlawz1DG67b28ZPHwGi3Uf153YrhsrJj3hl+/WCnr3iskrnd0S\
+            eWujVYPHEiU8MY4CUHBgE3hKzj4aQUad850xRs0R2ypgPkAUA4xwxgWeUBxwBbjH4qo\
+            Vws8A0T3ACD1S9DtXgD5pfJbwY54nklDFp7FIpAcDyaLhab52dlojjxbWJmA1BdWY02\
+            YwnXSNsSxZ6mEsWiqhWG6rGr16HXH1jBmeIpB8DKEqr4P/h6Yl+01fqifpyCvGPvRZE\
+            lRNki8TJb6k9qgoz0Cf9Z7LI0PhP+NsD06bxHmbRTLrWt+RIL4nmjZt0axEcyZbWcdp\
+            DmrmjQrZzEaR6JFuFs96re4I0B4o1vBie8ulOZdJyPscfDyQLEwCJrHP+/2mAN0w1Hx\
+            NbdLFAQ8BBzCBAAciHGAFclxk6sfpQDQdg2LAduS0XB8f13m1ZA71AMY85Ni2HKy5zq\
+            sVlJkxsi0H3ZWNl2jdHPe93gr1WMBCb/dToAN5O26bL7n/6MtxDYPUIrgfsHiI4SkyI\
+            5FaBF2nLujLhpGbDsyNje176dKRzKB6NdC9WJOmFt4uKaW6HQnNiDIX0Wud+ToZ1cY+\
+            qrKlFsXijBdQzD9TmFWBEpqt7wwihc8qe/O7B43RMn7aOAddr9EWLC9W2JmvhjeHKU4\
+            lzohVraUGWK3dHlN77Opar8jeFNnz7QObvc1MccCRhAmHKSakqowj/0IMiYoqDpPI7/\
+            +ufsq4Cni5KPU49bLOBx7nTQimjpLSW6N1/FWrp1H4FsLDKWGjTXXaWCWyZzTARA86y\
+            3KnrY94MOVDW2LwMKqH7JoTnEYY7FqO\",\"MYVdyzHkcG3UPZlptyS+VQx/uJRy4RP\
+            7OY02pheuKyEGJr0hnpVBToWo+sD/HjwJCmVXZCOTJrHfv0fePCOBUIGMJNfUOb1l3Y\
+            aQt6N4srw1/3eD2aLuzfxPDl7zyC/V274J6/RZrK7M/EufOaaDL7jK19Vm/+NRo67tJ\
+            D/Hl5N/AwAA//+4vLTkK0QAAA==\"]"
+        cookies: []
+        headers:
+          - name: date
+            value: Thu, 30 Jan 2025 13:51:29 GMT
+          - name: content-type
+            value: text/plain; charset=utf-8
+          - name: content-length
+            value: "1423"
+          - name: connection
+            value: close
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache, max-age=0
+          - name: content-encoding
+            value: gzip
+          - name: vary
+            value: Accept-Encoding, Authorization, Cookie, Authorization, X-Requested-With,
+              Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+        headersSize: 1422
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: 2025-01-30T13:51:29.234Z
+      time: 235
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 235
   pages: []
   version: "1.2"

--- a/agent/src/auth.test.ts
+++ b/agent/src/auth.test.ts
@@ -1,5 +1,5 @@
 import path from 'node:path'
-import { ModelTag, ModelUsage } from '@sourcegraph/cody-shared'
+import { ModelTag, ModelUsage, toModelRefStr } from '@sourcegraph/cody-shared'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 import {
     TESTING_CREDENTIALS,
@@ -126,22 +126,22 @@ describe(
             // Test things that should work when re-authenticated.
 
             // Chats should work, and it should use the default model.
-            // const chat = await client.sendSingleMessageToNewChatWithFullTranscript(
-            //     'hello after reauthentication'
-            // )
-            // expect(chat.lastMessage?.model).toBe(
-            //     FIXTURE_MODELS.differentFromDotcomAndS2DefaultChatModel[0]
-            // )
-            // expect(chat.lastMessage?.error).toBe(undefined)
+            const chat = await client.sendSingleMessageToNewChatWithFullTranscript(
+                'hello after reauthentication'
+            )
+            expect(chat.lastMessage?.model).toBe(
+                FIXTURE_MODELS.differentFromDotcomAndS2DefaultChatModel[0]
+            )
+            expect(chat.lastMessage?.error).toBe(undefined)
 
-            // // Listing models should work.
-            // const { models } = await client.request('chat/models', { modelUsage: ModelUsage.Chat })
-            // expect(models.length).toBeGreaterThanOrEqual(2)
-            // expect(models.map(({ model }) => model.id)).toContain('openai::2024-02-01::gpt-4o') // arbitrary model that we expect to be included
+            // Listing models should work.
+            const { models } = await client.request('chat/models', { modelUsage: ModelUsage.Chat })
+            expect(models.length).toBeGreaterThanOrEqual(2)
+            expect(models.map(({ model }) => model.id)).toContain('openai::2024-02-01::gpt-4o') // arbitrary model that we expect to be included
         })
 
         // Skipped this test because of flakiness.
-        it.skip('switches to a different account', async ({ task }) => {
+        it('switches to a different account', async ({ task }) => {
             // Re-authenticate to a different endpoint so we can switch from it. It is important to
             // do this even if the preceding test does it because we might not be running the prior
             // tests or we might be running with `repeats > 0`.
@@ -191,19 +191,19 @@ describe(
                 )
             ).rejects.toThrow(`No panel with ID ${preChatID}`)
             // Chats should work, and it should use the default model.
-            // const chat = await client.sendSingleMessageToNewChatWithFullTranscript(
-            //     'hello after switching accounts'
-            // )
+            const chat = await client.sendSingleMessageToNewChatWithFullTranscript(
+                'hello after switching accounts'
+            )
 
-            // expect(chat.lastMessage?.model).toBe(FIXTURE_MODELS.defaultS2ChatModel)
-            // expect(chat.lastMessage?.error).toBeUndefined()
+            expect(chat.lastMessage?.model).toBe(FIXTURE_MODELS.defaultS2ChatModel)
+            expect(chat.lastMessage?.error).toBeUndefined()
 
-            // // Listing models should work.
-            // const { models } = await client.request('chat/models', { modelUsage: ModelUsage.Chat })
-            // expect(models.length).toBeGreaterThanOrEqual(2)
-            // expect(models.map(({ model }) => toModelRefStr(model.modelRef!))).toContain(
-            //     'openai::2024-02-01::gpt-4o' // arbitrary model that we expect to be included
-            // )
+            // Listing models should work.
+            const { models } = await client.request('chat/models', { modelUsage: ModelUsage.Chat })
+            expect(models.length).toBeGreaterThanOrEqual(2)
+            expect(models.map(({ model }) => toModelRefStr(model.modelRef!))).toContain(
+                'openai::2024-02-01::gpt-4o' // arbitrary model that we expect to be included
+            )
         })
     }
 )

--- a/jetbrains/src/integrationTest/resources/recordings/integration-test_2927926756/recording.har.yaml
+++ b/jetbrains/src/integrationTest/resources/recordings/integration-test_2927926756/recording.har.yaml
@@ -5,75 +5,6 @@ log:
     name: Polly.JS
     version: 6.0.6
   entries:
-    - _id: 6e977d3842ddb417bf941a0f568426d9
-      _order: 0
-      cache: {}
-      request:
-        bodySize: 20
-        cookies: []
-        headers:
-          - name: content-type
-            value: application/json
-          - name: authorization
-            value: token
-              REDACTED_fc324d3667e841181b0779375f26dedc911d26b303d23b29b1a2d7ee63dc77eb
-          - name: user-agent
-            value: OTel-OTLP-Exporter-JavaScript/0.45.1
-          - name: host
-            value: sourcegraph.com
-        headersSize: 253
-        httpVersion: HTTP/1.1
-        method: POST
-        postData:
-          mimeType: application/json
-          params: []
-          textJSON:
-            resourceSpans: []
-        queryString: []
-        url: https://sourcegraph.com/-/debug/otlp/v1/traces
-      response:
-        bodySize: 21
-        content:
-          mimeType: application/json
-          size: 21
-          text: "{\"partialSuccess\":{}}"
-        cookies: []
-        headers:
-          - name: date
-            value: Tue, 28 Jan 2025 08:20:46 GMT
-          - name: content-type
-            value: application/json
-          - name: content-length
-            value: "21"
-          - name: connection
-            value: keep-alive
-          - name: cache-control
-            value: no-cache, max-age=0
-          - name: vary
-            value: Cookie,Authorization,Cookie,Cookie
-          - name: x-content-type-options
-            value: nosniff
-          - name: x-frame-options
-            value: DENY
-          - name: x-xss-protection
-            value: 1; mode=block
-          - name: strict-transport-security
-            value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1181
-        httpVersion: HTTP/1.1
-        redirectURL: ""
-        status: 200
-        statusText: OK
-      startedDateTime: 2025-01-28T08:20:45.420Z
-      time: 656
-      timings:
-        blocked: -1
-        connect: -1
-        dns: -1
-        receive: 0
-        send: 0
-        ssl: -1
-        wait: 656
     - _id: 897d3731ab8e15a1549f29445eafd1e1
       _order: 0
       cache: {}
@@ -102,25 +33,25 @@ log:
             value: gzip,deflate
           - name: host
             value: sourcegraph.com
-        headersSize: 358
+        headersSize: 431
         httpVersion: HTTP/1.1
         method: GET
         queryString: []
         url: https://sourcegraph.com/.api/client-config
       response:
-        bodySize: 238
+        bodySize: 227
         content:
           encoding: base64
           mimeType: text/plain; charset=utf-8
-          size: 238
-          text: "[\"H4sIAAAAAAAAAwAA\",\"AP//\",\"bI6xCsIwFEX3fkXo7OzQrQSHboWCzq/miYG8vJJ\
-            3g4r47y4Vl8zn3MN9d8451181vE6Z1sShHxxK5cMO7oQmoAr1KlticHtZDSpeRSgHaz\
-            eAEteKqPnPb5TsJ5hQgdcMfuISc9BHsyMaONk4T+1KIrBhqdumBRz211GzLShMMs7Tm\
-            YtFzf3gjt2n+wIAAP//AwAQiC5yFQEAAA==\"]"
+          size: 227
+          text: "[\"H4sIAAAAAAAAA2w=\",\"jrEKwjAURfd+Rejs7NCtBIduhYLOr+aJgby8kneDivjvLhWX\
+            zOfcw313zjnXXzW8TpnWxKEfHErlww7uhCagCvUqW2Jwe1kNKl5FKAdrN4AS14qo+c9\
+            vlOwnmFCB1wx+4hJz0EezIxo42ThP7UoisGGp26YFHPbXUbMtKEwyztOZi0XN/eCO3a\
+            f7AgAA//8DABCILnIVAQAA\"]"
         cookies: []
         headers:
           - name: date
-            value: Tue, 28 Jan 2025 08:20:41 GMT
+            value: Thu, 30 Jan 2025 15:44:38 GMT
           - name: content-type
             value: text/plain; charset=utf-8
           - name: transfer-encoding
@@ -151,8 +82,8 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2025-01-28T08:20:40.382Z
-      time: 668
+      startedDateTime: 2025-01-30T15:44:38.028Z
+      time: 219
       timings:
         blocked: -1
         connect: -1
@@ -160,7 +91,7 @@ log:
         receive: 0
         send: 0
         ssl: -1
-        wait: 668
+        wait: 219
     - _id: c7327f699da3de5388b86581bd3a348b
       _order: 0
       cache: {}
@@ -178,7 +109,7 @@ log:
           - name: content-type
             value: application/json
           - name: traceparent
-            value: 00-281dd0cc0c0cf441f73b35a696500eda-67580a8fa83c34ce-01
+            value: 00-6ff01464128b700623cd38bd8c9a457b-983a2580d9c9bdb5-01
           - name: user-agent
             value: jetbrains/6.0-localbuild (Node.js v20.12.2)
           - name: x-requested-with
@@ -290,14 +221,14 @@ log:
             value: 6.0-localbuild
         url: https://sourcegraph.com/.api/completions/stream?api-version=2&client-name=jetbrains&client-version=6.0-localbuild
       response:
-        bodySize: 781
+        bodySize: 814
         content:
           mimeType: text/event-stream
-          size: 781
+          size: 814
           text: >+
             event: completion
 
-            data: {"deltaText":"\n/**\n * The `foo()` method generates a Fibonacci sequence and prints the first 10 numbers in the sequence.\n */\n","stopReason":"stop_sequence"}
+            data: {"deltaText":"\n/**\n * Generates a Fibonacci sequence of 10 numbers and prints them to the console.\n * The sequence starts with 0 and 1, and each subsequent number is the sum of the previous two.\n */\n","stopReason":"stop_sequence"}
 
 
             event: done
@@ -307,7 +238,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Tue, 28 Jan 2025 08:20:45 GMT
+            value: Thu, 30 Jan 2025 15:44:41 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
@@ -336,8 +267,8 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2025-01-28T08:20:44.067Z
-      time: 1721
+      startedDateTime: 2025-01-30T15:44:39.544Z
+      time: 1696
       timings:
         blocked: -1
         connect: -1
@@ -345,7 +276,7 @@ log:
         receive: 0
         send: 0
         ssl: -1
-        wait: 1721
+        wait: 1696
     - _id: f1b1cde4cd57488b7f0137954f0302f5
       _order: 0
       cache: {}
@@ -403,7 +334,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Tue, 28 Jan 2025 08:20:43 GMT
+            value: Thu, 30 Jan 2025 15:44:39 GMT
           - name: content-type
             value: application/json
           - name: content-length
@@ -432,8 +363,8 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2025-01-28T08:20:42.524Z
-      time: 661
+      startedDateTime: 2025-01-30T15:44:38.856Z
+      time: 234
       timings:
         blocked: -1
         connect: -1
@@ -441,7 +372,7 @@ log:
         receive: 0
         send: 0
         ssl: -1
-        wait: 661
+        wait: 234
     - _id: a376faab1c8a1993bb48c745757f0a4a
       _order: 0
       cache: {}
@@ -512,7 +443,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Tue, 28 Jan 2025 08:20:41 GMT
+            value: Thu, 30 Jan 2025 15:44:38 GMT
           - name: content-type
             value: application/json
           - name: transfer-encoding
@@ -543,8 +474,8 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2025-01-28T08:20:41.102Z
-      time: 720
+      startedDateTime: 2025-01-30T15:44:38.263Z
+      time: 351
       timings:
         blocked: -1
         connect: -1
@@ -552,7 +483,7 @@ log:
         receive: 0
         send: 0
         ssl: -1
-        wait: 720
+        wait: 351
     - _id: 0484c4d780805faf3dd3ddabae814640
       _order: 0
       cache: {}
@@ -606,18 +537,18 @@ log:
             value: null
         url: https://sourcegraph.com/.api/graphql?CurrentSiteCodyLlmConfiguration
       response:
-        bodySize: 143
+        bodySize: 139
         content:
           encoding: base64
           mimeType: application/json
-          size: 143
-          text: "[\"H4sIAAAAAAAAAwAAAP//\",\"qlZKSSxJVLKqVirOLEkF0cn5KZU+Pr7O+XlpmemlRYkl\
-            mfl5YPncxKIS5/y8ktSKkvDMvJT8ciUrpZTM4sSknNQUpdra2loAAAAA//8DACsw2fR\
-            MAAAA\"]"
+          size: 139
+          text: "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqzixJBdHJ+SmVPj6+zvl5aZnppUWJJZn5eWD53MSiE\
+            uf8vJLUipLwzLyU/HIlK6WUzOLEpJzUFKXa2tpaAAAAAP//\",\"AwArMNn0TAAAAA==\
+            \"]"
         cookies: []
         headers:
           - name: date
-            value: Tue, 28 Jan 2025 08:20:41 GMT
+            value: Thu, 30 Jan 2025 15:44:38 GMT
           - name: content-type
             value: application/json
           - name: transfer-encoding
@@ -648,8 +579,8 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2025-01-28T08:20:41.141Z
-      time: 721
+      startedDateTime: 2025-01-30T15:44:38.308Z
+      time: 271
       timings:
         blocked: -1
         connect: -1
@@ -657,7 +588,7 @@ log:
         receive: 0
         send: 0
         ssl: -1
-        wait: 721
+        wait: 271
     - _id: e141c56e63809042300db9bf8551d492
       _order: 0
       cache: {}
@@ -726,7 +657,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Tue, 28 Jan 2025 08:20:41 GMT
+            value: Thu, 30 Jan 2025 15:44:38 GMT
           - name: content-type
             value: application/json
           - name: transfer-encoding
@@ -757,8 +688,8 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2025-01-28T08:20:41.123Z
-      time: 707
+      startedDateTime: 2025-01-30T15:44:38.285Z
+      time: 288
       timings:
         blocked: -1
         connect: -1
@@ -766,7 +697,7 @@ log:
         receive: 0
         send: 0
         ssl: -1
-        wait: 707
+        wait: 288
     - _id: 5b9030a4e18d1e000c71d6000a7cef6f
       _order: 0
       cache: {}
@@ -831,21 +762,33 @@ log:
             value: null
         url: https://sourcegraph.com/.api/graphql?CurrentUser
       response:
-        bodySize: 387
+        bodySize: 376
         content:
           encoding: base64
           mimeType: application/json
-          size: 387
-          text: "[\"H4sIAAAAAAAAAwAAAP//\",\"ZE/LTsJAFP2Xu25pDVHaSUgUBBdo4yM0GOPidnppp4+Z\
-            Og8Umv47aTBx4e6cnMe9p4ccLQLrgTutSdqtIT1SkQODdJc0vFKn5P7l6qnic/CgRJO\
-            SFntB+apF0QCz2pEHuTBdg8cEWwIGb8ppToXGrlwo68dhGIIHzpCWF4P5M2TKxrW/l9\
-            +tAw/wgBb19vURGJTWdoYFQVNOJ4VSRUNjA1fSkrQTrtoAg7tlESm+WeNX9k5uUWfVd\
-            b5enX6ibJdGOBNTk2abZfKczh5CdzzUcxPf+Bw86LRoUR9/R/RAF/Dvs9tiFMZrMHig\
-            dIFSnNAKJc0YkyonA+zjcxiG4QwAAP//AwBKjJM/TgEAAA==\"]"
+          size: 376
+          text: "[\"H4sIAAAAAAAAA2RPy07CQBT9l7tuaQ1R2klIFAQXaOMjNBjj4nZ6aaePmToPFJr+O2kwc\
+            eHunJzHvaeHHC0C64E7rUnarSE9UpEDg3SXNLxSp+T+5eqp4nPwoESTkhZ7QfmqRdEA\
+            s9qRB7kwXYPHBFsCBm/KaU6Fxq5cKOvHYRiCB86QlheD+TNkysa1v5ffrQMP8IAW9fb\
+            1ERiU1naGBUFTTieFUkVDYwNX0pK0E67aAIO7ZREpvlnjV/ZOblFn1XW+Xp1+omyXRj\
+            gTU5Nmm2XynM4eQnc81HMT3/gcPOi0aFEff0f0QBfw77PbYhTGazB4oHSBUpzQCiXNG\
+            JMqJwPs43MYhuEMAAD//wMASoyTP04BAAA=\"]"
+          textDecoded:
+            data:
+              currentUser:
+                avatarURL: https://lh3.googleusercontent.com/a/ACg8ocKFaqbYeuBkbj5dFEzx8bXV8a7i3sVbKCNPV7G0uyvk=s96-c
+                displayName: SourcegraphBot-9000
+                hasVerifiedEmail: true
+                id: VXNlcjozNDQ1Mjc=
+                organizations:
+                  nodes: []
+                primaryEmail:
+                  email: sourcegraphbot9k@gmail.com
+                username: sourcegraphbot9k-fnwmu
         cookies: []
         headers:
           - name: date
-            value: Tue, 28 Jan 2025 08:20:40 GMT
+            value: Thu, 30 Jan 2025 15:44:38 GMT
           - name: content-type
             value: application/json
           - name: transfer-encoding
@@ -876,8 +819,8 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2025-01-28T08:20:39.681Z
-      time: 689
+      startedDateTime: 2025-01-30T15:44:37.705Z
+      time: 288
       timings:
         blocked: -1
         connect: -1
@@ -885,7 +828,7 @@ log:
         receive: 0
         send: 0
         ssl: -1
-        wait: 689
+        wait: 288
     - _id: aef0c9fe7483280d9c05ac8e97e37571
       _order: 0
       cache: {}
@@ -964,7 +907,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Tue, 28 Jan 2025 08:20:42 GMT
+            value: Thu, 30 Jan 2025 15:44:38 GMT
           - name: content-type
             value: application/json
           - name: transfer-encoding
@@ -995,8 +938,8 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2025-01-28T08:20:41.174Z
-      time: 780
+      startedDateTime: 2025-01-30T15:44:38.374Z
+      time: 359
       timings:
         blocked: -1
         connect: -1
@@ -1004,7 +947,7 @@ log:
         receive: 0
         send: 0
         ssl: -1
-        wait: 780
+        wait: 359
     - _id: 4504fab53d7cb602861f73dc2aa883d2
       _order: 0
       cache: {}
@@ -1056,22 +999,21 @@ log:
             value: null
         url: https://sourcegraph.com/.api/graphql?SiteProductVersion
       response:
-        bodySize: 144
+        bodySize: 136
         content:
           encoding: base64
           mimeType: application/json
-          size: 144
-          text: "[\"H4sIAAAAAAAAAwAAAP//qlZKSSxJVLKqVirOLEkF0QVF+SmlySVhqUXFmfl5SlZKxgaWZ\
-            kYG8UYGRqa6Boa6RhbxpnqGhrpmJmYmSQbmxslp5uZKtbW1AAAAAP//AwDNL2nYSgAA\
-            AA==\"]"
+          size: 136
+          text: "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqzixJBdEFRfkppcklYalFxZn5eUpWSsYGlhYGRvFGB\
+            kamugaGukaW8aZ6hoa6lkYmxkbmyQaWxoYGSrW1tQAAAAD//wMAIDp+ikoAAAA=\"]"
           textDecoded:
             data:
               site:
-                productVersion: 309620_2025-01-28_5.11-6464b073cf77
+                productVersion: 309802_2025-01-29_5.11-924327c09310
         cookies: []
         headers:
           - name: date
-            value: Tue, 28 Jan 2025 08:20:41 GMT
+            value: Thu, 30 Jan 2025 15:44:38 GMT
           - name: content-type
             value: application/json
           - name: transfer-encoding
@@ -1102,8 +1044,8 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2025-01-28T08:20:41.159Z
-      time: 667
+      startedDateTime: 2025-01-30T15:44:38.347Z
+      time: 238
       timings:
         blocked: -1
         connect: -1
@@ -1111,7 +1053,7 @@ log:
         receive: 0
         send: 0
         ssl: -1
-        wait: 667
+        wait: 238
     - _id: fd0fee4687419870bc82cba9d1023319
       _order: 0
       cache: {}
@@ -1184,7 +1126,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Tue, 28 Jan 2025 08:20:43 GMT
+            value: Thu, 30 Jan 2025 15:44:39 GMT
           - name: content-type
             value: application/json
           - name: transfer-encoding
@@ -1215,8 +1157,8 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2025-01-28T08:20:42.496Z
-      time: 704
+      startedDateTime: 2025-01-30T15:44:38.820Z
+      time: 262
       timings:
         blocked: -1
         connect: -1
@@ -1224,7 +1166,7 @@ log:
         receive: 0
         send: 0
         ssl: -1
-        wait: 704
+        wait: 262
     - _id: fbb23499ae0eec5c2e188687b429531b
       _order: 0
       cache: {}
@@ -1256,45 +1198,45 @@ log:
         queryString: []
         url: https://sourcegraph.com/.api/modelconfig/supported-models.json
       response:
-        bodySize: 1947
+        bodySize: 1982
         content:
           encoding: base64
           mimeType: text/plain; charset=utf-8
-          size: 1947
-          text: "[\"H4sIAAAAAAAA/+ycUW/bNhCA3/srCD9tWKlSdJRkfmvTdiuwtMVadA/DHmjpbBORSIGiH\
-            AdF//sgyVZsi7aoRK4tWHlypLvjSfx8PJJHf3+BEEKDxJ9BxL6BSrgUgxEauA4ZvCzu\
-            KZjz1WXiEIf8FsB8dTNWcs4DUMlghP7NL2V/38tPuRAPMl0m9EzJmPtL3fJ2wJM4ZA8\
-            fWQSZ3OtSrhT78XK/6QlXcC/VXVJj+n0pZ216KuU0hBq7fxRC1kZlDILxGqOfYhCvP9\
-            gbjXiiFQtrrN4upR7N5p/+W/ZnJAMI93ZmLvE3TDa6dDSihF5gl2BKRyM/ZGkAeIg9n\
-            EghQOOQaUh0jWs3uRoaOh76kquhXz7C/a/bWrkDKx3bpnwWszEPueaw+XSlBAR8W6vQ\
-            nDHj9eWXwnBHSxmuEbb2etfc0TCV6iF/ib6fKuY/bLucaKbTzNns07jKoOagcvgVVO7\
-            5UmhY6H+4COT9YLTVh8VrZIsPIk71V3kHImvmwiOEGB4nYotPqd6QJIRsyP3Yah4SzS\
-            OmIbjN+upGJtrsQyq4ztHV8s70Jnnp4GcQoui6odFJ+ejho6jrbftp8WXazfcQk0tM3\
-            DW+ZZzWhZwV1OiTQdaMcmYVZ98nQunvLYNsTaXUM1BPRTJW8oyIzDCzRfKqXSRNIXfG\
-            +F3aOOL+mWnZhtp9TbQfaRvG0yQGCPpgWrlvRNee3EPH0pkJwF3BtAGtBat5OB2Sq2O\
-            F05OA8qoTTFLPenyn3iGRdFY5ZdO8tc9YA4gVZCoV5s800J5S1lqClwfFS0oOzPeuZn\
-            rCe8KXfrZMeKOw3QjqdaRPd3bWw3lKcLrrcFLHtePSIGhC0iB2dhB2I6+9tmeQXhyYQ\
-            csh3yBoZrDtsb1nsPsMlpsyo9HcHY0SzZQvg2pvbaH3RTN1Y5LbIG+ntXrwWKqlL6M4\
-            BA0dm8BTcnFtBRn1Lo/GGLVHrFXAAoA4AbjDORd4TnHINeAxS+q2794CxF8A7tA3iv7\
-            iGtAbg84Gfsz3ZSp08iqRqfJhqlg8e1Xsnb1q4EcP6yFgtQXVmtNWMc16NBv7EhzAhK\
-            Vh3TTldarlu0welbvX6K1Zc3NslsEDzq/grElctFk6s6v1IyEJixgUj0Do6g5222C69\
-            GhjdXfQXMawPHTZg5prozKe5uM4+kb3x9JmrR4J0DFoduDtzp5Ley5TwSccAjxVTKQh\
-            Uzjgk8mhAN0z2D+6Nh/ikAvAIcwhxKEUU6xBRaWnQZKlAlkWgAG7sddzfX5cF8VkBdR\
-            TiLjg2HU8bHjP2wVmuTByHQ99rgpv0Lrf7s+al49ZyIR//CS0I+uTrv2m53OXJw0MUo\
-            fgSciSGYZFbEcidQh6n6mgd3syNxOYexs79eKRn5mmHhHdcQN0r3a4aYR3SCquthNCc\
-            6Lsg+h7k/iuMGq0fVaFIz2K5ROvobgsuC5YjPgi+wdfL67GmItEq9SvmzHdFjroenH1\
-            xi4DLRPjVf5p1Ww9qx1kshsL7l6D+rpDwEjpE2ik9Pk47mu43xwq5U6JVdd+5d595tL\
-            9Bq2Pc+gVPvPKhHznouiK2lbm8AKmmMQunWBfRmMuINjjUr9SekYz9+LE1rLmntB8N3\
-            0aa3xRO3P//NUgtJlqGu10ujquPx6yXs9sH1afm5LuxhRn0xkrVo2SBmCNcidM7Ulkr\
-            R1h1rVejrpsH9h85zLDAccK5hzuMSF1RXPFYVkka2rmbCy3PVuqj5b3jOuQV48AnGe8\
-            bHKc7vIQAdNESV1CWvJXHz2tzPcQdqdgmB5q0MY6VWOrBBN9NUlWB22zxc7Mx1tisCP\
-            T8YaLmQc=\",\"YXDoeNYUDh3PksOdVk9kVb0n8anBcE/RcP5p9Tsjy+Ke29XPjTx6W\
-            vTk005nDiYs0Td2+pUDx9nADDfFcs3y524aVJi+KJ7xx4v/AwAA///CksVcUkcAAA==\
-            \"]"
+          size: 1982
+          text: "[\"H4sIAAAAAAAA/w==\",\"7Jzfc9q4E8Df+1doePp+5ypXFnHI8dam7V1nLm3n2uk93NyD\
+            sBfQYEseWSZkOv3fb2yD+WGB5QQ3cDhPBO+uFvvDalda8f0FQgj1En8KEfsGKuFS9Ia\
+            o5zqk97K4pmDOV28ThzjklwDmq4uxknMegEp6Q/R3/lb29718lQvxINNlQk+VjLm/1C\
+            0vBzyJQ/bwkUWQyb0u5UqxHy8Pmx5zBfdSzZIa0+9LOWvTEyknIdTY/a0QsjYqYxCM1\
+            xj9FIN4/cHeaMQTrVhYY/VuKbU2m7/6Z/k8IxlAePBh5hJ/wnjrkQ6HlNAr7BJM6XDo\
+            hywNAPexhxMpBGgcMg2JrnHtNldDfcdDX3I19L+PcP//Xa3cgZWO7VA+i9mIh1xz2P5\
+            0pQQEfFer0Jwy4/vLL4XhipYy3CBs4/ZuuKNhItVDfhN9P1XMf9h1OdFMp5mz2atRlU\
+            HNQeXwK6hc86XQsNB/cRHI+95w5xkWt5EtPog41V/lDEQ2zJVHCDF8nIgtPqV6S5IQs\
+            iX3Y2d4SDSPmIbgLntWtzLRZh9SwXWOrpYz053kpYOfQYji0fWNTsq1h2tR19v10+LL\
+            tJ/vPibXmLgbfMs4rQs5K6jRJ4OsGeXMKs6+T4TSX48MsjWVUk9BPRbJWMkLIjLDzBb\
+            JwXGRNIXcKeOztHHE/T3Tsg21h4Y4fqRtGE+TGCDogmnluhFde3LbjqVTE4D7gmkDWg\
+            tW83DaJ4PnCqcnAeXgLJiknvX8Tr02kXRWOWXTvLXLWAOIFWQqFeYvNNCeUtZagpcHx\
+            WtKWuZ73zAd4R3hSz+PTHijsN0I6k2kT7c66+A8JTjdTTip49pxaRA0IWkQuzgIzyOv\
+            vbFnkF61zKDllG8QNDN47Lm9Y/D8GSw3ZYbDuTscJpopXwbVp7WD3hfN1K1Jbou8vdb\
+            qwWOplr6M4hA0nFkBT8nVjRVk1Lt+NsaoPWJHBSwAiBOAGc65wHOKQ64Bj1hSt333Fi\
+            D+AjBD3yj6g2tAbww6W/gx35ep0MmrRKbKh4li8fRVsXf2qoEfHaxtwGoLqjWn7WA67\
+            1tjWZE0w1iOVEGxOlY9es0m4vqKGRYxKB6B0NVN6v9QWXLa9GXxJMu8EhzAmKVhXZH8\
+            OtXyXSaPyt4J9NasuZ0ZyuAB5+/gbEhcjFk6s2/0ZwqIPxNNl3Zo1qK5DFv5xGkPaq6\
+            NyrCZZ5HoGz0cPJuN+kyAjkCzljfbOy7tuUwFH3MI8EQxkYZM4YCPx20BeiDVXLs27+\
+            OQC8AhzCHEoRQTrEFFpadBkiWiWQ6KAbux13F9eVwXrYwF1BOIuODYdTxsuM+77Y25M\
+            HIdD32uCm/Retjuz1oVGrGQCf/5S6AzWR137bfcn7o4bmCQOgSPQ5ZMMSxiOxKpQ9D7\
+            TAW9O5C5mcA8ONipty5dSAU1aoDuYI+bRnj7pOLqcUJoTpR9EH1vEt8XRo22L6ptqUO\
+            x/MQbKC7b/QsWI77I/sE3i8EIc5Folfp1FdNdoYNuFoM3j1xfshr22CtNJ8HkeWz3eA\
+            26O9uAkdJH0Ejp03E8NHC3NVnKnRKrrv2+kfvEjaMtWtc19AqfeaUg37souqL2KDW8g\
+            AkmsUvH2JfRiAsIDrjUrZReUOVenBdcnvggNO/lmMQaX9VW7p+/GoS2U02jnbPuzewO\
+            J21209uH1aempPsxxVk5Y8WqUdIArFHuhKk9iaz1TJh1rZejro8PbL5zmeGAYwVzDve\
+            YkLqWzeKoNpI1HZs2ln/+vvw94zrk1QMolxkvmxzmvG4jYJooqUtIS/7qo6eV+Q7C82\
+            lXp21N2linamSVYKKvJsnqpG22eDb1+JEYPA==\",\"k3K84WJmKwz2Hc+awr7jWXK4\
+            1+qJrKp3JD42GB5oWc9frX7lZtncc7f6sZu1p8WTfNzZ4N6YJfrWTr9y3D2bmOG2WK5\
+            Z/thSg/7mF8Vn/PHi3wAAAP//ihLRq9BJAAA=\"]"
         cookies: []
         headers:
           - name: date
-            value: Tue, 28 Jan 2025 08:20:43 GMT
+            value: Thu, 30 Jan 2025 15:44:39 GMT
           - name: content-type
             value: text/plain; charset=utf-8
           - name: transfer-encoding
@@ -1325,8 +1267,8 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2025-01-28T08:20:43.217Z
-      time: 697
+      startedDateTime: 2025-01-30T15:44:39.102Z
+      time: 265
       timings:
         blocked: -1
         connect: -1
@@ -1334,6 +1276,6 @@ log:
         receive: 0
         send: 0
         ssl: -1
-        wait: 697
+        wait: 265
   pages: []
   version: "1.2"

--- a/lib/shared/src/misc/observable.test.ts
+++ b/lib/shared/src/misc/observable.test.ts
@@ -1190,4 +1190,25 @@ describe('retry', () => {
 
         expect(results).toEqual(['value', 'completed'])
     })
+
+    test('should retry tasks with various duration', async () => {
+        vi.useFakeTimers()
+
+        let count = 0
+        const source = new Observable(observer => {
+            count++
+            const randomTimeout = Math.floor(Math.random() * 10) + 1
+            setTimeout(() => observer.error(new Error(`Test Error ${count}`)), randomTimeout)
+        })
+
+        const errors: Error[] = []
+        source.pipe(retry(100)).subscribe({
+            error: err => errors.push(err),
+        })
+
+        await vi.advanceTimersByTimeAsync(1000)
+
+        expect(errors.length).toBe(1)
+        expect(errors[0].message).toBe('Test Error 101')
+    })
 })

--- a/lib/shared/src/misc/observable.ts
+++ b/lib/shared/src/misc/observable.ts
@@ -1365,16 +1365,15 @@ export function retry<T>(count: number): (source: ObservableLike<T>) => Observab
             function subscribe() {
                 subscription = source.subscribe({
                     next(value) {
-                        observer.next(value)
-                        retries = 0
+                        if (subscription) {
+                            observer.next(value)
+                            retries = 0
+                        }
                     },
                     error(err) {
                         if (retries < count && subscription) {
                             retries++
-                            if (subscription) {
-                                unsubscribe(subscription)
-                                subscription = null
-                            }
+                            unsuscribeThis()
                             subscribe()
                         } else {
                             observer.error(err)
@@ -1388,13 +1387,15 @@ export function retry<T>(count: number): (source: ObservableLike<T>) => Observab
                 })
             }
 
-            subscribe()
-
-            return () => {
+            function unsuscribeThis() {
                 if (subscription) {
                     unsubscribe(subscription)
                     subscription = undefined
                 }
             }
+
+            subscribe()
+
+            return () => unsuscribeThis()
         })
 }

--- a/lib/shared/src/misc/observable.ts
+++ b/lib/shared/src/misc/observable.ts
@@ -1355,3 +1355,46 @@ export async function testing__firstValueFromWithinTime<T>(
     }
     return result
 }
+
+export function retry<T>(count: number): (source: ObservableLike<T>) => Observable<T> {
+    return (source: ObservableLike<T>) =>
+        new Observable<T>(observer => {
+            let retries = 0
+            let subscription: UnsubscribableLike | undefined = undefined
+
+            function subscribe() {
+                subscription = source.subscribe({
+                    next(value) {
+                        observer.next(value)
+                        retries = 0
+                    },
+                    error(err) {
+                        if (retries < count && subscription) {
+                            retries++
+                            if (subscription) {
+                                unsubscribe(subscription)
+                                subscription = null
+                            }
+                            subscribe()
+                        } else {
+                            observer.error(err)
+                        }
+                    },
+                    complete() {
+                        if (subscription) {
+                            observer.complete()
+                        }
+                    },
+                })
+            }
+
+            subscribe()
+
+            return () => {
+                if (subscription) {
+                    unsubscribe(subscription)
+                    subscription = undefined
+                }
+            }
+        })
+}

--- a/lib/shared/src/models/sync.test.ts
+++ b/lib/shared/src/models/sync.test.ts
@@ -198,6 +198,7 @@ describe('server sent models', async () => {
     const result = await firstValueFrom(
         syncModels({
             resolvedConfig: Observable.of({
+                auth: { serverEndpoint: AUTH_STATUS_FIXTURE_AUTHED.endpoint },
                 configuration: {},
                 clientState: { modelPreferences: {} },
             } satisfies PartialDeep<ResolvedConfiguration> as ResolvedConfiguration),
@@ -255,10 +256,14 @@ describe('syncModels', () => {
             const configOverwritesSubject = new Subject<CodyLLMSiteConfiguration | null>()
             const clientConfigSubject = new Subject<CodyClientConfig>()
             const syncModelsObservable = syncModels({
-                resolvedConfig: Observable.of({
-                    configuration: {},
-                    clientState: { modelPreferences: {} },
-                } satisfies PartialDeep<ResolvedConfiguration> as ResolvedConfiguration),
+                resolvedConfig: authStatusSubject.pipe(shareReplay()).map(
+                    authStatus =>
+                        ({
+                            auth: { serverEndpoint: authStatus.endpoint },
+                            configuration: {},
+                            clientState: { modelPreferences: {} },
+                        }) satisfies PartialDeep<ResolvedConfiguration> as ResolvedConfiguration
+                ),
                 authStatus: authStatusSubject.pipe(shareReplay()),
                 configOverwrites: configOverwritesSubject.pipe(shareReplay()),
                 clientConfig: clientConfigSubject.pipe(shareReplay()),
@@ -508,6 +513,7 @@ describe('syncModels', () => {
         const result = await firstValueFrom(
             syncModels({
                 resolvedConfig: Observable.of({
+                    auth: { serverEndpoint: AUTH_STATUS_FIXTURE_AUTHED.endpoint },
                     configuration: {},
                     clientState: { modelPreferences: {} },
                 } satisfies PartialDeep<ResolvedConfiguration> as ResolvedConfiguration),
@@ -600,6 +606,7 @@ describe('syncModels', () => {
             return firstValueFrom(
                 syncModels({
                     resolvedConfig: Observable.of({
+                        auth: { serverEndpoint: DOTCOM_URL.toString() },
                         configuration: {},
                         clientState: { modelPreferences: {} },
                     } satisfies PartialDeep<ResolvedConfiguration> as ResolvedConfiguration),

--- a/lib/shared/src/sourcegraph-api/clientConfig.ts
+++ b/lib/shared/src/sourcegraph-api/clientConfig.ts
@@ -10,6 +10,7 @@ import {
     filter,
     firstValueFrom,
     promiseFactoryToObservable,
+    retry,
     startWith,
     switchMap,
 } from '../misc/observable'
@@ -129,7 +130,8 @@ export class ClientConfigSingleton {
                           startWith(undefined),
                           switchMap(() =>
                               promiseFactoryToObservable(signal => this.fetchConfig(authStatus, signal))
-                          )
+                          ),
+                          retry(3)
                       )
                     : Observable.of(undefined)
             ),

--- a/vscode/src/autoedits/create-autoedits-provider.ts
+++ b/vscode/src/autoedits/create-autoedits-provider.ts
@@ -127,13 +127,6 @@ export function isUserEligibleForAutoeditsFeature(
     authStatus: AuthStatus,
     productSubscription: UserProductSubscription | null
 ): AutoeditsUserEligibilityInfo {
-    console.log({
-        autoeditsFeatureFlagEnabled,
-        isTesting: process.env.CODY_TESTING === 'true',
-        isRunningInsideAgent: isRunningInsideAgent(),
-        isFreeUser: isFreeUser(authStatus, productSubscription),
-    })
-
     // Always enable auto-edit when testing
     if (process.env.CODY_TESTING === 'true') {
         return { isUserEligible: true }


### PR DESCRIPTION
## Changes

There are two main fixes in this PR:

1. Changes in `lib/shared/src/models/sync.ts` 
They ensure we are not mixing new `config` and old `authStatus`.
Previously it was possible to get an update when `config` changed, and then execute model computation code before auth had a chance to update. This could lead to using remote models from outdated (already changed) endpoint.

2. Change in `clientConfig.ts`
Why we need a retry here? To explain it we need understand the whole control flow:

> 1. `syncModels` function takes  `clientConfig: ClientConfigSingleton.getInstance().changes` as a parameter
> 2. computation of `clientConfig` internally calls `this.fetchConfig(authStatus, signal)`
> 3. `fetchConfig` is doing an GraphQL query, and GraphQL is using cache (`GraphQLResultCache`)
> 4. That cache is invalidated when `config` changes (note it is `config`, not `clientConfig`)
> 5. Cache invalidations aborts all pending requests - sometimes also `fetchConfig` request
> 6. That results in state of `ClientConfigSingleton.getInstance().changes` being set to `undefined`
> 7. If it's undefined we do not fetch any remote models in the `syncModels`


## Test plan

I reenabled automatic tests to verify it works

![image](https://github.com/user-attachments/assets/afaad276-512b-4479-8d01-de8dbb92c276)

