### PR TITLE
feat: Improve warm cody web startup time

### DIFF
--- a/web/demo/App.tsx
+++ b/web/demo/App.tsx
@@ -1,9 +1,8 @@
-import { type FC, useEffect, useState } from 'react'
-import { type CodyWebAgent, CodyWebChat, type InitialContext, createCodyAgent } from '../lib'
+import type { FC } from 'react'
+import { CodyWebChat, type InitialContext } from '../lib'
 
 // @ts-ignore
 import AgentWorker from '../lib/agent/agent.worker.ts?worker'
-
 const CREATE_AGENT_WORKER = (): Worker => new AgentWorker() as Worker
 
 // Include highlights styles for demo purpose, clients like
@@ -36,26 +35,17 @@ const INITIAL_CONTEXT: InitialContext = {
     isDirectory: true,
 }
 
-const agentPromise = createCodyAgent({
+const agentConfig = {
     accessToken,
     serverEndpoint,
-    createAgentWorker: CREATE_AGENT_WORKER,
     telemetryClientName: 'codydemo.testing',
-})
+    createAgentWorker: CREATE_AGENT_WORKER,
+}
 
 export const App: FC = () => {
-    const [agent, setAgent] = useState<CodyWebAgent | null>(null)
-
-    useEffect(() => {
-        agentPromise.then(agent => {
-            agent?.createNewChat()
-            setAgent(agent)
-        }, setAgent)
-    }, [])
-
     return (
         <div className={styles.root}>
-            <CodyWebChat agent={agent} initialContext={INITIAL_CONTEXT} viewType="sidebar" />
+            <CodyWebChat agentConfig={agentConfig} initialContext={INITIAL_CONTEXT} viewType="sidebar" />
         </div>
     )
 }

--- a/web/demo/App.tsx
+++ b/web/demo/App.tsx
@@ -36,16 +36,18 @@ const INITIAL_CONTEXT: InitialContext = {
     isDirectory: true,
 }
 
