### PR TITLE
fix/(chat): bottom prompt buttons cut off

### DIFF
--- a/vscode/webviews/chat/components/WelcomeMessage.module.css
+++ b/vscode/webviews/chat/components/WelcomeMessage.module.css
@@ -1,4 +1,5 @@
 
 .actions {
     --vscode-keybindingLabel-foreground: currentColor;
+    flex-flow: row wrap;
 }


### PR DESCRIPTION
### WHY
The `Recently Used` and `All Prompts` buttons currently get cut off if the chat window is too small.

https://github.com/user-attachments/assets/43cc8aa7-49f2-4ac7-9be2-06b05b37b98f
 
### WHAT
Update `flex` style for these buttons so they wrap to the next line instead of getting cut off.

https://github.com/user-attachments/assets/610d76ee-da60-454b-b3bf-d7745f347ad9

## Test plan
CI & ran local debugger. See videos above.
<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
