### PR TITLE
Improve URI handling

### DIFF
--- a/jetbrains/src/integrationTest/kotlin/com/sourcegraph/cody/edit/DocumentCodeTest.kt
+++ b/jetbrains/src/integrationTest/kotlin/com/sourcegraph/cody/edit/DocumentCodeTest.kt
@@ -58,7 +58,7 @@ class DocumentCodeTest : CodyIntegrationTextFixture() {
         EditUndoCodeVisionProvider.command)
 
     // Make sure a doc comment was inserted.
-    assertTrue(hasJavadocComment(myFixture.editor.document.text))
+    assertTrue(hasJavadocComment(editor.document.text))
 
     runAndWaitForCleanState(EditUndoAction.ID)
   }
@@ -69,21 +69,17 @@ class DocumentCodeTest : CodyIntegrationTextFixture() {
     assertNotNull("Lens group should be displayed", codeLenses.isNotEmpty())
 
     runAndWaitForCleanState(EditAcceptAction.ID)
-    assertThat(myFixture.editor.document.text, containsString("*/\n    public void foo() {"))
+    assertThat(editor.document.text, containsString("*/\n    public void foo() {"))
   }
 
   @Test
   fun testUndo() {
-    val originalDocument = myFixture.editor.document.text
+    val originalDocument = editor.document.text
     val codeLenses = runAndWaitForLenses(DocumentCodeAction.ID, EditUndoAction.ID)
     assertNotNull("Lens group should be displayed", codeLenses.isNotEmpty())
-    assertNotSame(
-        "Expected document to be changed", originalDocument, myFixture.editor.document.text)
+    assertNotSame("Expected document to be changed", originalDocument, editor.document.text)
 
     runAndWaitForCleanState(EditUndoAction.ID)
-    assertEquals(
-        "Expected document changes to be reverted",
-        originalDocument,
-        myFixture.editor.document.text)
+    assertEquals("Expected document changes to be reverted", originalDocument, editor.document.text)
   }
 }

--- a/jetbrains/src/integrationTest/resources/recordings/integration-test_2927926756/recording.har.yaml
+++ b/jetbrains/src/integrationTest/resources/recordings/integration-test_2927926756/recording.har.yaml
@@ -51,7 +51,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Mon, 17 Mar 2025 16:28:26 GMT
+            value: Tue, 18 Mar 2025 11:37:47 GMT
           - name: content-type
             value: text/plain; charset=utf-8
           - name: transfer-encoding
@@ -82,8 +82,8 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2025-03-17T16:28:25.976Z
-      time: 185
+      startedDateTime: 2025-03-18T11:37:47.381Z
+      time: 233
       timings:
         blocked: -1
         connect: -1
@@ -91,12 +91,12 @@ log:
         receive: 0
         send: 0
         ssl: -1
-        wait: 185
-    - _id: 91f9bb443aa5759eea66a51789caabd5
+        wait: 233
+    - _id: 5ea3115a239f4869c9ff8113640c6bd8
       _order: 0
       cache: {}
       request:
-        bodySize: 3395
+        bodySize: 3240
         cookies: []
         headers:
           - name: accept-encoding
@@ -109,7 +109,7 @@ log:
           - name: content-type
             value: application/json
           - name: traceparent
-            value: 00-22bd85a135e963177f44f2d06f56064b-730ce26868586a1b-01
+            value: 00-7a1b07e7ca5c94a91ab44d551a172795-c171edad28871096-01
           - name: user-agent
             value: jetbrains/6.0-localbuild (Node.js v20.12.2)
           - name: x-requested-with
@@ -149,10 +149,8 @@ log:
                   - Do not provide any additional commentary about the changes you made. Only respond with the generated code.
               - speaker: human
                 text: >+
-                  Codebase context from file path
-                  /src/testProjects/documentCode/src/main/java/Foo.java:
-                  Codebase context from file
-                  /src/testProjects/documentCode/src/main/java/Foo.java:
+                  Codebase context from file path src/main/java/Foo.java:
+                  Codebase context from file src/main/java/Foo.java:
 
                   import java.util.*;
 
@@ -163,18 +161,15 @@ log:
                 text: Ok.
               - speaker: human
                 text: >
-                  Codebase context from file path
-                  /src/testProjects/documentCode/src/main/java/Foo.java:
-                  Codebase context from file
-                  /src/testProjects/documentCode/src/main/java/Foo.java:
+                  Codebase context from file path src/main/java/Foo.java:
+                  Codebase context from file src/main/java/Foo.java:
 
                   }
               - speaker: assistant
                 text: Ok.
               - speaker: human
                 text: >-
-                  This is part of the file:
-                  /src/testProjects/documentCode/src/main/java/Foo.java
+                  This is part of the file: src/main/java/Foo.java
 
 
                   The user has the following code in their selection:
@@ -221,14 +216,14 @@ log:
             value: 6.0-localbuild
         url: https://sourcegraph.com/.api/completions/stream?api-version=8&client-name=jetbrains&client-version=6.0-localbuild
       response:
-        bodySize: 928
+        bodySize: 1606
         content:
           mimeType: text/event-stream
-          size: 928
+          size: 1606
           text: >+
             event: completion
 
-            data: {"deltaText":"\n    /**\n     * Generates and prints the first 10 numbers of the Fibonacci sequence.\n     * The sequence is built by adding the two preceding numbers, starting with 0 and 1.\n     */\n","stopReason":"stop_sequence"}
+            data: {"deltaText":"\n    /**\n     * Generates and prints the first 10 numbers of the Fibonacci sequence.\n     * The method creates a list starting with 0 and 1, then fills the subsequent\n     * positions by adding the two preceding numbers.\n     */\n","stopReason":"stop_sequence"}
 
 
             event: done
@@ -238,7 +233,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Mon, 17 Mar 2025 16:28:29 GMT
+            value: Tue, 18 Mar 2025 11:37:50 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
@@ -267,8 +262,8 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2025-03-17T16:28:27.627Z
-      time: 3455
+      startedDateTime: 2025-03-18T11:37:49.058Z
+      time: 2452
       timings:
         blocked: -1
         connect: -1
@@ -276,7 +271,7 @@ log:
         receive: 0
         send: 0
         ssl: -1
-        wait: 3455
+        wait: 2452
     - _id: f1b1cde4cd57488b7f0137954f0302f5
       _order: 0
       cache: {}
@@ -334,7 +329,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Mon, 17 Mar 2025 16:28:27 GMT
+            value: Tue, 18 Mar 2025 11:37:48 GMT
           - name: content-type
             value: application/json
           - name: content-length
@@ -363,8 +358,8 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2025-03-17T16:28:27.065Z
-      time: 161
+      startedDateTime: 2025-03-18T11:37:48.312Z
+      time: 221
       timings:
         blocked: -1
         connect: -1
@@ -372,7 +367,7 @@ log:
         receive: 0
         send: 0
         ssl: -1
-        wait: 161
+        wait: 221
     - _id: a376faab1c8a1993bb48c745757f0a4a
       _order: 0
       cache: {}
@@ -453,7 +448,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Mon, 17 Mar 2025 16:28:26 GMT
+            value: Tue, 18 Mar 2025 11:37:48 GMT
           - name: content-type
             value: application/json
           - name: transfer-encoding
@@ -484,8 +479,8 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2025-03-17T16:28:26.572Z
-      time: 265
+      startedDateTime: 2025-03-18T11:37:47.673Z
+      time: 309
       timings:
         blocked: -1
         connect: -1
@@ -493,7 +488,7 @@ log:
         receive: 0
         send: 0
         ssl: -1
-        wait: 265
+        wait: 309
     - _id: 0484c4d780805faf3dd3ddabae814640
       _order: 0
       cache: {}
