### PR TITLE
feat: Add experimental & nightly release channels for vsce

### DIFF
--- a/.github/workflows/release-vscode-experimental.yml
+++ b/.github/workflows/release-vscode-experimental.yml
@@ -1,9 +1,6 @@
-name: release-vscode-nightly
+name: release-vscode-experimental
 
 on:
-  schedule:
-    # Run every day at 00:00 UTC
-    - cron: "0 0 * * *"
   workflow_dispatch:
 
 concurrency:
@@ -51,7 +48,7 @@ jobs:
           service_account: "bundle-size-tracker@cody-core-dev.iam.gserviceaccount.com"
           create_credentials_file: true
           export_environment_variables: true
-      - run: CODY_RELEASE_TYPE=nightly pnpm -C vscode run release
+      - run: CODY_RELEASE_TYPE=experimental pnpm -C vscode run release
         id: create_release
         if: github.repository == 'sourcegraph/cody'
         env:
@@ -72,7 +69,7 @@ jobs:
         env:
           EXTENSION_BUNDLE_SIZE_MB: ${{ env.EXTENSION_BUNDLE_SIZE_MB }}
           WEBVIEW_BUNDLE_SIZE_MB: ${{ env.WEBVIEW_BUNDLE_SIZE_MB }}
-      - name: Tag nightly release
+      - name: Tag experimental release
         uses: actions/github-script@v6
         with:
           script: |
@@ -89,7 +86,7 @@ jobs:
           SLACK_CHANNEL: wg-cody-vscode
           SLACK_ICON: https://github.com/sourcegraph.png?size=48
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-          SLACK_MESSAGE: Nightly build failed
+          SLACK_MESSAGE: Experimental build failed
           SLACK_COLOR: danger
           SLACK_FOOTER: ""
           MSG_MINIMAL: actions url

--- a/.github/workflows/release-vscode-nightly.yml
+++ b/.github/workflows/release-vscode-nightly.yml
@@ -1,0 +1,92 @@
+name: release-vscode-nightly
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  release:
+    if: github.repository == 'sourcegraph/cody'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v3
+        with:
+          node-version-file: .tool-versions
+      - uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2 # SECURITY: pin third-party action hashes
+        with:
+          run_install: true
+      - run: pnpm build
+      - run: pnpm run test
+      - run: xvfb-run -a pnpm -C vscode run test:integration
+      - run: xvfb-run -a pnpm -C vscode run test:e2e
+        env:
+          NO_LOG_TESTING_TELEMETRY_CALLS: true
+      - run: pnpm -C vscode run build
+      - name: Check bundle sizes
+        run: |
+          cd vscode
+          pnpm ts-node ./scripts/measure-bundle-size.ts
+          cd ..
+          echo "Extension Bundle Size: $EXTENSION_BUNDLE_SIZE_MB MB"
+          echo "Webview Bundle Size: $WEBVIEW_BUNDLE_SIZE_MB MB"
+        env:
+          GITHUB_ENV: $GITHUB_ENV
+      - name: Authenticate to Google Cloud
+        id: auth
+        uses: "google-github-actions/auth@v2"
+        with:
+          project_id: "cody-core-dev"
+          workload_identity_provider: "projects/39257127245/locations/global/workloadIdentityPools/github/providers/cody"
+          service_account: "bundle-size-tracker@cody-core-dev.iam.gserviceaccount.com"
+          create_credentials_file: true
+          export_environment_variables: true
+      - run: CODY_RELEASE_TYPE=nightly pnpm -C vscode run release
+        id: create_release
+        if: github.repository == 'sourcegraph/cody'
+        env:
+          VSCODE_MARKETPLACE_TOKEN: ${{ secrets.VSCODE_MARKETPLACE_TOKEN }}
+          VSCODE_OPENVSX_TOKEN: ${{ secrets.VSCODE_OPENVSX_TOKEN }}
+      - name: Insert data into BigQuery
+        run: |
+          # Compute the current date
+          current_date=$(date +'%Y-%m-%d')
+
+          # Now create the JSON and insert into BigQuery
+          echo "{\"release_version\": \"${{ steps.create_release.outputs.version_tag }}\", \"extension_bundle_size_mb\": $EXTENSION_BUNDLE_SIZE_MB, \"webview_bundle_size_mb\": $WEBVIEW_BUNDLE_SIZE_MB, \"date\": \"$current_date\"}" > data.json
+          bq load \
+            --project_id='cody-core-dev' \
+            --source_format=NEWLINE_DELIMITED_JSON \
+            cody_release.bundle_sizes \
+            data.json
+        env:
+          EXTENSION_BUNDLE_SIZE_MB: ${{ env.EXTENSION_BUNDLE_SIZE_MB }}
+          WEBVIEW_BUNDLE_SIZE_MB: ${{ env.WEBVIEW_BUNDLE_SIZE_MB }}
+      - name: Tag insiders release
+        uses: actions/github-script@v6
+        with:
+          script: |
+            github.rest.git.createRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: "refs/tags/${{ steps.create_release.outputs.version_tag }}",
+              sha: context.sha
+            })
+      - name: Slack Notification
+        if: ${{ failure() }}
+        uses: rtCamp/action-slack-notify@b24d75fe0e728a4bf9fc42ee217caa686d141ee8 # SECURITY: pin third-party action hashes
+        env:
+          SLACK_CHANNEL: wg-cody-vscode
+          SLACK_ICON: https://github.com/sourcegraph.png?size=48
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          SLACK_MESSAGE: Nightly build failed
+          SLACK_COLOR: danger
+          SLACK_FOOTER: ""
+          MSG_MINIMAL: actions url

