### PR TITLE
fix(chat): expansion of current-tab generic mention when non editor tabs are opened

### DIFF
--- a/vscode/src/commands/context/open-tabs.ts
+++ b/vscode/src/commands/context/open-tabs.ts
@@ -14,7 +14,7 @@ export async function getContextFileFromTabs(): Promise<ContextItem[]> {
             // Get open tabs from the current editor
             const tabGroups = vscode.window.tabGroups.all
             const openTabs = tabGroups.flatMap(group =>
-                group.tabs.map(tab => tab.input)
+                group.tabs.map(tab => tab.input).filter(Boolean)
             ) as vscode.TabInputText[]
 
             return (


### PR DESCRIPTION
Here are a few short videos:
1. The bug in action:

https://github.com/user-attachments/assets/aba8daa5-0473-4ebb-b11d-142c1ccd89c4

2. Besides fixing the generic replacement I also added an option to `selectedCodePromptWithExtraFiles`
in order to get rid of parenthesis wrapping the `otherMentions`  if we don't need it such as in the case of the current-tabs.

https://github.com/user-attachments/assets/8af553c5-afa3-4c63-bf30-c3a533d1449d

and the fix:

https://github.com/user-attachments/assets/0aab3f83-c06c-439e-a694-385fc100597e


## Test plan
1. Create a prompt that uses the current-tab mention.
2. Open the Settings panel on VSCode (command + ,)
4. Run the prompt and notice it being replaced by the opened editor tabs instead of remaining on cody://current-tabs

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
