### PR TITLE
fix(ui): Consolidate the extension settings with the web view settings(SRCH-1649)

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -874,6 +874,13 @@
           "group": "other"
         }
       ],
+      "view/title": [
+        {
+          "command": "cody.menu.commands",
+          "when": "view == cody.chat && cody.activated",
+          "group": "navigation@1"
+        }
+      ],
       "editor/title": [
         {
           "command": "cody.menu.commands",

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -874,38 +874,6 @@
           "group": "other"
         }
       ],
-      "view/title": [
-        {
-          "command": "cody.menu.commands",
-          "when": "view == cody.chat && cody.activated",
-          "group": "navigation@1"
-        },
-        {
-          "command": "cody.welcome",
-          "when": "view == cody.chat",
-          "group": "7_cody@0"
-        },
-        {
-          "command": "cody.debug.export.logs",
-          "when": "view == cody.chat",
-          "group": "8_cody@1"
-        },
-        {
-          "command": "cody.debug.enable.all",
-          "when": "view == cody.chat",
-          "group": "8_cody@0"
-        },
-        {
-          "command": "cody.debug.outputChannel",
-          "when": "view == cody.chat",
-          "group": "8_cody@2"
-        },
-        {
-          "command": "cody.debug.reportIssue",
-          "when": "view == cody.chat",
-          "group": "9_cody@1"
-        }
-      ],
       "editor/title": [
         {
           "command": "cody.menu.commands",

--- a/vscode/webviews/components/UserMenu.tsx
+++ b/vscode/webviews/components/UserMenu.tsx
@@ -592,6 +592,7 @@ export const UserMenu: React.FunctionComponent<UserMenuProps> = ({
                                         close()
                                     }}
                                 >
+                                    <UniversityIcon size={16} strokeWidth={1.25} className="tw-mr-2" />
                                     <span className="tw-flex-grow">Getting Started Guide</span>
                                 </CommandItem>
 

--- a/vscode/webviews/components/UserMenu.tsx
+++ b/vscode/webviews/components/UserMenu.tsx
@@ -338,17 +338,19 @@ export const UserMenu: React.FunctionComponent<UserMenuProps> = ({
                                     <ExternalLinkIcon size={16} strokeWidth={1.25} />
                                 </CommandLink>
 
-                                {IDE === CodyIDE.VSCode && (<CommandItem
-                                    onSelect={() => {
-                                        getVSCodeAPI().postMessage({
-                                            command: 'command',
-                                            id: 'cody.debug.reportIssue',
-                                        })
-                                        close()
-                                    }}
-                                >)}
-                                    <span className="tw-flex-grow">Report Issue</span>
-                                </CommandItem>
+                                {IDE === CodyIDE.VSCode && (
+                                    <CommandItem
+                                        onSelect={() => {
+                                            getVSCodeAPI().postMessage({
+                                                command: 'command',
+                                                id: 'cody.debug.reportIssue',
+                                            })
+                                            close()
+                                        }}
+                                    >
+                                        <span className="tw-flex-grow">Report Issue</span>
+                                    </CommandItem>
+                                )}
                             </CommandGroup>
                         </CommandList>
                     ) : userMenuView === 'switch' ? (
@@ -587,18 +589,20 @@ export const UserMenu: React.FunctionComponent<UserMenuProps> = ({
                             </CommandGroup>
 
                             <CommandGroup>
-                                {IDE === CodyIDE.VSCode && (<CommandItem
-                                    onSelect={() => {
-                                        getVSCodeAPI().postMessage({
-                                            command: 'command',
-                                            id: 'cody.welcome',
-                                        })
-                                        close()
-                                    }}
-                                >
-                                    <BookOpenText size={16} strokeWidth={1.25} className="tw-mr-2" />
-                                    <span className="tw-flex-grow">Getting Started Guide</span>
-                                </CommandItem>)}
+                                {IDE === CodyIDE.VSCode && (
+                                    <CommandItem
+                                        onSelect={() => {
+                                            getVSCodeAPI().postMessage({
+                                                command: 'command',
+                                                id: 'cody.welcome',
+                                            })
+                                            close()
+                                        }}
+                                    >
+                                        <BookOpenText size={16} strokeWidth={1.25} className="tw-mr-2" />
+                                        <span className="tw-flex-grow">Getting Started Guide</span>
+                                    </CommandItem>
+                                )}
 
                                 {IDE === CodyIDE.VSCode && (
                                     <CommandItem onSelect={() => onMenuViewChange('debug')}>

--- a/vscode/webviews/components/UserMenu.tsx
+++ b/vscode/webviews/components/UserMenu.tsx
@@ -1,6 +1,8 @@
-import { type AuthenticatedAuthStatus, isDotCom } from '@sourcegraph/cody-shared'
+import { type AuthenticatedAuthStatus, CodyIDE, isDotCom } from '@sourcegraph/cody-shared'
 import {
     ArrowLeftRightIcon,
+    BookOpenText,
+    BugIcon,
     ChevronLeftIcon,
     ChevronRightIcon,
     ChevronsUpDown,
@@ -44,6 +46,7 @@ interface UserMenuProps {
     __storybook__open?: boolean
     // Whether to show the Sourcegraph Teams upgrade CTA or not.
     isWorkspacesUpgradeCtaEnabled?: boolean
+    IDE: CodyIDE
 }
 
 type MenuView = 'main' | 'switch' | 'add' | 'remove' | 'debug' | 'help'
@@ -57,6 +60,7 @@ export const UserMenu: React.FunctionComponent<UserMenuProps> = ({
     allowEndpointChange,
     __storybook__open,
     isWorkspacesUpgradeCtaEnabled,
+    IDE,
 }) => {
     const telemetryRecorder = useTelemetryRecorder()
     const { displayName, username, primaryEmail, endpoint } = authStatus
@@ -592,15 +596,17 @@ export const UserMenu: React.FunctionComponent<UserMenuProps> = ({
                                         close()
                                     }}
                                 >
-                                    <UniversityIcon size={16} strokeWidth={1.25} className="tw-mr-2" />
+                                    <BookOpenText size={16} strokeWidth={1.25} className="tw-mr-2" />
                                     <span className="tw-flex-grow">Getting Started Guide</span>
                                 </CommandItem>
 
-                                <CommandItem onSelect={() => onMenuViewChange('debug')}>
-                                    <BugIcon size={16} strokeWidth={1.25} className="tw-mr-2" />
-                                    <span className="tw-flex-grow">Debug</span>
-                                    <ChevronRightIcon size={16} strokeWidth={1.25} />
-                                </CommandItem>
+                                {IDE === CodyIDE.VSCode && (
+                                    <CommandItem onSelect={() => onMenuViewChange('debug')}>
+                                        <BugIcon size={16} strokeWidth={1.25} className="tw-mr-2" />
+                                        <span className="tw-flex-grow">Debug</span>
+                                        <ChevronRightIcon size={16} strokeWidth={1.25} />
+                                    </CommandItem>
+                                )}
 
                                 <CommandItem onSelect={() => onMenuViewChange('help')}>
                                     <CircleHelpIcon size={16} strokeWidth={1.25} className="tw-mr-2" />

--- a/vscode/webviews/components/UserMenu.tsx
+++ b/vscode/webviews/components/UserMenu.tsx
@@ -338,7 +338,7 @@ export const UserMenu: React.FunctionComponent<UserMenuProps> = ({
                                     <ExternalLinkIcon size={16} strokeWidth={1.25} />
                                 </CommandLink>
 
-                                <CommandItem
+                                {IDE === CodyIDE.VSCode && (<CommandItem
                                     onSelect={() => {
                                         getVSCodeAPI().postMessage({
                                             command: 'command',
@@ -346,7 +346,7 @@ export const UserMenu: React.FunctionComponent<UserMenuProps> = ({
                                         })
                                         close()
                                     }}
-                                >
+                                >)}
                                     <span className="tw-flex-grow">Report Issue</span>
                                 </CommandItem>
                             </CommandGroup>

--- a/vscode/webviews/components/UserMenu.tsx
+++ b/vscode/webviews/components/UserMenu.tsx
@@ -596,6 +596,7 @@ export const UserMenu: React.FunctionComponent<UserMenuProps> = ({
                                 </CommandItem>
 
                                 <CommandItem onSelect={() => onMenuViewChange('debug')}>
+                                    <BugIcon size={16} strokeWidth={1.25} className="tw-mr-2" />
                                     <span className="tw-flex-grow">Debug</span>
                                     <ChevronRightIcon size={16} strokeWidth={1.25} />
                                 </CommandItem>

--- a/vscode/webviews/components/UserMenu.tsx
+++ b/vscode/webviews/components/UserMenu.tsx
@@ -587,7 +587,7 @@ export const UserMenu: React.FunctionComponent<UserMenuProps> = ({
                             </CommandGroup>
 
                             <CommandGroup>
-                                <CommandItem
+                                {IDE === CodyIDE.VSCode && (<CommandItem
                                     onSelect={() => {
                                         getVSCodeAPI().postMessage({
                                             command: 'command',
@@ -598,7 +598,7 @@ export const UserMenu: React.FunctionComponent<UserMenuProps> = ({
                                 >
                                     <BookOpenText size={16} strokeWidth={1.25} className="tw-mr-2" />
                                     <span className="tw-flex-grow">Getting Started Guide</span>
-                                </CommandItem>
+                                </CommandItem>)}
 
                                 {IDE === CodyIDE.VSCode && (
                                     <CommandItem onSelect={() => onMenuViewChange('debug')}>

--- a/vscode/webviews/components/UserMenu.tsx
+++ b/vscode/webviews/components/UserMenu.tsx
@@ -304,7 +304,7 @@ export const UserMenu: React.FunctionComponent<UserMenuProps> = ({
                                         close()
                                     }}
                                 >
-                                    <span className="tw-flex-grow">Output Channel</span>
+                                    <span className="tw-flex-grow">Open Output Channel</span>
                                 </CommandItem>
                             </CommandGroup>
                         </CommandList>

--- a/vscode/webviews/components/UserMenu.tsx
+++ b/vscode/webviews/components/UserMenu.tsx
@@ -46,7 +46,7 @@ interface UserMenuProps {
     isWorkspacesUpgradeCtaEnabled?: boolean
 }
 
-type MenuView = 'main' | 'switch' | 'add' | 'remove'
+type MenuView = 'main' | 'switch' | 'add' | 'remove' | 'debug' | 'help'
 
 export const UserMenu: React.FunctionComponent<UserMenuProps> = ({
     isProUser,
@@ -259,6 +259,91 @@ export const UserMenu: React.FunctionComponent<UserMenuProps> = ({
                                     <span className="tw-flex-grow tw-rounded-md tw-text-center">
                                         Cancel
                                     </span>
+                                </CommandItem>
+                            </CommandGroup>
+                        </CommandList>
+                    ) : userMenuView === 'debug' ? (
+                        <CommandList>
+                            <CommandGroup title="Debug Menu">
+                                <CommandItem onSelect={() => onMenuViewChange('main')}>
+                                    <ChevronLeftIcon size={16} strokeWidth={1.25} className="tw-mr-2" />
+                                    <span className="tw-flex-grow">Back</span>
+                                </CommandItem>
+                            </CommandGroup>
+                            <CommandGroup>
+                                <CommandItem
+                                    onSelect={() => {
+                                        getVSCodeAPI().postMessage({
+                                            command: 'command',
+                                            id: 'cody.debug.export.logs',
+                                        })
+                                        close()
+                                    }}
+                                >
+                                    <span className="tw-flex-grow">Export Logs</span>
+                                </CommandItem>
+
+                                <CommandItem
+                                    onSelect={() => {
+                                        getVSCodeAPI().postMessage({
+                                            command: 'command',
+                                            id: 'cody.debug.enable.all',
+                                        })
+                                        close()
+                                    }}
+                                >
+                                    <span className="tw-flex-grow">Debug Mode</span>
+                                </CommandItem>
+
+                                <CommandItem
+                                    onSelect={() => {
+                                        getVSCodeAPI().postMessage({
+                                            command: 'command',
+                                            id: 'cody.debug.outputChannel',
+                                        })
+                                        close()
+                                    }}
+                                >
+                                    <span className="tw-flex-grow">Output Channel</span>
+                                </CommandItem>
+                            </CommandGroup>
+                        </CommandList>
+                    ) : userMenuView === 'help' ? (
+                        <CommandList>
+                            <CommandGroup title="Help Menu">
+                                <CommandItem onSelect={() => onMenuViewChange('main')}>
+                                    <ChevronLeftIcon size={16} strokeWidth={1.25} className="tw-mr-2" />
+                                    <span className="tw-flex-grow">Back</span>
+                                </CommandItem>
+                            </CommandGroup>
+                            <CommandGroup>
+                                <CommandLink
+                                    href="https://community.sourcegraph.com/"
+                                    target="_blank"
+                                    rel="noreferrer"
+                                    onSelect={() => {
+                                        telemetryRecorder.recordEvent(
+                                            'cody.userMenu.helpLink',
+                                            'open',
+                                            {}
+                                        )
+                                        close()
+                                    }}
+                                >
+                                    <span className="tw-flex-grow">Sourcegraph Community</span>
+                                    <ExternalLinkIcon size={16} strokeWidth={1.25} />
+                                </CommandLink>
+
+                                <CommandItem
+                                    onSelect={() => {
+                                        getVSCodeAPI().postMessage({
+                                            command: 'command',
+                                            id: 'cody.debug.reportIssue',
+                                        })
+                                        close()
+                                    }}
+                                >
+                                    <span className="tw-flex-grow">Report Issue</span>
                                 </CommandItem>
                             </CommandGroup>
                         </CommandList>
@@ -498,6 +583,31 @@ export const UserMenu: React.FunctionComponent<UserMenuProps> = ({
                             </CommandGroup>
 
                             <CommandGroup>
+                                <CommandItem
+                                    onSelect={() => {
+                                        getVSCodeAPI().postMessage({
+                                            command: 'command',
+                                            id: 'cody.welcome',
+                                        })
+                                        close()
+                                    }}
+                                >
+                                    <span className="tw-flex-grow">Getting Started Guide</span>
+                                </CommandItem>
+
+                                <CommandItem onSelect={() => onMenuViewChange('debug')}>
+                                    <span className="tw-flex-grow">Debug</span>
+                                    <ChevronRightIcon size={16} strokeWidth={1.25} />
+                                </CommandItem>
+
+                                <CommandItem onSelect={() => onMenuViewChange('help')}>
+                                    <CircleHelpIcon size={16} strokeWidth={1.25} className="tw-mr-2" />
+                                    <span className="tw-flex-grow">Help</span>
+                                    <ChevronRightIcon size={16} strokeWidth={1.25} />
+                                </CommandItem>
+                            </CommandGroup>
+
+                            <CommandGroup>
                                 {allowEndpointChange && (
                                     <CommandItem onSelect={() => onMenuViewChange('switch')}>
                                         <ArrowLeftRightIcon
@@ -513,26 +623,6 @@ export const UserMenu: React.FunctionComponent<UserMenuProps> = ({
                                     <LogOutIcon size={16} strokeWidth={1.25} className="tw-mr-2" />
                                     <span className="tw-flex-grow">Sign Out</span>
                                 </CommandItem>
-                            </CommandGroup>
-
-                            <CommandGroup>
-                                <CommandLink
-                                    href="https://community.sourcegraph.com/"
-                                    target="_blank"
-                                    rel="noreferrer"
-                                    onSelect={() => {
-                                        telemetryRecorder.recordEvent(
-                                            'cody.userMenu.helpLink',
-                                            'open',
-                                            {}
-                                        )
-                                        close()
-                                    }}
-                                >
-                                    <CircleHelpIcon size={16} strokeWidth={1.25} className="tw-mr-2" />
-                                    <span className="tw-flex-grow">Help</span>
-                                    <ExternalLinkIcon size={16} strokeWidth={1.25} />
-                                </CommandLink>
                             </CommandGroup>
                         </CommandList>
                     )}

--- a/vscode/webviews/components/UserMenu.tsx
+++ b/vscode/webviews/components/UserMenu.tsx
@@ -292,7 +292,7 @@ export const UserMenu: React.FunctionComponent<UserMenuProps> = ({
                                         close()
                                     }}
                                 >
-                                    <span className="tw-flex-grow">Debug Mode</span>
+                                    <span className="tw-flex-grow">Enable Debug Mode</span>
                                 </CommandItem>
 
                                 <CommandItem

--- a/vscode/webviews/tabs/TabsBar.tsx
+++ b/vscode/webviews/tabs/TabsBar.tsx
@@ -160,6 +160,7 @@ export const TabsBar = memo<TabsBarProps>(props => {
                                 allowEndpointChange={allowEndpointChange}
                                 className="!tw-opacity-100 tw-h-full"
                                 isWorkspacesUpgradeCtaEnabled={props.isWorkspacesUpgradeCtaEnabled}
+                                IDE={IDE}
                             />
                         )}
                     </div>


### PR DESCRIPTION
Closing https://linear.app/sourcegraph/issue/SRCH-1649/reduce-number-of-settings-buttons
Combine the two settings so that the UI is cleaner.

## Test plan
Tested this in the debugger.
[Before (Loom)](https://www.loom.com/share/7ec366dec5be4696b5808522674e1c3f)
[After (Loom)](https://www.loom.com/share/52ec7aa19a5e41edb7b66212e9d648dc)
<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
<img width="295" alt="Screenshot 2025-02-18 at 7 20 49 AM" src="https://github.com/user-attachments/assets/8577b8a3-4d83-4f08-a899-cf092157e28c" />

