### PR TITLE
feat(chat): UI for diff preview in chat CODY-5139

### DIFF
--- a/vscode/src/chat/chat-view/ChatController.ts
+++ b/vscode/src/chat/chat-view/ChatController.ts
@@ -749,10 +749,11 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
 
         this.postEmptyMessageInProgress(model)
 
-        const agentName = ['search', 'edit', 'insert'].includes(manuallySelectedIntent ?? '')
-            ? (manuallySelectedIntent as string)
-            : chatAgent ?? 'chat'
-        const agent = getAgent(agentName, model, {
+        // const agentName = ['search', 'edit', 'insert'].includes(manuallySelectedIntent ?? '')
+        //     ? (manuallySelectedIntent as string)
+        //     : chatAgent ?? 'chat'
+        // console.log(agentName)
+        const agent = getAgent('edit', model, {
             contextRetriever: this.contextRetriever,
             editor: this.editor,
             chatClient: this.chatClient,

--- a/vscode/src/chat/chat-view/ChatController.ts
+++ b/vscode/src/chat/chat-view/ChatController.ts
@@ -749,10 +749,10 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
 
         this.postEmptyMessageInProgress(model)
 
-        // const agentName = ['search', 'edit', 'insert'].includes(manuallySelectedIntent ?? '')
-        //     ? (manuallySelectedIntent as string)
-        //     : chatAgent ?? 'chat'
-        const agent = getAgent('edit', model, {
+        const agentName = ['search', 'edit', 'insert'].includes(manuallySelectedIntent ?? '')
+            ? (manuallySelectedIntent as string)
+            : chatAgent ?? 'chat'
+        const agent = getAgent(agentName, model, {
             contextRetriever: this.contextRetriever,
             editor: this.editor,
             chatClient: this.chatClient,

--- a/vscode/src/chat/chat-view/ChatController.ts
+++ b/vscode/src/chat/chat-view/ChatController.ts
@@ -749,10 +749,10 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
 
         this.postEmptyMessageInProgress(model)
 
-        const agentName = ['search', 'edit', 'insert'].includes(manuallySelectedIntent ?? '')
-            ? (manuallySelectedIntent as string)
-            : chatAgent ?? 'chat'
-        const agent = getAgent(agentName, model, {
+        // const agentName = ['search', 'edit', 'insert'].includes(manuallySelectedIntent ?? '')
+        //     ? (manuallySelectedIntent as string)
+        //     : chatAgent ?? 'chat'
+        const agent = getAgent('edit', model, {
             contextRetriever: this.contextRetriever,
             editor: this.editor,
             chatClient: this.chatClient,

--- a/vscode/src/chat/chat-view/ChatController.ts
+++ b/vscode/src/chat/chat-view/ChatController.ts
@@ -749,11 +749,10 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
 
         this.postEmptyMessageInProgress(model)
 
-        // const agentName = ['search', 'edit', 'insert'].includes(manuallySelectedIntent ?? '')
-        //     ? (manuallySelectedIntent as string)
-        //     : chatAgent ?? 'chat'
-        // console.log(agentName)
-        const agent = getAgent('edit', model, {
+        const agentName = ['search', 'edit', 'insert'].includes(manuallySelectedIntent ?? '')
+            ? (manuallySelectedIntent as string)
+            : chatAgent ?? 'chat'
+        const agent = getAgent(agentName, model, {
             contextRetriever: this.contextRetriever,
             editor: this.editor,
             chatClient: this.chatClient,

--- a/vscode/src/chat/chat-view/handlers/EditHandler.ts
+++ b/vscode/src/chat/chat-view/handlers/EditHandler.ts
@@ -71,27 +71,14 @@ export class EditHandler implements AgentHandler {
         }
 
         const { diff, replacement, document, originalRange } = result.task
-
-        const message = ['Here is the proposed change:\n']
-
-        const diffs =
-            diff ||
-            (replacement
-                ? [
-                      {
-                          type: 'insertion',
-                          text: replacement,
-                          range: originalRange,
-                      },
-                  ]
-                : [])
-
-        message.push(diffInChat(diffs, document, { showFullFile: false }))
+        const diffs = diff ?? [{ type: 'insertion', text: replacement ?? '', range: originalRange }]
+        const message = diffInChat(diffs, document, { showFullFile: false })
 
         delegate.postMessageInProgress({
             speaker: 'assistant',
-            text: PromptString.unsafe_fromLLMResponse(message.join('\n\n')),
+            text: PromptString.unsafe_fromLLMResponse(message),
         })
+
         delegate.postDone()
     }
 }

--- a/vscode/src/chat/diff.test.ts
+++ b/vscode/src/chat/diff.test.ts
@@ -11,11 +11,12 @@ describe('diffInChat', () => {
             // Add other required TextDocument properties as needed
         }) as vscode.TextDocument
 
+    const baseContent = `line1
+line2
+line3`
+
     test('formats single line insertion correctly', () => {
-        const content = `line1
-        line2
-        line3`
-        const document = createMockDocument(content)
+        const document = createMockDocument(baseContent)
         const diffs: Edit[] = [
             {
                 type: 'insertion',
@@ -37,10 +38,7 @@ describe('diffInChat', () => {
     })
 
     test('formats single line deletion correctly', () => {
-        const originalDoc = `line1
-        line2
-        line3`
-        const document = createMockDocument(originalDoc)
+        const document = createMockDocument(baseContent)
         const diffs: Edit[] = [
             {
                 type: 'deletion',
@@ -54,9 +52,7 @@ describe('diffInChat', () => {
 
 \`\`\`diff
  line1
-- line1
 - line2
-- line3
  line3
 \`\`\``
 

--- a/vscode/src/chat/diff.test.ts
+++ b/vscode/src/chat/diff.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, test } from 'vitest'
+import * as vscode from 'vscode'
+import type { Edit } from '../non-stop/line-diff'
+import { diffInChat } from './diff'
+
+describe('diffInChat', () => {
+    // Mock VSCode TextDocument
+    const createMockDocument = (content: string): vscode.TextDocument =>
+        ({
+            getText: () => content,
+            // Add other required TextDocument properties as needed
+        }) as vscode.TextDocument
+
+    test('formats single line insertion correctly', () => {
+        const content = `line1
+        line2
+        line3`
+        const document = createMockDocument(content)
+        const diffs: Edit[] = [
+            {
+                type: 'insertion',
+                text: 'new line',
+                range: new vscode.Range(1, 0, 1, 0),
+            },
+        ]
+
+        const result = diffInChat(diffs, document)
+        const expected = `Here is the proposed change:
+
+\`\`\`diff
+ line1
++ new line
+ line3
+\`\`\``
+
+        expect(result).toBe(expected)
+    })
+
+    test('formats single line deletion correctly', () => {
+        const originalDoc = `line1
+        line2
+        line3`
+        const document = createMockDocument(originalDoc)
+        const diffs: Edit[] = [
+            {
+                type: 'deletion',
+                range: new vscode.Range(1, 0, 1, 0),
+                oldText: 'line2',
+            },
+        ]
+
+        const result = diffInChat(diffs, document)
+        const expected = `Here is the proposed change:
+
+\`\`\`diff
+ line1
+- line1
+- line2
+- line3
+ line3
+\`\`\``
+
+        expect(result).toBe(expected)
+    })
+
+    test('formats decorated replacement correctly', () => {
+        const document = createMockDocument('line1\nold line\nline3')
+        const diffs: Edit[] = [
+            {
+                type: 'decoratedReplacement',
+                text: 'new line',
+                oldText: 'old line',
+                range: new vscode.Range(1, 0, 1, 0),
+            },
+        ]
+
+        const result = diffInChat(diffs, document)
+        const expected = `Here is the proposed change:
+
+\`\`\`diff
+ line1
+- old line
++ new line
+ line3
+\`\`\``
+
+        expect(result).toBe(expected)
+    })
+
+    test('shows compact diff with context when showFullFile is false', () => {
+        const document = createMockDocument('line1\nline2\nline3\nline4\nline5\nline6\nline7')
+        const diffs: Edit[] = [
+            {
+                type: 'insertion',
+                text: 'new line',
+                range: new vscode.Range(3, 0, 3, 0),
+            },
+        ]
+
+        const result = diffInChat(diffs, document, { showFullFile: false })
+        const expected = `Here is the proposed change:
+
+\`\`\`diff
+ line1
+ line2
+ line3
++ new line
+ line5
+ line6
+\`\`\``
+
+        expect(result).toBe(expected)
+    })
+})

--- a/vscode/src/chat/diff.ts
+++ b/vscode/src/chat/diff.ts
@@ -1,0 +1,88 @@
+import type { TextDocument } from 'vscode'
+import type { Edit } from '../non-stop/line-diff'
+
+export interface ChatDiffDisplayOptions {
+    showFullFile: boolean
+}
+
+export function diffInChat(
+    diffs: Edit[],
+    document: TextDocument,
+    options: ChatDiffDisplayOptions = { showFullFile: true }
+): string {
+    const message = ['Here is the proposed change:\n\n```diff']
+    const documentLines = document.getText().split('\n')
+    const modifiedLines = new Map<number, Edit>()
+
+    // Find first and last modified lines for compact diff
+    let firstModifiedLine = documentLines.length
+    let lastModifiedLine = 0
+
+    // Build modified lines map and find boundaries
+    for (const diff of diffs) {
+        for (let line = diff.range.start.line; line <= diff.range.end.line; line++) {
+            modifiedLines.set(line, diff)
+            firstModifiedLine = Math.min(firstModifiedLine, line)
+            lastModifiedLine = Math.max(lastModifiedLine, line)
+        }
+    }
+
+    // Determine the range of lines to process
+    const startLine = options.showFullFile ? 0 : Math.max(0, firstModifiedLine - 3) // Show 3 lines of context
+    const endLine = options.showFullFile
+        ? documentLines.length
+        : Math.min(documentLines.length, lastModifiedLine + 3)
+
+    for (let lineNumber = startLine; lineNumber < endLine; lineNumber++) {
+        const diff = modifiedLines.get(lineNumber)
+        if (!diff) {
+            message.push(` ${documentLines[lineNumber]}`)
+            continue
+        }
+
+        switch (diff.type) {
+            case 'deletion':
+                if (lineNumber === diff.range.start.line) {
+                    message.push(
+                        document
+                            .getText(diff.range)
+                            .trimEnd()
+                            .split('\n')
+                            .map(line => `- ${line}`)
+                            .join('\n')
+                    )
+                }
+                break
+            case 'decoratedReplacement':
+                if (lineNumber === diff.range.start.line) {
+                    message.push(
+                        diff.oldText
+                            .trimEnd()
+                            .split('\n')
+                            .map(line => `- ${line}`)
+                            .join('\n'),
+                        diff.text
+                            .trimEnd()
+                            .split('\n')
+                            .map(line => `+ ${line}`)
+                            .join('\n')
+                    )
+                }
+                break
+            case 'insertion':
+                if (lineNumber === diff.range.start.line) {
+                    message.push(
+                        diff.text
+                            .trimEnd()
+                            .split('\n')
+                            .map(line => `+ ${line}`)
+                            .join('\n')
+                    )
+                }
+                break
+        }
+    }
+
+    message.push('```')
+    return message.join('\n')
+}

--- a/vscode/src/chat/diff.ts
+++ b/vscode/src/chat/diff.ts
@@ -43,14 +43,7 @@ export function diffInChat(
         switch (diff.type) {
             case 'deletion':
                 if (lineNumber === diff.range.start.line) {
-                    message.push(
-                        document
-                            .getText(diff.range)
-                            .trimEnd()
-                            .split('\n')
-                            .map(line => `- ${line}`)
-                            .join('\n')
-                    )
+                    message.push(`- ${diff.oldText}`)
                 }
                 break
             case 'decoratedReplacement':

--- a/vscode/webviews/chat/ChatMessageContent/ChatMessageContent.module.css
+++ b/vscode/webviews/chat/ChatMessageContent/ChatMessageContent.module.css
@@ -1,8 +1,34 @@
+.wrapper {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
 .buttons-container {
     display: flex;
-    flex-wrap: wrap;
     align-items: center;
-    padding: 4px;
+    justify-content: space-between;
+    padding: 8px;
+    border: 1px solid var(--vscode-editor-foreground);
+    border-radius: 4px;
+    background: transparent;
+}
+
+.buttons-container-transparent {
+    composes: buttons-container;
+    border: none;
+    padding: 4px 0;
+}
+
+.leftInfo {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    color: var(--vscode-descriptionForeground);
+}
+
+.stats {
+    color: var(--vscode-descriptionForeground);
 }
 
 .buttons {
@@ -30,6 +56,16 @@
 
 .button .icon-container {
     margin-right: 0.25rem
+}
+
+.addition {
+    color: #3fb950;
+    font-weight: bold;
+}
+
+.deletion {
+    color: #f85149;
+    font-weight: bold;
 }
 
 .copy-button,

--- a/vscode/webviews/chat/ChatMessageContent/ChatMessageContent.tsx
+++ b/vscode/webviews/chat/ChatMessageContent/ChatMessageContent.tsx
@@ -13,7 +13,7 @@ import type { PriorHumanMessageInfo } from '../cells/messageCell/assistant/Assis
 import styles from './ChatMessageContent.module.css'
 import { GuardrailsStatusController } from './GuardRailStatusController'
 import { createButtons, createButtonsExperimentalUI } from './create-buttons'
-import { extractThinkContent, getCodeBlockId, getFileName } from './utils'
+import { extractThinkContent, getCodeBlockId } from './utils'
 
 export interface CodeBlockActionsProps {
     copyButtonOnSubmit: (text: string, event?: 'Keydown' | 'Button') => void
@@ -147,11 +147,8 @@ export const ChatMessageContent: React.FunctionComponent<ChatMessageContentProps
                     )
                 }
 
-                const metadataContainer = document.createElement('div')
-                metadataContainer.classList.add(styles.metadataContainer)
-                buttons.append(metadataContainer)
-
-                if (guardrails) {
+                const metadataContainer = buttons.querySelector(`.${styles.metadataContainer}`)
+                if (metadataContainer && guardrails) {
                     const container = document.createElement('div')
                     container.classList.add(styles.attributionContainer)
                     metadataContainer.append(container)
@@ -181,16 +178,24 @@ export const ChatMessageContent: React.FunctionComponent<ChatMessageContentProps
                     }
                 }
 
-                if (fileName) {
-                    const fileNameContainer = document.createElement('div')
-                    fileNameContainer.className = styles.fileNameContainer
-                    fileNameContainer.textContent = getFileName(fileName)
-                    fileNameContainer.title = fileName
-                    metadataContainer.append(fileNameContainer)
-                }
+                // Get the parent and buttons
+                const parent = preElement.parentNode
+                if (!parent) return
 
-                // Insert the buttons after the pre using insertBefore() because there is no insertAfter()
-                preElement.parentNode.insertBefore(buttons, preElement.nextSibling)
+                // Get the preview container and actions container
+                const previewContainer = buttons.querySelector(`[data-container-type="preview"]`)
+                const actionsContainer = buttons.querySelector(`[data-container-type="actions"]`)
+                if (!previewContainer || !actionsContainer) return
+
+                // First add the preview container
+                parent.insertBefore(previewContainer, preElement)
+
+                // Then move the code block after preview container
+                parent.removeChild(preElement)
+                parent.insertBefore(preElement, null)
+
+                // Finally add the actions container after the code block
+                parent.appendChild(actionsContainer)
             }
         }
     }, [

--- a/vscode/webviews/chat/ChatMessageContent/ChatMessageContent.tsx
+++ b/vscode/webviews/chat/ChatMessageContent/ChatMessageContent.tsx
@@ -178,7 +178,6 @@ export const ChatMessageContent: React.FunctionComponent<ChatMessageContentProps
                     }
                 }
 
-                // Get the parent and buttons
                 const parent = preElement.parentNode
                 if (!parent) return
 

--- a/vscode/webviews/chat/ChatMessageContent/create-buttons.ts
+++ b/vscode/webviews/chat/ChatMessageContent/create-buttons.ts
@@ -128,15 +128,6 @@ export function createButtonsExperimentalUI(
         }
     }
     buttonContainer1.appendChild(leftInfo)
-
-    // Add Open Diff button on the right
-    if (codeBlockName && !codeBlockName.includes('command')) {
-        const openDiffButton = document.createElement('button')
-        openDiffButton.className = styles.button
-        openDiffButton.innerHTML = 'Open Diff'
-        buttonContainer1.appendChild(openDiffButton)
-    }
-
     wrapper.appendChild(buttonContainer1)
 
     // Create button container 2 for action buttons

--- a/vscode/webviews/chat/ChatMessageContent/create-buttons.ts
+++ b/vscode/webviews/chat/ChatMessageContent/create-buttons.ts
@@ -78,13 +78,13 @@ export function createButtons(
 }
 
 function getLineChanges(text: string): { additions: number; deletions: number } {
-    const lines = text.split('\n')
+    const lines = text?.split('\n') ?? []
     let additions = 0
     let deletions = 0
 
     for (const line of lines) {
-        if (line.startsWith('+')) additions++
-        if (line.startsWith('-')) deletions++
+        if (line?.startsWith('+')) additions++
+        if (line?.startsWith('-')) deletions++
     }
 
     return { additions, deletions }

--- a/vscode/webviews/chat/ChatMessageContent/create-buttons.ts
+++ b/vscode/webviews/chat/ChatMessageContent/create-buttons.ts
@@ -104,10 +104,10 @@ export function createButtonsExperimentalUI(
     const wrapper = document.createElement('div')
     wrapper.className = styles.wrapper
 
-    // Create button container 1 for file info and diff button
+    // Create button container 1 for file info
     const buttonContainer1 = document.createElement('div')
     buttonContainer1.className = styles.buttonsContainerTransparent
-    buttonContainer1.dataset.containerType = 'preview' // Add data attribute to identify container
+    buttonContainer1.dataset.containerType = 'preview'
 
     // Add filename and stats on the left
     const leftInfo = document.createElement('div')
@@ -133,7 +133,7 @@ export function createButtonsExperimentalUI(
     // Create button container 2 for action buttons
     const buttonContainer2 = document.createElement('div')
     buttonContainer2.className = styles.buttonsContainerTransparent
-    buttonContainer2.dataset.containerType = 'actions' // Add data attribute to identify container
+    buttonContainer2.dataset.containerType = 'actions'
 
     if (!copyButtonOnSubmit) {
         wrapper.appendChild(buttonContainer2)


### PR DESCRIPTION
**WHY**
Improve the agentic chat's edit UX experience

**WHAT**
Based off @abeatrix's branch bee/chat-edit
- Closing https://linear.app/sourcegraph/issue/CODY-5136/ui-for-diff-preview-in-chat
- Add line diffs in the UI
- Move the file name to the top of the code block for better readability

## Test plan
Tested locally.
<img width="624" alt="Screenshot 2025-02-24 at 6 36 52 PM" src="https://github.com/user-attachments/assets/972f8814-7a21-44d0-9f87-a6fb147daade" />

<img width="601" alt="Screenshot 2025-02-24 at 10 19 21 PM" src="https://github.com/user-attachments/assets/b1739052-1283-482f-946a-e7ea72b96473" />


<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
