### PR TITLE
fix(chat): language filters in rules not applying correctly

### DIFF
--- a/lib/shared/src/rules/filters.test.ts
+++ b/lib/shared/src/rules/filters.test.ts
@@ -5,7 +5,7 @@ describe('ruleAppliesToFile', () => {
     const testFile1: Parameters<typeof ruleAppliesToFile>[1] = {
         repo: 'github.com/sourcegraph/sourcegraph',
         path: 'lib/shared/src/example.ts',
-        languages: ['typescript'],
+        languages: ['TypeScript'],
         textContent: 'const x = 1',
     }
     const testFile2: Parameters<typeof ruleAppliesToFile>[1] = {

--- a/lib/shared/src/rules/filters.ts
+++ b/lib/shared/src/rules/filters.ts
@@ -36,7 +36,9 @@ export function ruleAppliesToFile(
     if (language_filters) {
         // Use string matching instead of regex matching so 'C' does not match 'C++', 'CSS', 'CSharp', etc.
         // Use case-insensitive matching so 'Go' matches 'go'
-        const anyMatch = file.languages.some(language => stringMatch(language_filters, language, { caseInsensitive: true }))
+        const anyMatch = file.languages.some(language =>
+            stringMatch(language_filters, language, { caseInsensitive: true })
+        )
         if (!anyMatch) {
             return false
         }
@@ -62,7 +64,11 @@ function regExpMatch(filters: PatternFilters, value: string): boolean {
     return true
 }
 
-function stringMatch(filters: PatternFilters, value: string, options: { caseInsensitive?: boolean } = {}): boolean {
+function stringMatch(
+    filters: PatternFilters,
+    value: string,
+    options: { caseInsensitive?: boolean } = {}
+): boolean {
     const compare = (a: string, b: string): boolean =>
         options.caseInsensitive ? a.toLowerCase() === b.toLowerCase() : a === b
 


### PR DESCRIPTION
### WHY
The language filters users can specify for rules (i.e., via `lang: go`) are not currently applying correctly. Currently, a `*.rule.md` file marked with `lang: go` does not apply to Go files.

<img width="512" alt="image" src="https://github.com/user-attachments/assets/51525093-6b5c-4c2d-8a7e-867b22ba78ef" />

<img width="921" alt="image" src="https://github.com/user-attachments/assets/fce75431-a1d1-4ed0-9ca3-613b1055268d" />

_The `Check repo permissions in handlers` rule is not applying to the current `Go` file, even though `lang: go` is specified_
 
### WHAT
Fix the matching logic for language filters to compare case-insensitive strings instead of attempting to match via regex. This is for two reasons:
- The filters `go` and `Go` should both match a file like `test.go`. Currently only `Go` would match
- Using regex would require escaping special characters for languages like `C++` (because `+` is a special character). We want an exact match between language filter and language name anyways

<img width="719" alt="image" src="https://github.com/user-attachments/assets/b81d7eb2-fe12-4b18-9ba3-af3a082f8097" />

_The `Check repo permissions in handlers` now correctly applies to the current `Go` file_

## Test plan

Updated unit tests in `filters.test.ts` to include more extensive tests of language filters:
- Correctly capitalized `testFile`'s `languages` field to reflect how languages are [represented in `EXTENSION_TO_LANGUAGE`](https://sourcegraph.sourcegraph.com/github.com/sourcegraph/cody/-/blob/lib/shared/src/common/languages.ts) (this is why the bug was not caught earlier)
- Add tests for languages with special characters (C++)
- Add tests for languages whose names are substrings of other languages (C and C++, Java and JavaScript, etc.)

Also tested locally via debugger; ensured rules apply correctly to files of the same language and are ignored for files of different languages.

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
