### PR TITLE
feat(Smart Apply): Show Reapply for applied code blocks

### DIFF
--- a/vscode/webviews/chat/ChatMessageContent/create-buttons.ts
+++ b/vscode/webviews/chat/ChatMessageContent/create-buttons.ts
@@ -6,6 +6,7 @@ import {
     CopyCodeBlockIcon,
     EllipsisIcon,
     InsertCodeBlockIcon,
+    RefreshIcon,
     SaveCodeBlockIcon,
     SparkleIcon,
     SyncSpinIcon,
@@ -283,6 +284,22 @@ function createApplyButton(
             iconContainer.className = styles.iconContainer
             iconContainer.innerHTML = SyncSpinIcon
             button.prepend(iconContainer)
+
+            break
+        }
+        case 'Applied':
+        case 'Finished': {
+            button.innerHTML = 'Reapply'
+
+            // Add Refresh Icon
+            const iconContainer = document.createElement('div')
+            iconContainer.className = styles.iconContainer
+            iconContainer.innerHTML = RefreshIcon
+            button.prepend(iconContainer)
+
+            button.addEventListener('click', () =>
+                smartApply.onSubmit(smartApplyId, preText, humanMessage?.text, fileName)
+            )
 
             break
         }

--- a/vscode/webviews/icons/CodeBlockActionIcons.tsx
+++ b/vscode/webviews/icons/CodeBlockActionIcons.tsx
@@ -30,3 +30,5 @@ export const CloseIcon =
     '<svg role="img" width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg" fill="currentColor"><path fill-rule="evenodd" clip-rule="evenodd" d="M8 8.707l3.646 3.647.708-.707L8.707 8l3.647-3.646-.707-.708L8 7.293 4.354 3.646l-.707.708L7.293 8l-3.646 3.646.707.708L8 8.707z"/></svg>'
 
 export const TerminalIcon = '<i class="codicon codicon-terminal tw-align-middle"></i>'
+
+export const RefreshIcon = '<i class="codicon codicon-refresh tw-align-middle"></i>'


### PR DESCRIPTION
## Description

closes https://linear.app/sourcegraph/issue/CODY-4826/smart-apply-show-reapply-to-indicate-applied-state

Primary purpose of these changes:
- Give a UI indication of when a code block has already been applied and accepted. Especially useful when a user is actioning multiple code blocks in a response
- Make it obvious to the user that they can re-apply a codeblock if something went wrong, or they weren't happy with the result

https://github.com/user-attachments/assets/3c7a4094-f98c-4597-abcb-bb8897c98215


## Test plan

1. Make smart applies
2. Click "Apply"
3. Click "Accept"
4. Observe that "Reapply" appears

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
