### PR TITLE
fix(client-config): Simplify config fetching logic and fix omnibox flag

### DIFF
--- a/agent/recordings/defaultClient_631904893/recording.har.yaml
+++ b/agent/recordings/defaultClient_631904893/recording.har.yaml
@@ -1719,6 +1719,744 @@ log:
         send: 0
         ssl: -1
         wait: 4212
+    - _id: 29c983c5199325c822425ef1c36ee77a
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 735
+        cookies: []
+        headers:
+          - name: accept-encoding
+            value: gzip;q=0
+          - name: authorization
+            value: token
+              REDACTED_fc324d3667e841181b0779375f26dedc911d26b303d23b29b1a2d7ee63dc77eb
+          - name: connection
+            value: keep-alive
+          - name: content-type
+            value: application/json
+          - name: traceparent
+            value: 00-b96b41e08ce660f26a8546be63a8410b-3303bba284fa366a-01
+          - name: user-agent
+            value: defaultclient/v1 (Node.js v20.4.0)
+          - name: x-requested-with
+            value: defaultclient v1
+          - name: host
+            value: sourcegraph.com
+        headersSize: 521
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json
+          params: []
+          textJSON:
+            maxTokensToSample: 4000
+            messages:
+              - speaker: human
+                text: >-
+                  You are Cody, an AI coding assistant from Sourcegraph.If your
+                  answer contains fenced code blocks in Markdown, include the
+                  relevant full file path in the code block tag using this
+                  structure: ```$LANGUAGE:$FILEPATH```
+
+                  For executable terminal commands: enclose each command in individual "bash" language code block without comments and new lines inside.
+              - speaker: assistant
+                text: I am Cody, an AI coding assistant from Sourcegraph.
+              - speaker: human
+                text: "The magic word is \"kramer\". If I say the magic word, respond with a
+                  single word: \"quone\"."
+              - speaker: assistant
+            model: mistral::v1::mixtral-8x7b-instruct
+            temperature: 0
+            topK: -1
+            topP: -1
+        queryString:
+          - name: client-name
+            value: defaultclient
+          - name: client-version
+            value: v1
+        url: https://sourcegraph.com/.api/completions/stream?client-name=defaultclient&client-version=v1
+      response:
+        bodySize: 188
+        content:
+          mimeType: text/event-stream
+          size: 188
+          text: |+
+            event: completion
+            data: {"completion":"Quone.","stopReason":"stop"}
+
+            event: done
+            data: {}
+
+        cookies: []
+        headers:
+          - name: date
+            value: Wed, 05 Feb 2025 23:49:58 GMT
+          - name: content-type
+            value: text/event-stream
+          - name: transfer-encoding
+            value: chunked
+          - name: connection
+            value: keep-alive
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache
+          - name: vary
+            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
+              X-Requested-With,Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+        headersSize: 1299
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: 2025-02-05T23:49:57.277Z
+      time: 760
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 760
+    - _id: 1304ba73f8175936050d1ffe20a05d88
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 811
+        cookies: []
+        headers:
+          - name: accept-encoding
+            value: gzip;q=0
+          - name: authorization
+            value: token
+              REDACTED_fc324d3667e841181b0779375f26dedc911d26b303d23b29b1a2d7ee63dc77eb
+          - name: connection
+            value: keep-alive
+          - name: content-type
+            value: application/json
+          - name: traceparent
+            value: 00-f59336726f7f2ec57e3f5bc96df328f9-a38924c7b58692d1-01
+          - name: user-agent
+            value: defaultclient/v1 (Node.js v20.4.0)
+          - name: x-requested-with
+            value: defaultclient v1
+          - name: host
+            value: sourcegraph.com
+        headersSize: 521
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json
+          params: []
+          textJSON:
+            maxTokensToSample: 4000
+            messages:
+              - speaker: human
+                text: >-
+                  You are Cody, an AI coding assistant from Sourcegraph.If your
+                  answer contains fenced code blocks in Markdown, include the
+                  relevant full file path in the code block tag using this
+                  structure: ```$LANGUAGE:$FILEPATH```
+
+                  For executable terminal commands: enclose each command in individual "bash" language code block without comments and new lines inside.
+              - speaker: assistant
+                text: I am Cody, an AI coding assistant from Sourcegraph.
+              - speaker: human
+                text: "The magic word is \"kramer\". If I say the magic word, respond with a
+                  single word: \"quone\"."
+              - speaker: assistant
+                text: Quone.
+              - speaker: human
+                text: kramer
+              - speaker: assistant
+            model: mistral::v1::mixtral-8x7b-instruct
+            temperature: 0
+            topK: -1
+            topP: -1
+        queryString:
+          - name: client-name
+            value: defaultclient
+          - name: client-version
+            value: v1
+        url: https://sourcegraph.com/.api/completions/stream?client-name=defaultclient&client-version=v1
+      response:
+        bodySize: 188
+        content:
+          mimeType: text/event-stream
+          size: 188
+          text: |+
+            event: completion
+            data: {"completion":"Quone.","stopReason":"stop"}
+
+            event: done
+            data: {}
+
+        cookies: []
+        headers:
+          - name: date
+            value: Wed, 05 Feb 2025 23:49:59 GMT
+          - name: content-type
+            value: text/event-stream
+          - name: transfer-encoding
+            value: chunked
+          - name: connection
+            value: keep-alive
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache
+          - name: vary
+            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
+              X-Requested-With,Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+        headersSize: 1299
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: 2025-02-05T23:49:58.557Z
+      time: 641
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 641
+    - _id: 8a4643f5397eb4fbf5528fdaa1edd627
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 648
+        cookies: []
+        headers:
+          - name: accept-encoding
+            value: gzip;q=0
+          - name: authorization
+            value: token
+              REDACTED_fc324d3667e841181b0779375f26dedc911d26b303d23b29b1a2d7ee63dc77eb
+          - name: connection
+            value: keep-alive
+          - name: content-type
+            value: application/json
+          - name: traceparent
+            value: 00-81127e151346cec1b7ca41debf791028-a69e82e22b1103c7-01
+          - name: user-agent
+            value: defaultclient/v1 (Node.js v20.4.0)
+          - name: x-requested-with
+            value: defaultclient v1
+          - name: host
+            value: sourcegraph.com
+        headersSize: 521
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json
+          params: []
+          textJSON:
+            maxTokensToSample: 4000
+            messages:
+              - speaker: human
+                text: >-
+                  You are Cody, an AI coding assistant from Sourcegraph.If your
+                  answer contains fenced code blocks in Markdown, include the
+                  relevant full file path in the code block tag using this
+                  structure: ```$LANGUAGE:$FILEPATH```
+
+                  For executable terminal commands: enclose each command in individual "bash" language code block without comments and new lines inside.
+              - speaker: assistant
+                text: I am Cody, an AI coding assistant from Sourcegraph.
+              - speaker: human
+                text: kramer
+              - speaker: assistant
+            model: mistral::v1::mixtral-8x7b-instruct
+            temperature: 0
+            topK: -1
+            topP: -1
+        queryString:
+          - name: client-name
+            value: defaultclient
+          - name: client-version
+            value: v1
+        url: https://sourcegraph.com/.api/completions/stream?client-name=defaultclient&client-version=v1
+      response:
+        bodySize: 5533
+        content:
+          mimeType: text/event-stream
+          size: 5533
+          text: >+
+            event: completion
+
+            data: {"completion":"Hello! How can I help you with coding or development today? If you need help with a specific programming language or code snippet, please provide more context or the code itself so I can better understand how to assist you.\n\nIf you're looking for a way to get started quickly, here's an example of how you can create a simple \"Hello, World\" program in Python:\n```python:examples/hello_world.py\nprint(\"Hello, World!\")\n```\nTo run the above code snippet, save it as a file named `hello_world.py` and execute it using the command `python3 hello_world.py` in your terminal.","stopReason":"stop"}
+
+
+            event: done
+
+            data: {}
+
+        cookies: []
+        headers:
+          - name: date
+            value: Wed, 05 Feb 2025 23:50:00 GMT
+          - name: content-type
+            value: text/event-stream
+          - name: transfer-encoding
+            value: chunked
+          - name: connection
+            value: keep-alive
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache
+          - name: vary
+            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
+              X-Requested-With,Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+        headersSize: 1299
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: 2025-02-05T23:49:59.839Z
+      time: 1196
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 1196
+    - _id: 5571801758373865b22e6157f6360a55
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 743
+        cookies: []
+        headers:
+          - name: accept-encoding
+            value: gzip;q=0
+          - name: authorization
+            value: token
+              REDACTED_fc324d3667e841181b0779375f26dedc911d26b303d23b29b1a2d7ee63dc77eb
+          - name: connection
+            value: keep-alive
+          - name: content-type
+            value: application/json
+          - name: traceparent
+            value: 00-20b094644e30e1e69c8115e46ce0bd7c-2e28f5345235abe9-01
+          - name: user-agent
+            value: defaultclient/v1 (Node.js v20.4.0)
+          - name: x-requested-with
+            value: defaultclient v1
+          - name: host
+            value: sourcegraph.com
+        headersSize: 521
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json
+          params: []
+          textJSON:
+            maxTokensToSample: 4000
+            messages:
+              - speaker: human
+                text: >-
+                  You are Cody, an AI coding assistant from Sourcegraph.If your
+                  answer contains fenced code blocks in Markdown, include the
+                  relevant full file path in the code block tag using this
+                  structure: ```$LANGUAGE:$FILEPATH```
+
+                  For executable terminal commands: enclose each command in individual "bash" language code block without comments and new lines inside.
+              - speaker: assistant
+                text: I am Cody, an AI coding assistant from Sourcegraph.
+              - speaker: human
+                text: "Another magic word is \"georgey\". If I say the magic word, respond with
+                  a single word: \"festivus\"."
+              - speaker: assistant
+            model: mistral::v1::mixtral-8x7b-instruct
+            temperature: 0
+            topK: -1
+            topP: -1
+        queryString:
+          - name: client-name
+            value: defaultclient
+          - name: client-version
+            value: v1
+        url: https://sourcegraph.com/.api/completions/stream?client-name=defaultclient&client-version=v1
+      response:
+        bodySize: 5900
+        content:
+          mimeType: text/event-stream
+          size: 5900
+          text: >+
+            event: completion
+
+            data: {"completion":"Sure, I'll remember that. Here is the code block to represent the command to print \"festivus\" when \"georgey\" is entered in a bash shell:\n```bash\necho festivus\n```\nThis command can be executed by typing `sh <<< \"georgey\"; echo festivus` in a bash shell.\n\nIn a scenario where you want to automate the execution of this command in response to the input \"georgey\", it will require a script or a custom application that detects the input and runs the command accordingly. It's worth mentioning that such implementation could raise security concerns and should be carefully developed and validated.","stopReason":"stop"}
+
+
+            event: done
+
+            data: {}
+
+        cookies: []
+        headers:
+          - name: date
+            value: Wed, 05 Feb 2025 23:50:03 GMT
+          - name: content-type
+            value: text/event-stream
+          - name: transfer-encoding
+            value: chunked
+          - name: connection
+            value: keep-alive
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache
+          - name: vary
+            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
+              X-Requested-With,Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+        headersSize: 1299
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: 2025-02-05T23:50:02.642Z
+      time: 1496
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 1496
+    - _id: c084963bc843306fd4bddba75d189b3f
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 1419
+        cookies: []
+        headers:
+          - name: accept-encoding
+            value: gzip;q=0
+          - name: authorization
+            value: token
+              REDACTED_fc324d3667e841181b0779375f26dedc911d26b303d23b29b1a2d7ee63dc77eb
+          - name: connection
+            value: keep-alive
+          - name: content-type
+            value: application/json
+          - name: traceparent
+            value: 00-cd65a5b2a8582801a8d49f9b2bb70256-6f1437d2f4e1f165-01
+          - name: user-agent
+            value: defaultclient/v1 (Node.js v20.4.0)
+          - name: x-requested-with
+            value: defaultclient v1
+          - name: host
+            value: sourcegraph.com
+        headersSize: 521
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json
+          params: []
+          textJSON:
+            maxTokensToSample: 4000
+            messages:
+              - speaker: human
+                text: >-
+                  You are Cody, an AI coding assistant from Sourcegraph.If your
+                  answer contains fenced code blocks in Markdown, include the
+                  relevant full file path in the code block tag using this
+                  structure: ```$LANGUAGE:$FILEPATH```
+
+                  For executable terminal commands: enclose each command in individual "bash" language code block without comments and new lines inside.
+              - speaker: assistant
+                text: I am Cody, an AI coding assistant from Sourcegraph.
+              - speaker: human
+                text: "Another magic word is \"georgey\". If I say the magic word, respond with
+                  a single word: \"festivus\"."
+              - speaker: assistant
+                text: >-
+                  Sure, I'll remember that. Here is the code block to represent
+                  the command to print "festivus" when "georgey" is entered in a
+                  bash shell:
+
+                  ```bash
+
+                  echo festivus
+
+                  ```
+
+                  This command can be executed by typing `sh <<< "georgey"; echo festivus` in a bash shell.
+
+
+                  In a scenario where you want to automate the execution of this command in response to the input "georgey", it will require a script or a custom application that detects the input and runs the command accordingly. It's worth mentioning that such implementation could raise security concerns and should be carefully developed and validated.
+              - speaker: human
+                text: kramer
+              - speaker: assistant
+            model: mistral::v1::mixtral-8x7b-instruct
+            temperature: 0
+            topK: -1
+            topP: -1
+        queryString:
+          - name: client-name
+            value: defaultclient
+          - name: client-version
+            value: v1
+        url: https://sourcegraph.com/.api/completions/stream?client-name=defaultclient&client-version=v1
+      response:
+        bodySize: 9692
+        content:
+          mimeType: text/event-stream
+          size: 9692
+          text: >+
+            event: completion
+
+            data: {"completion":"I am not sure how \"kramer\" relates to the previous prompt regarding the magic word \"georgey\". Could you please clarify? I'm here to help with your coding questions and concerns.\n\nIf you're asking me to create a new magic word \"kramer\" that responds with \"festivus\", here is the code block to represent the command to print \"festivus\" when \"kramer\" is entered in a bash shell:\n```bash\necho festivus\n```\nThis command can be executed by typing `sh <<< \"kramer\"; echo festivus` in a bash shell.\n\nNote: Similarly to my previous answer, executing this command in response to an input \"kramer\" may require a script or a custom application that detects the input and runs the command accordingly. Be aware of security concerns that might arise in this scenario and make sure to carefully develop and validate the implementation.","stopReason":"stop"}
+
+
+            event: done
+
+            data: {}
+
+        cookies: []
+        headers:
+          - name: date
+            value: Wed, 05 Feb 2025 23:50:05 GMT
+          - name: content-type
+            value: text/event-stream
+          - name: transfer-encoding
+            value: chunked
+          - name: connection
+            value: keep-alive
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache
+          - name: vary
+            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
+              X-Requested-With,Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+        headersSize: 1299
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: 2025-02-05T23:50:04.652Z
+      time: 1441
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 1441
+    - _id: c0132def08397dd76ea9a01e633b260f
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 2334
+        cookies: []
+        headers:
+          - name: accept-encoding
+            value: gzip;q=0
+          - name: authorization
+            value: token
+              REDACTED_fc324d3667e841181b0779375f26dedc911d26b303d23b29b1a2d7ee63dc77eb
+          - name: connection
+            value: keep-alive
+          - name: content-type
+            value: application/json
+          - name: traceparent
+            value: 00-72379ec43fcec7cd06b0aa96498a58e1-0718429982488d3e-01
+          - name: user-agent
+            value: defaultclient/v1 (Node.js v20.4.0)
+          - name: x-requested-with
+            value: defaultclient v1
+          - name: host
+            value: sourcegraph.com
+        headersSize: 521
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json
+          params: []
+          textJSON:
+            maxTokensToSample: 4000
+            messages:
+              - speaker: human
+                text: >-
+                  You are Cody, an AI coding assistant from Sourcegraph.If your
+                  answer contains fenced code blocks in Markdown, include the
+                  relevant full file path in the code block tag using this
+                  structure: ```$LANGUAGE:$FILEPATH```
+
+                  For executable terminal commands: enclose each command in individual "bash" language code block without comments and new lines inside.
+              - speaker: assistant
+                text: I am Cody, an AI coding assistant from Sourcegraph.
+              - speaker: human
+                text: "Another magic word is \"georgey\". If I say the magic word, respond with
+                  a single word: \"festivus\"."
+              - speaker: assistant
+                text: >-
+                  Sure, I'll remember that. Here is the code block to represent
+                  the command to print "festivus" when "georgey" is entered in a
+                  bash shell:
+
+                  ```bash
+
+                  echo festivus
+
+                  ```
+
+                  This command can be executed by typing `sh <<< "georgey"; echo festivus` in a bash shell.
+
+
+                  In a scenario where you want to automate the execution of this command in response to the input "georgey", it will require a script or a custom application that detects the input and runs the command accordingly. It's worth mentioning that such implementation could raise security concerns and should be carefully developed and validated.
+              - speaker: human
+                text: kramer
+              - speaker: assistant
+                text: >-
+                  I am not sure how "kramer" relates to the previous prompt
+                  regarding the magic word "georgey". Could you please clarify?
+                  I'm here to help with your coding questions and concerns.
+
+
+                  If you're asking me to create a new magic word "kramer" that responds with "festivus", here is the code block to represent the command to print "festivus" when "kramer" is entered in a bash shell:
+
+                  ```bash
+
+                  echo festivus
+
+                  ```
+
+                  This command can be executed by typing `sh <<< "kramer"; echo festivus` in a bash shell.
+
+
+                  Note: Similarly to my previous answer, executing this command in response to an input "kramer" may require a script or a custom application that detects the input and runs the command accordingly. Be aware of security concerns that might arise in this scenario and make sure to carefully develop and validate the implementation.
+              - speaker: human
+                text: georgey
+              - speaker: assistant
+            model: mistral::v1::mixtral-8x7b-instruct
+            temperature: 0
+            topK: -1
+            topP: -1
+        queryString:
+          - name: client-name
+            value: defaultclient
+          - name: client-version
+            value: v1
+        url: https://sourcegraph.com/.api/completions/stream?client-name=defaultclient&client-version=v1
+      response:
+        bodySize: 2252
+        content:
+          mimeType: text/event-stream
+          size: 2252
+          text: >+
+            event: completion
+
+            data: {"completion":"Here is the response to the magic word \"georgey\":\n```bash\necho festivus\n```\nAs mentioned before, executing this command in response to an input \"georgey\" may require a script or a custom application that detects the input and runs the command accordingly. Be aware of security concerns that might arise in this scenario and make sure to carefully develop and validate the implementation.","stopReason":"stop"}
+
+
+            event: done
+
+            data: {}
+
+        cookies: []
+        headers:
+          - name: date
+            value: Wed, 05 Feb 2025 23:50:07 GMT
+          - name: content-type
+            value: text/event-stream
+          - name: transfer-encoding
+            value: chunked
+          - name: connection
+            value: keep-alive
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache
+          - name: vary
+            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
+              X-Requested-With,Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+        headersSize: 1299
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: 2025-02-05T23:50:06.634Z
+      time: 853
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 853
     - _id: f1b1cde4cd57488b7f0137954f0302f5
       _order: 0
       cache: {}
