### PR TITLE
Fix threading issues in 'Ask Cody To Fix' feature, add caching

### DIFF
--- a/jetbrains/src/main/java/com/sourcegraph/find/FindService.java
+++ b/jetbrains/src/main/java/com/sourcegraph/find/FindService.java
@@ -46,7 +46,7 @@ public class FindService implements Disposable {
   }
 
   public void refreshConfiguration() {
-    if (popup.isVisible()) {
+    if (popup != null && popup.isVisible()) {
       JavaToJSBridge javaToJSBridge = mainPanel.getJavaToJSBridge();
       if (javaToJSBridge != null) {
         mainPanel

--- a/jetbrains/src/main/kotlin/com/sourcegraph/cody/inspections/CodeActionQuickFix.kt
+++ b/jetbrains/src/main/kotlin/com/sourcegraph/cody/inspections/CodeActionQuickFix.kt
@@ -10,6 +10,7 @@ import com.sourcegraph.cody.agent.CodyAgentService
 import com.sourcegraph.cody.agent.protocol_generated.CodeActions_ProvideParams
 import com.sourcegraph.cody.agent.protocol_generated.CodeActions_TriggerParams
 import com.sourcegraph.cody.agent.protocol_generated.ProtocolCodeAction
+import com.sourcegraph.cody.agent.protocol_generated.ProtocolDiagnostic
 import com.sourcegraph.cody.agent.protocol_generated.ProtocolLocation
 import com.sourcegraph.cody.edit.actions.EditCodeAction
 
@@ -22,6 +23,10 @@ class CodeActionQuickFix(private val params: CodeActionQuickFixParams) :
     IntentionAction, HintAction, PriorityAction {
   companion object {
     const val FAMILY_NAME = "Cody Code Action"
+  }
+
+  public fun getDiagnostics(): List<ProtocolDiagnostic>? {
+    return params.action.diagnostics
   }
 
   override fun getPriority(): PriorityAction.Priority {

--- a/jetbrains/src/main/kotlin/com/sourcegraph/cody/inspections/CodyFixHighlightPass.kt
+++ b/jetbrains/src/main/kotlin/com/sourcegraph/cody/inspections/CodyFixHighlightPass.kt
@@ -7,13 +7,14 @@ import com.intellij.codeHighlighting.TextEditorHighlightingPassFactoryRegistrar
 import com.intellij.codeHighlighting.TextEditorHighlightingPassRegistrar
 import com.intellij.codeInsight.daemon.DaemonCodeAnalyzer
 import com.intellij.codeInsight.daemon.impl.DaemonCodeAnalyzerImpl
-import com.intellij.codeInsight.daemon.impl.HighlightInfo
 import com.intellij.lang.annotation.HighlightSeverity
+import com.intellij.openapi.application.runReadAction
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.progress.ProgressIndicator
 import com.intellij.openapi.progress.util.ProgressIndicatorUtils
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.psi.PsiFile
 import com.intellij.util.concurrency.annotations.RequiresEdt
 import com.sourcegraph.cody.agent.CodyAgentService
@@ -23,8 +24,8 @@ import com.sourcegraph.cody.agent.protocol_generated.CodeActions_ProvideParams
 import com.sourcegraph.cody.agent.protocol_generated.Diagnostics_PublishParams
 import com.sourcegraph.cody.agent.protocol_generated.ProtocolDiagnostic
 import com.sourcegraph.cody.agent.protocol_generated.ProtocolLocation
-import com.sourcegraph.cody.agent.protocol_generated.Range
 import java.util.concurrent.CompletableFuture
+import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.ExecutionException
 import org.eclipse.lsp4j.jsonrpc.ResponseErrorException
 
@@ -32,8 +33,6 @@ class CodyFixHighlightPass(val file: PsiFile, val editor: Editor) :
     TextEditorHighlightingPass(file.project, editor.document, false) {
 
   private val logger = Logger.getInstance(CodyFixHighlightPass::class.java)
-  private var myHighlights = emptyList<HighlightInfo>()
-  private val myRangeActions = mutableMapOf<Range, List<CodeActionQuickFixParams>>()
 
   override fun doCollectInformation(progress: ProgressIndicator) {
     if (!DaemonCodeAnalyzer.getInstance(file.project).isHighlightingAvailable(file) ||
@@ -41,100 +40,96 @@ class CodyFixHighlightPass(val file: PsiFile, val editor: Editor) :
       // wait until after code-analysis is completed
       return
     }
-    val uri = ProtocolTextDocumentExt.uriFor(file.virtualFile)
 
-    myRangeActions.clear()
-
-    myHighlights =
+    val myHighlights =
         DaemonCodeAnalyzerImpl.getHighlights(editor.document, HighlightSeverity.ERROR, file.project)
 
-    val protocolDiagnostics =
-        // TODO: We need to check how Enum comparison works to check if we can do things like
-        // >= HighlightSeverity.INFO
+    // TODO: We need to check how Enum comparison works to check if we can do things like
+    // >= HighlightSeverity.INFO
+    val actionPromises =
         myHighlights
             .filter { it.severity == HighlightSeverity.ERROR }
-            .mapNotNull {
+            .map { highlight ->
               try {
-                val range = document.codyRange(it.startOffset, it.endOffset)
-                ProtocolDiagnostic(
-                    message = it.description,
-                    // TODO: Wait for CODY-2882. This isn't currently used by the agent,  so we just
-                    // keep our lives simple.
-                    severity = "error",
-                    // TODO: Rik Nauta -- Got incorrect range; see QA report Aug 6 2024.
-                    location = ProtocolLocation(uri = uri, range = range),
-                    code = it.problemGroup?.problemName)
-              } catch (x: Exception) {
-                // Don't allow range errors to throw user-visible exceptions (QA found this).
-                logger.warn("Failed to convert highlight to protocol diagnostic", x)
-                null
+                if (progress.isCanceled) {
+                  return@map CompletableFuture.completedFuture(emptyList<CodeActionQuickFix>())
+                }
+
+                val uri = ProtocolTextDocumentExt.uriFor(file.virtualFile)
+                val range = document.codyRange(highlight.startOffset, highlight.endOffset)
+                val diagnostic =
+                    ProtocolDiagnostic(
+                        message = highlight.description,
+                        // TODO: Wait for CODY-2882. This isn't currently used by the agent,  so we
+                        // just keep our lives simple.
+                        severity = "error",
+                        // TODO: Rik Nauta -- Got incorrect range; see QA report Aug 6 2024.
+                        location = ProtocolLocation(uri = uri, range = range),
+                        code = highlight.problemGroup?.problemName)
+
+                val existingAction =
+                    myHighlightActions[file.virtualFile]?.filter {
+                      it.getDiagnostics()?.contains(diagnostic) == true
+                    }
+
+                if (!existingAction.isNullOrEmpty()) {
+                  return@map CompletableFuture.completedFuture(existingAction)
+                } else {
+                  val result = CompletableFuture<List<CodeActionQuickFix>>()
+
+                  CodyAgentService.withAgentRestartIfNeeded(file.project) { agent ->
+                    agent.server
+                        .diagnostics_publish(Diagnostics_PublishParams(listOf(diagnostic)))
+                        .get()
+
+                    val provideParam =
+                        CodeActions_ProvideParams(
+                            triggerKind = "Invoke", location = diagnostic.location)
+                    val actions =
+                        agent.server.codeActions_provide(provideParam).get().codeActions.map {
+                          CodeActionQuickFix(
+                              CodeActionQuickFixParams(action = it, location = diagnostic.location))
+                        }
+
+                    runReadAction {
+                      for (action in actions) {
+                        highlight.registerFix(
+                            action,
+                            /* options = */ null,
+                            /* displayName = */ null,
+                            /* fixRange = */ null,
+                            /* key = */ null)
+                      }
+                    }
+
+                    result.complete(actions)
+                  }
+
+                  return@map result
+                }
+              } catch (e: Exception) {
+                val responseErrorException =
+                    (e as? ExecutionException)?.cause as? ResponseErrorException
+                if (responseErrorException != null) {
+                  logger.warn("Failed to get code actions for diagnostic", e)
+                }
+                return@map CompletableFuture.completedFuture(emptyList<CodeActionQuickFix>())
               }
             }
 
-    if (protocolDiagnostics.isEmpty()) {
-      return
-    }
+    val allActions = CompletableFuture.allOf(*actionPromises.toTypedArray())
+    ProgressIndicatorUtils.awaitWithCheckCanceled(allActions, progress)
 
-    val done = CompletableFuture<Unit>()
-    CodyAgentService.withAgentRestartIfNeeded(file.project) { agent ->
-      try {
-        agent.server.diagnostics_publish(
-            Diagnostics_PublishParams(diagnostics = protocolDiagnostics))
-
-        for (diagnostic in protocolDiagnostics) {
-          if (progress.isCanceled) {
-            break
-          }
-
-          val location = diagnostic.location
-          if (myRangeActions.containsKey(location.range)) {
-            continue
-          }
-
-          val provideParam = CodeActions_ProvideParams(triggerKind = "Invoke", location = location)
-          val provideResponse = agent.server.codeActions_provide(provideParam).get()
-          myRangeActions[location.range] =
-              provideResponse.codeActions.map {
-                CodeActionQuickFixParams(action = it, location = location)
-              }
+    myHighlightActions[file.virtualFile] =
+        actionPromises.flatMap { actionPromise ->
+          if (!actionPromise.isCompletedExceptionally) actionPromise.get() else emptyList()
         }
-        done.complete(Unit)
-      } catch (e: Exception) {
-        val responseErrorException = (e as? ExecutionException)?.cause as? ResponseErrorException
-        if (responseErrorException != null) {
-          logger.warn("Failed to get code actions for diagnostic", e)
-          done.complete(Unit)
-        } else {
-          done.completeExceptionally(e)
-        }
-      }
-    }
-    ProgressIndicatorUtils.awaitWithCheckCanceled(done, progress)
   }
 
-  @RequiresEdt
-  override fun doApplyInformationToEditor() {
-    for (highlight in myHighlights) {
-      highlight.unregisterQuickFix {
-        (it as? CodeActionQuickFix)?.familyName == CodeActionQuickFix.FAMILY_NAME
-      }
+  @RequiresEdt override fun doApplyInformationToEditor() {}
 
-      if (highlight.startOffset > document.textLength ||
-          highlight.endOffset > document.textLength ||
-          highlight.startOffset > highlight.endOffset) {
-        break
-      }
-
-      val range = document.codyRange(highlight.startOffset, highlight.endOffset)
-      for (action in myRangeActions[range].orEmpty()) {
-        highlight.registerFix(
-            CodeActionQuickFix(action),
-            /* options = */ null,
-            /* displayName = */ null,
-            /* fixRange = */ null,
-            /* key = */ null)
-      }
-    }
+  companion object CodyFixHighlightPass {
+    private var myHighlightActions = ConcurrentHashMap<VirtualFile, List<CodeActionQuickFix>>()
   }
 }
 


### PR DESCRIPTION
## Changes

1. Removed `highlight.unregisterQuickFix` - it was not needed, as each highlight pass recreates all highlights and fixups from scratch
2. Moved `highlight.registerFix` execution to the proper thread
3. Added caching, so if location or content of the `ProtocolDiagnostic` object created based on the highlight does not change we reuse the previous `CodeActionQuickFix` without sending anything to the Cody agent

## Test plan

**Scenario 1:** issue which IntelliJ does NOT know how to fix

1. Edit kotlin code and change code like `class MyClass {}` to be `clas MyClass {}` 
2. Click Option + Enter - `Ask Cody to Fix` action should appear, run it
3. Proper fix should be applied by Cody


**Scenario 2:** issue which IntelliJ does know how to fix

1. Edit kotlin code and write code like `val x: String = 1` 
2. Click Option + Enter - few fixes should appear, with first on the list NOT being `Ask Cody to Fix`
3. Hit enter to apply IntelliJ fix - it should be successful
4. Hit Ctrl + Z to rollback the fix
5. Click Option + Enter again - this time pick `Ask Cody to Fix` option
6. Proper fix should be applied by Cody