### PR TITLE
fix(chat): Hide switch intent button for Cody Pro users

### DIFF
--- a/vscode/webviews/chat/Transcript.tsx
+++ b/vscode/webviews/chat/Transcript.tsx
@@ -704,7 +704,7 @@ const TranscriptInteraction: FC<TranscriptInteractionProps> = memo(props => {
                 intent={manuallySelectedIntent || intentResults?.intent}
                 manuallySelectIntent={setManuallySelectedIntent}
             />
-            {experimentalOneBoxEnabled && (
+            {experimentalOneBoxEnabled && !userInfo.isCodyProUser && (
                 <SwitchIntent
                     intent={humanMessage.intent}
                     manuallySelected={!!humanMessage.manuallySelectedIntent}


### PR DESCRIPTION
The switch intent button is now hidden for Cody Pro users while remaining visible for non-Pro users when the experimental one box feature is enabled. This change helps streamline the interface for Pro users.

Before the fix (PLG):

![Screenshot 2025-02-07 122851](https://github.com/user-attachments/assets/56315bfd-0a46-476b-b34d-a3176c76307c)

After the fix (PLG):

![Screenshot 2025-02-07 122143](https://github.com/user-attachments/assets/105c15f5-3a45-4236-8d63-2c4c95391788)

For non-PLG as usually visible:

![Screenshot 2025-02-07 122224](https://github.com/user-attachments/assets/e4679278-a244-48c3-80ee-2b334147c652)


## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
Manual testing to verify:
- Switch intent button is hidden for Cody Pro users
- Switch intent button remains visible for non-Pro users when experimental one box is enabled

## Changelog

- Hide switch intent button for Cody Pro users
