### PR TITLE
fix: Make @-button work in prompt editor v2

### DIFF
--- a/lib/prompt-editor/src/v2/MentionsMenu.module.css
+++ b/lib/prompt-editor/src/v2/MentionsMenu.module.css
@@ -3,9 +3,11 @@
 }
 
 .menu {
-    border: 1px solid #EFF2F5;
+    background: var(--vscode-sideBar-background);
+    color: var(--vscode-sideBar-foreground);
+    box-shadow: 0 0 8px 2px var(--vscode-widget-shadow);
+    border: 1px solid var(--vscode-dropdown-border);
     border-radius: 0.25rem;
-    box-shadow: 0px 20px 25px -5px var(--color-shadow-10, rgba(15, 17, 26, 0.10)), 0px 8px 10px -6px var(--color-shadow-10, rgba(15, 17, 26, 0.10));
     max-height: 300px;
     z-index: 1;
 }

--- a/lib/prompt-editor/src/v2/PromptEditor.tsx
+++ b/lib/prompt-editor/src/v2/PromptEditor.tsx
@@ -81,6 +81,11 @@ interface PromptEditorRefAPI {
     filterMentions(filter: (item: SerializedContextItem) => boolean): Promise<void>
     setInitialContextMentions(items: ContextItem[]): Promise<void>
     setEditorState(state: SerializedPromptEditorState): void
+
+    /**
+     * Triggers opening the at-mention menu at the end of the current input value.
+     */
+    openAtMentionMenu(): Promise<void>
 }
 
 const SUGGESTION_LIST_LENGTH_LIMIT = 20
@@ -213,6 +218,10 @@ export const PromptEditor: FunctionComponent<Props> = ({
             },
             async setInitialContextMentions(items: ContextItem[]): Promise<void> {
                 api.setInitialContextMentions(items)
+            },
+            async openAtMentionMenu() {
+                api.openAtMentionMenu()
+                api.setFocus(true)
             },
         }),
         [api]

--- a/lib/prompt-editor/src/v2/plugins/atMention.ts
+++ b/lib/prompt-editor/src/v2/plugins/atMention.ts
@@ -4,6 +4,8 @@ import { type EditorState, Plugin, PluginKey, TextSelection, type Transaction } 
 import { Decoration, DecorationSet } from 'prosemirror-view'
 import styles from './atMention.module.css'
 
