### PR TITLE
chore/release: VSCode stable release Slack announcements to point to the correct release branches

### DIFF
--- a/.github/workflows/release-vscode-stable.yml
+++ b/.github/workflows/release-vscode-stable.yml
@@ -80,8 +80,8 @@ jobs:
           minor=$(echo $tag | sed 's/\([0-9]*\)\.\([0-9]*\)\.\([0-9]*\)/\2/')
           next_minor=$(($minor + 2))
           echo "VERSION_ANCHOR=$version_anchor" >> $GITHUB_ENV
-          echo "CURRENT_RELEASE_BRANCH=vscode-v$major.$minor.x" >> $GITHUB_ENV
-          echo "NEXT_RELEASE_BRANCH=vscode-v$major.$next_minor.x" >> $GITHUB_ENV
+          echo "CURRENT_RELEASE_BRANCH=M$minor" >> $GITHUB_ENV
+          echo "NEXT_RELEASE_BRANCH=M$next_minor" >> $GITHUB_ENV
       - name: "Slack notification"
         run: |
           echo "Posting release announcement to Slack"


### PR DESCRIPTION
## Test plan

No test... we will watch what happens in Slack when we release M68 to stable. This is the last step in the job so if it fails the release is still done.

The diff URLs look like this now: https://github.com/sourcegraph/cody/compare/M66...M68