### PR TITLE
Fix cody web sandbox cors problem

### DIFF
--- a/lib/shared/src/sourcegraph-api/client-name-version.ts
+++ b/lib/shared/src/sourcegraph-api/client-name-version.ts
@@ -39,8 +39,15 @@ export function getClientIdentificationHeaders() {
               : 'Unknown environment'
     const headers: { [header: string]: string } = {
         'User-Agent': `${clientName}/${clientVersion} (${runtimeInfo})`,
-        'X-Requested-With': `${clientName} ${clientVersion}`,
     }
+
+    // Only set these headers in non-demo mode, because the demo mode is
+    // running in a local server and thus the backend will regard it as an
+    // untrusted cross-origin request.
+    if (!process.env.CODY_WEB_DEMO) {
+        headers['X-Requested-With'] = `${clientName} ${clientVersion}`
+    }
+
     return headers
 }
 

--- a/web/demo/App.tsx
+++ b/web/demo/App.tsx
@@ -46,12 +46,6 @@ export const App: FC = () => {
                 telemetryClientName="codydemo.testing"
                 initialContext={INITIAL_CONTEXT}
                 viewType="sidebar"
-            //     customHeaders={{
-            //         'X-Requested-With': 'Sourcegraph',
-            //         'X-Sourcegraph-Api-Client-Name': 'web',
-            //         'X-Sourcegraph-Api-Client-Version': '311182_2025-02-07_6.0-0368076adabd',
-            //         'X-Sourcegraph-Client': 'https://sourcegraph.sourcegraph.com'
-            // }}
             />
         </div>
     )

--- a/web/demo/App.tsx
+++ b/web/demo/App.tsx
@@ -46,6 +46,12 @@ export const App: FC = () => {
                 telemetryClientName="codydemo.testing"
                 initialContext={INITIAL_CONTEXT}
                 viewType="sidebar"
+            //     customHeaders={{
+            //         'X-Requested-With': 'Sourcegraph',
+            //         'X-Sourcegraph-Api-Client-Name': 'web',
+            //         'X-Sourcegraph-Api-Client-Version': '311182_2025-02-07_6.0-0368076adabd',
+            //         'X-Sourcegraph-Client': 'https://sourcegraph.sourcegraph.com'
+            // }}
             />
         </div>
     )


### PR DESCRIPTION
After https://sourcegraph.sourcegraph.com/github.com/sourcegraph/cody/-/commit/297c4a90fe56f00520865b0f72ee5450a648c706?editor=JetBrains&version=v7.4.2-experimental&utm_product_name=WebStorm&utm_product_version=2024.3

Cody Web sandbox is broken due to problems with CORS and headers; historically, all this system with headers and sandbox proxy is very fragile. This PR brings back header changes that we had before (headers shouldn't have x-requested-with header in sandbox otherwise we get cors problems)

## Test plan
- Check that cody web sandbox works

