### PR TITLE
fix: Stop button on cody web

### DIFF
--- a/lib/shared/src/sourcegraph-api/completions/browserClient.ts
+++ b/lib/shared/src/sourcegraph-api/completions/browserClient.ts
@@ -1,6 +1,6 @@
 import { fetchEventSource } from '@microsoft/fetch-event-source'
 
-import { dependentAbortController } from '../../common/abortController'
+import { dependentAbortController, onAbort } from '../../common/abortController'
 import { currentResolvedConfig } from '../../configuration/resolver'
 import { isError } from '../../utils'
 import { addClientInfoParams, addCodyClientIdentificationHeaders } from '../client-name-version'
@@ -125,12 +125,11 @@ export class SourcegraphBrowserCompletionsClient extends SourcegraphCompletionsC
             console.error(error)
         })
 
-
         // 'fetchEventSource' does not emit any event/message when the signal gets abborted. Instead,
         // the returned promise gets resolved. However we cannot really differentiate between the
         // promising resolving because the signal got abborted and the stream ended.
         // That's why we subscribe to the signal directly and trigger the completion callback.
-        signal?.addEventListener('abort', cb.onComplete, {once: true})
+        onAbort(signal, cb.onComplete)
     }
 
     protected async _fetchWithCallbacks(

--- a/lib/shared/src/sourcegraph-api/completions/browserClient.ts
+++ b/lib/shared/src/sourcegraph-api/completions/browserClient.ts
@@ -124,6 +124,13 @@ export class SourcegraphBrowserCompletionsClient extends SourcegraphCompletionsC
             abort.abort()
             console.error(error)
         })
+
+
+        // 'fetchEventSource' does not emit any event/message when the signal gets abborted. Instead,
+        // the returned promise gets resolved. However we cannot really differentiate between the
+        // promising resolving because the signal got abborted and the stream ended.
+        // That's why we subscribe to the signal directly and trigger the completion callback.
+        signal?.addEventListener('abort', cb.onComplete, {once: true})
     }
 
     protected async _fetchWithCallbacks(


### PR DESCRIPTION
There are currently two problems with the stop button functionality on
cody web:

1. After pressing the button the response stream continues for a while.
2. The button doesn't turn back into the submit button, making itj
   impossible to submit a follow up question.

This commit solves (2).

## Technical details

The way the chat response propagates through the system somwhat like
this (simplified)

response chunks -> typewriter effect -> webworker transport -> ui

We are also passing an abort signal all the way down to the logic that
initiates the response stream. When the close button is activated we are
trigger that signal.
But this abortion doesn't 'trickle back up' to typewriter, etc. because
`fetchEventSource` doesn't emit any event in this case.

The fix is to directly listen to the abort event and call the completion
callback.

Closes https://linear.app/sourcegraph/issue/CODY-4725/stop-button-state-does-not-get-updated-after-stopping


## Test plan

Manual testing.
