### PR TITLE
chore: Bump cody web version in preparation for publishing

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sourcegraph/cody-web",
-  "version": "0.32.0",
+  "version": "0.32.1",
   "description": "Cody standalone web app",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
The previous version didn't include TS types due to local issues. This
commit bumpts the version in order to release a fixed version.


## Test plan

`pnpm build` works and `dist/lib` is present