@@ -547,22 +542,18 @@ log:
             value: null
         url: https://sourcegraph.com/.api/graphql?CurrentSiteCodyLlmConfiguration
       response:
-        bodySize: 136
+        bodySize: 139
         content:
           encoding: base64
           mimeType: application/json
-          size: 136
+          size: 139
           text: "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqzixJBdHJ+SmVPj6+zvl5aZnppUWJJZn5eWD53MSiE\
-            uf8vJLUipLwzLyU/HIlK6WUzOLEpJzUFKXa2tpaAAAAAP//AwArMNn0TAAAAA==\"]"
-          textDecoded:
-            data:
-              site:
-                codyLLMConfiguration:
-                  smartContextWindow: disabled
+            uf8vJLUipLwzLyU/HIlK6WUzOLEpJzUFKXa2tpaAAAAAP//\",\"AwArMNn0TAAAAA==\
+            \"]"
         cookies: []
         headers:
           - name: date
-            value: Mon, 17 Mar 2025 16:28:26 GMT
+            value: Tue, 18 Mar 2025 11:37:48 GMT
           - name: content-type
             value: application/json
           - name: transfer-encoding
@@ -593,8 +584,8 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2025-03-17T16:28:26.622Z
-      time: 204
+      startedDateTime: 2025-03-18T11:37:47.719Z
+      time: 261
       timings:
         blocked: -1
         connect: -1
@@ -602,7 +593,7 @@ log:
         receive: 0
         send: 0
         ssl: -1
-        wait: 204
+        wait: 261
     - _id: e141c56e63809042300db9bf8551d492
       _order: 0
       cache: {}
@@ -671,7 +662,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Mon, 17 Mar 2025 16:28:26 GMT
+            value: Tue, 18 Mar 2025 11:37:48 GMT
           - name: content-type
             value: application/json
           - name: transfer-encoding
@@ -702,8 +693,8 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2025-03-17T16:28:26.598Z
-      time: 234
+      startedDateTime: 2025-03-18T11:37:47.697Z
+      time: 287
       timings:
         blocked: -1
         connect: -1
@@ -711,7 +702,7 @@ log:
         receive: 0
         send: 0
         ssl: -1
-        wait: 234
+        wait: 287
     - _id: 5b9030a4e18d1e000c71d6000a7cef6f
       _order: 0
       cache: {}
@@ -743,7 +734,7 @@ log:
             value: gzip,deflate
           - name: host
             value: sourcegraph.com
-        headersSize: 399
+        headersSize: 472
         httpVersion: HTTP/1.1
         method: POST
         postData:
@@ -802,7 +793,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Mon, 17 Mar 2025 16:28:25 GMT
+            value: Tue, 18 Mar 2025 11:37:47 GMT
           - name: content-type
             value: application/json
           - name: transfer-encoding
@@ -833,8 +824,8 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2025-03-17T16:28:25.751Z
-      time: 216
+      startedDateTime: 2025-03-18T11:37:46.407Z
+      time: 927
       timings:
         blocked: -1
         connect: -1
@@ -842,7 +833,7 @@ log:
         receive: 0
         send: 0
         ssl: -1
-        wait: 216
+        wait: 927
     - _id: aef0c9fe7483280d9c05ac8e97e37571
       _order: 0
       cache: {}
@@ -900,19 +891,28 @@ log:
             value: null
         url: https://sourcegraph.com/.api/graphql?CurrentUserCodySubscription
       response:
-        bodySize: 231
+        bodySize: 224
         content:
           encoding: base64
           mimeType: application/json
-          size: 231
+          size: 224
           text: "[\"H4sIAAAAAAAAA1zMsQrCMBSF4Xc5c4U2rUu2Ih0EwdJWB7fYZAjUJNzcDKXk3UVBUMfz8\
             3E2aMUKcsOciIzjSzT0nl6vY7rHmWxg692rRVacIiTaw3S8digQFuUg0Q9nFFAhLGtP\
             flBsTvZhOUIyJVN8vntD1uuRFXHLkBCl2O/Kelc1kxCyqmQtbvjTndNftvm1Oef8BAA\
-            A//8=\",\"AwD1okHswgAAAA==\"]"
+            A//8DAPWiQezCAAAA\"]"
+          textDecoded:
+            data:
+              currentUser:
+                codySubscription:
+                  applyProRateLimits: true
+                  currentPeriodEndAt: 2025-04-14T22:11:32Z
+                  currentPeriodStartAt: 2025-03-14T22:11:32Z
+                  plan: PRO
+                  status: ACTIVE
         cookies: []
         headers:
           - name: date
-            value: Mon, 17 Mar 2025 16:28:26 GMT
+            value: Tue, 18 Mar 2025 11:37:48 GMT
           - name: content-type
             value: application/json
           - name: transfer-encoding
@@ -943,8 +943,8 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2025-03-17T16:28:26.669Z
-      time: 303
+      startedDateTime: 2025-03-18T11:37:47.741Z
+      time: 364
       timings:
         blocked: -1
         connect: -1
@@ -952,7 +952,7 @@ log:
         receive: 0
         send: 0
         ssl: -1
-        wait: 303
+        wait: 364
     - _id: 4504fab53d7cb602861f73dc2aa883d2
       _order: 0
       cache: {}
@@ -1009,16 +1009,16 @@ log:
           encoding: base64
           mimeType: application/json
           size: 136
-          text: "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqzixJBdEFRfkppcklYalFxZn5eUpWSsaGZoaWFvFGB\
-            kamugbGuoYm8WZ6hrpGlmkpyclmBkZmFmZKtbW1AAAAAP//AwCDSibRSQAAAA==\"]"
+          text: "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqzixJBdEFRfkppcklYalFxZn5eUpWSsaGZmYWFvFGB\
+            kamugbGuoYW8WZ6hropxpapqWmmZmbJSUZKtbW1AAAAAP//AwDmN7ToSQAAAA==\"]"
           textDecoded:
             data:
               site:
-                productVersion: 316198_2025-03-14_6.1-29fdcc602686
+                productVersion: 316688_2025-03-18_6.1-d39eef566cb2
         cookies: []
         headers:
           - name: date
-            value: Mon, 17 Mar 2025 16:28:26 GMT
+            value: Tue, 18 Mar 2025 11:37:48 GMT
           - name: content-type
             value: application/json
           - name: transfer-encoding
@@ -1049,8 +1049,8 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2025-03-17T16:28:26.644Z
-      time: 197
+      startedDateTime: 2025-03-18T11:37:47.643Z
+      time: 340
       timings:
         blocked: -1
         connect: -1
@@ -1058,7 +1058,7 @@ log:
         receive: 0
         send: 0
         ssl: -1
-        wait: 197
+        wait: 340
     - _id: fd0fee4687419870bc82cba9d1023319
       _order: 0
       cache: {}
@@ -1110,28 +1110,20 @@ log:
             value: null
         url: https://sourcegraph.com/.api/graphql?ViewerSettings
       response:
-        bodySize: 280
+        bodySize: 283
         content:
           encoding: base64
           mimeType: application/json
