### PR TITLE
fix: remove chat footer link removals and border fixes

### DIFF
--- a/vscode/webviews/chat/components/QuickStart.tsx
+++ b/vscode/webviews/chat/components/QuickStart.tsx
@@ -166,7 +166,7 @@ export function QuickStart() {
                     <div className="tw-m-4">
                         <button
                             type="button"
-                            className="tw-rounded-md tw-border tw-px-4 tw-py-2 tw-text-md tw-border-border hover:tw-bg-muted"
+                            className="tw-rounded-md tw-border tw-border-border tw-px-4 tw-py-2 tw-text-md hover:tw-bg-muted"
                             onClick={e => {
                                 e.stopPropagation()
                                 setShowTipsOverlay(true)

--- a/vscode/webviews/chat/components/WelcomeFooter.tsx
+++ b/vscode/webviews/chat/components/WelcomeFooter.tsx
@@ -1,49 +1,13 @@
 import { CodyIDE } from '@sourcegraph/cody-shared'
+import { ExtensionPromotionalBanner } from '../../components/ExtensionPromotionalBanner'
 import { QuickStart } from './QuickStart'
 import styles from './WelcomeFooter.module.css'
-
-import { BookOpenText, type LucideProps, MessageCircleQuestion } from 'lucide-react'
-import type { ForwardRefExoticComponent } from 'react'
-import { ExtensionPromotionalBanner } from '../../components/ExtensionPromotionalBanner'
-
-interface ChatViewLink {
-    icon: ForwardRefExoticComponent<Omit<LucideProps, 'ref'>>
-    text: string
-    url: string
-}
-
-const chatLinks: ChatViewLink[] = [
-    {
-        icon: BookOpenText,
-        text: 'Documentation',
-        url: 'https://sourcegraph.com/docs/cody',
-    },
-    {
-        icon: MessageCircleQuestion,
-        text: 'Help and Support',
-        url: 'https://community.sourcegraph.com/',
-    },
-]
 
 export default function WelcomeFooter({ IDE }: { IDE: CodyIDE }): JSX.Element {
     return (
         <div className={styles.welcomeFooter}>
             {IDE === CodyIDE.Web && <ExtensionPromotionalBanner IDE={IDE} />}
             <QuickStart />
-            <div className={styles.links}>
-                {chatLinks.map(link => (
-                    <a
-                        key={link.url}
-                        href={link.url}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="tw-flex tw-flex-row tw-gap-3 tw-items-center tw-text-muted-foreground"
-                    >
-                        <link.icon size={16} />
-                        {link.text}
-                    </a>
-                ))}
-            </div>
         </div>
     )
 }

--- a/vscode/webviews/chat/components/WelcomeMessage.tsx
+++ b/vscode/webviews/chat/components/WelcomeMessage.tsx
@@ -1,15 +1,9 @@
 import { CodyIDE } from '@sourcegraph/cody-shared'
-import { BookCopy } from 'lucide-react'
 import type { FunctionComponent } from 'react'
-import { Kbd } from '../../components/Kbd'
 import { PromptList } from '../../components/promptList/PromptList'
-import { Button } from '../../components/shadcn/ui/button'
 import { useActionSelect } from '../../prompts/PromptsTab'
 import { View } from '../../tabs'
 import { PromptMigrationWidget } from './../../components/promptsMigration/PromptsMigration'
-
-import { clsx } from 'clsx'
-import styles from './WelcomeMessage.module.css'
 
 const localStorageKey = 'chat.welcome-message-dismissed'
 
@@ -29,9 +23,6 @@ export const WelcomeMessage: FunctionComponent<WelcomeMessageProps> = ({
     localStorage.removeItem(localStorageKey)
 
     const runAction = useActionSelect()
-    const handleRecentlyUsed = () => {
-        document.querySelector<HTMLButtonElement>("button[aria-label='Insert prompt']")?.click()
-    }
 
     return (
         <div className="tw-flex-1 tw-flex tw-flex-col tw-items-start tw-w-full tw-px-8 tw-gap-6 tw-transition-all tw-relative">

--- a/vscode/webviews/chat/components/WelcomeMessage.tsx
+++ b/vscode/webviews/chat/components/WelcomeMessage.tsx
@@ -50,25 +50,6 @@ export const WelcomeMessage: FunctionComponent<WelcomeMessageProps> = ({
                     telemetryLocation="WelcomeAreaPrompts"
                     onSelect={item => runAction(item, setView)}
                 />
-                <div className={clsx(styles.actions, 'tw-flex tw-py-2 tw-gap-8 tw-justify-center')}>
-                    <Button
-                        variant="ghost"
-                        className="tw-justify-center tw-basis-0 tw-whitespace-nowrap"
-                        onClick={handleRecentlyUsed}
-                    >
-                        Recently used{' '}
-                        {IDE === CodyIDE.VSCode && <Kbd macOS="opt+p" linuxAndWindows="alt+p" />}
-                    </Button>
-
-                    <Button
-                        variant="ghost"
-                        className="tw-justify-center tw-basis-0 tw-whitespace-nowrap"
-                        onClick={() => setView(View.Prompts)}
-                    >
-                        <BookCopy width={16} />
-                        All Prompts
-                    </Button>
-                </div>
             </div>
         </div>
     )

--- a/vscode/webviews/chat/components/WelcomeMessage.tsx
+++ b/vscode/webviews/chat/components/WelcomeMessage.tsx
@@ -2,7 +2,7 @@ import { CodyIDE } from '@sourcegraph/cody-shared'
 import type { FunctionComponent } from 'react'
 import { PromptList } from '../../components/promptList/PromptList'
 import { useActionSelect } from '../../prompts/PromptsTab'
-import { View } from '../../tabs'
+import type { View } from '../../tabs'
 import { PromptMigrationWidget } from './../../components/promptsMigration/PromptsMigration'
 
 const localStorageKey = 'chat.welcome-message-dismissed'


### PR DESCRIPTION
## Description

This PR removes the footer links in the chat (they're already available in the profile menu) and fix border styling.


**Old UI**
<img width="419" alt="image" src="https://github.com/user-attachments/assets/160393cd-10ab-4b49-988f-ea47fe4cb3c3" />

**New UI**
<img width="423" alt="image" src="https://github.com/user-attachments/assets/e7513807-ea71-4f47-baa5-1e85dcb86ae7" />


## Test plan

Tested locally, manually.