### PR TITLE
feat(commit generation): prioritize Gemini Flash models 

### DIFF
--- a/vscode/src/commands/scm/source-control.ts
+++ b/vscode/src/commands/scm/source-control.ts
@@ -6,6 +6,7 @@ import {
     type Message,
     type Model,
     type ModelContextWindow,
+    ModelTag,
     ModelUsage,
     Typewriter,
     getSimplePreamble,
@@ -36,11 +37,18 @@ export class CodySourceControl implements vscode.Disposable {
             vscode.commands.registerCommand('cody.command.abort-commit', () => this.statusUpdate()),
             subscriptionDisposable(
                 modelsService
-                    .getModels(ModelUsage.Chat)
+                    .getModels(ModelUsage.Edit)
                     .pipe(skipPendingOperation())
                     .subscribe(models => {
-                        const preferredModel = models.find(p => p.id.includes('gemini-2.0-flash-lite'))
-                        this.model = preferredModel ?? models.at(0)
+                        // Removes experimental and preview models
+                        const filtered = models.filter(
+                            m =>
+                                !m.tags.includes(ModelTag.Experimental) &&
+                                !m.tags.includes(ModelTag.Internal)
+                        )
+                        const flashLite = filtered.find(m => m.id.endsWith('gemini-2.0-flash-lite'))
+                        const flash = filtered.find(m => m.id.endsWith('gemini-2.0-flash'))
+                        this.model = flashLite ?? flash ?? filtered.at(0)
                     })
             )
         )


### PR DESCRIPTION

This commit updates the Cody Source Control to prioritize Gemini Flash models when selecting a model for edit commands. It filters out experimental models and then selects Gemini Flash Lite or Gemini Flash if available, falling back to the first available model if neither is found.

This change ensures that the edit commands utilize the most performant and suitable models.


## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

- Verify that the edit commands use Gemini Flash models if available.
- Verify that the edit commands fall back to other models if Gemini Flash is not available.

Connect to demo.sourcegraph and verify this change works on older instances
