### PR TITLE
bug fix: Fix 500ms delay when submitting chat message

### DIFF
--- a/vscode/test/e2e/chat-context.test.ts
+++ b/vscode/test/e2e/chat-context.test.ts
@@ -8,7 +8,7 @@ import {
 } from './common'
 import { test } from './helpers'
 
-test.skip('chat followup context', async ({ page, sidebar }) => {
+test('chat followup context', async ({ page, sidebar }) => {
     await sidebarSignin(page, sidebar)
 
     // Open chat.

--- a/vscode/test/e2e/chat-input.test.ts
+++ b/vscode/test/e2e/chat-input.test.ts
@@ -22,77 +22,76 @@ test.extend<ExpectedV2Events>({
         'cody.chat-question:executed',
         'cody.chatResponse:hasCode',
     ],
+})('chat input focus', async ({ page, sidebar }) => {
+    // This test requires that the window be focused in the OS window manager because it deals with
+    // focus.
+    await page.bringToFront()
+
+    await sidebarSignin(page, sidebar)
+    // Open the buzz.ts file from the tree view,
+    // and then submit a chat question from the command menu.
+    await sidebarExplorer(page).click()
+    await page.getByRole('treeitem', { name: 'buzz.ts' }).locator('a').dblclick()
+    await page.getByRole('tab', { name: 'buzz.ts' }).hover()
+
+    // Open a new chat panel before opening the file to make sure
+    // the chat panel is right next to the document. This helps to save loading time
+    // when we submit a question later as the question will be streamed to this panel
+    // directly instead of opening a new one.
+    await page.getByRole('tab', { name: 'Cody', exact: true }).locator('a').click()
+    const [chatPanel, lastChatInput, firstChatInput, chatInputs] = await createEmptyChatPanel(page)
+    await expect(firstChatInput).toBeFocused() // Chat should be focused initially.
+    await page.getByRole('tab', { name: 'Cody', exact: true }).locator('a').click()
+    await page.getByRole('tab', { name: 'buzz.ts' }).dblclick()
+
+    // Ensure equal-width columns so we can be sure the code we're about to click is in view (and is
+    // not out of the editor's scroll viewport). This became required due to new (undocumented)
+    // behavior in VS Code 1.88.0 where the Cody panel would take up ~80% of the width when it was
+    // focused, meaning that the buzz.ts editor tab would take up ~20% and the text we intend to
+    // click would be only partially visible, making the click() call fail.
+    await executeCommandInPalette(page, 'View: Reset Editor Group Sizes')
+
+    // Click in the file to make sure we're not focused in the chat panel. Use the Alt+L hotkey
+    // (`Cody: New Chat`) to switch back to the chat window we already opened and check that the
+    // input is focused.
+    await page.getByText("fizzbuzz.push('Buzz')").click()
+
+    // Submit a new chat question from the command menu.
+    await page
+        .locator('[id="workbench\\.parts\\.editor"]')
+        .getByLabel(/Commands \(/)
+        .click()
+    await page.waitForTimeout(100)
+
+    // HACK: The 'delay' command is used to make sure the response is streamed 400ms after
+    // the command is sent. This provides us with a small window to move the cursor
+    // from the new opened chat window back to the editor, before the chat has finished
+    // streaming its response.
+    await firstChatInput.fill('delay')
+    await firstChatInput.press('Enter')
+    await expect(lastChatInput).toBeFocused()
+
+    // Make sure the chat input box does not steal focus from the editor when editor
+    // is focused.
+    await expect(lastChatInput).toBeFocused()
+    await page.getByText("fizzbuzz.push('Buzz')").click()
+    await expect(firstChatInput).not.toBeFocused()
+    await expect(lastChatInput).not.toBeFocused()
+    // once the response is 'Done', check the input focus
+    await firstChatInput.hover()
+    await expect(chatPanel.getByText('Done')).toBeVisible()
+    await expect(firstChatInput).not.toBeFocused()
+    await expect(lastChatInput).not.toBeFocused()
+
+    // Click into the last chat input and submit a new follow-up chat message. The original focus
+    // area which is the chat input should still have the focus after the response is received.
+    await lastChatInput.click()
+    await lastChatInput.type('Regular chat message', { delay: 10 })
+    await lastChatInput.press('Enter')
+    await expect(chatPanel.getByText('hello from the assistant')).toBeVisible()
+    await expect(chatInputs.nth(1)).not.toBeFocused()
+    await expect(lastChatInput).toBeFocused()
 })
-    .skip('chat input focus', async ({ page, sidebar }) => {
-        // This test requires that the window be focused in the OS window manager because it deals with
-        // focus.
-        await page.bringToFront()
-
-        await sidebarSignin(page, sidebar)
-        // Open the buzz.ts file from the tree view,
-        // and then submit a chat question from the command menu.
-        await sidebarExplorer(page).click()
-        await page.getByRole('treeitem', { name: 'buzz.ts' }).locator('a').dblclick()
-        await page.getByRole('tab', { name: 'buzz.ts' }).hover()
-
-        // Open a new chat panel before opening the file to make sure
-        // the chat panel is right next to the document. This helps to save loading time
-        // when we submit a question later as the question will be streamed to this panel
-        // directly instead of opening a new one.
-        await page.getByRole('tab', { name: 'Cody', exact: true }).locator('a').click()
-        const [chatPanel, lastChatInput, firstChatInput, chatInputs] = await createEmptyChatPanel(page)
-        await expect(firstChatInput).toBeFocused() // Chat should be focused initially.
-        await page.getByRole('tab', { name: 'Cody', exact: true }).locator('a').click()
-        await page.getByRole('tab', { name: 'buzz.ts' }).dblclick()
-
-        // Ensure equal-width columns so we can be sure the code we're about to click is in view (and is
-        // not out of the editor's scroll viewport). This became required due to new (undocumented)
-        // behavior in VS Code 1.88.0 where the Cody panel would take up ~80% of the width when it was
-        // focused, meaning that the buzz.ts editor tab would take up ~20% and the text we intend to
-        // click would be only partially visible, making the click() call fail.
-        await executeCommandInPalette(page, 'View: Reset Editor Group Sizes')
-
-        // Click in the file to make sure we're not focused in the chat panel. Use the Alt+L hotkey
-        // (`Cody: New Chat`) to switch back to the chat window we already opened and check that the
-        // input is focused.
-        await page.getByText("fizzbuzz.push('Buzz')").click()
-
-        // Submit a new chat question from the command menu.
-        await page
-            .locator('[id="workbench\\.parts\\.editor"]')
-            .getByLabel(/Commands \(/)
-            .click()
-        await page.waitForTimeout(100)
-
-        // HACK: The 'delay' command is used to make sure the response is streamed 400ms after
-        // the command is sent. This provides us with a small window to move the cursor
-        // from the new opened chat window back to the editor, before the chat has finished
-        // streaming its response.
-        await firstChatInput.fill('delay')
-        await firstChatInput.press('Enter')
-        await expect(lastChatInput).toBeFocused()
-
-        // Make sure the chat input box does not steal focus from the editor when editor
-        // is focused.
-        await expect(lastChatInput).toBeFocused()
-        await page.getByText("fizzbuzz.push('Buzz')").click()
-        await expect(firstChatInput).not.toBeFocused()
-        await expect(lastChatInput).not.toBeFocused()
-        // once the response is 'Done', check the input focus
-        await firstChatInput.hover()
-        await expect(chatPanel.getByText('Done')).toBeVisible()
-        await expect(firstChatInput).not.toBeFocused()
-        await expect(lastChatInput).not.toBeFocused()
-
-        // Click into the last chat input and submit a new follow-up chat message. The original focus
-        // area which is the chat input should still have the focus after the response is received.
-        await lastChatInput.click()
-        await lastChatInput.type('Regular chat message', { delay: 10 })
-        await lastChatInput.press('Enter')
-        await expect(chatPanel.getByText('hello from the assistant')).toBeVisible()
-        await expect(chatInputs.nth(1)).not.toBeFocused()
-        await expect(lastChatInput).toBeFocused()
-    })
 
 test.extend<DotcomUrlOverride>({ dotcomUrl: mockServer.SERVER_URL })
     .skip('chat toolbar and row UI', async ({ page, sidebar }) => {


### PR DESCRIPTION
This removes the 500ms delay when submitting messages. It was introduced in #6720.

If I understood the PR correctly, it was introduced to fix the error message that shows up when trying to switch intent while a response is streaming in.

But instead of waiting 500ms before aborting, we go back to aborting, and explicitly abort a possible ongoing request before editing the message and resubmitting it.

In my testing, it fixes the bug.

I also re-added the tests that were commented out in #6720.

## Test plan

- Submit a message to Claude, saying something like "write me a long poem" so that it generates a lot of text
- While Claude is generating, switch the intent manually by clicking on the button
- No error message should pop up
