### PR TITLE
Fix paragraph spacing in submit button dropdown if no intent is detected

### DIFF
--- a/vscode/webviews/chat/cells/messageCell/human/editor/toolbar/SubmitButton.tsx
+++ b/vscode/webviews/chat/cells/messageCell/human/editor/toolbar/SubmitButton.tsx
@@ -62,13 +62,13 @@ function getIntentOptions({
             title: (
                 <div className="tw-flex tw-flex-col tw-self-start">
                     <p>Run detected intent</p>
-                    <p className="tw-text-sm tw-text-muted-foreground tw-min-h-10">
-                        {isDotComUser
-                            ? 'Detects intent and runs appropriately'
-                            : detectedIntent
-                              ? `Currently: ${detectedIntent === 'search' ? 'Search' : 'Chat'}`
-                              : ''}
-                    </p>
+                    {detectedIntent && (
+                        <p className="tw-text-sm tw-text-muted-foreground tw-min-h-10">
+                            {isDotComUser
+                                ? 'Detects intent and runs appropriately'
+                                : `Currently: ${detectedIntent === 'search' ? 'Search' : 'Chat'}`}
+                        </p>
+                    )}
                 </div>
             ),
             icon: Sparkles,

--- a/vscode/webviews/tailwind.config.mjs
+++ b/vscode/webviews/tailwind.config.mjs
@@ -1,6 +1,6 @@
 /** @type {import('tailwindcss').Config} */
-
-const plugin = require('tailwindcss/plugin')
+import plugin from 'tailwindcss/plugin'
+// const plugin = require('tailwindcss/plugin')
 
 export default {
     content: {


### PR DESCRIPTION
This PR resolves the UI bug detailed in [SRCH-1574](https://linear.app/sourcegraph/issue/SRCH-1574/paragraph-spacing-should-disappear-when-there-is-no-text-input).

Previously, an empty paragraph space caused inconsistent spacing between dropdown items. Now, spacing dynamically adjusts based on user input.

**Before:** 
<img width="415" alt="Screenshot 2025-02-05 at 10 50 00 AM" src="https://github.com/user-attachments/assets/ebaf7344-35a5-4a81-aeac-b590819f9b16" />

**After:** 
<img width="413" alt="Screenshot 2025-02-05 at 10 50 40 AM" src="https://github.com/user-attachments/assets/a7b4c8e6-4272-4669-9bb7-d7bdeec68c79" />

**In the case that intent is detected:**
<img width="410" alt="Screenshot 2025-02-05 at 10 51 31 AM" src="https://github.com/user-attachments/assets/29e9790b-696e-438b-a91a-39f7024794fb" />

**I would like guidance on:** 
This commit also updates a require statement to an ES6 module import, as the extension environment wouldn't run otherwise. Before merging, I'd appreciate feedback on whether others have encountered this issue—I couldn't start the environment without making this change. cc: @vovakulikov and @fkling 

## Test plan
Manual/Visual testing
1. Check state with no intent detected and ensure no space exists
2. Check state with intent detected and ensure the spacing has changed.
<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