-          size: 280
+          size: 283
           text: "[\"H4sIAAAAAAAAA4zPwUoDQRAE0H/pc75gbyoGAwrikttcOkk529D2LD292cRl/l0WAsGD4\
             LXqUVALnTiYuoXOghneI0Is1zX5FGOljpZEuIxw+YIF6xYck6Mm6tbG+KB45e/ro5ZD\
             f7Xgy4vkQSUP61KiLnzCJpFh7sF+HD5QJ42taMDrOxv0T1T3u3s3euFjyBm/xEPOjsw\
-            hxerd1n+Qocxvk4ao2G3yqVgtiptpm0RlhO3s+SRRfD3cGrXWfgAAAP//AwDHP3NmNg\
-            EAAA==\"]"
-          textDecoded:
-            data:
-              viewerSettings:
-                final: "{\"experimentalFeatures\":{\"enableLazyBlobSyntaxHighlighting\":true,\"\
-                  newSearchResultFiltersPanel\":true,\"newSearchResultsUI\":tru\
-                  e,\"proactiveSearchResultsAggregations\":true,\"searchResults\
-                  Aggregations\":true,\"showMultilineSearchConsole\":true},\"op\
-                  enInEditor\":{}}"
+            hxerd1n+Qocxvk4ao2G3yqVgtiptpm0RlhO3s+SRRfD3cGrXWfgAAAP//\",\"AwDHP\
+            3NmNgEAAA==\"]"
         cookies: []
         headers:
           - name: date
-            value: Mon, 17 Mar 2025 16:28:27 GMT
+            value: Tue, 18 Mar 2025 11:37:48 GMT
           - name: content-type
             value: application/json
           - name: transfer-encoding
@@ -1162,8 +1154,8 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2025-03-17T16:28:27.035Z
-      time: 211
+      startedDateTime: 2025-03-18T11:37:48.275Z
+      time: 286
       timings:
         blocked: -1
         connect: -1
@@ -1171,7 +1163,7 @@ log:
         receive: 0
         send: 0
         ssl: -1
-        wait: 211
+        wait: 286
     - _id: fbb23499ae0eec5c2e188687b429531b
       _order: 0
       cache: {}
@@ -1203,53 +1195,53 @@ log:
         queryString: []
         url: https://sourcegraph.com/.api/modelconfig/supported-models.json
       response:
-        bodySize: 2503
+        bodySize: 2547
         content:
           encoding: base64
           mimeType: text/plain; charset=utf-8
