### PR TITLE
fix(ui): Use timeout argument directly

### DIFF
--- a/vscode/src/services/StatusBar.ts
+++ b/vscode/src/services/StatusBar.ts
@@ -122,7 +122,7 @@ export class CodyStatusBar implements vscode.Disposable {
 
     addError(args: StatusBarErrorArgs) {
         const now = Date.now()
-        const ttl = args.timeout !== undefined ? Math.min(ONE_HOUR, args.timeout - now) : ONE_HOUR
+        const ttl = args.timeout !== undefined ? Math.min(ONE_HOUR, args.timeout) : ONE_HOUR
 
         const errorHandle = {}
         const remove = () => {
@@ -162,7 +162,7 @@ export class CodyStatusBar implements vscode.Disposable {
 
     addLoader<T>(args: StatusBarLoaderArgs) {
         const now = Date.now()
-        const ttl = args.timeout !== undefined ? Math.min(ONE_HOUR, args.timeout - now) : ONE_HOUR
+        const ttl = args.timeout !== undefined ? Math.min(ONE_HOUR, args.timeout) : ONE_HOUR
         const loaderHandle = {}
         const remove = () => {
             this.loaders.mutate(draft => {


### PR DESCRIPTION
When setting the remove timeout for status bar loaders and errors, we incorrectly treat `StatusBarErrorArgs.timeout` as a timestamp representing milliseconds since the epoch. However, every usage example passes the timeout as a number representing how many milliseconds to wait:

```
this.config.statusBar.addLoader({
    title: 'Completions are being generated',
    timeout: 30_000,
})
```

This PR fixes `StatusBar`'s. `addLoader` and `addError` methods to treat `StatusBarErrorArgs.timeout` as such.

## Test plan

Local testing via the debugger confirming that the ttl is properly set to the passed in timeout when it is smaller than one hour.
