### PR TITLE
fix(web): Don't show CTA on Cody Web for PLG

### DIFF
--- a/lib/shared/src/experimentation/FeatureFlagProvider.ts
+++ b/lib/shared/src/experimentation/FeatureFlagProvider.ts
@@ -131,7 +131,7 @@ export enum FeatureFlag {
     /**
      * Whether the user will see the CTA about upgrading to Sourcegraph Teams
      */
-    SourcegraphTeamsUpgradeCTA = 'teams-upgrade-available-cta',
+    SourcegraphTeamsUpgradeCTA = 'teams-upgrade-available-cta-editors',
 }
 
 const ONE_HOUR = 60 * 60 * 1000

--- a/vscode/webviews/Chat.tsx
+++ b/vscode/webviews/Chat.tsx
@@ -4,11 +4,11 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import type {
     AuthenticatedAuthStatus,
     ChatMessage,
-    CodyIDE,
     Guardrails,
     Model,
     PromptString,
 } from '@sourcegraph/cody-shared'
+import { CodyIDE } from '@sourcegraph/cody-shared'
 import { Transcript, focusLastHumanMessageEditor } from './chat/Transcript'
 import type { VSCodeWrapper } from './utils/VSCodeApi'
 

--- a/vscode/webviews/Chat.tsx
+++ b/vscode/webviews/Chat.tsx
@@ -261,7 +261,7 @@ export const Chat: React.FunctionComponent<React.PropsWithChildren<ChatboxProps>
                         isPromptsV2Enabled={isPromptsV2Enabled}
                     />
                     <WelcomeFooter IDE={userInfo.IDE} />
-                    {isWorkspacesUpgradeCtaEnabled && (
+                    {isWorkspacesUpgradeCtaEnabled && userInfo.IDE !== CodyIDE.Web && (
                         <div className="tw-absolute tw-bottom-0 tw-left-1/2 tw-transform tw--translate-x-1/2 tw-w-[95%] tw-z-1 tw-mb-4 tw-max-h-1/2">
                             <WelcomeNotice />
                         </div>


### PR DESCRIPTION
I missed the check for Cody Web dotcom users, this PR adds a check to only show CTAs in editor. 

## Test plan
ran locally, confirmed CTAs still show up on editor 

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
