### PR TITLE
Fix assertion error from webview (closes #2845)

### DIFF
--- a/jetbrains/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentService.kt
+++ b/jetbrains/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentService.kt
@@ -85,6 +85,8 @@ class CodyAgentService(private val project: Project) : Disposable {
       token: String?,
       secondsTimeout: Long = 45
   ): CompletableFuture<CodyAgent> {
+    WebUIService.getInstance(project).reset()
+
     ApplicationManager.getApplication().executeOnPooledThread {
       try {
         val future =


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/jetbrains/issues/2302.
Fixes https://github.com/sourcegraph/jetbrains/issues/2335.
Fixes https://github.com/sourcegraph/jetbrains/issues/2359.
Fixes https://github.com/sourcegraph/jetbrains/issues/2441.
Fixes https://github.com/sourcegraph/jetbrains/issues/2454.
Fixes https://github.com/sourcegraph/jetbrains/issues/2514.
Fixes https://github.com/sourcegraph/jetbrains/issues/2538.
Fixes https://github.com/sourcegraph/jetbrains/issues/2570.
Fixes https://github.com/sourcegraph/jetbrains/issues/2579.
Fixes https://github.com/sourcegraph/jetbrains/issues/2580.
Fixes https://github.com/sourcegraph/jetbrains/issues/2648.
Fixes https://github.com/sourcegraph/jetbrains/issues/2659.
Fixes https://github.com/sourcegraph/jetbrains/issues/2680.
Fixes https://github.com/sourcegraph/jetbrains/issues/2685.
Fixes https://github.com/sourcegraph/jetbrains/issues/2714.
Fixes https://github.com/sourcegraph/jetbrains/issues/2845.
Fixes https://github.com/sourcegraph/jetbrains/issues/3041.
Fixes https://github.com/sourcegraph/jetbrains/issues/3059.

---

The error appears when the agent start fails with an exception. We register the provider but there is no cleanup on failure. I think we can either drop the assert or **reset `WebUIService` just before the agent start**.  

## Test plan
I was not able to reproduce it without a debugger. It appears when the agent start fails with an exception. My repro is - put a breakpoint on the failing assert. Wait on it for about 60s. Resume - agent start failure notification should appear. Restart the agent.

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
