### PR TITLE
remove border from code styles, improve stories

### DIFF
--- a/vscode/webviews/chat/ChatMessageContent/ChatMessageContent.module.css
+++ b/vscode/webviews/chat/ChatMessageContent/ChatMessageContent.module.css
@@ -160,7 +160,6 @@
 body[data-vscode-theme-kind='vscode-light'] .content pre,
 body[data-vscode-theme-kind='vscode-light'] .content pre > code {
     /* Our syntax highlighter emits colors intended for dark backgrounds only. */
-    background-color: var(--code-background);
     color: var(--code-foreground);
 }
 

--- a/vscode/webviews/chat/ChatMessageContent/ChatMessageContent.module.css
+++ b/vscode/webviews/chat/ChatMessageContent/ChatMessageContent.module.css
@@ -2,11 +2,9 @@
     display: flex;
     flex-wrap: wrap;
     align-items: center;
-    border-style: solid;
-    border-width: 1px;
-    border-color: var(--vscode-sideBarSectionHeader-border);
-    border-bottom-left-radius: 2px;
-    border-bottom-right-radius: 2px;
+    background-color: var(--vscode-input-background);
+    border-bottom-left-radius: 4px;
+    border-bottom-right-radius: 4px;
     padding: 4px;
 }
 
@@ -137,12 +135,10 @@
     margin-block: 1rem;
 }
 
+/* code block styling */
 .content pre {
     padding: calc(var(--spacing) * 0.5);
     overflow-x: auto;
-    border-style: solid;
-    border-width: 1px;
-    border-color: var(--vscode-sideBarSectionHeader-border);
     border-bottom: none;
     margin: 1rem 0;
 }

--- a/vscode/webviews/chat/ChatMessageContent/ChatMessageContent.module.css
+++ b/vscode/webviews/chat/ChatMessageContent/ChatMessageContent.module.css
@@ -141,6 +141,7 @@
     overflow-x: auto;
     border-bottom: none;
     margin: 1rem 0;
+    border:1px solid var(--vscode-input-background);
 }
 
 .content code,
@@ -153,7 +154,6 @@
 .content pre,
 .content pre > code {
     /* Our syntax highlighter emits colors intended for dark backgrounds only. */
-    background-color: var(--code-background);
     color: var(--code-foreground);
     margin-bottom: 0;
 }

--- a/vscode/webviews/chat/Transcript.story.tsx
+++ b/vscode/webviews/chat/Transcript.story.tsx
@@ -356,3 +356,9 @@ export const WithToolUseResponse: StoryObj<typeof meta> = {
         transcript: transcriptFixture([...FIXTURE_TRANSCRIPT.toolUse]),
     },
 }
+
+export const WithCode: StoryObj<typeof meta> = {
+    args: {
+        transcript: transcriptFixture([...FIXTURE_TRANSCRIPT.generateCode]),
+    },
+}

--- a/vscode/webviews/chat/fixtures.ts
+++ b/vscode/webviews/chat/fixtures.ts
@@ -24,6 +24,7 @@ export const FIXTURE_TRANSCRIPT: Record<
     | 'explainCode'
     | 'explainCode2'
     | 'experimentalGenerateUnitTest'
+    | 'generateCode'
     | 'long'
     | 'empty'
     | 'toolUse',
@@ -150,6 +151,27 @@ export const FIXTURE_TRANSCRIPT: Record<
             contextFiles: [
                 { type: 'file', uri: URI.file('/a/b/file1.py'), source: ContextItemSource.User },
             ],
+        },
+    ]),
+    generateCode: transcriptFixture([
+        {
+            speaker: 'human',
+            text: ps`Generate a hello world in Rust.`,
+        },
+        {
+            speaker: 'assistant',
+            text: ps`This code generates a random 32-character string (nonce) using characters <pre><code>fn main() {
+    // String type - owned, mutable, heap-allocated
+    let mut owned_string = String::from("Hello");
+
+    // &str type - string slice, immutable reference
+    let string_literal = "World";
+
+    // Concatenation method 1: Using push_str()
+    owned_string.push_str(string_literal);
+    println!("Using push_str(): {}", owned_string);
+
+</code></pre> Hopefully that helps.`
         },
     ]),
     long: transcriptFixture([


### PR DESCRIPTION
## Test plan

Removes borders from code blocks. Ensures actions buttons aren't missed by giving them a background color.


Before & After
| <img width="384" alt="image" src="https://github.com/user-attachments/assets/27af2bf0-49f5-4fee-af63-44a345f87f48" /> | <img width="375" alt="image" src="https://github.com/user-attachments/assets/e54e4199-80f6-484e-b050-b3799b0f5540" /> |




<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
