### PR TITLE
Attempt at Solving Rider's IDE keybindings issues

### DIFF
--- a/jetbrains/src/main/kotlin/com/sourcegraph/cody/config/actions/WebViewBackspaceAction.kt
+++ b/jetbrains/src/main/kotlin/com/sourcegraph/cody/config/actions/WebViewBackspaceAction.kt
@@ -8,17 +8,10 @@ private val logger = Logger.getInstance(WebViewBackspaceAction::class.java)
 
 class WebViewBackspaceAction : DumbAwareEDTAction() {
     override fun actionPerformed(e: AnActionEvent) {
-        // fake print statement to prevent IDE from handling backspace
-        logger.info("CODE222: WebViewBackspaceAction actionPerformed")
-        logger.warn("Backspace Action Triggered") // Warnings are more visible in logs
-                System.out.println("Backspace pressed") // Direct console output
-
     }
 
     override fun update(e: AnActionEvent) {
         // Only enable this in webview context
-        logger.info("CODE222: WebViewBackspaceAction update")
-        logger.warn("Backspace Action Triggered") // Warnings are more visible in logs
         e.presentation.isEnabledAndVisible = false
     }
 }

--- a/jetbrains/src/main/kotlin/com/sourcegraph/cody/config/actions/WebViewBackspaceAction.kt
+++ b/jetbrains/src/main/kotlin/com/sourcegraph/cody/config/actions/WebViewBackspaceAction.kt
@@ -1,0 +1,24 @@
+package com.sourcegraph.cody.config.actions
+
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.sourcegraph.common.ui.DumbAwareEDTAction
+import com.intellij.openapi.diagnostic.Logger
+
+private val logger = Logger.getInstance(WebViewBackspaceAction::class.java)
+
+class WebViewBackspaceAction : DumbAwareEDTAction() {
+    override fun actionPerformed(e: AnActionEvent) {
+        // fake print statement to prevent IDE from handling backspace
+        logger.info("CODE222: WebViewBackspaceAction actionPerformed")
+        logger.warn("Backspace Action Triggered") // Warnings are more visible in logs
+                System.out.println("Backspace pressed") // Direct console output
+
+    }
+
+    override fun update(e: AnActionEvent) {
+        // Only enable this in webview context
+        logger.info("CODE222: WebViewBackspaceAction update")
+        logger.warn("Backspace Action Triggered") // Warnings are more visible in logs
+        e.presentation.isEnabledAndVisible = false
+    }
+}

--- a/jetbrains/src/main/kotlin/com/sourcegraph/cody/config/actions/WebViewShiftEnterAction.kt
+++ b/jetbrains/src/main/kotlin/com/sourcegraph/cody/config/actions/WebViewShiftEnterAction.kt
@@ -1,0 +1,17 @@
+package com.sourcegraph.cody.config.actions
+
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.sourcegraph.common.ui.DumbAwareEDTAction
+import com.intellij.openapi.diagnostic.Logger
+
+private val logger = Logger.getInstance(WebViewShiftEnterAction::class.java)
+
+class WebViewShiftEnterAction : DumbAwareEDTAction() {
+    override fun actionPerformed(e: AnActionEvent) {
+    }
+
+    override fun update(e: AnActionEvent) {
+        // Only enable this in webview context
+        e.presentation.isEnabledAndVisible = false
+    }
+}

--- a/jetbrains/src/main/resources/META-INF/plugin.xml
+++ b/jetbrains/src/main/resources/META-INF/plugin.xml
@@ -404,6 +404,12 @@
                     text="Webview Backspace">
                 <keyboard-shortcut first-keystroke="BACK_SPACE" keymap="$default"/>
             </action>
+            <action id="cody.webview.shiftenter"
+                    class="com.sourcegraph.cody.config.actions.WebViewShiftEnterAction"
+                    text="Webview Shift+Enter">
+                <keyboard-shortcut first-keystroke="shift ENTER" keymap="$default"/>
+                <keyboard-shortcut first-keystroke="shift ENTER" keymap="Mac OS X 10.5+"/>
+            </action>
         </group>
 
         <group id="CodyStatusBarActions" popup="true" searchable="false"

--- a/jetbrains/src/main/resources/META-INF/plugin.xml
+++ b/jetbrains/src/main/resources/META-INF/plugin.xml
@@ -398,6 +398,12 @@
                     <override-text place="GoToAction" text="Cody: Enable OffScreen Rendering"/>
                 </action>
             </group>
+
+            <action id="cody.webview.backspace"
+                    class="com.sourcegraph.cody.config.actions.WebViewBackspaceAction"
+                    text="Webview Backspace">
+                <keyboard-shortcut first-keystroke="BACK_SPACE" keymap="$default"/>
+            </action>
         </group>
 
         <group id="CodyStatusBarActions" popup="true" searchable="false"


### PR DESCRIPTION
## Problem
The JetBrains IDE was intercepting certain keyboard events (backspace and shift+enter) in the Cody chat webview before they could reach the chat interface. This caused issues with:
- Backspace not working properly for text deletion(Screenshot shows keymap specifically in rider ide that causes this behavior and removing that specific keymap solved it)

<img width="719" alt="image" src="https://github.com/user-attachments/assets/5aea3753-e038-4ddf-b807-c918b0abdb60" />

- Shift+Enter not working for multi-line input

<img width="705" alt="image" src="https://github.com/user-attachments/assets/fae6d835-b501-47a0-af78-0d3e9afe60cb" />


## Solution
Added two action handlers that intercept these keyboard events before the IDE's default handlers:

1. `WebViewBackspaceAction` - Intercepts backspace key events
2. `WebViewShiftEnterAction` - Intercepts shift+enter key events

These actions do nothing when triggered, effectively preventing the IDE from handling these keys while allowing the events to bubble down naturally to the webview. This restores expected text editing behavior in the chat interface.

## Implementation Details
- Created empty action handlers that extend `DumbAwareEDTAction`
- Registered keyboard shortcuts in plugin.xml for both default and Mac OS X keymaps
- Actions are invisible in menus but still intercept keyboard events
- Uses event bubbling to allow natural webview text handling

## Test plan

NOTE: This test is not a perfect. guarantee because I can't replicate the issue in the debugger at all because debugger has some strangeness with the Keymaps(this is despite the fact that I built the rider plugin). 

Verified that in the Cody chat webview:
- Backspace properly deletes text
- Shift+Enter creates new lines without triggering IDE actions



<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
