### PR TITLE
chore: Add prosemirror-lexical interop test

### DIFF
--- a/lib/prompt-editor/src/v2/lexical-interop.test.ts
+++ b/lib/prompt-editor/src/v2/lexical-interop.test.ts
@@ -1,0 +1,37 @@
+import { toSerializedPromptEditorValue } from '@sourcegraph/cody-shared'
+import { $createParagraphNode, $createTextNode, $getRoot, createEditor } from 'lexical'
+import { expect, test } from 'vitest'
+import { RICH_EDITOR_NODES } from '../nodes'
+import { $createContextItemMentionNode } from '../nodes/ContextItemMentionNode'
+import {
+    toSerializedPromptEditorValue as fromProseMirrorToEditorValue,
+    fromSerializedPromptEditorState,
+} from './lexical-interop'
+import { schema } from './promptInput'
+
+test('lexical -> prosemirror -> lexical', () => {
+    const editor = createEditor({ nodes: RICH_EDITOR_NODES })
+    editor.update(
+        () => {
+            const root = $getRoot()
+            const paragraph = $createParagraphNode()
+            paragraph.append(
+                $createTextNode('before '),
+                $createContextItemMentionNode(
+                    { type: 'file', uri: 'test.ts' },
+                    { isFromInitialContext: true }
+                ),
+                $createTextNode(' after')
+            )
+            root.append(paragraph)
+        },
+        { discrete: true }
+    )
+    const editorValue = toSerializedPromptEditorValue(editor)
+
+    expect(
+        fromProseMirrorToEditorValue(
+            schema.nodeFromJSON(fromSerializedPromptEditorState(editorValue.editorState))
+        )
+    ).toEqual(editorValue)
+})

--- a/lib/prompt-editor/src/v2/lexical-interop.ts
+++ b/lib/prompt-editor/src/v2/lexical-interop.ts
@@ -84,7 +84,7 @@ export function toSerializedPromptEditorValue(doc: Node): SerializedPromptEditor
             ? window.getComputedStyle(window.document.body).direction
             : null) === 'rtl'
             ? 'rtl'
-            : 'ltr'
+            : null
 
     doc.descendants(node => {
         if (node.type.name === 'mention') {
@@ -164,8 +164,8 @@ export function toSerializedPromptEditorValue(doc: Node): SerializedPromptEditor
         text: doc.textContent,
         contextItems,
         editorState: {
-            v: 'lexical-v1',
-            minReaderV: 'lexical-v1',
+            v: 'lexical-v0',
+            minReaderV: 'lexical-v0',
             lexicalEditorState: {
                 root: serializeRoot(doc),
             },


### PR DESCRIPTION
To make the prosemirror implementation work as a drop-in replacement we
use some utility function to convert lexical state to prosemirror and
back.
The utility function was written by carefully inspecting the lexical
serialized state, but that doesn't give us any confidence in its
correctness.

This commit adds a test for these utility functions.


## Test plan

vitest

