### PR TITLE
chore/(chat): Add a retry button for Cody API version error (CODY-4864)

### DIFF
--- a/lib/shared/src/chat/chat.ts
+++ b/lib/shared/src/chat/chat.ts
@@ -47,7 +47,8 @@ export class ChatClient {
             throw new Error('unable to determine Cody API version')
         }
 
-        const useApiV1 = params.model?.includes('claude-3')·&&·!(versions·instanceof·Error)·&&·versions.codyAPIVersion
+        const useApiV1 =
+            params.model?.includes('claude-3') && !(versions instanceof Error) && versions.codyAPIVersion
         const isLastMessageFromHuman = messages.length > 0 && messages.at(-1)!.speaker === 'human'
 
         const isFireworks =

--- a/lib/shared/src/chat/chat.ts
+++ b/lib/shared/src/chat/chat.ts
@@ -46,9 +46,6 @@ export class ChatClient {
         if (params.model?.includes('claude-3') && versions instanceof Error) {
             throw new Error('unable to determine Cody API version')
         }
-        if (!authStatus_.authenticated) {
-            throw new Error('not authenticated')
-        }
 
         const useApiV1 =
             params.model?.includes('claude-3') &&

--- a/lib/shared/src/chat/chat.ts
+++ b/lib/shared/src/chat/chat.ts
@@ -40,8 +40,9 @@ export class ChatClient {
         if (!authStatus_.authenticated) {
             throw new Error('not authenticated')
         }
+
         // Only check the API version if it's a claude-3 model. Claude-3 models are being deprecated already,
-        // but we still need to support them for old sg instances.
+        // but old sg instances might still have them.
         if (params.model?.includes('claude-3') && versions instanceof Error) {
             throw new Error('unable to determine Cody API version', { cause: versions })
         }

--- a/lib/shared/src/chat/chat.ts
+++ b/lib/shared/src/chat/chat.ts
@@ -47,10 +47,7 @@ export class ChatClient {
             throw new Error('unable to determine Cody API version')
         }
 
-        const useApiV1 =
-            params.model?.includes('claude-3') &&
-            !(versions instanceof Error) &&
-            versions.codyAPIVersion
+        const useApiV1 = params.model?.includes('claude-3')·&&·!(versions·instanceof·Error)·&&·versions.codyAPIVersion
         const isLastMessageFromHuman = messages.length > 0 && messages.at(-1)!.speaker === 'human'
 
         const isFireworks =

--- a/lib/shared/src/chat/chat.ts
+++ b/lib/shared/src/chat/chat.ts
@@ -36,7 +36,14 @@ export class ChatClient {
             currentSiteVersion(),
             await firstValueFrom(authStatus),
         ])
-        if (versions instanceof Error) {
+        const [authStatus_, versions] = await Promise.all([
+            await firstValueFrom(authStatus),
+            currentSiteVersion(),
+        ])
+        if (!authStatus_.authenticated) {
+            throw new Error('not authenticated')
+        }
+        if (params.model?.includes('claude-3') && versions instanceof Error) {
             throw new Error('unable to determine Cody API version', versions)
         }
         if (!authStatus_.authenticated) {

--- a/lib/shared/src/chat/chat.ts
+++ b/lib/shared/src/chat/chat.ts
@@ -51,10 +51,9 @@ export class ChatClient {
         }
 
         const useApiV1 =
+            params.model?.includes('claude-3') &&
             !(versions instanceof Error) &&
-            versions.codyAPIVersion !== undefined &&
-            versions.codyAPIVersion >= 1 &&
-            params.model?.includes('claude-3')
+            versions.codyAPIVersion
         const isLastMessageFromHuman = messages.length > 0 && messages.at(-1)!.speaker === 'human'
 
         const isFireworks =

--- a/lib/shared/src/chat/chat.ts
+++ b/lib/shared/src/chat/chat.ts
@@ -44,7 +44,7 @@ export class ChatClient {
         // Only check the API version if it's a claude-3 model. Claude-3 models are being deprecated already,
         // but old sg instances might still have them.
         if (params.model?.includes('claude-3') && versions instanceof Error) {
-            throw new Error('unable to determine Cody API version', { cause: versions })
+            throw new Error('unable to determine Cody API version')
         }
         if (!authStatus_.authenticated) {
             throw new Error('not authenticated')

--- a/lib/shared/src/chat/chat.ts
+++ b/lib/shared/src/chat/chat.ts
@@ -36,8 +36,11 @@ export class ChatClient {
             currentSiteVersion(),
             await firstValueFrom(authStatus),
         ])
-        if (!versions) {
-            throw new Error('unable to determine Cody API version')
+        if (versions instanceof Error) {
+            throw new Error(
+                'unable to determine Cody API version',
+                versions
+            )
         }
         if (!authStatus_.authenticated) {
             throw new Error('not authenticated')

--- a/lib/shared/src/chat/chat.ts
+++ b/lib/shared/src/chat/chat.ts
@@ -37,10 +37,7 @@ export class ChatClient {
             await firstValueFrom(authStatus),
         ])
         if (versions instanceof Error) {
-            throw new Error(
-                'unable to determine Cody API version',
-                versions
-            )
+            throw new Error('unable to determine Cody API version', versions)
         }
         if (!authStatus_.authenticated) {
             throw new Error('not authenticated')

--- a/lib/shared/src/sourcegraph-api/siteVersion.ts
+++ b/lib/shared/src/sourcegraph-api/siteVersion.ts
@@ -66,12 +66,12 @@ const authStatusAuthed: Observable<AuthStatus> = authStatus.filter(
 /**
  * Get the current site version. If authentication is pending, it awaits successful authentication.
  */
-export async function currentSiteVersion(): Promise<SiteAndCodyAPIVersions | null> {
+export async function currentSiteVersion(): Promise<SiteAndCodyAPIVersions | Error> {
     const authStatus = await firstResultFromOperation(authStatusAuthed)
     const siteVersion = await graphqlClient.getSiteVersion()
     if (isError(siteVersion)) {
         logError('siteVersion', `Failed to get site version from ${authStatus.endpoint}: ${siteVersion}`)
-        return null
+        return siteVersion
     }
     return {
         siteVersion,
@@ -88,7 +88,7 @@ interface CheckVersionInput {
 export async function isValidVersion({ minimumVersion }: { minimumVersion: string }): Promise<boolean> {
     const currentVersion = await currentSiteVersion()
 
-    if (currentVersion === null) {
+    if (currentVersion instanceof Error) {
         return false
     }
 

--- a/vscode/src/chat/chat-view/handlers/ChatHandler.ts
+++ b/vscode/src/chat/chat-view/handlers/ChatHandler.ts
@@ -78,7 +78,7 @@ export class ChatHandler implements AgentHandler {
         const prompter = new DefaultPrompter(explicitMentions, implicitMentions, false)
 
         const versions = await currentSiteVersion()
-        if (!versions) {
+        if (versions instanceof Error) {
             throw new Error('unable to determine site version')
         }
         const { prompt } = await this.buildPrompt(prompter, chatBuilder, signal, versions.codyAPIVersion)

--- a/vscode/src/edit/manager.ts
+++ b/vscode/src/edit/manager.ts
@@ -320,7 +320,7 @@ export class EditManager implements vscode.Disposable {
                 const replacementCode = PromptString.unsafe_fromLLMResponse(configuration.replacement)
 
                 const versions = await currentSiteVersion()
-                if (!versions) {
+                if (versions instanceof Error) {
                     throw new Error('unable to determine site version')
                 }
 

--- a/vscode/src/edit/provider.ts
+++ b/vscode/src/edit/provider.ts
@@ -62,7 +62,7 @@ export class EditProvider {
             const model = this.config.task.model
             const contextWindow = modelsService.getContextWindowByID(model)
             const versions = await currentSiteVersion()
-            if (!versions) {
+            if (versions instanceof Error) {
                 throw new Error('unable to determine site version')
             }
             const {

--- a/vscode/webviews/chat/ErrorItem.module.css
+++ b/vscode/webviews/chat/ErrorItem.module.css
@@ -81,11 +81,11 @@
     transform: translateY(50%) translateX(25%) rotate(45deg);
     border: 1px solid rgba(0 0 0 / 16%);
     background: linear-gradient(
-            45deg,
-            rgb(255 220 220 / 0%) calc(var(--error-item-reflection-position) + 35%),
-            rgb(255 220 220 / 50%) calc(var(--error-item-reflection-position) + 50%),
-            rgb(255 220 220 / 0%) calc(var(--error-item-reflection-position) + 65%)
-        ),
+        45deg,
+        rgb(255 220 220 / 0%) calc(var(--error-item-reflection-position) + 35%),
+        rgb(255 220 220 / 50%) calc(var(--error-item-reflection-position) + 50%),
+        rgb(255 220 220 / 0%) calc(var(--error-item-reflection-position) + 65%)
+    ),
         linear-gradient(rgb(255 255 255 / 55%), rgb(255 255 255 / 55%)),
         repeating-conic-gradient(#4ac1e8, #7048e8, #ff5543, #7048e8, #4ac1e8);
     box-shadow: 0 4px 8px 0 rgb(0 0 0 / 15%);
@@ -148,4 +148,8 @@
 
 .request-error-title {
     font-weight: bold;
+}
+
+.error-content {
+    margin-bottom: 16px;
 }

--- a/vscode/webviews/chat/ErrorItem.tsx
+++ b/vscode/webviews/chat/ErrorItem.tsx
@@ -1,6 +1,11 @@
 import React, { useCallback, useMemo } from 'react'
 
 import { type ChatError, RateLimitError } from '@sourcegraph/cody-shared'
+import { Tooltip, TooltipContent, TooltipTrigger } from '../components/shadcn/ui/tooltip'
+import type {
+    HumanMessageInitialContextInfo as InitialContextInfo,
+    PriorHumanMessageInfo,
+} from './cells/messageCell/assistant/AssistantMessageCell'
 
 import type { UserAccountInfo } from '../Chat'
 import type { ApiPostMessage } from '../Chat'
@@ -16,7 +21,8 @@ export const ErrorItem: React.FunctionComponent<{
     error: Omit<ChatError, 'isChatErrorGuard'>
     userInfo: Pick<UserAccountInfo, 'isCodyProUser' | 'isDotComUser'>
     postMessage?: ApiPostMessage
-}> = ({ error, userInfo, postMessage }) => {
+    humanMessage?: PriorHumanMessageInfo | null
+}> = ({ error, userInfo, postMessage, humanMessage }) => {
     if (typeof error !== 'string' && error.name === RateLimitError.errorName && postMessage) {
         return (
             <RateLimitErrorItem
@@ -26,22 +32,64 @@ export const ErrorItem: React.FunctionComponent<{
             />
         )
     }
-
-    return <RequestErrorItem error={error.message} />
+    return <RequestErrorItem error={error} humanMessage={humanMessage} />
 }
 
 /**
  * Renders a generic error message for chat request failures.
  */
 export const RequestErrorItem: React.FunctionComponent<{
-    error: string
-}> = ({ error }) => (
-    <div className={styles.requestError}>
-        <span className={styles.requestErrorTitle}>Request Failed: </span>
-        {error}
-    </div>
-)
+    error: Error
+    humanMessage?: PriorHumanMessageInfo | null
+}> = ({ error, humanMessage }) => {
+    const isApiVersionError = error.message.includes('unable to determine Cody API version')
 
+    const actions =
+        isApiVersionError && humanMessage
+            ? [
+                  {
+                      label: 'Try again',
+                      tooltip: 'Retry request without code context',
+                      onClick: () => {
+                          const options: InitialContextInfo = {
+                              repositories: false,
+                              files: false,
+                          }
+                          humanMessage.rerunWithDifferentContext(options)
+                      },
+                  },
+              ]
+            : []
+
+    return (
+        <div className={styles.requestError}>
+            <div className={styles.errorContent}>
+                <span className={styles.requestErrorTitle}>Request Failed: </span>
+                {error.message}
+            </div>
+            {actions.length > 0 && (
+                <menu className="tw-flex tw-gap-2 tw-text-sm tw-text-muted-foreground">
+                    <div className="tw-flex tw-flex-wrap tw-items-center tw-gap-x-4 tw-gap-y-2">
+                        <ul className="tw-whitespace-nowrap tw-flex tw-gap-2 tw-flex-wrap">
+                            {actions.map(({ label, tooltip, onClick }) => (
+                                <li key={label}>
+                                    <Tooltip>
+                                        <TooltipTrigger asChild>
+                                            <Button variant="outline" size="sm" onClick={onClick}>
+                                                {label}
+                                            </Button>
+                                        </TooltipTrigger>
+                                        <TooltipContent>{tooltip}</TooltipContent>
+                                    </Tooltip>
+                                </li>
+                            ))}
+                        </ul>
+                    </div>
+                </menu>
+            )}
+        </div>
+    )
+}
 /**
  * An error message shown in the chat.
  */

--- a/vscode/webviews/chat/cells/messageCell/assistant/AssistantMessageCell.tsx
+++ b/vscode/webviews/chat/cells/messageCell/assistant/AssistantMessageCell.tsx
@@ -120,6 +120,7 @@ export const AssistantMessageCell: FunctionComponent<{
                                     error={message.error}
                                     userInfo={userInfo}
                                     postMessage={postMessage}
+                                    humanMessage={humanMessage}
                                 />
                             )
                         ) : null}


### PR DESCRIPTION
This PR is for the fix-it issue "Add a retry button for Cody API version error".

**WHY**
When we have a network error, it can cause temporary Cody API version error. It would be nice to allow user to retry for retriable errors like this.

**WHAT**
Add a retry button for Cody API version error.

Restrict the Cody API version check to claude-3 models only since we don't need the check for the rest of the models. Claude-3 models are being deprecated already, but old sg instances might still have them.

## Test plan

CI & tested locally with debugger (see [Loom video](https://www.loom.com/share/3468a810fdfc43f6ba560e6eba95fb5f?sid=595964ef-bc93-4c01-a2d8-afc9c33f4e71))
<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
