### PR TITLE
chore(chat): add overflow to long endpoint URLs

### DIFF
--- a/vscode/webviews/components/UserMenu.tsx
+++ b/vscode/webviews/components/UserMenu.tsx
@@ -363,7 +363,7 @@ export const UserMenu: React.FunctionComponent<UserMenuProps> = ({
                             </CommandGroup>
                             <CommandGroup>
                                 {/* Display the latest endpoint first. */}
-                                {[...endpointHistory].reverse().map(storedEndpoint => (
+                                {[...endpointHistory].sort((a, b) => (a === endpoint ? -1 : b === endpoint ? 1 : 0)).map(storedEndpoint => (
                                     <CommandItem
                                         key={`${storedEndpoint}-account`}
                                         title={`Sign Out & Remove ${storedEndpoint}`}
@@ -384,13 +384,15 @@ export const UserMenu: React.FunctionComponent<UserMenuProps> = ({
                                                 Active
                                             </Badge>
                                         )}
-                                        <span className="tw-flex-grow tw-truncate">
-                                            {storedEndpoint}
-                                        </span>
+                                        <div className="tw-flex-grow tw-overflow-x-auto no-scrollbar">
+                                            <span className="tw-whitespace-nowrap">
+                                                {storedEndpoint}
+                                            </span>
+                                        </div>
                                         <Button
                                             size="sm"
                                             variant="text"
-                                            className="tw-ml-auto tw-p-0 !tw-w-fit"
+                                            className="tw-ml-auto tw-p-0 !tw-w-fit tw-shrink-0"
                                             onClick={e => {
                                                 e.stopPropagation()
                                                 setEndpointToRemove(storedEndpoint)
@@ -399,7 +401,7 @@ export const UserMenu: React.FunctionComponent<UserMenuProps> = ({
                                         >
                                             <CircleXIcon size={16} strokeWidth={1.25} />
                                         </Button>
-                                    </CommandItem>
+                                    </CommandItem>                            
                                 ))}
                             </CommandGroup>
                             <CommandGroup>

--- a/vscode/webviews/index.css
+++ b/vscode/webviews/index.css
@@ -58,3 +58,12 @@ a:hover {
     font-weight: bold;
 }
 
+/* Chrome, Safari and Opera */
+.no-scrollbar::-webkit-scrollbar {
+display: none;
+}
+
+.no-scrollbar {
+-ms-overflow-style: none;  /* IE and Edge */
+scrollbar-width: none;  /* Firefox */
+}


### PR DESCRIPTION
Long endpoints got chopped up in the switch account container, adding overflow and scrollability 

Before:
![CleanShot 2025-02-25 at 13 21 21@2x](https://github.com/user-attachments/assets/73b8345e-cc37-4b14-8e9e-0d6f37de3307)

After:
![CleanShot 2025-02-25 at 13 22 21](https://github.com/user-attachments/assets/2f120e81-2d4c-4079-91e9-9fd801fb9938)

## Test plan
Ran locally, tested account switching and confirmed still works 
<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
