### PR TITLE
feat(chat): Turn on prompt caching (CODY-4808)

### DIFF
--- a/lib/shared/src/experimentation/FeatureFlagProvider.ts
+++ b/lib/shared/src/experimentation/FeatureFlagProvider.ts
@@ -103,6 +103,9 @@ export enum FeatureFlag {
      */
     CodyPromptsV2 = 'prompt-creation-v2',
 
+    // Enables Anthropic's prompt caching feature on messages for Cody Clients
+    CodyPromptCachingOnMessages = 'cody-prompt-caching-on-messages',
+
     /** Whether user has access to the experimental agentic chat (fka Deep Cody) feature.
      * This replaces the old 'cody-deep-reflection' & 'deep-cody' that was used for internal testing.
      */


### PR DESCRIPTION
**Problem (why)**
Currently the daily cost and token usage on models is very high and we want to use prompt caching to reduce the cost.

**Background (context)**
We had a [client side](https://github.com/sourcegraph/cody/pull/6878) PR and [server side](https://github.com/sourcegraph/sourcegraph/pull/3198/files#diff-616552e63d25dcbd76f9dc1785012801c20fa9107e9581891d6f5271fec14fc6) PR that provided the prompt caching option. This PR just turns prompt caching on. 

**Implementation (what)**

- For each request, combine all the code context in messages into one message and add prompt caching to the message.

- Add a feature flag `cody-prompt-caching-on-messages` for all the messages

**Anthropic Docs (context)**
https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching
https://docs.anthropic.com/en/api/messages


## Test plan
CI & Local Testing
<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
