### PR TITLE
Revert "update strategy"

### DIFF
--- a/.github/workflows/generate-changelog.yml
+++ b/.github/workflows/generate-changelog.yml
@@ -53,8 +53,6 @@ jobs:
           echo "Latest Release: $RELEASE_LATEST_RELEASE"
           ./changelog update-as-pr \
             --github.repo=$GH_REPO \
-            --github.branch="kalan/update-changelog-gen-M66" \
-            --releaseregistry.commit=${RELEASE_LATEST_RELEASE} \ 
             --output.repo.base="main" \
             --output.repo=$GH_REPO \
             --output.pr.branch="release/vscode-%s" \
@@ -62,7 +60,7 @@ jobs:
             --output.pr.body="Automated release and changelog for VS code Cody %s" \
             --output.changelog="vscode/CHANGELOG.md" \
             --output.changelog.marker='<!--- {/_ CHANGELOG_START _/} -->' \
-            --releaseregistry.version=${VERSION}
+            --releaseregistry.version=$text
 
           #   --title "VS Code: Release v$VERSION" \
           #   --body "Automated release and changelog for VS code Cody" \


### PR DESCRIPTION
Accidentally pushed a commit directly to M66 thinking it was a different branch. This reverts commit 3a65234f79fea1d1525588dc90a02b0bb671f682.

## Test plan
N/A
<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
