### PR TITLE
Use Throwable instead of Exception when doing catch-it-all error handling

### DIFF
--- a/jetbrains/build.gradle.kts
+++ b/jetbrains/build.gradle.kts
@@ -213,7 +213,7 @@ fun download(url: String, output: File) {
     } else {
       error("Failed to download ${url}. Response code: $responseCode")
     }
-  } catch (e: Exception) {
+  } catch (e: Throwable) {
     e.printStackTrace()
     error("Failed to download ${url}")
   } finally {

--- a/jetbrains/src/integrationTest/kotlin/com/sourcegraph/cody/util/CodyIntegrationTextFixture.kt
+++ b/jetbrains/src/integrationTest/kotlin/com/sourcegraph/cody/util/CodyIntegrationTextFixture.kt
@@ -266,7 +266,7 @@ open class CodyIntegrationTextFixture : BasePlatformTestCase(), LensListener {
 
     try {
       return future.get(ASYNC_WAIT_TIMEOUT_SECONDS, TimeUnit.SECONDS)
-    } catch (e: Exception) {
+    } catch (e: Throwable) {
       val codeLenses = LensesService.getInstance(myFixture.project).getLenses(myFixture.editor)
       assertTrue(
           "Error while awaiting after action $actionIdToRun. Expected lenses: [${expectedLenses.joinToString()}], got: $codeLenses",

--- a/jetbrains/src/main/java/com/sourcegraph/cody/agent/CodyAgentException.java
+++ b/jetbrains/src/main/java/com/sourcegraph/cody/agent/CodyAgentException.java
@@ -5,7 +5,7 @@ public class CodyAgentException extends Exception {
     super(message);
   }
 
-  public CodyAgentException(String message, Exception e) {
+  public CodyAgentException(String message, Throwable e) {
     super(message, e);
   }
 

--- a/jetbrains/src/main/java/com/sourcegraph/cody/vscode/CancellationToken.java
+++ b/jetbrains/src/main/java/com/sourcegraph/cody/vscode/CancellationToken.java
@@ -23,7 +23,7 @@ public class CancellationToken {
         (isCancelled) -> {
           try {
             callback.accept(isCancelled);
-          } catch (Exception ignored) {
+          } catch (Throwable ignored) {
             // Do nothing about exceptions in cancellation callbacks
           }
         });

--- a/jetbrains/src/main/java/com/sourcegraph/config/ThemeUtil.java
+++ b/jetbrains/src/main/java/com/sourcegraph/config/ThemeUtil.java
@@ -27,7 +27,7 @@ public class ThemeUtil {
         if (value instanceof Color) {
           intelliJTheme.addProperty(key.toString(), getHexString(UIManager.getColor(key)));
         }
-      } catch (Exception e) {
+      } catch (Throwable e) {
         logger.warn(e.getMessage());
       }
     }

--- a/jetbrains/src/main/java/com/sourcegraph/find/FindService.java
+++ b/jetbrains/src/main/java/com/sourcegraph/find/FindService.java
@@ -115,7 +115,7 @@ public class FindService implements Disposable {
                 () -> {
                   try {
                     mainPanel.getPreviewPanel().getPreviewContent().openInEditorOrBrowser();
-                  } catch (Exception e) {
+                  } catch (Throwable e) {
                     logger.warn("Error opening file in editor", e);
                   }
                 });
@@ -209,7 +209,7 @@ public class FindService implements Disposable {
                   ActionManager.getInstance(),
                   0));
         }
-      } catch (Exception ignored) {
+      } catch (Throwable ignored) {
       }
     }
   }