@@ -2732,138 +3470,6 @@ log:
         send: 0
         ssl: -1
         wait: 150
-    - _id: 2481998e71355fc9ca2258fbaae1cf9a
-      _order: 0
-      cache: {}
-      request:
-        bodySize: 101
-        cookies: []
-        headers:
-          - _fromType: array
-            name: authorization
-            value: token
-              REDACTED_fc324d3667e841181b0779375f26dedc911d26b303d23b29b1a2d7ee63dc77eb
-          - _fromType: array
-            name: content-type
-            value: application/json; charset=utf-8
-          - _fromType: array
-            name: user-agent
-            value: defaultclient/v1 (Node.js v20.4.0)
-          - _fromType: array
-            name: x-requested-with
-            value: defaultclient v1
-          - _fromType: array
-            name: accept
-            value: "*/*"
-          - _fromType: array
-            name: content-length
-            value: "101"
-          - _fromType: array
-            name: accept-encoding
-            value: gzip,deflate
-          - name: host
-            value: sourcegraph.com
-        headersSize: 434
-        httpVersion: HTTP/1.1
-        method: POST
-        postData:
-          mimeType: application/json; charset=utf-8
-          params: []
-          textJSON:
-            query: |
-              
-              query TemporarySettings {
-                temporarySettings {
-                  contents
-                }
-              }
-            variables: {}
-        queryString:
-          - name: TemporarySettings
-            value: null
-        url: https://sourcegraph.com/.api/graphql?TemporarySettings
-      response:
-        bodySize: 508
-        content:
-          encoding: base64
-          mimeType: application/json
-          size: 508
-          text: "[\"H4sIAAAAAAAAA8SSy07DMBBFf8WyWFWt8yJU9Q7Bgn27AoPkJtPEwrGDPQaiKv+OnEiIB\
-            Wwoj+3M9fjcuXOktURJ+ZEidL110g1bQFSm8bFYWYNg0FNOj4IGD45p6fFaDpcVqmcQ\
-            lBNBd20gW+hJtiF5mp8LuiSCVrYemDV7K12tTMM8Qh/leWxOk2o5+HnMlQ0GYzPLPnt\
-            a2a7XgFBHCboAUeRBuqplyvQBmYMKDG6nEvgouzsK+hTADTPiZOQVeaPtXmrioLf8oV\
-            HYhr0QQsQvEm+Dq6Bxsm+TiHBGIqaRHXByUBq4g8rORK10bJCdnq1q1Sm8UZODg9R+4\
-            kPVgUfZ9TNAXMwqLVf5epdl/DzjWcHKorydJzjwQeP7GopxSX6BXzZgMHl34ZNFsjjV\
-            RlqyNF1/biP9Ixvfxk95uWabrPjnFE7LIOVlwS6+OqWfyuBDZW9x87g6mJcunABdlCz\
-            ffHn/9yMdx/ENAAD//wMAHMsNG54EAAA=\"]"
-          textDecoded:
-            data:
-              temporarySettings:
-                contents: "{\"user.lastDayActive\": \"Thu Sep 19 2024\",
-                  \"cody.onboarding.step\": 2, \"user.daysActiveCount\": 11,
-                  \"cody.onboarding.completed\": true,
-                  \"search.input.recentSearches\": [{\"query\": \"context:global
-                  repo:^github\\\\.com/sourcegraph/cody$ username:
-                  file:recording.har.yaml\", \"limitHit\": false, \"timestamp\":
-                  \"2024-05-27T11:41:13.535Z\", \"resultCount\": 3}, {\"query\":
-                  \"context:global repo:^github\\\\.com/sourcegraph/cody$
-                  username: file:agent/recordings/*/*.yaml\", \"limitHit\":
-                  false, \"timestamp\": \"2024-05-27T11:41:05.007Z\",
-                  \"resultCount\": 0}, {\"query\": \"context:global
-                  repo:^github\\\\.com/sourcegraph/cody$ username:
-                  file:agent/recordings/\", \"limitHit\": false, \"timestamp\":
-                  \"2024-05-27T11:40:57.913Z\", \"resultCount\": 3}, {\"query\":
-                  \"context:global repo:^github\\\\.com/sourcegraph/cody$
-                  username: file:agent/recordings/*.yaml\", \"limitHit\": false,
-                  \"timestamp\": \"2024-05-27T11:40:53.635Z\", \"resultCount\":
-                  0}, {\"query\": \"context:global
-                  repo:^github\\\\.com/sourcegraph/cody$
-                  sourcegraphbot9k-fnwmu\", \"limitHit\": false, \"timestamp\":
-                  \"2024-05-27T11:40:35.295Z\", \"resultCount\": 3}]}"
-        cookies: []
-        headers:
-          - name: date
-            value: Fri, 17 Jan 2025 13:17:22 GMT
-          - name: content-type
-            value: application/json
-          - name: transfer-encoding
-            value: chunked
-          - name: connection
-            value: close
-          - name: access-control-allow-credentials
-            value: "true"
-          - name: access-control-allow-origin
-            value: ""
-          - name: cache-control
-            value: no-cache, max-age=0
-          - name: vary
-            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
-              X-Requested-With,Cookie
-          - name: x-content-type-options
-            value: nosniff
-          - name: x-frame-options
-            value: DENY
-          - name: x-xss-protection
-            value: 1; mode=block
-          - name: strict-transport-security
-            value: max-age=31536000; includeSubDomains; preload
-          - name: content-encoding
-            value: gzip
-        headersSize: 1468
-        httpVersion: HTTP/1.1
-        redirectURL: ""
-        status: 200
-        statusText: OK
-      startedDateTime: 2025-01-17T13:17:21.369Z
-      time: 733
-      timings:
-        blocked: -1
-        connect: -1
-        dns: -1
-        receive: 0
-        send: 0
-        ssl: -1
-        wait: 733
     - _id: fd0fee4687419870bc82cba9d1023319
       _order: 0
       cache: {}

--- a/agent/src/index.test.ts
+++ b/agent/src/index.test.ts
@@ -404,7 +404,7 @@ describe('Agent', () => {
             )
         }, 30_000)
 
-        it.skip('webview/receiveMessage (type: reset)', async () => {
+        it('webview/receiveMessage (type: reset)', async () => {
             const id = await client.request('chat/new', null)
             await client.request('chat/setModel', {
                 id,
@@ -441,7 +441,7 @@ describe('Agent', () => {
         }, 30_000)
 
         describe('chat/editMessage', () => {
-            it.skip(
+            it(
                 'edits the last human chat message',
                 async () => {
                     const id = await client.request('chat/new', null)

--- a/lib/shared/src/sourcegraph-api/clientConfig.ts
+++ b/lib/shared/src/sourcegraph-api/clientConfig.ts
@@ -196,7 +196,7 @@ export class ClientConfigSingleton {
                     return true
                 }
 
-                if (semver.lt(siteVersion, '6.0.0')) {
+                if (!semver.lt(siteVersion, '6.0.0')) {
                     omniBoxEnabled = true
                 }
 

--- a/lib/shared/src/sourcegraph-api/clientConfig.ts
+++ b/lib/shared/src/sourcegraph-api/clientConfig.ts
@@ -1,6 +1,5 @@
 import { Observable, interval, map } from 'observable-fns'
 import semver from 'semver'
-import type { AuthStatus } from '..'
 import { authStatus } from '../auth/authStatus'
 import { editorWindowIsFocused } from '../editor/editorState'
 import { logDebug, logError } from '../logger'
@@ -133,7 +132,7 @@ export class ClientConfigSingleton {
                           filter((_value): _value is undefined => editorWindowIsFocused()),
                           startWith(undefined),
                           switchMap(() =>
-                              promiseFactoryToObservable(signal => this.fetchConfig(authStatus, signal))
+                              promiseFactoryToObservable(signal => this.fetchConfig(signal))
                           ),
                           retry(3)
                       )
@@ -169,99 +168,103 @@ export class ClientConfigSingleton {
         return await firstValueFrom(this.changes.pipe(skipPendingOperation()), signal)
     }
 
-    private async fetchConfig(authStatus: AuthStatus, signal?: AbortSignal): Promise<CodyClientConfig> {
+    private async fetchConfig(signal?: AbortSignal): Promise<CodyClientConfig> {
         logDebug('ClientConfigSingleton', 'refreshing configuration')
+        let omniBoxEnabled = false
 
-        try {
-            // Determine based on the site version if /.api/client-config is available.
-            const siteVersion = await graphqlClient.getSiteVersion(signal)
-
-            signal?.throwIfAborted()
-
-            let supportsClientConfig = false
-
-            let omniBoxEnabled = false
-
-            if (isError(siteVersion)) {
-                if (isAbortError(siteVersion)) {
-                    throw siteVersion
+        // Determine based on the site version if /.api/client-config is available.
+        return graphqlClient
+            .getSiteVersion(signal)
+            .then(siteVersion => {
+                signal?.throwIfAborted()
+                if (isError(siteVersion)) {
+                    if (isAbortError(siteVersion)) {
+                        throw siteVersion
+                    }
+                    logError(
+                        'ClientConfigSingleton',
+                        'Failed to determine site version, GraphQL error',
+                        siteVersion
+                    )
+                    return false // assume /.api/client-config is not supported
                 }
-                logError(
-                    'ClientConfigSingleton',
-                    'Failed to determine site version, GraphQL error',
-                    siteVersion
-                )
 
-                supportsClientConfig = false
-            } else {
                 // Insiders and dev builds support the new /.api/client-config endpoint
                 const insiderBuild = siteVersion.length > 12 || siteVersion.includes('dev')
+                if (insiderBuild) {
+                    omniBoxEnabled = true
+                    return true
+                }
+
+                if (semver.lt(siteVersion, '6.0.0')) {
+                    omniBoxEnabled = true
+                }
 
                 // Sourcegraph instances before 5.5.0 do not support the new /.api/client-config endpoint.
-                supportsClientConfig = insiderBuild || !semver.lt(siteVersion, '5.5.0')
-
-                const isDotCom =
-                    !authStatus.authenticated ||
-                    authStatus.endpoint.startsWith('https://sourcegraph.com')
-                // Enable OmniBox for Sourcegraph instances 6.0.0 and above or dev instances
-                omniBoxEnabled = !isDotCom && (insiderBuild || semver.gte(siteVersion, '6.0.0'))
-            }
-
-            signal?.throwIfAborted()
-
-            // If /.api/client-config is not available, fallback to the myriad of GraphQL
-            // requests that we previously used to determine the client configuration
-            const clientConfig = await (supportsClientConfig
-                ? this.fetchConfigEndpoint(signal)
-                : this.fetchClientConfigLegacy(signal))
-
-            signal?.throwIfAborted()
-            logDebug('ClientConfigSingleton', 'refreshed', JSON.stringify(clientConfig))
-
-            return Promise.all([
-                graphqlClient.viewerSettings(signal),
-                graphqlClient.codeSearchEnabled(signal),
-            ]).then(([viewerSettings, codeSearchEnabled]) => {
-                const config: CodyClientConfig = {
-                    ...clientConfig,
-                    intentDetection: 'enabled',
-                    notices: [],
-                    siteVersion: isError(siteVersion) ? undefined : siteVersion,
-                    omniBoxEnabled,
-                    codeSearchEnabled: isError(codeSearchEnabled) ? true : codeSearchEnabled,
+                if (semver.lt(siteVersion, '5.5.0')) {
+                    return false
                 }
-
-                // Don't fail the whole chat because of viewer setting (used only to show banners)
-                if (!isError(viewerSettings)) {
-                    config.intentDetection = ['disabled', 'enabled'].includes(
-                        viewerSettings['omnibox.intentDetection']
-                    )
-                        ? viewerSettings['omnibox.intentDetection']
-                        : 'enabled'
-                    // Make sure that notice object will have all important field (notices come from
-                    // instance global JSONC configuration so they can have any arbitrary field values.
-                    config.notices = Array.from<Partial<CodyNotice>, CodyNotice>(
-                        viewerSettings['cody.notices'] ?? [],
-                        (notice, index) => ({
-                            key: notice?.key ?? index.toString(),
-                            title: notice?.title ?? '',
-                            message: notice?.message ?? '',
-                        })
-                    )
-                }
-
-                if (codeSearchEnabled === false) {
-                    config.intentDetection = 'disabled'
-                }
-
-                return config
+                return true
             })
-        } catch (e) {
-            if (!isAbortError(e)) {
-                logError('ClientConfigSingleton', 'failed to refresh client config', e)
-            }
-            throw e
-        }
+            .then(supportsClientConfig => {
+                signal?.throwIfAborted()
+
+                // If /.api/client-config is not available, fallback to the myriad of GraphQL
+                // requests that we previously used to determine the client configuration
+                if (!supportsClientConfig) {
+                    return this.fetchClientConfigLegacy(signal)
+                }
+
+                return this.fetchConfigEndpoint(signal)
+            })
+            .then(async clientConfig => {
+                signal?.throwIfAborted()
+                logDebug('ClientConfigSingleton', 'refreshed', JSON.stringify(clientConfig))
+
+                return Promise.all([
+                    graphqlClient.viewerSettings(signal),
+                    graphqlClient.codeSearchEnabled(signal),
+                ]).then(([viewerSettings, codeSearchEnabled]) => {
+                    const config: CodyClientConfig = {
+                        ...clientConfig,
+                        intentDetection: 'enabled',
+                        notices: [],
+                        omniBoxEnabled,
+                        codeSearchEnabled: isError(codeSearchEnabled) ? true : codeSearchEnabled,
+                    }
+
+                    // Don't fail the whole chat because of viewer setting (used only to show banners)
+                    if (!isError(viewerSettings)) {
+                        config.intentDetection = ['disabled', 'enabled'].includes(
+                            viewerSettings['omnibox.intentDetection']
+                        )
+                            ? viewerSettings['omnibox.intentDetection']
+                            : 'enabled'
+                        // Make sure that notice object will have all important field (notices come from
+                        // instance global JSONC configuration so they can have any arbitrary field values.
+                        config.notices = Array.from<Partial<CodyNotice>, CodyNotice>(
+                            viewerSettings['cody.notices'] ?? [],
+                            (notice, index) => ({
+                                key: notice?.key ?? index.toString(),
+                                title: notice?.title ?? '',
+                                message: notice?.message ?? '',
+                            })
+                        )
+                    }
+
+                    if (codeSearchEnabled === false) {
+                        config.intentDetection = 'disabled'
+                    }
+
+                    return config
+                })
+            })
+            .catch(e => {
+                if (!isAbortError(e)) {
+                    logError('ClientConfigSingleton', 'failed to refresh client config', e)
+                }
+                throw e
+            })
     }
 
     private async fetchClientConfigLegacy(signal?: AbortSignal): Promise<CodyClientConfig> {


### PR DESCRIPTION
FIX: https://linear.app/sourcegraph/issue/CODY-4888

The change revert the client configuration fetching logic changes made by #6710.

I haven't found a way to reproduce the issue consistently, but I suspected it was the code change because: The new code attempts to get siteVersion, viewerSettings, and codeSearchEnabled in parallel, and the timeout could be happening because we're making multiple concurrent API calls

Key changes:
- Removed AuthStatus dependency since endpoint checks were removed
- Flattened nested promise structure using .then() chains
- Improved error handling by moving catch block to end of chain
- Make the API calls sequential rather than parallel
- Potentially avoid timeout issues by not overwhelming the network with concurrent requests

This makes the code more maintainable and fixes a logic issue with the omnibox feature flag.


## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

Unskipped the skipped tests and they are all passing again:

![image](https://github.com/user-attachments/assets/3356d4f9-8606-4e3a-8c51-010a35123790)

