### PR TITLE
fix/smart-apply: add insert events in the smart apply logging payload

### DIFF
--- a/vscode/src/edit/manager.ts
+++ b/vscode/src/edit/manager.ts
@@ -467,7 +467,16 @@ export class EditManager implements vscode.Disposable {
                     })
 
                     const provider = this.getProviderForTask(task)
+
+                    const applyStartTime = Date.now()
                     await provider.applyEdit('\n' + configuration.replacement)
+                    const applyTimeTakenMs = Date.now() - applyStartTime
+                    this.smartApplyContextLogger.addApplyContext(
+                        contextloggerRequestId,
+                        applyTimeTakenMs,
+                        task?.id
+                    )
+                    this.smartApplyContextLogger.logSmartApplyContextToTelemetry(contextloggerRequestId)
                     return task
                 }
 


### PR DESCRIPTION
Currently `insert` events are missing in the smart apply logging because they return early, the PR adds them in the current logging pipeline

## Test plan
- Open a empty file and ask the chat to make some changes
- Click on the smart apply event
- Observe the telemetry in the `Cody by Sourcegraph` output channel
```
█ telemetry-v2 recordEvent: cody.smart-apply.context/applied: {
    // ... metadata ....
    "privateMetadata": {
      "smartApplyContext": {
        "smartApplyModel": "anthropic::2024-10-22::claude-3-5-haiku-latest",
        "userQuery": "Similar to fireworks.ts add the anthropic provide in the file anthropic.ts ",
        "replacementCodeBlock": "import from '../ [...other chars] }\n}",
        "filePath": "src/autoedits/adapters/anthropic.ts",
        "fileContent": "",
        "selectionType": "insert",
        "selectionRange": [
          0,
          0
        ],
        "applyTaskId": "57b470f50a63a8af761abb9c5ed73c4806c78d473e5526067ea92f4d1fc22a4e"
      }
    },
  },
}
```
