### PR TITLE
chore(telemetry): Remove `billingMetadata` from auth telemetry event

### DIFF
--- a/vscode/src/services/AuthProvider.ts
+++ b/vscode/src/services/AuthProvider.ts
@@ -360,15 +360,7 @@ function reportAuthTelemetryEvent(authStatus: AuthStatus): void {
     } else {
         eventValue = 'disconnected'
     }
-    telemetryRecorder.recordEvent('cody.auth', eventValue, {
-        billingMetadata:
-            eventValue === 'connected'
-                ? {
-                      product: 'cody',
-                      category: 'billable',
-                  }
-                : undefined,
-    })
+    telemetryRecorder.recordEvent('cody.auth', eventValue)
 }
 function toCredentialsOnlyNormalized(
     config: ResolvedConfiguration | ResolvedConfigurationCredentialsOnly


### PR DESCRIPTION
Previously, `cody.auth:connected` events were tagged as billable events through `billingMetadata`. Now, this PR removes  this categorization from the `cody.auth:connected` telemetry event. related [thread](https://sourcegraph.slack.com/archives/C06358CMSRM/p1740785635874799)

## Test plan
CI
<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
