### PR TITLE
Remove current repo link to docs for enterprise users

### DIFF
--- a/vscode/src/chat/initialContext.ts
+++ b/vscode/src/chat/initialContext.ts
@@ -19,6 +19,7 @@ import {
     featureFlagProvider,
     fromVSCodeEvent,
     isDotCom,
+    isEnterpriseUser,
     isError,
     openctxController,
     pendingOperation,
@@ -184,8 +185,10 @@ export function getCorpusContextItemsForEditorState(): Observable<
                     authenticated: authStatus.authenticated,
                     endpoint: authStatus.endpoint,
                     allowRemoteContext: clientCapabilities().isCodyWeb || !isDotCom(authStatus),
+                    isEnterprise: isEnterpriseUser(authStatus),
                 }) satisfies Pick<AuthStatus, 'authenticated' | 'endpoint'> & {
                     allowRemoteContext: boolean
+                    isEnterprise: boolean
                 }
         ),
         distinctUntilChanged()
@@ -231,7 +234,7 @@ export function getCorpusContextItemsForEditorState(): Observable<
                     })
                 }
                 if (remoteReposForAllWorkspaceFolders.length === 0) {
-                    if (!clientCapabilities().isCodyWeb) {
+                    if (!clientCapabilities().isCodyWeb && !authStatus.isEnterprise) {
                         items.push({
                             type: 'open-link',
                             title: 'Current Repository',


### PR DESCRIPTION
[linear](https://linear.app/sourcegraph/issue/CODY-5054/hide-linkout-to-docs-page-for-current-repo-selector-for-ent-users
)
## Test plan

Current state causing confusion. When an Ent user has a project open locally that isn't available remotely, they get this "not yet available" CTA that links out to a docs page about [code host](https://sourcegraph.com/docs/admin/code_hosts) configuration, which is causing lots of questions to customer admins that are unnecessary
<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
![Screenshot 2025-02-17 at 3 37 51 PM](https://github.com/user-attachments/assets/07deb60c-bfa0-4f08-8953-272cc5708d1e)

After changes for Ent User with a local project that is available remotely
![Screenshot 2025-02-17 at 9 27 28 PM](https://github.com/user-attachments/assets/bfa9cf2b-96d5-4360-856d-b6b514904350)

After changes for Ent User with a local project that is **not** available remotely
![Screenshot 2025-02-17 at 9 28 15 PM](https://github.com/user-attachments/assets/d416a79e-71c9-4160-a425-e5c80f2456fa)

