### PR TITLE
feat/smart-apply: log fixupID to track in the edit

### DIFF
--- a/vscode/src/edit/edit-context-logging.ts
+++ b/vscode/src/edit/edit-context-logging.ts
@@ -5,12 +5,14 @@ import {
     featureFlagProvider,
     isDotComAuthed,
     storeLastValue,
+    telemetryRecorder,
 } from '@sourcegraph/cody-shared'
 import { LRUCache } from 'lru-cache'
 import * as uuid from 'uuid'
 import type * as vscode from 'vscode'
 import { gitMetadataForCurrentEditor } from '../repository/git-metadata-for-editor'
 import { GitHubDotComRepoMetadata } from '../repository/githubRepoMetadata'
+import { splitSafeMetadata } from '../services/telemetry-v2'
 import type { SmartSelectionType } from './prompt/smart-apply'
 
 const MAX_LOGGING_PAYLOAD_SIZE_BYTES = 1024 * 1024 // 1 MB
@@ -39,6 +41,7 @@ interface SmartApplySelectionContext extends SmartApplyBaseContext {
 
 interface SmartApplyFinalContext extends SmartApplySelectionContext {
     applyTimeMs: number
+    applyTaskId?: string
 }
 
 interface EditLoggingContext {
@@ -138,7 +141,11 @@ export class SmartApplyContextLogger {
         })
     }
 
