### PR TITLE
NLS eval: add fork:yes archived:yes to query

### DIFF
--- a/agent/src/cli/command-bench/strategy-chat-nls.ts
+++ b/agent/src/cli/command-bench/strategy-chat-nls.ts
@@ -76,7 +76,7 @@ async function runNLSSearch(examples: Example[]): Promise<ExampleOutput[]> {
         const repoNames = targetRepoRevs.map(repoRev => repoRev.repoName)
         const repoFilter = 'repo:' + repoNames.join('|')
 
-        const fullQuery = `${repoFilter} content:"${escapeNLSQuery(query)}"`
+        const fullQuery = `${repoFilter} fork:yes archived: yes content:"${escapeNLSQuery(query)}"`
         const resultsResp = await graphqlClient.nlsSearchQuery({
             query: fullQuery,
         })


### PR DESCRIPTION
In NLS evals, we weren't getting any results from repos that were directly forked, e.g. https://github.com/sourcegraph-testing/pinned-elasticsearch

## Test plan
Search eval now shows results from forks or archived repos.