-          size: 2503
-          text: "[\"H4sIAAAJbogA/+ycUXObOhbH3/MpNLxu5IIc4qzf0ty2e2dut91tp/uwcx9kOLY1AcSCc\
-            Jy50+++I2zjYAskYojtGp6ScHQkxz/+5xxJ6K8rhBCyUm8OIf0BScp4ZI2R5Qxs63p1\
-            L4EF2/zZHtgD+28+LDY344QvmA9Jao3Rf3N7ef1V/CQvi/nSJY3EPOEx86zr8m2fpXF\
-            An/9JQ5B294Vd4eXndb3rKUvgiSePqcb1x8LO2PWM81kAGr+fVkbG4+UxRJRpnH6JIb\
-            r/3dxpyFKR0EDj9fPaaus2/+nP9fcZch+C2i8zt/g3TEtf6XhMbHKDHRsTMh57Ac18w\
-            EM8wimPIhA4oAJSoRnaQ94MDQcj9C1vtmufd72xNu3EozGdsIAJBuXPtbksb053W8nL\
-            WmOvuCM4D9Ltv/DFP3BzWR4VMOPJs/xg1POyhHrPO66sVFCRyUHJnyb7lAkGibw7TWD\
-            vnscjAUvxHxb5/Mka7yAhLyuky9+jOBPf+SNEspsb17bta6Xhl0yULG3bLtm9eALlZU\
-            EqWEgF+J/ld/LAU6EeQxYxeccKBX/c+QjyslgxwK8QRauvaKgcJM/Evqnj7o7zSjHiN\
-            giGpYDIBx+LOYseWTTTqNgezOjD2gP6XuHhxPBWNEmApjySH75078/r0q+tsh8nvEf/\
-            KOi7rxNvt5F4azrR0w0+U4p3L+q9qK9EfYjtW2w7L9ISHme6THEj3+iLwlaNsvSK5ZN\
-            kE/L3lkE2llsu5pBU5xk+xAlIefarco3L0luZP5S7q841Rl3nGi6eU/aYVUhhBaADF/\
-            1DtjJjtL4LvdrSTHCPh3EAYle8XqXGDTU3jQH8Pos2yqLvjMG+aZXrfbmdq/is0tsGM\
-            Od+V4o7tEdvDLNxAqxhVq/IbXE7Oovij7imeuwQt8XSbw/bwSY1NSS3T3yLxPftmD4T\
-            LT7ejMa+Ghfg5cJ5SzbzvDplfi3fVd2cdWnXE37ChDeS7UZQv3xyzrnIu7BU+Kjy67y\
-            ceyADxywRVhiqkFSYHair5wfheeS1d+YMktYLsh0GDUM+GdhmDNo9gz2DOwwWS/Lj8c\
-            IZj1NBE4/7kGjQ+yZo8qCyK6lfpTe9+JWKfmPQTmLiidg3d0aQEfe2ZPaWsZaYI3aYy\
-            O0A5gPEKcAjzinDC4IDJgBPaAoatfsNIP4G8Ih+EPQHE4DeK9qU8KOex7NIpO9SniUe\
-            zBIaz9/lFum7BuPoYe0CVlNQjTntBtPFUBOEt1gOzWAsetpDcTFsjl6zQNxXzHnFbCq\
-            Sx2FPhj65XJ5iH6Y0C4Rm5uc+E/yDtEfFvjn0m7plSR497j/j/C9YdolXfRZ4VvV+JD\
-            mEZQwJCyESNOg6gjvkaLWKafw+Pprr+JmHzQpUduqV+01rVIhmnkOiH6QW1Ia9HgnQC\
-            QhalVq2tFrfc2nOZRaxKQMfzxIaZQFNsM+m064ArUk0t0NbDHHAIsABLCDAAY9mWEAS\
-            FiP1U5kOy0wYA3Zit+f64rlOQ5oITOM4eMb/e4LIUGi/yWboXjZD/3qCyCgdMO1LL6+\
-            5p7z31iA8zeifW14yjkMywbICwQtHE/v3kByS9+iH83pZlXjheC7V0uPhhEXgb8e0cH\
-            pqL5fa1btAq/mmGYQsYtgZuFiRhO0kqJ9yY+QMXPQ14bUhv96vXiPbmVif0IBG3vFnk\
-            c5kf4djvmvp0PVFBYNkYONpQNM5hmVsRiIZ2OijbII+1EiJCszazg7Es8s9HZpk9CI2\
-            dEwazOM7tm0by6p8+LrD2kxcC6QbUfzrEPzLb34+U3rzKSWz/KBAGP+haFOvxqpeOpM=\
-            \",\"457ZDpgdNXgXZdiV4MYJl4Ed2wTbrllWK6k1zGq1PZxwAqFPiU3mElqasO3XuD\
-            ZrXAqOZU2mDO7VVdlHlblKcCt9H0huW1lAn8fu5LFvq6rrMzhWOIZsKX/Bd8vRBLMoF\
-            UnmCQ2Tn1dt0N1y9L6Wx2IOa2/Z36hbPa7NNgCcDJbnsRPPNY707mF1VQWQhLyCSEIO\
-            R5KQQ5hsZ3Kr37ncaOeyY76lzzlwT1+J1u0C5wafBdGwut2xsqG2lQXWCGbYjh0y3a4\
-            IVA9JT3Enq6mnuZD1q++wWh3ktT79SlY0MguNBb7hGlX99PW7wqiccSr9HCiSXU5Q6T\
-            cB1s9RnX9t1CQFIOY5gLP3FF0pnqcaXa3GFMuqRpMBrFhVWiqAVdqdMLWazLUe2bYyg\
-            TNh1jFe5rptH1g+zNHCIfgsCzVZ69oYqY1L2K5NmyNbNePfySlpbxnfz4VGx1hBb246\
-            4NHRVE7cqefOyV8kxg7BzitOLzk5+i4rfDc5Oeq2s/iNRZZMuKaCz+M3+q6y3I/fao8\
-            Hxm9jEg8uzVuC8Ewqc9ucwWFXDA4HrjGF8hARMw4rvb4ViQdPaF4UiQ1OWKh5sbh0Ev\
-            V6l/DnzYHU23/W6pvUHwSiOsHJmtJUPJi13zu4TL7ZBA+r9zvWB6Lv7Kuuewv1CiGEf\
-            l79vPr/AL48Bv50XQAA\"]"
+          size: 2547
+          text: "[\"H4sIAAAJbogA/+yc33ObOhbH3/NXaHjdyAUR4qzf0ty2e2dut91tp/uwcx9kOLY1AcSCc\
+            JO50/99R9jGwRZIxOAfLTwl4ehIjj/+6pzDsf66QgghK/MXENFvkGaMx9YEWc7Itq5X\
+            91JYss2f7ZE9sv8WwHJzM0n5kgWQZtYE/bewl9df5U/yslggXdJYLFKeMN+6rt4OWJa\
+            E9PmfNAJpd1/alV5+XDe7nrEUvvP0MdO4fl/aGbuecz4PQeP3w8rIeL08gZgyjdNPCc\
+            T3v5s7jVgmUhpqvH5cW23dFj/9uX4/Ix5A2PhmFhb/hlnlLZ1MiE1usGNjQiYTP6R5A\
+            NjFY5zxOAaBQyogE5qlPRTDkDsaoy/FsF37YuqNtekkPk3olIVMMKi+rs1l+Qu6O0pe\
+            1hp7xR3BeZht/4Uv/oGby/KpgDlPn+ULo76fp9R/3nFlZYKKXC5K/jTdp0wwSOXdWQp\
+            793weC3gS/2FxwL9bkx0k5GVF9On3OMnFV/4IsZzGGXu2bV8rLT/l4qXpnW3bFbsXH0\
+            F5WZAJFlEBwUf5pjzwTKgXkcdM3rEiwR93XoO8LFau8DPE8eo9cpWL5LnYN3W83XVeK\
+            VbcBcLwJCAOIMBiweJHFs81MrZHM3q39oC+1ng4M74VQ1KgGY/li6/c+/O68mun8Ccp\
+            PzL7LhngX8HvvU6/vVb6rZlEzzcETKnfg64Pur7WdRfbt9h2XoQmPMl10eJGwdEnha2\
+            aZekVy4+STcjfOybZWHG5WEBaH2sEkKQgFTqoizc6ktwb42jj5pSCK1GrTleP5bjvcM\
+            PDC8oe8xotrAF05KF/yFFmjDZPoZdbmgvu8ygJQeyq16vkuKXoZglAMETSZpH0nTHZN\
+            52Cva+3CxWgdYLbgubC70pyXXt8ZJqNg2ANtHpJ7grc8UVIMvFMBdkhXp9hwmgTnBqS\
+            O4S+Zeh7PKYvJM44p+i3BK8QzluyKfbqlPm1fNdNc9HJ3UD4GRPeSrZbQf3yk3PJWV5\
+            XIcUgv3r5dV4WH8jIMQuEFYYqJBVmB+rq5UF4GXHtnXkIQDpPyHYYNNzyycg2Y9AeGB\
+            wY3GGwfC4/mSydySQTNPV5AKkGvS+Cpg8qu4r61XrTi18l6TcG7SwqT8S+uTOCjHi3F\
+            bNj7rXEHLHDRG4HsAAgyQAecUEZXhIcMgF4SjPQqN1vAMkXgEf0jaA/mAD0VjGmgh/1\
+            fZ7HInuT8Tz1YZ7SZPGmsMjetFjHAGsfsJqCasxpP5guXc0mvMXSNYOxnGkPxaXbHr1\
+            2G/GQMRcZs6lInoa9LKKpwDRJwmf8v+8Q4wBmNA+FpgD0RQ5D93IY+td3iNFv6mHVHd\
+            pwLr0GFp6K2TvbruEpgZRFEAsa9r1pO8Q0PXE67z0x3bPPBEeXTLGUHbx0NAnKHpIue\
+            Yu+OY1ENm3aq89EsqAZYJ9HUxZDsF3T0hmoHahdUyvzB9l1lBmq530u+Dtpj8oOZCMB\
+            9XnwjIu/YDklXs1Z7vGv19NeEqDzVNRfbH9/ieY6CSlyjxpUdoo+95vRqIw8i0QcfSO\
+            NO33LWU+U9ExB0DrR7KrN1FgzBy7zmM0YBHie0jgPaYoDNpv1BWjTxl/Cu3RxyGLAIS\
+            whxCGP51hAGpUrDTJZU5DlBAzYSbyB61+P69UXglb1pjlELGbYGXlYoR872vqhMEbOy\
+            EOfU95Ia7NfvXp2U1if0pDG/umrSJfSbOeYty0d+vRbASEZ2XgW0myB4SkxQ5GMbPRe\
+            DkHvGkI3FZmNkx3IZ59NHRoh/SU6OqZtkLZt2zjFksrfH9Zm6loi3Yrin4fgn7/9+UI=\
+            \",\"8S3yIbMIoWQY/6EY0yzHqll60+MB2j6gHbf4Porbl+QmKZdbO7YJtj2zwFZiax\
+            jYamc44xBCHxWb1MG6KjecMDQ2jSGMYe48dpB5mXJ/r8/M3qvMVZJb6/tAdLsKBIZQd\
+            ieUPa6srg/jWGVoEXuSv+C7p/EUszgTae4LDZMfV2PQ3dP4bSOPZWWrLLhtHmgZTavH\
+            tV0TwNlgeRndeJ6xOnqHyWMNkIS8gkhCDkeSkEOY7KbANXQvt+pedszb+pwD+/oqtG7\
+            r8xt8lkTD6vaB64baTp4PxDDHduKQ2bZBoH5JeoqHp7A/zVPY1Yle62OwZEojC7OJwD\
+            dco6ofPn9VGFUjTqWfA0WyzxRJ3wjYXKbqKjmybdMY4KTHXRHzIMDZW+eVYsWv4hTLt\
+            EYTAqxgVVoqiFXanTG2mtC1mdmuQoFLgdYxftZ12z2x3C3YwhEELI80cevaGKmNK9yu\
+            TdszW1f27+W8tKP2WZkXmE57bJrjGIvozU0PRDqa7Ik7zeQ5xReKsUOw84pTTM6Ov+P\
+            XN0+MX4vq0u3eQrvaxLHI0ynX5PHFJo6+qiz3N3G1xwM3cWMWD07QO8LwQvJz2zbWQL\
+            cvBt2RZ0yhPE7EjMNar8ci8eCy5i9FYouzFhq+Ylw5mHrdv/xxcz719p+1eif1Rz6qz\
+            nKyZjQTD2bj944wk+358LBqUl6fj77T9Nr0fdQrhBD6cfXj6v8DAGsUX6uDXQAA\"]"
         cookies: []
         headers:
           - name: date
-            value: Mon, 17 Mar 2025 16:28:27 GMT
+            value: Tue, 18 Mar 2025 11:37:48 GMT
           - name: content-type
             value: text/plain; charset=utf-8
           - name: transfer-encoding
@@ -1280,8 +1272,8 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2025-03-17T16:28:27.254Z
-      time: 199
+      startedDateTime: 2025-03-18T11:37:48.573Z
+      time: 309
       timings:
         blocked: -1
         connect: -1
@@ -1289,6 +1281,6 @@ log:
         receive: 0
         send: 0
         ssl: -1
-        wait: 199
+        wait: 309
   pages: []
   version: "1.2"

