### PR TITLE
Fix already disposed exception from withAgent

### DIFF
--- a/jetbrains/src/integrationTest/kotlin/com/sourcegraph/cody/util/CodyIntegrationTextFixture.kt
+++ b/jetbrains/src/integrationTest/kotlin/com/sourcegraph/cody/util/CodyIntegrationTextFixture.kt
@@ -87,7 +87,7 @@ open class CodyIntegrationTextFixture : BasePlatformTestCase(), LensListener {
       }
       recordingsFuture.get(ASYNC_WAIT_TIMEOUT_SECONDS, TimeUnit.SECONDS)
       CodyAgentService.getInstance(project)
-          .stopAgent(project)
+          .stopAgent()
           ?.get(ASYNC_WAIT_TIMEOUT_SECONDS, TimeUnit.SECONDS)
       CodyAgentService.getInstance(project).dispose()
     } finally {
@@ -107,7 +107,7 @@ open class CodyIntegrationTextFixture : BasePlatformTestCase(), LensListener {
     assertNotNull(
         "Unable to start agent in a timely fashion!",
         CodyAgentService.getInstance(project)
-            .startAgent(project, endpoint, token)
+            .startAgent(endpoint, token)
             .completeOnTimeout(null, ASYNC_WAIT_TIMEOUT_SECONDS, TimeUnit.SECONDS)
             .get())
   }

--- a/jetbrains/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentService.kt
+++ b/jetbrains/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentService.kt
@@ -183,10 +183,10 @@ class CodyAgentService(private val project: Project) : Disposable {
         callback: Consumer<CodyAgent>
     ) {
       if (CodyApplicationSettings.instance.isCodyEnabled) {
+        if (project.isDisposed) return
+        val instance = getInstance(project)
         ApplicationManager.getApplication().executeOnPooledThread {
           try {
-            if (project.isDisposed) return@executeOnPooledThread
-            val instance = getInstance(project)
             val isReadyButNotFunctional = instance.codyAgent.getNow(null)?.isConnected() == false
             val agent =
                 if (isReadyButNotFunctional && restartIfNeeded) instance.restartAgent(project)
@@ -196,7 +196,7 @@ class CodyAgentService(private val project: Project) : Disposable {
           } catch (e: Exception) {
             logger.warn("Failed to execute call to agent", e)
             if (restartIfNeeded && e !is ProcessCanceledException) {
-              getInstance(project).restartAgent(project)
+              instance.restartAgent(project)
             }
             throw e
           }

--- a/jetbrains/src/main/kotlin/com/sourcegraph/cody/agent/action/CodyAgentRestartAction.kt
+++ b/jetbrains/src/main/kotlin/com/sourcegraph/cody/agent/action/CodyAgentRestartAction.kt
@@ -9,7 +9,7 @@ import com.sourcegraph.common.ui.DumbAwareEDTAction
 class CodyAgentRestartAction : DumbAwareEDTAction("Restart Cody") {
   override fun actionPerformed(event: AnActionEvent) {
     event.project?.let { project ->
-      CodyAgentService.getInstance(project).restartAgent(project)
+      CodyAgentService.getInstance(project).restartAgent()
       NotificationsManager.getNotificationsManager()
           .getNotificationsOfType(CodyConnectionTimeoutExceptionNotification::class.java, project)
           .forEach { it.expire() }

--- a/jetbrains/src/main/kotlin/com/sourcegraph/cody/config/notification/CodySettingChangeListener.kt
+++ b/jetbrains/src/main/kotlin/com/sourcegraph/cody/config/notification/CodySettingChangeListener.kt
@@ -22,9 +22,9 @@ class CodySettingChangeListener(project: Project) : ChangeListener(project) {
 
             if (context.oldCodyEnabled != context.newCodyEnabled) {
               if (context.newCodyEnabled) {
-                CodyAgentService.getInstance(project).startAgent(project)
+                CodyAgentService.getInstance(project).startAgent()
               } else {
-                CodyAgentService.getInstance(project).stopAgent(project)
+                CodyAgentService.getInstance(project).stopAgent()
               }
             }
 
@@ -73,7 +73,7 @@ class CodySettingChangeListener(project: Project) : ChangeListener(project) {
 
             if (context.oldShouldAcceptNonTrustedCertificatesAutomatically !=
                 context.newShouldAcceptNonTrustedCertificatesAutomatically)
-                CodyAgentService.getInstance(project).restartAgent(project)
+                CodyAgentService.getInstance(project).restartAgent()
           }
         })
   }

--- a/jetbrains/src/main/kotlin/com/sourcegraph/cody/initialization/PostStartupActivity.kt
+++ b/jetbrains/src/main/kotlin/com/sourcegraph/cody/initialization/PostStartupActivity.kt
@@ -39,7 +39,7 @@ class PostStartupActivity : ProjectActivity {
     // For integration tests we do not want to start agent immediately as we would like to first
     // do some setup.
     if (ConfigUtil.isCodyEnabled() && !ConfigUtil.isIntegrationTestModeEnabled()) {
-      CodyAgentService.getInstance(project).startAgent(project)
+      CodyAgentService.getInstance(project).startAgent()
     }
 
     CodyStatusService.resetApplication(project)

--- a/jetbrains/src/main/kotlin/com/sourcegraph/cody/ui/web/WebUIProxy.kt
+++ b/jetbrains/src/main/kotlin/com/sourcegraph/cody/ui/web/WebUIProxy.kt
@@ -416,7 +416,7 @@ private class ExtensionRequestHandler(
     logger.warn("Browser render process terminated: ${status?.name}")
     ProjectManager.getInstance().openProjects.forEach { project ->
       TelemetryV2.sendTelemetryEvent(project, "cody.webview.request", "renderProcessTerminated")
-      CodyAgentService.getInstance(project).restartAgent(project)
+      CodyAgentService.getInstance(project).restartAgent()
     }
   }
 }


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/jetbrains/issues/3134.
Fixes https://github.com/sourcegraph/jetbrains/issues/2689.
Fixes https://github.com/sourcegraph/jetbrains/issues/2684.
Fixes https://github.com/sourcegraph/jetbrains/issues/2673.
Fixes https://github.com/sourcegraph/jetbrains/issues/2672.
Fixes https://github.com/sourcegraph/jetbrains/issues/2668.
Fixes https://github.com/sourcegraph/jetbrains/issues/2665.
Fixes https://github.com/sourcegraph/jetbrains/issues/2656.
Fixes https://github.com/sourcegraph/jetbrains/issues/2655.
Fixes https://github.com/sourcegraph/jetbrains/issues/2653.
Fixes https://github.com/sourcegraph/jetbrains/issues/2642.
Fixes https://github.com/sourcegraph/jetbrains/issues/2622.
Fixes https://github.com/sourcegraph/jetbrains/issues/2620.
Fixes https://github.com/sourcegraph/jetbrains/issues/1969.

## Test plan
Tested manually - quickly open and close a project. 
I tested the original implementation adding a `Thread.sleep` b/w `project.isDisposed` and `getInstance` call. Smth like this:

```kotlin
ApplicationManager.getApplication().executeOnPooledThread {
  if (project.isDisposed) return
  Thread.sleep(10000)
  MyService.getInstance(project).doTheWork() // AlreadyDisposedException when we exit the app during the sleep!
}
```



<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