--- a/jetbrains/src/main/java/com/sourcegraph/find/FooterPanel.java
+++ b/jetbrains/src/main/java/com/sourcegraph/find/FooterPanel.java
@@ -32,7 +32,7 @@ public class FooterPanel extends JBPanel<FooterPanel> {
           if (previewContent != null) {
             try {
               previewContent.openInEditorOrBrowser();
-            } catch (Exception e) {
+            } catch (Throwable e) {
               Logger logger = Logger.getInstance(FooterPanel.class);
               logger.warn(
                   "Error while opening preview content externally: "

--- a/jetbrains/src/main/java/com/sourcegraph/find/PreviewPanel.java
+++ b/jetbrains/src/main/java/com/sourcegraph/find/PreviewPanel.java
@@ -143,7 +143,7 @@ public class PreviewPanel extends JBPanelWithEmptyText implements Disposable {
               if (getPreviewContent() != null) {
                 getPreviewContent().openInEditorOrBrowser();
               }
-            } catch (Exception ex) {
+            } catch (Throwable ex) {
               Logger logger = Logger.getInstance(SelectionMetadataPanel.class);
               logger.warn("Error opening file in editor: " + ex.getMessage());
             }

--- a/jetbrains/src/main/java/com/sourcegraph/find/SelectionMetadataPanel.java
+++ b/jetbrains/src/main/java/com/sourcegraph/find/SelectionMetadataPanel.java
@@ -29,7 +29,7 @@ public class SelectionMetadataPanel extends JPanel {
               if (previewContent != null) {
                 try {
                   previewContent.openInEditorOrBrowser();
-                } catch (Exception e) {
+                } catch (Throwable e) {
                   Logger logger = Logger.getInstance(SelectionMetadataPanel.class);
                   logger.warn(
                       "Error opening file in editor: \"" + selectionMetadataLabel.getText() + "\"",

--- a/jetbrains/src/main/java/com/sourcegraph/find/browser/HttpSchemeHandler.java
+++ b/jetbrains/src/main/java/com/sourcegraph/find/browser/HttpSchemeHandler.java
@@ -32,7 +32,7 @@ public class HttpSchemeHandler extends CefResourceHandlerAdapter {
     String path;
     try {
       path = new URL(url).getPath();
-    } catch (Exception ignored) {
+    } catch (Throwable ignored) {
       logger.error("Failed to parse request url: " + url);
       return false;
     }

--- a/jetbrains/src/main/java/com/sourcegraph/find/browser/JSToJavaBridge.java
+++ b/jetbrains/src/main/java/com/sourcegraph/find/browser/JSToJavaBridge.java
@@ -23,7 +23,7 @@ public class JSToJavaBridge implements Disposable {
           try {
             JsonObject requestAsJson = JsonParser.parseString(requestAsString).getAsJsonObject();
             return requestHandler.handle(requestAsJson);
-          } catch (Exception e) {
+          } catch (Throwable e) {
             return requestHandler.handleInvalidRequest(e);
           }
         });

--- a/jetbrains/src/main/java/com/sourcegraph/find/browser/JSToJavaBridgeRequestHandler.java
+++ b/jetbrains/src/main/java/com/sourcegraph/find/browser/JSToJavaBridgeRequestHandler.java
@@ -130,7 +130,7 @@ public class JSToJavaBridgeRequestHandler {
           arguments = request.getAsJsonObject("arguments");
           try {
             previewContent = PreviewContent.fromJson(project, arguments);
-          } catch (Exception e) {
+          } catch (Throwable e) {
             return createErrorResponse(
                 "Parsing error while opening link: "
                     + e.getClass().getName()
@@ -145,7 +145,7 @@ public class JSToJavaBridgeRequestHandler {
                   () -> {
                     try {
                       previewContent.openInEditorOrBrowser();
-                    } catch (Exception e) {
+                    } catch (Throwable e) {
                       Logger logger = Logger.getInstance(JSToJavaBridgeRequestHandler.class);
                       logger.warn("Error while opening link.", e);
                     }
@@ -168,7 +168,7 @@ public class JSToJavaBridgeRequestHandler {
         default:
           return createErrorResponse("Unknown action: '" + action + "'.", "No stack trace");
       }
-    } catch (Exception e) {
+    } catch (Throwable e) {
       return createErrorResponse(
           action + ": " + e.getClass().getName() + ": " + e.getMessage(),
           convertStackTraceToString(e));
@@ -180,7 +180,7 @@ public class JSToJavaBridgeRequestHandler {
     return project;
   }
 
-  public JBCefJSQuery.Response handleInvalidRequest(@NotNull Exception e) {
+  public JBCefJSQuery.Response handleInvalidRequest(@NotNull Throwable e) {
     return createErrorResponse(
         "Invalid JSON passed to bridge. The error is: " + e.getClass() + ": " + e.getMessage(),
         convertStackTraceToString(e));
@@ -198,7 +198,7 @@ public class JSToJavaBridgeRequestHandler {
   }
 
   @NotNull
-  private String convertStackTraceToString(@NotNull Exception e) {
+  private String convertStackTraceToString(@NotNull Throwable e) {
     StringWriter sw = new StringWriter();
     PrintWriter pw = new PrintWriter(sw);
     e.printStackTrace(pw);

--- a/jetbrains/src/main/java/com/sourcegraph/vcs/RepoUtil.java
+++ b/jetbrains/src/main/java/com/sourcegraph/vcs/RepoUtil.java
@@ -53,7 +53,7 @@ public class RepoUtil {
       if (remoteBranchName == null) {
         remoteBranchName = codyProjectSettings.getDefaultBranchName();
       }
-    } catch (Exception err) {
+    } catch (Throwable err) {
       String message;
       if (err.getClass().getName().contains("PerforceAuthenticationException")) {
         message = "Perforce authentication error: " + err.getMessage();

--- a/jetbrains/src/main/java/com/sourcegraph/website/OpenRevisionAction.java
+++ b/jetbrains/src/main/java/com/sourcegraph/website/OpenRevisionAction.java
@@ -81,7 +81,7 @@ public class OpenRevisionAction extends DumbAwareEDTAction {
               String remoteUrl;
               try {
                 remoteUrl = RepoUtil.getRemoteRepoUrl(project, context.getRepoRoot());
-              } catch (Exception e) {
+              } catch (Throwable e) {
                 throw new RuntimeException(e);
               }
 

--- a/jetbrains/src/main/java/com/sourcegraph/website/SearchActionBase.java
+++ b/jetbrains/src/main/java/com/sourcegraph/website/SearchActionBase.java
@@ -92,7 +92,7 @@ public abstract class SearchActionBase extends DumbAwareEDTAction {
                 event
                     .getPresentation()
                     .setEnabled(selectedText != null && selectedText.length() > 0);
-              } catch (Exception exception) {
+              } catch (Throwable exception) {
                 Logger logger = Logger.getLogger(SearchActionBase.class.getName());
                 logger.log(Level.WARNING, "Problem while getting selected text", exception);
                 event.getPresentation().setEnabled(false);

--- a/jetbrains/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgent.kt
+++ b/jetbrains/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgent.kt
@@ -173,11 +173,11 @@ private constructor(
                 server.initialized(null)
                 CodyAgent(client, server, launcher, conn, listeningToJsonRpc)
               }
-        } catch (e: Exception) {
+        } catch (e: Throwable) {
           logger.warn("Failed to send 'initialize' JSON-RPC request Cody agent", e)
           throw e
         }
-      } catch (e: Exception) {
+      } catch (e: Throwable) {
         logger.warn("Unable to start Cody agent", e)
         throw e
       }
@@ -404,7 +404,7 @@ private constructor(
         } else {
           throw CodyAgentException("Failed to make Node process executable " + binary.absolutePath)
         }
-      } catch (e: Exception) {
+      } catch (e: Throwable) {
         logger.warn(e)
         logger.info("Failed to create a copy of the Node binary, proceeding with $binarySource")
         Files.deleteIfExists(binaryTarget)

--- a/jetbrains/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentClient.kt
+++ b/jetbrains/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentClient.kt
@@ -70,7 +70,7 @@ class CodyAgentClient(private val project: Project, private val webview: NativeW
     ApplicationManager.getApplication().invokeLater {
       try {
         result.complete(callback.invoke())
-      } catch (e: Exception) {
+      } catch (e: Throwable) {
         result.completeExceptionally(e)
       }
     }

--- a/jetbrains/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentService.kt
+++ b/jetbrains/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentService.kt
@@ -120,7 +120,7 @@ class CodyAgentService(private val project: Project) : Disposable {
         }
         setAgentError(project, msg)
         codyAgent.completeExceptionally(CodyAgentException(msg, e))
-      } catch (e: Exception) {
+      } catch (e: Throwable) {
         val msg = CodyBundle.getString("error.cody-starting.message")
         setAgentError(project, msg)
         logger.error(msg, e)
@@ -136,7 +136,7 @@ class CodyAgentService(private val project: Project) : Disposable {
       return (shutdownFuture ?: CompletableFuture.completedFuture(null)).thenCompose {
         WebUIService.getInstance(project).reset()
       }
-    } catch (e: Exception) {
+    } catch (e: Throwable) {
       logger.warn("Failed to stop Cody agent gracefully", e)
       return CompletableFuture.failedFuture(e)
     } finally {
@@ -190,7 +190,7 @@ class CodyAgentService(private val project: Project) : Disposable {
                 else instance.codyAgent
             callback.accept(agent.get())
             setAgentError(project, null)
-          } catch (e: Exception) {
+          } catch (e: Throwable) {
             logger.warn("Failed to execute call to agent", e)
             if (restartIfNeeded && e !is ProcessCanceledException) {
               instance.restartAgent()
@@ -213,7 +213,7 @@ class CodyAgentService(private val project: Project) : Disposable {
     fun isConnected(project: Project): Boolean {
       return try {
         getInstance(project).codyAgent.getNow(null)?.isConnected() == true
-      } catch (e: Exception) {
+      } catch (e: Throwable) {
         false
       }
     }

--- a/jetbrains/src/main/kotlin/com/sourcegraph/cody/autocomplete/CodyAutocompleteManager.kt
+++ b/jetbrains/src/main/kotlin/com/sourcegraph/cody/autocomplete/CodyAutocompleteManager.kt
@@ -320,7 +320,7 @@ class CodyAutocompleteManager {
               .andShowCloseShortcut()
       try {
         gotit.show(editor.contentComponent) { _, _ -> inlay.bounds!!.location }
-      } catch (e: Exception) {
+      } catch (e: Throwable) {
         logger.info("Failed to display gotit tooltip", e)
       }
     }
@@ -355,7 +355,7 @@ class CodyAutocompleteManager {
           }
           location
         }
-      } catch (e: Exception) {
+      } catch (e: Throwable) {
         logger.info("Failed to display gotit tooltip", e)
       }
     }

--- a/jetbrains/src/main/kotlin/com/sourcegraph/cody/autocomplete/render/AutocompleteRenderUtil.kt
+++ b/jetbrains/src/main/kotlin/com/sourcegraph/cody/autocomplete/render/AutocompleteRenderUtil.kt
@@ -13,7 +13,7 @@ object AutocompleteRenderUtil {
       try {
         editor.colorsScheme.getAttributes(
             DefaultLanguageHighlighterColors.INLAY_TEXT_WITHOUT_BACKGROUND)
-      } catch (ignored: Exception) {
+      } catch (ignored: Throwable) {
         editor.colorsScheme.getAttributes(DefaultLanguageHighlighterColors.INLINE_PARAMETER_HINT)
       }
 

--- a/jetbrains/src/main/kotlin/com/sourcegraph/cody/config/ui/CheckUpdatesTask.kt
+++ b/jetbrains/src/main/kotlin/com/sourcegraph/cody/config/ui/CheckUpdatesTask.kt
@@ -44,7 +44,7 @@ class CheckUpdatesTask(project: Project) :
         val getAllEnabledMethod = pluginUpdates.javaClass.getMethod("getAllEnabled")
         val allEnabled = getAllEnabledMethod.invoke(pluginUpdates)
         return allEnabled?.let { it as (Collection<PluginDownloader>) } ?: emptyList()
-      } catch (e: Exception) {
+      } catch (e: Throwable) {
         when (e) {
           is IllegalAccessException,
           is NoSuchMethodException,

--- a/jetbrains/src/main/kotlin/com/sourcegraph/cody/edit/EditCommandPrompt.kt
+++ b/jetbrains/src/main/kotlin/com/sourcegraph/cody/edit/EditCommandPrompt.kt
@@ -282,7 +282,7 @@ class EditCommandPrompt(
       connection?.disconnect()
       connection = null
       popup?.cancel()
-    } catch (x: Exception) {
+    } catch (x: Throwable) {
       logger.warn("Error cancelling edit command prompt", x)
     } finally {
       dispose()

--- a/jetbrains/src/main/kotlin/com/sourcegraph/cody/edit/lenses/actions/LensEditAction.kt
+++ b/jetbrains/src/main/kotlin/com/sourcegraph/cody/edit/lenses/actions/LensEditAction.kt
@@ -57,7 +57,7 @@ abstract class LensEditAction(val editAction: (Project, AnActionEvent, Editor, S
               }
 
       editAction(project, e, editor, taskId)
-    } catch (ex: Exception) {
+    } catch (ex: Throwable) {
       // Don't show error lens here; it's sort of pointless.
       logger.warn("Error accepting edit accept task: $ex")
     }

--- a/jetbrains/src/main/kotlin/com/sourcegraph/cody/error/CodyErrorSubmitter.kt
+++ b/jetbrains/src/main/kotlin/com/sourcegraph/cody/error/CodyErrorSubmitter.kt
@@ -35,7 +35,7 @@ class CodyErrorSubmitter : ErrorReportSubmitter() {
                 additionalInfo = additionalInfo)
         BrowserUtil.browse(url)
       }
-    } catch (e: Exception) {
+    } catch (e: Throwable) {
       consumer.consume(SubmittedReportInfo(SubmissionStatus.FAILED))
       return false
     }

--- a/jetbrains/src/main/kotlin/com/sourcegraph/cody/inspections/CodyFixHighlightPass.kt
+++ b/jetbrains/src/main/kotlin/com/sourcegraph/cody/inspections/CodyFixHighlightPass.kt
@@ -110,7 +110,7 @@ class CodyFixHighlightPass(val file: PsiFile, val editor: Editor) :
 
                   return@map result
                 }
-              } catch (e: Exception) {
+              } catch (e: Throwable) {
                 val responseErrorException =
                     (e as? ExecutionException)?.cause as? ResponseErrorException
                 if (responseErrorException != null) {

--- a/jetbrains/src/main/kotlin/com/sourcegraph/cody/listeners/CodyFileEditorListener.kt
+++ b/jetbrains/src/main/kotlin/com/sourcegraph/cody/listeners/CodyFileEditorListener.kt
@@ -27,7 +27,7 @@ class CodyFileEditorListener : FileEditorManagerListener {
       withAgent(source.project) { agent: CodyAgent ->
         agent.server.textDocument_didOpen(protocolTextFile)
       }
-    } catch (x: Exception) {
+    } catch (x: Throwable) {
       logger.warn("Error in fileOpened method for file: ${file.path}", x)
     }
   }
@@ -39,7 +39,7 @@ class CodyFileEditorListener : FileEditorManagerListener {
       withAgent(source.project) { agent: CodyAgent ->
         agent.server.textDocument_didClose(protocolTextFile)
       }
-    } catch (x: Exception) {
+    } catch (x: Throwable) {
       logger.warn("Error in fileClosed method for file: ${file.path}", x)
     }
   }
@@ -59,7 +59,7 @@ class CodyFileEditorListener : FileEditorManagerListener {
             try {
               val textDocument = ProtocolTextDocumentExt.fromVirtualEditorFile(editor, file)
               codyAgent.server.textDocument_didOpen(textDocument)
-            } catch (x: Exception) {
+            } catch (x: Throwable) {
               logger.warn("Error calling textDocument/didOpen for file: ${file.path}", x)
             }
           }
@@ -71,7 +71,7 @@ class CodyFileEditorListener : FileEditorManagerListener {
           try {
             val textDocument = ProtocolTextDocumentExt.fromVirtualEditorFile(editor, file!!)
             codyAgent.server.textDocument_didFocus(TextDocument_DidFocusParams(textDocument.uri))
-          } catch (x: Exception) {
+          } catch (x: Throwable) {
             logger.warn("Error calling textDocument/didFocus on ${file?.path}", x)
           }
         }

--- a/jetbrains/src/main/kotlin/com/sourcegraph/cody/ui/web/WebUIHost.kt
+++ b/jetbrains/src/main/kotlin/com/sourcegraph/cody/ui/web/WebUIHost.kt
@@ -120,7 +120,7 @@ internal class WebUIHostImpl(
               val decoded = URLDecoder.decode(encoded, "UTF-8")
               try {
                 Gson().fromJson(decoded, JsonArray::class.java).toList()
-              } catch (e: Exception) {
+              } catch (e: Throwable) {
                 null
               }
             } ?: emptyList()

--- a/jetbrains/src/main/kotlin/com/sourcegraph/common/BrowserOpener.kt
+++ b/jetbrains/src/main/kotlin/com/sourcegraph/common/BrowserOpener.kt
@@ -28,7 +28,7 @@ object BrowserOpener {
   fun openInBrowser(project: Project?, uri: URI) {
     try {
       BrowserUtil.browse(uri)
-    } catch (e: Exception) {
+    } catch (e: Throwable) {
       try {
         Desktop.getDesktop().browse(uri)
       } catch (e2: IOException) {

--- a/jetbrains/src/main/kotlin/com/sourcegraph/config/ConfigUtil.kt
+++ b/jetbrains/src/main/kotlin/com/sourcegraph/config/ConfigUtil.kt
@@ -177,7 +177,7 @@ object ConfigUtil {
       config
           .root()
           .render(ConfigRenderOptions.defaults().setComments(false).setOriginComments(false))
-    } catch (e: Exception) {
+    } catch (e: Throwable) {
       logger.info("No user defined settings file found. Proceeding with empty custom config")
       ""
     }

--- a/jetbrains/src/main/kotlin/com/sourcegraph/utils/CodyEditorUtil.kt
+++ b/jetbrains/src/main/kotlin/com/sourcegraph/utils/CodyEditorUtil.kt
@@ -186,7 +186,7 @@ object CodyEditorUtil {
           }
       runInEdtAndGet { descriptor.navigate(/* requestFocus= */ preserveFocus != true) }
       return true
-    } catch (e: Exception) {
+    } catch (e: Throwable) {
       logger.error("Cannot switch view to file ${vf.path}", e)
       return false
     }

--- a/jetbrains/src/main/kotlin/com/sourcegraph/utils/CodyFormatter.kt
+++ b/jetbrains/src/main/kotlin/com/sourcegraph/utils/CodyFormatter.kt
@@ -53,7 +53,7 @@ class CodyFormatter {
             } else psiFile.text
         return formattedText.substring(
             range.startOffset, range.endOffset + formattedText.length - document.textLength)
-      } catch (e: Exception) {
+      } catch (e: Throwable) {
         logger.error("Failed to format code snippet", e)
         return completionText
       }

--- a/jetbrains/src/main/kotlin/com/sourcegraph/utils/ThreadingUtil.kt
+++ b/jetbrains/src/main/kotlin/com/sourcegraph/utils/ThreadingUtil.kt
@@ -14,7 +14,7 @@ object ThreadingUtil {
     app.invokeLater {
       try {
         future.complete(task())
-      } catch (exception: Exception) {
+      } catch (exception: Throwable) {
         future.completeExceptionally(exception)
       }
     }


### PR DESCRIPTION
Fixes https://linear.app/sourcegraph/issue/BUGS-1045

## Problem
I've identified a bug where `AssertionError` is bubbling up to the UI. 
Specifically, when navigating to files in certain conditions, an error occurs:

```
java.lang.AssertionError: Cannot find tab for selection transfer, tab=loading…
```

This error happens because our current error handling only catches Exception instances, but AssertionError is a subclass of Error, not Exception.

## Solution

Modified error handling throughout the codebase to catch `Throwable` instead of just `Exception`. This ensures we properly catch and handle all types of errors, including `AssertionError` and subclasses of `Error`

This change improves the stability of the plugin by preventing unhandled errors from propagating to the UI. Users should no longer see this particular error dialog when navigating between files. While catching Throwable is generally not recommended in all scenarios (as it can mask serious issues like `OutOfMemoryError`), we mostly catch it in situations where we want to gracefully degrade instead of crashing the entire IDE.

## Technical Details
In Java/Kotlin's exception hierarchy:

```
Throwable
  ├── Error
  │    └── AssertionError
  └── Exception
```

When we use catch `(e: Exception)`, we only catch the right branch of this hierarchy, missing errors on the left branch. By using catch `(t: Throwable)`, we ensure we catch everything that can be thrown.

## Test plan

N/A - internal change