### PR TITLE
fix(command): Generate commit message now uses flash-lite instead of last selected model

### DIFF
--- a/vscode/src/commands/scm/source-control.ts
+++ b/vscode/src/commands/scm/source-control.ts
@@ -39,9 +39,7 @@ export class CodySourceControl implements vscode.Disposable {
                     .getModels(ModelUsage.Chat)
                     .pipe(skipPendingOperation())
                     .subscribe(models => {
-                        const preferredModel = models.find(p =>
-                            p.id.includes('gemini-2.0-flash-lite-preview-02-05')
-                        )
+                        const preferredModel = models.find(p => p.id.includes('gemini-2.0-flash-lite'))
                         this.model = preferredModel ?? models.at(0)
                     })
             )

--- a/vscode/src/commands/scm/source-control.ts
+++ b/vscode/src/commands/scm/source-control.ts
@@ -39,7 +39,9 @@ export class CodySourceControl implements vscode.Disposable {
                     .getModels(ModelUsage.Chat)
                     .pipe(skipPendingOperation())
                     .subscribe(models => {
-                        const preferredModel = models.find(p => p.id.includes('claude-3-haiku'))
+                        const preferredModel = models.find(p =>
+                            p.id.includes('gemini-2.0-flash-lite-preview-02-05')
+                        )
                         this.model = preferredModel ?? models.at(0)
                     })
             )


### PR DESCRIPTION
Fixes [BUGS-1320](https://linear.app/sourcegraph/issue/BUGS-1320)

After the deprecation of Haiku-3 the "generate commit message" command ended up
using the currently set model for chat instead of haiku.
 
Now we set it to the flash-lite model as it's the cheapest and the fastest, thus being
great for replacing the previous Haiku-3 model.

## Test plan
Enable debug mode and make modifications to source-controlled code. Use the generate commit message command or
button and notice we no longer use the last used model, instead we use flash-lite.

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
