### PR TITLE
Add support for external auth providers in code search

### DIFF
--- a/.github/workflows/release-jetbrains-experimental.yml
+++ b/.github/workflows/release-jetbrains-experimental.yml
@@ -41,3 +41,4 @@ jobs:
           popd > /dev/null
         env:
           PUBLISH_TOKEN: ${{ secrets.JETBRAINS_MARKETPLACE_PUBLISH_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.PRIVATE_SG_TOKEN }}

--- a/.github/workflows/release-jetbrains-experimental.yml
+++ b/.github/workflows/release-jetbrains-experimental.yml
@@ -29,7 +29,7 @@ jobs:
           image: tonistiigi/binfmt:latest
           platforms: all
       - name: Gradle Wrapper Validation
-        uses: gradle/wrapper-validation-action@v3
+        uses: gradle/actions/wrapper-validation@v4
       - uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2 # SECURITY: pin third-party action hashes
       - run: |
           echo "RELEASE_VERSION=$(./jetbrains/scripts/version-from-git-tag.sh)-experimental" >> $GITHUB_ENV

--- a/.github/workflows/release-jetbrains-prerelease.yml
+++ b/.github/workflows/release-jetbrains-prerelease.yml
@@ -28,7 +28,7 @@ jobs:
           image: tonistiigi/binfmt:latest
           platforms: all
       - name: Gradle Wrapper Validation
-        uses: gradle/wrapper-validation-action@v3
+        uses: gradle/actions/wrapper-validation@v4
       - uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2 # SECURITY: pin third-party action hashes
       - run: |
           echo "RELEASE_VERSION=$(./jetbrains/scripts/version-from-git-tag.sh)-nightly" >> $GITHUB_ENV

--- a/.github/workflows/release-jetbrains-prerelease.yml
+++ b/.github/workflows/release-jetbrains-prerelease.yml
@@ -40,3 +40,4 @@ jobs:
           popd > /dev/null
         env:
           PUBLISH_TOKEN: ${{ secrets.JETBRAINS_MARKETPLACE_PUBLISH_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.PRIVATE_SG_TOKEN }}

--- a/.github/workflows/release-jetbrains-stable.yml
+++ b/.github/workflows/release-jetbrains-stable.yml
@@ -26,7 +26,7 @@ jobs:
           image: tonistiigi/binfmt:latest
           platforms: all
       - name: Gradle Wrapper Validation
-        uses: gradle/wrapper-validation-action@v3
+        uses: gradle/actions/wrapper-validation@v4
       - uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2 # SECURITY: pin third-party action hashes
       - run: |
           echo "RELEASE_VERSION=$(./jetbrains/scripts/version-from-git-tag.sh)" >> $GITHUB_ENV

