### PR TITLE
Fix missing tab tooltips

### DIFF
--- a/jetbrains/src/main/kotlin/com/sourcegraph/cody/ui/web/WebPanelTabTitleProvider.kt
+++ b/jetbrains/src/main/kotlin/com/sourcegraph/cody/ui/web/WebPanelTabTitleProvider.kt
@@ -13,7 +13,7 @@ class WebPanelTabTitleProvider : EditorTabTitleProvider, DumbAware {
   }
 
   override fun getEditorTabTitle(project: Project, file: VirtualFile): String? {
-    return file.getUserData(WEB_PANEL_TITLE_KEY) ?: ""
+    return file.getUserData(WEB_PANEL_TITLE_KEY)
   }
 
   override fun getEditorTabTooltipText(project: Project, virtualFile: VirtualFile): String? {


### PR DESCRIPTION
Fixes https://linear.app/sourcegraph/issue/BUGS-1339
Fixes https://linear.app/sourcegraph/issue/BUGS-586

## Test plan

1. Open any file in. IntelliJ
2. Hover over the tab name - you should see a tooltip with a file path 