### PR TITLE
chore(release): remove unreleased section

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -76,12 +76,6 @@ This is a log of all notable changes to Cody for VS Code.
 
 - Revert "fix(ui): Hide unused prompts(SRCH-1648)" [#-1](https://github.com/sourcegraph/cody/pull/7101)
 
-## Unreleased
-
-### Fix
-
-- Remove reasoning models from Inline Edit model selector that could cause edits to fail. [#7238](https://github.com/sourcegraph/cody/pull/7238)
-
 ## 1.70.3
 
 ### Refactor


### PR DESCRIPTION
Unreleased section is not needed anymore as changelog is generated on release 

## Test plan
N/A
<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
