### PR TITLE
fix/auth: Extension authorizes Search even if Cody is disabled in site config

### DIFF
--- a/jetbrains/src/main/kotlin/com/sourcegraph/cody/initialization/PostStartupActivity.kt
+++ b/jetbrains/src/main/kotlin/com/sourcegraph/cody/initialization/PostStartupActivity.kt
@@ -30,7 +30,6 @@ class PostStartupActivity : ProjectActivity {
   override suspend fun execute(project: Project) {
     VerifyJavaBootRuntimeVersion().runActivity(project)
     SettingsMigration().runActivity(project)
-    CodyAuthNotificationActivity().runActivity(project)
     CodyWindowAdapter.addWindowFocusListener(project)
     ApplicationManager.getApplication().executeOnPooledThread {
       // Scheduling because this task takes ~2s to run
@@ -38,7 +37,10 @@ class PostStartupActivity : ProjectActivity {
     }
     // For integration tests we do not want to start agent immediately as we would like to first
     // do some setup.
-    if (ConfigUtil.isCodyEnabled() && !ConfigUtil.isIntegrationTestModeEnabled()) {
+    if (!ConfigUtil.isIntegrationTestModeEnabled()) {
+      if (ConfigUtil.isCodyEnabled()) {
+        CodyAuthNotificationActivity().runActivity(project)
+      }
       CodyAgentService.getInstance(project).startAgent()
     }
 


### PR DESCRIPTION
Fixes https://linear.app/sourcegraph/issue/CODY-5125/

## Changes

That change is surpassingly simple because:
1. We already prevent various actions from being invoked if Cody is disabled, .e.g:

```kt
abstract class BaseCommandAction : DumbAwareEDTAction() {

  override fun update(e: AnActionEvent) {
    super.update(e)
    val project = e.project
    e.presentation.isVisible =
        isCodyEnabled() && project != null && CodyAuthService.getInstance(project).isActivated()
  }

  // ...
```

2. All explicit calls to Cody are still disabled:

```kt
    @JvmStatic
    private fun withAgent(
        project: Project,
        restartIfNeeded: Boolean,
        callback: Consumer<CodyAgent>
    ) {
      if (CodyApplicationSettings.instance.isCodyEnabled) { 

      // ...
```

So with this changes Cody will start and initiialize, but:
* cody toolbar is hidden
* cody actions are disabled
* calling cody is disabling

Still, if authorization state will change in the cody we will get the notification and thus update Search component credentials.

## Test plan

1. Login to some custom Sourcegraph instance, e.g. sg02
2. Open `Settings` > `Tools` > `Sourcegraph & Cody` > `Cody`
3. Untick `Enable Cody`
4. Restart IntelliJ
5. Make sure Cody is disabled: 

- [x] Cody toolbar icon should not be visible
- [x] Cody status bar icon should not be visible
- [x] actions like autocomplete should not be invoked automatically nor should be possible to invoke them using shortcut (try `Option + K`)
- [x] There should be no Cody group in the context menus

6. Make sure Sourcegraph Search works by opening it (`Option + S`) and type `AuthSidebarViewProps`
7. It should find `AuthSidebarViewProps` file in `sourcegraph/sourcegraph`, open it in the editor
8. In the context menu find `Sourcegraph` and open the file on the web; it should open on the instance you selected in the step 1. (e.g. sg02) - verify that it is the case in the address bar


<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
