### PR TITLE
feat(auto-edit): Fix slightly misaligned image decorations

### DIFF
--- a/vscode/src/autoedits/renderer/decorators/default-decorator.ts
+++ b/vscode/src/autoedits/renderer/decorators/default-decorator.ts
@@ -394,6 +394,8 @@ export class DefaultDecorator implements AutoEditsDecorator {
             scale: '0.5',
             'transform-origin': '0px 0px',
             height: 'auto',
+            // The decoration will be entirely taken up by the image.
+            // Setting the line-height to 0 ensures that there is no additional padding added by the decoration area.
             'line-height': '0',
         })
 

--- a/vscode/src/autoedits/renderer/decorators/default-decorator.ts
+++ b/vscode/src/autoedits/renderer/decorators/default-decorator.ts
@@ -394,6 +394,7 @@ export class DefaultDecorator implements AutoEditsDecorator {
             scale: '0.5',
             'transform-origin': '0px 0px',
             height: 'auto',
+            'line-height': '0',
         })
 
         this.editor.setDecorations(this.addedLinesDecorationType, [


### PR DESCRIPTION
## Description

Need to set `line-height` to 0, as otherwise the "space" for the decoration is slightly padded by the empty line

<img width="320" alt="image" src="https://github.com/user-attachments/assets/65370001-2b8e-40c1-8d4e-437506d16794" />


## Test plan

Local testing, comparing images

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
