### PR TITLE
fix(commands): generate commit message to use gemini flash-2.0

### DIFF
--- a/vscode/src/commands/scm/source-control.ts
+++ b/vscode/src/commands/scm/source-control.ts
@@ -39,7 +39,7 @@ export class CodySourceControl implements vscode.Disposable {
                     .getModels(ModelUsage.Chat)
                     .pipe(skipPendingOperation())
                     .subscribe(models => {
-                        const preferredModel = models.find(p => p.id.includes('gemini-2.0-flash-lite'))
+                        const preferredModel = models.find(p => p.id.endsWith('gemini-2.0-flash'))
                         this.model = preferredModel ?? models.at(0)
                     })
             )


### PR DESCRIPTION
Fixes CODY-5158 
- Flash-lite was a preview model and right now it fails with error from the backend

## Test plan
Try to generate a commit message and see that it works.

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
