### PR TITLE
Fix already disposed from CodyAuthService

### DIFF
--- a/jetbrains/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentClient.kt
+++ b/jetbrains/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentClient.kt
@@ -190,14 +190,18 @@ class CodyAgentClient(private val project: Project, private val webview: NativeW
 
   @JsonNotification("window/didChangeContext")
   fun window_didChangeContext(params: Window_DidChangeContextParams) {
-    if (params.key == "cody.activated") {
-      CodyAuthService.getInstance(project).setActivated(params.value?.toBoolean() ?: false)
-      CodyStatusService.resetApplication(project)
-    }
-    if (params.key == "cody.serverEndpoint") {
-      val endpoint = params.value ?: return
-      CodyAuthService.getInstance(project).setEndpoint(SourcegraphServerPath(endpoint))
-      CodyStatusService.resetApplication(project)
+    runInEdt {
+      if (project.isDisposed) return@runInEdt
+
+      if (params.key == "cody.activated") {
+        CodyAuthService.getInstance(project).setActivated(params.value?.toBoolean() ?: false)
+        CodyStatusService.resetApplication(project)
+      }
+      if (params.key == "cody.serverEndpoint") {
+        val endpoint = params.value ?: return@runInEdt
+        CodyAuthService.getInstance(project).setEndpoint(SourcegraphServerPath(endpoint))
+        CodyStatusService.resetApplication(project)
+      }
     }
   }
 


### PR DESCRIPTION
This error has not manifested in any issues yet as it is related to the recent changes.

I noticed that when I quickly open and close a project I get an error:

```
com.intellij.serviceContainer.AlreadyDisposedException: Cannot create light service com.sourcegraph.cody.auth.CodyAuthService because container is already disposed (container=Project(name=runIde-demo, containerState=DISPOSE_COMPLETED, componentStore=/Users/mkondratek/runIdeProjects/runIde-demo) (disposed))
	at com.intellij.serviceContainer.ContainerUtilKt.throwAlreadyDisposedError(containerUtil.kt:40)
	at com.intellij.serviceContainer.ComponentManagerImpl.checkThatCreatingOfLightServiceIsAllowed(ComponentManagerImpl.kt:752)
	at com.intellij.serviceContainer.ComponentManagerImpl.getOrCreateLightService(ComponentManagerImpl.kt:732)
	at com.intellij.serviceContainer.ComponentManagerImpl.doGetService(ComponentManagerImpl.kt:688)
	at com.intellij.serviceContainer.ComponentManagerImpl.getService(ComponentManagerImpl.kt:630)
	at com.sourcegraph.cody.auth.CodyAuthService$Companion.getInstance(CodyAuthService.kt:44)
	at com.sourcegraph.cody.agent.CodyAgentClient.window_didChangeContext(CodyAgentClient.kt:199)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
	at org.eclipse.lsp4j.jsonrpc.services.GenericEndpoint.lambda$recursiveFindRpcMethods$0(GenericEndpoint.java:65)
	at org.eclipse.lsp4j.jsonrpc.services.GenericEndpoint.notify(GenericEndpoint.java:160)
	at org.eclipse.lsp4j.jsonrpc.RemoteEndpoint.handleNotification(RemoteEndpoint.java:231)
	at org.eclipse.lsp4j.jsonrpc.RemoteEndpoint.consume(RemoteEndpoint.java:198)
	at org.eclipse.lsp4j.jsonrpc.TracingMessageConsumer.consume(TracingMessageConsumer.java:119)
	at org.eclipse.lsp4j.jsonrpc.json.StreamMessageProducer.handleMessage(StreamMessageProducer.java:185)
	at org.eclipse.lsp4j.jsonrpc.json.StreamMessageProducer.listen(StreamMessageProducer.java:97)
	at org.eclipse.lsp4j.jsonrpc.json.ConcurrentMessageProcessor.run(ConcurrentMessageProcessor.java:114)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:539)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
	at java.base/java.lang.Thread.run(Thread.java:833)
```

It is related to the recent changes in auth handling (cc: @pkukielka). All we need to do is to verify that the project is not disposed and do it on EDT to limit a chance that it will go disposed b/w the check and the usage.

## Test plan
- quickly open and close a project (having cody toolwinndow opened)

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