--- a/vscode/scripts/release.ts
+++ b/vscode/scripts/release.ts
@@ -31,8 +31,13 @@ if (!packageJSONVersion) {
 }
 
 enum ReleaseType {
+    // sourcegraph.cody-ai - Stable channel
     Stable = 'stable',
+    // sourcegraph.cody-ai - Pre-release channel
     Insiders = 'insiders',
+    // sourcegraph.cody-testing - Stable channel
+    Experimental = 'experimental',
+    // sourcegraph.cody-testing - Pre-release channel
     Nightly = 'nightly',
 }
 const releaseType = process.env.CODY_RELEASE_TYPE
@@ -48,15 +53,15 @@ function validateReleaseType(releaseType: string | undefined): asserts releaseTy
 }
 validateReleaseType(releaseType)
 const isInsiderBuild = releaseType === ReleaseType.Insiders || releaseType === ReleaseType.Nightly
-function updatePackageForNightly(): void {
-    if (releaseType === ReleaseType.Nightly) {
-        packageJSON.name = 'cody-ai-nightly'
-        packageJSON.displayName = 'Cody: AI Code Assistant - Nightly'
+function updatePackageForTestingExtension(): void {
+    if (releaseType === ReleaseType.Nightly || releaseType === ReleaseType.Experimental) {
+        packageJSON.name = 'cody-testing'
+        packageJSON.displayName = 'Testing Extension'
         packageJSONWasModified = true
         writeJsonFileSync('package.json', packageJSON)
     }
 }
-updatePackageForNightly()
+updatePackageForTestingExtension()
 
 const dryRun = Boolean(process.env.CODY_RELEASE_DRY_RUN)
 const customDefaultSettingsFile = process.env.CODY_RELEASE_CUSTOM_DEFAULT_SETTINGS_FILE


### PR DESCRIPTION
CLOSE: https://linear.app/sourcegraph/issue/CODY-4777

This adds support for publishing nightly builds of the VS Code extension under a different package name and display name to avoid conflicts with the main extension.

- Added 'nightly' as a new ReleaseType enum value
- Added updatePackageForNightly() function to modify package.json for nightly builds
- Changed package name to 'cody-ai-nightly' for nightly releases
- Updated display name to 'Cody: AI Code Assistant - Nightly'
- Refactored insiders build checks to include nightly builds
- Updated publishing logic to handle nightly builds same as insiders
- Release nightly build under pre-release channel under the new name

NOTE: The nightly build is not intended to work with the main extension and is expected to cause conflicts if both are installed.


## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

1. Run release script with `CODY_RELEASE_TYPE=nightly pnpm -C vscode run release:dry-run` to generate a package for the nightly
2. Install the nightly builld using the package you can find in `vscode/dist/cody.vsix`
- Verify extension is installed with the updated name and display name. You might need to disable the stable release to avoid conflicts.

<img width="1994" alt="image" src="https://github.com/user-attachments/assets/ab281830-4ad2-49e9-9463-c373efd64cb5" />

## Expected behavior per release type

### Stable (sourcegraph.cody-ai):

- Builds as production release
- Removes all experimental settings
- Uses version directly from package.json
- Published to VS Code Marketplace main channel
- Triggered by git tag push

#### Insiders / Pre-release (sourcegraph.cody-ai):

- Builds as pre-release version
- Keeps experimental settings
- Uses incremented version with timestamp
- Published to VS Code Marketplace pre-release channel
- Creates an insiders tag

#### Experimental (sourcegraph.cody-testing):

- Changes package name to cody-testing
- Changes display name to "Testing Extension"
- Keeps experimental settings
- Uses incremented version with timestamp
- Published to VS Code Marketplace main channel under cody-testing
- Creates an experimental tag

#### Nightly (sourcegraph.cody-testing):

- Changes package name to cody-testing
- Changes display name to "Testing Extension"
- Keeps experimental settings
- Uses incremented version with timestamp
- Published to VS Code Marketplace pre-release channel under cody-testing
- Creates a nightly tag
- Runs automatically every night
