### PR TITLE
Remove the /reset command

### DIFF
--- a/vscode/src/chat/chat-view/ChatController.ts
+++ b/vscode/src/chat/chat-view/ChatController.ts
@@ -666,12 +666,6 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
                     `traceId: ${span.spanContext().traceId}`
                 )
 
-                if (inputText.match(/^\/reset$/)) {
-                    span.addEvent('clearAndRestartSession')
-                    span.end()
-                    return this.clearAndRestartSession()
-                }
-
                 // Set selected agent to deep-cody for Deep Cody model.
                 const model = await wrapInActiveSpan('chat.resolveModel', () =>
                     firstResultFromOperation(ChatBuilder.resolvedModelForChat(this.chatBuilder))


### PR DESCRIPTION
We have the /reset command for clearing out chat, but I don't think anyone uses it, and I don't think it's documented well. I suggest removing it.

## Test plan

Manually test it