### PR TITLE
fix: Mentions menu placement/behavior in prompt input v2

### DIFF
--- a/lib/prompt-editor/src/v2/MentionsMenu.module.css
+++ b/lib/prompt-editor/src/v2/MentionsMenu.module.css
@@ -3,9 +3,11 @@
 }
 
 .menu {
-    border: 1px solid #EFF2F5;
+    background: var(--vscode-sideBar-background);
+    color: var(--vscode-sideBar-foreground);
+    box-shadow: 0 0 8px 2px var(--vscode-widget-shadow);
+    border: 1px solid var(--vscode-dropdown-border);
     border-radius: 0.25rem;
-    box-shadow: 0px 20px 25px -5px var(--color-shadow-10, rgba(15, 17, 26, 0.10)), 0px 8px 10px -6px var(--color-shadow-10, rgba(15, 17, 26, 0.10));
     max-height: 300px;
     z-index: 1;
 }

--- a/lib/prompt-editor/src/v2/promptInput.ts
+++ b/lib/prompt-editor/src/v2/promptInput.ts
@@ -776,7 +776,9 @@ export const promptInput = setup({
                 'mentionsMenu.provider.set': {
                     actions: {
                         type: 'assignMentionsMenu',
-                        params: ({ event }) => ({ parent: event.provider }),
+                        // Reset items to an empty list so that we do not show previous/old items when a new provider
+                        // is selected.
+                        params: ({ event }) => ({ parent: event.provider, items: [] }),
                     },
                     target: '.loading',
                 },


### PR DESCRIPTION
This PR makes the following changes:

- Add ability for popover to flip vertically if there isn't enough space
  towards the bottom to show the menu.
- CSS tweaks for color and menu item size
- Prevent flickering of menu while the user is typing

Closes https://linear.app/sourcegraph/issue/SRCH-1691/expand-menu-other-directions-when-it-doesnt-fit-expanded-down

## Test plan

Manual testing