--- a/.github/workflows/release-jetbrains-stable.yml
+++ b/.github/workflows/release-jetbrains-stable.yml
@@ -36,3 +36,4 @@ jobs:
           popd > /dev/null
         env:
           PUBLISH_TOKEN: ${{ secrets.JETBRAINS_MARKETPLACE_PUBLISH_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.PRIVATE_SG_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-
       - name: Gradle Wrapper Validation
-        uses: gradle/actions/wrapper-validation@v3
+        uses: gradle/actions/wrapper-validation@v4
       - uses: actions/setup-node@v4
         with:
           node-version: 20

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/agent/protocol_generated/CodyAgentServer.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/agent/protocol_generated/CodyAgentServer.kt
@@ -136,6 +136,8 @@ interface CodyAgentServer {
   fun testing_ignore_overridePolicy(params: ContextFilters?): CompletableFuture<Null?>
   @JsonRequest("extension/reset")
   fun extension_reset(params: Null?): CompletableFuture<Null?>
+  @JsonRequest("internal/getAuthHeaders")
+  fun internal_getAuthHeaders(params: String): CompletableFuture<Map<String, String>>
 
   // =============
   // Notifications

--- a/agent/scripts/reverse-proxy.py
+++ b/agent/scripts/reverse-proxy.py
@@ -22,11 +22,12 @@ async def proxy_handler(request):
             del headers['Transfer-Encoding']
 
         # Use value of 'Authorization: Bearer' to fill 'X-Forwarded-User' and remove 'Authorization' header
-        if 'Authorization' in headers:
-            match = re.match('Bearer (.*)', headers['Authorization'])
-            if match:
-                headers['X-Forwarded-User'] = match.group(1)
-            del headers['Authorization']
+
+        match = re.match('Bearer (.*)', headers['Authorization'])
+        if match:
+            headers['X-Forwarded-User'] = match.group(1)
+            if 'Authorization' in headers:
+                del headers['Authorization']
 
         # Forward the request to target
         async with session.request(

--- a/agent/src/agent.ts
+++ b/agent/src/agent.ts
@@ -14,6 +14,7 @@ import {
     currentAuthStatusAuthed,
     firstNonPendingAuthStatus,
     firstResultFromOperation,
+    getAuthHeaders,
     resolvedConfig,
     telemetryRecorder,
     waitUntilComplete,
@@ -1411,6 +1412,11 @@ export class Agent extends MessageHandler implements ExtensionClient {
         this.registerAuthenticatedRequest('testing/ignore/overridePolicy', async contextFilters => {
             contextFiltersProvider.setTestingContextFilters(contextFilters)
             return null
+        })
+
+        this.registerAuthenticatedRequest('internal/getAuthHeaders', async url => {
+            const config = await firstResultFromOperation(resolvedConfig)
+            return await getAuthHeaders(config.auth, new URL(url))
         })
     }
 

--- a/jetbrains/CONTRIBUTING.md
+++ b/jetbrains/CONTRIBUTING.md
@@ -64,6 +64,15 @@ run `sdk use java 17-zulu`. Confirm that you have Java 17 installed with `java -
 >
 > From this point, YMMV, but you should be able to build agent!
 
+> 🤞 Building Code Search:
+>
+> To build Code Search component you need to set env variable GITHUB_TOKEN,
+> so build process can access sourcegraph/sourcegraph.
+>
+> You can generate new token at https://github.com/settings/tokens
+>
+> If you don't want to set token, you can skip building Code Search component by setting SKIP_CODE_SEARCH_BUILD env variable to true.
+
 ### Running
 
 | What                                                                                                     | Command                                                                  |

--- a/jetbrains/build.gradle.kts
+++ b/jetbrains/build.gradle.kts
@@ -343,7 +343,9 @@ tasks {
       return destinationDir
     }
 
-    val sourcegraphDir = unzipCodeSearch()
+    val codeSearchDirOverride = System.getenv("CODE_SEARCH_DIR_OVERRIDE")
+    val sourcegraphDir: File =
+        if (codeSearchDirOverride != null) file(codeSearchDirOverride) else unzipCodeSearch()
     exec {
       workingDir(sourcegraphDir.toString())
       commandLine(*pnpmPath, "install", "--frozen-lockfile", "--fix-lockfile")

--- a/jetbrains/build.gradle.kts
+++ b/jetbrains/build.gradle.kts
@@ -1,4 +1,5 @@
 import com.jetbrains.plugin.structure.base.utils.isDirectory
+import java.net.HttpURLConnection
 import java.net.URL
 import java.nio.file.FileSystems
 import java.nio.file.FileVisitResult
@@ -188,8 +189,32 @@ fun download(url: String, output: File) {
     return
   }
   println("Downloading... $url")
-  assert(output.parentFile.mkdirs()) { output.parentFile }
-  Files.copy(URL(url).openStream(), output.toPath())
+
+  // Optional: Retrieve the GitHub token if needed for authorization (require private repo access)
+  val githubToken = System.getenv("GITHUB_TOKEN")
+  val connection = URL(url).openConnection() as HttpURLConnection
+  try {
+    if (!githubToken.isNullOrEmpty()) {
+      connection.setRequestProperty("Authorization", "Bearer $githubToken")
+    }
+    connection.requestMethod = "GET"
+
+    val responseCode = connection.responseCode
+    if (responseCode == HttpURLConnection.HTTP_OK) {
+      assert(output.parentFile.mkdirs()) { output.parentFile }
+      connection.inputStream.use { input ->
+        output.outputStream().use { outputStream -> input.copyTo(outputStream) }
+      }
+      println("Downloaded $output")
+    } else {
+      error("Failed to download ${url}. Response code: $responseCode")
+    }
+  } catch (e: Exception) {
+    e.printStackTrace()
+    error("Failed to download ${url}")
+  } finally {
+    connection.disconnect()
+  }
 }
 
 fun copyRecursively(input: File, output: File) {
@@ -319,10 +344,9 @@ val pnpmPath =
     }
 
 tasks {
-  val codeSearchCommit = "9d86a4f7d183e980acfe5d6b6468f06aaa0d8acf"
+  val codeSearchCommit = "048679a2e7f2a2d94a49c46bc972c954cb2b5bac"
   fun downloadCodeSearch(): File {
-    val url =
-        "https://github.com/sourcegraph/sourcegraph-public-snapshot/archive/$codeSearchCommit.zip"
+    val url = "https://github.com/sourcegraph/sourcegraph/archive/$codeSearchCommit.zip"
     val destination = githubArchiveCache.resolve("$codeSearchCommit.zip")
     download(url, destination)
     return destination
@@ -332,7 +356,7 @@ tasks {
     val zip = downloadCodeSearch()
     val dir = githubArchiveCache.resolve("code-search")
     unzip(zip, dir, FileSystems.getDefault().getPathMatcher("glob:**.go"))
-    return dir.resolve("sourcegraph-public-snapshot-$codeSearchCommit")
+    return dir.resolve("sourcegraph-$codeSearchCommit")
   }
 
   fun buildCodeSearch(): File? {

--- a/jetbrains/build.gradle.kts
+++ b/jetbrains/build.gradle.kts
@@ -190,7 +190,8 @@ fun download(url: String, output: File) {
   }
   println("Downloading... $url")
 
-  // Optional: Retrieve the GitHub token if needed for authorization (require private repo access)
+  // Optional: Retrieve the GitHub token if needed for authorization
+  // (require sourcegraph/sourcegraph repo access)
   val githubToken = System.getenv("GITHUB_TOKEN")
   val connection = URL(url).openConnection() as HttpURLConnection
   try {

--- a/jetbrains/src/main/java/com/sourcegraph/find/FindPopupDialog.java
+++ b/jetbrains/src/main/java/com/sourcegraph/find/FindPopupDialog.java
@@ -48,8 +48,6 @@ public class FindPopupDialog extends DialogWrapper {
     this.setModal(false);
     // Prevent the dialog from being cancelable by any default behaviors
     myCancelAction.setEnabled(false);
-
-    super.show();
   }
 
   // Overwrite the createPeer function that is being used in the super constructor so that we can

--- a/jetbrains/src/main/java/com/sourcegraph/find/FindPopupPanel.java
+++ b/jetbrains/src/main/java/com/sourcegraph/find/FindPopupPanel.java
@@ -67,7 +67,8 @@ public class FindPopupPanel extends BorderLayoutPanel implements Disposable {
         new JSToJavaBridgeRequestHandler(project, this, findService);
     String endpointUrl = CodyAuthService.getInstance(project).getEndpoint().getUrl();
 
-    browser = JBCefApp.isSupported() ? new SourcegraphJBCefBrowser(requestHandler, endpointUrl) : null;
+    browser =
+        JBCefApp.isSupported() ? new SourcegraphJBCefBrowser(requestHandler, endpointUrl) : null;
     if (browser == null) {
       showNoBrowserErrorNotification();
       Logger logger = Logger.getInstance(JSToJavaBridgeRequestHandler.class);

--- a/jetbrains/src/main/java/com/sourcegraph/find/FindPopupPanel.java
+++ b/jetbrains/src/main/java/com/sourcegraph/find/FindPopupPanel.java
@@ -16,6 +16,7 @@ import com.intellij.ui.jcef.JBCefApp;
 import com.intellij.util.ui.JBUI;
 import com.intellij.util.ui.components.BorderLayoutPanel;
 import com.sourcegraph.Icons;
+import com.sourcegraph.cody.auth.CodyAuthService;
 import com.sourcegraph.common.NotificationGroups;
 import com.sourcegraph.common.ui.DumbAwareEDTAction;
 import com.sourcegraph.find.browser.BrowserAndLoadingPanel;
@@ -64,7 +65,9 @@ public class FindPopupPanel extends BorderLayoutPanel implements Disposable {
     browserAndLoadingPanel = new BrowserAndLoadingPanel(project);
     JSToJavaBridgeRequestHandler requestHandler =
         new JSToJavaBridgeRequestHandler(project, this, findService);
-    browser = JBCefApp.isSupported() ? new SourcegraphJBCefBrowser(requestHandler) : null;
+    String endpointUrl = CodyAuthService.getInstance(project).getEndpoint().getUrl();
+
+    browser = JBCefApp.isSupported() ? new SourcegraphJBCefBrowser(requestHandler, endpointUrl) : null;
     if (browser == null) {
       showNoBrowserErrorNotification();
       Logger logger = Logger.getInstance(JSToJavaBridgeRequestHandler.class);

--- a/jetbrains/src/main/java/com/sourcegraph/find/FindPopupPanel.java
+++ b/jetbrains/src/main/java/com/sourcegraph/find/FindPopupPanel.java
@@ -10,6 +10,7 @@ import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.ide.CopyPasteManager;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.Splitter;
+import com.intellij.openapi.util.Disposer;
 import com.intellij.ui.OnePixelSplitter;
 import com.intellij.ui.PopupBorder;
 import com.intellij.ui.jcef.JBCefApp;
@@ -19,10 +20,7 @@ import com.sourcegraph.Icons;
 import com.sourcegraph.cody.auth.CodyAuthService;
 import com.sourcegraph.common.NotificationGroups;
 import com.sourcegraph.common.ui.DumbAwareEDTAction;
-import com.sourcegraph.find.browser.BrowserAndLoadingPanel;
-import com.sourcegraph.find.browser.JSToJavaBridgeRequestHandler;
-import com.sourcegraph.find.browser.JavaToJSBridge;
-import com.sourcegraph.find.browser.SourcegraphJBCefBrowser;
+import com.sourcegraph.find.browser.*;
 import java.awt.*;
 import java.awt.datatransfer.StringSelection;
 import java.util.Date;
@@ -36,6 +34,7 @@ import org.jetbrains.annotations.Nullable;
  * href="https://sourcegraph.com/github.com/JetBrains/intellij-community/-/blob/platform/lang-impl/src/com/intellij/find/impl/FindPopupPanel.java">FindPopupPanel.java</a>
  */
 public class FindPopupPanel extends BorderLayoutPanel implements Disposable {
+  private final JavaToJSBridge javaToJSBridge;
   private final SourcegraphJBCefBrowser browser;
   private final PreviewPanel previewPanel;
   private final BrowserAndLoadingPanel browserAndLoadingPanel;
@@ -69,13 +68,20 @@ public class FindPopupPanel extends BorderLayoutPanel implements Disposable {
 
     browser =
         JBCefApp.isSupported() ? new SourcegraphJBCefBrowser(requestHandler, endpointUrl) : null;
+
     if (browser == null) {
+      javaToJSBridge = null;
       showNoBrowserErrorNotification();
       Logger logger = Logger.getInstance(JSToJavaBridgeRequestHandler.class);
       logger.warn("JCEF browser is not supported!");
     } else {
+      String initJSCode = "window.initializeSourcegraph();";
+      JSToJavaBridge jsToJavaBridge = new JSToJavaBridge(browser, requestHandler, initJSCode);
+      javaToJSBridge = new JavaToJSBridge(browser);
+      Disposer.register(this, jsToJavaBridge);
       browserAndLoadingPanel.setBrowser(browser);
     }
+
     // The border is needed on macOS because without it, window and splitter resize don't work
     // because the JCEF
     // doesn't properly pass the mouse events to Swing.
@@ -143,7 +149,7 @@ public class FindPopupPanel extends BorderLayoutPanel implements Disposable {
 
   @Nullable
   public JavaToJSBridge getJavaToJSBridge() {
-    return browser != null ? browser.getJavaToJSBridge() : null;
+    return javaToJSBridge;
   }
 
   public BrowserAndLoadingPanel.ConnectionAndAuthState getConnectionAndAuthState() {

--- a/jetbrains/src/main/java/com/sourcegraph/find/FindService.java
+++ b/jetbrains/src/main/java/com/sourcegraph/find/FindService.java
@@ -71,6 +71,7 @@ public class FindService implements Disposable {
       }
     } else {
       popup = new FindPopupDialog(project, mainPanel);
+      popup.show();
 
       // We add a manual listener to the global key handler since the editor component seems to work
       // around the

--- a/jetbrains/src/main/java/com/sourcegraph/find/FindService.java
+++ b/jetbrains/src/main/java/com/sourcegraph/find/FindService.java
@@ -11,6 +11,7 @@ import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.wm.ex.WindowManagerEx;
 import com.intellij.util.ui.UIUtil;
+import com.sourcegraph.config.ConfigUtil;
 import com.sourcegraph.find.browser.BrowserAndLoadingPanel;
 import com.sourcegraph.find.browser.JavaToJSBridge;
 import java.awt.*;
@@ -31,6 +32,10 @@ public class FindService implements Disposable {
     mainPanel = new FindPopupPanel(project, this);
   }
 
+  public static FindService getInstance(@NotNull Project project) {
+    return project.getService(FindService.class);
+  }
+
   public synchronized void showPopup() {
     createOrShowPopup();
   }
@@ -38,6 +43,15 @@ public class FindService implements Disposable {
   public void hidePopup() {
     popup.hide();
     hideMaterialUiOverlay();
+  }
+
+  public void refreshConfiguration() {
+    JavaToJSBridge javaToJSBridge = mainPanel.getJavaToJSBridge();
+    if (javaToJSBridge != null) {
+      mainPanel
+          .getJavaToJSBridge()
+          .callJS("pluginSettingsChanged", ConfigUtil.getConfigAsJson(project));
+    }
   }
 
   private void createOrShowPopup() {

--- a/jetbrains/src/main/java/com/sourcegraph/find/FindService.java
+++ b/jetbrains/src/main/java/com/sourcegraph/find/FindService.java
@@ -46,11 +46,13 @@ public class FindService implements Disposable {
   }
 
   public void refreshConfiguration() {
-    JavaToJSBridge javaToJSBridge = mainPanel.getJavaToJSBridge();
-    if (javaToJSBridge != null) {
-      mainPanel
-          .getJavaToJSBridge()
-          .callJS("pluginSettingsChanged", ConfigUtil.getConfigAsJson(project));
+    if (popup.isVisible()) {
+      JavaToJSBridge javaToJSBridge = mainPanel.getJavaToJSBridge();
+      if (javaToJSBridge != null) {
+        mainPanel
+            .getJavaToJSBridge()
+            .callJS("pluginSettingsChanged", ConfigUtil.getConfigAsJson(project));
+      }
     }
   }
 

--- a/jetbrains/src/main/java/com/sourcegraph/find/browser/HttpSchemeHandler.java
+++ b/jetbrains/src/main/java/com/sourcegraph/find/browser/HttpSchemeHandler.java
@@ -4,6 +4,7 @@ import com.google.common.collect.ImmutableMap;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URL;
 import java.util.Map;
 import java.util.Optional;
 import org.cef.callback.CefCallback;
@@ -25,7 +26,12 @@ public class HttpSchemeHandler extends CefResourceHandlerAdapter {
     String extension = getExtension(request.getURL());
     mimeType = getMimeType(extension);
     String url = request.getURL();
-    String path = url.replace("http://sourcegraph", "");
+    String path;
+    try {
+      path = new URL(url).getPath();
+    } catch (Exception ignored) {
+      return false;
+    }
 
     if (mimeType != null) {
       data = loadResource(path);

--- a/jetbrains/src/main/java/com/sourcegraph/find/browser/HttpSchemeHandler.java
+++ b/jetbrains/src/main/java/com/sourcegraph/find/browser/HttpSchemeHandler.java
@@ -1,6 +1,7 @@
 package com.sourcegraph.find.browser;
 
 import com.google.common.collect.ImmutableMap;
+import com.intellij.openapi.diagnostic.Logger;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -22,6 +23,8 @@ public class HttpSchemeHandler extends CefResourceHandlerAdapter {
   private int responseHeader = 400;
   private int offset = 0;
 
+  Logger logger = Logger.getInstance(HttpSchemeHandler.class);
+
   public boolean processRequest(@NotNull CefRequest request, @NotNull CefCallback callback) {
     String extension = getExtension(request.getURL());
     mimeType = getMimeType(extension);
@@ -30,6 +33,7 @@ public class HttpSchemeHandler extends CefResourceHandlerAdapter {
     try {
       path = new URL(url).getPath();
     } catch (Exception ignored) {
+      logger.error("Failed to parse request url: " + url);
       return false;
     }
 

--- a/jetbrains/src/main/java/com/sourcegraph/find/browser/JSToJavaBridgeRequestHandler.java
+++ b/jetbrains/src/main/java/com/sourcegraph/find/browser/JSToJavaBridgeRequestHandler.java
@@ -46,6 +46,8 @@ public class JSToJavaBridgeRequestHandler {
         case "getTheme":
           JsonObject currentThemeAsJson = ThemeUtil.getCurrentThemeAsJson();
           return createSuccessResponse(currentThemeAsJson);
+        case "getCustomRequestHeaders":
+          return createSuccessResponse(ConfigUtil.getAuthorizationHeadersAsJson(project));
         case "indicateSearchError":
           arguments = request.getAsJsonObject("arguments");
           // This must run on EDT (Event Dispatch Thread) because it changes the UI.

--- a/jetbrains/src/main/java/com/sourcegraph/find/browser/JavaToJSBridge.java
+++ b/jetbrains/src/main/java/com/sourcegraph/find/browser/JavaToJSBridge.java
@@ -7,11 +7,13 @@ import com.google.gson.JsonSyntaxException;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.ui.jcef.JBCefBrowserBase;
 import com.intellij.ui.jcef.JBCefJSQuery;
+import com.sourcegraph.config.ThemeUtil;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Function;
+import javax.swing.*;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -25,6 +27,13 @@ public class JavaToJSBridge {
     this.browser = browser;
     this.query = JBCefJSQuery.create(browser);
     this.lock = new ReentrantLock();
+
+    UIManager.addPropertyChangeListener(
+        propertyChangeEvent -> {
+          if (propertyChangeEvent.getPropertyName().equals("lookAndFeel")) {
+            this.callJS("themeChanged", ThemeUtil.getCurrentThemeAsJson());
+          }
+        });
   }
 
   public void callJS(@NotNull String action, @Nullable JsonObject arguments) {

--- a/jetbrains/src/main/java/com/sourcegraph/find/browser/SourcegraphJBCefBrowser.java
+++ b/jetbrains/src/main/java/com/sourcegraph/find/browser/SourcegraphJBCefBrowser.java
@@ -11,11 +11,11 @@ import org.jetbrains.annotations.NotNull;
 public class SourcegraphJBCefBrowser extends JBCefBrowser {
   private final JavaToJSBridge javaToJSBridge;
 
-  public SourcegraphJBCefBrowser(@NotNull JSToJavaBridgeRequestHandler requestHandler) {
-    super("http://sourcegraph/html/index.html");
-    // Create and set up JCEF browser
-    CefApp.getInstance()
-        .registerSchemeHandlerFactory("http", "sourcegraph", new HttpSchemeHandlerFactory());
+  public SourcegraphJBCefBrowser(
+      @NotNull JSToJavaBridgeRequestHandler requestHandler, String endpointUrl) {
+    super(endpointUrl.replaceAll("/+$", "").replace("https://", "http://") + "/html/index.html");
+
+    CefApp.getInstance().registerSchemeHandlerFactory("http", null, new HttpSchemeHandlerFactory());
 
     // Create bridges, set up handlers, then run init function
     String initJSCode = "window.initializeSourcegraph();";

--- a/jetbrains/src/main/java/com/sourcegraph/find/browser/SourcegraphJBCefBrowser.java
+++ b/jetbrains/src/main/java/com/sourcegraph/find/browser/SourcegraphJBCefBrowser.java
@@ -2,7 +2,6 @@ package com.sourcegraph.find.browser;
 
 import com.intellij.openapi.util.Disposer;
 import com.intellij.ui.jcef.JBCefBrowser;
-import com.sourcegraph.cody.config.notification.CodySettingChangeListener;
 import com.sourcegraph.config.ThemeUtil;
 import javax.swing.*;
 import org.cef.CefApp;
@@ -22,11 +21,6 @@ public class SourcegraphJBCefBrowser extends JBCefBrowser {
     JSToJavaBridge jsToJavaBridge = new JSToJavaBridge(this, requestHandler, initJSCode);
     Disposer.register(this, jsToJavaBridge);
     javaToJSBridge = new JavaToJSBridge(this);
-
-    requestHandler
-        .getProject()
-        .getService(CodySettingChangeListener.class)
-        .setJavaToJSBridge(javaToJSBridge);
 
     UIManager.addPropertyChangeListener(
         propertyChangeEvent -> {

--- a/jetbrains/src/main/kotlin/com/sourcegraph/cody/auth/CodyAuthService.kt
+++ b/jetbrains/src/main/kotlin/com/sourcegraph/cody/auth/CodyAuthService.kt
@@ -4,6 +4,7 @@ import com.intellij.openapi.components.Service
 import com.intellij.openapi.components.service
 import com.intellij.openapi.project.Project
 import com.sourcegraph.config.ConfigUtil
+import com.sourcegraph.find.FindService
 
 @Service(Service.Level.PROJECT)
 class CodyAuthService(val project: Project) {
@@ -18,6 +19,7 @@ class CodyAuthService(val project: Project) {
 
   fun setActivated(isActivated: Boolean) {
     this.isActivated = isActivated
+    if (isActivated) FindService.getInstance(project).refreshConfiguration()
   }
 
   fun getEndpoint(): SourcegraphServerPath {

--- a/jetbrains/src/main/kotlin/com/sourcegraph/cody/auth/CodyAuthService.kt
+++ b/jetbrains/src/main/kotlin/com/sourcegraph/cody/auth/CodyAuthService.kt
@@ -4,6 +4,7 @@ import com.intellij.openapi.components.Service
 import com.intellij.openapi.components.service
 import com.intellij.openapi.project.Project
 import com.sourcegraph.config.ConfigUtil
+import com.sourcegraph.config.ConfigUtil.isIntegrationTestModeEnabled
 import com.sourcegraph.find.FindService
 
 @Service(Service.Level.PROJECT)
@@ -19,7 +20,8 @@ class CodyAuthService(val project: Project) {
 
   fun setActivated(isActivated: Boolean) {
     this.isActivated = isActivated
-    if (isActivated) FindService.getInstance(project).refreshConfiguration()
+    if (isActivated && !isIntegrationTestModeEnabled())
+        FindService.getInstance(project).refreshConfiguration()
   }
 
   fun getEndpoint(): SourcegraphServerPath {

--- a/jetbrains/src/main/kotlin/com/sourcegraph/cody/config/notification/ChangeListener.kt
+++ b/jetbrains/src/main/kotlin/com/sourcegraph/cody/config/notification/ChangeListener.kt
@@ -4,11 +4,9 @@ import com.intellij.openapi.Disposable
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.project.Project
 import com.intellij.util.messages.MessageBusConnection
-import com.sourcegraph.find.browser.JavaToJSBridge
 
 abstract class ChangeListener(protected val project: Project) : Disposable {
   protected val connection: MessageBusConnection = project.messageBus.connect()
-  var javaToJSBridge: JavaToJSBridge? = null
   protected val logger = Logger.getInstance(ChangeListener::class.java)
 
   override fun dispose() {

--- a/jetbrains/src/main/kotlin/com/sourcegraph/cody/config/notification/CodySettingChangeListener.kt
+++ b/jetbrains/src/main/kotlin/com/sourcegraph/cody/config/notification/CodySettingChangeListener.kt
@@ -19,8 +19,6 @@ class CodySettingChangeListener(project: Project) : ChangeListener(project) {
         CodySettingChangeActionNotifier.TOPIC,
         object : CodySettingChangeActionNotifier {
           override fun afterAction(context: CodySettingChangeContext) {
-            // Notify JCEF about the config changes
-            javaToJSBridge?.callJS("pluginSettingsChanged", ConfigUtil.getConfigAsJson(project))
 
             if (context.oldCodyEnabled != context.newCodyEnabled) {
               if (context.newCodyEnabled) {

--- a/lib/shared/src/sourcegraph-api/utils.ts
+++ b/lib/shared/src/sourcegraph-api/utils.ts
@@ -54,6 +54,8 @@ export async function getAuthHeaders(auth: AuthCredentials, url: URL): Promise<R
 
 export async function addAuthHeaders(auth: AuthCredentials, headers: Headers, url: URL): Promise<void> {
     await getAuthHeaders(auth, url).then(authHeaders => {
-        Object.assign(headers, new Headers(authHeaders))
+        for (const [key, value] of Object.entries(authHeaders)) {
+            headers.set(key, value)
+        }
     })
 }

--- a/lib/shared/src/sourcegraph-api/utils.ts
+++ b/lib/shared/src/sourcegraph-api/utils.ts
@@ -54,8 +54,6 @@ export async function getAuthHeaders(auth: AuthCredentials, url: URL): Promise<R
 
 export async function addAuthHeaders(auth: AuthCredentials, headers: Headers, url: URL): Promise<void> {
     await getAuthHeaders(auth, url).then(authHeaders => {
-        for (const [key, value] of Object.entries(authHeaders)) {
-            headers.set(key, value)
-        }
+        Object.assign(headers, new Headers(authHeaders))
     })
 }

--- a/lib/shared/src/sourcegraph-api/utils.ts
+++ b/lib/shared/src/sourcegraph-api/utils.ts
@@ -46,6 +46,9 @@ export async function getAuthHeaders(auth: AuthCredentials, url: URL): Promise<R
             return await auth.credentials.getHeaders()
         }
     }
+
+    console.error('Cannot add headers: neither token nor headers found')
+
     return {}
 }
 

--- a/lib/shared/src/sourcegraph-api/utils.ts
+++ b/lib/shared/src/sourcegraph-api/utils.ts
@@ -36,17 +36,23 @@ export function toPartialUtf8String(buf: Buffer): { str: string; buf: Buffer } {
     }
 }
 
-export async function addAuthHeaders(auth: AuthCredentials, headers: Headers, url: URL): Promise<void> {
+export async function getAuthHeaders(auth: AuthCredentials, url: URL): Promise<Record<string, string>> {
     // We want to be sure we sent authorization headers only to the valid endpoint
     if (auth.credentials && url.host === new URL(auth.serverEndpoint).host) {
         if ('token' in auth.credentials) {
-            headers.set('Authorization', `token ${auth.credentials.token}`)
-        } else if (typeof auth.credentials.getHeaders === 'function') {
-            for (const [key, value] of Object.entries(await auth.credentials.getHeaders())) {
-                headers.set(key, value)
-            }
-        } else {
-            console.error('Cannot add headers: neither token nor headers found')
+            return { Authorization: `token ${auth.credentials.token}` }
+        }
+        if (typeof auth.credentials.getHeaders === 'function') {
+            return await auth.credentials.getHeaders()
         }
     }
+    return {}
+}
+
+export async function addAuthHeaders(auth: AuthCredentials, headers: Headers, url: URL): Promise<void> {
+    await getAuthHeaders(auth, url).then(authHeaders => {
+        for (const [key, value] of Object.entries(authHeaders)) {
+            headers.set(key, value)
+        }
+    })
 }

--- a/vscode/src/jsonrpc/agent-protocol.ts
+++ b/vscode/src/jsonrpc/agent-protocol.ts
@@ -279,6 +279,8 @@ export type ClientRequests = {
     // Called after the extension has been uninstalled by a user action.
     // Attempts to wipe out any state that the extension has stored.
     'extension/reset': [null, null]
+
+    'internal/getAuthHeaders': [string, Record<string, string>]
 }
 
 // ================


### PR DESCRIPTION
## Changes

This PR adds agent endpoint which allow us to fetch auth headers, which in turn we need to deliver to the sourcegraph search webview.

Webview changes are on a separate PR: https://github.com/pkukielka/sourcegraph-public-snapshot/pull/1

## Test plan

**Setup:** 

1. Clone git@github.com:pkukielka/sourcegraph-public-snapshot.git and checkout  `pkukielka/add-external-auth-providers-support` branch.
2. `export CODE_SEARCH_DIR_OVERRIDE=/path/to/pkukielka/sourcegraph-public-snapshot`
3. Checkout this PR (`pkukielka/ext-auth-fix-search` branch) in Cody project dir
4. `cd jetbrains`  
5. Run `./gradlew customRunIde -PforceCodeSearchBuild=true -PforceAgentBuild=true`
6.  Add external auth provider configuration:

```
{
  "cody.override.serverEndpoint":  "https://piotr-kukielka.sgdev.dev",

  "cody.auth.externalProviders": [
    {
      "endpoint": "https://piotr-kukielka.sgdev.dev",
      "executable": {
        "commandLine": ["echo '{ \"headers\": { \"Authorization\": \"token sgp_local_YOUR_TOKEN\" } }'"],
        "shell": "/bin/bash"
      }
    },
```

**Test**
1. Hit `Option + S` to open sourcegraph search
2. Search for cody repo and click `Open in Browser`
3. Make sure https://piotr-kukielka.sgdev.dev instance is opened
5. Comment out `"cody.override.serverEndpoint"` line and then switch to other account, e.g. on https://sg02.sourcegraphcloud.com/ (this one will authenticate using token), save settings
6. 2. Search for cody repo and click `Open in Browser`
7. Make sure https://sg02.sourcegraphcloud.com/ instance is opened

**Reproducing failing fetches:**
1. Edit config by changing `commandLine` line to:
`"commandLine": ["echo '{ \"headers\": { \"X-Forwarded-User\": \"SomeUser\" } }'"],`
2. Open Find Actions: (<kbd>Ctrl+Shift+A</kbd> / <kbd>⌘⇧A</kbd>)
3. Search for "Registry..." and open it
4. Find option `ide.browser.jcef.debug.port`
5. Change the default value to an open port (we use `9222`)
6. Restart IDE
7. Hit `Option + S` to open sourcegraph search
8. Notice sourcegraph search is not loading anymore
9. Go to http://localhost:9222/ and click on `Sourcegraph` link to inspect the failures in the devtools