### PR TITLE
fix(webviews): don't add aborted messages to new chat sessions

### DIFF
--- a/lib/shared/src/sourcegraph-api/utils.ts
+++ b/lib/shared/src/sourcegraph-api/utils.ts
@@ -47,8 +47,6 @@ export async function getAuthHeaders(auth: AuthCredentials, url: URL): Promise<R
         }
     }
 
-    console.error('Cannot add headers: neither token nor headers found')
-
     return {}
 }
 

--- a/vscode/src/chat/chat-view/ChatController.ts
+++ b/vscode/src/chat/chat-view/ChatController.ts
@@ -1485,7 +1485,7 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
         })
     }
 
-    public async clearAndRestartSession(chatMessages?: ChatMessage[]): Promise<void> {
+    public clearAndRestartSession(chatMessages?: ChatMessage[]): void {
         this.cancelSubmitOrEditOperation()
         // Only clear the session if session is not empty.
         if (!this.chatBuilder?.isEmpty()) {

--- a/vscode/src/chat/chat-view/ChatController.ts
+++ b/vscode/src/chat/chat-view/ChatController.ts
@@ -1130,7 +1130,7 @@ export class ChatController implements vscode.Disposable, vscode.WebviewViewProv
         }
     }
 
-    private async handleAbort(): Promise<void> {
+    private handleAbort(): void {
         this.cancelSubmitOrEditOperation()
         // Notify the webview there is no message in progress.
         this.postViewTranscript()

--- a/vscode/src/chat/chat-view/handlers/ChatHandler.ts
+++ b/vscode/src/chat/chat-view/handlers/ChatHandler.ts
@@ -174,8 +174,7 @@ export class ChatHandler implements AgentHandler {
                         break
                     }
                     case 'error': {
-                        typewriter.close()
-                        typewriter.stop(message.error)
+                        throw message.error
                     }
                 }
             }


### PR DESCRIPTION
CLOSE https://linear.app/sourcegraph/issue/CODY-5168

<img width="2002" alt="image" src="https://github.com/user-attachments/assets/80a311fc-208d-47b9-8b1e-7a4b494e49f2" />


This resolves an issue where aborting a chat operation and then restarting the session could cause the webview to go blank. The root cause was attempting to add aborted bot messages to a newly created empty ChatBuilder, which requires human messages first. The fix ensures we only create a new ChatBuilder if the current one isn't empty, improves abort handling, and adds better error management in the session saving process.

### Cause

<img width="770" alt="image" src="https://github.com/user-attachments/assets/c69d0764-2632-421e-a440-5f7baeac92de" />

1. When a chat was aborted, we would clear and restart the session, creating a new empty ChatBuilder
2. Then we'd try to add a bot message (from the aborted operation) to this empty session
3. Since ChatBuilder requires human messages before bot messages, this would throw an error
4. The error would cause the webview to go blank, resulting in a poor user experience

#### Changes

1. Only create a new ChatBuilder if the current one isn't empty
2. Check signal.throwIfAborted() early in the sendChat() method to fail fast
3. Make cancelSubmitOrEditOperation() synchronous and independent of session saving
4. Update the UI with postViewTranscript() when handling abort errors
5. Only attempt to save if there's a valid chat and the user is authenticated


## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

1. Start a new chat and type a question
2. Click the abort button while the bot is responding
3. Verify the chat view remains visible and functional
4. Verify you can send a new message after aborting

### Demo

https://github.com/user-attachments/assets/3c9dea8e-4a4e-4c78-986e-f04cb4c70dfe

