### PR TITLE
feat/smart-apply: add haiku 3.5 for a/b testing

### DIFF
--- a/lib/shared/src/experimentation/FeatureFlagProvider.ts
+++ b/lib/shared/src/experimentation/FeatureFlagProvider.ts
@@ -55,6 +55,9 @@ export enum FeatureFlag {
     CodyAutocompleteContextExperimentVariant4 = 'cody-autocomplete-context-experiment-variant-4',
     CodyAutocompleteContextExperimentControl = 'cody-autocomplete-context-experiment-control',
 
+    CodySmartApplyExperimentEnabledFeatureFlag = 'cody-smart-apply-experiment-enabled-flag',
+    CodySmartApplyExperimentVariant1 = 'cody-smart-apply-experiment-variant-1',
+
     CodyAutoEditExperimentEnabledFeatureFlag = 'cody-autoedit-experiment-enabled-flag',
 
     // Enables gpt-4o-mini as a default Edit model

--- a/vscode/src/edit/manager.ts
+++ b/vscode/src/edit/manager.ts
@@ -334,6 +334,7 @@ export class EditManager implements vscode.Disposable {
 
                 const contextloggerRequestId =
                     await this.smartApplyContextLogger.createSmartApplyLoggingRequest({
+                        model: model,
                         userQuery: configuration.instruction.toString(),
                         replacementCodeBlock: replacementCode.toString(),
                         document: configuration.document,

--- a/vscode/src/edit/smart-apply-context-logging.ts
+++ b/vscode/src/edit/smart-apply-context-logging.ts
@@ -1,4 +1,5 @@
 import {
+    type EditModel,
     FeatureFlag,
     displayPathWithoutWorkspaceFolderPrefix,
     featureFlagProvider,
@@ -21,6 +22,7 @@ interface RepoContext {
 }
 
 interface SmartApplyBaseContext extends RepoContext {
+    smartApplyModel: EditModel
     userQuery: string
     replacementCodeBlock: string
     filePath: string
@@ -60,6 +62,7 @@ export class SmartApplyContextLogger {
     )
 
     public createSmartApplyLoggingRequest(params: {
+        model: EditModel
         userQuery: string
         replacementCodeBlock: string
         document: vscode.TextDocument
@@ -70,6 +73,7 @@ export class SmartApplyContextLogger {
         const fileContent = params.document.getText()
 
         const baseContext: SmartApplyBaseContext = {
+            smartApplyModel: params.model,
             ...baseRepoContext,
             userQuery: params.userQuery,
             replacementCodeBlock: params.replacementCodeBlock,

--- a/vscode/src/services/utils/codeblock-action-tracker.ts
+++ b/vscode/src/services/utils/codeblock-action-tracker.ts
@@ -147,7 +147,7 @@ export async function handleCodeFromInsertAtCursor(text: string): Promise<void> 
 
 function getSmartApplyExperimentModel(): Observable<EditModel | undefined> {
     const defaultModel: EditModel = 'anthropic/claude-3-5-sonnet-20240620'
-    const haikuModel: EditModel = 'anthropic/claude-3-5-haiku-20241022'
+    const haikuModel: EditModel = 'anthropic::2024-10-22::claude-3-5-haiku-latest'
 
     return combineLatest(
         featureFlagProvider.evaluatedFeatureFlag(FeatureFlag.CodySmartApplyExperimentEnabledFeatureFlag),

--- a/vscode/src/services/utils/codeblock-action-tracker.ts
+++ b/vscode/src/services/utils/codeblock-action-tracker.ts
@@ -1,17 +1,25 @@
+import { Observable } from 'observable-fns'
 import * as vscode from 'vscode'
 
 import {
     type AuthStatus,
     type EditModel,
+    FeatureFlag,
     PromptString,
+    combineLatest,
+    distinctUntilChanged,
+    featureFlagProvider,
+    firstValueFrom,
     isDotCom,
+    skipPendingOperation,
+    switchMap,
     telemetryRecorder,
 } from '@sourcegraph/cody-shared'
-
 import { doesFileExist } from '../../commands/utils/workspace-files'
 import { executeSmartApply } from '../../edit/smart-apply'
 import { getEditor } from '../../editor/active-editor'
 import type { VSCodeEditor } from '../../editor/vscode-editor'
+import { isRunningInsideAgent } from '../../jsonrpc/isRunningInsideAgent'
 
 import { countCode, matchCodeSnippets } from './code-count'
 import { resolveRelativeOrAbsoluteUri } from './edit-create-file'
@@ -137,7 +145,30 @@ export async function handleCodeFromInsertAtCursor(text: string): Promise<void> 
     await vscode.workspace.applyEdit(workspaceEdit)
 }
 
-function getSmartApplyModel(authStatus: AuthStatus): EditModel | undefined {
+function getSmartApplyExperimentModel(): Observable<EditModel | undefined> {
+    const defaultModel: EditModel = 'anthropic/claude-3-5-sonnet-20240620'
+    const haikuModel: EditModel = 'anthropic/claude-3-5-haiku-20241022'
+
+    return combineLatest(
+        featureFlagProvider.evaluatedFeatureFlag(FeatureFlag.CodySmartApplyExperimentEnabledFeatureFlag),
+        featureFlagProvider.evaluatedFeatureFlag(FeatureFlag.CodySmartApplyExperimentVariant1)
+    ).pipe(
+        switchMap(([isExperimentEnabled, isVariant1Enabled]) => {
+            // We run fine tuning experiment for VSC client only.
+            // We disable for all agent clients like the JetBrains plugin.
+            if (isRunningInsideAgent() || !isExperimentEnabled) {
+                return Observable.of(defaultModel)
+            }
+            if (isVariant1Enabled) {
+                return Observable.of(haikuModel)
+            }
+            return Observable.of(defaultModel)
+        }),
+        distinctUntilChanged()
+    )
+}
+
+async function getSmartApplyModel(authStatus: AuthStatus): Promise<EditModel | undefined> {
     if (!isDotCom(authStatus)) {
         // We cannot be sure what model we're using for enterprise, we will let this fall through
         // to the default edit/smart apply behaviour where we use the configured enterprise model.
@@ -147,10 +178,12 @@ function getSmartApplyModel(authStatus: AuthStatus): EditModel | undefined {
     /**
      * For PLG, we have a greater model choice. We default this to Claude 3.5 Sonnet
      * as it is the most reliable model for smart apply from our testing.
-     * Right now we should prioritise reliability over latency, take this into account before changing
-     * this value.
+     * We choose the model based on the feature flag but default to the sonnet model if the flag is not enabled or as default model.
      */
-    return 'anthropic/claude-3-5-sonnet-20240620'
+    const smartApplyModel = await firstValueFrom(
+        getSmartApplyExperimentModel().pipe(skipPendingOperation())
+    )
+    return smartApplyModel
 }
 
 export async function handleSmartApply(
@@ -194,7 +227,7 @@ export async function handleSmartApply(
             id,
             document,
             instruction: PromptString.unsafe_fromUserQuery(instruction || ''),
-            model: getSmartApplyModel(authStatus),
+            model: await getSmartApplyModel(authStatus),
             replacement: code,
             isNewFile,
             traceparent,


### PR DESCRIPTION
## Context 
- The PR adds a basic a/b testing setup to experiment with the smart apply. 
- We will try haiku in a variant and based on the a/b results decide if the model is worth switching.

## Test plan
- Add yourself in the feature flag `cody-smart-apply-experiment-variant-1` and `cody-smart-apply-experiment-enabled-flag`
- Try the smart apply feature and see the updated model in `█ telemetry-v2 recordEvent: cody.command.edit/executed: {` events
