### PR TITLE
fix/tracing: Add Client Platform and agentVersion to traces

### DIFF
--- a/vscode/src/services/open-telemetry/CodyTraceExport.ts
+++ b/vscode/src/services/open-telemetry/CodyTraceExport.ts
@@ -9,7 +9,7 @@ const MAX_TRACE_RETAIN_MS = 60 * 1000
 export class CodyTraceExporter extends OTLPTraceExporter {
     private queuedSpans: Map<string, { span: ReadableSpan; enqueuedAt: number }> = new Map()
     private ide: CodyIDE
-    private extensionVersion?: string
+    private codyExtensionVersion?: string
     constructor(private configAccessor: () => OpenTelemetryServiceConfig | null) {
         super({
             url: configAccessor()?.traceUrl,
@@ -17,7 +17,7 @@ export class CodyTraceExporter extends OTLPTraceExporter {
             httpAgentOptions: { rejectUnauthorized: false },
         })
         this.ide = configAccessor()?.ide ?? CodyIDE.VSCode
-        this.extensionVersion = configAccessor()?.extensionVersion
+        this.codyExtensionVersion = configAccessor()?.extensionVersion
     }
 
     export(spans: ReadableSpan[], resultCallback: (result: ExportResult) => void): void {
@@ -44,7 +44,7 @@ export class CodyTraceExporter extends OTLPTraceExporter {
         for (const span of spans) {
             spanMap.set(span.spanContext().spanId, span)
             span.attributes.ide = this.ide
-            span.attributes.extensionVersion = this.extensionVersion
+            span.attributes.codyExtensionVersion = this.codyExtensionVersion
         }
 
         const spansToExport: ReadableSpan[] = []

--- a/vscode/src/services/open-telemetry/CodyTraceExport.ts
+++ b/vscode/src/services/open-telemetry/CodyTraceExport.ts
@@ -1,19 +1,23 @@
 import type { ExportResult } from '@opentelemetry/core'
 import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http'
 import type { ReadableSpan } from '@opentelemetry/sdk-trace-base'
+import { CodyIDE } from '@sourcegraph/cody-shared/src/configuration'
 import type { OpenTelemetryServiceConfig } from './OpenTelemetryService.node'
 
 const MAX_TRACE_RETAIN_MS = 60 * 1000
 
 export class CodyTraceExporter extends OTLPTraceExporter {
     private queuedSpans: Map<string, { span: ReadableSpan; enqueuedAt: number }> = new Map()
-
+    private ide: CodyIDE
+    private agentVersion?: string
     constructor(private configAccessor: () => OpenTelemetryServiceConfig | null) {
         super({
             url: configAccessor()?.traceUrl,
             headers: configAccessor()?.authHeaders,
             httpAgentOptions: { rejectUnauthorized: false },
         })
+        this.ide = configAccessor()?.ide ?? CodyIDE.VSCode
+        this.agentVersion = configAccessor()?.agentVersion
     }
 
     export(spans: ReadableSpan[], resultCallback: (result: ExportResult) => void): void {
@@ -39,6 +43,8 @@ export class CodyTraceExporter extends OTLPTraceExporter {
         const spanMap = new Map<string, ReadableSpan>()
         for (const span of spans) {
             spanMap.set(span.spanContext().spanId, span)
+            span.attributes.ide = this.ide
+            span.attributes.agentVersion = this.agentVersion
         }
 
         const spansToExport: ReadableSpan[] = []

--- a/vscode/src/services/open-telemetry/CodyTraceExport.ts
+++ b/vscode/src/services/open-telemetry/CodyTraceExport.ts
@@ -9,7 +9,7 @@ const MAX_TRACE_RETAIN_MS = 60 * 1000
 export class CodyTraceExporter extends OTLPTraceExporter {
     private queuedSpans: Map<string, { span: ReadableSpan; enqueuedAt: number }> = new Map()
     private ide: CodyIDE
-    private agentVersion?: string
+    private extensionVersion?: string
     constructor(private configAccessor: () => OpenTelemetryServiceConfig | null) {
         super({
             url: configAccessor()?.traceUrl,
@@ -17,7 +17,7 @@ export class CodyTraceExporter extends OTLPTraceExporter {
             httpAgentOptions: { rejectUnauthorized: false },
         })
         this.ide = configAccessor()?.ide ?? CodyIDE.VSCode
-        this.agentVersion = configAccessor()?.agentVersion
+        this.extensionVersion = configAccessor()?.extensionVersion
     }
 
     export(spans: ReadableSpan[], resultCallback: (result: ExportResult) => void): void {
@@ -44,7 +44,7 @@ export class CodyTraceExporter extends OTLPTraceExporter {
         for (const span of spans) {
             spanMap.set(span.spanContext().spanId, span)
             span.attributes.ide = this.ide
-            span.attributes.agentVersion = this.agentVersion
+            span.attributes.extensionVersion = this.extensionVersion
         }
 
         const spansToExport: ReadableSpan[] = []

--- a/vscode/src/services/open-telemetry/CodyTraceExportWeb.ts
+++ b/vscode/src/services/open-telemetry/CodyTraceExportWeb.ts
@@ -12,14 +12,14 @@ export class CodyTraceExporterWeb extends OTLPTraceExporter {
     private isTracingEnabled: boolean
     private queuedSpans: Map<string, { span: ReadableSpan; enqueuedAt: number }> = new Map()
     private ide: CodyIDE
-    private agentVersion?: string
+    private codyExtensionVersion?: string
     private lastExpiryCheck = 0
 
     constructor({
         isTracingEnabled,
         ide,
-        agentVersion,
-    }: { isTracingEnabled: boolean; ide: CodyIDE; agentVersion?: string }) {
+        codyExtensionVersion,
+    }: { isTracingEnabled: boolean; ide: CodyIDE; codyExtensionVersion?: string }) {
         super({
             httpAgentOptions: {
                 rejectUnauthorized: false,
@@ -30,7 +30,7 @@ export class CodyTraceExporterWeb extends OTLPTraceExporter {
         })
         this.isTracingEnabled = isTracingEnabled
         this.ide = ide
-        this.agentVersion = agentVersion
+        this.codyExtensionVersion = codyExtensionVersion
     }
 
     private removeExpiredSpans(now: number): void {
@@ -57,7 +57,7 @@ export class CodyTraceExporterWeb extends OTLPTraceExporter {
         const allSpans = [...spans, ...Array.from(this.queuedSpans.values()).map(q => q.span)]
         for (const span of allSpans) {
             span.attributes.ide = this.ide
-            span.attributes.agentVersion = this.agentVersion
+            span.attributes.codyExtensionVersion = this.codyExtensionVersion
         }
 
         // Build span hierarchy map

--- a/vscode/src/services/open-telemetry/CodyTraceExportWeb.ts
+++ b/vscode/src/services/open-telemetry/CodyTraceExportWeb.ts
@@ -11,15 +11,15 @@ const MAX_TRACE_RETAIN_MS = 60 * 1000 * 5 // 5 minutes
 export class CodyTraceExporterWeb extends OTLPTraceExporter {
     private isTracingEnabled: boolean
     private queuedSpans: Map<string, { span: ReadableSpan; enqueuedAt: number }> = new Map()
-    private clientPlatform: CodyIDE
+    private ide: CodyIDE
     private agentVersion?: string
     private lastExpiryCheck = 0
 
     constructor({
         isTracingEnabled,
-        clientPlatform,
+        ide,
         agentVersion,
-    }: { isTracingEnabled: boolean; clientPlatform: CodyIDE; agentVersion?: string }) {
+    }: { isTracingEnabled: boolean; ide: CodyIDE; agentVersion?: string }) {
         super({
             httpAgentOptions: {
                 rejectUnauthorized: false,
@@ -29,7 +29,7 @@ export class CodyTraceExporterWeb extends OTLPTraceExporter {
             },
         })
         this.isTracingEnabled = isTracingEnabled
-        this.clientPlatform = clientPlatform
+        this.ide = ide
         this.agentVersion = agentVersion
     }
 
@@ -56,7 +56,7 @@ export class CodyTraceExporterWeb extends OTLPTraceExporter {
         // Include queued spans for re-evaluation
         const allSpans = [...spans, ...Array.from(this.queuedSpans.values()).map(q => q.span)]
         for (const span of allSpans) {
-            span.attributes.clientPlatform = this.clientPlatform
+            span.attributes.ide = this.ide
             span.attributes.agentVersion = this.agentVersion
         }
 

--- a/vscode/src/services/open-telemetry/OpenTelemetryService.node.ts
+++ b/vscode/src/services/open-telemetry/OpenTelemetryService.node.ts
@@ -29,7 +29,8 @@ export interface OpenTelemetryServiceConfig {
     authHeaders: Record<string, string>
     debugVerbose: boolean
     ide: CodyIDE
-    agentVersion?: string
+    /** Version of the Cody VS Code extension (e.g. v1.66.0) */
+    extensionVersion?: string
 }
 export class OpenTelemetryService {
     private tracerProvider?: NodeTracerProvider
@@ -81,7 +82,7 @@ export class OpenTelemetryService {
                         debugVerbose: configuration.debugVerbose,
                         authHeaders: Object.fromEntries(headers.entries()),
                         ide: clientCapabilities().agentIDE,
-                        agentVersion: clientCapabilities().agentExtensionVersion,
+                        extensionVersion: clientCapabilities().agentExtensionVersion,
                     }
                     if (isEqual(this.lastConfig, newConfig)) {
                         return

--- a/vscode/src/services/open-telemetry/OpenTelemetryService.node.ts
+++ b/vscode/src/services/open-telemetry/OpenTelemetryService.node.ts
@@ -5,9 +5,11 @@ import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node'
 import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions'
 
 import {
+    type CodyIDE,
     FeatureFlag,
     type Unsubscribable,
     addAuthHeaders,
+    clientCapabilities,
     combineLatest,
     featureFlagProvider,
     resolvedConfig,
@@ -18,7 +20,6 @@ import { DiagConsoleLogger, DiagLogLevel, diag } from '@opentelemetry/api'
 import { BatchSpanProcessor } from '@opentelemetry/sdk-trace-base'
 import { externalAuthRefresh } from '@sourcegraph/cody-shared/src/configuration/auth-resolver'
 import { isEqual } from 'lodash'
-import { version } from '../../version'
 import { CodyTraceExporter } from './CodyTraceExport'
 import { ConsoleBatchSpanExporter } from './console-batch-span-exporter'
 
@@ -27,6 +28,8 @@ export interface OpenTelemetryServiceConfig {
     traceUrl: string
     authHeaders: Record<string, string>
     debugVerbose: boolean
+    ide: CodyIDE
+    agentVersion?: string
 }
 export class OpenTelemetryService {
     private tracerProvider?: NodeTracerProvider
@@ -51,7 +54,7 @@ export class OpenTelemetryService {
         this.tracerProvider = new NodeTracerProvider({
             resource: new Resource({
                 [SemanticResourceAttributes.SERVICE_NAME]: 'cody-client',
-                [SemanticResourceAttributes.SERVICE_VERSION]: version,
+                [SemanticResourceAttributes.SERVICE_VERSION]: clientCapabilities().agentExtensionVersion,
             }),
         })
         // Register once at startup
@@ -77,8 +80,9 @@ export class OpenTelemetryService {
                         traceUrl: traceUrl.toString(),
                         debugVerbose: configuration.debugVerbose,
                         authHeaders: Object.fromEntries(headers.entries()),
+                        ide: clientCapabilities().agentIDE,
+                        agentVersion: clientCapabilities().agentExtensionVersion,
                     }
-
                     if (isEqual(this.lastConfig, newConfig)) {
                         return
                     }

--- a/vscode/webviews/App.tsx
+++ b/vscode/webviews/App.tsx
@@ -163,7 +163,7 @@ export const App: React.FunctionComponent<{ vscodeAPI: VSCodeWrapper }> = ({ vsc
                 isTracingEnabled: true,
                 debugVerbose: true,
                 ide: config.clientCapabilities.agentIDE,
-                agentVersion: config.clientCapabilities.agentExtensionVersion,
+                codyExtensionVersion: config.clientCapabilities.agentExtensionVersion,
             })
         }
     }, [config, webviewTelemetryService])

--- a/vscode/webviews/App.tsx
+++ b/vscode/webviews/App.tsx
@@ -162,8 +162,8 @@ export const App: React.FunctionComponent<{ vscodeAPI: VSCodeWrapper }> = ({ vsc
             webviewTelemetryService.configure({
                 isTracingEnabled: true,
                 debugVerbose: true,
-                agentIDE: config.clientCapabilities.agentIDE,
-                extensionAgentVersion: config.clientCapabilities.agentExtensionVersion,
+                ide: config.clientCapabilities.agentIDE,
+                agentVersion: config.clientCapabilities.agentExtensionVersion,
             })
         }
     }, [config, webviewTelemetryService])

--- a/vscode/webviews/utils/webviewOpenTelemetryService.ts
+++ b/vscode/webviews/utils/webviewOpenTelemetryService.ts
@@ -2,7 +2,7 @@ import { DiagConsoleLogger, DiagLogLevel, diag } from '@opentelemetry/api'
 import { Resource } from '@opentelemetry/resources'
 import { BatchSpanProcessor, WebTracerProvider } from '@opentelemetry/sdk-trace-web'
 import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions'
-import type { CodyIDE } from '@sourcegraph/cody-shared/src/configuration'
+import { CodyIDE } from '@sourcegraph/cody-shared/src/configuration'
 import { CodyTraceExporterWeb } from '../../src/services/open-telemetry/CodyTraceExportWeb'
 
 // This class is used to initialize and manage the OpenTelemetry service for the webview.
@@ -14,8 +14,8 @@ export class WebviewOpenTelemetryService {
     private unloadInstrumentations?: () => void
     private isTracingEnabled = false
     private isInitialized = false
-    private agentIDE?: CodyIDE
-    private extensionAgentVersion?: string
+    private ide?: CodyIDE
+    private agentVersion?: string
     constructor() {
         if (!WebviewOpenTelemetryService.instance) {
             WebviewOpenTelemetryService.instance = this
@@ -26,8 +26,8 @@ export class WebviewOpenTelemetryService {
     public configure(options?: {
         isTracingEnabled?: boolean
         debugVerbose?: boolean
-        agentIDE?: CodyIDE
-        extensionAgentVersion?: string
+        ide?: CodyIDE
+        agentVersion?: string
     }): void {
         // If the service is already initialized or if it is not the instance that is being used, return
         if (this.isInitialized || WebviewOpenTelemetryService.instance !== this) {
@@ -37,12 +37,12 @@ export class WebviewOpenTelemetryService {
         const {
             isTracingEnabled = true,
             debugVerbose = false,
-            agentIDE,
-            extensionAgentVersion,
+            ide,
+            agentVersion,
         } = options || {}
         this.isTracingEnabled = isTracingEnabled
-        this.agentIDE = agentIDE
-        this.extensionAgentVersion = extensionAgentVersion
+        this.ide = ide
+        this.agentVersion = agentVersion
         const logLevel = debugVerbose ? DiagLogLevel.INFO : DiagLogLevel.ERROR
         diag.setLogger(new DiagConsoleLogger(), logLevel)
 
@@ -58,8 +58,8 @@ export class WebviewOpenTelemetryService {
                     new BatchSpanProcessor(
                         new CodyTraceExporterWeb({
                             isTracingEnabled: true,
-                            clientPlatform: this.agentIDE ?? ('defaultIDE' as CodyIDE),
-                            agentVersion: this.extensionAgentVersion,
+                            ide: this.ide ?? CodyIDE.VSCode,
+                            agentVersion: this.agentVersion,
                         })
                     )
                 )

--- a/vscode/webviews/utils/webviewOpenTelemetryService.ts
+++ b/vscode/webviews/utils/webviewOpenTelemetryService.ts
@@ -15,7 +15,7 @@ export class WebviewOpenTelemetryService {
     private isTracingEnabled = false
     private isInitialized = false
     private ide?: CodyIDE
-    private agentVersion?: string
+    private codyExtensionVersion?: string
     constructor() {
         if (!WebviewOpenTelemetryService.instance) {
             WebviewOpenTelemetryService.instance = this
@@ -27,17 +27,22 @@ export class WebviewOpenTelemetryService {
         isTracingEnabled?: boolean
         debugVerbose?: boolean
         ide?: CodyIDE
-        agentVersion?: string
+        codyExtensionVersion?: string
     }): void {
         // If the service is already initialized or if it is not the instance that is being used, return
         if (this.isInitialized || WebviewOpenTelemetryService.instance !== this) {
             return
         }
 
-        const { isTracingEnabled = true, debugVerbose = false, ide, agentVersion } = options || {}
+        const {
+            isTracingEnabled = true,
+            debugVerbose = false,
+            ide,
+            codyExtensionVersion,
+        } = options || {}
         this.isTracingEnabled = isTracingEnabled
         this.ide = ide
-        this.agentVersion = agentVersion
+        this.codyExtensionVersion = codyExtensionVersion
         const logLevel = debugVerbose ? DiagLogLevel.INFO : DiagLogLevel.ERROR
         diag.setLogger(new DiagConsoleLogger(), logLevel)
 
@@ -54,7 +59,7 @@ export class WebviewOpenTelemetryService {
                         new CodyTraceExporterWeb({
                             isTracingEnabled: true,
                             ide: this.ide ?? CodyIDE.VSCode,
-                            agentVersion: this.agentVersion,
+                            codyExtensionVersion: this.codyExtensionVersion,
                         })
                     )
                 )

--- a/vscode/webviews/utils/webviewOpenTelemetryService.ts
+++ b/vscode/webviews/utils/webviewOpenTelemetryService.ts
@@ -34,12 +34,7 @@ export class WebviewOpenTelemetryService {
             return
         }
 
-        const {
-            isTracingEnabled = true,
-            debugVerbose = false,
-            ide,
-            agentVersion,
-        } = options || {}
+        const { isTracingEnabled = true, debugVerbose = false, ide, agentVersion } = options || {}
         this.isTracingEnabled = isTracingEnabled
         this.ide = ide
         this.agentVersion = agentVersion


### PR DESCRIPTION
Part of CODY-4771. Adds agent version and ClientPlatform in OpenTelemetryService.

NOTE: the [version string](https://sourcegraph.com/github.com/sourcegraph/cody@adding-trace-versions/-/blob/vscode/src/version.ts?L11) uses pre-release and release versions properly and @abeatrix confirmed that too. The version string is what is actually the value of clientCapabilities.agentExtensionVersion

## Test plan
Tested locally with the debugger
- Run a local sourcegraph instance with `sg start`
- Run Open Telemetry Collector with `sg start otel`
- Run this branch on Cody repo  with the debugger 
<img width="731" alt="image" src="https://github.com/user-attachments/assets/f1363a2a-c563-4656-bb47-c8aa6f84be4c" />

- Make sure that the account used in Cody is local Sg instance account 
- Go to the URL `http://localhost:16686/-/debug/jaeger ` this shows you the local traces
- Checkout webview service
<img width="940" alt="image" src="https://github.com/user-attachments/assets/a3db2f1a-45d1-4f76-a082-2df3634ced0d" />

Look into your specific chat trace(which will give you Client Platform and agent Version )

<img width="474" alt="image" src="https://github.com/user-attachments/assets/f5bcb10e-e604-45bb-8601-81462b84374d" />

