### PR TITLE
fix(editor): fix range handling for editor selection content

### DIFF
--- a/vscode/src/chat/chat-view/ChatController.ts
+++ b/vscode/src/chat/chat-view/ChatController.ts
@@ -95,6 +95,7 @@ import type { startTokenReceiver } from '../../auth/token-receiver'
 import { getCurrentUserId } from '../../auth/user'
 import { getContextFileFromUri } from '../../commands/context/file-path'
 import { getContextFileFromCursor } from '../../commands/context/selection'
+import { getEditor } from '../../editor/active-editor'
 import type { VSCodeEditor } from '../../editor/vscode-editor'
 import type { ExtensionClient } from '../../extension-client'
 import { migrateAndNotifyForOutdatedModels } from '../../models/modelMigrator'
@@ -1147,7 +1148,7 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
 
     public async handleGetUserEditorContext(uri?: URI): Promise<void> {
         // Get selection from the active editor
-        const selection = vscode.window.activeTextEditor?.selection
+        const selection = getEditor()?.active?.selection
 
         // Determine context based on URI presence
         const contextItem = uri
@@ -1169,7 +1170,7 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
                           // Remove content to avoid sending large data to the webview
                           content: undefined,
                           isTooLarge: contextItem.size ? contextItem.size > userContextSize : undefined,
-                          source: ContextItemSource.User,
+                          source: ContextItemSource.Selection,
                           range: contextItem.range,
                       } satisfies ContextItem,
                   ]

--- a/vscode/src/commands/context/file-path.ts
+++ b/vscode/src/commands/context/file-path.ts
@@ -31,13 +31,10 @@ export async function getContextFileFromUri(
 
             // if the range is the full file, remove our range specifier so it
             // renders nicely in the UI
-            const fullRange = new vscode.Range(
-                0,
-                0,
-                doc.lineCount,
-                doc.lineAt(doc.lineCount - 1).text.length
+            const fullRange = doc.validateRange(
+                new vscode.Range(doc.positionAt(0), doc.positionAt(doc.getText().length - 1))
             )
-            if (range?.contains(fullRange)) {
+            if (range?.isEqual(fullRange)) {
                 range = undefined
             }
 

--- a/vscode/src/editor/vscode-editor.ts
+++ b/vscode/src/editor/vscode-editor.ts
@@ -77,10 +77,11 @@ export class VSCodeEditor implements Editor {
         if (selectionRange) {
             const startLine = selectionRange?.start?.line
             let endLine = selectionRange?.end?.line
+            const endChar = selectionRange?.end?.character
             if (startLine === endLine) {
                 endLine++
             }
-            range = new vscode.Range(startLine, 0, endLine, 0)
+            range = new vscode.Range(startLine, 0, endLine, endChar)
         }
 
         const doc = await vscode.workspace.openTextDocument(fileUri)

--- a/vscode/test/e2e/chat-atFile.test.ts
+++ b/vscode/test/e2e/chat-atFile.test.ts
@@ -310,7 +310,7 @@ test.extend<ExpectedV2Events>({
         'cody.chat-question:executed',
         'cody.chatResponse:noCode',
     ],
-}).only('@-mention symbol in chat', async ({ page, nap, sidebar, server }) => {
+})('@-mention symbol in chat', async ({ page, nap, sidebar, server }) => {
     mockEnterpriseRepoIdMapping(server)
 
     await sidebarSignin(page, sidebar)

--- a/vscode/test/e2e/chat-atFile.test.ts
+++ b/vscode/test/e2e/chat-atFile.test.ts
@@ -310,7 +310,7 @@ test.extend<ExpectedV2Events>({
         'cody.chat-question:executed',
         'cody.chatResponse:noCode',
     ],
-})('@-mention symbol in chat', async ({ page, nap, sidebar, server }) => {
+}).only('@-mention symbol in chat', async ({ page, nap, sidebar, server }) => {
     mockEnterpriseRepoIdMapping(server)
 
     await sidebarSignin(page, sidebar)
@@ -356,7 +356,7 @@ test.extend<ExpectedV2Events>({
 
     // @-file with the correct line range shows up in the chat view and it opens on click
     const contextCell = getContextCell(chatPanelFrame)
-    await expectContextCellCounts(contextCell, { files: 2 })
+    await expectContextCellCounts(contextCell, { files: 1 })
     await contextCell.hover()
     await openContextCell(contextCell)
     const chatContext = getContextCell(chatPanelFrame).last()


### PR DESCRIPTION
Close https://linear.app/sourcegraph/issue/CODY-5029

Fixes issues with range handling in file context and selection:

1. Preserves end character position when getting selection range in VSCodeEditor
2. Improves full file range detection using document validation and text length
3. Updates context source to correctly identify selection-based context
4. Uses editor helper to get active selection instead of direct VS Code API

## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

1. Select partial lines in editor and verify range includes correct end character
2. Test full file selection and verify range is properly detected
3. Verify context items show correct source when from selection
4. Confirm editor selections work correctly through helper function
