### PR TITLE
feat(vscode): add context via file explorer

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -520,14 +520,6 @@
         "enablement": "cody.activated && resourceSet"
       },
       {
-        "command": "cody.mention.files",
-        "category": "Cody",
-        "group": "Chat",
-        "title": "Add Files to Cody Chat",
-        "icon": "$(mention)",
-        "enablement": "cody.activated && resourceSet"
-      },
-      {
         "command": "cody.debug.export.logs",
         "category": "Cody Debug",
         "group": "Debug",
@@ -983,7 +975,7 @@
       ],
       "explorer/context": [
         {
-          "command": "cody.mention.files",
+          "command": "cody.mention.file",
           "when": "cody.activated && resourceSet && !explorerResourceIsFolder",
           "group": "4_cody"
         }

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -972,6 +972,13 @@
           "command": "cody.command.insertCodeToNewFile",
           "when": "webviewSection == 'codeblock-actions'"
         }
+      ],
+      "explorer/context": [
+        {
+          "command": "cody.mention.file",
+          "when": "cody.activated && resourceSet && !explorerResourceIsFolder",
+          "group": "4_cody"
+        }
       ]
     },
     "configuration": {

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -520,6 +520,14 @@
         "enablement": "cody.activated && resourceSet"
       },
       {
+        "command": "cody.mention.files",
+        "category": "Cody",
+        "group": "Chat",
+        "title": "Add Files to Cody Chat",
+        "icon": "$(mention)",
+        "enablement": "cody.activated && resourceSet"
+      },
+      {
         "command": "cody.debug.export.logs",
         "category": "Cody Debug",
         "group": "Debug",
@@ -975,7 +983,7 @@
       ],
       "explorer/context": [
         {
-          "command": "cody.mention.file",
+          "command": "cody.mention.files",
           "when": "cody.activated && resourceSet && !explorerResourceIsFolder",
           "group": "4_cody"
         }

--- a/vscode/src/chat/chat-view/ChatsController.ts
+++ b/vscode/src/chat/chat-view/ChatsController.ts
@@ -237,9 +237,6 @@ export class ChatsController implements vscode.Disposable {
             vscode.commands.registerCommand('cody.mention.file', uri =>
                 this.sendEditorContextToChat(uri)
             ),
-            vscode.commands.registerCommand('cody.mention.files', async uris => 
-                await Promise.all(uris.map((uri: URI | undefined) => this.sendEditorContextToChat(uri)))
-            ),
 
             // Codeblock commands
             vscode.commands.registerCommand(

--- a/vscode/src/chat/chat-view/ChatsController.ts
+++ b/vscode/src/chat/chat-view/ChatsController.ts
@@ -237,6 +237,9 @@ export class ChatsController implements vscode.Disposable {
             vscode.commands.registerCommand('cody.mention.file', uri =>
                 this.sendEditorContextToChat(uri)
             ),
+            vscode.commands.registerCommand('cody.mention.files', async uris => 
+                await Promise.all(uris.map((uri: URI | undefined) => this.sendEditorContextToChat(uri)))
+            ),
 
             // Codeblock commands
             vscode.commands.registerCommand(


### PR DESCRIPTION
closes https://linear.app/sourcegraph/issue/CODY-4947/re-add-right-click-file-context-option-for-cody-chat-in-vs-code-was

I tried to get it to add multiple like cursor does, but it seems that while vscode "highlights" multiple files with shift, it "selects" the one you clicked

## Test plan

1. Open file explorer
2. Right Click
3. Select "Add File to Cody Chat"
4. Observe file added to cody chat


https://www.loom.com/share/0deca006f6b0499cabc8b4a43a0e11cd
