### PR TITLE
fix ~5px pixel jitter when pressing Enter in chat in VS Code

### DIFF
--- a/vscode/webviews/.sourcegraph/no-scrollIntoView.rule.md
+++ b/vscode/webviews/.sourcegraph/no-scrollIntoView.rule.md
@@ -1,0 +1,14 @@
+---
+title: Do not use scrollIntoView in a VS Code webview
+---
+
+Using `HTMLElement.scrollIntoView()` in a VS Code webview causes the iframe to be incorrectly positioned, chopping off the top ~5px and adding an empty void in the bottom ~5px.
+
+Instead, only scroll the nearest ancestor scrollable container:
+
+```typescript
+const container = e.closest('[data-scrollable]')
+if (container && container instanceof HTMLElement) {
+    container.scrollTop = e.offsetTop - container.offsetTop
+}
+```

--- a/vscode/webviews/App.module.css
+++ b/vscode/webviews/App.module.css
@@ -1,8 +1,6 @@
 .outer-container {
-  background-color: var(--vscode-sideBar-background);
   display: flex;
   flex-direction: column;
-  box-sizing: border-box;
   height: 100%;
   overflow: hidden;
 }

--- a/vscode/webviews/CodyPanel.tsx
+++ b/vscode/webviews/CodyPanel.tsx
@@ -129,7 +129,7 @@ export const CodyPanel: FunctionComponent<CodyPanelProps> = ({
                     />
                 )}
                 {errorMessages && <ErrorBanner errors={errorMessages} setErrors={setErrorMessages} />}
-                <TabContainer value={view} ref={tabContainerRef}>
+                <TabContainer value={view} ref={tabContainerRef} data-scrollable>
                     {view === View.Chat && (
                         <Chat
                             chatEnabled={chatEnabled}

--- a/vscode/webviews/chat/Transcript.tsx
+++ b/vscode/webviews/chat/Transcript.tsx
@@ -800,8 +800,19 @@ const TranscriptInteraction: FC<TranscriptInteractionProps> = memo(props => {
 export function focusLastHumanMessageEditor(): void {
     const elements = document.querySelectorAll<HTMLElement>('[data-lexical-editor]')
     const lastEditor = elements.item(elements.length - 1)
-    lastEditor?.focus()
-    lastEditor?.scrollIntoView()
+    if (!lastEditor) {
+        return
+    }
+
+    lastEditor.focus()
+
+    // Only scroll the nearest scrollable ancestor container, not all scrollable ancestors, to avoid
+    // a bug in VS Code where the iframe is pushed up by ~5px.
+    const container = lastEditor?.closest('[data-scrollable]')
+    const editorScrollItemInContainer = lastEditor.parentElement
+    if (container && container instanceof HTMLElement && editorScrollItemInContainer) {
+        container.scrollTop = editorScrollItemInContainer.offsetTop - container.offsetTop
+    }
 }
 
 export function editHumanMessage({


### PR DESCRIPTION
Previously, pressing Enter in a chat message in VS Code's Cody chat would cause the iframe to be shifted up by ~5px. This was an annoying visual jitter. Now, this no longer happens.

## Test plan

CI

Also: Run in VS Code, type a chat message, press Enter, and ensure there is no jitter. Also ask a long chat question and ensure that the scroll-to-end works.

## Changelog

- Fixed an issue where pressing Enter in chat would cause brief visual jitter in the UI.