### PR TITLE
Use IntelliJ API which is present in all IntelliJ versions

### DIFF
--- a/jetbrains/src/main/kotlin/com/sourcegraph/cody/autocomplete/CodyAutocompleteManager.kt
+++ b/jetbrains/src/main/kotlin/com/sourcegraph/cody/autocomplete/CodyAutocompleteManager.kt
@@ -1,6 +1,7 @@
 package com.sourcegraph.cody.autocomplete
 
 import com.intellij.codeInsight.hint.HintManager
+import com.intellij.codeWithMe.ClientId
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.client.ClientSessionsManager
 import com.intellij.openapi.command.CommandProcessor
@@ -143,7 +144,7 @@ class CodyAutocompleteManager {
       }
       return
     }
-    val isRemoteDev = ClientSessionsManager.getAppSession()?.isRemote ?: false
+    val isRemoteDev = ClientSessionsManager.getAppSession(ClientId.current)?.isRemote ?: false
     if (isRemoteDev) {
       return
     }


### PR DESCRIPTION
Fixes https://linear.app/sourcegraph/issue/BUGS-1272

## Changes

Signatures of function `getAppSession`:
[IJ 2023.2](https://github.com/JetBrains/intellij-community/blob/idea/232.10203.10/platform/platform-impl/src/com/intellij/openapi/client/ClientSessionsManager.kt#L54): `fun getAppSession(clientId: ClientId = ClientId.current): ClientAppSession?`
[IJ 2025.1](https://github.com/JetBrains/intellij-community/blob/idea/251.18673.35/platform/core-api/src/com/intellij/openapi/client/ClientSessionsManager.kt#L33): `fun getAppSession(clientId: ClientId): ClientAppSession?`

So to fix it it was enough to add an default parameter explicitly.

## Test plan

**IJ 2023.2:**
1. Run IJ 2023.2 either using pre-installed IntelliJ 2023 or by using command: `./gradlew :customRunIDE -PplatformRuntimeVersion=2023.2  -PforceAgentBuild=true`
2. Trigger autocomplete and verify it succeeded

**IJ 2025.1:**
1. Run IJ 2025.1 either using pre-installed IntelliJ 2023 or by using command: `./gradlew :customRunIDE -PplatformRuntimeVersion=251.18673.35  -PforceAgentBuild=true`
2. Trigger autocomplete and verify it succeeded


<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
