### PR TITLE
Fix Repo filter dropdown z-index

### DIFF
--- a/vscode/webviews/chat/cells/messageCell/assistant/RepositorySelector.tsx
+++ b/vscode/webviews/chat/cells/messageCell/assistant/RepositorySelector.tsx
@@ -37,7 +37,7 @@ export const RepositorySelector = ({ onSelect }: IProps) => {
             {open && (
                 <div
                     onMouseDown={e => e.preventDefault()}
-                    className="tw-w-[100%] tw-mt-4 tw-absolute tw-top-10 tw-left-0 tw-bg-background tw-text-foreground tw-border tw-border-border tw-rounded-md tw-shadow-md tw-overflow-y-auto tw-max-h-[300px]"
+                    className="tw-w-[100%] tw-mt-4 tw-absolute tw-top-10 tw-left-0 tw-bg-background tw-text-foreground tw-border tw-border-border tw-rounded-md tw-shadow-md tw-overflow-y-auto tw-max-h-[300px] tw-z-10"
                 >
                     {repos.value?.map(repo => (
                         <Tooltip key={repo.id}>


### PR DESCRIPTION
closes: https://linear.app/sourcegraph/issue/SRCH-1585/followup-box-leaks-through-repo-filters

Fix the z-index for repo search filter dropdown. It overlaps over follow up input and breaks. 

## Test plan
Before
<img width="749" alt="image" src="https://github.com/user-attachments/assets/b81f414b-3311-4a0e-98c7-3531bd97ca63" />


After

<img width="740" alt="image" src="https://github.com/user-attachments/assets/2588efcd-c4ee-46d6-97bc-ce389acec0a3" />
