### PR TITLE
Clean up the "Ask Cody to Explain" functionality in terminal

### DIFF
--- a/vscode/src/commands/execute/terminal.ts
+++ b/vscode/src/commands/execute/terminal.ts
@@ -46,7 +46,7 @@ export async function executeExplainOutput(
 
         let prompt = template.replaceAll('{{PROCESS}}', promptArgs.name).replaceAll('{{OUTPUT}}', output)
         const options = promptArgs.creationOptions
-        if (options) {
+        if (options && options.toString() !== '{}') {
             span.addEvent('hasCreationOptions')
             prompt = prompt.concat(ps`\nProcess options: ${options}`)
         }

--- a/vscode/src/commands/execute/terminal.ts
+++ b/vscode/src/commands/execute/terminal.ts
@@ -23,7 +23,7 @@ export async function executeExplainOutput(
         const source = 'terminal'
         telemetryRecorder.recordEvent('cody.command.terminal', 'executed', {
             metadata: {
-                useCodebaseContex: 0,
+                useCodebaseContext: 0,
             },
             interactionID: requestID,
             privateMetadata: {


### PR DESCRIPTION
Specifically, `Process options` should not be included if it's empty.

Before:
![image](https://github.com/user-attachments/assets/9106c8d1-81d8-4775-a226-f06e7dc5a02e)

After:
![image](https://github.com/user-attachments/assets/1dcafd81-c325-496e-933f-67e6005dd762)

## Test plan

Manually test it.