-    public addSmartApplyFinalContext(requestId: SmartApplyLoggingRequestId, applyTimeMs: number): void {
+    public addApplyContext(
+        requestId: SmartApplyLoggingRequestId,
+        applyTimeMs: number,
+        applyTaskId: string | undefined
+    ): void {
         const request = this.getRequest(requestId)
         if (!request) {
             return
@@ -146,10 +153,29 @@ export class SmartApplyContextLogger {
         this.activeRequests.set(requestId, {
             ...request,
             applyTimeMs,
+            applyTaskId,
         })
     }
 
-    public getSmartApplyLoggingContext(
+    public logSmartApplyContextToTelemetry(requestId: SmartApplyLoggingRequestId): void {
+        const context = this.getSmartApplyLoggingContext(requestId)
+        if (!context) {
+            return
+        }
+        const { metadata, privateMetadata } = splitSafeMetadata(context)
+        telemetryRecorder.recordEvent('cody.smart-apply.context', 'applied', {
+            metadata: {
+                ...metadata,
+                recordsPrivateMetadataTranscript: 1,
+            },
+            privateMetadata: {
+                smartApplyContext: privateMetadata,
+            },
+            billingMetadata: { product: 'cody', category: 'billable' },
+        })
+    }
+
+    private getSmartApplyLoggingContext(
         requestId: SmartApplyLoggingRequestId
     ): SmartApplyFinalContext | undefined {
         const request = this.activeRequests.get(requestId)

--- a/vscode/src/edit/manager.ts
+++ b/vscode/src/edit/manager.ts
@@ -227,6 +227,7 @@ export class EditManager implements vscode.Disposable {
             intent: task.intent,
             mode: task.mode,
             source: task.source,
+            taskId: task.id,
             ...telemetryMetadata,
             editContext: editContextData,
         }
@@ -469,7 +470,7 @@ export class EditManager implements vscode.Disposable {
                 // Just using the replacement code from the response is not enough, as it may contain parts that are not suitable to apply,
                 // e.g. // ...
                 const applyStartTime = Date.now()
-                await this.executeEdit({
+                const task = await this.executeEdit({
                     configuration: {
                         id: configuration.id,
                         document: configuration.document,
@@ -482,27 +483,12 @@ export class EditManager implements vscode.Disposable {
                     source,
                 })
                 const applyTimeTakenMs = Date.now() - applyStartTime
-                this.smartApplyContextLogger.addSmartApplyFinalContext(
+                this.smartApplyContextLogger.addApplyContext(
                     contextloggerRequestId,
-                    applyTimeTakenMs
+                    applyTimeTakenMs,
+                    task?.id
                 )
-                const smartApplyContext =
-                    await this.smartApplyContextLogger.getSmartApplyLoggingContext(
-                        contextloggerRequestId
-                    )
-                if (smartApplyContext) {
-                    const { metadata, privateMetadata } = splitSafeMetadata(smartApplyContext)
-                    telemetryRecorder.recordEvent('cody.smart-apply.context', 'applied', {
-                        metadata: {
-                            ...metadata,
-                            recordsPrivateMetadataTranscript: 1,
-                        },
-                        privateMetadata: {
-                            smartApplyContext: privateMetadata,
-                        },
-                        billingMetadata: { product: 'cody', category: 'billable' },
-                    })
-                }
+                this.smartApplyContextLogger.logSmartApplyContextToTelemetry(contextloggerRequestId)
                 return
             })
         })

--- a/vscode/src/non-stop/FixupController.ts
+++ b/vscode/src/non-stop/FixupController.ts
@@ -598,6 +598,7 @@ export class FixupController
         const originalCodeCounts = countCode(task.original)
 
         const legacyMetadata = {
+            taskId: task.id,
             intent: EditIntentTelemetryMetadataMapping[task.intent] || task.intent,
             mode: EditModeTelemetryMetadataMapping[task.mode] || task.mode,
             source:

--- a/vscode/test/e2e/__snapshots__/command-edit.test.ts/edit-fixup-task-1.txt
+++ b/vscode/test/e2e/__snapshots__/command-edit.test.ts/edit-fixup-task-1.txt
@@ -75,6 +75,7 @@
     }
   ],
   "privateMetadata": {
+    "taskId": "9999",
     "languageId": "typescript",
     "model": "anthropic::2023-06-01::claude-3.5-sonnet"
   },

--- a/vscode/test/e2e/command-edit.test.ts
+++ b/vscode/test/e2e/command-edit.test.ts
@@ -8,6 +8,7 @@ import {
     type ExpectedV2Events,
     test as baseTest,
     stabilizeMetadataValues,
+    stabilizePrivateMetadataValues,
 } from './helpers'
 
 const test = baseTest.extend<DotcomUrlOverride>({ dotcomUrl: mockServer.SERVER_URL })
@@ -99,6 +100,7 @@ test.extend<ExpectedV2Events>({
         event => event.testId === 'cody.fixup.apply:succeeded'
     )
     stabilizeMetadataValues(['latency'], fixupApplySuccessEvent)
+    stabilizePrivateMetadataValues(['taskId'], fixupApplySuccessEvent)
     expect(JSON.stringify(fixupApplySuccessEvent?.parameters, null, 2)).toMatchSnapshot()
 })
 

--- a/vscode/test/e2e/helpers.ts
+++ b/vscode/test/e2e/helpers.ts
@@ -648,6 +648,7 @@ export function mockEnterpriseRepoMapping(server: MockServer, repoName: string):
 }
 
 const STABILIZED_NUMBER_VALUE_FOR_SNAPSHOT = 9999
+const STABILIZED_STRING_VALUE_FOR_SNAPSHOT = '9999'
 
 /**
  * Stabilizes metadata values in telemetry event parameters for consistent snapshot testing.
@@ -664,6 +665,17 @@ export function stabilizeMetadataValues(keys: string[], event?: TelemetryEventIn
                 typeof param.value === 'number'
                     ? STABILIZED_NUMBER_VALUE_FOR_SNAPSHOT
                     : 'stabilized_value_for_snapshot'
+        }
+    }
+}
+
+export function stabilizePrivateMetadataValues(keys: string[], event?: TelemetryEventInput | null) {
+    if (!event?.parameters?.privateMetadata) {
+        return
+    }
+    for (const key of keys) {
+        if (key in event.parameters.privateMetadata) {
+            event.parameters.privateMetadata[key] = STABILIZED_STRING_VALUE_FOR_SNAPSHOT
         }
     }
 }


### PR DESCRIPTION
## Context
- Track the `taskId` for the `edit` command and propagate the same to the  smart apply context.
- This changes will help link the rejected/accepted edit context with the smart apply task and help identify the challenging tasks where it fails.  

## Test plan
- Observe the `smart-apply` and `edit` telemetry events, which should be tagged with same `taskId` and `applyTaskId` and should be same for the common request.
