### PR TITLE
Make sure relevant stacktrace part is included in error reports

### DIFF
--- a/jetbrains/src/test/kotlin/com/sourcegraph/cody/error/CodyErrorSubmitterTest.kt
+++ b/jetbrains/src/test/kotlin/com/sourcegraph/cody/error/CodyErrorSubmitterTest.kt
@@ -1,5 +1,6 @@
 import com.intellij.testFramework.fixtures.BasePlatformTestCase
 import com.sourcegraph.cody.error.CodyErrorSubmitter
+import java.net.URLDecoder
 
 class CodyErrorSubmitterTest : BasePlatformTestCase() {
 
@@ -25,7 +26,8 @@ class CodyErrorSubmitterTest : BasePlatformTestCase() {
     val additionalInfo = "Additional debug information"
     val encodedUrl = codyErrorSubmitter.getEncodedUrl(null, null, additionalInfo)
     assertTrue(
-        encodedUrl.contains("&logs=Additional+info%3A+%60%60%60Additional+debug+information"))
+        encodedUrl.contains(
+            "&logs=Additional+info%3A%0A%60%60%60text%0AAdditional+debug+information"))
   }
 
   fun testGetEncodedUrlWithProjectAndThrowableText() {
@@ -40,5 +42,56 @@ class CodyErrorSubmitterTest : BasePlatformTestCase() {
     val longAdditionalInfo = "B".repeat(10000)
     val encodedUrl = codyErrorSubmitter.getEncodedUrl(null, longThrowableText, longAdditionalInfo)
     assertTrue(encodedUrl.length <= CodyErrorSubmitter.MAX_URL_LENGTH)
+  }
+
+  fun testGetEncodedUrlMinimalStacktrace() {
+    val longThrowableText = (1..1000).toList().joinToString("\n") { "Stack trace line $it" }
+    val longAdditionalInfo = (1..1000).toList().joinToString("\n") { "Additional info line $it" }
+
+    val longThrowableTextWithRelevantStacktrace =
+        longThrowableText.replace("line 500\n", "com.sourcegraph.cody.ProblematicClass\n")
+
+    val encodedUrl =
+        codyErrorSubmitter.getEncodedUrl(
+            null, longThrowableTextWithRelevantStacktrace, longAdditionalInfo)
+    assertTrue(encodedUrl.length <= CodyErrorSubmitter.MAX_URL_LENGTH)
+
+    val decodedUrl = URLDecoder.decode(encodedUrl, "utf-8")
+
+    assertTrue(decodedUrl.contains("Additional info line 1"))
+    assertTrue(decodedUrl.contains("Additional info line 276"))
+    assertFalse(decodedUrl.contains("Additional info line 277"))
+
+    assertFalse(decodedUrl.contains("Stack trace line 497"))
+    assertTrue(decodedUrl.contains("Stack trace line 498"))
+    assertTrue(decodedUrl.contains("Stack trace line 499"))
+    assertTrue(decodedUrl.contains("Stack trace com.sourcegraph.cody.ProblematicClass"))
+    assertTrue(decodedUrl.contains("Stack trace line 501"))
+    assertTrue(decodedUrl.contains("Stack trace line 502"))
+    assertFalse(decodedUrl.contains("Stack trace line 503"))
+  }
+
+  fun testGetEncodedUrlAdjustedStacktrace() {
+    val longThrowableText = (1..200).toList().joinToString("\n") { "Stack trace line $it" }
+    val longAdditionalInfo = (1..250).toList().joinToString("\n") { "Additional info line $it" }
+
+    val longThrowableTextWithRelevantStacktrace =
+        longThrowableText.replace("line 100\n", "com.sourcegraph.cody.ProblematicClass\n")
+
+    val encodedUrl =
+        codyErrorSubmitter.getEncodedUrl(
+            null, longThrowableTextWithRelevantStacktrace, longAdditionalInfo)
+    assertTrue(encodedUrl.length <= CodyErrorSubmitter.MAX_URL_LENGTH)
+
+    val decodedUrl = URLDecoder.decode(encodedUrl, "utf-8")
+
+    assertTrue(decodedUrl.contains("Additional info line 1"))
+    assertTrue(decodedUrl.contains("Additional info line 250"))
+
+    assertFalse(decodedUrl.contains("Stack trace line 82"))
+    assertTrue(decodedUrl.contains("Stack trace line 83"))
+    assertTrue(decodedUrl.contains("Stack trace com.sourcegraph.cody.ProblematicClass"))
+    assertTrue(decodedUrl.contains("Stack trace line 117"))
+    assertFalse(decodedUrl.contains("Stack trace line 118"))
   }
 }


### PR DESCRIPTION
## Changes

Sometimes we get error reports like this one, were there is no additional debug info and stacktrace does not contain anything Cody related: https://github.com/sourcegraph/jetbrains/issues/2982

This PR fixes two issues with our error reporter:
1. It makes sure we trim stacktrace more intelligently, by always including part which contains cody related stacktrace, if any
2. Stacktraces mostly takes all the space, which with current implementation was always trimming out "Additional debug info". Now instead we always include debug info and at least minimal stacktrace, and as much stacktrace with interesting context as possible.

## Test plan

N/A, automatic tests added.