### PR TITLE
Fix NPE warning in JetBrains

### DIFF
--- a/jetbrains/src/main/java/com/sourcegraph/find/FindService.java
+++ b/jetbrains/src/main/java/com/sourcegraph/find/FindService.java
@@ -46,7 +46,7 @@ public class FindService implements Disposable {
   }
 
   public void refreshConfiguration() {
-    if (popup.isVisible()) {
+    if (popup != null && popup.isVisible()) {
       JavaToJSBridge javaToJSBridge = mainPanel.getJavaToJSBridge();
       if (javaToJSBridge != null) {
         mainPanel


### PR DESCRIPTION
Simple fix - I just added a null check.

## Test plan

1. Start JetBrains
2. Make sure there is no NPE warning coming from `FindService` in the logs.