### PR TITLE
change(models): drop check for waitlist for o1 model

### DIFF
--- a/lib/shared/src/models/sync.ts
+++ b/lib/shared/src/models/sync.ts
@@ -215,7 +215,6 @@ export function syncModels({
                                                                 const newTags = model.tags.filter(
                                                                     tag => tag !== ModelTag.Waitlist
                                                                 )
-                                                                newTags.push(ModelTag.EarlyAccess)
                                                                 return { ...model, tags: newTags }
                                                             }
                                                             return model

--- a/lib/shared/src/models/sync.ts
+++ b/lib/shared/src/models/sync.ts
@@ -195,9 +195,6 @@ export function syncModels({
                                         distinctUntilChanged()
                                     )
                                     return combineLatest(
-                                        featureFlagProvider.evaluatedFeatureFlag(
-                                            FeatureFlag.CodyEarlyAccess
-                                        ),
                                         featureFlagProvider.evaluatedFeatureFlag(FeatureFlag.DeepCody),
                                         featureFlagProvider.evaluatedFeatureFlag(
                                             FeatureFlag.CodyChatDefaultToClaude35Haiku
@@ -206,24 +203,19 @@ export function syncModels({
                                     ).pipe(
                                         switchMap(
                                             ([
-                                                hasEarlyAccess,
                                                 hasAgenticChatFlag,
                                                 defaultToHaiku,
                                                 isToolCodyEnabled,
                                             ]) => {
                                                 // TODO(sqs): remove waitlist from localStorage when user has access
-                                                if (isDotComUser && hasEarlyAccess) {
+                                                if (isDotComUser) {
                                                     data.primaryModels = data.primaryModels.map(
                                                         model => {
                                                             if (model.tags.includes(ModelTag.Waitlist)) {
                                                                 const newTags = model.tags.filter(
                                                                     tag => tag !== ModelTag.Waitlist
                                                                 )
-                                                                newTags.push(
-                                                                    hasEarlyAccess
-                                                                        ? ModelTag.EarlyAccess
-                                                                        : ModelTag.OnWaitlist
-                                                                )
+                                                                newTags.push(ModelTag.EarlyAccess)
                                                                 return { ...model, tags: newTags }
                                                             }
                                                             return model


### PR DESCRIPTION
Fixes CODY-4933

## Test plan
Check with a pro user without the flag for early access that you now have access to o1 as part of early access. 
<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
