### PR TITLE
Fix "Open Selection in Sourcegraph Web" (closes #3037)

### DIFF
--- a/jetbrains/src/main/java/com/sourcegraph/website/FileActionBase.java
+++ b/jetbrains/src/main/java/com/sourcegraph/website/FileActionBase.java
@@ -2,16 +2,15 @@ package com.sourcegraph.website;
 
 import com.google.common.base.Strings;
 import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.actionSystem.CommonDataKeys;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.editor.*;
-import com.intellij.openapi.fileEditor.FileDocumentManager;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.sourcegraph.common.ErrorNotification;
 import com.sourcegraph.common.ui.DumbAwareEDTAction;
 import com.sourcegraph.find.PreviewContent;
 import com.sourcegraph.find.SourcegraphVirtualFile;
-import com.sourcegraph.utils.CodyEditorUtil;
 import com.sourcegraph.vcs.RepoInfo;
 import com.sourcegraph.vcs.RepoUtil;
 import com.sourcegraph.vcs.VCSType;
@@ -28,12 +27,11 @@ public abstract class FileActionBase extends DumbAwareEDTAction {
     if (project == null) {
       return;
     }
-    Editor editor = CodyEditorUtil.getFirstSelectedEditor(project);
+    Editor editor = event.getData(CommonDataKeys.EDITOR);
     if (editor == null) {
       return;
     }
-    Document currentDocument = editor.getDocument();
-    VirtualFile currentFile = FileDocumentManager.getInstance().getFile(currentDocument);
+    VirtualFile currentFile = event.getData(CommonDataKeys.VIRTUAL_FILE);
     if (currentFile == null) {
       return;
     }

--- a/jetbrains/src/main/kotlin/com/sourcegraph/cody/statusbar/CodyDisableLanguageForAutocompleteAction.kt
+++ b/jetbrains/src/main/kotlin/com/sourcegraph/cody/statusbar/CodyDisableLanguageForAutocompleteAction.kt
@@ -1,18 +1,19 @@
 package com.sourcegraph.cody.statusbar
 
 import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.actionSystem.CommonDataKeys
 import com.sourcegraph.cody.auth.CodyAuthService
 import com.sourcegraph.cody.autocomplete.CodyAutocompleteManager
 import com.sourcegraph.cody.config.CodyApplicationSettings
 import com.sourcegraph.common.ui.DumbAwareEDTAction
 import com.sourcegraph.config.ConfigUtil
-import com.sourcegraph.utils.CodyEditorUtil
+import com.sourcegraph.utils.CodyEditorUtil.getLanguage
 import com.sourcegraph.utils.CodyLanguageUtil
 
 class CodyDisableLanguageForAutocompleteAction : DumbAwareEDTAction() {
   override fun actionPerformed(e: AnActionEvent) {
     val applicationSettings = CodyApplicationSettings.instance
-    CodyEditorUtil.getLanguageForFocusedEditor(e)?.id?.let { languageId ->
+    e.getData(CommonDataKeys.EDITOR)?.let(::getLanguage)?.id?.let { languageId ->
       applicationSettings.blacklistedLanguageIds =
           applicationSettings.blacklistedLanguageIds.plus(languageId)
       CodyAutocompleteManager.instance.clearAutocompleteSuggestionsForLanguageId(languageId)
@@ -21,7 +22,7 @@ class CodyDisableLanguageForAutocompleteAction : DumbAwareEDTAction() {
 
   override fun update(e: AnActionEvent) {
     super.update(e)
-    val languageForFocusedEditor = CodyEditorUtil.getLanguageForFocusedEditor(e)
+    val languageForFocusedEditor = e.getData(CommonDataKeys.EDITOR)?.let(::getLanguage)
     val isLanguageBlacklisted =
         languageForFocusedEditor?.let { CodyLanguageUtil.isLanguageBlacklisted(it) } ?: false
     val languageName = languageForFocusedEditor?.displayName ?: ""

--- a/jetbrains/src/main/kotlin/com/sourcegraph/cody/statusbar/CodyDisableLanguageForAutocompleteAction.kt
+++ b/jetbrains/src/main/kotlin/com/sourcegraph/cody/statusbar/CodyDisableLanguageForAutocompleteAction.kt
@@ -1,28 +1,28 @@
 package com.sourcegraph.cody.statusbar
 
 import com.intellij.openapi.actionSystem.AnActionEvent
-import com.intellij.openapi.actionSystem.CommonDataKeys
 import com.sourcegraph.cody.auth.CodyAuthService
 import com.sourcegraph.cody.autocomplete.CodyAutocompleteManager
 import com.sourcegraph.cody.config.CodyApplicationSettings
 import com.sourcegraph.common.ui.DumbAwareEDTAction
 import com.sourcegraph.config.ConfigUtil
-import com.sourcegraph.utils.CodyEditorUtil.getLanguage
 import com.sourcegraph.utils.CodyLanguageUtil
+import com.sourcegraph.utils.CodyLanguageUtil.getLanguageForLastActiveEditor
 
 class CodyDisableLanguageForAutocompleteAction : DumbAwareEDTAction() {
   override fun actionPerformed(e: AnActionEvent) {
     val applicationSettings = CodyApplicationSettings.instance
-    e.getData(CommonDataKeys.EDITOR)?.let(::getLanguage)?.id?.let { languageId ->
+    getLanguageForLastActiveEditor(e)?.let { lang ->
       applicationSettings.blacklistedLanguageIds =
-          applicationSettings.blacklistedLanguageIds.plus(languageId)
-      CodyAutocompleteManager.instance.clearAutocompleteSuggestionsForLanguageId(languageId)
+          applicationSettings.blacklistedLanguageIds.plus(lang.id)
+      CodyAutocompleteManager.instance.clearAutocompleteSuggestionsForLanguageId(lang.id)
     }
   }
 
   override fun update(e: AnActionEvent) {
     super.update(e)
-    val languageForFocusedEditor = e.getData(CommonDataKeys.EDITOR)?.let(::getLanguage)
+
+    val languageForFocusedEditor = getLanguageForLastActiveEditor(e)
     val isLanguageBlacklisted =
         languageForFocusedEditor?.let { CodyLanguageUtil.isLanguageBlacklisted(it) } ?: false
     val languageName = languageForFocusedEditor?.displayName ?: ""

--- a/jetbrains/src/main/kotlin/com/sourcegraph/cody/statusbar/CodyEnableLanguageForAutocompleteAction.kt
+++ b/jetbrains/src/main/kotlin/com/sourcegraph/cody/statusbar/CodyEnableLanguageForAutocompleteAction.kt
@@ -1,10 +1,11 @@
 package com.sourcegraph.cody.statusbar
 
 import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.actionSystem.CommonDataKeys
 import com.sourcegraph.cody.config.CodyApplicationSettings
 import com.sourcegraph.common.ui.DumbAwareEDTAction
 import com.sourcegraph.config.ConfigUtil
-import com.sourcegraph.utils.CodyEditorUtil
+import com.sourcegraph.utils.CodyEditorUtil.getLanguage
 import com.sourcegraph.utils.CodyLanguageUtil
 
 class CodyEnableLanguageForAutocompleteAction : DumbAwareEDTAction() {
@@ -12,13 +13,13 @@ class CodyEnableLanguageForAutocompleteAction : DumbAwareEDTAction() {
     val applicationSettings = CodyApplicationSettings.instance
     applicationSettings.blacklistedLanguageIds =
         applicationSettings.blacklistedLanguageIds.filterNot {
-          it == CodyEditorUtil.getLanguageForFocusedEditor(e)?.id
+          it == (e.getData(CommonDataKeys.EDITOR)?.let(::getLanguage))?.id
         }
   }
 
   override fun update(e: AnActionEvent) {
     super.update(e)
-    val languageForFocusedEditor = CodyEditorUtil.getLanguageForFocusedEditor(e)
+    val languageForFocusedEditor = e.getData(CommonDataKeys.EDITOR)?.let(::getLanguage)
     val isLanguageBlacklisted =
         languageForFocusedEditor?.let { CodyLanguageUtil.isLanguageBlacklisted(it) } ?: false
     val languageName = languageForFocusedEditor?.displayName ?: ""

--- a/jetbrains/src/main/kotlin/com/sourcegraph/cody/statusbar/CodyEnableLanguageForAutocompleteAction.kt
+++ b/jetbrains/src/main/kotlin/com/sourcegraph/cody/statusbar/CodyEnableLanguageForAutocompleteAction.kt
@@ -1,25 +1,25 @@
 package com.sourcegraph.cody.statusbar
 
 import com.intellij.openapi.actionSystem.AnActionEvent
-import com.intellij.openapi.actionSystem.CommonDataKeys
 import com.sourcegraph.cody.config.CodyApplicationSettings
 import com.sourcegraph.common.ui.DumbAwareEDTAction
 import com.sourcegraph.config.ConfigUtil
-import com.sourcegraph.utils.CodyEditorUtil.getLanguage
 import com.sourcegraph.utils.CodyLanguageUtil
+import com.sourcegraph.utils.CodyLanguageUtil.getLanguageForLastActiveEditor
 
 class CodyEnableLanguageForAutocompleteAction : DumbAwareEDTAction() {
   override fun actionPerformed(e: AnActionEvent) {
     val applicationSettings = CodyApplicationSettings.instance
     applicationSettings.blacklistedLanguageIds =
         applicationSettings.blacklistedLanguageIds.filterNot {
-          it == (e.getData(CommonDataKeys.EDITOR)?.let(::getLanguage))?.id
+          it == getLanguageForLastActiveEditor(e)?.id
         }
   }
 
   override fun update(e: AnActionEvent) {
     super.update(e)
-    val languageForFocusedEditor = e.getData(CommonDataKeys.EDITOR)?.let(::getLanguage)
+
+    val languageForFocusedEditor = getLanguageForLastActiveEditor(e)
     val isLanguageBlacklisted =
         languageForFocusedEditor?.let { CodyLanguageUtil.isLanguageBlacklisted(it) } ?: false
     val languageName = languageForFocusedEditor?.displayName ?: ""

--- a/jetbrains/src/main/kotlin/com/sourcegraph/utils/CodyEditorUtil.kt
+++ b/jetbrains/src/main/kotlin/com/sourcegraph/utils/CodyEditorUtil.kt
@@ -130,6 +130,7 @@ object CodyEditorUtil {
   @JvmStatic
   fun getLanguage(editor: Editor): Language? {
     val project = editor.project ?: return null
+
     return CodyLanguageUtil.getLanguage(project, editor.document)
   }
 

--- a/jetbrains/src/main/kotlin/com/sourcegraph/utils/CodyEditorUtil.kt
+++ b/jetbrains/src/main/kotlin/com/sourcegraph/utils/CodyEditorUtil.kt
@@ -5,7 +5,6 @@ import com.intellij.ide.scratch.ScratchRootType
 import com.intellij.injected.editor.EditorWindow
 import com.intellij.lang.Language
 import com.intellij.lang.LanguageUtil
-import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.command.WriteCommandAction
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.editor.Document
@@ -81,12 +80,6 @@ object CodyEditorUtil {
   @JvmStatic
   fun getEditorForDocument(document: Document): Editor? {
     return getAllOpenEditors().find { it.document == document }
-  }
-
-  @JvmStatic
-  fun getLanguageForFocusedEditor(e: AnActionEvent): Language? {
-    val project = e.project ?: return null
-    return getSelectedEditors(project).firstOrNull()?.let { getLanguage(it) }
   }
 
   @JvmStatic

--- a/jetbrains/src/main/kotlin/com/sourcegraph/utils/CodyEditorUtil.kt
+++ b/jetbrains/src/main/kotlin/com/sourcegraph/utils/CodyEditorUtil.kt
@@ -79,11 +79,6 @@ object CodyEditorUtil {
   }
 
   @JvmStatic
-  fun getFirstSelectedEditor(project: Project): Editor? {
-    return getSelectedEditors(project).firstOrNull()
-  }
-
-  @JvmStatic
   fun getEditorForDocument(document: Document): Editor? {
     return getAllOpenEditors().find { it.document == document }
   }

--- a/jetbrains/src/main/kotlin/com/sourcegraph/utils/CodyLanguageUtil.kt
+++ b/jetbrains/src/main/kotlin/com/sourcegraph/utils/CodyLanguageUtil.kt
@@ -2,12 +2,24 @@ package com.sourcegraph.utils
 
 import com.intellij.lang.Language
 import com.intellij.lang.LanguageUtil
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.actionSystem.PlatformDataKeys
 import com.intellij.openapi.editor.Document
 import com.intellij.openapi.fileEditor.FileDocumentManager
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.findDocument
 import com.sourcegraph.config.ConfigUtil
 
 object CodyLanguageUtil {
+
+  @JvmStatic
+  fun getLanguageForLastActiveEditor(e: AnActionEvent): Language? {
+    val project = e.project ?: return null
+    return e.getData(PlatformDataKeys.LAST_ACTIVE_FILE_EDITOR)?.file?.findDocument()?.let {
+      getLanguage(project, it)
+    }
+  }
+
   @JvmStatic
   fun getLanguage(project: Project, document: Document): Language? {
     return LanguageUtil.getLanguageForPsi(


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/jetbrains/issues/3037.

I noticed there are a few places (actions) using first available editor instead of the editor from the given context. That caused the reported bug and could cause more similar issues. This PR makes Sourcegraph actions use editor provided by the context.

## Test plan
Try the scenario from https://github.com/sourcegraph/jetbrains/issues/3037.

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
