### PR TITLE
Report metadata about search result context items separately

### DIFF
--- a/lib/shared/src/telemetry-v2/events/chat-question.ts
+++ b/lib/shared/src/telemetry-v2/events/chat-question.ts
@@ -5,6 +5,7 @@ import type { ChatMessage, EventSource } from '../../chat/transcript/messages'
 import { type ContextItem, ContextItemSource } from '../../codebase-context/messages'
 import type { DefaultChatCommands } from '../../commands/types'
 import {
+    CODE_SEARCH_PROVIDER_URI,
     GIT_OPENCTX_PROVIDER_URI,
     REMOTE_DIRECTORY_PROVIDER_URI,
     REMOTE_FILE_PROVIDER_URI,
@@ -232,6 +233,7 @@ function publicContextSummary(globalPrefix: string, context: ContextItem[]) {
         [REMOTE_DIRECTORY_PROVIDER_URI]: cloneDeep(defaultSharedItemCount),
         [WEB_PROVIDER_URI]: cloneDeep(defaultSharedItemCount),
         [GIT_OPENCTX_PROVIDER_URI]: cloneDeep(defaultSharedItemCount),
+        [CODE_SEARCH_PROVIDER_URI]: cloneDeep(defaultSharedItemCount),
         other: cloneDeep(defaultSharedItemCount),
     }
 


### PR DESCRIPTION
We want to know when a user uses search results as context in a follow up query. With this
change we can get dedicated information about these context items (instead of them being grouped with 'other').

## Test plan

Manually tested. The telemetry payload now contains something like this:

```
{
  "version": 0,
  "metadata": [
    {
      "key": "userSpecifiedIntent",
      "value": 1
    },
    {
      "key": "detectedIntent",
      "value": 2
    },
    {
      "key": "detectedIntentScores.chat",
      "value": 0.9907577037811279
    },
    {
      "key": "detectedIntentScores.search",
      "value": 0.009242242202162743
    },
    [...]
    {
      "key": "context.byOpenctxProvider.internal-code-search-provider.total",
      "value": 1
    },
    {
      "key": "context.byOpenctxProvider.internal-code-search-provider.hasRange",
      "value": 0
    },
    {
      "key": "context.byOpenctxProvider.internal-code-search-provider.isIgnored",
      "value": 0
    },
    {
      "key": "context.byOpenctxProvider.internal-code-search-provider.isTooLarge",
      "value": 0
    },
    {
      "key": "context.byOpenctxProvider.internal-code-search-provider.URIs",
      "value": 1
    },
    {
      "key": "context.byOpenctxProvider.internal-code-search-provider.size.min",
      "value": 370
    },
    {
      "key": "context.byOpenctxProvider.internal-code-search-provider.size.max",
      "value": 370
    },
    {
      "key": "context.byOpenctxProvider.internal-code-search-provider.size.avg",
      "value": 370
    },
    {
      "key": "context.byOpenctxProvider.internal-code-search-provider.size.median",
      "value": 370
    },
    {
      "key": "context.byOpenctxProvider.internal-code-search-provider.size.total",
      "value": 370
    },
    [...]
  ],
  [...]
}
```
