### PR TITLE
do not force agent workspace root URI to be `file:` scheme

### DIFF
--- a/agent/src/agent.ts
+++ b/agent/src/agent.ts
@@ -394,7 +394,7 @@ export class Agent extends MessageHandler implements ExtensionClient {
             }
 
             this.workspace.workspaceRootUri = clientInfo.workspaceRootUri
-                ? vscode.Uri.parse(clientInfo.workspaceRootUri).with({ scheme: 'file' })
+                ? vscode.Uri.parse(clientInfo.workspaceRootUri)
                 : vscode.Uri.from({
                       scheme: 'file',
                       path: clientInfo.workspaceRootPath ?? undefined,


### PR DESCRIPTION
In https://github.com/sourcegraph/cody/pull/5391 the agent started forcing the workspaceRootUri to `file:` scheme. It was not documented why, and this is indicative of a bug elsewhere. In the rules PR (https://github.com/sourcegraph/cody/pull/6909), Cody Web starts caring about the workspace root URI and needs to use a `repo:` URI scheme. (Previously, the workspaceRootUri in Cody Web was an invalid URI `sourcegraph/cody`.)

## Test plan

CI