### PR TITLE
chore(release): fix new line rendering in changelog PRs

### DIFF
--- a/.github/workflows/generate-changelog.yml
+++ b/.github/workflows/generate-changelog.yml
@@ -100,7 +100,9 @@ jobs:
             --output.repo=$GH_REPO \
             --output.pr.branch="$PR_BRANCH" \
             --output.pr.title="Changelog for %s" \
-            --output.pr.body="Automated release and changelog for VS code Cody %s \n ## Test plan \n N/A - changelog update" \
+            --output.pr.body="Automated release and changelog for Cody VS Code %s
+            ## Test plan
+            N/A - changelog update" \
             --output.changelog="$CHANGELOG_PATH" \
             --output.changelog.marker='<!--- {/_ CHANGELOG_START _/} -->' \
             --releaseregistry.version=${VERSION}


### PR DESCRIPTION
Previously changelog PRs would print the raw new line strings in the PR body (example - https://github.com/sourcegraph/cody/pull/7148) because the changelog generator binary doesn't interpret `\n` properly. Manually adding new lines in the script instead to fix the markdown rendering

![CleanShot 2025-02-19 at 10 44 07@2x](https://github.com/user-attachments/assets/b744fc14-0177-4003-9011-064549ee19c1)



## Test plan
Tested on my `kalan/changelog-M68` branch, see [PR](https://github.com/sourcegraph/cody/pull/7148) on the fix
<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
