### PR TITLE
fix(auto-edit): Restore suffix decorations

### DIFF
--- a/vscode/src/autoedits/renderer/decorators/default-decorator.ts
+++ b/vscode/src/autoedits/renderer/decorators/default-decorator.ts
@@ -171,7 +171,6 @@ export class DefaultDecorator implements AutoEditsDecorator {
         }
 
         if (this.options.shouldRenderImage) {
-            console.log('RENDERING IMAGE...')
             this.renderAddedLinesImageDecorations(
                 addedLinesInfo.addedLinesDecorationInfo,
                 addedLinesInfo.startLine,
@@ -180,7 +179,6 @@ export class DefaultDecorator implements AutoEditsDecorator {
             return
         }
 
-        console.log('RENDERING NORMAL..')
         this.renderAddedLinesDecorations(
             addedLinesInfo.addedLinesDecorationInfo,
             addedLinesInfo.startLine,

--- a/vscode/src/autoedits/renderer/decorators/default-decorator.ts
+++ b/vscode/src/autoedits/renderer/decorators/default-decorator.ts
@@ -171,6 +171,7 @@ export class DefaultDecorator implements AutoEditsDecorator {
         }
 
         if (this.options.shouldRenderImage) {
+            console.log('RENDERING IMAGE...')
             this.renderAddedLinesImageDecorations(
                 addedLinesInfo.addedLinesDecorationInfo,
                 addedLinesInfo.startLine,
@@ -179,6 +180,7 @@ export class DefaultDecorator implements AutoEditsDecorator {
             return
         }
 
+        console.log('RENDERING NORMAL..')
         this.renderAddedLinesDecorations(
             addedLinesInfo.addedLinesDecorationInfo,
             addedLinesInfo.startLine,
@@ -356,6 +358,14 @@ export class DefaultDecorator implements AutoEditsDecorator {
                 })
             }
         }
+
+        const startLineLength = this.editor.document.lineAt(startLine).range.end.character
+        this.editor.setDecorations(this.insertMarkerDecorationType, [
+            {
+                range: new vscode.Range(startLine, 0, startLine, startLineLength),
+            },
+        ])
+        this.editor.setDecorations(this.addedLinesDecorationType, replacerDecorations)
     }
 
     private renderAddedLinesImageDecorations(


### PR DESCRIPTION
## Description

This code was accidentally deleted in [this diff](https://github.com/sourcegraph/cody/pull/6545/files#diff-56299bbe2e4acef8648098378efaaab9cce1f167f2ad66e37c3e253a51437f72R361-R420) (terrible diff)

Restoring it here.

This was caught by our E2E tests but we actually don't run them in PRs. @hitesh-1997 Do you know why this is?

## Test plan

E2E tests pass again, they have been failing on `main`

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
