### PR TITLE
Fix API incompatibility issue in IJ 2025

### DIFF
--- a/jetbrains/src/intellij2023/kotlin/com/sourcegraph/cody/autocomplete/CodyInlineCompletionProvider.kt
+++ b/jetbrains/src/intellij2023/kotlin/com/sourcegraph/cody/autocomplete/CodyInlineCompletionProvider.kt
@@ -4,6 +4,7 @@ import com.intellij.codeInsight.inline.completion.*
 import com.intellij.codeInsight.inline.completion.elements.InlineCompletionGrayTextElement
 import com.intellij.codeInsight.inline.completion.suggestion.InlineCompletionSingleSuggestion
 import com.intellij.codeInsight.inline.completion.suggestion.InlineCompletionSuggestion
+import com.intellij.codeWithMe.ClientId
 import com.intellij.openapi.application.ApplicationInfo
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.application.ReadAction
@@ -148,7 +149,7 @@ class CodyInlineCompletionProvider : InlineCompletionProvider {
 
   private fun isEnabled(): Boolean {
     val ideVersion = ApplicationInfo.getInstance().build.baselineVersion
-    val isRemoteDev = ClientSessionsManager.getAppSession()?.isRemote ?: false
+    val isRemoteDev = ClientSessionsManager.getAppSession(ClientId.current)?.isRemote ?: false
     return ideVersion >= 233 &&
         isRemoteDev &&
         ConfigUtil.isCodyEnabled() &&

--- a/jetbrains/src/intellij2024/kotlin/com/sourcegraph/cody/autocomplete/CodyInlineCompletionProvider.kt
+++ b/jetbrains/src/intellij2024/kotlin/com/sourcegraph/cody/autocomplete/CodyInlineCompletionProvider.kt
@@ -4,6 +4,7 @@ import com.intellij.codeInsight.inline.completion.*
 import com.intellij.codeInsight.inline.completion.elements.InlineCompletionGrayTextElement
 import com.intellij.codeInsight.inline.completion.suggestion.InlineCompletionSingleSuggestion
 import com.intellij.codeInsight.inline.completion.suggestion.InlineCompletionSuggestion
+import com.intellij.codeWithMe.ClientId
 import com.intellij.openapi.application.ApplicationInfo
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.application.ReadAction
@@ -139,7 +140,7 @@ class CodyInlineCompletionProvider : InlineCompletionProvider {
 
   private fun isEnabled(): Boolean {
     val ideVersion = ApplicationInfo.getInstance().build.baselineVersion
-    val isRemoteDev = ClientSessionsManager.getAppSession()?.isRemote ?: false
+    val isRemoteDev = ClientSessionsManager.getAppSession(ClientId.current)?.isRemote ?: false
     return ideVersion >= 233 &&
         isRemoteDev &&
         ConfigUtil.isCodyEnabled() &&


### PR DESCRIPTION
Fixes 
https://linear.app/sourcegraph/issue/BUGS-1365
https://linear.app/sourcegraph/issue/BUGS-1241
https://linear.app/sourcegraph/issue/BUGS-1214
https://linear.app/sourcegraph/issue/BUGS-1240

## Changes

Signatures of function `getAppSession`:
[IJ 2023.2](https://github.com/JetBrains/intellij-community/blob/idea/232.10203.10/platform/platform-impl/src/com/intellij/openapi/client/ClientSessionsManager.kt#L54): `fun getAppSession(clientId: ClientId = ClientId.current): ClientAppSession?`
[IJ 2025.1](https://github.com/JetBrains/intellij-community/blob/idea/251.18673.35/platform/core-api/src/com/intellij/openapi/client/ClientSessionsManager.kt#L33): `fun getAppSession(clientId: ClientId): ClientAppSession?`

So to fix it it was enough to add an default parameter explicitly.

## Test plan

**IJ 2023.2:**
1. Run IJ 2023.2 either using pre-installed IntelliJ 2023 or by using command: `./gradlew :customRunIDE -PplatformRuntimeVersion=2023.2  -PforceAgentBuild=true`
2. Trigger autocomplete and verify it succeeded

**IJ 2025.1:**
1. Run IJ 2025.1 either using pre-installed IntelliJ 2023 or by using command: `./gradlew :customRunIDE -PplatformRuntimeVersion=251.18673.35  -PforceAgentBuild=true`
2. Trigger autocomplete and verify it succeeded

**IJ 2025.1, split mode:**
1. Run IJ 2025.1 either using pre-installed IntelliJ 2023 or by using command: `./gradlew :customRunIDE -PplatformRuntimeVersion=251.18673.35  -PforceAgentBuild=true -PsplitMode=true`
2. Trigger autocomplete and verify it succeeded