+const agentPromise = createCodyAgent({
+    accessToken,
+    serverEndpoint,
+    createAgentWorker: CREATE_AGENT_WORKER,
+    telemetryClientName: 'codydemo.testing',
+})
+
 export const App: FC = () => {
     const [agent, setAgent] = useState<CodyWebAgent | null>(null)
 
     useEffect(() => {
-        createCodyAgent({
-            accessToken,
-            serverEndpoint,
-            createAgentWorker: CREATE_AGENT_WORKER,
-            telemetryClientName: 'codydemo.testing',
-        }).then(agent => {
+        agentPromise.then(agent => {
             agent?.createNewChat()
             setAgent(agent)
         }, setAgent)

--- a/web/demo/App.tsx
+++ b/web/demo/App.tsx
@@ -1,5 +1,5 @@
-import type { FC } from 'react'
-import { CodyWebChat, type InitialContext } from '../lib'
+import { type FC, useEffect, useState } from 'react'
+import { type CodyWebAgent, CodyWebChat, type InitialContext, createCodyAgent } from '../lib'
 
 // @ts-ignore
 import AgentWorker from '../lib/agent/agent.worker.ts?worker'
@@ -37,16 +37,23 @@ const INITIAL_CONTEXT: InitialContext = {
 }
 
 export const App: FC = () => {
+    const [agent, setAgent] = useState<CodyWebAgent | null>(null)
+
+    useEffect(() => {
+        createCodyAgent({
+            accessToken,
+            serverEndpoint,
+            createAgentWorker: CREATE_AGENT_WORKER,
+            telemetryClientName: 'codydemo.testing',
+        }).then(agent => {
+            agent?.createNewChat()
+            setAgent(agent)
+        }, setAgent)
+    }, [])
+
     return (
         <div className={styles.root}>
-            <CodyWebChat
-                accessToken={accessToken}
-                serverEndpoint={serverEndpoint}
-                createAgentWorker={CREATE_AGENT_WORKER}
-                telemetryClientName="codydemo.testing"
-                initialContext={INITIAL_CONTEXT}
-                viewType="sidebar"
-            />
+            <CodyWebChat agent={agent} initialContext={INITIAL_CONTEXT} viewType="sidebar" />
         </div>
     )
 }

--- a/web/lib/agent/agent.client.ts
+++ b/web/lib/agent/agent.client.ts
@@ -21,7 +21,6 @@ interface AgentClientOptions {
     createAgentWorker: () => Worker
     telemetryClientName?: string
     customHeaders?: Record<string, string>
-    repository?: string
     debug?: boolean
     trace?: boolean
 }
@@ -31,7 +30,6 @@ export async function createAgentClient({
     accessToken,
     createAgentWorker,
     customHeaders,
-    repository,
     telemetryClientName,
     debug = true,
     trace = false,
@@ -70,9 +68,7 @@ export async function createAgentClient({
     const serverInfo: ServerInfo = await rpc.sendRequest('initialize', {
         name: process.env.CODY_WEB_DEMO_STANDALONE_MODE === 'true' ? 'standalone-web' : 'web',
         version: '0.0.1',
-        // Empty root URI leads to openctx configuration resolution failure, any non-empty
-        // mock value (Cody Web doesn't really use any workspace related features)
-        workspaceRootUri: `repo:${repository ?? ''}`,
+        workspaceRootUri: '',
         capabilities: {
             edit: 'none',
             completions: 'none',

--- a/web/lib/agent/agent.client.ts
+++ b/web/lib/agent/agent.client.ts
@@ -9,7 +9,7 @@ import {
 } from 'vscode-jsonrpc/browser'
 
 // TODO(sqs): dedupe with agentClient.ts in [experimental Cody CLI](https://github.com/sourcegraph/cody/pull/3418)
-interface AgentClient {
+export interface AgentClient {
     serverInfo: ServerInfo
     rpc: MessageConnection
     dispose(): void

--- a/web/lib/components/CodyPromptTemplate.tsx
+++ b/web/lib/components/CodyPromptTemplate.tsx
@@ -36,7 +36,7 @@ import { useClientActionDispatcher } from 'cody-ai/webviews/client/clientState'
 import { ComposedWrappers, type Wrapper } from 'cody-ai/webviews/utils/composeWrappers'
 import { createWebviewTelemetryRecorder } from 'cody-ai/webviews/utils/telemetry'
 
-import type { CodyWebAgent } from './use-cody-agent'
+import { type UseCodyWebAgentInput, useCodyWebAgent } from './use-cody-agent'
 
 // Include global Cody Web styles to the styles bundle
 import '../global-styles/styles.css'
@@ -52,7 +52,7 @@ setDisplayPathEnvInfo({
 })
 
 export interface CodyPromptTemplateProps {
-    agent: CodyWebAgent | Error | null
+    agentConfig: UseCodyWebAgentInput
     className?: string
 
     initialEditorState?: SerializedPromptEditorState | undefined
@@ -72,13 +72,15 @@ export interface CodyPromptTemplateProps {
  * to run this with @ mentions in the prompt template editor.
  */
 export const CodyPromptTemplate: FunctionComponent<CodyPromptTemplateProps> = ({
-    agent,
+    agentConfig,
     className,
     disabled,
     initialEditorState,
     placeholder,
     onEditorApiReady,
 }) => {
+    const agent = useCodyWebAgent(agentConfig)
+
     if (isErrorLike(agent)) {
         return <p>Cody Web client agent error: {agent.message}</p>
     }

--- a/web/lib/components/CodyPromptTemplate.tsx
+++ b/web/lib/components/CodyPromptTemplate.tsx
@@ -36,7 +36,7 @@ import { useClientActionDispatcher } from 'cody-ai/webviews/client/clientState'
 import { ComposedWrappers, type Wrapper } from 'cody-ai/webviews/utils/composeWrappers'
 import { createWebviewTelemetryRecorder } from 'cody-ai/webviews/utils/telemetry'
 
-import { useCodyWebAgent } from './use-cody-agent'
+import type { CodyWebAgent } from './use-cody-agent'
 
 // Include global Cody Web styles to the styles bundle
 import '../global-styles/styles.css'
@@ -52,11 +52,7 @@ setDisplayPathEnvInfo({
 })
 
 export interface CodyPromptTemplateProps {
-    serverEndpoint: string
-    accessToken: string | null
-    createAgentWorker: () => Worker
-    telemetryClientName?: string
-    customHeaders?: Record<string, string>
+    agent: CodyWebAgent | Error | null
     className?: string
 
     initialEditorState?: SerializedPromptEditorState | undefined
@@ -76,30 +72,18 @@ export interface CodyPromptTemplateProps {
  * to run this with @ mentions in the prompt template editor.
  */
 export const CodyPromptTemplate: FunctionComponent<CodyPromptTemplateProps> = ({
-    serverEndpoint,
-    accessToken,
-    createAgentWorker,
-    telemetryClientName,
-    customHeaders,
+    agent,
     className,
     disabled,
     initialEditorState,
     placeholder,
     onEditorApiReady,
 }) => {
-    const { client, vscodeAPI } = useCodyWebAgent({
-        serverEndpoint,
-        accessToken,
-        createAgentWorker,
-        telemetryClientName,
-        customHeaders,
-    })
-
-    if (isErrorLike(client)) {
-        return <p>Cody Web client agent error: {client.message}</p>
+    if (isErrorLike(agent)) {
+        return <p>Cody Web client agent error: {agent.message}</p>
     }
 
-    if (client === null || vscodeAPI === null) {
+    if (agent === null) {
         return <PromptTemplateSkeleton className={classNames(className, styles.root)} />
     }
 
@@ -107,7 +91,7 @@ export const CodyPromptTemplate: FunctionComponent<CodyPromptTemplateProps> = ({
         <AppWrapper>
             <div className={classNames(className, styles.root)}>
                 <CodyPromptTemplatePanel
-                    vscodeAPI={vscodeAPI}
+                    vscodeAPI={agent.vscodeAPI}
                     className={styles.container}
                     disabled={disabled}
                     initialEditorState={initialEditorState}

--- a/web/lib/components/CodyWebChat.tsx
+++ b/web/lib/components/CodyWebChat.tsx
@@ -3,6 +3,7 @@ import {
     type FC,
     type FunctionComponent,
     useCallback,
+    useEffect,
     useLayoutEffect,
     useMemo,
     useRef,
@@ -127,6 +128,12 @@ export const CodyWebChat: FunctionComponent<CodyWebChatProps> = ({
     if (agent === null) {
         return <ChatSkeleton className={classNames(className, styles.root)} />
     }
+
+    useEffect(() => {
+        agent.client.rpc.sendNotification('workspaceFolder/didChange', {
+            uris: initialContext?.repository.name ? [`repo:${initialContext.repository.name}`] : [],
+        })
+    }, [initialContext?.repository, agent.client])
 
     return (
         <AppWrapper>

--- a/web/lib/components/CodyWebChat.tsx
+++ b/web/lib/components/CodyWebChat.tsx
@@ -36,7 +36,7 @@ import type { Config } from 'cody-ai/webviews/utils/useConfig'
 
 import type { CodyExternalApi, InitialContext } from '../types'
 
-import { useCodyWebAgent } from './use-cody-agent'
+import type { CodyWebAgent } from './use-cody-agent'
 
 // Include global Cody Web styles to the styles bundle
 import '../global-styles/styles.css'
@@ -87,12 +87,8 @@ export interface CodyWebChatController {
 }
 
 export interface CodyWebChatProps {
-    serverEndpoint: string
-    accessToken: string | null
-    createAgentWorker: () => Worker
-    telemetryClientName?: string
+    agent: CodyWebAgent | Error | null
     initialContext?: InitialContext
-    customHeaders?: Record<string, string>
     className?: string
 
     /** A controller that allows the host system to control the behavior of the chat. */
@@ -117,32 +113,18 @@ export interface CodyWebChatProps {
  * You can see the demo usage of this component in demo/App.tsx
  */
 export const CodyWebChat: FunctionComponent<CodyWebChatProps> = ({
-    serverEndpoint,
-    accessToken,
-    createAgentWorker,
+    agent,
     initialContext,
-    telemetryClientName,
-    customHeaders,
     className,
     onExternalApiReady,
     controller,
     viewType,
 }) => {
-    const { client, vscodeAPI } = useCodyWebAgent({
-        serverEndpoint,
-        accessToken,
-        createAgentWorker,
-        initialContext,
-        telemetryClientName,
-        customHeaders,
-        repository: initialContext?.repository.name,
-    })
-
-    if (isErrorLike(client)) {
-        return <p>Cody Web client agent error: {client.message}</p>
+    if (isErrorLike(agent)) {
+        return <p>Cody Web client agent error: {agent.message}</p>
     }
 
-    if (client === null || vscodeAPI === null) {
+    if (agent === null) {
         return <ChatSkeleton className={classNames(className, styles.root)} />
     }
 
@@ -150,7 +132,7 @@ export const CodyWebChat: FunctionComponent<CodyWebChatProps> = ({
         <AppWrapper>
             <div className={classNames(className, styles.root)}>
                 <CodyWebPanel
-                    vscodeAPI={vscodeAPI}
+                    vscodeAPI={agent.vscodeAPI}
                     initialContext={initialContext}
                     className={styles.container}
                     onExternalApiReady={onExternalApiReady}

--- a/web/lib/components/use-cody-agent.ts
+++ b/web/lib/components/use-cody-agent.ts
@@ -1,20 +1,9 @@
-import { forceHydration, hydrateAfterPostMessage, isErrorLike } from '@sourcegraph/cody-shared'
+import { forceHydration, hydrateAfterPostMessage } from '@sourcegraph/cody-shared'
 import type { ExtensionMessage } from 'cody-ai/src/chat/protocol'
 import { type VSCodeWrapper, setVSCodeWrapper } from 'cody-ai/webviews/utils/VSCodeApi'
-import {
-    type DependencyList,
-    type EffectCallback,
-    type MutableRefObject,
-    useCallback,
-    useEffect,
-    useMemo,
-    useRef,
-    useState,
-} from 'react'
-import type { MessageConnection } from 'vscode-jsonrpc/browser'
+import type { MutableRefObject } from 'react'
 import { URI } from 'vscode-uri'
-import { createAgentClient } from '../agent/agent.client'
-import type { InitialContext } from '../types'
+import { type AgentClient, createAgentClient } from '../agent/agent.client'
 
 /**
  * List of events that bypass active panel ID check in the listeners.
@@ -27,184 +16,113 @@ import type { InitialContext } from '../types'
  */
 const GLOBAL_MESSAGE_TYPES: Array<ExtensionMessage['type']> = ['rpc/response']
 
-interface AgentClient {
-    rpc: MessageConnection
-    dispose(): void
-}
-
 interface UseCodyWebAgentInput {
     serverEndpoint: string
     accessToken: string | null
     createAgentWorker: () => Worker
     telemetryClientName?: string
-    initialContext?: InitialContext
     customHeaders?: Record<string, string>
     repository?: string
 }
 
-interface UseCodyWebAgentResult {
-    client: AgentClient | Error | null
-    vscodeAPI: VSCodeWrapper | null
+export interface CodyWebAgent {
+    vscodeAPI: VSCodeWrapper
+    createNewChat: () => Promise<void>
 }
 
 /**
- * Creates Cody Web Agent instance and automatically creates a new chat.
+ * Creates Cody Web Agent instance.
  * Uses cody web-worker agent under the hood with json rpc as a connection between
  * main and web-worker threads, see agent.client.ts for more details
  */
-export function useCodyWebAgent(input: UseCodyWebAgentInput): UseCodyWebAgentResult {
-    const {
-        serverEndpoint,
-        accessToken,
-        telemetryClientName,
-        customHeaders,
-        repository,
-        createAgentWorker,
-    } = input
+export async function createCodyAgent(input: UseCodyWebAgentInput): Promise<CodyWebAgent> {
+    const { serverEndpoint, accessToken, telemetryClientName, customHeaders, createAgentWorker } = input
 
-    const activeWebviewPanelIDRef = useRef<string>('')
-    const [client, setClient] = useState<AgentClient | Error | null>(null)
+    const activeWebviewPanelIDRef = { current: '' }
 
-    useEffectOnce(() => {
-        createAgentClient({
+    try {
+        const agent = await createAgentClient({
             customHeaders,
             telemetryClientName,
             createAgentWorker,
             serverEndpoint: serverEndpoint,
             accessToken: accessToken ?? '',
-            repository,
         })
-            .then(setClient)
-            .catch(error => {
-                console.error('Cody Web Agent creation failed', error)
-                setClient(() => error as Error)
+
+        // Special override for chat creating for Cody Web, otherwise the create new chat doesn't work
+        // TODO: Move this special logic to the Cody Web agent handle "chat/web/new"
+        const createNewChat = async () => {
+            const { panelId, chatId } = await agent.rpc.sendRequest<{
+                panelId: string
+                chatId: string
+            }>('chat/web/new', null)
+
+            activeWebviewPanelIDRef.current = panelId
+
+            await agent.rpc.sendRequest('webview/receiveMessage', {
+                id: activeWebviewPanelIDRef.current,
+                message: { chatID: chatId, command: 'restoreHistory' },
             })
-    }, [accessToken, serverEndpoint, createAgentWorker, customHeaders, telemetryClientName])
-
-    // Special override for chat creating for Cody Web, otherwise the create new chat doesn't work
-    // TODO: Move this special logic to the Cody Web agent handle "chat/web/new"
-    const createNewChat = useCallback(async (agent: AgentClient | Error | null) => {
-        if (!agent || isErrorLike(agent)) {
-            return
         }
 
-        const { panelId, chatId } = await agent.rpc.sendRequest<{
-            panelId: string
-            chatId: string
-        }>('chat/web/new', null)
-
-        activeWebviewPanelIDRef.current = panelId
-
-        await agent.rpc.sendRequest('webview/receiveMessage', {
-            id: activeWebviewPanelIDRef.current,
-            message: { chatID: chatId, command: 'restoreHistory' },
-        })
-    }, [])
-
-    const isInitRef = useRef(false)
-    const vscodeAPI = useVSCodeAPI({ activeWebviewPanelIDRef, createNewChat, client })
-
-    // Always create new chat when Cody Web is opened for the first time
-    useEffect(() => {
-        // Skip panel creation if it already happened before
-        // React in dev mode run all effect twice so it's important here to
-        // run it only one first time to avoid panel ID mismatch in cody agent
-        if (isInitRef.current || !client || isErrorLike(client)) {
-            return
-        }
-
-        void createNewChat(client)
-        isInitRef.current = true
-    }, [client, createNewChat])
-
-    return { client, vscodeAPI }
-}
-
-interface useVSCodeAPIInput {
-    client: AgentClient | Error | null
-    activeWebviewPanelIDRef: MutableRefObject<string>
-    createNewChat: (client: AgentClient | Error | null) => Promise<void>
-}
-
-function useVSCodeAPI(input: useVSCodeAPIInput): VSCodeWrapper | null {
-    const { client, activeWebviewPanelIDRef, createNewChat } = input
-
-    const onMessageCallbacksRef = useRef<((message: ExtensionMessage) => void)[]>([])
-
-    return useMemo<VSCodeWrapper | null>(() => {
-        if (!client) {
-            return null
-        }
-        if (!isErrorLike(client)) {
-            client.rpc.onNotification(
-                'webview/postMessage',
-                ({ id, message }: { id: string; message: ExtensionMessage }) => {
-                    if (
-                        activeWebviewPanelIDRef.current === id ||
-                        GLOBAL_MESSAGE_TYPES.includes(message.type)
-                    ) {
-                        for (const callback of onMessageCallbacksRef.current) {
-                            callback(hydrateAfterPostMessage(message, uri => URI.from(uri as any)))
-                        }
-                    }
-                }
-            )
-        }
-
-        const vscodeAPI: VSCodeWrapper = {
-            postMessage: message => {
-                if (!isErrorLike(client)) {
-                    // Special override for Cody Web
-                    if (message.command === 'command' && message.id === 'cody.chat.new') {
-                        void createNewChat(client)
-                        return
-                    }
-                    void client.rpc.sendRequest('webview/receiveMessage', {
-                        id: activeWebviewPanelIDRef.current,
-                        message: forceHydration(message),
-                    })
-                }
-            },
-            onMessage: callback => {
-                if (!isErrorLike(client)) {
-                    onMessageCallbacksRef.current.push(callback)
-                    return () => {
-                        // Remove callback from onMessageCallbacks
-                        const index = onMessageCallbacksRef.current.indexOf(callback)
-                        if (index >= 0) {
-                            onMessageCallbacksRef.current.splice(index, 1)
-                        }
-                    }
-                }
-                return () => {}
-            },
-            getState: () => {
-                throw new Error('not implemented')
-            },
-            setState: () => {
-                throw new Error('not implemented')
-            },
-        }
-
+        const vscodeAPI = createVSCodeAPI({ activeWebviewPanelIDRef, createNewChat, client: agent })
         // Runtime sync side effect, ensure that later any cody UI
         // components will have access to the mocked/synthetic VSCode API
         setVSCodeWrapper(vscodeAPI)
-        return vscodeAPI
-    }, [client, createNewChat, activeWebviewPanelIDRef])
+        return { vscodeAPI, createNewChat }
+    } catch (error) {
+        console.error('Cody Web Agent creation failed', error)
+        throw error
+    }
 }
 
-function useEffectOnce(effect: EffectCallback, deps?: DependencyList) {
-    const isInitRef = useRef(false)
+function createVSCodeAPI(input: {
+    client: AgentClient
+    activeWebviewPanelIDRef: MutableRefObject<string>
+    createNewChat: () => Promise<void>
+}): VSCodeWrapper {
+    const { client, activeWebviewPanelIDRef, createNewChat } = input
+    const onMessageCallbacks: ((message: ExtensionMessage) => void)[] = []
 
-    // biome-ignore lint/correctness/useExhaustiveDependencies: effect will never be changed without deps change
-    useEffect(() => {
-        if (isInitRef.current) {
-            return
+    client.rpc.onNotification(
+        'webview/postMessage',
+        ({ id, message }: { id: string; message: ExtensionMessage }) => {
+            if (activeWebviewPanelIDRef.current === id || GLOBAL_MESSAGE_TYPES.includes(message.type)) {
+                for (const callback of onMessageCallbacks) {
+                    callback(hydrateAfterPostMessage(message, uri => URI.from(uri as any)))
+                }
+            }
         }
+    )
 
-        const result = effect()
-
-        isInitRef.current = true
-        return result
-    }, deps)
+    const vscodeAPI: VSCodeWrapper = {
+        postMessage: message => {
+            // Special override for Cody Web
+            if (message.command === 'command' && message.id === 'cody.chat.new') {
+                void createNewChat()
+                return
+            }
+            void client.rpc.sendRequest('webview/receiveMessage', {
+                id: activeWebviewPanelIDRef.current,
+                message: forceHydration(message),
+            })
+        },
+        onMessage: callback => {
+            onMessageCallbacks.push(callback)
+            return () => {
+                // Remove callback from onMessageCallbacks
+                const index = onMessageCallbacks.indexOf(callback)
+                if (index >= 0) {
+                    onMessageCallbacks.splice(index, 1)
+                }
+            }
+        },
+        getState: () => {
+            throw new Error('not implemented')
+        },
+        setState: () => {
+            throw new Error('not implemented')
+        },
+    }
+    return vscodeAPI
 }

--- a/web/lib/index.ts
+++ b/web/lib/index.ts
@@ -9,7 +9,6 @@ export {
 } from './components/CodyWebChat'
 export { CodyPromptTemplate, type CodyPromptTemplateProps } from './components/CodyPromptTemplate'
 export { ChatSkeleton } from './components/skeleton/ChatSkeleton'
-export { createCodyAgent, type CodyWebAgent } from './components/use-cody-agent'
 
 export type { Repository, InitialContext, CodyExternalApi, PromptEditorRefAPI } from './types'
 

--- a/web/lib/index.ts
+++ b/web/lib/index.ts
@@ -9,6 +9,7 @@ export {
 } from './components/CodyWebChat'
 export { CodyPromptTemplate, type CodyPromptTemplateProps } from './components/CodyPromptTemplate'
 export { ChatSkeleton } from './components/skeleton/ChatSkeleton'
+export { createCodyAgent, type CodyWebAgent } from './components/use-cody-agent'
 
 export type { Repository, InitialContext, CodyExternalApi, PromptEditorRefAPI } from './types'
 


### PR DESCRIPTION
One major problem with cody web right now is that we recreate the cody agent whenever we navigate to a page that shows cody web components.
Worse even, on e.g. the prompts page where we should three prompt inputs, we create three separate instances of the agent.

This initialization step takes time and uses server resources (having already caused Cloudflare overages (https://sourcegraph.slack.com/archives/C05EA9KQUTA/p1737688274086469)).

This PR proposes to only use a single instance of cody agent.

> [!IMPORTANT]
> My understanding of cody web and cody agent is limited. I don't know what implication it has to 'reuse' the same cody agent instance. I've manually tested the typical workflows (chatting, creating new chat, switching files with cody sidebar open, etc), but there are likely things I missed or am not aware of.

> [!IMPORTANT]
> This does **not** improve the initial loading time of cody web.

https://github.com/user-attachments/assets/dc5ed22f-15c2-4084-8c2e-a9cc133c38d9



## Test plan

Manual testing.
