### PR TITLE
feat(chat): Add the latest conversation to the welcome page

### DIFF
--- a/vscode/webviews/chat/components/LastConversation.tsx
+++ b/vscode/webviews/chat/components/LastConversation.tsx
@@ -1,0 +1,70 @@
+import type { CodyIDE } from '@sourcegraph/cody-shared'
+import { useExtensionAPI, useObservable } from '@sourcegraph/prompt-editor'
+import { HistoryIcon } from 'lucide-react'
+import type { FunctionComponent } from 'react'
+import { useMemo } from 'react'
+import { getRelativeChatPeriod } from '../../../src/common/time-date'
+import { Button } from '../../components/shadcn/ui/button'
+import { View } from '../../tabs/types'
+import { getVSCodeAPI } from '../../utils/VSCodeApi'
+
+interface LastConversationProps {
+    setView: (view: View) => void
+    IDE: CodyIDE
+}
+
+function useUserHistory() {
+    const userHistory = useExtensionAPI().userHistory
+    return useObservable(useMemo(() => userHistory(), [userHistory])).value
+}
+
+export const LastConversation: FunctionComponent<LastConversationProps> = ({ setView, IDE }) => {
+    const userHistory = useUserHistory()
+
+    const lastChat = useMemo(() => {
+        if (!userHistory?.chat) {
+            return null
+        }
+        const chats = Object.values(userHistory.chat)
+            .filter(chat => chat.interactions.length > 0)
+            .sort(
+                (a, b) =>
+                    new Date(b.lastInteractionTimestamp).getTime() -
+                    new Date(a.lastInteractionTimestamp).getTime()
+            )
+        return chats[0] || null
+    }, [userHistory])
+
+    if (!lastChat) {
+        return null
+    }
+
+    const lastMessage = lastChat.interactions[lastChat.interactions.length - 1]?.humanMessage?.text?.trim() || ''
+    const displayText = lastChat.chatTitle?.trim() || lastMessage
+    const truncatedText = displayText.length > 50 ? displayText.slice(0, 47) + '...' : displayText
+    const timePeriod = getRelativeChatPeriod(new Date(lastChat.lastInteractionTimestamp))
+
+    const handleClick = () => {
+        getVSCodeAPI().postMessage({
+            command: 'restoreHistory',
+            chatID: lastChat.lastInteractionTimestamp,
+        })
+        setView(View.Chat)
+    }
+
+    return (
+        <Button
+            variant="outline"
+            className="tw-w-full tw-flex tw-items-center tw-gap-2 tw-px-3 tw-py-2 tw-text-left tw-border-gray-500/20 dark:tw-border-gray-600/40"
+            onClick={handleClick}
+        >
+            <HistoryIcon size={16} className="tw-text-foreground/80" />
+            <div className="tw-flex-1 tw-min-w-0">
+                <div className="tw-text-sm tw-font-medium tw-text-foreground/80 tw-truncate">
+                    {truncatedText}
+                </div>
+                <div className="tw-text-xs tw-text-foreground/60">{timePeriod}</div>
+            </div>
+        </Button>
+    )
+}

--- a/vscode/webviews/chat/components/LastConversation.tsx
+++ b/vscode/webviews/chat/components/LastConversation.tsx
@@ -39,7 +39,8 @@ export const LastConversation: FunctionComponent<LastConversationProps> = ({ set
         return null
     }
 
-    const lastMessage = lastChat.interactions[lastChat.interactions.length - 1]?.humanMessage?.text?.trim() || ''
+    const lastMessage =
+        lastChat.interactions[lastChat.interactions.length - 1]?.humanMessage?.text?.trim() || ''
     const displayText = lastChat.chatTitle?.trim() || lastMessage
     const truncatedText = displayText.length > 50 ? displayText.slice(0, 47) + '...' : displayText
     const timePeriod = getRelativeChatPeriod(new Date(lastChat.lastInteractionTimestamp))

--- a/vscode/webviews/chat/components/WelcomeMessage.tsx
+++ b/vscode/webviews/chat/components/WelcomeMessage.tsx
@@ -43,9 +43,9 @@ export const WelcomeMessage: FunctionComponent<WelcomeMessageProps> = ({
                     onSelect={item => runAction(item, setView)}
                 />
             </div>
-            <div className="tw-mt-auto tw-w-full">
+            <div className="tw-mt-auto tw-w-full tw-mb-4 tw-pb-2">
                 <LastConversation setView={setView} IDE={IDE} />
-            </div>
+            </div>{' '}
         </div>
     )
 }

--- a/vscode/webviews/chat/components/WelcomeMessage.tsx
+++ b/vscode/webviews/chat/components/WelcomeMessage.tsx
@@ -27,11 +27,10 @@ export const WelcomeMessage: FunctionComponent<WelcomeMessageProps> = ({
 
     return (
         <div className="tw-flex-1 tw-flex tw-flex-col tw-items-start tw-w-full tw-px-8 tw-gap-6 tw-transition-all tw-relative">
-            {isPromptsV2Enabled && IDE !== CodyIDE.Web && (
-                <PromptMigrationWidget dismissible={true} className="tw-w-full" />
-            )}
             <div className="tw-flex tw-flex-col tw-gap-4 tw-w-full">
-                <LastConversation setView={setView} IDE={IDE} />
+                {isPromptsV2Enabled && IDE !== CodyIDE.Web && (
+                    <PromptMigrationWidget dismissible={true} className="tw-w-full" />
+                )}
                 <PromptList
                     showSearch={false}
                     showFirstNItems={4}
@@ -43,6 +42,9 @@ export const WelcomeMessage: FunctionComponent<WelcomeMessageProps> = ({
                     telemetryLocation="WelcomeAreaPrompts"
                     onSelect={item => runAction(item, setView)}
                 />
+            </div>
+            <div className="tw-mt-auto tw-w-full">
+                <LastConversation setView={setView} IDE={IDE} />
             </div>
         </div>
     )

--- a/vscode/webviews/chat/components/WelcomeMessage.tsx
+++ b/vscode/webviews/chat/components/WelcomeMessage.tsx
@@ -4,6 +4,7 @@ import { PromptList } from '../../components/promptList/PromptList'
 import { useActionSelect } from '../../prompts/PromptsTab'
 import type { View } from '../../tabs'
 import { PromptMigrationWidget } from './../../components/promptsMigration/PromptsMigration'
+import { LastConversation } from './LastConversation'
 
 const localStorageKey = 'chat.welcome-message-dismissed'
 
@@ -30,6 +31,7 @@ export const WelcomeMessage: FunctionComponent<WelcomeMessageProps> = ({
                 <PromptMigrationWidget dismissible={true} className="tw-w-full" />
             )}
             <div className="tw-flex tw-flex-col tw-gap-4 tw-w-full">
+                <LastConversation setView={setView} IDE={IDE} />
                 <PromptList
                     showSearch={false}
                     showFirstNItems={4}


### PR DESCRIPTION
**WHAT**
Add the latest conversation to the welcome page.

**WHY**
A lot of our competitors have the past conversations on the welcome page. This is a feature with good user experience.

## Test plan
Tested locally.
<img width="646" alt="Screenshot 2025-02-26 at 6 29 37 PM" src="https://github.com/user-attachments/assets/be0d6340-39eb-4b29-a0fd-3e88522c1d4a" />


<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
