### PR TITLE
chore/release: Bump package version and update changelog for 1.66

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -4,15 +4,12 @@ This is a log of all notable changes to Cody for VS Code.
 
 <!--- {/_ CHANGELOG_START _/} -->
 
-## Unreleased
-
-### Added
+## 1.66.1
 
 ### Fixed
-
-### Changed
-
-### Uncategorized
+- AutoEdits
+  - fix(auto-edit): fix the false notification for auto-edit non eligibility  [pull/7002](https://github.com/sourcegraph/cody/pull/7002)
+Manually backport b54029c9299d40fbbf2efa3e25a8e2d2a7adf1d8 #6971
 
 ## 1.66.0
 

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -3,7 +3,7 @@
   "name": "cody-ai",
   "private": true,
   "displayName": "Cody: AI Code Assistant",
-  "version": "1.66.0",
+  "version": "1.66.1",
   "publisher": "sourcegraph",
   "license": "Apache-2.0",
   "icon": "resources/sourcegraph.png",


### PR DESCRIPTION
## Test plan
No test plan, following the release captain playbook
<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
