### PR TITLE
refactor(telemetry): opt-out option

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -1056,7 +1056,7 @@
             "Sends usage data and errors.",
             "[Enterprise-only] Disables all extension telemetry."
           ],
-          "markdownDescription": "Controls the telemetry about Cody usage and errors for users connected to Enterprise instances. This setting only takes effect for Sourcegraph Enterprise users. For users connected to sourcegraph.com, telemetry is always enabled and cannot be configured due to the need to measure usage and consumption. See [Cody usage and privacy notice](https://about.sourcegraph.com/terms/cody-notice).",
+          "markdownDescription": "Controls the telemetry about Cody usage and errors for users connected to Enterprise instances. This setting only takes effect for Sourcegraph Enterprise users. For users connected to sourcegraph.com, this option is always enabled. See [Cody usage and privacy notice](https://about.sourcegraph.com/terms/cody-notice).",
           "default": "all"
         },
         "cody.autocomplete.advanced.provider": {

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -1052,8 +1052,11 @@
           "order": 99,
           "type": "string",
           "enum": ["all", "off"],
-          "enumDescriptions": ["Sends usage data and errors.", "Disables all extension telemetry."],
-          "markdownDescription": "Controls the telemetry about Cody usage and errors. See [Cody usage and privacy notice](https://about.sourcegraph.com/terms/cody-notice).",
+          "enumDescriptions": [
+            "Sends usage data and errors.",
+            "[Enterprise-only] Disables all extension telemetry."
+          ],
+          "markdownDescription": "Controls the telemetry about Cody usage and errors for users connected to Enterprise instances. This setting only takes effect for Sourcegraph Enterprise users. For users connected to sourcegraph.com, telemetry is always enabled and cannot be configured due to the need to measure usage and consumption. See [Cody usage and privacy notice](https://about.sourcegraph.com/terms/cody-notice).",
           "default": "all"
         },
         "cody.autocomplete.advanced.provider": {

--- a/vscode/src/services/telemetry-v2.ts
+++ b/vscode/src/services/telemetry-v2.ts
@@ -37,9 +37,17 @@ export function createOrUpdateTelemetryRecorderProvider(
                 new TimestampTelemetryProcessor(),
             ])
             // Telemetry can only be disabled for Non-Sourcegraph.com instances.
-            if (configuration.telemetryLevel === 'off' && !isDotCom(auth.serverEndpoint)) {
-                updateGlobalTelemetryInstances(defaultNoOpProvider)
-                return
+            if (configuration.telemetryLevel === 'off') {
+                if (auth.serverEndpoint && !isDotCom(auth.serverEndpoint)) {
+                    updateGlobalTelemetryInstances(defaultNoOpProvider)
+                    logDebug('TelemetryRecorderProvider', 'telemetry has been disabled.', {
+                        verbose: `telemetry is disabled for ${auth.serverEndpoint}`,
+                    })
+                    return
+                }
+                logDebug('TelemetryRecorderProvider', 'Failed to disable telemetry.', {
+                    verbose: 'telemetry cannot be disabled for sourcegraph.com',
+                })
             }
 
             const initialize = telemetryRecorderProvider === undefined

--- a/vscode/src/services/telemetry-v2.ts
+++ b/vscode/src/services/telemetry-v2.ts
@@ -3,6 +3,7 @@ import {
     NoOpTelemetryRecorderProvider,
     TelemetryRecorderProvider,
     clientCapabilities,
+    isDotCom,
     resolvedConfig,
     subscriptionDisposable,
     telemetryRecorder,
@@ -35,8 +36,8 @@ export function createOrUpdateTelemetryRecorderProvider(
             const defaultNoOpProvider = new NoOpTelemetryRecorderProvider([
                 new TimestampTelemetryProcessor(),
             ])
-
-            if (configuration.telemetryLevel === 'off') {
+            // Telemetry can only be disabled for Non-Sourcegraph.com instances.
+            if (configuration.telemetryLevel === 'off' && !isDotCom(auth.serverEndpoint)) {
                 updateGlobalTelemetryInstances(defaultNoOpProvider)
                 return
             }


### PR DESCRIPTION
This commit update the ability to disable telemetry for Enterprise-users only and no longer works for PLG users to ensure we can improve the product.

-   Updated the `cody.telemetry.level` configuration to reflect that telemetry can only be disabled for Enterprise instances.
-   Updated the telemetry provider to disable telemetry if the user is NOT on sourcegraph.com and has telemetry disabled.

This change ensures that telemetry is only disabled for Enterprise users, as telemetry is always enabled for sourcegraph.com users.

## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

Makes sure the description for the telemetry level configuration shows that it is for enterprise only:

![image](https://github.com/user-attachments/assets/0f72a984-0563-4355-8c01-efb02a198df1)

Verify telemetry is not disabled even if `cody.telemetry.level` is set to off.

