### PR TITLE
Fix 'Open Chat' Action

### DIFF
--- a/jetbrains/src/main/kotlin/com/sourcegraph/cody/CodyToolWindowContent.kt
+++ b/jetbrains/src/main/kotlin/com/sourcegraph/cody/CodyToolWindowContent.kt
@@ -72,9 +72,11 @@ class CodyToolWindowContent(val project: Project) {
     var logger = Logger.getInstance(CodyToolWindowContent::class.java)
 
     fun show(project: Project) {
-      ToolWindowManager.getInstance(project)
-          .getToolWindow(CodyToolWindowFactory.TOOL_WINDOW_ID)
-          ?.show()
+      executeOnInstanceIfNotDisposed(project) {
+        ToolWindowManager.getInstance(project)
+            .getToolWindow(CodyToolWindowFactory.TOOL_WINDOW_ID)
+            ?.show { webview?.proxy?.component?.requestFocusInWindow() }
+      }
     }
 
     fun executeOnInstanceIfNotDisposed(

--- a/jetbrains/src/main/kotlin/com/sourcegraph/cody/chat/OpenChatAction.kt
+++ b/jetbrains/src/main/kotlin/com/sourcegraph/cody/chat/OpenChatAction.kt
@@ -9,6 +9,5 @@ class OpenChatAction : DumbAwareEDTAction() {
   override fun actionPerformed(event: AnActionEvent) {
     val project = event.project ?: return
     CodyToolWindowContent.show(project)
-    TODO("NYI, focus the chat thru TypeScript")
   }
 }


### PR DESCRIPTION
Fixes https://linear.app/sourcegraph/issue/BUGS-1051
Fixes https://linear.app/sourcegraph/issue/BUGS-1041
Fixes https://github.com/sourcegraph/jetbrains/issues/2357
Fixes https://github.com/sourcegraph/jetbrains/issues/2317
Fixes https://github.com/sourcegraph/jetbrains/issues/2296

## Changes

This PR contains two changes:

1. Removes `TODO` which in kotlin throws an `NotImplementedError`
2. Adds code which makes sure chat windows always get focus on the input box when it gets opened

## Test plan

1. Open cody chat
2. Click outside of the input box to make sure it has no focus
3. Close Cody Chat panel
4. Hit `Option + Command + 9` (or run `Cody: Open Chat`)
5. Make sure Cody panel is visible and chat input box has focus
6. Click outside of the input box to make sure it has no focus
7. Hit `Option + Command + 9` (or run `Cody: Open Chat`)
8. Chat input box has focus should get focus back