### PR TITLE
feat/edit: adds the context for the edit command

### DIFF
--- a/lib/shared/src/experimentation/FeatureFlagProvider.ts
+++ b/lib/shared/src/experimentation/FeatureFlagProvider.ts
@@ -35,6 +35,7 @@ export enum FeatureFlag {
     // Data collection variants used for completions and next edit completions
     CodyAutocompleteDataCollectionFlag = 'cody-autocomplete-logs-collection-flag',
     SmartApplyContextDataCollectionFlag = 'cody-smart-apply-context-logs-collection-flag',
+    EditContextDataCollectionFlag = 'cody-edit-context-logs-collection-flag',
 
     // Enables fast-path HTTP client for PLG-users
     CodyAutocompleteFastPath = 'cody-autocomplete-fast-path',

--- a/vscode/src/edit/edit-context-logging.test.ts
+++ b/vscode/src/edit/edit-context-logging.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest'
+import { calculatePayloadSizeInBytes } from './edit-context-logging'
+
+describe('calculatePayloadSizeInBytes', () => {
+    it('returns correct byte size for an object payload', () => {
+        const payload = { a: 1, b: 'test' }
+        const expected = Buffer.byteLength(JSON.stringify(payload), 'utf8')
+        const result = calculatePayloadSizeInBytes(payload)
+        expect(result).toBe(expected)
+    })
+
+    it('returns correct byte size for a string payload', () => {
+        const payload = 'Hello, World!'
+        const expected = Buffer.byteLength(JSON.stringify(payload), 'utf8')
+        const result = calculatePayloadSizeInBytes(payload)
+        expect(result).toBe(expected)
+    })
+
+    it('returns undefined when JSON.stringify fails', () => {
+        // Creating a circular reference to force JSON.stringify to throw an error.
+        const payload: any = {}
+        payload.self = payload
+        const result = calculatePayloadSizeInBytes(payload)
+        expect(result).toBeUndefined()
+    })
+})

--- a/vscode/src/edit/edit-context-logging.ts
+++ b/vscode/src/edit/edit-context-logging.ts
@@ -216,10 +216,6 @@ export function shouldLogEditContextItem<T>(
     payload: T,
     isFeatureFlagEnabledForLogging: boolean
 ): boolean {
-    console.log('shouldLogEditContextItem', payload)
-    console.log('isDotComAuthed', isDotComAuthed())
-    console.log('isFeatureFlagEnabledForLogging', isFeatureFlagEnabledForLogging)
-
     // 🚨 SECURITY: included only for DotCom users and for users in the feature flag.
     if (isDotComAuthed() && isFeatureFlagEnabledForLogging) {
         const payloadSize = calculatePayloadSizeInBytes(payload)

--- a/vscode/src/edit/edit-context-logging.ts
+++ b/vscode/src/edit/edit-context-logging.ts
@@ -216,6 +216,10 @@ export function shouldLogEditContextItem<T>(
     payload: T,
     isFeatureFlagEnabledForLogging: boolean
 ): boolean {
+    console.log('shouldLogEditContextItem', payload)
+    console.log('isDotComAuthed', isDotComAuthed())
+    console.log('isFeatureFlagEnabledForLogging', isFeatureFlagEnabledForLogging)
+
     // 🚨 SECURITY: included only for DotCom users and for users in the feature flag.
     if (isDotComAuthed() && isFeatureFlagEnabledForLogging) {
         const payloadSize = calculatePayloadSizeInBytes(payload)
@@ -224,7 +228,7 @@ export function shouldLogEditContextItem<T>(
     return false
 }
 
-function calculatePayloadSizeInBytes<T>(payload: T): number | undefined {
+export function calculatePayloadSizeInBytes<T>(payload: T): number | undefined {
     try {
         const snippetSizeBytes = Buffer.byteLength(JSON.stringify(payload) || '', 'utf8')
         return snippetSizeBytes

--- a/vscode/src/edit/edit-context-logging.ts
+++ b/vscode/src/edit/edit-context-logging.ts
@@ -216,12 +216,12 @@ export function shouldLogEditContextItem<T>(
     payload: T,
     isFeatureFlagEnabledForLogging: boolean
 ): boolean {
+    // 🚨 SECURITY: included only for DotCom users and for users in the feature flag.
     if (isDotComAuthed() && isFeatureFlagEnabledForLogging) {
-        // 🚨 SECURITY: included only for DotCom users and for users in the feature flag.
-        return true
+        const payloadSize = calculatePayloadSizeInBytes(payload)
+        return payloadSize !== undefined && payloadSize < MAX_LOGGING_PAYLOAD_SIZE_BYTES
     }
-    const payloadSize = calculatePayloadSizeInBytes(payload)
-    return payloadSize !== undefined && payloadSize < MAX_LOGGING_PAYLOAD_SIZE_BYTES
+    return false
 }
 
 function calculatePayloadSizeInBytes<T>(payload: T): number | undefined {

--- a/vscode/src/edit/manager.ts
+++ b/vscode/src/edit/manager.ts
@@ -232,7 +232,10 @@ export class EditManager implements vscode.Disposable {
         }
         const { metadata, privateMetadata } = splitSafeMetadata(legacyMetadata)
         telemetryRecorder.recordEvent(`cody.command.${eventName}`, 'executed', {
-            metadata,
+            metadata: {
+                ...metadata,
+                recordsPrivateMetadataTranscript: editContextData === undefined ? 0 : 1,
+            },
             privateMetadata: {
                 ...privateMetadata,
                 model: task.model,

--- a/vscode/src/edit/manager.ts
+++ b/vscode/src/edit/manager.ts
@@ -25,11 +25,15 @@ import { isUriIgnoredByContextFilterWithNotification } from '../cody-ignore/cont
 import type { ExtensionClient } from '../extension-client'
 import { ACTIVE_TASK_STATES } from '../non-stop/codelenses/constants'
 import { splitSafeMetadata } from '../services/telemetry-v2'
+import {
+    EditLoggingFeatureFlagManager,
+    SmartApplyContextLogger,
+    getEditLoggingContext,
+} from './edit-context-logging'
 import type { ExecuteEditArguments } from './execute'
 import { SMART_APPLY_FILE_DECORATION, getSmartApplySelection } from './prompt/smart-apply'
 import { EditProvider } from './provider'
 import type { SmartApplyArguments } from './smart-apply'
-import { SmartApplyContextLogger } from './smart-apply-context-logging'
 import { getEditIntent } from './utils/edit-intent'
 import { getEditMode } from './utils/edit-mode'
 import { getEditLineSelection, getEditSmartSelection } from './utils/edit-selection'
@@ -48,7 +52,8 @@ export interface EditManagerOptions {
 export class EditManager implements vscode.Disposable {
     private disposables: vscode.Disposable[] = []
     private editProviders = new WeakMap<FixupTask, EditProvider>()
-    private smartApplyContextLogger = new SmartApplyContextLogger()
+    private loggingFeatureFlagManagerInstance = new EditLoggingFeatureFlagManager()
+    private smartApplyContextLogger = new SmartApplyContextLogger(this.loggingFeatureFlagManagerInstance)
 
     constructor(public options: EditManagerOptions) {
         /**
@@ -92,7 +97,7 @@ export class EditManager implements vscode.Disposable {
             editCommand,
             smartApplyCommand,
             startCommand,
-            this.smartApplyContextLogger
+            this.loggingFeatureFlagManagerInstance
         )
     }
 
@@ -210,11 +215,20 @@ export class EditManager implements vscode.Disposable {
         const isFixCommand = configuration.intent === 'fix' ? 'fix' : undefined
         const eventName = isDocCommand ?? isUnitTestCommand ?? isFixCommand ?? 'edit'
 
+        const editContextData = getEditLoggingContext({
+            isFeatureFlagEnabledForLogging:
+                this.loggingFeatureFlagManagerInstance.isEditContextDataCollectionFlagEnabled(),
+            instruction: task.instruction.toString(),
+            document,
+            selectionRange: task.selectionRange,
+        })
+
         const legacyMetadata = {
             intent: task.intent,
             mode: task.mode,
             source: task.source,
             ...telemetryMetadata,
+            editContext: editContextData,
         }
         const { metadata, privateMetadata } = splitSafeMetadata(legacyMetadata)
         telemetryRecorder.recordEvent(`cody.command.${eventName}`, 'executed', {


### PR DESCRIPTION
## Context
1. The PR adds the logging for the edit feature. The logging is only done for the `dotCom` users and the who are in the feature flag.
2. The data will be used offline to experiment with smaller model for instant smart apply feature and evaluation to select models for selection/applying phase. This will be used to create a synthetic dataset used for smart apply.

## Test plan
1. Added unit tests
2. Add yourself to the `cody-edit-context-logs-collection-flag` feature flag.
3. Observe the telemetry events in the output log:
```
█ telemetry-v2 recordEvent: cody.command.edit/executed: {
    ... other fields
    "privateMetadata": {
      "intent": "edit",
      "mode": "edit",
      "source": "editor",
      "editContext": {
        "userQuery": "remove user message from the function",
        "filePath": "code-matching-eval/edits_experiments/examples/manual-examples/codium-js-rewrite.js",
        "fileContent": "import React, { useState } from 'react';\n\nexport default function Home() {\n  const [message, setMessage] = useState('');\n  const [username, setUsername] = useState('');\n\n  const onMessageChange = (event) => {\n    setMessage(event.target.value);\n  };\n\n  const onUsernameChange = (event) => {\n    setUsername(event.target.value);\n  };\n\n  return (\n    <div>\n      <input \n        type=\"text\" \n        value={username} \n        placeholder=\"Your name\" \n        onInput={onUsernameChange} \n      />\n      <input \n        type=\"text\" \n        value={message} \n        placeholder=\"Your message\" \n        onInput={onMessageChange} \n      />\n    </div>\n  );\n}",
        "selectionRange": [
          42,
          651
        ]
      },
      "model": "anthropic::2024-10-22::claude-3-5-sonnet-latest"
    },
}
```
