### PR TITLE
fix(chat): At mention menu open outside the editor window

### DIFF
--- a/lib/prompt-editor/src/plugins/atMentions/atMentions.module.css
+++ b/lib/prompt-editor/src/plugins/atMentions/atMentions.module.css
@@ -1,6 +1,21 @@
+.popover-container {
+    position: absolute;
+    left: 0;
+}
+
+@media (max-width: 300px) {
+    .popover-container {
+        position: relative;
+
+        --outside-bound-editor-width: 48px;
+        min-width: calc(100vw - var(--outside-bound-editor-width));
+    }
+}
+
 .popover-dimensions {
     margin-top: 20px; /* show on the line below the cursor */
     width: clamp(300px, 65vw, 440px);
+    max-width: 100%;
 
     --max-items: 12;
     --mention-item-height: 30px;
@@ -12,6 +27,7 @@
         flex: 1;
     }
 }
+
 :global(.typeahead-flipped) .popover-dimensions {
     align-items: end;
 }

--- a/lib/prompt-editor/src/plugins/atMentions/atMentions.tsx
+++ b/lib/prompt-editor/src/plugins/atMentions/atMentions.tsx
@@ -229,15 +229,17 @@ export const MentionsPlugin: FunctionComponent<{
                         // max height of the visible menu. This ensures that the menu does not
                         // flip orientation as the user is typing if it suddenly has less
                         // results. It also makes the positioning less glitchy.
-                        <div data-at-mention-menu="" className={clsx(styles.popoverDimensions)}>
-                            <div className={styles.popover}>
-                                <MentionMenu
-                                    params={params}
-                                    updateMentionMenuParams={updateMentionMenuParams}
-                                    setEditorQuery={setEditorQuery}
-                                    data={data}
-                                    selectOptionAndCleanUp={selectOptionAndCleanUp}
-                                />
+                        <div className={styles.popoverContainer}>
+                            <div data-at-mention-menu="" className={clsx(styles.popoverDimensions)}>
+                                <div className={styles.popover}>
+                                    <MentionMenu
+                                        params={params}
+                                        updateMentionMenuParams={updateMentionMenuParams}
+                                        setEditorQuery={setEditorQuery}
+                                        data={data}
+                                        selectOptionAndCleanUp={selectOptionAndCleanUp}
+                                    />
+                                </div>
                             </div>
                         </div>,
                         anchorElementRef.current


### PR DESCRIPTION
## Description

When the Cody window is smaller than the min popup, the @ mention will display the tooltip box outside the bounds of the editor.

<img width="299" alt="Screenshot 2025-02-11 at 12 00 43 AM" src="https://github.com/user-attachments/assets/6851b212-8608-4787-af41-98fcb2a17163" />

## Solution

Add a parent container that can use media queries to determine when the parent is now smaller than minimum tooltip size.

<img width="217" alt="Screenshot 2025-02-11 at 1 38 37 PM" src="https://github.com/user-attachments/assets/c3f56150-e69c-4bb7-8b56-5c079eff82dc" />

## Asks

I know there is a better to store these CSS variables, open to suggestions. Thank you!

## Test plan

- Open the extension in your browser: `pnpm -C web dev`
- Shrink your chat extension sidebar smaller than 300px, the default minimum
