### PR TITLE
feat(prompt-editor): focus on file range when clicking on context item mention with ranges

### DIFF
--- a/lib/prompt-editor/src/nodes/tooltip.ts
+++ b/lib/prompt-editor/src/nodes/tooltip.ts
@@ -1,4 +1,9 @@
-import { ContextItemSource, type SerializedContextItem, displayPath } from '@sourcegraph/cody-shared'
+import {
+    ContextItemSource,
+    type SerializedContextItem,
+    displayPath,
+    displayPathWithLines,
+} from '@sourcegraph/cody-shared'
 import * as v from 'valibot'
 import { URI } from 'vscode-uri'
 
@@ -26,7 +31,9 @@ export function tooltipForContextItem(item: SerializedContextItem): string | und
             ? item.source === ContextItemSource.Initial
                 ? 'File is too large. Select a smaller range of lines from the file.'
                 : 'File is too large. Try adding the file again with a smaller range of lines.'
-            : displayPath(URI.parse(item.uri))
+            : item.range
+              ? displayPathWithLines(URI.parse(item.uri), item.range)
+              : displayPath(URI.parse(item.uri))
     }
     if (v.is(OpenCtxItemWithTooltipSchema, item)) {
         return item.mention.data.tooltip

--- a/lib/shared/src/index.ts
+++ b/lib/shared/src/index.ts
@@ -169,6 +169,7 @@ export type {
 } from './editor'
 export {
     displayPath,
+    displayPathWithLines,
     displayPathBasename,
     uriHasPrefix,
     displayPathDirname,

--- a/vscode/src/chat/chat-view/ChatController.ts
+++ b/vscode/src/chat/chat-view/ChatController.ts
@@ -343,9 +343,6 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
                 await vscode.commands.executeCommand('cody.fixup.codelens.undo', message.id)
                 break
             case 'openURI':
-                vscode.commands.executeCommand('vscode.open', message.uri)
-                break
-            case 'openURIWithRange':
                 vscode.commands.executeCommand('vscode.open', message.uri, {
                     selection: message.range,
                 })

--- a/vscode/src/chat/chat-view/ChatController.ts
+++ b/vscode/src/chat/chat-view/ChatController.ts
@@ -345,6 +345,11 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
             case 'openURI':
                 vscode.commands.executeCommand('vscode.open', message.uri)
                 break
+            case 'openURIWithRange':
+                vscode.commands.executeCommand('vscode.open', message.uri, {
+                    selection: message.range,
+                })
+                break
             case 'links': {
                 void openExternalLinks(message.value)
                 break

--- a/vscode/src/chat/protocol.ts
+++ b/vscode/src/chat/protocol.ts
@@ -75,6 +75,12 @@ export type WebviewMessage =
     | { command: 'links'; value: string }
     | { command: 'openURI'; uri: Uri }
     | {
+          command: 'openURIWithRange'
+          uri: Uri
+          range?: RangeData | undefined | null
+          source?: ContextItemSource | undefined | null
+      }
+    | {
           // Open a file from a Sourcegraph URL
           command: 'openRemoteFile'
           uri: Uri

--- a/vscode/src/chat/protocol.ts
+++ b/vscode/src/chat/protocol.ts
@@ -73,13 +73,7 @@ export type WebviewMessage =
     | ({ command: 'submit' } & WebviewSubmitMessage)
     | { command: 'restoreHistory'; chatID: string }
     | { command: 'links'; value: string }
-    | { command: 'openURI'; uri: Uri }
-    | {
-          command: 'openURIWithRange'
-          uri: Uri
-          range?: RangeData | undefined | null
-          source?: ContextItemSource | undefined | null
-      }
+    | { command: 'openURI'; uri: Uri; range?: RangeData | undefined | null }
     | {
           // Open a file from a Sourcegraph URL
           command: 'openRemoteFile'

--- a/vscode/webviews/promptEditor/config.ts
+++ b/vscode/webviews/promptEditor/config.ts
@@ -22,19 +22,11 @@ export const promptEditorConfig: PromptEditorConfig = {
     onContextItemMentionNodeMetaClick: (contextItem: SerializedContextItem) => {
         if (contextItem.uri) {
             const uri = URI.parse(contextItem.uri)
-            if (contextItem.range) {
-                getVSCodeAPI().postMessage({
-                    command: 'openURIWithRange',
-                    uri,
-                    range: contextItem.range,
-                    source: contextItem.source,
-                })
-            } else {
-                getVSCodeAPI().postMessage({
-                    command: 'openURI',
-                    uri,
-                })
-            }
+            getVSCodeAPI().postMessage({
+                command: 'openURI',
+                uri,
+                range: contextItem.range,
+            })
         }
     },
     badgeComponents: {

--- a/vscode/webviews/promptEditor/config.ts
+++ b/vscode/webviews/promptEditor/config.ts
@@ -22,10 +22,19 @@ export const promptEditorConfig: PromptEditorConfig = {
     onContextItemMentionNodeMetaClick: (contextItem: SerializedContextItem) => {
         if (contextItem.uri) {
             const uri = URI.parse(contextItem.uri)
-            getVSCodeAPI().postMessage({
-                command: 'openURI',
-                uri,
-            })
+            if (contextItem.range) {
+                getVSCodeAPI().postMessage({
+                    command: 'openURIWithRange',
+                    uri,
+                    range: contextItem.range,
+                    source: contextItem.source,
+                })
+            } else {
+                getVSCodeAPI().postMessage({
+                    command: 'openURI',
+                    uri,
+                })
+            }
         }
     },
     badgeComponents: {


### PR DESCRIPTION
This pull request makes 2 changes:
1. I've added the line range to the tooltip of MentionComponent mirroring what happens in ContextCell `contextItemsToDisplay` `FileLink`
2. When you command click on the mention if the mention contains a selection range we focus on that
   selection like we do from the FileLink component

See this video for demo of changes https://www.youtube.com/watch?v=aCesKaBi2nI

## Test plan
Run a command on a selection of code such as Explain Code and notice:
1. When you hover over the chip you see the line range in the tooltip
2. When you ctrl or command + click you are focused on the selection range of that context file

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
