### PR TITLE
Unclickable links no longer display in Cody WelcomeMessage

### DIFF
--- a/vscode/test/e2e/command-core.test.ts
+++ b/vscode/test/e2e/command-core.test.ts
@@ -28,6 +28,9 @@ test.extend<ExpectedV2Events>({
 })('Generate Unit Test Command (Edit)', async ({ page, sidebar, server }) => {
     server.onGraphQl('SiteProductVersion').replyJson({
         data: { site: { productVersion: '5.9.0' } },
+        capabilities: {
+            edit: 'enabled',
+        },
     })
 
     // Sign into Cody
@@ -66,6 +69,9 @@ test.extend<ExpectedV2Events>({
 })('Document Command (Edit)', async ({ page, sidebar, server }) => {
     server.onGraphQl('SiteProductVersion').replyJson({
         data: { site: { productVersion: '5.9.0' } },
+        capabilities: {
+            edit: 'enabled',
+        },
     })
 
     // Sign into Cody
@@ -111,6 +117,9 @@ test.extend<ExpectedV2Events>({
 })('Explain Command from Prompts Tab', async ({ page, sidebar, server }) => {
     server.onGraphQl('SiteProductVersion').replyJson({
         data: { site: { productVersion: '5.9.0' } },
+        capabilities: {
+            edit: 'enabled',
+        },
     })
 
     // Sign into Cody

--- a/vscode/webviews/chat/components/WelcomeMessage.test.tsx
+++ b/vscode/webviews/chat/components/WelcomeMessage.test.tsx
@@ -33,6 +33,7 @@ describe('WelcomeMessage', () => {
         vi.spyOn(useConfigModule, 'useConfig').mockReturnValue({
             clientCapabilities: {
                 isVSCode: true,
+                edit: 'enabled',
             } satisfies Partial<ClientCapabilitiesWithLegacyFields> as ClientCapabilitiesWithLegacyFields,
             authStatus: AUTH_STATUS_FIXTURE_AUTHED,
         } satisfies Partial<useConfigModule.Config> as useConfigModule.Config)
@@ -49,6 +50,7 @@ describe('WelcomeMessage', () => {
         vi.spyOn(useConfigModule, 'useConfig').mockReturnValue({
             clientCapabilities: {
                 isVSCode: false,
+                edit: 'enabled',
             } satisfies Partial<ClientCapabilitiesWithLegacyFields> as ClientCapabilitiesWithLegacyFields,
             authStatus: AUTH_STATUS_FIXTURE_AUTHED,
         } satisfies Partial<useConfigModule.Config> as useConfigModule.Config)

--- a/vscode/webviews/chat/components/WelcomeMessage.tsx
+++ b/vscode/webviews/chat/components/WelcomeMessage.tsx
@@ -40,7 +40,6 @@ export const WelcomeMessage: FunctionComponent<WelcomeMessageProps> = ({
                     appearanceMode="chips-list"
                     telemetryLocation="WelcomeAreaPrompts"
                     onSelect={item => runAction(item, setView)}
-                    IDE={IDE}
                 />
             </div>
         </div>

--- a/vscode/webviews/chat/components/WelcomeMessage.tsx
+++ b/vscode/webviews/chat/components/WelcomeMessage.tsx
@@ -40,6 +40,7 @@ export const WelcomeMessage: FunctionComponent<WelcomeMessageProps> = ({
                     appearanceMode="chips-list"
                     telemetryLocation="WelcomeAreaPrompts"
                     onSelect={item => runAction(item, setView)}
+                    IDE={IDE}
                 />
             </div>
         </div>

--- a/vscode/webviews/components/promptList/PromptList.tsx
+++ b/vscode/webviews/components/promptList/PromptList.tsx
@@ -1,7 +1,7 @@
 import clsx from 'clsx'
 import { type FC, useCallback, useMemo, useState } from 'react'
 
-import { CodyIDE, PromptMode, type Action, type PromptsInput } from '@sourcegraph/cody-shared'
+import { type Action, CodyIDE, PromptMode, type PromptsInput } from '@sourcegraph/cody-shared'
 
 import { useLocalStorage } from '../../components/hooks'
 import { useTelemetryRecorder } from '../../utils/telemetry'
@@ -172,10 +172,11 @@ export const PromptList: FC<PromptListProps> = props => {
                 promptFilters?.promoted || promptFilters?.owner || promptFilters?.tags
 
             if (shouldExcludeBuiltinCommands && isWebClient) {
-                return actions.filter(action =>
-                    action.actionType === 'prompt' &&
-                    !action.builtin &&
-                    action.mode === PromptMode.CHAT
+                return actions.filter(
+                    action =>
+                        action.actionType === 'prompt' &&
+                        !action.builtin &&
+                        action.mode === PromptMode.CHAT
                 )
             }
             if (shouldExcludeBuiltinCommands) {

--- a/vscode/webviews/components/promptList/PromptList.tsx
+++ b/vscode/webviews/components/promptList/PromptList.tsx
@@ -169,6 +169,8 @@ export const PromptList: FC<PromptListProps> = props => {
                 promptFilters?.promoted || promptFilters?.owner || promptFilters?.tags
 
             const isEditEnabled = clientCapabilities.edit === 'enabled'
+            // Prompts that perform edits are not usable on clients that don't support editing.
+            // To avoid cluttering the list with unusable prompts we ignore them completely.
             if (!isEditEnabled) {
                 actions = actions.filter(action =>
                     action.actionType === 'prompt' ? action.mode === 'CHAT' : action.mode === 'ask'


### PR DESCRIPTION
Before, unclickable prompts were still displayed in the WelcomeMessage when a user starts a new chat with Cody. This PR makes it so that only clickable items appear in the PromptList. 

The changes enhance the PromptList component by making it more context-aware with respect to the IDE and prompt modes. This should provide a better user experience, particularly for web-based clients, by showing clickable prompts and excluding non-clickable ones.

## Test plan
Before: 
![Screenshot 2025-02-14 at 10 35 10 AM](https://github.com/user-attachments/assets/61e842c6-1473-454c-b448-fc4b3d4777b3)

After: 
![Screenshot 2025-02-14 at 10 35 51 AM](https://github.com/user-attachments/assets/6a6fbbae-c44d-45ba-baef-51786c49b59d)
