### PR TITLE
Fix already disposed error from WebviewViewManager (closes #3040)

### DIFF
--- a/jetbrains/src/main/kotlin/com/sourcegraph/cody/ui/web/WebviewView.kt
+++ b/jetbrains/src/main/kotlin/com/sourcegraph/cody/ui/web/WebviewView.kt
@@ -105,6 +105,8 @@ internal class WebviewViewManager(private val project: Project) {
   }
 
   private fun provideView(viewHost: WebviewHost, provider: Provider) {
+    if (project.isDisposed) return
+
     val handle = "native-webview-view-${viewHost.id}"
     WebUIService.getInstance(project).createWebviewView(handle) { proxy ->
       viewHost.adopt(proxy)

--- a/jetbrains/src/main/kotlin/com/sourcegraph/utils/CodyEditorUtil.kt
+++ b/jetbrains/src/main/kotlin/com/sourcegraph/utils/CodyEditorUtil.kt
@@ -78,6 +78,7 @@ object CodyEditorUtil {
 
   @JvmStatic
   fun getSelectedEditors(project: Project): Array<out Editor> {
+    if (project.isDisposed) return emptyArray()
     return FileEditorManager.getInstance(project).selectedTextEditorWithRemotes
   }
 


### PR DESCRIPTION
Fixes #3040
Fixes #2660

## Test plan
unable to reproduce

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
