### PR TITLE
feat(autoedit): Enable image based rendering for dogfooding

### DIFF
--- a/lib/shared/src/experimentation/FeatureFlagProvider.ts
+++ b/lib/shared/src/experimentation/FeatureFlagProvider.ts
@@ -61,6 +61,9 @@ export enum FeatureFlag {
 
     CodyAutoEditExperimentEnabledFeatureFlag = 'cody-autoedit-experiment-enabled-flag',
 
+    // Enables image-based rendering of autoedit suggestions
+    CodyAutoEditImageRendering = 'cody-autoedit-image-rendering',
+
     // Enables gpt-4o-mini as a default Edit model
     CodyEditDefaultToGpt4oMini = 'cody-edit-default-to-gpt-4o-mini',
 

--- a/vscode/src/autoedits/test-helpers.ts
+++ b/vscode/src/autoedits/test-helpers.ts
@@ -85,7 +85,9 @@ export async function autoeditResultFor(
     const chatClient = null as unknown as ChatClient
     const extensionClient = defaultVSCodeExtensionClient()
     const fixupController = new FixupController(extensionClient)
-    const provider = existingProvider ?? new AutoeditsProvider(chatClient, fixupController)
+    const provider =
+        existingProvider ??
+        new AutoeditsProvider(chatClient, fixupController, { shouldRenderImage: false })
 
     let result: AutoeditsResult | null = null
 

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -729,7 +729,8 @@ function registerAutoEdits(
                 authStatus,
                 featureFlagProvider.evaluatedFeatureFlag(
                     FeatureFlag.CodyAutoEditExperimentEnabledFeatureFlag
-                )
+                ),
+                featureFlagProvider.evaluatedFeatureFlag(FeatureFlag.CodyAutoEditImageRendering)
             )
                 .pipe(
                     distinctUntilChanged((a, b) => {
@@ -739,15 +740,23 @@ function registerAutoEdits(
                             isEqual(a[2], b[2])
                         )
                     }),
-                    switchMap(([config, authStatus, autoeditsFeatureFlagEnabled]) => {
-                        return createAutoEditsProvider({
+                    switchMap(
+                        ([
                             config,
                             authStatus,
-                            chatClient,
-                            autoeditsFeatureFlagEnabled,
-                            fixupController,
-                        })
-                    }),
+                            autoeditFeatureFlagEnabled,
+                            autoeditImageRenderingEnabled,
+                        ]) => {
+                            return createAutoEditsProvider({
+                                config,
+                                authStatus,
+                                chatClient,
+                                autoeditFeatureFlagEnabled,
+                                autoeditImageRenderingEnabled,
+                                fixupController,
+                            })
+                        }
+                    ),
                     catchError(error => {
                         autoeditsOutputChannelLogger.logError('registerAutoedits', 'Error', error)
                         return NEVER


### PR DESCRIPTION
## Description

Gates the [image based renderer](https://github.com/sourcegraph/cody/pull/6545) behind a feature flag.

Will enable this by default on S2 so we get some dogfooding feedback

## Test plan

1. Disable the flag, check auto edits shows suffixes
2. Enable the flag, check auto edit shows images

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
