### PR TITLE
chat ui: remove user avatars, remove speaker name from follow-up message

### DIFF
--- a/vscode/webviews/chat/cells/messageCell/human/HumanMessageCell.tsx
+++ b/vscode/webviews/chat/cells/messageCell/human/HumanMessageCell.tsx
@@ -10,8 +10,7 @@ import isEqual from 'lodash/isEqual'
 import { ColumnsIcon } from 'lucide-react'
 import { type FC, memo, useMemo } from 'react'
 import type { UserAccountInfo } from '../../../../Chat'
-import { UserAvatar } from '../../../../components/UserAvatar'
-import { BaseMessageCell, MESSAGE_CELL_AVATAR_SIZE } from '../BaseMessageCell'
+import { BaseMessageCell } from '../BaseMessageCell'
 import { HumanMessageEditor } from './editor/HumanMessageEditor'
 
 import { Tooltip, TooltipContent, TooltipTrigger } from '../../../../components/shadcn/ui/tooltip'
@@ -94,14 +93,7 @@ const HumanMessageCellContent = memo<HumanMessageCellContent>(props => {
 
     return (
         <BaseMessageCell
-            speakerIcon={
-                <UserAvatar
-                    user={userInfo.user}
-                    size={MESSAGE_CELL_AVATAR_SIZE}
-                    sourcegraphGradientBorder={true}
-                />
-            }
-            speakerTitle={userInfo.user.displayName ?? userInfo.user.username}
+            speakerTitle={isFirstMessage && (userInfo.user.displayName ?? userInfo.user.username)}
             cellAction={
                 <div className="tw-flex tw-gap-2 tw-items-center tw-justify-end">
                     {isFirstMessage && <OpenInNewEditorAction />}


### PR DESCRIPTION
The user knows who they are, why show it next to every message? It clutters the UI. So I removed the avatar from the human messages (we still have the avatar in the top right).

I also removed the name from the follow-up message. It doesn't add anything.

Ideally we'd remove the "user name" every where but when I did that, the layout looked kinda bad because there was still the 'split into chat' button.

## Before
![before](https://github.com/user-attachments/assets/2ce844e1-275a-42e4-876c-5d18bb011a47)

## After
![after](https://github.com/user-attachments/assets/364a23a7-242b-4ed7-a49f-08de8df6b47f)

## Test plan

- N/A