### PR TITLE
fix(smart-apply): do not create new files on prefetching

### DIFF
--- a/vscode/src/services/utils/codeblock-action-tracker.ts
+++ b/vscode/src/services/utils/codeblock-action-tracker.ts
@@ -202,8 +202,13 @@ export async function handleSmartApply({
     const workspaceUri = vscode.workspace.workspaceFolders?.[0].uri
     const uri = await resolveRelativeOrAbsoluteUri(workspaceUri, fileUri, activeEditor?.document?.uri)
 
+    // TODO: move this logic to the smart apply manager
     const isNewFile = uri && !(await doesFileExist(uri))
     if (isNewFile) {
+        if (isPrefetch) {
+            return
+        }
+
         const workspaceEditor = new vscode.WorkspaceEdit()
         workspaceEditor.createFile(uri, { ignoreIfExists: false })
         await vscode.workspace.applyEdit(workspaceEditor)

--- a/vscode/webviews/chat/ChatMessageContent/ChatMessageContent.tsx
+++ b/vscode/webviews/chat/ChatMessageContent/ChatMessageContent.tsx
@@ -150,6 +150,7 @@ export const ChatMessageContent: React.FunctionComponent<ChatMessageContentProps
                     // TODO: extract this call into a separate `useEffect` call to avoid redundant calls
                     // which currently happen.
                     if (
+                        codeBlockName !== 'command' &&
                         (!isMessageLoading || areWeAlreadyOutsideTheCodeBlock) &&
                         // Ensure that we prefetch once per each suggested code block.
                         !prefetchedEdits.has(smartApplyId)


### PR DESCRIPTION
Fixing the bug reported by @abeatrix [in Slack](https://sourcegraph.slack.com/archives/C05AGQYD528/p1740624941556639), where new empty files were being created when opening chats that suggested new files. The issue was due to the smart apply prefetching logic not accounting for the new file and command blocks.

## Test plan

CI