### PR TITLE
Enable credentials synchronisation between Cody and Search extensions

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -368,6 +368,11 @@
         "enablement": "config.cody.internal.unstable"
       },
       {
+        "command": "cody.auth.requestEndpointSettings",
+        "category": "Cody",
+        "title": "Schedule export endpoint settings to Sourcegraph plugin"
+      },
+      {
         "command": "cody.settings.extension",
         "category": "Cody",
         "title": "Extension Settings",
@@ -971,13 +976,6 @@
         {
           "command": "cody.command.insertCodeToNewFile",
           "when": "webviewSection == 'codeblock-actions'"
-        }
-      ],
-      "explorer/context": [
-        {
-          "command": "cody.mention.file",
-          "when": "cody.activated && resourceSet && !explorerResourceIsFolder",
-          "group": "4_cody"
         }
       ]
     },

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -46,7 +46,12 @@ import { isReinstalling } from '../uninstall/reinstall'
 
 import type { CommandResult } from './CommandResult'
 import { showAccountMenu } from './auth/account-menu'
-import { showSignInMenu, showSignOutMenu, tokenCallbackHandler } from './auth/auth'
+import {
+    requestEndpointSettingsDeliveryToSearchPlugin,
+    showSignInMenu,
+    showSignOutMenu,
+    tokenCallbackHandler,
+} from './auth/auth'
 import { createAutoEditsProvider } from './autoedits/create-autoedits-provider'
 import { autoeditsOutputChannelLogger } from './autoedits/output-channel-logger'
 import { registerAutoEditTestRenderCommand } from './autoedits/renderer/mock-renderer'
@@ -605,7 +610,11 @@ function registerAuthCommands(disposables: vscode.Disposable[]): void {
         vscode.commands.registerCommand('cody.auth.signin', () => showSignInMenu()),
         vscode.commands.registerCommand('cody.auth.signout', () => showSignOutMenu()),
         vscode.commands.registerCommand('cody.auth.account', () => showAccountMenu()),
-        vscode.commands.registerCommand('cody.auth.support', () => showFeedbackSupportQuickPick())
+        vscode.commands.registerCommand('cody.auth.support', () => showFeedbackSupportQuickPick()),
+        vscode.commands.registerCommand(
+            'cody.auth.requestEndpointSettings',
+            async () => await requestEndpointSettingsDeliveryToSearchPlugin()
+        )
     )
 }
 


### PR DESCRIPTION
## Changes

This PR adds code for providing Cody credential headers to Sourcegraph Search extension.
To make it more secure (and prevent other hostile extension from stealing credentials) it works based on request/response pattern:

```

                                  Command:   cody.auth.requestEndpointSettings 
          [Sourcegraph Search] ---------------------------------------------------> 
          ↑                                                                       |
          |                                                                       |
          |                                                                       ↓
           <---------------------------------------------------------------- [Cody] 
                                Command:   sourcegraph.setEndpointSettings
```

Before executing the commands we check if extensions of a given id (`sourcegraph.cody-ai` in case of `cody.auth.requestEndpointSettings ` or `sourcegraph.sourcegraph` in case of `sourcegraph.setEndpointSettings`) indeed has that command defined. 
Because extension id is unique in VSC marketplace that should ensure no marketplace extension except Sourcegraph Search] can receive the credentials.

## Test plan

Requires corresponding `sourcegraph/sourcegraph` changes to test: https://github.com/sourcegraph/sourcegraph/pull/3585

1. Using Cody log in to some Sourcegraph `Instance A`
2. Open `settings.json` and add `"sourcegraph.loginWithCody": true,` entry, save file.
3. Verify if Sourcegraph Search extension also switched in to the same account
4. Comment out `"sourcegraph.loginWithCody": true,` entry, save file
5. Verify if Sourcegraph Search has refreshed and is not logged in to any account
6. Login to some other `Instance B`  manually by providing url and token
7. Verify that login to `Instance B` was successful
8. Click `Sign Out` - you should be signed out successfully
6. Login to `Instance B`  again
9. Uncomment `"sourcegraph.loginWithCody": true,` entry, save file
10. Make sure account switched to `Instance A`
11. Click `Sign Out` - view should be refreshed but you should remain signed in to `Instance A`
12. Comment out `"sourcegraph.loginWithCody": true,` entry, save file
13. You should be logged off