### PR TITLE
Handle case when VirtualFile is null

### DIFF
--- a/.github/workflows/scip-java.yml
+++ b/.github/workflows/scip-java.yml
@@ -45,6 +45,8 @@ jobs:
           pushd jetbrains
           scip-java index --build-tool=gradle
           popd > /dev/null
+        env:
+          GITHUB_TOKEN: ${{ secrets.PRIVATE_SG_ACCESS_TOKEN }}
 
       - name: Install src
         run: yarn global add @sourcegraph/src

--- a/jetbrains/src/main/kotlin/com/sourcegraph/cody/inspections/CodyFixHighlightPass.kt
+++ b/jetbrains/src/main/kotlin/com/sourcegraph/cody/inspections/CodyFixHighlightPass.kt
@@ -141,10 +141,11 @@ class CodyFixHighlightPass(val file: PsiFile, val editor: Editor) :
 class CodyFixHighlightPassFactory : TextEditorHighlightingPassFactoryRegistrar {
   private val factory: TextEditorHighlightingPassFactory =
       TextEditorHighlightingPassFactory { file, editor ->
-        when (file.virtualFile.fileSystem.protocol) {
-          "mock" -> null
-          else -> CodyFixHighlightPass(file, editor)
-        }
+          if (file.virtualFile == null) null
+          else when (file.virtualFile.fileSystem.protocol) {
+            "mock" -> null
+            else -> CodyFixHighlightPass(file, editor)
+          }
       }
 
   override fun registerHighlightingPassFactory(

--- a/jetbrains/src/main/kotlin/com/sourcegraph/cody/inspections/CodyFixHighlightPass.kt
+++ b/jetbrains/src/main/kotlin/com/sourcegraph/cody/inspections/CodyFixHighlightPass.kt
@@ -141,11 +141,12 @@ class CodyFixHighlightPass(val file: PsiFile, val editor: Editor) :
 class CodyFixHighlightPassFactory : TextEditorHighlightingPassFactoryRegistrar {
   private val factory: TextEditorHighlightingPassFactory =
       TextEditorHighlightingPassFactory { file, editor ->
-          if (file.virtualFile == null) null
-          else when (file.virtualFile.fileSystem.protocol) {
-            "mock" -> null
-            else -> CodyFixHighlightPass(file, editor)
-          }
+        if (file.virtualFile == null) null
+        else
+            when (file.virtualFile.fileSystem.protocol) {
+              "mock" -> null
+              else -> CodyFixHighlightPass(file, editor)
+            }
       }
 
   override fun registerHighlightingPassFactory(


### PR DESCRIPTION
Closes https://github.com/sourcegraph/jetbrains/issues/3087

During creation of TextEditorHighlightingPass VirtualFile can return null. This PR handles this situation.

## Test plan
N/A
<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
