### PR TITLE
fix(chat): remove current selection from initial mention

### DIFF
--- a/vscode/src/chat/initialContext.ts
+++ b/vscode/src/chat/initialContext.ts
@@ -152,7 +152,7 @@ function getCurrentFileOrSelection({
                     if (range) {
                         items.push({
                             ...contextFile,
-                            type: 'file',
+                            type: 'current-selection',
                             title: 'Current Selection',
                             description: `${displayPathBasename(contextFile.uri)}:${displayLineRange(
                                 range

--- a/vscode/src/chat/initialContext.ts
+++ b/vscode/src/chat/initialContext.ts
@@ -12,8 +12,10 @@ import {
     combineLatest,
     contextFiltersProvider,
     debounceTime,
+    displayLineRange,
     displayPathBasename,
     distinctUntilChanged,
+    expandToLineRange,
     featureFlagProvider,
     fromVSCodeEvent,
     isDotCom,
@@ -144,6 +146,28 @@ function getCurrentFileOrSelection({
                         source: ContextItemSource.Initial,
                         icon: 'file',
                     })
+
+                    const range = contextFile.range ? expandToLineRange(contextFile.range) : undefined
+                    // Add the current selection item if there's a range
+                    if (range) {
+                        items.push({
+                            ...contextFile,
+                            type: 'file',
+                            title: 'Current Selection',
+                            description: `${displayPathBasename(contextFile.uri)}:${displayLineRange(
+                                range
+                            )}`,
+                            range,
+                            isTooLarge:
+                                userContextSize !== undefined &&
+                                contextFile.size !== undefined &&
+                                contextFile.size > userContextSize,
+                            // NOTE: Do not set source to initial, this is used for
+                            // picking the correct prompt template for selection during prompt building.
+                            source: ContextItemSource.Selection,
+                            icon: 'list-selection',
+                        })
+                    }
                 }
                 return Observable.of(items)
             }

--- a/vscode/webviews/chat/cells/messageCell/human/editor/HumanMessageEditor.tsx
+++ b/vscode/webviews/chat/cells/messageCell/human/editor/HumanMessageEditor.tsx
@@ -387,17 +387,20 @@ export const HumanMessageEditor: FunctionComponent<{
 
     const defaultContext = useDefaultContextForChat()
     useEffect(() => {
-        let { initialContext } = defaultContext
+        // Don't show the initial codebase context if the model doesn't support streaming
+        // as including context result in longer processing time.
+        if(!currentChatModel?.tags?.includes(ModelTag.StreamDisabled)) {
+            return
+        }
+        // List of mention chips added to the first message.
         if (!isSent && isFirstMessage) {
             const editor = editorRef.current
             if (editor) {
-                // Don't show the initial codebase context if the model doesn't support streaming
-                // as including context result in longer processing time.
-                if (currentChatModel?.tags?.includes(ModelTag.StreamDisabled)) {
-                    initialContext = initialContext.filter(item => item.type !== 'tree')
-                }
+                let { initialContext } = defaultContext
                 // Remove documentation open-link items; they do not provide context.
-                const filteredItems = initialContext.filter(item => item.type !== 'open-link')
+                // Remove current selection to avoid crowding the input box. User can always add it back.
+                const removedInitialContextType = ['open-link', 'current-selection']
+                const filteredItems = initialContext.filter(item => !removedInitialContextType.includes(item.type))
                 void editor.setInitialContextMentions(filteredItems)
             }
         }

--- a/vscode/webviews/chat/cells/messageCell/human/editor/HumanMessageEditor.tsx
+++ b/vscode/webviews/chat/cells/messageCell/human/editor/HumanMessageEditor.tsx
@@ -387,12 +387,11 @@ export const HumanMessageEditor: FunctionComponent<{
 
     const defaultContext = useDefaultContextForChat()
     useEffect(() => {
-        if (isSent || !isFirstMessage || !editorRef.current) {
+        if (isSent || !isFirstMessage || !editorRef?.current) {
             return
         }
 
         // List of mention chips added to the first message.
-        const { initialContext } = defaultContext
         const editor = editorRef.current
 
         // Remove documentation open-link items; they do not provide context.
@@ -404,9 +403,11 @@ export const HumanMessageEditor: FunctionComponent<{
             ...(currentChatModel?.tags?.includes(ModelTag.StreamDisabled) ? ['tree'] : []),
         ])
 
-        const filteredItems = initialContext.filter(item => !excludedTypes.has(item.type))
+        const filteredItems = defaultContext?.initialContext.filter(
+            item => !excludedTypes.has(item.type)
+        )
         void editor.setInitialContextMentions(filteredItems)
-    }, [defaultContext, isSent, isFirstMessage, currentChatModel])
+    }, [defaultContext?.initialContext, isSent, isFirstMessage, currentChatModel])
 
     const focusEditor = useCallback(() => editorRef.current?.setFocus(true), [])
 


### PR DESCRIPTION
This commit fixes a regression from https://github.com/sourcegraph/cody/pull/7115, which aims to remove the current selection from being added as part of initial mentions chips in first message, but removed the option completely by mistake.

-   Adding the current text selection as a context item provided to the chat webview, but removes it from the initial at-mention context chips

## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

1. Core Functionality Tests:
- [ ] Select code in the editor and start a new chat
  - Expected: Selection should NOT appear in initial @-mention chips
  - Expected: Selection should be available as context in chat webview
- [ ] Verify selection content is properly passed to backend
  - Expected: Selection data exists in context payload

2. Regression Prevention:
- [ ] Start chat without any selection
  - Expected: Chat should initialize normally
  - Expected: @-mention chips should work as normal

3. Edge Cases:
- [ ] Test with large selections (>1000 characters)
- [ ] Test with multi-line code selections
- [ ] Test selections containing special characters/unicode
- [ ] Test with selections across different file types

4. Integration Testing:
- [ ] Verify selection context works with other context sources
- [ ] Check selection persistence across chat sessions
- [ ] Verify selection can be referenced in follow-up messages

5. UI Verification:
- [ ] Verify chat UI displays context correctly
- [ ] Check @-mention chips visual appearance
- [ ] Verify selection context is accessible but not in initial chips
