### PR TITLE
Agent: fix crash when using TextDocument.validateRange(...)

### DIFF
--- a/agent/src/AgentTextDocument.ts
+++ b/agent/src/AgentTextDocument.ts
@@ -133,7 +133,10 @@ export class AgentTextDocument implements vscode.TextDocument {
     }
 
     public validateRange(range: vscode.Range): vscode.Range {
-        throw new Error('Method not implemented.')
+        return new vscode_shim.Range(
+            this.validatePosition(range.start),
+            this.validatePosition(range.end)
+        )
     }
 
     public validatePosition(position: vscode.Position): vscode.Position {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "check:css": "stylelint --quiet --cache '**/*.css'",
     "check:build": "pnpm run -C vscode check:build",
     "biome": "biome check --apply --error-on-warnings .",
+    "format": "pnpm biome",
     "test": "vitest",
     "test:unit": "vitest run",
     "test:integration": "pnpm -C vscode test:integration",


### PR DESCRIPTION
Previously, running the agent tests caused the following error to get
logged:
```
----stderr----
Uncaught exception: Error: Method not implemented.
    at _AgentTextDocument.validateRange (/Users/olafurpg/dev/sourcegraph/cody/agent/src/AgentTextDocument.ts:136:15)
    at FixupTask.getContentChanges (/Users/olafurpg/dev/sourcegraph/cody/vscode/src/non-stop/FixupTask.ts:163:41)
```
The root problem is that we are using `TextDocument.validateRange()` in
the VS Code extension and this method is not implemented yet for non-VSC
clients.

I'm not 100% sure how serious this bug is, but the fix is simple enough
that we should just merge the fix.## Test plan


## Test plan

Manually confirmed there are no errors in stdout when running `pnpm test src/edit.test.ts` from the agent subdirectory.