--- a/jetbrains/src/main/java/com/sourcegraph/cody/vscode/IntelliJTextDocument.java
+++ b/jetbrains/src/main/java/com/sourcegraph/cody/vscode/IntelliJTextDocument.java
@@ -4,8 +4,8 @@ import com.intellij.lang.Language;
 import com.intellij.lang.LanguageUtil;
 import com.intellij.openapi.editor.Document;
 import com.intellij.openapi.editor.Editor;
-import com.intellij.openapi.fileEditor.FileDocumentManager;
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.vfs.VfsUtil;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.sourcegraph.cody.agent.protocol_generated.Position;
 import java.net.URI;
@@ -20,14 +20,13 @@ public class IntelliJTextDocument implements TextDocument {
 
   public IntelliJTextDocument(Editor editor, Project project) {
     this.editor = editor;
-    Document document = editor.getDocument();
-    this.file = FileDocumentManager.getInstance().getFile(document);
+    this.file = editor.getVirtualFile();
     this.language = LanguageUtil.getLanguageForPsi(project, file);
   }
 
   @Override
   public URI uri() {
-    return URI.create(file.getUrl());
+    return VfsUtil.toUri(file.getPath());
   }
 
   @Override

--- a/jetbrains/src/main/java/com/sourcegraph/website/FileActionBase.java
+++ b/jetbrains/src/main/java/com/sourcegraph/website/FileActionBase.java
@@ -31,6 +31,7 @@ public abstract class FileActionBase extends DumbAwareEDTAction {
     if (editor == null) {
       return;
     }
+
     VirtualFile currentFile = event.getData(CommonDataKeys.VIRTUAL_FILE);
     if (currentFile == null) {
       return;

--- a/jetbrains/src/main/java/com/sourcegraph/website/SearchActionBase.java
+++ b/jetbrains/src/main/java/com/sourcegraph/website/SearchActionBase.java
@@ -7,7 +7,6 @@ import com.intellij.openapi.editor.Caret;
 import com.intellij.openapi.editor.Document;
 import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.editor.SelectionModel;
-import com.intellij.openapi.fileEditor.FileDocumentManager;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.TextRange;
 import com.intellij.openapi.vfs.VirtualFile;
@@ -37,7 +36,7 @@ public abstract class SearchActionBase extends DumbAwareEDTAction {
     }
 
     //noinspection ConstantConditions selectedText != null, so the editor can't be null.
-    VirtualFile currentFile = FileDocumentManager.getInstance().getFile(editor.getDocument());
+    VirtualFile currentFile = editor.getVirtualFile();
     assert currentFile != null; // selectedText != null, so this can't be null.
 
     URLBuilder urlBuilder = new URLBuilder(project);
@@ -97,7 +96,7 @@ public abstract class SearchActionBase extends DumbAwareEDTAction {
   @Nullable
   private String getSelectedText(Editor editor) {
     Document currentDocument = editor.getDocument();
-    VirtualFile currentFile = FileDocumentManager.getInstance().getFile(currentDocument);
+    VirtualFile currentFile = editor.getVirtualFile();
     if (currentFile == null) {
       return null;
     }

--- a/jetbrains/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgent.kt
+++ b/jetbrains/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgent.kt
@@ -128,7 +128,7 @@ private constructor(
         try {
           val workspaceRootPath = ConfigUtil.getWorkspaceRootPath(project)
           val workspaceRootUri =
-              ProtocolTextDocumentExt.normalizeFileUri(workspaceRootPath.toUri().toString())
+              ProtocolTextDocumentExt.normalizeToVscUriFormat(workspaceRootPath.toUri().toString())
                   ?: throw CodyAgentException("Unsupported workspace location: $workspaceRootPath")
 
           return server

--- a/jetbrains/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgent.kt
+++ b/jetbrains/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgent.kt
@@ -126,15 +126,18 @@ private constructor(
         val server = launcher.remoteProxy
         val listeningToJsonRpc = launcher.startListening()
         try {
+          val workspaceRootPath = ConfigUtil.getWorkspaceRootPath(project)
+          val workspaceRootUri =
+              ProtocolTextDocumentExt.normalizeFileUri(workspaceRootPath.toUri().toString())
+                  ?: throw CodyAgentException("Unsupported workspace location: $workspaceRootPath")
+
           return server
               .initialize(
                   ClientInfo(
                       name = "JetBrains",
                       version = ConfigUtil.getPluginVersion(),
                       ideVersion = ApplicationInfo.getInstance().build.toString(),
-                      workspaceRootUri =
-                          ProtocolTextDocumentExt.normalizeUriOrPath(
-                              ConfigUtil.getWorkspaceRootPath(project).toUri().toString()),
+                      workspaceRootUri = workspaceRootUri,
                       extensionConfiguration =
                           ConfigUtil.getAgentConfiguration(project, endpoint, token),
                       capabilities =

--- a/jetbrains/src/main/kotlin/com/sourcegraph/cody/agent/protocol_extensions/ProtocolTextDocument.kt
+++ b/jetbrains/src/main/kotlin/com/sourcegraph/cody/agent/protocol_extensions/ProtocolTextDocument.kt
@@ -2,6 +2,7 @@ package com.sourcegraph.cody.agent.protocol_extensions
 
 import com.intellij.codeInsight.codeVision.ui.popup.layouter.bottom
 import com.intellij.codeInsight.codeVision.ui.popup.layouter.right
+import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.editor.event.CaretEvent
 import com.intellij.openapi.editor.event.DocumentEvent
@@ -15,14 +16,16 @@ import com.sourcegraph.cody.agent.protocol_generated.ProtocolTextDocument
 import com.sourcegraph.cody.agent.protocol_generated.ProtocolTextDocumentContentChangeEvent
 import com.sourcegraph.cody.agent.protocol_generated.Range
 import com.sourcegraph.cody.agent.protocol_generated.TestingParams
+import com.sourcegraph.cody.listeners.CodyFileEditorListener
 import com.sourcegraph.config.ConfigUtil
 import java.awt.Point
-import java.nio.file.FileSystems
 import java.util.Locale
 import kotlin.math.max
 import kotlin.math.min
 
 object ProtocolTextDocumentExt {
+  private val logger = Logger.getInstance(CodyFileEditorListener::class.java)
+
   private fun getTestingParams(
       uri: String,
       content: String? = null,
@@ -74,7 +77,7 @@ object ProtocolTextDocumentExt {
     val file = FileDocumentManager.getInstance().getFile(editor.document) ?: return null
     val start = editor.document.codyPosition(caret.offset)
     val selection = Range(start, start)
-    val uri = uriFor(file)
+    val uri = fileUriFor(file) ?: return null
     return ProtocolTextDocument(
         uri = uri,
         selection = selection,
@@ -84,7 +87,7 @@ object ProtocolTextDocumentExt {
   @RequiresEdt
   fun fromEditorWithRangeSelection(editor: Editor, event: SelectionEvent): ProtocolTextDocument? {
     val file = FileDocumentManager.getInstance().getFile(editor.document) ?: return null
-    val uri = uriFor(file)
+    val uri = fileUriFor(file) ?: return null
     val selection = editor.document.codyRange(event.newRange.startOffset, event.newRange.endOffset)
     return ProtocolTextDocument(
         uri = uri,
@@ -103,7 +106,7 @@ object ProtocolTextDocumentExt {
   @RequiresEdt
   fun fromEditorForDocumentEvent(editor: Editor, event: DocumentEvent): ProtocolTextDocument? {
     val file = FileDocumentManager.getInstance().getFile(event.document) ?: return null
-    val uri = uriFor(file)
+    val uri = fileUriFor(file) ?: return null
     val selection = event.document.codyRange(editor.caretModel.offset, editor.caretModel.offset)
 
     val content =
@@ -151,9 +154,9 @@ object ProtocolTextDocumentExt {
   fun fromVirtualEditorFile(
       editor: Editor,
       file: VirtualFile,
-  ): ProtocolTextDocument {
+  ): ProtocolTextDocument? {
     val content = FileDocumentManager.getInstance().getDocument(file)?.text
-    val uri = uriFor(file)
+    val uri = fileUriFor(file) ?: return null
     val selection = getSelection(editor)
     return ProtocolTextDocument(
         uri = uri,
@@ -163,27 +166,33 @@ object ProtocolTextDocumentExt {
         testing = getTestingParams(uri = uri, content = content, selection = selection))
   }
 
-  fun fromVirtualFile(file: VirtualFile): ProtocolTextDocument {
+  fun fromVirtualFile(file: VirtualFile): ProtocolTextDocument? {
     val content = FileDocumentManager.getInstance().getDocument(file)?.text
-    val uri = uriFor(file)
+    val uri = fileUriFor(file) ?: return null
     return ProtocolTextDocument(
         uri = uri, content = content, testing = getTestingParams(uri = uri, content = content))
   }
 
-  fun uriFor(file: VirtualFile): String {
-    val uriString = FileSystems.getDefault().getPath(file.path).toUri().toString()
-    return normalizeUriOrPath(uriString)
+  fun fileUriFor(file: VirtualFile): String? {
+    return normalizeFileUri(file.url)
   }
 
-  fun normalizeUriOrPath(uriString: String): String {
-    val hasScheme = uriString.startsWith("file://")
-    val path = (if (hasScheme) uriString.removePrefix("file://") else uriString).replace("\\", "/")
+  fun normalizeFileUri(uriString: String): String? {
+    val hasFileScheme = uriString.startsWith("file://")
+
+    if (uriString.contains("://") && !hasFileScheme) {
+      logger.warn("Unsupported URI scheme, skipping file processing: $uriString")
+      return null
+    }
+
+    val path =
+        (if (hasFileScheme) uriString.removePrefix("file://") else uriString).replace("\\", "/")
 
     // Normalize WSL paths
     val wslPrefix = "//wsl$"
     if (path.startsWith(wslPrefix)) {
       val newPath = "//wsl.localhost${path.removePrefix(wslPrefix)}"
-      return if (hasScheme) "file://$newPath" else newPath
+      return if (hasFileScheme) "file://$newPath" else newPath
     }
 
     // Normalize drive letters for Windows
@@ -194,7 +203,7 @@ object ProtocolTextDocumentExt {
           "${driveLetter}:/"
         }
 
-    if (!hasScheme) return normalizedPath
+    if (!hasFileScheme) return normalizedPath
     if (path.matches(Regex("^/[^/].*"))) {
       return "file://$normalizedPath"
     }

--- a/jetbrains/src/main/kotlin/com/sourcegraph/cody/agent/protocol_extensions/ProtocolTextDocument.kt
+++ b/jetbrains/src/main/kotlin/com/sourcegraph/cody/agent/protocol_extensions/ProtocolTextDocument.kt
@@ -74,7 +74,7 @@ object ProtocolTextDocumentExt {
   @RequiresEdt
   fun fromEditorWithOffsetSelection(editor: Editor, event: CaretEvent): ProtocolTextDocument? {
     val caret = event.caret ?: return null
-    val file = FileDocumentManager.getInstance().getFile(editor.document) ?: return null
+    val file = editor.virtualFile ?: return null
     val start = editor.document.codyPosition(caret.offset)
     val selection = Range(start, start)
     val uri = fileUriFor(file) ?: return null
@@ -86,7 +86,7 @@ object ProtocolTextDocumentExt {
 
   @RequiresEdt
   fun fromEditorWithRangeSelection(editor: Editor, event: SelectionEvent): ProtocolTextDocument? {
-    val file = FileDocumentManager.getInstance().getFile(editor.document) ?: return null
+    val file = editor.virtualFile ?: return null
     val uri = fileUriFor(file) ?: return null
     val selection = editor.document.codyRange(event.newRange.startOffset, event.newRange.endOffset)
     return ProtocolTextDocument(
@@ -105,7 +105,7 @@ object ProtocolTextDocumentExt {
 
   @RequiresEdt
   fun fromEditorForDocumentEvent(editor: Editor, event: DocumentEvent): ProtocolTextDocument? {
-    val file = FileDocumentManager.getInstance().getFile(event.document) ?: return null
+    val file = editor.virtualFile ?: return null
     val uri = fileUriFor(file) ?: return null
     val selection = event.document.codyRange(editor.caretModel.offset, editor.caretModel.offset)
 
@@ -146,7 +146,7 @@ object ProtocolTextDocumentExt {
 
   @RequiresEdt
   fun fromEditor(editor: Editor): ProtocolTextDocument? {
-    val file = FileDocumentManager.getInstance().getFile(editor.document) ?: return null
+    val file = editor.virtualFile ?: return null
     return fromVirtualEditorFile(editor, file)
   }
 

--- a/jetbrains/src/main/kotlin/com/sourcegraph/cody/autocomplete/Utils.kt
+++ b/jetbrains/src/main/kotlin/com/sourcegraph/cody/autocomplete/Utils.kt
@@ -55,10 +55,14 @@ object Utils {
     val virtualFile =
         FileDocumentManager.getInstance().getFile(editor.document)
             ?: return CompletableFuture.completedFuture(null)
+    val fileUri =
+        ProtocolTextDocumentExt.fileUriFor(virtualFile)
+            ?: return CompletableFuture.completedFuture(null)
+
     val params =
         if (lookupString.isNullOrEmpty())
             AutocompleteParams(
-                uri = ProtocolTextDocumentExt.uriFor(virtualFile),
+                uri = fileUri,
                 position = Position(position.line, position.character),
                 triggerKind =
                     if (triggerKind == InlineCompletionTriggerKind.INVOKE)
@@ -66,7 +70,7 @@ object Utils {
                     else AutocompleteParams.TriggerKindEnum.Automatic)
         else
             AutocompleteParams(
-                uri = ProtocolTextDocumentExt.uriFor(virtualFile),
+                uri = fileUri,
                 position = Position(position.line, position.character),
                 triggerKind = AutocompleteParams.TriggerKindEnum.Automatic,
                 selectedCompletionInfo =

--- a/jetbrains/src/main/kotlin/com/sourcegraph/cody/autocomplete/Utils.kt
+++ b/jetbrains/src/main/kotlin/com/sourcegraph/cody/autocomplete/Utils.kt
@@ -53,7 +53,7 @@ object Utils {
 
     val virtualFile = editor.virtualFile ?: return CompletableFuture.completedFuture(null)
     val fileUri =
-        ProtocolTextDocumentExt.fileUriFor(virtualFile)
+        ProtocolTextDocumentExt.vscNormalizedUriFor(virtualFile)
             ?: return CompletableFuture.completedFuture(null)
 
     val params =

--- a/jetbrains/src/main/kotlin/com/sourcegraph/cody/autocomplete/Utils.kt
+++ b/jetbrains/src/main/kotlin/com/sourcegraph/cody/autocomplete/Utils.kt
@@ -3,7 +3,6 @@ package com.sourcegraph.cody.autocomplete
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.editor.Editor
-import com.intellij.openapi.fileEditor.FileDocumentManager
 import com.intellij.openapi.project.Project
 import com.sourcegraph.cody.agent.CodyAgentService
 import com.sourcegraph.cody.agent.protocol.ErrorCode
@@ -52,9 +51,7 @@ object Utils {
       startPosition = findLastCommonSuffixElementPosition(originalText, lookupString)
     }
 
-    val virtualFile =
-        FileDocumentManager.getInstance().getFile(editor.document)
-            ?: return CompletableFuture.completedFuture(null)
+    val virtualFile = editor.virtualFile ?: return CompletableFuture.completedFuture(null)
     val fileUri =
         ProtocolTextDocumentExt.fileUriFor(virtualFile)
             ?: return CompletableFuture.completedFuture(null)

--- a/jetbrains/src/main/kotlin/com/sourcegraph/cody/ignore/IgnoreOracle.kt
+++ b/jetbrains/src/main/kotlin/com/sourcegraph/cody/ignore/IgnoreOracle.kt
@@ -6,7 +6,6 @@ import com.intellij.openapi.components.Service
 import com.intellij.openapi.components.service
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.editor.Editor
-import com.intellij.openapi.fileEditor.FileDocumentManager
 import com.intellij.openapi.project.Project
 import com.intellij.util.containers.SLRUMap
 import com.sourcegraph.cody.agent.CodyAgent
@@ -125,7 +124,7 @@ class IgnoreOracle(private val project: Project) {
 
   /** Like `policyForUri(String)` but fetches the uri from the passed Editor's Document. */
   fun policyForEditor(editor: Editor): Ignore_TestResult.PolicyEnum? {
-    val url = FileDocumentManager.getInstance().getFile(editor.document)?.url ?: return null
+    val url = editor.virtualFile?.url ?: return null
     val completable = policyForUri(url)
     return try {
       completable.get(policyAwaitTimeoutMs, TimeUnit.MILLISECONDS)

--- a/jetbrains/src/main/kotlin/com/sourcegraph/cody/inspections/CodyFixHighlightPass.kt
+++ b/jetbrains/src/main/kotlin/com/sourcegraph/cody/inspections/CodyFixHighlightPass.kt
@@ -51,11 +51,12 @@ class CodyFixHighlightPass(val file: PsiFile, val editor: Editor) :
             .filter { it.severity == HighlightSeverity.ERROR }
             .map { highlight ->
               try {
-                if (progress.isCanceled) {
+                val uri = ProtocolTextDocumentExt.fileUriFor(file.virtualFile)
+
+                if (progress.isCanceled || uri == null) {
                   return@map CompletableFuture.completedFuture(emptyList<CodeActionQuickFix>())
                 }
 
-                val uri = ProtocolTextDocumentExt.uriFor(file.virtualFile)
                 val range =
                     document.codyRange(highlight.startOffset, highlight.endOffset)
                         ?: return@map CompletableFuture.completedFuture(

--- a/jetbrains/src/main/kotlin/com/sourcegraph/cody/inspections/CodyFixHighlightPass.kt
+++ b/jetbrains/src/main/kotlin/com/sourcegraph/cody/inspections/CodyFixHighlightPass.kt
@@ -51,7 +51,7 @@ class CodyFixHighlightPass(val file: PsiFile, val editor: Editor) :
             .filter { it.severity == HighlightSeverity.ERROR }
             .map { highlight ->
               try {
-                val uri = ProtocolTextDocumentExt.fileUriFor(file.virtualFile)
+                val uri = ProtocolTextDocumentExt.vscNormalizedUriFor(file.virtualFile)
 
                 if (progress.isCanceled || uri == null) {
                   return@map CompletableFuture.completedFuture(emptyList<CodeActionQuickFix>())

--- a/jetbrains/src/main/kotlin/com/sourcegraph/cody/listeners/CodyCaretListener.kt
+++ b/jetbrains/src/main/kotlin/com/sourcegraph/cody/listeners/CodyCaretListener.kt
@@ -16,9 +16,10 @@ import com.sourcegraph.utils.CodyEditorUtil
 class CodyCaretListener(val project: Project) : CaretListener {
   override fun caretPositionChanged(e: CaretEvent) {
     if (!ConfigUtil.isCodyEnabled() ||
+        e.editor.project != project ||
+        !e.editor.document.isWritable ||
         (e.editor.editorKind != EditorKind.MAIN_EDITOR &&
-            !ConfigUtil.isIntegrationTestModeEnabled()) ||
-        e.editor.project != project) {
+            !ConfigUtil.isIntegrationTestModeEnabled())) {
       return
     }
 

--- a/jetbrains/src/main/kotlin/com/sourcegraph/cody/listeners/CodyFileEditorListener.kt
+++ b/jetbrains/src/main/kotlin/com/sourcegraph/cody/listeners/CodyFileEditorListener.kt
@@ -21,7 +21,7 @@ class CodyFileEditorListener : FileEditorManagerListener {
     try {
       val textEditor = source.getSelectedEditor(file) as? TextEditor ?: return
       val editor = textEditor.editor
-      val protocolTextFile = ProtocolTextDocumentExt.fromVirtualEditorFile(editor, file)
+      val protocolTextFile = ProtocolTextDocumentExt.fromVirtualEditorFile(editor, file) ?: return
       EditorChangesBus.documentChanged(editor.project, protocolTextFile)
 
       withAgent(source.project) { agent: CodyAgent ->
@@ -34,7 +34,7 @@ class CodyFileEditorListener : FileEditorManagerListener {
 
   override fun fileClosed(source: FileEditorManager, file: VirtualFile) {
     try {
-      val protocolTextFile = ProtocolTextDocumentExt.fromVirtualFile(file)
+      val protocolTextFile = ProtocolTextDocumentExt.fromVirtualFile(file) ?: return
       EditorChangesBus.documentChanged(source.project, protocolTextFile)
       withAgent(source.project) { agent: CodyAgent ->
         agent.server.textDocument_didClose(protocolTextFile)
@@ -57,7 +57,8 @@ class CodyFileEditorListener : FileEditorManagerListener {
         CodyEditorUtil.getAllOpenEditors().forEach { editor ->
           fileDocumentManager.getFile(editor.document)?.let { file ->
             try {
-              val textDocument = ProtocolTextDocumentExt.fromVirtualEditorFile(editor, file)
+              val textDocument =
+                  ProtocolTextDocumentExt.fromVirtualEditorFile(editor, file) ?: return@let
               codyAgent.server.textDocument_didOpen(textDocument)
             } catch (x: Exception) {
               logger.warn("Error calling textDocument/didOpen for file: ${file.path}", x)
@@ -69,7 +70,8 @@ class CodyFileEditorListener : FileEditorManagerListener {
         CodyEditorUtil.getSelectedEditors(project).forEach { editor ->
           val file = fileDocumentManager.getFile(editor.document)
           try {
-            val textDocument = ProtocolTextDocumentExt.fromVirtualEditorFile(editor, file!!)
+            val textDocument =
+                ProtocolTextDocumentExt.fromVirtualEditorFile(editor, file!!) ?: return@invokeLater
             codyAgent.server.textDocument_didFocus(TextDocument_DidFocusParams(textDocument.uri))
           } catch (x: Exception) {
             logger.warn("Error calling textDocument/didFocus on ${file?.path}", x)

--- a/jetbrains/src/main/kotlin/com/sourcegraph/cody/listeners/CodySelectionListener.kt
+++ b/jetbrains/src/main/kotlin/com/sourcegraph/cody/listeners/CodySelectionListener.kt
@@ -16,6 +16,7 @@ class CodySelectionListener(val project: Project) : SelectionListener {
     if (!ConfigUtil.isCodyEnabled() ||
         event.editor == null ||
         event.editor.project != project ||
+        !event.editor.document.isWritable ||
         (event.editor.editorKind != EditorKind.MAIN_EDITOR &&
             !ConfigUtil.isIntegrationTestModeEnabled())) {
       return

--- a/jetbrains/src/main/kotlin/com/sourcegraph/utils/CodyEditorUtil.kt
+++ b/jetbrains/src/main/kotlin/com/sourcegraph/utils/CodyEditorUtil.kt
@@ -21,7 +21,6 @@ import com.intellij.openapi.util.Key
 import com.intellij.openapi.util.TextRange
 import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.openapi.vfs.VirtualFile
-import com.intellij.openapi.vfs.ex.temp.TempFileSystem
 import com.intellij.util.concurrency.annotations.RequiresEdt
 import com.intellij.util.withScheme
 import com.sourcegraph.cody.agent.protocol_extensions.toOffsetRange
@@ -184,13 +183,8 @@ object CodyEditorUtil {
   fun findFileOrScratch(project: Project, uriString: String): VirtualFile? {
     try {
       val uri = URI.create(uriString)
-
-      if (ConfigUtil.isIntegrationTestModeEnabled()) {
-        return TempFileSystem.getInstance().refreshAndFindFileByPath(uri.path)
-      } else {
-        val fixedUri = if (uriString.startsWith("untitled")) uri.withScheme("file") else uri
-        return LocalFileSystem.getInstance().refreshAndFindFileByNioFile(fixedUri.toPath())
-      }
+      val fixedUri = if (uriString.startsWith("untitled")) uri.withScheme("file") else uri
+      return LocalFileSystem.getInstance().refreshAndFindFileByNioFile(fixedUri.toPath())
     } catch (e: URISyntaxException) {
       // Let's try scratch files
       val fileName = uriString.substringAfterLast(':').trimStart('/', '\\')

--- a/jetbrains/src/test/kotlin/com/sourcegraph/cody/agent/protocol/ProtocolTextDocumentTest.kt
+++ b/jetbrains/src/test/kotlin/com/sourcegraph/cody/agent/protocol/ProtocolTextDocumentTest.kt
@@ -239,11 +239,11 @@ class ProtocolTextDocumentTest : BasePlatformTestCase() {
   fun test_normalized_uri_or_path() {
     val testCases =
         listOf(
-            "\\\\wsl$\\Ubuntu\\home\\person" to "//wsl.localhost/Ubuntu/home/person",
-            "//wsl$/Ubuntu/home/person" to "//wsl.localhost/Ubuntu/home/person",
+            "\\\\wsl$\\Ubuntu\\home\\person" to "file://wsl.localhost/Ubuntu/home/person",
+            "//wsl$/Ubuntu/home/person" to "file://wsl.localhost/Ubuntu/home/person",
             "c:/home/person" to "c:/home/person",
             "D:/home/person" to "d:/home/person",
-            "file://\\\\wsl$\\Ubuntu\\home\\person" to "file:////wsl.localhost/Ubuntu/home/person",
+            "file://\\\\wsl$\\Ubuntu\\home\\person" to "file://wsl.localhost/Ubuntu/home/person",
             "file://c:/home/person" to "file:///c:/home/person",
             "file://Z:/home/PERSON" to "file:///z:/home/PERSON",
             "file:///C:/Users/person" to "file:///c:/Users/person",
@@ -251,65 +251,65 @@ class ProtocolTextDocumentTest : BasePlatformTestCase() {
             "file:///home/person/documents" to "file:///home/person/documents")
 
     for ((input, expected) in testCases) {
-      assertEquals(expected, ProtocolTextDocumentExt.normalizeFileUri(input))
+      assertEquals(expected, ProtocolTextDocumentExt.normalizeToVscUriFormat(input))
     }
   }
 
   fun test_wsl_path_with_backslashes() {
     val input = "\\\\wsl$\\Ubuntu\\home\\person"
-    val expected = "//wsl.localhost/Ubuntu/home/person"
-    assertEquals(expected, ProtocolTextDocumentExt.normalizeFileUri(input))
+    val expected = "file://wsl.localhost/Ubuntu/home/person"
+    assertEquals(expected, ProtocolTextDocumentExt.normalizeToVscUriFormat(input))
   }
 
   fun test_wsl_path_with_forward_slashes() {
     val input = "//wsl$/Ubuntu/home/person"
-    val expected = "//wsl.localhost/Ubuntu/home/person"
-    assertEquals(expected, ProtocolTextDocumentExt.normalizeFileUri(input))
+    val expected = "file://wsl.localhost/Ubuntu/home/person"
+    assertEquals(expected, ProtocolTextDocumentExt.normalizeToVscUriFormat(input))
   }
 
   fun testWindowsPathLowerCase() {
     val input = "c:/home/person"
     val expected = "c:/home/person"
-    assertEquals(expected, ProtocolTextDocumentExt.normalizeFileUri(input))
+    assertEquals(expected, ProtocolTextDocumentExt.normalizeToVscUriFormat(input))
   }
 
   fun testWindowsPathUpperCase() {
     val input = "D:/home/person"
     val expected = "d:/home/person"
-    assertEquals(expected, ProtocolTextDocumentExt.normalizeFileUri(input))
+    assertEquals(expected, ProtocolTextDocumentExt.normalizeToVscUriFormat(input))
   }
 
   fun testWslPathWithFileScheme() {
     val input = "file://\\\\wsl$\\Ubuntu\\home\\person"
-    val expected = "file:////wsl.localhost/Ubuntu/home/person"
-    assertEquals(expected, ProtocolTextDocumentExt.normalizeFileUri(input))
+    val expected = "file://wsl.localhost/Ubuntu/home/person"
+    assertEquals(expected, ProtocolTextDocumentExt.normalizeToVscUriFormat(input))
   }
 
   fun testWindowsPathWithFileScheme() {
     val input = "file://c:/home/person"
     val expected = "file:///c:/home/person"
-    assertEquals(expected, ProtocolTextDocumentExt.normalizeFileUri(input))
+    assertEquals(expected, ProtocolTextDocumentExt.normalizeToVscUriFormat(input))
   }
 
   fun testLinuxPath() {
     val input = "/home/person/documents"
     val expected = "/home/person/documents"
-    assertEquals(expected, ProtocolTextDocumentExt.normalizeFileUri(input))
+    assertEquals(expected, ProtocolTextDocumentExt.normalizeToVscUriFormat(input))
   }
 
   fun testLinuxPathWithFileScheme() {
     val input = "file:///home/person/documents"
     val expected = "file:///home/person/documents"
-    assertEquals(expected, ProtocolTextDocumentExt.normalizeFileUri(input))
+    assertEquals(expected, ProtocolTextDocumentExt.normalizeToVscUriFormat(input))
   }
 
   fun test_unsupportedNonFileScheme() {
     val input = "jar://temp/home/person"
-    assertEquals(null, ProtocolTextDocumentExt.normalizeFileUri(input))
+    assertEquals(null, ProtocolTextDocumentExt.normalizeToVscUriFormat(input))
   }
 
   fun test_conversionFromUnsupportedTempVirtualFile() {
     val vf = myFixture.createFile("virtualTempFile.txt", defaultContent)
-    assertEquals(null, ProtocolTextDocumentExt.fileUriFor(vf))
+    assertEquals(null, ProtocolTextDocumentExt.vscNormalizedUriFor(vf))
   }
 }


### PR DESCRIPTION
Fixes https://linear.app/sourcegraph/issue/BUGS-638

## Changes

1. Removed uri conversions which were [potentially harmful ](https://github.com/sourcegraph/jetbrains/issues/3080)and hard to reason about (`FileSystems.getDefault().getPath(file.path).toUri().toString()`)
2. Skip processing documents with schema other than `file://` (if there is no schema specified `file://` is assumed)
3. Skip processing non writable documents
4. Fix WSL handling

## Test plan

N/A

1. Automatic test added
5. I verified in debugger we no longer send content of e.g. jar files