### PR TITLE
Update cody web to 0.30.0

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sourcegraph/cody-web",
-  "version": "0.27.0",
+  "version": "0.30.0",
   "description": "Cody standalone web app",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
This updates the version of cody-web to 0.30.0 Current release is 0.29.0: https://www.npmjs.com/package/@sourcegraph/cody-web


## Test plan

Manual testing
