### PR TITLE
fix: Add support for open-link items to new prompt editor

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -40,7 +40,12 @@
             "correctness": {
                 "noInvalidUseBeforeDeclaration": "error",
                 "noUnusedPrivateClassMembers": "error",
-                "noUnusedImports": "error"
+                "noUnusedImports": "error",
+                "useExhaustiveDependencies": {
+                    "options": {
+                        "hooks": [{ "name": "useLatestRef", "stableResult": true }]
+                    }
+                }
             }
         }
     },

--- a/lib/prompt-editor/src/v2/PromptEditor.tsx
+++ b/lib/prompt-editor/src/v2/PromptEditor.tsx
@@ -56,6 +56,8 @@ interface Props extends KeyboardEventPluginProps {
     disabled?: boolean
 
     editorRef?: React.RefObject<PromptEditorRefAPI>
+
+    openExternalLink: (uri: string) => void
 }
 
 interface PromptEditorRefAPI {
@@ -105,6 +107,7 @@ export const PromptEditor: FunctionComponent<Props> = ({
     disabled,
     editorRef: ref,
     onEnterKey,
+    openExternalLink,
 }) => {
     // We use the interaction ID to differentiate between different
     // invocations of the mention-menu. That way upstream we don't trigger
@@ -170,6 +173,7 @@ export const PromptEditor: FunctionComponent<Props> = ({
         onFocusChange,
         onEnterKey,
         fetchMenuData,
+        openExternalLink,
     })
 
     const { show, items, selectedIndex, query, position: menuPosition, parent } = useMentionsMenu(input)
@@ -242,6 +246,7 @@ export const PromptEditor: FunctionComponent<Props> = ({
             if ('id' in item) {
                 return <MentionMenuProviderItemContent provider={item} />
             }
+            // TODO: Support item.badge
             return <MentionMenuContextItemContent item={item} query={parseMentionQuery(query, parent)} />
         },
         [query, parent]

--- a/lib/prompt-editor/src/v2/actions.ts
+++ b/lib/prompt-editor/src/v2/actions.ts
@@ -15,7 +15,12 @@ import {
 } from '@sourcegraph/cody-shared'
 import type { Node } from 'prosemirror-model'
 import { type EditorState, Selection, type Transaction } from 'prosemirror-state'
-import { type MenuItem, type MenuSelectionAPI, createMentionNode, schema } from './promptInput'
+import {
+    type MenuSelectionAPI as BaseMenuSelectionAPI,
+    type MenuItem,
+    createMentionNode,
+    schema,
+} from './promptInput'
 
 /**
  * Returns a {@link Transaction} to replace the current document with provided document.
@@ -181,6 +186,10 @@ export function getMentions(doc: Node): SerializedContextItem[] {
     return mentions
 }
 
+interface MenuSelectionAPI extends BaseMenuSelectionAPI {
+    openURI: (uri: string) => void
+}
+
 /**
  * The prompt editor supports different values as {@link MenuItem}s and different types have a
  * different effect on the editor value.
@@ -233,12 +242,12 @@ export function handleSelectMenuItem(item: MenuItem, api: MenuSelectionAPI) {
     if (item.type === 'open-link') {
         // "open-link" items are links to documentation, you can not commit them as mentions.
         api.deleteAtMention()
-        // TODO: Raise an event? Enqueue a task? to open the link.
+        api.openURI(item.uri.toString())
         return
     }
 
     // In all other cases we'll insert the selected item as a mention node.
-    api.replaceAtMentionValue(createMentionNode({ item: serializeContextItem(item) }))
+    api.replaceAtMention(createMentionNode({ item: serializeContextItem(item) }))
 }
 
 function insertMentions(

--- a/lib/prompt-editor/src/v2/plugins/atMention.ts
+++ b/lib/prompt-editor/src/v2/plugins/atMention.ts
@@ -164,6 +164,27 @@ export function replaceAtMention(state: EditorState, replacement: Node): Transac
     }
     return state.tr
 }
+/**
+ *
+ * Removes the current at-mention if an at-mention is currently present.
+ * @param state The current editor state
+ * @param replacement The node to replace the at-mention with
+ * @returns The transaction that replaces the at-mention
+ */
+export function deleteAtMention(state: EditorState): Transaction {
+    const decoration = getDecoration(state)
+    if (decoration) {
+        const tr = disableAtMention(state.tr.deleteRange(decoration.from, decoration.to))
+
+        return (
+            tr
+                // Move selection after the space after the node
+                .setSelection(TextSelection.create(tr.doc, decoration.from))
+                .scrollIntoView()
+        )
+    }
+    return state.tr
+}
 
 /**
  * Returns whether an at-mention is currently present in the editor.

--- a/lib/prompt-editor/src/v2/promptInput-react.ts
+++ b/lib/prompt-editor/src/v2/promptInput-react.ts
@@ -8,7 +8,7 @@ import { useActorRef, useSelector } from '@xstate/react'
 import type { Observable } from 'observable-fns'
 import type { Node } from 'prosemirror-model'
 import type { EditorState } from 'prosemirror-state'
-import { useEffect, useMemo, useRef } from 'react'
+import { type MutableRefObject, useEffect, useMemo, useRef } from 'react'
 import { type ActorRefFrom, fromCallback } from 'xstate'
 import type { AnyEventObject } from 'xstate'
 import { usePromptEditorConfig } from '../config'
@@ -22,7 +22,13 @@ import {
     upsertMentions,
 } from './actions'
 import { AT_MENTION_TRIGGER_CHARACTER, type Position, enableAtMention } from './plugins/atMention'
-import { type DataLoaderInput, type MenuItem, promptInput, schema } from './promptInput'
+import {
+    type DataLoaderInput,
+    type MenuItem,
+    type PromptInputOptions,
+    promptInput,
+    schema,
+} from './promptInput'
 
 type PromptInputLogic = typeof promptInput
 type PromptInputActor = ActorRefFrom<PromptInputLogic>
@@ -68,6 +74,11 @@ interface PromptEditorOptions {
     fetchMenuData: (args: { query: string; provider?: ContextMentionProviderMetadata }) => Observable<
         MenuItem[]
     >
+
+    /**
+     * Called when an 'open-link' context item is selected.
+     */
+    openExternalLink: (uri: string) => void
 }
 
 interface PromptEditorAPI {
@@ -114,10 +125,63 @@ export const usePromptInput = (options: PromptEditorOptions): [PromptInputActor,
 
     const focused = useRef(false)
 
-    const onFocusChangeRef = useRef(options.onFocusChange)
-    onFocusChangeRef.current = options.onFocusChange
-    const onEnterKeyRef = useRef(options.onEnterKey)
-    onEnterKeyRef.current = options.onEnterKey
+    const onFocusChangeRef = useLatestRef(options.onFocusChange)
+    const onEnterKeyRef = useLatestRef(options.onEnterKey)
+    const openExternalLinkRef = useLatestRef(options.openExternalLink)
+    const onContextItemMentionNodeMetaClickRef = useLatestRef(onContextItemMentionNodeMetaClick)
+
+    const actorOptions = useMemo(
+        (): PromptInputOptions => ({
+            editorViewProps: {
+                handleDOMEvents: {
+                    focus: () => {
+                        if (!focused.current) {
+                            focused.current = true
+                            onFocusChangeRef.current?.(true)
+                        }
+                    },
+                    blur: () => {
+                        if (focused.current) {
+                            focused.current = false
+                            onFocusChangeRef.current?.(false)
+                        }
+                    },
+                },
+                handleKeyDown: (_view, event) => {
+                    if (event.key === 'Enter') {
+                        onEnterKeyRef.current?.(event)
+                        return event.defaultPrevented
+                    }
+                    return false
+                },
+                handleClickOn(_view, _pos, node, _nodePos, _event, _direct) {
+                    if (node.type === schema.nodes.mention) {
+                        onContextItemMentionNodeMetaClickRef.current?.(node.attrs.item)
+                        return true
+                    }
+                    return false
+                },
+                nodeViews: {
+                    mention(node) {
+                        return new MentionView(node)
+                    },
+                },
+            },
+            handleSelectMenuItem: (item, api) => {
+                handleSelectMenuItem(item, { ...api, openURI: uri => openExternalLinkRef.current(uri) })
+            },
+            placeholder: options.placeholder,
+            initialDocument: options.initialDocument,
+            disabled: options.disabled,
+            contextWindowSizeInTokens: options.contextWindowSizeInTokens,
+        }),
+        [
+            options.placeholder,
+            options.initialDocument,
+            options.disabled,
+            options.contextWindowSizeInTokens,
+        ]
+    )
 
     const editor = useActorRef(
         promptInput.provide({
@@ -125,50 +189,7 @@ export const usePromptInput = (options: PromptEditorOptions): [PromptInputActor,
                 menuDataLoader: fetchMenuData,
             },
         }),
-        {
-            input: {
-                editorViewProps: {
-                    handleDOMEvents: {
-                        focus: () => {
-                            if (!focused.current) {
-                                focused.current = true
-                                onFocusChangeRef.current?.(true)
-                            }
-                        },
-                        blur: () => {
-                            if (focused.current) {
-                                focused.current = false
-                                onFocusChangeRef.current?.(false)
-                            }
-                        },
-                    },
-                    handleKeyDown: (_view, event) => {
-                        if (event.key === 'Enter') {
-                            onEnterKeyRef.current?.(event)
-                            return event.defaultPrevented
-                        }
-                        return false
-                    },
-                    handleClickOn(_view, _pos, node, _nodePos, _event, _direct) {
-                        if (node.type === schema.nodes.mention) {
-                            onContextItemMentionNodeMetaClick?.(node.attrs.item)
-                            return true
-                        }
-                        return false
-                    },
-                    nodeViews: {
-                        mention(node) {
-                            return new MentionView(node)
-                        },
-                    },
-                },
-                handleSelectMenuItem,
-                placeholder: options.placeholder,
-                initialDocument: options.initialDocument,
-                disabled: options.disabled,
-                contextWindowSizeInTokens: options.contextWindowSizeInTokens,
-            },
-        }
+        { input: actorOptions }
     )
 
     const api: PromptEditorAPI = useMemo(
@@ -303,4 +324,17 @@ export function useMentionsMenu(input: PromptInputActor): MentionsMenuData {
         query: mentionsMenu.query,
         position: mentionsMenu.position,
     }
+}
+
+/**
+ * Helper hook to always update a ref with the latest value.
+ */
+function useLatestRef<T>(value: T): MutableRefObject<T> {
+    const ref = useRef(value)
+
+    useEffect(() => {
+        ref.current = value
+    }, [value])
+
+    return ref
 }

--- a/lib/prompt-editor/src/v2/promptInput.test.ts
+++ b/lib/prompt-editor/src/v2/promptInput.test.ts
@@ -23,6 +23,7 @@ import { AT_MENTION_TRIGGER_CHARACTER, enableAtMention, hasAtMention } from './p
 import {
     type DataLoaderInput,
     type MenuItem,
+    type MenuSelectionAPI,
     type PromptInputOptions,
     getMentions,
     promptInput,
@@ -302,9 +303,17 @@ describe('actions', () => {
 
 describe('mentions menu', () => {
     const DEBOUNCE_TIME = 10
+
+    const openURI = vi.fn()
+
     beforeEach(() => {
         debounceAtMention.mockReturnValue(DEBOUNCE_TIME)
+        openURI.mockReset()
     })
+
+    const handleSelectMenuItemTest = (item: MenuItem, api: MenuSelectionAPI) => {
+        handleSelectMenuItem(item, { ...api, openURI })
+    }
 
     test('calls fetch function and updates available items', () => {
         fetchMenuData.mockImplementation(
@@ -314,7 +323,7 @@ describe('mentions menu', () => {
             ])
         )
 
-        const editor = createInput(d`test`, { handleSelectMenuItem })
+        const editor = createInput(d`test`, { handleSelectMenuItem: handleSelectMenuItemTest })
         const mention = createAtMention(editor)
         mention.type('file')
 
@@ -330,7 +339,7 @@ describe('mentions menu', () => {
     })
 
     test('debounces fetching of menu data', () => {
-        const editor = createInput(d``, { handleSelectMenuItem })
+        const editor = createInput(d``, { handleSelectMenuItem: handleSelectMenuItemTest })
         const mention = createAtMention(editor)
 
         expect.soft(fetchMenuData, 'initial fetch is done without debounce').toHaveBeenCalledTimes(1)
@@ -363,7 +372,7 @@ describe('mentions menu', () => {
         // works correctly together.
 
         test('apply normal context item', () => {
-            const editor = createInput(d`test `, { handleSelectMenuItem })
+            const editor = createInput(d`test `, { handleSelectMenuItem: handleSelectMenuItemTest })
             const item: ContextItem = {
                 type: 'file',
                 uri: URI.parse('file:///file.txt'),
@@ -393,7 +402,7 @@ describe('mentions menu', () => {
                 .mockImplementationOnce(mockFetchMenu([provider]))
                 .mockImplementationOnce(mockFetchMenu([provider]))
                 .mockImplementationOnce(mockFetchMenu([item]))
-            const editor = createInput(d`test `, { handleSelectMenuItem })
+            const editor = createInput(d`test `, { handleSelectMenuItem: handleSelectMenuItemTest })
             createAtMention(editor).type('file')
             clock.increment(DEBOUNCE_TIME)
 
@@ -420,7 +429,7 @@ describe('mentions menu', () => {
         })
 
         test('apply large file without range', () => {
-            const editor = createInput(d`test `, { handleSelectMenuItem })
+            const editor = createInput(d`test `, { handleSelectMenuItem: handleSelectMenuItemTest })
             createAtMention(editor)
 
             editor.send({
@@ -435,7 +444,7 @@ describe('mentions menu', () => {
         })
 
         test('apply large file with range', () => {
-            const editor = createInput(d`test `, { handleSelectMenuItem })
+            const editor = createInput(d`test `, { handleSelectMenuItem: handleSelectMenuItemTest })
             createAtMention(editor)
 
             editor.send({
@@ -482,7 +491,7 @@ describe('mentions menu', () => {
                     uri: 'file:///file2.txt',
                     size: 3,
                 }} `,
-                { contextWindowSizeInTokens: 10, handleSelectMenuItem }
+                { contextWindowSizeInTokens: 10, handleSelectMenuItem: handleSelectMenuItemTest }
             )
 
             createAtMention(editor)
@@ -528,7 +537,7 @@ describe('mentions menu', () => {
         })
         describe('special cases', () => {
             test('apply remote file', () => {
-                const editor = createInput(d`test `, { handleSelectMenuItem })
+                const editor = createInput(d`test `, { handleSelectMenuItem: handleSelectMenuItemTest })
                 createAtMention(editor)
 
                 editor.send({
@@ -555,7 +564,7 @@ describe('mentions menu', () => {
             })
 
             test('apply remote directory', () => {
-                const editor = createInput(d`test `, { handleSelectMenuItem })
+                const editor = createInput(d`test `, { handleSelectMenuItem: handleSelectMenuItemTest })
                 createAtMention(editor)
 
                 editor.send({
@@ -579,6 +588,25 @@ describe('mentions menu', () => {
                     'test @some-repo:'
                 )
                 expect(hasAtMention(getEditorState(editor))).toBe(true)
+            })
+
+            test('open link', () => {
+                const editor = createInput(d`test `, { handleSelectMenuItem: handleSelectMenuItemTest })
+                createAtMention(editor)
+
+                editor.send({
+                    type: 'atMention.apply',
+                    item: {
+                        type: 'open-link',
+                        uri: URI.parse('file:///file.txt'),
+                        name: 'some name',
+                        content: null,
+                    },
+                })
+
+                expect(getText(editor), 'at mention is removed').toBe('test ')
+                expect(hasAtMention(getEditorState(editor))).toBe(false)
+                expect(openURI, 'openURI was called').toHaveBeenCalledWith('file:///file.txt')
             })
         })
     })

--- a/lib/prompt-editor/src/v2/promptInput.ts
+++ b/lib/prompt-editor/src/v2/promptInput.ts
@@ -30,6 +30,7 @@ import {
 import {
     type Position,
     createAtMentionPlugin,
+    deleteAtMention,
     disableAtMention,
     getAtMentionPosition,
     getAtMentionValue,
@@ -226,8 +227,10 @@ export interface MenuSelectionAPI {
     setAtMentionValue(value: string): void
     /**
      * Remove the active at-mention and replace it with the provided string or node.
+     * If passed a string it has to be non-empty. If you want to remove the at-mention
+     * use {@link deleteAtMention} instead.
      */
-    replaceAtMentionValue(value: string | Node): void
+    replaceAtMention(value: string | Node): void
     /**
      * Remove the active at-mention.
      */
@@ -671,7 +674,7 @@ export const promptInput = setup({
                                     params: setAtMentionValue(context.editorState, value),
                                 })
                             },
-                            replaceAtMentionValue(value) {
+                            replaceAtMention(value) {
                                 enqueue({
                                     type: 'updateEditorState',
                                     params: replaceAtMention(
@@ -683,7 +686,7 @@ export const promptInput = setup({
                             deleteAtMention() {
                                 enqueue({
                                     type: 'updateEditorState',
-                                    params: replaceAtMention(context.editorState, schema.text('')),
+                                    params: deleteAtMention(context.editorState),
                                 })
                             },
                             setProvider(item) {

--- a/vscode/webviews/chat/cells/messageCell/human/editor/HumanMessageEditor.tsx
+++ b/vscode/webviews/chat/cells/messageCell/human/editor/HumanMessageEditor.tsx
@@ -423,7 +423,6 @@ export const HumanMessageEditor: FunctionComponent<{
         [linkOpener]
     )
 
-    // TODO: Finish implementing "current repo not indexed" handling for v2 editor
     const Editor = experimentalPromptEditorEnabled ? PromptEditorV2 : PromptEditor
 
     return (

--- a/vscode/webviews/promptEditor/PromptEditorV2.story.tsx
+++ b/vscode/webviews/promptEditor/PromptEditorV2.story.tsx
@@ -18,6 +18,9 @@ const meta: Meta<typeof PromptEditor> = {
         initialEditorState: undefined,
         onChange: () => {},
         editorClassName: styles.editor,
+        openExternalLink(uri) {
+            console.log('openExternalLink', uri)
+        },
     } satisfies React.ComponentProps<typeof PromptEditor>,
 
     decorators: [VSCodeStandaloneComponent],


### PR DESCRIPTION
This PR adds support for handling open-link context items to the new prompt input.

I also did some refactoring (e.g. name changes, adding useMemo) to code that relates to this change.

## Test plan

Manual testing and unit test
