### PR TITLE
fix(agentic chat): terminal and openCtx are not registered as tools

### DIFF
--- a/vscode/src/chat/agentic/CodyToolProvider.ts
+++ b/vscode/src/chat/agentic/CodyToolProvider.ts
@@ -187,7 +187,7 @@ export class CodyToolProvider {
         return CodyToolProvider.instance?.factory.getInstances() ?? []
     }
 
-    public static setupOpenCtxProviderListener(): void {
+    private static setupOpenCtxProviderListener(): void {
         const provider = CodyToolProvider.instance
         if (provider && !CodyToolProvider.configSubscription) {
             CodyToolProvider.configSubscription = toolboxManager.observable.subscribe({})

--- a/vscode/src/chat/agentic/CodyToolProvider.ts
+++ b/vscode/src/chat/agentic/CodyToolProvider.ts
@@ -180,6 +180,7 @@ export class CodyToolProvider {
 
     public static initialize(contextRetriever: Retriever): void {
         CodyToolProvider.instance = new CodyToolProvider(contextRetriever)
+        CodyToolProvider.setupOpenCtxProviderListener()
     }
 
     public static getTools(): CodyTool[] {

--- a/vscode/src/context/openctx.ts
+++ b/vscode/src/context/openctx.ts
@@ -35,7 +35,6 @@ import type {
 } from '@openctx/client'
 import type { createController } from '@openctx/vscode-lib'
 import { Observable, map } from 'observable-fns'
-import { CodyToolProvider } from '../chat/agentic/CodyToolProvider'
 import { logDebug } from '../output-channel-logger'
 import { createCodeSearchProvider } from './openctx/codeSearch'
 import { gitMentionsProvider } from './openctx/git'
@@ -113,7 +112,6 @@ export function observeOpenCtxController(
                           ),
                     mergeConfiguration,
                 })
-                CodyToolProvider.setupOpenCtxProviderListener()
                 return controller
             } catch (error) {
                 logDebug('openctx', `Failed to load OpenCtx client: ${error}`)


### PR DESCRIPTION

CLOSE https://linear.app/sourcegraph/issue/CODY-5063

Regression caused by https://github.com/sourcegraph/cody/pull/6909

The PR has moved the openCtx controller to be initialized before CodyToolProvider is initialized, causing the current logic to set up openctx provider listeners to fail.

This PR fixes the issue:

Move the OpenCtx provider listener setup from the controller initialization to the CodyToolProvider initialization to ensure proper setup timing and avoid circular dependencies.

## Test plan

- Verify OpenCtx provider listener is properly initialized when CodyToolProvider is initialized
- Confirm no functionality changes in OpenCtx controller behavior
- Ensure existing OpenCtx features continue to work as expected

Ask Cody `summarize my staged changes using the CLI tool` in agentic chat

Before:

![image](https://github.com/user-attachments/assets/f7da91f0-aad4-4f91-a8fc-d77b5472f451)

After:

![image](https://github.com/user-attachments/assets/95eae743-7cad-4f63-8d9f-0797770292c0)

