### PR TITLE
fix: Fix inconsistent workspace handling in agent

### DIFF
--- a/agent/src/AgentWorkspaceDocuments.ts
+++ b/agent/src/AgentWorkspaceDocuments.ts
@@ -40,7 +40,6 @@ export class AgentWorkspaceDocuments implements vscode_shim.WorkspaceDocuments {
         { document: AgentTextDocument; editor: AgentTextEditor }
     > = new Map()
 
-    public workspaceRootUri: vscode.Uri | undefined
     public activeDocumentFilePath: vscode.Uri | null = null
 
     private doPanic = this.params?.doPanic ? { doPanic: this.params.doPanic } : undefined

--- a/agent/src/vscode-shim.ts
+++ b/agent/src/vscode-shim.ts
@@ -344,7 +344,11 @@ const _workspace: typeof vscode.workspace = {
                   )
               )
     },
-    workspaceFolders,
+    get workspaceFolders() {
+        // According to the docs, workspaceFolders is `undefined` when no
+        // workspace has been opened.
+        return workspaceFolders.length === 0 ? undefined : workspaceFolders
+    },
     getWorkspaceFolder: (uri: vscode.Uri) => {
         for (const folder of workspaceFolders) {
             if (uriHasPrefix(uri, folder.uri, isWindows())) {

--- a/agent/src/vscode-shim.ts
+++ b/agent/src/vscode-shim.ts
@@ -1,7 +1,16 @@
 import { execSync } from 'node:child_process'
 import path from 'node:path'
 
-import { extensionForLanguage, logDebug, logError, setClientNameVersion } from '@sourcegraph/cody-shared'
+import {
+    extensionForLanguage,
+    fixPathSep,
+    isWindows,
+    logDebug,
+    logError,
+    pathFunctionsForURI,
+    setClientNameVersion,
+    uriHasPrefix,
+} from '@sourcegraph/cody-shared'
 import * as uuid from 'uuid'
 import type * as vscode from 'vscode'
 
@@ -170,26 +179,16 @@ export const onDidRenameFiles = new EventEmitter<vscode.FileRenameEvent>()
 export const onDidSaveTextDocument = new EventEmitter<vscode.TextDocument>()
 
 export interface WorkspaceDocuments {
-    workspaceRootUri?: vscode.Uri
     openTextDocument: (uri: vscode.Uri) => Promise<vscode.TextDocument>
     newTextEditorFromStringUri: (uri: string) => Promise<vscode.TextEditor>
 }
 let workspaceDocuments: WorkspaceDocuments | undefined
 export function setWorkspaceDocuments(newWorkspaceDocuments: WorkspaceDocuments): void {
     workspaceDocuments = newWorkspaceDocuments
-    if (newWorkspaceDocuments.workspaceRootUri) {
-        if (
-            !workspaceFolders
-                .map(wf => wf.uri.toString())
-                .includes(newWorkspaceDocuments.workspaceRootUri.toString())
-        ) {
-            setLastOpenedWorkspaceFolder(newWorkspaceDocuments.workspaceRootUri)
-        }
-    }
 }
 
 // Add/move the last opened workspace folder to the front of the workspace folders list.
-function setLastOpenedWorkspaceFolder(uri: vscode.Uri): void {
+export function setLastOpenedWorkspaceFolder(uri: vscode.Uri): void {
     const currentWorkspaceFolders = workspaceFolders.map(wf => wf.uri)
     if (currentWorkspaceFolders[0]?.toString() !== uri.toString()) {
         setWorkspaceFolders([uri, ...currentWorkspaceFolders])
@@ -346,18 +345,13 @@ const _workspace: typeof vscode.workspace = {
               )
     },
     workspaceFolders,
-    getWorkspaceFolder: () => {
-        // TODO: support multiple workspace roots
-        if (workspaceDocuments?.workspaceRootUri === undefined) {
-            throw new Error(
-                'workspaceDocuments is undefined. To fix this problem, make sure that the agent has been initialized.'
-            )
+    getWorkspaceFolder: (uri: vscode.Uri) => {
+        for (const folder of workspaceFolders) {
+            if (uriHasPrefix(uri, folder.uri, isWindows())) {
+                return folder
+            }
         }
-        return {
-            uri: workspaceDocuments.workspaceRootUri,
-            index: 0,
-            name: workspaceDocuments.workspaceRootUri?.path,
-        }
+        return undefined
     },
     // TODO: used by `WorkspaceRepoMapper` and will be used by `git.onDidOpenRepository`
     // https://github.com/sourcegraph/cody/issues/4136
@@ -370,7 +364,10 @@ const _workspace: typeof vscode.workspace = {
     onDidRenameFiles: onDidRenameFiles.event, // TODO: used by persistence tracker
     onDidDeleteFiles: onDidDeleteFiles.event, // TODO: used by persistence tracker
     registerTextDocumentContentProvider: () => emptyDisposable, // TODO: used by fixup controller
-    asRelativePath: (pathOrUri: string | vscode.Uri): string => {
+    asRelativePath: (
+        pathOrUri: string | vscode.Uri,
+        includeWorkspaceFolder: boolean = workspaceFolders.length > 1
+    ): string => {
         const uri: vscode.Uri | undefined =
             typeof pathOrUri === 'string'
                 ? Uri.file(pathOrUri)
@@ -382,14 +379,37 @@ const _workspace: typeof vscode.workspace = {
             return `${pathOrUri}`
         }
 
-        const relativePath = workspaceDocuments?.workspaceRootUri?.fsPath
-            ? path.relative(workspaceDocuments?.workspaceRootUri?.path ?? '', uri.path)
-            : uri.path
+        let relativePath: string | undefined = undefined
+
+        // Mimic the behavior of vscode.workspace.asRelativePath.
+        for (const folder of workspaceFolders) {
+            if (uriHasPrefix(uri, folder.uri, isWindows())) {
+                const pathFunctions = pathFunctionsForURI(folder.uri)
+                const workspacePrefix = folder.uri.path.endsWith('/')
+                    ? folder.uri.path.slice(0, -1)
+                    : folder.uri.path
+                const workspaceDisplayPrefix = includeWorkspaceFolder
+                    ? pathFunctions.basename(folder.uri.path) + pathFunctions.separator
+                    : ''
+                relativePath = fixPathSep(
+                    workspaceDisplayPrefix + uri.path.slice(workspacePrefix.length + 1),
+                    isWindows(),
+                    uri.scheme
+                )
+            }
+        }
+
+        if (!relativePath) {
+            // Return the input when the file is not part of a workspace or the workspace is empty
+            relativePath = pathOrUri.toString()
+        }
+
         if (isTesting) {
             // We insert relative paths in a lot of places like prompts that influence HTTP requests.
             // When testing, we try to normalize the file paths across Windows/Linux/macOS.
             return relativePath.replaceAll('\\', '/')
         }
+
         return relativePath
     },
     // TODO: used for Cody Context Filters, WorkspaceRepoMapper and custom commands

--- a/agent/vitest.config.ts
+++ b/agent/vitest.config.ts
@@ -22,4 +22,9 @@ export default defineProjectWithDefaults(__dirname, {
     resolve: {
         alias: { vscode: shimDirectory() },
     },
+    test: {
+        env: {
+            CODY_SHIM_TESTING: 'true',
+        },
+    }
 })

--- a/agent/vitest.config.ts
+++ b/agent/vitest.config.ts
@@ -26,5 +26,5 @@ export default defineProjectWithDefaults(__dirname, {
         env: {
             CODY_SHIM_TESTING: 'true',
         },
-    }
+    },
 })

--- a/lib/shared/src/editor/displayPath.ts
+++ b/lib/shared/src/editor/displayPath.ts
@@ -149,7 +149,7 @@ function _displayPath(
  * Fixes the path separators for Windows paths. This makes it possible to write cross-platform
  * tests.
  */
-function fixPathSep(fsPath: string, isWindows: boolean, scheme: string): string {
+export function fixPathSep(fsPath: string, isWindows: boolean, scheme: string): string {
     return isWindows && scheme === 'file' ? fsPath.replaceAll('/', '\\') : fsPath
 }
 

--- a/lib/shared/src/index.ts
+++ b/lib/shared/src/index.ts
@@ -180,6 +180,7 @@ export {
     displayPathDirname,
     displayPathWithoutWorkspaceFolderPrefix,
     setDisplayPathEnvInfo,
+    fixPathSep,
     type DisplayPathEnvInfo,
 } from './editor/displayPath'
 export { forceHydration, hydrateAfterPostMessage } from './editor/hydrateAfterPostMessage'

--- a/lib/shared/vitest.config.ts
+++ b/lib/shared/vitest.config.ts
@@ -4,5 +4,8 @@ export default defineProjectWithDefaults(__dirname, {
     test: {
         environment: 'jsdom', // needed for DOMPurify
         setupFiles: ['src/test/testSetup.ts'],
+        env: {
+            CODY_SHIM_TESTING: 'true',
+        },
     },
 })

--- a/lib/shared/vitest.config.ts
+++ b/lib/shared/vitest.config.ts
@@ -4,8 +4,5 @@ export default defineProjectWithDefaults(__dirname, {
     test: {
         environment: 'jsdom', // needed for DOMPurify
         setupFiles: ['src/test/testSetup.ts'],
-        env: {
-            CODY_SHIM_TESTING: 'true',
-        },
     },
 })

--- a/vscode/src/chat/chat-view/handlers/SearchHandler.ts
+++ b/vscode/src/chat/chat-view/handlers/SearchHandler.ts
@@ -130,19 +130,19 @@ async function getSearchScopesFromMentions(mentions: ContextItem[]): Promise<str
             const repoName =
                 (mention as ContextItemFile).remoteRepositoryName ||
                 (await getFirstRepoNameContainingUri(mention.uri))
-
-            const workspace = vscode.workspace.getWorkspaceFolder(mention.uri)
-            if (!repoName || !workspace) {
+            if (!repoName) {
                 return
             }
 
-            const filePath = escapeRegExp(mention.uri.toString().split(`${workspace.name}/`)[1] || '')
-
-            if (!filePath || !repoName) {
+            const filePath = vscode.workspace.asRelativePath(mention.uri, false)
+            // asRelativePath returns the input as is if no workspace folder is open
+            // Since we need to get the relative path of the file relative to workspace
+            // we'll bail if that's the case.
+            if (filePath.toString() === mention.uri.toString()) {
                 return
             }
 
-            return scopes.push(`(file:^${filePath}$ repo:^${repoName}$)`)
+            return scopes.push(`(file:^${escapeRegExp(filePath)}$ repo:^${repoName}$)`)
         })
     )
 

--- a/vscode/src/repository/remoteRepos.ts
+++ b/vscode/src/repository/remoteRepos.ts
@@ -48,7 +48,10 @@ export const remoteReposForAllWorkspaceFolders: Observable<
 ).pipe(
     switchMapReplayOperation(
         ([workspaceFolders]): Observable<RemoteRepo[] | typeof pendingOperation> => {
-            if (!workspaceFolders) {
+            // combineLatest won't complete/emit if the argument is an empty list.
+            // In order to ensure that functions like firstValueFrom work correctly,
+            // we have to return early here.
+            if (!workspaceFolders || workspaceFolders.length === 0) {
                 return Observable.of([])
             }
 


### PR DESCRIPTION
While trying to adapt #6947 to the changes from #6909, I noticed that workspace handling is inconsistent in the agent.
In particular:

- The agent accepts a `workspaceRootUri` upon initialization and stores it on `AgentWorkspaceDocuments`. This value
  eventually ends up in `workspaceFolders`.
- We support `workspaceFolder/didChange`, which updates `workspaceFolders` but doesn't affect `workspaceRootUri` in
  any way.
- `getWorkspaceFolder` and `asRelativePath` ignore `workspaces` and work directly with `workspaceRootUri`

So it seems that any client that wants to use `workspaceFolder/didChange` will eventually end up with an inconsistent state.

This PR aims to fix that. It removes `workspaceRootUri` and updates all places that used it to work with `workspaceFolders` instead. 
`asAbsolutePath` was updated to use the extension URI instead, which seems more in line with what the purpose of that method is (though it doesn't seem like we use it anywhere).
`workspaceFolders` is still initialized from the client info, directly instead of going through `workspaceDocuments`.

## Test plan

I've tested this manually in the context of #6947 and https://github.com/sourcegraph/sourcegraph/pull/3333. The following secanarios work as expected:

- On the chat page, remote repo mentions work (i.e. they appear in the mentions menu). No workspace is set.
- When opening the cody sidebar on a repo page, the workspace is updated (deduced by seeing the `Current repository` at-mentions entry point to the current repository, as well the default file filtering logic only suggest files from the current repository)
- With the cody sidebar open, navigate directory to a different repository via fuzzy finder. As above, the menu entry and the
  file search correctly resolve to the new repository.
  

> [!NOTE]
> What I've not been able to successfully test is the `Rules` provider. But I suspect that there might be unrelated issues
with it, because the network requests it made in the web demo resulted in [428](https://www.rfc-editor.org/rfc/rfc6585#section-3) errors, saying that the `X-Requested-Width` header was missing.
