### PR TITLE
Fix positioning of file-like chats in Recent Files

### DIFF
--- a/jetbrains/src/main/kotlin/com/sourcegraph/cody/ui/web/WebviewPanel.kt
+++ b/jetbrains/src/main/kotlin/com/sourcegraph/cody/ui/web/WebviewPanel.kt
@@ -3,6 +3,7 @@ package com.sourcegraph.cody.ui.web
 import com.intellij.openapi.application.runInEdt
 import com.intellij.openapi.application.runWriteAction
 import com.intellij.openapi.fileEditor.FileEditorManager
+import com.intellij.openapi.fileEditor.impl.EditorHistoryManager.IncludeInEditorHistoryFile
 import com.intellij.openapi.project.Project
 import com.intellij.testFramework.LightVirtualFile
 import com.sourcegraph.cody.agent.protocol.WebviewCreateWebviewPanelParams
@@ -14,7 +15,7 @@ import java.util.concurrent.CompletableFuture
 // - Closes Webview panels. Used when Agent stops.
 internal class WebviewPanelManager(private val project: Project) {
   fun createPanel(proxy: WebUIProxy, params: WebviewCreateWebviewPanelParams): WebviewViewDelegate {
-    val file = LightVirtualFile("Cody")
+    val file = object : LightVirtualFile("Cody"), IncludeInEditorHistoryFile {}
     file.fileType = WebPanelFileType.INSTANCE
     file.putUserData(WebPanelTabTitleProvider.WEB_PANEL_TITLE_KEY, params.title)
     file.putUserData(WebPanelEditor.WEB_UI_PROXY_KEY, proxy)


### PR DESCRIPTION
Before this PR, if you open a chat in a new panel (cmd + option + 0), it appears lower than expected in Recent Files list (cmd + E). I may become hard to find it among all the other files. The expected position for the recently modified file is on the top. 

The fix is simple. There is a risk, however. We need an experimental API for it. 

## Demo

### Before
![image](https://github.com/user-attachments/assets/076cc723-cabc-453e-853d-2e9b976af915)


### After
![image](https://github.com/user-attachments/assets/48a90940-86dc-4c63-84a6-27398caae802)


## Test plan
1. Open a few files (project files, lib classes files, scratches, etc)
2. Open New Chat 
3. Review Recent Files - New Chat should appear on the top

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
