### PR TITLE
disable windows/macOS e2e tests on main, shard ubuntu tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,11 +114,7 @@ jobs:
     steps:
       - id: set-matrix
         run: |
-          if [ "$GITHUB_EVENT_NAME" == "push" ] && [ "$GITHUB_REF" == "refs/heads/main" ]; then
-            echo 'matrix=[{"runner":"ubuntu"},{"runner":"windows"},{"runner":"macos"}]' >> $GITHUB_OUTPUT
-          else
-            echo 'matrix=[{"runner":"ubuntu","shard":"1/5"},{"runner":"ubuntu","shard":"2/5"},{"runner":"ubuntu","shard":"3/5"},{"runner":"ubuntu","shard":"4/5"},{"runner":"ubuntu","shard":"5/5"}]' >> $GITHUB_OUTPUT
-          fi
+          echo 'matrix=[{"runner":"ubuntu","shard":"1/5"},{"runner":"ubuntu","shard":"2/5"},{"runner":"ubuntu","shard":"3/5"},{"runner":"ubuntu","shard":"4/5"},{"runner":"ubuntu","shard":"5/5"}]' >> $GITHUB_OUTPUT
 
   test-e2e:
     needs: slow_tests_matrix_prep


### PR DESCRIPTION
The e2e tests pass fairly reliably on PRs where we break them up into 5 separate runs. But on main we run all the e2e tests in a single go. This appears to be causing test failures after 9min due to cancellation (and in general, it is flakier because it just takes 1 e2e test flake).

The Windows and macOS full e2e tests have been failing recently, so they are disabled. It would be good to reenable them. But now the Ubuntu e2e tests should pass on main.



## Test plan

n/a