### PR TITLE
chore/chat: remove extra Cody API version call in chat

### DIFF
--- a/lib/shared/src/chat/chat.ts
+++ b/lib/shared/src/chat/chat.ts
@@ -51,7 +51,7 @@ export class ChatClient {
         const isFireworks =
             params?.model?.startsWith('fireworks/') || params?.model?.startsWith('fireworks::')
         const augmentedMessages =
-            isFireworks || getApiVersion() > 0
+            isFireworks || isClaude3Model
                 ? sanitizeMessages(messages)
                 : isLastMessageFromHuman
                   ? messages.concat([{ speaker: 'assistant' }])


### PR DESCRIPTION
**WHAT**
[Follow up task](https://github.com/sourcegraph/cody/pull/6926#pullrequestreview-2592279996) from _Add a retry button for Cody API version error (CODY-4864)_ to remove the site version API call

**WHY**
For `apiVersion >= 1 && model?.includes(‘claude-3’)`, we would add a system prompt in https://sourcegraph.com/github.com/sourcegraph/cody/-/blob/lib/shared/src/chat/preamble.ts?L28

Therefore, we can just check if the first message is a system prompt or not in the `params.messages` without needing to make another API call for the site version. 

## Test plan
CI & tested locally with the debugger ([Loom video](https://www.loom.com/share/0705f01245a243628be9d78322952b1d))
<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
