### PR TITLE
fix/release: Update the JetBrains link to release notes.

### DIFF
--- a/jetbrains/src/main/resources/META-INF/plugin.xml
+++ b/jetbrains/src/main/resources/META-INF/plugin.xml
@@ -7,7 +7,7 @@
         Sourcegraph
     </vendor>
     <change-notes>
-        <![CDATA[Update notes are available on <a href="https://github.com/sourcegraph/jetbrains/releases">GitHub</a>.]]></change-notes>
+        <![CDATA[<a href="https://github.com/sourcegraph/cody/releases?q=JetBrains&expanded=true">Update notes are available on GitHub.</a>]]></change-notes>
 
     <depends>com.intellij.modules.json</depends>
     <depends>com.intellij.modules.platform</depends>


### PR DESCRIPTION
We will create releases in sourcegraph/cody now, because that's where the commits are! And link to this page to display them:

https://github.com/sourcegraph/cody/releases?q=JetBrains&expanded=true

## Test plan

```
cd jetbrains
./gradlew verifyPlugin
```

Land this, backport it, then release a v7.67 nightly and check that [the JetBrains Marketplace page](https://plugins.jetbrains.com/plugin/9682-cody-ai-code-assistant/edit/versions/nightly) looks good.