### PR TITLE
feat(commit message): commit message out of experimental stage

### DIFF
--- a/lib/shared/src/configuration.ts
+++ b/lib/shared/src/configuration.ts
@@ -130,7 +130,6 @@ interface RawClientConfiguration {
     experimentalAutoEditRendererTesting: boolean
     experimentalAutoEditConfigOverride: AutoEditsModelConfig | undefined
     experimentalAutoEditEnabled: boolean
-    experimentalCommitMessage: boolean
     experimentalNoodle: boolean
     experimentalMinionAnthropicKey: string | undefined
     experimentalNoxideEnabled: boolean

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -339,7 +339,7 @@
         "group": "Commit",
         "title": "Generate Commit Message (Experimental)",
         "icon": "$(cody-logo)",
-        "when": "cody.activated && config.cody.experimental.commitMessage && config.git.enabled && !cody.isGeneratingCommit"
+        "when": "cody.activated && config.git.enabled && !cody.isGeneratingCommit"
       },
       {
         "command": "cody.command.abort-commit",
@@ -747,7 +747,7 @@
         },
         {
           "command": "cody.command.generate-commit",
-          "when": "cody.activated && config.cody.experimental.commitMessage && config.git.enabled && !cody.isGeneratingCommit"
+          "when": "cody.activated && config.git.enabled && !cody.isGeneratingCommit"
         },
         {
           "command": "cody.command.abort-commit",
@@ -897,7 +897,7 @@
       "scm/title": [
         {
           "command": "cody.command.generate-commit",
-          "when": "cody.activated && config.cody.experimental.commitMessage && config.git.enabled && scmProvider == git && !cody.isGeneratingCommit",
+          "when": "cody.activated && config.git.enabled && scmProvider == git && !cody.isGeneratingCommit",
           "group": "navigation@1"
         },
         {
@@ -1026,12 +1026,6 @@
           "order": 99,
           "type": "boolean",
           "markdownDescription": "Enable OpenTelemetry tracing",
-          "default": false
-        },
-        "cody.experimental.commitMessage": {
-          "order": 99,
-          "type": "boolean",
-          "markdownDescription": "Enable commit message generation",
           "default": false
         },
         "cody.experimental.minion.anthropicKey": {

--- a/vscode/src/commands/index.ts
+++ b/vscode/src/commands/index.ts
@@ -77,7 +77,6 @@ export const CodyCommandMenuItems: MenuCommandAccessor[] = [
         icon: 'git-commit',
         command: { command: 'cody.command.generate-commit' },
         keybinding: '',
-        requires: { setting: 'cody.experimental.commitMessage' },
     },
     {
         key: 'custom',

--- a/vscode/src/configuration.test.ts
+++ b/vscode/src/configuration.test.ts
@@ -45,8 +45,6 @@ describe('getConfiguration', () => {
                         return true
                     case 'cody.experimental.tracing':
                         return true
-                    case 'cody.experimental.commitMessage':
-                        return true
                     case 'cody.debug.verbose':
                         return true
                     case 'cody.debug.filter':
@@ -177,7 +175,6 @@ describe('getConfiguration', () => {
             experimentalAutoEditRendererTesting: false,
             experimentalMinionAnthropicKey: undefined,
             experimentalTracing: true,
-            experimentalCommitMessage: true,
             experimentalNoodle: false,
             experimentalNoxideEnabled: true,
             codeActions: true,

--- a/vscode/src/configuration.ts
+++ b/vscode/src/configuration.ts
@@ -146,7 +146,6 @@ export function getConfiguration(
         autocompleteExperimentalGraphContext: getHiddenSetting<
             ClientConfiguration['autocompleteExperimentalGraphContext']
         >('autocomplete.experimental.graphContext', null),
-        experimentalCommitMessage: getHiddenSetting('experimental.commitMessage', true),
         experimentalNoodle: getHiddenSetting('experimental.noodle', false),
 
         experimentalTracing: getHiddenSetting('experimental.tracing', false),

--- a/vscode/src/testutils/mocks.ts
+++ b/vscode/src/testutils/mocks.ts
@@ -920,7 +920,6 @@ export const DEFAULT_VSCODE_SETTINGS = {
     experimentalAutoEditConfigOverride: undefined,
     experimentalMinionAnthropicKey: undefined,
     experimentalTracing: false,
-    experimentalCommitMessage: true,
     experimentalNoodle: false,
     experimentalNoxideEnabled: true,
     codeActions: true,

--- a/vscode/test/e2e/command-commit.test.ts
+++ b/vscode/test/e2e/command-commit.test.ts
@@ -19,7 +19,6 @@ test.beforeEach(() => {
 testGitWorkspace.extend<ExtraWorkspaceSettings>({
     extraWorkspaceSettings: {
         'cody.internal.unstable': true, // Needed for Cody Ignore
-        'cody.experimental.commitMessage': true,
     },
 })('use terminal output as context', async ({ page, sidebar }) => {
     await sidebarSignin(page, sidebar)


### PR DESCRIPTION
CLOSE https://linear.app/sourcegraph/issue/CODY-5048

This commit removes the `experimentalCommitMessage` feature flag and related code. This feature is no longer experimental and is now enabled by default.

The following changes were made:

- Removed the `experimentalCommitMessage` flag from `lib/shared/src/configuration.ts`, `vscode/src/commands/index.ts`, `vscode/src/testutils/mocks.ts`, `vscode/src/configuration.ts`, `vscode/test/e2e/command-commit.test.ts`, `vscode/src/configuration.test.ts`, and `vscode/package.json`.
- Updated the `when` clause for the "Generate Commit Message" command in `vscode/package.json` to remove the check for the `experimentalCommitMessage` setting.


## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

Everything should work as it currently is, including the e2e test.
