### PR TITLE
fix(ui): Hide unused prompts(SRCH-1648)

### DIFF
--- a/vscode/webviews/chat/components/WelcomeMessage.test.tsx
+++ b/vscode/webviews/chat/components/WelcomeMessage.test.tsx
@@ -2,6 +2,7 @@ import {
     AUTH_STATUS_FIXTURE_AUTHED,
     type ClientCapabilitiesWithLegacyFields,
     CodyIDE,
+    PromptMode,
 } from '@sourcegraph/cody-shared'
 import { fireEvent, render, screen } from '@testing-library/react'
 import { describe, expect, test, vi } from 'vitest'
@@ -16,12 +17,11 @@ vi.mocked(usePromptsQuery).mockReturnValue({
     value: {
         query: '',
         arePromptsSupported: true,
-        actions: [{ ...FIXTURE_PROMPTS[0], actionType: 'prompt' }],
+        actions: [{ ...FIXTURE_PROMPTS[0], actionType: 'prompt', mode: PromptMode.CHAT }],
     },
     done: false,
     error: null,
 })
-
 describe('WelcomeMessage', () => {
     function openCollapsiblePanels(): void {
         const closedPanelButtons = document.querySelectorAll('button[data-state="closed"]')

--- a/vscode/webviews/components/promptList/ActionItem.tsx
+++ b/vscode/webviews/components/promptList/ActionItem.tsx
@@ -42,16 +42,15 @@ export const ActionItem: FC<ActionItemProps> = props => {
         action.actionType === 'prompt' ? action.mode !== 'CHAT' : action.mode !== 'ask'
     const isDisabled = !isEditEnabled && isActionEditLike
 
+    if (isDisabled) {
+        return null
+    }
+
     return (
         <CommandItem
             value={commandRowValue(action)}
             disabled={isDisabled}
             className={clsx(className, styles.item)}
-            tooltip={
-                isDisabled
-                    ? 'Edit-like action is not supported in current read-only environment'
-                    : undefined
-            }
             onSelect={onSelect}
         >
             {action.actionType === 'prompt' ? (

--- a/vscode/webviews/components/promptList/ActionItem.tsx
+++ b/vscode/webviews/components/promptList/ActionItem.tsx
@@ -42,15 +42,16 @@ export const ActionItem: FC<ActionItemProps> = props => {
         action.actionType === 'prompt' ? action.mode !== 'CHAT' : action.mode !== 'ask'
     const isDisabled = !isEditEnabled && isActionEditLike
 
-    if (isDisabled) {
-        return null
-    }
-
     return (
         <CommandItem
             value={commandRowValue(action)}
             disabled={isDisabled}
             className={clsx(className, styles.item)}
+            tooltip={
+                isDisabled
+                    ? 'Edit-like action is not supported in current read-only environment'
+                    : undefined
+            }
             onSelect={onSelect}
         >
             {action.actionType === 'prompt' ? (

--- a/vscode/webviews/components/promptList/PromptList.tsx
+++ b/vscode/webviews/components/promptList/PromptList.tsx
@@ -169,7 +169,15 @@ export const PromptList: FC<PromptListProps> = props => {
             if (shouldExcludeBuiltinCommands) {
                 return actions.filter(action => action.actionType === 'prompt' && !action.builtin)
             }
-            return actions
+            return actions.filter(action => {
+                if (promptFilters?.core) {
+                    return action.actionType === 'prompt' && action.builtin
+                }
+                const isActionEditLike =
+                    action.actionType === 'prompt' ? action.mode !== 'CHAT' : action.mode !== 'ask'
+
+                return !isActionEditLike
+            })
         },
         [promptFilters]
     )
@@ -239,16 +247,18 @@ export const PromptList: FC<PromptListProps> = props => {
                             )}
                         </CommandLoading>
                     )}
-
-                {actions.map(action => (
-                    <ActionItem
-                        key={commandRowValue(action)}
-                        action={action}
-                        onSelect={onSelect}
-                        className={clsx(itemPaddingClass, styles.listItem)}
-                    />
-                ))}
-
+                {actions
+                    .filter(action =>
+                        action.actionType === 'prompt' ? action.mode === 'CHAT' : action.mode === 'ask'
+                    )
+                    .map(action => (
+                        <ActionItem
+                            key={commandRowValue(action)}
+                            action={action}
+                            onSelect={onSelect}
+                            className={clsx(itemPaddingClass, styles.listItem)}
+                        />
+                    ))}
                 {showPromptLibraryUnsupportedMessage && result && !result.arePromptsSupported && (
                     <>
                         <CommandSeparator alwaysRender={true} />


### PR DESCRIPTION
Closing https://linear.app/sourcegraph/issue/SRCH-1648/dont-show-unuseable-prompts-in-chat-prompt-list
Some prompts are unclickable when you can't use them in the current environment. This is bad user experience.

This PR hides the unused prompts.

## Test plan
Tested locally.
Before
<img width="1717" alt="Screenshot 2025-02-13 at 3 49 35 PM" src="https://github.com/user-attachments/assets/ffaf1f6c-16b4-4527-9f30-79692e8d4af9" />

After
<img width="1717" alt="Screenshot 2025-02-13 at 3 49 25 PM" src="https://github.com/user-attachments/assets/6f26a9bd-1f1a-4350-97c7-92a226b343b8" />
