### PR TITLE
fix(auto-edit): fix the false notification for auto-edit non eligibility

### DIFF
--- a/vscode/src/autoedits/create-autoedits-provider.ts
+++ b/vscode/src/autoedits/create-autoedits-provider.ts
@@ -102,13 +102,28 @@ export function createAutoEditsProvider({
     )
 }
 
+/**
+ * Displays an error notification to the user about non-eligibility for auto edits,
+ * but only if the user is currently in the Settings view (to avoid spamming them).
+ *
+ * This is because because of the flaky network issues we could evaluate the default feature flag value to false
+ * and show the non eligibility notification to the user even if they have access to the feature.
+ * Generally the users should see the notification only when they manully change the vscode config which could be either
+ * through the settings UI or `settings.json` file.
+ *
+ * @param {string | undefined} nonEligibilityReason - The reason why the user is currently not eligible
+ *                                                   for auto edits. If not provided, no notification occurs.
+ */
 export async function handleAutoeditsNotificationForNonEligibleUser(
     nonEligibilityReason?: string
 ): Promise<void> {
-    const switchToAutocompleteText = 'Switch to autocomplete'
+    if (!nonEligibilityReason || !isSettingsEditorOpen()) {
+        return
+    }
 
+    const switchToAutocompleteText = 'Switch to autocomplete'
     const selection = await vscode.window.showErrorMessage(
-        `Error: ${nonEligibilityReason ?? AUTOEDITS_NON_ELIGIBILITY_MESSAGES.FEATURE_FLAG_NOT_ELIGIBLE}`,
+        `Error: ${nonEligibilityReason}`,
         switchToAutocompleteText
     )
     if (selection === switchToAutocompleteText) {
@@ -120,6 +135,42 @@ export async function handleAutoeditsNotificationForNonEligibleUser(
                 vscode.ConfigurationTarget.Global
             )
     }
+}
+
+/**
+ * Checks whether the current view in VS Code is the Settings editor (JSON or UI).
+ *
+ * This function performs two checks:
+ *   1. Detect if the active text editor points to a known settings file (e.g., settings.json, settings.jsonc).
+ *   2. If there's no text editor open, examine the "Tab" label to see if it's the built-in Settings UI.
+ *
+ * Note: Using the tab's label is locale-specific; if a user runs VS Code in a non-English locale,
+ *       or if the label changes in future VS Code versions, this heuristic may fail.
+ *
+ * @returns {boolean} True if the user is most likely viewing the Settings editor (JSON or UI), false otherwise.
+ */
+function isSettingsEditorOpen(): boolean {
+    const activeEditor = vscode.window.activeTextEditor
+
+    // 1) If there's an active text editor, check if the file name matches typical settings files
+    if (activeEditor) {
+        const fsPath = activeEditor.document.uri.fsPath
+        if (fsPath.endsWith('settings.json') || fsPath.endsWith('settings.jsonc')) {
+            return true
+        }
+        return false
+    }
+
+    // 2) If there's no activeTextEditor, the user might be in the graphical Settings UI or have no editor at all
+    const activeTab = vscode.window.tabGroups.activeTabGroup?.activeTab
+    if (!activeTab) {
+        // No tab at all: definitely not a JSON settings file;
+        // could be just an empty Editor area, Start page, or something else
+        return false
+    }
+
+    // The built-in Settings UI tab typically has the label "Settings" (in English).
+    return activeTab.label === 'Settings'
 }
 
 export function isUserEligibleForAutoeditsFeature(


### PR DESCRIPTION
## Context

This PR fixes an issue where users would receive a non-eligibility notification for auto-edits even when they were in the experiment flag and it is enabled for them. This happens because of the flaky network issue, and although we get error while evaluating the feature flag, we return `false` by default. This creates noisy alerts for the users.

<img width="1054" alt="image" src="https://github.com/user-attachments/assets/fe14d5e3-1e00-4715-ab59-48693db2249f" />

To address this, I added a check that ensures the user is likely viewing the settings editor (either the JSON settings file or the graphical Settings UI) before displaying the non-eligibility notification.

## Test plan
1. Limit the networks bandwidth using charles proxy.
2. 