+export const AT_MENTION_TRIGGER_CHARACTER = '@'
+
 export interface Position {
     top: number
     bottom: number
@@ -28,7 +30,7 @@ const atMentionPluginKey = new PluginKey<AtMentionPluginState>('suggestions')
  * Creates a new at-mention plugin. The plugin tracks the presence of '@...' slices in the editor.
  * When an '@' character is typed, the plugin will activate and track the filter text.
  *
- * Note that this behavior has to be triggered explictly, i.e. not every '@' character that happens
+ * Note that this behavior has to be triggered explicitly, i.e. not every '@' character that happens
  * to be present in the value is an at-mention.
  *
  * @return An array of ProseMirror plugins
@@ -127,7 +129,7 @@ export function createAtMentionPlugin(): Plugin[] {
             rules: [
                 new InputRule(
                     // Trigger on @, at beginning or after space
-                    /(^|\s)@$/,
+                    new RegExp(`(^|\\s)${AT_MENTION_TRIGGER_CHARACTER}$`),
                     (state, match, start, end) => {
                         return enableAtMention(state.tr.insertText(match[0], start, end))
                     }
@@ -199,9 +201,8 @@ export function hasAtMentionChanged(nextState: EditorState, prevState: EditorSta
 }
 
 /**
- * Enables at-mention for the current cursor position.
- *
- * NOTE: This is only exported for testing purposes.
+ * Enables at-mention for the current cursor position. This function can be used to trigger
+ * at-mentions programmatically.
  *
  * @param tr An editor transaction
  * @returns The updated transaction
@@ -249,7 +250,7 @@ export function setAtMentionValue(state: EditorState, value: string): Transactio
         // Special case that requires a deletion operation
         return state.tr.delete(decoration.from + 1, decoration.to)
     }
-    if (value.startsWith('@')) {
+    if (value.startsWith(AT_MENTION_TRIGGER_CHARACTER)) {
         value = value.slice(1)
     }
     return state.tr.replaceWith(decoration.from + 1, decoration.to, state.schema.text(value))

--- a/lib/prompt-editor/src/v2/promptInput-react.ts
+++ b/lib/prompt-editor/src/v2/promptInput-react.ts
@@ -21,7 +21,7 @@ import {
     setDocument,
     upsertMentions,
 } from './actions'
-import type { Position } from './plugins/atMention'
+import { AT_MENTION_TRIGGER_CHARACTER, type Position, enableAtMention } from './plugins/atMention'
 import { type DataLoaderInput, type MenuItem, promptInput, schema } from './promptInput'
 
 type PromptInputLogic = typeof promptInput
@@ -73,6 +73,7 @@ interface PromptEditorOptions {
 interface PromptEditorAPI {
     setFocus(focus: boolean, options?: { moveCursorToEnd?: boolean }): void
     appendText(text: string): void
+    openAtMentionMenu(): void
     addMentions(items: ContextItem[], position?: 'before' | 'after', sep?: string): void
     upsertMentions(
         items: ContextItem[],
@@ -192,6 +193,13 @@ export const usePromptInput = (options: PromptEditorOptions): [PromptInputActor,
                 editor.send({
                     type: 'document.update',
                     transaction: state => appendToDocument(state, text),
+                })
+            },
+            openAtMentionMenu() {
+                editor.send({
+                    type: 'document.update',
+                    transaction: state =>
+                        enableAtMention(appendToDocument(state, AT_MENTION_TRIGGER_CHARACTER)),
                 })
             },
             addMentions(items: ContextItem[], position: 'before' | 'after' = 'after', seperator = ' ') {

--- a/lib/prompt-editor/src/v2/promptInput.test.ts
+++ b/lib/prompt-editor/src/v2/promptInput.test.ts
@@ -19,7 +19,7 @@ import {
     setDocument,
     upsertMentions,
 } from './actions'
-import { enableAtMention, hasAtMention } from './plugins/atMention'
+import { AT_MENTION_TRIGGER_CHARACTER, enableAtMention, hasAtMention } from './plugins/atMention'
 import {
     type DataLoaderInput,
     type MenuItem,
@@ -111,7 +111,7 @@ function getText(editor: PromptInputActor): string {
 function createAtMention(editor: PromptInputActor): { type: (value: string) => void } {
     editor.send({
         type: 'dispatch',
-        transaction: enableAtMention(getEditorState(editor).tr.insertText('@')),
+        transaction: enableAtMention(getEditorState(editor).tr.insertText(AT_MENTION_TRIGGER_CHARACTER)),
     })
 
     let previousState = getEditorState(editor)

--- a/lib/prompt-editor/src/v2/promptInput.ts
+++ b/lib/prompt-editor/src/v2/promptInput.ts
@@ -776,7 +776,9 @@ export const promptInput = setup({
                 'mentionsMenu.provider.set': {
                     actions: {
                         type: 'assignMentionsMenu',
-                        params: ({ event }) => ({ parent: event.provider }),
+                        // Reset items to an empty list so that we do not show previous/old items when a new provider
+                        // is selected.
+                        params: ({ event }) => ({ parent: event.provider, items: [] }),
                     },
                     target: '.loading',
                 },

--- a/vscode/webviews/chat/cells/messageCell/human/editor/HumanMessageEditor.tsx
+++ b/vscode/webviews/chat/cells/messageCell/human/editor/HumanMessageEditor.tsx
@@ -247,28 +247,22 @@ export const HumanMessageEditor: FunctionComponent<{
     )
 
     const onMentionClick = useCallback((): void => {
-        if (!editorRef.current) {
-            throw new Error('No editorRef')
+        if (editorRef.current) {
+            editorRef.current.openAtMentionMenu()
+            const value = editorRef.current.getSerializedValue()
+            telemetryRecorder.recordEvent('cody.humanMessageEditor.toolbar.mention', 'click', {
+                metadata: {
+                    isFirstMessage: isFirstMessage ? 1 : 0,
+                    isEdit: isSent ? 1 : 0,
+                    messageLength: value.text.length,
+                    contextItems: value.contextItems.length,
+                },
+                billingMetadata: {
+                    product: 'cody',
+                    category: 'billable',
+                },
+            })
         }
-        if (editorRef.current.getSerializedValue().text.trim().endsWith('@')) {
-            editorRef.current.setFocus(true, { moveCursorToEnd: true })
-        } else {
-            editorRef.current.appendText('@')
-        }
-
-        const value = editorRef.current.getSerializedValue()
-        telemetryRecorder.recordEvent('cody.humanMessageEditor.toolbar.mention', 'click', {
-            metadata: {
-                isFirstMessage: isFirstMessage ? 1 : 0,
-                isEdit: isSent ? 1 : 0,
-                messageLength: value.text.length,
-                contextItems: value.contextItems.length,
-            },
-            billingMetadata: {
-                product: 'cody',
-                category: 'billable',
-            },
-        })
     }, [telemetryRecorder.recordEvent, isFirstMessage, isSent])
 
     const extensionAPI = useExtensionAPI()


### PR DESCRIPTION
This PR makes the @-button in the editor toolbar work with the new prompt input.

To do this I added a new method to the editor API, `openAtMentionMenu`, instead of just appending `@`.

Note that unlike the current input we don't have to check whether there is already an `@` at the end of the input
because clicking the button will already 'deactivate' any at-mention that is currently present and we cannot 'reuse'
at-mentions.

Closes https://linear.app/sourcegraph/issue/SRCH-1692/prosemirror-clicking-the-button-doesnt-show-the-mentions-menu

## Test plan

Manual testing. Clicking the @-button with the new input enabled inserts an at-mention and focuses the editor.
The existing input continues to work as expected.
