### PR TITLE
refactor(chat): Render think content as Markdown

### DIFF
--- a/vscode/webviews/chat/ChatMessageContent/ChatMessageContent.tsx
+++ b/vscode/webviews/chat/ChatMessageContent/ChatMessageContent.tsx
@@ -236,7 +236,9 @@ export const ChatMessageContent: React.FunctionComponent<ChatMessageContentProps
                         </span>
                     </summary>
                     <div className="tw-px-4 tw-py-3 tw-mx-4 tw-text-sm tw-prose dark:tw-prose-invert tw-max-w-none tw-leading-relaxed tw-text-base/7 tw-text-muted-foreground">
-                        {thinkContent}
+                        <MarkdownFromCody className={clsx(styles.content, className)}>
+                            {thinkContent}
+                        </MarkdownFromCody>
                     </div>
                 </details>
             )}


### PR DESCRIPTION
CLOSE: https://linear.app/sourcegraph/issue/CODY-5137/improve-thinking-ux-for-new-sonnet-model-in-cody

This commit updates the rendering of "think" content in the chat interface to use Markdown. This improves the formatting and readability of the content.


## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

Ask Claude 3.7 Sonnet a question and confirm the thought process is rendered as markdown:

![image](https://github.com/user-attachments/assets/e64d7cfe-7da4-45e0-931f-99c4536be848)

Before

![image](https://github.com/user-attachments/assets/f779af80-53fc-4fe2-ab53-b39d7e07c4f5)

