### PR TITLE
experimental: Re-enable tool-cody for exploration

### DIFF
--- a/lib/shared/src/models/client.ts
+++ b/lib/shared/src/models/client.ts
@@ -35,10 +35,13 @@ function getDeepCodyServerModel(): ServerModel {
     }
 }
 
+export const ToolCodyModelRef = 'sourcegraph::2024-12-31::tool-cody'
+export const ToolCodyModelName = 'tool-cody'
+
 export const TOOL_CODY_MODEL: ServerModel = {
-    modelRef: 'sourcegraph::2024-12-31::tool-cody',
+    modelRef: ToolCodyModelRef,
     displayName: 'Tool Cody',
-    modelName: 'tool-cody',
+    modelName: ToolCodyModelName,
     capabilities: ['chat'],
     category: 'accuracy',
     status: 'internal' as ModelTag.Internal,

--- a/lib/shared/src/models/sync.ts
+++ b/lib/shared/src/models/sync.ts
@@ -26,7 +26,7 @@ import { RestClient } from '../sourcegraph-api/rest/client'
 import type { UserProductSubscription } from '../sourcegraph-api/userProductSubscription'
 import { CHAT_INPUT_TOKEN_BUDGET } from '../token/constants'
 import { isError } from '../utils'
-import { TOOL_CODY_MODEL, getExperimentalClientModelByFeatureFlag } from './client'
+import { TOOL_CODY_MODEL, ToolCodyModelName, getExperimentalClientModelByFeatureFlag } from './client'
 import { type Model, type ServerModel, createModel, createModelFromServerModel } from './model'
 import type {
     DefaultsAndUserPreferencesForEndpoint,
@@ -265,7 +265,7 @@ export function syncModels({
                                                 }
 
                                                 const hasToolCody = data.primaryModels.some(m =>
-                                                    m.id.includes('tool-cody')
+                                                    m.id.includes(ToolCodyModelName)
                                                 )
                                                 if (!hasToolCody && isToolCodyEnabled) {
                                                     clientModels.push(TOOL_CODY_MODEL)

--- a/vscode/src/chat/chat-view/ChatController.ts
+++ b/vscode/src/chat/chat-view/ChatController.ts
@@ -73,7 +73,11 @@ import { type Span, context } from '@opentelemetry/api'
 import { captureException } from '@sentry/core'
 import type { SubMessage } from '@sourcegraph/cody-shared/src/chat/transcript/messages'
 import { resolveAuth } from '@sourcegraph/cody-shared/src/configuration/auth-resolver'
-import { DeepCodyAgentID } from '@sourcegraph/cody-shared/src/models/client'
+import {
+    DeepCodyAgentID,
+    ToolCodyModelName,
+    ToolCodyModelRef,
+} from '@sourcegraph/cody-shared/src/models/client'
 import type { TelemetryEventParameters } from '@sourcegraph/telemetry'
 import { Subject, map } from 'observable-fns'
 import type { URI } from 'vscode-uri'
@@ -671,7 +675,10 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
                     firstResultFromOperation(ChatBuilder.resolvedModelForChat(this.chatBuilder))
                 )
                 this.chatBuilder.setSelectedModel(model)
-                const selectedAgent = model?.includes(DeepCodyAgentID) ? DeepCodyAgentID : undefined
+                let selectedAgent = model?.includes(DeepCodyAgentID) ? DeepCodyAgentID : undefined
+                if (model?.includes(ToolCodyModelName)) {
+                    selectedAgent = ToolCodyModelRef
+                }
 
                 this.chatBuilder.addHumanMessage({
                     text: inputText,
@@ -796,7 +803,10 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
         }
 
         this.chatBuilder.setSelectedModel(model)
-        const chatAgent = model.includes(DeepCodyAgentID) ? DeepCodyAgentID : undefined
+        let chatAgent = model.includes(DeepCodyAgentID) ? DeepCodyAgentID : undefined
+        if (model.includes(ToolCodyModelName)) {
+            chatAgent = ToolCodyModelRef
+        }
 
         const recorder = await OmniboxTelemetry.create({
             requestID,

--- a/vscode/src/chat/chat-view/handlers/registry.ts
+++ b/vscode/src/chat/chat-view/handlers/registry.ts
@@ -1,5 +1,5 @@
 import Anthropic from '@anthropic-ai/sdk'
-import { DeepCodyAgentID } from '@sourcegraph/cody-shared/src/models/client'
+import { DeepCodyAgentID, ToolCodyModelRef } from '@sourcegraph/cody-shared/src/models/client'
 import { getConfiguration } from '../../../configuration'
 import { ChatHandler } from './ChatHandler'
 import { DeepCodyHandler } from './DeepCodyHandler'
@@ -41,7 +41,7 @@ registerAgent(
     (_id: string, { contextRetriever, editor }: AgentTools) =>
         new EditHandler('insert', contextRetriever, editor)
 )
-registerAgent('sourcegraph::2024-12-31::tool-cody', (_id: string) => {
+registerAgent(ToolCodyModelRef, (_id: string) => {
     const config = getConfiguration()
     const anthropicAPI = new Anthropic({
         apiKey: config.experimentalMinionAnthropicKey,

--- a/vscode/webviews/components/modelSelectField/ModelSelectField.tsx
+++ b/vscode/webviews/components/modelSelectField/ModelSelectField.tsx
@@ -1,5 +1,5 @@
 import { type Model, ModelTag, isCodyProModel, isWaitlistModel } from '@sourcegraph/cody-shared'
-import { DeepCodyAgentID } from '@sourcegraph/cody-shared/src/models/client'
+import { DeepCodyAgentID, ToolCodyModelName } from '@sourcegraph/cody-shared/src/models/client'
 import { clsx } from 'clsx'
 import { BookOpenIcon, BrainIcon, BuildingIcon, ExternalLinkIcon } from 'lucide-react'
 import { type FunctionComponent, type ReactNode, useCallback, useMemo } from 'react'
@@ -403,7 +403,8 @@ const ModelUIGroup: Record<string, string> = {
 }
 
 const getModelDropDownUIGroup = (model: Model): string => {
-    if ([DeepCodyAgentID, 'tool-cody'].some(id => model.id.includes(id))) return ModelUIGroup.Agents
+    if ([DeepCodyAgentID, ToolCodyModelName].some(id => model.id.includes(id)))
+        return ModelUIGroup.Agents
     if (model.tags.includes(ModelTag.Power)) return ModelUIGroup.Power
     if (model.tags.includes(ModelTag.Balanced)) return ModelUIGroup.Balanced
     if (model.tags.includes(ModelTag.Speed)) return ModelUIGroup.Speed


### PR DESCRIPTION
This fixes `tool-cody` not working anymore by making the `model` and `agentName` checks actually check for tool-cody.

To test it, you need to set the experimental setting:

```json
{
    "cody.experimental.minion.anthropicKey": "anthropic api key here",
}
```

I also added a "run terminal command" tool that's by no means production ready but helped me test things easily and get more familiar with the codebase again.

## Test plan

- Set `"cody.experimental.minion.anthropicKey": "anthropic api key here"` in VS Code settings
- Open Cody, select `Tool Cody` that's now visible
- Ask Cody: "Can you run `wc -l` against <filename> please?"
- See it return the output