### PR TITLE
Rrhyne/improve code border styles

### DIFF
--- a/vscode/webviews/chat/ChatMessageContent/ChatMessageContent.module.css
+++ b/vscode/webviews/chat/ChatMessageContent/ChatMessageContent.module.css
@@ -2,8 +2,7 @@
     display: flex;
     flex-wrap: wrap;
     align-items: center;
-    border-style: solid;
-    border-width: 1px;
+    border-top: 1px solid;
     border-color: var(--vscode-sideBarSectionHeader-border);
     border-bottom-left-radius: 2px;
     border-bottom-right-radius: 2px;
@@ -137,12 +136,10 @@
     margin-block: 1rem;
 }
 
+/* code block styling */
 .content pre {
     padding: calc(var(--spacing) * 0.5);
     overflow-x: auto;
-    border-style: solid;
-    border-width: 1px;
-    border-color: var(--vscode-sideBarSectionHeader-border);
     border-bottom: none;
     margin: 1rem 0;
 }

--- a/vscode/webviews/chat/ChatMessageContent/ChatMessageContent.module.css
+++ b/vscode/webviews/chat/ChatMessageContent/ChatMessageContent.module.css
@@ -2,10 +2,6 @@
     display: flex;
     flex-wrap: wrap;
     align-items: center;
-    border-top: 1px solid;
-    border-color: var(--vscode-sideBarSectionHeader-border);
-    border-bottom-left-radius: 2px;
-    border-bottom-right-radius: 2px;
     padding: 4px;
 }
 
@@ -142,6 +138,8 @@
     overflow-x: auto;
     border-bottom: none;
     margin: 1rem 0;
+    border-radius: 3px;
+    border: 1px solid var(--vscode-input-background);
 }
 
 .content code,

--- a/vscode/webviews/chat/Transcript.story.tsx
+++ b/vscode/webviews/chat/Transcript.story.tsx
@@ -356,3 +356,9 @@ export const WithToolUseResponse: StoryObj<typeof meta> = {
         transcript: transcriptFixture([...FIXTURE_TRANSCRIPT.toolUse]),
     },
 }
+
+export const WithCode: StoryObj<typeof meta> = {
+    args: {
+        transcript: transcriptFixture([...FIXTURE_TRANSCRIPT.generateCode]),
+    },
+}

--- a/vscode/webviews/chat/fixtures.ts
+++ b/vscode/webviews/chat/fixtures.ts
@@ -24,6 +24,7 @@ export const FIXTURE_TRANSCRIPT: Record<
     | 'explainCode'
     | 'explainCode2'
     | 'experimentalGenerateUnitTest'
+    | 'generateCode'
     | 'long'
     | 'empty'
     | 'toolUse',
@@ -150,6 +151,27 @@ export const FIXTURE_TRANSCRIPT: Record<
             contextFiles: [
                 { type: 'file', uri: URI.file('/a/b/file1.py'), source: ContextItemSource.User },
             ],
+        },
+    ]),
+    generateCode: transcriptFixture([
+        {
+            speaker: 'human',
+            text: ps`Generate a hello world in Rust.`,
+        },
+        {
+            speaker: 'assistant',
+            text: ps`This code generates a random 32-character string (nonce) using characters <pre><code>fn main() {
+    // String type - owned, mutable, heap-allocated
+    let mut owned_string = String::from("Hello");
+
+    // &str type - string slice, immutable reference
+    let string_literal = "World";
+
+    // Concatenation method 1: Using push_str()
+    owned_string.push_str(string_literal);
+    println!("Using push_str(): {}", owned_string);
+
+</code></pre> Hopefully that helps.`
         },
     ]),
     long: transcriptFixture([

--- a/vscode/webviews/chat/fixtures.ts
+++ b/vscode/webviews/chat/fixtures.ts
@@ -171,7 +171,7 @@ export const FIXTURE_TRANSCRIPT: Record<
     owned_string.push_str(string_literal);
     println!("Using push_str(): {}", owned_string);
 
-</code></pre> Hopefully that helps.`
+</code></pre> Hopefully that helps.`,
         },
     ]),
     long: transcriptFixture([


### PR DESCRIPTION
Fixes the obnoxious borders on code blocks. 

Before and after:


<img width="838" alt="image" src="https://github.com/user-attachments/assets/3ac6be50-f905-4aec-84b8-b64a9d71ec6b" />

<img width="840" alt="image" src="https://github.com/user-attachments/assets/7f0e432f-ed17-4c79-a4a3-6029123c0171" />



## Test plan

Manually review to ensure the border and contrast around code edit areas is corrected
