### PR TITLE
chore(chat): Add the minus button to the thought process REL-758

### DIFF
--- a/vscode/webviews/chat/ChatMessageContent/ChatMessageContent.tsx
+++ b/vscode/webviews/chat/ChatMessageContent/ChatMessageContent.tsx
@@ -3,7 +3,7 @@ import type React from 'react'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import { clsx } from 'clsx'
-import { LoaderIcon, PlusIcon } from 'lucide-react'
+import { LoaderIcon, PlusIcon, MinusIcon } from 'lucide-react'
 import type { FixupTaskID } from '../../../src/non-stop/FixupTask'
 import { CodyTaskState } from '../../../src/non-stop/state'
 import { type ClientActionListener, useClientActionListener } from '../../client/clientState'
@@ -210,11 +210,14 @@ export const ChatMessageContent: React.FunctionComponent<ChatMessageContentProps
         [displayMarkdown]
     )
 
+    const [isOpen, setIsOpen] = useState(true)
+
     return (
         <div ref={rootRef} data-testid="chat-message-content">
             {thinkContent.length > 0 && (
                 <details
-                    open
+                    open={isOpen}
+                    onToggle={e => setIsOpen((e.target as HTMLDetailsElement).open)}
                     className="tw-container tw-mb-7 tw-border tw-border-gray-500/20 dark:tw-border-gray-600/40 tw-rounded-lg tw-overflow-hidden tw-backdrop-blur-sm"
                     title="Thinking & Reasoning Space"
                 >
@@ -229,7 +232,13 @@ export const ChatMessageContent: React.FunctionComponent<ChatMessageContentProps
                         {isThinking ? (
                             <LoaderIcon size={16} className="tw-animate-spin tw-text-muted-foreground" />
                         ) : (
-                            <PlusIcon size={16} className="tw-text-muted-foreground" />
+                            <>
+                                {isOpen ? (
+                                    <MinusIcon size={16} className="tw-text-muted-foreground" />
+                                ) : (
+                                    <PlusIcon size={16} className="tw-text-muted-foreground" />
+                                )}
+                            </>
                         )}
                         <span className="tw-font-medium tw-text-gray-600 dark:tw-text-gray-300">
                             {isThinking ? 'Thinking...' : 'Thought Process'}

--- a/vscode/webviews/chat/ChatMessageContent/ChatMessageContent.tsx
+++ b/vscode/webviews/chat/ChatMessageContent/ChatMessageContent.tsx
@@ -223,24 +223,24 @@ export const ChatMessageContent: React.FunctionComponent<ChatMessageContentProps
                 >
                     <summary
                         className={clsx(
-                            'tw-flex tw-items-center tw-gap-2 tw-px-3 tw-py-2 tw-bg-gray-100/50 dark:tw-bg-gray-800/80 tw-cursor-pointer tw-select-none tw-transition-colors',
+                            'tw-flex tw-items-center tw-gap-2 tw-px-3 tw-py-2 tw-bg-transparent dark:tw-bg-transparent tw-cursor-pointer tw-select-none tw-transition-colors',
                             {
                                 'tw-animate-pulse': isThinking,
                             }
                         )}
                     >
                         {isThinking ? (
-                            <LoaderIcon size={16} className="tw-animate-spin tw-text-muted-foreground" />
+                            <LoaderIcon size={16} className="tw-animate-spin tw-text-foreground/80" />
                         ) : (
                             <>
                                 {isOpen ? (
-                                    <MinusIcon size={16} className="tw-text-muted-foreground" />
+                                    <MinusIcon size={16} className="tw-text-foreground/80" />
                                 ) : (
-                                    <PlusIcon size={16} className="tw-text-muted-foreground" />
+                                    <PlusIcon size={16} className="tw-text-foreground/80" />
                                 )}
                             </>
                         )}
-                        <span className="tw-font-medium tw-text-gray-600 dark:tw-text-gray-300">
+                        <span className="tw-font-semibold tw-text-foreground/80">
                             {isThinking ? 'Thinking...' : 'Thought Process'}
                         </span>
                     </summary>

--- a/vscode/webviews/chat/ChatMessageContent/ChatMessageContent.tsx
+++ b/vscode/webviews/chat/ChatMessageContent/ChatMessageContent.tsx
@@ -3,7 +3,7 @@ import type React from 'react'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import { clsx } from 'clsx'
-import { LoaderIcon, PlusIcon, MinusIcon } from 'lucide-react'
+import { LoaderIcon, MinusIcon, PlusIcon } from 'lucide-react'
 import type { FixupTaskID } from '../../../src/non-stop/FixupTask'
 import { CodyTaskState } from '../../../src/non-stop/state'
 import { type ClientActionListener, useClientActionListener } from '../../client/clientState'
@@ -218,7 +218,7 @@ export const ChatMessageContent: React.FunctionComponent<ChatMessageContentProps
                 <details
                     open={isOpen}
                     onToggle={e => setIsOpen((e.target as HTMLDetailsElement).open)}
-                    className="tw-container tw-mb-7 tw-border tw-border-gray-500/20 dark:tw-border-gray-600/40 tw-rounded-lg tw-overflow-hidden tw-backdrop-blur-sm"
+                    className="tw-container tw-mb-4 tw-border tw-border-gray-500/20 dark:tw-border-gray-600/40 tw-rounded-lg tw-overflow-hidden tw-backdrop-blur-sm"
                     title="Thinking & Reasoning Space"
                 >
                     <summary


### PR DESCRIPTION
**WHAT**

- Add a minus icon for closing the thought process box.
- Change the text color.
- Remove the background color.
- Make the margin smaller.

**WHY**
To improve the thinking process UI.

## Test plan
[Loom](https://www.loom.com/share/5ffec50483f7415eb9b2f431947275f9)

Before
<img width="614" alt="Screenshot 2025-02-24 at 10 57 16 PM" src="https://github.com/user-attachments/assets/f31fb57a-c4ba-4609-87a6-ad2f3e2cb0f1" />

After
<img width="614" alt="Screenshot 2025-02-24 at 10 56 50 PM" src="https://github.com/user-attachments/assets/baf4499a-ffe6-4784-a9cb-f4dcff40d108" />

<img width="618" alt="Screenshot 2025-02-24 at 10 56 54 PM" src="https://github.com/user-attachments/assets/8b1f8f70-8e19-4e4c-aeda-98f7f299e6c8" />

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
