### PR TITLE
fix(context): Mark at-mention context items as user-added items

### DIFF
--- a/lib/shared/src/codebase-context/messages.ts
+++ b/lib/shared/src/codebase-context/messages.ts
@@ -40,6 +40,11 @@ interface ContextItemCommon {
 
     /**
      * The source of this context item.
+     *
+     * NOTE: For item explicitly added by the user, the source should be 'user' as
+     * it will be used to determine the {@link ChatContextTokenUsage} type, which is also
+     * used for prioritizing context items where user-added items are prioritized over
+     * non-user-added items, such as {@link getContextItemTokenUsageType}.
      */
     source?: ContextItemSource
 

--- a/lib/shared/src/context/openctx/context.ts
+++ b/lib/shared/src/context/openctx/context.ts
@@ -1,5 +1,5 @@
 import { URI } from 'vscode-uri'
-import type { ContextItemOpenCtx } from '../../codebase-context/messages'
+import { type ContextItemOpenCtx, ContextItemSource } from '../../codebase-context/messages'
 import { openCtx } from './api'
 
 // getContextForChatMessage returns context items for a given chat message from the OpenCtx providers.
@@ -51,6 +51,7 @@ export const getContextForChatMessage = async (
                         providerUri: item.providerUri,
                         content: item.ai?.content || '',
                         provider: 'openctx',
+                        source: ContextItemSource.User, // To indicate that this is a user-added item.
                     }) as ContextItemOpenCtx
             )
     } catch {

--- a/vscode/src/chat/chat-view/ContextRetriever.ts
+++ b/vscode/src/chat/chat-view/ContextRetriever.ts
@@ -41,6 +41,8 @@ export function toStructuredMentions(mentions: ContextItem[]): StructuredMention
     const symbols: ContextItemSymbol[] = []
     const openCtx: ContextItemOpenCtx[] = []
     for (const mention of mentions) {
+        // Update source type to user to indicate that this is a user-added item.
+        mention.source = mention.source ?? ContextItemSource.User
         switch (mention.type) {
             case 'repository':
                 repos.push(mention)


### PR DESCRIPTION
FIX https://linear.app/sourcegraph/issue/CODY-4843/agentic-context-removes-explicitly-mentioned-remote-file

- Update `getContextForChatMessage` in `lib/shared/src/context/openctx/context.ts` to set the `source` property of `ContextItemOpenCtx` to `ContextItemSource.User` to indicate that the item was added by the user.
- Update `toStructuredMentions` in `vscode/src/chat/chat-view/ContextRetriever.ts` to set the `source` property of `ContextItem` to `ContextItemSource.User` if it is not already set.
- Add a note in `lib/shared/src/codebase-context/messages.ts` explaining the purpose of the `source` property and how it is used to prioritize user-added context items.

This change ensures that user-added context items are properly identified and can be prioritized over non-user-added items when adding context during the prompt-building process and displaying context in the chat view.


## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

All the at-mentioned items should have labeled with source = user