### PR TITLE
fix: Fix chevron for open/closed search results

### DIFF
--- a/vscode/webviews/components/codeSnippet/components/RepoLink.tsx
+++ b/vscode/webviews/components/codeSnippet/components/RepoLink.tsx
@@ -58,7 +58,7 @@ export const RepoFileLink: React.FunctionComponent<React.PropsWithChildren<Props
         }
     }, [pathMatchRanges, fileName])
 
-    const Chevron = collapsed ? ChevronDown : ChevronRight
+    const Chevron = collapsed ? ChevronRight : ChevronDown
     const {
         clientCapabilities: { agentIDE },
     } = useConfig()


### PR DESCRIPTION
Closes https://linear.app/sourcegraph/issue/SRCH-1583/result-accordions-are-backwards

## Test plan

![2025-02-06_12-44](https://github.com/user-attachments/assets/8a8a1573-b1cd-49b3-8003-8426cc1beecb)


Trivial change, locally tested.

