### PR TITLE
fix(Cody Web):  send initial repo context

### DIFF
--- a/vscode/src/chat/agentic/CodyTool.ts
+++ b/vscode/src/chat/agentic/CodyTool.ts
@@ -203,6 +203,7 @@ class CliTool extends CodyTool {
 
 /**
  * Tool for retrieving the full content of files in the codebase.
+ * TODO: Use remote file retrieval for Cody Web.
  */
 class FileTool extends CodyTool {
     constructor() {

--- a/vscode/src/chat/chat-view/ChatController.ts
+++ b/vscode/src/chat/chat-view/ChatController.ts
@@ -112,7 +112,7 @@ import { openExternalLinks } from '../../services/utils/workspace-action'
 import { TestSupport } from '../../test-support'
 import type { MessageErrorType } from '../MessageProvider'
 import { getMentionMenuData } from '../context/chatContext'
-import { observeDefaultContext } from '../initialContext'
+import { observeDefaultContext, setWebInitialContext } from '../initialContext'
 import type {
     ConfigurationSubsetForWebview,
     ExtensionMessage,
@@ -301,6 +301,12 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
                 })
                 break
             }
+            case 'web/setInitialContextData':
+                logDebug('ChatController', 'setInitialContextData for Web', {
+                    verbose: { items: message.data },
+                })
+                setWebInitialContext(message.data)
+                break
             case 'abort':
                 this.handleAbort()
                 break

--- a/vscode/src/chat/protocol.ts
+++ b/vscode/src/chat/protocol.ts
@@ -26,6 +26,7 @@ import type { Uri } from 'vscode'
 import type { View } from '../../webviews/tabs/types'
 import type { FixupTaskID } from '../non-stop/FixupTask'
 import type { CodyTaskState } from '../non-stop/state'
+import type { InitialWebContextData } from './initialContext'
 
 /**
  * DO NOT USE DIRECTLY - ALWAYS USE a TelemetryRecorder from
@@ -156,6 +157,7 @@ export type WebviewMessage =
           selectedFilters: NLSSearchDynamicFilter[]
       }
     | { command: 'action/confirmation'; id: string; response: boolean }
+    | { command: 'web/setInitialContextData'; data: InitialWebContextData }
 
 export interface SmartApplyResult {
     taskId: FixupTaskID

--- a/web/demo/App.tsx
+++ b/web/demo/App.tsx
@@ -30,7 +30,7 @@ if (!accessToken) {
 }
 
 const INITIAL_CONTEXT: InitialContext = {
-    repository: { id: null, name: 'github.com/sourcegraph/review-agent-sandbox' },
+    repository: { id: 'UmVwb3NpdG9yeToyNzU5OQ==', name: 'github.com/sourcegraph/cody' },
     fileRange: null,
     fileURL: null,
     isDirectory: true,

--- a/web/lib/components/CodyWebChat.tsx
+++ b/web/lib/components/CodyWebChat.tsx
@@ -363,6 +363,31 @@ const CodyWebPanel: FC<CodyWebPanelProps> = props => {
         }
     }, [initialContextData])
 
+    useLayoutEffect(() => {
+        const { fileRange, fileURL } = initialContextData ?? {}
+        const { id, name } = initialContextData?.repository ?? {}
+        // Makes sure view is ready before we post message to set initial context data.
+        if (!view || !id || !name) {
+            return
+        }
+        vscodeAPI.postMessage({
+            command: 'web/setInitialContextData',
+            data: {
+                fileURL,
+                repository: {
+                    id: id,
+                    name: name,
+                },
+                range: fileRange
+                    ? {
+                          start: { line: fileRange.startLine, character: 0 },
+                          end: { line: fileRange.endLine + 1, character: 0 },
+                      }
+                    : undefined,
+            },
+        })
+    }, [initialContextData, vscodeAPI, view])
+
     const isLoading = !config || !view
 
     return (

--- a/web/lib/context.ts
+++ b/web/lib/context.ts
@@ -1,0 +1,10 @@
+import { shareReplay } from '@sourcegraph/cody-shared'
+import { Subject } from 'observable-fns'
+import type { InitialContext } from './types'
+
+const webInitialContextSubject = new Subject<InitialContext>()
+export const webInitialContext = webInitialContextSubject.pipe(shareReplay())
+
+export function setWebInitialContext(repo: InitialContext): void {
+    webInitialContextSubject.next(repo)
+}


### PR DESCRIPTION
FIX: https://linear.app/sourcegraph/issue/CODY-4914

This change adds support for passing initial context data from Cody Web to the client host. It enables proper repository context handling when using Cody in web environments.

Key changes:
- Add new types and subjects for managing web initial context state
- Implement context data flow from web UI to VS Code extension
- Update remote repository resolution to include web context
- Add message protocol for web initial context communication
- Set up demo app with proper initial repository context

## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

1. Build Cody web from this branch
2. I've provided the cody repo as initial context for Cody Web, so you can ask anything about the cody repo, e.g. "What's ChatController? What does it do?" in agentic chat
3. Confirm Agentic context has items instead of 0 item:

![image](https://github.com/user-attachments/assets/d5c8c343-e5da-4cfe-a5c2-8d49b963fb2a)


![image](https://github.com/user-attachments/assets/c50106b1-3dd6-481a-b5b9-893ec52d5c02)

### Before

Agentic context has none item event Agentic chat shows a codebase search was done

![image](https://github.com/user-attachments/assets/d918abe2-554f-46ec-b177-51b3c0fbb5ec)


![image](https://github.com/user-attachments/assets/7b487fa8-4387-44e0-880f-05cc47475644)
